### PR TITLE
fix(chain-events): serve the block-hash form instead of 503ing it

### DIFF
--- a/src/chain-events-degraded.ts
+++ b/src/chain-events-degraded.ts
@@ -56,6 +56,26 @@ import {
 type Row = Record<string, unknown>;
 
 const BLOCK_CHAIN_EVENTS = /^\/api\/v1\/blocks\/(\d+)\/chain-events$/;
+/**
+ * The same route, admitting the `0x` block-hash form of `{ref}`.
+ *
+ * The ROUTER already accepts a hash (`BLOCK_CHAIN_EVENTS_PATH_PATTERN`,
+ * workers/config.ts), and so does every reader underneath -- `answerBlockDetail`
+ * resolves a hash ref, and `loadBlockChainEventsColdTier` puts it through
+ * `resolveBlockHeight`. Only the tier MATCHER below was numeric-only, so a
+ * hash-form request routed in, matched no tier, asked no store, and fell out of
+ * `handleChainEventsFamily` as a 503 `data_tier_unavailable` -- a status that
+ * says "retry, this is temporary" for a request that could never succeed. That
+ * is what crawlers walking `/blocks/{hash}/chain-events` kept retrying, and why
+ * the sibling `/blocks/{ref}/events` served the same hash correctly all along.
+ *
+ * Deliberately a SECOND constant rather than a widened first: the degraded
+ * builder above pairs its match with a non-nullable `block_number`, which a
+ * hash cannot supply without a lookup. Keeping that one numeric means the
+ * widened form is used only where a ref is actually resolved.
+ */
+const BLOCK_CHAIN_EVENTS_REF =
+  /^\/api\/v1\/blocks\/(\d+|0x[0-9a-fA-F]{64})\/chain-events$/;
 const SUBNET_OWNERSHIP_HISTORY =
   /^\/api\/v1\/subnets\/(\d+)\/ownership-history$/;
 const SUBNET_CONVICTION = /^\/api\/v1\/subnets\/(\d+)\/conviction$/;
@@ -318,7 +338,7 @@ export async function hotTierBlockChainEvents(
   /** Which chain to read (#8700). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<ChainDetailAnswer<BlockChainEventsPayload> | null> {
-  const block = BLOCK_CHAIN_EVENTS.exec(url.pathname);
+  const block = BLOCK_CHAIN_EVENTS_REF.exec(url.pathname);
   if (!block) return null;
   return answerBlockDetail<BlockChainEventsPayload>(
     env,

--- a/tests/chain-events-degraded.test.ts
+++ b/tests/chain-events-degraded.test.ts
@@ -593,6 +593,56 @@ describe("block chain-events routes to the lakehouse off mainnet", () => {
   });
 });
 
+// The router has always admitted the `0x` hash form of {ref}, and so has every
+// reader underneath -- only the tier matcher was numeric-only. A hash therefore
+// routed in, matched no tier, asked NO STORE, and fell out of
+// handleChainEventsFamily as a 503 `data_tier_unavailable`: a retry-me status
+// for a request that could never succeed, which is what the crawlers walking
+// /blocks/{hash}/chain-events kept retrying against.
+describe("the 0x block-hash form of {ref} reaches a tier", () => {
+  const HASH = "0x" + "ab".repeat(32);
+
+  test("a hash-form path is matched and actually queries a store", async () => {
+    const queries: string[] = [];
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      queries.push(String(JSON.parse(String(init.body)).query));
+      return {
+        ok: true,
+        json: async () => ({ success: true, result: { rows: [] } }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    const env = mockEnv({ [R2_SQL_TOKEN_ENV]: "cfut_test" }) as unknown as Env;
+
+    const answer = await hotTierBlockChainEvents(
+      env,
+      new URL(`https://api.metagraph.sh/api/v1/blocks/${HASH}/chain-events`),
+      "testnet",
+    );
+
+    assert.notEqual(
+      answer,
+      null,
+      "a null here is the routing miss that became a 503 nothing could retry away",
+    );
+    assert.ok(
+      queries.length > 0,
+      "the point of matching is that a store gets asked at all",
+    );
+  });
+
+  test("a malformed hash is still not this route", async () => {
+    // 63 hex chars: close enough to prove the guard is the pattern, not a
+    // prefix check that would admit anything starting 0x.
+    const answer = await hotTierBlockChainEvents(
+      mockEnv() as unknown as Env,
+      new URL(
+        `https://api.metagraph.sh/api/v1/blocks/0x${"ab".repeat(31)}c/chain-events`,
+      ),
+    );
+    assert.equal(answer, null);
+  });
+});
+
 // Off mainnet there is no second source to fall back to, so a lakehouse read
 // that FAILS is a miss, not an empty block. The distinction is the whole point
 // of #9260: `events: []` for a block with 400 of them reads as a quiet chain.

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -563,12 +563,15 @@ export const BLOCK_EXTRINSICS_PATH_PATTERN =
 export const BLOCK_EVENTS_PATH_PATTERN =
   /^\/api\/v1\/blocks\/(\d+|0x[0-9a-fA-F]{64})\/events$/;
 // Per-block RAW pallet events (#1620), the all-events tier's sibling to
-// /events above. Dispatched inline in workers/api.ts by a numeric-only literal
-// regex; this named copy exists so isMainnetOnlyApiPath can reference the same
-// shape as its BLOCK_* neighbours rather than open-coding a third variant.
-// Accepts the hash form too, matching every other {ref} route -- the dispatch
-// site's numeric-only pattern is narrower, and a hash-form request is a 404
-// either way, so the wider shape here cannot admit anything the router serves.
+// /events above. Accepts the hash form, matching every other {ref} route.
+//
+// This pattern's width used to be justified by "a hash-form request is a 404
+// either way". It was not: it routed the request into handleChainEventsFamily,
+// whose tier matcher was numeric-only, so a hash asked no store and fell out as
+// a 503 `data_tier_unavailable`. The tier matcher now admits the same shape
+// this does (BLOCK_CHAIN_EVENTS_REF in src/chain-events-degraded.ts), so the
+// two agree and a hash is served -- or declines with the typed
+// `block_detail_unavailable` 503 the contract documents.
 export const BLOCK_CHAIN_EVENTS_PATH_PATTERN =
   /^\/api\/v1\/blocks\/(\d+|0x[0-9a-fA-F]{64})\/chain-events$/;
 // Block-explorer extrinsic routes (#1345 second slice): recent feed + per-extrinsic


### PR DESCRIPTION
## Summary

- `GET /api/v1/blocks/{0x…64hex}/chain-events` returned **503 `data_tier_unavailable`** for every block hash, valid ones included — a steady production stream driven by crawlers walking block-hash links.
- The router admitted a shape the tier matcher rejected, so the request **asked no store at all** (`cpuTimeMs: 1`) and fell out of the handler as a retry-me status it could never succeed at.

## What Changed

- **`src/chain-events-degraded.ts`** — adds `BLOCK_CHAIN_EVENTS_REF` (`\d+|0x[0-9a-fA-F]{64}`), the shape the router already uses, and switches `hotTierBlockChainEvents` to it.
- **`workers/config.ts`** — corrects the comment that justified the wide router pattern with *"a hash-form request is a 404 either way"*. It was a 503, and that pattern is what admitted it.
- **`tests/chain-events-degraded.test.ts`** — a regression test plus a negative control.

## The trace

| Where | Pattern | Hash? |
|---|---|---|
| `workers/config.ts:572` `BLOCK_CHAIN_EVENTS_PATH_PATTERN` | `(\d+\|0x[0-9a-fA-F]{64})` | **yes** |
| `src/chain-events-degraded.ts:58` `BLOCK_CHAIN_EVENTS` (before) | `(\d+)` | **no** |

A hash was admitted by the router (`workers/api.ts:5627`), missed `hotTierBlockChainEvents` → missed `coldTierChainEventsPayload` → missed `degradedChainEventsPayload` → 503 at `workers/api.ts:2311`.

Everything underneath already handled a hash: `answerBlockDetail` resolves a hash ref, and `loadBlockChainEventsColdTier` (`src/events-cold-tier.ts:327`) puts it through `resolveBlockHeight`. The sibling `/blocks/{ref}/events` served the same hash correctly all along — two views of one block behaving differently.

**Why the status mattered:** 503 means "retry, this is temporary". Well-behaved crawlers therefore retried forever, and `errorResponse` sets `cache-control: no-store` (`workers/http.ts:115`), so nothing amortised at the edge — every retry re-ran the rate-limit binding subrequest and a cache miss. That is the volume.

After this, a hash is served, or declines with the typed `block_detail_unavailable` 503 the contract already documents (`src/contracts.ts:4025`) for a block neither tier can read.

## The degraded builder stays numeric-only, deliberately

`degradedChainEventsPayload` pairs its match with a **non-nullable** `block_number`, which a hash cannot supply without a lookup. Only the matcher used where a ref actually gets resolved widens. Making `block_number` nullable so the empty payload could describe an unresolvable hash would be a public contract change, and this route declines rather than degrading anyway.

## Verification

The regression test was **proven to catch the bug, not assumed to**: with `hotTierBlockChainEvents` pointed back at the numeric-only pattern it fails (`1 failed | 33 skipped`); restored, it passes.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9482`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None changed.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. **No schema change** — `{ref}` is already declared `{type: "string"}` in `src/contracts.ts:4029`; this only makes the implementation match the route the contract already publishes. `npm run validate:api` green over 190 routes.

## Validation

- [x] `npm run lint` · `npx prettier --check` on all three changed files
- [x] `npm run typecheck`
- [x] `npm run validate:api` — 190 Worker API routes validated
- [x] `npx vitest run tests/chain-events-degraded.test.ts` — 34 passed
- [x] `git diff --check` clean
- [x] Patch coverage: **100% of changed lines**, verified by diff intersection rather than by whole-file percentage. `src/chain-events-degraded.ts` reports 100% branches and one uncovered line (the `hot:` closure) — confirmed pre-existing by re-running the same coverage command against `main`, which reports the identical function uncovered at the same statement. This PR adds no uncovered line.

Closes #9482
