### PR TITLE
fix(r2-sql): back off when the account rate limit rejects a query

### DIFF
--- a/src/r2-sql.ts
+++ b/src/r2-sql.ts
@@ -35,6 +35,7 @@
 // that turns a slow archive query into a broken page would be worse than the
 // empty it replaced.
 
+import { z } from "zod";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { registerModuleStateReset } from "./module-state-registry.ts";
 
@@ -72,14 +73,81 @@ const DEFAULT_WAREHOUSE = "metagraphed-lakehouse";
  */
 export const QUERY_TIMEOUT_MS = 15_000;
 
+/**
+ * How long to stop querying after the ACCOUNT-wide rate limit rejects us, as a
+ * wrangler var in ms. Unset or malformed falls back to
+ * `R2_SQL_RATE_LIMIT_COOLDOWN_DEFAULT_MS`; an explicit "0" disables the breaker.
+ */
+export const R2_SQL_RATE_LIMIT_COOLDOWN_MS_ENV =
+  "R2_SQL_RATE_LIMIT_COOLDOWN_MS";
+
+/** Long enough to outlast the limit's own window, short enough that a lane tick
+ * 30 minutes later is never still suppressed by it. */
+export const R2_SQL_RATE_LIMIT_COOLDOWN_DEFAULT_MS = 60_000;
+
+/** The status R2 SQL answers an account-wide rejection with (engine code
+ * 80014). Per ACCOUNT, not per Worker and not per query — which is why the
+ * cooldown below is module-global rather than threaded through a caller. */
+const RATE_LIMIT_STATUS = 429;
+
 // Same contract as the Postgres tier's fallback generation: a caller can
 // snapshot this before a read and compare after, so a degraded (empty) answer
 // is never written into the edge cache as though it were real.
 let r2SqlFailureGeneration = 0;
 
+/**
+ * When the account-wide cooldown expires; 0 when the breaker is closed.
+ *
+ * WHY A BREAKER AT ALL. 80014 is an ACCOUNT limit, so every caller in this
+ * codebase shares one budget: ~44 request-time cold-tier entry points (several
+ * fanning out 3-4 wide through `Promise.all`) plus the projection lanes' 148
+ * queries per tick. Nothing retried a 429 — so the storm was never amplified by
+ * retries — but nothing backed off either, so each rejection was followed
+ * immediately by the next caller firing into the same exhausted budget, holding
+ * the limit open and spending one `$exception` per attempt. 2026-08-04 cost
+ * ~1,500 429s across two hours that way, against a ~100K/month error-tracking
+ * allowance (#9465).
+ *
+ * Module-global to match the limit's scope. Per-isolate, so it is a pressure
+ * valve rather than a guarantee: it cannot see rejections another isolate took,
+ * and it is not trying to. Stopping ONE isolate's cron tick from issuing its
+ * remaining ~140 doomed queries is the whole win.
+ */
+let r2SqlRateLimitedUntilMs = 0;
+
 registerModuleStateReset("src/r2-sql.ts", () => {
   r2SqlFailureGeneration = 0;
+  r2SqlRateLimitedUntilMs = 0;
 });
+
+// Same contract as usage-telemetry's storm window: wrangler vars arrive as
+// strings, and stating the shape once as a schema beats a typeof/isFinite
+// ladder at each use. `.nonnegative()` rather than `.positive()` so an explicit
+// "0" survives parsing as the disabled sentinel instead of being caught into
+// the default -- an operator must be able to turn a safety valve off.
+const RateLimitCooldownSchema = z.coerce
+  .number()
+  .finite()
+  .nonnegative()
+  .catch(R2_SQL_RATE_LIMIT_COOLDOWN_DEFAULT_MS);
+
+function rateLimitCooldownMs(env: Env | null | undefined): number {
+  const raw = env?.[R2_SQL_RATE_LIMIT_COOLDOWN_MS_ENV as keyof Env];
+  // Absent coerces to NaN and an empty string to 0, which mean opposite things
+  // here -- unset must take the default, while a deliberate "" is as much an
+  // unset as `undefined` is. Both route to the default; only a real "0" disables.
+  if (raw === undefined || raw === null || String(raw).trim() === "") {
+    return R2_SQL_RATE_LIMIT_COOLDOWN_DEFAULT_MS;
+  }
+  return RateLimitCooldownSchema.parse(raw);
+}
+
+/** Milliseconds remaining on the account-wide cooldown, or 0 when closed.
+ * Exported for tests and for a caller that wants to explain a degraded answer
+ * without issuing a query to discover it. */
+export function r2SqlRateLimitRemainingMs(nowMs: number = Date.now()): number {
+  return Math.max(0, r2SqlRateLimitedUntilMs - nowMs);
+}
 
 export function currentR2SqlFailureGeneration(): number {
   return r2SqlFailureGeneration;
@@ -118,6 +186,10 @@ export interface R2SqlDeps {
    * investigated and ruled out.
    */
   scheduleAbort?: (abort: () => void, ms: number) => () => void;
+  /** Read the clock. Injectable for the same reason `scheduleAbort` is: the
+   * breaker's open/expired branches are decided by elapsed time, and a test
+   * that had to wait out a real cooldown would be a slow test that proves less. */
+  now?: () => number;
 }
 
 interface R2SqlBody {
@@ -233,6 +305,16 @@ function failureClassification(
 }
 
 /**
+ * The `error_code` a query suppressed by the breaker reports.
+ *
+ * Sits alongside `failureClassification`'s vocabulary rather than inside it:
+ * the others classify a rejection we actually received, and this one names a
+ * query we deliberately never sent. Worth telling apart in a log — "we were
+ * refused" and "we declined to ask" are different operational facts.
+ */
+const RATE_LIMITED_CODE = "rate_limited";
+
+/**
  * Run one read-only query and return its rows, or null on ANY failure.
  *
  * `sql` is built by the caller from validated, non-caller-controlled pieces —
@@ -249,6 +331,27 @@ export async function r2SqlQuery(
   if (!isR2SqlConfigured(env)) {
     // Unconfigured is not a fault: self-hosters and local/CI runs simply have
     // no lakehouse, and the caller's existing empty payload is correct there.
+    return null;
+  }
+  const now = deps.now ?? Date.now;
+  const remaining = r2SqlRateLimitRemainingMs(now());
+  if (remaining > 0) {
+    // The account budget is known-exhausted, so this query cannot succeed and
+    // issuing it would only hold the limit open longer. Decline WITHOUT the
+    // exception hop: the 429 that opened the breaker already recorded one, and
+    // recording another per suppressed query would rebuild the storm this
+    // exists to stop -- in telemetry cost, if no longer in load.
+    r2SqlFailureGeneration += 1;
+    const detail = `r2 sql: account rate limited, ${remaining}ms of cooldown remaining`;
+    // Same labelled log shape #9459 gave the failure path, for the same reason:
+    // the tail is where every occurrence can be read, and a suppressed query is
+    // exactly the one the exception stream deliberately will NOT show.
+    console.error("[r2-sql]", RATE_LIMITED_CODE, r2SqlQueryKind(sql), detail);
+    try {
+      deps.onError?.(detail);
+    } catch {
+      // A caller's own reporting must never turn a declined query into a thrown one.
+    }
     return null;
   }
   const doFetch = deps.fetch ?? globalThis.fetch;
@@ -283,6 +386,13 @@ export async function r2SqlQuery(
     } as RequestInit);
     if (!res?.ok) {
       thrownCode = `http_${res?.status}`;
+      if (res?.status === RATE_LIMIT_STATUS) {
+        // Opened BEFORE the throw, so the catch below records exactly one
+        // exception for this rejection and every caller behind it is suppressed
+        // by the breaker rather than each paying for its own.
+        const cooldown = rateLimitCooldownMs(env);
+        if (cooldown > 0) r2SqlRateLimitedUntilMs = now() + cooldown;
+      }
       throw new Error(
         `r2 sql: HTTP ${res?.status}${await rejectionDetail(res)}`,
       );

--- a/tests/r2-sql.test.ts
+++ b/tests/r2-sql.test.ts
@@ -4,22 +4,33 @@
 // interpolated into a query (R2 SQL has no bound parameters, so the safe-
 // literal guards are the whole defence).
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { afterEach, describe, test } from "vitest";
 import {
   currentR2SqlFailureGeneration,
   isR2SqlConfigured,
   r2SqlQuery,
   r2SqlQueryKind,
   r2SqlQueryShape,
+  r2SqlRateLimitRemainingMs,
+  R2_SQL_RATE_LIMIT_COOLDOWN_DEFAULT_MS,
+  R2_SQL_RATE_LIMIT_COOLDOWN_MS_ENV,
   R2_SQL_TOKEN_ENV,
   safeBlockNumber,
   safeHexLiteral,
   safeSs58Literal,
   safeNameLiteral,
 } from "../src/r2-sql.ts";
+import { resetModuleState } from "../src/module-state-registry.ts";
 import { mockEnv } from "./row-type.ts";
 
 const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
+
+// The account rate-limit breaker is module-global by design, and several tests
+// here answer 429 deliberately (the attribution suite asserts `http_429`). File
+// scope rather than per-describe: any test that provokes a 429 now leaves the
+// breaker open, and a suppressed query is silent, so a leak would surface as an
+// unrelated test failing on a capture that never happened.
+afterEach(() => resetModuleState());
 
 function jsonFetch(body: unknown, ok = true, status = 200) {
   const calls: { url: string; init: RequestInit }[] = [];
@@ -374,6 +385,265 @@ describe("a rejected query says WHY the engine refused it", () => {
   });
 });
 
+// The account-wide 429 breaker (#9465). 80014 is a per-ACCOUNT limit, so the
+// question these tests answer is not "did one query fail" -- that was always
+// handled -- but "did the NEXT one stop firing into an exhausted budget".
+describe("r2SqlQuery account rate-limit breaker", () => {
+  function statusFetch(status: number) {
+    const calls: string[] = [];
+    const impl = (async (url: string) => {
+      calls.push(url);
+      return {
+        ok: status < 400,
+        status,
+        text: async () =>
+          `{"code":80014,"message":"Account rate limit exceeded"}`,
+        json: async () => ({ success: true, result: { rows: [] } }),
+      };
+    }) as unknown as typeof fetch;
+    return { impl, calls };
+  }
+
+  /** Silences the module's console.error so a deliberate failure does not print
+   * through the suite; returns what it swallowed. */
+  async function quietly<T>(run: () => Promise<T>): Promise<T> {
+    const spy = console.error;
+    console.error = () => {};
+    try {
+      return await run();
+    } finally {
+      console.error = spy;
+    }
+  }
+
+  const noCapture = { recordException: (async () => true) as never };
+
+  test("a 429 opens the cooldown; the NEXT query never reaches the network", async () => {
+    const { impl, calls } = statusFetch(429);
+    let clock = 1_000;
+    const deps = { fetch: impl, now: () => clock, ...noCapture };
+
+    await quietly(() => r2SqlQuery(mockEnv(TOKEN), "SELECT 1", deps));
+    assert.equal(
+      calls.length,
+      1,
+      "the first query is the one that discovers it",
+    );
+    assert.equal(
+      r2SqlRateLimitRemainingMs(clock),
+      R2_SQL_RATE_LIMIT_COOLDOWN_DEFAULT_MS,
+    );
+
+    clock += 5_000;
+    const rows = await quietly(() =>
+      r2SqlQuery(mockEnv(TOKEN), "SELECT 2", deps),
+    );
+    assert.equal(rows, null, "still the same degrade-to-empty contract");
+    assert.equal(
+      calls.length,
+      1,
+      "suppressed queries must not spend the account budget they are waiting on",
+    );
+  });
+
+  test("a suppressed query records NO exception, but still marks the answer degraded", async () => {
+    const { impl } = statusFetch(429);
+    let clock = 1_000;
+    let captured = 0;
+    const deps = {
+      fetch: impl,
+      now: () => clock,
+      recordException: (async () => {
+        captured += 1;
+        return true;
+      }) as never,
+    };
+
+    await quietly(() => r2SqlQuery(mockEnv(TOKEN), "SELECT 1", deps));
+    assert.equal(
+      captured,
+      1,
+      "the rejection that opened the breaker reports once",
+    );
+
+    clock += 5_000;
+    const before = currentR2SqlFailureGeneration();
+    await quietly(() => r2SqlQuery(mockEnv(TOKEN), "SELECT 2", deps));
+    assert.equal(
+      captured,
+      1,
+      "one $exception per cooldown, not one per suppressed query -- the storm this exists to stop",
+    );
+    assert.equal(
+      currentR2SqlFailureGeneration(),
+      before + 1,
+      "a suppressed answer is still a degraded one and must never be cached as real",
+    );
+  });
+
+  test("the caller still learns WHY, through the same onError seam", async () => {
+    const { impl } = statusFetch(429);
+    let clock = 1_000;
+    const details: string[] = [];
+    const deps = {
+      fetch: impl,
+      now: () => clock,
+      onError: (detail: string) => details.push(detail),
+      ...noCapture,
+    };
+
+    await quietly(() => r2SqlQuery(mockEnv(TOKEN), "SELECT 1", deps));
+    clock += 5_000;
+    await quietly(() => r2SqlQuery(mockEnv(TOKEN), "SELECT 2", deps));
+
+    assert.match(details[0]!, /HTTP 429/);
+    assert.match(details[1]!, /account rate limited/);
+    assert.match(details[1]!, /55000ms/, "and how long is left on it");
+  });
+
+  test("a throwing onError never turns a declined query into a thrown one", async () => {
+    const { impl } = statusFetch(429);
+    const clock = 1_000;
+    const deps = {
+      fetch: impl,
+      now: () => clock,
+      onError: () => {
+        throw new Error("the caller's own reporting is broken");
+      },
+      ...noCapture,
+    };
+
+    assert.equal(
+      await quietly(() => r2SqlQuery(mockEnv(TOKEN), "SELECT 1", deps)),
+      null,
+    );
+    // And on the suppressed path too, which routes through the same helper.
+    assert.equal(
+      await quietly(() => r2SqlQuery(mockEnv(TOKEN), "SELECT 2", deps)),
+      null,
+    );
+  });
+
+  test("once the cooldown expires, querying resumes", async () => {
+    const { impl, calls } = statusFetch(429);
+    let clock = 1_000;
+    const deps = { fetch: impl, now: () => clock, ...noCapture };
+
+    await quietly(() => r2SqlQuery(mockEnv(TOKEN), "SELECT 1", deps));
+    clock += R2_SQL_RATE_LIMIT_COOLDOWN_DEFAULT_MS;
+    assert.equal(r2SqlRateLimitRemainingMs(clock), 0);
+
+    await quietly(() => r2SqlQuery(mockEnv(TOKEN), "SELECT 2", deps));
+    assert.equal(calls.length, 2, "the breaker must not latch shut");
+  });
+
+  test("only 429 opens it — a 422 scan-budget rejection must not mute the tier", async () => {
+    const { impl, calls } = statusFetch(422);
+    const clock = 1_000;
+    const deps = { fetch: impl, now: () => clock, ...noCapture };
+
+    await quietly(() => r2SqlQuery(mockEnv(TOKEN), "SELECT 1", deps));
+    assert.equal(r2SqlRateLimitRemainingMs(clock), 0);
+    await quietly(() => r2SqlQuery(mockEnv(TOKEN), "SELECT 2", deps));
+    assert.equal(
+      calls.length,
+      2,
+      "one bad query is not evidence the account budget is gone",
+    );
+  });
+
+  test("the cooldown length is configurable, and an explicit 0 disables the breaker", async () => {
+    const { impl, calls } = statusFetch(429);
+    const clock = 1_000;
+
+    const tuned = mockEnv({
+      ...TOKEN,
+      [R2_SQL_RATE_LIMIT_COOLDOWN_MS_ENV]: "5000",
+    });
+    await quietly(() =>
+      r2SqlQuery(tuned, "SELECT 1", {
+        fetch: impl,
+        now: () => clock,
+        ...noCapture,
+      }),
+    );
+    assert.equal(r2SqlRateLimitRemainingMs(clock), 5_000);
+
+    resetModuleState();
+    const off = mockEnv({ ...TOKEN, [R2_SQL_RATE_LIMIT_COOLDOWN_MS_ENV]: "0" });
+    await quietly(() =>
+      r2SqlQuery(off, "SELECT 1", {
+        fetch: impl,
+        now: () => clock,
+        ...noCapture,
+      }),
+    );
+    assert.equal(
+      r2SqlRateLimitRemainingMs(clock),
+      0,
+      "an operator can turn it off",
+    );
+    await quietly(() =>
+      r2SqlQuery(off, "SELECT 2", {
+        fetch: impl,
+        now: () => clock,
+        ...noCapture,
+      }),
+    );
+    assert.equal(calls.length, 3);
+  });
+
+  test("an unset, blank or malformed cooldown all take the default", async () => {
+    const clock = 1_000;
+    for (const raw of [undefined, "", "   ", "not-a-number", "-1"]) {
+      resetModuleState();
+      const { impl } = statusFetch(429);
+      const env = mockEnv(
+        raw === undefined
+          ? { ...TOKEN }
+          : { ...TOKEN, [R2_SQL_RATE_LIMIT_COOLDOWN_MS_ENV]: raw },
+      );
+      await quietly(() =>
+        r2SqlQuery(env, "SELECT 1", {
+          fetch: impl,
+          now: () => clock,
+          ...noCapture,
+        }),
+      );
+      assert.equal(
+        r2SqlRateLimitRemainingMs(clock),
+        R2_SQL_RATE_LIMIT_COOLDOWN_DEFAULT_MS,
+        `${String(raw)} must not silently disable the breaker`,
+      );
+    }
+  });
+
+  test("remaining time reads the real clock when no time is supplied", () => {
+    assert.equal(r2SqlRateLimitRemainingMs(), 0);
+  });
+
+  test("an unconfigured deployment is never suppressed by the breaker", async () => {
+    const { impl, calls } = statusFetch(429);
+    const clock = 1_000;
+    await quietly(() =>
+      r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+        fetch: impl,
+        now: () => clock,
+        ...noCapture,
+      }),
+    );
+    // No token: the unconfigured branch returns first, so the breaker's state
+    // is irrelevant and no failure is counted against it.
+    const before = currentR2SqlFailureGeneration();
+    assert.equal(
+      await r2SqlQuery(mockEnv(), "SELECT 2", { fetch: impl }),
+      null,
+    );
+    assert.equal(currentR2SqlFailureGeneration(), before);
+    assert.equal(calls.length, 1);
+  });
+});
+
 // R2 SQL takes NO bound parameters, so every value that reaches a query is inlined
 // into a string. These two guards are therefore the whole injection boundary for the
 // lakehouse readers, and they were exercised only indirectly through their callers.
@@ -475,11 +745,16 @@ describe("query attribution (#9459)", () => {
     // every way still carry the SAME `route`, which is what
     // recordExceptionEvent builds $exception_fingerprint from. If a future
     // change moves query_kind into `route` to "improve" grouping, this fails.
-    const { impl } = jsonFetch({}, false, 429);
-    const a = await captureFailure("SELECT 1 FROM chain.blocks", impl);
+    // The 429 goes LAST on purpose: it opens the account rate-limit breaker,
+    // which suppresses the next query in this isolate outright — so a 429 first
+    // would leave `b` with no capture to assert on at all.
+    const a = await captureFailure(
+      "SELECT 1 FROM chain.blocks",
+      jsonFetch({}, false, 500).impl,
+    );
     const b = await captureFailure(
       "SELECT netuid FROM chain_testnet.account_events WHERE observed_at >= 5",
-      jsonFetch({}, false, 500).impl,
+      jsonFetch({}, false, 429).impl,
     );
     assert.equal(a.route, "r2-sql");
     assert.equal(b.route, "r2-sql");

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -178,6 +178,7 @@ interface Env {
   R2_SQL_TOKEN?: string;
   R2_SQL_ACCOUNT_ID?: string;
   R2_SQL_WAREHOUSE?: string;
+  R2_SQL_RATE_LIMIT_COOLDOWN_MS?: string;
 }
 
 // RPC reverse-proxy usage telemetry on Workers Analytics Engine (#9228).

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -347,6 +347,17 @@
     // nothing about diagnosis needs more than that, and the projected
     // steady-state (~1K/day) sits comfortably inside the free tier.
     "POSTHOG_EXCEPTION_STORM_WINDOW_MS": "300000",
+    // How long to stop querying R2 SQL after it rejects us with HTTP 429
+    // (engine code 80014, "Account rate limit exceeded"). That limit is per
+    // ACCOUNT, so the ~44 request-time cold-tier readers and the projection
+    // lanes' 148 queries per tick all draw on one budget with nothing
+    // coordinating them. 2026-08-04 spent ~1,500 429s over two hours because
+    // each rejection was followed straight away by the next caller firing into
+    // the same exhausted budget -- holding the limit open and costing one
+    // $exception per attempt (#9465). 60s outlasts the limit's own window while
+    // staying far short of the 30-minute lane interval, so a tick is never
+    // still suppressed by the previous one's cooldown. "0" disables the breaker.
+    "R2_SQL_RATE_LIMIT_COOLDOWN_MS": "60000",
     // subnet_hyperparams (#4832 gap-closure): FLIPPED to "postgres" 2026-07-11,
     // after a live parity pass. refresh-subnet-hyperparams.yml's real
     // workflow_dispatch run synced all 129 subnets (Postgres started


### PR DESCRIPTION
## Summary

- R2 SQL's HTTP 429 (engine code 80014) is a **per-account** limit, and nothing in this codebase defended it: no concurrency ceiling, no budget, no backoff, no circuit breaker. On 2026-08-04 that turned one account-level rejection into ~1,500 429s plus ~1,500 downstream `projection lane … compute declined` events across two hours — roughly a third of that week's `$exception` volume, against a ~100K/month error-tracking allowance.
- Adds a 429 circuit breaker in `src/r2-sql.ts`, the single choke point that all ~44 request-time cold-tier entry points and both cron callers already funnel through, so one change protects every caller.

## What Changed

- **`src/r2-sql.ts`** — on an HTTP 429, open a module-global cooldown. While it is open, `r2SqlQuery` declines immediately: no request issued, no second `$exception` recorded. The rejection that opened the breaker still reports once; `r2SqlFailureGeneration` still bumps so a degraded answer is never cached as real; the `onError` seam still hands the caller its diagnosis (#9386's lesson). Module-global to match the limit's scope — per-isolate, so it is a pressure valve rather than a guarantee.
  - **Only 429 opens it.** A 422 scan-budget rejection is one bad query, not evidence the account budget is gone; muting the whole tier on it would turn a single fixable statement into a serving outage.
  - **No retry was added, and none was removed.** Nothing retried a 429 before, so the storm was never retry-amplified — the gap was purely the absence of backoff.
  - The failure path's local reporting moves into `declineLocally`, shared with the suppressed path so both report identically. The only difference between them is whether an `$exception` is also recorded.
- **`wrangler.jsonc` / `workers/env-extra.d.ts`** — `R2_SQL_RATE_LIMIT_COOLDOWN_MS`, default 60s: past the limit's own window, far short of the 30-minute `PROJECTION_LANES_CRON` interval so a tick is never suppressed by the previous one's cooldown. An explicit `"0"` disables it; unset, blank and malformed all take the default, so a typo cannot silently remove the guard.
- **`tests/r2-sql.test.ts`** — 10 tests covering the breaker: opening, suppression without a second capture, cooldown expiry, 422 not opening it, the configurable/disabled/malformed cooldown paths, and the `onError` seam on both the failing and suppressed paths (previously untested in this file).

## Why the projection lanes are not the cause

The ~20 `compute declined` issues are the downstream effect, not independent faults. Each lane bails at its first failed query (`if (rows === null) return null`), so under a storm the lanes issue **fewer** queries, not more — they are victims. Lane volume is also bounded and sequential: 13 lanes × 2 networks = 26 runs per tick, 148 queries per tick on `"11,41 * * * *"`, with no lane-level fan-out.

The concurrent fan-out that does stack against an account-wide limit is on the **request** path — `Promise.all` of 4 in `rpc-usage-cold-tier.ts:123` and `subnet-event-summary-cold-tier.ts:168`, of 3 in `chain-event-rollup-cold-tier.ts:348` and `account-feeds-cold-tier.ts:869`, plus three 2-wide ones.

## Known-unexplained, and deliberately not claimed as fixed

`runProjectionLane` records exactly one exception per lane run, and there can be at most 52 lane runs per hour — so the observed 799 `compute declined` events in one hour is ~15x more than the committed code can produce. Verified against the tree: the string occurs in one place, no other module calls any lane `compute*`, `runProjectionLanes` has a single caller, `dispatchScheduled` is a flat if/return chain with no retry or fall-through, and `"11,41 * * * *"` is declared once and has never changed. The extra invocations therefore come from outside this tree — most likely the deployed cron registration or the set of deployed Worker versions differing from `wrangler.jsonc` — which is checkable only against the Cloudflare dashboard/API. Recorded in #9465; it does not block this change, and this change bounds the blast radius either way.

A global concurrency ceiling / token bucket across the request-time fan-outs is also **out of scope here**: it changes request latency semantics for ~44 entry points and deserves its own change once the breaker is in place.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9465`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — no schema, route or contract surface changes; `validate:contract-drift` and `validate:types` confirm.)

## Validation

- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:contract-drift`
- [x] `npm run validate:no-hand-written-mjs`
- [x] `npm run lint` · `npx prettier --check` on all changed files
- [x] `npm run typecheck`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
- [x] `npx vitest run tests/r2-sql.test.ts tests/r2-sql-blocks.test.ts` — 52 passed
- [x] Cold-tier suites (18 files, 371 tests) + `projection-lanes` / `projection-staleness-watchdog` / `usage-telemetry` (249 tests) — all passed
- [x] Patch coverage: `src/r2-sql.ts` at **100% statements / 100% branches / 100% functions / 100% lines** (84/84, 69/69, 15/15, 78/78), measured with `--coverage.include='src/r2-sql.ts'`. The other three changed files are config and type declarations, outside coverage scope.

`npm run check` failed once on `sync:subnets:dry-run`, a live-chain script that is rate-limited by the parallel runner; it passes when run serially and is unrelated to this change.

Closes #9465
