### PR TITLE
fix(artifacts): stop spending an R2 miss to learn what the contract already knew

### DIFF
--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -5207,6 +5207,54 @@ export const MAINNET_ONLY_ROUTE_PATHS: readonly string[] = [
   "/api/v1/incidents",
 ];
 
+// Parameters whose value space is finite and enumerable at build time. Anything
+// else makes an artifact unbakeable BY DEFINITION rather than by effort -- the
+// key space of {ref}/{ss58}/{hash}/{uid}/{h160} is every block, account,
+// extrinsic and address that has ever existed.
+const BOUNDED_ARTIFACT_PARAMS: ReadonlySet<string> = new Set(["netuid", "tag"]);
+
+/**
+ * Artifact path template -> the live route that answers it, for artifacts that
+ * are computed live AND unbounded, i.e. the ones for which NO file is ever
+ * written at any key.
+ *
+ * Both halves of that predicate matter. `computed` alone is not enough: a
+ * computed artifact whose parameters are bounded ({netuid}, {tag}) IS baked to
+ * R2 by scripts/bake-computed-artifacts.ts and must still be read from there.
+ * It is the unbounded ones that no build can ever produce.
+ *
+ * DERIVED from the two contracts above rather than listed, for the same reason
+ * COMPUTED_ARTIFACT_IDS is: a third hand-maintained list is how a route gets
+ * renamed and leaves a stale orphan behind.
+ */
+const LIVE_ONLY_ARTIFACT_ROUTES: ReadonlyMap<string, string> = new Map(
+  PUBLIC_ARTIFACTS.filter(
+    (entry) =>
+      entry.computed &&
+      [...entry.path.matchAll(/\{(\w+)\}/g)].some(
+        (m) => !BOUNDED_ARTIFACT_PARAMS.has(m[1]!),
+      ),
+  ).flatMap((entry) => {
+    const live = API_ROUTES.find((r) => r.artifact_path === entry.path);
+    return live ? [[entry.path, live.path] as [string, string]] : [];
+  }),
+);
+
+/**
+ * The live route serving this artifact path, when the artifact is computed live
+ * with unbounded parameters -- otherwise null.
+ *
+ * A caller that gets a route back should NOT read R2 for the artifact: nothing
+ * has ever written it, and nothing ever will. `/metagraph/blocks/{ref}.json` is
+ * the case that made this worth having -- every request for it cost one R2
+ * GetObject miss (two when the pointer names a run prefix) before answering the
+ * 404 that was knowable without asking, and the site's own block pages link it,
+ * so crawlers walk it continuously (#9485).
+ */
+export function liveOnlyArtifactRoute(artifactPath: string): string | null {
+  return LIVE_ONLY_ARTIFACT_ROUTES.get(artifactPath) ?? null;
+}
+
 const MAINNET_ONLY_ROUTE_SET = new Set(MAINNET_ONLY_ROUTE_PATHS);
 
 /** Is this route template mainnet-only? */

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -1206,6 +1206,63 @@ describe("live health overlay (rpc-endpoints + freshness)", () => {
     assert.equal(reads, 0);
   });
 
+  // Computed-live artifacts with unbounded parameters have no file at any key
+  // and never will, so reading R2 to discover that spent a GetObject miss (two
+  // when the pointer names a run prefix) on a 404 the contract already knew.
+  // /metagraph/blocks/{ref}.json is linked from the site's own block pages, so
+  // crawlers walked it continuously and it became the largest single source of
+  // R2 errors in the Worker log.
+  test("a computed-live artifact answers from the contract, without touching R2", async () => {
+    let reads = 0;
+    const env = createLocalArtifactEnv({
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          reads += 1;
+          return null;
+        },
+      },
+    });
+    for (const path of [
+      "/metagraph/blocks/8090851.json",
+      "/metagraph/accounts/5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY.json",
+    ]) {
+      const res = await handleRequest(req(path), env as unknown as Env, {});
+      assert.equal(res.status, 404, path);
+      const body = (await res.json()) as {
+        error: { code: string };
+        live_route?: string;
+      };
+      assert.equal(body.error.code, "artifact_computed_live", path);
+    }
+    assert.equal(reads, 0, "the miss was knowable without asking the store");
+  });
+
+  test("a BOUNDED computed artifact is still read from R2", async () => {
+    // {netuid} is enumerable, so bake-computed-artifacts DOES write this one --
+    // the guard must key on unbounded parameters, not on `computed` alone, or
+    // it would blind a tier that genuinely has files.
+    let reads = 0;
+    const env = createLocalArtifactEnv({
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          reads += 1;
+          return null;
+        },
+      },
+    });
+    const res = await handleRequest(
+      req("/metagraph/subnets/7.json"),
+      env as unknown as Env,
+      {},
+    );
+    assert.notEqual(
+      (await res.json())?.error?.code,
+      "artifact_computed_live",
+      "a bounded computed artifact is baked and must still be read",
+    );
+    assert.ok(reads > 0, "R2 must still be consulted for artifacts that exist");
+  });
+
   test("/api/v1/subnets/:netuid/health ignores stale static R2 objects", async () => {
     let reads = 0;
     const env = createLocalArtifactEnv({

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -5,6 +5,7 @@ import {
   PUBLIC_ARTIFACTS,
   artifactPathFromTemplate,
   compileRoutePattern,
+  liveOnlyArtifactRoute,
 } from "../src/contracts.ts";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -5790,7 +5791,8 @@ async function handleRawArtifactRequest(
   url: URL,
   network: typeof DEFAULT_NETWORK = DEFAULT_NETWORK,
 ) {
-  if (!matchRawArtifact(url.pathname)) {
+  const matched = matchRawArtifact(url.pathname);
+  if (!matched) {
     return errorResponse(
       "not_found",
       "No public artifact contract matched this path.",
@@ -5812,6 +5814,30 @@ async function handleRawArtifactRequest(
       "Current-state health artifacts are retired; use the live API health endpoints instead.",
       410,
       { artifact_path: networkPath },
+    );
+  }
+  // Computed-live artifacts with UNBOUNDED parameters have no file at any key
+  // and never will -- {ref}/{ss58}/{hash} span every block, account and
+  // extrinsic that has ever existed, so the build cannot enumerate them and
+  // scripts/bake-computed-artifacts.ts explicitly does not try.
+  //
+  // Reading R2 to discover that cost a GetObject miss per request (two when the
+  // KV pointer names a run prefix, via readR2Object's `latest/` recovery read)
+  // and answered a 404 that was knowable from the contract without asking.
+  // /metagraph/blocks/{ref}.json is the one that showed up: the site's own block
+  // pages render it as a real link, so crawlers walk it continuously, and it was
+  // the single largest source of R2 errors in the Worker log (#9485).
+  //
+  // Same posture as the retired-health branch above -- decide from the contract,
+  // before any store is touched -- but a 404 rather than a 410: the resource is
+  // not gone, it is served live at the route named in the payload.
+  const liveRoute = liveOnlyArtifactRoute(matched.path);
+  if (liveRoute) {
+    return errorResponse(
+      "artifact_computed_live",
+      `This artifact is computed live and is never written as a file. Fetch ${liveRoute} instead.`,
+      404,
+      { artifact_path: networkPath, live_route: liveRoute },
     );
   }
   const artifact = await readArtifact(env, networkPath);
@@ -6802,8 +6828,10 @@ async function handleApiRequest(
   return response;
 }
 
+/** The matched artifact entry, so a caller can consult its contract (is it
+ * computed live?) and not just whether the path is shaped like one. */
 function matchRawArtifact(pathname: string) {
-  return RAW_ARTIFACT_ROUTES.some((candidate) =>
+  return RAW_ARTIFACT_ROUTES.find((candidate) =>
     candidate.pattern.test(pathname),
   );
 }


### PR DESCRIPTION
## Summary

- The **largest single source of R2 errors** in the Worker log was `GetObject` on `latest/blocks/<height>.json` — a key nothing has ever written and nothing ever will.
- `handleRawArtifactRequest` read R2 before consulting the contract, spending 1–2 GetObject misses per request to answer a 404 that was knowable without touching a store.

## What Changed

- **`src/contracts.ts`** — `liveOnlyArtifactRoute(artifactPath)`, derived from `PUBLIC_ARTIFACTS` + `API_ROUTES`: the live route serving an artifact that is computed live **with unbounded parameters**, else `null`.
- **`workers/api.ts`** — `matchRawArtifact` now returns the matched entry rather than a boolean, and `handleRawArtifactRequest` answers from the contract before any read.
- **`tests/api-coverage.test.ts`** — one test asserting the answer arrives with `reads === 0`, one pinning the bounded-artifact boundary.

## Why the key can never exist

`/metagraph/blocks/{ref}.json` is `COMPUTED_LIVE` (`src/contracts.ts:1702-1708`), description *"(no static file)"*, and `src/artifact-storage.ts:238-240` documents it as never written. `scripts/bake-computed-artifacts.ts:22-27` explicitly refuses it: *"Routes whose path parameters are unbounded — {ss58}, {hotkey}, {hash}, {ref}, {uid}, {h160} — are not bakeable."* A local build produces no `blocks/` directory at all.

The read cost: `METAGRAPH_ARCHIVE.get` (`workers/storage.ts:294`) → miss; when the KV pointer names a run prefix, a **second** `latest/`-prefixed recovery read (`workers/storage.ts:325-333`) → miss again; → `404 artifact_not_found`. No negative cache exists on that path (`pointerMemo`/`runManifestMemo` cache pointers, not misses), so every request repeats it.

The volume isn't incidental: `apps/ui/src/components/metagraphed/api-source-footer.tsx:20,35` renders this URL as a real anchor on every block page, so crawlers walk it continuously.

## The predicate is `computed AND unbounded` — never `computed` alone

A computed artifact with bounded parameters (`{netuid}`, `{tag}`) **is** baked to R2 and must still be read from there. Keying on `computed` alone would blind a tier that genuinely has files. Verified against the live contract:

```
/metagraph/blocks/{ref}.json            -> /api/v1/blocks/{ref}     (guarded)
/metagraph/subnets/{netuid}.json        -> null                     (baked, still read)
/metagraph/endpoints.json               -> null                     (not computed)
/metagraph/domains/{tag}/summary.json   -> null                     (bounded)
```

A test pins that boundary, so a future widening of the guard fails rather than silently 404ing a tier with real files.

## Scope

It resolves **38 artifact families**, not just blocks — `accounts/{ss58}*`, `validators/{hotkey}*`, `subnets/{netuid}/neurons/{uid}*`, `extrinsics/{hash}`, `surfaces/{surface_id}/verify`, and the `/blocks/{ref}/*` siblings are all the same shape.

Derived rather than listed, for the reason `COMPUTED_ARTIFACT_IDS` already documents at `src/contracts.ts:2143-2149`: a third hand-maintained list is how a renamed route leaves a stale orphan behind.

## Status choice

404, not 410 — the resource is not gone, it is served live — and the payload carries `live_route` so a caller gets something actionable. Same posture as the retired-health branch immediately above (`workers/api.ts:5809-5815`), which likewise decides before any read.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9485`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None changed.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. **No contract data changed** — only a derived helper added. `validate:contract-drift`, `validate:openapi` (190 routes + 24 feeds + 106 variants) and `validate:types` all green.

## Validation

- [x] `npm run lint` · `npx prettier --check` on all three changed files
- [x] `npm run typecheck`
- [x] `npm run validate:contract-drift` · `npm run validate:openapi` · `npm run validate:types`
- [x] `npx vitest run tests/api-coverage.test.ts tests/contracts.test.ts tests/invariants-contracts.test.ts` — 341 passed
- [x] `git diff --check` clean
- [x] Patch coverage: **100% of changed lines in both `src/contracts.ts` and `workers/api.ts`**, measured by diff intersection (changed hunks parsed from `git diff -U0`, intersected against the v8 statement map) rather than by whole-file percentage — zero uncovered lines inside any changed hunk.

Closes #9485
