### PR TITLE
fix(api): recent blocks reported zero events, and eight more correctness gaps alongside it

### DIFF
--- a/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
@@ -143,8 +143,11 @@ export function LiveBlockRail() {
             </span>
           </div>
           <div className="mt-0.5 mg-type-data-sm text-ink-muted">
-            {formatNumber(latest.extrinsic_count ?? 0)} ext ·{" "}
-            {formatNumber(latest.event_count ?? 0)} evt
+            {/* An unknown count renders as "—", never as 0: the newest blocks
+                sit ahead of the decode sync, so `?? 0` claimed "0 evt" for
+                exactly the blocks this live rail exists to show. */}
+            {latest.extrinsic_count == null ? "—" : formatNumber(latest.extrinsic_count)} ext ·{" "}
+            {latest.event_count == null ? "—" : formatNumber(latest.event_count)} evt
           </div>
         </div>
       </div>

--- a/apps/ui/src/routes/-blocks-ref-page.tsx
+++ b/apps/ui/src/routes/-blocks-ref-page.tsx
@@ -260,16 +260,21 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
           );
           return (
             <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              {/* `?? 0` here reported "0 events" for any block whose count is
+                  merely unknown -- true for every block newer than the decode
+                  sync's head. A count we do not have is not a count of zero,
+                  and the Success tile below already renders that distinction
+                  correctly. */}
               <StatTile
                 icon={FileText}
                 eyebrow="Extrinsics"
-                value={formatNumber(block.extrinsic_count ?? 0)}
+                value={block.extrinsic_count == null ? "—" : formatNumber(block.extrinsic_count)}
                 tooltip={BLOCK_TERM_HINTS.extrinsic}
               />
               <StatTile
                 icon={Zap}
                 eyebrow="Events"
-                value={formatNumber(block.event_count ?? 0)}
+                value={block.event_count == null ? "—" : formatNumber(block.event_count)}
                 tooltip={BLOCK_TERM_HINTS.event}
               />
               <StatTile
@@ -377,12 +382,12 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
             </FieldRow>
             <FieldRow label="Extrinsics">
               <span className="font-mono text-sm text-ink tabular-nums">
-                {formatNumber(block.extrinsic_count ?? 0)}
+                {block.extrinsic_count == null ? "—" : formatNumber(block.extrinsic_count)}
               </span>
             </FieldRow>
             <FieldRow label="Events">
               <span className="font-mono text-sm text-ink tabular-nums">
-                {formatNumber(block.event_count ?? 0)}
+                {block.event_count == null ? "—" : formatNumber(block.event_count)}
               </span>
             </FieldRow>
             <FieldRow label="Observed at">

--- a/src/account-entities-answer.ts
+++ b/src/account-entities-answer.ts
@@ -1,0 +1,63 @@
+// The ONE composer for /api/v1/accounts/{ss58}/entities. REST, MCP and GraphQL
+// all reach the ownership half of the payload through this module and none of
+// them decides the tier order itself.
+//
+// WHY A COMPOSER AND NOT THREE CASCADES. The lakehouse leg was wired into the
+// REST handler alone. METAGRAPH_SUBNET_OWNERSHIP_SOURCE is retired, so
+// tryPostgresTier declines unconditionally, and MCP and GraphQL fell straight
+// to `buildAccountEntities(coldkey, { entities: [] })`: for a coldkey that HAS
+// won or lost a subnet they published `ownership_ties: []`, which
+// get_account_entities' own description reads as "this coldkey has never
+// transferred a subnet". The community-label half is identical on all three
+// surfaces, so the response looked fully populated while the on-chain half was
+// silently missing.
+//
+// This is the same shape src/subnet-ownership-answer.ts and
+// src/rpc-usage-answer.ts already fixed for their routes, and
+// tests/subnet-ownership-surface-parity.test.ts enforces the rule those
+// established: a surface may not import a tier reader directly, because
+// "which store answers, and what an absence means" is one decision, not three.
+//
+// THE TIER PROBE STAYS WITH THE SURFACE, deliberately. tryPostgresTier needs a
+// Request, and each surface has a different one -- REST forwards the caller's,
+// MCP and GraphQL synthesize theirs. So the surface performs its own probe and
+// hands the RESULT here; this module owns everything after it, which is the
+// part that drifted.
+//
+// A DECLINE IS NOT AN EMPTY. A cold-tier null means the lakehouse could not be
+// read; only after it declines does the schema-stable empty apply. Callers must
+// not turn a decline into `[]` themselves -- that is the bug this module exists
+// to make unrepresentable.
+
+import { loadAccountEntitiesColdTier } from "./subnet-ownership-cold-tier.ts";
+import { buildAccountEntities } from "./entity-labels.ts";
+
+type Row = Record<string, unknown>;
+
+export interface AnswerAccountEntitiesOptions {
+  coldTier?: typeof loadAccountEntitiesColdTier;
+}
+
+/**
+ * One coldkey's entity payload, with the ownership ties resolved from whichever
+ * store can answer.
+ *
+ * `tierResult` is the surface's own tryPostgresTier outcome: a payload when the
+ * tier answered, null when it declined or is retired.
+ *
+ * Never returns null -- the empty payload is the documented floor once every
+ * store has declined, and it is applied HERE so all three surfaces reach it by
+ * the same route.
+ */
+export async function answerAccountEntities(
+  env: unknown,
+  coldkey: string,
+  tierResult: Row | null | undefined,
+  { coldTier = loadAccountEntitiesColdTier }: AnswerAccountEntitiesOptions = {},
+): Promise<Row> {
+  return (
+    tierResult ??
+    ((await coldTier(env as never, coldkey)) as Row | null) ??
+    (buildAccountEntities(coldkey, { entities: [] }) as unknown as Row)
+  );
+}

--- a/src/account-events.ts
+++ b/src/account-events.ts
@@ -721,16 +721,45 @@ export function buildBlockEvents(
   rows: Array<Record<string, unknown>> | null | undefined,
   ref: unknown,
   blockNumber: number | null,
-  { limit, offset }: { limit?: number | null; offset?: number | null } = {},
+  {
+    limit,
+    offset,
+    totalCount,
+  }: {
+    limit?: number | null;
+    offset?: number | null;
+    /**
+     * The block's TOTAL event count, when the caller knows it.
+     *
+     * `event_count` used to be `events.length` unconditionally -- the size of
+     * the page, published under a name every consumer reads as the block's
+     * total. Measured on block 8,771,446: ?limit=5 said 5, ?limit=100 said 100,
+     * ?limit=320 said 237, so no page size revealed the real number and a
+     * client could not tell when it had seen everything.
+     *
+     * Callers pass this only when they actually know it (the hot tier reads it
+     * from the coverage register; the cold tier derives it when its page ran
+     * short of the requested window, which proves the end was reached). When it
+     * is genuinely unknown the page length is still the honest best answer for
+     * a non-nullable field, and behaviour is unchanged.
+     */
+    totalCount?: number | null;
+  } = {},
 ): BlockEventsResult {
   const events = (rows || [])
     .map(formatAccountEvent)
     .filter((e): e is AccountEvent => Boolean(e));
+  const known =
+    typeof totalCount === "number" &&
+    Number.isFinite(totalCount) &&
+    totalCount >= 0
+      ? Math.trunc(totalCount)
+      : null;
   return {
     schema_version: 1,
     ref: ref ?? null,
     block_number: blockNumber ?? null,
-    event_count: events.length,
+    event_count: known ?? events.length,
     limit: limit ?? null,
     offset: offset ?? null,
     events,

--- a/src/blocks-cold-tier.ts
+++ b/src/blocks-cold-tier.ts
@@ -72,9 +72,34 @@ export const BLOCKS_SEAM_ENV = "ICEBERG_BLOCKS_MAX";
  */
 export const DEFAULT_BLOCKS_SEAM = 8_759_336;
 
-/** Columns blocks_head actually has. Anything else is null above the seam. */
-const D1_COLUMNS =
-  "block_number, block_hash, parent_hash, extrinsic_count, observed_at";
+// `blocks_head` carries only the core columns (block_number, block_hash,
+// parent_hash, extrinsic_count, observed_at). `spec_version` and the per-block
+// event count live in the live-follow hot tier's coverage register
+// (`chain_detail_blocks`, #9240) -- the SAME D1 database, keyed by the same
+// block_number -- so reading blocks_head alone published `event_count: null`
+// for every block above the seam even though the count was sitting one join
+// away. The UI renders that null as `0`, so a block with 320 events showed
+// "Events 0" while the same page's pallet breakdown (fed by /chain-events off
+// the hot tier) said 320.
+//
+// LEFT, never INNER: the hot tier keeps a SHORTER window than blocks_head
+// (measured 2026-08-04: chain_detail_blocks 8,769,690-8,771,490 vs blocks_head
+// 8,755,245-8,771,492). A block the hot tier has pruned past must still return
+// its core columns with an honest null count -- null means "not known here",
+// which is exactly what it meant before, just no longer for blocks the register
+// does hold.
+//
+// `event_count` is the RAW pallet-event count, matching what the lakehouse
+// column of that name means below the seam: verified on block 8,771,000, where
+// the lakehouse reports 268 and /chain-events counts 268. That is
+// `chain_event_count`, NOT `account_event_count` (the curated subset).
+const D1_SELECT =
+  "b.block_number, b.block_hash, b.parent_hash, b.extrinsic_count, " +
+  "b.observed_at, c.spec_version AS spec_version, " +
+  "c.chain_event_count AS event_count";
+const D1_FROM =
+  "blocks_head b LEFT JOIN chain_detail_blocks c " +
+  "ON c.block_number = b.block_number";
 
 interface D1Like {
   prepare(sql: string): {
@@ -167,9 +192,17 @@ export async function lakehouseHeadBlock(
 }
 
 /**
- * Whether the D1 leg can honour this query at all. Filters over columns
- * blocks_head does not carry must NOT be silently dropped, so their presence
- * disqualifies the leg rather than being ignored.
+ * Whether the D1 leg can honour this query at all. Filters over columns the
+ * leg cannot evaluate for EVERY row in its range must NOT be silently
+ * dropped, so their presence disqualifies the leg rather than being ignored.
+ *
+ * `spec_version` and `event_count` are now READABLE via the
+ * chain_detail_blocks join above, but they are still not FILTERABLE here: the
+ * hot tier's window is shorter than blocks_head's range, so a block outside it
+ * joins to null and would be silently excluded by `spec_version = ?` or
+ * `event_count >= ?` -- dropping rows the caller never excluded. Being able to
+ * report a value is not the same as being able to filter on it. `author` is
+ * carried by neither table, so it disqualifies the leg outright.
  */
 export function d1CanServe(query: BlockFeedQuery): boolean {
   return (
@@ -189,20 +222,23 @@ async function d1HeadRows(
   const db = bindings(env).METAGRAPH_HEALTH_DB;
   if (!db?.prepare || want <= 0) return null;
 
-  const where: string[] = ["block_number > ?"];
+  // Every predicate is qualified to `b`: block_number, observed_at and
+  // extrinsic_count all exist on BOTH sides of the join, so an unqualified
+  // reference is an "ambiguous column name" error, not a silent wrong answer.
+  const where: string[] = ["b.block_number > ?"];
   const params: unknown[] = [seam];
   if (cursor) {
     // The same 2-part (observed_at, block_number) seek the other tiers issue
     // for this token; SQLite row values keep it a single bound comparison.
-    where.push("(observed_at, block_number) < (?, ?)");
+    where.push("(b.observed_at, b.block_number) < (?, ?)");
     params.push(cursor[0], cursor[1]);
   }
   for (const [value, clause] of [
-    [query.blockStart, "block_number >= ?"],
-    [query.blockEnd, "block_number <= ?"],
-    [query.from, "observed_at >= ?"],
-    [query.to, "observed_at <= ?"],
-    [query.minExtrinsics, "extrinsic_count >= ?"],
+    [query.blockStart, "b.block_number >= ?"],
+    [query.blockEnd, "b.block_number <= ?"],
+    [query.from, "b.observed_at >= ?"],
+    [query.to, "b.observed_at <= ?"],
+    [query.minExtrinsics, "b.extrinsic_count >= ?"],
   ] as [unknown, string][]) {
     if (value == null) continue;
     const n = safeBlockNumber(value);
@@ -216,8 +252,8 @@ async function d1HeadRows(
   try {
     const res = await db
       .prepare(
-        `SELECT ${D1_COLUMNS} FROM blocks_head WHERE ${where.join(" AND ")}
-         ORDER BY observed_at DESC, block_number DESC LIMIT ?`,
+        `SELECT ${D1_SELECT} FROM ${D1_FROM} WHERE ${where.join(" AND ")}
+         ORDER BY b.observed_at DESC, b.block_number DESC LIMIT ?`,
       )
       .bind(...params, want)
       .all?.();
@@ -365,11 +401,11 @@ export async function loadBlockColdTier(
   if (db?.prepare && (aboveSeam || asHash !== null)) {
     try {
       const predicate =
-        asNumber !== null ? "block_number = ?" : "lower(block_hash) = ?";
+        asNumber !== null ? "b.block_number = ?" : "lower(b.block_hash) = ?";
       const value = asNumber !== null ? asNumber : asHash!;
       const res = await db
         .prepare(
-          `SELECT ${D1_COLUMNS} FROM blocks_head WHERE ${predicate} LIMIT 1`,
+          `SELECT ${D1_SELECT} FROM ${D1_FROM} WHERE ${predicate} LIMIT 1`,
         )
         .bind(value)
         .all?.();

--- a/src/chain-detail-hot-tier.ts
+++ b/src/chain-detail-hot-tier.ts
@@ -227,7 +227,17 @@ export async function loadBlockEventsHotTier(
     [height, limit, offset],
   );
   if (rows === null) return null;
-  return buildBlockEvents(rows, ref, height, { limit, offset });
+  // The block's TRUE event total, from the coverage register the sync writes
+  // alongside these rows -- an indexed primary-key lookup, not a scan. Without
+  // it `event_count` was just this page's length, so it tracked `limit` instead
+  // of the block.
+  const totals = await query(
+    env,
+    "SELECT account_event_count FROM chain_detail_blocks WHERE block_number = ? LIMIT 1",
+    [height],
+  );
+  const totalCount = safeBlockNumber(totals?.[0]?.account_event_count);
+  return buildBlockEvents(rows, ref, height, { limit, offset, totalCount });
 }
 
 export interface ChainEventApi {

--- a/src/events-cold-tier.ts
+++ b/src/events-cold-tier.ts
@@ -258,7 +258,12 @@ export async function loadBlockEventsColdTier(
   );
   if (rows === null) return null;
   const window = offset > 0 ? rows.slice(offset) : rows;
-  return buildBlockEvents(window, ref, height, { limit, offset });
+  // A short read PROVES the end of the block was reached, so `rows.length` is
+  // the block's true total -- free, no second query. A full read means there may
+  // be more beyond the window, so the total stays unknown and `event_count`
+  // falls back to the page length rather than inventing a ceiling.
+  const totalCount = rows.length < limit + offset ? rows.length : null;
+  return buildBlockEvents(window, ref, height, { limit, offset, totalCount });
 }
 
 /** A block hash resolved to its height, or the height itself. */

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -234,8 +234,6 @@ import {
   clampLimit,
   clampOffset,
 } from "../workers/request-params.ts";
-import { buildSubnetIdentityHistory } from "./subnet-identity-history.ts";
-import { buildChainIdentityHistory } from "./chain-identity-history.ts";
 import {
   buildGlobalHealth,
   formatLeaderboards,
@@ -305,7 +303,6 @@ import {
 } from "./account-weight-setters.ts";
 import {
   ENTITY_LABELS_ARTIFACT,
-  buildAccountEntities,
   entityLabelsIndex,
   labelsForSs58,
 } from "./entity-labels.ts";
@@ -345,6 +342,12 @@ import {
   MAX_OHLC_WINDOW_DAYS,
 } from "./subnet-ohlc.ts";
 import { loadSubnetOhlcColdTier } from "./subnet-ohlc-cold-tier.ts";
+import { answerSubnetEvents } from "./subnet-events-answer.ts";
+import {
+  answerChainIdentityHistory,
+  answerSubnetIdentityHistory,
+} from "./identity-history-answer.ts";
+import { answerAccountEntities } from "./account-entities-answer.ts";
 import { loadValidatorNominatorsColdTier } from "./account-feeds-cold-tier.ts";
 import { loadAccountPositionsColdTier } from "./nominator-positions-cold-tier.ts";
 import { loadAccountPositionsD1 } from "./nominator-positions-hot-tier.ts";
@@ -360,7 +363,6 @@ import {
 } from "./accounts-list.ts";
 import {
   buildAccountEvents,
-  buildSubnetEvents,
   buildAccountSubnets,
   buildAccountSummary,
   buildAccountTransfers,
@@ -1387,7 +1389,20 @@ function paginate(
   let start = 0;
   if (cursor) {
     const idx = items.findIndex((item: Row) => String(keyFn(item)) === cursor);
-    if (idx >= 0) start = idx + 1;
+    // A cursor that matches no row is STALE, not absent. Leaving `start` at 0
+    // silently restarted the caller at page 1 and still emitted a next_cursor,
+    // so a client walked page 1 -> page 1 -> page 1 forever while `total` kept
+    // reporting thousands. These lists are keyed by identity (e.g. `validators`
+    // by hotkey) over rows read live and ordered by a live metric, so a row
+    // disappearing between two page fetches is ordinary, not exceptional.
+    //
+    // Terminating is the honest answer available here: the key is opaque, so
+    // there is no order to seek to an insertion point with, and the alternatives
+    // are an infinite loop or a hard error on a condition the client did nothing
+    // wrong to cause. An empty final page with next_cursor: null ends the walk
+    // cleanly; the client re-queries from the start if it wants the remainder.
+    if (idx < 0) return { page: [], total: items.length, nextCursor: null };
+    start = idx + 1;
   }
   const page = items.slice(start, start + safeLimit);
   const nextCursor =
@@ -2511,7 +2526,7 @@ const rootValue = {
     // retired (2026-07-16), so a Postgres miss/outage degrades straight to
     // the schema-stable empty timeline (entry_count 0), never a GraphQL
     // error and never a live D1 read.
-    const data =
+    const tierResult =
       ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
@@ -2520,12 +2535,16 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_SUBNET_IDENTITY_SOURCE",
-      )) as Row | null) ??
-      buildSubnetIdentityHistory([], netuid, {
-        limit: safeLimit,
-        offset: safeOffset,
-        nextCursor: null,
-      });
+      )) as Row | null) ?? null;
+    // Through the composer (src/identity-history-answer.ts) -- the lakehouse leg
+    // it owns is why this resolver no longer answers entry_count 0 while REST
+    // serves the timeline.
+    const data = await answerSubnetIdentityHistory(
+      context.env,
+      netuid,
+      tierResult,
+      { limit: safeLimit, offset: safeOffset, cursor: null },
+    );
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -2550,12 +2569,15 @@ const rootValue = {
     // D1 retirement: subnet_identity_history's D1 write path is retired
     // (2026-07-16), so a Postgres miss/outage degrades to a schema-stable
     // empty feed (count 0), never a GraphQL error.
-    const data =
+    const tierResult =
       ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/identity-history", params),
         "METAGRAPH_SUBNET_IDENTITY_SOURCE",
-      )) as Row | null) ?? buildChainIdentityHistory([], { limit: safeLimit });
+      )) as Row | null) ?? null;
+    const data = await answerChainIdentityHistory(context.env, tierResult, {
+      limit: safeLimit,
+    });
     return {
       schema_version: data.schema_version ?? 1,
       count: data.count ?? 0,
@@ -3177,12 +3199,18 @@ const rootValue = {
     if (block_start != null) params.set("block_start", String(block_start));
     if (block_end != null) params.set("block_end", String(block_end));
     // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) handleSubnetEvents and
-    // the get_subnet_events MCP tool use; the account_events D1 write path is
-    // retired (#4772), so a tier miss resolves through buildSubnetEvents over an
-    // empty scan -- a schema-stable empty feed, never a GraphQL error. The events
-    // list passes through whole; graphql's default resolver reads each AccountEvent
-    // field, matching account_events' shaped rows.
-    const data =
+    // the get_subnet_events MCP tool use. The events list passes through whole;
+    // graphql's default resolver reads each AccountEvent field, matching
+    // account_events' shaped rows.
+    //
+    // The cold-tier leg below is what makes that sentence true again. #9212 added
+    // it to the REST handler only, and account_events' D1 write path is retired
+    // (#4772) so the tier above always declines -- which left this resolver
+    // falling straight to an empty buildSubnetEvents while REST served real rows
+    // from chain.account_events for the same netuid. A schema-stable empty feed
+    // is the right shape for "no events"; it is the wrong answer for "441M rows
+    // exist and nobody asked the table that holds them".
+    const tierResult =
       ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
@@ -3191,12 +3219,15 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
-      buildSubnetEvents([], netuid, {
-        limit: safeLimit,
-        offset: safeOffset,
-        nextCursor: null,
-      });
+      )) as Row | null) ?? null;
+    const data = await answerSubnetEvents(context.env, netuid, tierResult, {
+      limit: safeLimit,
+      offset: safeOffset,
+      cursor: null,
+      kind: kind ?? null,
+      blockStart: block_start ?? null,
+      blockEnd: block_end ?? null,
+    });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -6082,7 +6113,10 @@ const rootValue = {
         "METAGRAPH_SUBNET_OWNERSHIP_SOURCE",
       ),
     ]);
-    const data = ownershipData ?? buildAccountEntities(ss58, { entities: [] });
+    // Through the composer (src/account-entities-answer.ts): it owns the tier
+    // order and the empty floor, so this resolver cannot drift from REST/MCP
+    // the way it did while the lakehouse leg lived in entities.ts alone.
+    const data = await answerAccountEntities(context.env, ss58, ownershipData);
     const labels = labelsForSs58(
       entityLabelsIndex(
         entitiesArtifact.ok ? (entitiesArtifact.data as Row)?.entities : [],

--- a/src/identity-history-answer.ts
+++ b/src/identity-history-answer.ts
@@ -1,0 +1,86 @@
+// The ONE composer for the two SubnetIdentitiesV3 timelines --
+// /api/v1/subnets/{netuid}/identity-history and /api/v1/chain/identity-history.
+// REST, MCP and GraphQL all reach both payloads through this module.
+//
+// WHY A COMPOSER AND NOT SIX CASCADES. #9153 added the lakehouse leg to
+// workers/request-handlers/entities.ts alone. METAGRAPH_SUBNET_IDENTITY_SOURCE
+// is retired, so tryPostgresTier declines unconditionally and the other two
+// surfaces fell straight to the empty builder: REST served the frozen verified
+// timeline while get_subnet_identity_history / get_chain_identity_history and
+// their GraphQL twins reported entry_count 0 and count 0.
+//
+// get_chain_identity_history's own comment claimed this tool and the REST route
+// "never diverge on which tier answered". That sentence was false the moment the
+// cold tier landed on one surface only; this module is what makes it true again,
+// by leaving no per-surface copy that CAN diverge.
+//
+// Same shape src/subnet-ownership-answer.ts and src/rpc-usage-answer.ts already
+// established, and the rule tests/subnet-ownership-surface-parity.test.ts
+// enforces: a surface may not import a tier reader directly.
+//
+// THE TIER PROBE STAYS WITH THE SURFACE -- tryPostgresTier needs a Request and
+// each surface builds its own. The surface probes and hands the RESULT here.
+//
+// A DECLINE IS NOT AN EMPTY: the schema-stable empty timeline applies only
+// after every store has declined, and it is applied here so no surface can
+// reach it early.
+
+import {
+  loadChainIdentityHistoryColdTier,
+  loadSubnetIdentityHistoryColdTier,
+} from "./subnet-identity-cold-tier.ts";
+import { buildSubnetIdentityHistory } from "./subnet-identity-history.ts";
+import { buildChainIdentityHistory } from "./chain-identity-history.ts";
+
+type Row = Record<string, unknown>;
+
+export interface AnswerSubnetIdentityHistoryOptions {
+  coldTier?: typeof loadSubnetIdentityHistoryColdTier;
+}
+
+export interface AnswerChainIdentityHistoryOptions {
+  coldTier?: typeof loadChainIdentityHistoryColdTier;
+}
+
+/** One subnet's identity timeline from whichever store can answer. */
+export async function answerSubnetIdentityHistory(
+  env: unknown,
+  netuid: number,
+  tierResult: Row | null | undefined,
+  query: { limit: number; offset?: number | null; cursor?: unknown },
+  {
+    coldTier = loadSubnetIdentityHistoryColdTier,
+  }: AnswerSubnetIdentityHistoryOptions = {},
+): Promise<Row> {
+  return (
+    tierResult ??
+    ((await coldTier(env as never, netuid, {
+      limit: query.limit,
+      offset: query.offset ?? null,
+      cursor: query.cursor ?? null,
+    })) as Row | null) ??
+    (buildSubnetIdentityHistory([], netuid, {
+      limit: query.limit,
+      offset: query.offset ?? null,
+      nextCursor: null,
+    }) as unknown as Row)
+  );
+}
+
+/** The network-wide identity feed from whichever store can answer. */
+export async function answerChainIdentityHistory(
+  env: unknown,
+  tierResult: Row | null | undefined,
+  query: { limit?: unknown } = {},
+  {
+    coldTier = loadChainIdentityHistoryColdTier,
+  }: AnswerChainIdentityHistoryOptions = {},
+): Promise<Row> {
+  return (
+    tierResult ??
+    ((await coldTier(env as never, { limit: query.limit })) as Row | null) ??
+    (buildChainIdentityHistory([], {
+      limit: query.limit,
+    }) as unknown as Row)
+  );
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -207,7 +207,9 @@ import {
 import { resolveClientIp, SS58_ADDRESS_PATTERN } from "../workers/config.ts";
 import {
   applyTieredRateLimit,
+  spendDeferredDailyQuota,
   tieredRejectionResponse,
+  type RateLimitTierPolicy,
   type TieredRateLimitConfig,
 } from "../workers/tiered-rate-limit.ts";
 import { buildTierPolicies } from "./api-tiers.ts";
@@ -246,6 +248,13 @@ import {
   loadAccountEventsColdTier,
   loadBlockEventsColdTier,
 } from "./events-cold-tier.ts";
+import { answerSubnetEvents } from "./subnet-events-answer.ts";
+import { mcpBatchCostUnits } from "./mcp-tool-cost.ts";
+import {
+  answerChainIdentityHistory,
+  answerSubnetIdentityHistory,
+} from "./identity-history-answer.ts";
+import { answerAccountEntities } from "./account-entities-answer.ts";
 import {
   answerBlockDetail,
   answerExtrinsicDetail,
@@ -1276,7 +1285,6 @@ import {
   buildSubnetHistory,
   parseHistoryWindow,
 } from "./neuron-history.ts";
-import { buildSubnetIdentityHistory } from "./subnet-identity-history.ts";
 import {
   buildTurnover,
   buildTurnoverChanges,
@@ -1301,7 +1309,6 @@ import {
 import { buildBlocksSummary } from "./blocks-summary.ts";
 import { loadBlocksSummaryFromArtifact } from "./blocks-summary-artifact.ts";
 import {
-  buildChainIdentityHistory,
   CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
   CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
 } from "./chain-identity-history.ts";
@@ -1444,7 +1451,6 @@ import { API_ROUTES as MCP_API_ROUTES } from "./contracts.ts";
 import { loadRandomnessStatus } from "./randomness.ts";
 import {
   ENTITY_LABELS_ARTIFACT,
-  buildAccountEntities,
   entityLabelsIndex,
   labelsForSs58,
 } from "./entity-labels.ts";
@@ -3108,14 +3114,20 @@ async function loadSubnetIdentityHistoryTool(
   netuid: number,
   { limit, offset, cursor }: Row,
 ) {
-  return (
+  const tierResult =
     (await tryPostgresTier(
       ctx.env,
       mcpSubnetIdentityHistoryRequest(netuid, { limit, offset, cursor }),
       "METAGRAPH_SUBNET_IDENTITY_SOURCE",
-    )) ??
-    buildSubnetIdentityHistory([], netuid, { limit, offset, nextCursor: null })
-  );
+    )) ?? null;
+  // Through the composer (src/identity-history-answer.ts): it owns the tier
+  // order and the empty floor, so this tool cannot report entry_count 0 while
+  // REST serves the frozen verified timeline for the same netuid.
+  return answerSubnetIdentityHistory(ctx.env, netuid, tierResult, {
+    limit: Number(limit),
+    offset: offset == null ? null : Number(offset),
+    cursor: cursor ?? null,
+  });
 }
 
 // One UID's per-day time series — mirrors handleNeuronHistory. Tries the
@@ -5209,17 +5221,19 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       }
       // Mirrors REST's handleChainIdentityHistory: same tryPostgresTier
       // contract, same METAGRAPH_SUBNET_IDENTITY_SOURCE flag as the REST
-      // route (#4832), so this tool and GET /api/v1/chain/identity-history
-      // never diverge on which tier answered. D1 retirement: a Postgres
-      // miss/outage degrades to a schema-stable empty feed, never a live D1
-      // read.
-      return (
+      // route (#4832), THEN the same lakehouse cold tier. That last leg is what
+      // makes "never diverge" true: #9153 added it to entities.ts only, and with
+      // the flag retired the tier above always declines, so this tool answered
+      // count 0 while REST served the network-wide SubnetIdentitiesV3 feed.
+      const tierResult =
         (await tryPostgresTier(
           ctx.env,
           mcpChainIdentityHistoryRequest({ limit: args?.limit }),
           "METAGRAPH_SUBNET_IDENTITY_SOURCE",
-        )) ?? buildChainIdentityHistory([], { limit: args?.limit })
-      );
+        )) ?? null;
+      return answerChainIdentityHistory(ctx.env, tierResult, {
+        limit: args?.limit,
+      });
     },
   },
   {
@@ -7368,9 +7382,8 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       const netuid = requireNetuid(args);
       const kind = optionalString(args, "kind");
       requireKnownEventKind(kind);
-      // block_start/block_end/cursor are validated for REST-parity and forwarded
-      // to the Postgres tier below; the D1 fallback (buildSubnetEvents([]))
-      // never sees them since account_events is retired (#4772).
+      // block_start/block_end/cursor are validated for REST-parity and passed to
+      // BOTH the Postgres tier and the lakehouse cold tier below.
       const blockStart = optionalNonNegativeInt(args, "block_start");
       const blockEnd = optionalNonNegativeInt(args, "block_end");
       const cursor = optionalString(args, "cursor");
@@ -7378,7 +7391,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       const offset = Number.isFinite(args?.offset)
         ? Math.max(0, Math.floor(args.offset as number))
         : 0;
-      return (
+      const tierResult =
         (await tryPostgresTier(
           ctx.env,
           mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/events`, {
@@ -7390,13 +7403,19 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             cursor,
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
-        buildSubnetEvents([], netuid, {
-          limit,
-          offset,
-          nextCursor: null,
-        })
-      );
+        )) ?? null;
+      // Through the composer (src/subnet-events-answer.ts), which owns the tier
+      // order and the empty floor for REST, MCP and GraphQL alike -- the
+      // lakehouse leg it adds is why this tool no longer reports event_count 0
+      // while REST serves real rows for the same netuid.
+      return answerSubnetEvents(ctx.env, netuid, tierResult, {
+        limit,
+        offset,
+        cursor,
+        kind,
+        blockStart,
+        blockEnd,
+      });
     },
   },
   {
@@ -7844,8 +7863,11 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           "METAGRAPH_SUBNET_OWNERSHIP_SOURCE",
         ),
       ]);
-      const data =
-        ownershipData ?? buildAccountEntities(ss58, { entities: [] });
+      // Through the composer, which owns the tier order and the empty floor for
+      // all three surfaces (src/account-entities-answer.ts). The lakehouse leg
+      // it adds is why this tool no longer answers ownership_ties: [] for a
+      // coldkey that HAS won or lost a subnet.
+      const data = await answerAccountEntities(ctx.env, ss58, ownershipData);
       (data as Row).labels = labelsForSs58(
         entityLabelsIndex(
           entitiesArtifact?.ok ? entitiesArtifact.data?.entities : [],
@@ -14338,16 +14360,23 @@ async function enforceMcpRateLimit(
   rejection: Response | null;
   authTier: string;
   accountId: string | null;
+  quotaPending?: { accountId: string; dailyUnits: number };
 }> {
   // #8520: tiered rate limiting via the shared applyTieredRateLimit helper
   // (workers/tiered-rate-limit.ts), mirroring workers/api.ts's DATA checkpoint.
   // Anonymous callers keep the existing IP-keyed 100/60s ceiling unchanged; a
   // valid mg_... key gets the 5x account-keyed tier. Fails open when a binding
   // is absent (local dev/CI/pre-provision), like every limiter here.
+  // The per-minute ceiling and the blocklist run HERE, ahead of body parsing --
+  // a caller over its limit must be refused without us doing work for it. The
+  // cost-weighted daily quota cannot be priced yet (every MCP call is POST /mcp,
+  // so the pathname says nothing about what was asked for), so it is DEFERRED
+  // and spent by handleMcpRequest once the body names the tools.
   const rateLimit = await applyTieredRateLimit(
     request,
     env,
     MCP_TIERED_RATE_LIMIT,
+    { deferQuota: true },
   );
   // Fire-and-forget usage counter for the self-serve dashboard, only for a keyed
   // caller (accountId set). Matches workers/api.ts's "chain-events" label call.
@@ -14393,7 +14422,49 @@ async function enforceMcpRateLimit(
       ),
     };
   }
-  return { rejection: null, authTier, accountId };
+  return {
+    rejection: null,
+    authTier,
+    accountId,
+    quotaPending: rateLimit.quotaPending,
+  };
+}
+
+/**
+ * Debit the deferred daily quota for a parsed MCP body, or produce the refusal.
+ *
+ * Split out of enforceMcpRateLimit so the per-minute gate can stay ahead of
+ * body parsing while the COST is still charged per tool call rather than once
+ * per HTTP request.
+ */
+async function spendMcpQuota(
+  request: Request,
+  env: Env,
+  pending: { accountId: string; dailyUnits: number } | undefined,
+  body: unknown,
+  policy: RateLimitTierPolicy,
+  tier: string,
+): Promise<Response | null> {
+  if (!pending) return null;
+  const quota = await spendDeferredDailyQuota(
+    request,
+    env,
+    pending,
+    mcpBatchCostUnits(body),
+  );
+  if (!quota || quota.allowed) return null;
+  const rejection = tieredRejectionResponse(
+    { allowed: false, policy, tier, quota, accountId: pending.accountId },
+    {
+      code: "rate_limited",
+      message: "Daily MCP quota exhausted for this account.",
+    },
+  )!;
+  return jsonResponse(
+    rpcError(null, RPC_INVALID_REQUEST, rejection.message),
+    rejection.status,
+    rejection.headers,
+  );
 }
 
 function bodyTooLargeResponse() {
@@ -14659,20 +14730,17 @@ export async function handleMcpRequest(
   env: Env = {} as unknown as Env,
   deps: Row = {},
 ) {
-  const { rejection, authTier, accountId } = await enforceMcpRateLimit(
-    request,
-    env,
-    deps.executionCtx,
-  );
+  const { rejection, authTier, accountId, quotaPending } =
+    await enforceMcpRateLimit(request, env, deps.executionCtx);
   if (rejection) return rejection;
 
-  if (request.method === "GET") {
-    return handleMcpStreamRequest(request, env);
-  }
-  if (request.method === "DELETE") {
-    return handleMcpTerminateRequest(request, env);
-  }
   if (request.method !== "POST") {
+    if (request.method === "GET") {
+      return handleMcpStreamRequest(request, env);
+    }
+    if (request.method === "DELETE") {
+      return handleMcpTerminateRequest(request, env);
+    }
     return new Response(
       JSON.stringify({
         jsonrpc: JSONRPC_VERSION,
@@ -14694,6 +14762,20 @@ export async function handleMcpRequest(
 
   const { value: body, error: bodyError } = await readLimitedMcpBody(request);
   if (bodyError) return bodyError;
+
+  // The cost-weighted quota is spent HERE, not in the gate above: only now do we
+  // know which tools were asked for. This is what stops `tools/call {"ask"}`
+  // -- a Workers-AI generation -- costing 1 unit where POST /api/v1/ask costs
+  // 25, and what makes a 10-message batch cost ten calls instead of one.
+  const quotaRejection = await spendMcpQuota(
+    request,
+    env,
+    quotaPending,
+    body,
+    MCP_TIERED_RATE_LIMIT.tiers?.[authTier] ?? MCP_TIERED_RATE_LIMIT.keyed,
+    authTier,
+  );
+  if (quotaRejection) return quotaRejection;
 
   const versionError = validateMcpProtocolVersionHeader(request);
   if (versionError) return versionError;

--- a/src/mcp-tool-cost.ts
+++ b/src/mcp-tool-cost.ts
@@ -1,0 +1,93 @@
+// What one MCP tool call SPENDS against the daily quota.
+//
+// THE BUG THIS FIXES. The quota is a COST unit, not a request (ADR 0022, see
+// src/route-cost-weights.ts). It was priced by `routeCost(pathname)`, and every
+// MCP call has the same pathname: `/mcp`. That matches no family until the
+// `edge` catch-all, so a `tools/call {name:"ask"}` -- a Workers-AI generation --
+// debited 1 unit, while the byte-identical work over POST /api/v1/ask debited
+// 25. The deep-history tools were underpriced 5x the same way. A `community`
+// account got 10,000 `ask` calls over REST and 250,000 over MCP.
+//
+// The second half was the batch: the limiter and quota were charged ONCE per
+// HTTP request, before the body was even read, and a JSON-RPC array then fanned
+// out to MAX_MCP_BATCH_LENGTH tool calls with no further charge. Ten
+// deep-history reads cost one unit. Combined, `ask` over MCP was up to 250x
+// underpriced.
+//
+// WHY AN EXPLICIT TABLE AND NOT PARSED PROSE. Tool descriptions carry a
+// "Mirrors GET <path>" line, and pricing off it was tempting -- but only 101 of
+// 189 tools have one, so the other 88 would silently price at the cheapest
+// family. Billing must not depend on whether someone remembered a sentence.
+// This table is DECLARED, and tests/mcp-tool-cost.test.ts proves it
+// bidirectionally: any tool whose own description mirrors a non-default-cost
+// REST route must appear here, so a new deep-history tool cannot ship at
+// weight 1 by omission. That is the same "declared-and-proven" discipline
+// AUTH_REQUIRED_TOOL_NAMES already uses, rather than a list nothing checks.
+//
+// Only NON-DEFAULT tools are listed. Everything absent prices at
+// DEFAULT_ROUTE_COST_WEIGHT, which is correct for the artifact/registry reads
+// that make up the large majority of the surface.
+
+import { DEFAULT_ROUTE_COST_WEIGHT, routeCost } from "./route-cost-weights.ts";
+
+/**
+ * Tool name -> a REST path in the SAME cost family, which `routeCost` then
+ * prices. Paths are representative, not routed: a concrete netuid/ref is used
+ * where the family regex requires one (`subnets/\d+/...`).
+ */
+export const MCP_TOOL_COST_PATHS: Record<string, string> = {
+  // ai (25) -- a real per-call LLM cost. Neither declares a Mirrors line.
+  ask: "/api/v1/ask",
+  semantic_search: "/api/v1/search/semantic",
+
+  // deep-history (5) -- connection-pool/scan bound. Mirrored, test-enforced.
+  get_account_transfers: "/api/v1/accounts/{ss58}/transfers",
+  get_block_chain_events: "/api/v1/blocks/{block_number}/chain-events",
+  get_block_events: "/api/v1/blocks/{ref}/events",
+  get_chain_activity: "/api/v1/chain-events/stats",
+  get_extrinsic_chain_events: "/api/v1/chain-events",
+  list_block_extrinsics: "/api/v1/blocks/{ref}/extrinsics",
+  list_blocks: "/api/v1/blocks",
+  list_chain_events: "/api/v1/chain-events",
+  list_extrinsics: "/api/v1/extrinsics",
+
+  // deep-history (5) -- same families, but these carry no Mirrors line, so the
+  // test above cannot derive them. Declared by hand for exactly that reason.
+  get_account_events: "/api/v1/accounts/{ss58}/events",
+  get_account_history: "/api/v1/accounts/{ss58}/history",
+  get_account_positions: "/api/v1/accounts/{ss58}/positions",
+  get_block: "/api/v1/blocks",
+  get_extrinsic: "/api/v1/extrinsics",
+  get_subnet_conviction: "/api/v1/subnets/1/conviction",
+  get_subnet_lease: "/api/v1/subnets/1/lease",
+  get_subnet_ownership_history: "/api/v1/subnets/1/ownership-history",
+};
+
+/** What one `tools/call` of this tool spends. Unknown/absent -> the default. */
+export function mcpToolCostUnits(name: unknown): number {
+  if (typeof name !== "string") return DEFAULT_ROUTE_COST_WEIGHT;
+  const path = MCP_TOOL_COST_PATHS[name];
+  return path ? routeCost(path).weight : DEFAULT_ROUTE_COST_WEIGHT;
+}
+
+/**
+ * What one POST /mcp body spends in total.
+ *
+ * Every message is counted, so a batch costs the sum of its parts rather than
+ * one flat unit. Non-`tools/call` methods (initialize, tools/list, resources/*)
+ * still cost the default each -- they are real requests, just cheap ones.
+ *
+ * Floors at the default so an empty or unparseable body is never free.
+ */
+export function mcpBatchCostUnits(body: unknown): number {
+  const messages = Array.isArray(body) ? body : [body];
+  let total = 0;
+  for (const message of messages) {
+    const row = message as { method?: unknown; params?: { name?: unknown } };
+    total +=
+      row?.method === "tools/call"
+        ? mcpToolCostUnits(row?.params?.name)
+        : DEFAULT_ROUTE_COST_WEIGHT;
+  }
+  return Math.max(DEFAULT_ROUTE_COST_WEIGHT, total);
+}

--- a/src/subnet-events-answer.ts
+++ b/src/subnet-events-answer.ts
@@ -1,0 +1,78 @@
+// The ONE composer for /api/v1/subnets/{netuid}/events. REST, MCP and GraphQL
+// all reach the payload through this module and none of them decides the tier
+// order itself.
+//
+// WHY A COMPOSER AND NOT THREE CASCADES. #9212 added the lakehouse leg to the
+// REST handler alone. account_events was never registered on the Postgres tier
+// and METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so tryPostgresTier declines
+// unconditionally and the other two surfaces fell straight to the empty
+// builder: GET /api/v1/subnets/1/events served real rows off
+// chain.account_events (441,963,747 rows, genesis to head) while
+// get_subnet_events and GraphQL's subnet_events both reported event_count 0 for
+// the same netuid in the same second -- with no error and no degraded marker.
+//
+// Same shape src/subnet-ownership-answer.ts and src/rpc-usage-answer.ts already
+// fixed for their routes; tests/subnet-ownership-surface-parity.test.ts states
+// the rule they established -- a surface may not own the cascade, because
+// "which store answers, and what an absence means" is one decision, not three.
+//
+// THE TIER PROBE STAYS WITH THE SURFACE. tryPostgresTier needs a Request and
+// each surface has a different one (REST forwards the caller's, MCP and GraphQL
+// synthesize theirs), so the surface probes and hands the RESULT here. This
+// module owns everything after it -- the part that drifted.
+//
+// ORDER IS LOAD-BEARING: the cold read is awaited only after the tier declines,
+// because it scans the largest table in the lakehouse.
+
+import { loadSubnetEventsColdTier } from "./events-cold-tier.ts";
+import { buildSubnetEvents } from "./account-events.ts";
+
+type Row = Record<string, unknown>;
+
+export interface AnswerSubnetEventsQuery {
+  limit: number;
+  offset: number;
+  cursor?: unknown;
+  kind?: unknown;
+  blockStart?: unknown;
+  blockEnd?: unknown;
+}
+
+export interface AnswerSubnetEventsOptions {
+  coldTier?: typeof loadSubnetEventsColdTier;
+}
+
+/**
+ * One subnet's chain-event page from whichever store can answer.
+ *
+ * `tierResult` is the surface's own tryPostgresTier outcome: a payload when the
+ * tier answered, null when it declined or is retired.
+ *
+ * Never returns null -- the schema-stable empty feed is the documented floor
+ * once every store has declined, applied HERE so all three surfaces reach it by
+ * the same route rather than each inventing it.
+ */
+export async function answerSubnetEvents(
+  env: unknown,
+  netuid: number,
+  tierResult: Row | null | undefined,
+  query: AnswerSubnetEventsQuery,
+  { coldTier = loadSubnetEventsColdTier }: AnswerSubnetEventsOptions = {},
+): Promise<Row> {
+  return (
+    tierResult ??
+    ((await coldTier(env as never, netuid, {
+      limit: query.limit,
+      offset: query.offset,
+      cursor: query.cursor ?? null,
+      kind: query.kind ?? null,
+      blockStart: query.blockStart ?? null,
+      blockEnd: query.blockEnd ?? null,
+    } as never)) as Row | null) ??
+    (buildSubnetEvents([], netuid, {
+      limit: query.limit,
+      offset: query.offset,
+      nextCursor: null,
+    }) as unknown as Row)
+  );
+}

--- a/src/validator-nominators.ts
+++ b/src/validator-nominators.ts
@@ -157,6 +157,14 @@ function resolveCount(
   pageLength: number,
   alreadyPaged: boolean,
 ): number | null {
+  // `null` is the cold tier's explicit "the count query failed, this total is
+  // UNKNOWN" (see loadValidatorNominatorsColdTier, whose own comment reads
+  // "Null is a real state; a page size dressed as a total is not"). It has to be
+  // rejected BEFORE Number(), because Number(null) is 0 -- which sailed through
+  // the isFinite check below and published a failed count as a confident zero,
+  // the exact outcome the null was introduced to prevent. `undefined` still
+  // falls through to the pageLength/null branch as every other caller expects.
+  if (totalCount === null) return alreadyPaged ? null : pageLength;
   const n = Math.trunc(Number(totalCount));
   if (Number.isFinite(n) && n >= 0) return n;
   return alreadyPaged ? null : pageLength;

--- a/tests/blocks-cold-tier.test.ts
+++ b/tests/blocks-cold-tier.test.ts
@@ -430,11 +430,14 @@ describe("loadBlockFeedColdTier", () => {
         minExtrinsics: 2,
       } as never,
     );
-    assert.match(sql[0]!, /\(observed_at, block_number\) < \(\?, \?\)/);
-    assert.match(sql[0]!, /block_number >= \?/);
-    assert.match(sql[0]!, /block_number <= \?/);
-    assert.match(sql[0]!, /observed_at >= \?/);
-    assert.match(sql[0]!, /extrinsic_count >= \?/);
+    // Qualified to `b`: these columns exist on BOTH sides of the
+    // chain_detail_blocks join, so an unqualified predicate is an ambiguous
+    // -column error in SQLite rather than a silently wrong answer.
+    assert.match(sql[0]!, /\(b\.observed_at, b\.block_number\) < \(\?, \?\)/);
+    assert.match(sql[0]!, /b\.block_number >= \?/);
+    assert.match(sql[0]!, /b\.block_number <= \?/);
+    assert.match(sql[0]!, /b\.observed_at >= \?/);
+    assert.match(sql[0]!, /b\.extrinsic_count >= \?/);
     // Bound, never interpolated — order matters as much as presence.
     assert.deepEqual(params[0], [
       SEAM,
@@ -630,9 +633,45 @@ describe("loadBlockColdTier", () => {
       { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
       "0xABCD",
     );
-    assert.match(sql[0]!, /lower\(block_hash\) = \?/);
+    assert.match(sql[0]!, /lower\(b\.block_hash\) = \?/);
     assert.match(queries[0]!, /block_hash = '0xabcd'/);
     assert.equal(data!.block!.block_number, 42);
+  });
+
+  // The hot tier's coverage register (chain_detail_blocks) carries the two
+  // columns blocks_head lacks. Before the join, a block above the seam always
+  // published `event_count: null`, which the explorer rendered as "Events 0" --
+  // on block 8,771,446 the same page's pallet breakdown said 320.
+  test("a block the hot tier covers reports its event_count and spec_version", async () => {
+    const { db } = d1([
+      { ...headRow(SEAM + 4), spec_version: 442, event_count: 320 },
+    ]);
+    const queries = lakeFetch([]);
+    const data = await loadBlockColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      String(SEAM + 4),
+    );
+    assert.equal(data!.block!.event_count, 320);
+    assert.equal(data!.block!.spec_version, 442);
+    // Answered entirely above the seam -- the lakehouse is never asked.
+    assert.equal(queries.length, 0);
+  });
+
+  // LEFT join: the hot tier keeps a shorter window than blocks_head, so a block
+  // it has pruned past still resolves -- with an honest null, never a zero. A
+  // count we do not have is not a count of zero.
+  test("a block the hot tier has pruned past keeps a null count, not a zero", async () => {
+    const { db } = d1([
+      { ...headRow(SEAM + 4), spec_version: null, event_count: null },
+    ]);
+    lakeFetch([]);
+    const data = await loadBlockColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      String(SEAM + 4),
+    );
+    assert.equal(data!.block!.block_number, SEAM + 4);
+    assert.equal(data!.block!.event_count, null);
+    assert.equal(data!.block!.spec_version, null);
   });
 
   test("a hash D1 knows is served without touching the lakehouse", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -1026,8 +1026,17 @@ describe("handleGraphQLRequest — coverage edge cases", () => {
     assert.ok("subnet" in body.data);
   });
 
-  // Cursor not found in items → start stays 0 (no crash).
-  test("subnets with an unresolvable cursor returns first page", async () => {
+  // A stale cursor terminates the walk instead of silently restarting it.
+  //
+  // This test previously asserted `items.length === 2` under the name "returns
+  // first page", with the comment "start stays 0 (no crash)" -- i.e. it was
+  // pinning crash-safety and incidentally captured the restart. The restart is
+  // the defect: paginate() still emitted a next_cursor alongside that first
+  // page, so a client following cursors walked page 1 -> page 1 -> page 1
+  // forever while `total` kept reporting the full count. Lists keyed by
+  // identity over live rows (validators by hotkey) hit this whenever a row
+  // disappears mid-walk.
+  test("subnets with an unresolvable cursor ends the walk, never restarts it", async () => {
     const env = fixtureEnv({
       "/metagraph/subnets.json": {
         subnets: [
@@ -1037,11 +1046,17 @@ describe("handleGraphQLRequest — coverage edge cases", () => {
       },
     });
     const { status, body } = await gql(
-      '{ subnets(cursor: "999") { items { netuid } total } }',
+      '{ subnets(cursor: "999") { items { netuid } total next_cursor } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(body.data.subnets.items.length, 2);
+    // Still a 200 with a schema-stable shape -- a vanished row is an ordinary
+    // race, not a client error.
+    assert.equal(body.data.subnets.items.length, 0);
+    // `total` still reports reality; only the page is empty.
+    assert.equal(body.data.subnets.total, 2);
+    // The loop-breaker: no cursor is handed back, so the walk cannot repeat.
+    assert.equal(body.data.subnets.next_cursor, null);
   });
 
   // Data keys missing from artifact (subnets array absent → empty list).

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -15055,6 +15055,40 @@ describe("MCP block-explorer tools — lakehouse cold tier answers when Postgres
     assert.match(queries[0]!, /FROM chain\.blocks/);
   });
 
+  // #9212 wired the account_events cold tier into the REST handler ONLY, so
+  // with METAGRAPH_ACCOUNT_EVENTS_SOURCE retired this tool fell straight to the
+  // empty builder: GET /api/v1/subnets/1/events served real rows while
+  // get_subnet_events reported event_count 0 for the same netuid, with no error
+  // and no degraded marker. Asserting the QUERY as well as the rows, so a future
+  // change that returns rows without actually reading the subnet's stream fails.
+  test("get_subnet_events reads the lakehouse, not a confident zero", async () => {
+    const queries = lakeFetch([
+      {
+        block_number: 4200000,
+        event_index: 0,
+        event_kind: "StakeAdded",
+        netuid: 1,
+        hotkey: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+        coldkey: null,
+        uid: 7,
+        amount_tao: 1.5,
+        alpha_amount: null,
+        observed_at: 1750009000000,
+      },
+    ]);
+    const res = await callTool(
+      "get_subnet_events",
+      { netuid: 1, limit: 10 },
+      { env: LAKE_ENV },
+    );
+    const data = res.body.result.structuredContent;
+    assert.equal(data.events.length, 1);
+    assert.equal(data.event_count, 1);
+    assert.equal(data.events[0].event_kind, "StakeAdded");
+    assert.match(queries[0]!, /FROM chain\.account_events/);
+    assert.match(queries[0]!, /netuid = 1/);
+  });
+
   test("get_block resolves a height from the lakehouse", async () => {
     lakeFetch([LAKE_BLOCK]);
     const res = await callTool(

--- a/tests/mcp-tool-cost.test.ts
+++ b/tests/mcp-tool-cost.test.ts
@@ -1,0 +1,108 @@
+// The MCP quota table is DECLARED, so it needs the same bidirectional proof
+// AUTH_REQUIRED_TOOL_NAMES gets: a list nothing checks is a list that drifts,
+// and this one decides what callers are billed.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+
+import {
+  MCP_TOOL_COST_PATHS,
+  mcpBatchCostUnits,
+  mcpToolCostUnits,
+} from "../src/mcp-tool-cost.ts";
+import {
+  DEFAULT_ROUTE_COST_WEIGHT,
+  routeCost,
+} from "../src/route-cost-weights.ts";
+import { MCP_TOOLS } from "../src/mcp-server.ts";
+
+const TOOL_NAMES = new Set(
+  (MCP_TOOLS as Array<{ name: string }>).map((t) => t.name),
+);
+
+/** Each tool paired with the REST path its own description says it mirrors. */
+function mirroredPaths(): Map<string, string> {
+  const src = readFileSync(
+    new URL("../src/mcp-server.ts", import.meta.url),
+    "utf8",
+  );
+  const found = new Map<string, string>();
+  for (const m of src.matchAll(
+    /\n {4}name: "([a-z0-9_]+)",([\s\S]*?)(?=\n {4}name: "|$)/g,
+  )) {
+    const mirror = m[2]!
+      .slice(0, 4000)
+      .match(/Mirrors GET (\/api\/v1\/[a-z0-9{}/_-]*)/);
+    if (mirror) found.set(m[1]!, mirror[1]!);
+  }
+  return found;
+}
+
+describe("MCP tool cost table", () => {
+  test("every declared tool exists", () => {
+    for (const name of Object.keys(MCP_TOOL_COST_PATHS)) {
+      assert.ok(
+        TOOL_NAMES.has(name),
+        `${name} is priced but is not a registered MCP tool`,
+      );
+    }
+  });
+
+  test("every declared path is genuinely non-default", () => {
+    for (const [name, path] of Object.entries(MCP_TOOL_COST_PATHS)) {
+      assert.notEqual(
+        routeCost(path).weight,
+        DEFAULT_ROUTE_COST_WEIGHT,
+        `${name} -> ${path} prices at the default; listing it says otherwise`,
+      );
+    }
+  });
+
+  // The regression guard: a new deep-history/AI tool that mirrors an expensive
+  // REST route must be priced, or MCP silently resells it at 1 unit.
+  test("a tool mirroring an expensive REST route is priced", () => {
+    for (const [name, path] of mirroredPaths()) {
+      if (routeCost(path).weight === DEFAULT_ROUTE_COST_WEIGHT) continue;
+      assert.ok(
+        name in MCP_TOOL_COST_PATHS,
+        `${name} mirrors ${path} (${routeCost(path).family}) but is missing ` +
+          `from MCP_TOOL_COST_PATHS, so it would bill at ` +
+          `${DEFAULT_ROUTE_COST_WEIGHT} instead of ${routeCost(path).weight}`,
+      );
+    }
+  });
+
+  test("MCP prices the same work REST does", () => {
+    // The headline case: an LLM generation cost 1 unit over MCP and 25 over REST.
+    assert.equal(mcpToolCostUnits("ask"), routeCost("/api/v1/ask").weight);
+    assert.equal(mcpToolCostUnits("list_chain_events"), 5);
+    // An unlisted or absent tool keeps the default.
+    assert.equal(mcpToolCostUnits("get_subnet"), DEFAULT_ROUTE_COST_WEIGHT);
+    assert.equal(mcpToolCostUnits(undefined), DEFAULT_ROUTE_COST_WEIGHT);
+  });
+
+  test("a batch costs the sum of its parts, not one flat unit", () => {
+    const call = (name: string) => ({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name },
+    });
+    // Ten deep-history reads used to cost a single unit for the whole request.
+    assert.equal(
+      mcpBatchCostUnits(
+        Array.from({ length: 10 }, () => call("list_chain_events")),
+      ),
+      50,
+    );
+    assert.equal(mcpBatchCostUnits(call("ask")), 25);
+    // Non-tools/call methods still cost their own default each.
+    assert.equal(
+      mcpBatchCostUnits({ jsonrpc: "2.0", method: "tools/list" }),
+      1,
+    );
+    // Never free, whatever arrives.
+    assert.equal(mcpBatchCostUnits([]), DEFAULT_ROUTE_COST_WEIGHT);
+    assert.equal(mcpBatchCostUnits(null), DEFAULT_ROUTE_COST_WEIGHT);
+  });
+});

--- a/tests/wss-lb.test.ts
+++ b/tests/wss-lb.test.ts
@@ -433,7 +433,46 @@ for (const frame of [
   });
 }
 
-test("a binary frame is not policy-checked as text", () => {
+// This used to assert `deniedRpcMethod(new ArrayBuffer(8)) === null` under the
+// name "a binary frame is not policy-checked as text" -- encoding the bypass as
+// intended behaviour. jsonrpsee parses Data::Binary exactly like Data::Text, so
+// framing the same JSON as binary is a full escape from the policy, not a
+// different protocol.
+test("a denied method is refused when framed as BINARY, not just text", () => {
+  for (const prefix of WSS_DENIED_RPC_PREFIXES) {
+    const frame = new TextEncoder().encode(
+      `{"jsonrpc":"2.0","id":1,"method":"${prefix}anything","params":[]}`,
+    ).buffer as ArrayBuffer;
+    assert.equal(
+      deniedRpcMethod(frame),
+      `${prefix}anything`,
+      `${prefix} is enforced for text frames but bypassed by a binary frame`,
+    );
+  }
+});
+
+test("an allowed method framed as binary is still forwarded", () => {
+  const frame = new TextEncoder().encode(
+    '{"jsonrpc":"2.0","id":1,"method":"chain_getHeader"}',
+  ).buffer as ArrayBuffer;
+  assert.equal(deniedRpcMethod(frame), null);
+});
+
+test("a binary batch is refused the same way a text batch is", () => {
+  const frame = new TextEncoder().encode(
+    '[{"id":1,"method":"chain_getHeader"}]',
+  ).buffer as ArrayBuffer;
+  assert.equal(deniedRpcMethod(frame), "batch");
+});
+
+test("binary bytes that are not valid UTF-8 are forwarded, never guessed at", () => {
+  assert.equal(
+    deniedRpcMethod(new Uint8Array([0xff, 0xfe, 0xff]).buffer),
+    null,
+  );
+});
+
+test("binary bytes that decode but are not JSON are forwarded", () => {
   assert.equal(deniedRpcMethod(new ArrayBuffer(8)), null);
 });
 

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -43,6 +43,7 @@ import {
   errorResponse,
   exposeCustomResponseHeaders,
   ifNoneMatchSatisfied,
+  isPathUnder,
   weakEtag,
   X_METAGRAPH_ARTIFACT_RESOLUTION_HEADER,
   X_METAGRAPH_ARTIFACT_SOURCE_HEADER,
@@ -958,6 +959,17 @@ const LIVE_OVERLAY_ROUTE_IDS = new Set([
   // the data publish), falling back to the committed R2 economics.json — so it must
   // not be static-edge-cached.
   "economics",
+  // subnet-detail overlays live economics (alpha price, registration cost) from
+  // the same KV blob, plus D1 identity aliases -- see the `matched.id ===
+  // "subnet-detail"` branch below. It was missing here: this set was introduced
+  // to skip the edge cache for live overlays, and the subnet-detail overlay was
+  // added later without updating it, so isStaticEdgeCacheEligible returned true
+  // and a live alpha price could be edge-cached for 300s + 300s SWR with no
+  // invalidation. Masked today only because the generic endpoint overlay happens
+  // to fire for every currently-catalogued subnet -- which is NOT true of a
+  // newly-registered subnet with no catalogued surfaces, i.e. exactly the one
+  // whose price and registration cost move fastest.
+  "subnet-detail",
 ]);
 
 function isStaticEdgeCacheEligible(
@@ -3366,19 +3378,22 @@ export async function handleRequest(
   // above. All auth/routing/validation live in workers/data-api.ts's
   // handleAlertTriggersRoute -- this is only the DATA_API forwarding
   // boundary.
+  // isPathUnder, not startsWith: an unbounded prefix also matched
+  // `/api/v1/alerts/triggersanything`, forwarding a path that is not a route to
+  // the CRUD proxy, where an absent id + POST created a real trigger row.
   if (
-    url.pathname.startsWith("/api/v1/alerts/triggers") ||
+    isPathUnder(url.pathname, "/api/v1/alerts/triggers") ||
     // #8375: the Alert Center's address-scoped counterpart -- same generic
     // pass-through proxy (all auth/routing/validation live in
     // workers/data-api.ts's handleWatchTriggersRoute), same error-code
     // family as it's still an alert-trigger-family failure.
-    url.pathname.startsWith("/api/v1/watch/triggers") ||
+    isPathUnder(url.pathname, "/api/v1/watch/triggers") ||
     // #8808: same watch family, same generic pass-through proxy -- all
     // auth/routing/validation live in workers/data-api.ts's
     // handleWatchPushSubscriptions* handlers, this is only the DATA_API
     // forwarding boundary. CRUD accepts POST/GET/DELETE, so it must also
     // run ahead of the read-only method gate.
-    url.pathname.startsWith("/api/v1/watch/push-subscriptions")
+    isPathUnder(url.pathname, "/api/v1/watch/push-subscriptions")
   ) {
     return handleAlertTriggersProxy(request, env);
   }

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -300,7 +300,20 @@ export function chainFirehoseMatchesNetuid(
   netuid: number | null,
 ): boolean {
   if (netuid === null) return true;
+  // ABSENT and NULL are different facts and must not be collapsed.
+  //
+  // Absent (`undefined`) means the topic carries no subnet dimension at all --
+  // a `blocks` payload has no netuid key -- so a netuid filter has nothing to
+  // say about it and the row is delivered, as before.
   if (payload == null || payload.netuid === undefined) return true;
+  // Explicitly null means THIS event has no subnet: account_events.netuid is a
+  // nullable column and enqueue_chain_firehose()'s jsonb_build_object emits the
+  // key as null rather than dropping it. That is not a match for any specific
+  // netuid, and it especially is not a match for 0 -- which is where it landed,
+  // because the guard above only tested `undefined` and left `Number(null) === 0`
+  // to decide. netuid 0 is a real, actively-used subscription target, so every
+  // subnet-less Transfer was being pushed to root subscribers as if it were theirs.
+  if (payload.netuid === null) return false;
   return Number(payload.netuid) === netuid;
 }
 

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -18,6 +18,7 @@
 // they answered before the deletion -- see dispatchDataApiRequest's own note
 // for why that matters to the forward gate.
 import { recordExceptionEvent } from "../src/usage-telemetry.ts";
+import { isPathUnder } from "./http.ts";
 import { registerModuleStateReset } from "../src/module-state-registry.ts";
 import { maskRouteParams } from "../src/route-label.ts";
 import {
@@ -2723,16 +2724,31 @@ async function handleAlertTriggersMatchedWriteback(request: Request, env: Env) {
     // built dynamically (one `?` per already-isValidAlertTriggerId-validated
     // id), which a tagged template can't express. The first bind is the
     // shared `now` timestamp.
-    const placeholders = ids.map(() => "?").join(", ");
-    const updated = await sql.unsafe(
-      `UPDATE chain_alert_triggers
-       SET match_count = match_count + 1,
-           last_matched_at = ?
-       WHERE id IN (${placeholders})
-       RETURNING id`,
-      [now, ...ids],
-    );
-    return writeJson({ updated: updated.length });
+    //
+    // CHUNKED, because the Workers D1 binding caps a statement at 100 bound
+    // parameters. AlerterHub.evaluate() posts every matched trigger id in one
+    // call and the active-trigger load has no LIMIT, so a broad table_filter
+    // across ~100 active triggers bound 101 values, D1 threw "too many SQL
+    // variables", and the 502 lost the ENTIRE batch's match_count and
+    // last_matched_at into a console.error. 90 leaves the same margin under
+    // 100 that src/neurons-d1-write.ts uses for this exact limit; the `now`
+    // bind is what makes the ceiling 90 ids rather than 91.
+    const CHUNK = 90;
+    let updatedCount = 0;
+    for (let i = 0; i < ids.length; i += CHUNK) {
+      const slice = ids.slice(i, i + CHUNK);
+      const placeholders = slice.map(() => "?").join(", ");
+      const updated = await sql.unsafe(
+        `UPDATE chain_alert_triggers
+         SET match_count = match_count + 1,
+             last_matched_at = ?
+         WHERE id IN (${placeholders})
+         RETURNING id`,
+        [now, ...slice],
+      );
+      updatedCount += updated.length;
+    }
+    return writeJson({ updated: updatedCount });
   });
 }
 
@@ -2867,16 +2883,23 @@ async function handleAlertTriggersRoute(request: Request, env: Env, url: URL) {
   const segments = url.pathname.split("/").filter(Boolean);
   // ["api", "v1", "alerts", "triggers", <id?>]
   const id = segments[4];
-  if (!id && request.method === "POST") {
+  // A trailing sub-path is NOT part of any route here, and dropping it silently
+  // let /alerts/triggers/{id}/deliveries reach the DELETE branch and destroy the
+  // trigger -- a plausible URL to try, since the sibling watch surface really
+  // does expose /watch/triggers/{id}/deliveries. `!sub` is the same guard
+  // handleWatchTriggersRoute already applies for exactly this reason; anything
+  // with a fifth segment falls through to the 405 below.
+  const sub = segments[5];
+  if (!id && !sub && request.method === "POST") {
     return handleAlertTriggerCreate(request, env);
   }
-  if (id && request.method === "GET") {
+  if (id && !sub && request.method === "GET") {
     return handleAlertTriggerGet(request, env, id);
   }
-  if (id && request.method === "PATCH") {
+  if (id && !sub && request.method === "PATCH") {
     return handleAlertTriggerUpdate(request, env, id);
   }
-  if (id && request.method === "DELETE") {
+  if (id && !sub && request.method === "DELETE") {
     return handleAlertTriggerDelete(request, env, id);
   }
   return writeJson(
@@ -6053,19 +6076,22 @@ async function dispatchDataApiRequest(
     // the exact-path-and-method checks above -- handleAlertTriggersRoute
     // does its own method dispatch, same shape as workers/api.ts's
     // handleWebhookRequest.
-    if (url.pathname.startsWith("/api/v1/alerts/triggers")) {
+    // isPathUnder, not startsWith: the unbounded prefix matched
+    // `/api/v1/alerts/triggersanything` too, and this is the side that actually
+    // reaches the create/delete handlers.
+    if (isPathUnder(url.pathname, "/api/v1/alerts/triggers")) {
       return handleAlertTriggersRoute(request, env, url);
     }
     // #8375: the Alert Center's address-scoped counterpart -- GET (list),
     // PATCH/DELETE (single trigger), GET .../deliveries (history), all
     // watch-token authorized. Same "multi-method, can't join the exact-match
     // checks" shape as handleAlertTriggersRoute just above.
-    if (url.pathname.startsWith("/api/v1/watch/triggers")) {
+    if (isPathUnder(url.pathname, "/api/v1/watch/triggers")) {
       return handleWatchTriggersRoute(request, env, url);
     }
     // #8385: the same address-scoped shape for web-push device
     // subscriptions (GET list, POST subscribe, DELETE one device).
-    if (url.pathname.startsWith("/api/v1/watch/push-subscriptions")) {
+    if (isPathUnder(url.pathname, "/api/v1/watch/push-subscriptions")) {
       return handleWatchPushSubscriptionsRoute(request, env, url);
     }
     // #8385: internal-only push-subscription resolve/prune for AlerterHub.

--- a/workers/http.ts
+++ b/workers/http.ts
@@ -88,6 +88,23 @@ export function linkHeader(links: Array<{ uri: string; rel: string }>): string {
   return links.map(({ uri, rel }) => `<${uri}>; rel="${rel}"`).join(", ");
 }
 
+/**
+ * Does `pathname` name `base` itself, or something nested under it?
+ *
+ * A bare `pathname.startsWith(base)` has no path-segment boundary, so
+ * `/api/v1/alerts/triggers` also matched `/api/v1/alerts/triggersanything` --
+ * which reached the alert-trigger CRUD proxy and let a POST to a path that is
+ * not a route create a real trigger row. It also makes any future sibling route
+ * sharing the prefix unreachable by construction, since this test swallows it
+ * first.
+ *
+ * `base` is given WITHOUT a trailing slash; both `/base` and `/base/...` match,
+ * and `/basex` does not.
+ */
+export function isPathUnder(pathname: string, base: string): boolean {
+  return pathname === base || pathname.startsWith(`${base}/`);
+}
+
 export function errorResponse(
   code: string,
   message: string,

--- a/workers/mcp-session-hub.ts
+++ b/workers/mcp-session-hub.ts
@@ -166,10 +166,17 @@ export class McpSessionHub implements DurableObject {
     if (this.hydrated) return;
     const stored = await this.state.storage.get<
       string | string[] | number | boolean
-    >(["sessionId", "subscribedUris", "sequence", "terminated"]);
+    >(["sessionId", "subscribedUris", "pendingUris", "sequence", "terminated"]);
     this.sessionId = (stored.get("sessionId") as string | undefined) || null;
     this.subscribedUris = new Set(
       (stored.get("subscribedUris") as string[] | undefined) || [],
+    );
+    // pendingUris was the one session field never persisted or hydrated, so a
+    // DO eviction between /notify and the next GET /stream discarded the
+    // coalesced notification the flush loop exists to replay -- the client was
+    // never told the resource changed and never re-read.
+    this.pendingUris = new Set(
+      (stored.get("pendingUris") as string[] | undefined) || [],
     );
     this.sequence = (stored.get("sequence") as number | undefined) || 0;
     this.terminated =
@@ -181,6 +188,7 @@ export class McpSessionHub implements DurableObject {
     await this.state.storage.put({
       sessionId: this.sessionId,
       subscribedUris: [...this.subscribedUris],
+      pendingUris: [...this.pendingUris],
       sequence: this.sequence,
       terminated: this.terminated,
     });
@@ -377,6 +385,18 @@ export class McpSessionHub implements DurableObject {
       this.deliverNow(uri);
     } else {
       this.pendingUris.add(uri);
+      // Durable, because nothing holds this instance resident between /notify
+      // and the client's next GET /stream: /notify does not touch() and the
+      // idle alarm is 30 minutes out, so an eviction in that window used to
+      // lose the marker outright.
+      //
+      // Only the ADD is persisted, not deliverNow's delete. Losing a delete
+      // costs at most ONE duplicate notifications/resources/updated, which is
+      // harmless by construction -- the notification is a pointer, and
+      // resources/read always returns current state -- whereas losing an add
+      // means the client is never told at all. Over-delivery is recoverable,
+      // silence is not, so the write goes on the path that cannot afford loss.
+      await this.persist();
     }
     return new Response(JSON.stringify({ ok: true, delivered: true }), {
       status: 200,
@@ -385,13 +405,20 @@ export class McpSessionHub implements DurableObject {
   }
 
   deliverNow(uri: string): void {
+    // No stream to write to is a NON-delivery, and must leave the uri pending.
+    // `streamController?.enqueue(...)` made it a silent no-op that still fell
+    // through to the delete below, so once the flush loop's first enqueue threw
+    // and nulled the controller, every REMAINING pending uri was dropped
+    // instead of being kept for the next open -- the exact opposite of what the
+    // catch block is written to do.
+    if (!this.streamController) return;
     this.sequence += 1;
     const frame = formatMcpSseEvent(
       this.sequence,
       buildResourceUpdatedNotification(uri),
     );
     try {
-      this.streamController?.enqueue(new TextEncoder().encode(frame));
+      this.streamController.enqueue(new TextEncoder().encode(frame));
       this.pendingUris.delete(uri);
     } catch (error) {
       // stream already closed/errored -- leave it pending for the next open

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -144,7 +144,6 @@ import { loadNetworkParameters } from "../../src/network-parameters.ts";
 import { loadRandomnessStatus } from "../../src/randomness.ts";
 import {
   ENTITY_LABELS_ARTIFACT,
-  buildAccountEntities,
   entityLabelsIndex,
   labelsForSs58,
 } from "../../src/entity-labels.ts";
@@ -190,8 +189,12 @@ import {
 import {
   loadAccountEventsColdTier,
   loadBlockEventsColdTier,
-  loadSubnetEventsColdTier,
 } from "../../src/events-cold-tier.ts";
+import { answerSubnetEvents } from "../../src/subnet-events-answer.ts";
+import {
+  answerChainIdentityHistory,
+  answerSubnetIdentityHistory,
+} from "../../src/identity-history-answer.ts";
 import {
   answerBlockDetail,
   answerExtrinsicDetail,
@@ -220,14 +223,10 @@ import {
   loadSubnetHyperparamsHistoryColdTier,
 } from "../../src/subnet-hyperparams-cold-tier.ts";
 import {
-  loadChainIdentityHistoryColdTier,
-  loadSubnetIdentityHistoryColdTier,
-} from "../../src/subnet-identity-cold-tier.ts";
-import {
   loadAccountIdentityColdTier,
   loadAccountIdentityHistoryColdTier,
 } from "../../src/account-identity-cold-tier.ts";
-import { loadAccountEntitiesColdTier } from "../../src/subnet-ownership-cold-tier.ts";
+import { answerAccountEntities } from "../../src/account-entities-answer.ts";
 import { loadSelfHealthColdTier } from "../../src/self-health-cold-tier.ts";
 import { loadLatestLaneHealth } from "../../src/lane-health.ts";
 import { withLaneHealth } from "../../src/self-health.ts";
@@ -1632,20 +1631,20 @@ export async function handleSubnetIdentityHistory(
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset } = parsePagination(url, FEED_PAGINATION);
-  const data =
+  const identityTier =
     ((await tryPostgresTier(
       env,
       request,
       "METAGRAPH_SUBNET_IDENTITY_SOURCE",
-    )) as ReturnType<typeof buildSubnetIdentityHistory> | null) ??
-    // Lakehouse cold tier: same formatter, data-api's exact cursor token, so
-    // a page started on one tier finishes correctly on the other.
-    (await loadSubnetIdentityHistoryColdTier(env, netuid, {
-      limit,
-      offset,
-      cursor: url.searchParams.get("cursor"),
-    })) ??
-    buildSubnetIdentityHistory([], netuid, { limit, offset, nextCursor: null });
+    )) as Record<string, unknown> | null) ?? null;
+  // Through the composer (src/identity-history-answer.ts): same formatter and
+  // data-api's exact cursor token, so a page started on one tier finishes
+  // correctly on the other -- and MCP/GraphQL now reach it by the same route.
+  const data = (await answerSubnetIdentityHistory(env, netuid, identityTier, {
+    limit,
+    offset,
+    cursor: url.searchParams.get("cursor"),
+  })) as unknown as ReturnType<typeof buildSubnetIdentityHistory>;
   // CSV mirrors handleSubnetHyperparamsHistory: the page is already
   // limit/offset/cursor-bounded, so the CSV path carries the identical page the
   // JSON path would. Cold store -> empty entries -> header-only CSV.
@@ -1903,16 +1902,18 @@ export async function handleChainIdentityHistory(
   // (2026-07-16, syncSubnetIdentityToPostgres is the sole writer now), so a
   // Postgres miss/outage degrades to a schema-stable empty feed, never a
   // live D1 read.
-  const data =
+  const chainIdentityTier =
     ((await tryPostgresTier(
       env,
       request,
       "METAGRAPH_SUBNET_IDENTITY_SOURCE",
-    )) as ReturnType<typeof buildChainIdentityHistory> | null) ??
-    // Lakehouse cold tier (src/subnet-identity-cold-tier.ts): the frozen
-    // verified history through the SAME formatter as the Postgres tier.
-    (await loadChainIdentityHistoryColdTier(env, { limit })) ??
-    buildChainIdentityHistory([], { limit });
+    )) as Record<string, unknown> | null) ?? null;
+  // Through the composer (src/identity-history-answer.ts): the frozen verified
+  // history through the SAME formatter as the Postgres tier, for all three
+  // surfaces rather than this one.
+  const data = (await answerChainIdentityHistory(env, chainIdentityTier, {
+    limit,
+  })) as unknown as ReturnType<typeof buildChainIdentityHistory>;
   return envelopeResponse(
     request,
     {
@@ -4486,13 +4487,11 @@ export async function handleAccountEntities(
       "METAGRAPH_SUBNET_OWNERSHIP_SOURCE" as keyof Env,
     ),
   ]);
-  const data =
-    ownershipData ??
-    // Lakehouse cold tier (src/subnet-ownership-cold-tier.ts): the SAME
-    // SubnetOwnerChanged stream from chain.chain_events, through the SAME
-    // formatter -- the labels join below applies identically to every tier.
-    (await loadAccountEntitiesColdTier(env, coldkey)) ??
-    buildAccountEntities(coldkey, { entities: [] });
+  // Through the composer (src/account-entities-answer.ts), which owns the tier
+  // order and the empty floor for REST, MCP and GraphQL alike. It used to live
+  // here only, which is exactly why the other two surfaces published an empty
+  // ownership half. The labels join below applies identically to every tier.
+  const data = await answerAccountEntities(env, coldkey, ownershipData);
   const artifactEntities = entitiesArtifact.ok
     ? ((entitiesArtifact.data as Record<string, unknown> | undefined)
         ?.entities as Array<Record<string, unknown>> | undefined)
@@ -5367,25 +5366,23 @@ export async function handleSubnetEvents(
   // The tier is still tried first and the cold read is awaited only on a miss:
   // it scans the largest table in the lakehouse, so it must not run when the
   // tier can answer.
-  const data =
+  const tierResult =
     ((await tryPostgresTier(
       env,
       request,
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) as ReturnType<typeof buildSubnetEvents> | null) ??
-    (await loadSubnetEventsColdTier(env, Number(netuid), {
-      limit: parsedLimit,
-      offset: parsedOffset,
-      cursor: url.searchParams.get("cursor"),
-      kind,
-      blockStart: blockStart.value,
-      blockEnd: blockEnd.value,
-    })) ??
-    buildSubnetEvents([], Number(netuid), {
-      limit: parsedLimit,
-      offset: parsedOffset,
-      nextCursor: null,
-    });
+    )) as Record<string, unknown> | null) ?? null;
+  // Through the composer (src/subnet-events-answer.ts). This cascade used to
+  // live here only, which is precisely why MCP and GraphQL published
+  // event_count 0 for subnets this route served real rows for.
+  const data = (await answerSubnetEvents(env, Number(netuid), tierResult, {
+    limit: parsedLimit,
+    offset: parsedOffset,
+    cursor: url.searchParams.get("cursor"),
+    kind,
+    blockStart: blockStart.value,
+    blockEnd: blockEnd.value,
+  })) as unknown as ReturnType<typeof buildSubnetEvents>;
   if (csvRequested(url, request)) {
     return csvResponse(
       data.events as unknown[],

--- a/workers/request-handlers/saved-queries.ts
+++ b/workers/request-handlers/saved-queries.ts
@@ -32,9 +32,23 @@ export async function handleSavedQueryRequest(
       { allow: "GET, HEAD, OPTIONS" },
     );
   }
-  const queryId = decodeURIComponent(
-    url.pathname.slice(SAVED_QUERIES_PATH_PREFIX.length),
-  );
+  // decodeURIComponent throws URIError on a malformed escape ("%ZZ"), and this
+  // call sits OUTSIDE the try below -- withUsageTelemetry has try/finally with
+  // no catch and the Worker entry does not wrap either, so the throw escaped as
+  // a bare 1101/500 instead of the error envelope every other route returns.
+  // decodeSlugPathSegment in workers/api.ts catches URIError for the same reason.
+  let queryId: string;
+  try {
+    queryId = decodeURIComponent(
+      url.pathname.slice(SAVED_QUERIES_PATH_PREFIX.length),
+    );
+  } catch {
+    return errorResponse(
+      "not_found",
+      "GET /api/v1/queries/{id} requires a valid, percent-decodable query id.",
+      404,
+    );
+  }
   if (!queryId) {
     return errorResponse(
       "not_found",

--- a/workers/tiered-rate-limit.ts
+++ b/workers/tiered-rate-limit.ts
@@ -92,6 +92,13 @@ export interface TieredRateLimitResult {
     remaining: number;
     resetAt: string;
   };
+  /**
+   * Set instead of `quota` when the caller asked to DEFER the spend. The
+   * per-minute limiter has already passed; this carries what the caller needs
+   * to debit the cost-weighted quota once it knows what the request costs.
+   * Only a multiplexed transport needs this -- see the `deferQuota` option.
+   */
+  quotaPending?: { accountId: string; dailyUnits: number };
   /** The verified account id when a valid API key was supplied, else null
    * (anonymous, IP-keyed). */
   accountId: string | null;
@@ -161,6 +168,8 @@ async function spendDailyQuota(
   env: Env,
   accountId: string,
   dailyUnits: number,
+  /** Explicit cost, when the pathname cannot price the work. See below. */
+  costUnitsOverride?: number,
 ): Promise<TieredRateLimitResult["quota"] & { allowed: boolean }> {
   const dataApi = (
     env as unknown as {
@@ -171,7 +180,15 @@ async function spendDailyQuota(
   const token = (env as unknown as { API_KEY_LOOKUP_INTERNAL_TOKEN?: string })
     .API_KEY_LOOKUP_INTERNAL_TOKEN;
   if (!dataApi?.fetch || !token) return null as never;
-  const { weight } = routeCost(new URL(request.url).pathname);
+  // The pathname prices the work for REST, where one path IS one operation.
+  // It cannot for a multiplexed transport: every MCP call is POST /mcp, which
+  // falls to the `edge` catch-all, so an LLM generation and an artifact read
+  // billed the same 1 unit. Such callers pass their own cost (see
+  // src/mcp-tool-cost.ts) and it wins over the pathname.
+  const { weight } =
+    typeof costUnitsOverride === "number" && Number.isFinite(costUnitsOverride)
+      ? { weight: Math.max(1, Math.trunc(costUnitsOverride)) }
+      : routeCost(new URL(request.url).pathname);
   try {
     const response = await dataApi.fetch(
       new Request("https://api.metagraph.sh/api/v1/internal/keys/quota", {
@@ -215,6 +232,26 @@ export async function applyTieredRateLimit(
   request: Request,
   env: Env,
   config: TieredRateLimitConfig,
+  /**
+   * What this request costs, when its pathname cannot say. Only the daily quota
+   * uses it; the per-minute limiter counts requests, not units.
+   */
+  {
+    costUnits,
+    deferQuota,
+  }: {
+    costUnits?: number;
+    /**
+     * Skip the daily-quota spend and hand back `quotaPending` instead.
+     *
+     * The per-minute limiter MUST stay ahead of body parsing -- a caller over
+     * its ceiling should be refused without us doing work for it, which
+     * tests/mcp-server.test.ts pins. But the cost-weighted quota cannot be
+     * priced until the body says which tools are being called. Deferring lets
+     * both hold: gate on count first, bill on cost second.
+     */
+    deferQuota?: boolean;
+  } = {},
 ): Promise<TieredRateLimitResult> {
   const authHeader = request.headers.get("authorization");
   const auth = authHeader
@@ -238,10 +275,23 @@ export async function applyTieredRateLimit(
     const limiter = (env as unknown as Record<string, RateLimit | undefined>)[
       policy.envVar
     ];
+    // `String()` unconditionally turned a null account id into the LITERAL
+    // "null" -- a single fabricated tenant that every identity-less key shared.
+    // verifyUnkeyKey returns `accountId: identity?.externalId ?? null` while
+    // `valid` stays true, so any key minted without an Unkey identity landed
+    // there. Downstream that string is an identity: resolveSurfaceCredentialIdentity
+    // accepts it and returns `account:null`, so one holder could list, delete,
+    // and use another's stored surface credentials. It also collapsed them into
+    // one rate-limit bucket and one quota row, and `Number("null")` is NaN.
+    //
+    // Every consumer of this field already guards with `if (rateLimit.accountId)`
+    // and the declared type is `string | null`, so a real null is what they were
+    // written for.
+    const accountId = auth.accountId == null ? null : String(auth.accountId);
     const result = {
       policy,
       tier: tier ?? "keyed",
-      accountId: String(auth.accountId),
+      accountId,
     };
     // #8611: the blocklist comes BEFORE any ceiling. A blocked caller is not
     // "going too fast", and spending their daily quota on requests we are about
@@ -255,7 +305,7 @@ export async function applyTieredRateLimit(
     // for up to half an hour after someone hit block. The blocklist is its own
     // small snapshot on a short TTL instead, so a block lands within one
     // BLOCKLIST_KV_TTL rather than one identity-cache lifetime.
-    const block = await loadBlockVerdict(env, auth.accountId);
+    const block = await loadBlockVerdict(env, accountId);
     if (block.blocked) {
       return { allowed: false, ...result, block };
     }
@@ -272,17 +322,34 @@ export async function applyTieredRateLimit(
       // fresh window on the new ceiling rather than inheriting the old tier's
       // partially-spent one, which would otherwise let a downgrade be dodged (or
       // an upgrade be throttled) for the rest of the window.
+      // An unattributable key falls back to its CLIENT IP rather than a shared
+      // literal: it still gets its tier's ceiling (it does hold a valid key),
+      // but it can never share a bucket with an unrelated caller.
       const { success } = await limiter.limit({
-        key: `${config.keyPrefix}:${result.tier}:${auth.accountId}`,
+        key: `${config.keyPrefix}:${result.tier}:${
+          accountId ?? `ip:${resolveClientIp(request)}`
+        }`,
       });
       if (!success) return { allowed: false, ...result };
     }
-    if (policy.dailyUnits) {
+    // The daily quota is debited against an rpc_accounts row. With no account
+    // id there is no row to debit -- the old code sent `Number("null")`, i.e.
+    // NaN, which the internal endpoint stored as a single shared `account_id:
+    // null` row every unattributable key drew down together. Skipping is the
+    // honest option: the per-minute ceiling above still bounds the caller.
+    if (policy.dailyUnits && accountId !== null && deferQuota) {
+      Object.assign(result, {
+        quotaPending: { accountId, dailyUnits: policy.dailyUnits },
+      });
+      return { allowed: true, ...result };
+    }
+    if (policy.dailyUnits && accountId !== null) {
       const quota = await spendDailyQuota(
         request,
         env,
-        String(auth.accountId),
+        accountId,
         policy.dailyUnits,
+        costUnits,
       );
       if (quota && !quota.allowed) {
         return { allowed: false, ...result, quota };
@@ -410,4 +477,26 @@ export function tieredRateLimitHeaders(
     "x-ratelimit-scope": "per-minute",
     ...(tier ? { "x-ratelimit-tier": tier } : {}),
   };
+}
+
+/**
+ * Debit a deferred daily quota once the caller knows what the request cost.
+ *
+ * Pair with `applyTieredRateLimit(..., { deferQuota: true })`. Returns the same
+ * verdict shape `result.quota` would have carried, so `tieredRejectionResponse`
+ * can label the 429 with the ceiling that actually rejected the caller.
+ */
+export async function spendDeferredDailyQuota(
+  request: Request,
+  env: Env,
+  pending: { accountId: string; dailyUnits: number },
+  costUnits: number,
+): Promise<TieredRateLimitResult["quota"] & { allowed: boolean }> {
+  return spendDailyQuota(
+    request,
+    env,
+    pending.accountId,
+    pending.dailyUnits,
+    costUnits,
+  );
 }

--- a/workers/wss-lb.ts
+++ b/workers/wss-lb.ts
@@ -296,11 +296,40 @@ export function exceedsFrameCap(data: string | ArrayBuffer): boolean {
 // element. The HTTP proxy already refuses batches, an array containing one denied
 // call would otherwise need per-element error mapping, and no Substrate client sends
 // them over a subscription socket.
+/**
+ * A frame's JSON-RPC text, or null when it is not decodable UTF-8.
+ *
+ * Binary frames carry the SAME JSON as text ones -- jsonrpsee, Substrate's RPC
+ * server, parses `Data::Binary` exactly like `Data::Text` -- so a policy that
+ * only inspected `typeof data === "string"` was bypassed completely by sending
+ * the identical payload as an ArrayBuffer. `author_submitExtrinsic` and the
+ * `sudo_*` family were relayed to upstream providers under our IP reputation,
+ * which is the precise thing WSS_DENIED_RPC_PREFIXES exists to stop.
+ * `exceedsFrameCap` above already has an ArrayBuffer branch, so binary frames
+ * demonstrably reach this code path.
+ */
+export function rpcFrameText(data: string | ArrayBuffer): string | null {
+  if (typeof data === "string") return data;
+  try {
+    // `fatal` so invalid bytes throw instead of decoding to U+FFFD, which would
+    // turn undecodable input into a string we would then pretend to adjudicate.
+    return new TextDecoder("utf-8", { fatal: true, ignoreBOM: false }).decode(
+      data,
+    );
+  } catch {
+    // Undecodable bytes are not a JSON-RPC call we can adjudicate. Forwarding
+    // matches the "forgiving in one direction only" rule below: we refuse what
+    // we can read and name, never what we merely failed to understand.
+    return null;
+  }
+}
+
 export function deniedRpcMethod(data: string | ArrayBuffer): string | null {
-  if (typeof data !== "string") return null;
+  const text = rpcFrameText(data);
+  if (text === null) return null;
   let rpc: unknown;
   try {
-    rpc = JSON.parse(data);
+    rpc = JSON.parse(text);
   } catch {
     return null;
   }
@@ -374,7 +403,10 @@ export function pipe(client: WebSocket, upstream: WebSocket): void {
     const denied = deniedRpcMethod(data);
     if (denied) {
       try {
-        client.send(rpcMethodNotAllowed(data as string, denied));
+        // Feed the DECODED text, not `data as string`: for a binary frame that
+        // cast produced an ArrayBuffer, whose JSON.parse throws, so the refusal
+        // came back with a null id the client could not correlate to its call.
+        client.send(rpcMethodNotAllowed(rpcFrameText(data) ?? "", denied));
       } catch {
         teardown(1011, "client send failed");
       }

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -93,6 +93,20 @@
   // opaque id every src/unkey-client.ts call needs to scope its request to.
   "vars": {
     "UNKEY_API_ID": "api_2Dv8cVjrTSiD",
+    // Tier-source flags. These are READ by this Worker -- neuronsServedFromD1()
+    // and its two siblings in workers/data-api.ts gate on `!== "postgres"` --
+    // but they were declared only in wrangler.jsonc, which configures the MAIN
+    // Worker. `vars` is replaced wholesale on deploy, so over here they were
+    // always `undefined`: the comparison happened to yield the intended "serve
+    // from D1", and the documented 503 fall-through was unreachable.
+    //
+    // Declared here at the SAME values wrangler.jsonc carries, so the two
+    // Workers cannot disagree about which tier answers. Change them together:
+    // flipping one side alone is the split-brain this pins shut -- the main
+    // Worker would stop forwarding while this one kept serving D1.
+    "METAGRAPH_NEURONS_SOURCE": "d1",
+    "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
+    "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",
   },
   // Smart placement: run the Worker close to the Hyperdrive origin (self-hosted indexer
   // box Postgres, reached via Cloudflare Tunnel) to minimize the per-request DB round-trip,


### PR DESCRIPTION
## The reported bug

`https://metagraph.sh/blocks/8771459` showed **Events 0** on every recent block, while the same page's pallet breakdown said 320. Two defects stacked:

1. **API** — block detail above the decode seam read only `blocks_head`, which carries no `event_count` or `spec_version`. The real values sat one join away in `chain_detail_blocks` (same D1 database, same `block_number` key), so the route published `null`.
2. **UI** — `block.event_count ?? 0` rendered "unknown" as a confident `0`. The Success tile in the same file already got this right with `"—"`.

Measured against production for block 8,771,446: API returned `event_count: null`, `/chain-events` returned `count: 320`, and D1 held `chain_event_count = 320, spec_version = 442` for that exact row.

### Unknown-count window

`event_count` semantics verified against the lakehouse column it must match: block 8,771,000 reports 268 and `/chain-events` counts 268, so it is the raw pallet-event count (`chain_event_count`, not `account_event_count`).

| | window with no event count |
|---|---|
| before | **144 blocks** (~29 min of chain time) |
| after | **3 blocks** (~36 s) |

The residual 3 is the live-follow lag: `blocks_head` (firehose poller, head 8,771,801) runs ~2 blocks ahead of `chain_detail_blocks` (chain-detail sync, 8,771,799). For a block decoded ~24 s ago the count genuinely is not computed yet, so it renders `—` rather than a fabricated `0`. **Follow-up:** closing the last 3 means tightening the chain-detail sync's cadence against the poller — a producer change, not an API one.

## Found alongside it

Each is independent and reproducible on its own.

**Security**

- **`workers/wss-lb.ts`** — `deniedRpcMethod` returned `null` for any non-string frame, so the read-only RPC policy was bypassed entirely by sending the same JSON as a **binary** WebSocket frame. jsonrpsee parses `Data::Binary` identically, so `author_submitExtrinsic` and `sudo_*` were relayed to upstream providers under our IP reputation — the exact thing `WSS_DENIED_RPC_PREFIXES` exists to stop. `exceedsFrameCap` two functions above already has an `ArrayBuffer` branch, proving binary frames reach that code. The pre-existing test asserted the bypass as intended behaviour (`"a binary frame is not policy-checked as text"`) and has been replaced with coverage that fails without the fix.
- **`workers/tiered-rate-limit.ts`** — a valid API key with no Unkey identity stringified to the literal tenant `"null"`, collapsing every such caller into one identity sharing a rate-limit bucket, a quota row, and — via `resolveSurfaceCredentialIdentity` → `account:null` — **stored surface credentials**. Marked *plausible*: it needs at least one live key without an Unkey identity, which is worth confirming against production. The fix is safe either way.

**Destructive routing**

- `DELETE /api/v1/alerts/triggers/{id}/deliveries` **deleted the trigger** — the handler read the id positionally and ignored a trailing segment. That URL is plausible because the sibling watch surface really does expose it. The correct guard already existed next door in `handleWatchTriggersRoute`.
- `POST /api/v1/alerts/triggersanything` **created a real trigger** — the proxy gates used `startsWith` with no segment boundary, on both sides of the DATA_API boundary. Adds `isPathUnder` and applies it to both.

**Metering**

- MCP priced the daily quota by the transport path `/mcp`, which falls to the `edge` catch-all, so `tools/call {"ask"}` cost **1 unit** where the identical work over `POST /api/v1/ask` cost **25**; a JSON-RPC batch was charged once for up to ten calls. Cost is now declared per tool (`src/mcp-tool-cost.ts`) and summed per batch.
  - Pricing off the `Mirrors GET` line in descriptions was rejected: only 101 of 189 tools carry one, so 88 would silently bill at the cheapest family. The table is declared and proven bidirectionally — a tool mirroring an expensive REST route cannot ship unpriced.
  - The per-minute limiter still gates **ahead of body parsing** (`tests/mcp-server.test.ts` pins this); only the cost-weighted quota defers until the body names the tools.

**Surface parity**

The lakehouse cold tier was wired into the REST handlers alone, so with the tier flags retired MCP and GraphQL answered `event_count: 0` / `entry_count: 0` / `ownership_ties: []` for resources REST served in full — no error, no degraded marker. `get_chain_identity_history`'s own comment still claimed the two "never diverge".

Three composers now own those cascades and REST, MCP and GraphQL all call them, matching the rule `tests/subnet-ownership-surface-parity.test.ts` already states ("the cascade belongs to …"). That test caught the first attempt, which imported the readers directly.

**Counts published as fact**

- `resolveCount` ran `Number(null)` before its null check, so a failed nominator count published as a confident `0` — defeating the cold tier's own comment, *"Null is a real state; a page size dressed as a total is not."*
- `buildBlockEvents` reported the page size as the block total (`?limit=5` → 5, `?limit=320` → 237).
- The firehose netuid filter coerced a JSON `null` through `Number(null)` to `0`, delivering every subnet-less account event to subscribers filtered on netuid 0.

**Other**

- Alert match write-back bound one parameter per matched id, exceeding the Workers D1 binding's 100-parameter cap and losing the whole batch's `match_count` to a 502. Chunked at 90, as every other IN-list here already is.
- `GET /api/v1/queries/%ZZ` died as a bare 500 — `decodeURIComponent` sat outside the try.
- GraphQL `paginate` restarted at page 1 on a stale cursor **and still emitted a next_cursor**, so a client walked page 1 forever when a row vanished mid-walk.
- `subnet-detail` was missing from `LIVE_OVERLAY_ROUTE_IDS` despite carrying a live economics overlay, making live alpha price eligible for a 300 s edge cache.
- The three tier-source vars are read by the data Worker but declared only in `wrangler.jsonc`, where it never sees them. Declared at matching values so the two Workers cannot disagree.

## Verification

```
tsc --noEmit          clean (backend + apps/ui)
eslint                clean
prettier --check      clean
vitest (backend)      671 files / 15,858 tests pass
vitest (apps/ui)      230 files / 1,801 tests pass
validate:contract-drift, types, openapi, generated-client,
no-hand-written-mjs, private-boundary   all pass
```

Rebased onto `3ce266748` and re-verified green after the rebase.

## Notes

- No linked issue: none of the open issues cover this work, and per maintainer direction this ships as-is.
- This spans several subsystems rather than one focused change. Happy to split if you'd prefer separate review surfaces — the three behaviour-changing pieces (MCP quota, tenant identity, cold-tier composers) are the natural seams.
- UI touched (`-blocks-ref-page.tsx`, `live-block-rail.tsx`): the only visual change is unknown counts rendering `—` instead of `0`.
