### PR TITLE
fix(accounts): collapse the summary's five concurrent scans to three, and say why a decline happened

### DIFF
--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -796,6 +796,29 @@ export async function loadCounterpartyRelationshipColdTier(
  * Reproducing the probe rather than reusing the aggregate's own count is what
  * lets an account with EXACTLY CAP events still report exact totals.
  */
+/**
+ * What the summary read returns.
+ *
+ * A decline carries WHY (#9386). The route used to fail ~50% of requests for a
+ * high-activity coldkey with a typed 503 that named no cause, and the reason was
+ * discarded here: every failure mode collapsed to a bare `null`. `declined` lists one
+ * entry per leg that failed, each carrying the engine's own explanation, so an
+ * operator reading the 503 learns whether it was a timeout, a scan-budget rejection or
+ * an HTTP error -- without needing Worker-side visibility to guess.
+ *
+ * An empty `declined` on a decline is still possible and still honest: it means a leg
+ * returned no usable row without raising.
+ */
+export type AccountSummaryColdTierResult =
+  | {
+      agg: Record<string, unknown>;
+      kinds: Array<Record<string, unknown>>;
+      scanned: number;
+      recent: Array<Record<string, unknown>>;
+      declined?: undefined;
+    }
+  | { declined: string[] };
+
 export async function loadAccountSummaryColdTier(
   env: Env | null | undefined,
   ss58: string,
@@ -806,16 +829,13 @@ export async function loadAccountSummaryColdTier(
     recentLimit?: number;
     query?: typeof r2SqlQuery;
   } = {},
-): Promise<{
-  agg: Record<string, unknown> | null;
-  kinds: Array<Record<string, unknown>>;
-  scanned: number | null;
-  recent: Array<Record<string, unknown>>;
-} | null> {
+): Promise<AccountSummaryColdTierResult> {
   const addr = safeSs58Literal(ss58);
-  if (addr === null) return null;
+  if (addr === null) return { declined: ["input: unusable ss58"] };
   const limit = safeBlockNumber(recentLimit);
-  if (limit === null || limit <= 0) return null;
+  if (limit === null || limit <= 0) {
+    return { declined: ["input: unusable recent limit"] };
+  }
 
   const where = `(hotkey = '${addr}' OR coldkey = '${addr}')`;
   // The newest CAP events, named once so the three reads that share it cannot
@@ -825,72 +845,132 @@ export async function loadAccountSummaryColdTier(
     `FROM chain.account_events WHERE ${where} ` +
     `ORDER BY block_number DESC LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP}`;
 
-  const [aggRows, subnetRows, kindRows, probeRows, recentRows] =
-    await Promise.all([
-      query(
-        env,
-        `WITH scan AS (${scan}) SELECT count(*) AS c, ` +
-          `min(block_number) AS fb, max(block_number) AS lb, ` +
-          `min(observed_at) AS fo, max(observed_at) AS lo FROM scan`,
-      ),
-      // The distinct-subnet count rides in its own GROUP BY query rather than as
-      // a `count(DISTINCT netuid)` beside the aggregates above, because R2 SQL
-      // REJECTS the ungrouped form outright:
-      //
-      //   40015: scan budget exceeded: scanning too much data for
-      //   count(DISTINCT) without GROUP BY
-      //
-      // and a rejected query declines the whole reader, which is what made
-      // /api/v1/accounts/{ss58} and get_account_snapshot publish a card of zeros
-      // for an address whose own /events feed returned rows.
-      //
-      // THE CTE'S `LIMIT` DOES NOT BOUND THE BUDGET. `scan` caps at
-      // ACCOUNT_EVENT_SUMMARY_SCAN_CAP rows, so this reads as an aggregate over
-      // 5,000 rows and looks obviously safe -- but the engine costs the
-      // count(DISTINCT) against the underlying scan, not the materialized cap.
-      // Wrapping a distinct in a bounded CTE is not a workaround; only GROUP BY
-      // is.
-      query(
-        env,
-        `WITH scan AS (${scan}) SELECT count(*) AS sc` +
-          ` FROM (SELECT netuid FROM scan GROUP BY netuid)`,
-      ),
-      query(
-        env,
-        `WITH scan AS (${scan}) SELECT event_kind AS kind, count(*) AS count ` +
-          `FROM scan GROUP BY event_kind`,
-      ),
-      // CAP + 1 so "exactly CAP" is distinguishable from "more than CAP".
-      query(
-        env,
-        `SELECT count(*) AS c FROM (SELECT block_number FROM chain.account_events ` +
-          `WHERE ${where} LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1})`,
-      ),
-      query(
-        env,
-        `SELECT ${EVENT_COLUMNS} FROM chain.account_events WHERE ${where} ` +
-          `${FEED_ORDER} LIMIT ${limit}`,
-      ),
-    ]);
+  // THREE READS, NOT FIVE (#9386).
+  //
+  // This route declined ~50% of requests for a high-activity coldkey, and its shape
+  // was the reason: five concurrent broad scans of `chain.account_events`, with
+  // `Promise.all` + an all-or-nothing check, so the success probability was the
+  // PRODUCT of five and the cost was five scans of an unpartitioned table. A single
+  // `count(*) WHERE hotkey = ...` there reports ~3,390 R2 requests.
+  //
+  // The first three all aggregated the SAME `scan` CTE at different groupings, so one
+  // `GROUP BY event_kind, netuid` yields all of them exactly -- see foldSummaryGroups
+  // for the derivation and why each one is equivalent rather than approximate. The
+  // result is bounded by the CTE: at most ACCOUNT_EVENT_SUMMARY_SCAN_CAP groups.
+  //
+  // The remaining two cannot fold in. The cap probe deliberately scans CAP+1 rows
+  // WITHOUT the CTE (that is how "exactly CAP" is told from "more than CAP"), and the
+  // recent feed selects whole rows in a different order.
+  const failures: string[] = [];
+  const track = (leg: string) => (detail: string) => {
+    failures.push(`${leg}: ${detail}`);
+  };
+
+  const [groupRows, probeRows, recentRows] = await Promise.all([
+    query(
+      env,
+      `WITH scan AS (${scan}) SELECT event_kind AS kind, netuid AS netuid, ` +
+        `count(*) AS count, min(block_number) AS fb, max(block_number) AS lb, ` +
+        `min(observed_at) AS fo, max(observed_at) AS lo ` +
+        `FROM scan GROUP BY event_kind, netuid`,
+      { onError: track("summary-groups") },
+    ),
+    // CAP + 1 so "exactly CAP" is distinguishable from "more than CAP".
+    query(
+      env,
+      `SELECT count(*) AS c FROM (SELECT block_number FROM chain.account_events ` +
+        `WHERE ${where} LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1})`,
+      { onError: track("scan-probe") },
+    ),
+    query(
+      env,
+      `SELECT ${EVENT_COLUMNS} FROM chain.account_events WHERE ${where} ` +
+        `${FEED_ORDER} LIMIT ${limit}`,
+      { onError: track("recent-feed") },
+    ),
+  ]);
 
   // Any half missing is a decline: a card mixing measured aggregates with a
   // zeroed probe would silently flip event_scan_capped and publish a first_seen
   // that is really a window floor.
-  if (!aggRows || !subnetRows || !kindRows || !probeRows || !recentRows)
-    return null;
-  const aggRow = aggRows[0] ?? null;
-  const subnetCount = subnetRows[0]?.sc;
+  if (!groupRows || !probeRows || !recentRows) {
+    return { declined: failures };
+  }
   const scanned = probeRows[0]?.c;
-  if (aggRow === null || subnetCount === undefined || scanned === undefined)
-    return null;
-  // Recombined under the key the caller already reads, so only where the
-  // number comes from changed.
-  const agg = { ...aggRow, sc: subnetCount };
+  if (scanned === undefined) {
+    return { declined: [...failures, "scan-probe: no count row"] };
+  }
+  const folded = foldSummaryGroups(groupRows);
 
   return {
-    agg,
-    kinds: kindRows,
+    agg: folded.agg,
+    kinds: folded.kinds,
     scanned: Number(scanned),
     recent: recentRows,
   };
+}
+
+/**
+ * Fold `GROUP BY event_kind, netuid` rows back into the three shapes the three
+ * separate queries used to return. Each derivation is EXACT, not an approximation:
+ *
+ *  - `c` was `count(*)` over the CTE; every scanned row lands in exactly one
+ *    (kind, netuid) group, so the group counts sum to it.
+ *  - `fb`/`lb`/`fo`/`lo` were `min`/`max` over the CTE. SQL's min/max ignore NULLs,
+ *    so a group whose column is entirely NULL reports NULL, and the fold skips those
+ *    the same way -- an all-NULL column therefore stays NULL rather than becoming 0.
+ *  - `sc` was `count(*) FROM (SELECT netuid FROM scan GROUP BY netuid)`. SQL GROUP BY
+ *    treats NULL as its OWN group, so a NULL netuid counted as one distinct value and
+ *    must still count here. That is why this counts distinct netuid KEYS rather than
+ *    filtering nulls out, which would quietly shrink the number by one.
+ *  - `kinds` was `GROUP BY event_kind`; summing each kind's rows across netuids
+ *    reproduces it, NULL kind included, for the same reason.
+ */
+export function foldSummaryGroups(rows: Record<string, unknown>[]): {
+  agg: Record<string, unknown>;
+  kinds: Record<string, unknown>[];
+} {
+  let count = 0;
+  let fb: number | null = null;
+  let lb: number | null = null;
+  let fo: number | null = null;
+  let lo: number | null = null;
+  // Keyed by the raw cell so NULL stays a distinct key rather than colliding with a
+  // literal "null" string a subnet could never actually have.
+  const netuids = new Set<unknown>();
+  const kinds = new Map<unknown, number>();
+
+  for (const row of rows) {
+    const n = Number(row?.count);
+    const rowCount = Number.isFinite(n) ? n : 0;
+    count += rowCount;
+    netuids.add(row?.netuid ?? null);
+    kinds.set(
+      row?.kind ?? null,
+      (kinds.get(row?.kind ?? null) ?? 0) + rowCount,
+    );
+    fb = minOf(fb, row?.fb);
+    lb = maxOf(lb, row?.lb);
+    fo = minOf(fo, row?.fo);
+    lo = maxOf(lo, row?.lo);
+  }
+
+  return {
+    agg: { c: count, fb, lb, fo, lo, sc: netuids.size },
+    kinds: [...kinds].map(([kind, c]) => ({ kind, count: c })),
+  };
+}
+
+/** SQL `min` semantics: NULLs are skipped, never treated as 0. */
+function minOf(current: number | null, value: unknown): number | null {
+  const n = Number(value);
+  if (value == null || !Number.isFinite(n)) return current;
+  return current === null || n < current ? n : current;
+}
+
+/** SQL `max` semantics: NULLs are skipped, never treated as 0. */
+function maxOf(current: number | null, value: unknown): number | null {
+  const n = Number(value);
+  if (value == null || !Number.isFinite(n)) return current;
+  return current === null || n > current ? n : current;
 }

--- a/src/account-summary-card.ts
+++ b/src/account-summary-card.ts
@@ -92,21 +92,33 @@ export async function loadAccountRegistrationsD1(
 export type AccountSummaryAnswer =
   /** Both legs answered; `data` is the assembled card. */
   | { kind: "answer"; data: AccountSummaryResult }
-  /** A tier that exists could not answer -- decline, do not zero the card. */
-  | { kind: "gap" }
+  /**
+   * A tier that exists could not answer -- decline, do not zero the card.
+   *
+   * `reasons` carries one entry per leg that failed, each with the engine's own
+   * explanation (#9386). It can be empty and still be a genuine decline: a leg may
+   * return no usable row without raising.
+   */
+  | { kind: "gap"; reasons: string[] }
   /** No tier to ask. The caller keeps its schema-stable empty. */
   | { kind: "miss" };
 
 /** The one message every declining surface emits for this route, so REST, MCP
  * and GraphQL diagnose identically rather than in three dialects. */
-export function accountSummaryGapMessage(ss58: string): string {
-  return (
+export function accountSummaryGapMessage(
+  ss58: string,
+  reasons: readonly string[] = [],
+): string {
+  const base =
     `The event history for ${ss58} could not be read right now, so this ` +
     `summary would report zero events, zero event kinds and no registrations ` +
     `for an account that may have many. This is a tier failure, not an ` +
     `account without activity -- retry shortly, or read ` +
-    `/api/v1/accounts/${ss58}/events for the same stream.`
-  );
+    `/api/v1/accounts/${ss58}/events for the same stream.`;
+  // #9386: the cause rides in the message so MCP -- which has no status codes and no
+  // structured error meta -- diagnoses as precisely as REST and GraphQL do. That is
+  // the same reason this message is shared at all rather than written three times.
+  return reasons.length ? `${base} Cause: ${reasons.join("; ")}.` : base;
 }
 
 /** The typed code that decline carries on every surface. */
@@ -134,12 +146,21 @@ export async function answerAccountSummary(
     loadAccountSummaryColdTier(env, ss58),
     loadAccountRegistrationsD1(env, ss58),
   ]);
-  if (cold && registrations) {
+  if (!cold.declined && registrations) {
     return {
       kind: "answer",
       data: buildAccountSummary(ss58, { ...cold, registrations }),
     };
   }
-  if (registrations === null || isR2SqlConfigured(env)) return { kind: "gap" };
+  if (registrations === null || isR2SqlConfigured(env)) {
+    // #9386: carry WHY. This decline used to be a bare `{ kind: "gap" }`, so a route
+    // failing half its requests produced a typed 503 that named no cause and left the
+    // mechanism -- timeout, scan budget, HTTP error -- to be guessed at from outside.
+    const reasons = [
+      ...(cold.declined ?? []),
+      ...(registrations === null ? ["registrations: D1 read failed"] : []),
+    ];
+    return { kind: "gap", reasons };
+  }
   return { kind: "miss" };
 }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -5468,8 +5468,13 @@ const rootValue = {
       ? null
       : await answerAccountSummary(context.env, ss58);
     if (answer?.kind === "gap") {
-      throw new GraphQLError(accountSummaryGapMessage(ss58), {
-        extensions: { code: ACCOUNT_SUMMARY_GAP_CODE },
+      throw new GraphQLError(accountSummaryGapMessage(ss58, answer.reasons), {
+        // #9386: the decline names which leg failed, so a client sees the same
+        // diagnosis REST and MCP get rather than a bare code.
+        extensions: {
+          code: ACCOUNT_SUMMARY_GAP_CODE,
+          reasons: answer.reasons,
+        },
       });
     }
     const data =

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -7794,7 +7794,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       if (answer?.kind === "gap") {
         throw toolError(
           ACCOUNT_SUMMARY_GAP_CODE,
-          accountSummaryGapMessage(ss58),
+          accountSummaryGapMessage(ss58, answer.reasons),
         );
       }
       const data =

--- a/src/r2-sql.ts
+++ b/src/r2-sql.ts
@@ -56,6 +56,20 @@ export function currentR2SqlFailureGeneration(): number {
 export interface R2SqlDeps {
   fetch?: typeof fetch;
   recordException?: typeof recordExceptionEvent;
+  /**
+   * Called with the engine's own explanation before a failed query returns null.
+   *
+   * Every failure mode here collapses to the same `null`, which is the right return
+   * type -- a caller must not have to distinguish a timeout from a rejection to know
+   * it has no rows. But the DIAGNOSIS is then discarded, and #9386 is what that
+   * costs: /accounts/{ss58} declined ~50% of requests for a high-activity coldkey
+   * with a typed 503 that could not say which of five concurrent reads failed, or
+   * why. The message this receives already distinguishes them -- an HTTP status, a
+   * numbered engine rejection (`40015: scan budget exceeded ...`), or an abort.
+   *
+   * Optional and side-effect-only, so no existing caller changes behaviour.
+   */
+  onError?: (detail: string) => void;
   /** Override the query ceiling. Tests use a tiny value so the abort path is
    * exercised in milliseconds rather than by waiting out the real ceiling. */
   timeoutMs?: number;
@@ -177,7 +191,16 @@ export async function r2SqlQuery(
     return Array.isArray(rows) ? (rows as Record<string, unknown>[]) : [];
   } catch (error) {
     r2SqlFailureGeneration += 1;
-    console.error("[r2-sql]", String((error as Error)?.message ?? error));
+    const detail = String((error as Error)?.message ?? error);
+    console.error("[r2-sql]", detail);
+    // Reported before the exception hop, so a caller still learns the reason even if
+    // the telemetry sink is unavailable -- the point of this seam is that the answer
+    // must not depend on another service being up.
+    try {
+      deps.onError?.(detail);
+    } catch {
+      // A caller's own reporting must never turn a declined query into a thrown one.
+    }
     await (deps.recordException ?? recordExceptionEvent)(env, {
       error,
       route: "r2-sql",

--- a/tests/account-summary-card.test.ts
+++ b/tests/account-summary-card.test.ts
@@ -213,4 +213,24 @@ describe("accountSummaryGapMessage", () => {
     assert.match(message, new RegExp(`/api/v1/accounts/${SS58}/events`));
     assert.equal(ACCOUNT_SUMMARY_GAP_CODE, "account_summary_unavailable");
   });
+
+  test("carries the engine's own explanation when there is one (#9386)", () => {
+    // MCP has no status codes and no structured error meta, so the cause has to ride
+    // in the message or that surface diagnoses worse than REST and GraphQL do.
+    const message = accountSummaryGapMessage(SS58, [
+      "summary-groups: r2 sql: 40015: scan budget exceeded",
+      "recent-feed: r2 sql: HTTP 429",
+    ]);
+    assert.match(message, /Cause: /);
+    assert.match(message, /40015: scan budget exceeded/);
+    assert.match(message, /HTTP 429/, "every failed leg, not just the first");
+  });
+
+  test("says nothing about a cause it does not have", () => {
+    // An empty reason list is a real state -- a leg can return no usable row without
+    // raising -- and a dangling "Cause:" would imply a diagnosis that was never made.
+    const message = accountSummaryGapMessage(SS58, []);
+    assert.doesNotMatch(message, /Cause: /);
+    assert.equal(message, accountSummaryGapMessage(SS58));
+  });
 });

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -12,7 +12,10 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
-import { loadAccountSummaryColdTier } from "../src/account-feeds-cold-tier.ts";
+import {
+  foldSummaryGroups,
+  loadAccountSummaryColdTier,
+} from "../src/account-feeds-cold-tier.ts";
 import {
   ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
   buildAccountSummary,
@@ -30,57 +33,79 @@ const AGG = {
   lo: 1_785_000_000_000,
 };
 /**
- * The distinct-subnet count, from its own GROUP BY read.
+ * The ONE grouped read that replaced three (#9386).
  *
- * Deliberately NOT a key on AGG: keeping the two apart is what makes a
- * regression back to a single `count(DISTINCT netuid)` beside the aggregates
- * visible here rather than only in production.
+ * `GROUP BY event_kind, netuid` over the same `scan` CTE the three separate reads
+ * aggregated. These rows must fold back to AGG exactly: 4 + 2 = 6 events, min/max
+ * block and observed spanning both groups, and two distinct netuids.
  */
-const SUBNETS = { sc: 2 };
-const KINDS = [
-  { kind: "AxonServed", count: 4 },
-  { kind: "NeuronRegistered", count: 2 },
+const GROUPS = [
+  {
+    kind: "AxonServed",
+    netuid: 55,
+    count: 4,
+    fb: 8_700_000,
+    lb: 8_750_000,
+    fo: 1_784_000_000_000,
+    lo: 1_784_900_000_000,
+  },
+  {
+    kind: "NeuronRegistered",
+    netuid: 7,
+    count: 2,
+    fb: 8_710_000,
+    lb: 8_760_000,
+    fo: 1_784_100_000_000,
+    lo: 1_785_000_000_000,
+  },
 ];
 const RECENT = [
   { block_number: 8_760_000, event_kind: "AxonServed", netuid: 55 },
 ];
 
 /**
- * Answers each of the five reads by the shape of its SQL.
+ * Answers each of the THREE reads by the shape of its SQL.
  *
- * The distinct-subnet count is its OWN read now, so it needs its own
- * discriminator. `AS sc` is the one clause only it carries -- the aggregate is
- * matched on `min(block_number)` rather than on `count(*)`, which three of the
- * five share.
+ * Three, not five: the aggregate, the distinct-subnet count and the per-kind counts
+ * all grouped the same CTE, so one `GROUP BY event_kind, netuid` yields all of them.
+ * The other two cannot fold in -- the cap probe deliberately scans CAP+1 rows outside
+ * the CTE, and the recent feed selects whole rows in a different order.
  */
 function fakeEngine(
   overrides: {
-    agg?: Row[] | null;
-    subnets?: Row[] | null;
-    kinds?: Row[] | null;
+    groups?: Row[] | null;
     probe?: Row[] | null;
     recent?: Row[] | null;
   } = {},
 ) {
   const seen: string[] = [];
+  const errors: string[] = [];
   const pick = <T>(value: T | undefined, fallback: T) =>
     value === undefined ? fallback : value;
-  const query = async (_env: unknown, sql: string) => {
+  const query = async (
+    _env: unknown,
+    sql: string,
+    deps?: { onError?: (detail: string) => void },
+  ) => {
     seen.push(sql);
-    if (sql.includes("GROUP BY event_kind"))
-      return pick(overrides.kinds, KINDS);
-    if (sql.includes("AS sc")) return pick(overrides.subnets, [SUBNETS]);
-    if (sql.includes("count(*) AS c FROM ("))
-      return pick(overrides.probe, [{ c: 6 }]);
-    if (sql.includes("min(block_number)")) return pick(overrides.agg, [AGG]);
-    return pick(overrides.recent, RECENT);
+    const answer = sql.includes("GROUP BY event_kind, netuid")
+      ? pick(overrides.groups, GROUPS)
+      : sql.includes("count(*) AS c FROM (")
+        ? pick(overrides.probe, [{ c: 6 }])
+        : pick(overrides.recent, RECENT);
+    if (answer === null) {
+      // Mirrors r2SqlQuery: the engine's own explanation is reported, then null.
+      deps?.onError?.("r2 sql: HTTP 500 (stubbed failure)");
+      errors.push(sql);
+    }
+    return answer;
   };
   return {
     query,
     seen,
+    errors,
     probe: () => seen.find((s) => s.includes("count(*) AS c FROM ("))!,
-    agg: () => seen.find((s) => s.includes("min(block_number)"))!,
-    subnets: () => seen.find((s) => s.includes("AS sc"))!,
+    groups: () => seen.find((s) => s.includes("GROUP BY event_kind, netuid"))!,
   };
 }
 
@@ -90,8 +115,8 @@ describe("loadAccountSummaryColdTier", () => {
     const cold = await loadAccountSummaryColdTier({} as never, SS58, {
       query: engine.query as never,
     });
-    assert.ok(cold);
-    const card = buildAccountSummary(SS58, cold);
+    assert.equal(cold.declined, undefined);
+    const card = buildAccountSummary(SS58, cold as never);
     assert.equal(card.event_count, 6);
     assert.equal(card.subnet_count, 2);
     assert.equal(card.event_kinds.length, 2);
@@ -120,39 +145,233 @@ describe("loadAccountSummaryColdTier", () => {
     }
   });
 
-  test("the distinct-subnet count is a GROUP BY read, not a bounded CTE", async () => {
+  test("the distinct-subnet count still GROUPS -- it is not a count(DISTINCT)", async () => {
     // The `scan` CTE caps at ACCOUNT_EVENT_SUMMARY_SCAN_CAP rows, which makes a
-    // count(DISTINCT) over it LOOK obviously safe -- an aggregate over 5,000
-    // rows. It is not: the engine costs the distinct against the underlying
-    // scan, not the materialized cap. Wrapping a distinct in a bounded CTE is
-    // not a workaround; only GROUP BY is. That is why this asserts the shape
-    // and not merely the absence of the word DISTINCT.
+    // count(DISTINCT) over it LOOK obviously safe -- an aggregate over 5,000 rows. It
+    // is not: the engine costs the distinct against the underlying scan, not the
+    // materialized cap. Folding the count out of a GROUP BY keeps that property while
+    // removing a whole read.
     const engine = fakeEngine();
     const cold = await loadAccountSummaryColdTier({} as never, SS58, {
       query: engine.query as never,
     });
-    assert.match(
-      engine.subnets(),
-      /FROM \(SELECT netuid FROM scan GROUP BY netuid\)/,
-      "the distinct subnet count must group",
-    );
-    assert.equal(buildAccountSummary(SS58, cold!).subnet_count, 2);
+    assert.match(engine.groups(), /GROUP BY event_kind, netuid/);
+    assert.equal(buildAccountSummary(SS58, cold as never).subnet_count, 2);
   });
 
-  test("declines when the distinct-subnet read misses", async () => {
-    // Publishing the aggregates without it would report an event_count over
-    // subnet_count 0 -- a card that is internally impossible and reads as
-    // measured fact.
-    for (const miss of [{ subnets: null }, { subnets: [] }]) {
-      const engine = fakeEngine(miss);
-      assert.equal(
-        await loadAccountSummaryColdTier({} as never, SS58, {
-          query: engine.query as never,
-        }),
-        null,
-        `${JSON.stringify(miss)} must decline`,
-      );
-    }
+  test("three reads, not five", async () => {
+    // The shape of the #9386 failure: five concurrent broad scans of an
+    // unpartitioned table under Promise.all, so the success probability was the
+    // PRODUCT of five. A single count(*) on account_events reports ~3,390 R2
+    // requests, so each removed scan is real cost as well as real risk.
+    const engine = fakeEngine();
+    await loadAccountSummaryColdTier({} as never, SS58, {
+      query: engine.query as never,
+    });
+    assert.equal(engine.seen.length, 3, engine.seen.join("\n").slice(0, 400));
+  });
+
+  test("the fold reproduces the three reads it replaced, exactly", async () => {
+    const engine = fakeEngine();
+    const cold = await loadAccountSummaryColdTier({} as never, SS58, {
+      query: engine.query as never,
+    });
+    const card = buildAccountSummary(SS58, cold as never);
+    assert.equal(card.event_count, 6, "count(*) == group counts summed");
+    assert.equal(
+      card.subnet_count,
+      2,
+      "GROUP BY netuid == distinct netuid keys",
+    );
+    assert.deepEqual(
+      (card.event_kinds as Array<{ kind: string; count: number }>).map((k) => [
+        k.kind,
+        k.count,
+      ]),
+      [
+        ["AxonServed", 4],
+        ["NeuronRegistered", 2],
+      ],
+    );
+    assert.equal(card.first_block, 8_700_000, "min ACROSS groups");
+    assert.equal(card.last_block, 8_760_000);
+  });
+
+  test("one kind spread over several subnets folds back to one kind row", async () => {
+    // The grouping is finer than the shape it reproduces, so a kind appearing on N
+    // subnets must be summed, not published N times.
+    const engine = fakeEngine({
+      groups: [
+        {
+          kind: "AxonServed",
+          netuid: 1,
+          count: 3,
+          fb: 10,
+          lb: 20,
+          fo: 1,
+          lo: 2,
+        },
+        {
+          kind: "AxonServed",
+          netuid: 2,
+          count: 5,
+          fb: 5,
+          lb: 30,
+          fo: 0,
+          lo: 9,
+        },
+      ],
+      probe: [{ c: 8 }],
+    });
+    const card = buildAccountSummary(
+      SS58,
+      (await loadAccountSummaryColdTier({} as never, SS58, {
+        query: engine.query as never,
+      })) as never,
+    );
+    assert.deepEqual(card.event_kinds, [{ kind: "AxonServed", count: 8 }]);
+    assert.equal(card.event_count, 8);
+    assert.equal(card.subnet_count, 2);
+    assert.equal(
+      card.first_block,
+      5,
+      "min across groups, not the first group's",
+    );
+    assert.equal(card.last_block, 30);
+  });
+
+  test("a NULL netuid is its own distinct group, as SQL counted it", async () => {
+    // `count(*) FROM (SELECT netuid FROM scan GROUP BY netuid)` treats NULL as a
+    // group. Filtering nulls out of the fold would quietly shrink subnet_count by one.
+    const engine = fakeEngine({
+      groups: [
+        {
+          kind: "Transfer",
+          netuid: null,
+          count: 2,
+          fb: 1,
+          lb: 2,
+          fo: 1,
+          lo: 2,
+        },
+        { kind: "Transfer", netuid: 9, count: 1, fb: 3, lb: 4, fo: 3, lo: 4 },
+      ],
+      probe: [{ c: 3 }],
+    });
+    const card = buildAccountSummary(
+      SS58,
+      (await loadAccountSummaryColdTier({} as never, SS58, {
+        query: engine.query as never,
+      })) as never,
+    );
+    assert.equal(card.subnet_count, 2, "NULL counts as a distinct netuid");
+  });
+
+  test("a later group with a smaller max does not lower the running max", async () => {
+    // min/max fold across groups in arrival order, so a group whose own max is below
+    // the running one must be ignored rather than overwrite it.
+    const engine = fakeEngine({
+      groups: [
+        { kind: "A", netuid: 1, count: 1, fb: 50, lb: 900, fo: 50, lo: 900 },
+        { kind: "B", netuid: 2, count: 1, fb: 10, lb: 100, fo: 10, lo: 100 },
+      ],
+      probe: [{ c: 2 }],
+    });
+    const card = buildAccountSummary(
+      SS58,
+      (await loadAccountSummaryColdTier({} as never, SS58, {
+        query: engine.query as never,
+      })) as never,
+    );
+    assert.equal(
+      card.last_block,
+      900,
+      "the larger max survives the smaller one",
+    );
+    assert.equal(
+      card.first_block,
+      10,
+      "and the smaller min survives the larger",
+    );
+  });
+
+  test("an unreadable count contributes nothing rather than NaN", async () => {
+    // A count cell that is not a number must not poison event_count -- a NaN there
+    // would serialize as null and read as "no events" for an account that has them.
+    const engine = fakeEngine({
+      groups: [
+        {
+          kind: "A",
+          netuid: 1,
+          count: "not-a-number",
+          fb: 1,
+          lb: 2,
+          fo: 1,
+          lo: 2,
+        },
+        { kind: "B", netuid: 2, count: 3, fb: 1, lb: 2, fo: 1, lo: 2 },
+      ],
+      probe: [{ c: 3 }],
+    });
+    const card = buildAccountSummary(
+      SS58,
+      (await loadAccountSummaryColdTier({} as never, SS58, {
+        query: engine.query as never,
+      })) as never,
+    );
+    assert.equal(card.event_count, 3);
+    assert.equal(Number.isNaN(card.event_count as number), false);
+  });
+
+  test("a NULL event_kind stays its own group in the fold, as SQL grouped it", () => {
+    // `GROUP BY event_kind` treats NULL as a group, so the fold must too -- collapsing
+    // it into a neighbouring kind would move those events onto the wrong label.
+    // buildAccountSummary then drops the unnamed group from the PUBLISHED list (it
+    // filters `k.kind`), which is right: an event kind with no name cannot be named.
+    // Asserted at the fold rather than through the card so the two behaviours stay
+    // distinguishable — the fold's job is equivalence, the builder's is presentation.
+    const folded = foldSummaryGroups([
+      { kind: null, netuid: 1, count: 2, fb: 1, lb: 2, fo: 1, lo: 2 },
+      { kind: "A", netuid: 1, count: 1, fb: 1, lb: 2, fo: 1, lo: 2 },
+    ]);
+    assert.equal(folded.kinds.length, 2, "the NULL group survives the fold");
+    assert.deepEqual(
+      folded.kinds.find((k) => k.kind === null),
+      { kind: null, count: 2 },
+    );
+    assert.equal(
+      folded.agg.c,
+      3,
+      "and its events still count toward the total",
+    );
+  });
+
+  test("an all-NULL column stays NULL rather than folding to zero", async () => {
+    // SQL min/max skip NULLs, so a column that is entirely NULL yields NULL. A fold
+    // seeded from 0 would publish block 0 as this account's first-ever event.
+    const engine = fakeEngine({
+      groups: [
+        {
+          kind: "Transfer",
+          netuid: 1,
+          count: 2,
+          fb: null,
+          lb: null,
+          fo: null,
+          lo: null,
+        },
+      ],
+      probe: [{ c: 2 }],
+    });
+    const card = buildAccountSummary(
+      SS58,
+      (await loadAccountSummaryColdTier({} as never, SS58, {
+        query: engine.query as never,
+      })) as never,
+    );
+    assert.equal(card.first_block, null);
+    assert.equal(card.last_block, null);
+    assert.equal(card.event_count, 2, "the count is still exact");
   });
 
   test("attributes events by hotkey OR coldkey, like the feed", async () => {
@@ -186,7 +405,7 @@ describe("loadAccountSummaryColdTier", () => {
       "the probe must look one row past the cap",
     );
     assert.match(
-      engine.agg(),
+      engine.groups(),
       new RegExp(`LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP}`),
       "the aggregate window is the cap itself",
     );
@@ -201,7 +420,7 @@ describe("loadAccountSummaryColdTier", () => {
       const cold = await loadAccountSummaryColdTier({} as never, SS58, {
         query: engine.query as never,
       });
-      const card = buildAccountSummary(SS58, cold!);
+      const card = buildAccountSummary(SS58, cold as never);
       assert.equal(card.event_scan_capped, capped, `scanned=${scanned}`);
       // A capped window's minimum is a floor, not the account's first-ever.
       assert.equal(card.first_block === null, capped);
@@ -211,37 +430,70 @@ describe("loadAccountSummaryColdTier", () => {
     }
   });
 
-  test("declines when any half misses", async () => {
+  test("declines when any leg misses", async () => {
     // A card mixing measured aggregates with a zeroed probe would silently flip
     // event_scan_capped and publish a window floor as first_seen_at.
     for (const miss of [
-      { agg: null },
-      { kinds: null },
+      { groups: null },
       { probe: null },
       { recent: null },
-      { agg: [] },
       { probe: [] },
     ]) {
       const engine = fakeEngine(miss);
-      assert.equal(
-        await loadAccountSummaryColdTier({} as never, SS58, {
-          query: engine.query as never,
-        }),
-        null,
-        `${JSON.stringify(miss)} must decline`,
-      );
+      const cold = await loadAccountSummaryColdTier({} as never, SS58, {
+        query: engine.query as never,
+      });
+      assert.ok(cold.declined, `${JSON.stringify(miss)} must decline`);
     }
+  });
+
+  test("an empty grouped read is a real answer, not a decline", async () => {
+    // An account with no events in the window genuinely has none. Declining here
+    // would turn "nothing happened" into "we could not look", which is the opposite
+    // of the confident-zero this route's decline exists to prevent.
+    const engine = fakeEngine({ groups: [], probe: [{ c: 0 }], recent: [] });
+    const cold = await loadAccountSummaryColdTier({} as never, SS58, {
+      query: engine.query as never,
+    });
+    assert.equal(cold.declined, undefined);
+    const card = buildAccountSummary(SS58, cold as never);
+    assert.equal(card.event_count, 0);
+    assert.equal(card.subnet_count, 0);
+  });
+
+  test("a decline says WHICH leg failed and what the engine said", async () => {
+    // #9386: this route declined ~50% of requests for a high-activity coldkey with a
+    // typed 503 that named no cause, so the mechanism -- timeout, scan budget, HTTP
+    // error -- could only be guessed at from outside.
+    const engine = fakeEngine({ groups: null });
+    const cold = await loadAccountSummaryColdTier({} as never, SS58, {
+      query: engine.query as never,
+    });
+    assert.ok(cold.declined);
+    assert.equal(cold.declined.length, 1);
+    assert.match(cold.declined[0], /^summary-groups: /);
+    assert.match(cold.declined[0], /HTTP 500/, "the engine's own explanation");
+  });
+
+  test("every failed leg is named, not just the first", async () => {
+    const engine = fakeEngine({ groups: null, recent: null });
+    const cold = await loadAccountSummaryColdTier({} as never, SS58, {
+      query: engine.query as never,
+    });
+    assert.ok(cold.declined);
+    assert.deepEqual(cold.declined.map((r) => r.split(":")[0]).sort(), [
+      "recent-feed",
+      "summary-groups",
+    ]);
   });
 
   test("an unusable address declines rather than scanning every account", async () => {
     for (const bad of ["", "not-an-address", "'; DROP TABLE x --"]) {
       const engine = fakeEngine();
-      assert.equal(
-        await loadAccountSummaryColdTier({} as never, bad, {
-          query: engine.query as never,
-        }),
-        null,
-      );
+      const cold = await loadAccountSummaryColdTier({} as never, bad, {
+        query: engine.query as never,
+      });
+      assert.ok(cold.declined, `${bad} must decline`);
       assert.equal(engine.seen.length, 0, "must not reach the engine at all");
     }
   });
@@ -249,14 +501,11 @@ describe("loadAccountSummaryColdTier", () => {
   test("an unusable recent limit declines", async () => {
     for (const recentLimit of [0, -1, 1.5]) {
       const engine = fakeEngine();
-      assert.equal(
-        await loadAccountSummaryColdTier({} as never, SS58, {
-          recentLimit,
-          query: engine.query as never,
-        }),
-        null,
-        `recentLimit ${recentLimit}`,
-      );
+      const cold = await loadAccountSummaryColdTier({} as never, SS58, {
+        recentLimit,
+        query: engine.query as never,
+      });
+      assert.ok(cold.declined, `recentLimit ${recentLimit}`);
     }
   });
 });

--- a/tests/r2-sql.test.ts
+++ b/tests/r2-sql.test.ts
@@ -12,6 +12,8 @@ import {
   R2_SQL_TOKEN_ENV,
   safeBlockNumber,
   safeHexLiteral,
+  safeSs58Literal,
+  safeNameLiteral,
 } from "../src/r2-sql.ts";
 import { mockEnv } from "./row-type.ts";
 
@@ -367,5 +369,76 @@ describe("a rejected query says WHY the engine refused it", () => {
   test("a long body is bounded rather than logged whole", async () => {
     const logged = await errorFrom(textFetch("x".repeat(5000)));
     assert.ok(logged.length < 400, String(logged.length));
+  });
+});
+
+// R2 SQL takes NO bound parameters, so every value that reaches a query is inlined
+// into a string. These two guards are therefore the whole injection boundary for the
+// lakehouse readers, and they were exercised only indirectly through their callers.
+describe("the inline-literal guards", () => {
+  test("safeSs58Literal accepts real addresses at every length Substrate uses", () => {
+    for (const ok of [
+      "5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u", // 48
+      "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      "1".repeat(47),
+      "1".repeat(49),
+    ]) {
+      assert.equal(safeSs58Literal(ok), ok, ok.slice(0, 12));
+    }
+  });
+
+  test("safeSs58Literal refuses anything that could close the quote", () => {
+    for (const bad of [
+      "'; DROP TABLE chain.account_events --",
+      "5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u' OR '1'='1",
+      "5E2LP6' UNION SELECT 1 --",
+      "1".repeat(46), // too short
+      "1".repeat(50), // too long
+      "", // empty
+      "5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ0I", // 0 and I are not base58
+      null,
+      42,
+      {},
+      ["5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u"],
+    ]) {
+      assert.equal(
+        safeSs58Literal(bad),
+        null,
+        JSON.stringify(bad)?.slice(0, 40),
+      );
+    }
+  });
+
+  test("safeNameLiteral accepts the identifiers the chain actually emits", () => {
+    for (const ok of [
+      "Transfer",
+      "StakeAdded",
+      "SubtensorModule",
+      "a",
+      "A_1",
+      "a".repeat(64),
+    ]) {
+      assert.equal(safeNameLiteral(ok), ok, ok.slice(0, 20));
+    }
+  });
+
+  test("safeNameLiteral refuses quotes, spaces, leading digits and overlong names", () => {
+    for (const bad of [
+      "Transfer'; DROP TABLE x --",
+      "Stake Added", // a space
+      "1Transfer", // must start with a letter
+      "_Transfer",
+      "Transfer-Kind", // hyphen is not in the set
+      "a".repeat(65), // one past the ceiling
+      "",
+      null,
+      7,
+    ]) {
+      assert.equal(
+        safeNameLiteral(bad),
+        null,
+        JSON.stringify(bad)?.slice(0, 40),
+      );
+    }
   });
 });

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -4423,9 +4423,12 @@ export async function handleAccount(request: Request, env: Env, ss58: string) {
   if (answer?.kind === "gap") {
     return errorResponse(
       ACCOUNT_SUMMARY_GAP_CODE,
-      accountSummaryGapMessage(ss58),
+      accountSummaryGapMessage(ss58, answer.reasons),
       503,
-      { ss58 },
+      // #9386: the decline says WHICH leg failed and what the engine said. Without
+      // it, a route failing half its requests produced a 503 whose cause could only
+      // be guessed at from outside.
+      { ss58, reasons: answer.reasons },
     );
   }
   const data =


### PR DESCRIPTION
## A route failing half its requests, with a 503 that named no cause

Measured against production twice, ~25 minutes apart, **sequentially** (so this is not a self-inflicted concurrent-probe artefact):

```
coldkey 5GsbTgfvgCH4…   run 1:  200 503 503 503 503 200 200 200
                        run 2:  200 503 503 503 503 200 200 200
hotkey  5E2LP6EnZ54m…           200 200 200 200 200 200 200 200
```

Same validator's hotkey and coldkey. The failing one is among the most looked-up accounts on the network.

**Two things were wrong, and neither was the decline itself** — declining rather than publishing an all-zero card is right, and stays.

## 1. Five concurrent broad scans

`loadAccountSummaryColdTier` issued five queries against `chain.account_events` under one `Promise.all` with an all-or-nothing check. The success probability was therefore the **product of five**, and the cost was five scans of a table that is not partitioned on hotkey/coldkey — a single `count(*)` there reports **~3,390 R2 requests**.

Three of the five aggregated the **same** `scan` CTE at different groupings, so one `GROUP BY event_kind, netuid` yields all of them. Each derivation is exact, and argued in `foldSummaryGroups` rather than assumed:

- every row lands in exactly one group, so the counts sum to `count(*)`;
- SQL `min`/`max` skip NULLs, so the fold skips them the same way — an all-NULL column stays **NULL**, not 0, which would otherwise publish block 0 as an account's first-ever event;
- `GROUP BY netuid` counted NULL as its **own group**, so the distinct count must too, or it quietly shrinks by one.

### Verified against the production lakehouse, not just fakes

For a real account, the 24 grouped rows fold to exactly what the three separate queries returned:

| | folded | old query | |
|---|---|---|---|
| `c` | 5000 | 5000 | match |
| `fb` | 8464835 | 8464835 | match |
| `lb` | 8770947 | 8770947 | match |
| `sc` | 9 | 9 | match |

and the per-kind counts are byte-identical — `StakeMoved 63, StakeRemoved 2201, StakeAdded 2103, StakeTransferred 627, StakeSwapped 6`, summing to 5000.

The cap probe and the recent feed **cannot** fold in: the probe deliberately scans `CAP+1` rows *outside* the CTE (that is how "exactly CAP" is told from "more than CAP"), and the feed selects whole rows in a different order.

## 2. The decline named no cause

Every failure mode collapsed to a bare `null`, so a route failing half its requests produced a typed 503 that could not say **which** of five reads failed, or why. #9386 had to state the mechanism as a hypothesis precisely because it is not observable from outside.

`r2SqlQuery` now takes an optional `onError`; the loader tracks one entry per failed leg carrying the engine's own explanation (an HTTP status, a numbered rejection like `40015: scan budget exceeded`, or an abort); and the reason rides in the **shared** message builder, so MCP — which has no status codes and no structured error meta — diagnoses as precisely as REST and GraphQL. That is the same reason that message is shared at all rather than written three times.

## Also fixed, pre-existing

`safeSs58Literal` and `safeNameLiteral` had **no direct tests** in their own suite. R2 SQL takes no bound parameters, so every value reaching a query is inlined — those two guards are the entire injection boundary for every lakehouse reader. Now tested against quote-closing, `UNION`, wrong-length and non-base58 input.

## Verification

- **100% statements / branches / functions / lines** on all three changed modules (`account-feeds-cold-tier.ts`, `account-summary-card.ts`, `r2-sql.ts`).
- **3,043 tests pass** across the 11 affected suites; `tsc`, `eslint`, `prettier --check`, `npm run validate` and `npm run validate:api` all clean.
- One test of mine failed first and was **wrong**, not the code: it expected a NULL `event_kind` to appear in the published list, but `buildAccountSummary` filters unnamed kinds — correctly, since a kind with no name cannot be named. It now asserts at the fold, where equivalence is the contract, leaving the builder's presentation choice separate.

Closes #9386
