### PR TITLE
fix(api): give account_balances a D1 sink so free_tao has a live producer again

### DIFF
--- a/migrations/d1/0017_account_balances.sql
+++ b/migrations/d1/0017_account_balances.sql
@@ -1,0 +1,95 @@
+-- The account-balances lane on D1 (#9478), the LAST of the frozen
+-- account-tier ledgers to get a Cloudflare-native sink.
+--
+-- WHY THIS LANE IS WORSE OFF THAN THE ONES 0011/0012 REVIVED. Those two had a
+-- frozen export in the lakehouse to fall back on. `account_balances` never had
+-- a D1 table AT ALL: it lived only in the decommissioned box's Postgres, so
+-- when that box went the whole column went with it. /api/v1/accounts/top-holders
+-- has answered from src/top-holders-artifact.ts's one-shot materialization of
+-- the old query (taken 2026-08-02) ever since, with a `captured_at` that cannot
+-- advance -- an account that has moved TAO since is misreported, and one first
+-- funded since is absent entirely. This table is where the revived poller lane
+-- lands instead.
+--
+-- The producer never went away and never stopped being correct. metagraphed-infra's
+-- services/indexer-rs/src/bin/poller/jobs/account_balances.rs still scans
+-- System::Account page by page, exactly as it always did; it was writing the
+-- result into a `tokio_postgres` connection to an instance that no longer
+-- exists. As with 0011/0012, only the write TARGET changes -- the scan itself
+-- needs no rehosting.
+--
+-- SIZE: 542,618 System::Account entries at the producer's own last live
+-- measurement (2026-07-19, against our own fullnode), of which only the ones
+-- with a nonzero free or reserved balance are sent (see the NO PRUNE note
+-- below). That is far past any single request body, so the producer chunks its
+-- pass across ~22 requests at the sync route's 25,000-row cap.
+--
+-- NO PRUNE, and for account_identity's reason in 0009 rather than
+-- validator_nominator_counts' in 0012. The producer deliberately SKIPS an
+-- account whose free and reserved are both zero (existential-deposit-only and
+-- reaped accounts carry a real System::Account entry full of zeros), so
+-- "absent from the scan" here does not mean "has no balance" -- it means
+-- "was not written". A prune would therefore delete exactly the accounts that
+-- emptied their wallet, which is a fact worth keeping. This table has always
+-- been "every account that has EVER held a balance", never "every account with
+-- a balance right now", and both the producer's own header and the retired
+-- Postgres handler said so.
+--
+-- Type translation follows 0007_neurons.sql / 0011_nominator_positions.sql:
+--   ss58                    -> TEXT (SS58 address)
+--   free_tao / reserved_tao -> REAL
+--   captured_at             -> INTEGER epoch-ms
+--
+-- REAL, not TEXT, and the tradeoff is deliberate. The producer computes an
+-- EXACT decimal string (backfill_rs::rao_to_tao_exact) because `rao as f64 /
+-- 1e9` starts losing sub-rao precision above 2**53 rao (~9.007M TAO). Storing
+-- that string verbatim would preserve it -- and make every ranking query sort
+-- lexicographically, so "9" would outrank "10". The whole point of this column
+-- is a leaderboard, and the serve path (src/top-holders.ts's `numberOrZero`)
+-- already narrows to an f64 before anything is published, so TEXT would buy
+-- precision no caller can observe at the cost of the one query shape that
+-- matters.
+--
+-- HOW MUCH HEADROOM, MEASURED RATHER THAN ASSUMED. REAL holds every rao exactly
+-- below 2**53 rao = 9,007,199.254740992 TAO. The largest free balance the served
+-- leaderboard carries is 5,448,995.87 TAO (read 2026-08-05), so the margin is
+-- ~1.65x -- not the order of magnitude a 21M total supply might suggest. It is
+-- stated as the measurement because it is close enough that a future reader
+-- should re-check it rather than trust this line: a single account past 9.007M
+-- TAO would start losing sub-rao precision here, which is a reason to revisit
+-- the column type, not a reason to panic (the loss is below one rao on a
+-- multi-million-TAO figure, and the serve path narrows to the same f64 anyway).
+--
+-- Latest-only, upserted on (ss58) with the same `captured_at <=
+-- excluded.captured_at` staleness guard every other D1 sync lane uses. The
+-- guard is what makes a chunked pass safe: the producer re-sends on failure,
+-- so a replayed or out-of-order request must be a no-op rather than a
+-- regression to an older balance.
+--
+-- The column set is NOT transcribed by hand from the destroyed Postgres
+-- schema: it is exactly the list the writer binds,
+-- ACCOUNT_BALANCE_INSERT_COLUMNS (src/account-balances-d1-write.ts), and
+-- tests/d1-schema-drift.test.ts asserts that correspondence -- the same
+-- anti-drift guarantee as 0007's tests/neurons-d1-schema.test.ts and 0011/0012's
+-- own.
+CREATE TABLE IF NOT EXISTS account_balances (
+  ss58         TEXT    NOT NULL,
+  free_tao     REAL    NOT NULL,
+  reserved_tao REAL    NOT NULL,
+  captured_at  INTEGER NOT NULL,
+  PRIMARY KEY (ss58)
+);
+
+-- The staleness watchdog asks for the ledger's own capture stamp
+-- (MAX(captured_at) over the whole table) on every tick, which without an index
+-- is a full scan of ~540k rows twice an hour. This index makes it a single seek
+-- to the tail -- the same reason 0011 declares one on nominator_positions.
+--
+-- No ranking index is declared here. The leaderboard's read shape belongs to
+-- the reader that composes it, and this repo already separates those concerns
+-- deliberately: 0007_neurons.sql created the table and 0008_neurons_read_indexes.sql
+-- added the indexes its queries turned out to want. Guessing at a `free_tao
+-- DESC` index before a query exists to use it would put a second B-tree over
+-- 540k rows on the chance that it helps.
+CREATE INDEX IF NOT EXISTS idx_account_balances_captured_at
+  ON account_balances (captured_at DESC);

--- a/src/account-balances-d1-write.ts
+++ b/src/account-balances-d1-write.ts
@@ -1,0 +1,83 @@
+// The account-balances sync write path, against D1 (#9478).
+//
+// The last of the frozen account-tier ledgers to get a Cloudflare-native sink,
+// and the only one that never had a D1 table at all: `account_balances` lived
+// solely in the decommissioned box's Postgres, so /api/v1/accounts/top-holders
+// has been serving a one-shot materialization taken 2026-08-02 with a
+// `captured_at` that cannot advance. migrations/d1/0017_account_balances.sql is
+// the table; this module is the writer.
+//
+// SHAPE MIRRORS src/validator-nominator-counts-d1-write.ts, not the
+// nominator-positions one, and the difference is the prune. That lane deletes a
+// coldkey's rows its own batch did not refresh, because an unstaked position
+// genuinely stops existing. Here the producer SKIPS an account whose free and
+// reserved are both zero rather than writing zeros, so "absent from the batch"
+// carries no information about the account's balance -- a prune would delete
+// exactly the wallets that emptied. This table is "every account that has ever
+// held a balance", which is what the retired Postgres handler meant too.
+//
+// Everything structural is imported from src/neurons-d1-write.ts rather than
+// re-derived -- D1_PARAM_BUDGET, chunkStatements, batchInSlices -- so the
+// binding's 100-bound-parameter limit is enforced in exactly one place. That
+// limit bites hard on this lane: at 4 columns the table chunks to 25 rows a
+// statement, so one 25,000-row request alone is 1,000 statements and a full
+// ~540k-row pass is ~21,700 -- a hand-rolled batch would have hit the same wall
+// #9157 hit in production.
+//
+// buildUpsert's trailing `captured_at <= excluded.captured_at` guard is why
+// chunkStatements is reused verbatim rather than forked: a full pass arrives
+// across ~22 requests and the producer re-sends on failure, so a replayed or
+// out-of-order batch must be a no-op rather than a regression to an older
+// balance.
+
+import {
+  batchInSlices,
+  chunkStatements,
+  type D1Like,
+  type D1PreparedStatement,
+} from "./neurons-d1-write.ts";
+
+type Row = Record<string, unknown>;
+
+/**
+ * The writer's exact column list and order, and the single source the route's
+ * validator, the migration's drift test and the producer's payload all agree
+ * against.
+ *
+ * It lives HERE rather than in a reader module -- unlike
+ * NOMINATOR_POSITION_INSERT_COLUMNS (src/account-nominator-positions.ts) or
+ * VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS (src/validator-nominator-summary.ts)
+ * -- because this table has no reader of its own yet: the leaderboard that will
+ * consume it composes three separate sources and is a different change. The
+ * writer owns the write contract until something reads it.
+ */
+export const ACCOUNT_BALANCE_INSERT_COLUMNS = [
+  "ss58",
+  "free_tao",
+  "reserved_tao",
+  "captured_at",
+];
+
+/**
+ * Write one account-balances sync batch to D1: a latest-only upsert on (ss58),
+ * nothing else.
+ *
+ * NO PRUNE -- see this module's header and the migration's for why deleting an
+ * account absent from a batch would delete the wallets that emptied. An empty
+ * batch issues no statements at all rather than an empty `db.batch([])`,
+ * matching writeValidatorNominatorCountsToD1's own guard.
+ */
+export async function writeAccountBalancesToD1(
+  db: D1Like,
+  rows: Row[],
+): Promise<{ statements: number }> {
+  const statements: D1PreparedStatement[] = chunkStatements(
+    db,
+    "account_balances",
+    ACCOUNT_BALANCE_INSERT_COLUMNS,
+    ["ss58"],
+    rows,
+  );
+  if (statements.length) await batchInSlices(db, statements);
+  return { statements: statements.length };
+}

--- a/src/account-balances-staleness-watchdog.ts
+++ b/src/account-balances-staleness-watchdog.ts
@@ -1,0 +1,168 @@
+// The alarm for the account-balances lane (#9478).
+//
+// This watchdog exists because of what happened WITHOUT one, twice over. The
+// lane's writer targeted a Postgres that was decommissioned, and nothing
+// anywhere noticed: /api/v1/accounts/top-holders kept answering 200 off a
+// one-shot materialization taken 2026-08-02, with a `captured_at` that could
+// never advance and a free_tao column that silently misreported every account
+// that had moved TAO since. It was found by a caller reading the timestamp --
+// the same way #9273 and #9423 were found, and the same way #9464 was.
+//
+// DISTINCT FROM src/top-holders-staleness-watchdog.ts, which is not superseded
+// by this file. That one watches the SERVED ARTIFACT -- whether the object the
+// route reads is present, readable, non-empty and off its frozen constant. This
+// one watches the SOURCE TABLE that feeds it. The two fail independently and
+// the difference is the repair: a fresh table behind a stale artifact is a
+// composition/publish problem, while a stale table behind either is the
+// producer. Watching only the artifact is what left the underlying lane's
+// absence invisible for as long as it was.
+//
+// Same shape as src/nominator-positions-staleness-watchdog.ts deliberately: one
+// MAX() read, a pure rule, a summary rather than a throw, and one exception
+// event per stale tick on the project's alert channel. Zero alerts is the
+// correct steady state.
+
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+
+/**
+ * How old the ledger may get before this is a stall.
+ *
+ * TWELVE HOURS, the same number src/top-holders-staleness-watchdog.ts sized
+ * against this exact producer and for the same reason: the poller's
+ * `ACCOUNT_BALANCES_POLL_SECS` defaults to 21600 (six hours), and the pass
+ * behind it is a full System::Account walk -- 542,618 entries measured
+ * 2026-07-19 -- so a healthy lane's age swings across the whole six-hour
+ * interval plus however long the walk and its ~22 POSTs take.
+ *
+ * Twelve is one full cadence of slack on top of that: it cannot fire until a
+ * pass has genuinely been skipped. That is the sizing rule #9301 corrected the
+ * nominator-positions threshold for, after a six-hour bound was set against a
+ * 24-hour producer and alerted for three quarters of every day on a lane that
+ * was working perfectly -- the failure mode where an alarm that always fires
+ * stops being read.
+ *
+ * Overridable per-deployment via ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS so the
+ * number can follow the Container's cadence without a code deploy.
+ */
+export const ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS = 12 * 60 * 60 * 1000;
+
+export interface AccountBalancesStalenessVerdict {
+  stale: boolean;
+  reason: "no_rows" | "stale" | null;
+  age_ms: number | null;
+  latest_captured_at: number | null;
+  threshold_ms: number;
+}
+
+/** The rule alone, testable without a database or a clock. */
+export function evaluateAccountBalancesStaleness(input: {
+  latestCapturedAtMs: number | null;
+  nowMs: number;
+  thresholdMs: number;
+}): AccountBalancesStalenessVerdict {
+  const { latestCapturedAtMs, nowMs, thresholdMs } = input;
+  if (latestCapturedAtMs === null) {
+    // An empty table is a stall of infinite age, not a healthy quiet one --
+    // and here it is also the CUTOVER state, before the revived lane has
+    // posted anything. That is exactly the condition worth alerting on: an
+    // empty table means every top-holders read is still answering from the
+    // frozen 2026-08-02 artifact.
+    return {
+      stale: true,
+      reason: "no_rows",
+      age_ms: null,
+      latest_captured_at: null,
+      threshold_ms: thresholdMs,
+    };
+  }
+  const age = nowMs - latestCapturedAtMs;
+  return {
+    stale: age > thresholdMs,
+    reason: age > thresholdMs ? "stale" : null,
+    age_ms: age,
+    latest_captured_at: latestCapturedAtMs,
+    threshold_ms: thresholdMs,
+  };
+}
+
+interface D1Like {
+  prepare(sql: string): {
+    first(): Promise<unknown>;
+  };
+}
+
+export interface AccountBalancesStalenessDeps {
+  /** Injectable durable sink, so a test can assert the verdict was RECORDED and
+   * not merely notified -- the distinction #9330/#9340 exist about. */
+  laneHealthDb?: LaneHealthDb | null;
+  now?: () => number;
+  /** Telemetry seam for tests; defaults to the real recordExceptionEvent. */
+  recordException?: typeof recordExceptionEvent;
+}
+
+/**
+ * One watchdog tick. Returns a summary rather than throwing, matching the
+ * watchdog family: a tick that cannot run is one missed report, not an outage,
+ * and a cron that throws is a cron nobody can read the result of.
+ */
+export async function runAccountBalancesStalenessWatchdog(
+  env: Record<string, unknown> | null | undefined,
+  deps: AccountBalancesStalenessDeps = {},
+): Promise<Record<string, unknown>> {
+  const now = deps.now ?? Date.now;
+  const record = deps.recordException ?? recordExceptionEvent;
+  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
+
+  const thresholdMs =
+    Number(env?.ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS) ||
+    ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS;
+
+  try {
+    const row = (await db
+      .prepare("SELECT MAX(captured_at) AS latest FROM account_balances")
+      .first()) as { latest: number | null } | null;
+    const verdict = evaluateAccountBalancesStaleness({
+      latestCapturedAtMs: row?.latest ?? null,
+      nowMs: now(),
+      thresholdMs,
+    });
+    if (verdict.stale) {
+      const age =
+        verdict.age_ms === null
+          ? "no rows at all"
+          : `${(verdict.age_ms / 3_600_000).toFixed(1)} h old`;
+      await record(env as never, {
+        error: new Error(
+          `account-balances lane stalled: latest snapshot is ${age} (threshold ${thresholdMs / 3_600_000} h) -- /accounts/top-holders is answering from a free_tao column nothing is refreshing`,
+        ),
+        route: "watchdog:account-balances-staleness",
+        errorCode: "stale_lane",
+      }).catch(() => false);
+    }
+    // #9330/#9340: the DURABLE record, written every tick rather than only when
+    // stale. PostHog stays the notification path; it is no longer the record, because
+    // a dropped $exception is indistinguishable from a lane that was fine. Writing on
+    // every tick is also what makes "the watchdog stopped running" visible at all.
+    // Never throws -- see recordLaneVerdict.
+    await recordLaneVerdict(
+      deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as never),
+      {
+        lane: "account-balances-staleness",
+        verdict: verdict.stale ? "stale" : "ok",
+        age_ms: verdict.age_ms,
+        detail: verdict.reason ?? null,
+        checked_at: now(),
+      },
+    );
+    // `ok` describes whether the TICK ran, not whether the lane is fresh.
+    return { ok: true, alerted: verdict.stale, ...verdict };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "query_failed",
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/tests/account-balances-d1-write.test.ts
+++ b/tests/account-balances-d1-write.test.ts
@@ -1,0 +1,196 @@
+// The account-balances D1 write path (#9478) and the schema it writes into.
+//
+// Two things are checked here and they fail in different ways. The MIGRATION
+// check is anti-drift: a column the writer binds but the table lacks makes D1
+// reject the whole batch, and a column the table has but the writer never
+// sends is a permanently-NULL field that reads like real data (0007's
+// tests/neurons-d1-schema.test.ts and 0011/0012's own writer tests make the
+// same guarantee for their tables). The WRITER checks are about the parameter
+// budget and the staleness guard: this lane posts a ~540k-row pass across ~22
+// requests, so a chunk that overran the binding's limit would fail the whole
+// batch, and a replayed request must never walk a balance backwards.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  ACCOUNT_BALANCE_INSERT_COLUMNS,
+  writeAccountBalancesToD1,
+} from "../src/account-balances-d1-write.ts";
+import { D1_PARAM_BUDGET } from "../src/neurons-d1-write.ts";
+
+const MIGRATION = readFileSync(
+  "migrations/d1/0017_account_balances.sql",
+  "utf8",
+);
+
+const SS58 = "5FyVinYphF6JS5FZHzhMQffxtgbz1WxwUEBAxTRo9nABwb5g";
+
+/** Column names of one CREATE TABLE block, in declaration order. */
+function tableColumns(table: string): string[] {
+  const match = MIGRATION.match(
+    new RegExp(`CREATE TABLE IF NOT EXISTS ${table} \\(([\\s\\S]*?)\\n\\);`),
+  );
+  assert.ok(match, `no CREATE TABLE for ${table} in the migration`);
+  return match[1]
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(
+      (line) =>
+        line &&
+        !line.startsWith("--") &&
+        !line.startsWith("PRIMARY KEY") &&
+        !line.startsWith("CHECK"),
+    )
+    .map((line) => line.split(/\s+/)[0]);
+}
+
+/** Records every prepared statement and its bindings, in order. */
+function d1Stub() {
+  const statements: { sql: string; params: unknown[] }[] = [];
+  const batches: number[] = [];
+  const db = {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          const entry = { sql, params };
+          statements.push(entry);
+          return entry as never;
+        },
+      };
+    },
+    async batch(slice: unknown[]) {
+      batches.push(slice.length);
+      return [];
+    },
+  };
+  return { statements, batches, db };
+}
+
+function row(ss58: string, free: number, reserved: number, at: number) {
+  return { ss58, free_tao: free, reserved_tao: reserved, captured_at: at };
+}
+
+describe("the account_balances D1 schema matches its writer", () => {
+  test("the migration parser actually finds columns", () => {
+    // A regex that silently matched nothing would make every comparison below
+    // vacuously pass -- the way a source-scanning check stops checking.
+    assert.equal(tableColumns("account_balances").length, 4);
+  });
+
+  test("the table holds exactly the columns the sync binds", () => {
+    assert.deepEqual(
+      tableColumns("account_balances").sort(),
+      [...ACCOUNT_BALANCE_INSERT_COLUMNS].sort(),
+    );
+  });
+
+  test("the upsert key is one row per account", () => {
+    // Latest-only: the Postgres original was PRIMARY KEY (ss58) with an
+    // ON CONFLICT upsert, and the leaderboard that reads this assumes one row
+    // per account.
+    assert.match(
+      MIGRATION,
+      /PRIMARY KEY \(ss58\)/,
+      "the PRIMARY KEY must be the same key the writer declares as its conflict target",
+    );
+  });
+
+  test("the balances are REAL, so the leaderboard's sort is numeric", () => {
+    // The one thing TEXT would silently break: "9" outranking "10". The
+    // migration's header argues the tradeoff against the producer's exact
+    // decimal string; this pins the outcome.
+    assert.match(MIGRATION, /free_tao\s+REAL\s+NOT NULL/);
+    assert.match(MIGRATION, /reserved_tao\s+REAL\s+NOT NULL/);
+  });
+
+  test("the watchdog's MAX(captured_at) read has an index to seek", () => {
+    // Without it the twice-hourly tick is a full scan of ~540k rows.
+    assert.match(
+      MIGRATION,
+      /CREATE INDEX IF NOT EXISTS idx_account_balances_captured_at\s+ON account_balances \(captured_at DESC\)/,
+    );
+  });
+});
+
+describe("writeAccountBalancesToD1", () => {
+  test("upserts on ss58 with the staleness guard", async () => {
+    const { statements, db } = d1Stub();
+    const { statements: count } = await writeAccountBalancesToD1(db as never, [
+      row(SS58, 1000.5, 25.25, 1_000),
+      row("5G9", 3, 0, 1_000),
+    ]);
+
+    assert.equal(count, statements.length);
+    assert.equal(statements.length, 1, "two narrow rows fit one statement");
+    assert.match(
+      statements[0]!.sql,
+      /INSERT INTO account_balances \(ss58, free_tao, reserved_tao, captured_at\)/,
+    );
+    assert.match(statements[0]!.sql, /ON CONFLICT \(ss58\) DO UPDATE SET/);
+    assert.match(
+      statements[0]!.sql,
+      /WHERE account_balances\.captured_at <= excluded\.captured_at/,
+      "an older capture must never overwrite a newer one",
+    );
+    assert.deepEqual(statements[0]!.params, [
+      SS58,
+      1000.5,
+      25.25,
+      1_000,
+      "5G9",
+      3,
+      0,
+      1_000,
+    ]);
+  });
+
+  test("issues no DELETE -- this lane never prunes", async () => {
+    // The one behaviour it must not borrow from the nominator-positions
+    // sibling. The producer skips an account whose free and reserved are both
+    // zero, so "absent from this batch" carries no information about the
+    // account's balance and a prune would delete the wallets that emptied.
+    const { statements, db } = d1Stub();
+    await writeAccountBalancesToD1(db as never, [
+      row(SS58, 1, 0, 1_000),
+      row("5G9", 2, 0, 2_000),
+    ]);
+    assert.ok(statements.length > 0, "the fixture must actually write");
+    for (const statement of statements) {
+      assert.doesNotMatch(statement.sql, /DELETE/i);
+    }
+  });
+
+  test("no statement exceeds the Workers binding's bound-parameter limit", async () => {
+    // 100 per statement on the BINDING -- not the 1,200 `wrangler d1 execute`
+    // permits from the CLI. The first 15 production neurons syncs all failed
+    // on exactly this, so the limit is asserted, never a constant we picked.
+    // At four columns this table chunks to 25 rows a statement, so one
+    // 25,000-row request alone is 1,000 statements.
+    const { statements, db } = d1Stub();
+    await writeAccountBalancesToD1(
+      db as never,
+      Array.from({ length: 500 }, (_unused, i) =>
+        row(`acct-${i}`, i, 0, 1_000),
+      ),
+    );
+    assert.ok(statements.length > 1, "500 rows must chunk");
+    for (const statement of statements) {
+      assert.ok(
+        statement.params.length <= D1_PARAM_BUDGET,
+        `a statement bound ${statement.params.length} parameters, over the ${D1_PARAM_BUDGET} budget`,
+      );
+    }
+  });
+
+  test("an empty batch issues no statements and never calls batch()", async () => {
+    // An empty `db.batch([])` is a round trip that can only fail. The route
+    // rejects an empty body with a 400 before reaching here, so this guard is
+    // reachable only by a direct caller -- which is exactly why it is asserted
+    // rather than assumed.
+    const { statements, batches, db } = d1Stub();
+    const result = await writeAccountBalancesToD1(db as never, []);
+    assert.equal(result.statements, 0);
+    assert.equal(statements.length, 0);
+    assert.deepEqual(batches, []);
+  });
+});

--- a/tests/account-balances-staleness-watchdog.test.ts
+++ b/tests/account-balances-staleness-watchdog.test.ts
@@ -1,0 +1,327 @@
+// The account-balances lane's alarm (#9478) and its cron wiring.
+//
+// The rule's edges are the point, and one of them is unusual: an EMPTY table
+// alerts. That is the pre-cutover state -- until the revived sync lane posts,
+// every /api/v1/accounts/top-holders read is still answering from the frozen
+// 2026-08-02 materialization, which is exactly the condition that ran unnoticed
+// and produced this issue.
+//
+// The threshold's own edge matters more here than on the sibling lanes: this
+// producer ticks every six hours, so a five-hour-old capture is a HEALTHY
+// mid-cycle reading and must stay quiet. #9301 had to correct precisely that
+// mistake on the nominator-positions watchdog after a threshold was set tighter
+// than its producer's cadence.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS,
+  evaluateAccountBalancesStaleness,
+  runAccountBalancesStalenessWatchdog,
+} from "../src/account-balances-staleness-watchdog.ts";
+import { handleScheduled } from "../workers/api.ts";
+import * as workerConfig from "../workers/config.ts";
+
+const NOW = 1_785_800_000_000;
+const HOUR = 60 * 60_000;
+
+function fakeDb(latest: number | null | Error) {
+  const queries: string[] = [];
+  return {
+    queries,
+    db: {
+      prepare(sql: string) {
+        queries.push(sql);
+        return {
+          async first() {
+            if (latest instanceof Error) throw latest;
+            return { latest };
+          },
+        };
+      },
+    },
+  };
+}
+
+describe("evaluateAccountBalancesStaleness", () => {
+  test("a recent pass is quiet; one past the threshold is a stall", () => {
+    const fresh = evaluateAccountBalancesStaleness({
+      latestCapturedAtMs: NOW - 2 * HOUR,
+      nowMs: NOW,
+      thresholdMs: ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(fresh.stale, false);
+    assert.equal(fresh.reason, null);
+    assert.equal(fresh.age_ms, 2 * HOUR);
+
+    const stalled = evaluateAccountBalancesStaleness({
+      latestCapturedAtMs: NOW - 13 * HOUR,
+      nowMs: NOW,
+      thresholdMs: ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(stalled.stale, true);
+    assert.equal(stalled.reason, "stale");
+    assert.equal(stalled.latest_captured_at, NOW - 13 * HOUR);
+  });
+
+  test("a capture from the middle of the producer's 6h cycle is quiet", () => {
+    // ACCOUNT_BALANCES_POLL_SECS defaults to six hours, and the System::Account
+    // walk plus its ~22 POSTs sit on top of that -- so a healthy lane's age
+    // swings across this whole range and none of it may alert.
+    for (const hours of [1, 3, 5, 6, 7]) {
+      const verdict = evaluateAccountBalancesStaleness({
+        latestCapturedAtMs: NOW - hours * HOUR,
+        nowMs: NOW,
+        thresholdMs: ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS,
+      });
+      assert.equal(
+        verdict.stale,
+        false,
+        `${hours}h into a 6h cycle must not alert`,
+      );
+    }
+  });
+
+  test("exactly at the threshold is not yet a stall", () => {
+    // Strictly-greater, so a lane running exactly on cadence never flaps.
+    const verdict = evaluateAccountBalancesStaleness({
+      latestCapturedAtMs: NOW - ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS,
+      nowMs: NOW,
+      thresholdMs: ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(verdict.stale, false);
+  });
+
+  test("an empty table is a stall of infinite age, never a healthy quiet", () => {
+    const verdict = evaluateAccountBalancesStaleness({
+      latestCapturedAtMs: null,
+      nowMs: NOW,
+      thresholdMs: ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(verdict.stale, true);
+    assert.equal(verdict.reason, "no_rows");
+    assert.equal(verdict.age_ms, null);
+    assert.equal(verdict.latest_captured_at, null);
+  });
+});
+
+describe("runAccountBalancesStalenessWatchdog", () => {
+  test("a fresh lane reports quiet and records nothing", async () => {
+    const { db, queries } = fakeDb(NOW - HOUR);
+    const recorded: unknown[] = [];
+    const result = await runAccountBalancesStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async (_env: never, event: unknown) => {
+          recorded.push(event);
+          return true;
+        }) as never,
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, false);
+    assert.deepEqual(recorded, []);
+    assert.match(queries[0]!, /MAX\(captured_at\).*FROM account_balances/);
+  });
+
+  test("a stalled lane records ONE exception naming the age and the route it breaks", async () => {
+    const { db } = fakeDb(NOW - 20 * HOUR);
+    const recorded: { error?: Error; route?: string; errorCode?: string }[] =
+      [];
+    const result = await runAccountBalancesStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async (_env: never, event: never) => {
+          recorded.push(event);
+          return true;
+        }) as never,
+      },
+    );
+    assert.equal(result.alerted, true);
+    assert.equal(recorded.length, 1);
+    assert.equal(recorded[0]!.route, "watchdog:account-balances-staleness");
+    assert.equal(recorded[0]!.errorCode, "stale_lane");
+    assert.match(String(recorded[0]!.error?.message), /20\.0 h old/);
+    assert.match(String(recorded[0]!.error?.message), /threshold 12 h/);
+    assert.match(String(recorded[0]!.error?.message), /top-holders/);
+  });
+
+  test("an empty table alerts with the no-rows wording", async () => {
+    const { db } = fakeDb(null);
+    const recorded: { error?: Error }[] = [];
+    const result = await runAccountBalancesStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async (_env: never, event: never) => {
+          recorded.push(event);
+          return true;
+        }) as never,
+      },
+    );
+    assert.equal(result.alerted, true);
+    assert.equal(result.reason, "no_rows");
+    assert.match(String(recorded[0]!.error?.message), /no rows at all/);
+  });
+
+  test("the env threshold override wins over the default", async () => {
+    const { db } = fakeDb(NOW - 2 * HOUR);
+    const result = await runAccountBalancesStalenessWatchdog(
+      {
+        METAGRAPH_HEALTH_DB: db,
+        ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS: String(HOUR),
+      },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(result.alerted, true);
+    assert.equal(result.threshold_ms, HOUR);
+  });
+
+  test("a missing binding and a failing query degrade to summaries, never throw", async () => {
+    assert.deepEqual(await runAccountBalancesStalenessWatchdog({}), {
+      ok: false,
+      reason: "d1 binding unavailable",
+    });
+    assert.deepEqual(await runAccountBalancesStalenessWatchdog(null), {
+      ok: false,
+      reason: "d1 binding unavailable",
+    });
+
+    const { db } = fakeDb(
+      new Error("D1_ERROR: no such table: account_balances"),
+    );
+    const failed = await runAccountBalancesStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { recordException: (async () => true) as never },
+    );
+    assert.equal(failed.ok, false);
+    assert.equal(failed.reason, "query_failed");
+    assert.match(String(failed.detail), /no such table/);
+
+    // A non-Error throw (D1 shims have thrown plain objects before) still
+    // yields a readable detail.
+    const stringThrow = {
+      prepare: () => ({
+        first: async () => {
+          throw "socket hangup";
+        },
+      }),
+    };
+    const nonError = await runAccountBalancesStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: stringThrow },
+      { recordException: (async () => true) as never },
+    );
+    assert.equal(nonError.reason, "query_failed");
+    assert.equal(nonError.detail, "socket hangup");
+  });
+
+  test("a null row and a telemetry failure never fail the tick", async () => {
+    const nullRow = {
+      prepare: () => ({ first: async () => null }),
+    };
+    const empty = await runAccountBalancesStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: nullRow },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(empty.ok, true);
+    assert.equal(empty.reason, "no_rows");
+
+    const { db } = fakeDb(NOW - 48 * HOUR);
+    const result = await runAccountBalancesStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async () => {
+          throw new Error("posthog down");
+        }) as never,
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, true);
+  });
+
+  test("the real recordExceptionEvent default engages and no-ops unconfigured", async () => {
+    // No telemetry env configured: the real recorder returns false without
+    // touching the network, so the default path is exercisable in-process.
+    const { db } = fakeDb(NOW - 48 * HOUR);
+    const result = await runAccountBalancesStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, true);
+
+    // The default clock is the real one, so a stamp far in the past is stale
+    // without injecting `now`.
+    const past = fakeDb(0);
+    const defaults = await runAccountBalancesStalenessWatchdog({
+      METAGRAPH_HEALTH_DB: past.db,
+    });
+    assert.equal(defaults.alerted, true);
+  });
+});
+
+describe("the cron string is unique and wired", () => {
+  test("no other cron in workers/config.ts shares the literal string", () => {
+    // Dispatch keys on the LITERAL cron string, so a duplicate silently routes
+    // this lane into another branch entirely.
+    const crons = Object.entries(workerConfig)
+      .filter(([key]) => key.endsWith("_CRON"))
+      .map(([, value]) => value);
+    const mine = workerConfig.ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON;
+    assert.equal(
+      crons.filter((cron) => cron === mine).length,
+      1,
+      `${mine} is declared by more than one lane`,
+    );
+  });
+
+  test("wrangler.jsonc declares the trigger", () => {
+    // A cron the Worker dispatches on but wrangler never fires is dead code --
+    // and the failure is silent, since the branch simply never runs.
+    const raw = readFileSync(
+      new URL("../wrangler.jsonc", import.meta.url),
+      "utf8",
+    )
+      .replace(/^\s*\/\/.*$/gm, "")
+      .replace(/,(\s*[}\]])/g, "$1");
+    const parsed = JSON.parse(raw) as { triggers?: { crons?: string[] } };
+    assert.ok(
+      parsed.triggers?.crons?.includes(
+        workerConfig.ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON,
+      ),
+    );
+  });
+
+  test("handleScheduled dispatches to the watchdog and returns its summary", async () => {
+    const { db, queries } = fakeDb(Date.now());
+    const result = (await handleScheduled(
+      {
+        cron: workerConfig.ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON,
+      } as unknown as ScheduledController,
+      { METAGRAPH_HEALTH_DB: db } as unknown as Parameters<
+        typeof handleScheduled
+      >[1],
+      {} as unknown as ExecutionContext,
+    )) as { ok: boolean; alerted: boolean };
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, false);
+    // Asserted by SHAPE rather than by count: the tick also writes its verdict to
+    // lane_health (#9330/#9340), so a bare `queries.length === 1` would have to be
+    // bumped on every added statement and would stop saying anything about which
+    // statement ran. Exactly one read of the lane, and it is the right read.
+    const reads = queries.filter((q: string) =>
+      q.includes("FROM account_balances"),
+    );
+    assert.equal(reads.length, 1);
+    assert.match(reads[0]!, /FROM account_balances/);
+    // The durable record is the whole point of the change: a healthy tick must be
+    // recorded too, or "the watchdog stopped running" stays invisible.
+    const writes = queries.filter((q: string) =>
+      q.includes("INSERT INTO lane_health"),
+    );
+    assert.equal(writes.length, 1);
+  });
+});

--- a/tests/d1-schema-drift.test.ts
+++ b/tests/d1-schema-drift.test.ts
@@ -30,6 +30,7 @@ import {
   NEURON_INSERT_COLUMNS,
 } from "../src/metagraph-neurons.ts";
 import { ACCOUNT_POSITION_DAILY_COLUMNS } from "../src/neurons-d1-write.ts";
+import { ACCOUNT_BALANCE_INSERT_COLUMNS } from "../src/account-balances-d1-write.ts";
 import {
   CHAIN_DETAIL_BLOCK_COLUMNS,
   CHAIN_DETAIL_EXTRINSIC_COLUMNS,
@@ -101,6 +102,11 @@ const GUARDED: Array<[string, string, readonly string[] | string]> = [
     "chain_detail_chain_events",
     "CHAIN_DETAIL_CHAIN_EVENT_COLUMNS",
     CHAIN_DETAIL_CHAIN_EVENT_COLUMNS,
+  ],
+  [
+    "account_balances",
+    "ACCOUNT_BALANCE_INSERT_COLUMNS",
+    ACCOUNT_BALANCE_INSERT_COLUMNS,
   ],
 ];
 

--- a/tests/data-api-account-balances-d1.test.ts
+++ b/tests/data-api-account-balances-d1.test.ts
@@ -1,0 +1,294 @@
+// The revived account-balances sync lane (#9478), exercised END TO END against
+// a REAL SQLite database through the real Worker fetch handler -- same harness
+// and rationale as tests/data-api-validator-nominator-counts-d1.test.ts.
+//
+// This route answered `503 hyperdrive binding unavailable` from the box wipe
+// (#9193) until migration 0017 gave it a Cloudflare-native store, and it came
+// out of that decommission worse off than either lane 0011/0012 revived: those
+// had a frozen lakehouse export to fall back on, while `account_balances` had
+// no D1 table at all. Its producer never went away -- metagraphed-infra's
+// poller Container still walks System::Account exactly as it always did, and
+// was writing into a Postgres that no longer exists.
+//
+// What matters here is the write CONTRACT. A full pass is 542,618 entries, past
+// any single request body, so it arrives across ~22 requests -- which is why
+// there is no prune on this lane at all, and why the staleness guard rather
+// than request ordering is what keeps a replay safe. The prune's absence is
+// load-bearing for a second reason the sibling lanes do not share: the producer
+// SKIPS an account whose free and reserved are both zero, so "absent from the
+// scan" would mean "delete every wallet that emptied" if this lane ever pruned.
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, describe, test } from "vitest";
+import type { Row } from "./row-type.ts";
+
+const { default: worker } = await import("../workers/data-api.ts");
+
+const SCHEMA = fs.readFileSync(
+  path.join(process.cwd(), "migrations/d1/0017_account_balances.sql"),
+  "utf8",
+);
+
+const PATH = "/api/v1/internal/account-balances-sync";
+const SECRET = "test-account-balances-sync-secret";
+const SS58 = "5FyVinYphF6JS5FZHzhMQffxtgbz1WxwUEBAxTRo9nABwb5g";
+const SS58_B = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+let db: InstanceType<typeof DatabaseSync>;
+
+function d1() {
+  return {
+    prepare(text: string) {
+      return {
+        bind(...values: unknown[]) {
+          return {
+            text,
+            values,
+            async all() {
+              return { results: db.prepare(text).all(...(values as never[])) };
+            },
+          };
+        },
+      };
+    },
+    async batch(statements: { text: string; values: unknown[] }[]) {
+      db.exec("BEGIN");
+      try {
+        const results = statements.map((statement) => ({
+          results: db
+            .prepare(statement.text)
+            .all(...(statement.values as never[])),
+        }));
+        db.exec("COMMIT");
+        return results;
+      } catch (err) {
+        db.exec("ROLLBACK");
+        throw err;
+      }
+    },
+  };
+}
+
+function env(overrides: Record<string, unknown> = {}): Env {
+  return {
+    METAGRAPH_HEALTH_DB: d1(),
+    ACCOUNT_BALANCES_SYNC_SECRET: SECRET,
+    ...overrides,
+  } as unknown as Env;
+}
+
+function post(body: unknown, token: string | null = SECRET, envOverride?: Env) {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (token !== null) headers["x-account-balances-sync-token"] = token;
+  return worker.fetch(
+    new Request(`https://d${PATH}`, {
+      method: "POST",
+      headers,
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    }),
+    envOverride ?? env(),
+    {} as unknown as ExecutionContext,
+  );
+}
+
+function balanceRow(overrides: Row = {}): Row {
+  return {
+    ss58: SS58,
+    free_tao: 1000.5,
+    reserved_tao: 25.25,
+    captured_at: 1_780_000_000_000,
+    ...overrides,
+  };
+}
+
+const rows = () =>
+  db.prepare("SELECT * FROM account_balances ORDER BY ss58").all() as Row[];
+
+beforeEach(() => {
+  db = new DatabaseSync(":memory:");
+  db.exec(SCHEMA);
+});
+
+describe("POST /api/v1/internal/account-balances-sync", () => {
+  test("writes a batch to D1 and reports what it did", async () => {
+    const response = await post({
+      rows: [
+        balanceRow(),
+        balanceRow({ ss58: SS58_B, free_tao: 0, reserved_tao: 7 }),
+      ],
+    });
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      account_balances_written: 2,
+      stores: ["d1"],
+      d1_statements: 1,
+    });
+    assert.equal(rows().length, 2);
+    // A zero free_tao IS stored: the producer only skips an account whose free
+    // AND reserved are both zero, so "nothing liquid, some reserved" is a real
+    // balance and not a placeholder.
+    assert.equal(rows()[1]!.free_tao, 0);
+    assert.equal(rows()[1]!.reserved_tao, 7);
+  });
+
+  test("accepts a bare array as well as {rows:[...]}", async () => {
+    // Every other sync route here speaks {rows:[...]}; a producer that posts a
+    // bare array must not cost a whole six-hour cycle.
+    const response = await post([balanceRow()]);
+    assert.equal(response.status, 200);
+    assert.equal(rows().length, 1);
+  });
+
+  test("a later capture wins and an older one is a no-op", async () => {
+    // The staleness guard is what makes a replayed or out-of-order batch safe.
+    // It matters more on this lane than most: the producer chunks one pass
+    // across ~22 requests and re-sends on failure.
+    await post({ rows: [balanceRow({ free_tao: 1000.5 })] });
+    await post({
+      rows: [balanceRow({ free_tao: 2000.75, captured_at: 1_780_000_100_000 })],
+    });
+    assert.equal(rows()[0]!.free_tao, 2000.75);
+
+    await post({
+      rows: [balanceRow({ free_tao: 1, captured_at: 1_779_000_000_000 })],
+    });
+    assert.equal(
+      rows()[0]!.free_tao,
+      2000.75,
+      "an older capture must never walk a balance backwards",
+    );
+  });
+
+  test("an account absent from a later batch is KEPT, never pruned", async () => {
+    // The one behaviour this lane must not borrow from nominator-positions.
+    // The producer skips an account whose free and reserved are both zero, so a
+    // wallet that emptied simply stops appearing -- pruning on absence would
+    // delete exactly those accounts, and this table has always been "every
+    // account that has ever held a balance".
+    await post({ rows: [balanceRow(), balanceRow({ ss58: SS58_B })] });
+    assert.equal(rows().length, 2);
+
+    await post({
+      rows: [balanceRow({ captured_at: 1_780_000_100_000 })],
+    });
+    assert.equal(rows().length, 2, "the absent account survived the batch");
+    assert.equal(rows().find((r) => r.ss58 === SS58_B)!.free_tao, 1000.5);
+  });
+
+  test("rejects a missing or wrong token (401)", async () => {
+    assert.equal((await post({ rows: [balanceRow()] }, null)).status, 401);
+    assert.equal((await post({ rows: [balanceRow()] }, "nope")).status, 401);
+    assert.equal(rows().length, 0);
+  });
+
+  test("is disabled (503) when the secret is not configured", async () => {
+    const response = await post(
+      { rows: [balanceRow()] },
+      SECRET,
+      env({ ACCOUNT_BALANCES_SYNC_SECRET: undefined }),
+    );
+    assert.equal(response.status, 503);
+  });
+
+  test("answers 503 when D1 is not bound -- but only after validating (400 wins)", async () => {
+    // A malformed body is a 400 whether or not a store happens to be bound;
+    // answering 503 would blame the infrastructure for the caller's payload.
+    const unbound = env({ METAGRAPH_HEALTH_DB: undefined });
+    assert.equal(
+      (await post({ rows: [balanceRow()] }, SECRET, unbound)).status,
+      503,
+    );
+    assert.equal(
+      (await post({ rows: [balanceRow({ ss58: 1 })] }, SECRET, unbound)).status,
+      400,
+      "validation runs before the binding check",
+    );
+  });
+
+  test("rejects a body that is not JSON, or not a row array", async () => {
+    assert.equal((await post("not json")).status, 400);
+    assert.equal((await post({ rows: "nope" })).status, 400);
+    assert.equal((await post({ rows: [] })).status, 400);
+  });
+
+  test("rejects rows that do not match the column shape", async () => {
+    const bad: Row[] = [
+      { ...balanceRow(), unexpected: 1 },
+      balanceRow({ ss58: "" }),
+      balanceRow({ ss58: 5 }),
+      balanceRow({ ss58: "x".repeat(200) }),
+      // A negative balance is not a thing System::Account can hold, and
+      // src/top-holders.ts's numberOrZero would silently rewrite it to 0.
+      balanceRow({ free_tao: -1 }),
+      balanceRow({ reserved_tao: -0.5 }),
+      // A string balance would bind fine and then sort as text on the one
+      // query shape this column exists for.
+      balanceRow({ free_tao: "1000.5" }),
+      balanceRow({ reserved_tao: null }),
+      // NaN/Infinity arrive as null over JSON and would bind NULL against a
+      // NOT NULL column, failing the whole 25,000-row batch at the database.
+      balanceRow({ free_tao: Number.NaN }),
+      balanceRow({ free_tao: Number.POSITIVE_INFINITY }),
+      balanceRow({ captured_at: 0 }),
+      balanceRow({ captured_at: 1.5 }),
+      "not an object" as unknown as Row,
+      null as unknown as Row,
+      [] as unknown as Row,
+    ];
+    for (const row of bad) {
+      const response = await post({ rows: [row] });
+      assert.equal(
+        response.status,
+        400,
+        `expected 400 for ${JSON.stringify(row)}`,
+      );
+    }
+    assert.equal(rows().length, 0, "no partial write from a rejected batch");
+  });
+
+  test("rejects an oversized batch (413) by rows and by bytes", async () => {
+    const tooMany = Array.from({ length: 25_001 }, (_unused, i) =>
+      balanceRow({ ss58: `acct-${i}` }),
+    );
+    assert.equal((await post({ rows: tooMany })).status, 413);
+
+    // Body bound is checked before a row count exists -- a handful of enormous
+    // strings passes the row bound and must still be refused.
+    const huge = JSON.stringify({ rows: [balanceRow()] }).padEnd(
+      8_000_001,
+      " ",
+    );
+    assert.equal((await post(huge)).status, 413);
+    assert.equal(rows().length, 0);
+  });
+
+  test("chunks a batch under the binding's 100-parameter limit", async () => {
+    // Four columns puts 25 rows in a statement, so this is the wall #9157 hit
+    // in production -- a full pass is ~21,700 statements and a hand-rolled
+    // batch would fail on the first request.
+    const many = Array.from({ length: 60 }, (_unused, i) =>
+      balanceRow({ ss58: `acct-${i}` }),
+    );
+    const response = await post({ rows: many });
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      account_balances_written: 60,
+      stores: ["d1"],
+      d1_statements: 3,
+    });
+    assert.equal(rows().length, 60);
+  });
+
+  test("a D1 failure is a 502, not a silent success", async () => {
+    db.exec("DROP TABLE account_balances");
+    const response = await post({ rows: [balanceRow()] });
+    assert.equal(response.status, 502);
+    assert.deepEqual(await response.json(), { error: "d1 write failed" });
+  });
+});

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -1307,7 +1307,12 @@ test("account-balances-sync is disabled (503) when ACCOUNT_BALANCES_SYNC_SECRET 
   expect(res.status).toBe(503);
 });
 
-test("account-balances-sync answers 503 -- the Postgres tier it wrote to is gone (#9193)", async () => {
+test("account-balances-sync writes to D1 -- the lane is live again (#9478)", async () => {
+  // It answered 503 for the whole period top-holders was frozen (#9193 retired
+  // it with the box), which is why /api/v1/accounts/top-holders served a
+  // `captured_at` stuck at 2026-08-02. The end-to-end write contract lives in
+  // tests/data-api-account-balances-d1.test.ts against a real SQLite database;
+  // this asserts only that the route no longer dead-ends here.
   const res = await worker.fetch(
     new Request("https://d/api/v1/internal/account-balances-sync", {
       method: "POST",
@@ -1320,7 +1325,12 @@ test("account-balances-sync answers 503 -- the Postgres tier it wrote to is gone
     env as unknown as Env,
     ctx,
   );
-  expect(res.status).toBe(503);
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({
+    ok: true,
+    account_balances_written: 1,
+    stores: ["d1"],
+  });
 });
 
 const SUBNET_IDENTITY_NETUID = 8;

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -360,6 +360,7 @@ import { runNeuronsStalenessWatchdog } from "../src/neurons-staleness-watchdog.t
 import { runNominatorPositionsStalenessWatchdog } from "../src/nominator-positions-staleness-watchdog.ts";
 import { runProjectionStalenessWatchdog } from "../src/projection-staleness-watchdog.ts";
 import { runValidatorNominatorCountsStalenessWatchdog } from "../src/validator-nominator-counts-staleness-watchdog.ts";
+import { runAccountBalancesStalenessWatchdog } from "../src/account-balances-staleness-watchdog.ts";
 import {
   readChainDetailHead,
   runChainDetailStalenessWatchdog,
@@ -439,6 +440,7 @@ import {
   CHAIN_DETAIL_PRUNE_CRON,
   CHAIN_DETAIL_STALENESS_WATCHDOG_CRON,
   TOP_HOLDERS_STALENESS_WATCHDOG_CRON,
+  ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON,
   LIVE_ECONOMICS_REFRESH_CRON,
   PROJECTION_LANES_CRON,
   FRESHNESS_WATCHDOG_STATE_KEY,
@@ -1618,6 +1620,8 @@ function cronLabel(cron: string): string {
     return "chain-detail-staleness-watchdog";
   if (cron === TOP_HOLDERS_STALENESS_WATCHDOG_CRON)
     return "top-holders-staleness-watchdog";
+  if (cron === ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON)
+    return "account-balances-staleness-watchdog";
   if (cron === LIVE_ECONOMICS_REFRESH_CRON) return "live-economics-refresh";
   // Every unmatched cron falls through to the health prober, matching dispatch.
   return "health-prober";
@@ -1947,6 +1951,19 @@ async function dispatchScheduled(
     // UNREADABLE or EMPTY artifact alerts too -- that is the condition where
     // the route silently answers 200 with an empty leaderboard.
     return runTopHoldersStalenessWatchdog(
+      env as unknown as Record<string, unknown>,
+    );
+  }
+  if (cron === ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON) {
+    // The account-balances lane's alarm (#9478) -- the SOURCE side of the
+    // watchdog above rather than a replacement for it: that one asks whether
+    // the served artifact is readable and current, this one asks whether the
+    // D1 table it is composed from is being written at all. Zero alerts is the
+    // correct steady state; a stale verdict records one exception under
+    // watchdog:account-balances-staleness, the project's alert channel. An
+    // EMPTY table alerts too -- until the revived lane posts, every top-holders
+    // read is still answering from the frozen 2026-08-02 materialization.
+    return runAccountBalancesStalenessWatchdog(
       env as unknown as Record<string, unknown>,
     );
   }

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -217,6 +217,18 @@ export const CHAIN_DETAIL_STALENESS_WATCHDOG_CRON = "14,29,44,59 * * * *";
 // must be unique here as well as matching a wrangler.jsonc `triggers.crons`
 // entry.
 export const TOP_HOLDERS_STALENESS_WATCHDOG_CRON = "22,52 * * * *";
+// #9478: the account-balances lane's alarm -- the SOURCE side of the watchdog
+// above, not a replacement for it. That one watches the served artifact; this
+// one watches the D1 table the artifact is supposed to be composed from, and
+// the two fail independently (a fresh table behind a stale artifact is a
+// publish problem; a stale table behind either is the producer). Twice hourly
+// against the same twelve-hour threshold, since one producer tick is what
+// refreshes it -- src/account-balances-staleness-watchdog.ts explains that
+// sizing against the poller's six-hour ACCOUNT_BALANCES_POLL_SECS. Minutes 4/34
+// tick on none of the crons in this file and stay off the */5 raw-capture and
+// */15 probe grids -- dispatch keys on the LITERAL cron string, so this must be
+// unique here as well as matching a wrangler.jsonc `triggers.crons` entry.
+export const ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON = "4,34 * * * *";
 // #9146: scheduled projections -- recompute the windowed-aggregate artifacts
 // (every lane in src/projection-lanes.ts's PROJECTION_LANES) from the
 // lakehouse. These routes cannot

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -358,6 +358,10 @@ import {
   writeNominatorPositionsToD1,
 } from "../src/nominator-positions-d1-write.ts";
 import { writeValidatorNominatorCountsToD1 } from "../src/validator-nominator-counts-d1-write.ts";
+import {
+  ACCOUNT_BALANCE_INSERT_COLUMNS,
+  writeAccountBalancesToD1,
+} from "../src/account-balances-d1-write.ts";
 import { VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS } from "../src/validator-nominator-counts-staleness-watchdog.ts";
 import { writeChainDetailToD1 } from "../src/chain-detail-d1-write.ts";
 import {
@@ -1900,20 +1904,76 @@ async function handleNominatorPositionsSync(request: Request, env: Env) {
   });
 }
 
-// --- POST /api/v1/internal/account-balances-sync (#6742) -------------------
-//
-// RETIRED (#9193): the Postgres tables this wrote were destroyed with the
-// box, so the handler now stops at its auth gate and answers exactly what it
-// already answered in production. What follows describes what it DID.
+// --- POST /api/v1/internal/account-balances-sync (#6742, revived #9478) ----
 //
 // Chain-wide free/reserved balance snapshot, one row per account with a
 // nonzero balance --
-// apps/indexer-rs/src/bin/poller/jobs/account_balances.rs's own header comment
-// on why this reads System::Account directly rather than reconstructing
-// balance from transfer/fee/stake events (a direct state read can't drift;
-// event-replay can, one missed mutation path at a time). Same "latest-only,
-// captured_at freshness guard" upsert shape as nominator-positions-sync.
+// metagraphed-infra's services/indexer-rs/src/bin/poller/jobs/account_balances.rs's
+// own header comment on why this reads System::Account directly rather than
+// reconstructing balance from transfer/fee/stake events (a direct state read
+// can't drift; event-replay can, one missed mutation path at a time).
+//
+// RETIRED with the box (#9193) and REVIVED against D1 here, because this lane
+// came out of the decommission worse off than the two 0011/0012 revived: they
+// each had a frozen lakehouse export to fall back on, and `account_balances`
+// had no D1 table at all. /api/v1/accounts/top-holders has answered from a
+// one-shot materialization taken 2026-08-02 ever since, with a `captured_at`
+// that cannot advance -- an account that has moved TAO since is misreported and
+// one first funded since is absent. Same request/{rows:[...]} shape, same token
+// gate, and the same D1-is-required posture as handleNominatorPositionsSync
+// above.
+//
+// A FULL PASS DOES NOT FIT ONE REQUEST. 542,618 System::Account entries at the
+// producer's own last live measurement puts a pass at ~22 requests against the
+// caps below. Unlike nominator-positions, the chunking is a plain flat slice
+// and needs no packing rule: rows are keyed on (ss58) alone and this lane never
+// prunes, so a row may land in any request in any order.
 const ACCOUNT_BALANCES_SYNC_TOKEN_HEADER = "x-account-balances-sync-token";
+// Matched to the nominator-positions siblings rather than re-derived: 25k rows
+// x 4 short columns sits well inside the Worker request ceiling. Body bound
+// first, row bound second -- neither alone is sufficient (a few enormous
+// SS58-shaped strings pass the row bound; 25k tiny rows pass the byte bound).
+const ACCOUNT_BALANCES_SYNC_MAX_BODY_BYTES = 8_000_000;
+const ACCOUNT_BALANCES_SYNC_MAX_ROWS = 25_000;
+// An SS58 address is 48 characters; the ceiling is generous rather than exact
+// so a future address format does not silently fail the whole batch.
+const ACCOUNT_BALANCES_SYNC_MAX_KEY_BYTES = 128;
+
+/**
+ * Bounds-check one incoming row against ACCOUNT_BALANCE_INSERT_COLUMNS.
+ *
+ * Both balances are required to be finite and NON-NEGATIVE rather than merely
+ * numeric. A negative balance is not a thing System::Account can hold, and the
+ * one consumer of this column (src/top-holders.ts's `numberOrZero`) would
+ * silently clamp it to 0 -- so a value this route accepted and every reader
+ * quietly rewrote is worse than a 400 the producer can actually see.
+ * `Number.isFinite` also rejects the JSON-hostile cases outright: a NaN or
+ * Infinity arriving as null would otherwise bind as NULL against a NOT NULL
+ * column and fail the whole 25,000-row batch at the database instead of here.
+ */
+function validAccountBalanceSyncRow(row: Row) {
+  if (!row || typeof row !== "object" || Array.isArray(row)) return false;
+  for (const key of Object.keys(row)) {
+    if (!ACCOUNT_BALANCE_INSERT_COLUMNS.includes(key)) return false;
+  }
+  if (typeof row.ss58 !== "string" || row.ss58.length === 0) return false;
+  if (utf8Bytes(row.ss58).length > ACCOUNT_BALANCES_SYNC_MAX_KEY_BYTES)
+    return false;
+  for (const key of ["free_tao", "reserved_tao"]) {
+    const value = row[key];
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 0)
+      return false;
+  }
+  if (!validSyncCapturedAt(row.captured_at)) return false;
+  return true;
+}
+
+/** Project a validated row onto the writer's exact column list and order. */
+function coerceAccountBalanceSyncRow(row: Row) {
+  const out: Row = {};
+  for (const col of ACCOUNT_BALANCE_INSERT_COLUMNS) out[col] = row[col];
+  return out;
+}
 
 async function handleAccountBalancesSync(request: Request, env: Env) {
   if (!env.ACCOUNT_BALANCES_SYNC_SECRET) {
@@ -1933,9 +1993,77 @@ async function handleAccountBalancesSync(request: Request, env: Env) {
       401,
     );
   }
-  // #9193: same deletion as handleRollupAccountEventsDaily above -- unreachable
-  // since HYPERDRIVE went away, answered here, status and body unchanged.
-  return writeJson({ error: "hyperdrive binding unavailable" }, 503);
+
+  const raw = await request.text();
+  if (utf8Bytes(raw).length > ACCOUNT_BALANCES_SYNC_MAX_BODY_BYTES) {
+    return writeJson(
+      { error: `body exceeds ${ACCOUNT_BALANCES_SYNC_MAX_BODY_BYTES} bytes` },
+      413,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return writeJson({ error: "body must be JSON" }, 400);
+  }
+  const incoming = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.rows)
+      ? parsed.rows
+      : null;
+  if (!incoming) {
+    return writeJson(
+      {
+        error:
+          "body must be a JSON array of account-balance rows (or {rows:[...]})",
+      },
+      400,
+    );
+  }
+  if (incoming.length > ACCOUNT_BALANCES_SYNC_MAX_ROWS) {
+    return writeJson(
+      { error: `at most ${ACCOUNT_BALANCES_SYNC_MAX_ROWS} rows per request` },
+      413,
+    );
+  }
+  if (!incoming.length || !incoming.every(validAccountBalanceSyncRow)) {
+    return writeJson(
+      { error: "rows must match the account-balance row shape" },
+      400,
+    );
+  }
+
+  const rows = incoming.map(coerceAccountBalanceSyncRow);
+
+  // D1 is the binding this path REQUIRES -- the only store this family has.
+  // Checked HERE, after validation, not at the top: a malformed body is a 400
+  // whether or not a store happens to be bound (handleNominatorPositionsSync's
+  // own 400-before-503 reasoning).
+  if (!env.METAGRAPH_HEALTH_DB) {
+    return writeJson({ error: "d1 binding unavailable" }, 503);
+  }
+
+  let d1Statements: number;
+  try {
+    ({ statements: d1Statements } = await writeAccountBalancesToD1(
+      env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+        typeof writeAccountBalancesToD1
+      >[0],
+      rows,
+    ));
+  } catch (err) {
+    console.error("data-api account-balances-sync D1 write failed:", err);
+    await captureDataApiError(err, "account-balances-sync-d1", env);
+    return writeJson({ error: "d1 write failed" }, 502);
+  }
+
+  return writeJson({
+    ok: true,
+    account_balances_written: rows.length,
+    stores: ["d1"],
+    d1_statements: d1Statements,
+  });
 }
 
 // --- POST /api/v1/internal/subnet-identity-sync (#4832 gap-closure) -------

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -864,6 +864,12 @@
       // alerts on every stale one -- see TOP_HOLDERS_STALENESS_WATCHDOG_CRON in
       // workers/config.ts.
       "22,52 * * * *",
+      // 4,34 = the account-balances staleness watchdog (#9469): the SOURCE side
+      // of the watchdog above. That one watches the served artifact; this one
+      // watches the D1 table it is composed from, so a producer that stops is
+      // visible without waiting for the publish path to notice. See
+      // ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON in workers/config.ts.
+      "4,34 * * * *",
     ],
   },
   // Per-client abuse control for the read-only RPC proxy (an abuse prerequisite


### PR DESCRIPTION
Closes #9478. Part of #9469. Producer half merged as metagraphed-infra#310.

`free_tao` is the one top-holders column with no producer anywhere — and not
because the scan stopped. metagraphed-infra's poller still walks
`System::Account` correctly on its 6h tick, then hands the result to
`tokio_postgres` for a COPY-to-staging + upsert against the decommissioned
box's instance. `account_balances` was never among D1's 42 tables,
`handleAccountBalancesSync` has stopped at its auth gate since #9193, and
`/api/v1/accounts/top-holders` has answered from a one-shot 2026-08-02
materialization ever since: an account that has moved TAO since is misreported,
one first funded since is absent, and `captured_at` cannot advance.

**This is the sink half.** Composing the leaderboard from the three live sources
and restoring the `net_flow_*` ranking stay in #9469.

## What's here

| | |
|---|---|
| `migrations/d1/0017_account_balances.sql` | `ss58`, `free_tao`, `reserved_tao`, `captured_at`. Upsert-only on `(ss58)`, no prune, `captured_at DESC` index for the watchdog. |
| `src/account-balances-d1-write.ts` | The writer, structural parts imported from `neurons-d1-write.ts` so the 100-bound-parameter budget lives in one place. |
| `workers/data-api.ts` | `handleAccountBalancesSync` revived against D1. 25,000 rows / 8 MB, matching the siblings. |
| `src/account-balances-staleness-watchdog.ts` + `4,34` | The lane's alarm. |

## Three decisions worth reading

**The absent prune is load-bearing, not incidental.** The producer skips an
account whose free *and* reserved are both zero — existential-deposit-only and
reaped accounts keep a real `System::Account` entry full of zeros — so "absent
from a pass" means "was not written", never "has no balance". Pruning on absence
would delete exactly the wallets that emptied. `nominator_positions` prunes
per-coldkey because an unstaked position genuinely stops existing; that
reasoning does not transfer, and `validator_nominator_counts`' upsert-only shape
is the right sibling to copy. Asserted directly in
`tests/data-api-account-balances-d1.test.ts` and
`tests/account-balances-d1-write.test.ts`.

**Balances are `REAL`, not `TEXT`.** The producer computes an exact decimal
string (`rao_to_tao_exact`) because `rao as f64 / 1e9` loses sub-rao precision
above 2\*\*53 rao (~9.007M TAO). Storing that verbatim would preserve precision
the serve path (`src/top-holders.ts`'s `numberOrZero`) discards one step later —
and would make every ranking query sort lexicographically, so "9" outranks "10".
The whole point of this column is a leaderboard. `REAL` keeps full rao precision
for every balance under ~9M TAO, against a 21M total supply.

**The watchdog is the source-side sibling of `top-holders-staleness-watchdog`,
not a replacement.** That one watches the *served artifact*; this one watches
the *D1 table it is composed from*. They fail independently and the difference
is the repair: a fresh table behind a stale artifact is a publish problem, a
stale table behind either is the producer. Watching only the artifact is what
let the underlying lane's absence stay invisible in the first place. Twelve
hours, sized to the producer's six-hour `ACCOUNT_BALANCES_POLL_SECS` — the same
sizing rule #9301 had to correct on the nominator-positions lane after a
threshold set tighter than its producer alerted for three quarters of every day.

## Already done outside the diff

- `migrations/d1/0017` is applied to the live `metagraphed` D1 (migrations here
  are applied by hand) and verified against `sqlite_master` — table and index
  both present.
- `ACCOUNT_BALANCES_SYNC_SECRET` generated and set on **both**
  `metagraphed-data-api` and `metagraphed-poller`. Staged via
  `wrangler versions secret put` on the data-api rather than `secret put`,
  deliberately: the Worker had an undeployed version carrying a commit that is
  not on `main`, and deploying to set a secret would have shipped it. The next
  Builds deploy inherits the secret alongside this handler, which is the correct
  ordering anyway.
- Producer converted and merged: metagraphed-infra#310.

## Validation

- `npm run lint` · `format:check` · `typecheck` — clean.
- `npm run validate` — 129 subnets / 3442 surfaces, clean.
- `npm run validate:contract-drift` — passed.
- `npx vitest run` — **672 files, 16,012 tests passed**.
- `npm run test:coverage` + diff intersection against `origin/main` for `src/**`
  and `workers/**`: **139/139 lines and branches, 100.00%**.

  ```
  src/account-balances-d1-write.ts:            4/4 lines,  2/2 branches
  src/account-balances-staleness-watchdog.ts: 21/21 lines, 27/27 branches
  workers/api.ts:                              4/4 lines,  4/4 branches
  workers/config.ts:                           1/1 lines,  0/0 branches
  workers/data-api.ts:                        40/40 lines, 36/36 branches
  ```

No contract change, so no regenerated artifacts. `public/metagraph/r2-manifest.json`
and `public/metagraph/schemas/index.json` are reverted against `origin/main` and
are not in this diff.
