### PR TITLE
fix(emission): read the chain in batches, so the sampler stops 429ing itself dead

### DIFF
--- a/src/emission-gate-sampler.ts
+++ b/src/emission-gate-sampler.ts
@@ -62,6 +62,17 @@ export interface EmissionGateSample {
   current_ema: [number, { block: number } | null][];
 }
 
+/**
+ * Storage keys per `state_queryStorageAt` request.
+ *
+ * Comfortably above the ~72 `SubnetEmissionEnabled` and ~124 `SubnetEmaTaoFlow`
+ * keys the chain holds today (measured live 2026-08-05), so both are one call
+ * now, while still bounding the request body if the subnet count grows by an
+ * order of magnitude. Exported so a test can assert the chunking loop actually
+ * runs more than once rather than trusting a single-chunk happy path.
+ */
+export const STORAGE_BATCH_SIZE = 200;
+
 /** The maps key on `prefix ++ netuid as u16 little-endian`, Identity-hashed
  * (no hasher prefix), so the netuid is simply the last 4 hex chars. */
 export function netuidFromKey(key: string, prefix: string): number | null {
@@ -117,8 +128,49 @@ export async function sampleEmissionGate(
     return keys;
   }
 
-  async function readU64F64(storageKey: string): Promise<number | null> {
-    const raw = await rpc<string | null>("state_getStorage", [storageKey]);
+  /**
+   * Read many storage values in ONE request, chunked.
+   *
+   * `state_getStorage` fetches a single value, so asking for it per subnet cost
+   * this sampler ~207 calls a tick against an endpoint that serves 100 per
+   * client per minute (`RPC_REQUESTS_PER_MINUTE_LIMIT`, measured in #9378).
+   * It spent that allowance about six seconds in, threw, and lost the whole
+   * sample every ten minutes -- while also spending the raw-capture lanes'
+   * share of the same per-client budget (#9477).
+   *
+   * Chunked rather than one unbounded request: 72 keys is what the chain has
+   * today, and a body sized by the subnet count is the kind of thing that works
+   * until it abruptly does not.
+   */
+  async function queryStorage(
+    keys: string[],
+  ): Promise<Map<string, string | null>> {
+    const values = new Map<string, string | null>();
+    for (let i = 0; i < keys.length; i += STORAGE_BATCH_SIZE) {
+      const chunk = keys.slice(i, i + STORAGE_BATCH_SIZE);
+      const pages = await rpc<{ changes?: [string, string | null][] }[] | null>(
+        "state_queryStorageAt",
+        [chunk],
+      );
+      for (const page of pages ?? []) {
+        for (const [key, value] of page?.changes ?? []) {
+          values.set(key, value ?? null);
+        }
+      }
+    }
+    // A key the node simply omits is UNSET, which is a real reading, not a
+    // missing one -- record it so a caller reading this map cannot mistake
+    // "absent from the response" for "never asked for". Same reason
+    // state_getStorage's own `null` was never treated as a failure.
+    for (const key of keys) if (!values.has(key)) values.set(key, null);
+    return values;
+  }
+
+  function u64f64At(
+    values: Map<string, string | null>,
+    storageKey: string,
+  ): number | null {
+    const raw = values.get(storageKey) ?? null;
     if (raw === null) return null;
     const bits = decodeLeU128(raw);
     return bits === null ? null : u64f64U128ToFloat(bits);
@@ -128,12 +180,16 @@ export async function sampleEmissionGate(
   const blockNumber = parseInt(header.number, 16);
   const observedAt = now();
 
-  const [bar, quantile, exponent, totalIssuanceRaw] = await Promise.all([
-    readU64F64(EMISSION_GATE_BAR_STORAGE_KEY),
-    readU64F64(EMISSION_BAR_QUANTILE_STORAGE_KEY),
-    readU64F64(EMISSION_GATE_EXPONENT_STORAGE_KEY),
-    rpc<string | null>("state_getStorage", [TOTAL_ISSUANCE_STORAGE_KEY]),
+  const paramValues = await queryStorage([
+    EMISSION_GATE_BAR_STORAGE_KEY,
+    EMISSION_BAR_QUANTILE_STORAGE_KEY,
+    EMISSION_GATE_EXPONENT_STORAGE_KEY,
+    TOTAL_ISSUANCE_STORAGE_KEY,
   ]);
+  const bar = u64f64At(paramValues, EMISSION_GATE_BAR_STORAGE_KEY);
+  const quantile = u64f64At(paramValues, EMISSION_BAR_QUANTILE_STORAGE_KEY);
+  const exponent = u64f64At(paramValues, EMISSION_GATE_EXPONENT_STORAGE_KEY);
+  const totalIssuanceRaw = paramValues.get(TOTAL_ISSUANCE_STORAGE_KEY) ?? null;
 
   // Halvings, not the emission itself: the TAO-per-block figure drifts with
   // issuance, but the HALVING COUNT is a step function that moves a handful
@@ -152,31 +208,32 @@ export async function sampleEmissionGate(
   };
 
   const enabledKeys = await keysPaged(SUBNET_EMISSION_ENABLED_PREFIX);
+  const enabledValues = await queryStorage(enabledKeys);
   const currentEnabled = new Map<number, boolean>();
   for (const key of enabledKeys) {
     const netuid = netuidFromKey(key, SUBNET_EMISSION_ENABLED_PREFIX);
     if (netuid === null) continue;
-    const raw = await rpc<string | null>("state_getStorage", [key]);
+    const raw = enabledValues.get(key) ?? null;
     // 0x00 is disabled; anything else present is enabled.
     currentEnabled.set(netuid, raw !== "0x00");
   }
 
-  const flowObservations: FlowParamObservation[] = [];
-  for (const [item, key] of Object.entries(FLOW_PARAM_ITEMS) as [
+  const flowEntries = Object.entries(FLOW_PARAM_ITEMS) as [
     FlowParamItem,
     string,
-  ][]) {
-    const raw = await rpc<string | null>("state_getStorage", [key]);
-    flowObservations.push({ item, raw });
-  }
+  ][];
+  const flowValues = await queryStorage(flowEntries.map(([, key]) => key));
+  const flowObservations: FlowParamObservation[] = flowEntries.map(
+    ([item, key]) => ({ item, raw: flowValues.get(key) ?? null }),
+  );
 
   const emaKeys = await keysPaged(SUBNET_EMA_TAO_FLOW_PREFIX);
+  const emaValues = await queryStorage(emaKeys);
   const currentEma = new Map<number, { block: number } | null>();
   for (const key of emaKeys) {
     const netuid = netuidFromKey(key, SUBNET_EMA_TAO_FLOW_PREFIX);
     if (netuid === null) continue;
-    const raw = await rpc<string | null>("state_getStorage", [key]);
-    currentEma.set(netuid, decodeSubnetEmaTaoFlow(raw));
+    currentEma.set(netuid, decodeSubnetEmaTaoFlow(emaValues.get(key) ?? null));
   }
 
   return {

--- a/tests/emission-gate-sampler.test.ts
+++ b/tests/emission-gate-sampler.test.ts
@@ -8,6 +8,7 @@ import { describe, test } from "vitest";
 import {
   netuidFromKey,
   sampleEmissionGate,
+  STORAGE_BATCH_SIZE,
   SUBNET_EMA_TAO_FLOW_PREFIX,
   SUBNET_EMISSION_ENABLED_PREFIX,
 } from "../src/emission-gate-sampler.ts";
@@ -47,6 +48,26 @@ function rpcFetch(answer: (method: string, params: unknown[]) => unknown): {
   return { impl, calls };
 }
 
+/** The chain's storage, per key. The sampler reads these in BATCHES
+ * (`state_queryStorageAt`), so the transport below turns this per-key view into
+ * the batched response shape — keeping each test's intent expressed as "what
+ * does this key hold" rather than as request plumbing. */
+function healthyStorage(key: string): string | null {
+  if (key === TOTAL_ISSUANCE_STORAGE_KEY) return "0x0000c16ff2862300"; // u64 LE
+  if (key === ENABLED_KEY_7) return "0x00"; // disabled
+  if (key === EMA_KEY_7) return null;
+  return null;
+}
+
+/** `state_queryStorageAt`'s answer: one page whose `changes` pairs every
+ * requested key with its value. */
+function changesFor(
+  keys: string[],
+  value: (key: string) => string | null,
+): unknown {
+  return [{ changes: keys.map((key) => [key, value(key)]) }];
+}
+
 /** The minimal healthy chain: header, null gate params, one enabled subnet,
  * flow params unset, one EMA entry. */
 function healthyAnswer(method: string, params: unknown[]): unknown {
@@ -57,14 +78,22 @@ function healthyAnswer(method: string, params: unknown[]): unknown {
     if (prefix === SUBNET_EMA_TAO_FLOW_PREFIX) return [EMA_KEY_7];
     return [];
   }
-  if (method === "state_getStorage") {
-    const key = params[0];
-    if (key === TOTAL_ISSUANCE_STORAGE_KEY) return "0x0000c16ff2862300"; // u64 LE
-    if (key === ENABLED_KEY_7) return "0x00"; // disabled
-    if (key === EMA_KEY_7) return null;
-    return null;
+  if (method === "state_queryStorageAt") {
+    return changesFor(params[0] as string[], healthyStorage);
   }
   throw new Error(`unexpected method ${method}`);
+}
+
+/** The healthy chain with specific storage keys overridden. */
+function answerWith(
+  overrides: Record<string, string | null>,
+): (method: string, params: unknown[]) => unknown {
+  return (method, params) =>
+    method === "state_queryStorageAt"
+      ? changesFor(params[0] as string[], (key) =>
+          key in overrides ? overrides[key]! : healthyStorage(key),
+        )
+      : healthyAnswer(method, params);
 }
 
 describe("netuidFromKey", () => {
@@ -124,11 +153,7 @@ describe("sampleEmissionGate", () => {
   });
 
   test("a non-0x00 enablement value reads as enabled", async () => {
-    const { impl } = rpcFetch((m, p) =>
-      m === "state_getStorage" && p[0] === ENABLED_KEY_7
-        ? "0x01"
-        : healthyAnswer(m, p),
-    );
+    const { impl } = rpcFetch(answerWith({ [ENABLED_KEY_7]: "0x01" }));
     const sample = await sampleEmissionGate({
       rpcUrl: "https://rpc.test",
       fetchImpl: impl,
@@ -240,10 +265,8 @@ describe("sampleEmissionGate", () => {
 
   test("an unset TotalIssuance reads halvings as null, and the global fetch default engages", async () => {
     const realFetch = globalThis.fetch;
-    globalThis.fetch = rpcFetch((m, p) =>
-      m === "state_getStorage" && p[0] === TOTAL_ISSUANCE_STORAGE_KEY
-        ? null
-        : healthyAnswer(m, p),
+    globalThis.fetch = rpcFetch(
+      answerWith({ [TOTAL_ISSUANCE_STORAGE_KEY]: null }),
     ).impl;
     try {
       const sample = await sampleEmissionGate({ rpcUrl: "https://rpc.test" });
@@ -254,13 +277,15 @@ describe("sampleEmissionGate", () => {
   });
 
   test("an undecodable gate value and a malformed EMA key both degrade, never throw", async () => {
-    const { impl } = rpcFetch((m, p) => {
-      if (m === "state_getStorage" && p[0] === EMISSION_GATE_BAR_STORAGE_KEY)
-        return "0xnothex"; // present but undecodable -> null param
-      if (m === "state_getKeysPaged" && p[0] === SUBNET_EMA_TAO_FLOW_PREFIX)
-        return [SUBNET_EMA_TAO_FLOW_PREFIX + "070000", EMA_KEY_7];
-      return healthyAnswer(m, p);
+    // present but undecodable -> null param
+    const undecodable = answerWith({
+      [EMISSION_GATE_BAR_STORAGE_KEY]: "0xnothex",
     });
+    const { impl } = rpcFetch((m, p) =>
+      m === "state_getKeysPaged" && p[0] === SUBNET_EMA_TAO_FLOW_PREFIX
+        ? [SUBNET_EMA_TAO_FLOW_PREFIX + "070000", EMA_KEY_7]
+        : undecodable(m, p),
+    );
     const sample = await sampleEmissionGate({
       rpcUrl: "https://rpc.test",
       fetchImpl: impl,
@@ -269,13 +294,79 @@ describe("sampleEmissionGate", () => {
     assert.deepEqual(sample.current_ema, [[7, null]]);
   });
 
+  // The batched read is what keeps this sampler inside the endpoint's 100
+  // requests/minute/client budget (#9477). Before it, one state_getStorage per
+  // subnet cost ~207 calls a tick, 429'd about six seconds in, and threw away
+  // the whole sample every ten minutes.
+  test("reads every subnet's storage in ONE call, not one call per subnet", async () => {
+    const { impl, calls } = rpcFetch(healthyAnswer);
+    await sampleEmissionGate({ rpcUrl: "https://rpc.test", fetchImpl: impl });
+    assert.equal(
+      calls.filter((c) => c.method === "state_getStorage").length,
+      0,
+      "the per-key method is what blew the budget — nothing may still use it",
+    );
+    // header + params + 2 keysPaged + enabled + flow + ema.
+    assert.ok(calls.length <= 8, `expected <=8 RPC calls, got ${calls.length}`);
+  });
+
+  test("chunks a key list longer than the batch size", async () => {
+    // One key past the bound, so the loop must run twice rather than once.
+    const many = Array.from(
+      { length: STORAGE_BATCH_SIZE + 1 },
+      (_, i) =>
+        SUBNET_EMISSION_ENABLED_PREFIX + i.toString(16).padStart(4, "0"),
+    );
+    const { impl, calls } = rpcFetch((m, p) => {
+      if (m === "state_getKeysPaged" && p[0] === SUBNET_EMISSION_ENABLED_PREFIX)
+        return many;
+      return healthyAnswer(m, p);
+    });
+    await sampleEmissionGate({ rpcUrl: "https://rpc.test", fetchImpl: impl });
+    const batched = calls.filter((c) => c.method === "state_queryStorageAt");
+    const enabledBatches = batched.filter((c) =>
+      (c.params[0] as string[])[0]?.startsWith(SUBNET_EMISSION_ENABLED_PREFIX),
+    );
+    assert.equal(enabledBatches.length, 2);
+    assert.equal((enabledBatches[0]!.params[0] as string[]).length, 200);
+    assert.equal((enabledBatches[1]!.params[0] as string[]).length, 1);
+  });
+
+  test("a key the node omits from `changes` reads as unset, not as missing", async () => {
+    // The node is entitled to answer with fewer pairs than were asked for.
+    // Those keys are UNSET, which is a real reading — dropping them would let
+    // an absent subnet look like one that was never queried.
+    const { impl } = rpcFetch((m, p) =>
+      m === "state_queryStorageAt" ? [{ changes: [] }] : healthyAnswer(m, p),
+    );
+    const sample = await sampleEmissionGate({
+      rpcUrl: "https://rpc.test",
+      fetchImpl: impl,
+    });
+    assert.equal(sample.current.block_emission_halvings, null);
+    // null !== "0x00", so an unset enablement still reads as enabled.
+    assert.deepEqual(sample.current_enabled, [[7, true]]);
+    assert.deepEqual(sample.current_ema, [[7, null]]);
+  });
+
+  test("a null or page-less batch result degrades rather than throwing", async () => {
+    for (const result of [null, [], [{}]]) {
+      const { impl } = rpcFetch((m, p) =>
+        m === "state_queryStorageAt" ? result : healthyAnswer(m, p),
+      );
+      const sample = await sampleEmissionGate({
+        rpcUrl: "https://rpc.test",
+        fetchImpl: impl,
+      });
+      assert.equal(sample.current.emission_gate_bar, null);
+    }
+  });
+
   test("gate params decode through the u64f64 path when present", async () => {
     // 1.0 in U64F64: integer part 1 in the high 64 bits -> LE u128 hex.
     const oneU64F64 = "0x" + "00".repeat(8) + "01" + "00".repeat(7);
-    const { impl } = rpcFetch((m, p) =>
-      m === "state_getStorage" && p[0] === EMISSION_GATE_BAR_STORAGE_KEY
-        ? oneU64F64
-        : healthyAnswer(m, p),
+    const { impl } = rpcFetch(
+      answerWith({ [EMISSION_GATE_BAR_STORAGE_KEY]: oneU64F64 }),
     );
     const sample = await sampleEmissionGate({
       rpcUrl: "https://rpc.test",


### PR DESCRIPTION
## Summary

- The 10-minute emission-gate sampler tick has been failing outright in production: `state_getStorage: HTTP 429`, `outcome: "exception"`, ~16s wall time, **nothing recorded** — no gate params, no flow observations, no EMA. The lane goes dark every tick and the only trace is a cron exception.
- Cause: the sampler issued **~207 RPC calls per tick with no pacing** against an endpoint that serves 100 per client per minute. This replaces the per-key reads with batched `state_queryStorageAt`, taking the tick to **7 calls**.

## What Changed

- **`src/emission-gate-sampler.ts`** — a `queryStorage(keys)` helper that reads many storage values per request via `state_queryStorageAt`, chunked at `STORAGE_BATCH_SIZE = 200`. The two per-subnet loops (`SubnetEmissionEnabled`, `SubnetEmaTaoFlow`) and the two small param fan-outs now go through it; `readU64F64`'s per-key RPC is replaced by decoding out of the batch.
- **`tests/emission-gate-sampler.test.ts`** — the harness now expresses the chain as a per-key `healthyStorage(key)` view that the transport turns into the batched response shape, so each existing test keeps stating "what does this key hold" rather than being rewritten around request plumbing. Four new tests cover the batching itself.

## The measurement

Counted from the code and confirmed live against `https://archive.chain.opentensor.ai` on 2026-08-05:

| Step | Before | After |
|---|---|---|
| `chain_getHeader` | 1 | 1 |
| gate params + issuance | 4 | 1 |
| `keysPaged(enabled)` | 1 | 1 |
| **enabled values** | **72** | **1** |
| flow params | 4 | 1 |
| `keysPaged(EMA)` | 1 | 1 |
| **EMA values** | **~124** | **1** |
| | **~207** | **7** |

`state_getKeysPaged` on `SubnetEmissionEnabled` returns 72 keys; `state_queryStorageAt` with all 72 returns all 72 values, non-null, in one call. The ceiling is `RPC_REQUESTS_PER_MINUTE_LIMIT = 100` per **client** per minute (`src/raw-capture-sync.ts:126`, measured in #9378) — the observed tick was issuing at roughly 1,000/minute and died about six seconds in.

Because the limit is per client and this sampler points at the same public archive as the raw-capture lanes (`EMISSION_SAMPLER_RPC_URL || CHAIN_HEAD_RPC_URL || archive.chain.opentensor.ai`), it was also spending **their** budget — the class of problem `pacedLaneBudget` exists to prevent.

## Behaviour is unchanged

- A key the node omits from `changes` is recorded as `null` — the same reading `state_getStorage`'s own `null` gave — so "unset" stays distinct from "never asked for", and the `0x00`-is-disabled rule sees exactly what it saw before.
- Chunked at 200 rather than one unbounded request: 72 and ~124 are today's numbers, and a request body sized by the subnet count is the kind of thing that works until it abruptly does not. A test asserts the chunking loop actually runs twice rather than trusting a single-chunk happy path.

## Deliberately not in scope

- **Whether an upstream 429 should fail the whole tick.** `rpc()` still throws on any non-2xx and loses the entire sample. Now that a tick is 7 calls this is far less likely to fire, but a partial sample may still be better than none. Noted in #9477.
- **Pinning the reads to one block hash.** The sampler reads `chain_getHeader` for the number, then reads storage at whatever head each call lands on. Batching narrows that window considerably; closing it entirely is a behaviour change beyond the call-volume fix.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9477`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None changed.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — no route, schema or contract surface changes.)

## Validation

- [x] `npm run lint` · `npx prettier --check` on both changed files
- [x] `npm run typecheck`
- [x] `npx vitest run tests/emission-gate-sampler.test.ts` — 16 passed
- [x] The full emission suite — `emission-gate-sampler`, `emission-drift-check`, `emission-gate-history`, `emission-pipeline`, `emission-flow-monitor` — 85 passed
- [x] Patch coverage: `src/emission-gate-sampler.ts` at **100% statements / 100% branches / 100% functions / 100% lines** (78/78, 50/50, 8/8, 67/67), measured with `--coverage.include='src/emission-gate-sampler.ts'`
- [x] `git diff --check` clean; branch rebased on current `main`

Closes #9477
