### PR TITLE
fix(ui): pin every table header to its own scrollport, not the page offset

### DIFF
--- a/apps/ui/playwright.config.ts
+++ b/apps/ui/playwright.config.ts
@@ -63,13 +63,17 @@ export default defineConfig({
   // that run.
   projects: [
     {
-      name: "overflow",
-      testMatch: /responsive-overflow\.spec\.ts$/,
+      // Layout-measurement sweeps: load a route, measure the rendered DOM,
+      // assert. No interaction, no hydration races, so they take the parallel
+      // phase. A spec matching NEITHER project silently never runs -- add new
+      // measurement specs to this pattern.
+      name: "measurement",
+      testMatch: /(responsive-overflow|sticky-table-header)\.spec\.ts$/,
     },
     {
       name: "interaction",
       testMatch: /(evidence-deep-link|multisig-related-error|offline)\.spec\.ts$/,
-      dependencies: ["overflow"],
+      dependencies: ["measurement"],
       // 6 tests across 3 files. Serial within the phase costs a few seconds
       // and removes the last source of self-contention for exactly the tests
       // that proved sensitive to it.

--- a/apps/ui/src/components/metagraphed/call-module-extrinsics-table.tsx
+++ b/apps/ui/src/components/metagraphed/call-module-extrinsics-table.tsx
@@ -118,7 +118,7 @@ export function CallModuleExtrinsicsTable({
       ))}
       table={
         <table className="w-full text-left text-sm">
-          <thead className="sticky top-0 z-[var(--mg-z-sticky)] mg-glass shadow-[var(--mg-shadow-hairline)]">
+          <thead className="mg-table-head-pinned">
             <tr>
               <th className="px-4 py-2.5">Hash</th>
               <th className="px-4 py-2.5">Block</th>

--- a/apps/ui/src/components/metagraphed/emission-pipeline-table.tsx
+++ b/apps/ui/src/components/metagraphed/emission-pipeline-table.tsx
@@ -137,7 +137,7 @@ export function EmissionPipelineTable({
       ))}
       table={
         <table className="w-full text-left text-sm">
-          <thead className="sticky top-0 z-[var(--mg-z-sticky)] mg-glass shadow-[var(--mg-shadow-hairline)]">
+          <thead className="mg-table-head-pinned">
             <tr>
               <th className="px-4 py-2.5">Subnet</th>
               <th className="px-4 py-2.5 text-right" title="Stage 1: the published price share">

--- a/apps/ui/src/components/metagraphed/sticky-table-header-anchoring.test.ts
+++ b/apps/ui/src/components/metagraphed/sticky-table-header-anchoring.test.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// The geometry this protects is asserted for real, in a real browser, by
+// tests/e2e/sticky-table-header.spec.ts -- that spec is the one that can tell
+// a pinned header from an inert one, and neither of these bugs was visible in
+// source. This file covers what that spec cannot reach: /subnets has no HAR
+// fixture (the overflow sweep covers /subnets/1, not the index), and it is
+// the route where the bug was reported.
+//
+// The rule: a <thead>/<th> pinned inside a bounded scroll container offsets by
+// 0. --mg-sticky-offset is the app-header stack height, published by AppShell
+// for things that stick against the PAGE (the hub tab strip, the filter bar).
+// Applying it inside a bounded box does not push the header below the app
+// header -- it pushes it that far down INSIDE the table, floating it over the
+// first rows. Measured on /subnets before the fix: container top 559px,
+// header top 690px, in a 504px-tall scrollport.
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+
+const appStyles = read("../../styles.css");
+const subnetsPage = read("../../routes/-subnets-index-page.tsx");
+const kitStyles = read("../../../../../packages/ui-kit/src/styles.css");
+const listShell = read("../../../../../packages/ui-kit/src/components/metagraphed/list-shell.tsx");
+
+const pinnedRule = /\.mg-table-head-pinned\s*\{([^}]*)\}/g;
+
+describe("sticky table header anchoring", () => {
+  it("keeps the subnets table header inside a bounded scroll container", () => {
+    // The premise of every assertion below. If the bounded viewport is ever
+    // removed (back to page scroll), `top: 0` becomes the WRONG answer and
+    // this whole file should be revisited rather than made to pass.
+    //
+    // The viewport is ListShell's, not this page's: the page used to declare
+    // a second `max-h` div of its own purely to own the virtualizer's ref,
+    // which nested two bounded scrollers and left the outer one inert. It now
+    // hands that ref to the shell instead, so the element the virtualizer
+    // measures and the element the header pins to are the same one.
+    expect(subnetsPage).toContain("viewportRef={tableScrollRef}");
+    expect(subnetsPage).not.toContain("max-h-[var(--mg-list-viewport-max,70vh)]");
+    expect(listShell).toContain(
+      'className="max-h-[var(--mg-list-viewport-max,70vh)] overflow-y-auto"',
+    );
+    // The cap must carry a literal fallback. A bare var() that fails to
+    // resolve computes `max-height: none`, which silently unbounds the
+    // viewport and makes every sticky header in the app inert again --
+    // observed once, in this repo, mid-fix.
+    expect(listShell).toContain("--mg-list-viewport-max,70vh");
+    expect(kitStyles).toContain("--mg-list-viewport-max: 70vh");
+  });
+
+  it("pins every table header to its scrollport, not to the app-header offset", () => {
+    const rules = [...kitStyles.matchAll(pinnedRule)];
+    expect(rules.length, "no .mg-table-head-pinned rule found").toBeGreaterThan(0);
+
+    for (const [, body] of rules) {
+      expect(body).toContain("position: sticky");
+      expect(body).toMatch(/top:\s*0;/);
+      // The specific regression: the page-scroll offset used inside the box.
+      expect(body).not.toContain("--mg-sticky-offset");
+      // And the second one: a translucent header lets the row passing
+      // underneath read through the column labels.
+      expect(body).toContain("background: var(--card)");
+    }
+  });
+
+  it("routes every sticky table header through that one class", () => {
+    // /subnets carried its own `.mg-subnets-sticky-head` copy of the same
+    // idea, and that copy is what drifted -- wrong offset, and gated to
+    // >=1024px while the table renders from 768px. Two definitions of "how a
+    // table header sticks" is the actual root cause; one is the fix.
+    expect(appStyles).not.toContain(".mg-subnets-sticky-head {");
+    expect(subnetsPage).not.toContain("mg-subnets-sticky-head");
+    expect(subnetsPage).toContain("mg-table-head-pinned");
+  });
+
+  it("does not gate that stickiness above the width where the table renders", () => {
+    // ListShell swaps to cards below `md` (768px), so the table is on screen
+    // from 768px up. The old rule sat inside `@media (min-width: 1024px)`,
+    // leaving 768-1023px with a static header that scrolled out of the
+    // bounded box entirely -- a full-height table of unlabelled columns.
+    // Assert the declaration sits at the top level of the sheet: count the
+    // media queries opened before it against the block-closing braces.
+    const ruleAt = kitStyles.indexOf(".mg-table-head-pinned {");
+    expect(ruleAt).toBeGreaterThan(-1);
+    const before = kitStyles.slice(0, ruleAt);
+    const opens = (before.match(/@media/g) ?? []).length;
+    const closes = (before.match(/^}/gm) ?? []).length;
+    expect(
+      opens,
+      "the .mg-table-head-pinned rule is nested inside an unclosed @media block",
+    ).toBeLessThanOrEqual(closes);
+  });
+});

--- a/apps/ui/src/components/metagraphed/validator-nominators-table.tsx
+++ b/apps/ui/src/components/metagraphed/validator-nominators-table.tsx
@@ -114,7 +114,7 @@ export function ValidatorNominatorsTable({ queryOptions, search, setSearch }: Pr
       ))}
       table={
         <table className="w-full text-left text-sm">
-          <thead className="sticky top-0 z-[var(--mg-z-sticky)] mg-glass shadow-[var(--mg-shadow-hairline)]">
+          <thead className="mg-table-head-pinned">
             <tr>
               <th className="px-4 py-2.5">Coldkey</th>
               <th className="px-4 py-2.5 text-right">Net staked</th>

--- a/apps/ui/src/routes/-blocks-index-page.tsx
+++ b/apps/ui/src/routes/-blocks-index-page.tsx
@@ -456,7 +456,7 @@ function BlocksTable() {
         ))}
         table={
           <table className="w-full text-left text-sm">
-            <thead className="sticky top-0 z-[var(--mg-z-sticky)] mg-glass shadow-[var(--mg-shadow-hairline)]">
+            <thead className="mg-table-head-pinned">
               <tr>
                 <th className="px-4 py-2.5">Block</th>
                 <th className="px-4 py-2.5">Hash</th>

--- a/apps/ui/src/routes/-extrinsics-index-page.tsx
+++ b/apps/ui/src/routes/-extrinsics-index-page.tsx
@@ -266,7 +266,7 @@ function ExtrinsicsTable() {
       ))}
       table={
         <table className="w-full text-left text-sm">
-          <thead className="sticky top-0 z-[var(--mg-z-sticky)] mg-glass shadow-[var(--mg-shadow-hairline)]">
+          <thead className="mg-table-head-pinned">
             <tr>
               <th className="px-4 py-2.5">Hash</th>
               <th className="px-4 py-2.5">Block</th>

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -1127,6 +1127,9 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
         isEmpty={rows.length === 0}
         isStale={isFetching}
         empty={emptyNode}
+        // react-virtual measures against ListShell's bounded viewport -- the
+        // same element .mg-table-head-pinned pins to at top: 0.
+        viewportRef={tableScrollRef}
         cards={[
           ...mobileRows.map((s) => (
             <Link
@@ -1218,449 +1221,441 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
           const firstPad = compact ? "pl-3 pr-1 py-1.5" : "pl-4 pr-1 py-2.5";
           const monoSize = compact ? "mg-type-data" : "mg-type-caption";
           return (
-            // #8248: bounded, internally-scrolling virtualized region -- this
-            // div (not the page) is the sticky-header containing block and
-            // the scroll viewport react-virtual measures against. Nested one
-            // level inside ListShell's own `.mg-table-scroll` horizontal-
-            // scroll wrapper, so it doesn't interact with that wrapper's
-            // existing page-sticky CSS override (#subnets-list
-            // div:has(> .mg-table-scroll) { overflow: visible }), which only
-            // ever targeted `.mg-table-scroll`'s own ancestors.
-            <div ref={tableScrollRef} className="max-h-[70vh] overflow-y-auto">
-              <table className="w-full text-left text-sm">
-                <thead>
-                  <tr>
-                    <th
-                      className={classNames(firstPad, "mg-subnets-sticky-head w-6")}
-                      aria-label="Watch"
+            // #8248's bounded, internally-scrolling virtualized region now
+            // comes from ListShell itself (`viewportRef` above), rather than
+            // a second `max-h-[70vh] overflow-y-auto` div declared here. Both
+            // existed for a while: this one owned tableScrollRef, ListShell's
+            // owned the sticky <thead>, and the outer of the two could never
+            // scroll because the inner capped its content at the same 70vh.
+            // One viewport, one ref, one thing the header pins against.
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr>
+                  <th
+                    className={classNames(firstPad, "mg-table-head-pinned w-6")}
+                    aria-label="Watch"
+                  />
+                  <th
+                    className={classNames(firstPad, "mg-table-head-pinned w-6")}
+                    aria-label="Compare"
+                  />
+                  <th
+                    className={classNames(cellPad, "mg-table-head-pinned")}
+                    aria-sort={ariaSort(search.sort === "netuid", search.order)}
+                  >
+                    <SortHeader
+                      label="UID"
+                      field="netuid"
+                      active={search.sort === "netuid"}
+                      order={search.order}
+                      onSort={onSort}
                     />
-                    <th
-                      className={classNames(firstPad, "mg-subnets-sticky-head w-6")}
-                      aria-label="Compare"
+                  </th>
+                  <th
+                    className={classNames(cellPad, "mg-table-head-pinned")}
+                    aria-sort={ariaSort(search.sort === "name", search.order)}
+                  >
+                    <SortHeader
+                      label="Name"
+                      field="name"
+                      active={search.sort === "name"}
+                      order={search.order}
+                      onSort={onSort}
                     />
+                  </th>
+                  {columns.isVisible("symbol") ? (
                     <th
-                      className={classNames(cellPad, "mg-subnets-sticky-head")}
-                      aria-sort={ariaSort(search.sort === "netuid", search.order)}
+                      className={classNames(cellPad, "mg-table-head-pinned")}
+                      aria-sort={ariaSort(search.sort === "symbol", search.order)}
                     >
                       <SortHeader
-                        label="UID"
-                        field="netuid"
-                        active={search.sort === "netuid"}
+                        label="Symbol"
+                        field="symbol"
+                        active={search.sort === "symbol"}
                         order={search.order}
                         onSort={onSort}
                       />
                     </th>
+                  ) : null}
+                  {columns.isVisible("curation") ? (
                     <th
-                      className={classNames(cellPad, "mg-subnets-sticky-head")}
-                      aria-sort={ariaSort(search.sort === "name", search.order)}
+                      className={classNames(cellPad, "mg-table-head-pinned")}
+                      aria-sort={ariaSort(search.sort === "curation_level", search.order)}
+                      title="Source: how this subnet's registry entry was curated — native chain data, machine-verified, maintainer-reviewed, adapter-backed, community-seeded, or an unverified candidate."
                     >
                       <SortHeader
-                        label="Name"
-                        field="name"
-                        active={search.sort === "name"}
+                        label="Source"
+                        field="curation_level"
+                        active={search.sort === "curation_level"}
                         order={search.order}
                         onSort={onSort}
                       />
                     </th>
-                    {columns.isVisible("symbol") ? (
-                      <th
-                        className={classNames(cellPad, "mg-subnets-sticky-head")}
-                        aria-sort={ariaSort(search.sort === "symbol", search.order)}
-                      >
-                        <SortHeader
-                          label="Symbol"
-                          field="symbol"
-                          active={search.sort === "symbol"}
-                          order={search.order}
-                          onSort={onSort}
-                        />
-                      </th>
-                    ) : null}
-                    {columns.isVisible("curation") ? (
-                      <th
-                        className={classNames(cellPad, "mg-subnets-sticky-head")}
-                        aria-sort={ariaSort(search.sort === "curation_level", search.order)}
-                        title="Source: how this subnet's registry entry was curated — native chain data, machine-verified, maintainer-reviewed, adapter-backed, community-seeded, or an unverified candidate."
-                      >
-                        <SortHeader
-                          label="Source"
-                          field="curation_level"
-                          active={search.sort === "curation_level"}
-                          order={search.order}
-                          onSort={onSort}
-                        />
-                      </th>
-                    ) : null}
-                    {columns.isVisible("surfaces") ? (
-                      <th
-                        className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
-                        aria-sort={ariaSort(search.sort === "surfaces_count", search.order)}
-                        title="Verified public surfaces registered for this subnet (APIs, docs, dashboards, data artifacts, SSE streams)."
-                      >
-                        <SortHeader
-                          label="Surfaces"
-                          field="surfaces_count"
-                          active={search.sort === "surfaces_count"}
-                          order={search.order}
-                          onSort={onSort}
-                          align="right"
-                        />
-                      </th>
-                    ) : null}
-                    {columns.isVisible("readiness") ? (
-                      <th
-                        className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
-                        aria-sort={ariaSort(search.sort === "integration_readiness", search.order)}
-                        title="Profile: how complete this subnet's public-interface profile is (buildable → emerging → identity-only → dormant), based on registered surfaces and evidence."
-                      >
-                        <SortHeader
-                          label="Profile"
-                          field="integration_readiness"
-                          active={search.sort === "integration_readiness"}
-                          order={search.order}
-                          onSort={onSort}
-                          align="right"
-                        />
-                      </th>
-                    ) : null}
-                    {columns.isVisible("registration") ? (
-                      <th
-                        className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
-                        aria-sort={ariaSort(search.sort === "registration_cost_tao", search.order)}
-                        title="Current recycle/burn cost (in TAO) to register a new UID on this subnet. Dimmed when registration is closed."
-                      >
-                        <SortHeader
-                          label="Reg. cost"
-                          field="registration_cost_tao"
-                          active={search.sort === "registration_cost_tao"}
-                          order={search.order}
-                          onSort={onSort}
-                          align="right"
-                        />
-                      </th>
-                    ) : null}
-                    {columns.isVisible("emission") ? (
-                      <th
-                        className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
-                        aria-sort={ariaSort(search.sort === "emission_share", search.order)}
-                        // #8746: stage-1 price share, not TAO received.
-                        title="Stage 1 of the v440 emission pipeline: share of alpha price, not the share of TAO this subnet receives."
-                      >
-                        <SortHeader
-                          label="Emission"
-                          field="emission_share"
-                          active={search.sort === "emission_share"}
-                          order={search.order}
-                          onSort={onSort}
-                          align="right"
-                        />
-                      </th>
-                    ) : null}
-                    {columns.isVisible("alphaPrice") ? (
-                      <th
-                        className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
-                        aria-sort={ariaSort(search.sort === "alpha_price_tao", search.order)}
-                      >
-                        <SortHeader
-                          label="Alpha price"
-                          field="alpha_price_tao"
-                          active={search.sort === "alpha_price_tao"}
-                          order={search.order}
-                          onSort={onSort}
-                          align="right"
-                        />
-                      </th>
-                    ) : null}
-                    {columns.isVisible("priceChange") ? (
-                      <th
-                        className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
-                        title={`Alpha price change over the selected trend window (${trendWindow})`}
-                      >
-                        <span className="mg-type-caption font-normal text-ink-muted">
-                          {trendWindow} %
-                        </span>
-                      </th>
-                    ) : null}
-                    {columns.isVisible("totalStake") ? (
-                      <th
-                        className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
-                        aria-sort={ariaSort(search.sort === "total_stake_tao", search.order)}
-                      >
-                        <SortHeader
-                          label="Total stake"
-                          field="total_stake_tao"
-                          active={search.sort === "total_stake_tao"}
-                          order={search.order}
-                          onSort={onSort}
-                          align="right"
-                        />
-                      </th>
-                    ) : null}
-                    {columns.isVisible("marketCap") ? (
-                      <th
-                        className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
-                        aria-sort={ariaSort(search.sort === "alpha_market_cap_tao", search.order)}
-                      >
-                        <SortHeader
-                          label="Market cap"
-                          field="alpha_market_cap_tao"
-                          active={search.sort === "alpha_market_cap_tao"}
-                          order={search.order}
-                          onSort={onSort}
-                          align="right"
-                        />
-                      </th>
-                    ) : null}
-                    {columns.isVisible("updated") ? (
-                      <th
-                        className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
-                        aria-sort={ariaSort(search.sort === "updated_at", search.order)}
-                      >
-                        <SortHeader
-                          label="Updated"
-                          field="updated_at"
-                          active={search.sort === "updated_at"}
-                          order={search.order}
-                          onSort={onSort}
-                          align="right"
-                        />
-                      </th>
-                    ) : null}
-                    {columns.isVisible("health") ? (
-                      <th
-                        className={classNames(
-                          cellPad,
-                          "mg-subnets-sticky-head mg-type-micro text-ink-muted font-normal text-left",
-                        )}
-                      >
-                        Health
-                      </th>
-                    ) : null}
-                    {columns.isVisible("age") ? (
-                      <th
-                        className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
-                        aria-sort={ariaSort(search.sort === "registered_at_block", search.order)}
-                        title="Time since this subnet's registration block."
-                      >
-                        <SortHeader
-                          label="Age"
-                          field="registered_at_block"
-                          active={search.sort === "registered_at_block"}
-                          order={search.order}
-                          onSort={onSort}
-                          align="right"
-                        />
-                      </th>
-                    ) : null}
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-border">
-                  {/* #8248: top spacer -- stands in for the height of every row
+                  ) : null}
+                  {columns.isVisible("surfaces") ? (
+                    <th
+                      className={classNames(cellPad, "mg-table-head-pinned text-right")}
+                      aria-sort={ariaSort(search.sort === "surfaces_count", search.order)}
+                      title="Verified public surfaces registered for this subnet (APIs, docs, dashboards, data artifacts, SSE streams)."
+                    >
+                      <SortHeader
+                        label="Surfaces"
+                        field="surfaces_count"
+                        active={search.sort === "surfaces_count"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("readiness") ? (
+                    <th
+                      className={classNames(cellPad, "mg-table-head-pinned text-right")}
+                      aria-sort={ariaSort(search.sort === "integration_readiness", search.order)}
+                      title="Profile: how complete this subnet's public-interface profile is (buildable → emerging → identity-only → dormant), based on registered surfaces and evidence."
+                    >
+                      <SortHeader
+                        label="Profile"
+                        field="integration_readiness"
+                        active={search.sort === "integration_readiness"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("registration") ? (
+                    <th
+                      className={classNames(cellPad, "mg-table-head-pinned text-right")}
+                      aria-sort={ariaSort(search.sort === "registration_cost_tao", search.order)}
+                      title="Current recycle/burn cost (in TAO) to register a new UID on this subnet. Dimmed when registration is closed."
+                    >
+                      <SortHeader
+                        label="Reg. cost"
+                        field="registration_cost_tao"
+                        active={search.sort === "registration_cost_tao"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("emission") ? (
+                    <th
+                      className={classNames(cellPad, "mg-table-head-pinned text-right")}
+                      aria-sort={ariaSort(search.sort === "emission_share", search.order)}
+                      // #8746: stage-1 price share, not TAO received.
+                      title="Stage 1 of the v440 emission pipeline: share of alpha price, not the share of TAO this subnet receives."
+                    >
+                      <SortHeader
+                        label="Emission"
+                        field="emission_share"
+                        active={search.sort === "emission_share"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("alphaPrice") ? (
+                    <th
+                      className={classNames(cellPad, "mg-table-head-pinned text-right")}
+                      aria-sort={ariaSort(search.sort === "alpha_price_tao", search.order)}
+                    >
+                      <SortHeader
+                        label="Alpha price"
+                        field="alpha_price_tao"
+                        active={search.sort === "alpha_price_tao"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("priceChange") ? (
+                    <th
+                      className={classNames(cellPad, "mg-table-head-pinned text-right")}
+                      title={`Alpha price change over the selected trend window (${trendWindow})`}
+                    >
+                      <span className="mg-type-caption font-normal text-ink-muted">
+                        {trendWindow} %
+                      </span>
+                    </th>
+                  ) : null}
+                  {columns.isVisible("totalStake") ? (
+                    <th
+                      className={classNames(cellPad, "mg-table-head-pinned text-right")}
+                      aria-sort={ariaSort(search.sort === "total_stake_tao", search.order)}
+                    >
+                      <SortHeader
+                        label="Total stake"
+                        field="total_stake_tao"
+                        active={search.sort === "total_stake_tao"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("marketCap") ? (
+                    <th
+                      className={classNames(cellPad, "mg-table-head-pinned text-right")}
+                      aria-sort={ariaSort(search.sort === "alpha_market_cap_tao", search.order)}
+                    >
+                      <SortHeader
+                        label="Market cap"
+                        field="alpha_market_cap_tao"
+                        active={search.sort === "alpha_market_cap_tao"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("updated") ? (
+                    <th
+                      className={classNames(cellPad, "mg-table-head-pinned text-right")}
+                      aria-sort={ariaSort(search.sort === "updated_at", search.order)}
+                    >
+                      <SortHeader
+                        label="Updated"
+                        field="updated_at"
+                        active={search.sort === "updated_at"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("health") ? (
+                    <th
+                      className={classNames(
+                        cellPad,
+                        "mg-table-head-pinned mg-type-micro text-ink-muted font-normal text-left",
+                      )}
+                    >
+                      Health
+                    </th>
+                  ) : null}
+                  {columns.isVisible("age") ? (
+                    <th
+                      className={classNames(cellPad, "mg-table-head-pinned text-right")}
+                      aria-sort={ariaSort(search.sort === "registered_at_block", search.order)}
+                      title="Time since this subnet's registration block."
+                    >
+                      <SortHeader
+                        label="Age"
+                        field="registered_at_block"
+                        active={search.sort === "registered_at_block"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {/* #8248: top spacer -- stands in for the height of every row
                     above the rendered slice, so real `<tr>`s never need
                     absolute positioning (which would drop them out of table
                     row-group layout and break column alignment). */}
-                  {virtualPaddingTop > 0 ? (
-                    <tr aria-hidden>
-                      <td colSpan={20} style={{ height: virtualPaddingTop }} />
-                    </tr>
-                  ) : null}
-                  {virtualRows.map((vRow) => {
-                    const s = rows[vRow.index];
-                    return (
-                      <tr
-                        key={s.netuid}
-                        data-index={vRow.index}
-                        ref={rowVirtualizer.measureElement}
-                        className="mg-row-accent hover:bg-surface/40"
-                      >
-                        <td className={classNames(firstPad, "align-middle")}>
-                          <button
-                            type="button"
-                            onClick={() => watchlist.toggle(s.netuid)}
-                            aria-pressed={watchlist.isWatched(s.netuid)}
-                            aria-label={
-                              watchlist.isWatched(s.netuid)
-                                ? `Remove SN${s.netuid} from watchlist`
-                                : `Add SN${s.netuid} to watchlist`
-                            }
-                            className="mg-tap-target flex items-center justify-center rounded p-1 text-ink-muted hover:text-ink-strong"
+                {virtualPaddingTop > 0 ? (
+                  <tr aria-hidden>
+                    <td colSpan={20} style={{ height: virtualPaddingTop }} />
+                  </tr>
+                ) : null}
+                {virtualRows.map((vRow) => {
+                  const s = rows[vRow.index];
+                  return (
+                    <tr
+                      key={s.netuid}
+                      data-index={vRow.index}
+                      ref={rowVirtualizer.measureElement}
+                      className="mg-row-accent hover:bg-surface/40"
+                    >
+                      <td className={classNames(firstPad, "align-middle")}>
+                        <button
+                          type="button"
+                          onClick={() => watchlist.toggle(s.netuid)}
+                          aria-pressed={watchlist.isWatched(s.netuid)}
+                          aria-label={
+                            watchlist.isWatched(s.netuid)
+                              ? `Remove SN${s.netuid} from watchlist`
+                              : `Add SN${s.netuid} to watchlist`
+                          }
+                          className="mg-tap-target flex items-center justify-center rounded p-1 text-ink-muted hover:text-ink-strong"
+                        >
+                          <Star
+                            className={classNames(
+                              "size-3.5",
+                              watchlist.isWatched(s.netuid) && "fill-accent text-accent",
+                            )}
+                          />
+                        </button>
+                      </td>
+                      <td className={classNames(firstPad, "align-middle")}>
+                        <CompareToggle netuid={s.netuid} />
+                      </td>
+                      <td className={classNames(cellPad, "font-mono text-ink-muted", monoSize)}>
+                        <EntityHoverCard kind="subnet" netuid={s.netuid}>
+                          <Link
+                            to="/subnets/$netuid"
+                            params={{ netuid: s.netuid }}
+                            className="hover:text-ink-strong"
                           >
-                            <Star
-                              className={classNames(
-                                "size-3.5",
-                                watchlist.isWatched(s.netuid) && "fill-accent text-accent",
-                              )}
-                            />
-                          </button>
-                        </td>
-                        <td className={classNames(firstPad, "align-middle")}>
-                          <CompareToggle netuid={s.netuid} />
-                        </td>
-                        <td className={classNames(cellPad, "font-mono text-ink-muted", monoSize)}>
-                          <EntityHoverCard kind="subnet" netuid={s.netuid}>
-                            <Link
-                              to="/subnets/$netuid"
-                              params={{ netuid: s.netuid }}
-                              className="hover:text-ink-strong"
-                            >
-                              {String(s.netuid).padStart(3, "0")}
-                            </Link>
-                          </EntityHoverCard>
-                          {/* #6643: age-in-days, estimated from the already-fetched
+                            {String(s.netuid).padStart(3, "0")}
+                          </Link>
+                        </EntityHoverCard>
+                        {/* #6643: age-in-days, estimated from the already-fetched
                         registered_at_block/block delta -- no new backend call. */}
-                          <div className="mg-type-caption font-sans text-ink-muted/70 whitespace-nowrap">
-                            {formatSubnetAge(subnetAgeDays(s.registered_at_block, s.block))}
-                          </div>
-                        </td>
-                        <td className={cellPad}>
-                          <EntityHoverCard kind="subnet" netuid={s.netuid}>
-                            <Link
-                              to="/subnets/$netuid"
-                              params={{ netuid: s.netuid }}
-                              className="inline-flex items-center gap-2 font-medium text-ink-strong hover:underline"
-                            >
-                              <BrandIcon
-                                url={s.website}
-                                repoUrl={s.repo}
-                                iconUrl={s.icon_url}
-                                netuid={s.netuid}
-                                name={s.name}
-                                fallback={s.netuid}
-                                size={compact ? 18 : 20}
-                              />
-                              <span className="truncate">{s.name ?? `Subnet ${s.netuid}`}</span>
-                            </Link>
-                          </EntityHoverCard>
-                        </td>
-                        {columns.isVisible("symbol") ? (
-                          <td className={classNames(cellPad, "mg-type-data text-ink-muted")}>
-                            {s.symbol ?? "—"}
-                          </td>
-                        ) : null}
-                        {columns.isVisible("curation") ? (
-                          <td className={cellPad}>
-                            <ProvenanceChip level={s.curation_level} />
-                          </td>
-                        ) : null}
-                        {columns.isVisible("surfaces") ? (
-                          <td className={classNames(cellPad, "text-right")}>
-                            <SurfacesCell subnet={s} density={density} />
-                          </td>
-                        ) : null}
-                        {columns.isVisible("readiness") ? (
-                          <td className={classNames(cellPad, "text-right")}>
-                            <ReadinessGauge
-                              score={s.integration_readiness}
-                              tier={s.readiness_tier}
-                              details={s.service_kinds}
-                              compact={compact}
+                        <div className="mg-type-caption font-sans text-ink-muted/70 whitespace-nowrap">
+                          {formatSubnetAge(subnetAgeDays(s.registered_at_block, s.block))}
+                        </div>
+                      </td>
+                      <td className={cellPad}>
+                        <EntityHoverCard kind="subnet" netuid={s.netuid}>
+                          <Link
+                            to="/subnets/$netuid"
+                            params={{ netuid: s.netuid }}
+                            className="inline-flex items-center gap-2 font-medium text-ink-strong hover:underline"
+                          >
+                            <BrandIcon
+                              url={s.website}
+                              repoUrl={s.repo}
+                              iconUrl={s.icon_url}
+                              netuid={s.netuid}
+                              name={s.name}
+                              fallback={s.netuid}
+                              size={compact ? 18 : 20}
                             />
-                          </td>
-                        ) : null}
-                        {columns.isVisible("registration") ? (
-                          <td
-                            className={classNames(
-                              cellPad,
-                              "text-right mg-type-data tabular-nums",
-                              // #3364: dim the cost only when registration is explicitly
-                              // closed. `registration_allowed === undefined` (economics
-                              // entry present but flag absent, or no entry at all) keeps
-                              // the neutral tone — do NOT read it as "open".
-                              s.registration_allowed === false ? "text-ink-muted" : "text-ink",
-                            )}
-                            title={
-                              s.registration_allowed === false
-                                ? "Registration currently closed"
-                                : s.registration_allowed === true
-                                  ? "Registration open"
-                                  : undefined
-                            }
-                          >
-                            {formatTao(s.registration_cost_tao)}
-                          </td>
-                        ) : null}
-                        {columns.isVisible("emission") ? (
-                          <td
-                            className={classNames(cellPad, "text-right mg-type-data tabular-nums")}
-                          >
-                            <EmissionCell share={s.emission_share} />
-                          </td>
-                        ) : null}
-                        {columns.isVisible("alphaPrice") ? (
-                          <FinancialTrendCell
-                            netuid={s.netuid}
-                            field="alpha_price_tao"
-                            current={s.alpha_price_tao}
-                            digits={4}
-                            compact={compact}
-                            usdPerTao={taoUsd}
-                            window={trendWindow}
-                          />
-                        ) : null}
-                        {columns.isVisible("priceChange") ? (
-                          <PctChangeCell
-                            netuid={s.netuid}
-                            current={s.alpha_price_tao}
-                            window={trendWindow}
+                            <span className="truncate">{s.name ?? `Subnet ${s.netuid}`}</span>
+                          </Link>
+                        </EntityHoverCard>
+                      </td>
+                      {columns.isVisible("symbol") ? (
+                        <td className={classNames(cellPad, "mg-type-data text-ink-muted")}>
+                          {s.symbol ?? "—"}
+                        </td>
+                      ) : null}
+                      {columns.isVisible("curation") ? (
+                        <td className={cellPad}>
+                          <ProvenanceChip level={s.curation_level} />
+                        </td>
+                      ) : null}
+                      {columns.isVisible("surfaces") ? (
+                        <td className={classNames(cellPad, "text-right")}>
+                          <SurfacesCell subnet={s} density={density} />
+                        </td>
+                      ) : null}
+                      {columns.isVisible("readiness") ? (
+                        <td className={classNames(cellPad, "text-right")}>
+                          <ReadinessGauge
+                            score={s.integration_readiness}
+                            tier={s.readiness_tier}
+                            details={s.service_kinds}
                             compact={compact}
                           />
-                        ) : null}
-                        {columns.isVisible("totalStake") ? (
-                          <FinancialTrendCell
-                            netuid={s.netuid}
-                            field="total_stake_tao"
-                            current={s.total_stake_tao}
-                            compact={compact}
-                            window={trendWindow}
-                            symbol={s.netuid === 0 ? "τ" : (s.symbol ?? "α")}
-                          />
-                        ) : null}
-                        {columns.isVisible("marketCap") ? (
-                          <FinancialTrendCell
-                            netuid={s.netuid}
-                            field="alpha_market_cap_tao"
-                            current={s.alpha_market_cap_tao}
-                            compact={compact}
-                            usdPerTao={taoUsd}
-                            window={trendWindow}
-                          />
-                        ) : null}
-                        {columns.isVisible("updated") ? (
-                          <td
-                            className={classNames(
-                              cellPad,
-                              "text-right mg-type-data text-ink-muted",
-                            )}
-                          >
-                            <TimeAgo at={s.updated_at ?? s.freshness} />
-                          </td>
-                        ) : null}
-                        {columns.isVisible("health") ? (
-                          <td className={cellPad}>
-                            <HealthPill state={s.health} />
-                          </td>
-                        ) : null}
-                        {columns.isVisible("age") ? (
-                          <td
-                            className={classNames(
-                              cellPad,
-                              "text-right mg-type-data tabular-nums text-ink-muted",
-                            )}
-                          >
-                            {formatSubnetAge(subnetAgeDays(s.registered_at_block, s.block))}
-                          </td>
-                        ) : null}
-                      </tr>
-                    );
-                  })}
-                  {virtualPaddingBottom > 0 ? (
-                    <tr aria-hidden>
-                      <td colSpan={20} style={{ height: virtualPaddingBottom }} />
+                        </td>
+                      ) : null}
+                      {columns.isVisible("registration") ? (
+                        <td
+                          className={classNames(
+                            cellPad,
+                            "text-right mg-type-data tabular-nums",
+                            // #3364: dim the cost only when registration is explicitly
+                            // closed. `registration_allowed === undefined` (economics
+                            // entry present but flag absent, or no entry at all) keeps
+                            // the neutral tone — do NOT read it as "open".
+                            s.registration_allowed === false ? "text-ink-muted" : "text-ink",
+                          )}
+                          title={
+                            s.registration_allowed === false
+                              ? "Registration currently closed"
+                              : s.registration_allowed === true
+                                ? "Registration open"
+                                : undefined
+                          }
+                        >
+                          {formatTao(s.registration_cost_tao)}
+                        </td>
+                      ) : null}
+                      {columns.isVisible("emission") ? (
+                        <td className={classNames(cellPad, "text-right mg-type-data tabular-nums")}>
+                          <EmissionCell share={s.emission_share} />
+                        </td>
+                      ) : null}
+                      {columns.isVisible("alphaPrice") ? (
+                        <FinancialTrendCell
+                          netuid={s.netuid}
+                          field="alpha_price_tao"
+                          current={s.alpha_price_tao}
+                          digits={4}
+                          compact={compact}
+                          usdPerTao={taoUsd}
+                          window={trendWindow}
+                        />
+                      ) : null}
+                      {columns.isVisible("priceChange") ? (
+                        <PctChangeCell
+                          netuid={s.netuid}
+                          current={s.alpha_price_tao}
+                          window={trendWindow}
+                          compact={compact}
+                        />
+                      ) : null}
+                      {columns.isVisible("totalStake") ? (
+                        <FinancialTrendCell
+                          netuid={s.netuid}
+                          field="total_stake_tao"
+                          current={s.total_stake_tao}
+                          compact={compact}
+                          window={trendWindow}
+                          symbol={s.netuid === 0 ? "τ" : (s.symbol ?? "α")}
+                        />
+                      ) : null}
+                      {columns.isVisible("marketCap") ? (
+                        <FinancialTrendCell
+                          netuid={s.netuid}
+                          field="alpha_market_cap_tao"
+                          current={s.alpha_market_cap_tao}
+                          compact={compact}
+                          usdPerTao={taoUsd}
+                          window={trendWindow}
+                        />
+                      ) : null}
+                      {columns.isVisible("updated") ? (
+                        <td
+                          className={classNames(cellPad, "text-right mg-type-data text-ink-muted")}
+                        >
+                          <TimeAgo at={s.updated_at ?? s.freshness} />
+                        </td>
+                      ) : null}
+                      {columns.isVisible("health") ? (
+                        <td className={cellPad}>
+                          <HealthPill state={s.health} />
+                        </td>
+                      ) : null}
+                      {columns.isVisible("age") ? (
+                        <td
+                          className={classNames(
+                            cellPad,
+                            "text-right mg-type-data tabular-nums text-ink-muted",
+                          )}
+                        >
+                          {formatSubnetAge(subnetAgeDays(s.registered_at_block, s.block))}
+                        </td>
+                      ) : null}
                     </tr>
-                  ) : null}
-                </tbody>
-              </table>
-            </div>
+                  );
+                })}
+                {virtualPaddingBottom > 0 ? (
+                  <tr aria-hidden>
+                    <td colSpan={20} style={{ height: virtualPaddingBottom }} />
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
           );
         })()}
       />

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -233,14 +233,17 @@ function ValidatorsDirectory({
               overflow-y-auto div keeps tableScrollRef for react-virtual's
               vertical scroll measurement. */}
           <div className="mg-table-scroll overflow-x-auto">
-            <div ref={tableScrollRef} className="max-h-[70vh] overflow-y-auto">
+            <div
+              ref={tableScrollRef}
+              className="max-h-[var(--mg-list-viewport-max,70vh)] overflow-y-auto"
+            >
               <table
                 className={classNames(
                   "w-full text-left text-sm",
                   compact && "[&_td]:!py-1 [&_th]:!py-1",
                 )}
               >
-                <thead className="sticky top-0 z-[var(--mg-z-sticky)] bg-surface">
+                <thead className="mg-table-head-pinned">
                   <tr>
                     <th className="w-6 px-3 py-2" aria-label="Watch" />
                     <th className="w-6 px-3 py-2" aria-label="Compare" />

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -116,37 +116,18 @@
   height: 0;
 }
 
-/* A desktop subnet table fits the shell, so an overflow ancestor is both
-   unnecessary and harmful: it becomes the sticky cells' containing block.
-   Tablet retains horizontal scrolling; mobile uses the card fallback. */
-@media (min-width: 1024px) {
-  /* The desktop table header is the persistent navigation layer. Keeping the
-     filter toolbar in normal flow prevents two sticky rows from racing for a
-     ResizeObserver-derived offset as filters wrap. */
-  #subnets-list > div > div:first-child {
-    position: static;
-  }
-  #subnets-list .mg-table-scroll {
-    overflow: visible;
-  }
-  #subnets-list div:has(> .mg-table-scroll) {
-    overflow: visible;
-  }
-}
+/* The subnets table header used to be styled here, by a bespoke
+   `.mg-subnets-sticky-head` rule that pinned it with
+   `top: var(--mg-sticky-offset)` -- the app-header stack height (131px live),
+   applied inside a 504px-tall bounded scrollport, which parked the column
+   labels a third of the way down the table on top of the first three rows.
+   It also only applied at >=1024px while the table renders from 768px, so
+   tablet had no header at all.
 
-.mg-subnets-sticky-head {
-  background: var(--card);
-  box-shadow: 0 1px 0 var(--border);
-}
-@media (min-width: 1024px) {
-  .mg-subnets-sticky-head {
-    position: sticky;
-    top: var(--mg-sticky-offset, 3.5rem);
-    z-index: 10;
-    background: color-mix(in oklab, var(--card) 94%, transparent);
-    backdrop-filter: blur(8px);
-  }
-}
+   Both are gone, and so is the rule: /subnets now uses ui-kit's shared
+   `.mg-table-head-pinned`, the single definition every list table in the app
+   pins with. A second, page-specific copy of "how a table header sticks" is
+   what let these two drift apart from the rest in the first place. */
 
 /* ============================================================
  * Paint-safety invariants.

--- a/apps/ui/tests/e2e/sticky-table-header.spec.ts
+++ b/apps/ui/tests/e2e/sticky-table-header.spec.ts
@@ -1,0 +1,189 @@
+import { existsSync } from "node:fs";
+import { test, expect } from "@playwright/test";
+import { harPathForRoute, DATED_ENDPOINT_PATTERNS, findHarFixture } from "./har-path.ts";
+
+// A sticky <thead> pins against ITS OWN scroll container, and nothing else.
+// Every regression in this area has come from getting that one sentence
+// wrong, in one of two directions -- both of which shipped simultaneously:
+//
+//   1. Wrong offset. /subnets pinned its header with
+//      `top: var(--mg-sticky-offset)` -- the app-header stack height, which
+//      is only meaningful when the PAGE is the scroller. Its real container
+//      was a `max-h-[70vh] overflow-y-auto` box, so sticky held the header
+//      131px BELOW that box's top edge forever, floating the column labels
+//      over the first three rows. That is the screenshot users reported.
+//
+//   2. Right offset, no container. ListShell's tables declared
+//      `sticky top-0` against an `overflow-x-auto` wrapper. Per CSS
+//      Overflow 3 §3 a non-`visible` value on one axis coerces the other to
+//      `auto`, so that wrapper WAS the container -- but with no max-height
+//      it never scrolled, and the declaration was a no-op. The header read
+//      as sticky in the markup and scrolled away in the browser.
+//
+// Case 2 is why this test lives in a browser and not in a source-grep unit
+// test: `sticky top-0` is textually perfect in both the broken and the fixed
+// tree. Only real layout tells them apart. It is also why the assertions
+// below check that the container ACTUALLY SCROLLS before checking where the
+// header landed -- an inert sticky header trivially satisfies
+// "header top === container top" at rest, so measuring alone would have
+// called the broken tree green.
+const ROUTES = ["/chain/blocks", "/chain/extrinsics", "/validators"];
+
+// Both sides of the `md` breakpoint where ListShell swaps cards for a table.
+// 768 is not decoration: /subnets shipped with its sticky rule gated to
+// `@media (min-width: 1024px)` while the table itself renders from 768px, so
+// tablet had a `position: static` header that scrolled out of the bounded box
+// and left the reader 129 rows of unlabelled numbers.
+const VIEWPORTS = [
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+
+/** Runs in the page. Scrolls every sticky <thead>'s container and reports where it landed. */
+function measureStickyHeaders() {
+  const results: {
+    container: string;
+    scrollRange: number;
+    headerHeight: number;
+    containerScrolls: boolean;
+    scrolledBy: number;
+    drift: number;
+  }[] = [];
+
+  for (const thead of Array.from(document.querySelectorAll("thead"))) {
+    if (getComputedStyle(thead).position !== "sticky") continue;
+
+    let node = thead.parentElement;
+    let container: HTMLElement | null = null;
+    while (node && node !== document.documentElement) {
+      const style = getComputedStyle(node);
+      if (/(auto|scroll)/.test(style.overflowY)) {
+        container = node;
+        break;
+      }
+      node = node.parentElement;
+    }
+    // No bounded ancestor at all means the page is the scroller. That is a
+    // legitimate arrangement elsewhere in the app (the filter bar, the hub
+    // tab strip), but not one any table in these routes uses -- so record it
+    // as a container-less entry and let the assertions reject it rather than
+    // silently skipping and passing on nothing.
+    if (!container) {
+      results.push({
+        container: "PAGE",
+        scrollRange: 0,
+        headerHeight: 0,
+        containerScrolls: false,
+        scrolledBy: 0,
+        drift: 0,
+      });
+      continue;
+    }
+
+    const headerHeight = thead.getBoundingClientRect().height;
+    const scrollRange = container.scrollHeight - container.clientHeight;
+    // Threshold is the header's OWN height, not a constant and not 1px. An
+    // unbounded wrapper is not always exactly zero-range: /chain/extrinsics
+    // reported scrollHeight 1962 vs clientHeight 1959 -- three sub-pixel
+    // rows of slack, enough for a `> clientHeight` check to call the broken
+    // tree a real scroller, and enough for the header to "stay pinned"
+    // across a 3px scroll. Requiring the container to be able to scroll the
+    // header entirely out of view is what makes the pin observable, and it
+    // scales with density/font settings instead of guessing a pixel budget.
+    const containerScrolls = scrollRange >= headerHeight;
+    // Scroll far enough that a non-sticky header is unambiguously gone, but
+    // clamp to what the container can actually travel.
+    container.scrollTop = Math.min(400, scrollRange);
+
+    results.push({
+      container: container.className || container.tagName,
+      scrollRange: Math.round(scrollRange),
+      headerHeight: Math.round(headerHeight),
+      containerScrolls,
+      scrolledBy: container.scrollTop,
+      // getBoundingClientRect().top is the border edge; clientTop is the
+      // border width, so this compares against the scrollport's top.
+      drift: Math.round(
+        thead.getBoundingClientRect().top -
+          (container.getBoundingClientRect().top + container.clientTop),
+      ),
+    });
+  }
+  return results;
+}
+
+for (const route of ROUTES) {
+  test.describe(route, () => {
+    const harPath = harPathForRoute(route);
+    if (!existsSync(harPath)) {
+      throw new Error(
+        `Missing HAR fixture for ${route}: ${harPath}. Run ` +
+          `\`npm run test:e2e:record-har --workspace=apps/ui\` against a live dev server first.`,
+      );
+    }
+
+    for (const viewport of VIEWPORTS) {
+      test(`table header pins to its own scrollport at ${viewport.name} (${viewport.width}px)`, async ({
+        page,
+      }) => {
+        // Same replay contract as responsive-overflow.spec.ts -- see the long
+        // rationale there for `notFound: "fallback"` and the dated-endpoint
+        // re-registration.
+        await page.routeFromHAR(harPath, {
+          url: "**/api.metagraph.sh/**",
+          notFound: "fallback",
+          update: false,
+        });
+        for (const pattern of DATED_ENDPOINT_PATTERNS) {
+          const fixture = findHarFixture(harPath, pattern);
+          if (fixture) await page.route(pattern, (r) => r.fulfill(fixture));
+        }
+        await page.setViewportSize({ width: viewport.width, height: viewport.height });
+        await page.goto(route);
+        try {
+          await page.waitForLoadState("networkidle", { timeout: 5000 });
+        } catch {
+          await page.waitForTimeout(2000);
+        }
+        await page.evaluate(() => document.fonts.ready);
+        // Generous, and measured: /chain/extrinsics needs ~10s to paint its
+        // table even on an idle machine, and the default 5s failed only that
+        // route, only under 4 parallel workers -- the classic self-inflicted
+        // sweep failure. The wait is for the element, so fast routes don't
+        // pay it.
+        await expect(page.locator("table thead").first()).toBeVisible({ timeout: 20_000 });
+
+        const headers = await page.evaluate(measureStickyHeaders);
+
+        // Guard the guard: if the table stopped rendering, or the <thead>
+        // stopped being sticky, every per-header assertion below would pass
+        // vacuously and this file would quietly stop testing anything.
+        expect(
+          headers.length,
+          `${route} at ${viewport.width}px rendered no sticky <thead>. Either the ` +
+            `table did not render (fixture drift) or the sticky declaration was dropped.`,
+        ).toBeGreaterThan(0);
+
+        for (const h of headers) {
+          expect(
+            h.containerScrolls,
+            `${route} at ${viewport.width}px: sticky <thead> inside "${h.container}", which can ` +
+              `only scroll ${h.scrollRange}px against a ${h.headerHeight}px header -- the ` +
+              `header can never be scrolled out of view, so the sticky declaration does ` +
+              `nothing and the labels scroll away with the page. Give the wrapper a ` +
+              `max-height, or drop the sticky declaration instead of leaving it inert.`,
+          ).toBe(true);
+
+          expect(
+            h.drift,
+            `${route} at ${viewport.width}px: sticky <thead> settled ${h.drift}px from the top ` +
+              `of its scrollport ("${h.container}") after scrolling it ${h.scrolledBy}px. ` +
+              `A positive drift means the header is floating down over the rows -- almost ` +
+              `always a page-chrome offset (--mg-sticky-offset) applied inside a bounded box, ` +
+              `where the only correct value is 0.`,
+          ).toBe(0);
+        }
+      });
+    }
+  });
+}

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2043,64 +2043,61 @@ function ListShell({
   empty,
   isEmpty,
   isStale,
+  viewportRef,
   stickyHeader: _stickyHeader = true
 }) {
-  const rootRef = React3.useRef(null);
-  const filterRef = React3.useRef(null);
-  const [filterH, setFilterH] = React3.useState(0);
-  React3.useLayoutEffect(() => {
-    const el = filterRef.current;
-    if (!el) return;
-    setFilterH(Math.round(el.getBoundingClientRect().height));
-  }, []);
-  React3.useEffect(() => {
-    const el = filterRef.current;
-    if (!el || typeof ResizeObserver === "undefined") return;
-    const ro = new ResizeObserver((entries) => {
-      const h = Math.round(
-        entries[0]?.contentRect.height ?? el.getBoundingClientRect().height
-      );
-      setFilterH((prev) => prev === h ? prev : h);
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
   const tableCard = "rounded border border-border bg-card overflow-hidden";
-  return /* @__PURE__ */ jsxRuntime.jsxs(
-    "div",
-    {
-      ref: rootRef,
-      style: { ["--mg-list-filter-offset"]: `${filterH}px` },
-      children: [
-        /* @__PURE__ */ jsxRuntime.jsx(
+  return /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
+    /* @__PURE__ */ jsxRuntime.jsx(
+      "div",
+      {
+        className: classNames(
+          // Sticky below `md`, in normal flow at and above it. Offset reads
+          // --mg-sticky-offset (published by AppShell to match real header +
+          // ticker height) with a fallback.
+          //
+          // The breakpoint is the same one that swaps cards for the table,
+          // and that is the whole reason for it: a page-sticky filter bar and
+          // a table header pinned inside a bounded viewport are in different
+          // scroll contexts, so once the page scrolls far enough for the
+          // table's top to pass under this bar, the bar covers the header --
+          // the column labels disappear again, by a different mechanism than
+          // the one they were just fixed for. Below `md` there is no table
+          // (cards render instead), nothing to cover, and a filter bar that
+          // follows a long list is genuinely useful, so it stays pinned.
+          //
+          // /subnets reached this conclusion first and encoded it as a
+          // page-specific override in apps/ui/src/styles.css
+          // (`#subnets-list > div > div:first-child { position: static }`,
+          // at >=1024px only, which is why tablet still showed the overlap).
+          // That override is deleted; this is the general rule.
+          "sticky md:static z-[var(--mg-z-raised)] -mx-4 md:mx-0 mb-3",
+          "bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80",
+          "border-b border-border md:border md:rounded md:bg-card",
+          "px-3 py-2 md:p-2.5"
+        ),
+        style: {
+          top: "calc(var(--mg-sticky-offset, 3.5rem) + var(--mg-tabs-h, 0px))"
+        },
+        children: /* @__PURE__ */ jsxRuntime.jsx("div", { className: "flex flex-wrap items-center gap-2", children: filters })
+      }
+    ),
+    isEmpty ? empty : /* @__PURE__ */ jsxRuntime.jsxs("div", { className: isStale ? "opacity-70 transition-opacity" : void 0, children: [
+      cards ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "md:hidden space-y-2", children: cards }) : null,
+      /* @__PURE__ */ jsxRuntime.jsx("div", { className: cards ? "hidden md:block" : void 0, children: /* @__PURE__ */ jsxRuntime.jsxs("div", { className: tableCard, children: [
+        /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-table-scroll overflow-x-auto", children: /* @__PURE__ */ jsxRuntime.jsx(
           "div",
           {
-            ref: filterRef,
-            className: classNames(
-              // Sticky filter bar. Offset reads --mg-sticky-offset (published by
-              // AppShell to match real header + ticker height) with a fallback.
-              "sticky z-[var(--mg-z-raised)] -mx-4 md:mx-0 mb-3",
-              "bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80",
-              "border-b border-border md:border md:rounded md:bg-card",
-              "px-3 py-2 md:p-2.5"
-            ),
-            style: {
-              top: "calc(var(--mg-sticky-offset, 3.5rem) + var(--mg-tabs-h, 0px))"
-            },
-            children: /* @__PURE__ */ jsxRuntime.jsx("div", { className: "flex flex-wrap items-center gap-2", children: filters })
+            ref: viewportRef,
+            className: "max-h-[var(--mg-list-viewport-max,70vh)] overflow-y-auto",
+            children: table
           }
-        ),
-        isEmpty ? empty : /* @__PURE__ */ jsxRuntime.jsxs("div", { className: isStale ? "opacity-70 transition-opacity" : void 0, children: [
-          cards ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "md:hidden space-y-2", children: cards }) : null,
-          /* @__PURE__ */ jsxRuntime.jsx("div", { className: cards ? "hidden md:block" : void 0, children: /* @__PURE__ */ jsxRuntime.jsxs("div", { className: tableCard, children: [
-            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-table-scroll overflow-x-auto", children: table }),
-            footer
-          ] }) }),
-          cards && footer ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "md:hidden mt-3", children: footer }) : null
-        ] })
-      ]
-    }
-  );
+        ) }),
+        footer
+      ] }) }),
+      cards && footer ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "md:hidden mt-3", children: footer }) : null
+    ] })
+  ] });
 }
 function LoadMore({
   hasMore,

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -215,6 +215,13 @@
   --mg-z-progress: 60;
   --mg-z-skip-link: 100;
 }
+.mg-table-head-pinned {
+  position: sticky;
+  top: 0;
+  z-index: var(--mg-z-sticky);
+  background: var(--card);
+  box-shadow: var(--mg-shadow-hairline);
+}
 .mg-glass {
   background: color-mix(in oklab, var(--card) 95%, transparent);
 }
@@ -770,6 +777,7 @@ html[data-density=compact] .bg-card > table td {
 :root {
   --mg-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
   --mg-sticky-offset: 3.5rem;
+  --mg-list-viewport-max: 70vh;
 }
 @media (prefers-reduced-motion: reduce) {
   .mg-fade-in,

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import * as React3 from 'react';
-import { createContext, forwardRef, useId, useState, useMemo, useCallback, useRef, useEffect, useLayoutEffect, useContext } from 'react';
+import { createContext, forwardRef, useId, useState, useMemo, useCallback, useRef, useEffect, useContext } from 'react';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import { ChevronDown, X, Search, Check, ArrowUp, Copy, Rows3, Rows2, Download, Info, AlertCircle, RefreshCw, Link, Link2, Share2, ChevronLeft, ChevronRight, Clock, Inbox, ExternalLink as ExternalLink$1, List, LayoutGrid, Grid3x3, ChevronUp, Globe, BookOpen, Github, LayoutDashboard, Columns3, RotateCcw, AlertTriangle, Filter, Loader2, MoreHorizontal, Lock } from 'lucide-react';
 import { jsx, jsxs, Fragment } from 'react/jsx-runtime';
@@ -2014,64 +2014,61 @@ function ListShell({
   empty,
   isEmpty,
   isStale,
+  viewportRef,
   stickyHeader: _stickyHeader = true
 }) {
-  const rootRef = useRef(null);
-  const filterRef = useRef(null);
-  const [filterH, setFilterH] = useState(0);
-  useLayoutEffect(() => {
-    const el = filterRef.current;
-    if (!el) return;
-    setFilterH(Math.round(el.getBoundingClientRect().height));
-  }, []);
-  useEffect(() => {
-    const el = filterRef.current;
-    if (!el || typeof ResizeObserver === "undefined") return;
-    const ro = new ResizeObserver((entries) => {
-      const h = Math.round(
-        entries[0]?.contentRect.height ?? el.getBoundingClientRect().height
-      );
-      setFilterH((prev) => prev === h ? prev : h);
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
   const tableCard = "rounded border border-border bg-card overflow-hidden";
-  return /* @__PURE__ */ jsxs(
-    "div",
-    {
-      ref: rootRef,
-      style: { ["--mg-list-filter-offset"]: `${filterH}px` },
-      children: [
-        /* @__PURE__ */ jsx(
+  return /* @__PURE__ */ jsxs("div", { children: [
+    /* @__PURE__ */ jsx(
+      "div",
+      {
+        className: classNames(
+          // Sticky below `md`, in normal flow at and above it. Offset reads
+          // --mg-sticky-offset (published by AppShell to match real header +
+          // ticker height) with a fallback.
+          //
+          // The breakpoint is the same one that swaps cards for the table,
+          // and that is the whole reason for it: a page-sticky filter bar and
+          // a table header pinned inside a bounded viewport are in different
+          // scroll contexts, so once the page scrolls far enough for the
+          // table's top to pass under this bar, the bar covers the header --
+          // the column labels disappear again, by a different mechanism than
+          // the one they were just fixed for. Below `md` there is no table
+          // (cards render instead), nothing to cover, and a filter bar that
+          // follows a long list is genuinely useful, so it stays pinned.
+          //
+          // /subnets reached this conclusion first and encoded it as a
+          // page-specific override in apps/ui/src/styles.css
+          // (`#subnets-list > div > div:first-child { position: static }`,
+          // at >=1024px only, which is why tablet still showed the overlap).
+          // That override is deleted; this is the general rule.
+          "sticky md:static z-[var(--mg-z-raised)] -mx-4 md:mx-0 mb-3",
+          "bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80",
+          "border-b border-border md:border md:rounded md:bg-card",
+          "px-3 py-2 md:p-2.5"
+        ),
+        style: {
+          top: "calc(var(--mg-sticky-offset, 3.5rem) + var(--mg-tabs-h, 0px))"
+        },
+        children: /* @__PURE__ */ jsx("div", { className: "flex flex-wrap items-center gap-2", children: filters })
+      }
+    ),
+    isEmpty ? empty : /* @__PURE__ */ jsxs("div", { className: isStale ? "opacity-70 transition-opacity" : void 0, children: [
+      cards ? /* @__PURE__ */ jsx("div", { className: "md:hidden space-y-2", children: cards }) : null,
+      /* @__PURE__ */ jsx("div", { className: cards ? "hidden md:block" : void 0, children: /* @__PURE__ */ jsxs("div", { className: tableCard, children: [
+        /* @__PURE__ */ jsx("div", { className: "mg-table-scroll overflow-x-auto", children: /* @__PURE__ */ jsx(
           "div",
           {
-            ref: filterRef,
-            className: classNames(
-              // Sticky filter bar. Offset reads --mg-sticky-offset (published by
-              // AppShell to match real header + ticker height) with a fallback.
-              "sticky z-[var(--mg-z-raised)] -mx-4 md:mx-0 mb-3",
-              "bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80",
-              "border-b border-border md:border md:rounded md:bg-card",
-              "px-3 py-2 md:p-2.5"
-            ),
-            style: {
-              top: "calc(var(--mg-sticky-offset, 3.5rem) + var(--mg-tabs-h, 0px))"
-            },
-            children: /* @__PURE__ */ jsx("div", { className: "flex flex-wrap items-center gap-2", children: filters })
+            ref: viewportRef,
+            className: "max-h-[var(--mg-list-viewport-max,70vh)] overflow-y-auto",
+            children: table
           }
-        ),
-        isEmpty ? empty : /* @__PURE__ */ jsxs("div", { className: isStale ? "opacity-70 transition-opacity" : void 0, children: [
-          cards ? /* @__PURE__ */ jsx("div", { className: "md:hidden space-y-2", children: cards }) : null,
-          /* @__PURE__ */ jsx("div", { className: cards ? "hidden md:block" : void 0, children: /* @__PURE__ */ jsxs("div", { className: tableCard, children: [
-            /* @__PURE__ */ jsx("div", { className: "mg-table-scroll overflow-x-auto", children: table }),
-            footer
-          ] }) }),
-          cards && footer ? /* @__PURE__ */ jsx("div", { className: "md:hidden mt-3", children: footer }) : null
-        ] })
-      ]
-    }
-  );
+        ) }),
+        footer
+      ] }) }),
+      cards && footer ? /* @__PURE__ */ jsx("div", { className: "md:hidden mt-3", children: footer }) : null
+    ] })
+  ] });
 }
 function LoadMore({
   hasMore,

--- a/packages/ui-kit/src/components/metagraphed/list-shell.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/list-shell.test.ts
@@ -8,21 +8,33 @@ const source = readFileSync(
 );
 
 describe("ListShell sticky table wrappers", () => {
-  it("sticks the <thead> to the page scroll instead of a bounded internal viewport", () => {
-    // The table's <thead> sticks against the *page* scroll (offset by the app
-    // header + the filter bar's measured height), not an internal
-    // overflow-bounded wrapper -- so there is no nested vertical scrollbar.
-    // The wrapper only ever scrolls horizontally, on any viewport.
+  it("bounds the table wrapper so a `sticky top-0` <thead> has something to pin against", () => {
+    // This assertion is the inverse of the one it replaces, which required
+    // the <thead> to stick against the PAGE with "no nested vertical
+    // scrollbar". That arrangement is unreachable: `overflow-x: auto` makes
+    // the wrapper a scroll container on BOTH axes (CSS Overflow 3 §3 coerces
+    // a `visible` axis to `auto` when the other axis isn't `visible`), so it
+    // is always the header's containing block. Unbounded, it never scrolls,
+    // and `sticky top-0` silently resolved to a no-op on every table in this
+    // shell -- verified in a browser on /chain/blocks: computed
+    // `overflow: auto/auto` with scrollHeight === clientHeight.
     expect(source).toContain('"mg-table-scroll overflow-x-auto"');
+    // The cap is a token, not a literal -- /validators builds its own shell
+    // and has to agree with this one.
+    expect(source).toContain(
+      '"max-h-[var(--mg-list-viewport-max,70vh)] overflow-y-auto"',
+    );
     expect(source).not.toContain("overflow-x-clip");
     expect(source).not.toContain("overflow-y-clip");
   });
 
-  it("publishes the filter bar's measured height so the table header can offset below it", () => {
-    // ResizeObserver-measured filter height, published as a CSS var on the
-    // root wrapper -- the sticky offset math reads --mg-sticky-offset
-    // (from AppShell) plus this to land the <thead> just below the filter bar.
-    expect(source).toContain("--mg-list-filter-offset");
+  it("no longer publishes a filter-height offset for the header to read", () => {
+    // --mg-list-filter-offset existed so a page-sticky <thead> could clear
+    // the filter bar. Nothing ever read it (it was published, never
+    // consumed), and a header pinned to its own scrollport has no use for
+    // it -- the correct offset there is 0, independent of page chrome.
+    expect(source).not.toContain("--mg-list-filter-offset");
+    expect(source).not.toContain("ResizeObserver");
   });
 
   it("stacks the filter bar below the page's sticky tab strip, not on top of it", () => {

--- a/packages/ui-kit/src/components/metagraphed/list-shell.tsx
+++ b/packages/ui-kit/src/components/metagraphed/list-shell.tsx
@@ -1,10 +1,4 @@
-import {
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
+import { type ReactNode, type RefObject } from "react";
 import { AlertCircle, RefreshCw } from "lucide-react";
 import { classNames } from "@/lib/format";
 import { Skeleton } from "./skeleton";
@@ -18,10 +12,17 @@ import { Skeleton } from "./skeleton";
  *   fallback for tabular data.
  * - `table` renders on viewports >= md with horizontal scroll for overflow.
  *
- * The table's <thead> sticks against the *page* scroll (offset by the
- * app header + this filter bar) rather than an internal bounded viewport,
- * so there is no nested vertical scrollbar. The wrapper only scrolls
- * horizontally when a wide table overflows on narrow viewports.
+ * The table's <thead> sticks against the bounded viewport this shell puts
+ * around it, so consumers pin their header with `sticky top-0` and nothing
+ * else. That is the ONE pattern -- a <thead> cannot stick against the page
+ * from in here, and every attempt to make it do so has been inert: an
+ * `overflow-x: auto` wrapper computes `overflow-y` to `auto` too (CSS
+ * Overflow 3 §3: a non-`visible` value on one axis coerces the other), so
+ * this wrapper is unavoidably the header's scroll container. Without a
+ * max-height it simply never scrolls, and `sticky top-0` resolved to a
+ * no-op on /chain/blocks, /chain/extrinsics, and three component tables --
+ * headers that read as sticky in the markup but scrolled away in the
+ * browser. Bounding the wrapper is what makes the declaration real.
  */
 export function ListShell({
   filters,
@@ -31,6 +32,7 @@ export function ListShell({
   empty,
   isEmpty,
   isStale,
+  viewportRef,
   stickyHeader: _stickyHeader = true,
 }: {
   filters: ReactNode;
@@ -41,45 +43,44 @@ export function ListShell({
   isEmpty?: boolean;
   /** Subtly dim loaded content while a background refetch is in flight. */
   isStale?: boolean;
-  /** Retained for API compatibility -- header stickiness is now always
-   *  page-scroll relative and needs no per-instance opt-in. */
+  /**
+   * Handle on the bounded viewport, for a virtualizer's `getScrollElement`.
+   *
+   * Exists so a virtualized route doesn't hand-roll a second bounded div
+   * inside this one just to own a ref -- /subnets did exactly that and ended
+   * up with two nested `max-h-[70vh]` scrollers, the outer one permanently
+   * inert. There is one viewport per list, and this is how you reach it.
+   */
+  viewportRef?: RefObject<HTMLDivElement | null>;
+  /** Retained for API compatibility -- every table in this shell gets the
+   *  bounded viewport, so stickiness needs no per-instance opt-in. */
   stickyHeader?: boolean;
 }) {
-  // Measure the filter bar and publish its height as --mg-list-filter-offset
-  // on the root wrapper so the table's <thead> can stick just below it.
-  const rootRef = useRef<HTMLDivElement>(null);
-  const filterRef = useRef<HTMLDivElement>(null);
-  const [filterH, setFilterH] = useState(0);
-  useLayoutEffect(() => {
-    const el = filterRef.current;
-    if (!el) return;
-    setFilterH(Math.round(el.getBoundingClientRect().height));
-  }, []);
-  useEffect(() => {
-    const el = filterRef.current;
-    if (!el || typeof ResizeObserver === "undefined") return;
-    const ro = new ResizeObserver((entries) => {
-      const h = Math.round(
-        entries[0]?.contentRect.height ?? el.getBoundingClientRect().height,
-      );
-      setFilterH((prev) => (prev === h ? prev : h));
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
-
   const tableCard = "rounded border border-border bg-card overflow-hidden";
   return (
-    <div
-      ref={rootRef}
-      style={{ ["--mg-list-filter-offset" as string]: `${filterH}px` }}
-    >
+    <div>
       <div
-        ref={filterRef}
         className={classNames(
-          // Sticky filter bar. Offset reads --mg-sticky-offset (published by
-          // AppShell to match real header + ticker height) with a fallback.
-          "sticky z-[var(--mg-z-raised)] -mx-4 md:mx-0 mb-3",
+          // Sticky below `md`, in normal flow at and above it. Offset reads
+          // --mg-sticky-offset (published by AppShell to match real header +
+          // ticker height) with a fallback.
+          //
+          // The breakpoint is the same one that swaps cards for the table,
+          // and that is the whole reason for it: a page-sticky filter bar and
+          // a table header pinned inside a bounded viewport are in different
+          // scroll contexts, so once the page scrolls far enough for the
+          // table's top to pass under this bar, the bar covers the header --
+          // the column labels disappear again, by a different mechanism than
+          // the one they were just fixed for. Below `md` there is no table
+          // (cards render instead), nothing to cover, and a filter bar that
+          // follows a long list is genuinely useful, so it stays pinned.
+          //
+          // /subnets reached this conclusion first and encoded it as a
+          // page-specific override in apps/ui/src/styles.css
+          // (`#subnets-list > div > div:first-child { position: static }`,
+          // at >=1024px only, which is why tablet still showed the overlap).
+          // That override is deleted; this is the general rule.
+          "sticky md:static z-[var(--mg-z-raised)] -mx-4 md:mx-0 mb-3",
           "bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80",
           "border-b border-border md:border md:rounded md:bg-card",
           "px-3 py-2 md:p-2.5",
@@ -102,7 +103,29 @@ export function ListShell({
           {cards ? <div className="md:hidden space-y-2">{cards}</div> : null}
           <div className={cards ? "hidden md:block" : undefined}>
             <div className={tableCard}>
-              <div className="mg-table-scroll overflow-x-auto">{table}</div>
+              {/* Two nested wrappers, one axis each. The outer keeps the
+                  edge-fade mask and thin horizontal scrollbar that
+                  .mg-table-scroll styles; the inner is the bounded viewport
+                  the <thead> pins against. `max-h` (not `h`) means a short
+                  table is untouched -- the cap only engages once the list is
+                  taller than the screen, which is exactly when a header that
+                  scrolls away starts costing the reader the column labels. */}
+              <div className="mg-table-scroll overflow-x-auto">
+                <div
+                  ref={viewportRef}
+                  // Token WITH a fallback, matching how the rest of the app
+                  // reads --mg-sticky-offset. A bare `var(--x)` that fails to
+                  // resolve computes `max-height: none` -- no cap, so the
+                  // viewport is unbounded, so the sticky <thead> is inert
+                  // again. That is this exact bug, reintroduced silently by
+                  // the thing meant to prevent it, and it is not theoretical:
+                  // it happened once already here, and every list route in
+                  // the e2e sweep went red at once. The literal is the floor.
+                  className="max-h-[var(--mg-list-viewport-max,70vh)] overflow-y-auto"
+                >
+                  {table}
+                </div>
+              </div>
               {footer}
             </div>
           </div>

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -431,6 +431,28 @@
  * softer `bg-card/60` inset panels. Both compose var(--card), so they
  * theme automatically -- no separate dark-mode override needed.
  * ============================================================ */
+/* A table header pinned inside a bounded list viewport (ListShell's, or a
+   route that builds its own). One definition so every list agrees on where
+   the header sits and what it looks like.
+
+   `top: 0` because the viewport it pins to IS the reference -- never
+   --mg-sticky-offset, which measures the app-header stack and belongs to
+   things sticking against the PAGE. Getting that wrong is what put the
+   /subnets column labels 131px down inside their own table.
+
+   Opaque, deliberately, where these headers used to be `mg-glass` (80% where
+   backdrop-filter is supported). Glass was harmless while the headers were
+   inert and never actually overlapped anything; the moment they started
+   pinning for real, the row passing underneath read straight through the
+   column labels. Nothing shows through an opaque header. */
+.mg-table-head-pinned {
+  position: sticky;
+  top: 0;
+  z-index: var(--mg-z-sticky);
+  background: var(--card);
+  box-shadow: var(--mg-shadow-hairline);
+}
+
 .mg-glass {
   background: color-mix(in oklab, var(--card) 95%, transparent);
 }
@@ -1106,6 +1128,13 @@ html[data-density="compact"] .bg-card > table td {
 :root {
   --mg-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
   --mg-sticky-offset: 3.5rem;
+  /* How tall a list's bounded scroll viewport may grow before it scrolls
+     internally -- the box a sticky <thead> pins to at top: 0. Proportional
+     rather than a pixel constant so it tracks the viewport, and defined once
+     because two places need to agree on it: ListShell (every list route) and
+     /validators, which builds its own shell. When they disagreed by hand
+     nothing broke loudly -- the tables just capped at different heights. */
+  --mg-list-viewport-max: 70vh;
 }
 @media (prefers-reduced-motion: reduce) {
   .mg-fade-in,
@@ -1604,10 +1633,11 @@ html[data-density="compact"] .bg-card > table td {
 
 /* Horizontal-scroll fade mask for wide data tables — soft-clips left/right
    edges instead of hard-cutting mid-column so users see there's more to
-   scroll. The table's <thead> sticks against the page scroll (under the
-   filter bar) via --mg-sticky-offset + --mg-list-filter-offset (published by
-   ListShell), so the wrapper itself never needs to scroll vertically -- no
-   nested scrollbar. */
+   scroll. Horizontal only: ListShell nests a `max-h-[70vh] overflow-y-auto`
+   div inside this one, and THAT is the viewport a sticky <thead> pins
+   against (`top: 0`). Don't put a max-height on this element instead -- the
+   mask would then fade the pinned header's own left/right edges as it
+   travels. */
 .mg-table-scroll {
   mask-image: linear-gradient(
     to right,


### PR DESCRIPTION
## What was wrong

The `/subnets` column labels rendered a third of the way down the table, floating over the first three rows. Three defects, one cause — every past fix reasoned about *page* scroll without checking which element was actually the sticky header's containing block.

**1. Wrong offset (the reported bug).** `.mg-subnets-sticky-head` pinned with `top: var(--mg-sticky-offset)` — the app-header stack height, measured live at **131px**. But #8314 had already made the table an internally-scrolling `max-h-[70vh]` box and never updated the CSS, so sticky held the header 131px *below* that box's top edge on every frame.

> Measured before the fix: container top `559px`, header top `690px`, in a `504px`-tall scrollport.

**2. Wrong breakpoint.** That rule was gated to `≥1024px` while the table renders from `768px` (ListShell swaps to cards below it) — two hardcoded breakpoints that had to agree and didn't. At 900px the header computed `position: static` and scrolled out of the box entirely, leaving 129 rows of unlabelled numbers.

**3. Sticky headers that were dead code.** ListShell's doc comment *and its test* both asserted the `<thead>` sticks against the page with "no nested vertical scrollbar." That is unreachable: `overflow-x: auto` coerces `overflow-y` to `auto` (CSS Overflow 3 §3), so the wrapper is always the containing block — and unbounded, it never scrolls. `sticky top-0` was a no-op on `/chain/blocks`, `/chain/extrinsics`, validator-nominators, emission-pipeline and call-module-extrinsics.

> Confirmed in a browser on `/chain/blocks`: computed `overflow: auto/auto`, `scrollHeight === clientHeight`.

## What changed

One definition — `.mg-table-head-pinned` in ui-kit — used by all seven tables, pinning at `top: 0` to a single bounded viewport that ListShell owns. `/subnets`' bespoke `.mg-subnets-sticky-head` copy is deleted; a second definition of "how a table header sticks" is what let it drift.

- `/subnets` hands its virtualizer ref to that viewport via a new `viewportRef` prop, instead of nesting a second `max-h` div inside it (which had left the outer of the two permanently inert).
- Removed the `#subnets-list` `:has()` overflow overrides and `--mg-list-filter-offset` (published, read by nothing) — both leftovers of the abandoned page-sticky arrangement.
- The filter bar sits in normal flow at `≥md`, so it can't cover the header it sits above. This generalises the `≥1024px` override `/subnets` already carried, which is why tablet still showed the overlap.
- Headers are opaque rather than `mg-glass` (80% where `backdrop-filter` is supported). Harmless while they were inert; once they genuinely pinned, the row passing underneath read through the column labels.

### On the one remaining literal

The viewport cap is `var(--mg-list-viewport-max,70vh)` — token **with** a literal fallback, matching how the app already reads `var(--mg-sticky-offset, 3.5rem)`. A bare `var()` that fails to resolve computes `max-height: none`, which unbounds the viewport and makes every sticky header inert again. That is not hypothetical: it regressed mid-change and turned the entire e2e sweep red at once.

## Verification

The guard (`tests/e2e/sticky-table-header.spec.ts`) measures real layout, because `sticky top-0` is textually identical in the broken and fixed trees — no source-grep test can tell them apart. **It was verified to fail on the pre-fix tree** (all four ListShell cases) before being trusted.

Its "does this container actually scroll" threshold is the header's own height rather than a constant: `/chain/extrinsics` reported a 3px sub-pixel scroll range that satisfied a naive `> clientHeight` check and passed on a broken tree.

| Check | Result |
| --- | --- |
| `sticky-table-header.spec.ts` | 6/6 |
| `responsive-overflow.spec.ts` | 88/88 — no new violations from the layout change |
| ui-kit vitest | 121/121 |
| typecheck (`apps/ui`, `packages/ui-kit`) | clean |
| lint | 0 errors |

Manually verified at 390 / 768 / 1024 / 1440px on `/subnets` and `/chain/blocks`, scrolled inside each table: header pinned flush at `drift=0` in every case.

## Notes

- `packages/ui-kit/dist/` is tracked and regenerated here, so it's in the same commit.
- **Known residual, pre-existing:** on `/chain/*` the hub tab strip is page-sticky, so scrolling to the very bottom can slide a table's top under it and hide the pinned header. Same class as the filter-bar overlap fixed here, but the tab strip is hub-wide navigation — de-stickying it is a nav decision, not a table fix, so it's left alone.
