### PR TITLE
feat(projections): give the projection lanes a network dimension, so testnet gets its own artifacts

### DIFF
--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -17,6 +17,12 @@
 // (one lane's throw never skips the next) and each failure records exactly
 // one exception under `projection:<name>` so a silently dead lane is visible.
 
+import {
+  type ChainNetworkId,
+  chainTable,
+  DEFAULT_CHAIN_NETWORK,
+  LAKEHOUSE_NAMESPACES,
+} from "./chain-network.ts";
 import { isR2SqlConfigured, r2SqlQuery } from "./r2-sql.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import {
@@ -111,7 +117,10 @@ export interface ProjectionLane {
    * or null when the lakehouse could not answer EVERY query — a partial
    * artifact would serve one window's fresh numbers next to another's
    * garbage, so all-or-nothing is the only honest contract. */
-  compute(env: Env): Promise<Record<string, unknown> | null>;
+  compute(
+    env: Env,
+    network: ChainNetworkId,
+  ): Promise<Record<string, unknown> | null>;
   /**
    * Optional: fan ONE computed body out across several R2 keys, as
    * `key -> body`. Defaults to `{ [artifactKey]: body }`.
@@ -132,9 +141,9 @@ export interface ProjectionLane {
 /** Every value a lane inlines below is a module constant or a computed
  * integer — never caller input — per src/r2-sql.ts's no-bound-params
  * contract. */
-function transferWindowSql(cutoff: number): string[] {
+function transferWindowSql(cutoff: number, network: ChainNetworkId): string[] {
   const scope =
-    `FROM chain.account_events ` +
+    `FROM ${chainTable("account_events", network)} ` +
     `WHERE event_kind = '${TRANSFER_KIND}' AND observed_at >= ${cutoff}`;
   // The same five statements workers/data-api.ts issues for this route, in
   // the same split: the two DISTINCT counts were separated there because each
@@ -167,6 +176,7 @@ function transferWindowSql(cutoff: number): string[] {
  * queries, windows computed from this run's generated_at. */
 async function computeChainTransfers(
   env: Env,
+  network: ChainNetworkId,
 ): Promise<Record<string, unknown> | null> {
   const generatedAt = Date.now();
   const windows: Record<string, unknown> = {};
@@ -178,7 +188,7 @@ async function computeChainTransfers(
       receiversCountSql,
       sendersSql,
       receiversSql,
-    ] = transferWindowSql(generatedAt - days * DAY_MS);
+    ] = transferWindowSql(generatedAt - days * DAY_MS, network);
     // Sequential on purpose: one second-scale scan in flight at a time, the
     // posture every cold-tier caller of r2SqlQuery takes.
     const totals = await r2SqlQuery(env, totalsSql!);
@@ -233,6 +243,7 @@ export const STAKE_FLOW_PROJECTION_WINDOWS: Record<string, number> = {
 
 async function computeChainStakeFlow(
   env: Env,
+  network: ChainNetworkId,
 ): Promise<Record<string, unknown> | null> {
   const generatedAt = Date.now();
   const windows: Record<string, unknown> = {};
@@ -243,7 +254,7 @@ async function computeChainStakeFlow(
       env,
       `SELECT netuid, event_kind, COALESCE(SUM(amount_tao), 0) AS total_tao, ` +
         `COUNT(*) AS event_count, MAX(observed_at) AS last_observed ` +
-        `FROM chain.account_events ` +
+        `FROM ${chainTable("account_events", network)} ` +
         `WHERE event_kind IN ('${STAKE_ADDED_KIND}', '${STAKE_REMOVED_KIND}') ` +
         `AND observed_at >= ${cutoff} GROUP BY netuid, event_kind`,
     );
@@ -278,9 +289,12 @@ const SIGNED_COUNT_EXPR = "SUM(CASE WHEN signer IS NOT NULL THEN 1 ELSE 0 END)";
  * same split data-api runs (base extrinsic aggregate, the per-day DISTINCT
  * signer count in its own statement, the blocks aggregate, and the blocks
  * freshness read), grouped by UTC epoch-day instead of a rendered string. */
-function chainActivityWindowSql(cutoff: number): string[] {
-  const extrinsics = `FROM chain.extrinsics WHERE observed_at >= ${cutoff}`;
-  const blocks = `FROM chain.blocks WHERE observed_at >= ${cutoff}`;
+function chainActivityWindowSql(
+  cutoff: number,
+  network: ChainNetworkId,
+): string[] {
+  const extrinsics = `FROM ${chainTable("extrinsics", network)} WHERE observed_at >= ${cutoff}`;
+  const blocks = `FROM ${chainTable("blocks", network)} WHERE observed_at >= ${cutoff}`;
   return [
     // `success = TRUE` (not the bare `success` data-api writes) is the
     // predicate form the extrinsics cold tier already issues against this
@@ -318,6 +332,7 @@ function withDayLabels(
  * buildChainActivity. */
 async function computeChainActivity(
   env: Env,
+  network: ChainNetworkId,
 ): Promise<Record<string, unknown> | null> {
   const generatedAt = Date.now();
   const windows: Record<string, unknown> = {};
@@ -325,6 +340,7 @@ async function computeChainActivity(
   for (const [label, days] of Object.entries(ANALYTICS_WINDOWS)) {
     const [baseSql, signersSql, blocksSql, freshSql] = chainActivityWindowSql(
       generatedAt - days * DAY_MS,
+      network,
     );
     const base = await r2SqlQuery(env, baseSql!);
     if (base === null) return null;
@@ -367,8 +383,11 @@ async function computeChainActivity(
  * the unfiltered full-window share denominator. The optional call_module
  * scope is NOT precomputed — its value space is unbounded, so the reader
  * declines filtered calls instead of approximating them. */
-function chainCallsWindowSql(cutoff: number): string[] {
-  const scope = `FROM chain.extrinsics WHERE observed_at >= ${cutoff}`;
+function chainCallsWindowSql(
+  cutoff: number,
+  network: ChainNetworkId,
+): string[] {
+  const scope = `FROM ${chainTable("extrinsics", network)} WHERE observed_at >= ${cutoff}`;
   return [
     `SELECT MAX(observed_at) AS newest_observed ${scope}`,
     `SELECT call_module, COUNT(*) AS count ${scope} ` +
@@ -387,13 +406,14 @@ function chainCallsWindowSql(cutoff: number): string[] {
  * separately, pre-LIMIT, exactly like the live tier. */
 async function computeChainCalls(
   env: Env,
+  network: ChainNetworkId,
 ): Promise<Record<string, unknown> | null> {
   const generatedAt = Date.now();
   const windows: Record<string, unknown> = {};
   let rowCount = 0;
   for (const [label, days] of Object.entries(ANALYTICS_WINDOWS)) {
     const [freshSql, moduleSql, moduleFunctionSql, totalSql] =
-      chainCallsWindowSql(generatedAt - days * DAY_MS);
+      chainCallsWindowSql(generatedAt - days * DAY_MS, network);
     const fresh = await r2SqlQuery(env, freshSql!);
     if (fresh === null) return null;
     const moduleRows = await r2SqlQuery(env, moduleSql!);
@@ -427,12 +447,16 @@ async function computeChainCalls(
  * non-NULL values per day (PERCENTILE_CONT ignores NULLs), keep the middle
  * one (odd count) or middle two (even count), and AVG them — which IS the
  * 0.5-quantile linear interpolation, not an approximation of it. */
-function chainFeesMedianSql(cutoff: number, column: string): string {
+function chainFeesMedianSql(
+  cutoff: number,
+  column: string,
+  network: ChainNetworkId,
+): string {
   return (
     `WITH ranked AS (SELECT ${EPOCH_DAY_EXPR} AS day_index, ${column}, ` +
     `ROW_NUMBER() OVER (PARTITION BY ${EPOCH_DAY_EXPR} ORDER BY ${column}) AS rn, ` +
     `COUNT(*) OVER (PARTITION BY ${EPOCH_DAY_EXPR}) AS cnt ` +
-    `FROM chain.extrinsics WHERE observed_at >= ${cutoff} ` +
+    `FROM ${chainTable("extrinsics", network)} WHERE observed_at >= ${cutoff} ` +
     `AND signer IS NOT NULL AND ${column} IS NOT NULL) ` +
     `SELECT day_index, AVG(${column}) AS median_value FROM ranked ` +
     `WHERE rn * 2 = cnt OR rn * 2 = cnt + 1 OR rn * 2 = cnt + 2 ` +
@@ -441,8 +465,8 @@ function chainFeesMedianSql(cutoff: number, column: string): string {
 }
 
 /** GET /api/v1/chain/fees' non-median statements for one window cutoff. */
-function chainFeesWindowSql(cutoff: number): string[] {
-  const scope = `FROM chain.extrinsics WHERE observed_at >= ${cutoff}`;
+function chainFeesWindowSql(cutoff: number, network: ChainNetworkId): string[] {
+  const scope = `FROM ${chainTable("extrinsics", network)} WHERE observed_at >= ${cutoff}`;
   return [
     `SELECT ${EPOCH_DAY_EXPR} AS day_index, COUNT(*) AS extrinsic_count, ` +
       `${SIGNED_COUNT_EXPR} AS signed_extrinsic_count, ` +
@@ -466,25 +490,26 @@ function chainFeesWindowSql(cutoff: number): string[] {
  * precomputed — the reader declines filtered calls. */
 async function computeChainFees(
   env: Env,
+  network: ChainNetworkId,
 ): Promise<Record<string, unknown> | null> {
   const generatedAt = Date.now();
   const windows: Record<string, unknown> = {};
   let rowCount = 0;
   for (const [label, days] of Object.entries(ANALYTICS_WINDOWS)) {
     const cutoff = generatedAt - days * DAY_MS;
-    const [dailySql, payersSql, freshSql] = chainFeesWindowSql(cutoff);
+    const [dailySql, payersSql, freshSql] = chainFeesWindowSql(cutoff, network);
     const daily = await r2SqlQuery(env, dailySql!);
     if (daily === null) return null;
     const payers = await r2SqlQuery(env, payersSql!);
     if (payers === null) return null;
     const feeMedians = await r2SqlQuery(
       env,
-      chainFeesMedianSql(cutoff, "fee_tao"),
+      chainFeesMedianSql(cutoff, "fee_tao", network),
     );
     if (feeMedians === null) return null;
     const tipMedians = await r2SqlQuery(
       env,
-      chainFeesMedianSql(cutoff, "tip_tao"),
+      chainFeesMedianSql(cutoff, "tip_tao", network),
     );
     if (tipMedians === null) return null;
     const fresh = await r2SqlQuery(env, freshSql!);
@@ -535,8 +560,11 @@ async function computeChainFees(
  * network observed_at), then the leaderboard in BOTH supported sort orders at
  * the route's maximum limit. call_module is not precomputed — the reader
  * declines filtered calls. */
-function chainSignersWindowSql(cutoff: number): string[] {
-  const scope = `FROM chain.extrinsics WHERE observed_at >= ${cutoff}`;
+function chainSignersWindowSql(
+  cutoff: number,
+  network: ChainNetworkId,
+): string[] {
+  const scope = `FROM ${chainTable("extrinsics", network)} WHERE observed_at >= ${cutoff}`;
   const leaderboard = (orderBy: string) =>
     `SELECT signer, COUNT(*) AS tx_count, ` +
     `SUM(COALESCE(fee_tao, 0)) AS total_fee_tao, ` +
@@ -554,6 +582,7 @@ function chainSignersWindowSql(cutoff: number): string[] {
 /** GET /api/v1/chain/signers, every supported window and both sorts. */
 async function computeChainSigners(
   env: Env,
+  network: ChainNetworkId,
 ): Promise<Record<string, unknown> | null> {
   const generatedAt = Date.now();
   const windows: Record<string, unknown> = {};
@@ -561,6 +590,7 @@ async function computeChainSigners(
   for (const [label, days] of Object.entries(ANALYTICS_WINDOWS)) {
     const [freshSql, txCountSql, feeSql] = chainSignersWindowSql(
       generatedAt - days * DAY_MS,
+      network,
     );
     const fresh = await r2SqlQuery(env, freshSql!);
     if (fresh === null) return null;
@@ -592,6 +622,7 @@ async function computeChainSigners(
  * rollup, the distribution, and the limit slice). */
 async function computeChainAlphaVolume(
   env: Env,
+  network: ChainNetworkId,
 ): Promise<Record<string, unknown> | null> {
   const generatedAt = Date.now();
   const cutoff = generatedAt - DAY_MS;
@@ -601,7 +632,7 @@ async function computeChainAlphaVolume(
       `COALESCE(SUM(alpha_amount), 0) AS alpha_volume, ` +
       `COALESCE(SUM(amount_tao), 0) AS tao_volume, ` +
       `COUNT(*) AS event_count, MAX(observed_at) AS last_observed ` +
-      `FROM chain.account_events ` +
+      `FROM ${chainTable("account_events", network)} ` +
       `WHERE event_kind IN ('${STAKE_ADDED_KIND}', '${STAKE_REMOVED_KIND}') ` +
       `AND observed_at >= ${cutoff} GROUP BY netuid, event_kind`,
   );
@@ -624,9 +655,10 @@ function subnetDistinctWindowSql(
   eventKind: string,
   countAlias: string,
   distinctAlias: string,
+  network: ChainNetworkId,
 ): { networkSql: string; subnetSql: string } {
   const scope =
-    `FROM chain.account_events ` +
+    `FROM ${chainTable("account_events", network)} ` +
     `WHERE event_kind = '${eventKind}' AND observed_at >= ${cutoff}`;
   return {
     networkSql:
@@ -651,14 +683,17 @@ async function computeSubnetDistinctWindow(
 } | null> {
   const networkRows = await r2SqlQuery(env, sql.networkSql);
   if (networkRows === null) return null;
-  const network = networkRows[0] ?? null;
+  // The CHAIN-WIDE scope row, not a chain network -- the artifact key it lands
+  // under is `network` and cannot be renamed, but the local is named for what
+  // it holds so the two senses of the word cannot be confused here.
+  const chainWide = networkRows[0] ?? null;
   let rows: Record<string, unknown>[] = [];
-  if (network?.newest_observed != null) {
+  if (chainWide?.newest_observed != null) {
     const subnetRows = await r2SqlQuery(env, sql.subnetSql);
     if (subnetRows === null) return null;
     rows = subnetRows;
   }
-  return { network, rows };
+  return { network: chainWide, rows };
 }
 
 /** GET /api/v1/chain/stake-transfers, every supported window — the
@@ -666,6 +701,7 @@ async function computeSubnetDistinctWindow(
  * aggregate, stored verbatim for buildChainStakeTransfers. */
 async function computeChainStakeTransfers(
   env: Env,
+  network: ChainNetworkId,
 ): Promise<Record<string, unknown> | null> {
   const generatedAt = Date.now();
   const windows: Record<string, unknown> = {};
@@ -678,6 +714,7 @@ async function computeChainStakeTransfers(
         STAKE_TRANSFERRED_EVENT_KIND,
         "transfers",
         "distinct_senders",
+        network,
       ),
     );
     if (window === null) return null;
@@ -696,6 +733,7 @@ async function computeChainStakeTransfers(
  * stake-transfers lane over the StakeMoved stream. */
 async function computeChainStakeMoves(
   env: Env,
+  network: ChainNetworkId,
 ): Promise<Record<string, unknown> | null> {
   const generatedAt = Date.now();
   const windows: Record<string, unknown> = {};
@@ -708,6 +746,7 @@ async function computeChainStakeMoves(
         STAKE_MOVED_EVENT_KIND,
         "movements",
         "distinct_movers",
+        network,
       ),
     );
     if (window === null) return null;
@@ -727,9 +766,12 @@ async function computeChainStakeMoves(
  * supported sort orders at the route's maximum limit. The PAIR_FILTER
  * predicate is inlined the same way data-api inlines it (it is private to
  * src/chain-transfer-pairs.ts). */
-function chainTransferPairsWindowSql(cutoff: number): string[] {
+function chainTransferPairsWindowSql(
+  cutoff: number,
+  network: ChainNetworkId,
+): string[] {
   const scope =
-    `FROM chain.account_events ` +
+    `FROM ${chainTable("account_events", network)} ` +
     `WHERE event_kind = '${TRANSFER_KIND}' AND observed_at >= ${cutoff} ` +
     `AND hotkey IS NOT NULL AND coldkey IS NOT NULL ` +
     `AND hotkey <> '' AND coldkey <> '' AND hotkey <> coldkey ` +
@@ -763,6 +805,7 @@ function chainTransferPairsWindowSql(cutoff: number): string[] {
 /** GET /api/v1/chain/transfer-pairs, every supported window and both sorts. */
 async function computeChainTransferPairs(
   env: Env,
+  network: ChainNetworkId,
 ): Promise<Record<string, unknown> | null> {
   const generatedAt = Date.now();
   const windows: Record<string, unknown> = {};
@@ -770,6 +813,7 @@ async function computeChainTransferPairs(
   for (const [label, days] of Object.entries(CHAIN_TRANSFER_PAIR_WINDOWS)) {
     const [totalsSql, volumeSql, countSql] = chainTransferPairsWindowSql(
       generatedAt - days * DAY_MS,
+      network,
     );
     const totals = await r2SqlQuery(env, totalsSql!);
     if (totals === null) return null;
@@ -810,11 +854,12 @@ async function computeChainTransferPairs(
  */
 async function computeBlocksSummary(
   env: Env,
+  network: ChainNetworkId,
 ): Promise<Record<string, unknown> | null> {
   const generatedAt = Date.now();
   const rows = await r2SqlQuery(
     env,
-    `SELECT ${BLOCKS_SUMMARY_READ_COLUMNS} FROM chain.blocks ` +
+    `SELECT ${BLOCKS_SUMMARY_READ_COLUMNS} FROM ${chainTable("blocks", network)} ` +
       `ORDER BY block_number DESC LIMIT ${BLOCKS_SUMMARY_SCAN_CAP}`,
   );
   if (rows === null || rows.length === 0) return null;
@@ -856,6 +901,7 @@ async function computeBlocksSummary(
  */
 async function computeChainRegistrations(
   env: Env,
+  network: ChainNetworkId,
 ): Promise<Record<string, unknown> | null> {
   const generatedAt = Date.now();
   const windows: Record<string, unknown> = {};
@@ -863,7 +909,7 @@ async function computeChainRegistrations(
   for (const [label, days] of Object.entries(CHAIN_REGISTRATIONS_WINDOWS)) {
     const cutoff = generatedAt - days * DAY_MS;
     const scope =
-      `FROM chain.account_events ` +
+      `FROM ${chainTable("account_events", network)} ` +
       `WHERE event_kind = '${REGISTRATION_EVENT_KIND}' ` +
       `AND observed_at >= ${cutoff}`;
 
@@ -973,6 +1019,7 @@ const DEREGISTRATION_READ_COLUMNS =
  */
 async function computeChainDeregistrations(
   env: Env,
+  network: ChainNetworkId,
 ): Promise<Record<string, unknown> | null> {
   const generatedAt = Date.now();
   const lookbackDays = Math.max(
@@ -980,7 +1027,7 @@ async function computeChainDeregistrations(
   );
   const rows = await r2SqlQuery(
     env,
-    `SELECT ${DEREGISTRATION_READ_COLUMNS} FROM chain.account_events ` +
+    `SELECT ${DEREGISTRATION_READ_COLUMNS} FROM ${chainTable("account_events", network)} ` +
       `WHERE event_kind = '${REGISTRATION_EVENT_KIND}' ` +
       `AND observed_at >= ${generatedAt - lookbackDays * DAY_MS}`,
   );
@@ -1118,6 +1165,43 @@ interface ProjectionBucket {
   put(key: string, value: string): Promise<unknown>;
 }
 
+/**
+ * Which chains the lanes run for.
+ *
+ * DERIVED from the lakehouse namespace map rather than listed again: a network
+ * that has a namespace has decoded tables, and a network that has decoded
+ * tables is exactly one these lanes can project. A second hand-written list
+ * would let a chain gain a decode lane and silently never get its artifacts.
+ */
+export const PROJECTION_NETWORKS = Object.keys(
+  LAKEHOUSE_NAMESPACES,
+) as ChainNetworkId[];
+
+/**
+ * Where one network's projection artifact lives.
+ *
+ * MAINNET KEEPS ITS KEY UNCHANGED, the same asymmetry `networkKvKey` uses for
+ * the KV cache and `chainTable` for the lakehouse namespace: every artifact
+ * already written stays readable, and a mainnet request after this change
+ * reads exactly the object it read before. Testnet gets its own keyspace, so a
+ * testnet card can never be served to a mainnet caller no matter what a reader
+ * does with it afterwards.
+ *
+ * The insertion point is after the `metagraph/projections/` prefix rather than
+ * at the front of the key, so the projections stay one prefix in the bucket
+ * and a listing still groups them.
+ */
+export function projectionKey(
+  artifactKey: string,
+  network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
+): string {
+  if (network === DEFAULT_CHAIN_NETWORK) return artifactKey;
+  const prefix = "metagraph/projections/";
+  return artifactKey.startsWith(prefix)
+    ? `${prefix}${network}/${artifactKey.slice(prefix.length)}`
+    : `${network}/${artifactKey}`;
+}
+
 export interface ProjectionLaneDeps {
   recordException?: typeof recordExceptionEvent;
 }
@@ -1139,8 +1223,14 @@ export async function runProjectionLane(
   env: Env,
   lane: ProjectionLane,
   deps: ProjectionLaneDeps = {},
+  network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<ProjectionLaneResult> {
   const record = deps.recordException ?? recordExceptionEvent;
+  // One label for logs, telemetry and the result map, so a failing testnet lane
+  // is not reported under the mainnet lane's name -- which would make an
+  // exception on the secondary chain look like an outage on the primary.
+  const label =
+    network === DEFAULT_CHAIN_NETWORK ? lane.name : `${lane.name}:${network}`;
   const bucket = (env as { METAGRAPH_ARCHIVE?: ProjectionBucket } | null)
     ?.METAGRAPH_ARCHIVE;
   if (!bucket?.put) {
@@ -1148,24 +1238,24 @@ export async function runProjectionLane(
     // refuse before spending second-scale queries on an answer that would be
     // dropped (raw-capture-sync's posture).
     return {
-      name: lane.name,
+      name: label,
       ok: false,
       rows: null,
       reason: "r2_binding_missing",
     };
   }
   try {
-    const body = await lane.compute(env);
+    const body = await lane.compute(env, network);
     if (body === null) {
       console.error(
-        `[projection:${lane.name}] compute declined; previous artifact left in place`,
+        `[projection:${label}] compute declined; previous artifact left in place`,
       );
       await record(env, {
-        error: new Error(`projection lane ${lane.name}: compute declined`),
-        route: `projection:${lane.name}`,
+        error: new Error(`projection lane ${label}: compute declined`),
+        route: `projection:${label}`,
       });
       return {
-        name: lane.name,
+        name: label,
         ok: false,
         rows: null,
         reason: "compute_declined",
@@ -1175,11 +1265,11 @@ export async function runProjectionLane(
       ? lane.split(body)
       : { [lane.artifactKey]: body };
     for (const [key, value] of Object.entries(objects)) {
-      await bucket.put(key, JSON.stringify(value));
+      await bucket.put(projectionKey(key, network), JSON.stringify(value));
     }
     const rows = (body as { row_count?: unknown }).row_count;
     return {
-      name: lane.name,
+      name: label,
       ok: true,
       rows: typeof rows === "number" ? rows : null,
     };
@@ -1187,11 +1277,11 @@ export async function runProjectionLane(
     // A throwing store is the same decline as a failed compute: the previous
     // artifact survives, and the NEXT lane still runs.
     console.error(
-      `[projection:${lane.name}]`,
+      `[projection:${label}]`,
       String((error as Error)?.message ?? error),
     );
-    await record(env, { error, route: `projection:${lane.name}` });
-    return { name: lane.name, ok: false, rows: null, reason: "lane_failed" };
+    await record(env, { error, route: `projection:${label}` });
+    return { name: label, ok: false, rows: null, reason: "lane_failed" };
   }
 }
 
@@ -1222,10 +1312,17 @@ export async function runProjectionLanes(
   }
   const lanes: Record<string, number | null> = {};
   let ok = true;
-  for (const lane of PROJECTION_LANES) {
-    const result = await runProjectionLane(env, lane, deps);
-    lanes[lane.name] = result.rows;
-    ok = ok && result.ok;
+  for (const network of PROJECTION_NETWORKS) {
+    for (const lane of PROJECTION_LANES) {
+      const result = await runProjectionLane(env, lane, deps, network);
+      lanes[result.name] = result.rows;
+      // MAINNET DECIDES THE VERDICT. A testnet lane that cannot answer -- its
+      // decode lane is younger and its tables can genuinely be empty for a
+      // window -- must not report the whole tick as failed, or the signal that
+      // mainnet is broken stops meaning anything. Its own decline is still
+      // logged and recorded under its own `:testnet` route label.
+      if (network === DEFAULT_CHAIN_NETWORK) ok = ok && result.ok;
+    }
   }
   return { ok, lanes };
 }

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -14,7 +14,11 @@ import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.ts";
 import { tieredRejectionResponse } from "../workers/tiered-rate-limit.ts";
 import { API_ROUTES, compileRoutePattern } from "../src/contracts.ts";
 import * as workerConfig from "../workers/config.ts";
-import { PROJECTION_LANES } from "../src/projection-lanes.ts";
+import {
+  PROJECTION_LANES,
+  PROJECTION_NETWORKS,
+  projectionKey,
+} from "../src/projection-lanes.ts";
 import { type AnyFn, type Row } from "./row-type.ts";
 import type { RpcEndpoint } from "../workers/request-handlers/rpc-proxy.ts";
 
@@ -3458,7 +3462,14 @@ describe("handleScheduled PROJECTION_LANES_CRON", () => {
     // to be edited in lockstep. Deriving means registering a lane can never
     // again break this by omission -- it can only fail if the lane genuinely
     // did not run or did not write, which is what this test is for.
-    const registered = PROJECTION_LANES.map((lane) => lane.name);
+    // Every lane x every network (#9412): mainnet keeps the bare lane name,
+    // each other chain is suffixed, so a testnet failure is never reported
+    // under the mainnet lane's name.
+    const registered = PROJECTION_NETWORKS.flatMap((network) =>
+      PROJECTION_LANES.map((lane) =>
+        network === "mainnet" ? lane.name : `${lane.name}:${network}`,
+      ),
+    );
     const outcome = result as {
       ok: boolean;
       lanes: Record<string, number | null>;
@@ -3482,13 +3493,15 @@ describe("handleScheduled PROJECTION_LANES_CRON", () => {
     assert.equal(outcome.ok, true);
     assert.deepEqual(
       puts.sort(),
-      [
-        ...PROJECTION_LANES.map((lane) => lane.artifactKey),
-        // The one lane that fans its single computed body across two objects
-        // (src/chain-deregistrations-artifact.ts's header says why).
-        "metagraph/projections/chain-deregistrations-by-hotkey.json",
-      ].sort(),
-      "each lane writes its own artifact key, plus any it declares a split for",
+      PROJECTION_NETWORKS.flatMap((network) =>
+        [
+          ...PROJECTION_LANES.map((lane) => lane.artifactKey),
+          // The one lane that fans its single computed body across two objects
+          // (src/chain-deregistrations-artifact.ts's header says why).
+          "metagraph/projections/chain-deregistrations-by-hotkey.json",
+        ].map((key) => projectionKey(key, network)),
+      ).sort(),
+      "each lane writes its own artifact key per network, plus any split it declares",
     );
   });
 
@@ -3530,9 +3543,21 @@ describe("handleScheduled PROJECTION_LANES_CRON", () => {
     assert.ok(
       !puts.includes("metagraph/projections/chain-transfer-pairs.json"),
     );
-    // -2 failed lanes, +1 for the chain-deregistrations split's second object.
-    assert.equal(puts.length, Object.keys(lanes).length - 2 + 1);
+    // The Transfer filter is network-agnostic, so BOTH chains' copies of those
+    // two lanes fail: two per network, plus one extra object for the
+    // chain-deregistrations split on each.
+    const failedPerNetwork = 2;
+    const splitExtraPerNetwork = 1;
+    assert.equal(
+      puts.length,
+      Object.keys(lanes).length -
+        failedPerNetwork * PROJECTION_NETWORKS.length +
+        splitExtraPerNetwork * PROJECTION_NETWORKS.length,
+    );
     assert.ok(puts.includes("metagraph/projections/chain-stake-flow.json"));
+    // And mainnet's verdict is what set ok:false -- the testnet copies of the
+    // same two lanes failed too, but they never decide the tick.
+    assert.equal(lanes["chain-transfers:testnet"], null);
   });
 });
 

--- a/tests/projection-lanes.test.ts
+++ b/tests/projection-lanes.test.ts
@@ -6,18 +6,19 @@ import assert from "node:assert/strict";
 import { afterEach, describe, test, vi } from "vitest";
 import {
   PROJECTION_LANES,
+  PROJECTION_NETWORKS,
+  projectionKey,
   STAKE_FLOW_PROJECTION_WINDOWS,
   runProjectionLane,
   runProjectionLanes,
   type ProjectionLane,
 } from "../src/projection-lanes.ts";
-import { CHAIN_TRANSFERS_PROJECTION_KEY } from "../src/chain-transfers-artifact.ts";
 import { BLOCKS_SUMMARY_SCAN_CAP } from "../src/blocks-summary.ts";
-import { CHAIN_TRANSFER_PAIRS_PROJECTION_KEY } from "../src/chain-transfer-pairs-artifact.ts";
 import {
   CHAIN_DEREGISTRATIONS_HOTKEY_PROJECTION_KEY,
   CHAIN_DEREGISTRATIONS_PROJECTION_KEY,
 } from "../src/chain-deregistrations-artifact.ts";
+import { LAKEHOUSE_NAMESPACES } from "../src/chain-network.ts";
 import { type Row } from "./row-type.ts";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -283,6 +284,7 @@ describe("chain-transfers lane compute", () => {
     );
     const body = (await laneNamed("chain-transfers").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     assert.equal(queries.length, 10);
     const cutoff7d = NOW - 7 * DAY_MS;
@@ -337,6 +339,7 @@ describe("chain-transfers lane compute", () => {
     lakeFetch([], [], "fail");
     const body = await laneNamed("chain-transfers").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     );
     assert.equal(body, null);
   });
@@ -344,22 +347,34 @@ describe("chain-transfers lane compute", () => {
   test("a failure in the leaderboard statements declines too", async () => {
     lakeFetch([], [], [], "fail");
     assert.equal(
-      await laneNamed("chain-transfers").compute(LAKE_ENV as unknown as Env),
+      await laneNamed("chain-transfers").compute(
+        LAKE_ENV as unknown as Env,
+        "mainnet",
+      ),
       null,
     );
     lakeFetch([], [], [], [], "fail");
     assert.equal(
-      await laneNamed("chain-transfers").compute(LAKE_ENV as unknown as Env),
+      await laneNamed("chain-transfers").compute(
+        LAKE_ENV as unknown as Env,
+        "mainnet",
+      ),
       null,
     );
     lakeFetch("fail");
     assert.equal(
-      await laneNamed("chain-transfers").compute(LAKE_ENV as unknown as Env),
+      await laneNamed("chain-transfers").compute(
+        LAKE_ENV as unknown as Env,
+        "mainnet",
+      ),
       null,
     );
     lakeFetch([], "fail");
     assert.equal(
-      await laneNamed("chain-transfers").compute(LAKE_ENV as unknown as Env),
+      await laneNamed("chain-transfers").compute(
+        LAKE_ENV as unknown as Env,
+        "mainnet",
+      ),
       null,
     );
   });
@@ -389,6 +404,7 @@ describe("blocks-summary lane compute", () => {
     const queries = lakeFetch(BLOCKS);
     const body = (await laneNamed("blocks-summary").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
 
     assert.equal(queries.length, 1);
@@ -413,7 +429,10 @@ describe("blocks-summary lane compute", () => {
     // all-or-nothing contract exists to prevent.
     lakeFetch([]);
     assert.equal(
-      await laneNamed("blocks-summary").compute(LAKE_ENV as unknown as Env),
+      await laneNamed("blocks-summary").compute(
+        LAKE_ENV as unknown as Env,
+        "mainnet",
+      ),
       null,
     );
   });
@@ -421,7 +440,10 @@ describe("blocks-summary lane compute", () => {
   test("declines when the lakehouse query fails", async () => {
     lakeFetch("fail");
     assert.equal(
-      await laneNamed("blocks-summary").compute(LAKE_ENV as unknown as Env),
+      await laneNamed("blocks-summary").compute(
+        LAKE_ENV as unknown as Env,
+        "mainnet",
+      ),
       null,
     );
   });
@@ -442,6 +464,7 @@ describe("chain-registrations lane compute", () => {
     const queries = lakeFetch(STAMP, PAIRS, STAMP, PAIRS);
     const body = (await laneNamed("chain-registrations").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
 
     assert.equal(queries.length, 4, "2 windows x (stamp + pairs)");
@@ -469,6 +492,7 @@ describe("chain-registrations lane compute", () => {
     lakeFetch(STAMP, PAIRS);
     const body = (await laneNamed("chain-registrations").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     const rows = ((body.windows as Row)["7d"] as Row).rows as Row[];
     assert.deepEqual(
@@ -482,6 +506,7 @@ describe("chain-registrations lane compute", () => {
     const queries = lakeFetch([{ newest_observed: null }]);
     const body = (await laneNamed("chain-registrations").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     assert.equal(queries.length, 2, "one stamp per window, no pair read");
     const win = (body.windows as Row)["7d"] as Row;
@@ -494,6 +519,7 @@ describe("chain-registrations lane compute", () => {
     assert.equal(
       await laneNamed("chain-registrations").compute(
         LAKE_ENV as unknown as Env,
+        "mainnet",
       ),
       null,
     );
@@ -507,6 +533,7 @@ describe("chain-registrations lane compute", () => {
     assert.equal(
       await laneNamed("chain-registrations").compute(
         LAKE_ENV as unknown as Env,
+        "mainnet",
       ),
       null,
     );
@@ -522,6 +549,7 @@ describe("chain-registrations lane compute", () => {
     ]);
     const body = (await laneNamed("chain-registrations").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     const win = (body.windows as Row)["7d"] as Row;
     // The events still count -- they happened -- but only "A" is a registrant.
@@ -537,6 +565,7 @@ describe("chain-registrations lane compute", () => {
     lakeFetch(STAMP, [{ netuid: 5, hotkey: "A", n: "oops" }]);
     const body = (await laneNamed("chain-registrations").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     assert.deepEqual(((body.windows as Row)["7d"] as Row).rows, [
       { netuid: 5, registrations: 0, distinct_registrants: 1 },
@@ -550,6 +579,7 @@ describe("chain-registrations lane compute", () => {
     ]);
     const body = (await laneNamed("chain-registrations").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     const rows = ((body.windows as Row)["7d"] as Row).rows as Row[];
     assert.deepEqual(
@@ -563,6 +593,7 @@ describe("chain-registrations lane compute", () => {
     lakeFetch(STAMP, [{ netuid: "not-a-number", hotkey: "A", n: 9 }]);
     const body = (await laneNamed("chain-registrations").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     assert.deepEqual(((body.windows as Row)["7d"] as Row).rows, []);
   });
@@ -590,6 +621,7 @@ describe("chain-stake-flow lane compute", () => {
     const queries = lakeFetch(ROWS, []);
     const body = (await laneNamed("chain-stake-flow").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     // One query per PROJECTED window -- the union of the chain route's set and
     // the per-subnet route's, since both are served from this one artifact.
@@ -625,12 +657,18 @@ describe("chain-stake-flow lane compute", () => {
   test("a failed window declines the whole compute", async () => {
     lakeFetch("fail");
     assert.equal(
-      await laneNamed("chain-stake-flow").compute(LAKE_ENV as unknown as Env),
+      await laneNamed("chain-stake-flow").compute(
+        LAKE_ENV as unknown as Env,
+        "mainnet",
+      ),
       null,
     );
     lakeFetch([], "fail");
     assert.equal(
-      await laneNamed("chain-stake-flow").compute(LAKE_ENV as unknown as Env),
+      await laneNamed("chain-stake-flow").compute(
+        LAKE_ENV as unknown as Env,
+        "mainnet",
+      ),
       null,
     );
   });
@@ -669,6 +707,7 @@ describe("chain-activity lane compute", () => {
     );
     const body = (await laneNamed("chain-activity").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     assert.equal(queries.length, 8);
     const cutoff7d = NOW - 7 * DAY_MS;
@@ -738,7 +777,10 @@ describe("chain-activity lane compute", () => {
     ] as ("fail" | unknown[])[][]) {
       lakeFetch(...responses);
       assert.equal(
-        await laneNamed("chain-activity").compute(LAKE_ENV as unknown as Env),
+        await laneNamed("chain-activity").compute(
+          LAKE_ENV as unknown as Env,
+          "mainnet",
+        ),
         null,
       );
     }
@@ -748,13 +790,19 @@ describe("chain-activity lane compute", () => {
     // In the extrinsic rows...
     lakeFetch([{ day_index: "bogus", extrinsic_count: "1" }], [], [], []);
     assert.equal(
-      await laneNamed("chain-activity").compute(LAKE_ENV as unknown as Env),
+      await laneNamed("chain-activity").compute(
+        LAKE_ENV as unknown as Env,
+        "mainnet",
+      ),
       null,
     );
     // ...and in the block rows.
     lakeFetch([], [], [{ day_index: -5, block_count: "1" }], []);
     assert.equal(
-      await laneNamed("chain-activity").compute(LAKE_ENV as unknown as Env),
+      await laneNamed("chain-activity").compute(
+        LAKE_ENV as unknown as Env,
+        "mainnet",
+      ),
       null,
     );
   });
@@ -783,6 +831,7 @@ describe("chain-calls lane compute", () => {
     );
     const body = (await laneNamed("chain-calls").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     assert.equal(queries.length, 8);
     const cutoff7d = NOW - 7 * DAY_MS;
@@ -843,7 +892,10 @@ describe("chain-calls lane compute", () => {
     ] as ("fail" | unknown[])[][]) {
       lakeFetch(...responses);
       assert.equal(
-        await laneNamed("chain-calls").compute(LAKE_ENV as unknown as Env),
+        await laneNamed("chain-calls").compute(
+          LAKE_ENV as unknown as Env,
+          "mainnet",
+        ),
         null,
       );
     }
@@ -891,6 +943,7 @@ describe("chain-fees lane compute", () => {
     );
     const body = (await laneNamed("chain-fees").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     assert.equal(queries.length, 10);
     const cutoff7d = NOW - 7 * DAY_MS;
@@ -975,7 +1028,10 @@ describe("chain-fees lane compute", () => {
     ] as ("fail" | unknown[])[][]) {
       lakeFetch(...responses);
       assert.equal(
-        await laneNamed("chain-fees").compute(LAKE_ENV as unknown as Env),
+        await laneNamed("chain-fees").compute(
+          LAKE_ENV as unknown as Env,
+          "mainnet",
+        ),
         null,
       );
     }
@@ -985,19 +1041,28 @@ describe("chain-fees lane compute", () => {
     // In the daily series...
     lakeFetch([{ day_index: null, extrinsic_count: "1" }], [], [], [], []);
     assert.equal(
-      await laneNamed("chain-fees").compute(LAKE_ENV as unknown as Env),
+      await laneNamed("chain-fees").compute(
+        LAKE_ENV as unknown as Env,
+        "mainnet",
+      ),
       null,
     );
     // ...in the fee medians...
     lakeFetch([], [], [{ day_index: "bogus", median_value: 1 }], [], []);
     assert.equal(
-      await laneNamed("chain-fees").compute(LAKE_ENV as unknown as Env),
+      await laneNamed("chain-fees").compute(
+        LAKE_ENV as unknown as Env,
+        "mainnet",
+      ),
       null,
     );
     // ...and in the tip medians.
     lakeFetch([], [], [], [{ day_index: -1, median_value: 1 }], []);
     assert.equal(
-      await laneNamed("chain-fees").compute(LAKE_ENV as unknown as Env),
+      await laneNamed("chain-fees").compute(
+        LAKE_ENV as unknown as Env,
+        "mainnet",
+      ),
       null,
     );
   });
@@ -1026,6 +1091,7 @@ describe("chain-signers lane compute", () => {
     );
     const body = (await laneNamed("chain-signers").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     assert.equal(queries.length, 6);
     const cutoff7d = NOW - 7 * DAY_MS;
@@ -1064,7 +1130,10 @@ describe("chain-signers lane compute", () => {
     )[][]) {
       lakeFetch(...responses);
       assert.equal(
-        await laneNamed("chain-signers").compute(LAKE_ENV as unknown as Env),
+        await laneNamed("chain-signers").compute(
+          LAKE_ENV as unknown as Env,
+          "mainnet",
+        ),
         null,
       );
     }
@@ -1087,6 +1156,7 @@ describe("chain-alpha-volume lane compute", () => {
     const queries = lakeFetch(ROWS);
     const body = (await laneNamed("chain-alpha-volume").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     assert.equal(queries.length, 1);
     assert.match(queries[0]!, /FROM chain\.account_events/);
@@ -1110,7 +1180,10 @@ describe("chain-alpha-volume lane compute", () => {
   test("a failed query declines the compute", async () => {
     lakeFetch("fail");
     assert.equal(
-      await laneNamed("chain-alpha-volume").compute(LAKE_ENV as unknown as Env),
+      await laneNamed("chain-alpha-volume").compute(
+        LAKE_ENV as unknown as Env,
+        "mainnet",
+      ),
       null,
     );
   });
@@ -1129,6 +1202,7 @@ describe("chain-stake-transfers lane compute", () => {
     );
     const body = (await laneNamed("chain-stake-transfers").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     // Three statements, not four: the guarded window issued only its
     // network read.
@@ -1165,6 +1239,7 @@ describe("chain-stake-transfers lane compute", () => {
     lakeFetch([]);
     const body = (await laneNamed("chain-stake-transfers").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     assert.deepEqual((body.windows as Row)["7d"], {
       days: 7,
@@ -1178,6 +1253,7 @@ describe("chain-stake-transfers lane compute", () => {
     assert.equal(
       await laneNamed("chain-stake-transfers").compute(
         LAKE_ENV as unknown as Env,
+        "mainnet",
       ),
       null,
     );
@@ -1186,6 +1262,7 @@ describe("chain-stake-transfers lane compute", () => {
     assert.equal(
       await laneNamed("chain-stake-transfers").compute(
         LAKE_ENV as unknown as Env,
+        "mainnet",
       ),
       null,
     );
@@ -1202,6 +1279,7 @@ describe("chain-stake-moves lane compute", () => {
     );
     const body = (await laneNamed("chain-stake-moves").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     assert.equal(queries.length, 3);
     assert.match(queries[0]!, /event_kind = 'StakeMoved'/);
@@ -1229,7 +1307,10 @@ describe("chain-stake-moves lane compute", () => {
   test("a failed statement declines the whole compute", async () => {
     lakeFetch("fail");
     assert.equal(
-      await laneNamed("chain-stake-moves").compute(LAKE_ENV as unknown as Env),
+      await laneNamed("chain-stake-moves").compute(
+        LAKE_ENV as unknown as Env,
+        "mainnet",
+      ),
       null,
     );
   });
@@ -1265,6 +1346,7 @@ describe("chain-transfer-pairs lane compute", () => {
     );
     const body = (await laneNamed("chain-transfer-pairs").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     assert.equal(queries.length, 6);
     const cutoff7d = NOW - 7 * DAY_MS;
@@ -1319,6 +1401,7 @@ describe("chain-transfer-pairs lane compute", () => {
       assert.equal(
         await laneNamed("chain-transfer-pairs").compute(
           LAKE_ENV as unknown as Env,
+          "mainnet",
         ),
         null,
       );
@@ -1354,7 +1437,15 @@ describe("runProjectionLanes", () => {
     // lane and the runner were both right and the TEST was what had to be
     // edited in lockstep. Deriving means registering a lane can only fail this
     // if the lane genuinely did not run or did not write.
-    const registered = PROJECTION_LANES.map((lane) => lane.name);
+    // Every lane x every network (#9412): mainnet keeps its bare name, each
+    // other chain is suffixed, so a failing testnet lane is never reported
+    // under the mainnet lane's name. Derived from BOTH registries rather than
+    // written out, for the reason the note above gives.
+    const registered = PROJECTION_NETWORKS.flatMap((network) =>
+      PROJECTION_LANES.map((lane) =>
+        network === "mainnet" ? lane.name : `${lane.name}:${network}`,
+      ),
+    );
     const outcome = result as {
       ok: boolean;
       lanes: Record<string, number | null>;
@@ -1377,14 +1468,25 @@ describe("runProjectionLanes", () => {
     assert.equal(outcome.ok, true);
     assert.deepEqual(
       puts.map((put) => put.key).sort(),
-      [
-        ...PROJECTION_LANES.map((lane) => lane.artifactKey),
-        // The one lane that fans its single computed body across two objects
-        // (src/chain-deregistrations-artifact.ts's header says why).
-        CHAIN_DEREGISTRATIONS_HOTKEY_PROJECTION_KEY,
-      ].sort(),
-      "each lane writes its own artifact key, plus any it declares a split for",
+      PROJECTION_NETWORKS.flatMap((network) =>
+        [
+          ...PROJECTION_LANES.map((lane) => lane.artifactKey),
+          // The one lane that fans its single computed body across two objects
+          // (src/chain-deregistrations-artifact.ts's header says why).
+          CHAIN_DEREGISTRATIONS_HOTKEY_PROJECTION_KEY,
+        ].map((key) => projectionKey(key, network)),
+      ).sort(),
+      "each lane writes its own artifact key per network, plus any split it declares",
     );
+    // MAINNET'S KEYS ARE UNPREFIXED. Every artifact written before #9412 stays
+    // readable and a mainnet request reads the object it read before -- the
+    // asymmetry networkKvKey and chainTable already use.
+    for (const lane of PROJECTION_LANES) {
+      assert.ok(
+        puts.some((put) => put.key === lane.artifactKey),
+        `${lane.name} must still write its unprefixed mainnet key`,
+      );
+    }
   });
 
   test("one failed lane never skips the next — failures are isolated", async () => {
@@ -1405,23 +1507,79 @@ describe("runProjectionLanes", () => {
     assert.equal(result.lanes["chain-stake-flow"], 0);
     assert.equal(result.lanes["chain-stake-moves"], 0);
     assert.equal(result.lanes["blocks-summary"], 1);
-    assert.equal(Object.keys(result.lanes).length, PROJECTION_LANES.length);
+    assert.equal(
+      Object.keys(result.lanes).length,
+      PROJECTION_LANES.length * PROJECTION_NETWORKS.length,
+    );
     assert.deepEqual(
       puts.map((put) => put.key),
-      PROJECTION_LANES.flatMap((lane) =>
-        lane.artifactKey === CHAIN_DEREGISTRATIONS_PROJECTION_KEY
-          ? [lane.artifactKey, CHAIN_DEREGISTRATIONS_HOTKEY_PROJECTION_KEY]
-          : [lane.artifactKey],
+      PROJECTION_NETWORKS.flatMap((network) =>
+        PROJECTION_LANES.flatMap((lane) =>
+          (lane.artifactKey === CHAIN_DEREGISTRATIONS_PROJECTION_KEY
+            ? [lane.artifactKey, CHAIN_DEREGISTRATIONS_HOTKEY_PROJECTION_KEY]
+            : [lane.artifactKey]
+          ).map((key) => projectionKey(key, network)),
+        ),
       ).filter(
         (key) =>
-          key !== CHAIN_TRANSFERS_PROJECTION_KEY &&
-          key !== CHAIN_TRANSFER_PAIRS_PROJECTION_KEY,
+          // The two lanes stubbed to fail write nothing, on EITHER network.
+          !key.endsWith("chain-transfers.json") &&
+          !key.endsWith("chain-transfer-pairs.json"),
       ),
     );
+    // Each network reports its OWN failure under its own route label, so a
+    // testnet decline never lands in the mainnet lane's telemetry -- which
+    // would make an outage on the secondary chain page as one on the primary.
     assert.deepEqual(
       events.map((event) => event.route),
-      ["projection:chain-transfers", "projection:chain-transfer-pairs"],
+      PROJECTION_NETWORKS.flatMap((network) =>
+        ["chain-transfers", "chain-transfer-pairs"].map((lane) =>
+          network === "mainnet"
+            ? `projection:${lane}`
+            : `projection:${lane}:${network}`,
+        ),
+      ),
     );
+  });
+
+  // A testnet lane's decline is REPORTED but must not fail the tick: its decode
+  // lane is younger and its tables can genuinely be empty for a window, so
+  // letting it set `ok: false` would drain the meaning out of the one signal
+  // that says mainnet is broken.
+  test("only mainnet decides the tick verdict", async () => {
+    // EVERY testnet query fails; every mainnet one succeeds.
+    lakeFetchWithBlocks((sql) => sql.includes("chain_testnet."));
+    const { puts, bucket } = archiveBucket();
+    const seen: string[] = [];
+    const result = await runProjectionLanes(
+      { ...LAKE_ENV, METAGRAPH_ARCHIVE: bucket } as unknown as Env,
+      {
+        recordException: (async (_env: unknown, event: { route?: string }) => {
+          seen.push(String(event.route));
+          return true;
+        }) as never,
+      },
+    );
+    assert.equal(result.ok, true, "a testnet decline must not fail the tick");
+    // Reported, not swallowed: every testnet lane records under its own label.
+    assert.ok(seen.length > 0, "the testnet declines must still be recorded");
+    assert.ok(
+      seen.every((route) => route.endsWith(":testnet")),
+      `only testnet lanes should have declined: ${seen.join(", ")}`,
+    );
+    // And mainnet's artifacts still landed, unprefixed.
+    for (const lane of PROJECTION_LANES) {
+      assert.ok(
+        puts.some((put) => put.key === lane.artifactKey),
+        `${lane.name} must still write its mainnet artifact`,
+      );
+      assert.ok(
+        !puts.some(
+          (put) => put.key === projectionKey(lane.artifactKey, "testnet"),
+        ),
+        `${lane.name} must not write a testnet artifact from a failed read`,
+      );
+    }
   });
 });
 
@@ -1461,6 +1619,7 @@ describe("chain-deregistrations lane compute", () => {
     const queries = lakeFetch(REGS);
     const body = (await laneNamed("chain-deregistrations").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
 
     // One query for two windows. The 7d window is derived from the same rows,
@@ -1489,6 +1648,7 @@ describe("chain-deregistrations lane compute", () => {
     lakeFetch(REGS);
     const body = (await laneNamed("chain-deregistrations").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     const win = (body.windows as Row)["7d"] as Row;
     assert.deepEqual(win.rows, [
@@ -1513,6 +1673,7 @@ describe("chain-deregistrations lane compute", () => {
     lakeFetch(REGS);
     const body = (await laneNamed("chain-deregistrations").compute(
       LAKE_ENV as unknown as Env,
+      "mainnet",
     )) as Row;
     const derivation = ((body.windows as Row)["7d"] as Row).derivation as Row;
     assert.equal(derivation.method, "uid-reuse");
@@ -1528,6 +1689,7 @@ describe("chain-deregistrations lane compute", () => {
     assert.equal(
       await laneNamed("chain-deregistrations").compute(
         LAKE_ENV as unknown as Env,
+        "mainnet",
       ),
       null,
     );
@@ -1538,6 +1700,7 @@ describe("chain-deregistrations lane compute", () => {
     assert.equal(
       await laneNamed("chain-deregistrations").compute(
         LAKE_ENV as unknown as Env,
+        "mainnet",
       ),
       null,
     );
@@ -1589,5 +1752,70 @@ describe("lane registry", () => {
       wrangler.includes(`"${PROJECTION_LANES_CRON}"`),
       `wrangler.jsonc declares no "${PROJECTION_LANES_CRON}" cron, so no projection ever recomputes`,
     );
+  });
+});
+
+// #9412: the lanes read the network's OWN namespace and write to its own key.
+// Every assertion below is paired with the positive -- the query was issued,
+// and here is the namespace in it -- because "it does not read chain.*" passes
+// perfectly on a lane that reads nothing at all.
+describe("projection lanes are network-scoped end to end", () => {
+  test("projectionKey leaves mainnet alone and namespaces every other chain", () => {
+    const key = "metagraph/projections/blocks-summary.json";
+    assert.equal(projectionKey(key), key, "mainnet must stay unprefixed");
+    assert.equal(projectionKey(key, "mainnet"), key);
+    assert.equal(
+      projectionKey(key, "testnet"),
+      "metagraph/projections/testnet/blocks-summary.json",
+      "the network goes INSIDE the projections prefix, so a listing still groups them",
+    );
+    // A key that is not under the projections prefix still gets scoped rather
+    // than passed through: an unscoped key would be one object two chains
+    // overwrite in turn, each serving the other's numbers.
+    assert.equal(
+      projectionKey("metagraph/other/thing.json", "testnet"),
+      "testnet/metagraph/other/thing.json",
+    );
+  });
+
+  test("the network list is derived from the lakehouse namespaces", () => {
+    // Not a second hand-written roster: a chain that gains a decode namespace
+    // is exactly a chain these lanes can project, and listing them separately
+    // would let one gain tables and silently never get artifacts.
+    assert.deepEqual(
+      [...PROJECTION_NETWORKS].sort(),
+      Object.keys(LAKEHOUSE_NAMESPACES).sort(),
+    );
+  });
+
+  test("every lane reads its own namespace, and never the other's", async () => {
+    for (const network of PROJECTION_NETWORKS) {
+      const expected = LAKEHOUSE_NAMESPACES[network];
+      const foreign = Object.values(LAKEHOUSE_NAMESPACES).filter(
+        (ns) => ns !== expected,
+      );
+      for (const lane of PROJECTION_LANES) {
+        const queries = lakeFetch([]);
+        await lane.compute(LAKE_ENV as unknown as Env, network);
+        assert.ok(
+          queries.length > 0,
+          `${lane.name} on ${network} issued no query at all`,
+        );
+        for (const sql of queries) {
+          assert.match(
+            sql,
+            new RegExp(`FROM ${expected}\\.\\w+`),
+            `${lane.name} on ${network} read the wrong namespace: ${sql}`,
+          );
+          for (const other of foreign) {
+            assert.doesNotMatch(
+              sql,
+              new RegExp(`FROM ${other}\\.\\w+`),
+              `${lane.name} on ${network} still reads ${other}: ${sql}`,
+            );
+          }
+        }
+      }
+    }
   });
 });


### PR DESCRIPTION
Part of #9412. **The writer half only** — the lanes fill both chains' artifacts, and nothing reads
the testnet ones yet.

Thirteen route families are gated to mainnet for exactly one reason: the projection lanes that feed
them hardcode `FROM chain.*`. Every one of them reads `blocks`, `extrinsics` or `account_events` —
tables the decode lane already fills for **both** chains (`chain_testnet` is decoded through
7,700,842 and advancing hourly). Nothing about those routes is mainnet-specific except the
namespace in their `FROM` clause.

## Why this is split from opening the routes

#8700's own rule: a route must not be opened before its data exists, because a route answering an
empty forever reads as broken rather than unsupported. So the artifacts get written and **verified
in production** first; the gate comes off in a second PR against #9412 once
`metagraph/projections/testnet/*` is confirmed present and non-empty.

That also makes this PR's blast radius on mainnet exactly zero: mainnet keys, mainnet queries and
the mainnet verdict are byte-identical to before.

## What changed

- **Every `FROM` goes through `chainTable()`** — the function that exists for exactly this, so a
  lane cannot be network-aware in its `WHERE` clause and mainnet-only in its `FROM`, which is the
  failure that looks completely correct in review.
- **`projectionKey()` scopes the R2 key the way `networkKvKey` scopes KV: mainnet unchanged.**
  Every artifact already written stays readable and a mainnet request reads the object it read
  before. The network segment goes *inside* the `metagraph/projections/` prefix so a bucket listing
  still groups them.
- **`PROJECTION_NETWORKS` is derived from `LAKEHOUSE_NAMESPACES`**, not written out again: a chain
  with a decode namespace is exactly a chain these lanes can project, and a second roster would let
  a chain gain tables and silently never get artifacts.
- **Per-network labels, and mainnet alone decides the verdict.** Results, logs and telemetry read
  `chain-transfers` / `chain-transfers:testnet`. A testnet lane's decline is logged and recorded
  under its own route but must not set `ok: false` — its decode lane is younger and its tables can
  genuinely be empty for a window, and letting it fail the tick would drain the meaning out of the
  one signal that says mainnet is broken.

`computeSubnetDistinctWindow` had a local named `network` holding the **chain-wide scope row** — the
opposite sense of the word from the parameter now threaded past it. The artifact key it lands under
is `network` and cannot be renamed, so the local is.

## Verification

- `npx vitest run` — **15,861 passed**.
- A new test drives **all 13 lanes × 2 networks** and asserts each issues its queries against its
  own namespace and never the other's — paired with the positive that a query was issued at all,
  because "it does not read `chain.*`" passes perfectly on a lane that reads nothing.
- Another stubs every `chain_testnet` query to fail and asserts the tick still reports `ok: true`,
  the declines are still recorded under `:testnet` routes, mainnet's artifacts still land
  unprefixed, and **no testnet artifact is written from a failed read**.
- The two roster assertions (here and in `tests/api-coverage.test.ts`) stay derived from the
  registries rather than hand-listed — the property their own comments say they exist to preserve.
- Patch coverage: **29/29 lines, 16/16 branches**, by diff intersection.

## After this merges

The cron writes `metagraph/projections/testnet/*` on its next tick (`11,41 * * * *`). Once those
objects are confirmed present and non-empty, the follow-up opens `/blocks/summary` and the twelve
`/chain/*` families on testnet.
