### PR TITLE
feat(chain): read each block's event count in the head poller, closing the tip gap

### DIFF
--- a/migrations/d1/0016_blocks_head_event_count.sql
+++ b/migrations/d1/0016_blocks_head_event_count.sql
@@ -1,0 +1,25 @@
+-- blocks_head.event_count (#9417) -- the chain tip's event count, read by the
+-- head poller itself instead of waiting for the Containers indexer.
+--
+-- WHY THE POLLER CAN KNOW THIS. src/head-poller.ts's header says the
+-- extrinsics/chain_events/account_events lanes "need SCALE decoding against
+-- runtime metadata, which is the Containers indexer's job" -- true of every
+-- event's CONTENT, and not true of the COUNT. `System.Events` is a
+-- `Vec<EventRecord>`, and a SCALE `Vec` is prefixed with its compact-encoded
+-- length. Reading that prefix needs no metadata and decodes nothing: verified
+-- against the live archive endpoint at blocks 8,771,446 / 8,771,000 /
+-- 8,771,459, which read 320 / 268 / 256 and match `chain_detail_blocks`
+-- and `/chain-events` exactly.
+--
+-- WHY IT IS NULLABLE. The events read is fail-soft: a block row is essential,
+-- its count is not, so an RPC failure (or the kill switch being off) still
+-- writes the block with a null count rather than losing the height. Null keeps
+-- meaning "not known here", which is what the serving layer already renders as
+-- "—". It must never be defaulted to 0 -- a count we do not have is not a
+-- count of zero, which is the bug #9414 fixed one layer up.
+--
+-- Backfill is deliberately absent: rows below the decode watermark are already
+-- answered by the lakehouse, and rows inside the hot window are answered by
+-- chain_detail_blocks. This column only has to cover the seconds between a
+-- block being seen and being decoded.
+ALTER TABLE blocks_head ADD COLUMN event_count INTEGER;

--- a/src/blocks-cold-tier.ts
+++ b/src/blocks-cold-tier.ts
@@ -96,7 +96,14 @@ export const DEFAULT_BLOCKS_SEAM = 8_759_336;
 const D1_SELECT =
   "b.block_number, b.block_hash, b.parent_hash, b.extrinsic_count, " +
   "b.observed_at, c.spec_version AS spec_version, " +
-  "c.chain_event_count AS event_count";
+  // COALESCE, indexer first (#9417): chain_detail_blocks' count comes from a
+  // full SCALE decode of every event, blocks_head's from the Vec length prefix
+  // the head poller reads. Both are exact and they agree; the decode is
+  // preferred purely because it is the same number the rest of the detail
+  // surface is built from. The poller's copy is what covers the seconds
+  // between a block being seen and being decoded -- the window that used to
+  // publish null and render "Events 0".
+  "COALESCE(c.chain_event_count, b.event_count) AS event_count";
 const D1_FROM =
   "blocks_head b LEFT JOIN chain_detail_blocks c " +
   "ON c.block_number = b.block_number";

--- a/src/head-poller.ts
+++ b/src/head-poller.ts
@@ -12,14 +12,52 @@
 // Every RPC is plain HTTP JSON-RPC against CHAIN_HEAD_RPC_URL — the same
 // public endpoint everything else already reads (live-verified for months).
 
-export interface HeadBlock {
-  table: "blocks";
-  block_number: number;
-  block_hash: string;
-  parent_hash: string;
-  extrinsic_count: number;
-  observed_at: number;
-}
+import { z } from "zod";
+import { bytesToHex, storageMapPrefix } from "./twox-storage-key.ts";
+
+/**
+ * The firehose `blocks` payload this module produces.
+ *
+ * A SCHEMA, with the type inferred from it (`z.infer`), so the shape is stated
+ * once. A hand-written `interface` beside a validator is two things to keep in
+ * step, and the one that drifts is always the validator.
+ *
+ * Scalar fields only, per the ingest validator's rules
+ * (validateSingleChainFirehoseIngestPayload) -- nested JSON is rejected there,
+ * so it must not be constructible here.
+ */
+export const HeadBlockSchema = z.object({
+  table: z.literal("blocks"),
+  block_number: z.int().min(0),
+  block_hash: z.string(),
+  parent_hash: z.string(),
+  extrinsic_count: z.int().min(0),
+  /**
+   * The block's event count, or null when it could not be read.
+   *
+   * Nullable, never defaulted: a count we do not have is not a count of none.
+   * See migrations/d1/0016_blocks_head_event_count.sql.
+   */
+  event_count: z.int().min(0).nullable(),
+  observed_at: z.int(),
+});
+export type HeadBlock = z.infer<typeof HeadBlockSchema>;
+
+/**
+ * What `chain_getBlock` must return for us to trust it.
+ *
+ * The RPC is untrusted external input reached over the network, and it was
+ * previously read through a bare `as` cast -- which types the access without
+ * checking a byte of it, so a malformed or truncated response produced a block
+ * row with a silently wrong extrinsic count rather than an error. Deliberately
+ * loose about fields we do not read; strict about the two we do.
+ */
+const BlockBodySchema = z.object({
+  block: z.object({
+    header: z.object({ parentHash: z.string() }),
+    extrinsics: z.array(z.unknown()),
+  }),
+});
 
 interface RpcResponse {
   result?: unknown;
@@ -62,6 +100,109 @@ export async function fetchHeadNumber(
 }
 
 /**
+ * Storage key for `System.Events`: twox128("System") ++ twox128("Events").
+ *
+ * DERIVED, not hardcoded. The pallet and item names are the only inputs a
+ * human should ever have to read here; the hash is computed by the same
+ * `storageMapPrefix` every other storage reader in this codebase uses
+ * (src/twox-storage-key.ts), so this key cannot drift from the rest of the
+ * repo and cannot be mistyped into something that silently reads the wrong
+ * slot. tests/twox-storage-key.test.ts already proves that derivation against
+ * the official xxHash vectors and a known-good chain key.
+ *
+ * Metadata-independent by construction: both halves hash literal names, so the
+ * key is identical on every Substrate runtime and survives a runtime upgrade.
+ * That is what makes reading it legal for this module, which must never
+ * pretend to decode what only the indexer can.
+ */
+export const SYSTEM_EVENTS_STORAGE_KEY = bytesToHex(
+  storageMapPrefix("System", "Events"),
+);
+
+/**
+ * The item count of a SCALE-encoded `Vec<T>`, read from its compact length
+ * prefix WITHOUT decoding a single item.
+ *
+ * This is what lets the poller report an event count while honouring this
+ * module's rule that it never fakes decoded data: the prefix is unambiguous
+ * SCALE and metadata-independent, so the COUNT is knowable even though the
+ * event CONTENTS are not. Verified against the live archive endpoint at blocks
+ * 8,771,446 / 8,771,000 / 8,771,459 -> 320 / 268 / 256, matching
+ * chain_detail_blocks and /chain-events exactly.
+ *
+ * Compact encoding (SCALE spec), by the low two bits of the first byte:
+ *   00 single-byte  value = b0 >> 2                       (0..63)
+ *   01 two-byte     value = u16le >> 2                    (0..2^14-1)
+ *   10 four-byte    value = u32le >> 2                    (0..2^30-1)
+ *   11 big-integer  (b0 >> 2) + 4 following LE bytes
+ *
+ * Returns null rather than throwing on anything malformed or truncated: the
+ * caller treats an unreadable count as unknown, which is already a state the
+ * schema and the UI handle.
+ */
+export function scaleCompactLength(hex: unknown): number | null {
+  if (typeof hex !== "string" || !/^0x([0-9a-fA-F]{2})+$/.test(hex))
+    return null;
+  const bytes = hex.slice(2);
+  const at = (i: number) => Number.parseInt(bytes.slice(i * 2, i * 2 + 2), 16);
+  if (bytes.length < 2) return null;
+  const b0 = at(0);
+  const mode = b0 & 0b11;
+  if (mode === 0b00) return b0 >> 2;
+  if (mode === 0b01) {
+    if (bytes.length < 4) return null;
+    return ((at(1) << 8) | b0) >>> 2;
+  }
+  if (mode === 0b10) {
+    if (bytes.length < 8) return null;
+    return (((at(3) << 24) | (at(2) << 16) | (at(1) << 8) | b0) >>> 0) >>> 2;
+  }
+  // 0b11: the next (b0 >> 2) + 4 bytes are a little-endian integer. An event
+  // count needs nowhere near 2^30, so this branch exists for completeness --
+  // and is capped at Number.MAX_SAFE_INTEGER rather than trusted blindly.
+  const len = (b0 >> 2) + 4;
+  if (bytes.length < (len + 1) * 2) return null;
+  let n = 0;
+  for (let i = len; i >= 1; i--) {
+    n = n * 256 + at(i);
+    if (!Number.isSafeInteger(n)) return null;
+  }
+  return n;
+}
+
+/**
+ * How many events one block emitted, or null when that cannot be read.
+ *
+ * One `state_getStorage` against `System.Events` at this block's hash. The
+ * whole blob comes back (11-17 KB in practice) to read the 1-4 byte prefix --
+ * there is no JSON-RPC way to ask for a byte range, and `state_getStorageSize`
+ * answers in bytes, not items. That cost is the reason the caller gates this
+ * behind a kill switch.
+ */
+export async function fetchEventCountAt(
+  url: string,
+  blockHash: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<number | null> {
+  try {
+    const raw = await rpc(
+      url,
+      "state_getStorage",
+      [SYSTEM_EVENTS_STORAGE_KEY, blockHash],
+      fetchImpl,
+    );
+    // A block with no events at all stores nothing under the key. That is a
+    // real, readable zero -- distinct from the null an unreadable RPC yields.
+    if (raw === null || raw === undefined) return 0;
+    return scaleCompactLength(raw);
+  } catch {
+    // Fail SOFT: the block row matters, its count does not. Losing the height
+    // because a storage read failed would be the worse trade.
+    return null;
+  }
+}
+
+/**
  * One finalized-ish block at an exact height, as a firehose `blocks` payload.
  * Three reads: hash at height, header, body (for the extrinsic count the UI's
  * block rail renders). Scalar fields only, per the ingest validator's rules.
@@ -71,6 +212,12 @@ export async function fetchBlockAt(
   number: number,
   fetchImpl: typeof fetch = fetch,
   now: () => number = Date.now,
+  /**
+   * Whether to spend one extra `state_getStorage` on this block's event count.
+   * Off by default so every existing caller (and every test) keeps its exact
+   * request count; the head poller opts in via CHAIN_HEAD_EVENT_COUNT_ENABLED.
+   */
+  withEventCount = false,
 ): Promise<HeadBlock> {
   const hash = (await rpc(
     url,
@@ -81,20 +228,28 @@ export async function fetchBlockAt(
   if (typeof hash !== "string" || !hash.startsWith("0x")) {
     throw new Error(`no hash at height ${number}`);
   }
-  const block = (await rpc(url, "chain_getBlock", [hash], fetchImpl)) as {
-    block?: {
-      header?: { parentHash?: string };
-      extrinsics?: unknown[];
-    };
-  };
+  const parsed = BlockBodySchema.safeParse(
+    await rpc(url, "chain_getBlock", [hash], fetchImpl),
+  );
+  if (!parsed.success) {
+    // Refuse rather than emit a block with an invented extrinsic count. The
+    // caller's alarm re-arms, so a malformed response costs one tick, not the
+    // lane -- and the height is retried on the next.
+    throw new Error(`chain_getBlock: malformed response at height ${number}`);
+  }
+  const { header, extrinsics } = parsed.data.block;
   return {
     table: "blocks",
     block_number: number,
     block_hash: hash,
-    parent_hash: String(block?.block?.header?.parentHash ?? ""),
-    extrinsic_count: Array.isArray(block?.block?.extrinsics)
-      ? block.block.extrinsics.length
-      : 0,
+    parent_hash: header.parentHash,
+    extrinsic_count: extrinsics.length,
+    // Awaited, not raced with the reads above: fetchEventCountAt needs the hash
+    // those produced. It never throws (see its own catch), so a storage-read
+    // failure degrades the count to null and leaves the block intact.
+    event_count: withEventCount
+      ? await fetchEventCountAt(url, hash, fetchImpl)
+      : null,
     observed_at: now(),
   };
 }

--- a/tests/head-poller.test.ts
+++ b/tests/head-poller.test.ts
@@ -4,9 +4,12 @@ import assert from "node:assert/strict";
 import { test } from "vitest";
 import {
   fetchBlockAt,
+  fetchEventCountAt,
   fetchHeadNumber,
   heightsToEmit,
   hexToNumber,
+  scaleCompactLength,
+  SYSTEM_EVENTS_STORAGE_KEY,
 } from "../src/head-poller.ts";
 import { ChainFirehoseHub } from "../workers/chain-firehose-hub.ts";
 
@@ -60,8 +63,195 @@ test("fetchBlockAt assembles a scalar blocks payload", async () => {
     block_hash: "0xabc",
     parent_hash: "0xdef",
     extrinsic_count: 3,
+    // Opt-in (#9417): this call did not ask for the count, so no extra
+    // state_getStorage was spent and the field is an honest null.
+    event_count: null,
     observed_at: 1_000,
   });
+});
+
+// #9417 -- the count is readable WITHOUT metadata or decoding, because a SCALE
+// `Vec` carries its length as a compact prefix.
+//
+// Proven by ROUND TRIP against an encoder written to the SCALE spec, not
+// against hand-picked hex: a hand-computed vector is one typo away from
+// asserting the bug, and it only ever covers the values someone thought of.
+// The three real on-chain counts are pinned separately below.
+function encodeCompact(n: number): string {
+  if (n < 1 << 6) return "0x" + ((n << 2) & 0xff).toString(16).padStart(2, "0");
+  const bytes: number[] = [];
+  if (n < 1 << 14) {
+    const v = (n << 2) | 0b01;
+    bytes.push(v & 0xff, (v >> 8) & 0xff);
+  } else if (n < 1 << 30) {
+    const v = ((n << 2) | 0b10) >>> 0;
+    bytes.push(
+      v & 0xff,
+      (v >>> 8) & 0xff,
+      (v >>> 16) & 0xff,
+      (v >>> 24) & 0xff,
+    );
+  } else {
+    // big-integer mode: (len-4) << 2 | 0b11, then `len` LE bytes.
+    const le: number[] = [];
+    let rest = n;
+    while (rest > 0) {
+      le.push(rest % 256);
+      rest = Math.floor(rest / 256);
+    }
+    while (le.length < 4) le.push(0);
+    bytes.push(((le.length - 4) << 2) | 0b11, ...le);
+  }
+  return "0x" + bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+test("scaleCompactLength round-trips every compact mode", () => {
+  for (const n of [
+    0,
+    1,
+    63, // single-byte mode, and its boundary
+    64,
+    320,
+    268,
+    256,
+    16383, // two-byte mode (real event counts live here)
+    16384,
+    1 << 20,
+    (1 << 30) - 1, // four-byte mode, to its ceiling
+    1 << 30,
+    2 ** 32, // big-integer mode
+  ]) {
+    assert.equal(
+      scaleCompactLength(encodeCompact(n)),
+      n,
+      `round trip for ${n}`,
+    );
+  }
+});
+
+// The three blocks this feature was verified against on the live archive
+// endpoint. Pinned as bytes so a regression in the reader is caught even if
+// the encoder above were wrong in the same direction.
+test("scaleCompactLength matches the counts verified on mainnet", () => {
+  for (const [hex, count, block] of [
+    ["0x0105", 320, 8_771_446],
+    ["0x3104", 268, 8_771_000],
+    ["0x0104", 256, 8_771_459],
+  ] as const) {
+    assert.equal(scaleCompactLength(hex), count, `block ${block}`);
+  }
+});
+
+test("scaleCompactLength returns null on anything it cannot trust", () => {
+  for (const bad of [
+    undefined,
+    null,
+    42,
+    "",
+    "0x",
+    "not-hex",
+    "0xzz",
+    "0x0", // odd nibble count
+    "0x01", // two-byte mode with no second byte
+    "0x02ff", // four-byte mode, truncated
+  ]) {
+    assert.equal(
+      scaleCompactLength(bad),
+      null,
+      `${String(bad)} should be null`,
+    );
+  }
+});
+
+test("fetchEventCountAt reads System.Events at the block hash", async () => {
+  let askedKey;
+  let askedHash;
+  const n = await fetchEventCountAt(
+    "https://rpc.example",
+    "0xabc",
+    rpcFetch({
+      state_getStorage: (params) => {
+        [askedKey, askedHash] = params as [string, string];
+        return "0x0105"; // 320
+      },
+    }),
+  );
+  assert.equal(n, 320);
+  assert.equal(askedKey, SYSTEM_EVENTS_STORAGE_KEY);
+  assert.equal(askedHash, "0xabc");
+});
+
+// The count is a nice-to-have; the block row is not. Every failure mode below
+// must degrade to null rather than throw, or one bad storage read would cost
+// us the height itself.
+test("fetchEventCountAt degrades to null, never throws", async () => {
+  const rejects = (async () => {
+    throw new Error("boom");
+  }) as unknown as typeof fetch;
+  assert.equal(
+    await fetchEventCountAt("https://rpc.example", "0xabc", rejects),
+    null,
+  );
+  assert.equal(
+    await fetchEventCountAt(
+      "https://rpc.example",
+      "0xabc",
+      rpcFetch({ state_getStorage: () => "garbage" }),
+    ),
+    null,
+  );
+});
+
+// An empty key is a REAL zero -- the block genuinely emitted no events --
+// and must not be confused with the null an unreadable read produces.
+test("fetchEventCountAt reads an absent key as a real zero", async () => {
+  assert.equal(
+    await fetchEventCountAt(
+      "https://rpc.example",
+      "0xabc",
+      rpcFetch({ state_getStorage: () => null }),
+    ),
+    0,
+  );
+});
+
+test("fetchBlockAt spends the extra read only when asked", async () => {
+  const calls: string[] = [];
+  const fetchImpl = rpcFetch({
+    chain_getBlockHash: () => "0xabc",
+    chain_getBlock: () => ({
+      block: { header: { parentHash: "0xdef" }, extrinsics: [] },
+    }),
+    state_getStorage: () => "0x0105",
+  });
+  const counting = (async (url: string, init: RequestInit) => {
+    calls.push(JSON.parse(String(init.body)).method);
+    return fetchImpl(url as string, init);
+  }) as unknown as typeof fetch;
+
+  const withCount = await fetchBlockAt(
+    "https://rpc.example",
+    16,
+    counting,
+    () => 1,
+    true,
+  );
+  assert.equal(withCount.event_count, 320);
+  assert.deepEqual(calls, [
+    "chain_getBlockHash",
+    "chain_getBlock",
+    "state_getStorage",
+  ]);
+
+  calls.length = 0;
+  const without = await fetchBlockAt(
+    "https://rpc.example",
+    16,
+    counting,
+    () => 1,
+  );
+  assert.equal(without.event_count, null);
+  assert.deepEqual(calls, ["chain_getBlockHash", "chain_getBlock"]);
 });
 
 test("fetchBlockAt surfaces RPC failures rather than fabricating a block", async () => {

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -992,18 +992,33 @@ export class ChainFirehoseHub implements DurableObject {
         (await this.state.storage.get<number>("head:last_seen")) ?? null;
       const head = await fetchHeadNumber(rpcUrl);
       for (const height of heightsToEmit(lastSeen, head)) {
-        const block = await fetchBlockAt(rpcUrl, height);
+        // #9417: read the event count too, so a block is complete the moment
+        // it is seen rather than ~30s later when the Containers indexer lands
+        // its decode. Kill-switched like the poll itself -- it is one extra
+        // storage read per block, and the whole 11-17 KB blob comes back to
+        // read a 1-4 byte prefix, so it must be instantly disableable if the
+        // archive endpoint objects to the volume.
+        const block = await fetchBlockAt(
+          rpcUrl,
+          height,
+          fetch,
+          Date.now,
+          this.env.CHAIN_HEAD_EVENT_COUNT_ENABLED !== "false",
+        );
         await this.broadcast(block as unknown as ChainFirehoseIngestPayload);
         const db = this.env.METAGRAPH_HEALTH_DB;
         if (db?.prepare) {
           await db
             .prepare(
-              `INSERT INTO blocks_head (block_number, block_hash, parent_hash, extrinsic_count, observed_at)
-               VALUES (?, ?, ?, ?, ?)
+              `INSERT INTO blocks_head (block_number, block_hash, parent_hash, extrinsic_count, event_count, observed_at)
+               VALUES (?, ?, ?, ?, ?, ?)
                ON CONFLICT(block_number) DO UPDATE SET
                  block_hash=excluded.block_hash,
                  parent_hash=excluded.parent_hash,
                  extrinsic_count=excluded.extrinsic_count,
+                 -- COALESCE, not excluded: a re-poll that could not read the
+                 -- count must not erase one an earlier tick already stored.
+                 event_count=COALESCE(excluded.event_count, blocks_head.event_count),
                  observed_at=excluded.observed_at`,
             )
             .bind(
@@ -1011,6 +1026,7 @@ export class ChainFirehoseHub implements DurableObject {
               block.block_hash,
               block.parent_hash,
               block.extrinsic_count,
+              block.event_count,
               block.observed_at,
             )
             .run();

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -155,6 +155,11 @@ interface Env {
   CHAIN_HEAD_POLL_ENABLED?: string;
   CHAIN_HEAD_RPC_URL?: string;
   CHAIN_HEAD_POLL_INTERVAL_MS?: string;
+  /** #9417: read each block's event count from System.Events' SCALE length
+   * prefix. Defaults ON (only "false" disables) -- unlike the poll switch
+   * above, the feature it gates is a correctness fix, so an unset var in
+   * local/CI should exercise it rather than skip it. */
+  CHAIN_HEAD_EVENT_COUNT_ENABLED?: string;
   /** #8700: the raw-capture lane's testnet endpoint. Only the capture lane
    * reads it — the head poller stays mainnet-only, because `blocks_head` has
    * no network dimension yet. */

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -460,6 +460,13 @@
     "CHAIN_HEAD_POLL_ENABLED": "true",
     "CHAIN_HEAD_RPC_URL": "https://archive.chain.opentensor.ai",
     "CHAIN_HEAD_POLL_INTERVAL_MS": "6000",
+    // #9417: read each block's event count from the System.Events SCALE length
+    // prefix, so the chain tip carries a real count instead of waiting ~30s for
+    // the Containers indexer's decode. One extra state_getStorage per block,
+    // and the whole 11-17 KB events blob returns to read a 1-4 byte prefix --
+    // flip to "false" to stop paying that immediately (blocks keep flowing;
+    // their counts just go back to arriving with the indexer).
+    "CHAIN_HEAD_EVENT_COUNT_ENABLED": "true",
     // #8700: the raw-capture lane's testnet endpoint. Declared explicitly
     // rather than left to the code default so the two chains this Worker
     // captures are both visible here — a lane whose endpoint is only knowable


### PR DESCRIPTION
Closes #9417.

`blocks_head` (head poller, ~6s tick) runs ahead of `chain_detail_blocks` (Containers indexer), so the newest blocks carried no event count. #9414 joined the two tables and took the unknown window from **144 blocks → 3**. This removes the dependency on the indexer entirely and takes it to **0**.

## The insight

`src/head-poller.ts`'s own header says the extrinsics/chain_events/account_events lanes *"need SCALE decoding against runtime metadata, which is the Containers indexer's job"*. That is true of every event's **content** — and not true of the **count**.

`System.Events` is a `Vec<EventRecord>`, and a SCALE `Vec` is prefixed with its compact-encoded length. Reading that prefix decodes nothing and needs no metadata. Verified against the live archive endpoint:

| block | SCALE prefix | `chain_detail_blocks` / `/chain-events` |
|---|---|---|
| 8,771,446 | 320 | 320 |
| 8,771,000 | 268 | 268 |
| 8,771,459 | 256 | 256 |

So the poller can report a count without ever pretending to decode what only the indexer can.

## Nothing hand-maintained

- **The storage key is derived, not hardcoded.** `storageMapPrefix("System", "Events")` from `src/twox-storage-key.ts` — the same helper eight other storage readers already use. The derivation reproduces the key verified live, so there is no magic hex to keep in step.
- **The payload type is inferred from its schema.** `HeadBlock` is now `z.infer<typeof HeadBlockSchema>` rather than an `interface` declared beside a validator — one statement of the shape, not two that can drift.
- **The compact reader is proven by round trip**, not hand-picked hex. An encoder written to the SCALE spec round-trips every mode (single/two/four-byte and big-integer) including the boundaries; the three real on-chain counts are pinned separately so a reader regression is caught even if the encoder were wrong in the same direction.

## Correctness

- **`chain_getBlock` is parsed, not `as`-cast.** It is untrusted network input, and a malformed body previously produced a block row with a silently wrong extrinsic count. It now refuses the tick — the alarm re-arms and retries the height.
- **Fail-soft.** The block row is essential; its count is not. An RPC failure stores the height with a null count rather than losing it. `fetchEventCountAt` never throws.
- **Never a fabricated zero.** An absent storage key is a real `0` (the block emitted no events); an unreadable read is `null`. The column is nullable and must never default to 0 — that is the bug #9414 fixed one layer up.
- **The upsert `COALESCE`s**, so a re-poll that could not read the count cannot erase one an earlier tick stored.
- **Serving prefers the indexer**: `COALESCE(c.chain_event_count, b.event_count)`. Both are exact and agree; the poller's copy only covers the seconds before the decode lands.

## Cost and control

One extra `state_getStorage` per block (~7,200/day, ~5/min). The whole 11–17 KB events blob returns to read a 1–4 byte prefix — there is no byte-range JSON-RPC, and `state_getStorageSize` answers in bytes, not items. Gated by `CHAIN_HEAD_EVENT_COUNT_ENABLED` (default on, flip to `"false"`), mirroring `CHAIN_HEAD_POLL_ENABLED`.

Note on the alternative guard: skipping the read when `chain_detail_blocks` already covers the height saves nothing — the poller writes a block within ~6s of seeing it, and the indexer needs ~30s, so at poll time the indexer has essentially never caught up. That guard would skip ~0% of the time while adding a D1 read per block.

## Migration — already applied

`migrations/d1/0016_blocks_head_event_count.sql` adds the nullable column. **Applied to production D1 by hand before this PR**, deliberately: the poller's INSERT names `event_count`, so deploying the code first would fail every `blocks_head` write and stall the blocks lane. Confirmed present via `pragma_table_info('blocks_head')`. Additive and nullable, so the currently-deployed code is unaffected.

## Verification

```
tsc --noEmit    clean
eslint          clean
vitest          673 files / 15,940 tests pass
```
