### PR TITLE
perf(capture): flush in chunks, pace the reads, run the lanes concurrently

### DIFF
--- a/src/raw-capture-sync.ts
+++ b/src/raw-capture-sync.ts
@@ -22,6 +22,7 @@ import {
   type RawCaptureStore,
   type WatermarkStore,
 } from "./raw-chain-capture.ts";
+import { RAW_CAPTURE_CRON } from "../workers/config.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import {
   CHAIN_RPC_URLS,
@@ -87,37 +88,36 @@ export const RAW_CAPTURE_GENESIS_FLOOR = 8756635;
 export const TESTNET_RAW_CAPTURE_GENESIS_FLOOR = 7_700_000;
 
 /**
- * Blocks per tick, per network. Each block costs three RPC calls.
+ * The per-lane tick budget, DERIVED from the endpoint's own limit.
  *
- * Two ceilings apply, and the tighter one wins per network.
- *
- * THE PLATFORM CEILING is 1000 subrequests per invocation, and both networks
- * run in ONE invocation, so the budgets are bounded together rather than
+ * THE PLATFORM CEILING is 1000 subrequests per invocation, and every lane runs
+ * in ONE invocation, so the budgets are bounded together rather than
  * individually.
  *
- * THE ENDPOINT CEILING is ~100 requests per client per minute, measured against
- * the public testnet RPC by replaying this lane's exact call pattern (#9378):
+ * THE ENDPOINT CEILING is ~100 requests per client per minute, measured by
+ * replaying this lane's exact call pattern (#9378):
  *
  *     FAILED after 33 blocks (100 calls) in 23.0s: HTTP 429
  *
- * It is per CLIENT, not per host — probing test.chain.opentensor.ai straight
+ * It is per CLIENT, not per host -- probing test.chain.opentensor.ai straight
  * afterwards stopped after 4 blocks, because the first probe had already spent
- * the budget. So there is no sibling endpoint to spread across, and a testnet
- * tick that asks for more than ~33 blocks does not go faster; it just gets the
- * surplus refused. The original 100 here made 300 calls to have 200 rejected
- * every five minutes, against an endpoint we do not own.
+ * the budget. So there is no sibling endpoint to spread across.
  *
- * 32, not 33: 32*3 + 1 head fetch = 97 calls, leaving headroom rather than
- * landing exactly on the limit, where a single retry tips the tick into a 429.
+ * THESE USED TO BE TWO HAND-WRITTEN NUMBERS (150 mainnet, 32 testnet), and
+ * #9430 is what that cost. 32 was pinned just under the measured 429; 150 was
+ * chosen when mainnet was the only lane. Together they sustained 109 calls/min
+ * against a 100/min ceiling the moment a second lane existed -- over budget in
+ * the worst case with nothing to say so -- while testnet saturated its own cap
+ * every tick and sat ~92 hours from closing a gap the interval could close in
+ * ~16.
  *
- * Mainnet keeps its original 150. It sits at the tip in steady state (~25
- * blocks/tick, ~76 calls) so it does not approach the limit; the budget only
- * matters there for a backfill, and lowering it would slow a recovery this
- * measurement says nothing about.
+ * The limit is PER MINUTE, so that is what the budget reads. An unpaced tick is
+ * bounded by one minute's allowance however long it runs; a paced one is
+ * bounded by its own span. Both numbers below fall out of the same three
+ * measured inputs -- the ceiling, the calls per block, and the cron interval --
+ * so a cadence change or a third network moves them together instead of leaving
+ * one behind.
  */
-const MAX_BLOCKS_PER_TICK = 150;
-const TESTNET_MAX_BLOCKS_PER_TICK = 32;
-
 /**
  * Requests the public RPC serves one client per minute, measured (#9378).
  *
@@ -129,6 +129,48 @@ export const RPC_REQUESTS_PER_MINUTE_LIMIT = 100;
 
 /** RPC calls one captured block costs: hash, block body, events blob. */
 export const RPC_CALLS_PER_BLOCK = 3;
+
+const RPC_BUDGET_UTILISATION = 0.8;
+
+/**
+ * Fraction of the interval a tick may spend reading.
+ *
+ * Not all of it: cron jitter and a redeploy landing mid-tick both want slack,
+ * and a tick still running when the next fires would double the rate. Chunked
+ * flushing (see captureTick) is what makes even this much affordable -- a
+ * killed invocation now loses one chunk rather than everything it read.
+ */
+const TICK_SPEND_FRACTION = 0.8;
+
+/** Blocks per durable write. One R2 PUT each, so this trades a few writes for
+ * how much a killed invocation discards -- 25 blocks is ~2 minutes of chain. */
+const FLUSH_EVERY_BLOCKS = 25;
+
+/** The paced budget for ONE lane, given how many share the client allowance. */
+export function pacedLaneBudget(
+  laneCount: number,
+  cronMinutes: number,
+  limitPerMinute: number = RPC_REQUESTS_PER_MINUTE_LIMIT,
+): { maxBlocks: number; minGapMs: number } {
+  const callsPerMinute = (limitPerMinute * RPC_BUDGET_UTILISATION) / laneCount;
+  const blocksPerMinute = callsPerMinute / RPC_CALLS_PER_BLOCK;
+  return {
+    // Lanes run CONCURRENTLY, so each gets the whole spendable interval rather
+    // than its share of it.
+    maxBlocks: Math.max(
+      1,
+      Math.floor(blocksPerMinute * cronMinutes * TICK_SPEND_FRACTION),
+    ),
+    minGapMs: Math.ceil(60_000 / blocksPerMinute),
+  };
+}
+
+/** The `*` `/N` minute step of a cron. An unreadable cron falls back to the
+ * shipped cadence, narrowing the budget rather than widening it. */
+export function cronStepMinutes(cron: string): number {
+  const step = Number(cron.split(" ")[0]!.replace("*/", ""));
+  return Number.isInteger(step) && step > 0 ? step : 5;
+}
 
 /**
  * The capture lanes, as data.
@@ -146,7 +188,16 @@ export interface RawCaptureLane {
   defaultRpcUrl: string;
   genesisFloor: number;
   maxPerTick: number;
+  /** Gap between two blocks' reads, so the tick's span is the budget rather
+   * than one minute's allowance. */
+  minGapMs: number;
+  /** Blocks per durable write. */
+  flushEvery: number;
 }
+
+/** Every lane draws on ONE client allowance, so they share one derived
+ * budget. Declared before the table because the table needs it. */
+const LANE_BUDGET = pacedLaneBudget(2, cronStepMinutes(RAW_CAPTURE_CRON));
 
 export const RAW_CAPTURE_LANES: readonly RawCaptureLane[] = [
   {
@@ -154,7 +205,9 @@ export const RAW_CAPTURE_LANES: readonly RawCaptureLane[] = [
     rpcUrlEnv: "CHAIN_HEAD_RPC_URL",
     defaultRpcUrl: DEFAULT_RPC_URL,
     genesisFloor: RAW_CAPTURE_GENESIS_FLOOR,
-    maxPerTick: MAX_BLOCKS_PER_TICK,
+    maxPerTick: LANE_BUDGET.maxBlocks,
+    minGapMs: LANE_BUDGET.minGapMs,
+    flushEvery: FLUSH_EVERY_BLOCKS,
   },
   {
     network: "testnet",
@@ -164,7 +217,9 @@ export const RAW_CAPTURE_LANES: readonly RawCaptureLane[] = [
     // an archive endpoint means a widened floor stays possible later.
     defaultRpcUrl: CHAIN_RPC_URLS.testnet,
     genesisFloor: TESTNET_RAW_CAPTURE_GENESIS_FLOOR,
-    maxPerTick: TESTNET_MAX_BLOCKS_PER_TICK,
+    maxPerTick: LANE_BUDGET.maxBlocks,
+    minGapMs: LANE_BUDGET.minGapMs,
+    flushEvery: FLUSH_EVERY_BLOCKS,
   },
 ];
 
@@ -239,6 +294,8 @@ export async function runRawCaptureSync(
     fetchImpl?: typeof fetch;
     now?: () => number;
     recordException?: typeof recordExceptionEvent;
+    /** Injectable so a test asserts the PACING without waiting for it (#9430). */
+    sleepFn?: (ms: number) => Promise<void>;
   } = {},
 ): Promise<RawCaptureSyncResult> {
   const now = deps.now ?? Date.now;
@@ -275,24 +332,29 @@ export async function runRawCaptureSync(
 
   // Each lane is captured independently and IN ORDER, mainnet first.
   //
-  // Isolation is the whole point of the loop shape. Testnet is a best-effort
-  // secondary lane against a chain that gets wiped; a testnet RPC outage must
-  // not stop mainnet capture, and — because the mainnet lane runs first and its
-  // watermark is already durable by then — it cannot. The reverse is also true:
-  // a mainnet failure still lets testnet run, so one broken endpoint degrades
-  // one lane rather than the cron.
-  const lanes: RawCaptureLaneResult[] = [];
-  for (const lane of RAW_CAPTURE_LANES) {
-    lanes.push(
-      await runLane(lane, {
+  // CONCURRENT, not sequential (#9430). Isolation is still the whole point:
+  // testnet is a best-effort secondary lane, and a testnet RPC outage must not
+  // stop mainnet capture. `runLane` already converts every failure into a
+  // result rather than a throw, so `Promise.all` here cannot let one lane's
+  // failure reject the other's -- isolation comes from that, not from ordering.
+  //
+  // Sequential was what made the budget unusable. Each lane is paced to its own
+  // share of the per-minute allowance, so running them in parallel does not
+  // raise the combined rate at all -- it just stops each lane idling through
+  // the other's turn. Two lanes each getting the WHOLE interval instead of half
+  // is the entire throughput gain here.
+  const lanes: RawCaptureLaneResult[] = await Promise.all(
+    RAW_CAPTURE_LANES.map((lane) =>
+      runLane(lane, {
         env,
         store,
         now,
         capture,
         fetchImpl: deps.fetchImpl,
+        sleepFn: deps.sleepFn,
       }),
-    );
-  }
+    ),
+  );
 
   const mainnet = lanes.find((lane) => lane.network === "mainnet");
   // The top-level result keeps mainnet's shape verbatim: this function's return
@@ -327,6 +389,7 @@ async function runLane(
     now: () => number;
     capture: typeof recordExceptionEvent;
     fetchImpl?: typeof fetch;
+    sleepFn?: (ms: number) => Promise<void>;
   },
 ): Promise<RawCaptureLaneResult> {
   const { env, store, now, capture } = ctx;
@@ -338,7 +401,10 @@ async function runLane(
       genesisFloor: lane.genesisFloor,
       maxPerTick: lane.maxPerTick,
       network: lane.network,
+      minGapMs: lane.minGapMs,
+      flushEvery: lane.flushEvery,
       fetchImpl: ctx.fetchImpl,
+      sleepFn: ctx.sleepFn,
       now,
     });
     if (result.stoppedAt !== undefined) {

--- a/src/raw-chain-capture.ts
+++ b/src/raw-chain-capture.ts
@@ -223,11 +223,34 @@ export async function captureTick(deps: {
   /** Which chain these bytes came from. Decides the R2 key prefix only —
    * everything else here is chain-agnostic, because capture never decodes. */
   network?: ChainNetworkId;
+  /**
+   * Minimum gap between two blocks' reads, so a tick's calls are SPREAD across
+   * it rather than fired as fast as the network allows.
+   *
+   * The endpoint's limit is per MINUTE, so an unpaced tick is bounded by one
+   * minute's allowance however long the tick runs -- which is what pinned the
+   * testnet cap at 32 blocks (#9430). Pacing makes the tick's own span the
+   * budget instead. Zero (the default) keeps the previous behaviour exactly.
+   */
+  minGapMs?: number;
+  /** Blocks per durable write. Smaller means less work lost to an invocation
+   * killed mid-tick, at one R2 PUT each. */
+  flushEvery?: number;
   fetchImpl?: typeof fetch;
   now?: () => number;
+  /** Injectable so a test asserts the PACING without waiting for it. A real
+   * timer is not dependable under the shared-registry pass (#9123). */
+  sleepFn?: (ms: number) => Promise<void>;
 }): Promise<CaptureResult> {
   const fetchImpl = deps.fetchImpl ?? fetch;
   const now = deps.now ?? Date.now;
+  const minGapMs = deps.minGapMs ?? 0;
+  // Default is the whole tick, so a caller that has not opted in writes once
+  // exactly as before.
+  const flushEvery = deps.flushEvery ?? Number.POSITIVE_INFINITY;
+  const sleepFn =
+    deps.sleepFn ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   const stored = await deps.watermark.read();
   // An unset watermark starts just below the floor, so the first tick captures
   // the floor block itself rather than skipping it.
@@ -257,12 +280,41 @@ export async function captureTick(deps: {
     };
   }
 
-  const blocks: RawBlockCapture[] = [];
+  // FLUSHED IN CHUNKS, NOT AT THE END. Holding a whole tick in memory and
+  // writing once meant a tick could only be as long as we were willing to lose
+  // -- an invocation killed by a redeploy discarded everything it had read. So
+  // a paced tick, which is the only way to use a per-MINUTE budget across a
+  // five-minute interval, was unaffordable (#9430).
+  //
+  // The no-gap guarantee is unchanged, and rests on the same ordering it always
+  // did: bytes durable FIRST, watermark only after. The watermark therefore
+  // never claims a height whose object is missing, so a retry re-reads exactly
+  // the range that did not land -- from the same `lastContiguous`, producing
+  // the same chunk boundaries and the same key, overwriting byte-for-byte
+  // rather than appending a duplicate.
+  const flush = async (batch: RawBlockCapture[]) => {
+    const first = batch[0]!.block_number;
+    const last = batch[batch.length - 1]!.block_number;
+    await deps.store.put(
+      rawBatchKey(first, last, deps.network),
+      batch.map((b) => JSON.stringify(b)).join("\n") + "\n",
+    );
+    // Only now -- the bytes are durable, so the watermark may claim them.
+    await deps.watermark.write(last);
+    return last;
+  };
+
+  let pending: RawBlockCapture[] = [];
+  let captured = 0;
+  let watermark = lastContiguous;
   let stoppedAt: number | undefined;
   let reason: string | undefined;
-  for (const height of heights) {
+  for (const [index, height] of heights.entries()) {
+    // BEFORE the read, and never before the first: the gap belongs between two
+    // blocks' bursts, so pacing never delays a tick that captures one block.
+    if (index > 0 && minGapMs > 0) await sleepFn(minGapMs);
     try {
-      blocks.push(await fetchRawBlock(deps.rpcUrl, height, fetchImpl, now));
+      pending.push(await fetchRawBlock(deps.rpcUrl, height, fetchImpl, now));
     } catch (error) {
       // Stop at the FIRST failure and keep the prefix. Continuing past it
       // would create exactly the hole this module exists to prevent.
@@ -270,9 +322,20 @@ export async function captureTick(deps: {
       reason = String((error as Error)?.message ?? error);
       break;
     }
+    if (pending.length >= flushEvery) {
+      watermark = await flush(pending);
+      captured += pending.length;
+      pending = [];
+    }
+  }
+  // Whatever the last chunk holds, including everything when the tick stopped
+  // early: the prefix before a failure is still good data.
+  if (pending.length > 0) {
+    watermark = await flush(pending);
+    captured += pending.length;
   }
 
-  if (blocks.length === 0) {
+  if (captured === 0) {
     return {
       captured: 0,
       watermark: lastContiguous,
@@ -282,21 +345,10 @@ export async function captureTick(deps: {
     };
   }
 
-  const first = blocks[0]!.block_number;
-  const last = blocks[blocks.length - 1]!.block_number;
-  // One object per contiguous batch, keyed by its range: a retry of the same
-  // range overwrites byte-for-byte rather than appending a duplicate.
-  await deps.store.put(
-    rawBatchKey(first, last, deps.network),
-    blocks.map((b) => JSON.stringify(b)).join("\n") + "\n",
-  );
-  // Only now — the bytes are durable, so the watermark may claim them.
-  await deps.watermark.write(last);
-
   return {
-    captured: blocks.length,
-    watermark: last,
-    behind: head - last,
+    captured,
+    watermark,
+    behind: head - watermark,
     stoppedAt,
     reason,
   };

--- a/tests/raw-capture-sync.test.ts
+++ b/tests/raw-capture-sync.test.ts
@@ -4,6 +4,7 @@
 // store or watermark must be a loud no-op, never a quiet one, because a lane
 // that silently does nothing looks exactly like a healthy one.
 import assert from "node:assert/strict";
+import { RAW_CAPTURE_CRON } from "../workers/config.ts";
 import { DatabaseSync } from "node:sqlite";
 import fs from "node:fs";
 import path from "node:path";
@@ -12,6 +13,8 @@ import {
   d1Watermark,
   RAW_CAPTURE_GENESIS_FLOOR,
   RAW_CAPTURE_LANES,
+  cronStepMinutes,
+  pacedLaneBudget,
   RPC_CALLS_PER_BLOCK,
   RPC_REQUESTS_PER_MINUTE_LIMIT,
   runRawCaptureSync,
@@ -118,11 +121,15 @@ function envWith(over: Record<string, unknown> = {}) {
   return { env, puts };
 }
 
+/** Pacing has its own tests; every other test skips the wait. */
+const noSleep = async () => {};
+
 describe("runRawCaptureSync — refusal paths", () => {
   test("disabled is a quiet no-op, not an error", async () => {
     const captures: unknown[] = [];
     const { env } = envWith({ RAW_CAPTURE_ENABLED: undefined });
     const result = await runRawCaptureSync(env as never, {
+      sleepFn: noSleep,
       recordException: (async (...a: unknown[]) => {
         captures.push(a);
         return true;
@@ -136,6 +143,7 @@ describe("runRawCaptureSync — refusal paths", () => {
     const captures: { route?: string }[] = [];
     const { env } = envWith({ METAGRAPH_ARCHIVE: undefined });
     const result = await runRawCaptureSync(env as never, {
+      sleepFn: noSleep,
       recordException: (async (_e: unknown, ev: { route?: string }) => {
         captures.push(ev);
         return true;
@@ -150,6 +158,7 @@ describe("runRawCaptureSync — refusal paths", () => {
     const captures: unknown[] = [];
     const { env } = envWith({ METAGRAPH_HEALTH_DB: undefined });
     const result = await runRawCaptureSync(env as never, {
+      sleepFn: noSleep,
       recordException: (async () => {
         captures.push(1);
         return true;
@@ -163,6 +172,7 @@ describe("runRawCaptureSync — refusal paths", () => {
     const captures: { route?: string }[] = [];
     const { env } = envWith();
     const result = await runRawCaptureSync(env as never, {
+      sleepFn: noSleep,
       fetchImpl: (async () => {
         throw new Error("rpc down");
       }) as unknown as typeof fetch,
@@ -187,6 +197,7 @@ describe("runRawCaptureSync — capture", () => {
   test("first tick starts at the genesis floor and persists the watermark", async () => {
     const { env, puts } = envWith();
     const result = await runRawCaptureSync(env as never, {
+      sleepFn: noSleep,
       fetchImpl: rpcFetch(RAW_CAPTURE_GENESIS_FLOOR + 2),
       now: () => 5000,
     });
@@ -206,10 +217,12 @@ describe("runRawCaptureSync — capture", () => {
   test("a second tick resumes from the persisted watermark, not the floor", async () => {
     const { env, puts } = envWith();
     await runRawCaptureSync(env as never, {
+      sleepFn: noSleep,
       fetchImpl: rpcFetch(RAW_CAPTURE_GENESIS_FLOOR + 1),
       now: () => 1,
     });
     const second = await runRawCaptureSync(env as never, {
+      sleepFn: noSleep,
       fetchImpl: rpcFetch(RAW_CAPTURE_GENESIS_FLOOR + 4),
       now: () => 2,
     });
@@ -221,10 +234,12 @@ describe("runRawCaptureSync — capture", () => {
   test("caught up: no work and no write", async () => {
     const { env, puts } = envWith();
     await runRawCaptureSync(env as never, {
+      sleepFn: noSleep,
       fetchImpl: rpcFetch(RAW_CAPTURE_GENESIS_FLOOR),
       now: () => 1,
     });
     const again = await runRawCaptureSync(env as never, {
+      sleepFn: noSleep,
       fetchImpl: rpcFetch(RAW_CAPTURE_GENESIS_FLOOR),
       now: () => 2,
     });
@@ -236,10 +251,18 @@ describe("runRawCaptureSync — capture", () => {
   test("reports lag so a backlog is observable rather than inferred", async () => {
     const { env } = envWith();
     const result = await runRawCaptureSync(env as never, {
+      sleepFn: noSleep,
       fetchImpl: rpcFetch(RAW_CAPTURE_GENESIS_FLOOR + 10_000),
       now: () => 1,
     });
-    assert.equal(result.captured, 150, "bounded per tick");
+    // The DERIVED cap, not a literal: the budget follows the cron and the lane
+    // count, so restating it here would be the second hand-written number
+    // #9430 exists to remove.
+    assert.equal(
+      result.captured,
+      RAW_CAPTURE_LANES[0]!.maxPerTick,
+      "bounded per tick",
+    );
     assert.ok(
       (result.behind ?? 0) > 9000,
       "still far behind, and says so — the next ticks drain it",
@@ -286,6 +309,7 @@ describe("runRawCaptureSync — capture", () => {
     }) as unknown as typeof fetch;
     try {
       const result = await runRawCaptureSync(env as never, {
+        sleepFn: noSleep,
         fetchImpl: flaky,
         now: () => 9,
       });
@@ -306,6 +330,7 @@ describe("runRawCaptureSync — capture", () => {
   test("a thrown non-Error still yields a reason instead of 'undefined'", async () => {
     const { env } = envWith();
     const result = await runRawCaptureSync(env as never, {
+      sleepFn: noSleep,
       fetchImpl: (async () => {
         throw "string failure";
       }) as unknown as typeof fetch,
@@ -343,6 +368,7 @@ describe("the testnet capture lane", () => {
   test("mainnet's R2 prefix and watermark row are untouched by testnet's", async () => {
     const { env, puts } = envWith();
     const result = await runRawCaptureSync(env as never, {
+      sleepFn: noSleep,
       fetchImpl: rpcFetch(
         RAW_CAPTURE_GENESIS_FLOOR + 1,
         TESTNET_RAW_CAPTURE_GENESIS_FLOOR + 1,
@@ -395,6 +421,7 @@ describe("the testnet capture lane", () => {
     // well-formed blocks — so the only proof is provenance in the payload.
     const { env, puts } = envWith();
     await runRawCaptureSync(env as never, {
+      sleepFn: noSleep,
       fetchImpl: rpcFetch(
         RAW_CAPTURE_GENESIS_FLOOR,
         TESTNET_RAW_CAPTURE_GENESIS_FLOOR,
@@ -419,6 +446,7 @@ describe("the testnet capture lane", () => {
     // The reason the lanes run in sequence with independent error handling.
     const { env, puts } = envWith();
     const result = await runRawCaptureSync(env as never, {
+      sleepFn: noSleep,
       fetchImpl: (async (url: unknown, init?: { body?: string }) => {
         if (String(url).includes("test.finney"))
           throw new Error("testnet down");
@@ -491,23 +519,118 @@ describe("the testnet capture lane", () => {
     );
   });
 
-  test("the testnet budget stays inside the endpoint's measured rate limit", () => {
-    // #9378. The public RPC serves ~100 requests per client per minute — proven
-    // by replaying this lane's exact call pattern until it 429'd at call 100.
-    // The lane shipped asking for 100 BLOCKS (300 calls), so two-thirds of every
-    // tick was refused: not a data bug (the no-gap guarantee retries) but 200
-    // rejected requests every five minutes at an endpoint we do not own.
-    //
-    // Asserted rather than commented because the failure is invisible in
-    // production — a throttled tick looks exactly like a slow one.
-    const testnet = RAW_CAPTURE_LANES.find(
-      (lane) => lane.network === "testnet",
-    );
-    assert.ok(testnet, "no testnet lane declared");
-    const calls = testnet.maxPerTick * RPC_CALLS_PER_BLOCK + 1;
+  // This used to assert that a whole TICK fit inside one minute's allowance,
+  // and that premise is exactly what capped testnet at 32 blocks (#9430). An
+  // UNPACED tick fires its burst at network speed, so one minute bounds it
+  // however long the tick is. A paced one spends the tick, so the tick bounds
+  // it -- and what has to fit the limit is the RATE.
+  test("the paced rate across all lanes stays inside the measured limit", () => {
+    for (const lane of RAW_CAPTURE_LANES) {
+      assert.ok(lane.minGapMs > 0, `${lane.network} is not paced at all`);
+      const callsPerMinute =
+        (60_000 / lane.minGapMs) *
+        RPC_CALLS_PER_BLOCK *
+        RAW_CAPTURE_LANES.length;
+      assert.ok(
+        callsPerMinute < RPC_REQUESTS_PER_MINUTE_LIMIT,
+        `${lane.network} sustains ${callsPerMinute.toFixed(0)} calls/min across ${RAW_CAPTURE_LANES.length} lanes, at or over ${RPC_REQUESTS_PER_MINUTE_LIMIT}/min`,
+      );
+    }
+  });
+
+  test("a paced tick finishes inside its own interval", () => {
+    // Lanes run CONCURRENTLY, so the wall time is one lane's, not the sum --
+    // but it still has to leave slack for jitter and a mid-tick redeploy.
+    const intervalMs = cronStepMinutes(RAW_CAPTURE_CRON) * 60_000;
+    for (const lane of RAW_CAPTURE_LANES) {
+      const spendMs = lane.maxPerTick * lane.minGapMs;
+      assert.ok(
+        spendMs < intervalMs,
+        `${lane.network} would spend ${(spendMs / 60_000).toFixed(1)} min of a ${intervalMs / 60_000} min tick`,
+      );
+    }
+  });
+
+  // The paired positive: a budget test that only says "not too fast" is
+  // satisfied by a lane that never catches up.
+  test("the budget lets every lane outpace the chain it follows", () => {
+    const ticksPerHour = 60 / cronStepMinutes(RAW_CAPTURE_CRON);
+    for (const lane of RAW_CAPTURE_LANES) {
+      const perHour = lane.maxPerTick * ticksPerHour;
+      // Bittensor produces a block every 12 s on both chains.
+      assert.ok(
+        perHour > 3600 / 12,
+        `${lane.network} captures ${perHour}/h against a chain producing 300/h -- it can never catch up`,
+      );
+    }
+  });
+
+  test("a third network would narrow the shared allowance", () => {
+    const two = pacedLaneBudget(2, cronStepMinutes(RAW_CAPTURE_CRON));
+    const three = pacedLaneBudget(3, cronStepMinutes(RAW_CAPTURE_CRON));
+    assert.ok(three.maxBlocks < two.maxBlocks);
+    assert.ok(three.minGapMs > two.minGapMs);
+  });
+
+  test("an unreadable cron narrows the budget rather than widening it", () => {
+    assert.equal(cronStepMinutes("11,41 * * * *"), 5);
+    assert.equal(cronStepMinutes(""), 5);
+    assert.equal(cronStepMinutes("*/2 * * * *"), 2);
+  });
+});
+
+// #9430. Concurrency is what turns the shared budget into throughput -- each
+// lane gets the whole interval instead of half -- but only if isolation still
+// holds, which now comes from runLane converting failures into results rather
+// than from ordering.
+describe("the lanes run concurrently, and stay isolated", () => {
+  test("one lane's endpoint failing does not stop the other", async () => {
+    const { env } = envWith();
+    // Only the testnet endpoint fails.
+    const result = (await runRawCaptureSync(env as never, {
+      sleepFn: noSleep,
+      now: () => 1,
+      fetchImpl: (async (url: string, init: RequestInit) => {
+        if (String(url).includes("test.finney")) {
+          throw new Error("testnet endpoint down");
+        }
+        return rpcFetch(RAW_CAPTURE_GENESIS_FLOOR + 100)(
+          url as never,
+          init as never,
+        );
+      }) as never,
+    })) as { lanes?: { network: string; ok: boolean; captured?: number }[] };
+    const lanes = result.lanes ?? [];
+    const mainnet = lanes.find((l) => l.network === "mainnet");
+    const testnet = lanes.find((l) => l.network === "testnet");
+    // The POSITIVE first: mainnet actually captured. An "isolation" test where
+    // neither lane ran passes for the wrong reason.
     assert.ok(
-      calls < RPC_REQUESTS_PER_MINUTE_LIMIT,
-      `a testnet tick issues ${calls} calls, at or over the endpoint's ${RPC_REQUESTS_PER_MINUTE_LIMIT}/min limit`,
+      (mainnet?.captured ?? 0) > 0,
+      "mainnet captured nothing, so isolation proves nothing",
     );
+    assert.equal(
+      testnet?.ok,
+      false,
+      "the failing lane must report its failure",
+    );
+  });
+
+  test("both lanes are attempted in one tick", async () => {
+    const { env } = envWith();
+    const seen = new Set<string>();
+    const result = (await runRawCaptureSync(env as never, {
+      sleepFn: noSleep,
+      now: () => 1,
+      fetchImpl: (async (url: string, init: RequestInit) => {
+        seen.add(String(url).includes("test.finney") ? "testnet" : "mainnet");
+        return rpcFetch(RAW_CAPTURE_GENESIS_FLOOR + 100)(
+          url as never,
+          init as never,
+        );
+      }) as never,
+    })) as { lanes?: { network: string }[] };
+    assert.deepEqual([...seen].sort(), ["mainnet", "testnet"]);
+    assert.equal((result.lanes ?? []).length, RAW_CAPTURE_LANES.length);
   });
 });

--- a/tests/raw-chain-capture.test.ts
+++ b/tests/raw-chain-capture.test.ts
@@ -438,3 +438,142 @@ describe("captureTick — the no-gap guarantee", () => {
     }
   });
 });
+
+// #9430. The whole point of chunked flushing is what survives an invocation
+// that does NOT finish, so these assert the durability boundary rather than
+// the happy path.
+describe("captureTick flushes in chunks", () => {
+  function chunkedDeps(opts: {
+    heights: number;
+    flushEvery?: number;
+    minGapMs?: number;
+    failAt?: number;
+  }) {
+    const puts: { key: string; lines: number }[] = [];
+    const marks: number[] = [];
+    const gaps: number[] = [];
+    return {
+      puts,
+      marks,
+      gaps,
+      deps: {
+        rpcUrl: "https://rpc.invalid",
+        genesisFloor: 100,
+        maxPerTick: opts.heights,
+        flushEvery: opts.flushEvery,
+        minGapMs: opts.minGapMs ?? 0,
+        sleepFn: async (ms: number) => {
+          gaps.push(ms);
+        },
+        store: {
+          put: async (key: string, value: string) => {
+            puts.push({ key, lines: value.trimEnd().split("\n").length });
+          },
+        },
+        watermark: {
+          read: async () => 99,
+          write: async (n: number) => {
+            marks.push(n);
+          },
+        },
+        now: () => 1,
+        fetchImpl: rpcFetch({
+          head: 100 + opts.heights,
+          ...(opts.failAt ? { failAt: opts.failAt } : {}),
+        }),
+      },
+    };
+  }
+
+  test("writes one object per chunk, and the watermark trails each", async () => {
+    const { puts, marks, deps } = chunkedDeps({ heights: 10, flushEvery: 4 });
+    const result = await captureTick(deps as never);
+    assert.equal(result.captured, 10);
+    // 4 + 4 + 2, the last being the remainder.
+    assert.deepEqual(
+      puts.map((p) => p.lines),
+      [4, 4, 2],
+    );
+    // BYTES FIRST, WATERMARK AFTER -- one mark per chunk, each naming that
+    // chunk's last block, so the watermark never claims a height whose object
+    // is not already durable.
+    assert.deepEqual(marks, [103, 107, 109]);
+    assert.equal(result.watermark, 109);
+  });
+
+  // The property the whole change rests on: a tick that dies mid-way keeps
+  // everything it flushed, and the watermark points at exactly that.
+  test("a failure keeps every flushed chunk and claims no more", async () => {
+    const { puts, marks, deps } = chunkedDeps({
+      heights: 10,
+      flushEvery: 3,
+      failAt: 106,
+    });
+    const result = await captureTick(deps as never);
+    // 100-102 and 103-105 landed; 106 failed, so nothing beyond it is claimed.
+    assert.deepEqual(
+      puts.map((p) => p.lines),
+      [3, 3],
+    );
+    assert.deepEqual(marks, [102, 105]);
+    assert.equal(result.watermark, 105);
+    assert.equal(result.stoppedAt, 106);
+    assert.equal(result.captured, 6);
+  });
+
+  test("a failure before any chunk flushes claims nothing at all", async () => {
+    const { puts, marks, deps } = chunkedDeps({
+      heights: 10,
+      flushEvery: 5,
+      failAt: 100,
+    });
+    const result = await captureTick(deps as never);
+    assert.deepEqual(puts, []);
+    assert.deepEqual(marks, []);
+    assert.equal(result.captured, 0);
+    assert.equal(result.watermark, 99, "the watermark must not move");
+  });
+
+  // A retry re-reads from the same watermark, so it rebuilds the same chunk
+  // boundaries and overwrites byte-for-byte rather than appending a duplicate.
+  test("a retry of an unflushed range reproduces the same key", async () => {
+    const first = chunkedDeps({ heights: 6, flushEvery: 3 });
+    await captureTick(first.deps as never);
+    const second = chunkedDeps({ heights: 6, flushEvery: 3 });
+    await captureTick(second.deps as never);
+    assert.deepEqual(
+      first.puts.map((p) => p.key),
+      second.puts.map((p) => p.key),
+    );
+  });
+
+  test("without flushEvery it writes once, exactly as before", async () => {
+    const { puts, marks, deps } = chunkedDeps({ heights: 7 });
+    await captureTick(deps as never);
+    assert.equal(puts.length, 1);
+    assert.equal(puts[0]!.lines, 7);
+    assert.deepEqual(marks, [106]);
+  });
+
+  test("pacing waits between blocks, never before the first", async () => {
+    const { gaps, deps } = chunkedDeps({ heights: 4, minGapMs: 4500 });
+    const result = await captureTick(deps as never);
+    assert.equal(result.captured, 4);
+    assert.deepEqual(gaps, [4500, 4500, 4500]);
+  });
+
+  test("the default sleep is a real timer, not a no-op", async () => {
+    // Every other test injects one, so without this the shipped pacing would be
+    // exercised by nothing. One millisecond: this is about the wiring.
+    const { deps } = chunkedDeps({ heights: 3, minGapMs: 20 });
+    const { sleepFn: _injected, ...shipped } = deps as Record<string, unknown>;
+    const started = Date.now();
+    const result = await captureTick(shipped as never);
+    assert.equal(result.captured, 3);
+    // Two gaps between three blocks, so at least ~40ms of real waiting.
+    assert.ok(
+      Date.now() - started >= 30,
+      "the shipped pacing did not actually wait",
+    );
+  });
+});


### PR DESCRIPTION
Closes #9430.

I closed this issue once, on the arithmetic that pacing cannot pay for itself. That arithmetic was
correct **given the durability model** — which I had treated as fixed rather than as the actual
constraint. Three things blocked it, and only the first is a law:

1. the safe shared rate is ~26.7 blocks/min (80 calls/min ÷ 3 calls/block);
2. lanes ran **sequentially**, so each got half the tick;
3. a batch was durable only at **end of tick**, so a tick could not spend its interval without
   risking everything it had read.

(2) and (3) were just how `captureTick` happened to be written.

## Chunked flush is the one that unlocks the rest

Each chunk is put and the watermark advanced as the tick goes, so a killed invocation loses one
chunk instead of everything.

**The no-gap guarantee is unchanged**, and rests on the same ordering it always did — bytes durable
first, watermark only after. So the watermark never claims a height whose object is missing, and a
retry re-reads exactly the range that did not land, from the same `lastContiguous`, producing the
same chunk boundaries and the same key. Overwrite byte-for-byte, never append a duplicate.

## Then concurrency, which is where the throughput actually comes from

Isolation used to come from ordering — mainnet ran first, so its watermark was durable before
testnet could fail. It now comes from `runLane` converting every failure into a result rather than a
throw, so `Promise.all` cannot let one lane's failure reject the other's. Each lane gets the *whole*
interval instead of half.

## And pacing, which bounds the rate by construction

The limit is per **minute**, so an unpaced tick is capped by one minute's allowance however long it
runs. That single fact is what pinned testnet at 32 blocks. Spreading the reads makes the tick's own
span the budget instead.

## The hand-written caps are gone

150 was chosen when mainnet was the only lane; 32 was pinned just under a measured 429. Together
they sustained **109 calls/min against a 100/min ceiling** the moment a second lane existed. Both now
derive from the ceiling, the calls per block, and the cron interval, so a cadence change or a third
network moves them together rather than leaving one behind.

**53 blocks/lane/tick at a 4.5 s gap → 636 blocks/hour per lane** against a chain producing 300, at
80 calls/min combined. Testnet's deficit clears in **~23 h rather than ~92**.

## Verified against the real endpoint

Fired a tick with `wrangler dev --remote --test-scheduled`:

```
mainnet  +31 blocks   err=None
testnet  +57 blocks   err=None
```

- **No 429 on either lane** at the paced rate — the risk this whole design is shaped around.
- Both lanes advanced **simultaneously and mid-tick**, which demonstrates concurrency and chunked
  flush at once: previously nothing landed until the tick ended.

One honesty note on those numbers: production still runs the old code on its own `*/5` cron, so the
totals span my fired tick *and* a production tick. The attribution between them is ambiguous; what
is unambiguous is that both lanes moved concurrently, mid-tick, with no errors.

## Tests assert the durability boundary, not the happy path

- a mid-tick failure keeps every flushed chunk and claims no more (`marks: [102, 105]`,
  `stoppedAt: 106`);
- a failure before the first flush claims nothing at all — the watermark must not move;
- a retry of an unflushed range reproduces the same key;
- omitting `flushEvery` writes once, exactly as before;
- the shipped default sleep is a real timer, since every other test injects one.

Patch coverage **36/36 lines, 21/21 branches**. Full suite green.
