### PR TITLE
feat(validators): take-change eligibility, nominator concentration and dividend efficiency

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -11742,9 +11742,12 @@ export interface components {
         ValidatorHistoryArtifact: {
             hotkey: string;
             netuid: number | null;
+            /** @description take_last_changed_date + TxDelegateTakeRateLimit (216,000 blocks / 30.00 days, read from the chain's runtime metadata default). NULL when no change is resolvable in the retained window, which is SHORTER than the rate limit — so 'no change seen' cannot be resolved to 'eligible now'. */
+            next_take_change_eligible_date: string | null;
             point_count: number;
             points: {
                 consensus?: number | null;
+                dividend_efficiency?: number | null;
                 dividends?: number | null;
                 emission_alpha?: number | null;
                 netuid?: number | null;
@@ -11753,6 +11756,7 @@ export interface components {
                 snapshot_date: string;
                 /** @description Native alpha, NOT converted to TAO — the unit the subnet actually emits in, and what an operator compares day over day. The TAO-priced equivalents remain total_stake_tao/total_emission_tao on the same point. */
                 stake_alpha?: number | null;
+                stake_share?: number | null;
                 subnet_count: number | null;
                 take?: number | null;
                 total_emission_tao: number | null;
@@ -11764,14 +11768,20 @@ export interface components {
                 validator_trust?: number | null;
             }[];
             schema_version: number;
+            take_change_observable: boolean;
+            take_last_changed_date: string | null;
+            take_u16: number | null;
             window: string | null;
         } & {
             [key: string]: unknown;
         };
         ValidatorNominatorsArtifact: {
+            concentration_complete: boolean;
             hotkey: string;
             limit: number;
-            nominator_count: number;
+            /** @description Distinct delegating coldkeys in the window. NULL when the rows are a page and the true total could not be read (#9393) — it is deliberately not the page size, which is what this reported before and which tracked ?limit. */
+            nominator_count: number | null;
+            nominator_gini: number | null;
             nominators: {
                 coldkey: string;
                 event_count: number;
@@ -11785,6 +11795,8 @@ export interface components {
             schema_version: number;
             /** @enum {string} */
             sort: "net_staked" | "gross_staked" | "last_activity";
+            top_nominator_share: number | null;
+            top5_nominator_share: number | null;
             window: string | null;
         } & {
             [key: string]: unknown;
@@ -51059,6 +51071,7 @@ export interface operations {
                      *       "data": {
                      *         "hotkey": "example",
                      *         "netuid": 7,
+                     *         "next_take_change_eligible_date": "example",
                      *         "point_count": 1,
                      *         "points": [
                      *           {
@@ -51070,6 +51083,9 @@ export interface operations {
                      *           }
                      *         ],
                      *         "schema_version": 1,
+                     *         "take_change_observable": false,
+                     *         "take_last_changed_date": "example",
+                     *         "take_u16": 1,
                      *         "window": "30d"
                      *       },
                      *       "meta": {
@@ -51180,9 +51196,11 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "concentration_complete": false,
                      *         "hotkey": "example",
                      *         "limit": 1,
                      *         "nominator_count": 1,
+                     *         "nominator_gini": 0.5,
                      *         "nominators": [
                      *           {
                      *             "coldkey": "example",
@@ -51197,6 +51215,8 @@ export interface operations {
                      *         "offset": 1,
                      *         "schema_version": 1,
                      *         "sort": "net_staked",
+                     *         "top_nominator_share": 0.5,
+                     *         "top5_nominator_share": 0.5,
                      *         "window": "30d"
                      *       },
                      *       "meta": {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -11454,6 +11454,7 @@
           "data": {
             "hotkey": "example",
             "netuid": 7,
+            "next_take_change_eligible_date": "example",
             "point_count": 1,
             "points": [
               {
@@ -11465,6 +11466,9 @@
               }
             ],
             "schema_version": 1,
+            "take_change_observable": false,
+            "take_last_changed_date": "example",
+            "take_u16": 1,
             "window": "30d"
           },
           "meta": {
@@ -11496,9 +11500,11 @@
       "ValidatorNominatorsArtifactResponse": {
         "value": {
           "data": {
+            "concentration_complete": false,
             "hotkey": "example",
             "limit": 1,
             "nominator_count": 1,
+            "nominator_gini": 0.5,
             "nominators": [
               {
                 "coldkey": "example",
@@ -11513,6 +11519,8 @@
             "offset": 1,
             "schema_version": 1,
             "sort": "net_staked",
+            "top_nominator_share": 0.5,
+            "top5_nominator_share": 0.5,
             "window": "30d"
           },
           "meta": {
@@ -48275,6 +48283,17 @@
               }
             ]
           },
+          "next_take_change_eligible_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "take_last_changed_date + TxDelegateTakeRateLimit (216,000 blocks / 30.00 days, read from the chain's runtime metadata default). NULL when no change is resolvable in the retained window, which is SHORTER than the rate limit — so 'no change seen' cannot be resolved to 'eligible now'."
+          },
           "point_count": {
             "maximum": 9007199254740991,
             "minimum": 0,
@@ -48287,6 +48306,17 @@
                 "consensus": {
                   "anyOf": [
                     {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "dividend_efficiency": {
+                  "anyOf": [
+                    {
+                      "minimum": 0,
                       "type": "number"
                     },
                     {
@@ -48359,6 +48389,17 @@
                     }
                   ],
                   "description": "Native alpha, NOT converted to TAO — the unit the subnet actually emits in, and what an operator compares day over day. The TAO-priced equivalents remain total_stake_tao/total_emission_tao on the same point."
+                },
+                "stake_share": {
+                  "anyOf": [
+                    {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "subnet_count": {
                   "anyOf": [
@@ -48453,6 +48494,31 @@
             "minimum": -9007199254740991,
             "type": "integer"
           },
+          "take_change_observable": {
+            "type": "boolean"
+          },
+          "take_last_changed_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "take_u16": {
+            "anyOf": [
+              {
+                "maximum": 65535,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "window": {
             "anyOf": [
               {
@@ -48469,6 +48535,10 @@
           "hotkey",
           "window",
           "netuid",
+          "take_u16",
+          "take_last_changed_date",
+          "next_take_change_eligible_date",
+          "take_change_observable",
           "point_count",
           "points"
         ],
@@ -48477,6 +48547,9 @@
       "ValidatorNominatorsArtifact": {
         "additionalProperties": {},
         "properties": {
+          "concentration_complete": {
+            "type": "boolean"
+          },
           "hotkey": {
             "type": "string"
           },
@@ -48486,9 +48559,29 @@
             "type": "integer"
           },
           "nominator_count": {
-            "maximum": 9007199254740991,
-            "minimum": 0,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Distinct delegating coldkeys in the window. NULL when the rows are a page and the true total could not be read (#9393) — it is deliberately not the page size, which is what this reported before and which tracked ?limit."
+          },
+          "nominator_gini": {
+            "anyOf": [
+              {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "nominators": {
             "items": {
@@ -48559,6 +48652,30 @@
             ],
             "type": "string"
           },
+          "top_nominator_share": {
+            "anyOf": [
+              {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "top5_nominator_share": {
+            "anyOf": [
+              {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "window": {
             "anyOf": [
               {
@@ -48578,6 +48695,10 @@
           "limit",
           "offset",
           "nominator_count",
+          "concentration_complete",
+          "top_nominator_share",
+          "top5_nominator_share",
+          "nominator_gini",
           "nominators"
         ],
         "type": "object"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -11742,9 +11742,12 @@ export interface components {
         ValidatorHistoryArtifact: {
             hotkey: string;
             netuid: number | null;
+            /** @description take_last_changed_date + TxDelegateTakeRateLimit (216,000 blocks / 30.00 days, read from the chain's runtime metadata default). NULL when no change is resolvable in the retained window, which is SHORTER than the rate limit — so 'no change seen' cannot be resolved to 'eligible now'. */
+            next_take_change_eligible_date: string | null;
             point_count: number;
             points: {
                 consensus?: number | null;
+                dividend_efficiency?: number | null;
                 dividends?: number | null;
                 emission_alpha?: number | null;
                 netuid?: number | null;
@@ -11753,6 +11756,7 @@ export interface components {
                 snapshot_date: string;
                 /** @description Native alpha, NOT converted to TAO — the unit the subnet actually emits in, and what an operator compares day over day. The TAO-priced equivalents remain total_stake_tao/total_emission_tao on the same point. */
                 stake_alpha?: number | null;
+                stake_share?: number | null;
                 subnet_count: number | null;
                 take?: number | null;
                 total_emission_tao: number | null;
@@ -11764,14 +11768,20 @@ export interface components {
                 validator_trust?: number | null;
             }[];
             schema_version: number;
+            take_change_observable: boolean;
+            take_last_changed_date: string | null;
+            take_u16: number | null;
             window: string | null;
         } & {
             [key: string]: unknown;
         };
         ValidatorNominatorsArtifact: {
+            concentration_complete: boolean;
             hotkey: string;
             limit: number;
-            nominator_count: number;
+            /** @description Distinct delegating coldkeys in the window. NULL when the rows are a page and the true total could not be read (#9393) — it is deliberately not the page size, which is what this reported before and which tracked ?limit. */
+            nominator_count: number | null;
+            nominator_gini: number | null;
             nominators: {
                 coldkey: string;
                 event_count: number;
@@ -11785,6 +11795,8 @@ export interface components {
             schema_version: number;
             /** @enum {string} */
             sort: "net_staked" | "gross_staked" | "last_activity";
+            top_nominator_share: number | null;
+            top5_nominator_share: number | null;
             window: string | null;
         } & {
             [key: string]: unknown;
@@ -51059,6 +51071,7 @@ export interface operations {
                      *       "data": {
                      *         "hotkey": "example",
                      *         "netuid": 7,
+                     *         "next_take_change_eligible_date": "example",
                      *         "point_count": 1,
                      *         "points": [
                      *           {
@@ -51070,6 +51083,9 @@ export interface operations {
                      *           }
                      *         ],
                      *         "schema_version": 1,
+                     *         "take_change_observable": false,
+                     *         "take_last_changed_date": "example",
+                     *         "take_u16": 1,
                      *         "window": "30d"
                      *       },
                      *       "meta": {
@@ -51180,9 +51196,11 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "concentration_complete": false,
                      *         "hotkey": "example",
                      *         "limit": 1,
                      *         "nominator_count": 1,
+                     *         "nominator_gini": 0.5,
                      *         "nominators": [
                      *           {
                      *             "coldkey": "example",
@@ -51197,6 +51215,8 @@ export interface operations {
                      *         "offset": 1,
                      *         "schema_version": 1,
                      *         "sort": "net_staked",
+                     *         "top_nominator_share": 0.5,
+                     *         "top5_nominator_share": 0.5,
                      *         "window": "30d"
                      *       },
                      *       "meta": {

--- a/schemas-src/routes/validator-history.ts
+++ b/schemas-src/routes/validator-history.ts
@@ -44,6 +44,13 @@ const ValidatorHistoryPointSchema = z
         "Whether the permit was held that day. The scoped series reports a lost permit rather than dropping the day, so 'lost the permit' stays distinguishable from 'no data'.",
       ),
     rewards_per_1000_alpha: z.number().nullable().optional(),
+    // #9390. `dividends` is already normalised by the chain (the column sums to ~1.0
+    // across a subnet's neurons), so it IS the dividend share; efficiency is that over
+    // stake share. Above 1 the validator out-earns its stake, below 1 it under-earns.
+    // The denominator is TOTAL subnet stake including miners -- measured at 99.87-100%
+    // validator stake, so the distinction is sub-0.2%.
+    stake_share: z.number().min(0).nullable().optional(),
+    dividend_efficiency: z.number().min(0).nullable().optional(),
   })
   .strict();
 
@@ -55,6 +62,18 @@ export const ValidatorHistoryArtifactSchema = z
     // The subnet this series was scoped to; null for the cross-subnet rollup, so a
     // consumer never has to probe a point to learn which shape it received.
     netuid: z.int().min(0).nullable(),
+    // #9390: take is a delegate-level fact, reported once for the series rather than
+    // per point, and compared as the u16 the chain stores it in — the float rendering
+    // is not stable and diffing it manufactures changes that never happened.
+    take_u16: z.int().min(0).max(65535).nullable(),
+    take_last_changed_date: z.string().nullable(),
+    next_take_change_eligible_date: z
+      .string()
+      .nullable()
+      .describe(
+        "take_last_changed_date + TxDelegateTakeRateLimit (216,000 blocks / 30.00 days, read from the chain's runtime metadata default). NULL when no change is resolvable in the retained window, which is SHORTER than the rate limit — so 'no change seen' cannot be resolved to 'eligible now'.",
+      ),
+    take_change_observable: z.boolean(),
     point_count: z.int().min(0),
     points: z.array(ValidatorHistoryPointSchema),
   })

--- a/schemas-src/routes/validator-nominators.ts
+++ b/schemas-src/routes/validator-nominators.ts
@@ -31,7 +31,19 @@ export const ValidatorNominatorsArtifactSchema = z
     sort: z.enum(["net_staked", "gross_staked", "last_activity"]),
     limit: z.int().min(0).max(100),
     offset: z.int().min(0),
-    nominator_count: z.int().min(0),
+    nominator_count: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe(
+        "Distinct delegating coldkeys in the window. NULL when the rows are a page and the true total could not be read (#9393) — it is deliberately not the page size, which is what this reported before and which tracked ?limit.",
+      ),
+    // #9390: how concentrated the delegated stake is. Null unless the rows in hand are
+    // the whole set -- a top-holder share computed over one page describes the page.
+    concentration_complete: z.boolean(),
+    top_nominator_share: z.number().min(0).max(1).nullable(),
+    top5_nominator_share: z.number().min(0).max(1).nullable(),
+    nominator_gini: z.number().min(0).max(1).nullable(),
     nominators: z.array(ValidatorNominatorEntrySchema),
   })
   .passthrough();

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -619,6 +619,26 @@ export async function loadValidatorNominatorsColdTier(
   );
   if (rows === null) return null;
 
+  // #9393: the TRUE distinct-coldkey count, which the scan above cannot know -- it is
+  // bounded by `LIMIT limit + offset`, so its length is the page size by construction.
+  // Passing that as `totalCount` made nominator_count track `limit` (20 with limit=20,
+  // 100 with limit=100) for a validator whose detail card reported 2,474.
+  //
+  // Wrapped in a GROUP BY subquery, not `count(DISTINCT coldkey)`: R2 SQL rejects the
+  // ungrouped form outright with `40015: scan budget exceeded: scanning too much data
+  // for count(DISTINCT) without GROUP BY`, and a rejected query would decline the whole
+  // reader. Same idiom, and same reason, as loadAccountSummaryColdTier.
+  const countRows = await r2SqlQuery(
+    env,
+    `SELECT count(*) AS c FROM (SELECT coldkey FROM chain.account_events` +
+      ` WHERE ${where.join(" AND ")} GROUP BY coldkey)`,
+  );
+  // A failed count leaves the total UNKNOWN rather than falling back to the page size.
+  // Null is a real state; a page size dressed as a total is not.
+  const counted = Number(countRows?.[0]?.c);
+  const totalCount =
+    countRows === null || !Number.isFinite(counted) ? null : counted;
+
   // data-api wrapped every sum in COALESCE(..., 0); replicate that client-side
   // rather than lean on the beta engine's function coverage. Without it an
   // all-null group would be skipped by the builder instead of counted at zero.
@@ -633,7 +653,8 @@ export async function loadValidatorNominatorsColdTier(
       sort,
       limit,
       offset,
-      totalCount: page.length,
+      totalCount,
+      alreadyPaged: true,
     }),
     generatedAt: latestObservedIso(page),
   };

--- a/src/validator-history.ts
+++ b/src/validator-history.ts
@@ -46,6 +46,109 @@ function rewardsPer1000Tao(
 // DESC LIMIT MAX_HISTORY_POINTS`), one point per snapshot_date. Null-safe:
 // no rows (cold store / empty window) yields a zeroed, empty-point card,
 // matching the sibling history routes.
+/**
+ * Take is a u16 fraction of 0xFFFF on chain, and MUST be compared as one.
+ *
+ * The stored float is a rendering of that integer, and the rendering is not stable.
+ * Measured on a real series (`5G9hfkx9…`, netuid 4) whose take never changed:
+ *
+ *     2026-07-17..19   0.009994659
+ *     2026-07-20..02   0.00999466
+ *     2026-08-03       0.009994659342336155
+ *
+ * All three are u16 655. Comparing the floats reports three take changes that did not
+ * happen — and this feature exists to inform a decision the chain then locks for 30
+ * days, so a phantom change is worse than no answer. An epsilon would not fix it
+ * either: the right tolerance is exactly one u16 step, which is what rounding gives.
+ */
+export const TAKE_DENOMINATOR = 0xffff;
+
+export function takeToU16(value: unknown): number | null {
+  const n = toFiniteOrNull(value);
+  if (n === null || n < 0 || n > 1) return null;
+  return Math.round(n * TAKE_DENOMINATOR);
+}
+
+/**
+ * Blocks between permitted delegate-take changes.
+ *
+ * Read from the chain's own runtime metadata rather than assumed: the
+ * `SubtensorModule.TxDelegateTakeRateLimit` storage item is UNSET on mainnet, so the
+ * runtime falls back to its declared default, which decodes to 216,000 — exactly 30.00
+ * days at 12s blocks. (An unset storage item means the default, never zero.)
+ */
+export const TAKE_CHANGE_RATE_LIMIT_BLOCKS = 216_000;
+
+interface TakeChangeView {
+  take_u16: number | null;
+  take_last_changed_date: string | null;
+  next_take_change_eligible_date: string | null;
+  take_change_observable: boolean;
+}
+
+/**
+ * When this hotkey's take last changed, within the retained window.
+ *
+ * `points` arrive NEWEST FIRST. Two things make this deliberately conservative:
+ *
+ *  1. A leading run of null/0 take is NOT a take of zero. The same real series begins
+ *     `null,null,null,null,0,0,0` before its steady value — the column simply was not
+ *     being captured yet. Reporting the step out of that run as a take change would
+ *     manufacture one for every validator alive when capture started.
+ *  2. The retained window (~26 days) is SHORTER than the 30-day rate limit, so "no
+ *     change seen" cannot be resolved to "eligible now". It reports unknown.
+ *
+ * `take_change_observable` says which of those two situations produced a null, so a
+ * caller never has to guess whether the absence is "stable" or "we cannot tell".
+ */
+function takeChangeView(points: Row[]): TakeChangeView {
+  const series = points
+    .map((p) => ({
+      date: typeof p.snapshot_date === "string" ? p.snapshot_date : null,
+      u16: takeToU16(p.take),
+    }))
+    .filter((x) => x.date !== null);
+
+  const newestU16 = series.find((x) => x.u16 !== null)?.u16 ?? null;
+
+  // Oldest-first, with the un-capturable prefix dropped: leading nulls, and the run of
+  // zeroes that directly precedes the first nonzero reading (see (1) above).
+  const chrono = [...series].reverse();
+  let start = 0;
+  while (start < chrono.length && chrono[start].u16 === null) start += 1;
+  let firstNonZero = start;
+  while (firstNonZero < chrono.length && chrono[firstNonZero].u16 === 0)
+    firstNonZero += 1;
+  // Only treat the zero-run as unusable when a nonzero value follows it. A validator
+  // whose take is genuinely 0 throughout keeps its whole series.
+  if (firstNonZero < chrono.length) start = firstNonZero;
+
+  const usable = chrono.slice(start).filter((x) => x.u16 !== null);
+  let changedDate: string | null = null;
+  for (let i = 1; i < usable.length; i += 1) {
+    if (usable[i].u16 !== usable[i - 1].u16) changedDate = usable[i].date;
+  }
+
+  const eligible =
+    changedDate === null
+      ? null
+      : new Date(
+          Date.parse(`${changedDate}T00:00:00Z`) +
+            TAKE_CHANGE_RATE_LIMIT_BLOCKS * 12 * 1000,
+        )
+          .toISOString()
+          .slice(0, 10);
+
+  return {
+    take_u16: newestU16,
+    take_last_changed_date: changedDate,
+    next_take_change_eligible_date: eligible,
+    // A change was actually resolvable; a false with a null date means the window
+    // simply does not reach far enough back to say.
+    take_change_observable: changedDate !== null || usable.length >= 2,
+  };
+}
+
 /** A rate/score column: kept as a plain finite number, or null when absent. */
 function toRateOrNull(v: unknown): number | null {
   const n = toFiniteOrNull(v);
@@ -83,6 +186,56 @@ function subnetScopedFields(r: Row): Row {
     // a day the poller missed.
     validator_permit: r.validator_permit == null ? null : !!r.validator_permit,
     rewards_per_1000_alpha: rewardsPer1000Tao(stakeAlpha, emissionAlpha),
+    ...stakeShareView(
+      stakeAlpha,
+      r.subnet_total_stake,
+      toRateOrNull(r.dividends),
+    ),
+  };
+}
+
+interface StakeShareView {
+  stake_share: number | null;
+  dividend_efficiency: number | null;
+}
+
+/**
+ * This validator's share of the subnet's stake, and how its dividends compare to it.
+ *
+ * `dividends` is already normalised by the chain — the column sums to ~1.0 across a
+ * subnet's neurons on any given day (measured: 0.99989 on netuid 64) — so it IS the
+ * dividend share and needs no denominator of its own. Efficiency is therefore simply
+ * dividend share over stake share: above 1 the validator out-earns its stake, below 1
+ * it under-earns, and that is the number that says which subnet to leave.
+ *
+ * THE DENOMINATOR IS TOTAL SUBNET STAKE, including miners, because that is what
+ * `subnet_snapshots.total_stake_tao` measures and it rides on a join this query already
+ * does. Dividends actually accrue to validators, so the strictly correct denominator is
+ * validator stake — measured across netuids 1/4/8/64 that is 99.87–100% of total, i.e.
+ * a sub-0.2% difference, the same order as the snapshot total's own drift from the
+ * summed neuron rows (0.05–0.21%). Naming it `stake_share` rather than
+ * `validator_stake_share` keeps the field honest about which denominator it used.
+ *
+ * Both sides are the same unit (alpha for non-root subnets), so the ratio is unit-free.
+ */
+function stakeShareView(
+  stakeAlpha: number | null,
+  subnetTotal: unknown,
+  dividends: number | null,
+): StakeShareView {
+  const total = toFiniteOrNull(subnetTotal);
+  if (stakeAlpha === null || total === null || total <= 0) {
+    return { stake_share: null, dividend_efficiency: null };
+  }
+  const share = stakeAlpha / total;
+  const rounded = Math.round(share * 1e6) / 1e6;
+  return {
+    stake_share: rounded,
+    // Undefined with no stake: a validator holding nothing has no share to out-earn.
+    dividend_efficiency:
+      dividends === null || share <= 0
+        ? null
+        : Math.round((dividends / share) * 1e6) / 1e6,
   };
 }
 
@@ -116,6 +269,16 @@ export function buildValidatorHistory(
     // be probed to know which shape the points carry.
     netuid: scoped ? netuid : null,
     window: window ?? null,
+    // #9390: take is a delegate-level fact, so it is reported once for the series
+    // rather than per point. Only the scoped series carries `take` at all.
+    ...(scoped
+      ? takeChangeView(points as Row[])
+      : {
+          take_u16: null,
+          take_last_changed_date: null,
+          next_take_change_eligible_date: null,
+          take_change_observable: false,
+        }),
     point_count: points.length,
     points,
   };

--- a/src/validator-nominators.ts
+++ b/src/validator-nominators.ts
@@ -87,6 +87,81 @@ interface ColdkeyBucket {
 // read path. Null-safe: no rows (cold store / empty window / no nominators)
 // yields a zeroed, empty list — never throws, matching the sibling account
 // tiers (stake-flow, counterparties).
+/**
+ * The count to publish.
+ *
+ * When the caller handed us every row, their number IS the total. When it handed us a
+ * page, only an explicitly supplied total is trustworthy — falling back to the page
+ * length there is the #9393 defect.
+ */
+/**
+ * How concentrated this validator's delegated stake is.
+ *
+ * The question an operator actually asks: **if my biggest delegator leaves, how much
+ * goes with them.** Shaped like `/accounts/{ss58}/portfolio`'s existing
+ * `stake_concentration` block rather than inventing a second vocabulary for the same
+ * idea.
+ *
+ * COMPUTED OVER THE ROWS PRESENT, and honest about it. When the route is serving a
+ * page of a larger set, a "top nominator share" derived from that page describes the
+ * page, not the validator — the same class of mistake as a UI filtering client-side
+ * over one page of 1,184 rows. So this returns nulls unless the rows in hand are the
+ * whole set, which is exactly when `nominator_count` equals the number of rows.
+ *
+ * Negative net stake (a coldkey that withdrew more than it added in the window) is
+ * clamped out of the denominator rather than allowed to inflate everyone else's share
+ * past 1.
+ */
+function concentrationView(
+  nominators: Nominator[],
+  reportedCount: number | null,
+): Row {
+  const complete =
+    reportedCount !== null && reportedCount === nominators.length;
+  const stakes = nominators
+    .map((n) => Number(n.net_staked_tao))
+    .filter((v) => Number.isFinite(v) && v > 0)
+    .sort((a, b) => b - a);
+  const total = stakes.reduce((sum, v) => sum + v, 0);
+  if (!complete || stakes.length === 0 || total <= 0) {
+    return {
+      concentration_complete: complete,
+      top_nominator_share: null,
+      top5_nominator_share: null,
+      nominator_gini: null,
+    };
+  }
+  const share = (n: number) =>
+    Math.round((stakes.slice(0, n).reduce((s, v) => s + v, 0) / total) * 1e6) /
+    1e6;
+  // Gini over the ascending stakes: sum((2i - n - 1) * x_i) / (n * sum(x)).
+  const asc = [...stakes].reverse();
+  const n = asc.length;
+  const weighted = asc.reduce(
+    (sum, v, i) => sum + (2 * (i + 1) - n - 1) * v,
+    0,
+  );
+  return {
+    concentration_complete: true,
+    top_nominator_share: share(1),
+    top5_nominator_share: share(5),
+    // A single nominator is perfectly concentrated, but Gini is undefined at n=1
+    // (the formula divides by n and yields 0, which would read as perfectly EQUAL).
+    nominator_gini:
+      n < 2 ? null : Math.round((weighted / (n * total)) * 1e6) / 1e6,
+  };
+}
+
+function resolveCount(
+  totalCount: unknown,
+  pageLength: number,
+  alreadyPaged: boolean,
+): number | null {
+  const n = Math.trunc(Number(totalCount));
+  if (Number.isFinite(n) && n >= 0) return n;
+  return alreadyPaged ? null : pageLength;
+}
+
 export function buildValidatorNominators(
   rows: Row[] | null | undefined,
   hotkey: unknown,
@@ -96,12 +171,25 @@ export function buildValidatorNominators(
     limit = NOMINATOR_LIMIT_DEFAULT,
     offset = 0,
     totalCount,
+    alreadyPaged = false,
   }: {
     window?: string;
     sort?: string;
     limit?: unknown;
     offset?: unknown;
     totalCount?: unknown;
+    /**
+     * True when `rows` is ALREADY the requested page (the SQL read applied
+     * LIMIT/OFFSET), so this builder must not slice it again.
+     *
+     * Split from `totalCount` by #9393. The two used to be the same signal —
+     * `totalCount == null` meant both "page in memory" and "no total supplied" — which
+     * left no way to say "these rows are a page AND the total is unknown". The loader
+     * worked around it by passing `page.length` as the total, and that page size then
+     * shipped as `nominator_count`, tracking `limit` (20, then 100) for a validator
+     * with 2,474 nominators.
+     */
+    alreadyPaged?: boolean;
   } = {},
 ): Row {
   const normalizedSort = NOMINATOR_SORTS.includes(sort)
@@ -178,6 +266,7 @@ export function buildValidatorNominators(
   // last_observed_ms is an internal sort key, never part of the public shape.
   for (const nominator of nominators) delete nominator.last_observed_ms;
 
+  const count = resolveCount(totalCount, nominators.length, alreadyPaged);
   return {
     schema_version: 1,
     hotkey,
@@ -185,14 +274,13 @@ export function buildValidatorNominators(
     sort: normalizedSort,
     limit: normalizedLimit,
     offset: normalizedOffset,
-    nominator_count:
-      totalCount == null
-        ? nominators.length
-        : Math.max(0, Math.trunc(Number(totalCount))) || 0,
-    nominators:
-      totalCount == null
-        ? nominators.slice(normalizedOffset, normalizedOffset + normalizedLimit)
-        : nominators,
+    // Null ONLY when the rows are a page and the true total could not be read: an
+    // unknown total is a real state, and a page size dressed as a total is not.
+    nominator_count: count,
+    ...concentrationView(nominators, count),
+    nominators: alreadyPaged
+      ? nominators
+      : nominators.slice(normalizedOffset, normalizedOffset + normalizedLimit),
   };
 }
 

--- a/tests/account-feeds-cold-tier.test.ts
+++ b/tests/account-feeds-cold-tier.test.ts
@@ -732,7 +732,7 @@ describe("loadValidatorNominatorsColdTier", () => {
   }
 
   test("carries the retired Postgres projection and predicate verbatim", async () => {
-    const q = sqlFetch([nominatorRow(OTHER, 20)]);
+    const q = sqlFetch([nominatorRow(OTHER, 20)], [{ c: 1 }]);
     const res = await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
       limit: 20,
       window: "30d",
@@ -757,7 +757,7 @@ describe("loadValidatorNominatorsColdTier", () => {
   });
 
   test("rewrites the kind IN-list as an OR, never leaning on IN", async () => {
-    const q = sqlFetch([nominatorRow(OTHER, 5)]);
+    const q = sqlFetch([nominatorRow(OTHER, 5)], [{ c: 1 }]);
     await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, { limit: 5 });
     assert.match(
       q[0]!,
@@ -772,7 +772,7 @@ describe("loadValidatorNominatorsColdTier", () => {
       ["gross_staked", "gross_staked_tao DESC, coldkey ASC"],
       ["last_activity", "last_observed DESC, coldkey ASC"],
     ] as const) {
-      const q = sqlFetch([nominatorRow(OTHER, 5)]);
+      const q = sqlFetch([nominatorRow(OTHER, 5)], [{ c: 1 }]);
       const res = await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
         limit: 5,
         sort,
@@ -785,7 +785,7 @@ describe("loadValidatorNominatorsColdTier", () => {
   test("declines a sort it cannot express rather than serving the default order", async () => {
     // Silently substituting net_staked under the caller's requested label
     // would be a wrong answer wearing the right label.
-    const q = sqlFetch([nominatorRow(OTHER, 5)]);
+    const q = sqlFetch([nominatorRow(OTHER, 5)], [{ c: 1 }]);
     assert.equal(
       await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
         limit: 5,
@@ -818,7 +818,7 @@ describe("loadValidatorNominatorsColdTier", () => {
   });
 
   test("declines past the offset-emulation cap rather than paging wrongly", async () => {
-    const q = sqlFetch([nominatorRow(OTHER, 5)]);
+    const q = sqlFetch([nominatorRow(OTHER, 5)], [{ c: 1 }]);
     assert.equal(
       await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
         limit: 5,
@@ -830,7 +830,7 @@ describe("loadValidatorNominatorsColdTier", () => {
   });
 
   test("narrows on an exact coldkey, and declines an unusable one", async () => {
-    const q = sqlFetch([nominatorRow(OTHER, 5)]);
+    const q = sqlFetch([nominatorRow(OTHER, 5)], [{ c: 1 }]);
     await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
       limit: 5,
       coldkey: OTHER,
@@ -838,7 +838,7 @@ describe("loadValidatorNominatorsColdTier", () => {
     assert.match(q[0]!, new RegExp(`coldkey = '${OTHER}'`));
 
     // A filter that cannot be inlined must not widen to every nominator.
-    const bad = sqlFetch([nominatorRow(OTHER, 5)]);
+    const bad = sqlFetch([nominatorRow(OTHER, 5)], [{ c: 1 }]);
     assert.equal(
       await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
         limit: 5,
@@ -852,15 +852,18 @@ describe("loadValidatorNominatorsColdTier", () => {
   test("coalesces null sums to zero, as data-api's COALESCE did", async () => {
     // Without this the builder skips the group entirely, losing a nominator a
     // healthy read did return.
-    sqlFetch([
-      {
-        coldkey: OTHER,
-        staked_tao: null,
-        unstaked_tao: null,
-        event_count: 2,
-        last_observed: 1_785_000_000_000,
-      },
-    ]);
+    sqlFetch(
+      [
+        {
+          coldkey: OTHER,
+          staked_tao: null,
+          unstaked_tao: null,
+          event_count: 2,
+          last_observed: 1_785_000_000_000,
+        },
+      ],
+      [{ c: 1 }],
+    );
     const res = await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
       limit: 5,
     });
@@ -872,7 +875,7 @@ describe("loadValidatorNominatorsColdTier", () => {
   });
 
   test("falls back to the default window for an unknown label", async () => {
-    sqlFetch([nominatorRow(OTHER, 5)]);
+    sqlFetch([nominatorRow(OTHER, 5)], [{ c: 1 }]);
     const res = await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
       limit: 5,
       window: "1y",
@@ -881,7 +884,7 @@ describe("loadValidatorNominatorsColdTier", () => {
   });
 
   test("a validator with no nominators answers an empty list, not a decline", async () => {
-    sqlFetch([]);
+    sqlFetch([], [{ c: 0 }]);
     const res = await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
       limit: 5,
     });
@@ -890,7 +893,7 @@ describe("loadValidatorNominatorsColdTier", () => {
   });
 
   test("declines an unusable hotkey, limit or offset rather than scanning", async () => {
-    const q = sqlFetch([]);
+    const q = sqlFetch([], [{ c: 0 }]);
     assert.equal(
       await loadValidatorNominatorsColdTier(TOKEN as never, "not-an-ss58", {
         limit: 5,

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -19555,24 +19555,32 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
     const realFetch = globalThis.fetch;
     let capturedQuery = "";
     globalThis.fetch = (async (_u: string, init: RequestInit) => {
-      capturedQuery = JSON.parse(String(init.body)).query;
+      const query = JSON.parse(String(init.body)).query as string;
+      // #9393: the loader now issues a SECOND query for the true distinct-coldkey
+      // count, because the leaderboard scan is bounded by LIMIT and its length is the
+      // page size rather than the total. Only the leaderboard query is captured, so
+      // the assertions below still describe the scan they were written for.
+      const isCount = query.includes("count(*) AS c");
+      if (!isCount) capturedQuery = query;
       return {
         ok: true,
         status: 200,
         json: async () => ({
           success: true,
           result: {
-            rows: [
-              {
-                coldkey: COLDKEY,
-                staked_tao: 12.5,
-                unstaked_tao: 2.5,
-                event_count: 3,
-                last_observed: 1785544524000,
-                net_staked_tao: 10,
-                gross_staked_tao: 15,
-              },
-            ],
+            rows: isCount
+              ? [{ c: 1 }]
+              : [
+                  {
+                    coldkey: COLDKEY,
+                    staked_tao: 12.5,
+                    unstaked_tao: 2.5,
+                    event_count: 3,
+                    last_observed: 1785544524000,
+                    net_staked_tao: 10,
+                    gross_staked_tao: 15,
+                  },
+                ],
           },
         }),
       };

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -15458,17 +15458,22 @@ describe("MCP block-explorer tools — lakehouse cold tier answers when Postgres
   });
 
   test("get_validator_nominators serves the nominator list from the lakehouse", async () => {
-    const queries = lakeFetch([
-      {
-        coldkey: "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F",
-        staked_tao: 40,
-        unstaked_tao: 5,
-        event_count: 4,
-        last_observed: 1785544524000,
-        net_staked_tao: 35,
-        gross_staked_tao: 45,
-      },
-    ]);
+    const queries = lakeFetch(
+      [
+        {
+          coldkey: "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F",
+          staked_tao: 40,
+          unstaked_tao: 5,
+          event_count: 4,
+          last_observed: 1785544524000,
+          net_staked_tao: 35,
+          gross_staked_tao: 45,
+        },
+      ],
+      // #9393: the loader now also reads the TRUE distinct-coldkey count, because the
+      // scan above is bounded by LIMIT and its length is the page size, not the total.
+      [{ c: 1 }],
+    );
     const res = await callTool(
       "get_validator_nominators",
       { hotkey: LAKE_EXTRINSIC.signer, sort: "last_activity" },

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -3181,17 +3181,23 @@ describe("cold tier answers when Postgres misses (lakehouse-backed handlers)", (
   });
 
   test("handleValidatorNominators serves the nominator list from the lakehouse", async () => {
-    const q = lakeFetch([
-      {
-        coldkey: COUNTERPARTY,
-        staked_tao: 40,
-        unstaked_tao: 5,
-        event_count: 4,
-        last_observed: 1_785_544_524_000,
-        net_staked_tao: 35,
-        gross_staked_tao: 45,
-      },
-    ]);
+    const q = lakeFetch(
+      [
+        {
+          coldkey: COUNTERPARTY,
+          staked_tao: 40,
+          unstaked_tao: 5,
+          event_count: 4,
+          last_observed: 1_785_544_524_000,
+          net_staked_tao: 35,
+          gross_staked_tao: 45,
+        },
+      ],
+      // #9393: the loader also reads the TRUE distinct-coldkey count now -- the
+      // leaderboard scan is bounded by LIMIT, so its length is the page size, not
+      // the total, which is what used to ship as nominator_count.
+      [{ c: 1 }],
+    );
     const body = await json(
       await handleValidatorNominators(
         req(`/api/v1/validators/${ADDR}/nominators`),

--- a/tests/validator-history.test.ts
+++ b/tests/validator-history.test.ts
@@ -344,3 +344,165 @@ describe("buildValidatorHistory — scoped to one subnet (#9383)", () => {
     assert.equal(point.rewards_per_1000_alpha, null);
   });
 });
+
+// #9390: take-change detection and dividend efficiency.
+describe("buildValidatorHistory — operator signals (#9390)", () => {
+  // The REAL series measured on 5G9hfkx9…/netuid 4, newest first. The take never
+  // changed; a float diff reports four changes.
+  const REAL_TAKE_SERIES = [
+    { snapshot_date: "2026-08-03", take: 0.009994659342336155 },
+    { snapshot_date: "2026-08-02", take: 0.00999466 },
+    { snapshot_date: "2026-07-20", take: 0.00999466 },
+    { snapshot_date: "2026-07-19", take: 0.009994659 },
+    { snapshot_date: "2026-07-17", take: 0.009994659 },
+    { snapshot_date: "2026-07-16", take: 0 },
+    { snapshot_date: "2026-07-14", take: 0 },
+    { snapshot_date: "2026-07-13", take: null },
+    { snapshot_date: "2026-07-10", take: null },
+  ];
+
+  test("three float renderings of one u16 are NOT a take change", () => {
+    const card = buildValidatorHistory(REAL_TAKE_SERIES, HOTKEY, { netuid: 4 });
+    assert.equal(card.take_u16, 655, "all three renderings are u16 655");
+    assert.equal(
+      card.take_last_changed_date,
+      null,
+      "this validator never changed its take",
+    );
+  });
+
+  test("the leading null/0 run is not read as a take of zero", () => {
+    // The column simply was not being captured yet. Reporting the step out of that run
+    // would manufacture a change for every validator alive when capture started.
+    const card = buildValidatorHistory(REAL_TAKE_SERIES, HOTKEY, { netuid: 4 });
+    assert.equal(card.take_last_changed_date, null);
+    assert.equal(card.next_take_change_eligible_date, null);
+  });
+
+  test("a REAL take change is detected and dated", () => {
+    const card = buildValidatorHistory(
+      [
+        { snapshot_date: "2026-08-03", take: 0.18 },
+        { snapshot_date: "2026-08-02", take: 0.18 },
+        { snapshot_date: "2026-08-01", take: 0.009994659 },
+        { snapshot_date: "2026-07-31", take: 0.009994659 },
+      ],
+      HOTKEY,
+      { netuid: 4 },
+    );
+    assert.equal(card.take_last_changed_date, "2026-08-02");
+    // + 216,000 blocks * 12s = exactly 30 days.
+    assert.equal(card.next_take_change_eligible_date, "2026-09-01");
+    assert.equal(card.take_change_observable, true);
+  });
+
+  test("a validator whose take is genuinely 0 throughout keeps its series", () => {
+    const card = buildValidatorHistory(
+      [
+        { snapshot_date: "2026-08-03", take: 0 },
+        { snapshot_date: "2026-08-02", take: 0 },
+      ],
+      HOTKEY,
+      { netuid: 4 },
+    );
+    assert.equal(card.take_u16, 0);
+    assert.equal(card.take_change_observable, true, "two usable readings");
+  });
+
+  test("a series too short to resolve a change says so", () => {
+    const card = buildValidatorHistory(
+      [{ snapshot_date: "2026-08-03", take: 0.18 }],
+      HOTKEY,
+      { netuid: 4 },
+    );
+    assert.equal(card.take_last_changed_date, null);
+    assert.equal(
+      card.take_change_observable,
+      false,
+      "one reading cannot show a change -- distinct from 'stable'",
+    );
+  });
+
+  test("the unscoped series reports no take at all", () => {
+    const card = buildValidatorHistory(REAL_TAKE_SERIES, HOTKEY, {});
+    assert.equal(card.take_u16, null);
+    assert.equal(card.take_change_observable, false);
+  });
+
+  test("dividend efficiency is dividend share over stake share", () => {
+    const point = (
+      buildValidatorHistory(
+        [
+          {
+            snapshot_date: "2026-08-04",
+            netuid: 64,
+            stake_alpha: 2_118_872,
+            subnet_total_stake: 3_899_868,
+            dividends: 0.546273,
+          },
+        ],
+        HOTKEY,
+        { netuid: 64 },
+      ).points as Row[]
+    )[0];
+    // 2,118,872 / 3,899,868 = 0.54331890… -> 0.543319 at 6dp
+    assert.equal(point.stake_share, 0.543319);
+    // 0.546273 / 0.543319 = 1.005437 -> earning slightly above its stake share
+    assert.ok(
+      Math.abs((point.dividend_efficiency as number) - 1.005437) < 1e-5,
+    );
+  });
+
+  test("efficiency is null rather than Infinity when there is no stake", () => {
+    for (const [stake, total] of [
+      [0, 3_899_868],
+      [100, 0],
+      [100, null],
+    ] as const) {
+      const point = (
+        buildValidatorHistory(
+          [
+            {
+              snapshot_date: "2026-08-04",
+              netuid: 64,
+              stake_alpha: stake,
+              subnet_total_stake: total,
+              dividends: 0.5,
+            },
+          ],
+          HOTKEY,
+          { netuid: 64 },
+        ).points as Row[]
+      )[0];
+      assert.equal(point.dividend_efficiency, null, `${stake}/${total}`);
+    }
+  });
+
+  test("a point with an unusable snapshot_date is excluded from take detection", () => {
+    // A row whose date cannot be read cannot be ordered, and an unorderable row in a
+    // change-detection series would attribute the change to the wrong day.
+    const card = buildValidatorHistory(
+      [
+        { snapshot_date: 20260803, take: 0.18 },
+        { snapshot_date: "2026-08-02", take: 0.009994659 },
+      ],
+      HOTKEY,
+      { netuid: 4 },
+    );
+    assert.equal(card.take_last_changed_date, null);
+    assert.equal(card.take_change_observable, false, "one usable reading left");
+  });
+
+  test("the card still satisfies its published schema", () => {
+    const card = buildValidatorHistory(REAL_TAKE_SERIES, HOTKEY, {
+      window: "30d",
+      netuid: 4,
+    });
+    const parsed = ValidatorHistoryArtifactSchema.safeParse(card);
+    assert.equal(
+      parsed.success,
+      true,
+      parsed.success ? "" : JSON.stringify(parsed.error.issues),
+    );
+  });
+});

--- a/tests/validator-nominators.test.ts
+++ b/tests/validator-nominators.test.ts
@@ -110,7 +110,10 @@ describe("buildValidatorNominators", () => {
         },
       ],
       HOTKEY,
-      { totalCount: 5, limit: 2, offset: 2 },
+      // alreadyPaged: the SQL applied LIMIT/OFFSET, so the builder must not slice
+      // again. Split from totalCount by #9393 -- the two used to be one signal, which
+      // is why a page length could be published as the total.
+      { totalCount: 5, limit: 2, offset: 2, alreadyPaged: true },
     ) as Row;
     assert.equal(d.nominator_count, 5);
     assert.deepEqual(
@@ -439,5 +442,88 @@ describe("GET /api/v1/validators/{hotkey}/nominators via the Worker", () => {
       env,
     );
     assert.equal(unsupported.res.status, 400);
+  });
+});
+
+// #9393 + #9390: the count must be the real total, and concentration must not be
+// computed over a page and passed off as describing the validator.
+describe("buildValidatorNominators — count and concentration", () => {
+  function nominators(...amounts: number[]) {
+    return amounts.map((amount, i) => added(`ck-${i}`, amount));
+  }
+
+  test("a page reports an UNKNOWN total rather than its own length", () => {
+    // The #9393 defect exactly: nominator_count tracked ?limit (20 with limit=20,
+    // 100 with limit=100) for a validator whose detail card reported 2,474.
+    const d = buildValidatorNominators(nominators(10, 5), HOTKEY, {
+      alreadyPaged: true,
+    }) as Row;
+    assert.equal(d.nominator_count, null);
+    assert.equal(d.concentration_complete, false);
+    assert.equal(d.top_nominator_share, null);
+  });
+
+  test("a page with a known total reports the total, not the page", () => {
+    const d = buildValidatorNominators(nominators(10, 5), HOTKEY, {
+      alreadyPaged: true,
+      totalCount: 2474,
+    }) as Row;
+    assert.equal(d.nominator_count, 2474);
+    // 2 rows describing 2,474 nominators cannot support a concentration claim.
+    assert.equal(d.concentration_complete, false);
+    assert.equal(d.nominator_gini, null);
+  });
+
+  test("concentration is computed only when the rows ARE the whole set", () => {
+    const d = buildValidatorNominators(
+      nominators(50, 30, 10, 5, 3, 2),
+      HOTKEY,
+      {
+        alreadyPaged: true,
+        totalCount: 6,
+      },
+    ) as Row;
+    assert.equal(d.concentration_complete, true);
+    // 50 of 100 total
+    assert.equal(d.top_nominator_share, 0.5);
+    // 50+30+10+5+3 = 98 of 100
+    assert.equal(d.top5_nominator_share, 0.98);
+    assert.ok((d.nominator_gini as number) > 0);
+  });
+
+  test("one nominator is not reported as perfectly EQUAL", () => {
+    // Gini's formula yields 0 at n=1, which reads as perfect equality when the truth
+    // is perfect concentration. Null is the honest answer.
+    const d = buildValidatorNominators(nominators(50), HOTKEY, {
+      alreadyPaged: true,
+      totalCount: 1,
+    }) as Row;
+    assert.equal(d.top_nominator_share, 1);
+    assert.equal(d.nominator_gini, null);
+  });
+
+  test("net-negative nominators do not push shares past 1", () => {
+    // A coldkey that withdrew more than it added in the window has negative net stake;
+    // leaving it in the denominator would inflate everyone else past 100%.
+    const d = buildValidatorNominators(
+      [added("ck-a", 50), removed("ck-b", 20)],
+      HOTKEY,
+      { alreadyPaged: true, totalCount: 2 },
+    ) as Row;
+    assert.ok((d.top_nominator_share as number) <= 1);
+  });
+
+  test("the in-memory paging path is unchanged", () => {
+    // Every caller but the cold tier passes the full set and lets the builder page.
+    const d = buildValidatorNominators(nominators(10, 5, 1), HOTKEY, {
+      limit: 2,
+    }) as Row;
+    assert.equal(
+      d.nominator_count,
+      3,
+      "the total, since these ARE all the rows",
+    );
+    assert.equal((d.nominators as Row[]).length, 2, "still paged here");
+    assert.equal(d.concentration_complete, true);
   });
 });

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -5060,6 +5060,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
               nd.validator_trust AS validator_trust, nd.consensus AS consensus,
               nd.dividends AS dividends, nd.take AS take,
               nd.validator_permit AS validator_permit,
+              s.total_stake_tao AS subnet_total_stake,
               nd.stake_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END AS total_stake_tao,
               nd.emission_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END AS total_emission_tao
             FROM neuron_daily nd
@@ -5074,6 +5075,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
               nd.validator_trust AS validator_trust, nd.consensus AS consensus,
               nd.dividends AS dividends, nd.take AS take,
               nd.validator_permit AS validator_permit,
+              s.total_stake_tao AS subnet_total_stake,
               nd.stake_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END AS total_stake_tao,
               nd.emission_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END AS total_emission_tao
             FROM neuron_daily nd


### PR DESCRIPTION
Three operator signals that were one derivation away from data already returned — plus the count bug that made one of them impossible.

## 1. Take-change eligibility

**Take is a u16 fraction of `0xFFFF` and must be compared as one.** The stored float is a rendering of that integer, and the rendering is not stable. Measured on a real series whose take never changed:

```
2026-07-17..19   0.009994659
2026-07-20..02   0.00999466
2026-08-03       0.009994659342336155
```

All three are **u16 655**. A float diff reports three changes that never happened — and this informs a decision the chain then locks for 30 days, so a phantom change is worse than no answer. An epsilon wouldn't fix it either: the correct tolerance is exactly one u16 step, which is what rounding gives.

The leading `null`/`0` run is excluded too. The same real series opens `null,null,null,null,0,0,0` — the column simply wasn't being captured yet — and reading the step out of that run as a take change would manufacture one for **every validator alive when capture started**.

**The rate limit is read from chain, not assumed.** `SubtensorModule.TxDelegateTakeRateLimit` is *unset* on mainnet, so the runtime falls back to its declared default. Decoded from the runtime metadata storage entry: `0xc04b030000000000` → **216,000 blocks = exactly 30.00 days** at 12s.

The retained window (~26 days) is *shorter* than that rate limit, so "no change seen" genuinely cannot be resolved to "eligible now". `take_change_observable` distinguishes "stable" from "we cannot tell".

## 2. Nominator concentration

`top_nominator_share`, `top5_nominator_share`, `nominator_gini` — shaped like the existing `stake_concentration` block on `/accounts/{ss58}/portfolio` rather than inventing a second vocabulary for the same idea.

Computed **only when the rows in hand are the whole set**. A top-holder share derived from one page describes the page, not the validator. Gini is null at n=1, where the formula yields 0 — which would read as *perfectly equal* when the truth is perfectly concentrated.

## 3. Dividend efficiency

`dividends` is already normalised by the chain — the column sums to ~0.9999 across a subnet's neurons — so it **is** the dividend share, and efficiency is that over stake share. Above 1 the validator out-earns its stake; below 1 it under-earns. That's the number that says which subnet to leave.

The denominator is total subnet stake, from a join this query already does. Dividends actually accrue to validators, so the strictly correct denominator is validator stake — measured across netuids 1/4/8/64 that is **99.87–100%** of total, a sub-0.2% difference, the same order as the snapshot total's own drift from the summed neuron rows (0.05–0.21%). The field is named `stake_share`, not `validator_stake_share`, so it stays honest about which denominator it used.

## And the count bug — #9393

`nominator_count` on `/validators/{hotkey}/nominators` was **the page size**:

```
?limit=20   -> nominator_count: 20
?limit=100  -> nominator_count: 100
/validators/{hotkey} -> nominator_count: 2474
```

The loader passed `page.length` as `totalCount` over a scan bounded by `LIMIT`, so it could never be the total. Verified against the production lakehouse, the true 30-day distinct-coldkey count for that hotkey is **2,925**.

Fixed with the wrapped `GROUP BY` count this repo already uses for exactly this reason — R2 SQL rejects an ungrouped `count(DISTINCT)` with `40015: scan budget exceeded`. A failed count now leaves `nominator_count` **null** rather than falling back to the page size: an unknown total is a real state; a page size dressed as a total is not.

That required splitting two signals that had been conflated. `totalCount == null` used to mean *both* "page in memory" and "no total supplied", leaving no way to express "these rows are a page **and** the total is unknown" — which is precisely why the loader reached for `page.length`. `alreadyPaged` now carries the paging question separately. Every caller but the cold tier passes `[]` with no total, so their behaviour is unchanged.

## Verification

- **100% statements / branches / functions / lines** on both changed modules.
- 2,423 tests pass across `graphql` + `mcp-server`; 2,591 across all affected suites. `tsc`, `eslint`, `prettier --check`, `npm run validate` clean; `openapi.json` and generated types regenerated here.
- The new count query was **run against the production lakehouse** before shipping, not just against fakes.
- The rate limit was **decoded from live runtime metadata**, not taken from notes.

Closes #9390
Closes #9393
