### PR TITLE
fix(networks): stop telling callers testnet has no chain history, when it has

### DIFF
--- a/apps/ui/src/components/metagraphed/native-only-notice.tsx
+++ b/apps/ui/src/components/metagraphed/native-only-notice.tsx
@@ -7,10 +7,16 @@ import { getNetwork } from "@/lib/metagraphed/config";
  * Shown when a route's data 404s on a non-mainnet network, either because the
  * artifact simply isn't built yet (`artifact_not_found`) or because the route
  * is deliberately mainnet-only (`not_found` with `meta.network` set — see
- * `ErrorState` in ./states.tsx). Those partitions (e.g. testnet) carry native
- * chain data only, so most enrichment / health / interface artifacts
- * legitimately don't exist yet — an informational empty notice (surfacing the
+ * `ErrorState` in ./states.tsx). An informational empty notice (surfacing the
  * API's own `coverage.notes`) is the honest signal, not a red error card (#370).
+ *
+ * THE HEADING NAMES THIS VIEW, NOT THE NETWORK. It used to read "{network}
+ * carries native chain data only", which was a claim about the whole partition
+ * rather than about the route that 404'd -- and it stopped being true as
+ * testnet gained live chain state, blocks, extrinsics, chain events and the
+ * analytics over them, while this card kept telling people the partition had
+ * none of it. Scoping the sentence to the view keeps it correct however much
+ * the network goes on to serve.
  */
 export function NativeOnlyNotice({ context }: { context?: string }) {
   const network = getNetwork();
@@ -26,7 +32,7 @@ export function NativeOnlyNotice({ context }: { context?: string }) {
         <Compass className="size-4 shrink-0 text-ink-muted" />
         <div className="min-w-0 flex-1">
           <div className="mb-1 font-display text-sm font-medium text-ink-strong">
-            {network.label} carries native chain data only
+            Not published for {network.label}
           </div>
           <p className="text-xs leading-relaxed text-ink-muted">
             {notes ||

--- a/apps/ui/src/lib/metagraphed/config.ts
+++ b/apps/ui/src/lib/metagraphed/config.ts
@@ -119,8 +119,16 @@ export const CHAIN_NETWORKS: ChainNetwork[] = [
     id: "testnet",
     label: "Testnet",
     prefix: "testnet",
+    // WRITTEN AS A SHAPE, NOT AN INVENTORY. This said "native chain registry
+    // only (identities; no curated services/health)" for weeks after testnet
+    // gained live chain state, blocks, extrinsics, chain events and the
+    // analytics over them -- steering people away from the very thing that had
+    // just shipped. The API's own /api/v1/networks carries the precise answer
+    // (served_families / partial_families / unserved_families); this is the
+    // one-line orientation beside the selector, so it says only what stays
+    // true as routes are added.
     description:
-      "Bittensor testnet — native chain registry only (identities; no curated services/health).",
+      "Bittensor testnet — this chain's own state and indexed history. No curated registry (services, health, schemas): that is mainnet-only.",
   },
 ];
 

--- a/src/network-capabilities.ts
+++ b/src/network-capabilities.ts
@@ -235,12 +235,18 @@ export function buildNetworkCapabilities(input: {
       partial_families: universalFamilies.filter((entry) =>
         partialKeys.has(entry.family),
       ),
-      // Accurate as of #8700, and deliberately specific about WHICH kind of
-      // chain data is missing. The previous wording said registry data
-      // including "surfaces" was served on every network, which was wrong --
-      // /api/v1/testnet/surfaces has always 404'd, because the testnet build
-      // emits native-chain registry artifacts only, not curated ones.
-      note: "Live chain state (burn, balances, network parameters, sudo key, crowdloans) is read from this network's own RPC and served here. Indexed chain HISTORY -- blocks, extrinsics, events and the analytics built on them -- is indexed for mainnet only, so those families and the curated-registry families (surfaces, profiles, endpoints, health) are unavailable.",
+      // DESCRIBES THE SHAPE, NOT A ROUTE LIST. The previous wording enumerated
+      // what was missing -- "blocks, extrinsics, events and the analytics built
+      // on them are indexed for mainnet only" -- and every one of those became
+      // false as #9394, #9411 and #9422 opened them, while the note kept
+      // telling callers not to ask. A summary that lists specifics goes stale
+      // the moment the specifics move; `served_families`, `unserved_families`
+      // and `partial_families` beside it are the precise answer and are
+      // derived, so this says only what remains true by construction.
+      //
+      // The test in tests/network-capabilities.test.ts holds it to that: a
+      // family this note calls unavailable must not appear as served.
+      note: "Live chain state (burn, balances, network parameters, sudo key, crowdloans) is read from this network's own RPC. Indexed chain history and the analytics over it are served wherever this network's own decode lane has run -- see served_families for exactly which, and partial_families for those where only some routes qualify. The curated-registry families (surfaces, profiles, endpoints, health) are mainnet-only: they are built from curation this network has no equivalent of, not from chain data.",
     };
   });
 }

--- a/tests/network-capabilities.test.ts
+++ b/tests/network-capabilities.test.ts
@@ -28,6 +28,7 @@ import {
 } from "../src/network-artifacts.ts";
 import { LIVE_CHAIN_ROUTE_PATHS } from "../src/live-chain-routes.ts";
 import { CHAIN_HISTORY_ROUTE_PATHS } from "../src/chain-history-routes.ts";
+import { PROJECTION_ROUTE_PATHS } from "../src/projection-routes.ts";
 
 const NETWORKS = {
   mainnet: { id: "mainnet", chain: "finney", prefix: "", isDefault: true },
@@ -51,6 +52,7 @@ function matrix() {
     nonArtifactRoutes: [
       ...LIVE_CHAIN_ROUTE_PATHS,
       ...CHAIN_HISTORY_ROUTE_PATHS,
+      ...PROJECTION_ROUTE_PATHS,
     ],
   });
 }
@@ -349,5 +351,74 @@ describe("GET /api/v1/networks never 404s", () => {
     assert.deepEqual(mainnet?.aliases, ["finney", "mainnet"]);
     const testnet = payload.networks.find((n) => n.id === "testnet");
     assert.deepEqual(testnet?.aliases, ["test", "testnet"]);
+  });
+});
+
+// The note is prose beside three derived lists, and prose drifts. It claimed
+// "blocks, extrinsics, events and the analytics built on them are indexed for
+// mainnet only" for weeks after #9394/#9411/#9422 opened every one of them --
+// telling callers not to ask for routes that answer. This is what stops that
+// recurring: whatever the note names as unavailable must actually be absent
+// from served_families.
+describe("the note cannot contradict the families beside it", () => {
+  test("no family the note calls mainnet-only is actually served", () => {
+    const payload = matrix() as unknown as {
+      networks: {
+        id: string;
+        note: string | null;
+        served_families: { family: string }[];
+        partial_families?: { family: string }[];
+      }[];
+    };
+    // Only the data-serving networks carry this note; `local` has its own
+    // setup pointer and no family lists to contradict.
+    const withNotes = payload.networks.filter(
+      (n) => n.served_families.length > 0 && (n.note ?? "").length > 0,
+    );
+    assert.ok(withNotes.length > 0, "no network carries a note to check");
+    for (const network of withNotes) {
+      const note = (network.note ?? "").toLowerCase();
+      const served = new Set([
+        ...network.served_families.map((f) => f.family),
+        ...(network.partial_families ?? []).map((f) => f.family),
+      ]);
+      // Families the note explicitly names as mainnet-only.
+      const claimed = ["surfaces", "profiles", "endpoints", "health"].filter(
+        (family) =>
+          note.includes(family) && /mainnet-only|unavailable/.test(note),
+      );
+      assert.ok(
+        claimed.length > 0,
+        `${network.id}: the note names no unavailable family, so this assertion proves nothing`,
+      );
+      for (const family of claimed) {
+        assert.ok(
+          !served.has(family),
+          `${network.id}: the note calls "${family}" mainnet-only, but it is served`,
+        );
+      }
+    }
+  });
+
+  // The paired positive: the note must not go the other way either, dismissing
+  // a whole area the network genuinely serves.
+  test("the note does not deny chain history a network actually serves", () => {
+    const payload = matrix() as unknown as {
+      networks: {
+        id: string;
+        note: string | null;
+        served_families: { family: string }[];
+      }[];
+    };
+    const testnet = payload.networks.find((n) => n.id === "testnet");
+    if (!testnet?.note) return;
+    const served = new Set(testnet.served_families.map((f) => f.family));
+    if (served.has("blocks") || served.has("extrinsics")) {
+      assert.doesNotMatch(
+        testnet.note,
+        /indexed for mainnet only/i,
+        "the note denies indexed history this network serves",
+      );
+    }
   });
 });


### PR DESCRIPTION
The capability matrix exists so a caller can decide what a network serves **without a request**
(#8699). Its testnet note has been saying the opposite of the truth since #9394:

> "Indexed chain HISTORY — blocks, extrinsics, events and the analytics built on them — is indexed
> for mainnet only, so those families … are unavailable."

Testnet serves all of it. The **same payload** lists `blocks` (6), `extrinsics` (2) and
`chain-events` (2) under `served_families`, and `chain` (13) under `partial_families`. The note
contradicted the data printed beside it, and steered agents away from routes that answer.

Measured against production just now:

```
testnet served_families:  blocks 6, chain-events 2, coverage 1, crowdloans 2,
                          evm 1, extrinsics 2, network 2, networks 1
testnet partial_families: accounts 4, chain 13, economics 1, subnets 5, sudo 1
```

## The note now describes a shape, not an inventory

Enumerating what is missing is precisely what made it wrong — every specific it named became false
as #9394, #9411 and #9422 opened them, while the sentence stayed put. `served_families`,
`unserved_families` and `partial_families` are the precise answer and are derived; the note now says
only what stays true by construction: live state from this chain's RPC, indexed history wherever
this chain's decode lane has run, and the curated-registry families mainnet-only *because they are
built from curation rather than from chain data*.

A test holds it there, in both directions: a family the note calls unavailable must not appear as
served, and the note must not deny indexed history a network actually serves.

## Two more instances of the same drift, in the UI

- The **network selector** described testnet as "native chain registry only (identities; no curated
  services/health)" — the first thing anyone reads before switching.
- **`NativeOnlyNotice`**'s heading read "{network} carries native chain data only" — a claim about
  the whole partition, on a card that fires for **one** route. It names the view now
  ("Not published for Testnet"), which stays correct however much the network goes on to serve.

Both are copy-only; no behaviour, no layout, no new components.

## A test that had quietly stopped testing the right thing

`tests/network-capabilities.test.ts` built its matrix without `PROJECTION_ROUTE_PATHS`, so since
#9422 every assertion in that file was about a matrix **the router does not build**. Fixed, which is
also what let the note guard above be written against the real payload.

## Verification

- `npx vitest run` — full suite green; `validate:contract-drift` passes with the regenerated
  contract.
- `apps/ui` typechecks clean (the `viewportRef` error you may see locally is a stale `packages/ui-kit`
  build, not a break — it clears after `npm run build --workspace=packages/ui-kit`, and CI builds it
  as a prior step).
- No patch-coverage delta: the change is a string, a heading, and a test fixture.
