### PR TITLE
fix(validators): restore the operator-identity join the Postgres removal severed

### DIFF
--- a/src/account-identity.ts
+++ b/src/account-identity.ts
@@ -107,3 +107,34 @@ export async function loadAccountIdentity(
   );
   return buildAccountIdentity(rows?.[0] ?? null, account);
 }
+
+/**
+ * Every identity row keyed by account, for the bulk coldkey_identity join on
+ * the /validators leaderboard and detail. The whole table is read on purpose:
+ * it holds one row per account that ever called set_identity (a few hundred),
+ * so an unfiltered SELECT beats a per-coldkey IN list that would trip D1's
+ * 100-parameter bind cap on a full leaderboard.
+ *
+ * Never throws: the join is an enhancement, and a failed read degrades every
+ * row to the same schema-stable has_identity:false shape the leaderboard
+ * served while the join was missing — not a dead route.
+ */
+export async function loadIdentityByColdkeyMap(
+  d1: (sql: string, params: unknown[]) => Promise<Record<string, unknown>[]>,
+): Promise<Map<string, Record<string, unknown>>> {
+  const map = new Map<string, Record<string, unknown>>();
+  try {
+    const rows = await d1(
+      `SELECT ${ACCOUNT_IDENTITY_INSERT_COLUMNS.join(", ")} FROM account_identity`,
+      [],
+    );
+    for (const row of rows ?? []) {
+      if (row && typeof row.account === "string" && row.account) {
+        map.set(row.account, row);
+      }
+    }
+  } catch {
+    // Degraded join, served as "no identity" on every row.
+  }
+  return map;
+}

--- a/src/metagraph-neurons.ts
+++ b/src/metagraph-neurons.ts
@@ -5,7 +5,11 @@
 // Pure + exported for tests; the Worker handlers run the D1 or Postgres query
 // and call these builders.
 
-import { buildAccountIdentity, IDENTITY_FIELDS } from "./account-identity.ts";
+import {
+  buildAccountIdentity,
+  IDENTITY_FIELDS,
+  loadIdentityByColdkeyMap,
+} from "./account-identity.ts";
 import { NeuronSchema } from "../schemas-src/routes/subnet-metagraph.ts";
 import {
   parseFieldsParam,
@@ -1033,12 +1037,12 @@ export async function loadD1AlphaPricesByNetuid(
   }
 }
 
-// No identityByColdkey passed here (#5234): account_identity's D1 write path
-// is retired -- Postgres is the only actively-written copy -- so this D1
-// fallback deliberately serves a stable coldkey_identity:{has_identity:false,
-// ...} shape rather than joining a frozen/stale D1 copy. The live route
-// (workers/data-api.ts's /api/v1/validators, Postgres-backed) is what
-// actually joins.
+// The identity join reads D1's account_identity directly. The old #5234
+// posture ("D1 write path is retired -- the Postgres-backed route is what
+// actually joins") stopped being true when Postgres was removed: D1 became
+// the only path and every operator name silently vanished from /validators.
+// account_identity is actively written in D1 (the account-identity-sync
+// path), so it is joined here like any other side table.
 export async function loadGlobalValidators(
   d1: D1Runner,
   {
@@ -1046,7 +1050,7 @@ export async function loadGlobalValidators(
     limit = GLOBAL_VALIDATOR_LIMIT_DEFAULT,
   }: { sort?: string; limit?: unknown } = {},
 ): Promise<Row> {
-  const [rows, priceByNetuid] = await Promise.all([
+  const [rows, priceByNetuid, identityByColdkey] = await Promise.all([
     d1(
       "SELECT netuid, uid, hotkey, coldkey, validator_trust, emission_tao, " +
         "stake_tao, block_number, captured_at FROM neurons " +
@@ -1055,8 +1059,14 @@ export async function loadGlobalValidators(
       [],
     ),
     loadD1AlphaPricesByNetuid(d1),
+    loadIdentityByColdkeyMap(d1),
   ]);
-  return buildGlobalValidators(rows, { sort, limit, priceByNetuid });
+  return buildGlobalValidators(rows, {
+    sort,
+    limit,
+    priceByNetuid,
+    identityByColdkey,
+  });
 }
 
 export async function loadNeuron(
@@ -1236,19 +1246,23 @@ export function buildValidatorDetail(
   };
 }
 
-// No identityByColdkey passed here either -- see loadGlobalValidators' comment.
+// Identity joined here too -- see loadGlobalValidators' comment.
 export async function loadValidatorDetail(
   d1: D1Runner,
   hotkey: unknown,
 ): Promise<Row> {
-  const [rows, priceByNetuid] = await Promise.all([
+  const [rows, priceByNetuid, identityByColdkey] = await Promise.all([
     d1(
       `SELECT ${NEURON_COLUMNS}, netuid FROM neurons WHERE hotkey = ? AND validator_permit = 1 ORDER BY netuid ASC, uid ASC`,
       [hotkey],
     ),
     loadD1AlphaPricesByNetuid(d1),
+    loadIdentityByColdkeyMap(d1),
   ]);
-  return buildValidatorDetail(rows, hotkey, { priceByNetuid });
+  return buildValidatorDetail(rows, hotkey, {
+    priceByNetuid,
+    identityByColdkey,
+  });
 }
 
 // The buildValidatorDetail fields a stake-decision comparison actually reads

--- a/tests/account-identity.test.ts
+++ b/tests/account-identity.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   buildAccountIdentity,
   loadAccountIdentity,
+  loadIdentityByColdkeyMap,
   sanitizeAccountIdentityFields,
 } from "../src/account-identity.ts";
 
@@ -147,5 +148,41 @@ describe("loadAccountIdentity", () => {
     const d1 = async () => null as unknown as Record<string, unknown>[];
     const data = await loadAccountIdentity(d1, "5Acc0");
     assert.equal(data.has_identity, false);
+  });
+});
+
+describe("loadIdentityByColdkeyMap — the bulk coldkey_identity join", () => {
+  test("keys every returned row by account and skips rows without one", async () => {
+    let seenSql = "";
+    const map = await loadIdentityByColdkeyMap(async (sql) => {
+      seenSql = sql;
+      return [
+        identityRow({ account: "5CkA", name: "Ventura Labs" }),
+        identityRow({ account: "5CkB", name: "Yuma" }),
+        identityRow({ account: null, name: "orphan" }),
+        { name: "no account at all" },
+      ];
+    });
+    // Whole-table read on purpose: no WHERE, no IN list to trip D1's
+    // 100-parameter bind cap on a full leaderboard.
+    assert.match(seenSql, /FROM account_identity$/);
+    assert.doesNotMatch(seenSql, /WHERE/);
+    assert.equal(map.size, 2);
+    assert.equal(map.get("5CkA")?.name, "Ventura Labs");
+    assert.equal(map.get("5CkB")?.name, "Yuma");
+  });
+
+  test("never throws: a failed read degrades to an empty map", async () => {
+    const map = await loadIdentityByColdkeyMap(async () => {
+      throw new Error("account_identity unavailable");
+    });
+    assert.equal(map.size, 0);
+  });
+
+  test("a non-array result degrades to an empty map too", async () => {
+    const map = await loadIdentityByColdkeyMap(
+      async () => null as unknown as Record<string, unknown>[],
+    );
+    assert.equal(map.size, 0);
   });
 });

--- a/tests/data-api-neurons-d1.test.ts
+++ b/tests/data-api-neurons-d1.test.ts
@@ -581,12 +581,24 @@ test("GET /api/v1/subnets/:netuid/validators ranks by stake with the uid tiebrea
 
 // --- Global validators + detail ----------------------------------------------
 
+// The coldkey-identity join reads account_identity in the same database.
+// Regression pin for the post-Postgres blackout: the dispatcher used to pass
+// identityByColdkey: new Map(), so every operator name vanished when the
+// Postgres route (which did the join) was removed.
+function insertIdentity(account: string, name: string) {
+  db.prepare(
+    `INSERT INTO account_identity (account, name, url, github, image, discord, description, additional, captured_at)
+     VALUES (?, ?, NULL, NULL, NULL, NULL, NULL, NULL, ?)`,
+  ).run(account, name, Date.now());
+}
+
 test("GET /api/v1/validators serves the leaderboard from D1 with real prices and realized-return baselines", async () => {
   // Current state: one validator on root (price 1) with stake 200.
   insertNeuron({
     netuid: 0,
     uid: 0,
     hotkey: "5Val",
+    coldkey: "5ColdVal",
     stake_tao: 200,
     validator_permit: 1,
   });
@@ -600,6 +612,7 @@ test("GET /api/v1/validators serves the leaderboard from D1 with real prices and
     validator_permit: 1,
     snapshot_date: dayAgo(1),
   });
+  insertIdentity("5ColdVal", "Ventura Labs");
   const res = await call(req("/api/v1/validators"));
   assert.equal(res.status, 200);
   const body = (await res.json()) as Row;
@@ -612,6 +625,11 @@ test("GET /api/v1/validators serves the leaderboard from D1 with real prices and
     null,
     "the baseline window resolved from neuron_daily on D1",
   );
+  // The identity join is live again: the coldkey's account_identity row
+  // surfaces as coldkey_identity, not the degraded has_identity:false shape.
+  const identity = entry.coldkey_identity as Row;
+  assert.equal(identity.has_identity, true);
+  assert.equal(identity.name, "Ventura Labs");
 });
 
 test("GET /api/v1/validators honors an explicit sort and clamps a bogus limit", async () => {
@@ -663,6 +681,7 @@ test("GET /api/v1/validators/:hotkey aggregates one hotkey across subnets with p
     validator_permit: 1,
   });
   insertPrice(7, dayAgo(0), 0.5);
+  insertIdentity("5Cold7-0", "Yuma");
   const res = await call(req("/api/v1/validators/5Val"));
   assert.equal(res.status, 200);
   const body = (await res.json()) as Row;
@@ -670,6 +689,8 @@ test("GET /api/v1/validators/:hotkey aggregates one hotkey across subnets with p
   assert.equal(body.subnet_count, 2);
   // root 100 * 1 + netuid-7 100 * 0.5
   assert.equal(body.total_stake_tao, 150);
+  // Detail carries the same identity join as the leaderboard.
+  assert.equal((body.coldkey_identity as Row).name, "Yuma");
 });
 
 // --- nominator_count, joined from D1 (#9146) ---------------------------------

--- a/tests/metagraph-neurons.test.ts
+++ b/tests/metagraph-neurons.test.ts
@@ -1894,6 +1894,10 @@ describe("metagraph-neurons loaders", () => {
             { netuid: 2, alpha_price_tao: 1 },
           ];
         }
+        // The identity join reads account_identity in the same pass.
+        if (sql.includes("account_identity")) {
+          return [{ account: "ck-a", name: "Ventura Labs" }];
+        }
         seenSql = sql;
         seenParams = params;
         return [
@@ -1924,6 +1928,35 @@ describe("metagraph-neurons loaders", () => {
     assert.deepEqual(seenParams, []);
     assert.equal(data.validators.length, 1);
     assert.equal(data.validators[0].hotkey, "hk-a");
+    // The D1 loader joins account_identity itself now (the old #5234 posture
+    // left this Map empty and relied on a Postgres route that no longer exists).
+    assert.equal(data.validators[0].coldkey_identity.name, "Ventura Labs");
+    assert.equal(data.validators[0].coldkey_identity.has_identity, true);
+  });
+
+  test("loadGlobalValidators degrades to no-identity when the identity read fails", async () => {
+    const data = await loadGlobalValidators(async (sql) => {
+      if (sql.includes("subnet_snapshots")) {
+        return [{ netuid: 1, alpha_price_tao: 1 }];
+      }
+      if (sql.includes("account_identity")) {
+        throw new Error("account_identity unavailable");
+      }
+      return [
+        {
+          netuid: 1,
+          uid: 0,
+          hotkey: "hk-a",
+          coldkey: "ck-a",
+          stake_tao: 10,
+          emission_tao: 7,
+          validator_trust: 0.7,
+        },
+      ];
+    });
+    assert.equal(data.validators.length, 1);
+    assert.equal(data.validators[0].coldkey_identity.has_identity, false);
+    assert.equal(data.validators[0].coldkey_identity.name, null);
   });
 
   test("loadValidatorDetail queries by hotkey + validator_permit, ordered by netuid/uid", async () => {
@@ -1938,6 +1971,10 @@ describe("metagraph-neurons loaders", () => {
           { netuid: 2, alpha_price_tao: 1 },
         ];
       }
+      // Identity join, same as the leaderboard loader.
+      if (sql.includes("account_identity")) {
+        return [{ account: "ck-a", name: "Yuma" }];
+      }
       seenSql = sql;
       seenParams = params;
       return [
@@ -1950,6 +1987,7 @@ describe("metagraph-neurons loaders", () => {
     assert.deepEqual(seenParams, ["hk-a"]);
     assert.equal(data.hotkey, "hk-a");
     assert.equal(data.subnet_count, 2);
+    assert.equal(data.coldkey_identity.name, "Yuma");
   });
 });
 

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -110,6 +110,7 @@ import {
   ACCOUNT_IDENTITY_INSERT_COLUMNS,
   IDENTITY_FIELDS,
   buildAccountIdentity,
+  loadIdentityByColdkeyMap,
 } from "../src/account-identity.ts";
 import {
   fillConfirmedZeros,
@@ -5168,11 +5169,13 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
     };
   }
 
-  // GET /api/v1/validators?sort=&limit=. The nominator-count, tempo and
-  // identity joins keep their Postgres loaders' degraded values (no D1
-  // homes); prices and realized-return baselines port for real. The serving
-  // Worker fills nominator_count over this response from the lakehouse (#9146)
-  // -- see this dispatcher's header.
+  // GET /api/v1/validators?sort=&limit=. Prices, realized-return baselines,
+  // nominator counts, tempos AND the coldkey_identity join are all D1-native
+  // now. Identity was the last straggler: this dispatcher shipped with
+  // identityByColdkey: new Map() while "the Postgres-backed route" did the
+  // join -- and when Postgres was removed, every operator name on /validators
+  // silently vanished. account_identity IS actively written in D1 (the
+  // account-identity-sync path above), so the join reads it directly.
   if (url.pathname === "/api/v1/validators") {
     return async (sql, env) => {
       const sortParam = url.searchParams.get("sort");
@@ -5193,6 +5196,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
         priceByNetuid,
         nominatorCounts,
         tempos,
+        identityByColdkey,
       ] = await Promise.all([
         sql`
           SELECT netuid, uid, hotkey, coldkey, validator_trust, emission_tao, stake_tao, block_number, captured_at, take
@@ -5202,6 +5206,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
         loadAlphaPricesByNetuidD1(sql, env),
         loadNominatorCountsD1(sql, env),
         loadSubnetTemposD1(sql, env),
+        loadIdentityByColdkeyMap((s, p) => sql.unsafe(s, p)),
       ]);
       return json(
         buildGlobalValidators(rows, {
@@ -5209,7 +5214,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
           limit,
           priceByNetuid,
           featuredHotkeys: new Set(),
-          identityByColdkey: new Map(),
+          identityByColdkey,
           nominatorCounts,
           tempoByNetuid: tempos,
           realizedStakeByHotkey,
@@ -5225,20 +5230,27 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
   if (validatorDetail) {
     return async (sql, env) => {
       const hotkey = decodeURIComponent(validatorDetail[1]);
-      const [rows, realizedByHotkey, priceByNetuid, nominatorCount, tempos] =
-        await Promise.all([
-          sql.unsafe(
-            `SELECT ${NEURON_COLUMNS}, netuid FROM neurons WHERE hotkey = ? AND validator_permit = 1 ORDER BY netuid ASC, uid ASC`,
-            [hotkey],
-          ),
-          loadRealizedStakeBaselinesD1(sql, { hotkey }, env),
-          loadAlphaPricesByNetuidD1(sql, env),
-          loadNominatorCountD1(sql, hotkey, env),
-          loadSubnetTemposD1(sql, env),
-        ]);
+      const [
+        rows,
+        realizedByHotkey,
+        priceByNetuid,
+        nominatorCount,
+        tempos,
+        identityByColdkey,
+      ] = await Promise.all([
+        sql.unsafe(
+          `SELECT ${NEURON_COLUMNS}, netuid FROM neurons WHERE hotkey = ? AND validator_permit = 1 ORDER BY netuid ASC, uid ASC`,
+          [hotkey],
+        ),
+        loadRealizedStakeBaselinesD1(sql, { hotkey }, env),
+        loadAlphaPricesByNetuidD1(sql, env),
+        loadNominatorCountD1(sql, hotkey, env),
+        loadSubnetTemposD1(sql, env),
+        loadIdentityByColdkeyMap((s, p) => sql.unsafe(s, p)),
+      ]);
       return json(
         buildValidatorDetail(rows, hotkey, {
-          identityByColdkey: new Map(),
+          identityByColdkey,
           priceByNetuid,
           nominatorCount,
           tempoByNetuid: tempos,


### PR DESCRIPTION
Closes #9442.

Verified live before this change: `GET /api/v1/validators` returns `coldkey_identity: {has_identity:false}` on all of the top 100 rows — every operator name is gone from the /validators UI, which renders `coldkey_identity.name` correctly and simply never receives it.

## Root cause

The D1 dispatcher shipped with `identityByColdkey: new Map()` ('the identity join keeps its Postgres loader's degraded values — no D1 home'), and `loadGlobalValidators`/`loadValidatorDetail` carried the #5234 posture that 'the Postgres-backed route is what actually joins'. Postgres removal made the D1 path the only path; the join silently vanished. The premise is stale: `account_identity` IS actively written in D1 via the account-identity-sync path (verified live: 470 rows, 369 named, newest capture today).

## What

- `loadIdentityByColdkeyMap` in `src/account-identity.ts`, beside `loadAccountIdentity`, deriving its SELECT from `ACCOUNT_IDENTITY_INSERT_COLUMNS` (single source of truth). Whole-table read on purpose — a few hundred rows; no per-coldkey IN list to trip D1's 100-parameter bind cap. Never throws: a failed read degrades to the schema-stable `has_identity:false` shape, not a dead leaderboard.
- Joined at all four serve points (data-api's two handlers + the two src loaders); stale comments corrected so the next migration can't repeat this.

## Tests

- Loader unit branches (keying, account-less rows skipped, throw → empty map, non-array → empty map).
- data-api route regression pins on a real local D1: leaderboard row carries `has_identity:true` + name; detail carries the same join.
- metagraph-neurons loader tests updated for the new query + a degrade-on-failure case.

Scoped run: 185 tests green across the three touched files; tsc clean.