### PR TITLE
fix(firehose): release the SSE slot when the subscriber is provably gone

### DIFF
--- a/tests/chain-firehose-hub.test.ts
+++ b/tests/chain-firehose-hub.test.ts
@@ -1185,6 +1185,38 @@ test("ChainFirehoseHub broadcast: dropping a stalled SSE client also releases it
   await res.body!.cancel();
 });
 
+// The per-IP quota is only meaningful if a slot comes back when its subscriber
+// goes away. cancel() covers the consumer-side disconnect and the lifetime
+// timeout covers the hour cap, but neither covers the UA-dependent case the
+// heartbeat's own catch was written for: the stream is gone and cancel() never
+// fired. That used to be swallowed, so the slot sat occupied for up to an hour
+// and 20 such ghosts returned 503 to a caller with nothing live at all.
+test("ChainFirehoseHub /subscribe (SSE): a heartbeat that cannot enqueue releases the per-IP slot", async () => {
+  vi.useFakeTimers();
+  try {
+    const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
+    const res = await hub.fetch(subscribeRequest("203.0.113.9"));
+    assert.equal(hub.sseClientsByIp.get("203.0.113.9"), 1);
+
+    // The runtime closed the stream without invoking cancel() -- exactly the
+    // case the catch exists for. The next heartbeat's enqueue now throws.
+    const entry = [...hub.sseClients][0]!;
+    entry.controller.close();
+
+    await vi.advanceTimersByTimeAsync(CHAIN_FIREHOSE_SSE_HEARTBEAT_INTERVAL_MS);
+
+    assert.equal(hub.sseClients.size, 0, "the dead entry is still registered");
+    assert.equal(
+      hub.sseClientsByIp.has("203.0.113.9"),
+      false,
+      "the quota slot is still held by a subscriber that no longer exists",
+    );
+    await res.body!.cancel();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
 test("ChainFirehoseHub.addSseClient: a second connection from the same IP increments rather than overwrites the count", () => {
   const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
   hub.addSseClient({ ip: "203.0.113.9" } as unknown as SseEntryLike);

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -1291,18 +1291,36 @@ export class ChainFirehoseHub implements DurableObject {
             }
           }
 
-          // #8364: heartbeat. A `try` around the enqueue because a client
-          // that disconnected without the runtime having called cancel() yet
-          // (a real possibility -- cancel() timing is UA-dependent) would
-          // otherwise throw here and leave the interval itself still
-          // running; the catch is a no-op because cancel()/the lifetime
-          // timeout below are what actually clear this interval; this just
-          // keeps one late tick from crashing the DO.
+          // #8364: heartbeat. A `try` around the enqueue because a client that
+          // disconnected without the runtime having called cancel() yet (a real
+          // possibility -- cancel() timing is UA-dependent) would otherwise
+          // throw here and leave the interval itself still running.
+          //
+          // The catch RELEASES rather than doing nothing. A throwing enqueue is
+          // not noise to be swallowed: it is the disconnect signal for exactly
+          // the case cancel() did not cover, and it is the only one that
+          // arrives promptly. Waiting instead for the lifetime timeout meant a
+          // client that had already vanished held its per-IP slot for up to an
+          // hour, so 20 such ghosts returned 503 "too many connections" to a
+          // caller with no live connections at all -- a quota spent on
+          // subscribers that no longer exist (#9489). Releasing here bounds
+          // that at one heartbeat interval instead.
+          //
+          // Safe against the other three release paths: removeSseClient is
+          // idempotent (it returns early when the entry is already gone) and
+          // clears this very interval, so a later cancel() or lifetime timeout
+          // cannot double-release, whichever order they land in.
           entry.heartbeatTimer = setInterval(() => {
             try {
               controller.enqueue(encoder.encode(": heartbeat\n\n"));
             } catch {
-              // see comment above
+              try {
+                controller.close();
+              } catch {
+                // already closed by the runtime -- the release below is what
+                // this tick is actually here for.
+              }
+              this.removeSseClient(entry);
             }
           }, CHAIN_FIREHOSE_SSE_HEARTBEAT_INTERVAL_MS);
 


### PR DESCRIPTION
## Summary

- The chain firehose returns **503 "too many connections"** to callers that hold **no live connections at all**, because a per-IP quota slot outlives the subscriber holding it — for up to an hour.
- The disconnect signal that would have released it was being swallowed.

## What Changed

- **`workers/chain-firehose-hub.ts`** — the SSE heartbeat's `catch` now closes the controller and calls `removeSseClient(entry)` instead of doing nothing.
- **`tests/chain-firehose-hub.test.ts`** — a regression test for the exact case.

## The defect

`removeSseClient` is reached from three paths: the stream's `cancel()`, the lifetime timeout, and `broadcast()`'s stall/throw cleanup. None of them covers the case the heartbeat's own comment describes — *"a client that disconnected without the runtime having called cancel() yet (a real possibility — cancel() timing is UA-dependent)"*:

```ts
try {
  controller.enqueue(encoder.encode(": heartbeat\n\n"));
} catch {
  // see comment above          <-- swallowed
}
```

A throwing `enqueue` **is** the disconnect signal for that case, and it is the only one that arrives promptly. Swallowing it left the entry in `sseClients`/`sseClientsByIp` until either `broadcast()` happened to notice (needs the queue past its 64-frame high-water mark) or the **1-hour** `CHAIN_FIREHOSE_SSE_MAX_CONNECTION_LIFETIME_MS` timer fired.

`CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP` is **20**. Twenty ghosts and that IP is locked out while holding nothing.

The frontend is what makes it bite: `useChainStream` has six call sites, each its own `EventSource`, multiplied by tabs and by `EventSource`'s native fast auto-reconnect (only downgraded to 5-minute backoff after 3 consecutive failures). 20 arrives quickly, and every reconnect can leave another ghost behind.

## Why this is safe

`removeSseClient` returns early once the entry is deleted and clears this very interval, so a later `cancel()` or lifetime timeout cannot double-release, whichever order they land in. The release bounds a ghost's hold at one heartbeat interval (15 s) instead of an hour.

The firehose itself is healthy, for the record — the Postgres `NOTIFY` upstream is retired (#9426/#9429), but `ChainFirehoseHub.alarm()` polls chain head every ~6 s and production enables it (`wrangler.jsonc:501-502`). This is purely slot exhaustion, not a dead feed.

## Verification

The test was **proven to catch the bug, not assumed to**: with the source change reverted (test kept) it fails; restored, it passes. It simulates the real case directly — closing `entry.controller` out-of-band so `cancel()` never fires, then advancing one heartbeat interval.

## Deliberately not in this PR

1. **`resolveClientIp`'s shared `"anonymous"` bucket** (`workers/config.ts:656-658`) — where `cf-connecting-ip` is absent, every client shares one bucket's 20 slots. There is already a test asserting that behaviour, so changing it is a decision, not a bug fix.
2. **The untyped 503** — a bare `new Response("too many connections", …)` at four sites whose comments call the identical shape intentional. Giving it a typed code and `Retry-After` belongs in its own change.
3. **Topics with no live producer** — `extrinsics`, `chain_events`, `account_events` are still accepted but nothing has broadcast them since the Postgres trigger retired; a subscriber gets a 200 that never emits.

All three are recorded on #9489.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9489`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None changed.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — connection lifecycle only, no route or schema surface.)

## Validation

- [x] `npm run lint` · `npx prettier --check` on both changed files
- [x] `npm run typecheck`
- [x] `npx vitest run tests/chain-firehose-hub.test.ts tests/chain-firehose-routes.test.ts` — 172 passed
- [x] `git diff --check` clean
- [x] Patch coverage: **100% of changed lines**, measured by diff intersection (changed hunks from `git diff -U0` intersected against the v8 statement map) — zero uncovered lines inside either changed hunk.

Closes #9489
