### PR TITLE
fix(projections): record the staleness watchdog's verdict durably, not only when it alerts

### DIFF
--- a/src/projection-staleness-watchdog.ts
+++ b/src/projection-staleness-watchdog.ts
@@ -19,6 +19,7 @@
 
 import { DEFAULT_CHAIN_NETWORK, projectionKey } from "./chain-network.ts";
 import { PROJECTION_LANES, PROJECTION_NETWORKS } from "./projection-lanes.ts";
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { PROJECTION_LANES_CRON } from "../workers/config.ts";
 
@@ -177,6 +178,9 @@ export interface ProjectionStalenessDeps {
   now?: () => number;
   /** Telemetry seam for tests; defaults to the real recordExceptionEvent. */
   recordException?: typeof recordExceptionEvent;
+  /** Injectable durable sink, so a test can assert the verdict was RECORDED and
+   * not merely notified -- the distinction #9330/#9340 exist about. */
+  laneHealthDb?: LaneHealthDb | null;
 }
 
 /** Every lane x every network, labelled the way the runner labels them. */
@@ -260,6 +264,36 @@ export async function runProjectionStalenessWatchdog(
       errorCode: "stale_lane",
     }).catch(() => false);
   }
+
+  // #9330/#9340: the DURABLE record, written every tick rather than only when
+  // stale. This watchdog shipped notifying through `recordExceptionEvent`
+  // alone -- the exact channel that has already discarded three outages, since
+  // PostHog drops `$exception` once the free-tier quota is exhausted and this
+  // project runs at roughly 1M events/day. A dropped notification is
+  // indistinguishable from a fleet that was fine.
+  //
+  // It matters more here than for its siblings, not less: this is the only
+  // watchdog covering 26 lanes, and its healthy output is silence. Without a
+  // row per tick there is nothing anywhere that distinguishes "every
+  // projection was fresh" from "the watchdog has not run since the deploy".
+  //
+  // Never throws -- see recordLaneVerdict.
+  await recordLaneVerdict(
+    deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as never),
+    {
+      lane: "projection-staleness",
+      verdict: verdict.stale ? "stale" : "ok",
+      // The OLDEST lane's age, since one stale lane is a stale fleet and that
+      // is the number worth keeping a history of.
+      age_ms: verdict.entries.reduce<number | null>(
+        (oldest, entry) =>
+          entry.age_ms === null ? oldest : Math.max(oldest ?? 0, entry.age_ms),
+        null,
+      ),
+      detail: verdict.stale ? verdict.stale_lanes.join(",") : null,
+      checked_at: now(),
+    },
+  );
 
   return { ok: true, ...verdict };
 }

--- a/tests/projection-staleness-watchdog.test.ts
+++ b/tests/projection-staleness-watchdog.test.ts
@@ -375,6 +375,122 @@ describe("the threshold follows the producer's cadence", () => {
   });
 });
 
+// #9330/#9340. This watchdog shipped notifying through recordExceptionEvent
+// alone -- the channel that has already discarded three outages, because
+// PostHog drops $exception once the free-tier quota is exhausted. Its healthy
+// output is silence, so without a row per tick nothing distinguishes "all 26
+// lanes were fresh" from "the watchdog has not run since the deploy".
+describe("every tick leaves a durable verdict, not just a notification", () => {
+  /** A lane_health sink that records what was written. */
+  function laneHealth() {
+    const rows: Record<string, unknown>[] = [];
+    return {
+      rows,
+      db: {
+        // Only the INSERT is recorded: recordLaneVerdict also prunes expired
+        // rows on the way through, and counting that would make this assert
+        // the number of statements rather than the number of verdicts.
+        prepare(sql: string) {
+          const isInsert = sql.startsWith("INSERT INTO lane_health");
+          return {
+            bind(...values: unknown[]) {
+              return {
+                async run() {
+                  if (isInsert) {
+                    rows.push({
+                      lane: values[0],
+                      verdict: values[1],
+                      age_ms: values[2],
+                      detail: values[3],
+                    });
+                  }
+                  return {};
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  function bucketAt(iso: string | null) {
+    return {
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          if (iso === null) return null;
+          return {
+            async json() {
+              return { schema_version: 1, generated_at: iso };
+            },
+          };
+        },
+      },
+    } as unknown as Record<string, unknown>;
+  }
+
+  test("a HEALTHY tick still writes a row", async () => {
+    const now = Date.parse("2026-08-04T17:00:00.000Z");
+    const sink = laneHealth();
+    const events: unknown[] = [];
+    await runProjectionStalenessWatchdog(
+      bucketAt(new Date(now - 12 * 60_000).toISOString()),
+      {
+        now: () => now,
+        laneHealthDb: sink.db as never,
+        recordException: (async () => {
+          events.push(1);
+          return true;
+        }) as never,
+      },
+    );
+    // Nothing was notified -- and that is exactly why the row has to exist.
+    assert.deepEqual(events, []);
+    assert.equal(sink.rows.length, 1);
+    assert.equal(sink.rows[0]!.lane, "projection-staleness");
+    assert.equal(sink.rows[0]!.verdict, "ok");
+  });
+
+  test("a stale tick records WHICH lanes, not just that something was stale", async () => {
+    const now = Date.parse("2026-08-04T17:00:00.000Z");
+    const sink = laneHealth();
+    await runProjectionStalenessWatchdog(
+      bucketAt(new Date(now - 31 * HOUR).toISOString()),
+      {
+        now: () => now,
+        laneHealthDb: sink.db as never,
+        recordException: (async () => true) as never,
+      },
+    );
+    assert.equal(sink.rows.length, 1);
+    assert.equal(sink.rows[0]!.verdict, "stale");
+    // The OLDEST age, since one stale lane is a stale fleet.
+    assert.equal(sink.rows[0]!.age_ms, 31 * HOUR);
+    assert.match(String(sink.rows[0]!.detail), /chain-/);
+  });
+
+  test("a missing lane_health table never breaks the tick", async () => {
+    // D1 migrations here are applied BY HAND, so the table can legitimately be
+    // absent. A watchdog whose alarm-recording broke its alarm would be worse
+    // than the bug it reports.
+    const now = Date.parse("2026-08-04T17:00:00.000Z");
+    const result = (await runProjectionStalenessWatchdog(
+      bucketAt(new Date(now - 12 * 60_000).toISOString()),
+      {
+        now: () => now,
+        laneHealthDb: {
+          prepare() {
+            throw new Error("no such table: lane_health");
+          },
+        } as never,
+        recordException: (async () => true) as never,
+      },
+    )) as { ok: boolean; stale: boolean };
+    assert.equal(result.ok, true);
+    assert.equal(result.stale, false);
+  });
+});
+
 describe("the watchdog cron", () => {
   // Dispatch keys on the LITERAL cron string, so a duplicate silently steals
   // the other's tick.


### PR DESCRIPTION
Follow-up to #9427, found by firing that watchdog against production and getting **nothing back**.

The tick ran, returned 200, and logged nothing at all — which is the correct healthy output and is
also **indistinguishable from a watchdog that has not run since the deploy**. That is the exact
ambiguity `src/lane-health.ts` exists to remove, and its header says why:

> PostHog drops `$exception` silently once the free-tier quota is exhausted, and this project runs
> at roughly 1M events/day. So the failure mode is precise and has now happened three times: the
> lane stops, the watchdog runs on schedule, computes the correct verdict, and its only output is
> discarded.

Every other staleness watchdog in the repo writes a row per tick. The one I shipped this morning
did not — confirmed against production, where the other five are accumulating `ok` rows:

```
chain-detail-staleness                 ok  n=36  last=21:14
nominator-positions-staleness          ok  n=18  last=21:08
neurons-staleness                      ok  n=36  last=21:06
rpc-usage-staleness                    ok  n=9   last=21:00
validator-nominator-counts-staleness   ok  n=18  last=20:49
```

It matters **more** here rather than less: this is the only watchdog covering 26 lanes, and it is
the thing guarding the projection fix that landed hours ago.

## What it writes

`projection-staleness` every tick, with:

- **the oldest lane's age**, not the newest — one stale lane is a stale fleet, and that is the
  number worth keeping a history of;
- **which lanes** in `detail`, so a row says more than "something was stale".

A missing `lane_health` table stays a no-op. D1 migrations here are applied by hand, so the table
can legitimately be absent, and a watchdog whose alarm-recording broke its alarm would be worse than
the bug it reports — that case has its own test.

## Verification

- `npx vitest run` — **15,981 passed**.
- Patch coverage **2/2 lines, 10/10 branches**.
- The healthy-tick test asserts the row exists *precisely because* nothing was notified — the whole
  point being that silence must leave a trace.
