### PR TITLE
fix(telemetry): say which r2-sql query failed, without a new fingerprint

### DIFF
--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -120,7 +120,22 @@ const TRANSFER_KIND = "Transfer";
  */
 export const PROJECTION_QUERY_TIMEOUT_MS = 4 * QUERY_TIMEOUT_MS;
 
-/** Every lane statement runs on the lane bound, never the request bound. */
+/**
+ * Every lane statement runs on the lane bound, never the request bound.
+ *
+ * That sentence has been here since #9423 and was not true of the whole
+ * module: eight statements across six lanes (stake-flow, chain-fees' two
+ * median passes, alpha-volume, blocks-summary, registrations' stamp + pair
+ * reads, deregistrations) called r2SqlQuery directly and silently took the
+ * 15s REQUEST default — the very bound #9423 had just established a cron does
+ * not share. Several are among the heaviest reads here: account_events
+ * aggregated or scanned over multi-day windows, the same shape whose growth
+ * is what made #9423's own lane start aborting.
+ *
+ * So this is the only entry point, and `r2SqlQuery` is imported for nothing
+ * else — a direct call is now visible as one, and tests/projection-lanes.test.ts
+ * asserts against the source that none creeps back in.
+ */
 function laneQuery(env: Env, sql: string) {
   return r2SqlQuery(env, sql, { timeoutMs: PROJECTION_QUERY_TIMEOUT_MS });
 }
@@ -272,7 +287,7 @@ async function computeChainStakeFlow(
   let rowCount = 0;
   for (const [label, days] of Object.entries(STAKE_FLOW_PROJECTION_WINDOWS)) {
     const cutoff = generatedAt - days * DAY_MS;
-    const rows = await r2SqlQuery(
+    const rows = await laneQuery(
       env,
       `SELECT netuid, event_kind, COALESCE(SUM(amount_tao), 0) AS total_tao, ` +
         `COUNT(*) AS event_count, MAX(observed_at) AS last_observed ` +
@@ -524,12 +539,12 @@ async function computeChainFees(
     if (daily === null) return null;
     const payers = await laneQuery(env, payersSql!);
     if (payers === null) return null;
-    const feeMedians = await r2SqlQuery(
+    const feeMedians = await laneQuery(
       env,
       chainFeesMedianSql(cutoff, "fee_tao", network),
     );
     if (feeMedians === null) return null;
-    const tipMedians = await r2SqlQuery(
+    const tipMedians = await laneQuery(
       env,
       chainFeesMedianSql(cutoff, "tip_tao", network),
     );
@@ -648,7 +663,7 @@ async function computeChainAlphaVolume(
 ): Promise<Record<string, unknown> | null> {
   const generatedAt = Date.now();
   const cutoff = generatedAt - DAY_MS;
-  const rows = await r2SqlQuery(
+  const rows = await laneQuery(
     env,
     `SELECT netuid, event_kind, ` +
       `COALESCE(SUM(alpha_amount), 0) AS alpha_volume, ` +
@@ -965,7 +980,7 @@ async function computeBlocksSummary(
   network: ChainNetworkId,
 ): Promise<Record<string, unknown> | null> {
   const generatedAt = Date.now();
-  const rows = await r2SqlQuery(
+  const rows = await laneQuery(
     env,
     `SELECT ${BLOCKS_SUMMARY_READ_COLUMNS} FROM ${chainTable("blocks", network)} ` +
       `ORDER BY block_number DESC LIMIT ${BLOCKS_SUMMARY_SCAN_CAP}`,
@@ -1023,7 +1038,7 @@ async function computeChainRegistrations(
 
     // Cheap gate, no DISTINCT: the window's freshness stamp, and a null means
     // the window holds no registrations so the heavy read is worth skipping.
-    const stampRows = await r2SqlQuery(
+    const stampRows = await laneQuery(
       env,
       `SELECT MAX(observed_at) AS newest_observed ${scope}`,
     );
@@ -1033,7 +1048,7 @@ async function computeChainRegistrations(
     let rows: Record<string, unknown>[] = [];
     let networkRegistrants = 0;
     if (newestObserved != null) {
-      const pairs = await r2SqlQuery(
+      const pairs = await laneQuery(
         env,
         `SELECT netuid, hotkey, COUNT(*) AS n ${scope} GROUP BY netuid, hotkey`,
       );
@@ -1133,7 +1148,7 @@ async function computeChainDeregistrations(
   const lookbackDays = Math.max(
     ...Object.values(CHAIN_DEREGISTRATIONS_WINDOWS),
   );
-  const rows = await r2SqlQuery(
+  const rows = await laneQuery(
     env,
     `SELECT ${DEREGISTRATION_READ_COLUMNS} FROM ${chainTable("account_events", network)} ` +
       `WHERE event_kind = '${REGISTRATION_EVENT_KIND}' ` +

--- a/src/r2-sql.ts
+++ b/src/r2-sql.ts
@@ -15,6 +15,20 @@
 // table's parts. That is fine for an archival tier BEHIND an edge cache and
 // wrong as a hot path -- which is exactly how the callers use it.
 //
+// RE-MEASURED 2026-08-05, end to end through the deployed Worker with the
+// edge cache defeated, because the numbers above had aged into a misleading
+// comment. Eight uncached runs of GET /api/v1/accounts/{ss58}/events for the
+// top-balance account -- a filtered, ordered, LIMITed scan of account_events,
+// no GROUP BY:
+//   4.0s  4.0s  5.0s  5.6s  6.2s  8.7s   (limit=200)
+//   5.6s  11.0s                          (limit=50)
+// So a plain page of one account's events is a 4-11s read, not a ~2s one,
+// with a ~2.7x spread run to run and no relationship to the page size. The
+// engine's profile did not change; the table grew. Read the ceiling below
+// against THESE numbers, not the 2026-08-02 ones -- and see #9459 for why the
+// tail that crosses the ceiling could not be attributed to a specific query
+// until this module started labelling its captures.
+//
 // Failure posture matches workers/postgres-tier.ts: ANY failure (missing
 // token, HTTP error, malformed body, timeout) returns null so the caller
 // degrades to the schema-stable empty it already has, never a 5xx. A tier
@@ -35,9 +49,27 @@ export const R2_SQL_WAREHOUSE_ENV = "R2_SQL_WAREHOUSE";
 const DEFAULT_ACCOUNT = "918f0f0e2eb26709d1cf4fb76085c8fb";
 const DEFAULT_WAREHOUSE = "metagraphed-lakehouse";
 
-/** Hard ceiling per query. Deliberately well above the ~2.2s worst case
- * measured above, so an ordinary heavy scan is not mistaken for a fault,
- * while a genuinely stuck query still cannot pin a request open. */
+/**
+ * Hard ceiling per query on the REQUEST path, so a genuinely stuck query
+ * cannot pin a caller's request open.
+ *
+ * Sized when the worst measured read was ~2.2s, which made 15s a ~7x
+ * headroom. The 2026-08-05 re-measurement above puts the same class of read
+ * at 4-11s, so the headroom is now ~1.4x over the observed max, and a run-to-
+ * run spread of ~2.7x means the tail crosses it — which is exactly the steady
+ * AbortError stream #9459 is about.
+ *
+ * DELIBERATELY UNCHANGED HERE. Raising it is a caller-facing change to every
+ * cold-tier route, and readers that issue two reads in sequence (e.g.
+ * loadValidatorNominatorsColdTier's page + its true-count subquery) stack it,
+ * so the number should be chosen against the query that actually aborts, not
+ * against the one route probed above. That query is unidentifiable today —
+ * every failure here captures under one flat `route: "r2-sql"` — which is why
+ * this change ships the attribution first. #9423 is the precedent and the
+ * caution both: the fix there WAS a bigger bound, and its own comment still
+ * says a statement that cannot answer in time is a query to fix rather than
+ * one to wait longer for.
+ */
 export const QUERY_TIMEOUT_MS = 15_000;
 
 // Same contract as the Postgres tier's fallback generation: a caller can
@@ -129,6 +161,78 @@ async function rejectionDetail(
 }
 
 /**
+ * The lakehouse table a statement reads, e.g. `chain.account_events`.
+ *
+ * The coarse half of #9459's attribution: a bounded label (four tables times
+ * two namespaces, per LAKEHOUSE_NAMESPACES) that an inbox can group and filter
+ * by. The FIRST `FROM` is the right one even for the CTE and subquery shapes
+ * this codebase builds — `SELECT count(*) FROM (SELECT coldkey FROM
+ * chain.account_events ...)` names the derived table nowhere and the real one
+ * once.
+ *
+ * Never throws and never returns empty: an unrecognised statement is reported
+ * as `unknown` rather than omitted, so "we could not tell" stays visibly
+ * distinct from "this capture predates attribution".
+ */
+export function r2SqlQueryKind(sql: string): string {
+  const match =
+    /\bFROM\s+([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?)/i.exec(sql);
+  return match?.[1] ?? "unknown";
+}
+
+/**
+ * The statement with its literals collapsed to `?`, whitespace flattened.
+ *
+ * The precise half of the attribution: the shape identifies the exact call
+ * site, which the table alone cannot — a dozen readers query
+ * `chain.account_events`, and the point of #9459 is to say WHICH one is slow.
+ *
+ * Collapsing is not only for cardinality. It removes the one class of value
+ * that reaches a query here from outside (an ss58 address, a block height, a
+ * hash — public chain data, but caller-supplied all the same), so what leaves
+ * this module is a shape rather than a record of who looked up what. Length
+ * is capped by sanitizeLabel in usage-telemetry.ts at the same 256 chars every
+ * other free-form field gets; no second cap is invented here.
+ *
+ * String literals go first: they can contain digits, and collapsing numbers
+ * first would leave `'0x1a2b'` half-rewritten. The number pass is anchored on
+ * word boundaries so identifiers that merely contain digits (`net_flow_7d`,
+ * `ss58`) survive intact — they are the diagnostic content, the same reason
+ * normalizeExceptionMessage refuses to be a blanket hex-strip.
+ */
+export function r2SqlQueryShape(sql: string): string {
+  return sql
+    .replace(/'[^']*'/g, "?")
+    .replace(/\b\d+(?:\.\d+)?\b/g, "?")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Which failure this was, for the `error_code` property: `timeout`,
+ * `http_<status>`, `engine_<code>` or `transport`.
+ *
+ * The other half of #9459's blocker. Timeouts, 429s, 422 scan-budget
+ * rejections and 400s all arrive at the same catch and all captured as one
+ * undifferentiated `r2-sql:Error`; PostHog even titled the aggregate issue
+ * "HTTP 500" off one unrepresentative sample while the actual 500s numbered
+ * two.
+ *
+ * The timeout arm reads the signal rather than sniffing the message, because
+ * the abort's own text ("The operation was aborted") is the runtime's, not
+ * ours, and has changed spelling across workerd versions before.
+ */
+function failureClassification(
+  aborted: boolean,
+  thrownCode: string | undefined,
+): string {
+  if (aborted) return "timeout";
+  // No recorded code means the throw came from the transport (DNS, TLS, a
+  // socket dropped mid-body) rather than from a response we inspected.
+  return thrownCode ?? "transport";
+}
+
+/**
  * Run one read-only query and return its rows, or null on ANY failure.
  *
  * `sql` is built by the caller from validated, non-caller-controlled pieces —
@@ -163,6 +267,10 @@ export async function r2SqlQuery(
     () => abort.abort(),
     deps.timeoutMs ?? QUERY_TIMEOUT_MS,
   );
+  // Set at the throw site rather than parsed back out of the message in the
+  // catch: the status and the engine's numbered code are both in hand here,
+  // and a message-sniffing classifier is exactly the thing that goes stale.
+  let thrownCode: string | undefined;
   try {
     const res = await doFetch(url, {
       method: "POST",
@@ -174,6 +282,7 @@ export async function r2SqlQuery(
       signal: abort.signal,
     } as RequestInit);
     if (!res?.ok) {
+      thrownCode = `http_${res?.status}`;
       throw new Error(
         `r2 sql: HTTP ${res?.status}${await rejectionDetail(res)}`,
       );
@@ -181,6 +290,9 @@ export async function r2SqlQuery(
     const body = (await res.json()) as R2SqlBody;
     if (body?.success !== true) {
       const first = body?.errors?.[0];
+      // `engine` unnumbered rather than `engine_undefined`: a rejection whose
+      // body carried no code is a real, distinct state, not a missing field.
+      thrownCode = first?.code ? `engine_${first.code}` : "engine";
       throw new Error(
         `r2 sql: ${first?.message ?? "query failed"}${first?.code ? ` (${first.code})` : ""}`,
       );
@@ -192,7 +304,13 @@ export async function r2SqlQuery(
   } catch (error) {
     r2SqlFailureGeneration += 1;
     const detail = String((error as Error)?.message ?? error);
-    console.error("[r2-sql]", detail);
+    const errorCode = failureClassification(abort.signal.aborted, thrownCode);
+    const queryKind = r2SqlQueryKind(sql);
+    // Workers logs get the same attribution the exception does — #9459's
+    // option 1 and option 2 are not alternatives, they cost nothing together,
+    // and a tail is the one place you can read every occurrence rather than
+    // one per storm-guard window.
+    console.error("[r2-sql]", errorCode, queryKind, detail);
     // Reported before the exception hop, so a caller still learns the reason even if
     // the telemetry sink is unavailable -- the point of this seam is that the answer
     // must not depend on another service being up.
@@ -203,7 +321,14 @@ export async function r2SqlQuery(
     }
     await (deps.recordException ?? recordExceptionEvent)(env, {
       error,
+      // Unchanged, and that is the point: `route` is the fingerprint input, so
+      // every occurrence stays in the one issue it is in today. The three
+      // fields below are properties only — see recordExceptionEvent for why
+      // splitting the fingerprint would multiply billable volume instead.
       route: "r2-sql",
+      errorCode,
+      queryKind,
+      queryShape: r2SqlQueryShape(sql),
     });
     return null;
   } finally {

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -1084,6 +1084,20 @@ export interface ExceptionEvent {
   route?: string;
   mcpTool?: string;
   errorCode?: string;
+  /**
+   * Which query a query-engine capture site was running when it failed.
+   *
+   * `queryKind` is the coarse, bounded bucket you filter an inbox by (a
+   * lakehouse table, e.g. `chain.account_events`); `queryShape` is the
+   * statement itself with its literals collapsed, which names the exact call
+   * site. Both are OPTIONAL and omitted-not-defaulted, so no existing capture
+   * site's payload changes.
+   *
+   * Both are deliberately kept OUT of the fingerprint — see the note in
+   * recordExceptionEvent for why that is a cost decision, not a style one.
+   */
+  queryKind?: string;
+  queryShape?: string;
 }
 
 // ─── $exception storm guard ────────────────────────────────────────────────
@@ -1341,6 +1355,25 @@ export async function recordExceptionEvent(
     if (mcpTool !== undefined) properties.mcp_tool = mcpTool;
     const errorCode = sanitizeLabel(event.errorCode);
     if (errorCode !== undefined) properties.error_code = errorCode;
+    // Query attribution rides along as PROPERTIES, never as fingerprint input.
+    //
+    // #9459: `route: "r2-sql"` collapses a timeout, a 429, a 422 scan-budget
+    // rejection and a 400 into one issue, so the inbox cannot say which query
+    // is slow. The obvious fix -- fold the answer into the fingerprint -- is
+    // the expensive one, because the storm guard above windows PER
+    // FINGERPRINT: one fingerprint at one event per window becomes N
+    // fingerprints at one event per window EACH, i.e. N times the billable
+    // volume, against the tightest budget this project has (~90K/month of a
+    // 100K free tier before the current fixes).
+    //
+    // A property costs bytes on an event that is already being sent, and
+    // PostHog groups Issues on $exception_fingerprint (set explicitly above),
+    // so occurrences stay in ONE issue while every sampled event names the
+    // query that produced it. Attribution without volume.
+    const queryKind = sanitizeLabel(event.queryKind);
+    if (queryKind !== undefined) properties.query_kind = queryKind;
+    const queryShape = sanitizeLabel(event.queryShape);
+    if (queryShape !== undefined) properties.query_shape = queryShape;
     assignDeployment(properties, env);
 
     const doFetch = deps.fetch ?? globalThis.fetch;

--- a/tests/projection-lanes.test.ts
+++ b/tests/projection-lanes.test.ts
@@ -3,6 +3,7 @@
 // as sharply as its presence — and the lane computes are asserted as the
 // validated-literal R2 SQL that replicates data-api's route semantics.
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { afterEach, describe, test, vi } from "vitest";
 import {
   PROJECTION_LANES,
@@ -1960,5 +1961,31 @@ describe("lane statements run on the lane bound, not the request bound", () => {
     // legible: same query, no caller waiting.
     assert.equal(PROJECTION_QUERY_TIMEOUT_MS, 4 * QUERY_TIMEOUT_MS);
     assert.ok(PROJECTION_QUERY_TIMEOUT_MS > QUERY_TIMEOUT_MS);
+  });
+
+  test("no lane statement calls r2SqlQuery directly, bypassing the bound", () => {
+    // #9459: the test above it passed while EIGHT statements across five lanes
+    // did exactly this — the transfer-pairs lane #9423 fixed went through
+    // laneQuery, and nothing checked its siblings, which were quietly taking
+    // the 15s REQUEST default on account_events aggregates over multi-day
+    // windows. A behavioural test cannot see the difference (the bound is a
+    // number handed to a timer, and a stubbed fetch resolves instantly), so
+    // this reads the source: laneQuery is the single seam, and the only
+    // mention of r2SqlQuery outside it is the import that feeds it.
+    const source = readFileSync(
+      new URL("../src/projection-lanes.ts", import.meta.url),
+      "utf8",
+    );
+    const calls = source.match(/\br2SqlQuery\(/g) ?? [];
+    assert.equal(
+      calls.length,
+      1,
+      `r2SqlQuery is called ${calls.length} times; only laneQuery may call it`,
+    );
+    assert.match(
+      source,
+      /function laneQuery\([^)]*\)[^{]*\{\s*return r2SqlQuery\(/,
+      "the one call must be laneQuery's own",
+    );
   });
 });

--- a/tests/r2-sql.test.ts
+++ b/tests/r2-sql.test.ts
@@ -9,6 +9,8 @@ import {
   currentR2SqlFailureGeneration,
   isR2SqlConfigured,
   r2SqlQuery,
+  r2SqlQueryKind,
+  r2SqlQueryShape,
   R2_SQL_TOKEN_ENV,
   safeBlockNumber,
   safeHexLiteral,
@@ -440,5 +442,196 @@ describe("the inline-literal guards", () => {
         JSON.stringify(bad)?.slice(0, 40),
       );
     }
+  });
+});
+
+// #9459: every failure here captured under one flat `route: "r2-sql"`, so a
+// timeout, a 429, a 422 scan-budget rejection and a 400 shared one fingerprint
+// and the inbox could not say which query was slow. The fix has to buy that
+// attribution WITHOUT splitting the fingerprint, because the storm guard
+// windows per fingerprint -- N fingerprints at one event per window each is N
+// times the billable volume against the tightest budget this project has.
+describe("query attribution (#9459)", () => {
+  /** Capture the one exception event a failed query records. */
+  async function captureFailure(
+    sql: string,
+    fetchImpl: typeof fetch,
+    extra: Record<string, unknown> = {},
+  ) {
+    const captured: Record<string, unknown>[] = [];
+    await r2SqlQuery(mockEnv(TOKEN), sql, {
+      fetch: fetchImpl,
+      recordException: (async (_e: unknown, ev: Record<string, unknown>) => {
+        captured.push(ev);
+        return true;
+      }) as never,
+      ...extra,
+    });
+    return captured[0]!;
+  }
+
+  test("the fingerprint input is unchanged — attribution is properties only", async () => {
+    // The whole cost argument in one assertion: two queries that differ in
+    // every way still carry the SAME `route`, which is what
+    // recordExceptionEvent builds $exception_fingerprint from. If a future
+    // change moves query_kind into `route` to "improve" grouping, this fails.
+    const { impl } = jsonFetch({}, false, 429);
+    const a = await captureFailure("SELECT 1 FROM chain.blocks", impl);
+    const b = await captureFailure(
+      "SELECT netuid FROM chain_testnet.account_events WHERE observed_at >= 5",
+      jsonFetch({}, false, 500).impl,
+    );
+    assert.equal(a.route, "r2-sql");
+    assert.equal(b.route, "r2-sql");
+    assert.notEqual(a.queryKind, b.queryKind);
+    assert.notEqual(a.errorCode, b.errorCode);
+  });
+
+  test("an HTTP rejection is classified by its status", async () => {
+    const captured = await captureFailure(
+      "SELECT 1 FROM chain.blocks",
+      jsonFetch({}, false, 429).impl,
+    );
+    // The 429 storm of 2026-08-04 was indistinguishable from the steady
+    // timeout leak in the inbox; this is the field that separates them.
+    assert.equal(captured.errorCode, "http_429");
+    assert.equal(captured.queryKind, "chain.blocks");
+  });
+
+  test("an engine rejection carries its numbered code", async () => {
+    const captured = await captureFailure(
+      "SELECT count(DISTINCT coldkey) FROM chain.account_events",
+      jsonFetch({
+        success: false,
+        errors: [
+          { code: 40015, message: "scan budget exceeded: count(DISTINCT)" },
+        ],
+      }).impl,
+    );
+    assert.equal(captured.errorCode, "engine_40015");
+  });
+
+  test("an engine rejection with no code is `engine`, not `engine_undefined`", async () => {
+    const captured = await captureFailure(
+      "SELECT 1 FROM chain.blocks",
+      jsonFetch({ success: false, errors: [{ message: "nope" }] }).impl,
+    );
+    assert.equal(captured.errorCode, "engine");
+  });
+
+  test("a transport throw is `transport` — no response was ever inspected", async () => {
+    const captured = await captureFailure(
+      "SELECT 1 FROM chain.blocks",
+      (async () => {
+        throw new Error("network down");
+      }) as unknown as typeof fetch,
+    );
+    assert.equal(captured.errorCode, "transport");
+  });
+
+  test("an abort is `timeout`, read off the signal rather than the message", async () => {
+    // The abort's text is the runtime's, not ours, and has changed spelling
+    // across workerd versions -- so the classifier must not sniff it. Same
+    // driven-abort shape as the timeout test above (#9123): the stubbed fetch
+    // only settles on abort, so nothing else can end this promise.
+    let fire: (() => void) | undefined;
+    const impl = (async (_u: string, init: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        (init.signal as AbortSignal).addEventListener("abort", () =>
+          reject(new Error("The operation was aborted")),
+        );
+      })) as unknown as typeof fetch;
+    const pending = captureFailure("SELECT 1 FROM chain.blocks", impl, {
+      scheduleAbort: (abort: () => void) => {
+        fire = abort;
+        return () => {};
+      },
+    });
+    (fire as unknown as () => void)();
+    assert.equal((await pending).errorCode, "timeout");
+  });
+
+  test("the shape names the exact query with its literals collapsed", async () => {
+    const captured = await captureFailure(
+      `SELECT netuid, COUNT(*) AS n FROM chain.account_events` +
+        ` WHERE coldkey = '5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F'` +
+        ` AND observed_at >= 1754352000000 GROUP BY netuid`,
+      jsonFetch({}, false, 500).impl,
+    );
+    assert.equal(
+      captured.queryShape,
+      "SELECT netuid, COUNT(*) AS n FROM chain.account_events" +
+        " WHERE coldkey = ? AND observed_at >= ? GROUP BY netuid",
+    );
+    // The address the caller looked up is gone; the query that was slow is not.
+    assert.equal(
+      String(captured.queryShape).includes("5EYCAe5"),
+      false,
+      "a caller-supplied address must not ride out on a telemetry property",
+    );
+  });
+});
+
+describe("r2SqlQueryKind — the bounded half of the attribution", () => {
+  test("names the qualified lakehouse table", () => {
+    assert.equal(
+      r2SqlQueryKind("SELECT * FROM chain.account_events WHERE x = 1"),
+      "chain.account_events",
+    );
+    assert.equal(
+      r2SqlQueryKind("SELECT * FROM chain_testnet.blocks"),
+      "chain_testnet.blocks",
+    );
+  });
+
+  test("takes the FIRST FROM, so a subquery reports the real table", () => {
+    // loadValidatorNominatorsColdTier's true-count read: the outer FROM is a
+    // derived table with no name worth reporting, the inner one is the answer.
+    assert.equal(
+      r2SqlQueryKind(
+        "SELECT count(*) AS c FROM (SELECT coldkey FROM chain.account_events" +
+          " WHERE observed_at >= 1 GROUP BY coldkey)",
+      ),
+      "chain.account_events",
+    );
+  });
+
+  test("matches case-insensitively and accepts an unqualified table", () => {
+    assert.equal(r2SqlQueryKind("select n from blocks"), "blocks");
+  });
+
+  test("reports `unknown` rather than nothing when there is no FROM", () => {
+    // Visibly "we could not tell", never confusable with a capture that
+    // predates attribution altogether.
+    assert.equal(r2SqlQueryKind("SELECT 1"), "unknown");
+    assert.equal(r2SqlQueryKind(""), "unknown");
+  });
+});
+
+describe("r2SqlQueryShape — the precise half of the attribution", () => {
+  test("collapses string and numeric literals and flattens whitespace", () => {
+    assert.equal(
+      r2SqlQueryShape(
+        "SELECT *\n  FROM chain.blocks\n  WHERE block_number = 8755000\n" +
+          "    AND hash = '0xdeadbeef'",
+      ),
+      "SELECT * FROM chain.blocks WHERE block_number = ? AND hash = ?",
+    );
+  });
+
+  test("collapses a float, and a string literal that contains digits", () => {
+    assert.equal(
+      r2SqlQueryShape("SELECT x FROM t WHERE a > 1.5 AND b = 'sn74 2026'"),
+      "SELECT x FROM t WHERE a > ? AND b = ?",
+    );
+  });
+
+  test("keeps identifiers that merely contain digits", () => {
+    // `net_flow_7d` and `ss58` are diagnostic content, not literals -- the
+    // same reason normalizeExceptionMessage refuses to be a blanket strip.
+    assert.equal(
+      r2SqlQueryShape("SELECT ss58, net_flow_7d FROM chain.account_events"),
+      "SELECT ss58, net_flow_7d FROM chain.account_events",
+    );
   });
 });

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -1174,6 +1174,63 @@ describe("recordExceptionEvent", () => {
     assert.equal("error_code" in calls[0].body.properties, false);
   });
 
+  // #9459: query attribution has to arrive WITHOUT splitting the issue, or the
+  // storm guard's per-fingerprint window turns one event per window into N.
+  test("query attribution rides as properties and leaves the fingerprint alone", async () => {
+    const calls: Row[] = [];
+    await recordExceptionEvent(
+      CONFIGURED,
+      {
+        error: thrownError(Error, "The operation was aborted"),
+        route: "r2-sql",
+        errorCode: "timeout",
+        queryKind: "chain.account_events",
+        queryShape: "SELECT netuid FROM chain.account_events WHERE x >= ?",
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    const { properties } = calls[0].body;
+    assert.equal(properties.query_kind, "chain.account_events");
+    assert.equal(
+      properties.query_shape,
+      "SELECT netuid FROM chain.account_events WHERE x >= ?",
+    );
+    assert.equal(properties.error_code, "timeout");
+    // The load-bearing assertion: still `route:type`, with nothing about the
+    // query folded in. A second query kind on this route must land in the SAME
+    // PostHog issue and so must cost the same one event per window.
+    assert.equal(properties.$exception_fingerprint, "r2-sql:Error");
+  });
+
+  test("omits query_kind / query_shape when not supplied", async () => {
+    // Omitted-not-defaulted, the same contract sample_rate and error_code
+    // keep: every pre-existing capture site's payload is byte-identical.
+    const calls: Row[] = [];
+    await recordExceptionEvent(
+      CONFIGURED,
+      { error: thrownError(Error, "boom"), route: "x" },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal("query_kind" in calls[0].body.properties, false);
+    assert.equal("query_shape" in calls[0].body.properties, false);
+  });
+
+  test("a query shape longer than the label cap is truncated, not dropped", async () => {
+    const calls: Row[] = [];
+    await recordExceptionEvent(
+      CONFIGURED,
+      {
+        error: thrownError(Error, "boom"),
+        route: "r2-sql",
+        queryShape: `SELECT ${"a".repeat(400)} FROM chain.blocks`,
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    // 256 = MAX_LABEL_CHARS, shared with every other free-form field here, so
+    // a pathological statement cannot ship an unbounded payload.
+    assert.equal(calls[0].body.properties.query_shape.length, 256);
+  });
+
   test("never posts when the deployment is unconfigured", async () => {
     let calls = 0;
     const recorded = await recordExceptionEvent(


### PR DESCRIPTION
## Summary

- `AbortError` on route `r2-sql` is the largest live exception source (~60–90/hour), but every failure in `src/r2-sql.ts` captures under a flat `route: "r2-sql"` — timeouts, 429s, 422 scan-budget rejections and 400s share one fingerprint, so the inbox cannot say which query is slow.
- Ships issue #9459's **option 2**: attribution as **properties**, never as fingerprint input, so occurrences stay in one PostHog issue and billable `$exception` volume does not move.
- Fixes the one provable case of the 15s ceiling being applied to the wrong caller: **eight statements across six projection lanes** bypassed `laneQuery` and silently took the 15s *request* default.

## What Changed

**Attribution (`src/usage-telemetry.ts`, `src/r2-sql.ts`)**

`recordExceptionEvent` builds `$exception_fingerprint` from `route` alone — verified in the tree, and now asserted directly by a test. `route: "r2-sql"` is therefore left exactly as it is, and three fields ride along on the event that was already being sent:

| Property | Value | Answers |
|---|---|---|
| `error_code` | `timeout` \| `http_<status>` \| `engine_<code>` \| `transport` | Which failure this was — the 429 storm vs. the steady timeout leak |
| `query_kind` | the lakehouse table, e.g. `chain.account_events` | Which lane/table, bounded (4 tables × 2 namespaces) |
| `query_shape` | the statement with literals collapsed to `?` | Which **exact** call site |

- `error_code` is recorded **at the throw site** (the HTTP status and the engine's numbered code are both in hand there), and the timeout arm reads `signal.aborted` rather than sniffing `"The operation was aborted"` — that text is the runtime's and has changed spelling across workerd versions.
- `query_shape` collapsing is not only for cardinality: it removes the one class of caller-supplied value that reaches a query here (ss58 addresses, block heights, hashes), so what leaves the module is a shape, not a record of who looked up what. Length is capped by the existing `sanitizeLabel` (256 chars) — no new cap invented.
- `queryKind` / `queryShape` are optional and omitted-not-defaulted on `ExceptionEvent`, so every other capture site's payload is byte-identical.
- The same two labels go into the `console.error` line, so a Workers tail shows every occurrence rather than one per storm-guard window (#9459's option 1 and option 2 cost nothing together).

**Lane bound (`src/projection-lanes.ts`)**

`laneQuery`'s comment has said "every lane statement runs on the lane bound, never the request bound" since #9423, and it was not true of the module: `computeChainStakeFlow`, `computeChainFees` (both median passes), `computeChainAlphaVolume`, `computeBlocksSummary`, `computeChainRegistrations` (stamp + pair reads) and `computeChainDeregistrations` called `r2SqlQuery` directly, taking the 15s request default on `account_events` reads over multi-day windows — the same shape whose growth made #9423's own lane start aborting. All eight now go through `laneQuery`; `r2SqlQuery` is imported for nothing else. The existing behavioural test only covered `chain-transfer-pairs`, so a structural test now asserts against the source that exactly one `r2SqlQuery(` call exists and that it is `laneQuery`'s.

**Is the 15s ceiling right? — measured, and deliberately left alone**

The comment sized 15s against a "~2.2s worst case" from 2026-08-02. Re-measured live 2026-08-05, end to end through the deployed Worker with the edge cache defeated — eight uncached runs of `GET /api/v1/accounts/{ss58}/events` for the top-balance account:

```
4.0s  4.0s  5.0s  5.6s  6.2s  8.7s   (limit=200)
5.6s  11.0s                          (limit=50)
```

So headroom is ~1.4× over the observed max, not ~7×, with a ~2.7× run-to-run spread — the tail genuinely crosses the ceiling, and a degraded answer is never cached, so a query in the 15–30s band re-runs and re-aborts on every request. That is a real defect, and the header comment now carries these numbers instead of the stale ones.

It is **not** fixed by a bigger number here: raising it is caller-facing across every cold-tier route, sequential readers stack it (`loadValidatorNominatorsColdTier` issues a page read plus a true-count subquery), and the bound should be sized against the query that actually aborts — which is unidentifiable today and is precisely what this PR makes visible. #9423 is both the precedent and the caution: the fix there was a bigger bound, and its own comment still says a statement that cannot answer in time is a query to fix rather than one to wait longer for.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9459`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state. `query_shape` strips every literal before it leaves the module.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (`npm run build` produced no committable diff — no schema or contract change.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — telemetry properties only, no contract surface.)

## Validation

- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run validate:contract-drift`
- [x] `npm run scan:public-safety`
- [x] `npm run lint` · `npm run format:check` · `npx tsc --noEmit`
- [x] `git diff --check`
- [x] **Tests** — every test file importing the three changed modules: **45 files, 4,139 tests, all passing** (`npx vitest run $(grep -rl "projection-lanes.ts\|r2-sql.ts\|usage-telemetry.ts" tests)`), after `npm run build` so the reader tests have their artifacts.
- [x] **Patch coverage** — measured by intersecting `coverage-final.json` against the added lines of `git diff -U0 -- src/`, rather than reading whole-file percentages: **0 uncovered statements, 0 uncovered branches, 0 uncovered functions** across all 184 changed `src/**` lines (`src/r2-sql.ts` 128, `src/usage-telemetry.ts` 33, `src/projection-lanes.ts` 23).

New tests cover: the fingerprint staying `r2-sql:Error` while `query_kind`/`error_code` differ; each `error_code` arm (`http_429`, `engine_40015`, bare `engine`, `transport`, and `timeout` via a driven abort); the shape collapsing an ss58 out of a real query; `r2SqlQueryKind` on qualified/unqualified/subquery/no-`FROM` input; `r2SqlQueryShape` preserving digit-bearing identifiers (`net_flow_7d`); the 256-char cap; omitted-not-defaulted; and the projection-lane structural guard.

## Template Used

- `.github/PULL_REQUEST_TEMPLATE/backend-code.md`

Closes #9459
