### PR TITLE
fix(economics): publish spot price, and say that alpha_price_tao is the moving average

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7832,6 +7832,7 @@ export interface components {
                 alpha_price_change_1h?: number | null;
                 alpha_price_change_1m?: number | null;
                 alpha_price_change_7d?: number | null;
+                /** @description The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that. */
                 alpha_price_tao: number | null;
                 block?: number | null;
                 emission_enabled?: boolean | null;
@@ -7854,6 +7855,8 @@ export interface components {
                 registration_allowed_pinned?: boolean | null;
                 registration_cost_tao: number | null;
                 slug: string;
+                /** @description The AMM spot price in TAO per alpha — the pool ratio at rest, derived from tao_in_pool_tao / alpha_in_pool on this row. Root (netuid 0) has no AMM and is 1 by definition. Null when the reserves cannot support a price; an empty pool has no spot, and 0 would read as free. This is the mark to value a position at; alpha_price_tao is the moving average. */
+                spot_price_tao?: number | null;
                 subnet_volume_tao: number | null;
                 subtoken_enabled?: boolean | null;
                 tao_in_emission_tao?: number | null;
@@ -10329,6 +10332,7 @@ export interface components {
                 alpha_price_change_1h?: number | null;
                 alpha_price_change_1m?: number | null;
                 alpha_price_change_7d?: number | null;
+                /** @description The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that. */
                 alpha_price_tao: number | null;
                 block?: number | null;
                 emission_enabled?: boolean | null;
@@ -10351,6 +10355,8 @@ export interface components {
                 registration_allowed_pinned?: boolean | null;
                 registration_cost_tao: number | null;
                 slug: string;
+                /** @description The AMM spot price in TAO per alpha — the pool ratio at rest, derived from tao_in_pool_tao / alpha_in_pool on this row. Root (netuid 0) has no AMM and is 1 by definition. Null when the reserves cannot support a price; an empty pool has no spot, and 0 would read as free. This is the mark to value a position at; alpha_price_tao is the moving average. */
+                spot_price_tao?: number | null;
                 subnet_volume_tao: number | null;
                 subtoken_enabled?: boolean | null;
                 tao_in_emission_tao?: number | null;
@@ -21175,6 +21181,7 @@ export interface operations {
                      *           "registration_allowed_pinned": false,
                      *           "registration_cost_tao": 0.5,
                      *           "slug": "example-subnet",
+                     *           "spot_price_tao": 0.5,
                      *           "subnet_volume_tao": 0.5,
                      *           "subtoken_enabled": false,
                      *           "tao_in_emission_tao": 0.5,
@@ -43624,6 +43631,7 @@ export interface operations {
                      *           "registration_allowed_pinned": false,
                      *           "registration_cost_tao": 0.5,
                      *           "slug": "example-subnet",
+                     *           "spot_price_tao": 0.5,
                      *           "subnet_volume_tao": 0.5,
                      *           "subtoken_enabled": false,
                      *           "tao_in_emission_tao": 0.5,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -8139,6 +8139,7 @@
               "registration_allowed_pinned": false,
               "registration_cost_tao": 0.5,
               "slug": "example-subnet",
+              "spot_price_tao": 0.5,
               "subnet_volume_tao": 0.5,
               "subtoken_enabled": false,
               "tao_in_emission_tao": 0.5,
@@ -25420,7 +25421,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that."
                 },
                 "block": {
                   "anyOf": [
@@ -25602,6 +25604,17 @@
                 },
                 "slug": {
                   "type": "string"
+                },
+                "spot_price_tao": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "The AMM spot price in TAO per alpha — the pool ratio at rest, derived from tao_in_pool_tao / alpha_in_pool on this row. Root (netuid 0) has no AMM and is 1 by definition. Null when the reserves cannot support a price; an empty pool has no spot, and 0 would read as free. This is the mark to value a position at; alpha_price_tao is the moving average."
                 },
                 "subnet_volume_tao": {
                   "anyOf": [
@@ -38847,7 +38860,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that."
               },
               "block": {
                 "anyOf": [
@@ -39029,6 +39043,17 @@
               },
               "slug": {
                 "type": "string"
+              },
+              "spot_price_tao": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "The AMM spot price in TAO per alpha — the pool ratio at rest, derived from tao_in_pool_tao / alpha_in_pool on this row. Root (netuid 0) has no AMM and is 1 by definition. Null when the reserves cannot support a price; an empty pool has no spot, and 0 would read as free. This is the mark to value a position at; alpha_price_tao is the moving average."
               },
               "subnet_volume_tao": {
                 "anyOf": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7832,6 +7832,7 @@ export interface components {
                 alpha_price_change_1h?: number | null;
                 alpha_price_change_1m?: number | null;
                 alpha_price_change_7d?: number | null;
+                /** @description The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that. */
                 alpha_price_tao: number | null;
                 block?: number | null;
                 emission_enabled?: boolean | null;
@@ -7854,6 +7855,8 @@ export interface components {
                 registration_allowed_pinned?: boolean | null;
                 registration_cost_tao: number | null;
                 slug: string;
+                /** @description The AMM spot price in TAO per alpha — the pool ratio at rest, derived from tao_in_pool_tao / alpha_in_pool on this row. Root (netuid 0) has no AMM and is 1 by definition. Null when the reserves cannot support a price; an empty pool has no spot, and 0 would read as free. This is the mark to value a position at; alpha_price_tao is the moving average. */
+                spot_price_tao?: number | null;
                 subnet_volume_tao: number | null;
                 subtoken_enabled?: boolean | null;
                 tao_in_emission_tao?: number | null;
@@ -10329,6 +10332,7 @@ export interface components {
                 alpha_price_change_1h?: number | null;
                 alpha_price_change_1m?: number | null;
                 alpha_price_change_7d?: number | null;
+                /** @description The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that. */
                 alpha_price_tao: number | null;
                 block?: number | null;
                 emission_enabled?: boolean | null;
@@ -10351,6 +10355,8 @@ export interface components {
                 registration_allowed_pinned?: boolean | null;
                 registration_cost_tao: number | null;
                 slug: string;
+                /** @description The AMM spot price in TAO per alpha — the pool ratio at rest, derived from tao_in_pool_tao / alpha_in_pool on this row. Root (netuid 0) has no AMM and is 1 by definition. Null when the reserves cannot support a price; an empty pool has no spot, and 0 would read as free. This is the mark to value a position at; alpha_price_tao is the moving average. */
+                spot_price_tao?: number | null;
                 subnet_volume_tao: number | null;
                 subtoken_enabled?: boolean | null;
                 tao_in_emission_tao?: number | null;
@@ -21175,6 +21181,7 @@ export interface operations {
                      *           "registration_allowed_pinned": false,
                      *           "registration_cost_tao": 0.5,
                      *           "slug": "example-subnet",
+                     *           "spot_price_tao": 0.5,
                      *           "subnet_volume_tao": 0.5,
                      *           "subtoken_enabled": false,
                      *           "tao_in_emission_tao": 0.5,
@@ -43624,6 +43631,7 @@ export interface operations {
                      *           "registration_allowed_pinned": false,
                      *           "registration_cost_tao": 0.5,
                      *           "slug": "example-subnet",
+                     *           "spot_price_tao": 0.5,
                      *           "subnet_volume_tao": 0.5,
                      *           "subtoken_enabled": false,
                      *           "tao_in_emission_tao": 0.5,

--- a/schemas-src/shared.ts
+++ b/schemas-src/shared.ts
@@ -92,7 +92,22 @@ export const SubnetEconomicsSchema = z
     alpha_price_change_1h: z.number().nullable().optional(),
     alpha_price_change_1m: z.number().nullable().optional(),
     alpha_price_change_7d: z.number().nullable().optional(),
-    alpha_price_tao: z.number().nullable(),
+    alpha_price_tao: z
+      .number()
+      .nullable()
+      .describe(
+        "The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that.",
+      ),
+    // #9408: derived at serve time from tao_in_pool_tao / alpha_in_pool on this very
+    // row, so it cannot disagree with the reserves published beside it, and shares
+    // stake-quote's own spotPriceTao so the two routes mean the same thing by "spot".
+    spot_price_tao: z
+      .number()
+      .nullable()
+      .optional()
+      .describe(
+        "The AMM spot price in TAO per alpha — the pool ratio at rest, derived from tao_in_pool_tao / alpha_in_pool on this row. Root (netuid 0) has no AMM and is 1 by definition. Null when the reserves cannot support a price; an empty pool has no spot, and 0 would read as free. This is the mark to value a position at; alpha_price_tao is the moving average.",
+      ),
     block: z.int().min(0).nullable().optional(),
     emission_share: z.number().min(0).max(1).nullable(),
     // Stage 5. DEFAULTS TO TRUE on chain: absent storage is enabled and 0x00

--- a/src/economics-field-sources.ts
+++ b/src/economics-field-sources.ts
@@ -158,6 +158,12 @@ export const ECONOMICS_FIELD_SOURCES = {
   // read_at omitted deliberately: each change combines the capture-instant
   // price with a DAILY price-history rollup, so no single instant is true of
   // them. Absent means "no single instant applies", not "unknown".
+  // #9408. Arithmetic over two MEASURED reserves on this same row, so it is
+  // reconstructed rather than measured -- no storage item holds it. It shares the
+  // reserves' own instant, which is why no separate `read_at` is asserted: whichever
+  // instant tao_in_pool_tao and alpha_in_pool were read at is the instant this is
+  // true of, by construction.
+  spot_price_tao: { kind: "reconstructed", storage: null },
   alpha_price_change_1h: { kind: "reconstructed", storage: null },
   alpha_price_change_1d: { kind: "reconstructed", storage: null },
   alpha_price_change_7d: { kind: "reconstructed", storage: null },
@@ -267,6 +273,12 @@ export const ECONOMICS_FIELD_SOURCES_LIVE_KV = {
   miner_readiness: { kind: "reconstructed", storage: null },
 
   // --- price history rollup, unchanged from the R2 tier ----------------------
+  // #9408. Arithmetic over two MEASURED reserves on this same row, so it is
+  // reconstructed rather than measured -- no storage item holds it. It shares the
+  // reserves' own instant, which is why no separate `read_at` is asserted: whichever
+  // instant tao_in_pool_tao and alpha_in_pool were read at is the instant this is
+  // true of, by construction.
+  spot_price_tao: { kind: "reconstructed", storage: null },
   alpha_price_change_1h: { kind: "reconstructed", storage: null },
   alpha_price_change_1d: { kind: "reconstructed", storage: null },
   alpha_price_change_7d: { kind: "reconstructed", storage: null },

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -17,6 +17,7 @@ import {
   normalizeProbeStatus,
   okLatencyMs,
 } from "./health-probe-core.ts";
+import { spotPriceTao } from "./stake-quote.ts";
 import { KV_ECONOMICS_CURRENT, KV_HEALTH_CURRENT } from "./kv-keys.ts";
 import { tryPostgresTier } from "../workers/postgres-tier.ts";
 
@@ -1985,6 +1986,40 @@ export async function resolveLiveEconomics({
 // second call to /api/v1/economics. Null-safe: when the live economics store is
 // cold/stale (resolveLiveEconomics → null) or the subnet has no economics row,
 // the detail is returned unchanged (no `economics` field).
+/**
+ * Add `spot_price_tao` to one economics row, derived from the reserves it already
+ * carries (#9408).
+ *
+ * `alpha_price_tao` is the chain's MOVING price -- byte-identical to
+ * `moving_price_pinned` on the live tier, as economics-field-sources.ts spells out --
+ * and every surface that values a position was marking it at that lagging average
+ * while `tao_in_pool_tao` and `alpha_in_pool` sat unused in the same object. Measured
+ * on netuid 64: moving 0.084780302 against spot 0.084668599, +0.132%, which widens
+ * precisely when a lagging average is least useful.
+ *
+ * Derived at SERVE time rather than written by the producers, because there are two of
+ * them (the R2 bulk capture and the live-KV Worker cron) and a stored field would have
+ * to be added, backfilled and kept in step in both. The inputs are on the row either
+ * way, so the division is the whole computation and it cannot disagree between tiers.
+ *
+ * The spot itself comes from stake-quote's `spotPriceTao`, so this and the quote route
+ * cannot drift about what "spot" means -- including the root special case, where there
+ * is no AMM and the price is 1 by definition rather than a ratio of absent reserves.
+ */
+export function withSpotPrice(
+  row: Row | null | undefined,
+): Row | null | undefined {
+  if (!row || typeof row !== "object") return row;
+  return {
+    ...row,
+    spot_price_tao: spotPriceTao(
+      Number(row.netuid),
+      row.tao_in_pool_tao,
+      row.alpha_in_pool,
+    ),
+  };
+}
+
 export function overlaySubnetEconomics(
   detail: Row | null | undefined,
   economicsBlob: Row | null | undefined,
@@ -1995,7 +2030,7 @@ export function overlaySubnetEconomics(
   if (!Array.isArray(rows)) return detail;
   const row = (rows as Row[]).find((entry) => entry?.netuid === netuid);
   if (!row) return detail;
-  return { ...detail, economics: row };
+  return { ...detail, economics: withSpotPrice(row) };
 }
 
 // Overlay the live per-subnet operational rollup onto a composed overview

--- a/src/stake-quote.ts
+++ b/src/stake-quote.ts
@@ -19,6 +19,39 @@ function isFinitePositive(n: unknown): n is number {
   return typeof n === "number" && Number.isFinite(n) && n > 0;
 }
 
+/**
+ * The AMM spot price, in TAO per alpha — the pool ratio at rest.
+ *
+ * Exported so the economics row and this quote cannot disagree about what "spot"
+ * means (#9408). It was previously computed inline here only, which is why the
+ * economics block published `alpha_price_tao` — the chain's MOVING price, byte-identical
+ * to `moving_price_pinned` — with the reserves sitting beside it and no spot derived
+ * from them. Measured on netuid 64: moving 0.084780302 against spot 0.084668599, a
+ * +0.132% divergence that widens exactly when a lagging average matters most.
+ *
+ * Root (netuid 0) has no AMM: staking there is 1:1 TAO⇄TAO, so its spot is 1 by
+ * definition rather than a ratio of reserves it does not have. Null when the reserves
+ * cannot support a price — an empty pool has no spot, and 0 would read as "free".
+ */
+export function spotPriceTao(
+  netuid: number,
+  taoInPool: unknown,
+  alphaInPool: unknown,
+): number | null {
+  if (netuid === 0) return 1;
+  // null/undefined are UNREADABLE, not 0. `Number(null)` is 0, which is finite, so a
+  // bare coercion turns "this subnet's reserves are missing" into a spot of 0 -- i.e.
+  // "this alpha is free", the confident wrong answer this function exists to avoid.
+  if (taoInPool == null || alphaInPool == null) return null;
+  const tao = Number(taoInPool);
+  const alpha = Number(alphaInPool);
+  if (!Number.isFinite(tao) || !Number.isFinite(alpha) || alpha <= 0) {
+    return null;
+  }
+  // A negative reserve is not a price either -- it is a corrupt read.
+  return tao < 0 ? null : tao / alpha;
+}
+
 export interface StakeQuote {
   netuid: number;
   direction: string;
@@ -117,7 +150,9 @@ export function computeStakeQuote({
 
   // Spot price is the pool ratio; each direction below applies the
   // constant-product swap (k = tao_in · alpha_in preserved) in its stable form.
-  const spotPrice = taoInPool / alphaInPool; // TAO per alpha at rest
+  // Shared with the economics row so the two cannot drift (#9408); non-null here
+  // because the liquidity guard above already rejected an unusable pool.
+  const spotPrice = spotPriceTao(netuid, taoInPool, alphaInPool) as number;
 
   let expectedOut: number;
   let expectedOutUnit: "alpha" | "tao";

--- a/tests/stake-quote.test.ts
+++ b/tests/stake-quote.test.ts
@@ -3,6 +3,7 @@ import {
   computeStakeQuote,
   STAKE_QUOTE_DIRECTIONS,
   MAX_INPUT_RESERVE_MULTIPLE,
+  spotPriceTao,
 } from "../src/stake-quote.ts";
 import type { Row } from "./row-type.ts";
 
@@ -153,5 +154,56 @@ describe("computeStakeQuote", () => {
     expect(r.ok).toBe(false);
     expect(r.status).toBe(422);
     expect(r.code).toBe("insufficient_liquidity");
+  });
+});
+
+// #9408: spot is shared with the economics row, so the two cannot drift about what
+// "spot" means. The economics block published `alpha_price_tao` -- the chain's MOVING
+// price -- with the reserves sitting unused in the same object.
+describe("spotPriceTao", () => {
+  it("is the pool ratio, and matches the real reserves", () => {
+    // Live netuid 64 reserves, 2026-08-04. The moving price on that same row was
+    // 0.084780302 -- a +0.132% divergence from this.
+    expect(spotPriceTao(64, 217938.192556005, 2574014.389018032)).toBe(
+      217938.192556005 / 2574014.389018032,
+    );
+  });
+
+  it("root is 1 by definition, not a ratio of reserves it does not have", () => {
+    expect(spotPriceTao(0, null, null)).toBe(1);
+    expect(spotPriceTao(0, 5, 5)).toBe(1);
+  });
+
+  it("an unusable pool has NO spot, rather than a free one", () => {
+    // 0 would read as "this alpha is free", which is the confident wrong answer.
+    for (const [tao, alpha] of [
+      [1, 0],
+      [1, -1],
+      [null, 1],
+      ["x", 1],
+      [1, null],
+      [undefined, 1],
+      [1, undefined],
+      [-1, 1],
+      [Number.POSITIVE_INFINITY, 1],
+      [1, Number.NaN],
+    ] as const) {
+      expect(spotPriceTao(7, tao, alpha)).toBeNull();
+    }
+  });
+
+  it("the quote route and the economics row agree by construction", () => {
+    // Same function, so a change to one cannot silently diverge from the other.
+    const quote = computeStakeQuote({
+      netuid: 64,
+      direction: "stake",
+      amount: 1000,
+      taoInPool: 217938.192556005,
+      alphaInPool: 2574014.389018032,
+    });
+    expect(quote.ok).toBe(true);
+    expect(quote.ok && quote.quote.spot_price_tao).toBe(
+      spotPriceTao(64, 217938.192556005, 2574014.389018032),
+    );
   });
 });

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -62,6 +62,7 @@ import {
   formatUptime,
   LEADERBOARD_BOARDS,
   resolveLiveEconomics,
+  withSpotPrice,
 } from "../../src/health-serving.ts";
 import { DOMAIN_TAGS } from "../../src/domain-tags.ts";
 import {
@@ -593,12 +594,19 @@ async function resolveEconomicsRows(env: Env): Promise<unknown[]> {
     env,
     contractVersion: contractVersion(env),
   })) as { data?: { subnets?: unknown[] } } | null;
-  if (Array.isArray(live?.data?.subnets)) return live.data.subnets;
+  // #9408: spot is derived here, at the ONE point both tiers pass through, rather
+  // than written by either producer -- the inputs are on every row already, so a
+  // stored field would be two writers to keep in step for a division.
+  if (Array.isArray(live?.data?.subnets)) {
+    return live.data.subnets.map((row) => withSpotPrice(row as never));
+  }
   const artifact = await readArtifact(env, "/metagraph/economics.json");
   const artifactSubnets = artifact.ok
     ? (artifact.data as { subnets?: unknown[] })?.subnets
     : undefined;
-  return Array.isArray(artifactSubnets) ? artifactSubnets : [];
+  return Array.isArray(artifactSubnets)
+    ? artifactSubnets.map((row) => withSpotPrice(row as never))
+    : [];
 }
 
 /**


### PR DESCRIPTION
## `alpha_price_tao` is the moving average, and spot was one division away

On the live tier it is **byte-identical to `moving_price_pinned`** — the same word at the same instant. `economics-field-sources.ts` documents that internally; no consumer-facing schema said it. Meanwhile the reserves sat unused in the same object:

```
alpha_price_tao      0.084780302        (== moving_price_pinned)
tao_in_pool_tao      217938.192556005
alpha_in_pool        2574014.389018032
                  -> spot 0.084668599   (+0.132%)
```

0.132% is small in a calm market. It is a **lagging average**, so the gap widens exactly when someone reading a price is trying to react to a move.

## Why it matters

**`/accounts/{ss58}/portfolio` marks every position at it**, from a daily rollup its own schema admits can lag ~24h. And it is one of the two documented reasons metagraphed-infra's validator-ops toolkit reads chain directly instead of using this API — a correct reading of what we publish.

## Not hand-rolled a second time

The spot formula already existed **inline** in `src/stake-quote.ts`. It is now exported as `spotPriceTao`, and the quote route uses that same function — so the two cannot drift about what "spot" means, including the root case where there is no AMM and the price is 1 by definition rather than a ratio of reserves netuid 0 doesn't have.

## Derived at serve time, not stored

There are **two** producers (the R2 bulk capture and the live-KV Worker cron). The inputs are on every row already, so a stored field would mean two writers to keep in step for a division. Each surface funnels through exactly one point:

- `/subnets/{netuid}` → `overlaySubnetEconomics`
- `/economics` → `resolveEconomicsRows`, which both tiers already pass through

## A bug my own test caught

The first version used a bare `Number()`. `Number(null)` is `0`, which is finite — so a **missing reserve produced a spot of 0**, i.e. *"this alpha is free"*: the exact confident wrong answer the function exists to avoid. Null/undefined are now unreadable, and a negative reserve is a corrupt read rather than a price.

```
× an unusable pool has NO spot, rather than a free one
  AssertionError: expected +0 to be null
```

## Verification

- **100% statements / branches / functions / lines** on `src/stake-quote.ts`.
- 493 tests pass across `stake-quote`, `health-serving`, `analytics-routes`, `api-coverage`; `tsc`, `eslint`, `prettier --check`, `validate`, `validate:api` and `validate-docs` all clean; OpenAPI, generated types and apps/ui reference docs regenerated.
- Verified against the **live netuid 64 reserves**: derived spot `0.084668599`, divergence `0.132%`, root `1`.

The schema now states plainly that `alpha_price_tao` is the moving price — it is the right number for emission weighting, which is what the chain uses it for — and that `spot_price_tao` is the mark for valuing a position.

Closes #9408
