### PR TITLE
docs(scripts): retire the Postgres-era jobs, and guard the SQL-type defect on D1

### DIFF
--- a/.github/workflows/check-emission-drift.yml
+++ b/.github/workflows/check-emission-drift.yml
@@ -6,12 +6,29 @@ name: Check emission drift
 # underneath it, and the runtime ships every two to three days. This is the
 # other half.
 #
-# MOVED OFF THE INDEXER BOX. This ran as a ~30-minute systemd timer there. It is
-# the only one of the box's four remaining refresh jobs that can move as-is,
-# because it is the only one that needs no database: it reads chain state and
-# alerts, and writes nothing. The other three (emission-gate-sample,
-# reconcile-neurons, export-parquet) all require DATABASE_URL and are blocked on
-# the chain-data tier's own migration.
+# MOVED OFF THE INDEXER BOX. This ran as a ~30-minute systemd timer there. It was
+# the only one of the box's four remaining refresh jobs that could move as-is,
+# because it is the only one that needed no database: it reads chain state and
+# alerts, and writes nothing.
+#
+# THE OTHER THREE ARE RETIRED, NOT BLOCKED. An earlier note here said
+# emission-gate-sample, reconcile-neurons and export-parquet were "blocked on the
+# chain-data tier's own migration". That migration is done and Postgres is gone --
+# the estate is Cloudflare-only -- so there is nothing left to unblock, and the
+# note was sending readers to look for work that will never exist. What actually
+# became of each:
+#
+#   emission-gate-sample -> RUNS, as EMISSION_GATE_SAMPLE_CRON in workers/config.ts
+#   reconcile-neurons    -> obsolete. Neurons are D1-native and the lane has a
+#                           single producer by design; a second writer would lose
+#                           UIDs to the prune, so reconciling from outside it is
+#                           not a thing to restore.
+#   export-parquet       -> obsolete. It existed to move Postgres into the
+#                           lakehouse, and that move is complete.
+#
+# The scripts stay in the tree, unrun, the same way the box roles do in
+# metagraphed-infra: a future validator box may want some of this shape back, and
+# deleting them buys nothing that leaving them costs.
 #
 # Zero alerts is the correct steady state and means the reconstruction still
 # holds -- not that the monitor is broken. The script prints a summary line every

--- a/scripts/chain-firehose-relay.ts
+++ b/scripts/chain-firehose-relay.ts
@@ -1,3 +1,16 @@
+// RETIRED 2026-08-04 -- DOES NOT RUN, AND CANNOT.
+//
+// The estate is Cloudflare-only: every paid server was decommissioned and Postgres
+// is gone. Concretely, the relay ran ON the indexer box, polling its local Postgres and pushing to an
+// ingest URL. The head is now a Durable Object firehose; there is no box and no
+// Postgres to poll.
+//
+// Kept in the tree rather than deleted, the same way metagraphed-infra keeps its box
+// roles: a future validator box may want some of this shape back, and deleting it
+// buys nothing that leaving it costs. Do not "fix" it by pointing it at a new
+// database -- if this capability is ever wanted again it should be rebuilt against
+// whatever store exists then, not resurrected against a connection string.
+
 // Box-side relay for the realtime chain-event firehose (#4981, #5027, ADR
 // 0015).
 //

--- a/scripts/export-parquet.ts
+++ b/scripts/export-parquet.ts
@@ -1,3 +1,16 @@
+// RETIRED 2026-08-04 -- DOES NOT RUN, AND CANNOT.
+//
+// The estate is Cloudflare-only: every paid server was decommissioned and Postgres
+// is gone. Concretely, it existed to move Postgres into the lakehouse, reading both databases through
+// DuckDB's postgres extension on the box that hosted them. That move is complete
+// and both the box and the databases are gone.
+//
+// Kept in the tree rather than deleted, the same way metagraphed-infra keeps its box
+// roles: a future validator box may want some of this shape back, and deleting it
+// buys nothing that leaving it costs. Do not "fix" it by pointing it at a new
+// database -- if this capability is ever wanted again it should be rebuilt against
+// whatever store exists then, not resurrected against a connection string.
+
 // Nightly bulk export of core registry + chain tables to Parquet, uploaded
 // to R2 under a dated prefix + a `latest/` alias, with a discovery manifest
 // (#2538, successor to #2115's "exporter" half — see that issue's closing

--- a/scripts/reconcile-neurons.ts
+++ b/scripts/reconcile-neurons.ts
@@ -1,3 +1,17 @@
+// RETIRED 2026-08-04 -- DOES NOT RUN, AND CANNOT.
+//
+// The estate is Cloudflare-only: every paid server was decommissioned and Postgres
+// is gone. Concretely, neurons are D1-native and the lane has a SINGLE producer by design -- a second
+// writer loses UIDs to the prune. Reconciling from outside that lane is not a
+// thing to restore; NEURONS_STALENESS_WATCHDOG_CRON covers the freshness question
+// this script was reached for.
+//
+// Kept in the tree rather than deleted, the same way metagraphed-infra keeps its box
+// roles: a future validator box may want some of this shape back, and deleting it
+// buys nothing that leaving it costs. Do not "fix" it by pointing it at a new
+// database -- if this capability is ever wanted again it should be rebuilt against
+// whatever store exists then, not resurrected against a connection string.
+
 // Drift-detection reconciler (#5776, successor to #2115's "reconciler" half
 // -- see #2538 for the sibling "exporter" half, which this deliberately
 // does NOT share a job with: exporting is a bulk dump, reconciling needs a


### PR DESCRIPTION
The estate is Cloudflare-only — every paid server is decommissioned and Postgres is gone. Four files hadn't caught up, and both kinds of staleness send a reader (or an agent) after work that does not exist.

## The comment was wrong twice

`check-emission-drift.yml` said the other three refresh jobs were *"blocked on the chain-data tier's own migration"*.

That migration is done, so nothing is blocked. And the list was wrong on its own terms: **`emission-gate-sample` needs no database and already runs**, as `EMISSION_GATE_SAMPLE_CRON` in `workers/config.ts`. The comment now says what actually became of each.

## Three scripts that cannot run, and won't again

| Script | Why |
|---|---|
| `chain-firehose-relay.ts` | polled the indexer box's local Postgres; the head is a Durable Object firehose now |
| `reconcile-neurons.ts` | neurons are D1-native with a **single** producer by design — a second writer loses UIDs to the prune |
| `export-parquet.ts` | read both databases via DuckDB's postgres extension, on the box that hosted them |

Each still opened with setup instructions written as though you could follow them. Each now opens with a RETIRED banner carrying **why**, so the reason survives the next reader.

The banners explicitly say *not* to "fix" these by pointing them at a new database. If one of these capabilities is ever wanted again it should be rebuilt against whatever store exists then — not resurrected against a connection string.

## Kept, not deleted

Same reasoning metagraphed-infra applies to its box roles: a validator box is expected once the Ventura Labs contract lands, and it may want some of this shape back. Deleting them buys nothing that leaving them costs.

The `postgres`/`pg` dependencies are deliberately untouched — these files still import them, so dropping them is a separate change with its own blast radius.

## Verification

`tsc`, `eslint`, `prettier --check`, `validate` (129 subnets), `validate:api` (190 routes), `validate-docs`, `validate-workflows` (26 files) all clean. `emission-pipeline` 31/31.

Closes #9424

---

## Added: the SQL-type guard, on the right engine (step 1 of #9426)

`tests/data-api-sql-types.test.ts` exists for a real bug — `realized-return-baseline-query` shipped comparing a DATE column against an integer and returned nothing on **every invocation for days** without one test going red. It asserts that against PGlite.

But the query it guards, `loadRealizedStakeBaselinesD1`, **runs on D1**. The test has been protecting the wrong engine — and the wrong engine was the *forgiving* one:

| | `date_column >= 12345` |
|---|---|
| **Postgres** | raises `operator does not exist: date >= integer` — loud |
| **SQLite/D1** | type affinity; no error, quietly matches nothing |

So the defect this test family exists for is **silent on D1** and was merely survivable on Postgres. It matters more here, and nothing was checking it.

`tests/data-api-d1-sql-types.test.ts` adds the D1 twin using `node:sqlite` — no new dependency — loading the real DDL from `migrations/d1/0007_neurons.sql` so column types are production's, not a fixture's.

Seven tests: the schema facts the reasoning rests on (`snapshot_date` is TEXT; ISO dates order correctly as strings, including across a month boundary), the defect in the form D1 expresses it, and the tolerance widening the floor rather than narrowing it — a sign error there reads as "no baseline" rather than as a bug.

**Every negative assertion is paired with a positive control**, because "returns zero rows" also passes on an empty table and would otherwise prove nothing.

The PGlite test **stays** until #9426 step 2 re-points type generation at the D1 schema, so there is never a window with no guard at all.

79 tests pass across the three related files.

Part of #9426