### PR TITLE
fix(telemetry): put the exception budget where autocaptured faults pass

### DIFF
--- a/apps/ui/src/lib/analytics.test.ts
+++ b/apps/ui/src/lib/analytics.test.ts
@@ -235,31 +235,43 @@ describe("analytics (PostHog web analytics)", () => {
       expect(startSessionRecording).not.toHaveBeenCalled();
     });
 
-    it("captureException drops a repeat of the same error signature inside the throttle window (#9451)", async () => {
+    it("before_send throttles a repeated $exception, including autocaptured ones (#9451)", async () => {
       vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
-      const { captureException } = await import("./analytics");
-      captureException(new Error("boom"));
-      captureException(new Error("boom"));
-      await vi.waitFor(() => expect(captureExceptionSpy).toHaveBeenCalled());
-      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
-      // A DIFFERENT signature is never delayed by an unrelated storm.
-      captureException(new TypeError("other fault"));
-      await vi.waitFor(() => expect(captureExceptionSpy).toHaveBeenCalledTimes(2));
+      const { capturePageview } = await import("./analytics");
+      capturePageview("https://metagraph.sh/");
+      await vi.waitFor(() => expect(init).toHaveBeenCalled());
+      const beforeSend = init.mock.calls[0][1].before_send as (e: unknown) => unknown;
+
+      // An autocaptured exception never passes through captureException, so
+      // before_send is the only thing standing between it and ingestion.
+      const autocaptured = {
+        event: "$exception",
+        properties: { $exception_values: ["Invalid regular expression"] },
+      };
+      expect(beforeSend(autocaptured)).toBe(autocaptured);
+      expect(beforeSend({ ...autocaptured })).toBeNull();
+
+      // A different fault is never delayed by an unrelated storm.
+      const other = { event: "$exception", properties: { $exception_values: ["other"] } };
+      expect(beforeSend(other)).toBe(other);
+
+      // Non-exception events pass through untouched and spend no budget.
+      const pageview = { event: "$pageview", properties: {} };
+      expect(beforeSend(pageview)).toBe(pageview);
     });
 
     it("admitClientException re-admits a signature once its window elapses, and enforces the page cap (#9451)", async () => {
       vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
       const { admitClientException } = await import("./analytics");
-      const err = new Error("boom");
-      expect(admitClientException(err, 0)).toBe(true);
-      expect(admitClientException(err, 59_999)).toBe(false);
-      expect(admitClientException(err, 60_000)).toBe(true);
+      expect(admitClientException("Error:boom", 0)).toBe(true);
+      expect(admitClientException("Error:boom", 59_999)).toBe(false);
+      expect(admitClientException("Error:boom", 60_000)).toBe(true);
       // Hard per-pageload cap: a cascade minting distinct signatures cannot
       // spend unbounded quota. 2 admissions consumed above; the cap is 20.
       for (let i = 0; i < 18; i += 1) {
-        expect(admitClientException(new Error(`cascade ${i}`), 0)).toBe(true);
+        expect(admitClientException(`cascade ${i}`, 0)).toBe(true);
       }
-      expect(admitClientException(new Error("over the cap"), 0)).toBe(false);
+      expect(admitClientException("over the cap", 0)).toBe(false);
     });
 
     it("captureException shares the same lazily-loaded instance as capturePageview/captureEvent (no second init)", async () => {

--- a/apps/ui/src/lib/analytics.ts
+++ b/apps/ui/src/lib/analytics.ts
@@ -163,6 +163,30 @@ function loadPostHog(): Promise<PostHog | null> {
         // captured the first frames. SPA navigations are handled by
         // syncReplayPolicy() below.
         disable_session_recording: isReplayBlockedRoute(currentPathname()),
+        // #9451 follow-up: the throttle in captureException() below only sees
+        // exceptions this app routes through it (error boundaries via
+        // error-reporting.ts). The project has exception AUTOCAPTURE enabled,
+        // and posthog-js sends those straight from its own window.onerror /
+        // unhandledrejection handlers -- never through our wrapper -- so an
+        // unhandled fault in a render loop was still completely unthrottled.
+        // That is not hypothetical: the `Invalid regular expression: /^*/
+        // settings/*$/` storm (a malformed replay-blocklist rule, since
+        // corrected project-side) arrived this way, `handled: false`, once
+        // per pageview across every route.
+        //
+        // before_send is posthog-js's documented last gate before dispatch
+        // and sees EVERY event including autocaptured ones, so the same
+        // admitClientException() budget now governs both paths. Returning
+        // null drops the event client-side, which means it is never ingested
+        // and therefore never billed (PostHog bills ingested $exception
+        // events; a drop before send costs nothing). Non-exception events
+        // pass through untouched.
+        before_send: (event) => {
+          if (event?.event !== "$exception") return event;
+          const values = event.properties?.["$exception_values"];
+          const signature = Array.isArray(values) ? values.join("|") : String(values ?? "");
+          return admitClientException(signature) ? event : null;
+        },
         capture_pageview: false,
         // posthog-js's own default for capture_pageleave is
         // 'if_capture_pageview' -- i.e. it piggybacks on capture_pageview's
@@ -335,29 +359,38 @@ export function captureEvent(name: string, properties?: Record<string, unknown>)
 // #9451: client-side $exception cost guard, the browser twin of
 // src/usage-telemetry.ts's admitExceptionCapture. The server side throttles
 // per fingerprint per isolate; here the unit of blast radius is one page
-// load (a render-loop error boundary or a failing effect can call
-// reportError on every frame), so the guard is two-layered: at most one
-// capture per error signature per window, and a hard cap per page load no
-// matter how many distinct signatures a cascade mints. Unlike the server
-// guard this is NOT env-gated -- there is no test-determinism concern here
-// (the throttle state is module-scoped and vi.resetModules() clears it),
-// and an unconfigured token already short-circuits before the guard runs.
+// load (a render loop can throw on every frame), so the guard is two-layered:
+// at most one capture per error signature per window, and a hard cap per page
+// load no matter how many distinct signatures a cascade mints. Unlike the
+// server guard this is NOT env-gated -- there is no test-determinism concern
+// (the state is module-scoped, and vi.resetModules() clears it).
+//
+// Enforced in exactly ONE place: the `before_send` hook in loadPostHog above.
+// That is deliberate. before_send is the only gate BOTH exception paths pass
+// through -- this module's own captureException AND posthog-js's exception
+// autocapture, which sends from its internal window.onerror handler and never
+// touches our wrapper. An earlier revision also called this from
+// captureException, which double-spent the budget: one explicit capture
+// consumed a slot on the way in and then met its own throttle again in
+// before_send, where a second signature miss could drop an event that had
+// already been admitted.
 const EXCEPTION_WINDOW_MS = 60_000;
 const EXCEPTION_PAGE_CAP = 20;
 const exceptionLastSentAt = new Map<string, number>();
 let exceptionsSentThisPage = 0;
 
-/** Decide whether this exception may be captured now. Exported for tests
- * only -- captureException is a silent no-op without a token, so "throttled"
- * would otherwise be indistinguishable from "unconfigured" (same reasoning
- * as the server-side admitExceptionCapture's export). */
-export function admitClientException(error: unknown, nowMs: number = Date.now()): boolean {
+/** Decide whether an exception with this signature may be sent now.
+ *
+ * Takes the already-normalized signature STRING rather than the error object:
+ * before_send sees a serialized PostHog event (`$exception_values`), not the
+ * original `Error`, so a string keeps the one budget keyed consistently no
+ * matter which path produced the event. Exported for tests -- a dropped event
+ * is otherwise indistinguishable from an unconfigured no-op. */
+export function admitClientException(signature: string, nowMs: number = Date.now()): boolean {
   if (exceptionsSentThisPage >= EXCEPTION_PAGE_CAP) return false;
-  // Name+message, not a stack hash: two occurrences of the same fault can
+  // Message text, not a stack hash: two occurrences of the same fault can
   // carry different chunk URLs in their stacks (lazy-loaded routes), and
   // PostHog's own issue grouping is message-led anyway (#9019 server-side).
-  const err = error instanceof Error ? error : null;
-  const signature = `${err?.name ?? typeof error}:${err?.message ?? String(error)}`;
   const lastSentAt = exceptionLastSentAt.get(signature);
   if (lastSentAt !== undefined && nowMs - lastSentAt < EXCEPTION_WINDOW_MS) return false;
   exceptionLastSentAt.set(signature, nowMs);
@@ -375,14 +408,14 @@ export function admitClientException(error: unknown, nowMs: number = Date.now())
  * call site. Same best-effort, no-op-when-unconfigured contract as every
  * other export here.
  *
- * #9451: throttled via admitClientException above, and #7761's
- * `startSessionRecording(true)` force-record is REMOVED -- forcing a
- * recording per exception coupled error volume to session-replay billing,
- * so one storm spent two quotas at once. Replay stays on its configured
- * sample rate; exceptions no longer override it. */
+ * #9451: no throttle call here -- the budget is enforced once, in the
+ * `before_send` hook (see admitClientException below for why one gate rather
+ * than two). #7761's `startSessionRecording(true)` force-record is REMOVED:
+ * forcing a recording per exception coupled error volume to session-replay
+ * billing, so one storm spent two quotas at once. Replay stays on its
+ * configured sample rate; exceptions no longer override it. */
 export function captureException(error: unknown, properties?: Record<string, unknown>): void {
   if (!POSTHOG_TOKEN) return;
-  if (!admitClientException(error)) return;
   void loadPostHog().then((posthog) => {
     posthog?.captureException(error, properties);
   });

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -1250,6 +1250,39 @@ function exceptionListEntry(error: unknown): {
 }
 
 /**
+ * Platform lifecycle messages that are NOT faults, and must never spend
+ * error-tracking quota or land in the error inbox.
+ *
+ * "Durable Object reset because its code was updated" is the runtime telling
+ * us a deploy landed while a DO was live. It is expected on EVERY deploy,
+ * self-heals (the alarm/request simply re-runs), and there is no action a
+ * reader could take. workers/api.ts's firehose-ingest handler already
+ * documents it as "expected/occasional, not a real fault" and swallows it at
+ * that one call site -- but the DOs' own alarm loops capture it too, and
+ * their per-isolate change-detectors (e.g. ChainFirehoseHub's
+ * lastCapturedHeadPollerError) are defeated by construction here: the reset
+ * WIPES the isolate holding the memo, so the next occurrence always looks
+ * new. That is why this needs to be central rather than another local guard
+ * -- all four DOs (chain-firehose, mcp-session, subnet-status, alerter) can
+ * raise it, and a deploy-heavy day captured 43 of them.
+ *
+ * Deliberately an exact-prefix list of runtime-owned strings, not a fuzzy
+ * "looks benign" heuristic: anything broader would eventually swallow a real
+ * fault, which is the failure mode that actually costs debugging time.
+ */
+const BENIGN_PLATFORM_MESSAGE_PREFIXES = [
+  "Durable Object reset because its code was updated",
+] as const;
+
+/** Exported for tests: a suppressed capture is otherwise indistinguishable
+ * from the unconfigured no-op, the same reasoning as admitExceptionCapture. */
+export function isBenignPlatformMessage(message: string): boolean {
+  return BENIGN_PLATFORM_MESSAGE_PREFIXES.some((prefix) =>
+    message.startsWith(prefix),
+  );
+}
+
+/**
  * Capture one exception as a PostHog `$exception` event. Same no-throw,
  * no-op-when-unconfigured contract as recordUsageEvent/recordMcpToolCallEvent.
  *
@@ -1274,6 +1307,15 @@ export async function recordExceptionEvent(
     if (!event || typeof event !== "object") return false;
 
     const { type, entry } = exceptionListEntry(event.error);
+    // Before the storm guard, not after: a benign platform message must never
+    // consume a fingerprint's window either, or a deploy-time reset would
+    // suppress the NEXT genuine fault on that same route for a full window.
+    if (
+      typeof entry.value === "string" &&
+      isBenignPlatformMessage(entry.value)
+    ) {
+      return false;
+    }
     const route = sanitizeLabel(event.route);
     const mcpTool = sanitizeLabel(event.mcpTool);
     // A stable string groups every occurrence of "this site threw this

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -8,6 +8,7 @@ import {
   USAGE_EVENT_DISTINCT_ID,
   USAGE_EVENT_NAME,
   admitExceptionCapture,
+  isBenignPlatformMessage,
   MCP_PROTOCOL_ROUTE_PREFIX,
   classifyMcpErrorType,
   resolveDeployment,
@@ -779,6 +780,64 @@ describe("recordMcpInitializeEvent", () => {
 // comment for the sources. These tests pin that shape so a future refactor
 // can't silently drift from it.
 describe("recordExceptionEvent", () => {
+  test("drops a Durable Object code-update reset without sending anything", async () => {
+    // Expected on every deploy, self-healing, and raised by all four DOs --
+    // the per-isolate change-detectors cannot suppress it because the reset
+    // is what wipes the isolate holding the memo.
+    const calls: Row[] = [];
+    const recorded = await recordExceptionEvent(
+      CONFIGURED,
+      {
+        error: new Error("Durable Object reset because its code was updated."),
+        route: "head-poller",
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(recorded, false);
+    assert.equal(calls.length, 0);
+  });
+
+  test("a genuine fault on the same route is still captured after a reset was dropped", async () => {
+    // The suppression runs BEFORE the storm guard, so a dropped platform
+    // message must not have consumed head-poller's throttle window.
+    const calls: Row[] = [];
+    const deps = { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) };
+    await recordExceptionEvent(
+      CONFIGURED,
+      {
+        error: new Error("Durable Object reset because its code was updated."),
+        route: "reset-route",
+      },
+      deps,
+    );
+    const recorded = await recordExceptionEvent(
+      CONFIGURED,
+      { error: new Error("real fault"), route: "reset-route" },
+      deps,
+    );
+    assert.equal(recorded, true);
+    assert.equal(calls.length, 1);
+    assert.equal(
+      calls[0].body.properties.$exception_list[0].value,
+      "real fault",
+    );
+  });
+
+  test("isBenignPlatformMessage matches only the exact runtime prefix", () => {
+    assert.equal(
+      isBenignPlatformMessage(
+        "Durable Object reset because its code was updated.",
+      ),
+      true,
+    );
+    // A real fault that merely mentions the same subject must NOT be swallowed.
+    assert.equal(
+      isBenignPlatformMessage("failed to reach Durable Object reset endpoint"),
+      false,
+    );
+    assert.equal(isBenignPlatformMessage("boom"), false);
+  });
+
   test("stamps frames with the chunk id of the file they came from", async () => {
     // Models production faithfully: `posthog-cli sourcemap inject` prepends an
     // IIFE that registers globalThis._posthogChunkIds[<a stack captured INSIDE


### PR DESCRIPTION
Closes #9457. Follow-up to #9453, from reading the live PostHog error inbox rather than the code.

## 1. The throttle was in the wrong place

#9453 added a client-side `$exception` throttle inside `captureException()`. But the project has **exception autocapture on**, and posthog-js sends those from its own `window.onerror` / `unhandledrejection` handlers — they never touch our wrapper. The throttle covered the path that was already well-behaved (error boundaries) and missed the one that actually stormed: the `Invalid regular expression: /^*/settings/*$/` fault arrived `handled: false`, once per pageview, on every route, for 3 real users.

Moved into posthog-js's `before_send`, the single gate every `$exception` crosses regardless of origin. `null` drops the event client-side, so it is never ingested and never billed.

This also collapses a **double-spend #9453 introduced**: an explicit capture consumed a budget slot on the way in, then met the same throttle again in `before_send`, where a second signature miss could drop an event already admitted. One gate, one budget, keyed on a normalized signature string that both paths produce.

## 2. Deploy resets are not faults

`Durable Object reset because its code was updated` — 43 in the last week. Expected on every deploy, self-healing, nothing a reader can act on. `workers/api.ts`'s firehose-ingest handler already treats it as benign at that one call site, but the DOs' alarm loops capture it, and `ChainFirehoseHub.lastCapturedHeadPollerError` **cannot** suppress it by construction: the reset wipes the isolate holding the memo, so every occurrence looks new.

Suppressed centrally in `recordExceptionEvent` (all four DOs can raise it) via an exact-prefix list of runtime-owned strings — deliberately not a fuzzy "looks benign" match, which would eventually swallow a real fault. Runs *before* the storm guard, so a dropped platform message never consumes a genuine fingerprint's window.

## Why it matters

Measured 2026-08-04: `$exception` is running ~1.5–4.6K/day ≈ **~90K/month against the 100K free tier** — borderline every month. Product analytics is fine at ~450K/month against 1M (the 0.05 sampling collapses ~270K real requests/day into ~13K ingested).

## Verification

- `apps/ui`: `vitest run src/lib/analytics.test.ts src/lib/error-reporting.test.ts` — 34/34. New test drives the real `before_send` off `init`'s captured options with an autocapture-shaped event, so it fails if the hook stops being wired.
- root: `vitest run tests/usage-telemetry.test.ts` — 163/163; `tests/mcp-usage-telemetry.test.ts` + `tests/request-usage-telemetry.test.ts` — 93/93. Covers the suppression, the "real fault still captured on the same route afterwards" case, and the negative match.
- Prettier clean in both workspaces (each has its own config).

Confined to `apps/ui/src/lib/**` + tests — no visual change.