### PR TITLE
fix(observability): let the top-holders watchdog alert on the state it was built for

### DIFF
--- a/src/top-holders-artifact.ts
+++ b/src/top-holders-artifact.ts
@@ -20,19 +20,6 @@ import { buildTopHoldersList } from "./top-holders.ts";
 export const TOP_HOLDERS_ARTIFACT_KEY =
   "metagraph/materialized/top-holders.json";
 
-/**
- * When the ONE materialization this reader was built around was taken.
- *
- * The artifact carries its own `generated_at`; this is that value, committed,
- * so a caller can tell "the frozen snapshot, still" from "something wrote
- * here". src/top-holders-staleness-watchdog.ts is the consumer, and the whole
- * point is that it self-retires: the day a producer overwrites this key, the
- * string stops matching and the watchdog becomes an ordinary staleness alarm
- * with no code change.
- */
-export const TOP_HOLDERS_FROZEN_GENERATED_AT =
-  "2026-08-02T22:38:17.501738+00:00";
-
 interface ArtifactBucket {
   get(key: string): Promise<{ json(): Promise<unknown> } | null>;
 }

--- a/src/top-holders-staleness-watchdog.ts
+++ b/src/top-holders-staleness-watchdog.ts
@@ -21,26 +21,40 @@
 // route SQL"`, and whose every row carries the same fixed `captured_at`. That
 // answer does not age gracefully -- it does not age at all.
 //
-// ## Why the frozen state is RECORDED and not PAGED
+// ## It alerts on every tick, and that is the point (#9475)
 //
-// The sibling watchdogs emit one exception per stale tick, and for their lanes
-// that is right: each was watching a lane that had a writer, so the alert had
-// somewhere to land and a reason to stop. This one would fire twice an hour
-// forever, because the condition it reports is permanent and is already
-// declared in source (TOP_HOLDERS_FROZEN_GENERATED_AT). Two separate things in
-// this repo say why that is not acceptable: `$exception` volume is the
-// project's metered cost (the storm guard in src/usage-telemetry.ts exists for
-// exactly this), and src/nominator-positions-staleness-watchdog.ts names the
-// other cost directly -- "the failure mode where an alarm that always fires
-// stops being read".
+// This shipped in #9464 special-casing the frozen snapshot: a committed
+// `TOP_HOLDERS_FROZEN_GENERATED_AT` constant matched the artifact's own
+// `generated_at`, and that one verdict recorded a `lane_health` row without
+// notifying. The reasoning was exception cost plus alarm fatigue. Both parts
+// were wrong, and the shape was worse than either:
 //
-// So the frozen snapshot is written to `lane_health` on EVERY tick, which puts
-// it on GET /api/v1/self-health under `lanes[]` and inside `stale_lane_count`
-// permanently and queryably (#9330/#9340 built that surface for precisely the
-// question "was anything stale overnight"). It just does not re-page anyone
-// about a state the code itself documents.
+//   - The cost claim does not survive arithmetic. Twice hourly is 48 events a
+//     day against a project running ~1M/day -- 0.005%, and the production
+//     storm guard (POSTHOG_EXCEPTION_STORM_WINDOW_MS, 5 min) does not even
+//     engage at a 30-minute spacing. There was no cost to trade anything for.
 //
-// EVERY OTHER VERDICT PAGES, and those are the ones with an operator action:
+//   - It made the watchdog silent on the exact defect it was built for. #9464
+//     exists because a frozen leaderboard went three days unnoticed; a
+//     watchdog that answers that by writing a row into a table nobody queries
+//     lets the next three days pass the same way. `lane_health` is the RECORD,
+//     which is why it is still written every tick -- it was never a substitute
+//     for the notification.
+//
+//   - Suppressing on a hardcoded timestamp is a known-bad-state allowlist. It
+//     disables the alarm for precisely the condition that is currently true,
+//     indefinitely, and a second frozen materialization would have to be
+//     hand-added to keep it quiet. Nothing else in this repo suppresses an
+//     alarm that way, and the two sibling lanes this one is modelled on
+//     (#9273, #9301) both alerted every tick while dead -- and both got fixed.
+//
+// So there is no frozen branch and no constant. A leaderboard nothing refreshes
+// is `stale`, it says so on every tick, and it keeps saying so until someone
+// gives the lane a producer or withdraws the route. An alarm that fires
+// forever on a defect that persists forever is not noise; it is an accurate
+// report, and the way to silence it is to fix the thing.
+//
+// The other verdicts name faults with different repairs:
 //
 //   absent / unreadable  the R2 object is gone or is not the shape the reader
 //                        accepts, so loadTopHoldersFromArtifact declines and
@@ -48,23 +62,16 @@
 //                        -- 200 OK, `account_count: 0`, silent in aggregate.
 //   empty                the object is well-formed and carries no rows, which
 //                        serves the same empty page from a different fault.
-//   stale                `generated_at` has MOVED off the frozen constant --
-//                        someone built the sink -- and the lane has since
-//                        fallen past its own producer cadence. This branch is
-//                        dead today and is the point: the day top-holders has
-//                        a writer again, this file is already the ordinary
-//                        staleness alarm for it, with no code change.
 
 import {
   TOP_HOLDERS_ARTIFACT_KEY,
-  TOP_HOLDERS_FROZEN_GENERATED_AT,
   topHoldersArtifactRows,
 } from "./top-holders-artifact.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 
 /**
- * How old the leaderboard may get before a REFRESHED lane counts as stalled.
+ * How old the leaderboard may get before it is a stall.
  *
  * TWELVE HOURS, sized to the producer this lane has when it has one:
  * `ACCOUNT_BALANCES_POLL_SECS` defaults to 21600 (six hours) in the poller
@@ -79,8 +86,9 @@ import { recordExceptionEvent } from "./usage-telemetry.ts";
  * a 24-hour producer and alerted three quarters of every day on a lane that
  * was working.
  *
- * It does NOT govern the frozen snapshot, which is stale by identity rather
- * than by age -- see this module's header.
+ * The artifact in place today is days past this and climbing, so the verdict
+ * is `stale` on every tick until the lane gets a producer -- see the module
+ * header for why that is reported rather than suppressed.
  *
  * Overridable per-deployment via TOP_HOLDERS_STALENESS_THRESHOLD_MS so the
  * number can follow a future sink's cadence without a code deploy.
@@ -88,7 +96,7 @@ import { recordExceptionEvent } from "./usage-telemetry.ts";
 export const TOP_HOLDERS_STALENESS_THRESHOLD_MS = 12 * 60 * 60 * 1000;
 
 export type TopHoldersStalenessReason =
-  "absent" | "unreadable" | "empty" | "frozen" | "stale" | null;
+  "absent" | "unreadable" | "empty" | "stale" | null;
 
 /** What the watchdog found in the bucket, normalized so the rule below needs
  * neither R2 nor a JSON parser. `present: false` carries WHY, because "the
@@ -100,10 +108,6 @@ export type TopHoldersArtifactState =
 
 export interface TopHoldersStalenessVerdict {
   stale: boolean;
-  /** Whether this tick has something to NOTIFY about, which is deliberately
-   * NOT the same as `stale`: the frozen snapshot is stale on every tick and
-   * newsworthy on none of them. */
-  alert: boolean;
   reason: TopHoldersStalenessReason;
   age_ms: number | null;
   generated_at: string | null;
@@ -123,7 +127,6 @@ export function evaluateTopHoldersStaleness(input: {
     // this is the one condition that is completely invisible from outside.
     return {
       stale: true,
-      alert: true,
       reason: artifact.reason,
       age_ms: null,
       generated_at: null,
@@ -137,7 +140,6 @@ export function evaluateTopHoldersStaleness(input: {
     // route is serving it, and nothing can say how old it is.
     return {
       stale: true,
-      alert: true,
       reason: "unreadable",
       age_ms: null,
       generated_at: generatedAt,
@@ -146,23 +148,13 @@ export function evaluateTopHoldersStaleness(input: {
   }
   const ageMs = nowMs - at;
   if (rowCount === 0) {
-    // Checked BEFORE the frozen comparison: an artifact emptied in place still
-    // serves nobody, and reporting that as "frozen, as expected" would be the
-    // watchdog agreeing with the outage.
+    // Distinguished from a plain `stale` even though both are stalls: an
+    // artifact present and well-formed with no rows serves an empty
+    // leaderboard NOW, regardless of its age, and that is a different repair
+    // from one that merely stopped being refreshed.
     return {
       stale: true,
-      alert: true,
       reason: "empty",
-      age_ms: ageMs,
-      generated_at: generatedAt,
-      threshold_ms: thresholdMs,
-    };
-  }
-  if (generatedAt === TOP_HOLDERS_FROZEN_GENERATED_AT) {
-    return {
-      stale: true,
-      alert: false,
-      reason: "frozen",
       age_ms: ageMs,
       generated_at: generatedAt,
       threshold_ms: thresholdMs,
@@ -171,7 +163,6 @@ export function evaluateTopHoldersStaleness(input: {
   const stale = ageMs > thresholdMs;
   return {
     stale,
-    alert: stale,
     reason: stale ? "stale" : null,
     age_ms: ageMs,
     generated_at: generatedAt,
@@ -244,7 +235,7 @@ export async function runTopHoldersStalenessWatchdog(
     thresholdMs,
   });
 
-  if (verdict.alert) {
+  if (verdict.stale) {
     const age =
       verdict.age_ms === null
         ? "age unknown"
@@ -262,10 +253,10 @@ export async function runTopHoldersStalenessWatchdog(
   }
 
   // #9330/#9340: the DURABLE record, written every tick rather than only when
-  // stale. It carries more weight here than for any sibling, because this is
-  // the lane whose alerting is deliberately quiet -- the `frozen` row on every
-  // tick is the ONLY thing standing between a permanently dead leaderboard and
-  // nobody knowing. Never throws -- see recordLaneVerdict.
+  // stale. PostHog stays the notification path; it is no longer the record,
+  // because a dropped `$exception` is indistinguishable from a lane that was
+  // fine, and writing on every tick is also what makes "the watchdog stopped
+  // running" visible at all. Never throws -- see recordLaneVerdict.
   await recordLaneVerdict(
     deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as never),
     {
@@ -278,5 +269,5 @@ export async function runTopHoldersStalenessWatchdog(
   );
 
   // `ok` describes whether the TICK ran, not whether the lane is fresh.
-  return { ok: true, alerted: verdict.alert, ...verdict };
+  return { ok: true, alerted: verdict.stale, ...verdict };
 }

--- a/tests/top-holders-staleness-watchdog.test.ts
+++ b/tests/top-holders-staleness-watchdog.test.ts
@@ -15,13 +15,18 @@ import {
 } from "../src/top-holders-staleness-watchdog.ts";
 import {
   TOP_HOLDERS_ARTIFACT_KEY,
-  TOP_HOLDERS_FROZEN_GENERATED_AT,
   topHoldersArtifactRows,
 } from "../src/top-holders-artifact.ts";
 import { TOP_HOLDERS_STALENESS_WATCHDOG_CRON } from "../workers/config.ts";
 
 const HOUR = 3_600_000;
 const NOW = Date.parse("2026-08-05T02:00:00.000Z");
+
+/** The `generated_at` of the one-shot pre-decommission materialization sitting
+ * in R2 today. A literal, deliberately NOT a constant imported from source:
+ * #9475 deleted that constant because keying the alarm off it is what kept the
+ * alarm quiet on the live defect. Here it is only a fixture. */
+const FROZEN_GENERATED_AT = "2026-08-02T22:38:17.501738+00:00";
 
 /** A present artifact carrying `rows` rows, generated at `generatedAt`. */
 function present(
@@ -40,38 +45,45 @@ function verdictFor(
 }
 
 describe("evaluateTopHoldersStaleness", () => {
-  // The production state, replayed. It is stale, it is recorded, and it
-  // deliberately does NOT page: the condition is permanent and declared in
-  // source, and an alarm that fires twice an hour forever stops being read.
-  test("the frozen pre-decommission snapshot is stale but not an alert", () => {
-    const verdict = verdictFor(present(TOP_HOLDERS_FROZEN_GENERATED_AT));
+  // The production state, replayed. #9475: this is `stale` with no
+  // special-casing, so the tick notifies -- the snapshot's own timestamp buys
+  // it no exemption, which is the whole correction.
+  test("the frozen pre-decommission snapshot is plainly stale", () => {
+    const verdict = verdictFor(present(FROZEN_GENERATED_AT));
     assert.equal(verdict.stale, true);
-    assert.equal(verdict.alert, false);
-    assert.equal(verdict.reason, "frozen");
-    assert.equal(verdict.generated_at, TOP_HOLDERS_FROZEN_GENERATED_AT);
-    // The age is still measured, so the durable row carries how long this has
-    // been going on even though nobody is paged about it.
+    assert.equal(verdict.reason, "stale");
+    assert.equal(verdict.generated_at, FROZEN_GENERATED_AT);
     assert.ok(verdict.age_ms !== null && verdict.age_ms > 2 * 24 * HOUR);
   });
 
-  // The branch that is dead today and is the whole point of the file: the day
-  // a Cloudflare-native sink writes this key, `generated_at` stops matching the
-  // constant and this becomes an ordinary staleness alarm with no code change.
-  test("once the artifact moves off the frozen constant it alerts on age", () => {
-    const refreshed = verdictFor(
-      present(new Date(NOW - 3 * HOUR).toISOString()),
+  // The regression guard for #9475 itself. A rule that reads any particular
+  // `generated_at` as a reason to stay quiet is the bug; the ONLY thing that
+  // decides a present, non-empty artifact's verdict is its age.
+  test("no timestamp is exempt -- only age decides", () => {
+    const fresh = new Date(NOW - HOUR).toISOString();
+    const old = new Date(NOW - 20 * HOUR).toISOString();
+    // Same instant, expressed the way the frozen artifact expresses it and the
+    // way an ISO writer would: neither spelling changes the verdict.
+    for (const stamp of [old, "2026-08-04T06:00:00.000000+00:00"]) {
+      const verdict = verdictFor(present(stamp));
+      assert.equal(verdict.stale, true, stamp);
+      assert.equal(verdict.reason, "stale", stamp);
+    }
+    assert.equal(verdictFor(present(fresh)).stale, false);
+    assert.equal(verdictFor(present(fresh)).reason, null);
+    assert.equal(verdictFor(present(fresh)).age_ms, HOUR);
+    // And the production timestamp specifically is not treated differently
+    // from any other artifact of the same age.
+    const sameAgeAsFrozen = verdictFor(
+      present(new Date(Date.parse(FROZEN_GENERATED_AT)).toISOString()),
     );
-    assert.equal(refreshed.stale, false);
-    assert.equal(refreshed.alert, false);
-    assert.equal(refreshed.reason, null);
-    assert.equal(refreshed.age_ms, 3 * HOUR);
-
-    const stalled = verdictFor(
-      present(new Date(NOW - 20 * HOUR).toISOString()),
+    assert.deepEqual(
+      { stale: sameAgeAsFrozen.stale, reason: sameAgeAsFrozen.reason },
+      {
+        stale: verdictFor(present(FROZEN_GENERATED_AT)).stale,
+        reason: "stale",
+      },
     );
-    assert.equal(stalled.stale, true);
-    assert.equal(stalled.alert, true, "a lane WITH a producer must page");
-    assert.equal(stalled.reason, "stale");
   });
 
   // The sizing rule #9301 corrected the nominator-positions threshold for: a
@@ -103,22 +115,29 @@ describe("evaluateTopHoldersStaleness", () => {
       [{ present: false, reason: "unreadable" } as const, "unreadable"],
       [present(null), "unreadable"],
       [present("not a timestamp"), "unreadable"],
-      [present(TOP_HOLDERS_FROZEN_GENERATED_AT, 0), "empty"],
+      [present(FROZEN_GENERATED_AT, 0), "empty"],
     ] as const) {
       const verdict = verdictFor(artifact);
       assert.equal(verdict.stale, true, reason);
-      assert.equal(verdict.alert, true, reason);
       assert.equal(verdict.reason, reason);
     }
   });
 
-  // An artifact emptied in place still serves nobody. Reporting that as
-  // "frozen, as expected" would be the watchdog agreeing with the outage.
-  test("empty beats frozen even at the frozen timestamp", () => {
-    const verdict = verdictFor(present(TOP_HOLDERS_FROZEN_GENERATED_AT, 0));
+  // An artifact present and well-formed with no rows serves an empty
+  // leaderboard NOW, whatever its age, which is a different repair from one
+  // that merely stopped being refreshed -- so it keeps its own reason even
+  // when the age alone would already have said `stale`.
+  test("empty outranks age, and still reports the age", () => {
+    const verdict = verdictFor(present(FROZEN_GENERATED_AT, 0));
+    assert.equal(verdict.stale, true);
     assert.equal(verdict.reason, "empty");
-    assert.equal(verdict.alert, true);
     assert.notEqual(verdict.age_ms, null, "age is still measurable here");
+    // Even a FRESH artifact with no rows is a stall, which age alone misses.
+    const freshButEmpty = verdictFor(
+      present(new Date(NOW - HOUR).toISOString(), 0),
+    );
+    assert.equal(freshButEmpty.stale, true);
+    assert.equal(freshButEmpty.reason, "empty");
   });
 
   test("an absent or unparseable artifact reports no age rather than zero", () => {
@@ -127,11 +146,7 @@ describe("evaluateTopHoldersStaleness", () => {
   });
 
   test("the threshold travels on every verdict", () => {
-    const verdict = verdictFor(
-      present(TOP_HOLDERS_FROZEN_GENERATED_AT),
-      NOW,
-      7,
-    );
+    const verdict = verdictFor(present(FROZEN_GENERATED_AT), NOW, 7);
     assert.equal(verdict.threshold_ms, 7);
   });
 });
@@ -163,14 +178,14 @@ describe("readTopHoldersArtifactState", () => {
 
   const frozenBody = {
     schema_version: 1,
-    generated_at: TOP_HOLDERS_FROZEN_GENERATED_AT,
+    generated_at: FROZEN_GENERATED_AT,
     rows: [{ ss58: "5A", free_tao: "1" }],
   };
 
   test("reads the real artifact shape", async () => {
     assert.deepEqual(await readTopHoldersArtifactState(bucket(frozenBody)), {
       present: true,
-      generatedAt: TOP_HOLDERS_FROZEN_GENERATED_AT,
+      generatedAt: FROZEN_GENERATED_AT,
       rowCount: 1,
     });
   });
@@ -267,7 +282,7 @@ describe("runTopHoldersStalenessWatchdog", () => {
 
   const frozenBody = {
     schema_version: 1,
-    generated_at: TOP_HOLDERS_FROZEN_GENERATED_AT,
+    generated_at: FROZEN_GENERATED_AT,
     rows: [{ ss58: "5A" }, { ss58: "5B" }],
   };
 
@@ -286,30 +301,53 @@ describe("runTopHoldersStalenessWatchdog", () => {
     );
   });
 
-  // The heart of the design: the frozen lane is written down on every tick and
-  // pages nobody. Without the row there is nothing anywhere that distinguishes
-  // a permanently dead leaderboard from one nobody has looked at.
-  test("the frozen lane records every tick and notifies on none", async () => {
-    const events: unknown[] = [];
+  // The heart of the correction (#9475): the lane in production today BOTH
+  // records and notifies. Recording alone is what let #9464 ship a watchdog
+  // that was silent on the very defect it was built for.
+  test("the live frozen artifact notifies AND records, every tick", async () => {
+    const events: { route?: string; errorCode?: string; error?: Error }[] = [];
     const spy = laneHealthSpy();
     const result = (await runTopHoldersStalenessWatchdog(envWith(frozenBody), {
       now: () => NOW,
       laneHealthDb: spy.db,
-      recordException: (async (_e: unknown, ev: unknown) => {
+      recordException: (async (_e: unknown, ev: never) => {
         events.push(ev);
         return true;
       }) as never,
     })) as Record<string, unknown>;
     assert.equal(result.ok, true);
     assert.equal(result.stale, true);
-    assert.equal(result.alerted, false);
-    assert.equal(result.reason, "frozen");
-    assert.deepEqual(events, [], "a permanent, documented state must not page");
+    assert.equal(result.alerted, true);
+    assert.equal(result.reason, "stale");
+    assert.equal(events.length, 1, "the production state must page");
+    assert.equal(events[0]!.route, "watchdog:top-holders-staleness");
+    assert.equal(events[0]!.errorCode, "stale_lane");
     assert.equal(spy.rows.length, 1);
     assert.equal(spy.rows[0]!.lane, "top-holders-staleness");
     assert.equal(spy.rows[0]!.verdict, "stale");
-    assert.equal(spy.rows[0]!.detail, "frozen");
+    assert.equal(spy.rows[0]!.detail, "stale");
     assert.equal(spy.rows[0]!.checked_at, NOW);
+  });
+
+  // Two consecutive ticks over the unchanged artifact: neither goes quiet.
+  // Nothing in this module carries state that would let the second tick
+  // decide the first one already covered it.
+  test("a repeat tick over the same artifact alerts again", async () => {
+    const events: unknown[] = [];
+    const spy = laneHealthSpy();
+    const run = () =>
+      runTopHoldersStalenessWatchdog(envWith(frozenBody), {
+        now: () => NOW,
+        laneHealthDb: spy.db,
+        recordException: (async () => {
+          events.push(1);
+          return true;
+        }) as never,
+      });
+    await run();
+    await run();
+    assert.equal(events.length, 2);
+    assert.equal(spy.rows.length, 2);
   });
 
   test("an absent artifact pages, because the route then serves an empty list", async () => {
@@ -431,7 +469,7 @@ describe("runTopHoldersStalenessWatchdog", () => {
       envWith(frozenBody, { METAGRAPH_HEALTH_DB: spy.db }),
     )) as Record<string, unknown>;
     assert.equal(result.ok, true);
-    assert.equal(result.reason, "frozen");
+    assert.equal(result.reason, "stale");
     assert.equal(spy.rows.length, 1, "falls back to env.METAGRAPH_HEALTH_DB");
     assert.ok(Number(spy.rows[0]!.checked_at) > 0, "uses the real clock");
   });
@@ -497,7 +535,7 @@ describe("the watchdog's cron", () => {
               async json() {
                 return {
                   schema_version: 1,
-                  generated_at: TOP_HOLDERS_FROZEN_GENERATED_AT,
+                  generated_at: FROZEN_GENERATED_AT,
                   rows: [{ ss58: "5A" }],
                 };
               },
@@ -511,8 +549,8 @@ describe("the watchdog's cron", () => {
     // watchdog that read nothing is the failure this module exists to prevent.
     assert.equal(read, 1);
     assert.equal(result.ok, true);
-    assert.equal(result.reason, "frozen");
-    assert.equal(result.alerted, false);
+    assert.equal(result.reason, "stale");
+    assert.equal(result.alerted, true);
   });
 
   test("an unbound bucket still reports through the cron wrapper", async () => {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1939,13 +1939,13 @@ async function dispatchScheduled(
     );
   }
   if (cron === TOP_HOLDERS_STALENESS_WATCHDOG_CRON) {
-    // The top-holders leaderboard's alarm (#9464). UNLIKE its siblings, zero
-    // alerts is NOT the current steady state and is not expected to be: the
-    // lane has no producer, so every tick records a `frozen` verdict to
-    // `lane_health` (published on /api/v1/self-health) without paging. An
-    // ABSENT, UNREADABLE or EMPTY artifact DOES record one exception under
-    // watchdog:top-holders-staleness -- that is the condition where the route
-    // silently answers 200 with an empty leaderboard instead of a frozen one.
+    // The top-holders leaderboard's alarm (#9464). Zero alerts is the correct
+    // steady state and is NOT the current one: the lane has no producer, so it
+    // records one exception under watchdog:top-holders-staleness on every tick
+    // and will until the artifact gets a writer or the route is withdrawn
+    // (#9475 removed the special case that kept this quiet). An ABSENT,
+    // UNREADABLE or EMPTY artifact alerts too -- that is the condition where
+    // the route silently answers 200 with an empty leaderboard.
     return runTopHoldersStalenessWatchdog(
       env as unknown as Record<string, unknown>,
     );

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -211,7 +211,7 @@ export const CHAIN_DETAIL_STALENESS_WATCHDOG_CRON = "14,29,44,59 * * * *";
 // reading `captured_at`, not by us. Twice hourly: the tick is one R2 get, so a
 // cheap cadence costs nothing and bounds detection well inside the twelve-hour
 // threshold (src/top-holders-staleness-watchdog.ts explains that sizing, and
-// why the frozen snapshot records a verdict without paging anyone). Minutes
+// why a lane with no producer reports stale on every tick). Minutes
 // 22/52 tick on none of the crons in this file and stay off the */5 raw-capture
 // and */15 probe grids -- dispatch keys on the LITERAL cron string, so this
 // must be unique here as well as matching a wrangler.jsonc `triggers.crons`

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -861,8 +861,8 @@
       // 22,52 = the top-holders staleness watchdog (#9464): the leaderboard is
       // served from a one-shot pre-decommission artifact with no producer, and
       // nothing reported that for three days. Records a verdict every tick and
-      // pages only when the artifact goes absent/unreadable/empty -- see
-      // TOP_HOLDERS_STALENESS_WATCHDOG_CRON in workers/config.ts.
+      // alerts on every stale one -- see TOP_HOLDERS_STALENESS_WATCHDOG_CRON in
+      // workers/config.ts.
       "22,52 * * * *",
     ],
   },


### PR DESCRIPTION
Closes #9475. Corrects the judgement call I flagged for review in #9464 — it was wrong, and this removes it.

## What #9464 shipped

```ts
if (generatedAt === TOP_HOLDERS_FROZEN_GENERATED_AT) {
  return { stale: true, alert: false, reason: "frozen", ... };
}
```

`TOP_HOLDERS_FROZEN_GENERATED_AT` was a committed copy of the live artifact's own `generated_at`. When it matched, the tick wrote a `lane_health` row and notified nobody. I justified it on exception cost and alarm fatigue.

## Why it was wrong

**The cost claim doesn't survive arithmetic.** 48 events/day against ~1M/day is 0.005%, and production sets `POSTHOG_EXCEPTION_STORM_WINDOW_MS: "300000"` — a 5-minute per-fingerprint window that never engages at 30-minute spacing. There was no cost to trade for anything. I asserted a number without checking it.

**It made the watchdog silent on the exact defect it was built for.** #9464 exists because a frozen leaderboard went three days unnoticed. Answering that with a row in a table nobody queries lets the next three days pass identically. #9330/#9340 were explicit that `lane_health` is the *record* and not a substitute for the notification — and I used it as one.

**Suppressing on a hardcoded timestamp is a known-bad-state allowlist.** It disables the alarm for precisely the condition that is true right now, indefinitely, and a second frozen materialization would need hand-adding to stay quiet. Nothing else in this repo suppresses an alarm that way.

**The alarm-fatigue citation was misapplied.** #9273's header warns against a threshold mis-sized against a *healthy* producer, so a working lane alerts three quarters of the day — a false positive. A leaderboard nothing refreshes is a true positive. Both sibling lanes this one is modelled on (#9273, #9301) alerted every tick while dead, and both got fixed. That is the mechanism working.

## The change

Delete the branch and the constant. A stale leaderboard is `stale`, reports every tick, and keeps reporting until the lane gets a producer or the route is withdrawn. `alert` collapses back into `stale` — a field that only existed to carry the exemption.

`absent` / `unreadable` / `empty` are unchanged. `empty` still deliberately outranks age, because a *fresh* artifact with zero rows serves an empty leaderboard just the same.

Net effect in production: the lane now emits one `$exception` per tick under `watchdog:top-holders-staleness` until top-holders has a writer again. That is the intended state, not a regression.

## Notable tests

- **`no timestamp is exempt -- only age decides`** — the regression guard for this issue specifically. Nothing about a particular `generated_at` may buy a quiet verdict.
- **`the live frozen artifact notifies AND records, every tick`** — asserts both sinks fire on the production state, which is the assertion #9464 got backwards.
- **`a repeat tick over the same artifact alerts again`** — two consecutive ticks, two events. Guards against re-introducing suppression via cross-tick state.
- **`empty outranks age, and still reports the age`** — now also covers the fresh-but-empty case that age alone would miss.

The test file no longer imports the frozen timestamp from source; it keeps it as a local fixture, since the whole point is that source must not key on it.

## Verification

`npm run lint`, `format:check`, `typecheck`, `validate` clean. `npx vitest run` — **670 files, 15,986 tests, all passing**. Patch coverage by diff intersection over every changed `src/**` and `workers/**` line: zero uncovered statements, branches or functions.

No `openapi.json` change this time (comments and code only), so no contract regen — confirmed by re-running `apps/ui`'s `generate-openapi-docs.ts` and getting no drift, rather than assuming it. Rebased onto `main` after #9468/#9472 landed, since #9472 also touched `wrangler.jsonc`.
