### PR TITLE
fix(api): testnet block detail returned an empty block at every height

### DIFF
--- a/src/blocks-cold-tier.ts
+++ b/src/blocks-cold-tier.ts
@@ -312,7 +312,19 @@ export async function loadBlockColdTier(
     network === DEFAULT_CHAIN_NETWORK
       ? bindings(env).METAGRAPH_HEALTH_DB
       : undefined;
-  const aboveSeam = asNumber !== null && asNumber > seam;
+  // "Above the seam" means "too new for the lakehouse, so D1 is the only
+  // source" — a statement that is only true on mainnet, because only mainnet
+  // HAS a D1 tier. Off mainnet the lakehouse is the sole source at every
+  // height, so nothing is ever above the seam.
+  //
+  // Guarding on the network rather than on the seam VALUE, because the value
+  // is 0 there (see resolveBlocksSeam) and `n > 0` is true for every real
+  // block — which made every testnet block short-circuit to an empty result at
+  // the `if (aboveSeam)` below, without ever reaching the lakehouse that had
+  // it. The feed did not share the bug: it uses the seam as a ceiling, not as
+  // a source switch, so the same 0 meant the right thing there.
+  const aboveSeam =
+    network === DEFAULT_CHAIN_NETWORK && asNumber !== null && asNumber > seam;
   if (db?.prepare && (aboveSeam || asHash !== null)) {
     try {
       const predicate =

--- a/tests/chain-history-networks.test.ts
+++ b/tests/chain-history-networks.test.ts
@@ -244,6 +244,61 @@ describe("the D1 hot tier is mainnet's alone", () => {
       }
     });
   });
+  test("a testnet block inside the decoded range is RETURNED, not blanked", async () => {
+    // The bug this pins (#9394 shipped it, caught in production): the detail
+    // path reads `aboveSeam` as "too new for the lakehouse, D1 only". With the
+    // off-mainnet seam of 0, every real block is > 0, so every testnet block
+    // short-circuited to an empty result before reaching the lakehouse that
+    // held it.
+    //
+    // The existing tests missed it because they asserted what must NOT happen
+    // (no D1 query) rather than what must: that a block comes back. A negative
+    // assertion passes perfectly on a function that returns nothing at all.
+    const row = {
+      block_number: 7_700_500,
+      block_hash: "0xtestnetblockhash",
+      parent_hash: "0xparent",
+      author: null,
+      extrinsic_count: 8,
+      event_count: 20,
+      spec_version: 441,
+      observed_at: 1_700_000_000_000,
+    };
+    resetDecodeWatermarkCache();
+    await withSql([row], async (queries) => {
+      const block = (await loadBlockColdTier(
+        mockEnv(TOKEN),
+        "7700500",
+        "testnet",
+      )) as Record<string, unknown> | null;
+      assert.ok(queries.length > 0, "the lakehouse was never queried");
+      assert.ok(
+        queries.some((q) => q.includes("chain_testnet.blocks")),
+        `queried the wrong namespace: ${queries.join(" | ")}`,
+      );
+      const inner = (block?.block ?? block) as Record<string, unknown> | null;
+      assert.equal(
+        inner?.block_hash,
+        "0xtestnetblockhash",
+        `expected the row back, got ${JSON.stringify(block)}`,
+      );
+    });
+  });
+
+  test("a mainnet block above the seam still short-circuits, unchanged", async () => {
+    // The other direction: making the detail path network-aware must not stop
+    // mainnet treating a too-new height as a D1-only miss, which is what keeps
+    // it from scanning the lakehouse for a block it cannot contain.
+    resetDecodeWatermarkCache();
+    await withSql([], async (queries) => {
+      await loadBlockColdTier(mockEnv(TOKEN), "99999999");
+      assert.deepEqual(
+        queries,
+        [],
+        "mainnet scanned the lakehouse for a block above its seam",
+      );
+    });
+  });
 });
 
 // The list feeds the capability matrix, so it must match the router in BOTH


### PR DESCRIPTION
Shipped in #9394, caught in production minutes later while verifying it.

```
$ curl .../api/v1/testnet/blocks/7700500
{"data":{"ref":"7700500","block":null,...}}      # decoded_through = 7,700,842
```

Every height, including ones well inside the decoded range. The **feed** on the same data was fine —
`/api/v1/testnet/blocks` correctly returned 7700842, 7700841, 7700840.

## Cause: one value, two readings

`loadBlockColdTier` reads `aboveSeam` as *"too new for the lakehouse, so D1 is the only source"*:

```ts
const aboveSeam = asNumber !== null && asNumber > seam;
...
if (aboveSeam) return buildBlock(undefined as never, ref);   // empty
```

`resolveBlocksSeam` returns **0** off mainnet, meaning the *opposite* — "nothing is above the seam,
the lakehouse is the only source". And `n > 0` holds for every real block, so every testnet height
took the short-circuit and returned empty **without ever querying the lakehouse that held it**.

The same 0 means the right thing in the feed, which uses the seam as a **ceiling** rather than a
**source switch**. That's why one path worked and the other didn't — and why the seam's two readings
needed separating once a second network existed.

Fixed by guarding on the network rather than the seam value: off mainnet there is no D1 tier, so
nothing is ever above the seam.

## Why the existing tests missed it

They asserted what must **not** happen — no D1 query, no `block_number < 1` ceiling — rather than
what must: that a block comes back.

**A negative assertion passes perfectly on a function that returns nothing at all.** That's the
lesson worth keeping from this one.

The new tests:

- a testnet block inside the decoded range is **returned**, with its hash, from `chain_testnet.blocks`
- mainnet **still** short-circuits above its own seam, so the fix doesn't cost mainnet its D1-only miss

Both confirmed to **fail against the buggy code** before landing — the first with
`AssertionError: the lakehouse was never queried`.

## Verification

112 tests green across the 6 affected suites; `tsc`, `eslint`, `format:check` clean.

Closes #9397
Part of #8700