### PR TITLE
test(api): cover the deferred-quota, URIError and MCP-refusal branches

### DIFF
--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1363,6 +1363,104 @@ describe("MCP transport handling", () => {
     }
   });
 
+  // Minimal KV double for the api-key lookup cache (each suite defines its own,
+  // matching tests/tiered-rate-limit.test.ts).
+  function createFakeKv() {
+    const store = new Map<string, string>();
+    return {
+      async get(key: string, options?: { type?: string }) {
+        if (!store.has(key)) return null;
+        const raw = store.get(key)!;
+        return options?.type === "json" ? JSON.parse(raw) : raw;
+      },
+      async put(key: string, value: string) {
+        store.set(key, value);
+      },
+    };
+  }
+
+  // #9414: the cost-weighted quota is spent AFTER the body is parsed, because
+  // only then is it known which tools were asked for -- every MCP call shares
+  // the pathname `/mcp`, which prices at the `edge` catch-all. An exhausted
+  // quota must still refuse, and must say which ceiling did it.
+  test("an exhausted daily quota refuses the call after the body is priced", async () => {
+    const spends: { cost: number }[] = [];
+    const env = {
+      METAGRAPH_CONTROL: createFakeKv(),
+      API_KEY_LOOKUP_INTERNAL_TOKEN: "test-lookup-token",
+      MCP_RATE_LIMITER: {
+        async limit() {
+          return { success: true };
+        },
+      },
+      MCP_RATE_LIMITER_PAID: {
+        async limit() {
+          return { success: true };
+        },
+      },
+      MCP_RATE_LIMITER_KEYED: {
+        async limit() {
+          return { success: true };
+        },
+      },
+      DATA_API: {
+        fetch: async (request: Request) => {
+          const path = new URL(request.url).pathname;
+          if (path === "/api/v1/internal/keys/quota") {
+            spends.push(JSON.parse(await request.clone().text()));
+            return new Response(
+              JSON.stringify({
+                allowed: false,
+                used: 250000,
+                limit: 250000,
+                remaining: 0,
+                resetAt: "2026-08-05T00:00:00.000Z",
+              }),
+              { status: 200 },
+            );
+          }
+          return new Response(
+            JSON.stringify({
+              valid: true,
+              code: "VALID",
+              tier: "paid",
+              accountId: "42",
+            }),
+            { status: 200 },
+          );
+        },
+      },
+    } as unknown as Env;
+
+    const response = await handleMcpRequest(
+      new Request(MCP_URL, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer mg_aValidOpaqueUnkeyGeneratedSuffix",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: "ask", arguments: { question: "hi" } },
+        }),
+      }),
+      env,
+      makeDeps(),
+    );
+
+    assert.equal(response.status, 429);
+    const body = (await response.json()) as Row;
+    assert.match(body.error.message, /Daily MCP quota exhausted/);
+    // Priced by the TOOL, not the transport: `ask` is the ai family (25),
+    // where `/mcp` alone would have debited the edge catch-all's 1.
+    assert.deepEqual(
+      spends.map((s) => s.cost),
+      [25],
+    );
+  });
+
   test("the MCP rate limiter is enforced before body parsing", async () => {
     let rateLimitKey;
     const request = new Request(MCP_URL, {

--- a/tests/saved-queries-handler.test.ts
+++ b/tests/saved-queries-handler.test.ts
@@ -45,6 +45,25 @@ describe("handleSavedQueryRequest", () => {
     assert.equal(body.meta.contract_version.length > 0, true);
   });
 
+  // #9414: decodeURIComponent sat OUTSIDE the try, so a malformed escape threw
+  // a URIError that escaped the Worker entirely -- withUsageTelemetry has
+  // try/finally with no catch and the entry does not wrap either, so the
+  // request died as a bare 1101/500 instead of an error envelope.
+  test("a malformed percent-escape is an envelope, not an unhandled throw", async () => {
+    for (const bad of ["%ZZ", "%E0%A4%A", "%"]) {
+      const body = await json(
+        await handleSavedQueryRequest(
+          req(`/api/v1/queries/${bad}`),
+          mockEnv(),
+          new URL(`https://api.metagraph.sh/api/v1/queries/${bad}`),
+        ),
+        404,
+      );
+      assert.equal(body.ok, false, `${bad} should answer, not throw`);
+      assert.equal(body.error.code, "not_found");
+    }
+  });
+
   test("404s on an unknown query id", async () => {
     const body = await json(
       await handleSavedQueryRequest(

--- a/tests/tiered-rate-limit.test.ts
+++ b/tests/tiered-rate-limit.test.ts
@@ -6,6 +6,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   applyTieredRateLimit,
+  spendDeferredDailyQuota,
   tieredRateLimitHeaders,
   tieredRejectionResponse,
 } from "../workers/tiered-rate-limit.ts";
@@ -750,6 +751,68 @@ describe("daily quotas (#8608)", () => {
 
   const ok = (body: Row) => async () =>
     new Response(JSON.stringify(body), { status: 200 });
+
+  // #9414: a multiplexed transport (POST /mcp) cannot be priced by pathname --
+  // every call shares one -- so it defers the spend until the body names the
+  // tools, then debits through spendDeferredDailyQuota.
+  test("deferQuota hands back the pending handle instead of spending", async () => {
+    const { env, spends } = envWith("paid", ok({ allowed: true }));
+    const result = await applyTieredRateLimit(req(), env, CONFIG, {
+      deferQuota: true,
+    });
+    assert.equal(result.allowed, true);
+    // Nothing debited yet -- that is the whole point of deferring.
+    assert.deepEqual(spends, []);
+    assert.equal(result.quota, undefined);
+    assert.deepEqual(result.quotaPending, {
+      accountId: "42",
+      dailyUnits: 1000,
+    });
+  });
+
+  test("spendDeferredDailyQuota debits the deferred cost, not one flat unit", async () => {
+    const { env, spends } = envWith(
+      "paid",
+      ok({
+        allowed: true,
+        used: 50,
+        limit: 1000,
+        remaining: 950,
+        resetAt: "x",
+      }),
+    );
+    const verdict = await spendDeferredDailyQuota(
+      req(),
+      env,
+      { accountId: "42", dailyUnits: 1000 },
+      50,
+    );
+    assert.equal(verdict.allowed, true);
+    assert.equal(verdict.remaining, 950);
+    // The cost travelled through verbatim: a 10-message batch of 5-unit tools.
+    assert.equal((spends[0] as { body: { cost: number } }).body.cost, 50);
+  });
+
+  test("a deferred spend can still refuse, and reports which ceiling did", async () => {
+    const { env } = envWith(
+      "paid",
+      ok({
+        allowed: false,
+        used: 1000,
+        limit: 1000,
+        remaining: 0,
+        resetAt: "x",
+      }),
+    );
+    const verdict = await spendDeferredDailyQuota(
+      req(),
+      env,
+      { accountId: "42", dailyUnits: 1000 },
+      25,
+    );
+    assert.equal(verdict.allowed, false);
+    assert.equal(verdict.remaining, 0);
+  });
 
   test("a tier with NO dailyUnits never touches the quota store", async () => {
     // free must not pay the round trip, and today's keyed callers gain no cap.


### PR DESCRIPTION
Follow-up to #9414, which merged before these landed.

Patch coverage on that PR measured **91.49% against a 99% gate** — computed by intersecting `coverage/lcov.info` hit data with the lines the diff actually changed, since a whole-file percentage answers the wrong question for `codecov/patch`. Eight executable lines had no test reaching them, all on paths #9414 introduced:

| file | lines | path |
|---|---|---|
| `workers/tiered-rate-limit.ts` | 341, 344, 495 | the `deferQuota` branch and `spendDeferredDailyQuota` |
| `src/mcp-server.ts` | 14449, 14455–14456, 14463 | `spendMcpQuota`'s refusal |
| `workers/request-handlers/saved-queries.ts` | 46 | the `URIError` catch |

## What's covered now

- **`deferQuota` returns the pending handle without spending.** Asserts nothing is debited at that point — the whole reason the spend defers is that a multiplexed transport can't be priced by pathname until the body names the tools.
- **`spendDeferredDailyQuota` forwards the batch cost verbatim**, and a deferred spend can still refuse and report which ceiling did it.
- **Malformed percent-escapes answer with an envelope** — `%ZZ`, `%E0%A4%A`, and a bare `%` — rather than escaping as an unhandled `URIError` and dying as a bare 1101/500.
- **An exhausted daily quota refuses after the body is priced**, asserting the debit is the tool's own cost (`ask` = 25, the AI family) rather than the transport pathname's edge weight of 1. That is the end-to-end proof of #9414's metering fix, not just a branch toucher.

Changed lines now measure **94/94**.

## Verification

```
tsc --noEmit    clean
eslint          clean
patch coverage  94/94 = 100.00%  (gate 99%)
overall         99.18% stmts / 98.01% branches / 99.13% funcs / 99.42% lines
```

Tests only — no source changes.
