### PR TITLE
fix(economics): serve spot_price_tao on the full economics blob's rows

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -4759,6 +4759,8 @@ export type SubnetEconomics = {
   registration_allowed?: Maybe<Scalars['Boolean']['output']>;
   registration_cost_tao?: Maybe<Scalars['Float']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
+  /** The AMM spot price in TAO per alpha, derived at serve time from tao_in_pool_tao / alpha_in_pool on this row (#9408). alpha_price_tao is the chain's MOVING average; this is the mark to value a position at. Root (netuid 0) is 1 by definition; null when the reserves cannot support a price. */
+  spot_price_tao?: Maybe<Scalars['Float']['output']>;
   subnet_volume_tao?: Maybe<Scalars['Float']['output']>;
   tao_in_pool_tao?: Maybe<Scalars['Float']['output']>;
   total_stake_alpha?: Maybe<Scalars['Float']['output']>;
@@ -9109,6 +9111,7 @@ export type SubnetEconomicsResolvers<ContextType = GqlContext, ParentType extend
   registration_allowed?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   registration_cost_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   slug?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  spot_price_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   subnet_volume_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   tao_in_pool_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   total_stake_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -1100,6 +1100,8 @@ export const SDL = /* GraphQL */ `
     slug: String
     emission_share: Float
     alpha_price_tao: Float
+    "The AMM spot price in TAO per alpha, derived at serve time from tao_in_pool_tao / alpha_in_pool on this row (#9408). alpha_price_tao is the chain's MOVING average; this is the mark to value a position at. Root (netuid 0) is 1 by definition; null when the reserves cannot support a price."
+    spot_price_tao: Float
     alpha_market_cap_tao: Float
     alpha_fdv_tao: Float
     "Signed %-change in alpha_price_tao over ~1h. Always null from daily snapshots (#7227)."

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -247,6 +247,7 @@ import {
   resolveLiveEconomics,
   resolveLiveHealth,
   subnetBadgeStatus,
+  withSpotPricedEconomics,
 } from "./health-serving.ts";
 import { loadSubnetProfile } from "./profiles-mcp.ts";
 import {
@@ -1500,9 +1501,12 @@ function loadEconomics(context: GqlContext) {
       env: context.env,
       contractVersion: contractVersion(context.env),
     });
-    if (Array.isArray(live?.data?.subnets)) return live.data;
+    // Spot on every row (#9408 completion), on whichever tier answered.
+    if (Array.isArray(live?.data?.subnets)) {
+      return withSpotPricedEconomics(live.data as Row);
+    }
     const res = await readArtifact(context.env, ARTIFACT.economics);
-    return res.ok ? res.data : null;
+    return res.ok ? withSpotPricedEconomics(res.data as Row) : null;
   });
 }
 

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -2020,6 +2020,29 @@ export function withSpotPrice(
   };
 }
 
+/**
+ * Map a whole economics blob's `subnets` rows through withSpotPrice.
+ *
+ * #9408 reached the subnet-detail card and the registry leaderboards, but the
+ * full-blob surfaces — REST /api/v1/economics, the MCP economics tools and
+ * GraphQL's economics root — kept serving rows without spot while declaring the
+ * field in their schemas. One blob-level helper, called at each surface's
+ * tier-merge point, closes that: whichever tier answered, the rows pass through
+ * here. Null-safe: a blob that is not an object, or has no subnets array, is
+ * returned unchanged.
+ */
+export function withSpotPricedEconomics(
+  blob: Row | null | undefined,
+): Row | null | undefined {
+  if (!blob || typeof blob !== "object") return blob;
+  const rows = blob.subnets;
+  if (!Array.isArray(rows)) return blob;
+  return {
+    ...blob,
+    subnets: (rows as Row[]).map((row) => withSpotPrice(row)),
+  };
+}
+
 export function overlaySubnetEconomics(
   detail: Row | null | undefined,
   economicsBlob: Row | null | undefined,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1197,6 +1197,7 @@ import {
   overlaySubnetHealth,
   resolveLiveEconomics,
   resolveLiveHealth,
+  withSpotPrice,
 } from "./health-serving.ts";
 import {
   buildNeuronDetail,
@@ -2786,7 +2787,9 @@ async function loadSubnetEconomics(ctx: McpCtx, netuid: number) {
     captured_at: blob?.captured_at ?? null,
     summary: blob?.summary ?? null,
     economics:
-      blob?.subnets?.find((row: Row) => row?.netuid === netuid) ?? null,
+      withSpotPrice(
+        blob?.subnets?.find((row: Row) => row?.netuid === netuid),
+      ) ?? null,
   };
 }
 
@@ -3204,9 +3207,13 @@ async function loadEconomicsSubnetRows(ctx: McpCtx) {
     env: ctx.env,
     contractVersion: mcpContractVersion(ctx),
   });
-  if (Array.isArray(live?.data?.subnets)) return live.data.subnets;
+  if (Array.isArray(live?.data?.subnets)) {
+    return live.data.subnets.map((row: Row) => withSpotPrice(row) as Row);
+  }
   const blob = await loadArtifactData(ctx, "/metagraph/economics.json");
-  return Array.isArray(blob?.subnets) ? blob.subnets : [];
+  return Array.isArray(blob?.subnets)
+    ? blob.subnets.map((row: Row) => withSpotPrice(row) as Row)
+    : [];
 }
 
 // AI-dependent tools (semantic_search, ask) need the VECTORIZE + AI bindings and

--- a/src/network-economics.ts
+++ b/src/network-economics.ts
@@ -6,7 +6,10 @@ import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS } from "./contracts.ts";
-import { resolveLiveEconomics } from "./health-serving.ts";
+import {
+  resolveLiveEconomics,
+  withSpotPricedEconomics,
+} from "./health-serving.ts";
 import {
   GetEconomicsInputSchema,
   GetEconomicsOutputSchema,
@@ -165,8 +168,11 @@ export async function loadNetworkEconomics(
   if (!blob || typeof blob !== "object") {
     throw networkEconomicsError("not_found", "Economics snapshot unavailable.");
   }
+  // Spot on every row (#9408 completion), derived BEFORE the query filters so a
+  // `fields` projection treats it like any other column — selectable, and
+  // dropped from a narrowed row rather than force-appended to it.
   const transformed = applyQueryFilters(
-    blob as Record<string, unknown>,
+    withSpotPricedEconomics(blob as Row) as Record<string, unknown>,
     queryUrl,
     "economics",
     [],

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -1983,6 +1983,33 @@ describe("emission-pipeline route", () => {
     assert.equal(r2Sources.validator_count.read_at, "capture");
   });
 
+  // #9408 completion: the full economics blob was the one surface still serving
+  // rows without spot_price_tao while its schema declared the field. Both tiers
+  // pass through the same injection point, so both are asserted here.
+  test("economics rows carry serve-time spot_price_tao on both tiers", async () => {
+    const withReserves = SUBNETS.map((row, i) =>
+      i === 0 ? { ...row, tao_in_pool_tao: 100, alpha_in_pool: 400 } : row,
+    );
+    const live = await getJson(
+      "https://api.metagraph.sh/api/v1/economics",
+      envWithEconomics({ chain_state: CHAIN_STATE, subnets: withReserves }),
+    );
+    assert.equal(live.status, 200);
+    assert.equal(live.body.meta.source, "live-kv");
+    const liveRows = live.body.data.subnets;
+    assert.equal(liveRows[0].spot_price_tao, 0.25);
+    // A row without reserves is an explicit null, never omitted or zero.
+    assert.equal(liveRows[1].spot_price_tao, null);
+
+    // R2 fallback: the committed artifact's rows pass through the same point.
+    const r2 = await getJson(
+      "https://api.metagraph.sh/api/v1/economics?limit=1",
+      envWithEconomics(null),
+    );
+    assert.equal(r2.status, 200);
+    assert.notEqual(r2.body.data.subnets[0].spot_price_tao, undefined);
+  });
+
   test("serves the decomposition with its pinned block", async () => {
     const { status, body } = await getJson(
       "https://api.metagraph.sh/api/v1/chain/emission-pipeline",

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -884,18 +884,53 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     const env = fixtureEnv({
       "/metagraph/economics.json": {
         subnets: [
-          { netuid: 1, name: "Root", emission_share: 0.05, miner_count: 10 },
+          {
+            netuid: 1,
+            name: "Root",
+            emission_share: 0.05,
+            miner_count: 10,
+            tao_in_pool_tao: 100,
+            alpha_in_pool: 400,
+          },
         ],
       },
     });
     const { status, body } = await gql(
-      "{ economics { total subnets { netuid name emission_share miner_count } } }",
+      "{ economics { total subnets { netuid name emission_share miner_count spot_price_tao } } }",
       env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.economics.total, 1);
     assert.equal(body.data.economics.subnets[0].netuid, 1);
     assert.equal(body.data.economics.subnets[0].emission_share, 0.05);
+    // #9408 completion: spot derived at serve time from the row's own reserves.
+    assert.equal(body.data.economics.subnets[0].spot_price_tao, 0.25);
+  });
+
+  test("economics rows carry spot on the live KV tier too (#9408 completion)", async () => {
+    const blob = {
+      contract_version: "test-contract",
+      captured_at: new Date(Date.now() - 60_000).toISOString(),
+      schema_version: 1,
+      summary: { with_economics_count: 1, subnet_count: 1 },
+      subnets: [
+        {
+          netuid: 7,
+          emission_share: 1,
+          tao_in_pool_tao: 50,
+          alpha_in_pool: 200,
+        },
+      ],
+    };
+    const env = fixtureEnv({}, { kv: { "economics:current": blob } });
+    env.METAGRAPH_CONTRACT_VERSION = "test-contract";
+    const { status, body } = await gql(
+      "{ economics { subnets { netuid spot_price_tao } } }",
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.economics.subnets[0].netuid, 7);
+    assert.equal(body.data.economics.subnets[0].spot_price_tao, 0.25);
   });
 
   test("economics exposes the network-value summary rollup (#6641)", async () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -9447,6 +9447,8 @@ describe("MCP economics + metagraph data tools", () => {
     total_stake_alpha: 1000,
     max_stake_alpha: 5000,
     alpha_price_tao: 0.06,
+    tao_in_pool_tao: 100,
+    alpha_in_pool: 400,
   };
   const ECON_BLOB = {
     contract_version: "test-contract",
@@ -9475,6 +9477,8 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.netuid, 7);
     assert.equal(out.economics.open_slots, 3);
     assert.equal(out.economics.registration_cost_tao, 0.5);
+    // #9408 completion: spot derived at serve time from the row's own reserves.
+    assert.equal(out.economics.spot_price_tao, 0.25);
     assert.equal(out.summary.with_economics_count, 1);
     assert.equal(out.captured_at, FRESH_RUN);
   });
@@ -9491,6 +9495,8 @@ describe("MCP economics + metagraph data tools", () => {
     const out = res.body.result.structuredContent;
     assert.equal(out.source, "r2-fallback");
     assert.equal(out.economics.netuid, 7);
+    // Spot rides the R2 fallback tier too — same serve-time derivation.
+    assert.equal(out.economics.spot_price_tao, 0.25);
   });
 
   test("get_subnet_economics falls back to R2 when the KV blob is off-contract", async () => {

--- a/tests/network-economics.test.ts
+++ b/tests/network-economics.test.ts
@@ -165,6 +165,32 @@ describe("network-economics — loadNetworkEconomics", () => {
     );
   });
 
+  test("every returned row carries serve-time spot_price_tao (#9408 completion)", async () => {
+    const blob = {
+      ...ECON_BLOB,
+      subnets: [
+        // Root: 1 by definition (no AMM), reserves or not.
+        { ...ECON_ROW, netuid: 0 },
+        { ...ECON_ROW, netuid: 7, tao_in_pool_tao: 100, alpha_in_pool: 400 },
+        // No reserves on the row → explicit null, never 0 (0 would read as free).
+        { ...ECON_ROW, netuid: 9 },
+      ],
+    };
+    const out = await loadNetworkEconomics(
+      makeCtx(),
+      { sort: "netuid", order: "asc" },
+      makeDeps(blob),
+    );
+    assert.deepEqual(
+      out.subnets.map((row) => [row.netuid, row.spot_price_tao]),
+      [
+        [0, 1],
+        [7, 0.25],
+        [9, null],
+      ],
+    );
+  });
+
   test("null-fills optional envelope fields and tolerates missing subnets[]", async () => {
     const out = await loadNetworkEconomics(
       makeCtx(),

--- a/tests/subnet-economics-overlay.test.ts
+++ b/tests/subnet-economics-overlay.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import { overlaySubnetEconomics } from "../src/health-serving.ts";
+import {
+  overlaySubnetEconomics,
+  withSpotPricedEconomics,
+} from "../src/health-serving.ts";
 import type { Row } from "./row-type.ts";
 
 const blob = {
@@ -51,4 +54,30 @@ test("overlaySubnetEconomics leaves detail unchanged when no row matches", () =>
 test("overlaySubnetEconomics returns a non-object detail untouched", () => {
   assert.equal(overlaySubnetEconomics(null, blob, 1), null);
   assert.equal(overlaySubnetEconomics(undefined, blob, 1), undefined);
+});
+
+test("withSpotPricedEconomics derives spot on every row (#9408 completion)", () => {
+  const out = withSpotPricedEconomics({
+    captured_at: "t",
+    subnets: [
+      // Root has no AMM: 1 by definition, reserves or not.
+      { netuid: 0, alpha_price_tao: 1 },
+      { netuid: 7, tao_in_pool_tao: 100, alpha_in_pool: 400 },
+      // Reserves that cannot support a price → explicit null, never 0.
+      { netuid: 9, tao_in_pool_tao: null, alpha_in_pool: null },
+    ],
+  }) as Row;
+  assert.equal(out.subnets[0].spot_price_tao, 1);
+  assert.equal(out.subnets[1].spot_price_tao, 0.25);
+  assert.equal(out.subnets[2].spot_price_tao, null);
+  // The rest of the blob rides along unchanged.
+  assert.equal(out.captured_at, "t");
+});
+
+test("withSpotPricedEconomics is null-safe on cold or malformed blobs", () => {
+  assert.equal(withSpotPricedEconomics(null), null);
+  assert.equal(withSpotPricedEconomics(undefined), undefined);
+  assert.deepEqual(withSpotPricedEconomics({ summary: {} }), { summary: {} });
+  const noArray = { subnets: "nope" } as unknown as Row;
+  assert.deepEqual(withSpotPricedEconomics(noArray), noArray);
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -317,6 +317,7 @@ import {
   overlaySubnetHealth,
   resolveLiveEconomics,
   resolveLiveHealth,
+  withSpotPricedEconomics,
 } from "../src/health-serving.ts";
 import {
   deriveNetuidGroupedAliases,
@@ -6309,6 +6310,12 @@ async function handleApiRequest(
   }
 
   let baseData = live ? live.data : artifact.data;
+  // Spot on every economics row (#9408 completion): the detail card and the
+  // leaderboards already derive spot_price_tao at serve time; the full blob was
+  // the one surface still without it. Both tiers pass through this point.
+  if (matched.id === "economics") {
+    baseData = withSpotPricedEconomics(baseData as Row) as typeof baseData;
+  }
   // Per-subnet economics overlay (#1308): attach the live economics row so
   // /api/v1/subnets/{netuid} carries validator/miner counts, registration, stake
   // and alpha price in one call. Null-safe — a cold/stale economics tier leaves


### PR DESCRIPTION
Closes #9437.

#9409 derived spot at serve time for the subnet-detail card and the registry leaderboards, but every surface serving the FULL economics blob kept returning rows without `spot_price_tao` while declaring the field in its schema. Verified live before this change: `GET /api/v1/economics` rows carry no `spot_price_tao` and `alpha_price_tao` is byte-identical to `moving_price_pinned`.

## What

One blob-level helper, `withSpotPricedEconomics`, applied at each surface's tier-merge point — whichever tier answered, the rows pass through it:

- `workers/api.ts` — the one point both tiers of the generic economics route pass through (mirrors the #9408 leaderboards approach).
- `src/network-economics.ts` — applied BEFORE `applyQueryFilters`, so a `fields` projection treats spot like any other column: selectable, and dropped from a narrowed row rather than force-appended (the alternative broke the existing projection contract test, which is how the placement was chosen).
- `src/mcp-server.ts` — the single-row wrap in `loadSubnetEconomics`, and both tiers of `loadEconomicsSubnetRows` (feeds `get_registry_leaderboards`, `get_domain_summary`, `compare_subnets`).
- `src/graphql.ts` + `src/graphql-sdl.ts` — the economics root's rows, and the `SubnetEconomics.spot_price_tao` field the SDL never declared (generated types committed).

Semantics unchanged from #9409: root (netuid 0) is 1 by definition; reserves that cannot support a price yield an explicit null, never 0. No schema-src changes — the REST/MCP row schema already declared the field, so no openapi regen is needed; `field_sources` already carries the `reconstructed` provenance entry.

## Tests

- `withSpotPricedEconomics` unit branches (root / derived / null-reserves / cold / malformed).
- REST both tiers (live-KV and R2 fallback) on `/api/v1/economics`.
- MCP `get_subnet_economics` live + R2 assertions; `get_economics` row mapping incl. the fields-projection contract staying intact.
- GraphQL economics root on both tiers, including the new SDL field.

Scoped run: 2,527 tests green; changed-line coverage verified by lcov x diff intersection (the single untaken branch direction is the non-economics side of one route check, exercised broadly by the full suite).