### PR TITLE
feat(validators): group a multi-key operator's rows under one entry

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -26,11 +26,21 @@ const TD_NUM = `${TD_BASE} text-right tabular-nums`;
  * fixed (12 headers over 9 cells, columns showing another column's data) is
  * structurally impossible here. `header` values are unique (asserted in tests).
  */
+/**
+ * Optional per-row render context. `group` is present when the page has
+ * operator grouping on: `index` 0 is the group's anchor row (carries the
+ * operator name and, when the group has several keys, the ×N chip); later
+ * indexes are continuation rows rendered without repeating the name.
+ */
+export interface ValidatorCellContext {
+  group?: { size: number; index: number };
+}
+
 export interface ValidatorColumn {
   header: string;
   thClassName: string;
   tdClassName: string;
-  cell: (v: GlobalValidator) => ReactNode;
+  cell: (v: GlobalValidator, ctx?: ValidatorCellContext) => ReactNode;
   /** #8251: sorting is client-side over the full fetched set now, so any
    *  numeric row field is a valid key — this names the `GlobalValidator`
    *  field the column ranks by. Columns without one (identity, derived-on-
@@ -94,30 +104,50 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     header: "Operator",
     thClassName: TH_BASE,
     tdClassName: TD_BASE,
-    cell: (v) => (
-      <div className="flex items-center gap-1.5 min-w-0">
-        {v.featured ? <SponsoredBadge /> : null}
-        <Link
-          to="/validators/$hotkey"
-          params={{ hotkey: v.hotkey }}
-          className="flex min-w-0 items-center gap-2 hover:underline"
-          title={v.hotkey}
-        >
-          <ValidatorIdentityChip hotkey={v.hotkey} identity={v.coldkey_identity} size={20} />
-        </Link>
-        {/* Own AddressDisplay outside the operator Link (not inside it) --
-            AddressDisplay's CopyButton doesn't stop click propagation, so
-            nesting it inside the /validators/$hotkey Link above would make a
-            copy click also navigate away. */}
-        <AddressDisplay
-          ss58={v.hotkey}
-          fallback={<>{v.hotkey}</>}
-          compact
-          linkToAccount={false}
-          valueClassName="shrink-0 font-mono mg-type-data-sm text-ink-muted"
-        />
-      </div>
-    ),
+    cell: (v, ctx) => {
+      const group = ctx?.group;
+      // A continuation row of a multi-key operator: same operator as the row
+      // above, so the name is not repeated — the icon + hotkey identify the
+      // key, and the indent reads as "still the same operator".
+      const continuation = group != null && group.size > 1 && group.index > 0;
+      return (
+        <div className={classNames("flex items-center gap-1.5 min-w-0", continuation && "pl-6")}>
+          {v.featured ? <SponsoredBadge /> : null}
+          <Link
+            to="/validators/$hotkey"
+            params={{ hotkey: v.hotkey }}
+            className="flex min-w-0 items-center gap-2 hover:underline"
+            title={v.hotkey}
+          >
+            <ValidatorIdentityChip
+              hotkey={v.hotkey}
+              identity={v.coldkey_identity}
+              size={20}
+              showName={!continuation}
+            />
+          </Link>
+          {group != null && group.size > 1 && group.index === 0 ? (
+            <span
+              className="shrink-0 rounded-full border border-border bg-surface px-1.5 mg-type-caption tabular-nums text-ink-muted"
+              title={`This operator runs ${group.size} validator keys — grouped under its best-ranked one`}
+            >
+              ×{group.size}
+            </span>
+          ) : null}
+          {/* Own AddressDisplay outside the operator Link (not inside it) --
+              AddressDisplay's CopyButton doesn't stop click propagation, so
+              nesting it inside the /validators/$hotkey Link above would make a
+              copy click also navigate away. */}
+          <AddressDisplay
+            ss58={v.hotkey}
+            fallback={<>{v.hotkey}</>}
+            compact
+            linkToAccount={false}
+            valueClassName="shrink-0 font-mono mg-type-data-sm text-ink-muted"
+          />
+        </div>
+      );
+    },
   },
   {
     ...numeric("Take"),

--- a/apps/ui/src/lib/metagraphed/group-validators.test.ts
+++ b/apps/ui/src/lib/metagraphed/group-validators.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "vitest";
+import { groupByOperator } from "./group-validators";
+import type { GlobalValidator } from "./types";
+
+function v(hotkey: string, name: string | null, extra: Partial<GlobalValidator> = {}) {
+  return {
+    hotkey,
+    coldkey: `ck-${hotkey}`,
+    coldkey_identity:
+      name == null ? { has_identity: false, name: null } : { has_identity: true, name },
+    ...extra,
+  } as GlobalValidator;
+}
+
+describe("groupByOperator", () => {
+  test("pulls an operator's later keys up adjacent to its best-ranked row", () => {
+    // Sorted input (e.g. by stake): Ventura's keys sit at ranks 1, 3 and 5.
+    const rows = [
+      v("A", "Ventura Labs"),
+      v("B", null),
+      v("C", "Ventura Labs"),
+      v("D", "Yuma"),
+      v("E", "Ventura Labs"),
+    ];
+    const { list, info } = groupByOperator(rows);
+    expect(list.map((r) => r.hotkey)).toEqual(["A", "C", "E", "B", "D"]);
+    expect(info.get("A")).toEqual({ size: 3, index: 0 });
+    expect(info.get("C")).toEqual({ size: 3, index: 1 });
+    expect(info.get("E")).toEqual({ size: 3, index: 2 });
+    // Single-key rows are their own group of one, in their original order.
+    expect(info.get("B")).toEqual({ size: 1, index: 0 });
+    expect(info.get("D")).toEqual({ size: 1, index: 0 });
+  });
+
+  test("rows without a declared identity never merge, even together", () => {
+    const rows = [v("A", null), v("B", null), v("C", null)];
+    const { list, info } = groupByOperator(rows);
+    expect(list.map((r) => r.hotkey)).toEqual(["A", "B", "C"]);
+    for (const key of ["A", "B", "C"]) {
+      expect(info.get(key)).toEqual({ size: 1, index: 0 });
+    }
+  });
+
+  test("a blank or whitespace-only name is treated as no identity", () => {
+    const rows = [v("A", "  "), v("B", "  ")];
+    const { list, info } = groupByOperator(rows);
+    expect(list.map((r) => r.hotkey)).toEqual(["A", "B"]);
+    expect(info.get("A")).toEqual({ size: 1, index: 0 });
+  });
+
+  test("has_identity:false rows never group even when a name string leaks through", () => {
+    const rows = [
+      {
+        hotkey: "A",
+        coldkey: "ck-A",
+        coldkey_identity: { has_identity: false, name: "Ghost" },
+      } as GlobalValidator,
+      {
+        hotkey: "B",
+        coldkey: "ck-B",
+        coldkey_identity: { has_identity: false, name: "Ghost" },
+      } as GlobalValidator,
+    ];
+    const { info } = groupByOperator(rows);
+    expect(info.get("A")).toEqual({ size: 1, index: 0 });
+    expect(info.get("B")).toEqual({ size: 1, index: 0 });
+  });
+
+  test("names differing only by surrounding whitespace group together", () => {
+    const rows = [v("A", "Yuma"), v("B", " Yuma ")];
+    const { list, info } = groupByOperator(rows);
+    expect(list.map((r) => r.hotkey)).toEqual(["A", "B"]);
+    expect(info.get("B")).toEqual({ size: 2, index: 1 });
+  });
+});

--- a/apps/ui/src/lib/metagraphed/group-validators.ts
+++ b/apps/ui/src/lib/metagraphed/group-validators.ts
@@ -1,0 +1,61 @@
+import type { GlobalValidator } from "./types";
+
+export interface OperatorGroupInfo {
+  /** Total keys this operator runs in the current (filtered) view. */
+  size: number;
+  /** This row's position within its operator group — 0 is the anchor row. */
+  index: number;
+}
+
+/**
+ * Cluster an operator's validator keys adjacent under its best-ranked row.
+ *
+ * Teams run several validator keys (Ventura Labs, Yuma, …), and a flat ranked
+ * list repeats the same operator name at every rank its keys land on. This
+ * regroups the CURRENT sort order without inventing aggregate rows: the first
+ * row an operator occurs at (its best rank under the active sort) becomes the
+ * group anchor, its remaining keys are pulled up adjacent to it in their own
+ * relative order, and everything else keeps its position. Every row is still a
+ * real per-key row — nothing is summed or blended across keys, so per-key
+ * take/APY/stake stay honest and every row still links to its own detail page.
+ *
+ * Grouping is by the coldkey identity's declared name (trimmed): the same
+ * self-declared brand across keys IS the duplication being collapsed. Rows
+ * without a declared identity are their own group of one.
+ */
+export function groupByOperator(rows: GlobalValidator[]): {
+  list: GlobalValidator[];
+  info: Map<string, OperatorGroupInfo>;
+} {
+  const nameOf = (v: GlobalValidator): string | null => {
+    const name = v.coldkey_identity?.has_identity ? v.coldkey_identity.name : null;
+    const trimmed = typeof name === "string" ? name.trim() : "";
+    return trimmed.length > 0 ? trimmed : null;
+  };
+  const members = new Map<string, GlobalValidator[]>();
+  const anchors: GlobalValidator[] = [];
+  for (const v of rows) {
+    const name = nameOf(v);
+    if (!name) {
+      anchors.push(v);
+      continue;
+    }
+    const group = members.get(name);
+    if (group) group.push(v);
+    else {
+      members.set(name, [v]);
+      anchors.push(v);
+    }
+  }
+  const list: GlobalValidator[] = [];
+  const info = new Map<string, OperatorGroupInfo>();
+  for (const anchor of anchors) {
+    const name = nameOf(anchor);
+    const group = name ? (members.get(name) ?? [anchor]) : [anchor];
+    group.forEach((v, index) => {
+      list.push(v);
+      info.set(v.hotkey, { size: group.length, index });
+    });
+  }
+  return { list, info };
+}

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -26,6 +26,7 @@ import { validatorsQuery } from "@/lib/metagraphed/queries";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { formatNumber, isStaleFreshness, classNames } from "@/lib/metagraphed/format";
 import { matchesQuery, sortBy } from "@/lib/metagraphed/url-state";
+import { groupByOperator } from "@/lib/metagraphed/group-validators";
 import { useWatchlist } from "@/lib/metagraphed/watchlist";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
 import { ValidatorCardList } from "@/components/metagraphed/validator-card-list";
@@ -107,6 +108,7 @@ function ValidatorsDirectory({
   const navigate = useNavigate({ from: "/validators/" });
   const sort = search.sort || "total_stake_tao";
   const order = search.order ?? "desc";
+  const grouped = search.grouped ?? true;
   // One canonical fetch regardless of the URL's sort/filter state — the query
   // key never changes with UI state, so sorting/searching re-uses the cached
   // full set instead of refetching.
@@ -139,7 +141,7 @@ function ValidatorsDirectory({
 
   // Client-side search + sort over the full set. Watched rows pin to the top
   // within the current sort (stable partition, not a separate list).
-  const rows = useMemo(() => {
+  const sortedRows = useMemo(() => {
     const filtered = all.filter(
       (v) =>
         matchesQuery([v.hotkey, v.coldkey, v.coldkey_identity?.name], search.q) &&
@@ -155,6 +157,15 @@ function ValidatorsDirectory({
     for (const v of sorted) (watchlist.isWatched(v.hotkey) ? watched : rest).push(v);
     return [...watched, ...rest];
   }, [all, search.q, search.watched, sort, order, watchlist]);
+
+  // Cluster an operator's keys adjacent under its best-ranked row (default on):
+  // one "Ventura Labs ×3" entry instead of the same name repeated at three
+  // ranks. Per-key rows survive untouched — nothing is summed across keys.
+  const { rows, groupInfo } = useMemo(() => {
+    if (!grouped) return { rows: sortedRows, groupInfo: null };
+    const { list, info } = groupByOperator(sortedRows);
+    return { rows: list, groupInfo: info };
+  }, [sortedRows, grouped]);
 
   // #8251: virtualized table body — the same padding-row technique the
   // /subnets table established (#8314): only the visible slice mounts as real
@@ -194,6 +205,20 @@ function ValidatorsDirectory({
         />
         {/* #8256: only offered once something is starred -- an always-visible
             filter that can only ever return nothing is furniture. */}
+        <button
+          type="button"
+          onClick={() => setSearch({ grouped: !grouped })}
+          aria-pressed={grouped}
+          title="Cluster an operator's validator keys under one entry"
+          className={classNames(
+            "inline-flex min-h-9 items-center gap-1.5 rounded border px-2.5 py-1 mg-type-caption font-medium transition-colors",
+            grouped
+              ? "border-accent/40 bg-accent/10 text-accent-text"
+              : "border-border bg-card text-ink-muted hover:border-accent/40 hover:text-ink-strong",
+          )}
+        >
+          Group by operator
+        </button>
         {watchlist.count > 0 ? (
           <button
             type="button"
@@ -309,7 +334,7 @@ function ValidatorsDirectory({
                         </td>
                         {VALIDATOR_COLUMNS.map((col) => (
                           <td key={col.header} className={col.tdClassName}>
-                            {col.cell(v)}
+                            {col.cell(v, { group: groupInfo?.get(v.hotkey) })}
                           </td>
                         ))}
                       </tr>

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -17,6 +17,11 @@ export const validatorsSearchSchema = z.object({
   // A search param (not component state) so a filtered view is shareable and
   // survives a reload.
   watched: fallback(z.boolean(), false).default(false),
+  // Cluster an operator's keys adjacent under its best-ranked row, so a team
+  // running several validators (Ventura Labs, Yuma, …) reads as one entry
+  // with a ×N chip instead of the same name repeated at every rank. On by
+  // default; the toggle exists for anyone who wants the raw flat ranking.
+  grouped: fallback(z.boolean(), true).default(true),
   sort: fallback(z.string(), "total_stake_tao").default("total_stake_tao"),
   // #5344: bring Validators up to the canonical ranked-list interaction model
   // (Subnets) — a sort DIRECTION toggled by clicking a column header, and a row


### PR DESCRIPTION
Closes #9444. Companion to #9443 (identity join restored) — this handles the duplication that becomes visible once names flow again.

## What

- `groupByOperator` in `apps/ui/src/lib/metagraphed/group-validators.ts` — pure clustering over the sorted rows: an operator's keys are pulled adjacent under its best-ranked row; everything else keeps its position. No aggregate rows are invented — per-key take/APY/stake stay honest, and each row keeps its own `/validators/$hotkey` link.
- Anchor row renders the operator name + a ×N chip (`This operator runs N validator keys`); continuation rows indent and drop the repeated name (icon + hotkey identify the key).
- `grouped` search param (default **on**, stripped from the URL at default, shareable when off) with a `Group by operator` toggle chip beside the Watched filter.
- Grouping is by the coldkey identity's declared name (trimmed); `has_identity:false` rows never merge, even with an identical leaked name string.

## Notes

- Table stays a flat virtualized array — no changes to the virtualizer, CSV export, heatmap, or card list.
- Watched-row pinning composes: members follow their anchor into the watched partition.
- Unit tests cover clustering order, group metadata, no-identity isolation, whitespace normalization, and the has_identity guard. `tsc` clean for the touched files (the one pre-existing `-subnets-index-page.tsx` error on main is untouched); prettier-formatted from inside the workspace.