### PR TITLE
fix(ci): route Dependabot PRs down the tokenless Codecov path

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -681,9 +681,32 @@ jobs:
 
       # Upload coverage to Codecov — the primary PR coverage gate (delta-based
       # project + patch, see codecov.yml). vitest's thresholds are now just a
-      # local backstop. Same-repo PRs and main pushes use the repository token;
-      # fork PRs use Codecov's public-repo tokenless upload path instead.
-      # Missing coverage or upload errors fail the test job.
+      # local backstop. Missing coverage or upload errors fail the test job.
+      #
+      # WHICH PATH A RUN TAKES is decided by whether it can read secrets, NOT by
+      # whether the branch lives in this repo — those are different questions and
+      # conflating them is what broke every Dependabot PR (#9300):
+      #
+      #   main pushes + ordinary same-repo PRs -> token path
+      #   fork PRs                             -> tokenless
+      #   DEPENDABOT PRs                       -> tokenless
+      #
+      # A Dependabot PR is same-repo, so it used to take the token path — but
+      # `pull_request` runs triggered by Dependabot get their own secret scope
+      # and cannot read `secrets.CODECOV_TOKEN`. It resolved to the empty string,
+      # and Codecov rejected the protected branch outright:
+      #
+      #   -> Token length: 0
+      #   error -- Commit creating failed: {"message":"Token required because
+      #            branch is protected"}
+      #
+      # With fail_ci_if_error: true that fails the whole test job, so no
+      # dependency bump could ever go green. Routing it down the same tokenless
+      # path forks already use is the honest fix: from this workflow's point of
+      # view Dependabot IS a no-secrets trigger. The alternative — granting the
+      # token in the repo's Dependabot secret scope — leaves the workflow broken
+      # by default for anyone who clones it, and silently re-breaks if that
+      # setting is ever lost.
       #
       # Explicit override_branch/commit/pr on BOTH paths below: GITHUB_SHA is the
       # ephemeral refs/pull/:N/merge commit on pull_request events, and the
@@ -702,7 +725,7 @@ jobs:
       # recur here. Bump deliberately (not blindly to whatever's newest) if pinning
       # ever needs to move.
       - name: Upload coverage to Codecov
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -721,8 +744,8 @@ jobs:
       # codecov-cli's own auto-detection never adds this prefix either (verified in its source), so it
       # must be supplied explicitly. override_commit/override_pr are unaffected -- that check only
       # inspects the branch string.
-      - name: Upload coverage to Codecov (fork PR tokenless)
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+      - name: "Upload coverage to Codecov (tokenless: fork or Dependabot)"
+        if: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverage/lcov.info,./coverage-mocked/lcov.info
@@ -734,7 +757,7 @@ jobs:
           fail_ci_if_error: true
 
       - name: Upload Vitest results to Codecov
-        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')) }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -747,8 +770,8 @@ jobs:
           override_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
           fail_ci_if_error: false
 
-      - name: Upload Vitest results to Codecov (fork PR tokenless)
-        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+      - name: "Upload Vitest results to Codecov (tokenless: fork or Dependabot)"
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./reports/junit/vitest.xml,./reports/junit/vitest-mocked.xml

--- a/scripts/validate-workflows.ts
+++ b/scripts/validate-workflows.ts
@@ -105,6 +105,29 @@ for (const workflow of workflows) {
       workflow,
       "validate workflow must detect rebuilt-but-untracked public artifacts after build",
     );
+    // The Codecov split, checked STRUCTURALLY rather than by step name.
+    //
+    // This rule used to look each step up by an exact literal
+    // ("Upload coverage to Codecov (fork PR tokenless)"), which made the step's
+    // TITLE part of the contract: renaming it to say what it now covers failed
+    // CI while changing nothing the rule cares about. A step's name is prose.
+    // What the rule is actually about is which upload carries the token, and
+    // that is readable from the steps themselves.
+    const codecovSteps = workflowSteps(content).filter((step) =>
+      step.block.includes("uses: codecov/codecov-action@"),
+    );
+    const coverageUploads = codecovSteps.filter((step) =>
+      step.block.includes("./coverage/lcov.info"),
+    );
+    const tokenless = codecovSteps.filter(
+      (step) => !step.block.includes("secrets.CODECOV_TOKEN"),
+    );
+    const tokenlessCoverage = tokenless.filter((step) =>
+      step.block.includes("./coverage/lcov.info"),
+    );
+    const tokenlessResults = tokenless.filter((step) =>
+      step.block.includes("vitest.xml"),
+    );
     check(
       content.includes(
         "github.event.pull_request.head.repo.full_name == github.repository",
@@ -112,27 +135,25 @@ for (const workflow of workflows) {
         content.includes(
           "github.event.pull_request.head.repo.full_name != github.repository",
         ) &&
-        workflowStepBlock(content, "Upload coverage to Codecov").includes(
-          "token: ${{ secrets.CODECOV_TOKEN }}",
+        // One of each: a trusted upload that carries the token, and an
+        // untrusted one that must not.
+        coverageUploads.some((step) =>
+          step.block.includes("token: ${{ secrets.CODECOV_TOKEN }}"),
         ) &&
-        !workflowStepBlock(
-          content,
-          "Upload coverage to Codecov (fork PR tokenless)",
-        ).includes("secrets.CODECOV_TOKEN") &&
-        workflowStepBlock(
-          content,
-          "Upload coverage to Codecov (fork PR tokenless)",
-        ).includes("fail_ci_if_error: true") &&
-        forkCodecovStepUsesForkBranchPrefix(
-          content,
-          "Upload coverage to Codecov (fork PR tokenless)",
+        tokenlessCoverage.length > 0 &&
+        // A tokenless upload that swallows its own failure reports nothing and
+        // hides that it reported nothing.
+        tokenlessCoverage.every((step) =>
+          step.block.includes("fail_ci_if_error: true"),
         ) &&
-        forkCodecovStepUsesForkBranchPrefix(
-          content,
-          "Upload Vitest results to Codecov (fork PR tokenless)",
+        // Codecov rejects an unprefixed branch from an untrusted upload, so
+        // both tokenless steps must send owner:branch.
+        tokenlessResults.length > 0 &&
+        [...tokenlessCoverage, ...tokenlessResults].every((step) =>
+          usesForkBranchPrefix(step.block),
         ),
       workflow,
-      "validate workflow must split Codecov coverage uploads into trusted-token and fork-tokenless paths",
+      "validate workflow must split Codecov coverage uploads into trusted-token and tokenless paths",
     );
   }
   if (
@@ -279,19 +300,37 @@ function workflowJobBlock(content: string, jobName: string): string {
   return match?.[0] || "";
 }
 
-function workflowStepBlock(content: string, stepName: string): string {
-  const marker = `- name: ${stepName}`;
-  const start = content.indexOf(marker);
-  if (start === -1) return "";
-  const next = content.indexOf("\n      - name:", start + marker.length);
-  return content.slice(start, next === -1 ? undefined : next);
+/**
+ * Every `- name:` step in a workflow, as {name, block}.
+ *
+ * Enumerated rather than looked up by literal, so a rule can select steps by
+ * what they DO -- which upload carries the token -- instead of by what they are
+ * called. Names are prose and get rewritten; the contract should not move with
+ * them. Quoted names are unwrapped, since YAML requires quoting once a name
+ * contains a colon.
+ */
+function workflowSteps(content: string): { name: string; block: string }[] {
+  const steps: { name: string; block: string }[] = [];
+  const marker = /^      - name: (.+)$/gm;
+  const starts: { name: string; index: number }[] = [];
+  for (const m of content.matchAll(marker)) {
+    starts.push({
+      name: m[1].trim().replace(/^["'](.*)["']$/, "$1"),
+      index: m.index ?? 0,
+    });
+  }
+  for (const [i, step] of starts.entries()) {
+    steps.push({
+      name: step.name,
+      block: content.slice(step.index, starts[i + 1]?.index),
+    });
+  }
+  return steps;
 }
 
-function forkCodecovStepUsesForkBranchPrefix(
-  content: string,
-  stepName: string,
-): boolean {
-  const block = workflowStepBlock(content, stepName);
+/** Whether an upload sends Codecov the owner-prefixed branch it requires from
+ * an untrusted (tokenless) uploader. */
+function usesForkBranchPrefix(block: string): boolean {
   return /override_branch:\s*\$\{\{\s*github\.event\.pull_request\.head\.repo\.owner\.login\s*\}\}:\$\{\{\s*github\.event\.pull_request\.head\.ref\s*\}\}/.test(
     block,
   );

--- a/scripts/validate-workflows.ts
+++ b/scripts/validate-workflows.ts
@@ -311,7 +311,10 @@ function workflowJobBlock(content: string, jobName: string): string {
  */
 function workflowSteps(content: string): { name: string; block: string }[] {
   const steps: { name: string; block: string }[] = [];
-  const marker = /^      - name: (.+)$/gm;
+  // Six spaces is the indent a step sits at inside jobs.<id>.steps. Written as {6}
+  // rather than as literal spaces so the count is readable and cannot be miscounted
+  // by eye -- which is exactly what no-regex-spaces is for.
+  const marker = /^ {6}- name: (.+)$/gm;
   const starts: { name: string; index: number }[] = [];
   for (const m of content.matchAll(marker)) {
     starts.push({


### PR DESCRIPTION
Every Dependabot PR fails its `test` job. #9300 is just the one that surfaced it.

```
-> Token length: 0
error -- Commit creating failed: {"message":"Token required because branch is protected"}
==> Failed to run upload-coverage
```

## The condition asked the wrong question

The four Codecov steps picked their path by **where the branch lives**:

```yaml
if: ... head.repo.full_name == github.repository    # token path
if: ... head.repo.full_name != github.repository    # tokenless path
```

A Dependabot branch **is** same-repo, so it took the token path — but `pull_request` runs triggered
by Dependabot get their own secret scope and cannot read `secrets.CODECOV_TOKEN`. It resolved to the
empty string, Codecov rejected the protected branch, and `fail_ci_if_error: true` failed the job.

What actually decides the path is **whether the run can read secrets**, not whether the branch is
local. Those coincide for ordinary PRs and for forks, and diverge for exactly one trigger.

Dependabot now takes the same tokenless path forks already use — which already supplies the
`owner:branch` prefix that makes Codecov treat a branch as unprotected. That prefix is precisely what
a Dependabot branch needs.

## Why not just grant the token

Granting `CODECOV_TOKEN` in the repo's Dependabot secret scope would also work, and is worse: it
leaves the workflow broken by default for anyone who clones the repo, and silently re-breaks if that
setting is ever lost. The fix belongs in the workflow, where the reason is visible.

## Verified by evaluating the conditions, not reading them

Each `if` expression evaluated against every trigger shape:

```
scenario         tokened    tokenless   tokened    tokenless
main push        RUN        skip        RUN        skip
same-repo PR     RUN        skip        RUN        skip
DEPENDABOT PR    skip       RUN         skip       RUN
fork PR          skip       RUN         skip       RUN
```

Exactly one path per scenario, no gaps and no doubles.

## One incidental

The two renamed steps are quoted — a colon-space inside an unquoted YAML scalar starts a nested
mapping and broke the parse. Caught by validating the YAML rather than eyeballing it.

Closes #9404