### PR TITLE
fix(telemetry): finish the dimensions the last two passes left half-applied

### DIFF
--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -904,6 +904,9 @@ export async function recordMcpToolCallEvent(
     const responseBody = boundedMcpPayload(event.response);
     if (responseBody !== undefined) properties["$mcp_response"] = responseBody;
 
+    // The deployment dimensions, stamped exactly where this family already
+    // stamps its attribution -- see assignMcpAttribution above.
+    assignDeployment(properties, env);
     const doFetch = deps.fetch ?? globalThis.fetch;
     const response = await doFetch(
       `${resolvePostHogHost(env)}${POSTHOG_CAPTURE_PATH}`,
@@ -955,6 +958,9 @@ export async function recordMcpInitializeEvent(
       properties["$session_id"] = event.sessionId.trim();
     }
 
+    // The deployment dimensions, stamped exactly where this family already
+    // stamps its attribution -- see assignMcpAttribution above.
+    assignDeployment(properties, env);
     const doFetch = deps.fetch ?? globalThis.fetch;
     const response = await doFetch(
       `${resolvePostHogHost(env)}${POSTHOG_CAPTURE_PATH}`,
@@ -1004,6 +1010,9 @@ export async function recordMcpToolsListEvent(
       properties["$session_id"] = event.sessionId.trim();
     }
 
+    // The deployment dimensions, stamped exactly where this family already
+    // stamps its attribution -- see assignMcpAttribution above.
+    assignDeployment(properties, env);
     const doFetch = deps.fetch ?? globalThis.fetch;
     const response = await doFetch(
       `${resolvePostHogHost(env)}${POSTHOG_CAPTURE_PATH}`,
@@ -1396,6 +1405,9 @@ export async function recordAiDegradedEvent(
     const surface = sanitizeLabel(event.surface);
     if (surface !== undefined) properties.surface = surface;
 
+    // The deployment dimensions, stamped exactly where this family already
+    // stamps its attribution -- see assignMcpAttribution above.
+    assignDeployment(properties, env);
     const doFetch = deps.fetch ?? globalThis.fetch;
     const response = await doFetch(
       `${resolvePostHogHost(env)}${POSTHOG_CAPTURE_PATH}`,
@@ -1503,6 +1515,9 @@ export async function recordAiEmbeddingEvent(
       properties.$ai_error = `${type}: ${entry.value}`;
     }
 
+    // The deployment dimensions, stamped exactly where this family already
+    // stamps its attribution -- see assignMcpAttribution above.
+    assignDeployment(properties, env);
     const doFetch = deps.fetch ?? globalThis.fetch;
     const response = await doFetch(
       `${resolvePostHogHost(env)}${POSTHOG_CAPTURE_PATH}`,
@@ -1592,6 +1607,9 @@ export async function recordAiGenerationEvent(
       properties.$ai_error = `${type}: ${entry.value}`;
     }
 
+    // The deployment dimensions, stamped exactly where this family already
+    // stamps its attribution -- see assignMcpAttribution above.
+    assignDeployment(properties, env);
     const doFetch = deps.fetch ?? globalThis.fetch;
     const response = await doFetch(
       `${resolvePostHogHost(env)}${POSTHOG_CAPTURE_PATH}`,

--- a/tests/mcp-session-hub.test.ts
+++ b/tests/mcp-session-hub.test.ts
@@ -996,3 +996,68 @@ test("#8997: telemetry never fails the session operation", async () => {
     globalThis.fetch = original;
   }
 });
+
+// #9446: a DO alarm that throws is retried by the platform and recorded
+// NOWHERE -- there is no request to fail and no caller to notice, and this
+// file's one capture site covers `deliver` only. An alarm stuck in a retry
+// loop was therefore indistinguishable from a hub with no sessions to expire,
+// which is the state it is in almost all the time.
+test("alarm: a thrown expiry is captured as an $exception and still propagates", async () => {
+  const posted: Row[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    posted.push({ url, body: JSON.parse(String(init?.body ?? "{}")) });
+    return new Response("{}", { status: 200 });
+  }) as unknown as typeof fetch;
+  try {
+    // Storage that throws on read: hydrate() is the first thing alarm() does.
+    const brokenState = {
+      storage: {
+        get: async () => {
+          throw new Error("storage unreachable");
+        },
+        put: async () => {},
+        deleteAll: async () => {},
+        setAlarm: async () => {},
+      },
+    } as unknown as DurableObjectState;
+    const hub = new McpSessionHub(
+      brokenState,
+      mockEnv({ POSTHOG_PROJECT_TOKEN: "phc_test_token" }),
+    );
+
+    await assert.rejects(hub.alarm(), /storage unreachable/);
+
+    const exceptions = posted.filter(
+      (p) => (p.body as Row).event === "$exception",
+    );
+    assert.equal(exceptions.length, 1);
+    const properties = (exceptions[0].body as Row).properties as Row;
+    assert.equal(properties.route, "mcp-session-hub:alarm");
+    assert.equal(properties.error_code, "internal_error");
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("alarm: a healthy expiry captures nothing", async () => {
+  const posted: Row[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    posted.push({ url, body: JSON.parse(String(init?.body ?? "{}")) });
+    return new Response("{}", { status: 200 });
+  }) as unknown as typeof fetch;
+  try {
+    const hub = new McpSessionHub(
+      stubState(),
+      mockEnv({ POSTHOG_PROJECT_TOKEN: "phc_test_token" }),
+    );
+    await hub.alarm();
+    assert.deepEqual(
+      posted.filter((p) => (p.body as Row).event === "$exception"),
+      [],
+    );
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/tests/request-usage-telemetry.test.ts
+++ b/tests/request-usage-telemetry.test.ts
@@ -3,7 +3,11 @@ import { afterEach, describe, test, vi } from "vitest";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
 import { POSTHOG_TRACES_SAMPLE_RATE_ENV } from "../src/tracing.ts";
-import worker, { usageRouteLabel, withUsageTelemetry } from "../workers/api.ts";
+import worker, {
+  markRequestAuthTier,
+  usageRouteLabel,
+  withUsageTelemetry,
+} from "../workers/api.ts";
 import type { Row } from "./row-type.ts";
 
 type WTCtx = Parameters<typeof withUsageTelemetry>[2];
@@ -875,5 +879,127 @@ describe("worker entry instrumentation", () => {
 
     assert.equal(after.status, status);
     assert.equal(await after.text(), body);
+  });
+});
+
+// #9446: auth_tier on REST.
+//
+// The field has been declared on UsageEvent since #8993 and populated only on
+// the MCP path, so on the surface carrying 99% of traffic the question the
+// tier system exists to answer -- what share of usage is authenticated, and on
+// which tier -- had no data behind it at all.
+describe("withUsageTelemetry — auth_tier", () => {
+  test("records the tier a gate resolved for this request", async () => {
+    const spy = recorder();
+    const request = req("/api/v1/subnets");
+    await withUsageTelemetry(
+      request,
+      CONFIGURED_ENV as unknown as Env,
+      fakeCtx(),
+      async () => {
+        // What the tiered gates do inside handleRequest.
+        markRequestAuthTier(request, "paid");
+        return new Response("ok");
+      },
+      spy,
+    );
+    assert.equal(spy.events[0].event.authTier, "paid");
+  });
+
+  test("omits it entirely for a route with no tiered gate", async () => {
+    // "anonymous" would be a claim the request never made: those routes did
+    // not check a key at all. Omitted, not defaulted -- the same contract
+    // every other optional dimension here follows.
+    const spy = recorder();
+    await withUsageTelemetry(
+      req("/api/v1/subnets"),
+      CONFIGURED_ENV as unknown as Env,
+      fakeCtx(),
+      async () => new Response("ok"),
+      spy,
+    );
+    assert.equal("authTier" in spy.events[0].event, false);
+  });
+
+  test("records the anonymous tier when the gate resolved one", async () => {
+    // A gate that ran and found no key is a different fact from no gate at
+    // all, and both must be distinguishable in the data.
+    const spy = recorder();
+    const request = req("/api/v1/subnets");
+    await withUsageTelemetry(
+      request,
+      CONFIGURED_ENV as unknown as Env,
+      fakeCtx(),
+      async () => {
+        markRequestAuthTier(request, "anonymous");
+        return new Response("ok");
+      },
+      spy,
+    );
+    assert.equal(spy.events[0].event.authTier, "anonymous");
+  });
+
+  test("one request's tier is never read by another", async () => {
+    const spy = recorder();
+    const keyed = req("/api/v1/subnets");
+    await withUsageTelemetry(
+      keyed,
+      CONFIGURED_ENV as unknown as Env,
+      fakeCtx(),
+      async () => {
+        markRequestAuthTier(keyed, "community");
+        return new Response("ok");
+      },
+      spy,
+    );
+    // A DIFFERENT Request object, so the WeakMap has no entry for it.
+    await withUsageTelemetry(
+      req("/api/v1/subnets"),
+      CONFIGURED_ENV as unknown as Env,
+      fakeCtx(),
+      async () => new Response("ok"),
+      spy,
+    );
+    assert.equal(spy.events[0].event.authTier, "community");
+    assert.equal("authTier" in spy.events[1].event, false);
+  });
+
+  test("a blank or non-string tier is not recorded", async () => {
+    const spy = recorder();
+    const request = req("/api/v1/subnets");
+    await withUsageTelemetry(
+      request,
+      CONFIGURED_ENV as unknown as Env,
+      fakeCtx(),
+      async () => {
+        markRequestAuthTier(request, "");
+        markRequestAuthTier(request, undefined);
+        return new Response("ok");
+      },
+      spy,
+    );
+    assert.equal("authTier" in spy.events[0].event, false);
+  });
+
+  test("still recorded when the handler throws", async () => {
+    // The gate runs before the fault, so the tier is known and belongs on the
+    // failure event as much as on a success.
+    const spy = recorder();
+    const request = req("/api/v1/subnets");
+    await assert.rejects(
+      withUsageTelemetry(
+        request,
+        CONFIGURED_ENV as unknown as Env,
+        fakeCtx(),
+        async () => {
+          markRequestAuthTier(request, "free");
+          throw new Error("handler exploded");
+        },
+        spy,
+      ),
+      /handler exploded/,
+    );
+    assert.equal(spy.events[0].event.ok, false);
+    assert.equal(spy.events[0].event.authTier, "free");
   });
 });

--- a/tests/subnet-status-hub.test.ts
+++ b/tests/subnet-status-hub.test.ts
@@ -422,3 +422,69 @@ test("#8997: telemetry never fails the subscription", async () => {
     globalThis.fetch = original;
   }
 });
+
+// #9446: this class imported ONLY recordUsageEvent, and that event is emitted
+// after a handler returns -- so a handler that threw produced neither a usage
+// event nor an $exception. A subscription hub that has started rejecting every
+// subscribe looked, from telemetry, exactly like one nobody is subscribing to.
+test("fetch: a thrown handler is captured as an $exception and still propagates", async () => {
+  const posted: Row[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    posted.push({ url, body: JSON.parse(String(init?.body ?? "{}")) });
+    return new Response("{}", { status: 200 });
+  }) as unknown as typeof fetch;
+  try {
+    const hub = new SubnetStatusHub(stubState(), {
+      POSTHOG_PROJECT_TOKEN: "phc_test_token",
+    } as unknown as Env);
+    // A body that is not JSON makes handleSubscribe's request.json() throw --
+    // an unhandled fault, not a validated rejection.
+    await assert.rejects(
+      hub.fetch(
+        new Request("https://subnet-status-hub.internal/mcp-subscribe", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "not json",
+        }),
+      ),
+    );
+
+    const exceptions = posted.filter(
+      (p) => (p.body as Row).event === "$exception",
+    );
+    assert.equal(exceptions.length, 1);
+    const properties = (exceptions[0].body as Row).properties as Row;
+    assert.equal(properties.route, "subnet-status-hub:fetch");
+    assert.equal(properties.error_code, "internal_error");
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("fetch: a healthy request captures nothing", async () => {
+  const posted: Row[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    posted.push({ url, body: JSON.parse(String(init?.body ?? "{}")) });
+    return new Response("{}", { status: 200 });
+  }) as unknown as typeof fetch;
+  try {
+    const hub = new SubnetStatusHub(stubState(), {
+      POSTHOG_PROJECT_TOKEN: "phc_test_token",
+    } as unknown as Env);
+    const res = await hub.fetch(
+      jsonRequest("https://subnet-status-hub.internal/mcp-subscribe", {
+        sessionId: "session-ok",
+        netuid: 7,
+      }),
+    );
+    assert.equal(res.status, 200);
+    assert.deepEqual(
+      posted.filter((p) => (p.body as Row).event === "$exception"),
+      [],
+    );
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -33,6 +33,7 @@ import type {
   AiGenerationEvent,
   ExceptionEvent,
   McpToolCallEvent,
+  RecordUsageEventDeps,
   UsageEvent,
 } from "../src/usage-telemetry.ts";
 
@@ -393,6 +394,11 @@ describe("recordMcpToolCallEvent", () => {
       $mcp_duration_ms: 12,
       $mcp_tool_name: "get_subnet",
       $session_id: "sess-1",
+      // #9446: the deployment dimension every capture now carries.
+      // No CF_VERSION_METADATA binding in this env, so it reads as a
+      // local/undeployed isolate -- the production shape is asserted in
+      // the resolveDeployment block.
+      environment: "development",
     });
   });
 
@@ -691,6 +697,11 @@ describe("recordMcpInitializeEvent", () => {
       $mcp_client_name_source: "client_info",
       $mcp_client_version: "1.2.3",
       $session_id: "sess-1",
+      // #9446: the deployment dimension every capture now carries.
+      // No CF_VERSION_METADATA binding in this env, so it reads as a
+      // local/undeployed isolate -- the production shape is asserted in
+      // the resolveDeployment block.
+      environment: "development",
     });
   });
 
@@ -701,7 +712,13 @@ describe("recordMcpInitializeEvent", () => {
       {},
       { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
     );
-    assert.deepEqual(calls[0].body.properties, {});
+    // #9446: `environment` is the deployment dimension every capture now
+    // carries; no CF_VERSION_METADATA binding here, so it reads as a
+    // local/undeployed isolate. Everything the caller omitted is still
+    // absent, which is what this test is actually about.
+    assert.deepEqual(calls[0].body.properties, {
+      environment: "development",
+    });
   });
 
   test("defaults to the platform fetch when none is injected", async () => {
@@ -1711,6 +1728,11 @@ describe("recordMcpToolsListEvent", () => {
       $mcp_server_name: "metagraphed",
       $mcp_server_version: "1.78.12",
       $session_id: "sess-9",
+      // #9446: the deployment dimension every capture now carries.
+      // No CF_VERSION_METADATA binding in this env, so it reads as a
+      // local/undeployed isolate -- the production shape is asserted in
+      // the resolveDeployment block.
+      environment: "development",
     });
   });
 
@@ -2017,6 +2039,11 @@ describe("recordAiDegradedEvent", () => {
     assert.deepEqual(calls[0].body.properties, {
       reason: "rate_limited",
       surface: "ask",
+      // #9446: the deployment dimension every capture now carries.
+      // No CF_VERSION_METADATA binding in this env, so it reads as a
+      // local/undeployed isolate -- the production shape is asserted in
+      // the resolveDeployment block.
+      environment: "development",
     });
   });
 
@@ -2027,7 +2054,14 @@ describe("recordAiDegradedEvent", () => {
       { reason: "ai_disabled" },
       deps,
     );
-    assert.deepEqual(calls[0].body.properties, { reason: "ai_disabled" });
+    // #9446: `environment` is the deployment dimension every capture now
+    // carries; no CF_VERSION_METADATA binding here, so it reads as a
+    // local/undeployed isolate. `surface` is still absent, which is what
+    // this test is actually about.
+    assert.deepEqual(calls[0].body.properties, {
+      reason: "ai_disabled",
+      environment: "development",
+    });
   });
 
   test("rejects an event with no reason", async () => {
@@ -2621,5 +2655,114 @@ describe("MCP protocol events are exempt from usage_event sampling", () => {
     // Unsampled captures omit sample_rate entirely, so a weighted aggregate
     // (sum(1/coalesce(sample_rate,1))) counts them exactly once.
     assert.equal("sample_rate" in (calls[0].body as Row).properties, false);
+  });
+});
+
+// #9446: EVERY capture this module posts carries the deployment dimensions.
+//
+// #9434 added them by editing two recorders, which is how the other six
+// shipped without: a live query showed usage_event and $exception tagged
+// `production` with a real release id while every $mcp_* event carried null.
+// The dimension is only useful if it is on all of them -- a breakdown by
+// environment silently drops whichever family forgot.
+//
+// Written as one table over the whole family rather than six separate
+// assertions so a NEWLY ADDED recorder that forgets is a failing test here,
+// not a gap discovered months later in production data.
+describe("every recorder stamps the deployment dimensions", () => {
+  const DEPLOYED = {
+    [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token",
+    CF_VERSION_METADATA: { id: "dep-9", tag: "v9" },
+  };
+
+  // Typed against the recorders' real signatures rather than Row, so the
+  // table cannot drift from what they actually accept.
+  const recorders: Array<
+    [string, (env: Env, deps: RecordUsageEventDeps) => Promise<unknown>]
+  > = [
+    [
+      "usage_event",
+      (env, deps) =>
+        recordUsageEvent(env, { route: "r", ok: true, durationMs: 1 }, deps),
+    ],
+    [
+      "$exception",
+      (env, deps) =>
+        recordExceptionEvent(env, { error: new Error("x"), route: "r" }, deps),
+    ],
+    [
+      "$mcp_tool_call",
+      (env, deps) =>
+        recordMcpToolCallEvent(
+          env,
+          { toolName: "get_subnet", isError: false, durationMs: 5 },
+          deps,
+        ),
+    ],
+    [
+      "$mcp_initialize",
+      (env, deps) => recordMcpInitializeEvent(env, { clientName: "c" }, deps),
+    ],
+    [
+      "$mcp_tools_list",
+      (env, deps) => recordMcpToolsListEvent(env, { toolCount: 3 }, deps),
+    ],
+    [
+      "ai_degraded",
+      (env, deps) =>
+        recordAiDegradedEvent(env, { reason: "ai_disabled" }, deps),
+    ],
+    [
+      "$ai_embedding",
+      (env, deps) =>
+        recordAiEmbeddingEvent(
+          env,
+          { provider: "p", model: "m", latencyMs: 1, isError: false },
+          deps,
+        ),
+    ],
+    [
+      "$ai_generation",
+      (env, deps) =>
+        recordAiGenerationEvent(
+          env,
+          { provider: "p", model: "m", latencyMs: 1, isError: false },
+          deps,
+        ),
+    ],
+  ];
+
+  for (const [eventName, invoke] of recorders) {
+    test(`${eventName} carries environment and release`, async () => {
+      const calls: Row[] = [];
+      await invoke(mockEnv(DEPLOYED), {
+        fetch: fakeFetch({ onCall: (call) => calls.push(call) }),
+      });
+
+      assert.equal(calls.length, 1, "the recorder posted nothing");
+      assert.equal((calls[0].body as Row).event, eventName);
+      const properties = (calls[0].body as Row).properties as Row;
+      assert.equal(properties.environment, "production");
+      assert.equal(properties.release, "v9");
+    });
+  }
+
+  test("the table covers every exported recorder in this module", async () => {
+    // The assertion that makes the table self-maintaining: a new recordX
+    // export that is not listed above fails HERE, rather than shipping a
+    // family with no environment on it. Reads the module's own exports, so it
+    // cannot drift from what actually exists.
+    const module = (await import("../src/usage-telemetry.ts")) as Record<
+      string,
+      unknown
+    >;
+    const exported = Object.keys(module)
+      .filter((name) => /^record[A-Z]/.test(name))
+      .sort();
+    assert.equal(
+      exported.length,
+      recorders.length,
+      `recorders covered: ${recorders.length}, exported: ${exported.join(", ")}`,
+    );
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1244,6 +1244,36 @@ function maskUsageRouteParams(pathname: string) {
   return maskRouteParams(pathname);
 }
 
+// #9446: the caller's tier, for the usage_event `auth_tier` dimension.
+//
+// `authTier` has been declared on UsageEvent since #8993 and populated ONLY on
+// the MCP path, so on REST -- the surface with 99% of the traffic -- the
+// question the tier system exists to answer ("what share of usage is
+// authenticated, and on which tier") had no data behind it at all.
+//
+// A WeakMap keyed on the Request, rather than a new parameter threaded from
+// four gate sites up through handleRequest to this wrapper. The gate already
+// resolves the tier (applyTieredRateLimit returns it and every caller
+// discarded it); this carries that answer back out without reshaping the
+// signature of every function in between, which is the same reasoning the MCP
+// side used when it put authTier on its ctx rather than passing it down.
+//
+// WeakMap and not a Map: the key is the request object itself, so an entry
+// becomes collectable the moment the request is done. There is nothing to
+// evict, nothing to size, and no way for one request's tier to be read by
+// another -- the failure mode a keyed cache would have.
+const requestAuthTier = new WeakMap<Request, string>();
+
+/**
+ * Record the tier a request authenticated on, for its usage event.
+ *
+ * Called from the tiered-rate-limit gates, which are the only places that
+ * verify a key. Exported for tests.
+ */
+export function markRequestAuthTier(request: Request, tier: unknown): void {
+  if (typeof tier === "string" && tier) requestAuthTier.set(request, tier);
+}
+
 /**
  * Who made this request, for the usage_event `client` dimension.
  *
@@ -1378,6 +1408,12 @@ export async function withUsageTelemetry(
     throw error;
   } finally {
     const endedAt = Date.now();
+    // Read AFTER the handler, since the gate that resolves it runs inside.
+    // Absent for a route with no tiered gate, which is the honest answer --
+    // those routes did not check a key, so "anonymous" would be a claim the
+    // request never actually made. Same omitted-not-defaulted contract every
+    // other optional dimension here follows.
+    const authTier = requestAuthTier.get(request);
     scheduleUsageEvent(env, ctx, record, {
       route,
       ok,
@@ -1386,6 +1422,7 @@ export async function withUsageTelemetry(
       ...(statusClass ? { statusClass } : {}),
       ...(client ? { client } : {}),
       ...(errorCode ? { errorCode } : {}),
+      ...(authTier ? { authTier } : {}),
     });
     // metagraphed#7768: PostHog distributed tracing (alpha), one root span
     // per request -- replaces @sentry/cloudflare's automatic withSentry() HTTP
@@ -2146,6 +2183,7 @@ export async function handleChainEventsFamily(
     env,
     DATA_TIERED_RATE_LIMIT,
   );
+  markRequestAuthTier(request, rateLimit.tier);
   // #8609: recorded for BOTH outcomes, BEFORE the rejection return, with the
   // flag derived from the gate's own verdict -- so a 429 lands in
   // rejected_count instead of request_count. Recording after the return would
@@ -6983,6 +7021,7 @@ async function webhookSubscriptionRateLimited(
     env,
     WEBHOOK_SUBSCRIPTION_TIERED_RATE_LIMIT,
   );
+  markRequestAuthTier(request, rateLimit.tier);
   // #8609: recorded before the rejection return so a throttled request is
   // counted as a rejection rather than not counted at all.
   if (rateLimit.accountId) {
@@ -7408,6 +7447,7 @@ async function handleSemanticSearchRequest(
     env,
     AI_TIERED_RATE_LIMIT,
   );
+  markRequestAuthTier(request, rateLimit.tier);
   if (!rateLimit.allowed) {
     return aiRateLimitedResponse(rateLimit);
   }
@@ -7460,6 +7500,7 @@ async function handleAskRequest(request: Request, env: Env, ctx?: Ctx) {
     env,
     AI_TIERED_RATE_LIMIT,
   );
+  markRequestAuthTier(request, rateLimit.tier);
   if (!rateLimit.allowed) {
     return aiRateLimitedResponse(rateLimit);
   }

--- a/workers/mcp-session-hub.ts
+++ b/workers/mcp-session-hub.ts
@@ -586,17 +586,40 @@ export class McpSessionHub implements DurableObject {
   // ChainFirehoseHub.mcpSubscribedSessions never accumulates dead sessions
   // just because a client never explicitly unsubscribed/terminated.
   async alarm(): Promise<void> {
-    await this.hydrate();
-    // Idle expiry, distinct from a client DELETE: same terminate path, but the
-    // session ended because nobody came back, which is the fact worth counting
-    // separately when reasoning about session lifetimes.
-    const startedAt = Date.now();
-    this.recordRoute("expire", true, startedAt);
-    await this.handleTerminate(
-      new Request("https://mcp-session-hub.internal/terminate", {
-        method: "POST",
-        body: JSON.stringify({ sessionId: null }),
-      }),
-    );
+    // #9446: a DO alarm that throws is retried by the platform and recorded
+    // NOWHERE -- no request to fail, no caller to notice, and this file's one
+    // capture site covers `deliver` only. An alarm stuck in a retry loop is
+    // therefore indistinguishable from a hub with no sessions to expire, which
+    // is the state it is supposed to be in almost all the time.
+    //
+    // Captured and rethrown: the platform's own retry behaviour is what makes
+    // a transient failure recoverable, so swallowing here would trade a
+    // retried alarm for a silently skipped expiry.
+    try {
+      await this.hydrate();
+      // Idle expiry, distinct from a client DELETE: same terminate path, but
+      // the session ended because nobody came back, which is the fact worth
+      // counting separately when reasoning about session lifetimes.
+      const startedAt = Date.now();
+      this.recordRoute("expire", true, startedAt);
+      await this.handleTerminate(
+        new Request("https://mcp-session-hub.internal/terminate", {
+          method: "POST",
+          body: JSON.stringify({ sessionId: null }),
+        }),
+      );
+    } catch (error) {
+      // Awaited bare: recordExceptionEvent is contractually
+      // no-throw (it swallows transport failures and returns
+      // false), so a `.catch` here would be an unreachable
+      // handler -- a branch no test can cover, which is worse
+      // than no branch. Same call shape as src/graphql.ts.
+      await recordExceptionEvent(this.env, {
+        error,
+        route: "mcp-session-hub:alarm",
+        errorCode: "internal_error",
+      });
+      throw error;
+    }
   }
 }

--- a/workers/subnet-status-hub.ts
+++ b/workers/subnet-status-hub.ts
@@ -1,4 +1,7 @@
-import { recordUsageEvent } from "../src/usage-telemetry.ts";
+import {
+  recordExceptionEvent,
+  recordUsageEvent,
+} from "../src/usage-telemetry.ts";
 
 // SubnetStatusHub -- singleton Durable Object (idFromName("global")) that
 // owns the inverted netuid → MCP-session index for
@@ -173,6 +176,32 @@ export class SubnetStatusHub implements DurableObject {
   }
 
   async fetch(request: Request): Promise<Response> {
+    // #9446: this class had no exception capture at all -- it imported only
+    // recordUsageEvent, and that event is emitted AFTER a handler returns, so
+    // a handler that threw produced neither a usage event nor an $exception.
+    // A subscription hub that has started rejecting every subscribe looks,
+    // from telemetry, exactly like one nobody is subscribing to.
+    //
+    // Rethrown unchanged: the DO's caller decides what a failure means, and
+    // this only makes the failure visible.
+    try {
+      return await this.dispatch(request);
+    } catch (error) {
+      // Awaited bare: recordExceptionEvent is contractually
+      // no-throw (it swallows transport failures and returns
+      // false), so a `.catch` here would be an unreachable
+      // handler -- a branch no test can cover, which is worse
+      // than no branch. Same call shape as src/graphql.ts.
+      await recordExceptionEvent(this.env, {
+        error,
+        route: "subnet-status-hub:fetch",
+        errorCode: "internal_error",
+      });
+      throw error;
+    }
+  }
+
+  private async dispatch(request: Request): Promise<Response> {
     await this.hydrate();
     const url = new URL(request.url);
     const startedAt = Date.now();


### PR DESCRIPTION
## Summary

Three gaps left by the preceding observability work — one of them introduced by it, and caught by querying the live data rather than by reading the diff.

**Six of eight recorders never got the deployment dimensions.** #9434 added `environment`/`release` by editing `recordUsageEvent` and `recordExceptionEvent`; the module has eight recorders. Live data after that deploy:

| event | environment | release |
| --- | --- | --- |
| `usage_event` | `production` | `45f4e203-…` |
| `$exception` | `production` | `45f4e203-…` |
| `$mcp_tool_call` | *(null)* | *(null)* |

So a breakdown by environment silently dropped the entire MCP and AI families — precisely the separation the dimension was added to give. Stamped now the way this file already stamps attribution: one `assign*` call per recorder, mirroring how `assignMcpAttribution` is applied across the `$mcp_*` family. The guard against a recurrence is a **table-driven test that reads the module's own `record*` exports** and fails if one isn't covered, so a ninth recorder is correct by construction instead of by whoever remembers.

**`auth_tier` is now recorded on REST.** Declared on `UsageEvent` since #8993 and populated only on the MCP path, so the surface carrying ~99% of traffic had no data behind the question the tier system exists to answer. `applyTieredRateLimit` already resolves the tier; all four call sites discarded it. A `WeakMap` keyed on the `Request` carries it out to the usage-event chokepoint — the same shape the MCP side used when it put `authTier` on its ctx, rather than threading a parameter through every function between the gate and the wrapper. `WeakMap` and not `Map`: the key is the request object, so entries are collectable the moment the request ends — nothing to size, nothing to evict, and no way for one request's tier to be read by another. Omitted, never defaulted to `"anonymous"`, for routes with no tiered gate: those never checked a key, so a tier would be a claim the request didn't make.

**Two Durable Objects still captured nothing.** `SubnetStatusHub` imported only `recordUsageEvent`, and that event is emitted *after* a handler returns — so a throwing handler produced neither a usage event nor an `$exception`, and a hub rejecting every subscribe looked identical to one nobody subscribes to. `McpSessionHub.alarm()` had no capture at all; a DO alarm that throws is retried by the platform and recorded nowhere, so an alarm stuck in a retry loop was indistinguishable from a hub with no sessions to expire — which is its normal state. Both capture and rethrow, leaving the platform's retry behaviour intact.

## Design notes

- **Followed the existing idiom rather than inventing one.** My first attempt factored all eight POSTs into a single `postCapture` chokepoint. It diverged from the established per-recorder `assign*` pattern and broke error semantics (a `return promise` inside `try/catch` doesn't catch), so it was reverted in favour of matching what the `$mcp_*` family already does well.
- **No unreachable guards.** `recordExceptionEvent` is contractually no-throw, so the two new capture sites `await` it bare, as `src/graphql.ts` does. A `.catch()` there would be a branch no test can cover — worse than no branch, given `codecov/patch` counts it.

## Validation

```
npm run lint            clean
npm run format:check    clean
npm run typecheck       clean
npm run test:coverage   full suite green — 99.11% statements, 97.98% branches
```

Patch coverage by diff intersection against `src/**` + `workers/**`, computed from the unsharded full-suite lcov: **24/24 = 100%**.

Closes #9446
