### PR TITLE
fix(telemetry): give data-api and registry-sync-api a trace rate they can emit at

### DIFF
--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -70,6 +70,12 @@ export const POSTHOG_TRACES_SAMPLE_RATE_ENV = "POSTHOG_TRACES_SAMPLE_RATE";
  * one -- can run at a rate that actually answers questions, while REST stays
  * dark until its volume is dealt with. Turning REST on later is a config
  * change, not a code change.
+ *
+ * #9466: two of those four Workers now do set the general rate, in their own
+ * configs -- data-api at 0.01 and registry-sync-api at 1. The "set in no
+ * wrangler config" state above was per-config all along: wrangler.jsonc
+ * configures only the main Worker, so a rate omitted there is omitted for
+ * api.ts, not globally. api.ts REST remains at 0 on its own volume.
  */
 export const POSTHOG_TRACES_SAMPLE_RATE_MCP_ENV =
   "POSTHOG_TRACES_SAMPLE_RATE_MCP";

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -115,6 +115,44 @@
     // as the main Worker: one capture per fingerprint per 5 minutes per
     // isolate, suppressed count carried on the next admitted event.
     "POSTHOG_EXCEPTION_STORM_WINDOW_MS": "300000",
+    // #9466: REST trace sampling, finally non-zero on this Worker.
+    //
+    // #9000 set POSTHOG_TRACES_SAMPLE_RATE_MCP in wrangler.jsonc and left the
+    // general rate unset, which reads as "REST stays dark" -- but `vars` are
+    // per-config, so what it actually left unset was the rate on THIS config
+    // too. src/tracing.ts defaults to 0, so the sampled branch in this
+    // Worker's fetch (workers/data-api.ts) has been dead code since #7768.
+    //
+    // THE ARITHMETIC, measured 2026-08-04 from Cloudflare's own
+    // workersInvocationsAdaptive (30-day window, per scriptName). NOT from
+    // usage_event: this Worker emits none -- recordUsageEvent is called only
+    // from api.ts and the five hub Workers -- which is also why these spans
+    // are worth having at all.
+    //
+    //   peak day    1,032,820 requests  (2026-07-31)
+    //   after the wipe 49,670 requests  (2026-08-04)
+    //
+    // That 20x spread inside four days is structural, not a lull, and both
+    // steps are ours: #9186 (08-02) unbound HYPERDRIVE, #9411 (08-04) stopped
+    // the main Worker forwarding chain-events here. Confirmed by the hourly
+    // data-api:main ratio collapsing 0.85 -> 0.20 -> 0.08 while the main
+    // Worker's OWN hourly volume rose -- a quiet window would have moved both.
+    //
+    // So the rate is sized against the PEAK, not the current floor: this
+    // Worker's volume has already moved 20x once, and a backfill or a
+    // re-tiered read path moves it back with no config change to catch it.
+    // Against ~600K spans/month of headroom (1M free tier less the ~400K/month
+    // wrangler.jsonc measured on 2026-08-02):
+    //
+    //   0.02  ->  620K/month at peak  -- over the headroom, rejected
+    //   0.01  ->  310K/month at peak, ~15K/month at current volume
+    //
+    // 0.01 is simply the largest round rate that still fits on the worst day
+    // observed. It buys per-route p50/p95 for the tier the main Worker's
+    // usage_event can only measure from the outside (that timing includes the
+    // DATA_API subrequest, so tier latency is currently unattributable).
+    // Re-derive from measurement -- not estimate -- if volume shape moves.
+    "POSTHOG_TRACES_SAMPLE_RATE": "0.01",
   },
   // Smart placement: run the Worker close to the Hyperdrive origin (self-hosted indexer
   // box Postgres, reached via Cloudflare Tunnel) to minimize the per-request DB round-trip,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -279,10 +279,17 @@
     //
     // 1.0 is safe HERE specifically because MCP is the cheap surface:
     // ~1.9K tool calls/day, so ~56K spans/month against a 1M/month free tier.
-    // The general POSTHOG_TRACES_SAMPLE_RATE is deliberately left UNSET, so
-    // REST stays at 0 -- at ~1.1M requests/day even 1% would be 330K
-    // spans/month on an account already ~33x over its event allowance (#9004).
-    // Raise REST once that volume is dealt with; it is a config change.
+    // The general POSTHOG_TRACES_SAMPLE_RATE is deliberately left UNSET on
+    // THIS config, so this Worker's REST stays at 0 -- at ~1.1M requests/day
+    // even 1% would be 330K spans/month on an account already ~33x over its
+    // event allowance (#9004). Raise it once that volume is dealt with; it is
+    // a config change.
+    //
+    // #9466: `vars` are per-config, so leaving it unset here left it unset on
+    // the two Workers this file does NOT configure either -- data-api and
+    // registry-sync-api, whose own sampled branches were dead code as a
+    // result. Both now set their own measured rate (0.01 and 1 respectively);
+    // see those configs for the arithmetic. This line governs api.ts alone.
     "POSTHOG_TRACES_SAMPLE_RATE_MCP": "1",
     // usage_event sampling, sized against the 1M/MONTH free tier. See
     // src/usage-telemetry.ts's sampling header for the mechanism (and for

--- a/wrangler.registry.jsonc
+++ b/wrangler.registry.jsonc
@@ -44,6 +44,36 @@
   // capture per fingerprint per 5 minutes per isolate.
   "vars": {
     "POSTHOG_EXCEPTION_STORM_WINDOW_MS": "300000",
+    // #9466: trace sampling at 1.0 -- every request, unsampled.
+    //
+    // Same root cause as wrangler.data.jsonc's own rate: src/tracing.ts
+    // defaults to 0, #9000 set only the MCP rate and only in wrangler.jsonc,
+    // and `vars` are per-config -- so the sampled branch in this Worker's
+    // fetch (workers/registry-sync-api.ts) has been dead code since #7768.
+    //
+    // THE ARITHMETIC, measured 2026-08-04 from Cloudflare's own
+    // workersInvocationsAdaptive (30-day window, per scriptName). Not from
+    // usage_event -- this Worker emits none.
+    //
+    //   830 requests in 31 days = ~27/day, peak 150/day, and SEVEN days
+    //   with zero traffic at all.
+    //
+    // Which is the whole point: this is a CI-only write path, so the
+    // interesting question is not "what do requests look like in aggregate"
+    // but "did each sync run, and how long did it take" -- and at 830
+    // requests/month there is no aggregate to speak of anyway.
+    //
+    // 1.0 costs 830 spans/month, 0.083% of the 1M/month free tier. It is
+    // cheaper than the main Worker's MCP rate (~56K/month, #9000) by two
+    // orders of magnitude, so the budget that forces wrangler.data.jsonc down
+    // to 0.01 simply does not bind here.
+    //
+    // Sampling this path would be actively harmful rather than merely
+    // wasteful: 0.05 -- the rate that looks natural next to data-api's --
+    // yields ~42 spans/MONTH and ~7 on the busiest day, so most days record
+    // nothing and a failed sync is most likely invisible. There is no
+    // meaningful saving to buy with that.
+    "POSTHOG_TRACES_SAMPLE_RATE": "1",
   },
   "observability": {
     "enabled": true,


### PR DESCRIPTION
`src/tracing.ts` defaults `POSTHOG_TRACES_SAMPLE_RATE` to `0`, and #9000 set only `POSTHOG_TRACES_SAMPLE_RATE_MCP`, only in `wrangler.jsonc`. `vars` are per-config, so the two Workers that file does not configure had no rate at all — `shouldSampleTrace(env)` was always false, and the sampled branch in `workers/data-api.ts` and `workers/registry-sync-api.ts` has been dead code since #7768.

This is config only. Both Workers already have `POSTHOG_PROJECT_TOKEN` set as a secret and `POSTHOG_TRACES_SAMPLE_RATE` is already declared in `workers/env-extra.d.ts`, so the spans emit as soon as the rate is non-zero.

Closes #9466

## The measurement

Source is Cloudflare's `workersInvocationsAdaptive`, 30-day window, grouped by `scriptName`. Deliberately **not** PostHog `usage_event`: neither Worker emits it — `recordUsageEvent` is called only from `api.ts` and the five hub Workers — which is also the reason these spans are worth having.

| Worker | 30-day peak/day | Current/day | Mean |
|---|---|---|---|
| `metagraphed-data-api` | **1,032,820** (07-31) | 49,670 (08-04) | — |
| `metagraphed-registry-sync-api` | **150** | ~27 | 830 requests / 31 days |

### data-api → `0.01`

data-api's volume moved 20x in four days: ~1.03M/day on 07-31, ~49.7K/day on 08-04. That is **structural, not a lull**, and both steps are ours — #9186 (08-02) unbound `HYPERDRIVE`, #9411 (08-04) stopped the main Worker forwarding chain-events here. Confirmed by the hourly `data-api:main` ratio collapsing 0.85 → 0.20 → 0.08 *while the main Worker's own hourly volume rose*; a quiet window would have moved both.

So the rate is sized against the **peak**, not today's floor — this Worker's volume has already moved 20x once, and a backfill or a re-tiered read path moves it back with no config change to catch it. Against ~600K spans/month of headroom (1M free tier less the ~400K/month `wrangler.jsonc` measured on 2026-08-02):

| Rate | Peak-day projection | vs headroom |
|---|---|---|
| 0.05 | 1,549K/month | 258% — no |
| 0.02 | 620K/month | 103% — no |
| **0.01** | **310K/month** | **52% — fits** |

0.01 is simply the largest round rate that still fits on the worst day observed. At current volume it is ~15K/month. This **confirms** the issue's starting estimate rather than overturning it, but it is now the output of the arithmetic rather than an input to it.

### registry-sync-api → `1`, not `0.05`

**The 0.05 starting point is overturned.** 830 requests in 31 days, seven days with zero traffic at all. Unsampled costs 830 spans/month — 0.083% of the tier, two orders of magnitude cheaper than the main Worker's MCP rate (~56K/month). The budget that forces data-api down to 0.01 does not bind here at all.

Sampling this path would be actively harmful rather than merely thrifty: 0.05 yields **~42 spans/month and ~7 on the busiest day**, so most days would record nothing and a failed sync would most likely be invisible. There is no saving worth buying with that.

## Are these spans actually useful?

Being explicit, since they are single-span traces with no parent/child nesting (`src/tracing.ts`'s header).

**What they answer that `usage_event` does not:** `usage_event` does not observe either Worker *at all*. Neither calls `recordUsageEvent`, so there is currently no per-route latency or success signal for either one anywhere — Cloudflare's dashboard aggregates have no route dimension, and PostHog has nothing. Concretely:

- **data-api** — per-route p50/p95 for the tier, and per-route `ok=false` rate. Today the main Worker's `usage_event` times the whole request *including* the `DATA_API` subrequest, so tier latency is unattributable: a slow route cannot be pinned on data-api versus the main Worker's own work. The span times the inner leg, and the difference gives the outer.
- **registry-sync-api** — whether each CI sync ran and how long it took, on a write path with no timing record today.

**The honest limitation:** with no trace propagation, a data-api span cannot be joined to the main-Worker request that caused it. Attribution is distributional — compare per-route percentiles — not per-request. At 0.01 a tail data-api route may see only a handful of spans a day, so this is a trend and percentile instrument, not a debugging one. It will tell you *which* route regressed, not *why* a given request was slow.

## Notes

- I could not re-verify the PostHog budget headroom live: the stored personal API key returns 403 (expired). The ~400K/month baseline is `wrangler.jsonc`'s own measured 2026-08-02 record, not a fresh query. The data-api decision holds comfortably either way — 0.01 is under the tier even if that baseline were double.
- `wrangler.jsonc` and `src/tracing.ts` each asserted the rate "was set in no wrangler config"; both are corrected in place, since this change makes them false. The main Worker's own REST rate stays 0 on its own ~720K/day volume.

## Gates

`npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run validate` all clean; `npx vitest run` — 669 files, 15,943 tests, all passing. `npm run build` regenerated nothing (config-only, no contract drift).
