### PR TITLE
fix(ui): pin table column widths so they stop shifting as virtualized rows mount

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -46,14 +46,20 @@ export interface ValidatorColumn {
    *  field the column ranks by. Columns without one (identity, derived-on-
    *  scroll cells) render a plain, non-interactive header. */
   sortKey?: string;
+  /** Relative width for the table's <colgroup>; see TableColGroup. Weights
+   *  follow what auto-layout settled on at 1280px, so pinning them keeps the
+   *  table looking as it does today rather than retuning it. */
+  width: number;
 }
 
 const numeric = (
   header: string,
-): Pick<ValidatorColumn, "header" | "thClassName" | "tdClassName"> => ({
+  width: number,
+): Pick<ValidatorColumn, "header" | "thClassName" | "tdClassName" | "width"> => ({
   header,
   thClassName: `${TH_BASE} text-right`,
   tdClassName: `${TD_NUM} text-ink`,
+  width,
 });
 
 // #8251: 30d stake trend, lazily fetched per row only once it scrolls into
@@ -102,6 +108,7 @@ function Stake30dDeltaCell({ hotkey }: { hotkey: string }) {
 export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
   {
     header: "Operator",
+    width: 350,
     thClassName: TH_BASE,
     tdClassName: TD_BASE,
     cell: (v, ctx) => {
@@ -150,13 +157,13 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     },
   },
   {
-    ...numeric("Take"),
+    ...numeric("Take", 72),
     sortKey: "take",
     tdClassName: `${TD_NUM} text-ink-muted`,
     cell: (v) => formatTakePct(v.take),
   },
   {
-    ...numeric("Est. APY"),
+    ...numeric("Est. APY", 89),
     sortKey: "apy_estimate",
     // apy_estimate (#2551) is a 0..1 fraction; formatApyPct takes a percentage.
     cell: (v) => {
@@ -171,28 +178,28 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     },
   },
   {
-    ...numeric("Active subnets"),
+    ...numeric("Active subnets", 139),
     sortKey: "subnet_count",
     cell: (v) => formatNumber(v.subnet_count),
   },
   {
-    ...numeric("Nominators"),
+    ...numeric("Nominators", 115),
     sortKey: "nominator_count",
     tdClassName: `${TD_NUM} text-ink-muted`,
     cell: (v) => (v.nominator_count != null ? formatNumber(v.nominator_count) : "—"),
   },
   {
-    ...numeric("Dominance"),
+    ...numeric("Dominance", 113),
     sortKey: "stake_dominance",
     cell: (v) => (v.stake_dominance != null ? `${(v.stake_dominance * 100).toFixed(2)}%` : "—"),
   },
   {
-    ...numeric("Total stake"),
+    ...numeric("Total stake", 129),
     sortKey: "total_stake_tao",
     cell: (v) => taoCompact(v.total_stake_tao),
   },
   {
-    ...numeric("30d Δ"),
+    ...numeric("30d Δ", 75),
     tdClassName: `${TD_NUM}`,
     cell: (v) => <Stake30dDeltaCell hotkey={v.hotkey} />,
   },

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -5,6 +5,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { getTaoMarket } from "@/lib/metagraphed/market.functions";
 import { ChevronDown, Coins, Layers, Server, Star } from "lucide-react";
+import { TableColGroup, columnWidths } from "@jsonbored/ui-kit";
 import {
   AsyncPanel,
   Chip,
@@ -142,21 +143,21 @@ type SubnetRow = Subnet & {
 // registered-UID cap, not a real signal) and had no customizer escape hatch
 // worth keeping for a column that carries zero information.
 const SUBNET_COLUMNS: ColumnDef[] = [
-  { id: "netuid", label: "UID", required: true },
-  { id: "name", label: "Name", required: true },
-  { id: "alphaPrice", label: "Price (α)", defaultVisible: true },
-  { id: "priceChange", label: "24h/7d %", defaultVisible: true },
-  { id: "emission", label: "Emission", defaultVisible: true },
-  { id: "totalStake", label: "Total stake", defaultVisible: true },
-  { id: "health", label: "Health", defaultVisible: true },
-  { id: "age", label: "Age", defaultVisible: true },
-  { id: "marketCap", label: "Market cap", defaultVisible: false },
-  { id: "registration", label: "Reg. cost", defaultVisible: false },
-  { id: "symbol", label: "Symbol", defaultVisible: false },
-  { id: "surfaces", label: "Surfaces", defaultVisible: false },
-  { id: "curation", label: "Source", defaultVisible: false },
-  { id: "readiness", label: "Profile", defaultVisible: false },
-  { id: "updated", label: "Updated", defaultVisible: false },
+  { id: "netuid", label: "UID", required: true, width: 143 },
+  { id: "name", label: "Name", required: true, width: 217 },
+  { id: "alphaPrice", label: "Price (α)", defaultVisible: true, width: 128 },
+  { id: "priceChange", label: "24h/7d %", defaultVisible: true, width: 109 },
+  { id: "emission", label: "Emission", defaultVisible: true, width: 109 },
+  { id: "totalStake", label: "Total stake", defaultVisible: true, width: 123 },
+  { id: "health", label: "Health", defaultVisible: true, width: 132 },
+  { id: "age", label: "Age", defaultVisible: true, width: 162 },
+  { id: "marketCap", label: "Market cap", defaultVisible: false, width: 130 },
+  { id: "registration", label: "Reg. cost", defaultVisible: false, width: 110 },
+  { id: "symbol", label: "Symbol", defaultVisible: false, width: 90 },
+  { id: "surfaces", label: "Surfaces", defaultVisible: false, width: 100 },
+  { id: "curation", label: "Source", defaultVisible: false, width: 110 },
+  { id: "readiness", label: "Profile", defaultVisible: false, width: 110 },
+  { id: "updated", label: "Updated", defaultVisible: false, width: 120 },
 ];
 
 function joinCatalog(
@@ -1233,7 +1234,10 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
             // owned the sticky <thead>, and the outer of the two could never
             // scroll because the inner capped its content at the same 70vh.
             // One viewport, one ref, one thing the header pins against.
-            <table className="w-full text-left text-sm">
+            <table className="w-full min-w-[1100px] table-fixed text-left text-sm">
+              {/* Pins the column tracks so they cannot be re-derived from
+                  whichever virtualized rows happen to be mounted. */}
+              <TableColGroup widths={columnWidths(SUBNET_COLUMNS, columns.isVisible, [42, 36])} />
               <thead>
                 <tr>
                   <th

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -37,6 +37,7 @@ import {
   ValidatorCompareToggle,
 } from "@/components/metagraphed/validators-compare-drawer";
 import { SortHeader, ariaSort, SearchInput } from "@/components/metagraphed/table-controls";
+import { TableColGroup } from "@jsonbored/ui-kit";
 import type { GlobalValidator } from "@/lib/metagraphed/types";
 import { useMeasuredRowHeight } from "@/hooks/use-measured-row-height";
 
@@ -272,10 +273,13 @@ function ValidatorsDirectory({
           <div ref={tableScrollRef} className="mg-table-scroll mg-list-viewport">
             <table
               className={classNames(
-                "w-full text-left text-sm",
+                "w-full min-w-[1100px] table-fixed text-left text-sm",
                 compact && "[&_td]:!py-1 [&_th]:!py-1",
               )}
             >
+              {/* Pins the column tracks so they cannot be re-derived from
+                  whichever virtualized rows happen to be mounted. */}
+              <TableColGroup widths={[46, 40, ...VALIDATOR_COLUMNS.map((c) => c.width)]} />
               <thead className="mg-table-head-pinned">
                 <tr>
                   <th className="w-6 px-3 py-2" aria-label="Watch" />

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -4964,6 +4964,25 @@ function useColumnVisibility(pageKey, columns) {
   }, [columns]);
   return { visible, isVisible, toggle, reset, setVisible };
 }
+function TableColGroup({ widths }) {
+  const total = widths.reduce((sum3, w) => sum3 + w, 0);
+  return /* @__PURE__ */ jsxRuntime.jsx("colgroup", { children: widths.map((w, i) => (
+    // Positional by definition: a <col> IS its index in the row.
+    /* @__PURE__ */ jsxRuntime.jsx(
+      "col",
+      {
+        style: { width: `${(w / total * 100).toFixed(3)}%` }
+      },
+      `col-${i}`
+    )
+  )) });
+}
+function columnWidths(columns, isVisible, leading = []) {
+  return [
+    ...leading,
+    ...columns.filter((c) => isVisible(c.id)).map((c) => c.width ?? 100)
+  ];
+}
 var VARIANT_ICON = {
   empty: lucideReact.Inbox,
   filtered: lucideReact.Filter,
@@ -6707,6 +6726,7 @@ exports.StatWithSpark = StatWithSpark;
 exports.StatusBadge = StatusBadge;
 exports.StickyToolbar = StickyToolbar;
 exports.TabStrip = TabStrip;
+exports.TableColGroup = TableColGroup;
 exports.TableSkeleton = TableSkeleton;
 exports.TableState = TableState;
 exports.TimeAgo = TimeAgo;
@@ -6722,6 +6742,7 @@ exports.YieldPercentileStrip = YieldPercentileStrip;
 exports.buildCsvDownloadUrl = buildCsvDownloadUrl;
 exports.classNames = classNames;
 exports.cn = cn;
+exports.columnWidths = columnWidths;
 exports.defaultVisible = defaultVisible;
 exports.fmtYield = fmtYield;
 exports.isScrolledPast = isScrolledPast;

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -4935,6 +4935,25 @@ function useColumnVisibility(pageKey, columns) {
   }, [columns]);
   return { visible, isVisible, toggle, reset, setVisible };
 }
+function TableColGroup({ widths }) {
+  const total = widths.reduce((sum3, w) => sum3 + w, 0);
+  return /* @__PURE__ */ jsx("colgroup", { children: widths.map((w, i) => (
+    // Positional by definition: a <col> IS its index in the row.
+    /* @__PURE__ */ jsx(
+      "col",
+      {
+        style: { width: `${(w / total * 100).toFixed(3)}%` }
+      },
+      `col-${i}`
+    )
+  )) });
+}
+function columnWidths(columns, isVisible, leading = []) {
+  return [
+    ...leading,
+    ...columns.filter((c) => isVisible(c.id)).map((c) => c.width ?? 100)
+  ];
+}
 var VARIANT_ICON = {
   empty: Inbox,
   filtered: Filter,
@@ -6544,4 +6563,4 @@ function RoutePending({
   );
 }
 
-export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, CandlestickMini, ChartSkeleton, Chip, ClaudeIcon, ColumnCustomizer, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DefinitionList, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Divider, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EmptyState, EntityHero, ExternalLink, FilterChipRow, FilterField, FilterInput, FilterSelect, FilterSheet, FilterToolbar, FreshnessIndicator, GhostButton, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, Indicator, InfoTooltip, Kbd, KeyChip, ListShell, LiveTickerProvider, LoadMore, LoadingPill, McpToolsList, MetaStrip, MethodologyCallout, MetricGrid, MiniRadial, MiniStack, MobileCollapse, NoDataSpark, OpenAIIcon, PageActions, PageHero, PageSection, PagerBar, PagerFooter, Panel, PanelError, PanelHeader, PanelSkeleton, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, ProvenanceChip, QueryBar, QueryProgress, ReadinessGauge, RealtimeFreshness, ResponsiveTable, ReviewChip, RoutePending, SCOPES, SHARE_COPIED_EVENT, SankeyMini, ScrollReveal, ScrollShadow, SectionAnchor, SectionHeading, SectionLabel, SegmentedToggle, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StackedAreaMini, StatTile, StatWithSpark, StatusBadge, StickyToolbar, TabStrip, TableSkeleton, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, classNames, cn, defaultVisible, fmtYield, isScrolledPast, layoutSankey, layoutStackedArea, nextTabIndex, prefetchBrandIcon, rovingTabIndex, safeExternalUrl, tierFreshnessLabel, useColumnVisibility, useLiveTicker, useQueryBarContext, useRovingTablist, useScrolled };
+export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, CandlestickMini, ChartSkeleton, Chip, ClaudeIcon, ColumnCustomizer, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DefinitionList, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Divider, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EmptyState, EntityHero, ExternalLink, FilterChipRow, FilterField, FilterInput, FilterSelect, FilterSheet, FilterToolbar, FreshnessIndicator, GhostButton, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, Indicator, InfoTooltip, Kbd, KeyChip, ListShell, LiveTickerProvider, LoadMore, LoadingPill, McpToolsList, MetaStrip, MethodologyCallout, MetricGrid, MiniRadial, MiniStack, MobileCollapse, NoDataSpark, OpenAIIcon, PageActions, PageHero, PageSection, PagerBar, PagerFooter, Panel, PanelError, PanelHeader, PanelSkeleton, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, ProvenanceChip, QueryBar, QueryProgress, ReadinessGauge, RealtimeFreshness, ResponsiveTable, ReviewChip, RoutePending, SCOPES, SHARE_COPIED_EVENT, SankeyMini, ScrollReveal, ScrollShadow, SectionAnchor, SectionHeading, SectionLabel, SegmentedToggle, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StackedAreaMini, StatTile, StatWithSpark, StatusBadge, StickyToolbar, TabStrip, TableColGroup, TableSkeleton, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, classNames, cn, columnWidths, defaultVisible, fmtYield, isScrolledPast, layoutSankey, layoutStackedArea, nextTabIndex, prefetchBrandIcon, rovingTabIndex, safeExternalUrl, tierFreshnessLabel, useColumnVisibility, useLiveTicker, useQueryBarContext, useRovingTablist, useScrolled };

--- a/packages/ui-kit/src/components/metagraphed/table-colgroup.tsx
+++ b/packages/ui-kit/src/components/metagraphed/table-colgroup.tsx
@@ -1,0 +1,45 @@
+import type { ColumnDef } from "./use-column-visibility";
+
+/**
+ * Builds a <colgroup> that pins a table's column widths.
+ *
+ * Virtualized tables cannot use `table-layout: auto`: the browser derives
+ * column widths from the rows currently in the DOM, and a virtualizer
+ * replaces those rows on every scroll, so the columns keep being re-measured
+ * and everything -- including the pinned header -- slides sideways while the
+ * reader scrolls. Measured before this: 43px of drift on /subnets, 123px on
+ * /validators.
+ *
+ * `table-layout: fixed` stops that, but only if the columns have declared
+ * widths; without them the browser splits the table evenly and a checkbox
+ * column gets as much room as a name. Percentages (rather than pixels) keep
+ * the proportions when the table is stretched wider than its minimum, and
+ * pairing them with a `min-width` on the table keeps horizontal scrolling
+ * working when the container is narrower than the columns need.
+ */
+export function TableColGroup({ widths }: { widths: number[] }) {
+  const total = widths.reduce((sum, w) => sum + w, 0);
+  return (
+    <colgroup>
+      {widths.map((w, i) => (
+        // Positional by definition: a <col> IS its index in the row.
+        <col
+          key={`col-${i}`}
+          style={{ width: `${((w / total) * 100).toFixed(3)}%` }}
+        />
+      ))}
+    </colgroup>
+  );
+}
+
+/** Weights for the visible subset, falling back to an even share. */
+export function columnWidths(
+  columns: readonly ColumnDef[],
+  isVisible: (id: string) => boolean,
+  leading: number[] = [],
+): number[] {
+  return [
+    ...leading,
+    ...columns.filter((c) => isVisible(c.id)).map((c) => c.width ?? 100),
+  ];
+}

--- a/packages/ui-kit/src/components/metagraphed/use-column-visibility.ts
+++ b/packages/ui-kit/src/components/metagraphed/use-column-visibility.ts
@@ -7,6 +7,21 @@ export interface ColumnDef {
   required?: boolean;
   /** Default visibility if no persisted state exists. */
   defaultVisible?: boolean;
+  /**
+   * Relative width, used to build the table's <colgroup>.
+   *
+   * Needed because these tables are virtualized: with `table-layout: auto`
+   * the browser sizes columns from the rows currently in the DOM, and a
+   * virtualizer swaps that set on every scroll, so the columns -- and the
+   * pinned header sitting on top of them -- visibly shift as the reader
+   * scrolls. Measured drift before this existed: 43px on /subnets, 123px on
+   * /validators.
+   *
+   * A weight, not a fixed size: the visible column set changes as columns are
+   * toggled, so widths are normalised over whatever is on screen rather than
+   * being absolute. Columns without one fall back to an even share.
+   */
+  width?: number;
 }
 
 const STORAGE_PREFIX = "mg:cols:v1:";

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -250,6 +250,10 @@ export {
   type ColumnDef,
 } from "@/components/metagraphed/use-column-visibility";
 export {
+  TableColGroup,
+  columnWidths,
+} from "@/components/metagraphed/table-colgroup";
+export {
   Panel,
   type PanelProps,
   type PanelTone,


### PR DESCRIPTION
The remaining half of the "table contents shift while scrolling" report, after #9448 fixed the row-height and scroll-container halves.

With `table-layout: auto` the browser derives column widths from the rows currently in the DOM. A virtualizer replaces that set on every scroll — so the columns, and the header pinned on top of them, slide sideways as you scroll the entries.

Measured while scrolling the list (not the page):

| Route | Column drift before | After |
|---|---|---|
| `/subnets` | 43px | **0px** |
| `/validators` | 123px | **0px** |

Zero at 1280 and 900.

## Why weights rather than pixels

`table-layout: fixed` stops the re-derivation, but only if columns have declared widths — without them the browser splits the table evenly and the watch checkbox gets as much room as the operator name.

So each column carries a relative weight, rendered into a `<colgroup>` by `TableColGroup`:

- **Weights, not fixed sizes** — `/subnets` columns are toggleable, so the visible set changes as columns are turned on and off. Widths are normalised over whatever is actually on screen.
- **Percentages plus `min-w-[1100px]`** — percentages keep the proportions when the table stretches wider than its minimum; the min-width keeps horizontal scrolling working when the container is narrower than the columns need. A table sized purely in percentages can never overflow, which would have silently removed that scrolling.

The weights are the widths auto-layout had already settled on at 1280px, so this pins the current appearance rather than retuning it.

## Residual, stated plainly

`/subnets` still shows 105px (@1280) and 383px (@900) of scroll-height movement — roughly 3px per row. That is **genuine row-height variance** (rows are 55–58px depending on what they render), not estimate error: `useMeasuredRowHeight` from #9448 removed the estimate component. Eliminating it entirely would mean forcing uniform row heights, which is a content decision rather than a layout fix.

`/validators` is 0px on both axes.

## Verification

| Check | Result |
|---|---|
| e2e (CI=1, --workers=2, production Worker build) | 104 passed, 2 skipped, exit 0 |
| apps/ui vitest | 232 files, 1812 tests |
| ui-kit vitest | 121 |
| typecheck + lint | clean |
