### PR TITLE
fix(weights): the overdue verdicts never reached production — tempo was wired into a loader nothing calls

### DIFF
--- a/src/subnet-weight-setters-loader.ts
+++ b/src/subnet-weight-setters-loader.ts
@@ -53,5 +53,47 @@ export async function loadSubnetWeightSettersColdTier(
   // share computed against a summed page would grow as the page shrank.
   return buildSubnetWeightSetters(rollup.rows, rollup.totals, netuid, {
     window: windowLabel,
+    tempo: await loadSubnetTempo(env, netuid),
   });
+}
+
+/**
+ * This subnet's tempo, for the overdue verdicts (#9389).
+ *
+ * THIS LOADER IS THE ONE PRODUCTION USES. #9389 wired tempo into the sibling D1
+ * loader in src/subnet-weight-setters.ts, which no call site reaches -- REST, MCP and
+ * GraphQL all come through here. The result was a shipped feature that was inert:
+ * every published card carried `tempo: null` and `overdue: null`, so the alarm existed
+ * and could never fire. Verified against production immediately after the deploy, which
+ * is the only reason it was caught.
+ *
+ * Never fatal, for the same reason as the sibling: if the hyperparams row is missing or
+ * the read throws, the leaderboard still serves with the verdicts null. Losing the card
+ * because a cadence was unknown would trade a useful answer for no answer.
+ */
+async function loadSubnetTempo(
+  env: Parameters<typeof r2SqlQuery>[0],
+  netuid: number,
+): Promise<unknown> {
+  const db = (env as { METAGRAPH_HEALTH_DB?: D1Like } | null | undefined)
+    ?.METAGRAPH_HEALTH_DB;
+  if (!db?.prepare) return null;
+  try {
+    const res = await db
+      .prepare("SELECT tempo FROM subnet_hyperparams WHERE netuid = ?")
+      .bind(netuid)
+      .first?.();
+    return (res as { tempo?: unknown } | null)?.tempo ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** The minimal D1 surface this needs, so tests can hand it a plain object. */
+interface D1Like {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      first?(): Promise<unknown>;
+    };
+  };
 }

--- a/tests/subnet-weight-setters-loader.test.ts
+++ b/tests/subnet-weight-setters-loader.test.ts
@@ -162,3 +162,81 @@ describe("all three subnet weight-setter surfaces go through the one loader", ()
     }
   });
 });
+
+// #9389 shipped the overdue verdicts wired into the sibling D1 loader, which NO call
+// site reaches -- REST, MCP and GraphQL all come through the cold tier. The published
+// card carried tempo: null and overdue: null on every subnet, so the alarm existed and
+// could never fire. These tests exist so that cannot recur silently.
+describe("loadSubnetWeightSettersColdTier — the overdue verdicts reach production", () => {
+  function tempoDb(tempo: unknown, { throws = false } = {}) {
+    const seen: unknown[][] = [];
+    return {
+      seen,
+      METAGRAPH_HEALTH_DB: {
+        prepare: (sql: string) => ({
+          bind: (...values: unknown[]) => ({
+            first: async () => {
+              seen.push([sql, ...values]);
+              if (throws) throw new Error("D1_ERROR: no such table");
+              return tempo === undefined ? null : { tempo };
+            },
+          }),
+        }),
+      },
+    };
+  }
+
+  test("the tempo is read and the verdicts are evaluated", async () => {
+    const engine = fakeEngine();
+    const env = tempoDb(360);
+    const data = await loadSubnetWeightSettersColdTier(env as never, 7, {
+      windowDays: 7,
+      windowLabel: "7d",
+      query: engine.query as never,
+    });
+    assert.equal((data as Row).tempo, 360, "the card must carry the cadence");
+    assert.equal(
+      (data!.setters as Array<Row>)[0].overdue !== null,
+      true,
+      "a setter with a known tempo must be evaluated, not left null",
+    );
+    assert.equal(env.seen.length, 1, "one lookup, by primary key");
+    assert.match(String(env.seen[0][0]), /WHERE netuid = \?/);
+    assert.equal(env.seen[0][1], 7, "scoped to the requested subnet");
+  });
+
+  test("a missing hyperparams row leaves the verdicts null, not the card", async () => {
+    const engine = fakeEngine();
+    const data = await loadSubnetWeightSettersColdTier(
+      tempoDb(undefined) as never,
+      7,
+      { windowDays: 7, windowLabel: "7d", query: engine.query as never },
+    );
+    assert.ok(data, "the leaderboard still serves");
+    assert.equal((data as Row).tempo, null);
+    assert.equal((data!.setters as Array<Row>)[0].overdue, null);
+  });
+
+  test("a throwing tempo read cannot break the leaderboard", async () => {
+    const engine = fakeEngine();
+    const data = await loadSubnetWeightSettersColdTier(
+      tempoDb(360, { throws: true }) as never,
+      7,
+      { windowDays: 7, windowLabel: "7d", query: engine.query as never },
+    );
+    assert.ok(data);
+    assert.equal((data as Row).tempo, null);
+    assert.equal((data!.setters as Array<Row>).length > 0, true);
+  });
+
+  test("no D1 binding at all is survived", async () => {
+    const engine = fakeEngine();
+    const data = await loadSubnetWeightSettersColdTier({} as never, 7, {
+      windowDays: 7,
+      windowLabel: "7d",
+      query: engine.query as never,
+    });
+    assert.ok(data);
+    assert.equal((data as Row).tempo, null);
+  });
+});


### PR DESCRIPTION
## The alarm shipped and could not fire

#9389 added the overdue verdicts and wired `tempo` into `loadSubnetWeightSetters` in `src/subnet-weight-setters.ts`. **No call site reaches that function.** REST, MCP and GraphQL all serve this route through `loadSubnetWeightSettersColdTier`, which called `buildSubnetWeightSetters` without a tempo.

Verified against production immediately after the deploy:

```
GET /api/v1/subnets/8/weights/setters
  tempo=None  overdue_setter_count=0 of 14
```

Every published card carried `tempo: null` and `overdue: null`, on every subnet — including SN8, whose two stale setters (one **6.3 days** behind) are the exact measurement #9389 was built from and quoted in its own PR body.

The unit tests all passed, because they exercised the loader that isn't used.

## Fix

Read the tempo in the cold-tier loader — the path production actually takes. Same posture as the sibling: a single indexed lookup by primary key, and never fatal. A missing `subnet_hyperparams` row or a throwing read leaves the verdicts null and still serves the leaderboard, because losing the card over an unknown cadence would trade a useful answer for no answer.

## Why this cannot recur silently

Four regression tests on the **production** loader, and the first one fails when the `tempo` argument is removed — confirmed by removing it, not assumed:

```
× the tempo is read and the verdicts are evaluated
  Tests  1 failed | 10 passed (11)
```

They cover the wired case, a missing hyperparams row, a throwing read, and no D1 binding at all.

## Verification

- **100% statements / branches / functions / lines** on `src/subnet-weight-setters-loader.ts`.
- 1,344 tests pass in the mcp-server suite; `tsc`, `eslint`, `prettier --check`, `npm run validate` clean.
- One unrelated failure (`service_count >= 1`) appeared first and was confirmed **pre-existing** — it reproduces with this change stashed, and clears once the worktree is built. Not caused here.

Refs #9389
