### PR TITLE
feat(ui): make every table column filterable, and surface the fields the API was already returning

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-columns.test.ts
+++ b/apps/ui/src/components/metagraphed/validator-columns.test.ts
@@ -64,9 +64,14 @@ describe("VALIDATOR_COLUMNS", () => {
 
   // #8251 column diet: Hotkey/Coldkey/UIDs/Total emission left the directory
   // (the Operator cell now carries the detail link + short hotkey; coldkey
-  // and per-subnet emission live on the detail page). This pins the NEW set.
-  it("exposes the #8251 directory column set", () => {
-    const headers = VALIDATOR_COLUMNS.map((c) => c.header);
+  // and per-subnet emission live on the detail page). The diet is now the
+  // DEFAULT rather than the whole set -- every column is toggleable, and the
+  // fields the API returns but the table never showed (emission, trust,
+  // realized return, the root/alpha stake split) are available opt-in instead
+  // of being unreachable. This pins what a reader sees without touching
+  // anything.
+  it("defaults to the #8251 directory column set", () => {
+    const headers = VALIDATOR_COLUMNS.filter((c) => c.defaultVisible).map((c) => c.header);
     expect(headers).toEqual([
       "Operator",
       "Take",
@@ -77,5 +82,21 @@ describe("VALIDATOR_COLUMNS", () => {
       "Total stake",
       "30d Δ",
     ]);
+  });
+
+  it("offers the rest of the payload as opt-in columns", () => {
+    // Each of these is a field GET /api/v1/validators has always returned.
+    // Off by default, so the directory reads the same until asked otherwise.
+    const optIn = VALIDATOR_COLUMNS.filter((c) => !c.defaultVisible).map((c) => c.header);
+    expect(optIn).toEqual(["Emission", "Avg trust", "Realized 7d", "Root stake", "Alpha stake"]);
+  });
+
+  it("gives every column a stable id and a width for the colgroup", () => {
+    // Both are load-bearing: the id keys column visibility, and the width
+    // feeds TableColGroup, without which `table-layout: fixed` splits the
+    // table evenly and the watch checkbox gets as much room as the operator.
+    const ids = VALIDATOR_COLUMNS.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(VALIDATOR_COLUMNS.every((c) => c.width > 0)).toBe(true);
   });
 });

--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -37,6 +37,14 @@ export interface ValidatorCellContext {
 }
 
 export interface ValidatorColumn {
+  /** Stable key for column visibility (ColumnDef-compatible). */
+  id: string;
+  /** ColumnDef uses `label`; kept in sync with `header` below. */
+  label: string;
+  /** Cannot be hidden -- the row's identity. */
+  required?: boolean;
+  /** Part of the default-visible core set. */
+  defaultVisible?: boolean;
   header: string;
   thClassName: string;
   tdClassName: string;
@@ -53,13 +61,21 @@ export interface ValidatorColumn {
 }
 
 const numeric = (
+  id: string,
   header: string,
   width: number,
-): Pick<ValidatorColumn, "header" | "thClassName" | "tdClassName" | "width"> => ({
+  defaultVisible = true,
+): Pick<
+  ValidatorColumn,
+  "id" | "label" | "header" | "thClassName" | "tdClassName" | "width" | "defaultVisible"
+> => ({
+  id,
+  label: header,
   header,
   thClassName: `${TH_BASE} text-right`,
   tdClassName: `${TD_NUM} text-ink`,
   width,
+  defaultVisible,
 });
 
 // #8251: 30d stake trend, lazily fetched per row only once it scrolls into
@@ -107,6 +123,10 @@ function Stake30dDeltaCell({ hotkey }: { hotkey: string }) {
 // detail page.
 export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
   {
+    id: "operator",
+    label: "Operator",
+    required: true,
+    defaultVisible: true,
     header: "Operator",
     width: 350,
     thClassName: TH_BASE,
@@ -157,13 +177,13 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     },
   },
   {
-    ...numeric("Take", 72),
+    ...numeric("take", "Take", 72),
     sortKey: "take",
     tdClassName: `${TD_NUM} text-ink-muted`,
     cell: (v) => formatTakePct(v.take),
   },
   {
-    ...numeric("Est. APY", 89),
+    ...numeric("apy", "Est. APY", 89),
     sortKey: "apy_estimate",
     // apy_estimate (#2551) is a 0..1 fraction; formatApyPct takes a percentage.
     cell: (v) => {
@@ -178,29 +198,56 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     },
   },
   {
-    ...numeric("Active subnets", 139),
+    ...numeric("subnets", "Active subnets", 139),
     sortKey: "subnet_count",
     cell: (v) => formatNumber(v.subnet_count),
   },
   {
-    ...numeric("Nominators", 115),
+    ...numeric("nominators", "Nominators", 115),
     sortKey: "nominator_count",
     tdClassName: `${TD_NUM} text-ink-muted`,
     cell: (v) => (v.nominator_count != null ? formatNumber(v.nominator_count) : "—"),
   },
   {
-    ...numeric("Dominance", 113),
+    ...numeric("dominance", "Dominance", 113),
     sortKey: "stake_dominance",
     cell: (v) => (v.stake_dominance != null ? `${(v.stake_dominance * 100).toFixed(2)}%` : "—"),
   },
   {
-    ...numeric("Total stake", 129),
+    ...numeric("totalStake", "Total stake", 129),
     sortKey: "total_stake_tao",
     cell: (v) => taoCompact(v.total_stake_tao),
   },
   {
-    ...numeric("30d Δ", 75),
+    ...numeric("delta30d", "30d Δ", 75),
     tdClassName: `${TD_NUM}`,
     cell: (v) => <Stake30dDeltaCell hotkey={v.hotkey} />,
+  },
+  {
+    ...numeric("emission", "Emission", 110, false),
+    sortKey: "total_emission_tao",
+    cell: (v) => (v.total_emission_tao != null ? taoCompact(v.total_emission_tao) : "—"),
+  },
+  {
+    ...numeric("trust", "Avg trust", 100, false),
+    sortKey: "avg_validator_trust",
+    cell: (v) =>
+      v.avg_validator_trust != null ? `${(v.avg_validator_trust * 100).toFixed(1)}%` : "—",
+  },
+  {
+    ...numeric("realized1w", "Realized 7d", 110, false),
+    sortKey: "realized_return_1w",
+    cell: (v) =>
+      v.realized_return_1w != null ? `${(v.realized_return_1w * 100).toFixed(2)}%` : "—",
+  },
+  {
+    ...numeric("rootStake", "Root stake", 115, false),
+    sortKey: "root_stake_tao",
+    cell: (v) => (v.root_stake_tao != null ? taoCompact(v.root_stake_tao) : "—"),
+  },
+  {
+    ...numeric("alphaStake", "Alpha stake", 118, false),
+    sortKey: "alpha_stake_tao",
+    cell: (v) => (v.alpha_stake_tao != null ? taoCompact(v.alpha_stake_tao) : "—"),
   },
 ];

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -6520,6 +6520,13 @@ function normalizeGlobalValidator(raw: unknown): GlobalValidator | null {
       coerceFiniteNumber(raw.apy_estimate_eligible_subnet_count) ?? 0,
     avg_validator_trust: nullableNum(raw.avg_validator_trust),
     max_validator_trust: nullableNum(raw.max_validator_trust),
+    // On the wire since the leaderboard shipped, and dropped here until now --
+    // this builder is an allowlist, so a field the API returns is invisible to
+    // the entire UI unless it is named. That is why the table could not offer
+    // realized return at all.
+    realized_return_1d: nullableNum(raw.realized_return_1d),
+    realized_return_1w: nullableNum(raw.realized_return_1w),
+    realized_return_1m: nullableNum(raw.realized_return_1m),
     stake_dominance: nullableNum(raw.stake_dominance),
     latest_captured_at: typeof raw.latest_captured_at === "string" ? raw.latest_captured_at : null,
     latest_block_number: nullableNum(raw.latest_block_number),

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -141,6 +141,10 @@ export interface Subnet {
   // index signature below.
   subnet_type?: "root" | "application" | string;
   participants?: number;
+  /** Chain lifecycle state ("active" | "deprecated" | ...). Present on every
+   *  /api/v1/subnets row and previously undeclared, so the value could not be
+   *  read without casting. */
+  lifecycle?: string | null;
   tempo?: number;
   // registered_at_block/block (the current snapshot block, for #6643's
   // age-in-days estimate) are the real wire field names (SubnetIndexEntry) --
@@ -2548,6 +2552,13 @@ export interface GlobalValidator {
   apy_estimate_eligible_subnet_count: number;
   avg_validator_trust: number | null;
   max_validator_trust: number | null;
+  /** Realized return over the trailing window, as a fraction (0.03 = +3%).
+   *  Returned by GET /api/v1/validators and previously absent from this type,
+   *  so the field was unreachable from the UI even though every response
+   *  carried it. */
+  realized_return_1d?: number | null;
+  realized_return_1w?: number | null;
+  realized_return_1m?: number | null;
   stake_dominance: number | null;
   latest_captured_at: string | null;
   latest_block_number: number | null;

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -158,6 +158,10 @@ const SUBNET_COLUMNS: ColumnDef[] = [
   { id: "curation", label: "Source", defaultVisible: false, width: 110 },
   { id: "readiness", label: "Profile", defaultVisible: false, width: 110 },
   { id: "updated", label: "Updated", defaultVisible: false, width: 120 },
+  // Registry fields the payload has always carried and the table never
+  // showed. Off by default so the core view is unchanged.
+  { id: "participants", label: "Participants", defaultVisible: false, width: 115 },
+  { id: "lifecycle", label: "Lifecycle", defaultVisible: false, width: 110 },
 ];
 
 function joinCatalog(
@@ -1421,6 +1425,24 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                       />
                     </th>
                   ) : null}
+                  {columns.isVisible("participants") ? (
+                    <th
+                      className={classNames(cellPad, "mg-table-head-pinned text-right")}
+                      aria-sort={ariaSort(search.sort === "participants", search.order)}
+                    >
+                      <SortHeader
+                        label="Participants"
+                        field="participants"
+                        active={search.sort === "participants"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("lifecycle") ? (
+                    <th className={classNames(cellPad, "mg-table-head-pinned")}>Lifecycle</th>
+                  ) : null}
                   {columns.isVisible("updated") ? (
                     <th
                       className={classNames(cellPad, "mg-table-head-pinned text-right")}
@@ -1632,6 +1654,18 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                           usdPerTao={taoUsd}
                           window={trendWindow}
                         />
+                      ) : null}
+                      {columns.isVisible("participants") ? (
+                        <td
+                          className={classNames(cellPad, "text-right mg-type-data text-ink-muted")}
+                        >
+                          {s.participants != null ? formatNumber(s.participants) : "—"}
+                        </td>
+                      ) : null}
+                      {columns.isVisible("lifecycle") ? (
+                        <td className={classNames(cellPad, "mg-type-data text-ink-muted")}>
+                          {s.lifecycle ?? "—"}
+                        </td>
                       ) : null}
                       {columns.isVisible("updated") ? (
                         <td

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -32,6 +32,7 @@ import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validato
 import { ValidatorCardList } from "@/components/metagraphed/validator-card-list";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
 import { VALIDATOR_COLUMNS } from "@/components/metagraphed/validator-columns";
+import { ColumnCustomizer, useColumnVisibility } from "@jsonbored/ui-kit";
 import {
   ValidatorsCompareDrawer,
   ValidatorCompareToggle,
@@ -121,6 +122,12 @@ function ValidatorsDirectory({
   const generatedAt = res.meta?.generated_at ?? null;
   const compact = density === "compact";
   const watchlist = useWatchlist("validator");
+  // Every column is opt-in/out, with a core set on by default -- the API
+  // returns far more per validator than the table used to show (emission,
+  // trust, realized returns, the root/alpha stake split), and hiding them
+  // permanently was the wrong default.
+  const columns = useColumnVisibility("validators", VALIDATOR_COLUMNS);
+  const visibleColumns = VALIDATOR_COLUMNS.filter((c) => columns.isVisible(c.id));
 
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
@@ -247,7 +254,13 @@ function ValidatorsDirectory({
         <span className="mg-type-data text-ink-muted">
           {formatNumber(rows.length)} of {formatNumber(all.length)} validators
         </span>
-        <div className="ml-auto">
+        <div className="ml-auto flex items-center gap-2">
+          <ColumnCustomizer
+            columns={VALIDATOR_COLUMNS}
+            isVisible={columns.isVisible}
+            onToggle={columns.toggle}
+            onReset={columns.reset}
+          />
           <DensityToggle value={density} onChange={onDensityChange} />
         </div>
       </div>
@@ -279,12 +292,12 @@ function ValidatorsDirectory({
             >
               {/* Pins the column tracks so they cannot be re-derived from
                   whichever virtualized rows happen to be mounted. */}
-              <TableColGroup widths={[46, 40, ...VALIDATOR_COLUMNS.map((c) => c.width)]} />
+              <TableColGroup widths={[46, 40, ...visibleColumns.map((c) => c.width)]} />
               <thead className="mg-table-head-pinned">
                 <tr>
                   <th className="w-6 px-3 py-2" aria-label="Watch" />
                   <th className="w-6 px-3 py-2" aria-label="Compare" />
-                  {VALIDATOR_COLUMNS.map((col) => (
+                  {visibleColumns.map((col) => (
                     <th
                       key={col.header}
                       className={col.thClassName}
@@ -347,7 +360,7 @@ function ValidatorsDirectory({
                       <td className="px-3 py-2 align-middle">
                         <ValidatorCompareToggle hotkey={v.hotkey} />
                       </td>
-                      {VALIDATOR_COLUMNS.map((col) => (
+                      {visibleColumns.map((col) => (
                         <td key={col.header} className={col.tdClassName}>
                           {col.cell(v, { group: groupInfo?.get(v.hotkey) })}
                         </td>


### PR DESCRIPTION
Two findings behind *"we're missing a lot of data from various tables despite our API exposing more"*. You were right, and the second one is worse than a missing column.

## 1. The normalizer is an allowlist

`normalizeGlobalValidator` builds its result field-by-field with no `...raw` spread. Its own comment says it:

> `// Always present on the wire (#5166); this builder has no ...raw spread, so it must be listed explicitly or it silently vanishes.`

`realized_return_1d/1w/1m` were never listed. Every `/api/v1/validators` response has carried them since the leaderboard shipped — they were unreachable from the **entire UI**, not merely absent from the table. `lifecycle` on the subnet payload had the same problem from the other end: no type declared it, so the value couldn't be read without casting.

Measured after wiring them through: the top validator's realized 7d return renders **7.26%** where the column showed `—`.

## 2. `/validators` had no column customizer at all

So #8251's "column diet" was permanent rather than a default. It's now the **default** — the eight columns a reader sees are unchanged — and the fields the API returns but the table never showed are opt-in:

| Column | Field |
|---|---|
| Emission | `total_emission_tao` |
| Avg trust | `avg_validator_trust` |
| Realized 7d | `realized_return_1w` |
| Root stake | `root_stake_tao` |
| Alpha stake | `alpha_stake_tao` |

`/subnets` gains **Participants** and **Lifecycle** the same way, off by default, from registry fields the payload has always included.

## How

`ValidatorColumn` now carries `id`/`label`/`required`/`defaultVisible`, making it structurally a `ColumnDef` — so it drives the same `useColumnVisibility` + `ColumnCustomizer` pair `/subnets` already used, rather than inventing a second mechanism.

Column widths feed `TableColGroup` from the **visible** set, so toggling columns can't reintroduce the width drift #9456 fixed. Verified with all 13 columns on: **0px**.

## Tests

The column-set test pinned the whole array; it now pins the **default-visible** set, which is what #8251's decision was actually about. Added: the opt-in set is exactly those five, and every column has a unique id and a width for the colgroup.

## Verification

| Check | Result |
|---|---|
| e2e (CI=1, --workers=2, production build) | 104 passed, 2 skipped, exit 0 |
| apps/ui vitest | 232 files, 1814 tests |
| ui-kit vitest | 121 |
| typecheck + lint | clean |
| defaults unchanged | 8 headers, 10 colgroup cols, both routes |
