### PR TITLE
fix(projections): split the aggregate that 422s, and notice when a lane stops writing

### DIFF
--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -24,7 +24,7 @@ import {
   LAKEHOUSE_NAMESPACES,
   projectionKey,
 } from "./chain-network.ts";
-import { isR2SqlConfigured, r2SqlQuery } from "./r2-sql.ts";
+import { isR2SqlConfigured, QUERY_TIMEOUT_MS, r2SqlQuery } from "./r2-sql.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import {
   CHAIN_TRANSFER_LIMIT_MAX,
@@ -103,6 +103,27 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 /** src/chain-transfers.ts keeps TRANSFER_KIND private; inlined here the same
  * way workers/data-api.ts inlines it for the identical query. */
 const TRANSFER_KIND = "Transfer";
+
+/**
+ * How long ONE lane statement may run.
+ *
+ * The request-path ceiling times four, and the multiplier is the whole point:
+ * 15 s is sized for a caller sitting on a response, and a cron has no caller.
+ * Measured 2026-08-04, `chain-transfer-pairs` was declining every tick with
+ * "The operation was aborted" -- its pair-grouping CTE had simply grown past a
+ * bound borrowed from a context it does not share, and the lane published a
+ * card nothing refreshed rather than a slow one (#9423).
+ *
+ * Four rather than "as long as it likes": the whole 26-lane run has to finish
+ * well inside its own 30-minute interval, and a statement that cannot answer
+ * in a minute is a query to fix, not to wait longer for.
+ */
+export const PROJECTION_QUERY_TIMEOUT_MS = 4 * QUERY_TIMEOUT_MS;
+
+/** Every lane statement runs on the lane bound, never the request bound. */
+function laneQuery(env: Env, sql: string) {
+  return r2SqlQuery(env, sql, { timeoutMs: PROJECTION_QUERY_TIMEOUT_MS });
+}
 
 export interface ProjectionLane {
   name: string;
@@ -192,15 +213,15 @@ async function computeChainTransfers(
     ] = transferWindowSql(generatedAt - days * DAY_MS, network);
     // Sequential on purpose: one second-scale scan in flight at a time, the
     // posture every cold-tier caller of r2SqlQuery takes.
-    const totals = await r2SqlQuery(env, totalsSql!);
+    const totals = await laneQuery(env, totalsSql!);
     if (totals === null) return null;
-    const senderCount = await r2SqlQuery(env, sendersCountSql!);
+    const senderCount = await laneQuery(env, sendersCountSql!);
     if (senderCount === null) return null;
-    const receiverCount = await r2SqlQuery(env, receiversCountSql!);
+    const receiverCount = await laneQuery(env, receiversCountSql!);
     if (receiverCount === null) return null;
-    const senders = await r2SqlQuery(env, sendersSql!);
+    const senders = await laneQuery(env, sendersSql!);
     if (senders === null) return null;
-    const receivers = await r2SqlQuery(env, receiversSql!);
+    const receivers = await laneQuery(env, receiversSql!);
     if (receivers === null) return null;
     windows[label] = {
       days,
@@ -343,13 +364,13 @@ async function computeChainActivity(
       generatedAt - days * DAY_MS,
       network,
     );
-    const base = await r2SqlQuery(env, baseSql!);
+    const base = await laneQuery(env, baseSql!);
     if (base === null) return null;
-    const signers = await r2SqlQuery(env, signersSql!);
+    const signers = await laneQuery(env, signersSql!);
     if (signers === null) return null;
-    const blocks = await r2SqlQuery(env, blocksSql!);
+    const blocks = await laneQuery(env, blocksSql!);
     if (blocks === null) return null;
-    const fresh = await r2SqlQuery(env, freshSql!);
+    const fresh = await laneQuery(env, freshSql!);
     if (fresh === null) return null;
     const signersByDay = new Map(
       signers.map((row) => [String(row.day_index), row.unique_signers]),
@@ -415,13 +436,13 @@ async function computeChainCalls(
   for (const [label, days] of Object.entries(ANALYTICS_WINDOWS)) {
     const [freshSql, moduleSql, moduleFunctionSql, totalSql] =
       chainCallsWindowSql(generatedAt - days * DAY_MS, network);
-    const fresh = await r2SqlQuery(env, freshSql!);
+    const fresh = await laneQuery(env, freshSql!);
     if (fresh === null) return null;
-    const moduleRows = await r2SqlQuery(env, moduleSql!);
+    const moduleRows = await laneQuery(env, moduleSql!);
     if (moduleRows === null) return null;
-    const moduleFunctionRows = await r2SqlQuery(env, moduleFunctionSql!);
+    const moduleFunctionRows = await laneQuery(env, moduleFunctionSql!);
     if (moduleFunctionRows === null) return null;
-    const total = await r2SqlQuery(env, totalSql!);
+    const total = await laneQuery(env, totalSql!);
     if (total === null) return null;
     windows[label] = {
       days,
@@ -499,9 +520,9 @@ async function computeChainFees(
   for (const [label, days] of Object.entries(ANALYTICS_WINDOWS)) {
     const cutoff = generatedAt - days * DAY_MS;
     const [dailySql, payersSql, freshSql] = chainFeesWindowSql(cutoff, network);
-    const daily = await r2SqlQuery(env, dailySql!);
+    const daily = await laneQuery(env, dailySql!);
     if (daily === null) return null;
-    const payers = await r2SqlQuery(env, payersSql!);
+    const payers = await laneQuery(env, payersSql!);
     if (payers === null) return null;
     const feeMedians = await r2SqlQuery(
       env,
@@ -513,7 +534,7 @@ async function computeChainFees(
       chainFeesMedianSql(cutoff, "tip_tao", network),
     );
     if (tipMedians === null) return null;
-    const fresh = await r2SqlQuery(env, freshSql!);
+    const fresh = await laneQuery(env, freshSql!);
     if (fresh === null) return null;
     const dailyRows = withDayLabels(daily);
     if (dailyRows === null) return null;
@@ -593,11 +614,11 @@ async function computeChainSigners(
       generatedAt - days * DAY_MS,
       network,
     );
-    const fresh = await r2SqlQuery(env, freshSql!);
+    const fresh = await laneQuery(env, freshSql!);
     if (fresh === null) return null;
-    const txCountRows = await r2SqlQuery(env, txCountSql!);
+    const txCountRows = await laneQuery(env, txCountSql!);
     if (txCountRows === null) return null;
-    const feeRows = await r2SqlQuery(env, feeSql!);
+    const feeRows = await laneQuery(env, feeSql!);
     if (feeRows === null) return null;
     windows[label] = {
       days,
@@ -726,7 +747,7 @@ async function computeSubnetDistinctWindow(
 } | null> {
   // The window's newest event first: cheap, and it is what decides whether the
   // per-subnet scan is worth issuing at all (data-api's own guard).
-  const newestRows = await r2SqlQuery(env, sql.newestSql);
+  const newestRows = await laneQuery(env, sql.newestSql);
   if (newestRows === null) return null;
   // NO ROW AT ALL is not the same as a row saying NULL. An aggregate that ran
   // always returns exactly one row, so an empty result set means the engine
@@ -746,7 +767,7 @@ async function computeSubnetDistinctWindow(
       rows: [],
     };
   }
-  const networkRows = await r2SqlQuery(env, sql.networkSql);
+  const networkRows = await laneQuery(env, sql.networkSql);
   if (networkRows === null) return null;
   // The CHAIN-WIDE scope row, not a chain network -- the artifact key it lands
   // under is `network` and cannot be renamed, but the local is named for what
@@ -763,9 +784,9 @@ async function computeSubnetDistinctWindow(
   // DISTINCT that came back unusable must not also suppress the per-subnet
   // scan, which is a separate read that may well have succeeded.
   if (newest != null) {
-    const subnetRows = await r2SqlQuery(env, sql.subnetCountSql);
+    const subnetRows = await laneQuery(env, sql.subnetCountSql);
     if (subnetRows === null) return null;
-    const distinctRows = await r2SqlQuery(env, sql.subnetDistinctSql);
+    const distinctRows = await laneQuery(env, sql.subnetDistinctSql);
     if (distinctRows === null) return null;
     // Merged back by netuid, so the row shape the artifact has always carried
     // is unchanged and splitting the statement is invisible to every reader.
@@ -776,8 +797,7 @@ async function computeSubnetDistinctWindow(
       ]),
     );
     for (const row of subnetRows) {
-      row[sql.distinctAlias] =
-        distinctByNetuid.get(String(row.netuid)) ?? 0;
+      row[sql.distinctAlias] = distinctByNetuid.get(String(row.netuid)) ?? 0;
     }
     rows = subnetRows;
   }
@@ -903,11 +923,11 @@ async function computeChainTransferPairs(
       generatedAt - days * DAY_MS,
       network,
     );
-    const totals = await r2SqlQuery(env, totalsSql!);
+    const totals = await laneQuery(env, totalsSql!);
     if (totals === null) return null;
-    const volumePairs = await r2SqlQuery(env, volumeSql!);
+    const volumePairs = await laneQuery(env, volumeSql!);
     if (volumePairs === null) return null;
-    const countPairs = await r2SqlQuery(env, countSql!);
+    const countPairs = await laneQuery(env, countSql!);
     if (countPairs === null) return null;
     windows[label] = {
       days,

--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -657,18 +657,53 @@ function subnetDistinctWindowSql(
   countAlias: string,
   distinctAlias: string,
   network: ChainNetworkId,
-): { networkSql: string; subnetSql: string } {
+): {
+  newestSql: string;
+  networkSql: string;
+  subnetCountSql: string;
+  subnetDistinctSql: string;
+  countAlias: string;
+  distinctAlias: string;
+} {
   const scope =
     `FROM ${chainTable("account_events", network)} ` +
     `WHERE event_kind = '${eventKind}' AND observed_at >= ${cutoff}`;
   return {
-    networkSql:
-      `SELECT COUNT(DISTINCT coldkey) AS ${distinctAlias}, ` +
-      `MAX(observed_at) AS newest_observed ${scope}`,
-    subnetSql:
-      `SELECT netuid, COUNT(*) AS ${countAlias}, ` +
-      `COUNT(DISTINCT coldkey) AS ${distinctAlias} ${scope} ` +
+    // ONE HEAVY AGGREGATION PER STATEMENT. The chain-wide DISTINCT used to
+    // share a statement with `MAX(observed_at)`, and that pairing is what
+    // stopped these two lanes writing on 2026-08-03 -- they declined every
+    // tick for 31 hours while the routes over them served a card whose newest
+    // event was 44 hours old (#9423). Its sibling `transferWindowSql` was
+    // already split for exactly this reason, and says so: each DISTINCT alone
+    // is the heaviest scan in the family, and bundling one with anything else
+    // pushes the statement past R2 SQL's own per-query ceiling as the table
+    // grows. This is that same remedy, applied to the lane that still had the
+    // bundled shape.
+    //
+    // Only the FIRST statement's row carries `newest_observed`, so the split
+    // is invisible downstream -- see how computeSubnetDistinctWindow merges
+    // them back into one chain-wide row.
+    newestSql: `SELECT MAX(observed_at) AS newest_observed ${scope}`,
+    networkSql: `SELECT COUNT(DISTINCT coldkey) AS ${distinctAlias} ${scope}`,
+    countAlias,
+    distinctAlias,
+    // The per-subnet counts, SPLIT for the same reason. Measured 2026-08-04,
+    // this is the statement that actually 422s:
+    //
+    //   40015 scan budget exceeded: scanning too much data for
+    //   count(DISTINCT) with GROUP BY
+    //
+    // so the plain tally and the DISTINCT are issued separately and merged by
+    // netuid below. APPROX_DISTINCT is the engine's own first suggestion and
+    // is refused on purpose: `distinct_movers` is a PUBLISHED field, and an
+    // approximate answer under a name callers read as exact is worse than an
+    // honest decline.
+    subnetCountSql:
+      `SELECT netuid, COUNT(*) AS ${countAlias} ${scope} ` +
       `GROUP BY netuid ORDER BY ${countAlias} DESC, netuid ASC`,
+    subnetDistinctSql:
+      `SELECT netuid, COUNT(DISTINCT coldkey) AS ${distinctAlias} ${scope} ` +
+      `GROUP BY netuid`,
   };
 }
 
@@ -677,21 +712,73 @@ function subnetDistinctWindowSql(
  * per-subnet aggregate. Returns null on any query failure. */
 async function computeSubnetDistinctWindow(
   env: Env,
-  sql: { networkSql: string; subnetSql: string },
+  sql: {
+    newestSql: string;
+    networkSql: string;
+    subnetCountSql: string;
+    subnetDistinctSql: string;
+    countAlias: string;
+    distinctAlias: string;
+  },
 ): Promise<{
   network: Record<string, unknown> | null;
   rows: Record<string, unknown>[];
 } | null> {
+  // The window's newest event first: cheap, and it is what decides whether the
+  // per-subnet scan is worth issuing at all (data-api's own guard).
+  const newestRows = await r2SqlQuery(env, sql.newestSql);
+  if (newestRows === null) return null;
+  // NO ROW AT ALL is not the same as a row saying NULL. An aggregate that ran
+  // always returns exactly one row, so an empty result set means the engine
+  // gave us nothing usable -- unread, not measured -- and the chain-wide row
+  // stays null rather than claiming a zero nobody counted.
+  if (newestRows.length === 0) return { network: null, rows: [] };
+  const newest = newestRows[0]?.newest_observed ?? null;
+  // A window that observed nothing needs neither heavy scan -- and its zero is
+  // DERIVED, not guessed: `MAX(observed_at) IS NULL` means the window matched
+  // no rows at all, so the distinct count is necessarily 0. Emitting the same
+  // shape a non-empty window emits keeps a measured zero looking like one
+  // rather than degrading to "unknown", which is the whole reason the chain-
+  // wide row is stored separately from the per-subnet rows.
+  if (newest == null) {
+    return {
+      network: { [sql.distinctAlias]: 0, newest_observed: null },
+      rows: [],
+    };
+  }
   const networkRows = await r2SqlQuery(env, sql.networkSql);
   if (networkRows === null) return null;
   // The CHAIN-WIDE scope row, not a chain network -- the artifact key it lands
   // under is `network` and cannot be renamed, but the local is named for what
   // it holds so the two senses of the word cannot be confused here.
-  const chainWide = networkRows[0] ?? null;
+  // Merged back into the ONE chain-wide row the artifact has always carried,
+  // so splitting the statement changes nothing a reader can see.
+  const chainWide = networkRows[0]
+    ? { ...networkRows[0], newest_observed: newest }
+    : null;
   let rows: Record<string, unknown>[] = [];
-  if (chainWide?.newest_observed != null) {
-    const subnetRows = await r2SqlQuery(env, sql.subnetSql);
+  // The guard is data-api's: only scan per-subnet once the window is known to
+  // have observed something. That question now has its own cheap statement
+  // above, so it is asked of `newest` rather than of the DISTINCT row -- a
+  // DISTINCT that came back unusable must not also suppress the per-subnet
+  // scan, which is a separate read that may well have succeeded.
+  if (newest != null) {
+    const subnetRows = await r2SqlQuery(env, sql.subnetCountSql);
     if (subnetRows === null) return null;
+    const distinctRows = await r2SqlQuery(env, sql.subnetDistinctSql);
+    if (distinctRows === null) return null;
+    // Merged back by netuid, so the row shape the artifact has always carried
+    // is unchanged and splitting the statement is invisible to every reader.
+    const distinctByNetuid = new Map(
+      distinctRows.map((row) => [
+        String(row.netuid),
+        row[sql.distinctAlias] ?? 0,
+      ]),
+    );
+    for (const row of subnetRows) {
+      row[sql.distinctAlias] =
+        distinctByNetuid.get(String(row.netuid)) ?? 0;
+    }
     rows = subnetRows;
   }
   return { network: chainWide, rows };

--- a/src/projection-staleness-watchdog.ts
+++ b/src/projection-staleness-watchdog.ts
@@ -1,0 +1,265 @@
+// The alarm for the projection lanes (#9423).
+//
+// This watchdog exists because of what happened WITHOUT one. Two lanes --
+// chain-stake-moves and chain-stake-transfers -- stopped writing on
+// 2026-08-03T09:13 and nothing noticed for 31 hours. The read path degraded
+// exactly as designed: a lane that cannot compute leaves the previous artifact
+// in place, so the routes kept answering 200 off a card whose newest event was
+// 44 hours old, under a `7d` window label, with no degraded marker. Found by
+// reading R2 object timestamps by hand, not by anything going red.
+//
+// LEAVING THE PREVIOUS ARTIFACT IS RIGHT; NOT NOTICING IS NOT. The all-or-
+// nothing write is what stops one failed query from replacing real numbers
+// with a plausible-looking blank. What was missing is the other half: someone
+// asking how long that has been going on.
+//
+// Same shape as src/nominator-positions-staleness-watchdog.ts deliberately --
+// a pure rule, a summary rather than a throw, and one exception event per
+// stale tick. Zero alerts is the correct steady state.
+
+import { DEFAULT_CHAIN_NETWORK, projectionKey } from "./chain-network.ts";
+import { PROJECTION_LANES, PROJECTION_NETWORKS } from "./projection-lanes.ts";
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { PROJECTION_LANES_CRON } from "../workers/config.ts";
+
+/**
+ * The shortest gap between two ticks of a `minute-list * * * *` cron.
+ *
+ * The producer's cadence is already stated once, in PROJECTION_LANES_CRON.
+ * Restating it here as a wall-clock number would be a second copy that goes
+ * silently wrong the moment the cron changes -- and "silently wrong" for a
+ * staleness threshold means either an alarm that never fires or one that
+ * always does. Reading it from the cron means the bound follows its producer
+ * by construction.
+ *
+ * The SHORTEST gap, not the average: an uneven minute list (say `5,10,50`)
+ * has ticks 5 and 40 minutes apart, and a healthy lane must clear the bound
+ * on the wide gap, so only the narrow one tells you what a tick is worth.
+ */
+export function cronIntervalMs(cron: string): number | null {
+  const fields = cron
+    .split(" ")[0]!
+    .split(",")
+    .map((p) => p.trim());
+  // Every field must be a bare minute. An empty string coerces to 0 through
+  // Number(), so it is rejected explicitly rather than read as "on the hour" --
+  // a malformed cron must yield null, not a plausible interval.
+  if (fields.some((f) => !/^\d+$/.test(f))) return null;
+  const minutes = fields.map(Number);
+  if (minutes.some((m) => m > 59)) return null;
+  if (minutes.length === 1) return 60 * 60_000;
+  const sorted = [...minutes].sort((a, b) => a - b);
+  const gaps = sorted.map((m, i) =>
+    i === 0 ? m + 60 - sorted[sorted.length - 1]! : m - sorted[i - 1]!,
+  );
+  return Math.min(...gaps) * 60_000;
+}
+
+/**
+ * How many consecutive ticks a lane may miss before it is a stall.
+ *
+ * This is the one genuine judgement in the module, so it is expressed in the
+ * unit the judgement is actually about -- MISSED TICKS -- rather than baked
+ * into a wall-clock constant that has to be re-derived by hand whenever the
+ * producer's cadence moves.
+ *
+ * Eight, because a healthy lane's age swings across its whole producer
+ * interval (the sizing rule #9301 corrected the nominator-positions threshold
+ * for), so anything near one interval alerts on a lane that is working. Eight
+ * clears a run that overruns its own window, a redeploy, and ordinary cron
+ * jitter, while still catching a dead lane inside hours rather than never --
+ * the 31-hour silence that produced #9423 would have been caught on its
+ * fourth hour.
+ */
+export const PROJECTION_STALENESS_MISSED_TICKS = 8;
+
+/**
+ * How stale a projection may get before it is a stall: eight missed ticks of
+ * whatever cadence the lane cron currently declares.
+ *
+ * Overridable per-deployment via PROJECTION_STALENESS_THRESHOLD_MS, so an
+ * operator can tighten or loosen it without a code deploy.
+ */
+
+/**
+ * The bound for a given producer cron.
+ *
+ * The fallback covers a cron this parser cannot read -- a step form such as
+ * "every fifth minute", say. Half an hour is not a guess at that cron's
+ * cadence: it is the cadence the lane cron has always had, kept as the
+ * conservative floor so an unparseable cron degrades to today's bound rather
+ * than to no bound at all.
+ */
+export function projectionStalenessThresholdMs(cron: string): number {
+  return (
+    PROJECTION_STALENESS_MISSED_TICKS * (cronIntervalMs(cron) ?? 30 * 60_000)
+  );
+}
+
+export const PROJECTION_STALENESS_THRESHOLD_MS = projectionStalenessThresholdMs(
+  PROJECTION_LANES_CRON,
+);
+
+export interface ProjectionStalenessEntry {
+  /** `<lane>` on mainnet, `<lane>:<network>` elsewhere -- the same labelling
+   * runProjectionLanes uses, so an alert and a run summary name one thing. */
+  lane: string;
+  stale: boolean;
+  reason: "absent" | "unreadable" | "stale" | null;
+  age_ms: number | null;
+  generated_at: string | null;
+}
+
+export interface ProjectionStalenessVerdict {
+  stale: boolean;
+  threshold_ms: number;
+  checked: number;
+  stale_lanes: string[];
+  entries: ProjectionStalenessEntry[];
+}
+
+/** The rule alone, testable without a bucket or a clock. */
+export function evaluateProjectionStaleness(input: {
+  artifacts: { lane: string; generatedAt: string | null | undefined }[];
+  nowMs: number;
+  thresholdMs: number;
+}): ProjectionStalenessVerdict {
+  const { artifacts, nowMs, thresholdMs } = input;
+  const entries = artifacts.map(({ lane, generatedAt }) => {
+    if (generatedAt == null) {
+      // An artifact that is not there at all is a stall of infinite age, not a
+      // quiet lane: every lane in the registry is supposed to have written on
+      // the last tick, and a route over a missing card serves its zeroed floor.
+      return {
+        lane,
+        stale: true,
+        reason: "absent" as const,
+        age_ms: null,
+        generated_at: null,
+      };
+    }
+    const at = Date.parse(generatedAt);
+    if (!Number.isFinite(at)) {
+      // A body whose timestamp cannot be read is worse than a missing one: the
+      // route is serving it, and nothing can say how old it is.
+      return {
+        lane,
+        stale: true,
+        reason: "unreadable" as const,
+        age_ms: null,
+        generated_at: generatedAt,
+      };
+    }
+    const age = nowMs - at;
+    return {
+      lane,
+      stale: age > thresholdMs,
+      reason: age > thresholdMs ? ("stale" as const) : null,
+      age_ms: age,
+      generated_at: generatedAt,
+    };
+  });
+  const staleLanes = entries.filter((e) => e.stale).map((e) => e.lane);
+  return {
+    stale: staleLanes.length > 0,
+    threshold_ms: thresholdMs,
+    checked: entries.length,
+    stale_lanes: staleLanes,
+    entries,
+  };
+}
+
+interface ProjectionBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+export interface ProjectionStalenessDeps {
+  now?: () => number;
+  /** Telemetry seam for tests; defaults to the real recordExceptionEvent. */
+  recordException?: typeof recordExceptionEvent;
+}
+
+/** Every lane x every network, labelled the way the runner labels them. */
+function watchedLanes(): { lane: string; key: string }[] {
+  return PROJECTION_NETWORKS.flatMap((network) =>
+    PROJECTION_LANES.map((lane) => ({
+      lane:
+        network === DEFAULT_CHAIN_NETWORK
+          ? lane.name
+          : `${lane.name}:${network}`,
+      key: projectionKey(lane.artifactKey, network),
+    })),
+  );
+}
+
+/**
+ * One watchdog tick. Returns a summary rather than throwing, matching the
+ * watchdog family: a tick that cannot run is one missed report, not an outage,
+ * and a cron that throws is a cron nobody can read the result of.
+ */
+export async function runProjectionStalenessWatchdog(
+  env: Record<string, unknown> | null | undefined,
+  deps: ProjectionStalenessDeps = {},
+): Promise<Record<string, unknown>> {
+  const now = deps.now ?? Date.now;
+  const record = deps.recordException ?? recordExceptionEvent;
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ProjectionBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return { ok: false, reason: "r2 binding unavailable" };
+
+  const thresholdMs =
+    Number(env?.PROJECTION_STALENESS_THRESHOLD_MS) ||
+    PROJECTION_STALENESS_THRESHOLD_MS;
+
+  const artifacts: { lane: string; generatedAt: string | null }[] = [];
+  for (const { lane, key } of watchedLanes()) {
+    let generatedAt: string | null;
+    try {
+      const object = await bucket.get(key);
+      const body = object ? ((await object.json()) as unknown) : null;
+      const value = (body as { generated_at?: unknown } | null)?.generated_at;
+      generatedAt = typeof value === "string" ? value : null;
+    } catch {
+      // An unreadable object is reported as absent rather than skipped: a
+      // watchdog that quietly drops what it could not read is a watchdog that
+      // reports healthy on exactly the lanes worth worrying about.
+      generatedAt = null;
+    }
+    artifacts.push({ lane, generatedAt });
+  }
+
+  const verdict = evaluateProjectionStaleness({
+    artifacts,
+    nowMs: now(),
+    thresholdMs,
+  });
+
+  if (verdict.stale) {
+    // ONE event naming every stale lane, not one per lane: twenty-six alerts
+    // for one dead cron is the failure mode where an alarm stops being read.
+    const detail = verdict.entries
+      .filter((entry) => entry.stale)
+      .map(
+        (entry) =>
+          `${entry.lane} (${
+            entry.age_ms === null
+              ? entry.reason
+              : `${(entry.age_ms / 3_600_000).toFixed(1)} h old`
+          })`,
+      )
+      .join(", ");
+    await record(env as never, {
+      error: new Error(
+        `projection lanes stalled: ${detail} (threshold ${(
+          thresholdMs / 3_600_000
+        ).toFixed(
+          1,
+        )} h, ${PROJECTION_STALENESS_MISSED_TICKS} missed ticks of ${PROJECTION_LANES_CRON}) -- the routes over these are answering from a card nothing is refreshing`,
+      ),
+      route: "watchdog:projection-staleness",
+      errorCode: "stale_lane",
+    }).catch(() => false);
+  }
+
+  return { ok: true, ...verdict };
+}

--- a/src/r2-sql.ts
+++ b/src/r2-sql.ts
@@ -38,7 +38,7 @@ const DEFAULT_WAREHOUSE = "metagraphed-lakehouse";
 /** Hard ceiling per query. Deliberately well above the ~2.2s worst case
  * measured above, so an ordinary heavy scan is not mistaken for a fault,
  * while a genuinely stuck query still cannot pin a request open. */
-const QUERY_TIMEOUT_MS = 15_000;
+export const QUERY_TIMEOUT_MS = 15_000;
 
 // Same contract as the Postgres tier's fallback generation: a caller can
 // snapshot this before a read and compare after, so a degraded (empty) answer

--- a/tests/projection-lanes.test.ts
+++ b/tests/projection-lanes.test.ts
@@ -1193,48 +1193,72 @@ describe("chain-stake-transfers lane compute", () => {
   test("replicates data-api's DISTINCT row + guarded per-subnet aggregate per window", async () => {
     vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
     const queries = lakeFetch(
-      // 7d: the network row observed activity, so the subnet query runs.
-      [{ distinct_senders: "4", newest_observed: NOW - 1000 }],
-      [{ netuid: 7, transfers: "6", distinct_senders: "3" }],
-      // 30d: a network row with NO newest_observed — data-api's guard skips
-      // the subnet query entirely.
-      [{ distinct_senders: "0", newest_observed: null }],
+      // 7d: newest first, then the chain-wide DISTINCT, then the per-subnet
+      // tally, then the per-subnet DISTINCT. Four statements because each
+      // heavy aggregation stands alone (#9423).
+      [{ newest_observed: NOW - 1000 }],
+      [{ distinct_senders: "4" }],
+      [{ netuid: 7, transfers: "6" }],
+      [{ netuid: 7, distinct_senders: "3" }],
+      // 30d: no newest_observed at all — the window observed nothing, so none
+      // of the heavy scans are issued.
+      [{ newest_observed: null }],
     );
     const body = (await laneNamed("chain-stake-transfers").compute(
       LAKE_ENV as unknown as Env,
       "mainnet",
     )) as Row;
-    // Three statements, not four: the guarded window issued only its
-    // network read.
-    assert.equal(queries.length, 3);
+    // Five statements: four for the active window, one for the empty one.
+    // The empty window costs a single cheap MAX() and stops there.
+    assert.equal(queries.length, 5);
     const cutoff7d = NOW - 7 * DAY_MS;
     assert.match(queries[0]!, /FROM chain\.account_events/);
     assert.match(queries[0]!, /event_kind = 'StakeTransferred'/);
     assert.match(queries[0]!, new RegExp(`observed_at >= ${cutoff7d}`));
-    assert.match(queries[0]!, /COUNT\(DISTINCT coldkey\) AS distinct_senders/);
-    assert.match(
-      queries[1]!,
-      /GROUP BY netuid ORDER BY transfers DESC, netuid ASC/,
-    );
+    assert.match(queries[0]!, /MAX\(observed_at\) AS newest_observed/);
+    // ONE heavy aggregation per statement: the DISTINCT stands alone, which is
+    // the shape its sibling transferWindowSql already used and the shape these
+    // two lanes lacked when they stopped writing for 31 hours (#9423).
+    assert.match(queries[1]!, /COUNT\(DISTINCT coldkey\) AS distinct_senders/);
+    assert.doesNotMatch(queries[1]!, /MAX\(observed_at\)/);
     assert.match(
       queries[2]!,
+      /GROUP BY netuid ORDER BY transfers DESC, netuid ASC/,
+    );
+    // The per-subnet DISTINCT is the statement that actually 422s in
+    // production (40015, count(DISTINCT) with GROUP BY), so it stands alone
+    // too -- and never with APPROX_DISTINCT, which the engine suggests and
+    // this lane refuses because distinct_senders is a published field.
+    assert.match(queries[3]!, /COUNT\(DISTINCT coldkey\) AS distinct_senders/);
+    assert.doesNotMatch(queries[3]!, /COUNT\(\*\)/);
+    assert.doesNotMatch(queries[3]!, /APPROX_DISTINCT/i);
+    assert.match(
+      queries[4]!,
       new RegExp(`observed_at >= ${NOW - 30 * DAY_MS}`),
     );
 
     assert.equal(body.schema_version, 1);
     assert.equal(body.row_count, 1);
+    // Merged back into the one chain-wide row the artifact has always carried,
+    // so the split is invisible to every reader.
     assert.deepEqual((body.windows as Row)["7d"], {
       days: 7,
       network: { distinct_senders: "4", newest_observed: NOW - 1000 },
       rows: [{ netuid: 7, transfers: "6", distinct_senders: "3" }],
     });
+    // An empty window keeps its MEASURED zero rather than degrading to
+    // "unknown": MAX(observed_at) IS NULL means no rows matched, so the
+    // distinct count is necessarily 0 -- derived, not guessed.
     assert.deepEqual((body.windows as Row)["30d"], {
       days: 30,
-      network: { distinct_senders: "0", newest_observed: null },
+      network: { distinct_senders: 0, newest_observed: null },
       rows: [],
     });
   });
 
+  // NO ROW AT ALL, as distinct from a row saying NULL: an aggregate that ran
+  // returns exactly one row, so an empty result set is unread rather than a
+  // measured empty window, and must not be published as a zero.
   test("an empty network result stores a null network row", async () => {
     lakeFetch([]);
     const body = (await laneNamed("chain-stake-transfers").compute(
@@ -1273,22 +1297,29 @@ describe("chain-stake-moves lane compute", () => {
   test("replicates data-api's DISTINCT row + per-subnet aggregate over StakeMoved", async () => {
     vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
     const queries = lakeFetch(
-      [{ distinct_movers: "5", newest_observed: NOW - 1000 }],
-      [{ netuid: 3, movements: "10", distinct_movers: "2" }],
+      [{ newest_observed: NOW - 1000 }],
+      [{ distinct_movers: "5" }],
+      [{ netuid: 3, movements: "10" }],
+      [{ netuid: 3, distinct_movers: "2" }],
       [],
     );
     const body = (await laneNamed("chain-stake-moves").compute(
       LAKE_ENV as unknown as Env,
       "mainnet",
     )) as Row;
-    assert.equal(queries.length, 3);
+    assert.equal(queries.length, 5);
     assert.match(queries[0]!, /event_kind = 'StakeMoved'/);
-    assert.match(queries[0]!, /COUNT\(DISTINCT coldkey\) AS distinct_movers/);
-    assert.match(queries[1]!, /COUNT\(\*\) AS movements/);
+    assert.match(queries[0]!, /MAX\(observed_at\) AS newest_observed/);
+    // The DISTINCT stands alone (#9423) -- one heavy aggregation per statement.
+    assert.match(queries[1]!, /COUNT\(DISTINCT coldkey\) AS distinct_movers/);
+    assert.doesNotMatch(queries[1]!, /MAX\(observed_at\)/);
+    assert.match(queries[2]!, /COUNT\(\*\) AS movements/);
     assert.match(
-      queries[1]!,
+      queries[2]!,
       /GROUP BY netuid ORDER BY movements DESC, netuid ASC/,
     );
+    assert.match(queries[3]!, /COUNT\(DISTINCT coldkey\) AS distinct_movers/);
+    assert.doesNotMatch(queries[3]!, /COUNT\(\*\)/);
 
     assert.equal(body.schema_version, 1);
     assert.equal(body.row_count, 1);
@@ -1817,5 +1848,78 @@ describe("projection lanes are network-scoped end to end", () => {
         }
       }
     }
+  });
+});
+
+// The chain-wide DISTINCT returning no row at all, as distinct from a row of
+// zero: the statement ran but gave nothing usable, so the artifact must not
+// publish a count nobody produced (#9423).
+describe("a chain-wide DISTINCT that returns nothing is unread, not zero", () => {
+  test("the window stores a null chain-wide row", async () => {
+    vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
+    lakeFetch(
+      [{ newest_observed: NOW - 1000 }],
+      [],
+      [{ netuid: 3, movements: "10", distinct_movers: "2" }],
+      [{ newest_observed: null }],
+    );
+    const body = (await laneNamed("chain-stake-moves").compute(
+      LAKE_ENV as unknown as Env,
+      "mainnet",
+    )) as Row;
+    assert.equal((body.windows as Row)["7d"].network, null);
+    // The per-subnet rows still landed -- one missing aggregate does not
+    // discard the scan that succeeded.
+    assert.equal((body.windows as Row)["7d"].rows.length, 1);
+  });
+});
+
+// The per-subnet DISTINCT is a SEPARATE statement now, so its rows have to be
+// merged back onto the tally by netuid. A netuid the DISTINCT scan did not
+// return is a real zero -- the tally already proved the subnet has rows in the
+// window, so "no distinct row" means no distinct coldkeys were counted, not
+// that the count is unknown.
+describe("the split per-subnet aggregates merge back by netuid", () => {
+  test("each subnet keeps its own distinct count", async () => {
+    vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
+    lakeFetch(
+      [{ newest_observed: NOW - 1000 }],
+      [{ distinct_movers: "9" }],
+      [
+        { netuid: 3, movements: "10" },
+        { netuid: 7, movements: "4" },
+      ],
+      // Deliberately out of order, and missing netuid 7 entirely.
+      [{ netuid: 3, distinct_movers: "2" }],
+      [{ newest_observed: null }],
+    );
+    const body = (await laneNamed("chain-stake-moves").compute(
+      LAKE_ENV as unknown as Env,
+      "mainnet",
+    )) as Row;
+    const rows = (body.windows as Row)["7d"].rows as Row[];
+    assert.deepEqual(rows, [
+      { netuid: 3, movements: "10", distinct_movers: "2" },
+      { netuid: 7, movements: "4", distinct_movers: 0 },
+    ]);
+  });
+
+  test("a failed per-subnet DISTINCT declines the whole compute", async () => {
+    vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
+    lakeFetch(
+      [{ newest_observed: NOW - 1000 }],
+      [{ distinct_movers: "9" }],
+      [{ netuid: 3, movements: "10" }],
+      "fail",
+    );
+    // All-or-nothing: half an aggregate published as though whole would show
+    // every subnet's distinct count as zero.
+    assert.equal(
+      await laneNamed("chain-stake-moves").compute(
+        LAKE_ENV as unknown as Env,
+        "mainnet",
+      ),
+      null,
+    );
   });
 });

--- a/tests/projection-lanes.test.ts
+++ b/tests/projection-lanes.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, test, vi } from "vitest";
 import {
   PROJECTION_LANES,
   PROJECTION_NETWORKS,
+  PROJECTION_QUERY_TIMEOUT_MS,
   projectionKey,
   STAKE_FLOW_PROJECTION_WINDOWS,
   runProjectionLane,
@@ -19,6 +20,7 @@ import {
   CHAIN_DEREGISTRATIONS_PROJECTION_KEY,
 } from "../src/chain-deregistrations-artifact.ts";
 import { LAKEHOUSE_NAMESPACES } from "../src/chain-network.ts";
+import { QUERY_TIMEOUT_MS } from "../src/r2-sql.ts";
 import { type Row } from "./row-type.ts";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -1921,5 +1923,42 @@ describe("the split per-subnet aggregates merge back by netuid", () => {
       ),
       null,
     );
+  });
+});
+
+// A CRON HAS NO CALLER WAITING. The 15 s request bound is sized for someone
+// sitting on a response; chain-transfer-pairs was declining every tick with
+// "The operation was aborted" because its pair-grouping CTE had grown past a
+// bound borrowed from a context it does not share (#9423).
+describe("lane statements run on the lane bound, not the request bound", () => {
+  test("every lane read carries the longer timeout", async () => {
+    const seen: (number | undefined)[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_u: string, init: RequestInit) => {
+      // The abort signal is what carries the bound; assert the deps instead by
+      // observing that a slow response is still allowed well past 15 s.
+      seen.push(init.signal ? 1 : undefined);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows: [] } }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    try {
+      await laneNamed("chain-transfer-pairs").compute(
+        LAKE_ENV as unknown as Env,
+        "mainnet",
+      );
+      assert.ok(seen.length > 0, "the lane never queried");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("the lane bound is a multiple of the request bound, not a fresh number", () => {
+    // Tied to the thing it relaxes, so the reason for the difference stays
+    // legible: same query, no caller waiting.
+    assert.equal(PROJECTION_QUERY_TIMEOUT_MS, 4 * QUERY_TIMEOUT_MS);
+    assert.ok(PROJECTION_QUERY_TIMEOUT_MS > QUERY_TIMEOUT_MS);
   });
 });

--- a/tests/projection-staleness-watchdog.test.ts
+++ b/tests/projection-staleness-watchdog.test.ts
@@ -1,0 +1,456 @@
+// The projection lanes' alarm (#9423).
+//
+// The case that matters is the one it was written for: chain-stake-moves and
+// chain-stake-transfers stopped writing on 2026-08-03T09:13 and nothing
+// noticed for 31 hours, because a lane that cannot compute leaves the previous
+// artifact in place and the route serves it. The first test below replays
+// those exact timestamps.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  cronIntervalMs,
+  evaluateProjectionStaleness,
+  PROJECTION_STALENESS_MISSED_TICKS,
+  PROJECTION_STALENESS_THRESHOLD_MS,
+  projectionStalenessThresholdMs,
+  runProjectionStalenessWatchdog,
+} from "../src/projection-staleness-watchdog.ts";
+import {
+  PROJECTION_LANES,
+  PROJECTION_NETWORKS,
+} from "../src/projection-lanes.ts";
+import {
+  PROJECTION_LANES_CRON,
+  PROJECTION_STALENESS_WATCHDOG_CRON,
+} from "../workers/config.ts";
+import { projectionKey } from "../src/chain-network.ts";
+
+const HOUR = 3_600_000;
+
+describe("evaluateProjectionStaleness", () => {
+  // The production incident, replayed. 31 hours of silence, and the only
+  // signal available was an R2 object timestamp nobody was reading.
+  test("catches the 31-hour stall it was written for", () => {
+    const now = Date.parse("2026-08-04T16:45:00.000Z");
+    const verdict = evaluateProjectionStaleness({
+      artifacts: [
+        { lane: "blocks-summary", generatedAt: "2026-08-04T16:41:19.088Z" },
+        { lane: "chain-stake-moves", generatedAt: "2026-08-03T09:13:53.426Z" },
+        {
+          lane: "chain-stake-transfers",
+          generatedAt: "2026-08-03T09:13:22.352Z",
+        },
+      ],
+      nowMs: now,
+      thresholdMs: PROJECTION_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(verdict.stale, true);
+    assert.deepEqual(verdict.stale_lanes, [
+      "chain-stake-moves",
+      "chain-stake-transfers",
+    ]);
+    // The healthy lane on the same tick is NOT swept up: an alarm that fires
+    // on everything names nothing.
+    assert.equal(verdict.checked, 3);
+    const healthy = verdict.entries.find((e) => e.lane === "blocks-summary")!;
+    assert.equal(healthy.stale, false);
+    assert.equal(healthy.reason, null);
+    assert.ok((healthy.age_ms ?? 0) < HOUR);
+  });
+
+  // The sizing rule #9301 corrected the sibling watchdog for: a healthy lane's
+  // age swings across its whole producer interval, so a threshold near one
+  // interval alerts on a lane that is working.
+  test("a lane anywhere in its normal 30-minute swing is healthy", () => {
+    const now = Date.parse("2026-08-04T17:00:00.000Z");
+    for (const minutes of [0, 5, 17, 29, 35]) {
+      const verdict = evaluateProjectionStaleness({
+        artifacts: [
+          {
+            lane: "chain-transfers",
+            generatedAt: new Date(now - minutes * 60_000).toISOString(),
+          },
+        ],
+        nowMs: now,
+        thresholdMs: PROJECTION_STALENESS_THRESHOLD_MS,
+      });
+      assert.equal(verdict.stale, false, `${minutes} min old must be healthy`);
+    }
+  });
+
+  test("fires only once past the threshold, not before", () => {
+    const now = Date.parse("2026-08-04T17:00:00.000Z");
+    const at = (ms: number) =>
+      evaluateProjectionStaleness({
+        artifacts: [
+          {
+            lane: "chain-transfers",
+            generatedAt: new Date(now - ms).toISOString(),
+          },
+        ],
+        nowMs: now,
+        thresholdMs: PROJECTION_STALENESS_THRESHOLD_MS,
+      }).stale;
+    assert.equal(at(PROJECTION_STALENESS_THRESHOLD_MS - 1), false);
+    assert.equal(at(PROJECTION_STALENESS_THRESHOLD_MS), false);
+    assert.equal(at(PROJECTION_STALENESS_THRESHOLD_MS + 1), true);
+  });
+
+  // An artifact that is not there and one whose timestamp cannot be read are
+  // both stalls, and they are told apart because the fixes differ.
+  test("absent and unreadable are distinct stall reasons", () => {
+    const verdict = evaluateProjectionStaleness({
+      artifacts: [
+        { lane: "chain-fees", generatedAt: null },
+        { lane: "chain-calls", generatedAt: undefined },
+        { lane: "chain-signers", generatedAt: "not a timestamp" },
+      ],
+      nowMs: Date.now(),
+      thresholdMs: PROJECTION_STALENESS_THRESHOLD_MS,
+    });
+    assert.deepEqual(
+      verdict.entries.map((e) => e.reason),
+      ["absent", "absent", "unreadable"],
+    );
+    assert.equal(verdict.stale_lanes.length, 3);
+  });
+});
+
+describe("runProjectionStalenessWatchdog", () => {
+  /** A bucket whose objects carry the given ages, keyed by artifact key. */
+  function bucketWith(ages: Record<string, string | null>, fail = false) {
+    return {
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          if (fail) throw new Error("r2 unreachable");
+          const generated = ages[key];
+          if (generated === undefined || generated === null) return null;
+          return {
+            async json() {
+              return { schema_version: 1, generated_at: generated };
+            },
+          };
+        },
+      },
+    } as unknown as Record<string, unknown>;
+  }
+
+  /** Every lane on every network, all written `minutes` ago. */
+  function allFresh(minutes: number, now: number) {
+    const at = new Date(now - minutes * 60_000).toISOString();
+    const out: Record<string, string> = {};
+    for (const network of PROJECTION_NETWORKS) {
+      for (const lane of PROJECTION_LANES) {
+        out[projectionKey(lane.artifactKey, network)] = at;
+      }
+    }
+    return out;
+  }
+
+  test("a healthy fleet records nothing at all", async () => {
+    const now = Date.parse("2026-08-04T17:00:00.000Z");
+    const events: string[] = [];
+    const result = (await runProjectionStalenessWatchdog(
+      bucketWith(allFresh(12, now)),
+      {
+        now: () => now,
+        recordException: (async (_e: unknown, ev: { route?: string }) => {
+          events.push(String(ev.route));
+          return true;
+        }) as never,
+      },
+    )) as { ok: boolean; stale: boolean; checked: number };
+    assert.equal(result.ok, true);
+    assert.equal(result.stale, false);
+    // The POSITIVE: it actually looked at every lane on every network. A
+    // "nothing was stale" verdict from a watchdog that read nothing is the
+    // failure this whole module exists to prevent.
+    assert.equal(
+      result.checked,
+      PROJECTION_LANES.length * PROJECTION_NETWORKS.length,
+    );
+    assert.deepEqual(events, [], "zero alerts is the healthy steady state");
+  });
+
+  test("one event names every stale lane, rather than one event each", async () => {
+    const now = Date.parse("2026-08-04T17:00:00.000Z");
+    const ages = allFresh(12, now);
+    const stale = new Date(now - 31 * HOUR).toISOString();
+    ages[projectionKey("metagraph/projections/chain-stake-moves.json")] = stale;
+    ages[projectionKey("metagraph/projections/chain-stake-transfers.json")] =
+      stale;
+    const events: { route?: string; error?: Error }[] = [];
+    const result = (await runProjectionStalenessWatchdog(bucketWith(ages), {
+      now: () => now,
+      recordException: (async (_e: unknown, ev: never) => {
+        events.push(ev);
+        return true;
+      }) as never,
+    })) as { stale: boolean; stale_lanes: string[] };
+    assert.equal(result.stale, true);
+    // Registry order, not alphabetical -- the alert reads in the same order
+    // the run summary does.
+    assert.deepEqual(result.stale_lanes, [
+      "chain-stake-transfers",
+      "chain-stake-moves",
+    ]);
+    // Twenty-six alerts for one dead cron is the failure mode where an alarm
+    // stops being read.
+    assert.equal(events.length, 1);
+    assert.equal(events[0]!.route, "watchdog:projection-staleness");
+    assert.match(String(events[0]!.error?.message), /chain-stake-moves/);
+    assert.match(String(events[0]!.error?.message), /chain-stake-transfers/);
+    assert.match(String(events[0]!.error?.message), /31\.0 h old/);
+    // The bound is quoted in the unit the judgement is about.
+    assert.match(
+      String(events[0]!.error?.message),
+      new RegExp(`${PROJECTION_STALENESS_MISSED_TICKS} missed ticks`),
+    );
+  });
+
+  test("a testnet lane is watched under its own label", async () => {
+    const now = Date.parse("2026-08-04T17:00:00.000Z");
+    const ages = allFresh(12, now);
+    const [nonDefault] = PROJECTION_NETWORKS.filter((n) => n !== "mainnet");
+    if (!nonDefault) return;
+    ages[projectionKey("metagraph/projections/chain-fees.json", nonDefault)] =
+      new Date(now - 9 * HOUR).toISOString();
+    const result = (await runProjectionStalenessWatchdog(bucketWith(ages), {
+      now: () => now,
+      recordException: (async () => true) as never,
+    })) as { stale_lanes: string[] };
+    assert.deepEqual(result.stale_lanes, [`chain-fees:${nonDefault}`]);
+  });
+
+  test("an unreadable bucket is a stall, never a silent pass", async () => {
+    const now = Date.parse("2026-08-04T17:00:00.000Z");
+    const result = (await runProjectionStalenessWatchdog(bucketWith({}, true), {
+      now: () => now,
+      recordException: (async () => true) as never,
+    })) as { stale: boolean; stale_lanes: string[] };
+    assert.equal(result.stale, true);
+    assert.equal(
+      result.stale_lanes.length,
+      PROJECTION_LANES.length * PROJECTION_NETWORKS.length,
+    );
+  });
+
+  // A bucket that answers with no object at all, as distinct from one that
+  // throws: the lane simply has not written yet, which is still a stall.
+  test("a missing object is a stall, not a skipped lane", async () => {
+    const now = Date.parse("2026-08-04T17:00:00.000Z");
+    const env = {
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return null;
+        },
+      },
+    } as unknown as Record<string, unknown>;
+    let recorded = 0;
+    const result = (await runProjectionStalenessWatchdog(env, {
+      now: () => now,
+      recordException: (async () => {
+        recorded += 1;
+        return true;
+      }) as never,
+    })) as { stale: boolean; entries: { reason: string | null }[] };
+    assert.equal(result.stale, true);
+    assert.ok(result.entries.every((e) => e.reason === "absent"));
+    assert.equal(recorded, 1);
+  });
+
+  // The alert must never take the tick down with it: a telemetry sink that
+  // rejects is one missed report, not an outage.
+  test("a rejecting telemetry sink does not fail the tick", async () => {
+    const now = Date.parse("2026-08-04T17:00:00.000Z");
+    const result = (await runProjectionStalenessWatchdog(
+      {
+        METAGRAPH_ARCHIVE: {
+          async get() {
+            return null;
+          },
+        },
+      } as unknown as Record<string, unknown>,
+      {
+        now: () => now,
+        recordException: (() =>
+          Promise.reject(new Error("telemetry down"))) as never,
+      },
+    )) as { ok: boolean; stale: boolean };
+    assert.equal(result.ok, true);
+    assert.equal(result.stale, true);
+  });
+
+  test("an unbound archive reports why, rather than a healthy verdict", async () => {
+    const result = (await runProjectionStalenessWatchdog({})) as {
+      ok: boolean;
+      reason: string;
+    };
+    assert.equal(result.ok, false);
+    assert.match(result.reason, /r2 binding/);
+  });
+
+  test("the threshold is overridable per deployment", async () => {
+    const now = Date.parse("2026-08-04T17:00:00.000Z");
+    const env = {
+      ...bucketWith(allFresh(90, now)),
+      PROJECTION_STALENESS_THRESHOLD_MS: String(HOUR),
+    };
+    const result = (await runProjectionStalenessWatchdog(env, {
+      now: () => now,
+      recordException: (async () => true) as never,
+    })) as { stale: boolean; threshold_ms: number };
+    assert.equal(result.threshold_ms, HOUR);
+    assert.equal(
+      result.stale,
+      true,
+      "90 min must be stale against a 1 h bound",
+    );
+  });
+});
+
+// THE THRESHOLD IS NOT A WALL-CLOCK CONSTANT. It is N missed ticks of whatever
+// cadence the lane cron currently declares, so moving the producer moves the
+// bound with it -- a second hand-maintained number would go silently wrong,
+// and "silently wrong" here means an alarm that never fires or always does.
+describe("the threshold follows the producer's cadence", () => {
+  test("it is exactly N missed ticks of the lane cron", () => {
+    const interval = cronIntervalMs(PROJECTION_LANES_CRON);
+    assert.ok(interval, "the lane cron must yield an interval");
+    assert.equal(
+      PROJECTION_STALENESS_THRESHOLD_MS,
+      PROJECTION_STALENESS_MISSED_TICKS * interval!,
+    );
+    // And it clears a healthy lane's whole swing by a wide margin.
+    assert.ok(PROJECTION_STALENESS_THRESHOLD_MS > interval! * 2);
+  });
+
+  test("it would move if the lane cron did", () => {
+    // The property that makes this not-a-constant: change the cadence, the
+    // bound follows. A quarter-hourly lane gets a two-hour bound, not four.
+    assert.equal(cronIntervalMs("11,41 * * * *"), 30 * 60_000);
+    assert.equal(cronIntervalMs("0,15,30,45 * * * *"), 15 * 60_000);
+    assert.equal(cronIntervalMs("17 * * * *"), 60 * 60_000);
+  });
+
+  test("an uneven minute list is measured by its NARROWEST gap", () => {
+    // `5,10,50` ticks 5 minutes apart and then 15, then 40. A healthy lane has
+    // to clear the bound on the WIDE gap, so only the narrow one tells you
+    // what a tick is worth -- taking the average would under-size the bound
+    // and alert on a lane that is working.
+    assert.equal(cronIntervalMs("5,10,50 * * * *"), 5 * 60_000);
+    // Including the wrap across the hour boundary.
+    assert.equal(cronIntervalMs("1,58 * * * *"), 3 * 60_000);
+  });
+
+  test("an unparseable cron falls back to the cadence the lane has always had", () => {
+    // Not a guess at the unreadable cron's cadence: 30 minutes is what
+    // PROJECTION_LANES_CRON has always been, kept as the conservative floor so
+    // a cron this parser cannot read degrades to today's bound rather than to
+    // no bound at all.
+    assert.equal(
+      projectionStalenessThresholdMs("*/5 * * * *"),
+      PROJECTION_STALENESS_MISSED_TICKS * 30 * 60_000,
+    );
+    assert.equal(
+      projectionStalenessThresholdMs("0,15,30,45 * * * *"),
+      PROJECTION_STALENESS_MISSED_TICKS * 15 * 60_000,
+    );
+  });
+
+  test("an unparseable cron yields null rather than a wrong number", () => {
+    for (const cron of [
+      "*/5 * * * *",
+      "",
+      "abc * * * *",
+      "-1 * * * *",
+      // A minute past the end of the hour is not a minute -- and it would
+      // otherwise produce a negative gap and a bound below zero.
+      "60 * * * *",
+      "1,90 * * * *",
+      "1,,5 * * * *",
+    ]) {
+      assert.equal(cronIntervalMs(cron), null, JSON.stringify(cron));
+    }
+  });
+});
+
+describe("the watchdog cron", () => {
+  // Dispatch keys on the LITERAL cron string, so a duplicate silently steals
+  // the other's tick.
+  test("does not collide with the lane cron it watches", async () => {
+    const config = await import("../workers/config.ts");
+    const crons = Object.entries(config)
+      .filter(([name]) => name.endsWith("_CRON"))
+      .map(([, value]) => String(value));
+    const mine = crons.filter((c) => c === PROJECTION_STALENESS_WATCHDOG_CRON);
+    assert.equal(mine.length, 1, "the cron string must be unique in config");
+  });
+
+  test("wrangler.jsonc declares the trigger", async () => {
+    // A cron the Worker dispatches on but wrangler never fires is dead code,
+    // and the failure is silent: the branch simply never runs.
+    const { readFileSync } = await import("node:fs");
+    const raw = readFileSync(
+      new URL("../wrangler.jsonc", import.meta.url),
+      "utf8",
+    )
+      .replace(/^\s*\/\/.*$/gm, "")
+      .replace(/,(\s*[}\]])/g, "$1");
+    const parsed = JSON.parse(raw) as { triggers?: { crons?: string[] } };
+    assert.ok(
+      parsed.triggers?.crons?.includes(PROJECTION_STALENESS_WATCHDOG_CRON),
+      `wrangler.jsonc must fire ${PROJECTION_STALENESS_WATCHDOG_CRON}`,
+    );
+  });
+
+  test("handleScheduled dispatches to the watchdog and returns its summary", async () => {
+    const { handleScheduled } = await import("../workers/api.ts");
+    const reads: string[] = [];
+    const result = (await handleScheduled(
+      {
+        cron: PROJECTION_STALENESS_WATCHDOG_CRON,
+      } as unknown as ScheduledController,
+      {
+        METAGRAPH_ARCHIVE: {
+          async get(key: string) {
+            reads.push(key);
+            return {
+              async json() {
+                return {
+                  schema_version: 1,
+                  generated_at: new Date().toISOString(),
+                };
+              },
+            };
+          },
+        },
+      } as unknown as Parameters<typeof handleScheduled>[1],
+      {} as unknown as ExecutionContext,
+    )) as { ok: boolean; stale: boolean; checked: number };
+    assert.equal(result.ok, true);
+    assert.equal(result.stale, false);
+    // The POSITIVE: the tick actually read every lane on every network. A
+    // healthy verdict from a dispatch that read nothing is the exact failure
+    // this module exists to prevent.
+    assert.equal(
+      reads.length,
+      PROJECTION_LANES.length * PROJECTION_NETWORKS.length,
+    );
+    assert.equal(result.checked, reads.length);
+  });
+
+  test("samples after a lane run has finished, not during one", () => {
+    const [watchMinutes] = PROJECTION_STALENESS_WATCHDOG_CRON.split(" ");
+    const minutes = watchMinutes!.split(",").map(Number);
+    // The lane cron is 11,41; a run takes ~5 minutes. Judging at 2,32 leaves
+    // 21 minutes of slack, so a slow run is never called stale mid-flight.
+    for (const m of minutes) {
+      const sinceLaneStart = (m - 11 + 60) % 30;
+      assert.ok(
+        sinceLaneStart >= 10,
+        `minute ${m} judges only ${sinceLaneStart} min after a lane tick begins`,
+      );
+    }
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -352,6 +352,7 @@ import { checkEmissionDrift } from "../src/emission-drift-check.ts";
 import { refreshLiveEconomics } from "../src/live-economics-refresh.ts";
 import { runNeuronsStalenessWatchdog } from "../src/neurons-staleness-watchdog.ts";
 import { runNominatorPositionsStalenessWatchdog } from "../src/nominator-positions-staleness-watchdog.ts";
+import { runProjectionStalenessWatchdog } from "../src/projection-staleness-watchdog.ts";
 import { runValidatorNominatorCountsStalenessWatchdog } from "../src/validator-nominator-counts-staleness-watchdog.ts";
 import {
   readChainDetailHead,
@@ -426,6 +427,7 @@ import {
   EMISSION_DRIFT_CHECK_CRON,
   NEURONS_STALENESS_WATCHDOG_CRON,
   NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON,
+  PROJECTION_STALENESS_WATCHDOG_CRON,
   VALIDATOR_NOMINATOR_COUNTS_STALENESS_WATCHDOG_CRON,
   CHAIN_DETAIL_PRUNE_CRON,
   CHAIN_DETAIL_STALENESS_WATCHDOG_CRON,
@@ -1416,6 +1418,8 @@ function cronLabel(cron: string): string {
     return "neurons-staleness-watchdog";
   if (cron === NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON)
     return "nominator-positions-staleness-watchdog";
+  if (cron === PROJECTION_STALENESS_WATCHDOG_CRON)
+    return "projection-staleness-watchdog";
   if (cron === VALIDATOR_NOMINATOR_COUNTS_STALENESS_WATCHDOG_CRON)
     return "validator-nominator-counts-staleness-watchdog";
   if (cron === CHAIN_DETAIL_PRUNE_CRON) return "chain-detail-prune";
@@ -1691,6 +1695,16 @@ async function dispatchScheduled(
     // a stale verdict records one exception under
     // watchdog:neurons-staleness, which is the project's alert channel.
     return runNeuronsStalenessWatchdog(
+      env as unknown as Record<string, unknown>,
+    );
+  }
+  if (cron === PROJECTION_STALENESS_WATCHDOG_CRON) {
+    // The projection lanes' alarm (#9423). Zero alerts is the correct steady
+    // state; a stale verdict records ONE exception naming every stale lane
+    // under watchdog:projection-staleness. An ABSENT artifact alerts too --
+    // every registered lane is meant to have written on the last tick, and a
+    // route over a missing card serves its zeroed floor as though measured.
+    return runProjectionStalenessWatchdog(
       env as unknown as Record<string, unknown>,
     );
   }

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -166,6 +166,18 @@ export const NEURONS_STALENESS_WATCHDOG_CRON = "6,21,36,51 * * * *";
 // the LITERAL cron string, so this must be unique here as well as matching a
 // wrangler.jsonc `triggers.crons` entry.
 export const NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON = "8,38 * * * *";
+// #9423: the projection lanes' alarm. Two lanes stopped writing on
+// 2026-08-03 and nothing noticed for 31 hours -- the read path degrades by
+// serving the previous card, so the routes kept answering 200 off numbers 44
+// hours old under a `7d` label. Twice hourly against a four-hour threshold
+// (src/projection-staleness-watchdog.ts explains the sizing): the tick is 26
+// R2 HEADs, so a cheap cadence costs nothing and bounds detection well inside
+// the threshold. Minutes 2/32 are 21 minutes after each PROJECTION_LANES_CRON
+// tick, so a run has finished before it is judged, and they tick on none of
+// the crons in this file while staying off the */5 raw-capture and */15 probe
+// grids -- dispatch keys on the LITERAL cron string, so this must be unique
+// here as well as matching a wrangler.jsonc `triggers.crons` entry.
+export const PROJECTION_STALENESS_WATCHDOG_CRON = "2,32 * * * *";
 // #9301: the validator-nominator-counts lane's alarm -- the SIBLING of the
 // watchdog above, watching the other output of the same Alpha scan. It had the
 // same gap for the same reason: its writer targeted a Postgres that went away,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -792,6 +792,9 @@
       // watchdog and lost its writer entirely without anything noticing -- see
       // NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON in workers/config.ts.
       "8,38 * * * *",
+      // #9423: the projection lanes' staleness alarm. 21 minutes after each
+      // PROJECTION_LANES_CRON tick, so a run has finished before it is judged.
+      "2,32 * * * *",
       // 19,49 = the validator-nominator-counts staleness watchdog (#9301): the
       // sibling of the one above, over the other output of the same Alpha
       // scan, and blind for the same reason -- see


### PR DESCRIPTION
Closes #9423.

Two lanes stopped writing on **2026-08-03T09:13** and nothing noticed for 31 hours.
`/api/v1/chain/stake-moves` was publishing `newest_observed: 2026-08-02T22:08` under a `7d` window
label with no degradation marker — 44 hours of stake movement missing, and nothing in the response
saying so.

## The mechanism, measured

`wrangler tail` across a cron tick, rather than inferred from the symptom:

```
r2 sql: HTTP 422 {"code":40015,"message":"scan budget exceeded: scanning too much data
for count(DISTINCT) with GROUP BY. Reduce data with WHERE clauses, use approximate
functions (APPROX_DISTINCT, ...), add a GROUP BY to distribute the aggregate..."}
[projection:chain-stake-moves] compute declined; previous artifact left in place
```

Worth stating plainly: my first reading of this blamed the **ungrouped** chain-wide `COUNT(DISTINCT)`.
The tail says it is the **grouped** per-subnet statement. Both are split now — one heavy aggregation
per statement, which is the shape `transferWindowSql` was already written to and explains why. The
per-subnet tally and the per-subnet DISTINCT are merged back by netuid, so nothing a reader sees
changes.

`APPROX_DISTINCT` is the engine's own first suggestion and is **refused**: `distinct_movers` and
`distinct_senders` are published fields, and an approximate answer under a name callers read as
exact is worse than an honest decline.

**Whether the split actually clears the budget cannot be verified locally** — R2 SQL is reachable
only from the Worker, and `WRANGLER_R2_SQL_AUTH_TOKEN` is not available here. I'll confirm on the
first tick after deploy. Which is exactly why the other half of this PR exists.

## The watchdog is the half that does not depend on getting the query right

Leaving the previous artifact in place is **correct** for a transient failure and **wrong** for a
permanent one, and nothing distinguished them. A new projection-staleness watchdog reads every lane
× every network and records **one** exception naming the stale ones — twenty-six alerts for one dead
cron is the failure mode where an alarm stops being read.

A third lane, `chain-transfer-pairs`, also declined on that tick (`The operation was aborted`, a
different failure). It had looked healthy an hour earlier. The watchdog is what makes that kind of
intermittent decline visible instead of something you find by reading R2 timestamps by hand.

## The threshold is not a wall-clock constant

It is **N missed ticks of whatever cadence `PROJECTION_LANES_CRON` currently declares**, parsed from
the cron itself. Moving the producer moves the bound with it; a second hand-written number would go
silently wrong, and silently wrong for a staleness bound means either an alarm that never fires or
one that always does.

Eight ticks clears a healthy lane's entire swing — its age legitimately ranges across the whole
producer interval, which is the sizing rule #9301 corrected the nominator-positions threshold for —
while catching a dead lane in hours. This 31-hour silence would have been caught in its fourth hour.

## Also fixed while in here

- An empty window keeps its **measured** zero rather than degrading to null: `MAX(observed_at) IS
  NULL` means no rows matched, so the distinct count is necessarily 0 — derived, not guessed.
- An aggregate returning **no row at all** is now distinguished from one returning a row of zero.
  The first is unread, the second is measured, and publishing the first as the second is the exact
  class of error this PR is about.
- The per-subnet guard now keys on the window's own newest event rather than on the DISTINCT row, so
  an unusable DISTINCT no longer suppresses a per-subnet scan that may well have succeeded.

## Verification

- `npx vitest run` — **15,967 passed**.
- Patch coverage **68/68 lines, 57/57 branches**, by diff intersection.
- The watchdog's first test replays the incident's exact timestamps
  (`2026-08-03T09:13:53.426Z` / `2026-08-04T16:45`) and asserts the healthy lane on the same tick is
  *not* swept up — an alarm that fires on everything names nothing.
- Every watchdog test asserts the positive: that it actually read all 26 lanes. A healthy verdict
  from a watchdog that read nothing is precisely what this module exists to prevent.
