### PR TITLE
fix(ui): stop virtualized table rows drifting as you scroll, and put the scroll affordance on the element that scrolls

### DIFF
--- a/apps/ui/src/components/metagraphed/sticky-table-header-anchoring.test.ts
+++ b/apps/ui/src/components/metagraphed/sticky-table-header-anchoring.test.ts
@@ -38,10 +38,15 @@ describe("sticky table header anchoring", () => {
     // measures and the element the header pins to are the same one.
     expect(subnetsPage).toContain("viewportRef={tableScrollRef}");
     expect(subnetsPage).not.toContain("mg-list-viewport");
-    // Conditional, not a literal: `stickyHeader={false}` drops the bounded
-    // box along with the pin, so a list that opts out page-scrolls entirely
-    // rather than getting a scroll region whose header scrolls away inside it.
-    expect(listShell).toContain('stickyHeader ? "mg-list-viewport" : undefined');
+    // ONE element carries both classes: .mg-table-scroll for the edge-fade and
+    // thin scrollbar, .mg-list-viewport for the height cap, both overflow axes
+    // and overscroll containment. Nesting them does not work -- `overflow-y:
+    // auto` coerces `overflow-x` to `auto`, so an inner vertical scroller
+    // steals the horizontal axis and strands the affordance on an element that
+    // can no longer scroll.
+    expect(listShell).toContain('"mg-table-scroll mg-list-viewport"');
+    // `stickyHeader={false}` drops the bounded box along with the pin.
+    expect(listShell).toContain('"mg-table-scroll overflow-x-auto"');
     // The cap must carry a literal fallback. A bare var() that fails to
     // resolve computes `max-height: none`, which silently unbounds the
     // viewport and makes every sticky header in the app inert again --

--- a/apps/ui/src/hooks/use-measured-row-height.ts
+++ b/apps/ui/src/hooks/use-measured-row-height.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState, type RefObject } from "react";
+
+/**
+ * The real height of a virtualized table's rows, for `estimateSize`.
+ *
+ * A virtualizer positions every unmounted row using the estimate and every
+ * mounted row using its measured height (these tables pass
+ * `rowVirtualizer.measureElement` as a row ref). When the two disagree, the
+ * total size is re-derived on every mount, so the scrollbar and all the
+ * offsets below the viewport slide while the reader scrolls -- content
+ * shifting under the cursor for no reason the reader can see.
+ *
+ * Both tables disagreed, in opposite directions, and neither was noticeable
+ * until the header was pinned and the list scrolled inside its own viewport:
+ *
+ *   /subnets     estimate 49, actual 56  -> scrollHeight grew  6524 -> 7255
+ *   /validators  estimate 41, actual 39  -> scrollHeight shrank 41672 -> 41180
+ *
+ * A literal is not the fix. Row height is a product of density, font size and
+ * whatever the row renders (both of these stack two lines in their first
+ * column), so any constant is right for exactly one combination and silently
+ * wrong for the rest -- which is how these two drifted apart in the first
+ * place. Measure the row that is actually on screen instead, and keep the
+ * caller's constant only as the pre-measurement seed.
+ */
+export function useMeasuredRowHeight(
+  scrollRef: RefObject<HTMLElement | null>,
+  /** Seed used for the very first render, before a row exists to measure. */
+  fallback: number,
+): number {
+  const [height, setHeight] = useState(fallback);
+
+  // Re-seed when the caller's fallback changes (density toggles), so the
+  // measurement below starts from the right ballpark rather than easing over
+  // from the previous density's value.
+  const [seed, setSeed] = useState(fallback);
+  if (seed !== fallback) {
+    setSeed(fallback);
+    setHeight(fallback);
+  }
+
+  useEffect(() => {
+    const root = scrollRef.current;
+    if (!root || typeof ResizeObserver === "undefined") return;
+
+    const measure = () => {
+      const row = root.querySelector<HTMLElement>("tbody tr[data-index]");
+      if (!row) return;
+      const next = Math.round(row.getBoundingClientRect().height);
+      // Guard the update: setting state on every observation would re-render
+      // the list on every scroll frame, and a 0 would come from a row that is
+      // display:none mid-transition.
+      if (next > 0) setHeight((prev) => (prev === next ? prev : next));
+    };
+
+    measure();
+    // Rows change height when the container width changes (cells wrap) and
+    // when density toggles, so observe rather than measuring once.
+    const observer = new ResizeObserver(measure);
+    observer.observe(root);
+    const row = root.querySelector<HTMLElement>("tbody tr[data-index]");
+    if (row) observer.observe(row);
+    return () => observer.disconnect();
+  }, [scrollRef, seed]);
+
+  return height;
+}

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -93,6 +93,7 @@ import { useWatchlist } from "@/lib/metagraphed/watchlist";
 import { LeaderboardsSection, LeaderboardsCsvExportMenu } from "./-leaderboards-page";
 import { DomainsRollup } from "@/components/metagraphed/domains-rollup";
 import type { AgentCatalogSummary, Subnet, SubnetEconomics } from "@/lib/metagraphed/types";
+import { useMeasuredRowHeight } from "@/hooks/use-measured-row-height";
 
 // #8248: fetch every active subnet in one shot instead of cursor-paginating --
 // the whole list (129 rows) is virtualized client-side, so there is no
@@ -721,10 +722,14 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
   // grid/matrix early return below) since hooks can't be conditional --
   // grid/matrix renders just never read `rowVirtualizer`'s output.
   const tableScrollRef = useRef<HTMLDivElement>(null);
+  const rowHeight = useMeasuredRowHeight(tableScrollRef, density === "compact" ? 37 : 49);
   const rowVirtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => tableScrollRef.current,
-    estimateSize: () => (density === "compact" ? 37 : 49),
+    // Measured, not guessed -- see use-measured-row-height.ts. The literal
+    // here is only the pre-measurement seed; it read 49 against real 56px
+    // rows, which grew the scroll height by ~731px as the reader scrolled.
+    estimateSize: () => rowHeight,
     overscan: 12,
   });
   const virtualRows = rowVirtualizer.getVirtualItems();

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -38,6 +38,7 @@ import {
 } from "@/components/metagraphed/validators-compare-drawer";
 import { SortHeader, ariaSort, SearchInput } from "@/components/metagraphed/table-controls";
 import type { GlobalValidator } from "@/lib/metagraphed/types";
+import { useMeasuredRowHeight } from "@/hooks/use-measured-row-height";
 
 // #8251: one request for the FULL directory (~1,014 validators live; the API
 // cap was raised 100 -> 2000 in the same change) — the table body is
@@ -172,10 +173,14 @@ function ValidatorsDirectory({
   // in-flow `<tr>`s, with two spacer rows standing in for off-screen space,
   // so the sticky header and column alignment keep working.
   const tableScrollRef = useRef<HTMLDivElement>(null);
+  const rowHeight = useMeasuredRowHeight(tableScrollRef, compact ? 33 : 41);
   const rowVirtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => tableScrollRef.current,
-    estimateSize: () => (compact ? 33 : 41),
+    // Measured, not guessed -- see use-measured-row-height.ts. The literal
+    // here is only the pre-measurement seed; it read 41 against real 39px
+    // rows, which shrank the scroll height by ~492px as the reader scrolled.
+    estimateSize: () => rowHeight,
     overscan: 12,
   });
   const virtualRows = rowVirtualizer.getVirtualItems();
@@ -248,109 +253,114 @@ function ValidatorsDirectory({
 
       {rows.length > 0 ? (
         <div className="hidden md:block rounded-md border border-border">
-          {/* Split horizontal/vertical scroll into their own single-axis
-              containers (the same shape the /subnets table's ListShell
-              wrapper uses, #8314) -- a single combined overflow-auto div
-              left the extra columns (Nominators/Dominance/Total
-              stake/30d Δ) scrollable but visually undiscoverable at
-              tablet widths, with no affordance signaling it. mg-table-scroll
-              (ui-kit) adds the edge-fade/thin-scrollbar treatment; the inner
-              overflow-y-auto div keeps tableScrollRef for react-virtual's
-              vertical scroll measurement. */}
-          <div className="mg-table-scroll overflow-x-auto">
-            <div ref={tableScrollRef} className="mg-list-viewport">
-              <table
-                className={classNames(
-                  "w-full text-left text-sm",
-                  compact && "[&_td]:!py-1 [&_th]:!py-1",
-                )}
-              >
-                <thead className="mg-table-head-pinned">
-                  <tr>
-                    <th className="w-6 px-3 py-2" aria-label="Watch" />
-                    <th className="w-6 px-3 py-2" aria-label="Compare" />
-                    {VALIDATOR_COLUMNS.map((col) => (
-                      <th
-                        key={col.header}
-                        className={col.thClassName}
-                        aria-sort={col.sortKey ? ariaSort(sort === col.sortKey, order) : undefined}
-                      >
-                        {col.sortKey ? (
-                          <SortHeader
-                            label={col.header}
-                            field={col.sortKey}
-                            active={sort === col.sortKey}
-                            order={order}
-                            onSort={onSort}
-                            align={col.thClassName.includes("text-right") ? "right" : "left"}
-                          />
-                        ) : (
-                          col.header
-                        )}
-                      </th>
-                    ))}
+          {/* ONE scroll container carrying BOTH sets of styling.
+              This was split into single-axis wrappers (#8314) because a
+              combined overflow-auto div left the extra columns
+              (Nominators/Dominance/Total stake/30d Δ) scrollable but
+              undiscoverable at tablet widths -- no fade, no affordance. That
+              diagnosis was right; the remedy was not. Splitting cannot work,
+              because `overflow-y: auto` coerces `overflow-x` to `auto` too
+              (CSS Overflow 3 §3), so the inner div took the horizontal axis
+              anyway and the outer .mg-table-scroll -- the one carrying the
+              fade and the thin scrollbar -- was left unable to scroll at all.
+              The affordance was on the wrong element the whole time.
+              Measured on a sibling route: inner scrolled x at 958 > 708 while
+              the outer could not move, with a 15px default scrollbar inside
+              the bounded region.
+              Putting .mg-table-scroll ON the scroller is what actually
+              delivers the affordance the original comment wanted. */}
+          <div ref={tableScrollRef} className="mg-table-scroll mg-list-viewport">
+            <table
+              className={classNames(
+                "w-full text-left text-sm",
+                compact && "[&_td]:!py-1 [&_th]:!py-1",
+              )}
+            >
+              <thead className="mg-table-head-pinned">
+                <tr>
+                  <th className="w-6 px-3 py-2" aria-label="Watch" />
+                  <th className="w-6 px-3 py-2" aria-label="Compare" />
+                  {VALIDATOR_COLUMNS.map((col) => (
+                    <th
+                      key={col.header}
+                      className={col.thClassName}
+                      aria-sort={col.sortKey ? ariaSort(sort === col.sortKey, order) : undefined}
+                    >
+                      {col.sortKey ? (
+                        <SortHeader
+                          label={col.header}
+                          field={col.sortKey}
+                          active={sort === col.sortKey}
+                          order={order}
+                          onSort={onSort}
+                          align={col.thClassName.includes("text-right") ? "right" : "left"}
+                        />
+                      ) : (
+                        col.header
+                      )}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {virtualPaddingTop > 0 ? (
+                  <tr aria-hidden>
+                    <td
+                      colSpan={VALIDATOR_COLUMNS.length + 2}
+                      style={{ height: virtualPaddingTop }}
+                    />
                   </tr>
-                </thead>
-                <tbody className="divide-y divide-border">
-                  {virtualPaddingTop > 0 ? (
-                    <tr aria-hidden>
-                      <td
-                        colSpan={VALIDATOR_COLUMNS.length + 2}
-                        style={{ height: virtualPaddingTop }}
-                      />
-                    </tr>
-                  ) : null}
-                  {virtualRows.map((vRow) => {
-                    const v = rows[vRow.index];
-                    return (
-                      <tr
-                        key={v.hotkey}
-                        data-index={vRow.index}
-                        ref={rowVirtualizer.measureElement}
-                        className="hover:bg-surface/40"
-                      >
-                        <td className="px-3 py-2 align-middle">
-                          <button
-                            type="button"
-                            onClick={() => watchlist.toggle(v.hotkey)}
-                            aria-pressed={watchlist.isWatched(v.hotkey)}
-                            aria-label={
-                              watchlist.isWatched(v.hotkey)
-                                ? "Remove from watchlist"
-                                : "Add to watchlist"
-                            }
-                            className="mg-tap-target flex items-center justify-center rounded p-1 text-ink-muted hover:text-ink-strong"
-                          >
-                            <Star
-                              className={classNames(
-                                "size-3.5",
-                                watchlist.isWatched(v.hotkey) && "fill-accent text-accent",
-                              )}
-                            />
-                          </button>
+                ) : null}
+                {virtualRows.map((vRow) => {
+                  const v = rows[vRow.index];
+                  return (
+                    <tr
+                      key={v.hotkey}
+                      data-index={vRow.index}
+                      ref={rowVirtualizer.measureElement}
+                      className="hover:bg-surface/40"
+                    >
+                      <td className="px-3 py-2 align-middle">
+                        <button
+                          type="button"
+                          onClick={() => watchlist.toggle(v.hotkey)}
+                          aria-pressed={watchlist.isWatched(v.hotkey)}
+                          aria-label={
+                            watchlist.isWatched(v.hotkey)
+                              ? "Remove from watchlist"
+                              : "Add to watchlist"
+                          }
+                          className="mg-tap-target flex items-center justify-center rounded p-1 text-ink-muted hover:text-ink-strong"
+                        >
+                          <Star
+                            className={classNames(
+                              "size-3.5",
+                              watchlist.isWatched(v.hotkey) && "fill-accent text-accent",
+                            )}
+                          />
+                        </button>
+                      </td>
+                      <td className="px-3 py-2 align-middle">
+                        <ValidatorCompareToggle hotkey={v.hotkey} />
+                      </td>
+                      {VALIDATOR_COLUMNS.map((col) => (
+                        <td key={col.header} className={col.tdClassName}>
+                          {col.cell(v, { group: groupInfo?.get(v.hotkey) })}
                         </td>
-                        <td className="px-3 py-2 align-middle">
-                          <ValidatorCompareToggle hotkey={v.hotkey} />
-                        </td>
-                        {VALIDATOR_COLUMNS.map((col) => (
-                          <td key={col.header} className={col.tdClassName}>
-                            {col.cell(v, { group: groupInfo?.get(v.hotkey) })}
-                          </td>
-                        ))}
-                      </tr>
-                    );
-                  })}
-                  {virtualPaddingBottom > 0 ? (
-                    <tr aria-hidden>
-                      <td
-                        colSpan={VALIDATOR_COLUMNS.length + 2}
-                        style={{ height: virtualPaddingBottom }}
-                      />
+                      ))}
                     </tr>
-                  ) : null}
-                </tbody>
-              </table>
-            </div>
+                  );
+                })}
+                {virtualPaddingBottom > 0 ? (
+                  <tr aria-hidden>
+                    <td
+                      colSpan={VALIDATOR_COLUMNS.length + 2}
+                      style={{ height: virtualPaddingBottom }}
+                    />
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
           </div>
         </div>
       ) : (

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2047,6 +2047,7 @@ function ListShell({
   stickyHeader = true
 }) {
   const tableCard = "rounded border border-border bg-card overflow-hidden";
+  const viewportClass = stickyHeader ? "mg-table-scroll mg-list-viewport" : "mg-table-scroll overflow-x-auto";
   return /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
     /* @__PURE__ */ jsxRuntime.jsx(
       "div",
@@ -2093,14 +2094,7 @@ function ListShell({
     ) : /* @__PURE__ */ jsxRuntime.jsxs("div", { className: isStale ? "opacity-70 transition-opacity" : void 0, children: [
       cards ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "md:hidden space-y-2", children: cards }) : null,
       /* @__PURE__ */ jsxRuntime.jsx("div", { className: cards ? "hidden md:block" : void 0, children: /* @__PURE__ */ jsxRuntime.jsxs("div", { className: tableCard, children: [
-        /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-table-scroll overflow-x-auto", children: /* @__PURE__ */ jsxRuntime.jsx(
-          "div",
-          {
-            ref: viewportRef,
-            className: stickyHeader ? "mg-list-viewport" : void 0,
-            children: table
-          }
-        ) }),
+        /* @__PURE__ */ jsxRuntime.jsx("div", { ref: viewportRef, className: viewportClass, children: table }),
         footer
       ] }) }),
       cards && footer ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "md:hidden mt-3", children: footer }) : null

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -217,7 +217,7 @@
 }
 .mg-list-viewport {
   max-height: var(--mg-list-viewport-max, 70vh);
-  overflow-y: auto;
+  overflow: auto;
   overscroll-behavior: contain;
 }
 .mg-table-head-pinned {

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -2018,6 +2018,7 @@ function ListShell({
   stickyHeader = true
 }) {
   const tableCard = "rounded border border-border bg-card overflow-hidden";
+  const viewportClass = stickyHeader ? "mg-table-scroll mg-list-viewport" : "mg-table-scroll overflow-x-auto";
   return /* @__PURE__ */ jsxs("div", { children: [
     /* @__PURE__ */ jsx(
       "div",
@@ -2064,14 +2065,7 @@ function ListShell({
     ) : /* @__PURE__ */ jsxs("div", { className: isStale ? "opacity-70 transition-opacity" : void 0, children: [
       cards ? /* @__PURE__ */ jsx("div", { className: "md:hidden space-y-2", children: cards }) : null,
       /* @__PURE__ */ jsx("div", { className: cards ? "hidden md:block" : void 0, children: /* @__PURE__ */ jsxs("div", { className: tableCard, children: [
-        /* @__PURE__ */ jsx("div", { className: "mg-table-scroll overflow-x-auto", children: /* @__PURE__ */ jsx(
-          "div",
-          {
-            ref: viewportRef,
-            className: stickyHeader ? "mg-list-viewport" : void 0,
-            children: table
-          }
-        ) }),
+        /* @__PURE__ */ jsx("div", { ref: viewportRef, className: viewportClass, children: table }),
         footer
       ] }) }),
       cards && footer ? /* @__PURE__ */ jsx("div", { className: "md:hidden mt-3", children: footer }) : null

--- a/packages/ui-kit/src/components/metagraphed/list-shell.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/list-shell.test.ts
@@ -18,14 +18,15 @@ describe("ListShell sticky table wrappers", () => {
     // and `sticky top-0` silently resolved to a no-op on every table in this
     // shell -- verified in a browser on /chain/blocks: computed
     // `overflow: auto/auto` with scrollHeight === clientHeight.
-    expect(source).toContain('"mg-table-scroll overflow-x-auto"');
+    // Both classes on ONE element (see the note in list-shell.tsx).
+    expect(source).toContain('"mg-table-scroll mg-list-viewport"');
     // The whole viewport contract (height cap, overflow axis, overscroll
     // containment) lives in one ui-kit class -- /validators builds its own
     // shell and has to agree with this one. Applied conditionally, because
     // `stickyHeader={false}` must drop the bounded box too: keeping it while
     // dropping the pin gives an inner scroll region whose header scrolls away
     // inside it.
-    expect(source).toContain('stickyHeader ? "mg-list-viewport" : undefined');
+    expect(source).toContain('"mg-table-scroll overflow-x-auto"');
     expect(source).not.toContain("overflow-x-clip");
     expect(source).not.toContain("overflow-y-clip");
   });

--- a/packages/ui-kit/src/components/metagraphed/list-shell.tsx
+++ b/packages/ui-kit/src/components/metagraphed/list-shell.tsx
@@ -67,6 +67,12 @@ export function ListShell({
   stickyHeader?: boolean;
 }) {
   const tableCard = "rounded border border-border bg-card overflow-hidden";
+  // .mg-table-scroll brings the edge-fade + thin scrollbar; .mg-list-viewport
+  // brings the height cap, both overflow axes and overscroll containment. They
+  // belong on the SAME element (see the note below).
+  const viewportClass = stickyHeader
+    ? "mg-table-scroll mg-list-viewport"
+    : "mg-table-scroll overflow-x-auto";
   return (
     <div>
       <div
@@ -119,25 +125,17 @@ export function ListShell({
           {cards ? <div className="md:hidden space-y-2">{cards}</div> : null}
           <div className={cards ? "hidden md:block" : undefined}>
             <div className={tableCard}>
-              {/* Two nested wrappers, one axis each. The outer keeps the
-                  edge-fade mask and thin horizontal scrollbar that
-                  .mg-table-scroll styles; the inner (.mg-list-viewport) is
-                  the bounded viewport the <thead> pins against. The cap is
-                  `max-height`, not `height`, so a short table is untouched --
-                  it only engages once the list is taller than the screen,
-                  which is exactly when a header that scrolls away starts
-                  costing the reader the column labels. */}
-              <div className="mg-table-scroll overflow-x-auto">
-                {/* No bounded viewport when stickiness is opted out of:
-                    keeping the box while dropping the pin would give the
-                    worst of both -- an inner scroll region whose header
-                    scrolls away inside it. */}
-                <div
-                  ref={viewportRef}
-                  className={stickyHeader ? "mg-list-viewport" : undefined}
-                >
-                  {table}
-                </div>
+              {/* ONE scroll container, both axes. These used to be two
+                  nested divs -- .mg-table-scroll for x, an inner bounded div
+                  for y -- and that does not work: `overflow-y: auto` coerces
+                  `overflow-x` to `auto` as well, so the inner div quietly took
+                  the horizontal axis too and left .mg-table-scroll unable to
+                  scroll at all. Its edge-fade and thin-scrollbar styling then
+                  applied to an element that never moved, while a 15px default
+                  scrollbar appeared inside the bounded region. Same coercion
+                  rule that made the headers inert in the first place. */}
+              <div ref={viewportRef} className={viewportClass}>
+                {table}
               </div>
               {footer}
             </div>

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -449,7 +449,23 @@
    making every sticky header in the app inert again. */
 .mg-list-viewport {
   max-height: var(--mg-list-viewport-max, 70vh);
-  overflow-y: auto;
+  /* BOTH axes, on ONE element -- pair this with .mg-table-scroll on the same
+     div rather than nesting them.
+
+     Splitting them does not work, and the reason is the same CSS rule behind
+     the original inert-header bug: `overflow-y: auto` coerces `overflow-x`
+     from `visible` to `auto` (CSS Overflow 3 §3). So an inner vertical
+     scroller silently becomes a horizontal one too and STEALS that axis from
+     the .mg-table-scroll wrapper around it. Measured on /chain/extrinsics at
+     820px: the inner div scrolled x (958 > 708) while the outer could not
+     scroll at all -- which stranded the edge-fade affordance and the thin
+     scrollbar styling on an element that no longer moved, and put a 15px
+     default scrollbar INSIDE the bounded region.
+
+     One element scrolls both axes, carries both sets of styling, and the
+     sticky header pins to it vertically while travelling with the content
+     horizontally, which is what a table header should do. */
+  overflow: auto;
   overscroll-behavior: contain;
 }
 


### PR DESCRIPTION
Scrolling the **entries inside a table** (not the page) makes content shift. Two measured causes; a third is diagnosed but deliberately not fixed here.

> Measurement note: my first attempts at this reported *zero* drift and were wrong. The in-app browser pane pauses `requestAnimationFrame` when hidden, so react-virtual never re-rendered and I was measuring a frozen component. Every number below comes from Playwright with real rendering.

## 1. The row-height estimate didn't match reality

A virtualizer positions unmounted rows with the estimate and mounted rows with their measured height. When they disagree, every mount re-derives the total and slides everything below it — content moving under the cursor for no visible reason.

| Route | Estimate | Actual | `scrollHeight` while scrolling |
|---|---|---|---|
| `/subnets` | 49 | 56 | 6524 → 7255 (**+731px**) |
| `/validators` | 41 | 39 | 41672 → 41180 (**−492px**) |

Both wrong, in opposite directions. A literal can't fix it: row height is a product of density, font size and what the row renders, so any constant is right for one combination and quietly wrong for the rest — which is precisely how these two drifted apart.

`useMeasuredRowHeight` measures the row that's on screen and feeds it to `estimateSize`, keeping the caller's constant only as a pre-measurement seed.

**After:** `/validators` **492px → 0px**. `/subnets` **731px → 101px** — the remainder is genuine 55/56px row variance, not estimate error.

## 2. Horizontal scrolling had moved off `.mg-table-scroll`

Nesting a bounded vertical scroller inside the horizontal one doesn't split the axes: `overflow-y: auto` coerces `overflow-x` to `auto` too — the same CSS Overflow 3 §3 rule behind the original inert-header bug.

Measured on `/chain/extrinsics` at 820px:

- inner div scrolled X (958 > 708)
- outer `.mg-table-scroll` **couldn't scroll at all**
- so the edge-fade and thin-scrollbar styling sat on an element that never moved
- and a **15px default scrollbar** appeared inside the bounded region

One element now carries both classes and both axes. Fade and thin scrollbar (11px) apply to the thing that actually scrolls, the header pins vertically and travels with content horizontally, and there's no nested scroller.

`/validators` is merged the same way. Its comment correctly diagnosed the missing affordance and drew the wrong conclusion — the remedy is putting `.mg-table-scroll` **on** the scroller, not beside it.

## 3. Still open: column widths shift

Measured drift of **43px** (`/subnets`) and **123px** (`/validators`) in header column widths while scrolling. That's `table-layout: auto` recomputing from whichever rows happen to be mounted.

The fix is `table-layout: fixed` with a defined width per column. It's tractable — `ValidatorColumn` is a typed config and both `<thead>` and the rows map the same array, so a `<colgroup>` slots in — but it changes how every table apportions space, and `/subnets` has toggleable columns so widths need to be relative weights normalised over the visible set. That's a visual design decision, so it gets its own PR rather than riding along here.

## Verification

| Check | Result |
|---|---|
| e2e (CI=1, --workers=2, production Worker build) | 104 passed, 2 skipped, exit 0 |
| apps/ui vitest | 232 files, 1810 tests |
| ui-kit vitest | 121 |
| typecheck + lint | clean |
