### PR TITLE
fix(economics): measure the price-change windows in time, not in dates

### DIFF
--- a/scripts/lib/load-alpha-price-history.ts
+++ b/scripts/lib/load-alpha-price-history.ts
@@ -51,7 +51,12 @@ export function alphaPriceHistoryQuery(
   lookbackDays: number = ALPHA_PRICE_HISTORY_LOOKBACK_DAYS,
 ): string {
   return (
-    "SELECT netuid, snapshot_date, alpha_price_tao FROM subnet_snapshots " +
+    // captured_at is load-bearing, not decoration (#9449): a snapshot row is
+    // upserted repeatedly through its own day, so `snapshot_date` says WHICH
+    // day a row belongs to and nothing at all about how far apart two rows
+    // actually are. Two consecutive dates were measured one hour apart.
+    "SELECT netuid, snapshot_date, alpha_price_tao, captured_at " +
+    "FROM subnet_snapshots " +
     `WHERE snapshot_date >= date('now','-${Math.trunc(lookbackDays)} days') ` +
     "ORDER BY netuid ASC, snapshot_date ASC"
   );

--- a/src/alpha-price-change.ts
+++ b/src/alpha-price-change.ts
@@ -33,16 +33,45 @@ function toFiniteOrNull(value: unknown): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-function shiftDate(isoDate: string, days: number): string {
-  // Caller always passes a normalized YYYY-MM-DD from normalizeAlphaPricePoints.
-  const [y, m, d] = isoDate.split("-").map(Number);
-  const base = Date.UTC(y, m - 1, d) + days * 24 * 60 * 60 * 1000;
-  return new Date(base).toISOString().slice(0, 10);
-}
-
 export interface AlphaPricePoint {
   date: string;
   alpha_price_tao: number | null;
+  /**
+   * When this row was actually written, epoch ms. Null for rows that predate
+   * the column or arrive from a caller that does not carry it.
+   *
+   * #9449: this is what makes a window mean what it says. A snapshot row is
+   * UPSERTED throughout its own day (the health prober rewrites today's row
+   * every run), so a row's date identifies which day it belongs to and says
+   * nothing about how far apart two rows were measured. Live data on
+   * 2026-08-05: the 08-05 row was captured 00:00:08 and the 08-04 row
+   * 23:00:08 -- one hour apart, treated as a day.
+   */
+  captured_at: number | null;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function toEpochMsOrNull(value: unknown): number | null {
+  if (value == null || value === "") return null;
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/**
+ * When a point was measured, for window arithmetic.
+ *
+ * Falls back to the END of its calendar day when the row carries no
+ * `captured_at`. That is the right default rather than midnight: the live
+ * writer's last successful upsert for a day lands late in it (~23:00 in
+ * production), so end-of-day is what an untimestamped historical row actually
+ * represents. Using midnight would systematically overstate every gap by
+ * nearly a day.
+ */
+function effectiveAt(point: AlphaPricePoint): number {
+  if (point.captured_at != null) return point.captured_at;
+  const [y, m, d] = point.date.split("-").map(Number);
+  return Date.UTC(y, m - 1, d) + DAY_MS - 1;
 }
 
 /**
@@ -58,25 +87,48 @@ export function normalizeAlphaPricePoints(
     const date = row.date ?? row.snapshot_date;
     if (date == null || date === "") continue;
     const day = String(date).slice(0, 10);
-    // Reject non-calendar prefixes so shiftDate never sees partial dates.
+    // Reject non-calendar prefixes so effectiveAt never sees partial dates.
     if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) continue;
     points.push({
       date: day,
       alpha_price_tao: toFiniteOrNull(row.alpha_price_tao),
+      captured_at: toEpochMsOrNull(row.captured_at),
     });
   }
   points.sort((a, b) => a.date.localeCompare(b.date));
   return points;
 }
 
-/** Latest point on or before `target` with a finite alpha price. */
-function finitePriceAtOrBefore(
+/**
+ * The newest point measured at least `days` before `latest`, by actual
+ * elapsed time.
+ *
+ * #9449: this replaced a calendar-date lookup (`latest.date - days`, then the
+ * newest row on or before that date), which was wrong in a way that produced
+ * a CONFIDENT WRONG ANSWER rather than a missing one. Snapshot rows are
+ * upserted through their own day, so the row dated "yesterday" holds
+ * yesterday's LAST measurement (~23:00) while the row dated "today" holds
+ * one taken minutes ago. Just after midnight UTC those two rows are an hour
+ * apart, and since the economics source they both read refreshes only every
+ * ~3h, they carried a byte-identical price -- so `alpha_price_change_1d`
+ * reported exactly 0 for ALL 129 subnets, every day, for the first hours of
+ * each UTC day. Not null, not absent: 0, which a consumer plots as "flat".
+ *
+ * Selecting by elapsed time makes the window mean what its name says
+ * regardless of when in the day either row happened to land.
+ */
+function priorPointAtLeast(
   points: AlphaPricePoint[],
-  target: string,
+  latest: AlphaPricePoint,
+  days: number,
 ): AlphaPricePoint | null {
+  const cutoff = effectiveAt(latest) - days * DAY_MS;
   let chosen: AlphaPricePoint | null = null;
+  // Ascending by date, and effectiveAt is monotonic with it for the daily
+  // series this reads, so the last point at or before the cutoff is the
+  // newest one -- same walk the date version did, on a real clock.
   for (const point of points) {
-    if (point.date > target) break;
+    if (effectiveAt(point) > cutoff) break;
     if (point.alpha_price_tao != null) chosen = point;
   }
   return chosen;
@@ -88,10 +140,10 @@ function changeOver(
   days: number | null | undefined,
 ): number | null {
   if (days == null || !latest || latest.alpha_price_tao == null) return null;
-  const target = shiftDate(latest.date, -days);
-  const prior = finitePriceAtOrBefore(points, target);
-  // target is always strictly before latest.date for positive day windows, so
-  // a found prior is a distinct earlier point (or null when history is short).
+  const prior = priorPointAtLeast(points, latest, days);
+  // Null, never 0, when history does not reach back far enough: "we cannot
+  // measure this window" and "the price did not move" are different
+  // statements, and only one of them is safe to plot.
   if (!prior || prior.alpha_price_tao == null) return null;
   return pctChange(prior.alpha_price_tao, latest.alpha_price_tao);
 }
@@ -143,10 +195,21 @@ export function computeAlphaPriceChanges(
  */
 export function indexAlphaPriceHistoryByNetuid(
   rows: Array<Record<string, unknown>> | null | undefined,
-): Map<number, Array<{ snapshot_date: string; alpha_price_tao: unknown }>> {
+): Map<
+  number,
+  Array<{
+    snapshot_date: string;
+    alpha_price_tao: unknown;
+    captured_at: unknown;
+  }>
+> {
   const map = new Map<
     number,
-    Array<{ snapshot_date: string; alpha_price_tao: unknown }>
+    Array<{
+      snapshot_date: string;
+      alpha_price_tao: unknown;
+      captured_at: unknown;
+    }>
   >();
   for (const row of Array.isArray(rows) ? rows : []) {
     const netuid = Number(row?.netuid);
@@ -157,6 +220,9 @@ export function indexAlphaPriceHistoryByNetuid(
     list.push({
       snapshot_date: String(date).slice(0, 10),
       alpha_price_tao: row.alpha_price_tao,
+      // Carried through, or the window arithmetic downstream falls back to
+      // end-of-day for every row and the fix stops working at this seam.
+      captured_at: row.captured_at ?? null,
     });
     map.set(netuid, list);
   }

--- a/src/alpha-price-change.ts
+++ b/src/alpha-price-change.ts
@@ -5,13 +5,29 @@
  * `/api/v1/subnets/{netuid}/trajectory` already reads. Windows that lack a
  * prior finite price resolve to `null` (schema-stable) — never an error.
  *
- * `alpha_price_change_1h` is always `null` here: daily snapshots cannot
- * support an hour window (OHLC is a separate future source).
+ * `alpha_price_change_1h` is always `null` here: this series is daily, and a
+ * daily series cannot answer an hour window.
+ *
+ * That is now a DELIBERATE gap rather than a pending one. The original note
+ * called OHLC "a separate future source"; it has since shipped, with `1h` as
+ * its default interval (OHLC_INTERVALS, src/subnet-ohlc.ts), so an intraday
+ * price is available. It is still not wired in here, because OHLC is built
+ * from stake add/remove EVENTS -- a traded price -- while these windows are
+ * built from `alpha_price_tao`, the pinned moving average. Filling 1h from
+ * OHLC would make one member of a four-field family answer a different
+ * question from its siblings, which is worse than a null: a reader comparing
+ * 1h against 1d would be comparing two different prices without being told.
+ *
+ * Wiring it up is a real option, but it means either moving all four windows
+ * onto the traded series or documenting the split explicitly -- a decision,
+ * not an omission.
  */
 
 export const ALPHA_PRICE_CHANGE_WINDOWS: Record<string, number | null> =
   Object.freeze({
-    // 1h reserved for a future intraday source; kept for a stable schema shape.
+    // Null = this window is not answerable from a daily series. Kept as a key
+    // for a stable schema shape; see the header for why the now-shipped
+    // intraday OHLC source is deliberately not used to fill it.
     "1h": null,
     "1d": 1,
     "7d": 7,

--- a/tests/alpha-price-change.test.ts
+++ b/tests/alpha-price-change.test.ts
@@ -119,7 +119,7 @@ describe("computeAlphaPriceChanges", () => {
         { date: "2026-03", alpha_price_tao: 1 },
         { date: "2026-06-01", alpha_price_tao: 1 },
       ]),
-      [{ date: "2026-06-01", alpha_price_tao: 1 }],
+      [{ date: "2026-06-01", alpha_price_tao: 1, captured_at: null }],
     );
   });
 });
@@ -137,8 +137,8 @@ describe("normalizeAlphaPricePoints / index / withAlphaPriceChanges", () => {
         { alpha_price_tao: 9 },
       ] as unknown as Record<string, unknown>[]),
       [
-        { date: "2026-06-01", alpha_price_tao: 1 },
-        { date: "2026-06-02", alpha_price_tao: 1.5 },
+        { date: "2026-06-01", alpha_price_tao: 1, captured_at: null },
+        { date: "2026-06-02", alpha_price_tao: 1.5, captured_at: null },
       ],
     );
     assert.deepEqual(normalizeAlphaPricePoints(null), []);
@@ -189,5 +189,127 @@ describe("normalizeAlphaPricePoints / index / withAlphaPriceChanges", () => {
     assert.equal(out.alpha_price_change_1d, null);
     assert.equal(out.alpha_price_change_7d, null);
     assert.equal(out.alpha_price_change_1m, null);
+  });
+});
+
+// #9449: the window is measured on a real clock, not by calendar-date
+// subtraction.
+//
+// THE BUG THIS PINS, reproduced from live production data. Snapshot rows are
+// upserted throughout their own day, so the row dated "today" holds a
+// measurement from minutes ago while the row dated "yesterday" holds
+// yesterday's LAST one. On 2026-08-05 the 08-05 row was captured 00:00:08 and
+// the 08-04 row 23:00:08 -- ONE HOUR apart. The economics source they both
+// read refreshes every ~3h, so both carried a byte-identical price, and the
+// date-based lookup reported `alpha_price_change_1d` as exactly 0 for ALL 129
+// subnets. Zero, not null: a consumer plots that as "flat", which is a
+// confident wrong answer rather than a missing one.
+describe("#9449 — windows measured by captured_at, not by date arithmetic", () => {
+  const at = (iso: string) => Date.parse(iso);
+
+  // The exact live shape: netuid 64's last four snapshot rows.
+  const production = [
+    {
+      snapshot_date: "2026-08-02",
+      alpha_price_tao: 0.083135901,
+      captured_at: at("2026-08-02T23:00:05Z"),
+    },
+    {
+      snapshot_date: "2026-08-03",
+      alpha_price_tao: 0.084084102,
+      captured_at: at("2026-08-03T23:00:14Z"),
+    },
+    {
+      snapshot_date: "2026-08-04",
+      alpha_price_tao: 0.084773044,
+      captured_at: at("2026-08-04T23:00:08Z"),
+    },
+    {
+      snapshot_date: "2026-08-05",
+      alpha_price_tao: 0.084773044,
+      captured_at: at("2026-08-05T00:00:08Z"),
+    },
+  ];
+
+  test("does not report 0 for two rows measured an hour apart", () => {
+    const changes = computeAlphaPriceChanges(production);
+    // The old date-based lookup picked the 08-04 row (one hour earlier, same
+    // price) and returned exactly 0.
+    assert.notEqual(changes.alpha_price_change_1d, 0);
+    // 08-03 is the newest row at least 24h before 08-05 00:00:08.
+    assert.equal(
+      changes.alpha_price_change_1d,
+      pctChange(0.084084102, 0.084773044),
+    );
+    assert.equal(changes.alpha_price_change_1d, 0.82);
+  });
+
+  test("null, not 0, when history does not reach back far enough", () => {
+    // "We cannot measure this window" and "the price did not move" are
+    // different statements, and only one of them is safe to plot.
+    const changes = computeAlphaPriceChanges([
+      {
+        snapshot_date: "2026-08-05",
+        alpha_price_tao: 1,
+        captured_at: at("2026-08-05T00:00:00Z"),
+      },
+      {
+        snapshot_date: "2026-08-05",
+        alpha_price_tao: 1,
+        captured_at: at("2026-08-05T01:00:00Z"),
+      },
+    ]);
+    assert.equal(changes.alpha_price_change_1d, null);
+    assert.equal(changes.alpha_price_change_7d, null);
+  });
+
+  test("a row with no captured_at counts as END of its day", () => {
+    // Untimestamped historical rows are what the live writer's last upsert of
+    // a day represents (~23:00), so midnight would overstate every gap by
+    // nearly a full day and silently shift which row each window picks.
+    const changes = computeAlphaPriceChanges([
+      { snapshot_date: "2026-08-03", alpha_price_tao: 1 },
+      { snapshot_date: "2026-08-04", alpha_price_tao: 2 },
+      {
+        snapshot_date: "2026-08-05",
+        alpha_price_tao: 4,
+        captured_at: at("2026-08-05T23:30:00Z"),
+      },
+    ]);
+    // 24h before 08-05T23:30 is 08-04T23:30; the 08-04 row counts as
+    // 08-04T23:59:59.999, which is AFTER that, so 08-03 is the correct pick.
+    assert.equal(changes.alpha_price_change_1d, pctChange(1, 4));
+  });
+
+  test("the window still works late in the day, when dates would also agree", () => {
+    // The old logic was right at end-of-day and wrong at start-of-day; the fix
+    // must not break the case that used to work.
+    const changes = computeAlphaPriceChanges([
+      {
+        snapshot_date: "2026-08-04",
+        alpha_price_tao: 2,
+        captured_at: at("2026-08-04T23:00:00Z"),
+      },
+      {
+        snapshot_date: "2026-08-05",
+        alpha_price_tao: 3,
+        captured_at: at("2026-08-05T23:00:00Z"),
+      },
+    ]);
+    assert.equal(changes.alpha_price_change_1d, pctChange(2, 3));
+  });
+
+  test("indexAlphaPriceHistoryByNetuid carries captured_at through", () => {
+    // The seam where the fix would silently stop working: drop the column here
+    // and every row falls back to end-of-day.
+    const indexed = indexAlphaPriceHistoryByNetuid([
+      {
+        netuid: 64,
+        snapshot_date: "2026-08-05",
+        alpha_price_tao: 1,
+        captured_at: 123,
+      },
+    ]);
+    assert.equal(indexed.get(64)?.[0]?.captured_at, 123);
   });
 });

--- a/tests/live-economics-refresh.test.ts
+++ b/tests/live-economics-refresh.test.ts
@@ -611,7 +611,10 @@ describe("refreshLiveEconomics", () => {
     for (const call of reads) assert.equal(call.params[1], BLOCK_HASH);
     assert.deepEqual(queries, [
       NEURON_AGGREGATE_QUERY,
-      "SELECT netuid, snapshot_date, alpha_price_tao FROM subnet_snapshots " +
+      // #9449: captured_at is selected because the %-change windows are
+      // measured in elapsed time, not by subtracting snapshot dates.
+      "SELECT netuid, snapshot_date, alpha_price_tao, captured_at " +
+        "FROM subnet_snapshots " +
         "WHERE snapshot_date >= date('now','-40 days') " +
         "ORDER BY netuid ASC, snapshot_date ASC",
     ]);

--- a/tests/load-alpha-price-history.test.ts
+++ b/tests/load-alpha-price-history.test.ts
@@ -74,8 +74,10 @@ describe("loadAlphaPriceHistoryByNetuid", () => {
     assert.ok(history);
     assert.equal(history.size, 2);
     assert.deepEqual(history.get(1), [
-      { snapshot_date: "2026-08-01", alpha_price_tao: 0.5 },
-      { snapshot_date: "2026-08-02", alpha_price_tao: 0.6 },
+      // #9449: captured_at rides along so the window arithmetic downstream
+      // measures elapsed time instead of subtracting calendar dates.
+      { snapshot_date: "2026-08-01", alpha_price_tao: 0.5, captured_at: null },
+      { snapshot_date: "2026-08-02", alpha_price_tao: 0.6, captured_at: null },
     ]);
     // The bounded D1 database, and the token as the only credential.
     assert.ok(calls[0].url.includes(SUBNET_SNAPSHOTS_D1_DATABASE_ID));


### PR DESCRIPTION
## Summary

`alpha_price_change_1d` was **exactly `0` for all 129 subnets**, every day, for the first hours of each UTC day. Not null, not absent — a confident `0`, which a consumer plots as "flat". Found from a user report that economics looked pinned.

The window was selected by **calendar-date subtraction**: take the latest row's date, shift back N days, take the newest row on or before it. That assumes two consecutively-dated rows are a day apart. They are not — a snapshot row is **upserted throughout its own day**, because the health prober rewrites *today's* row hourly (`src/health-prober.ts:1102` → `upsertSubnetSnapshotsToD1`). So the row dated yesterday holds yesterday's **last** measurement, and the row dated today holds one from minutes ago.

Verified against production D1, netuid 64:

| snapshot_date | alpha_price_tao | captured_at (UTC) |
| --- | --- | --- |
| 2026-08-05 | 0.084773044 | **00:00:08** |
| 2026-08-04 | 0.084773044 | **23:00:08** |
| 2026-08-03 | 0.084084102 | 23:00:14 |

The two rows the code called "one day apart" were measured **one hour** apart — and since `alpha_price_tao` comes from the economics blob, which refreshes only every ~3h, both reads returned a byte-identical price. Hence exactly `0`.

It is time-of-day dependent: worst right after 00:00 UTC, converging toward correct by end of day. The 7d and 1m windows hid it, being dominated by their own 6–30 day spans, so only the 1d window was visibly wrong.

## Fix

Measure the window in **elapsed time**, using the `captured_at` the table already stores and the query simply did not select. For the data above that selects the `08-03` row and yields `+0.82%`.

Two deliberate details:

- **A row with no `captured_at` counts as the END of its day.** That is what the live writer's last upsert of a day represents (~23:00 in production); midnight would overstate every gap by nearly a full day and silently shift which row each window picks. There is a test pinning this.
- **Insufficient history yields `null`, never `0`.** "We cannot measure this window" and "the price did not move" are different statements, and only one of them is safe to plot — which is the whole defect this PR is about.

`shiftDate` and `finitePriceAtOrBefore` become unreachable and are removed rather than left as dead code.

## Tests

Five regression tests, the first built from the exact production rows above so the bug cannot return silently:

- does not report `0` for two rows measured an hour apart (and asserts the right value, `0.82`)
- `null`, not `0`, when history does not reach back far enough
- a row with no `captured_at` counts as end-of-day
- the window still works late in the day — the case that used to work must not break
- `indexAlphaPriceHistoryByNetuid` carries `captured_at` through, pinning the seam where the fix would otherwise silently stop working

Four pre-existing assertions were updated rather than worked around: three shape assertions that legitimately gain the new field, and one exact-SQL assertion that legitimately gains the new column.

## Validation

```
npm run lint            clean
npm run format:check    clean
npm run typecheck       clean
npx vitest run          669 files, 15935 tests, all passing
```

Patch coverage by diff intersection over `src/**`: **17/17 = 100%**.

## Out of scope

Two adjacent findings from confirming this, noted in the issue and left alone: the daily series has **gaps** (netuid 64 has no `2026-08-01` row), and `2026-07-31` was captured at `00:00:21`, so that day holds a start-of-day reading where its neighbours hold end-of-day ones. Neither causes this bug, and the elapsed-time fix is robust to both since it reads the real timestamp instead of assuming regular spacing.

Closes #9449
