### PR TITLE
test(d1): check column drift against the applied D1 schema, not a Postgres mirror

### DIFF
--- a/tests/d1-schema-drift.test.ts
+++ b/tests/d1-schema-drift.test.ts
@@ -1,0 +1,147 @@
+// SELECT/INSERT-list drift protection, checked against the D1 schema itself (#9426).
+//
+// tests/db-row-types.test.ts does this today as type-level assertions against
+// generated/db -- Kanel output produced by introspecting a scratch POSTGRES container
+// loaded from deploy/postgres/schema.sql. Two things are wrong with that as the guard:
+//
+//   1. It checks the wrong database. These queries run on D1. A column present in the
+//      Postgres schema and absent from D1 passes that gate and fails in production.
+//   2. Its column lists are HAND-WRITTEN in the test. So the thing protecting us from
+//      drift is itself a list someone has to remember to update, which is the shape of
+//      problem it exists to prevent.
+//
+// This checks the column constants the code ACTUALLY USES against the DDL that is
+// ACTUALLY APPLIED. Nothing is hand-listed in between and there is no codegen step: the
+// migrations are executed into an in-memory SQLite via node:sqlite, and the column set
+// is read back with PRAGMA table_info. If a migration drops a column a query still
+// names, this fails.
+//
+// Only D1-resident tables belong here. The cold tier (blocks, extrinsics,
+// account_events, chain_events) lives in the R2 lakehouse and is a different engine
+// with a different dialect -- asserting its columns against D1 DDL would be the same
+// wrong-database mistake in a new place.
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, test } from "vitest";
+import {
+  NEURON_COLUMNS,
+  NEURON_INSERT_COLUMNS,
+} from "../src/metagraph-neurons.ts";
+import { ACCOUNT_POSITION_DAILY_COLUMNS } from "../src/neurons-d1-write.ts";
+import {
+  CHAIN_DETAIL_BLOCK_COLUMNS,
+  CHAIN_DETAIL_EXTRINSIC_COLUMNS,
+  CHAIN_DETAIL_ACCOUNT_EVENT_COLUMNS,
+  CHAIN_DETAIL_CHAIN_EVENT_COLUMNS,
+} from "../src/chain-detail-d1-write.ts";
+
+/** Every D1 migration, executed in order, exactly as production had them applied. */
+function d1Database(): DatabaseSync {
+  const dir = path.join(process.cwd(), "migrations/d1");
+  const db = new DatabaseSync(":memory:");
+  for (const file of fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".sql"))
+    .sort()) {
+    db.exec(fs.readFileSync(path.join(dir, file), "utf8"));
+  }
+  return db;
+}
+
+const db = d1Database();
+
+function columnsOf(table: string): Set<string> {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{
+    name: string;
+  }>;
+  return new Set(rows.map((r) => r.name));
+}
+
+/**
+ * Normalise a column constant to a list.
+ *
+ * These constants are not consistently shaped: the INSERT-side ones are arrays, while
+ * NEURON_COLUMNS is a comma-separated SELECT-list STRING. That inconsistency is worth
+ * fixing at the source, but a drift guard that only understood one shape would silently
+ * skip the other -- so this accepts both and the guard covers everything today.
+ */
+function columnList(value: readonly string[] | string): string[] {
+  return (typeof value === "string" ? value.split(",") : [...value])
+    .map((c) => c.trim())
+    .filter(Boolean);
+}
+
+/** Table -> the column lists the code names when reading or writing it. */
+const GUARDED: Array<[string, string, readonly string[] | string]> = [
+  ["neurons", "NEURON_COLUMNS", NEURON_COLUMNS],
+  ["neurons", "NEURON_INSERT_COLUMNS", NEURON_INSERT_COLUMNS],
+  [
+    "account_position_daily",
+    "ACCOUNT_POSITION_DAILY_COLUMNS",
+    ACCOUNT_POSITION_DAILY_COLUMNS,
+  ],
+  [
+    "chain_detail_blocks",
+    "CHAIN_DETAIL_BLOCK_COLUMNS",
+    CHAIN_DETAIL_BLOCK_COLUMNS,
+  ],
+  [
+    "chain_detail_extrinsics",
+    "CHAIN_DETAIL_EXTRINSIC_COLUMNS",
+    CHAIN_DETAIL_EXTRINSIC_COLUMNS,
+  ],
+  [
+    "chain_detail_account_events",
+    "CHAIN_DETAIL_ACCOUNT_EVENT_COLUMNS",
+    CHAIN_DETAIL_ACCOUNT_EVENT_COLUMNS,
+  ],
+  [
+    "chain_detail_chain_events",
+    "CHAIN_DETAIL_CHAIN_EVENT_COLUMNS",
+    CHAIN_DETAIL_CHAIN_EVENT_COLUMNS,
+  ],
+];
+
+describe("the D1 migrations apply", () => {
+  test("every migration in migrations/d1 executes in order", () => {
+    // The precondition for everything below. If this fails, the migration set is not
+    // self-consistent and no drift assertion beneath it means anything.
+    assert.ok(columnsOf("neurons").size > 0, "neurons did not get created");
+  });
+
+  test("each guarded table exists", () => {
+    // A positive control for the assertions below: columnsOf() on a table that does
+    // not exist returns an EMPTY set, and "every column in [] is present" is vacuously
+    // true. Without this, a renamed table would make its drift test pass by having
+    // nothing left to check.
+    for (const [table] of GUARDED) {
+      assert.ok(
+        columnsOf(table).size > 0,
+        `${table} is missing from migrations/d1 -- the drift test for it would ` +
+          `otherwise pass vacuously`,
+      );
+    }
+  });
+});
+
+describe("column constants match the applied D1 schema", () => {
+  for (const [table, name, columns] of GUARDED) {
+    test(`${name} exists on ${table}`, () => {
+      const named = columnList(columns);
+      assert.ok(
+        named.length > 0,
+        `${name} is empty -- nothing would be checked`,
+      );
+      const actual = columnsOf(table);
+      const missing = named.filter((c) => !actual.has(c));
+      assert.deepEqual(
+        missing,
+        [],
+        `${name} names ${missing.length} column(s) that migrations/d1 does not ` +
+          `create on ${table}: ${missing.join(", ")}`,
+      );
+    });
+  }
+});


### PR DESCRIPTION
Step 2 of #9426 — and it changes the recommendation I made on that issue.

## What I found

`tests/db-row-types.test.ts` guards SELECT/INSERT-list drift with type assertions against `generated/db`. That directory is Kanel output, produced by introspecting a **scratch Postgres container** loaded from `deploy/postgres/schema.sql`, gated by `validate:db-types-drift`.

Two things are wrong with it as a guard:

1. **It checks the wrong database.** These queries run on D1. A column present in the Postgres schema and absent from D1 passes the gate and fails in production — the exact failure it exists to prevent.
2. **Its column lists are hand-written in the test.** The thing protecting us from drift is itself a list someone must remember to update.

And the decisive fact: **no production code imports `generated/db` at all.** Its only consumer is that one test. A Docker + Postgres + Kanel + drift-gate pipeline exists to produce 44 type files read by nothing that serves traffic.

## This replaces it

Column constants the code **actually uses**, checked against the DDL **actually applied**. Every `migrations/d1/*.sql` executes in order into an in-memory SQLite via `node:sqlite` — no new dependency, no codegen, no Docker — and columns are read back with `PRAGMA table_info`.

**Proven to catch what it claims.** Adding a `ghost_column` to `NEURON_COLUMNS` fails with:

> `NEURON_COLUMNS names 1 column(s) that migrations/d1 does not create on neurons: ghost_column`

Verified by doing it, not by assuming.

## Two traps handled explicitly

- `PRAGMA table_info` on a missing table returns **empty**, and "every column in the list is present in {}" is vacuously true — so a **renamed table would make its own drift test pass**. A separate test asserts every guarded table is non-empty first.
- The constants aren't consistently shaped: INSERT-side ones are arrays, `NEURON_COLUMNS` is a comma-separated string. A guard understanding one shape would silently skip the other, so it normalises both. The inconsistency is worth fixing at source and is flagged in the test.

Cold-tier tables (`blocks`, `extrinsics`, `account_events`, `chain_events`) are deliberately **not** covered — they're in the R2 lakehouse, and asserting their columns against D1 DDL would be the same wrong-database mistake in a new place.

## On Drizzle

I recommended Drizzle for step 2 before knowing the pipeline's only consumer was a test. Adding a dependency to preserve a codegen step we can delete outright would be the wrong call. Drizzle remains a good answer for *schema-as-source-of-truth and generated migrations* — the hand-applied-migration problem — but that is a separate decision from this guard.

## Sequencing

`db-row-types.test.ts` and the Kanel pipeline **stay** until step 3 removes them, so there is never a window with no guard at all.

`tsc`, `eslint`, `prettier --check` clean; 85 tests pass across the three related files.

Part of #9426