### PR TITLE
fix(observability): report the verdicts and faults that currently reach nobody

### DIFF
--- a/src/lakehouse-seam-watchdog.ts
+++ b/src/lakehouse-seam-watchdog.ts
@@ -34,6 +34,12 @@
 // them duplicated as a repository secret, plus a third-party trigger hop, to
 // ask a question the Worker can ask itself.
 import { r2SqlQuery } from "./r2-sql.ts";
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+import {
+  recordLaneVerdict,
+  type LaneHealthDb,
+  type LaneHealthRecord,
+} from "./lane-health.ts";
 import { blocksSeamFloor } from "./blocks-cold-tier.ts";
 import {
   DECODE_WATERMARK_KEY,
@@ -247,14 +253,35 @@ async function capturedThrough(env: unknown): Promise<number | null> {
  * tick that cannot run is one missed report, not an outage, and a cron that
  * throws is a cron nobody can read the result of.
  */
+/** This watchdog's lane name in `lane_health`, and on the self-health card. */
+const LAKEHOUSE_SEAM_LANE = "lakehouse-seam";
+
+/** One verdict minus the fields recordVerdict fills in for every call. */
+type LaneVerdictInput = Omit<LaneHealthRecord, "lane" | "checked_at">;
+
 export async function runLakehouseSeamWatchdog(
   env: Parameters<typeof r2SqlQuery>[0],
   // Injectable so the MEASURED path is testable without a lakehouse. Same seam
   // as r2-sql.ts's scheduleAbort and webhooks.ts's sleepFn: a branch that can
   // only run against live infrastructure is a branch nothing verifies.
-  deps: { query?: typeof r2SqlQuery; now?: () => number } = {},
+  deps: {
+    query?: typeof r2SqlQuery;
+    now?: () => number;
+    laneHealthDb?: LaneHealthDb;
+    recordExceptionEvent?: typeof recordExceptionEvent;
+  } = {},
 ): Promise<Record<string, unknown>> {
   const query = deps.query ?? r2SqlQuery;
+  const laneHealthDb =
+    deps.laneHealthDb ??
+    ((env as { METAGRAPH_HEALTH_DB?: LaneHealthDb })?.METAGRAPH_HEALTH_DB as
+      LaneHealthDb | undefined);
+  const recordVerdict = (verdict: LaneVerdictInput) =>
+    recordLaneVerdict(laneHealthDb, {
+      lane: LAKEHOUSE_SEAM_LANE,
+      ...verdict,
+      checked_at: (deps.now ?? Date.now)(),
+    });
   const rows = await query(
     env,
     "SELECT min(block_number) AS lo, max(block_number) AS hi, count(*) AS n FROM chain.blocks",
@@ -263,6 +290,15 @@ export async function runLakehouseSeamWatchdog(
   // a query fails. Unconfigured is not a fault -- self-hosters and CI have no
   // lakehouse -- so it is reported as skipped rather than as drift.
   if (rows === null) {
+    // ...but it is equally not a MEASUREMENT, and `unknown` is the vocabulary's
+    // own word for that. Recording it is what distinguishes a lakehouse this
+    // watchdog cannot reach from a seam it checked and found correct -- before
+    // this, both produced exactly nothing.
+    await recordVerdict({
+      verdict: "unknown",
+      age_ms: null,
+      detail: "lakehouse_unavailable",
+    });
     return {
       ok: false,
       skipped: true,
@@ -283,6 +319,43 @@ export async function runLakehouseSeamWatchdog(
     hi: num(row?.hi),
     count: num(row?.n),
     now: (deps.now ?? Date.now)(),
+  });
+
+  // #9440: NOTIFY on drift, and RECORD on every tick.
+  //
+  // This watchdog previously did neither. It computed `reasons` correctly and
+  // returned them to `handleScheduled`, whose return value
+  // workers/api.entry.ts discards -- so a drifted decode seam was measured
+  // every tick and reported to nobody, on any channel. Its siblings have had
+  // the notification half since #9330 and the durable half since #9340/#9431;
+  // this one was simply never wired to either.
+  if (reasons.length > 0) {
+    const record = deps.recordExceptionEvent ?? recordExceptionEvent;
+    await record(env as never, {
+      error: new Error(`lakehouse decode seam drifted: ${reasons.join(", ")}`),
+      route: "watchdog:lakehouse-seam",
+      errorCode: "stale_lane",
+    }).catch(() => false);
+  }
+
+  // PostHog is the notification path, never the record: it drops $exception
+  // once the free-tier quota is exhausted, which is the failure lane_health
+  // exists for (see src/lane-health.ts). Written on EVERY tick, because a
+  // healthy seam's output is silence and silence cannot be told from a
+  // watchdog that stopped running.
+  //
+  // Never throws -- see recordLaneVerdict.
+  await recordVerdict({
+    verdict: reasons.length > 0 ? "stale" : "ok",
+    // Null, and not for want of trying: this watchdog measures a seam in
+    // BLOCK NUMBERS (how far the published watermark trails what the lakehouse
+    // holds), and there is no clock reading that converts to it honestly. The
+    // per-lane watchdogs report an age because their lag genuinely is a
+    // duration; inventing one here would put a fabricated number in the column
+    // triage reads. The distances live in `detail`, which carries the reasons
+    // verbatim.
+    age_ms: null,
+    detail: reasons.length > 0 ? reasons.join(",") : null,
   });
 
   return {

--- a/src/safe-mode-watchdog.ts
+++ b/src/safe-mode-watchdog.ts
@@ -32,6 +32,7 @@
 // that the monitor is broken. The summary line prints every run for that
 // reason, matching check-emission-drift.ts.
 import { bytesToHex, storageMapPrefix } from "../src/twox-storage-key.ts";
+import { recordExceptionEvent } from "./usage-telemetry.ts";
 
 /** Public archive RPC. A var, not a secret: the endpoint is public. */
 export const SAFE_MODE_RPC_URL_DEFAULT = "https://archive.chain.opentensor.ai";
@@ -148,9 +149,13 @@ async function safeModeExtrinsics(
  */
 export async function runSafeModeWatchdog(
   env: Record<string, unknown> | null | undefined,
-  deps: { fetchImpl?: Fetcher } = {},
+  deps: {
+    fetchImpl?: Fetcher;
+    recordExceptionEvent?: typeof recordExceptionEvent;
+  } = {},
 ): Promise<Record<string, unknown>> {
   const doFetch = deps.fetchImpl ?? fetch;
+  const record = deps.recordExceptionEvent ?? recordExceptionEvent;
   const rpcUrl = String(env?.SAFE_MODE_RPC_URL || SAFE_MODE_RPC_URL_DEFAULT);
   const apiBase = String(env?.SAFE_MODE_API_BASE || SAFE_MODE_API_BASE_DEFAULT);
   try {
@@ -165,6 +170,24 @@ export async function runSafeModeWatchdog(
       enteredUntil: entered,
       extrinsics,
     });
+    // #9440: this watchdog reported on NO channel at all. It computed
+    // `reasons` correctly and returned them to handleScheduled, whose return
+    // value workers/api.entry.ts discards -- so the chain entering SafeMode,
+    // the single most consequential event this repo watches for, was detected
+    // every tick and told to nobody.
+    //
+    // Notification only, deliberately no lane_health row: that table backs the
+    // PUBLIC self-health card, whose vocabulary is ok/stale/unknown and whose
+    // consumers read a non-ok lane as "our data is behind". SafeMode is a
+    // CHAIN condition, not a staleness of ours -- filing it as a stale lane
+    // would publish a false statement about our own freshness.
+    if (reasons.length > 0) {
+      await record(env as never, {
+        error: new Error(`SafeMode watchdog: ${reasons.join(", ")}`),
+        route: "watchdog:safe-mode",
+        errorCode: "safe_mode_active",
+      }).catch(() => false);
+    }
     return {
       // `ok` describes whether the TICK ran, not whether SafeMode is quiet.
       ok: true,
@@ -173,6 +196,15 @@ export async function runSafeModeWatchdog(
       ...summary,
     };
   } catch (err) {
+    // A tick that cannot run is one missed report -- but an UNREACHABLE
+    // SafeMode monitor is itself worth reporting, because its silence is
+    // indistinguishable from "the chain is fine". That equivalence is the
+    // whole reason this monitor exists.
+    await record(env as never, {
+      error: err,
+      route: "watchdog:safe-mode",
+      errorCode: "watchdog_unreachable",
+    }).catch(() => false);
     return {
       ok: false,
       reason: "unreachable",

--- a/tests/alerter-hub.test.ts
+++ b/tests/alerter-hub.test.ts
@@ -2025,3 +2025,161 @@ test("#8997: telemetry never fails the evaluation", async () => {
     globalThis.fetch = original;
   }
 });
+
+// --- #9440: trigger-refresh failure telemetry --------------------------------
+//
+// #8997 gave this class delivery telemetry, which covers "an endpoint is
+// broken". It does not cover the quieter and worse failure: a hub whose
+// trigger cache stops refreshing keeps evaluating every chain event against
+// whatever it last loaded, forever. Deliveries still fire, so the
+// failures-only delivery event stays silent, and triggers created, edited or
+// deactivated after the failure simply never take effect.
+//
+// Bounded by ALERTER_HUB_TRIGGER_CACHE_TTL_MS (5 min), which gates the refresh
+// attempt itself -- so unlike a per-evaluation event this cannot scale with
+// chain activity.
+
+test("#9440: a THROWN trigger refresh emits one usage_event", async () => {
+  const cap = captureTelemetry();
+  try {
+    const hub = new AlerterHub(
+      STATE,
+      mockEnv({
+        ...TELEMETRY_ENV,
+        DATA_API: fakeDataApi(async () => {
+          throw new Error("data-api unreachable");
+        }),
+        ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+      }),
+    );
+    await hub.refreshTriggers();
+
+    const usage = cap.posted.filter(
+      (p) => (p.body as Row).event === "usage_event",
+    );
+    assert.equal(usage.length, 1);
+    const props = (usage[0].body as Row).properties as Row;
+    assert.equal(props.route, "alerter-hub:trigger-refresh");
+    assert.equal(props.ok, false);
+  } finally {
+    cap.restore();
+  }
+});
+
+test("#9440: a NON-2XX trigger refresh is reported identically", async () => {
+  // The same silent-stale-cache failure through a different door: a 500 left
+  // the cache untouched and said nothing. From the hub's side the two are the
+  // same event -- the refresh did not happen.
+  const cap = captureTelemetry();
+  try {
+    const hub = new AlerterHub(
+      STATE,
+      mockEnv({
+        ...TELEMETRY_ENV,
+        DATA_API: fakeDataApi(
+          async () => new Response("nope", { status: 500 }),
+        ),
+        ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+      }),
+    );
+    await hub.refreshTriggers();
+
+    const usage = cap.posted.filter(
+      (p) => (p.body as Row).event === "usage_event",
+    );
+    assert.equal(usage.length, 1);
+    assert.equal(
+      ((usage[0].body as Row).properties as Row).route,
+      "alerter-hub:trigger-refresh",
+    );
+    // The stale cache is still served -- the degradation is correct and stays.
+    assert.equal(hub.triggersLoadedAt, 0);
+  } finally {
+    cap.restore();
+  }
+});
+
+test("#9440: a SUCCESSFUL trigger refresh emits nothing", async () => {
+  const cap = captureTelemetry();
+  try {
+    const hub = new AlerterHub(
+      STATE,
+      mockEnv({
+        ...TELEMETRY_ENV,
+        DATA_API: fakeDataApi(
+          async () =>
+            new Response(JSON.stringify({ triggers: [] }), { status: 200 }),
+        ),
+        ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+      }),
+    );
+    await hub.refreshTriggers();
+
+    assert.deepEqual(
+      cap.posted.filter((p) => (p.body as Row).event === "usage_event"),
+      [],
+    );
+  } finally {
+    cap.restore();
+  }
+});
+
+// --- #9440: evaluate() faults reach PostHog ----------------------------------
+//
+// This class imported no exception capture at all, and ChainFirehoseHub's
+// ping swallowed the rejection -- so a hub failing BEFORE it reached any
+// delivery produced nothing on either side of the boundary: no
+// delivery-failure event (none was attempted), no exception. Alerting stopped
+// silently.
+
+test("#9440: a thrown evaluate() is captured and still propagates", async () => {
+  const cap = captureTelemetry();
+  try {
+    const hub = new AlerterHub(STATE, mockEnv(TELEMETRY_ENV));
+    // Force the fault inside evaluate() itself.
+    hub.evaluate = async () => {
+      throw new Error("evaluate exploded");
+    };
+    await assert.rejects(
+      hub.fetch(
+        new Request("https://alerter-hub.internal/evaluate", {
+          method: "POST",
+          body: JSON.stringify({ table: "account_events", netuid: 7 }),
+        }),
+      ),
+      /evaluate exploded/,
+    );
+
+    const exceptions = cap.posted.filter(
+      (p) => (p.body as Row).event === "$exception",
+    );
+    assert.equal(exceptions.length, 1);
+    const props = (exceptions[0].body as Row).properties as Row;
+    assert.equal(props.route, "alerter-hub:evaluate");
+    assert.equal(props.error_code, "internal_error");
+  } finally {
+    cap.restore();
+  }
+});
+
+test("#9440: a successful evaluate() captures nothing", async () => {
+  const cap = captureTelemetry();
+  try {
+    const hub = new AlerterHub(STATE, mockEnv(TELEMETRY_ENV));
+    hub.triggers = [];
+    hub.triggersLoadedAt = Date.now();
+    const res = await hub.fetch(
+      new Request("https://alerter-hub.internal/evaluate", {
+        method: "POST",
+        body: JSON.stringify({ table: "account_events", netuid: 7 }),
+      }),
+    );
+    assert.equal(res.status, 200);
+    assert.deepEqual(
+      cap.posted.filter((p) => (p.body as Row).event === "$exception"),
+      [],
+    );
+  } finally {
+    cap.restore();
+  }
+});

--- a/tests/chain-firehose-hub.test.ts
+++ b/tests/chain-firehose-hub.test.ts
@@ -43,8 +43,11 @@ import {
   parseChainFirehoseTopics,
   validateChainEventsSubscribePayload,
   validateChainFirehoseIngestPayload,
+  shouldEmitAlerterUnreachable,
+  ALERTER_UNREACHABLE_EVENT_WINDOW_MS,
 } from "../workers/chain-firehose-hub.ts";
 import { MCP_CHAIN_STREAM_RESOURCE_URI } from "../workers/mcp-session-hub.ts";
+import { resetModuleState } from "../src/module-state-registry.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 
 // SseClientEntry/ChainEventSubscriberEntry aren't exported from the source
@@ -2231,4 +2234,46 @@ test("#8997: telemetry never fails a connection operation", () => {
   } finally {
     globalThis.fetch = original;
   }
+});
+
+// --- #9440: reporting an unreachable AlerterHub ------------------------------
+//
+// broadcast() pings AlerterHub once per chain event, and that ping's catch was
+// bare. It was the outer half of an end-to-end blind spot: AlerterHub records
+// only failed DELIVERIES, so a hub that is unreachable, timing out, or
+// throwing before it reaches a trigger delivers nothing and reports nothing --
+// and this side swallowed the evidence. Alerting could stop completely with no
+// signal on either side of the boundary.
+//
+// The guard is what keeps reporting it affordable: an unbounded capture here
+// would emit thousands per hour during exactly the incident it exists to
+// report, on a project already over its PostHog allowance (#9004).
+
+test("#9440: the alerter-unreachable guard admits once per window", () => {
+  // The guard is isolate-global by design (that is what bounds the cost), so
+  // a test asserting its window has to start from a known state -- earlier
+  // tests in this file drive broadcast() against hubs with no ALERTER_HUB
+  // binding and legitimately trip it.
+  resetModuleState();
+  const t0 = 1_000_000;
+  assert.equal(shouldEmitAlerterUnreachable(t0), true);
+  assert.equal(shouldEmitAlerterUnreachable(t0 + 1), false);
+  assert.equal(
+    shouldEmitAlerterUnreachable(t0 + ALERTER_UNREACHABLE_EVENT_WINDOW_MS - 1),
+    false,
+  );
+  // One event per window is enough to say "alerting is down"; the duration of
+  // the outage is visible from the run of them.
+  assert.equal(
+    shouldEmitAlerterUnreachable(t0 + ALERTER_UNREACHABLE_EVENT_WINDOW_MS),
+    true,
+  );
+});
+
+test("#9440: the guard's state does not leak across test files", () => {
+  // Registered with the module-state registry, so a burst in one file cannot
+  // suppress the first capture in the next -- the cross-file channel that
+  // registry exists to close.
+  resetModuleState();
+  assert.equal(shouldEmitAlerterUnreachable(1), true);
 });

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -429,9 +429,19 @@ test("a body stream that errors mid-read still records ok:false on the trace spa
   } finally {
     globalThis.fetch = original;
   }
-  expect(posted.length).toBe(1);
-  const span = posted[0].body.resourceSpans[0].scopeSpans[0].spans[0];
+  // #9440: an uncaught fault now posts TWO things -- the span this test was
+  // written for, and an $exception carrying the stack. Selected by shape
+  // rather than by index so neither assertion depends on POST ordering.
+  const spans = posted.filter((p) => p.body.resourceSpans);
+  expect(spans.length).toBe(1);
+  const span = spans[0].body.resourceSpans[0].scopeSpans[0].spans[0];
   expect(span.status.code).toBe(2); // ERROR
+
+  const exceptions = posted.filter((p) => p.body.event === "$exception");
+  expect(exceptions.length).toBe(1);
+  expect(exceptions[0].body.properties.route).toBe(
+    "/api/v1/internal/neurons-sync",
+  );
 });
 
 // POST /api/v1/internal/backfill-neuron-daily -- deep-history ingest for

--- a/tests/freshness-watchdog.test.ts
+++ b/tests/freshness-watchdog.test.ts
@@ -317,3 +317,134 @@ test("waitUntil receives the telemetry write when a context is present", async (
   assert.equal(res.reported, true);
   assert.equal(scheduled.length, 1);
 });
+
+// ---- the durable record (#9440) ----
+//
+// shouldReport deliberately suppresses a repeat of the same signature, so a
+// lane critical for six hours notifies once and then goes quiet -- correct for
+// a notification, useless as a record. Everything this watchdog computed lived
+// only in the return value, and workers/api.entry.ts discards what `scheduled`
+// returns: measured every tick, then dropped. These pin the row per tick.
+
+function laneHealthSpy() {
+  const rows: Record<string, unknown>[] = [];
+  return {
+    rows,
+    db: {
+      prepare: (sql: string) => ({
+        bind: (...values: unknown[]) => ({
+          run: async () => {
+            // Only the INSERT carries a verdict; recordLaneVerdict also issues
+            // a retention DELETE on the way through.
+            if (sql.startsWith("INSERT")) {
+              rows.push({
+                lane: values[0],
+                verdict: values[1],
+                age_ms: values[2],
+                detail: values[3],
+              });
+            }
+          },
+        }),
+      }),
+    },
+  };
+}
+
+test("records an ok verdict on a tick that found nothing stale", async () => {
+  const spy = laneHealthSpy();
+  await runFreshnessWatchdog(envWith(undefined), undefined, {
+    // Timestamped against the REAL clock, not the NOW fixture the pure
+    // evaluateFreshness tests use: this path calls Date.now() itself, so a
+    // fixture-dated source reads as stale by however long ago the fixture is.
+    readArtifact: (async () => ({
+      sources: [source({ timestamp: new Date().toISOString() })],
+    })) as never,
+    laneHealthDb: spy.db as never,
+  });
+  assert.equal(spy.rows.length, 1);
+  assert.equal(spy.rows[0].lane, "freshness");
+  assert.equal(spy.rows[0].verdict, "ok");
+  assert.equal(spy.rows[0].detail, null);
+});
+
+test("records a stale verdict naming the sources, not just a count", async () => {
+  const spy = laneHealthSpy();
+  await runFreshnessWatchdog(envWith(undefined), undefined, {
+    readArtifact: (async () => staleArtifact) as never,
+    laneHealthDb: spy.db as never,
+  });
+  assert.equal(spy.rows.length, 1);
+  assert.equal(spy.rows[0].verdict, "stale");
+  // "which source" is the first question asked of a stale verdict, and the
+  // count is derivable from the names -- not the other way round.
+  assert.ok(String(spy.rows[0].detail).includes("a"));
+});
+
+test("records a row on EVERY tick, including one shouldReport suppresses", async () => {
+  const spy = laneHealthSpy();
+  const signature = evaluateFreshness(
+    staleArtifact.sources,
+    Date.now(),
+  ).signature;
+  const res = (await runFreshnessWatchdog(
+    envWith({ get: async () => signature, put: async () => {} }),
+    undefined,
+    {
+      readArtifact: (async () => staleArtifact) as never,
+      laneHealthDb: spy.db as never,
+    },
+  )) as Record<string, unknown>;
+  // The notification is correctly suppressed as a repeat...
+  assert.equal(res.reported, false);
+  // ...and the record is written anyway. This is the case the whole change
+  // exists for: a stall in its sixth hour notifies nobody and must still be
+  // visible somewhere.
+  assert.equal(spy.rows.length, 1);
+  assert.equal(spy.rows[0].verdict, "stale");
+});
+
+test("records `unknown` when the artifact cannot be read", async () => {
+  const spy = laneHealthSpy();
+  const res = (await runFreshnessWatchdog(envWith(undefined), undefined, {
+    readArtifact: (async () => null) as never,
+    laneHealthDb: spy.db as never,
+  })) as Record<string, unknown>;
+  assert.equal(res.ok, false);
+  assert.equal(spy.rows.length, 1);
+  // NOT a synonym for ok: the watchdog could not evaluate the lane at all.
+  // Without this row, a watchdog that cannot read its own artifact and one
+  // reporting everything fresh both produce silence.
+  assert.equal(spy.rows[0].verdict, "unknown");
+  assert.equal(spy.rows[0].detail, "artifact_unavailable");
+});
+
+test("records `unknown` when the tick throws outright", async () => {
+  const spy = laneHealthSpy();
+  const res = (await runFreshnessWatchdog(envWith(undefined), undefined, {
+    readArtifact: (async () => {
+      throw new Error("R2 unreachable");
+    }) as never,
+    laneHealthDb: spy.db as never,
+  })) as Record<string, unknown>;
+  assert.equal(res.ok, false);
+  assert.equal(spy.rows.length, 1);
+  assert.equal(spy.rows[0].verdict, "unknown");
+  assert.equal(spy.rows[0].detail, "unreachable");
+});
+
+test("a lane_health write that fails never breaks the tick", async () => {
+  // D1 migrations here are applied by hand, so an unapplied migration means
+  // "no such table" on a live deployment. A watchdog whose alarm-recording
+  // broke its alarm would be worse than the bug being fixed.
+  const res = (await runFreshnessWatchdog(envWith(undefined), undefined, {
+    readArtifact: (async () => staleArtifact) as never,
+    laneHealthDb: {
+      prepare: () => {
+        throw new Error("no such table: lane_health");
+      },
+    } as never,
+  })) as Record<string, unknown>;
+  assert.equal(res.ok, true);
+  assert.equal(res.stale_count, 1);
+});

--- a/tests/lakehouse-seam-watchdog.test.ts
+++ b/tests/lakehouse-seam-watchdog.test.ts
@@ -511,3 +511,115 @@ describe("the cron wiring", () => {
     );
   });
 });
+
+// ---- reporting the verdict (#9440) ----
+//
+// This watchdog previously reported on NO channel at all: it computed
+// `reasons` correctly and returned them to handleScheduled, whose return value
+// workers/api.entry.ts discards. A drifted decode seam was measured every tick
+// and told to nobody. Its siblings have had the notification half since #9330
+// and the durable half since #9340/#9431.
+describe("the watchdog's own reporting", () => {
+  function spies() {
+    const rows: Record<string, unknown>[] = [];
+    const captures: Record<string, unknown>[] = [];
+    return {
+      rows,
+      captures,
+      deps: {
+        laneHealthDb: {
+          prepare: (sql: string) => ({
+            bind: (...values: unknown[]) => ({
+              run: async () => {
+                if (sql.startsWith("INSERT")) {
+                  rows.push({
+                    lane: values[0],
+                    verdict: values[1],
+                    age_ms: values[2],
+                    detail: values[3],
+                  });
+                }
+              },
+            }),
+          }),
+        } as never,
+        recordExceptionEvent: (async (_env: unknown, event: unknown) => {
+          captures.push(event as Record<string, unknown>);
+          return true;
+        }) as never,
+      },
+    };
+  }
+
+  test("a healthy tick records ok and notifies nobody", async () => {
+    const s = spies();
+    await runLakehouseSeamWatchdog(
+      env({
+        body: { decoded_through: HI, updated_at: "2026-08-03T11:40:00Z" },
+      }) as never,
+      { query: measured(), now: () => NOW, ...s.deps },
+    );
+    assert.equal(s.rows.length, 1, "a row per tick, healthy or not");
+    assert.equal(s.rows[0].lane, "lakehouse-seam");
+    assert.equal(s.rows[0].verdict, "ok");
+    assert.equal(s.rows[0].detail, null);
+    assert.deepEqual(s.captures, [], "a healthy seam pages no one");
+  });
+
+  test("a drifted tick both notifies and records", async () => {
+    const s = spies();
+    await runLakehouseSeamWatchdog(
+      env({
+        body: { decoded_through: HI, updated_at: "2026-08-01T00:00:00Z" },
+      }) as never,
+      { query: measured(), now: () => NOW, ...s.deps },
+    );
+    assert.equal(s.captures.length, 1);
+    assert.equal(s.captures[0].route, "watchdog:lakehouse-seam");
+    assert.equal(s.captures[0].errorCode, "stale_lane");
+    assert.match(
+      (s.captures[0].error as Error).message,
+      /lakehouse decode seam drifted/,
+    );
+    assert.equal(s.rows.length, 1);
+    assert.equal(s.rows[0].verdict, "stale");
+    assert.ok(String(s.rows[0].detail).length > 0);
+    // Measured in BLOCK NUMBERS, not time -- inventing a duration here would
+    // put a fabricated number in the column triage reads.
+    assert.equal(s.rows[0].age_ms, null);
+  });
+
+  test("an unreachable lakehouse records `unknown`, never silence", async () => {
+    const s = spies();
+    const result = await runLakehouseSeamWatchdog({} as never, s.deps);
+    assert.equal(result.skipped, true);
+    assert.equal(s.rows.length, 1);
+    // Not a synonym for ok: nothing was measured. Before this, a lakehouse
+    // this watchdog cannot reach and a seam it checked and found correct both
+    // produced exactly nothing.
+    assert.equal(s.rows[0].verdict, "unknown");
+    assert.equal(s.rows[0].detail, "lakehouse_unavailable");
+    assert.deepEqual(s.captures, [], "unreachable is not drift");
+  });
+
+  test("a lane_health write that fails never breaks the tick", async () => {
+    // D1 migrations here are applied by hand, so "no such table" is a real
+    // production state until someone applies one.
+    const result = await runLakehouseSeamWatchdog(
+      env({
+        body: { decoded_through: HI, updated_at: "2026-08-03T11:40:00Z" },
+      }) as never,
+      {
+        query: measured(),
+        now: () => NOW,
+        laneHealthDb: {
+          prepare: () => {
+            throw new Error("no such table: lane_health");
+          },
+        } as never,
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.drifted, false);
+  });
+});

--- a/tests/registry-sync-api.test.ts
+++ b/tests/registry-sync-api.test.ts
@@ -675,9 +675,17 @@ test("a body stream that errors mid-read still records ok:false on the trace spa
   } finally {
     globalThis.fetch = original;
   }
-  expect(calls.length).toBe(1);
-  const span = calls[0].body.resourceSpans[0].scopeSpans[0].spans[0];
+  // #9440: an uncaught fault now posts TWO things -- the span this test was
+  // written for, and an $exception carrying the stack. Selected by shape
+  // rather than by index so neither assertion depends on POST ordering.
+  const spans = calls.filter((c) => c.body.resourceSpans);
+  expect(spans.length).toBe(1);
+  const span = spans[0].body.resourceSpans[0].scopeSpans[0].spans[0];
   expect(span.status.code).toBe(2); // ERROR
+
+  const exceptions = calls.filter((c) => c.body.event === "$exception");
+  expect(exceptions.length).toBe(1);
+  expect(exceptions[0].body.properties.route).toBe("registry-sync");
 });
 
 // Hyperdrive's connection-retry tests (METAGRAPHED-7) are gone with Hyperdrive:

--- a/tests/safe-mode-watchdog.test.ts
+++ b/tests/safe-mode-watchdog.test.ts
@@ -249,3 +249,92 @@ describe("SafeMode alerting rule (#8696)", () => {
     assert.equal(result.detail, "socket closed");
   });
 });
+
+// ---- reporting (#9440) ----
+//
+// This watchdog reported on NO channel. It computed `reasons` correctly and
+// returned them to handleScheduled, whose return value workers/api.entry.ts
+// discards -- so the chain entering SafeMode, the most consequential event this
+// repo watches for, was detected every tick and told to nobody.
+describe("the watchdog's own reporting", () => {
+  function captureSpy() {
+    const captures: Record<string, unknown>[] = [];
+    return {
+      captures,
+      recordExceptionEvent: (async (_env: unknown, event: unknown) => {
+        captures.push(event as Record<string, unknown>);
+        return true;
+      }) as never,
+    };
+  }
+
+  const quietChain = (async (url: string) =>
+    String(url).includes("/api/v1/extrinsics")
+      ? new Response(JSON.stringify({ ok: true, data: { extrinsics: [] } }), {
+          status: 200,
+        })
+      : new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: null }), {
+          status: 200,
+        })) as unknown as typeof fetch;
+
+  const pausedChain = (async (url: string) =>
+    String(url).includes("/api/v1/extrinsics")
+      ? new Response(JSON.stringify({ ok: true, data: { extrinsics: [] } }), {
+          status: 200,
+        })
+      : new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0x1234" }),
+          { status: 200 },
+        )) as unknown as typeof fetch;
+
+  test("an ACTIVE pause is reported, not merely returned", async () => {
+    const spy = captureSpy();
+    const result = await runSafeModeWatchdog(null, {
+      fetchImpl: pausedChain,
+      recordExceptionEvent: spy.recordExceptionEvent,
+    });
+    assert.equal(result.alerted, true);
+    assert.equal(spy.captures.length, 1);
+    assert.equal(spy.captures[0].route, "watchdog:safe-mode");
+    assert.equal(spy.captures[0].errorCode, "safe_mode_active");
+    assert.match((spy.captures[0].error as Error).message, /SafeMode watchdog/);
+  });
+
+  test("a quiet chain reports nothing", async () => {
+    const spy = captureSpy();
+    const result = await runSafeModeWatchdog(null, {
+      fetchImpl: quietChain,
+      recordExceptionEvent: spy.recordExceptionEvent,
+    });
+    assert.equal(result.alerted, false);
+    assert.deepEqual(spy.captures, [], "a quiet chain pages no one");
+  });
+
+  test("an unreachable tick reports itself", async () => {
+    // The monitor's silence is indistinguishable from "the chain is fine",
+    // and that equivalence is the whole reason it exists -- so a tick that
+    // cannot run has to say so rather than returning quietly.
+    const spy = captureSpy();
+    const result = await runSafeModeWatchdog(null, {
+      fetchImpl: (async () => {
+        throw new Error("rpc unreachable");
+      }) as unknown as typeof fetch,
+      recordExceptionEvent: spy.recordExceptionEvent,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "unreachable");
+    assert.equal(spy.captures.length, 1);
+    assert.equal(spy.captures[0].errorCode, "watchdog_unreachable");
+  });
+
+  test("a capture that fails never breaks the tick", async () => {
+    const result = await runSafeModeWatchdog(null, {
+      fetchImpl: pausedChain,
+      recordExceptionEvent: (async () => {
+        throw new Error("posthog unreachable");
+      }) as never,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, true);
+  });
+});

--- a/tests/worker-entry-uncaught-capture.test.ts
+++ b/tests/worker-entry-uncaught-capture.test.ts
@@ -1,0 +1,229 @@
+// #9440: uncaught faults at a Worker's top-level `fetch` reach PostHog.
+//
+// #9430 closed this on workers/api.ts. The same hole was open on the other two
+// Workers for the same reason: each wraps its dispatcher only to emit a TRACE
+// SPAN, and tracing is off by default (src/tracing.ts defaults the rate to 0,
+// and neither wrangler.data.jsonc nor wrangler.registry.jsonc sets one). So
+// the unsampled path -- which is every request in production -- returned the
+// dispatcher's promise unwrapped, and an uncaught fault reached Cloudflare's
+// logs and nothing else.
+//
+// Both Workers already had a capture helper; neither was reachable from the
+// entry. These tests pin the entry, not the helper, because "the label exists"
+// and "a request reaches it" are different claims -- the distinction that let
+// three dead route labels survive in #9430.
+import assert from "node:assert/strict";
+import { afterEach, describe, test } from "vitest";
+import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
+import { POSTHOG_TRACES_SAMPLE_RATE_ENV } from "../src/tracing.ts";
+import type { Row } from "./row-type.ts";
+
+const CONFIGURED = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" };
+
+// Every recorder in src/usage-telemetry.ts POSTs through globalThis.fetch, so
+// swapping it is how a test observes a capture without reaching PostHog.
+function captureTelemetry() {
+  const posted: Row[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    posted.push({ url, body: JSON.parse(String(init?.body ?? "{}")) });
+    return new Response("{}", { status: 200 });
+  }) as unknown as typeof fetch;
+  return {
+    posted,
+    exceptions: () =>
+      posted.filter((p) => (p.body as Row).event === "$exception"),
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+let active: ReturnType<typeof captureTelemetry> | null = null;
+afterEach(() => {
+  active?.restore();
+  active = null;
+});
+
+describe("data-api", () => {
+  // A matched write route, so dispatch reaches a handler rather than the
+  // 404/method gate. The handler reads its shared-secret binding first, so a
+  // throwing getter produces a genuine UNHANDLED fault -- the class this
+  // capture exists for. A broken D1 would not do: those failures are caught
+  // and turned into responses, which is exactly why they were never the gap.
+  const request = () =>
+    new Request("https://data-api.internal/api/v1/internal/neurons-sync", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+
+  const explodingEnv = (over: Record<string, unknown> = {}) =>
+    ({
+      ...CONFIGURED,
+      ...over,
+      get NEURONS_SYNC_SECRET(): string {
+        throw new Error("binding exploded");
+      },
+    }) as unknown as Env;
+
+  test("captures an uncaught fault on the UNSAMPLED path", async () => {
+    active = captureTelemetry();
+    const { default: worker } = await import("../workers/data-api.ts");
+    // No trace rate set: the production shape, and the path that previously
+    // returned the dispatcher's promise entirely unwrapped.
+    await assert.rejects(
+      worker.fetch(request(), explodingEnv(), undefined as never),
+      /binding exploded/,
+    );
+
+    const exceptions = active.exceptions();
+    assert.equal(exceptions.length, 1);
+    const props = (exceptions[0].body as Row).properties as Row;
+    assert.equal(props.route, "/api/v1/internal/neurons-sync");
+    assert.equal(props.error_code, "internal_error");
+  });
+
+  test("captures an uncaught fault on the SAMPLED path too", async () => {
+    active = captureTelemetry();
+    const { default: worker } = await import("../workers/data-api.ts");
+    await assert.rejects(
+      worker.fetch(
+        request(),
+        explodingEnv({ [POSTHOG_TRACES_SAMPLE_RATE_ENV]: "1" }),
+        undefined as never,
+      ),
+      /binding exploded/,
+    );
+    assert.equal(active.exceptions().length, 1);
+  });
+
+  test("captures nothing when the deployment is unconfigured", async () => {
+    active = captureTelemetry();
+    const { default: worker } = await import("../workers/data-api.ts");
+    const env = {
+      get NEURONS_SYNC_SECRET(): string {
+        throw new Error("binding exploded");
+      },
+    } as unknown as Env;
+
+    await assert.rejects(
+      worker.fetch(request(), env, undefined as never),
+      /binding exploded/,
+    );
+    assert.deepEqual(active.exceptions(), []);
+  });
+
+  test("a request whose URL cannot be read still names the Worker", async () => {
+    // The fallback exists so a malformed URL turns one fault into ONE capture,
+    // not none: the route dimension degrades to naming the Worker rather than
+    // the capture vanishing. Reproduced with a url getter that throws, which
+    // is what makes both the dispatcher's own `new URL()` and the label
+    // derivation fail on the same request.
+    active = captureTelemetry();
+    const { default: worker } = await import("../workers/data-api.ts");
+    const unreadable = {
+      method: "GET",
+      headers: new Headers(),
+      get url(): string {
+        throw new Error("url exploded");
+      },
+    } as unknown as Request;
+
+    await assert.rejects(
+      worker.fetch(
+        unreadable,
+        { ...CONFIGURED } as unknown as Env,
+        undefined as never,
+      ),
+      /url exploded/,
+    );
+    const exceptions = active.exceptions();
+    assert.equal(exceptions.length, 1);
+    assert.equal(
+      ((exceptions[0].body as Row).properties as Row).route,
+      "data-api",
+    );
+  });
+
+  test("drains through waitUntil when a context is available", async () => {
+    // An already-failing request must not also be made slower by the capture.
+    active = captureTelemetry();
+    const { default: worker } = await import("../workers/data-api.ts");
+    const scheduled: Promise<unknown>[] = [];
+
+    await assert.rejects(
+      worker.fetch(request(), explodingEnv(), {
+        waitUntil: (p: Promise<unknown>) => scheduled.push(p),
+      } as never),
+      /binding exploded/,
+    );
+    assert.equal(scheduled.length, 1);
+    await Promise.all(scheduled);
+    assert.equal(active.exceptions().length, 1);
+  });
+});
+
+describe("registry-sync-api", () => {
+  const request = () =>
+    new Request(
+      "https://registry-sync.internal/api/v1/internal/registry-sync",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      },
+    );
+
+  test("captures an uncaught fault on the UNSAMPLED path", async () => {
+    active = captureTelemetry();
+    const { default: worker } = await import("../workers/registry-sync-api.ts");
+    // A env whose URL parse succeeds but whose dispatch throws: the token
+    // check reads a getter that blows up.
+    const env = {
+      ...CONFIGURED,
+      get REGISTRY_SYNC_SECRET(): string {
+        throw new Error("binding exploded");
+      },
+    } as unknown as Env;
+
+    await assert.rejects(worker.fetch(request(), env), /binding exploded/);
+
+    const exceptions = active.exceptions();
+    assert.equal(exceptions.length, 1);
+    const props = (exceptions[0].body as Row).properties as Row;
+    assert.equal(props.route, "registry-sync");
+    assert.equal(props.error_code, "internal_error");
+  });
+
+  test("captures an uncaught fault on the SAMPLED path too", async () => {
+    // This Worker has no ExecutionContext (CI-only write path), so both the
+    // span and the capture are awaited inline -- the tradeoff already
+    // accepted here for error capture.
+    active = captureTelemetry();
+    const { default: worker } = await import("../workers/registry-sync-api.ts");
+    const env = {
+      ...CONFIGURED,
+      [POSTHOG_TRACES_SAMPLE_RATE_ENV]: "1",
+      get REGISTRY_SYNC_SECRET(): string {
+        throw new Error("binding exploded");
+      },
+    } as unknown as Env;
+
+    await assert.rejects(worker.fetch(request(), env), /binding exploded/);
+    assert.equal(active.exceptions().length, 1);
+  });
+
+  test("captures nothing when the deployment is unconfigured", async () => {
+    active = captureTelemetry();
+    const { default: worker } = await import("../workers/registry-sync-api.ts");
+    const env = {
+      get REGISTRY_SYNC_SECRET(): string {
+        throw new Error("binding exploded");
+      },
+    } as unknown as Env;
+
+    await assert.rejects(worker.fetch(request(), env), /binding exploded/);
+    assert.deepEqual(active.exceptions(), []);
+  });
+});

--- a/workers/alerter-hub.ts
+++ b/workers/alerter-hub.ts
@@ -25,7 +25,10 @@ import {
   triggerMatchesEvent,
   type EvaluatorAlertTrigger,
 } from "../src/alert-triggers.ts";
-import { recordUsageEvent } from "../src/usage-telemetry.ts";
+import {
+  recordExceptionEvent,
+  recordUsageEvent,
+} from "../src/usage-telemetry.ts";
 import { buildDeregRiskSnapshot } from "../src/dereg-risk.ts";
 import {
   mapBounded,
@@ -487,6 +490,7 @@ export class AlerterHub implements DurableObject {
       // awaits this indirectly via evaluate().
       return;
     }
+    const refreshStartedAt = Date.now();
     try {
       const upstream = await this.env.DATA_API.fetch(
         "https://data-api.internal/api/v1/internal/alert-triggers-active",
@@ -498,7 +502,18 @@ export class AlerterHub implements DurableObject {
           signal: AbortSignal.timeout(ALERT_TRIGGER_REFRESH_TIMEOUT_MS),
         },
       );
-      if (!upstream.ok) return;
+      // #9440: the same silent-stale-cache failure as the catch below, through
+      // a different door -- a 500 from DATA_API left the cache untouched and
+      // said nothing. Reported identically, since from the hub's side the two
+      // are the same event: the refresh did not happen.
+      if (!upstream.ok) {
+        this.emitTelemetry({
+          route: "alerter-hub:trigger-refresh",
+          ok: false,
+          durationMs: Date.now() - refreshStartedAt,
+        });
+        return;
+      }
       const body = (await upstream.json()) as { triggers?: Trigger[] };
       if (Array.isArray(body?.triggers)) {
         this.triggers = body.triggers;
@@ -521,7 +536,24 @@ export class AlerterHub implements DurableObject {
       }
     } catch {
       // Best-effort refresh -- keep serving the stale cache rather than
-      // throwing out of evaluate().
+      // throwing out of evaluate(). That degradation is correct and stays.
+      //
+      // #9440: what was NOT correct is that it was silent. A hub whose trigger
+      // cache stops refreshing keeps evaluating every chain event against
+      // whatever it last loaded, forever, and looks perfectly healthy doing it
+      // -- deliveries still fire, so even the failures-only delivery event
+      // stays quiet. Triggers created, edited or deactivated after the failure
+      // simply never take effect, and nothing anywhere says so.
+      //
+      // Naturally bounded to one event per ALERTER_HUB_TRIGGER_CACHE_TTL_MS
+      // (5 min) per hub, because that TTL is what gates the refresh attempt --
+      // so this cannot scale with chain activity the way a per-evaluation
+      // event would.
+      this.emitTelemetry({
+        route: "alerter-hub:trigger-refresh",
+        ok: false,
+        durationMs: Date.now() - refreshStartedAt,
+      });
     }
     // #6746/#6747: only fetch the metric snapshot when at least one ACTIVE
     // trigger actually has a condition -- the overwhelming common case
@@ -872,11 +904,29 @@ export class AlerterHub implements DurableObject {
           headers: { "content-type": "application/json" },
         });
       }
-      const result = await this.evaluate(payload);
-      return new Response(JSON.stringify(result), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
+      // #9440: evaluate() throwing was, until now, entirely unrecorded on
+      // BOTH sides of this boundary -- this class imported no exception
+      // capture at all, and ChainFirehoseHub's ping swallowed the rejection
+      // (workers/chain-firehose-hub.ts). So a hub failing before it reached
+      // any delivery produced nothing: not a delivery-failure event (none was
+      // attempted), not an exception, nothing. Alerting stopped silently.
+      //
+      // Rethrown after capture: the caller's own timeout/catch still decides
+      // what the firehose does about it, which must not change.
+      try {
+        const result = await this.evaluate(payload);
+        return new Response(JSON.stringify(result), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      } catch (error) {
+        await recordExceptionEvent(this.env, {
+          error,
+          route: "alerter-hub:evaluate",
+          errorCode: "internal_error",
+        }).catch(() => false);
+        throw error;
+      }
     }
     return new Response("not found", { status: 404 });
   }

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -32,6 +32,11 @@ import {
   shouldSampleTrace,
 } from "../src/tracing.ts";
 import {
+  recordLaneVerdict,
+  type LaneHealthDb,
+  type LaneVerdict,
+} from "../src/lane-health.ts";
+import {
   applyQueryFilters,
   canonicalListSearch,
   paginationLinkHeader,
@@ -789,17 +794,28 @@ export async function runUpgradeRadarScan(env: Env, ctx?: Ctx) {
 export async function runFreshnessWatchdog(
   env: Env,
   ctx?: Ctx,
-  deps: { readArtifact?: ArtifactReader } = {},
+  deps: { readArtifact?: ArtifactReader; laneHealthDb?: LaneHealthDb } = {},
 ) {
   const startedAt = Date.now();
   const readArtifactFn = (deps.readArtifact ??
     (readArtifact as unknown as ArtifactReader)) as ArtifactReader;
+  const laneHealthDb = deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as never);
   try {
     const artifact = (await readArtifactFn(
       env,
       "/metagraph/freshness.json",
     )) as { sources?: unknown } | null;
-    if (!artifact) return { ok: false, reason: "artifact_unavailable" };
+    if (!artifact) {
+      // #9440: `unknown` is the vocabulary's own word for "the watchdog could
+      // not evaluate the lane", and it is NOT a synonym for ok. Without this
+      // row, a watchdog that cannot read its own artifact is indistinguishable
+      // from one reporting everything fresh -- both produce silence.
+      await recordFreshnessLaneVerdict(laneHealthDb, {
+        verdict: "unknown",
+        detail: "artifact_unavailable",
+      });
+      return { ok: false, reason: "artifact_unavailable" };
+    }
 
     const verdict = evaluateFreshness(artifact.sources, Date.now());
     // No KV means no memory of what was already reported. Report anyway rather
@@ -829,6 +845,38 @@ export async function runFreshnessWatchdog(
       }
     }
 
+    // #9440: the DURABLE record, written on EVERY tick rather than only when
+    // shouldReport decides this verdict is worth notifying about.
+    //
+    // That distinction is the whole bug. `shouldReport` deliberately
+    // suppresses a repeat of the same signature, so a lane that has been
+    // critical for six hours notifies once and then goes quiet -- correct for
+    // a notification, useless as a record. Everything this watchdog computed
+    // (which sources are stale, which are critical, how many were checked)
+    // existed only in the return value, and workers/api.entry.ts discards
+    // what `scheduled` returns. It was measured, then dropped.
+    //
+    // Never throws -- see recordLaneVerdict.
+    await recordFreshnessLaneVerdict(laneHealthDb, {
+      // `critical` is a subset of `stale`, so the latter alone decides the
+      // verdict; severity lives in `detail` and in the notification.
+      verdict: verdict.stale.length > 0 ? "stale" : "ok",
+      // The names, not the counts: "which source" is the first question asked
+      // of a stale verdict, and the count is derivable from it.
+      detail:
+        verdict.stale.length > 0
+          ? // The ids, not the entries: a stale entry is an object, and
+            // joining those yields a row of "[object Object]". Critical
+            // sources are a SUBSET of stale (critical = stale filtered by
+            // behavior+required), so listing stale alone covers both without
+            // repeating any id.
+            verdict.stale
+              .slice(0, FRESHNESS_LANE_DETAIL_LIMIT)
+              .map((entry) => entry.id)
+              .join(",")
+          : null,
+    });
+
     return {
       ok: true,
       checked: verdict.checked,
@@ -842,9 +890,44 @@ export async function runFreshnessWatchdog(
       stale: verdict.stale.slice(0, 10),
     };
   } catch {
-    // A tick that cannot run is one missed report, not an outage.
+    // A tick that cannot run is one missed report, not an outage -- but it is
+    // still a tick that produced no measurement, and saying so is the point of
+    // the `unknown` verdict. Before this, an unreachable watchdog and a
+    // healthy one were both silent.
+    await recordFreshnessLaneVerdict(laneHealthDb, {
+      verdict: "unknown",
+      detail: "unreachable",
+    });
     return { ok: false, reason: "unreachable" };
   }
+}
+
+// Same bound the alert body uses, for the same reason: a total publish stall
+// makes every source stale at once, and a row listing all of them is one
+// nobody reads.
+const FRESHNESS_LANE_DETAIL_LIMIT = 10;
+
+/**
+ * One freshness verdict, in the shape src/lane-health.ts stores. Wrapped
+ * because this watchdog records from four places (no artifact, stale, ok,
+ * unreachable) and the lane name and clock must be identical across all of
+ * them -- a lane whose name varies by branch is a lane the self-health card
+ * reads as several.
+ */
+function recordFreshnessLaneVerdict(
+  db: LaneHealthDb | null | undefined,
+  { verdict, detail }: { verdict: LaneVerdict; detail: string | null },
+) {
+  return recordLaneVerdict(db, {
+    lane: "freshness",
+    verdict,
+    // This watchdog evaluates each source against the policy that source
+    // declares for itself, so there is no single fleet-wide age to report --
+    // unlike the per-lane watchdogs, whose age_ms is one lane's own lag.
+    age_ms: null,
+    detail,
+    checked_at: Date.now(),
+  });
 }
 
 // #8704: per-subnet chain news for the subnet feed.

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -64,6 +64,7 @@ import {
   schema as chainEventsGraphqlSchema,
 } from "../src/graphql.ts";
 import { MCP_CHAIN_STREAM_RESOURCE_URI } from "./mcp-session-hub.ts";
+import { registerModuleStateReset } from "../src/module-state-registry.ts";
 
 export const CHAIN_FIREHOSE_INGEST_TOKEN_HEADER = "x-chain-firehose-sync-token";
 
@@ -106,6 +107,35 @@ export const CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE = 10;
 // evaluate() cycle, but a real ceiling so a slow/stuck evaluator can no
 // longer stall handleIngest()'s response to the box-side relay indefinitely.
 export const ALERTER_HUB_EVALUATE_TIMEOUT_MS = 15_000;
+
+// #9440: how often an unreachable AlerterHub may be reported from here.
+//
+// broadcast() runs once per chain event, so this is the one capture in this
+// file whose natural rate is the chain's, not a user's. The window makes the
+// cost of reporting an alerting outage independent of how long it lasts --
+// the same shape, and the same reasoning, as shouldEmitCondition in
+// workers/wss-lb.ts.
+export const ALERTER_UNREACHABLE_EVENT_WINDOW_MS = 5 * 60 * 1000;
+
+let alerterUnreachableLastSentMs: number | null = null;
+
+registerModuleStateReset("workers/chain-firehose-hub.ts", () => {
+  alerterUnreachableLastSentMs = null;
+});
+
+/** True at most once per window per isolate. Exported for tests. */
+export function shouldEmitAlerterUnreachable(
+  nowMs: number = Date.now(),
+): boolean {
+  if (
+    alerterUnreachableLastSentMs !== null &&
+    nowMs - alerterUnreachableLastSentMs < ALERTER_UNREACHABLE_EVENT_WINDOW_MS
+  ) {
+    return false;
+  }
+  alerterUnreachableLastSentMs = nowMs;
+  return true;
+}
 
 // Per-field string length bound -- generous over every string field the
 // trigger actually emits (call_module/call_function/pallet/method/signer/
@@ -1699,7 +1729,25 @@ export class ChainFirehoseHub implements DurableObject {
           signal: AbortSignal.timeout(ALERTER_HUB_EVALUATE_TIMEOUT_MS),
         });
       } catch {
-        // best-effort -- see the comment above
+        // Still best-effort for the BROADCAST -- see the comment above; a slow
+        // or dead alerter must never block the firehose.
+        //
+        // #9440: but it is no longer silent. This bare catch was the outer half
+        // of an end-to-end blind spot: AlerterHub records only failed
+        // DELIVERIES, so a hub that is unreachable, timing out, or throwing
+        // before it ever reaches a trigger delivers nothing and reports
+        // nothing -- and this side swallowed the evidence. Alerting could stop
+        // completely with no signal on either side of the boundary.
+        //
+        // Rate-bounded because broadcast() runs once per chain event: an
+        // unbounded capture here would emit thousands per hour during exactly
+        // the incident it exists to report, which is how a project ~33x over
+        // its PostHog allowance (#9004) loses the rest of its telemetry too.
+        // One event per window per isolate is enough to say "alerting is
+        // down"; the duration of the outage is visible from the run of them.
+        if (shouldEmitAlerterUnreachable()) {
+          this.emitTelemetry("alerter-unreachable", false);
+        }
       }
     }
   }

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -227,6 +227,53 @@ async function captureDataApiError(
 
 export { captureDataApiError as captureDataApiErrorForTest };
 
+/**
+ * The low-cardinality route label for this request, or a Worker-level fallback
+ * when the URL cannot be parsed (#9440).
+ *
+ * A malformed URL must not turn one fault into two, so this never throws --
+ * the route dimension degrades to naming the Worker rather than vanishing,
+ * which is the dimension that was missing entirely before.
+ */
+function maskedDataApiRoute(request: Request): string {
+  try {
+    return maskRouteParams(new URL(request.url).pathname);
+  } catch {
+    return "data-api";
+  }
+}
+
+/**
+ * Capture a fault that escaped every handled path, from the Worker's own
+ * `fetch` entry (#9440).
+ *
+ * Separate from captureDataApiError because the ROUTE is derived differently:
+ * the handled sites each name the lane they belong to, while here the only
+ * thing known about the fault is which URL was being served -- masked, since a
+ * span/exception label keyed on a raw pathname is unaggregatable (#9001).
+ *
+ * Scheduled through waitUntil when a context exists so an already-failing
+ * request is not also made slower; awaited otherwise so a direct call (tests,
+ * a binding invocation with no ctx) still records.
+ */
+async function captureUncaughtDataApiError(
+  error: unknown,
+  route: string,
+  env: Env,
+  ctx: ExecutionContext | undefined,
+): Promise<void> {
+  const pending = recordExceptionEvent(env, {
+    error,
+    route,
+    errorCode: "internal_error",
+  }).catch(() => false);
+  if (typeof ctx?.waitUntil === "function") {
+    ctx.waitUntil(pending);
+    return;
+  }
+  await pending;
+}
+
 const ANALYTICS_DAY_MS = 24 * 60 * 60 * 1000;
 
 // The resolved window label to pass into a build* function's `{ window }` option,
@@ -6423,8 +6470,28 @@ export default {
     // leaderboard/chain-events Postgres queries the original rollout's
     // tracesSampleRate comment called out as the highest-value place to have
     // span visibility.
+    // #9440: the uncaught-fault capture runs REGARDLESS of trace sampling,
+    // and outside the sampled block below, because tracing is off by default
+    // on this Worker (its config sets no rate at all) -- so putting error
+    // capture inside the sampled path would mean an unhandled fault here is
+    // recorded exactly never. captureDataApiError covers the ~18 handled
+    // sites; this covers everything that escapes them, which is the class
+    // that has no stack anywhere today.
+    //
+    // Same shape as withUsageTelemetry's catch in workers/api.ts: observe and
+    // rethrow, never handle.
     if (!shouldSampleTrace(env)) {
-      return dispatchDataApiRequest(request, env);
+      try {
+        return await dispatchDataApiRequest(request, env);
+      } catch (error) {
+        await captureUncaughtDataApiError(
+          error,
+          maskedDataApiRoute(request),
+          env,
+          ctx,
+        );
+        throw error;
+      }
     }
     const startedAt = Date.now();
     // #9001: masked, like the $exception route above. A span NAME is the
@@ -6432,7 +6499,7 @@ export default {
     // per-route latency unaggregatable -- `/api/v1/subnets/123/conviction`
     // and `/api/v1/subnets/124/conviction` would never be compared.
     // workers/api.ts has always used the low-cardinality route id here.
-    const route = maskRouteParams(new URL(request.url).pathname);
+    const route = maskedDataApiRoute(request);
     let ok = true;
     try {
       const response = await dispatchDataApiRequest(request, env);
@@ -6440,6 +6507,7 @@ export default {
       return response;
     } catch (error) {
       ok = false;
+      await captureUncaughtDataApiError(error, route, env, ctx);
       throw error;
     } finally {
       const endedAt = Date.now();

--- a/workers/registry-sync-api.ts
+++ b/workers/registry-sync-api.ts
@@ -554,8 +554,19 @@ export default {
     // low-traffic write path -- see captureRegistrySyncError's own comment),
     // so the span is awaited directly rather than scheduled via waitUntil,
     // same tradeoff already accepted for error capture on this Worker.
+    // #9440: capture uncaught faults REGARDLESS of trace sampling, and
+    // outside the sampled block -- tracing is off by default and this config
+    // sets no rate, so an error capture nested inside the sampled path would
+    // fire exactly never. captureRegistrySyncError already covers the write
+    // path's own catch (:543); this covers everything that escapes it, which
+    // until now reached only Cloudflare's logs.
     if (!shouldSampleTrace(env)) {
-      return dispatchRegistrySyncRequest(request, env);
+      try {
+        return await dispatchRegistrySyncRequest(request, env);
+      } catch (error) {
+        await captureRegistrySyncError(error, env);
+        throw error;
+      }
     }
     const startedAt = Date.now();
     const route = "registry-sync";
@@ -566,6 +577,7 @@ export default {
       return response;
     } catch (error) {
       ok = false;
+      await captureRegistrySyncError(error, env);
       throw error;
     } finally {
       await recordTraceSpan(env, {


### PR DESCRIPTION
## Summary

`workers/api.entry.ts` discards what `scheduled` returns — the Workers runtime ignores it. So any watchdog verdict that lives only in a cron's return value has been computed correctly and then dropped. Three were, in different ways, and the alerting path could stop end-to-end with nothing recorded on either side of it.

**`lakehouse-seam` and `safe-mode` reported on no channel at all.** Both compute `reasons` correctly and return them into the void: a drifted decode seam, and **the chain entering SafeMode** — the most consequential thing this repo watches for — were detected every tick and told to nobody. Neither notified, neither recorded. Their siblings have had the notification half since #9330 and the durable half since #9340/#9431; these two were simply never wired to either.

**`freshness` notified, but only when the verdict was new.** `shouldReport` deliberately suppresses a repeat of the same signature, so a lane critical for six hours notifies once and then goes quiet — correct for a notification, useless as a record. Which sources were stale existed only in the discarded return value. It now writes a `lane_health` row on every tick, naming the stale sources rather than counting them (the count is derivable from the names; the reverse isn't).

**A watchdog that could not RUN was indistinguishable from a healthy one.** Each returns `{ok:false, reason:"unreachable"}` rather than throwing — deliberately, since a cron that throws is a cron nobody can read the result of — but that means `handleScheduled`'s `$exception` capture never fires, and the tick's only output looks exactly like the silence that means everything is fine. `lane_health`'s vocabulary already had the right word and nothing used it: `unknown`, documented in `schemas-src/routes/self-health.ts` as explicitly *not* a synonym for `ok`.

**`safe-mode` deliberately gets no `lane_health` row.** That table backs the public `/api/v1/self-health` card, whose vocabulary is ok/stale/unknown and whose consumers read a non-ok lane as "our data is behind". SafeMode is a *chain* condition, not a staleness of ours — filing it there would publish a false statement about our own freshness. It notifies instead, and reports its own unreachability, because a SafeMode monitor's silence is the one thing that must never be ambiguous.

**Alerting could die with no signal on either side.** `AlerterHub` swallowed both a thrown trigger refresh and a non-2xx, so a hub whose cache stopped refreshing kept evaluating every chain event against a frozen trigger list forever while looking perfectly healthy — deliveries still fire, so even the failures-only delivery event from #8997 stayed quiet, and triggers created or deactivated after the failure silently never took effect. It also imported no exception capture at all, so `evaluate()` throwing was unrecorded; and `ChainFirehoseHub`'s `/evaluate` ping was a bare `catch {}`, swallowing the evidence from the outer side. All three now report.

**`data-api` and `registry-sync-api` still swallowed uncaught faults** for exactly the reason #9434 fixed on the main Worker: each wraps its dispatcher only to emit a trace span, and tracing is off by default with no rate set in either config — so the unsampled path, which is every request in production, returned the dispatcher's promise unwrapped. Both already had a capture helper; neither was reachable from its entry.

## Design notes

- **Bounding is per-producer, not uniform.** `AlerterHub`'s refresh event is naturally bounded by the 5-minute cache TTL that gates the refresh attempt itself, so it needs no guard. The firehose's does: `broadcast()` runs once per chain event, so an unbounded capture would emit thousands per hour during exactly the incident it exists to report. That one gets a time window, the same shape as `shouldEmitCondition` in `wss-lb.ts`.
- **`age_ms` is null on both new lanes, on purpose.** `freshness` evaluates each source against the policy that source declares for itself, so there is no single fleet-wide age; `lakehouse-seam` measures a seam in *block numbers*, and no clock reading converts to that honestly. Inventing a duration would put a fabricated number in the column triage reads — the same defect #8963 removed from `$mcp_duration_ms`.
- **A `lane_health` write that fails never breaks a tick.** D1 migrations here are applied by hand, so "no such table" is a real production state; `recordLaneVerdict` already treats every failure as a no-op returning false, and there are tests pinning that a broken table leaves each tick's result intact.
- The two Worker-entry captures run **outside** the sampled block, not inside it — nesting them under `shouldSampleTrace` would mean an unhandled fault is recorded exactly never, since neither config sets a rate.

## Out of scope

Setting `POSTHOG_TRACES_SAMPLE_RATE` on `data-api`/`registry-sync-api`. Their span code is currently unreachable, but picking a rate has quota consequences on a project that already exhausted its August allowance, and deserves a measured number rather than being a side effect of this fix.

## Validation

```
npm run lint                    clean
npm run format:check            clean
npm run typecheck               clean
npm run validate                129 subnets, 3442 surfaces, 136 providers
npm run validate:contract-drift passed
npx vitest run                  669 files, 15889 tests, all passing
```

Patch coverage measured by diff intersection against the changed lines in `src/**` and `workers/**`: **128/128 = 100%**.

Two pre-existing tests were updated rather than worked around: both asserted an exact count of PostHog POSTs on a thrown request, and an uncaught fault now correctly emits an `$exception` alongside the span. They now select by payload shape instead of by index, so neither depends on POST ordering.

Closes #9440
