### PR TITLE
fix(telemetry): guard every $exception emitter, not just the main Worker's

### DIFF
--- a/apps/ui/src/lib/analytics.test.ts
+++ b/apps/ui/src/lib/analytics.test.ts
@@ -224,16 +224,42 @@ describe("analytics (PostHog web analytics)", () => {
       expect(capture).not.toHaveBeenCalled();
     });
 
-    it("captureException force-starts session replay past its sample-rate skip (issue 7761)", async () => {
+    it("captureException never force-starts session replay (#9451 reversed issue 7761's coupling)", async () => {
       vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
       const { captureException } = await import("./analytics");
-      const err = new Error("boom");
-      captureException(err);
+      captureException(new Error("boom"));
       await vi.waitFor(() => expect(captureExceptionSpy).toHaveBeenCalled());
-      expect(startSessionRecording).toHaveBeenCalledWith(true);
-      // Every exception-linked recording call must be paired with the
-      // capture itself, never called standalone with nothing captured.
-      expect(startSessionRecording).toHaveBeenCalledTimes(1);
+      // #7761 forced a recording per exception, which converted every
+      // exception storm into billable replay quota. Replay stays on its
+      // configured sample rate now; an exception must not override it.
+      expect(startSessionRecording).not.toHaveBeenCalled();
+    });
+
+    it("captureException drops a repeat of the same error signature inside the throttle window (#9451)", async () => {
+      vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
+      const { captureException } = await import("./analytics");
+      captureException(new Error("boom"));
+      captureException(new Error("boom"));
+      await vi.waitFor(() => expect(captureExceptionSpy).toHaveBeenCalled());
+      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+      // A DIFFERENT signature is never delayed by an unrelated storm.
+      captureException(new TypeError("other fault"));
+      await vi.waitFor(() => expect(captureExceptionSpy).toHaveBeenCalledTimes(2));
+    });
+
+    it("admitClientException re-admits a signature once its window elapses, and enforces the page cap (#9451)", async () => {
+      vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
+      const { admitClientException } = await import("./analytics");
+      const err = new Error("boom");
+      expect(admitClientException(err, 0)).toBe(true);
+      expect(admitClientException(err, 59_999)).toBe(false);
+      expect(admitClientException(err, 60_000)).toBe(true);
+      // Hard per-pageload cap: a cascade minting distinct signatures cannot
+      // spend unbounded quota. 2 admissions consumed above; the cap is 20.
+      for (let i = 0; i < 18; i += 1) {
+        expect(admitClientException(new Error(`cascade ${i}`), 0)).toBe(true);
+      }
+      expect(admitClientException(new Error("over the cap"), 0)).toBe(false);
     });
 
     it("captureException shares the same lazily-loaded instance as capturePageview/captureEvent (no second init)", async () => {

--- a/apps/ui/src/lib/analytics.ts
+++ b/apps/ui/src/lib/analytics.ts
@@ -8,8 +8,10 @@
  * `isFeatureEnabled()` and never touches `posthog-js` directly elsewhere.
  * Session replay has no separate exported function --
  * it's configured once in `loadPostHog`'s `session_recording` block below
- * and otherwise runs itself (posthog-js's own recorder), except for the
- * exception-linked force-record call inside `captureException`.
+ * and otherwise runs itself (posthog-js's own recorder). #7761's
+ * exception-linked force-record call was removed in #9451: it converted
+ * every exception into a billable recording, which is exactly the wrong
+ * coupling during an exception storm.
  * `captureException` is called from error-reporting.ts's `reportError` --
  * metagraphed#7766: Sentry (formerly a parallel sink there) is fully removed
  * now that parity was proven; this module's `posthog-js` instance is the
@@ -330,6 +332,39 @@ export function captureEvent(name: string, properties?: Record<string, unknown>)
   void loadPostHog().then((posthog) => posthog?.capture(name, properties));
 }
 
+// #9451: client-side $exception cost guard, the browser twin of
+// src/usage-telemetry.ts's admitExceptionCapture. The server side throttles
+// per fingerprint per isolate; here the unit of blast radius is one page
+// load (a render-loop error boundary or a failing effect can call
+// reportError on every frame), so the guard is two-layered: at most one
+// capture per error signature per window, and a hard cap per page load no
+// matter how many distinct signatures a cascade mints. Unlike the server
+// guard this is NOT env-gated -- there is no test-determinism concern here
+// (the throttle state is module-scoped and vi.resetModules() clears it),
+// and an unconfigured token already short-circuits before the guard runs.
+const EXCEPTION_WINDOW_MS = 60_000;
+const EXCEPTION_PAGE_CAP = 20;
+const exceptionLastSentAt = new Map<string, number>();
+let exceptionsSentThisPage = 0;
+
+/** Decide whether this exception may be captured now. Exported for tests
+ * only -- captureException is a silent no-op without a token, so "throttled"
+ * would otherwise be indistinguishable from "unconfigured" (same reasoning
+ * as the server-side admitExceptionCapture's export). */
+export function admitClientException(error: unknown, nowMs: number = Date.now()): boolean {
+  if (exceptionsSentThisPage >= EXCEPTION_PAGE_CAP) return false;
+  // Name+message, not a stack hash: two occurrences of the same fault can
+  // carry different chunk URLs in their stacks (lazy-loaded routes), and
+  // PostHog's own issue grouping is message-led anyway (#9019 server-side).
+  const err = error instanceof Error ? error : null;
+  const signature = `${err?.name ?? typeof error}:${err?.message ?? String(error)}`;
+  const lastSentAt = exceptionLastSentAt.get(signature);
+  if (lastSentAt !== undefined && nowMs - lastSentAt < EXCEPTION_WINDOW_MS) return false;
+  exceptionLastSentAt.set(signature, nowMs);
+  exceptionsSentThisPage += 1;
+  return true;
+}
+
 /** Captures a caught exception via posthog-js's dedicated `captureException`
  * (never the generic `.capture("$exception", ...)`, which PostHog's own docs
  * warn is "unreliable because it does not attach required metadata" --
@@ -338,21 +373,17 @@ export function captureEvent(name: string, properties?: Record<string, unknown>)
  * flat into the event (PostHog's own signature), not nested the way
  * Sentry's `{ extra: context }` shape is -- see error-reporting.ts's own
  * call site. Same best-effort, no-op-when-unconfigured contract as every
- * other export here. */
+ * other export here.
+ *
+ * #9451: throttled via admitClientException above, and #7761's
+ * `startSessionRecording(true)` force-record is REMOVED -- forcing a
+ * recording per exception coupled error volume to session-replay billing,
+ * so one storm spent two quotas at once. Replay stays on its configured
+ * sample rate; exceptions no longer override it. */
 export function captureException(error: unknown, properties?: Record<string, unknown>): void {
   if (!POSTHOG_TOKEN) return;
+  if (!admitClientException(error)) return;
   void loadPostHog().then((posthog) => {
-    // metagraphed#7761's own explicit requirement: "always-on [replay] for
-    // sessions with an exception". `startSessionRecording(true)` is
-    // posthog-js's documented override to force this session's recording
-    // past its sample-rate dice roll (`{ sampling: true, linked_flag: true }`
-    // shorthand) -- it does not retroactively invent pre-exception frames,
-    // but posthog-js's recorder already buffers a rolling pre-trigger
-    // window internally (see `trigger_pending_buffer_interval_millis` in
-    // node_modules/@posthog/types), so calling this the moment an exception
-    // is captured keeps that lead-up context rather than starting a bare
-    // recording from this instant. A no-op if replay is already recording.
-    posthog?.startSessionRecording(true);
     posthog?.captureException(error, properties);
   });
 }

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -107,6 +107,14 @@
     "METAGRAPH_NEURONS_SOURCE": "d1",
     "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",
+    // #9430's $exception storm guard reads this var per-Worker
+    // (src/usage-telemetry.ts), and `vars` are per-config -- declaring it
+    // only in wrangler.jsonc left THIS Worker's captures entirely unguarded,
+    // and this is the Worker where the 871,649-event `wallet-auth-keys`
+    // storm actually happened (see wrangler.jsonc's narration). Same value
+    // as the main Worker: one capture per fingerprint per 5 minutes per
+    // isolate, suppressed count carried on the next admitted event.
+    "POSTHOG_EXCEPTION_STORM_WINDOW_MS": "300000",
   },
   // Smart placement: run the Worker close to the Hyperdrive origin (self-hosted indexer
   // box Postgres, reached via Cloudflare Tunnel) to minimize the per-request DB round-trip,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -330,12 +330,16 @@
     // that storm's real cost was the error inbox and the alerts it took down
     // with it, not the events themselves.
     //
-    // 60s is sized to diagnosis, not to volume: a recurring fault's hundredth
-    // occurrence in a minute carries the same type, message and stack as its
-    // first. The same storm under this guard is ~5.7K events instead of 872K,
-    // still reports continuously for all four days, and still says how many
-    // occurrences it stood for.
-    "POSTHOG_EXCEPTION_STORM_WINDOW_MS": "60000",
+    // Widened 60s -> 300s (2026-08-04): measured at 60s, the steady-state
+    // fault lanes alone (r2-sql:Error/AbortError plus ~20 projection-lane
+    // fingerprints, each admitted once per minute per isolate) still summed
+    // to ~4.6K $exception/day = ~140K/month, over the 100K free error-
+    // tracking tier -- during the same window PostHog billed real money for
+    // the July storms. At 300s a recurring fault still reports 12x/hour per
+    // isolate with its suppressed count carried on the next admitted event;
+    // nothing about diagnosis needs more than that, and the projected
+    // steady-state (~1K/day) sits comfortably inside the free tier.
+    "POSTHOG_EXCEPTION_STORM_WINDOW_MS": "300000",
     // subnet_hyperparams (#4832 gap-closure): FLIPPED to "postgres" 2026-07-11,
     // after a live parity pass. refresh-subnet-hyperparams.yml's real
     // workflow_dispatch run synced all 129 subnets (Postgres started

--- a/wrangler.registry.jsonc
+++ b/wrangler.registry.jsonc
@@ -37,6 +37,14 @@
   // not "the shared-secret check, or just don't send one and see".
   "workers_dev": false,
   "preview_urls": false,
+  // #9430's $exception storm guard reads this var per-Worker
+  // (src/usage-telemetry.ts), and `vars` are per-config -- without it this
+  // Worker's recordExceptionEvent calls (workers/registry-sync-api.ts) run
+  // uncapped. Same value as the main Worker and wrangler.data.jsonc: one
+  // capture per fingerprint per 5 minutes per isolate.
+  "vars": {
+    "POSTHOG_EXCEPTION_STORM_WINDOW_MS": "300000",
+  },
   "observability": {
     "enabled": true,
     "head_sampling_rate": 1,


### PR DESCRIPTION
## What

Closes #9451 — part of the 2026-08-04 billing-overage response (surprise ~$650 July invoice; target posture is free-tier everywhere).

Post-#9430 measurement (2026-08-03/04) showed $exception still pacing ~140K/month against the 100K free error-tracking tier, because the guard only existed in one of the three capturing Workers and the web client had no guard at all.

- **wrangler.jsonc**: `POSTHOG_EXCEPTION_STORM_WINDOW_MS` 60000 → 300000. At 60s, the steady-state fault lanes (`r2-sql:Error`/`AbortError` + ~20 `projection:*` fingerprints, one admission per fingerprint per window per isolate) alone summed over the tier. 300s still reports every live fault 12x/hour per isolate, with the suppressed count carried on the next admitted event (#9430's existing mechanism — no code change).
- **wrangler.data.jsonc / wrangler.registry.jsonc**: declare the same var. `vars` are per-config, so these two Workers — including the one where the 871,649-event `wallet-auth-keys` storm actually happened — were running `recordExceptionEvent` with no guard.
- **apps/ui/src/lib/analytics.ts**: client-side twin of the server guard — one capture per error signature per 60s plus a hard 20-captures-per-pageload cap (a render-loop boundary otherwise captures per frame); and #7761's `startSessionRecording(true)` force-record is removed, so an exception storm no longer converts into billable session-replay quota. Confined to `apps/ui/src/lib/**` + its test — no visual change.

## Verification

- `apps/ui`: `vitest run src/lib/analytics.test.ts src/lib/error-reporting.test.ts` — 34/34 pass; prettier clean.
- Volume math: current fleet pace ~4.6K/day ÷ 5 (window widening) ≈ ~1K/day ≈ ~30K/month, comfortably inside the free tier, before the two newly-guarded Workers' contribution is even counted.