### PR TITLE
fix(observability): report when a day's subnet snapshot never lands

### DIFF
--- a/src/health-prober.ts
+++ b/src/health-prober.ts
@@ -36,6 +36,8 @@ import {
   type ObservationsDb,
 } from "./observations-d1.ts";
 import { tryPostgresTier } from "../workers/postgres-tier.ts";
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import {
   recordSubnetIdentityChanges,
   syncSubnetIdentityToPostgres,
@@ -1130,6 +1132,11 @@ export async function syncSubnetSnapshotToPostgres(
 interface WriteSubnetSnapshotOverrides {
   now?: () => number;
   readArtifact?: (env: Env, path: string) => Promise<Row>;
+  /** #9452 seams: the outcome reporting is the behaviour under test, so both
+   * of its channels are injectable rather than reachable only against a real
+   * D1 and a real PostHog token. */
+  laneHealthDb?: LaneHealthDb;
+  recordExceptionEvent?: typeof recordExceptionEvent;
 }
 
 // Daily growth snapshot (AI-4). Captures each subnet's structural maturity into
@@ -1139,21 +1146,84 @@ interface WriteSubnetSnapshotOverrides {
 // syncSubnetSnapshotToPostgres below) and recordSubnetIdentityChanges reads
 // its own latest-hash baseline from Postgres too now (see that function's own
 // header comment in src/subnet-identity-history.ts).
+/** This writer's lane name in `lane_health`, and on the self-health card. */
+const SUBNET_SNAPSHOT_LANE = "subnet-snapshot";
+
+/**
+ * Report the outcome of one snapshot write (#9452).
+ *
+ * THE BUG THIS CLOSES: every decline below used to be a bare
+ * `return { ok: false, reason }`, and the value was returned into the void --
+ * `workers/api.entry.ts` discards what `scheduled` returns. So "the economics
+ * source gave us nothing, and today's history was never written" and
+ * "everything is fine" produced byte-identical telemetry: silence. A whole day
+ * of `subnet_snapshots` went missing on 2026-08-01 -- all 129 subnets -- and
+ * was found four days later by reading the table by hand.
+ *
+ * Two channels, for the reason src/lane-health.ts documents: PostHog is the
+ * NOTIFICATION and can be dropped by someone else's quota, so the `lane_health`
+ * row is the RECORD. The row is written on every run, healthy or not, because
+ * a healthy snapshot lane's output is silence and silence is exactly what a
+ * stopped one produces.
+ *
+ * `stale` rather than a bespoke verdict on failure: a day whose row never
+ * landed genuinely leaves this lane behind, which is what the self-health
+ * card's readers understand a non-ok lane to mean.
+ *
+ * Never throws -- see recordLaneVerdict, and the capture is caught here.
+ */
+async function reportSnapshotOutcome(
+  env: Env,
+  outcome: { ok: boolean; reason?: string; rows?: number },
+  deps: WriteSubnetSnapshotOverrides,
+): Promise<void> {
+  const now = deps.now || (() => Date.now());
+  await recordLaneVerdict(
+    deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as unknown as LaneHealthDb),
+    {
+      lane: SUBNET_SNAPSHOT_LANE,
+      verdict: outcome.ok ? "ok" : "stale",
+      // The write either happened for this run or it did not; there is no
+      // meaningful "how far behind" to report from inside a single run, and
+      // inventing one would put a fabricated number in the column triage reads.
+      age_ms: null,
+      detail: outcome.ok ? null : (outcome.reason ?? "unknown"),
+      checked_at: now(),
+    },
+  );
+  if (outcome.ok) return;
+  const record = deps.recordExceptionEvent ?? recordExceptionEvent;
+  await record(env, {
+    error: new Error(
+      `subnet snapshot write declined: ${outcome.reason ?? "unknown"} -- ` +
+        "today's row was not written, so the daily series has a hole",
+    ),
+    route: "subnet-snapshot-write",
+    errorCode: "stale_lane",
+  }).catch(() => false);
+}
+
 export async function writeSubnetSnapshot(
   env: Env,
   overrides: WriteSubnetSnapshotOverrides = {},
 ): Promise<Row> {
+  // Every `return { ok: false, ... }` below routes through here first, so a
+  // decline cannot be added later that forgets to report itself.
+  const decline = async (reason: string, extra: Row = {}): Promise<Row> => {
+    await reportSnapshotOutcome(env, { ok: false, reason }, overrides);
+    return { ok: false, reason, ...extra };
+  };
   const now = overrides.now || (() => Date.now());
   const readArtifact = overrides.readArtifact;
   if (typeof readArtifact !== "function") {
-    return { ok: false, reason: "unavailable" };
+    return decline("unavailable");
   }
   const profilesResult = await readArtifact(env, "/metagraph/profiles.json");
-  if (!profilesResult?.ok) return { ok: false, reason: "profiles_unavailable" };
+  if (!profilesResult?.ok) return decline("profiles_unavailable");
   const profiles: Row[] = Array.isArray((profilesResult.data as Row)?.profiles)
     ? ((profilesResult.data as Row).profiles as Row[])
     : [];
-  if (!profiles.length) return { ok: false, reason: "no_profiles" };
+  if (!profiles.length) return decline("no_profiles");
 
   const capturedAt = now();
   const identityArgs = { profiles, now: capturedAt };
@@ -1205,15 +1275,14 @@ export async function writeSubnetSnapshot(
     Number.isInteger(profile.netuid),
   ).length;
   if (!rows) {
-    return { ok: false, reason: "no_rows", identity_history: identityHistory };
+    return decline("no_rows", { identity_history: identityHistory });
   }
   if (!syncResult.synced) {
-    return {
-      ok: false,
-      reason: syncResult.reason,
+    return decline(String(syncResult.reason ?? "sync_declined"), {
       identity_history: identityHistory,
-    };
+    });
   }
+  await reportSnapshotOutcome(env, { ok: true, rows }, overrides);
   return {
     ok: true,
     date,

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -2112,3 +2112,124 @@ describe("emission-pipeline route", () => {
     assert.equal(bad.status, 400);
   });
 });
+
+// #9452: the snapshot write REPORTS its outcome instead of returning it.
+//
+// THE INCIDENT THIS CLOSES: 2026-08-01 is missing entirely from
+// subnet_snapshots -- all 129 subnets, a whole day of price/economics history
+// that does not exist -- and nothing said so. Every decline was a bare
+// `return { ok: false, reason }`, and workers/api.entry.ts discards what
+// `scheduled` returns, so "the economics source gave us nothing and today's
+// history was never written" and "everything is fine" produced byte-identical
+// telemetry. It was found four days later by reading the table by hand.
+describe("#9452 — writeSubnetSnapshot reports its verdict", () => {
+  function spies() {
+    const rows: Row[] = [];
+    const captures: Row[] = [];
+    return {
+      rows,
+      captures,
+      overrides: {
+        laneHealthDb: {
+          prepare: (sql: string) => ({
+            bind: (...values: unknown[]) => ({
+              run: async () => {
+                if (sql.startsWith("INSERT")) {
+                  rows.push({
+                    lane: values[0],
+                    verdict: values[1],
+                    age_ms: values[2],
+                    detail: values[3],
+                  });
+                }
+              },
+            }),
+          }),
+          batch: async () => [],
+        } as never,
+        recordExceptionEvent: (async (_env: unknown, event: unknown) => {
+          captures.push(event as Row);
+          return true;
+        }) as never,
+      },
+    };
+  }
+
+  test("a decline records a stale lane row AND notifies", async () => {
+    const s = spies();
+    const result = (await writeSubnetSnapshot({} as never, {
+      // No profiles artifact: the shape a degraded upstream produces.
+      readArtifact: (() => Promise.resolve({ ok: false })) as never,
+      ...s.overrides,
+    })) as Row;
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "profiles_unavailable");
+
+    assert.equal(s.rows.length, 1, "a row per run, healthy or not");
+    assert.equal(s.rows[0].lane, "subnet-snapshot");
+    assert.equal(s.rows[0].verdict, "stale");
+    assert.equal(s.rows[0].detail, "profiles_unavailable");
+
+    assert.equal(s.captures.length, 1);
+    assert.equal(s.captures[0].route, "subnet-snapshot-write");
+    assert.equal(s.captures[0].errorCode, "stale_lane");
+    assert.match(
+      (s.captures[0].error as Error).message,
+      /profiles_unavailable/,
+    );
+  });
+
+  test("an empty profiles list is a decline, not a quiet success", async () => {
+    // The exact shape that loses a day: the artifact reads fine and carries
+    // nothing, so there is nothing to write and no error to throw.
+    const s = spies();
+    const result = (await writeSubnetSnapshot({} as never, {
+      readArtifact: (() =>
+        Promise.resolve({ ok: true, data: { profiles: [] } })) as never,
+      ...s.overrides,
+    })) as Row;
+
+    assert.equal(result.reason, "no_profiles");
+    assert.equal(s.rows[0].verdict, "stale");
+    assert.equal(s.captures.length, 1);
+  });
+
+  test("a missing reader is reported too, not silently skipped", async () => {
+    const s = spies();
+    const result = (await writeSubnetSnapshot(
+      {} as never,
+      s.overrides as never,
+    )) as Row;
+    assert.equal(result.reason, "unavailable");
+    assert.equal(s.rows[0].verdict, "stale");
+    assert.equal(s.captures.length, 1);
+  });
+
+  test("a lane_health write that fails never breaks the run", async () => {
+    // D1 migrations here are applied by hand, so "no such table" is a real
+    // production state. A writer whose alarm-recording broke its write would
+    // be worse than the bug being fixed.
+    const result = (await writeSubnetSnapshot({} as never, {
+      readArtifact: (() => Promise.resolve({ ok: false })) as never,
+      laneHealthDb: {
+        prepare: () => {
+          throw new Error("no such table: lane_health");
+        },
+      } as never,
+      recordExceptionEvent: (async () => true) as never,
+    })) as Row;
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "profiles_unavailable");
+  });
+
+  test("a capture that throws never breaks the run either", async () => {
+    const result = (await writeSubnetSnapshot({} as never, {
+      readArtifact: (() => Promise.resolve({ ok: false })) as never,
+      recordExceptionEvent: (async () => {
+        throw new Error("posthog unreachable");
+      }) as never,
+    })) as Row;
+    assert.equal(result.reason, "profiles_unavailable");
+  });
+});


### PR DESCRIPTION
## Summary

**2026-08-01 is missing entirely from `subnet_snapshots`** — all 129 subnets, a whole day of price/economics history that does not exist. Nothing reported it. I found it four days later by reading the table by hand while investigating #9449.

Daily coverage from production D1 — every other day in the last 21 has full 129-subnet coverage:

```
2026-08-05  129
2026-08-04  129
2026-08-03  129
2026-08-02  129
2026-08-01  ← absent
2026-07-31  129
```

## Why nothing noticed

The write path reported its outcome by **returning it**, and `workers/api.entry.ts` discards what `scheduled` returns. So "the economics source gave us nothing and today's history was never written" and "everything is fine" produced byte-identical telemetry: silence.

There were **four** distinct ways to lose a day, none of them reported — a failed profiles read, an empty profiles list, no rows carrying an integer netuid, and a declined sync. Every one of them now routes through a single `decline` helper, so a decline added later cannot forget to report itself.

Two channels, for the reason `src/lane-health.ts` already documents: PostHog is the **notification** and can be dropped by someone else's quota, so the `lane_health` row is the **record**. The row is written on every run rather than only on failure — a healthy snapshot lane's output is silence, which is exactly what a stopped one produces.

The verdict is `stale` rather than a bespoke value: a day whose row never landed genuinely leaves this lane behind, which is what a non-ok lane means to the self-health card's readers.

## What was NOT the gap

`upsertSubnetSnapshotsToD1` already captures on a thrown write (`route: "observations-d1-snapshots"`), and there were **zero** such captures on 2026-08-01. That is what pointed at the silent early returns rather than a failed insert — worth stating, because "add a capture to the D1 write" would have been the obvious fix and would have changed nothing.

For context, `$exception` by route on that day (the `wallet-auth-keys` storm day):

```
wallet-auth-keys        97,181
realized-return-...      2,466
tao-usd-index            1,196
...
subnet-snapshot-sync        20   ← the Postgres half of the dual write
```

## Why this matters beyond one row

This is the series `alpha_price_change_*` reads (#9449) and that `/api/v1/subnets/{netuid}/trajectory` serves. A hole silently changes what every window computes over. The elapsed-time fix in #9450 tolerates gaps, but the history stays wrong for that day.

## Tests

Five, covering each decline path and both failure modes of the reporting itself:

- a decline records a `stale` lane row **and** notifies
- an empty profiles list is a decline, not a quiet success — the exact shape that loses a day
- a missing reader is reported too, not silently skipped
- a `lane_health` write that fails never breaks the run (D1 migrations here are applied by hand, so "no such table" is a real production state)
- a capture that throws never breaks the run either

## Validation

```
npm run lint            clean
npm run format:check    clean
npm run typecheck       clean
npx vitest run          669 files, 15935 tests, all passing
```

Patch coverage by diff intersection over `src/**`: **30/30 = 100%**.

Rebased onto current `main` (includes #9453); no overlap — that PR widened the storm window and guarded other Workers' configs, this one is the snapshot writer.

## Out of scope

Backfilling 2026-08-01 itself. Those economics values are likely unrecoverable, and whether to reconstruct them from another tier is a separate call.

Closes #9452
