### PR TITLE
fix(api): answer an external consumer's seven interface defects across REST, MCP and the permit model

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -5338,6 +5338,7 @@ export type SubnetValidatorEconomics = {
   degraded_reason?: Maybe<Scalars['String']['output']>;
   earning_entry_cost_tao?: Maybe<Scalars['Float']['output']>;
   earning_floor_cost_tao?: Maybe<Scalars['Float']['output']>;
+  /** The smallest stake that actually EARNS dividends here, excluding the subnet owner -- its permit is unconditional, so an owner earning on ~0 stake would report a floor of 0. Null when NO non-owner has earned on this subnet, which is a real answer (the owner is taking the dividends), not a missing one. */
   earning_floor_units?: Maybe<Scalars['Float']['output']>;
   /** Reported, never scored. Gate-closed subnets still emit alpha at a comparable rate and are less contested, so per unit of stake they pay MORE -- the gate is an exit-liquidity question, not an eligibility one. */
   emission_gate_open?: Maybe<Scalars['Boolean']['output']>;

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -5671,7 +5671,13 @@ export type ValidatorEconomicsHistoryPoint = {
   __typename?: 'ValidatorEconomicsHistoryPoint';
   earning_floor_alpha?: Maybe<Scalars['Float']['output']>;
   emission_gate_open?: Maybe<Scalars['Boolean']['output']>;
+  /** The validator cap in force on this day. permit_floor_alpha is the observed floor REGARDLESS of cap state, so it cannot be read without this -- and joining today's cap onto an old point is wrong for any subnet whose cap moved. */
+  max_validators?: Maybe<Scalars['Int']['output']>;
+  /** Where max_validators came from: observed = the hyperparameter change-log recorded it at or before this day; current = the change-log does not reach this far back, so the LIVE cap is reported. */
+  max_validators_source?: Maybe<Scalars['String']['output']>;
   permit_floor_alpha?: Maybe<Scalars['Float']['output']>;
+  /** Whether the permit set was full on this day (validators_permitted >= max_validators). NOT the same measure as the current record's cap_binding, which counts UIDs clearing the threshold against slots -- only the permitted set survives in a daily snapshot. */
+  permit_set_full?: Maybe<Scalars['Boolean']['output']>;
   snapshot_date: Scalars['String']['output'];
   tao_inflow_per_day?: Maybe<Scalars['Float']['output']>;
   validators_active: Scalars['Int']['output'];
@@ -9838,7 +9844,10 @@ export type ValidatorEconomicsExclusionResolvers<ContextType = GqlContext, Paren
 export type ValidatorEconomicsHistoryPointResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ValidatorEconomicsHistoryPoint'] = ResolversParentTypes['ValidatorEconomicsHistoryPoint']> = ResolversObject<{
   earning_floor_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   emission_gate_open?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  max_validators?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  max_validators_source?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   permit_floor_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  permit_set_full?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   snapshot_date?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   tao_inflow_per_day?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   validators_active?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -8739,7 +8739,7 @@ export interface components {
                 as_of: string | null;
                 id: string;
                 /** @enum {string} */
-                lane: "adapter-snapshot" | "candidate-discovery" | "candidate-verification" | "health-probe" | "native-data" | "schema-snapshot";
+                lane: "adapter-snapshot" | "candidate-discovery" | "candidate-verification" | "health-probe" | "native-data" | "schema-snapshot" | "economics" | "live-rpc";
                 notes?: string;
                 path: string;
                 required_for_publish: boolean;
@@ -8756,8 +8756,10 @@ export interface components {
                 adapter_snapshot_as_of: string | null;
                 blocking_source_count: number;
                 candidate_discovery_as_of: string | null;
+                economics_as_of?: string | null;
                 health_probe_as_of: string | null;
                 health_surface_count: number;
+                live_rpc_as_of?: string | null;
                 missing_blocking_source_count: number;
                 native_data_as_of: string;
                 native_snapshot_captured_at: string;
@@ -19665,7 +19667,7 @@ export interface operations {
                      *             "lane": "adapter-snapshot",
                      *             "path": "example",
                      *             "required_for_publish": true,
-                     *             "stale_after_hours": 1,
+                     *             "stale_after_hours": 0.5,
                      *             "stale_behavior": "block",
                      *             "status": "captured",
                      *             "timestamp": "example",
@@ -19677,8 +19679,10 @@ export interface operations {
                      *           "adapter_snapshot_as_of": "example",
                      *           "blocking_source_count": 5000000,
                      *           "candidate_discovery_as_of": "example",
+                     *           "economics_as_of": "example",
                      *           "health_probe_as_of": "example",
                      *           "health_surface_count": 1,
+                     *           "live_rpc_as_of": "example",
                      *           "missing_blocking_source_count": 5000000,
                      *           "native_data_as_of": "example",
                      *           "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
@@ -41126,7 +41130,7 @@ export interface operations {
                      *             "lane": "adapter-snapshot",
                      *             "path": "example",
                      *             "required_for_publish": true,
-                     *             "stale_after_hours": 1,
+                     *             "stale_after_hours": 0.5,
                      *             "stale_behavior": "block",
                      *             "status": "captured",
                      *             "timestamp": "example",
@@ -41138,8 +41142,10 @@ export interface operations {
                      *           "adapter_snapshot_as_of": "example",
                      *           "blocking_source_count": 5000000,
                      *           "candidate_discovery_as_of": "example",
+                     *           "economics_as_of": "example",
                      *           "health_probe_as_of": "example",
                      *           "health_surface_count": 1,
+                     *           "live_rpc_as_of": "example",
                      *           "missing_blocking_source_count": 5000000,
                      *           "native_data_as_of": "example",
                      *           "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -12260,7 +12260,10 @@ export interface components {
         ValidatorEconomicsHistoryPoint: {
             earning_floor_alpha: number | null;
             emission_gate_open: boolean | null;
+            max_validators: number | null;
+            max_validators_source: ("observed" | "current") | null;
             permit_floor_alpha: number | null;
+            permit_set_full: boolean | null;
             snapshot_date: string;
             tao_inflow_per_day: number | null;
             validators_active: number;
@@ -53135,7 +53138,10 @@ export interface operations {
                      *           {
                      *             "earning_floor_alpha": 0.5,
                      *             "emission_gate_open": false,
+                     *             "max_validators": 1,
+                     *             "max_validators_source": "observed",
                      *             "permit_floor_alpha": 0.5,
+                     *             "permit_set_full": false,
                      *             "snapshot_date": "example",
                      *             "tao_inflow_per_day": 0.5,
                      *             "validators_active": 1,

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -6733,7 +6733,7 @@ export interface components {
             generated_at: string;
             notes?: string | string[];
             /** @constant */
-            openapi_url: "/api/v1/openapi.json";
+            openapi_url: "/metagraph/openapi.json";
             /** @constant */
             primary_domain: "api.metagraph.sh";
             response_envelope: {
@@ -12483,7 +12483,7 @@ export interface operations {
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
-                     *         "openapi_url": "/api/v1/openapi.json",
+                     *         "openapi_url": "/metagraph/openapi.json",
                      *         "primary_domain": "api.metagraph.sh",
                      *         "response_envelope": {
                      *           "error_schema_ref": "#/components/schemas/ErrorEnvelope",
@@ -12628,7 +12628,7 @@ export interface operations {
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
-                     *         "openapi_url": "/api/v1/openapi.json",
+                     *         "openapi_url": "/metagraph/openapi.json",
                      *         "primary_domain": "api.metagraph.sh",
                      *         "response_envelope": {
                      *           "error_schema_ref": "#/components/schemas/ErrorEnvelope",

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -2195,7 +2195,7 @@
     "note": "Omit the network segment for mainnet. `finney` aliases `mainnet` and `test` aliases `testnet`. `local` is served but hosts no registry data — it returns a setup pointer for a self-run node.",
     "path_form": "/api/v1/{network}/..."
   },
-  "openapi_url": "/api/v1/openapi.json",
+  "openapi_url": "/metagraph/openapi.json",
   "primary_domain": "api.metagraph.sh",
   "response_envelope": {
     "error_schema_ref": "#/components/schemas/ErrorEnvelope",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -5255,7 +5255,7 @@
                 "lane": "adapter-snapshot",
                 "path": "example",
                 "required_for_publish": true,
-                "stale_after_hours": 1,
+                "stale_after_hours": 0.5,
                 "stale_behavior": "block",
                 "status": "captured",
                 "timestamp": "example",
@@ -5267,8 +5267,10 @@
               "adapter_snapshot_as_of": "example",
               "blocking_source_count": 5000000,
               "candidate_discovery_as_of": "example",
+              "economics_as_of": "example",
               "health_probe_as_of": "example",
               "health_surface_count": 1,
+              "live_rpc_as_of": "example",
               "missing_blocking_source_count": 5000000,
               "native_data_as_of": "example",
               "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
@@ -28537,7 +28539,9 @@
                     "candidate-verification",
                     "health-probe",
                     "native-data",
-                    "schema-snapshot"
+                    "schema-snapshot",
+                    "economics",
+                    "live-rpc"
                   ],
                   "type": "string"
                 },
@@ -28551,9 +28555,8 @@
                   "type": "boolean"
                 },
                 "stale_after_hours": {
-                  "maximum": 9007199254740991,
                   "minimum": 0,
-                  "type": "integer"
+                  "type": "number"
                 },
                 "stale_behavior": {
                   "enum": [
@@ -28642,6 +28645,16 @@
                   }
                 ]
               },
+              "economics_as_of": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "health_probe_as_of": {
                 "anyOf": [
                   {
@@ -28656,6 +28669,16 @@
                 "maximum": 9007199254740991,
                 "minimum": 0,
                 "type": "integer"
+              },
+              "live_rpc_as_of": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "missing_blocking_source_count": {
                 "maximum": 9007199254740991,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -10843,7 +10843,10 @@
               {
                 "earning_floor_alpha": 0.5,
                 "emission_gate_open": false,
+                "max_validators": 1,
+                "max_validators_source": "observed",
                 "permit_floor_alpha": 0.5,
+                "permit_set_full": false,
                 "snapshot_date": "example",
                 "tao_inflow_per_day": 0.5,
                 "validators_active": 1,
@@ -48525,10 +48528,46 @@
               }
             ]
           },
+          "max_validators": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_validators_source": {
+            "anyOf": [
+              {
+                "enum": [
+                  "observed",
+                  "current"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "permit_floor_alpha": {
             "anyOf": [
               {
                 "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "permit_set_full": {
+            "anyOf": [
+              {
+                "type": "boolean"
               },
               {
                 "type": "null"
@@ -48572,7 +48611,10 @@
           "validators_active",
           "validators_earning",
           "emission_gate_open",
-          "tao_inflow_per_day"
+          "tao_inflow_per_day",
+          "max_validators",
+          "max_validators_source",
+          "permit_set_full"
         ],
         "type": "object"
       },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -1601,7 +1601,7 @@
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
             "notes": "Example description.",
-            "openapi_url": "/api/v1/openapi.json",
+            "openapi_url": "/metagraph/openapi.json",
             "primary_domain": "api.metagraph.sh",
             "response_envelope": {
               "error_schema_ref": "#/components/schemas/ErrorEnvelope",
@@ -16847,7 +16847,7 @@
             ]
           },
           "openapi_url": {
-            "const": "/api/v1/openapi.json",
+            "const": "/metagraph/openapi.json",
             "type": "string"
           },
           "primary_domain": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -8739,7 +8739,7 @@ export interface components {
                 as_of: string | null;
                 id: string;
                 /** @enum {string} */
-                lane: "adapter-snapshot" | "candidate-discovery" | "candidate-verification" | "health-probe" | "native-data" | "schema-snapshot";
+                lane: "adapter-snapshot" | "candidate-discovery" | "candidate-verification" | "health-probe" | "native-data" | "schema-snapshot" | "economics" | "live-rpc";
                 notes?: string;
                 path: string;
                 required_for_publish: boolean;
@@ -8756,8 +8756,10 @@ export interface components {
                 adapter_snapshot_as_of: string | null;
                 blocking_source_count: number;
                 candidate_discovery_as_of: string | null;
+                economics_as_of?: string | null;
                 health_probe_as_of: string | null;
                 health_surface_count: number;
+                live_rpc_as_of?: string | null;
                 missing_blocking_source_count: number;
                 native_data_as_of: string;
                 native_snapshot_captured_at: string;
@@ -19665,7 +19667,7 @@ export interface operations {
                      *             "lane": "adapter-snapshot",
                      *             "path": "example",
                      *             "required_for_publish": true,
-                     *             "stale_after_hours": 1,
+                     *             "stale_after_hours": 0.5,
                      *             "stale_behavior": "block",
                      *             "status": "captured",
                      *             "timestamp": "example",
@@ -19677,8 +19679,10 @@ export interface operations {
                      *           "adapter_snapshot_as_of": "example",
                      *           "blocking_source_count": 5000000,
                      *           "candidate_discovery_as_of": "example",
+                     *           "economics_as_of": "example",
                      *           "health_probe_as_of": "example",
                      *           "health_surface_count": 1,
+                     *           "live_rpc_as_of": "example",
                      *           "missing_blocking_source_count": 5000000,
                      *           "native_data_as_of": "example",
                      *           "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
@@ -41126,7 +41130,7 @@ export interface operations {
                      *             "lane": "adapter-snapshot",
                      *             "path": "example",
                      *             "required_for_publish": true,
-                     *             "stale_after_hours": 1,
+                     *             "stale_after_hours": 0.5,
                      *             "stale_behavior": "block",
                      *             "status": "captured",
                      *             "timestamp": "example",
@@ -41138,8 +41142,10 @@ export interface operations {
                      *           "adapter_snapshot_as_of": "example",
                      *           "blocking_source_count": 5000000,
                      *           "candidate_discovery_as_of": "example",
+                     *           "economics_as_of": "example",
                      *           "health_probe_as_of": "example",
                      *           "health_surface_count": 1,
+                     *           "live_rpc_as_of": "example",
                      *           "missing_blocking_source_count": 5000000,
                      *           "native_data_as_of": "example",
                      *           "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -12260,7 +12260,10 @@ export interface components {
         ValidatorEconomicsHistoryPoint: {
             earning_floor_alpha: number | null;
             emission_gate_open: boolean | null;
+            max_validators: number | null;
+            max_validators_source: ("observed" | "current") | null;
             permit_floor_alpha: number | null;
+            permit_set_full: boolean | null;
             snapshot_date: string;
             tao_inflow_per_day: number | null;
             validators_active: number;
@@ -53135,7 +53138,10 @@ export interface operations {
                      *           {
                      *             "earning_floor_alpha": 0.5,
                      *             "emission_gate_open": false,
+                     *             "max_validators": 1,
+                     *             "max_validators_source": "observed",
                      *             "permit_floor_alpha": 0.5,
+                     *             "permit_set_full": false,
                      *             "snapshot_date": "example",
                      *             "tao_inflow_per_day": 0.5,
                      *             "validators_active": 1,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6733,7 +6733,7 @@ export interface components {
             generated_at: string;
             notes?: string | string[];
             /** @constant */
-            openapi_url: "/api/v1/openapi.json";
+            openapi_url: "/metagraph/openapi.json";
             /** @constant */
             primary_domain: "api.metagraph.sh";
             response_envelope: {
@@ -12483,7 +12483,7 @@ export interface operations {
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
-                     *         "openapi_url": "/api/v1/openapi.json",
+                     *         "openapi_url": "/metagraph/openapi.json",
                      *         "primary_domain": "api.metagraph.sh",
                      *         "response_envelope": {
                      *           "error_schema_ref": "#/components/schemas/ErrorEnvelope",
@@ -12628,7 +12628,7 @@ export interface operations {
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
-                     *         "openapi_url": "/api/v1/openapi.json",
+                     *         "openapi_url": "/metagraph/openapi.json",
                      *         "primary_domain": "api.metagraph.sh",
                      *         "response_envelope": {
                      *           "error_schema_ref": "#/components/schemas/ErrorEnvelope",

--- a/schemas-src/mcp-tools/extrinsics.ts
+++ b/schemas-src/mcp-tools/extrinsics.ts
@@ -3,6 +3,14 @@
 // schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
 // reuse. Modeled fresh, matching each hand-written literal field-for-field.
 import { z } from "zod";
+import { limitSchema, offsetSchema } from "./shared.ts";
+
+/**
+ * Page-size ceiling for the extrinsics feeds and the two fixed-call_module feeds
+ * modelled on them (get_sudo, get_governance_config_changes). Exported so those two
+ * read it rather than restating it — they previously declared no maximum at all (#9460).
+ */
+export const EXTRINSICS_LIMIT_MAX = 100;
 import {
   AccountEventItemSchema,
   ExtrinsicItemSchema,
@@ -23,8 +31,8 @@ export const ListExtrinsicsInputSchema = z
     block_end: z.int().min(0).optional(),
     from: z.int().min(0).optional(),
     to: z.int().min(0).optional(),
-    limit: z.int().min(1).max(100).optional(),
-    offset: z.int().min(0).optional(),
+    limit: limitSchema(EXTRINSICS_LIMIT_MAX).optional(),
+    offset: offsetSchema().optional(),
     cursor: z.string().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/extrinsics.ts
+++ b/schemas-src/mcp-tools/extrinsics.ts
@@ -8,7 +8,7 @@ import { limitSchema, offsetSchema } from "./shared.ts";
 /**
  * Page-size ceiling for the extrinsics feeds and the two fixed-call_module feeds
  * modelled on them (get_sudo, get_governance_config_changes). Exported so those two
- * read it rather than restating it — they previously declared no maximum at all (#9460).
+ * read it rather than restating it — they previously declared no maximum at all.
  */
 export const EXTRINSICS_LIMIT_MAX = 100;
 import {

--- a/schemas-src/mcp-tools/get-economics.ts
+++ b/schemas-src/mcp-tools/get-economics.ts
@@ -11,6 +11,7 @@
 // constraint means NOT tightening beyond what already shipped, even though
 // the real per-row data happens to satisfy the deeper REST schema too.
 import { z } from "zod";
+import { fieldsSchema, netuidSchema, offsetSchema } from "./shared.ts";
 
 const ECONOMICS_SORT_FIELDS = [
   "alpha_fdv_tao",
@@ -38,14 +39,17 @@ const ECONOMICS_SORT_FIELDS = [
 
 export const GetEconomicsInputSchema = z
   .object({
-    netuid: z.int().min(0).optional(),
+    netuid: netuidSchema().optional(),
     registration_allowed: z.enum(["true", "false"]).optional(),
     q: z.string().optional(),
     sort: z.enum(ECONOMICS_SORT_FIELDS).optional(),
     order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
+    // #9460: `sort` and `order` were enums and this was a bare string with no stated
+    // format anywhere — comma-separated? a JSON array? — so the one parameter an agent
+    // could not guess was the only one left undocumented.
+    fields: fieldsSchema().optional(),
     limit: z.int().min(1).max(1000).optional(),
-    cursor: z.int().min(0).optional(),
+    cursor: offsetSchema().optional(),
   })
   .strict();
 export type GetEconomicsInput = z.infer<typeof GetEconomicsInputSchema>;

--- a/schemas-src/mcp-tools/get-economics.ts
+++ b/schemas-src/mcp-tools/get-economics.ts
@@ -44,7 +44,7 @@ export const GetEconomicsInputSchema = z
     q: z.string().optional(),
     sort: z.enum(ECONOMICS_SORT_FIELDS).optional(),
     order: z.enum(["asc", "desc"]).optional(),
-    // #9460: `sort` and `order` were enums and this was a bare string with no stated
+    // `sort` and `order` were enums while this was a bare string with no stated
     // format anywhere — comma-separated? a JSON array? — so the one parameter an agent
     // could not guess was the only one left undocumented.
     fields: fieldsSchema().optional(),

--- a/schemas-src/mcp-tools/get-subnet-validator-economics.ts
+++ b/schemas-src/mcp-tools/get-subnet-validator-economics.ts
@@ -10,10 +10,16 @@ import {
   ValidatorEconomicsRankingArtifactSchema,
   SubnetValidatorEconomicsHistoryArtifactSchema,
 } from "../routes/validator-economics.ts";
+import { limitSchema, netuidSchema, offsetSchema } from "./shared.ts";
+import { VALIDATOR_ECONOMICS_LIMIT_MAX } from "../../src/route-limits.ts";
+import {
+  VALIDATOR_ECONOMICS_HISTORY_WINDOWS,
+  VALIDATOR_ECONOMICS_SORTS,
+} from "../../src/validator-economics.ts";
 
 export const GetSubnetValidatorEconomicsInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetValidatorEconomicsInput = z.infer<
@@ -31,9 +37,15 @@ export type GetSubnetValidatorEconomicsOutput = z.infer<
 // validating on" into a single agent call.
 export const ListValidatorEconomicsInputSchema = z
   .object({
-    sort: z.string().optional(),
-    limit: z.int().min(1).optional(),
-    offset: z.int().min(0).optional(),
+    // #9460: an enum, not a free string. The description already named all five keys,
+    // and REST rejected anything else with a 400 — but MCP took any string and SILENTLY
+    // ranked by the default, echoing that default back as `sort`. A model that guessed
+    // got a plausible list answering a question nobody asked. Read from the same
+    // constant the ranking and the REST validator use.
+    sort: z.enum(VALIDATOR_ECONOMICS_SORTS).optional(),
+    // Was unbounded while the mirrored route rejected anything over 512.
+    limit: limitSchema(VALIDATOR_ECONOMICS_LIMIT_MAX).optional(),
+    offset: offsetSchema().optional(),
     emission_gate_open: z.boolean().optional(),
     cap_binding: z.boolean().optional(),
   })
@@ -51,8 +63,18 @@ export type ListValidatorEconomicsOutput = z.infer<
 // get_subnet_validator_economics_history (#9326).
 export const GetSubnetValidatorEconomicsHistoryInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    window: z.string().optional(),
+    netuid: netuidSchema(),
+    // #9460: the one window parameter of 55 that was not an enum. Its sibling
+    // get_subnet_burn_history already declared one, so a model reading the two
+    // together had no way to know this was the same kind of closed set.
+    window: z
+      .enum(
+        Object.keys(VALIDATOR_ECONOMICS_HISTORY_WINDOWS) as [
+          string,
+          ...string[],
+        ],
+      )
+      .optional(),
   })
   .strict();
 export type GetSubnetValidatorEconomicsHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-validator-economics.ts
+++ b/schemas-src/mcp-tools/get-subnet-validator-economics.ts
@@ -37,7 +37,7 @@ export type GetSubnetValidatorEconomicsOutput = z.infer<
 // validating on" into a single agent call.
 export const ListValidatorEconomicsInputSchema = z
   .object({
-    // #9460: an enum, not a free string. The description already named all five keys,
+    // An enum, not a free string. The description already named all five keys,
     // and REST rejected anything else with a 400 — but MCP took any string and SILENTLY
     // ranked by the default, echoing that default back as `sort`. A model that guessed
     // got a plausible list answering a question nobody asked. Read from the same
@@ -64,7 +64,7 @@ export type ListValidatorEconomicsOutput = z.infer<
 export const GetSubnetValidatorEconomicsHistoryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    // #9460: the one window parameter of 55 that was not an enum. Its sibling
+    // The one window parameter of 55 that was not an enum. Its sibling
     // get_subnet_burn_history already declared one, so a model reading the two
     // together had no way to know this was the same kind of closed set.
     window: z

--- a/schemas-src/mcp-tools/governance-feeds.ts
+++ b/schemas-src/mcp-tools/governance-feeds.ts
@@ -8,6 +8,8 @@
 // identical JSON Schema and the diff-audit script already treats them as
 // equal (see list_accounts/get_top_holders in #8070).
 import { z } from "zod";
+import { limitSchema, offsetSchema } from "./shared.ts";
+import { EXTRINSICS_LIMIT_MAX } from "./extrinsics.ts";
 import { ExtrinsicItemSchema } from "./shared.ts";
 import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
 
@@ -20,8 +22,11 @@ export const GetSudoInputSchema = z
     block_end: z.int().min(0).optional(),
     from: z.int().min(0).optional(),
     to: z.int().min(0).optional(),
-    limit: z.int().min(1).optional(),
-    offset: z.int().min(0).optional(),
+    // #9460: both feeds say "same filters as list_extrinsics" and were modelled on it,
+    // but dropped its `.max(100)` — declaring unbounded while the tier they forward to
+    // caps at 100. A copy-paste omission, not a wider ceiling.
+    limit: limitSchema(EXTRINSICS_LIMIT_MAX).optional(),
+    offset: offsetSchema().optional(),
     cursor: z.string().optional(),
   })
   .strict();
@@ -69,8 +74,11 @@ export const GetGovernanceConfigChangesInputSchema = z
     block_end: z.int().min(0).optional(),
     from: z.int().min(0).optional(),
     to: z.int().min(0).optional(),
-    limit: z.int().min(1).optional(),
-    offset: z.int().min(0).optional(),
+    // #9460: both feeds say "same filters as list_extrinsics" and were modelled on it,
+    // but dropped its `.max(100)` — declaring unbounded while the tier they forward to
+    // caps at 100. A copy-paste omission, not a wider ceiling.
+    limit: limitSchema(EXTRINSICS_LIMIT_MAX).optional(),
+    offset: offsetSchema().optional(),
     cursor: z.string().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/governance-feeds.ts
+++ b/schemas-src/mcp-tools/governance-feeds.ts
@@ -22,7 +22,7 @@ export const GetSudoInputSchema = z
     block_end: z.int().min(0).optional(),
     from: z.int().min(0).optional(),
     to: z.int().min(0).optional(),
-    // #9460: both feeds say "same filters as list_extrinsics" and were modelled on it,
+    // Both feeds say "same filters as list_extrinsics" and were modelled on it,
     // but dropped its `.max(100)` — declaring unbounded while the tier they forward to
     // caps at 100. A copy-paste omission, not a wider ceiling.
     limit: limitSchema(EXTRINSICS_LIMIT_MAX).optional(),
@@ -74,7 +74,7 @@ export const GetGovernanceConfigChangesInputSchema = z
     block_end: z.int().min(0).optional(),
     from: z.int().min(0).optional(),
     to: z.int().min(0).optional(),
-    // #9460: both feeds say "same filters as list_extrinsics" and were modelled on it,
+    // Both feeds say "same filters as list_extrinsics" and were modelled on it,
     // but dropped its `.max(100)` — declaring unbounded while the tier they forward to
     // caps at 100. A copy-paste omission, not a wider ceiling.
     limit: limitSchema(EXTRINSICS_LIMIT_MAX).optional(),

--- a/schemas-src/mcp-tools/rpc-tools.ts
+++ b/schemas-src/mcp-tools/rpc-tools.ts
@@ -151,7 +151,7 @@ export type GetBestRpcEndpointOutput = z.infer<
 
 export const CallRpcInputSchema = z
   .object({
-    // #9460: a hard allowlist, so it ships as one. The description spelled all thirteen
+    // A hard allowlist, so it ships as one. The description spelled all thirteen
     // methods out in prose while the schema said "any string", which meant an agent had
     // to read English to avoid a guaranteed rejection — and `call_subnet_surface.method`
     // right beside it already declared its enum. Read from the same sets the proxy

--- a/schemas-src/mcp-tools/rpc-tools.ts
+++ b/schemas-src/mcp-tools/rpc-tools.ts
@@ -10,6 +10,10 @@
 // to match this epic's usual item-shape convention.
 import { z } from "zod";
 import { OpenObjectSchema } from "./shared.ts";
+import {
+  SAFE_RPC_METHODS,
+  SAFE_RPC_STATE_QUERY_METHODS,
+} from "../../workers/config.ts";
 
 const RpcUsageLatencyMsSchema = z
   .object({
@@ -147,7 +151,17 @@ export type GetBestRpcEndpointOutput = z.infer<
 
 export const CallRpcInputSchema = z
   .object({
-    method: z.string(),
+    // #9460: a hard allowlist, so it ships as one. The description spelled all thirteen
+    // methods out in prose while the schema said "any string", which meant an agent had
+    // to read English to avoid a guaranteed rejection — and `call_subnet_surface.method`
+    // right beside it already declared its enum. Read from the same sets the proxy
+    // enforces, so a method added there cannot be missing here.
+    method: z.enum(
+      [...SAFE_RPC_METHODS, ...SAFE_RPC_STATE_QUERY_METHODS].sort() as [
+        string,
+        ...string[],
+      ],
+    ),
     params: z.array(z.unknown()).optional(),
     network: z.enum(["finney", "test"]).optional(),
   })

--- a/schemas-src/mcp-tools/shared.ts
+++ b/schemas-src/mcp-tools/shared.ts
@@ -10,6 +10,57 @@
 // two helpers are the Zod equivalent of that same shallow-on-purpose shape.
 import { z } from "zod";
 import { NeuronSchema } from "../routes/subnet-metagraph.ts";
+import { MAX_OFFSET } from "../../workers/request-params.ts";
+
+// --- Bounded input primitives (#9460) --------------------------------------
+//
+// Every tool author wrote `z.int().min(0)` inline, so no parameter declared a real
+// upper bound and all of them inherited `z.int()`'s safe-integer sentinel — see
+// src/mcp-input-schema.ts for why that made the published schema unreadable. These
+// helpers put the bound where the fact lives: `limitSchema` takes the same constant
+// from `src/route-limits.ts` that the handler enforces and the OpenAPI `maximum`
+// publishes, so an MCP tool can no longer advertise a ceiling its own route rejects.
+// `scripts/validate-mcp.ts` asserts the two agree.
+
+/**
+ * A subnet id. Bounded because it genuinely is: `netuid` is a u16 on chain, and
+ * `isU16Netuid` is what the REST routes reject against.
+ */
+export const netuidSchema = () => z.int().min(0).max(65535);
+
+/** A page size, capped at the mirrored route's own ceiling. */
+export const limitSchema = (max: number) => z.int().min(1).max(max);
+
+/**
+ * A page offset. `MAX_OFFSET` is the deep-paging bound every paginated route already
+ * clamps to — previously declared as unbounded here and silently clamped there.
+ */
+export const offsetSchema = () => z.int().min(0).max(MAX_OFFSET);
+
+/**
+ * The accepted `fields` syntax, which was documented NOWHERE a caller could see it:
+ * 27 of 31 `fields` parameters were bare `{"type":"string"}`, 19 of them with no
+ * mention in the tool description either. The format is a comma-separated list of bare
+ * row-field names — mirrors `FIELD_NAME_PATTERN` in src/field-projection.ts, which is
+ * what actually rejects a malformed value.
+ *
+ * Deliberately as permissive as `parseFieldsParam` actually is, not as tidy as the
+ * canonical form looks: that parser trims each segment and drops empty ones, so
+ * `"netuid, name"` and `"netuid,,name"` are both accepted. A stricter pattern would
+ * make a generated client reject input the server takes — the same defect as an MCP
+ * tool declaring a page-size ceiling its own route does not enforce.
+ */
+export const FIELDS_PATTERN =
+  "^[\\s,]*[A-Za-z_][A-Za-z0-9_]*(\\s*,[\\s,]*[A-Za-z_][A-Za-z0-9_]*)*[\\s,]*$";
+export const fieldsSchema = () =>
+  z
+    .string()
+    .regex(new RegExp(FIELDS_PATTERN))
+    .describe(
+      "Comma-separated row field names to project, e.g. `netuid,name,slug`. " +
+        "Bare identifiers only — not a JSON array, no paths or indices. " +
+        "An unknown name is rejected rather than ignored.",
+    );
 
 // Bare `{type:"object"}` (hand-written, no `properties`/`additionalProperties`
 // declared -- JSON Schema's own default for an omitted additionalProperties

--- a/schemas-src/mcp-tools/shared.ts
+++ b/schemas-src/mcp-tools/shared.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 import { NeuronSchema } from "../routes/subnet-metagraph.ts";
 import { MAX_OFFSET } from "../../workers/request-params.ts";
 
-// --- Bounded input primitives (#9460) --------------------------------------
+// --- Bounded input primitives --------------------------------------
 //
 // Every tool author wrote `z.int().min(0)` inline, so no parameter declared a real
 // upper bound and all of them inherited `z.int()`'s safe-integer sentinel — see

--- a/schemas-src/mcp-tools/validators.ts
+++ b/schemas-src/mcp-tools/validators.ts
@@ -5,7 +5,12 @@
 // covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
 // matching each hand-written literal field-for-field.
 import { z } from "zod";
-import { NeuronFieldsInputSchema, OpenObjectArraySchema } from "./shared.ts";
+import {
+  limitSchema,
+  NeuronFieldsInputSchema,
+  OpenObjectArraySchema,
+} from "./shared.ts";
+import { GLOBAL_VALIDATOR_LIMIT_MAX } from "../../src/route-limits.ts";
 
 // Mirrors workers/config.ts's SS58_ADDRESS_PATTERN (inlined rather than
 // cross-imported from workers/, matching this directory's existing
@@ -58,7 +63,11 @@ const GLOBAL_VALIDATOR_SORTS = [
 export const ListGlobalValidatorsInputSchema = z
   .object({
     sort: z.enum(GLOBAL_VALIDATOR_SORTS).optional(),
-    limit: z.int().min(1).max(100).optional(),
+    // #9460: was a hardcoded 100 while this tool's own description — interpolated from
+    // GLOBAL_VALIDATOR_LIMIT_MAX — said "max 2000", and the handler clamped to 2000.
+    // The tool advertised 2000 in prose, 100 in schema, and served 2000. Now the
+    // constant is the only declaration, as src/route-limits.ts intended.
+    limit: limitSchema(GLOBAL_VALIDATOR_LIMIT_MAX).optional(),
   })
   .strict();
 export type ListGlobalValidatorsInput = z.infer<

--- a/schemas-src/mcp-tools/validators.ts
+++ b/schemas-src/mcp-tools/validators.ts
@@ -63,7 +63,7 @@ const GLOBAL_VALIDATOR_SORTS = [
 export const ListGlobalValidatorsInputSchema = z
   .object({
     sort: z.enum(GLOBAL_VALIDATOR_SORTS).optional(),
-    // #9460: was a hardcoded 100 while this tool's own description — interpolated from
+    // Was a hardcoded 100 while this tool's own description — interpolated from
     // GLOBAL_VALIDATOR_LIMIT_MAX — said "max 2000", and the handler clamped to 2000.
     // The tool advertised 2000 in prose, 100 in schema, and served 2000. Now the
     // constant is the only declaration, as src/route-limits.ts intended.

--- a/schemas-src/routes/evidence-search.ts
+++ b/schemas-src/routes/evidence-search.ts
@@ -37,7 +37,7 @@ const FreshnessSourceSchema = z
       "health-probe",
       "native-data",
       "schema-snapshot",
-      // Serve-time lanes (#9460): both move on their own schedule rather than the
+      // Serve-time lanes: both move on their own schedule rather than the
       // publish's, so they exist only in the live overlay, never in the built artifact.
       "economics",
       "live-rpc",
@@ -45,7 +45,7 @@ const FreshnessSourceSchema = z
     notes: z.string().optional(),
     path: z.string(),
     required_for_publish: z.boolean(),
-    // Not an integer since #9460: the live-RPC lane's window is minutes, not hours.
+    // Not an integer since the live-RPC lane's window is minutes, not hours.
     stale_after_hours: z.number().min(0),
     stale_behavior: z.enum(["block", "warn"]),
     status: z.enum(["captured", "current", "degraded", "missing", "stale"]),
@@ -71,7 +71,7 @@ export const FreshnessArtifactSchema = ArtifactBaseSchema.extend({
       // Live-injected by mergeFreshness(), not in the hand-edited schema --
       // see header.
       operational_probe_as_of: z.string().nullable().optional(),
-      // Also live-injected (#9460): the two lanes that move independently of the
+      // Also live-injected: the two lanes that move independently of the
       // publish. Optional for the same reason the line above is — the built artifact
       // carries neither, so only the served response has them.
       economics_as_of: z.string().nullable().optional(),

--- a/schemas-src/routes/evidence-search.ts
+++ b/schemas-src/routes/evidence-search.ts
@@ -37,11 +37,16 @@ const FreshnessSourceSchema = z
       "health-probe",
       "native-data",
       "schema-snapshot",
+      // Serve-time lanes (#9460): both move on their own schedule rather than the
+      // publish's, so they exist only in the live overlay, never in the built artifact.
+      "economics",
+      "live-rpc",
     ]),
     notes: z.string().optional(),
     path: z.string(),
     required_for_publish: z.boolean(),
-    stale_after_hours: z.int().min(0),
+    // Not an integer since #9460: the live-RPC lane's window is minutes, not hours.
+    stale_after_hours: z.number().min(0),
     stale_behavior: z.enum(["block", "warn"]),
     status: z.enum(["captured", "current", "degraded", "missing", "stale"]),
     timestamp: z.string().nullable(),
@@ -66,6 +71,11 @@ export const FreshnessArtifactSchema = ArtifactBaseSchema.extend({
       // Live-injected by mergeFreshness(), not in the hand-edited schema --
       // see header.
       operational_probe_as_of: z.string().nullable().optional(),
+      // Also live-injected (#9460): the two lanes that move independently of the
+      // publish. Optional for the same reason the line above is — the built artifact
+      // carries neither, so only the served response has them.
+      economics_as_of: z.string().nullable().optional(),
+      live_rpc_as_of: z.string().nullable().optional(),
       publish_ready_without_age_check: z.boolean(),
       schema_snapshot_as_of: z.string().nullable(),
       stale_window_warnings: z.array(z.string()),

--- a/schemas-src/routes/meta-contracts.ts
+++ b/schemas-src/routes/meta-contracts.ts
@@ -136,7 +136,7 @@ export type ContractsArtifact = z.infer<typeof ContractsArtifactSchema>;
 export const ApiIndexArtifactSchema = ArtifactBaseSchema.extend({
   artifact_contracts: z.array(ArtifactContractEntrySchema),
   base_path: z.literal("/api/v1"),
-  // #9460: the RAW artifact, matching what /api/v1/contracts has always advertised.
+  // the RAW artifact, matching what /api/v1/contracts has always advertised.
   // This pinned `/api/v1/openapi.json`, which serves the spec inside the success
   // envelope — valid for the envelope rule, and not a valid OpenAPI document, so every
   // generator pointed here by the index failed on a spec that was published and fine.

--- a/schemas-src/routes/meta-contracts.ts
+++ b/schemas-src/routes/meta-contracts.ts
@@ -136,7 +136,11 @@ export type ContractsArtifact = z.infer<typeof ContractsArtifactSchema>;
 export const ApiIndexArtifactSchema = ArtifactBaseSchema.extend({
   artifact_contracts: z.array(ArtifactContractEntrySchema),
   base_path: z.literal("/api/v1"),
-  openapi_url: z.literal("/api/v1/openapi.json"),
+  // #9460: the RAW artifact, matching what /api/v1/contracts has always advertised.
+  // This pinned `/api/v1/openapi.json`, which serves the spec inside the success
+  // envelope — valid for the envelope rule, and not a valid OpenAPI document, so every
+  // generator pointed here by the index failed on a spec that was published and fine.
+  openapi_url: z.literal("/metagraph/openapi.json"),
   primary_domain: z.literal("api.metagraph.sh"),
   response_envelope: ResponseEnvelopeContractSchema,
   routes: z.array(ApiRouteSchema),

--- a/schemas-src/routes/validator-economics.ts
+++ b/schemas-src/routes/validator-economics.ts
@@ -62,7 +62,7 @@ export const SubnetValidatorEconomicsArtifactSchema = z
     permit_floor_units: z.number().nullable(),
     permit_floor_cost_tao: z.number().nullable(),
     permit_entry_cost_tao: z.number().nullable(),
-    // The EARNING floors exclude the subnet owner (#9460): its permit is unconditional,
+    // The EARNING floors exclude the subnet owner: its permit is unconditional,
     // so an owner earning on ~0 stake reported a floor of 0 -- "free to earn here" -- and
     // a 0-alpha buy cannot be priced, which then dropped the subnet out of the
     // cross-subnet ranking as unpriceable. Null means no NON-OWNER has earned here,
@@ -190,7 +190,7 @@ export type ValidatorEconomicsRankingQuery = z.infer<
 // The cap WAS omitted here, because `subnet_snapshots` carries no historical
 // `max_validators` and applying today's cap to an old snapshot would manufacture a
 // transition that never happened. That reasoning was right about the hazard and wrong
-// about the remedy (#9460): `permit_floor_alpha` is the observed floor REGARDLESS of cap
+// about the remedy: `permit_floor_alpha` is the observed floor REGARDLESS of cap
 // state, so without a cap the series cannot be read at all, and every consumer joined
 // today's cap off the current record — committing the same error, silently, and getting
 // it wrong for any subnet whose cap moved inside the window.

--- a/schemas-src/routes/validator-economics.ts
+++ b/schemas-src/routes/validator-economics.ts
@@ -182,10 +182,17 @@ export type ValidatorEconomicsRankingQuery = z.infer<
 // floors are unambiguous; cost is a present-tense question the per-subnet route
 // answers.
 //
-// `cap_binding` is absent for a different reason: `subnet_snapshots` carries no
-// historical `max_validators`, and applying today's cap to an old snapshot would
-// manufacture a transition that never happened. Omitted rather than published as a
-// permanently-null field.
+// The cap WAS omitted here, because `subnet_snapshots` carries no historical
+// `max_validators` and applying today's cap to an old snapshot would manufacture a
+// transition that never happened. That reasoning was right about the hazard and wrong
+// about the remedy (#9460): `permit_floor_alpha` is the observed floor REGARDLESS of cap
+// state, so without a cap the series cannot be read at all, and every consumer joined
+// today's cap off the current record — committing the same error, silently, and getting
+// it wrong for any subnet whose cap moved inside the window.
+//
+// So the cap ships, resolved per day from the `subnet_hyperparams_history` change-log,
+// with `max_validators_source` naming the days that fall back to the live value. An
+// approximation the caller can see is not the failure mode being guarded against.
 export const ValidatorEconomicsHistoryPointSchema = z
   .object({
     snapshot_date: z.string(),
@@ -196,6 +203,9 @@ export const ValidatorEconomicsHistoryPointSchema = z
     validators_earning: z.int().min(0),
     emission_gate_open: z.boolean().nullable(),
     tao_inflow_per_day: z.number().nullable(),
+    max_validators: z.int().min(1).nullable(),
+    max_validators_source: z.enum(["observed", "current"]).nullable(),
+    permit_set_full: z.boolean().nullable(),
   })
   .strict();
 

--- a/schemas-src/routes/validator-economics.ts
+++ b/schemas-src/routes/validator-economics.ts
@@ -62,6 +62,11 @@ export const SubnetValidatorEconomicsArtifactSchema = z
     permit_floor_units: z.number().nullable(),
     permit_floor_cost_tao: z.number().nullable(),
     permit_entry_cost_tao: z.number().nullable(),
+    // The EARNING floors exclude the subnet owner (#9460): its permit is unconditional,
+    // so an owner earning on ~0 stake reported a floor of 0 -- "free to earn here" -- and
+    // a 0-alpha buy cannot be priced, which then dropped the subnet out of the
+    // cross-subnet ranking as unpriceable. Null means no NON-OWNER has earned here,
+    // which is a real answer about the subnet rather than a missing reading.
     earning_floor_units: z.number().nullable(),
     earning_floor_cost_tao: z.number().nullable(),
     earning_entry_cost_tao: z.number().nullable(),

--- a/scripts/validate-mcp.ts
+++ b/scripts/validate-mcp.ts
@@ -334,7 +334,7 @@ for (const tool of tools) {
   );
 }
 
-// --- Input-schema honesty (#9460) ------------------------------------------
+// --- Input-schema honesty ------------------------------------------
 //
 // The published input schema is the WHOLE contract an MCP client sees: dispatch
 // validates that arguments are an object and nothing else — no types, no enums, no

--- a/scripts/validate-mcp.ts
+++ b/scripts/validate-mcp.ts
@@ -10,6 +10,16 @@ import { existsSync, readFileSync } from "node:fs";
 import { Ajv2020 } from "ajv/dist/2020.js";
 import { handleRequest } from "../workers/api.ts";
 import { PRIMARY_DOMAIN, REPOSITORY_URL } from "../src/contracts.ts";
+import {
+  ACCOUNTS_LIST_LIMIT_MAX,
+  CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
+  CHAIN_TURNOVER_LIMIT_MAX,
+  GLOBAL_VALIDATOR_LIMIT_MAX,
+  MOVERS_LIMIT_MAX,
+  SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
+  TOP_HOLDERS_LIMIT_MAX,
+  VALIDATOR_ECONOMICS_LIMIT_MAX,
+} from "../src/route-limits.ts";
 import { MCP_SERVER_INFO } from "../src/mcp-server.ts";
 import {
   MCP_SERVER_VERSION,
@@ -321,6 +331,105 @@ for (const tool of tools) {
     tool.inputSchema?.type,
     "object",
     `${tool.name}: inputSchema must be an object schema`,
+  );
+}
+
+// --- Input-schema honesty (#9460) ------------------------------------------
+//
+// The published input schema is the WHOLE contract an MCP client sees: dispatch
+// validates that arguments are an object and nothing else — no types, no enums, no
+// bounds — so a schema that misdescribes a parameter is not caught anywhere at runtime.
+// Three classes had accumulated, all of them invisible to the one assertion above.
+
+const SENTINEL_MAX = Number.MAX_SAFE_INTEGER;
+const SENTINEL_MIN = Number.MIN_SAFE_INTEGER;
+
+/** Walk every subschema of a published input schema, with a readable path. */
+function* walkSchema(
+  schema: unknown,
+  path = "",
+): Generator<{ path: string; node: Row }> {
+  if (!schema || typeof schema !== "object") return;
+  if (Array.isArray(schema)) {
+    for (const [index, entry] of schema.entries()) {
+      yield* walkSchema(entry, `${path}[${index}]`);
+    }
+    return;
+  }
+  const node = schema as Row;
+  yield { path: path || ".", node };
+  for (const [key, value] of Object.entries(node)) {
+    if (value && typeof value === "object") {
+      yield* walkSchema(value, path ? `${path}.${key}` : key);
+    }
+  }
+}
+
+for (const tool of tools) {
+  for (const { path, node } of walkSchema(tool.inputSchema)) {
+    if (node.type !== "integer") continue;
+    // Zod's `z.int()` carries the safe-integer range as a real constraint, so every
+    // integer parameter published one whether or not anyone chose it — which made a
+    // deliberate `.max()` indistinguishable from the default. listToolDefinitions()
+    // strips them; this is what keeps a newly-added `z.int()` from reintroducing the
+    // class. Add a real `.max()`, or leave the parameter genuinely unbounded.
+    assert.notEqual(
+      node.maximum,
+      SENTINEL_MAX,
+      `${tool.name}: ${path} publishes Zod's safe-integer sentinel as a maximum`,
+    );
+    assert.notEqual(
+      node.minimum,
+      SENTINEL_MIN,
+      `${tool.name}: ${path} publishes Zod's safe-integer sentinel as a minimum`,
+    );
+  }
+}
+
+// Every `limit` must declare the same ceiling the mirrored REST route enforces. #8251
+// moved a ceiling in one place and left the published contract declaring the old one,
+// so a client generated from our own spec rejected the request our own site makes;
+// src/route-limits.ts exists to make that impossible and only helps if it is read.
+const MCP_LIMIT_CEILINGS: Record<string, number> = {
+  list_global_validators: GLOBAL_VALIDATOR_LIMIT_MAX,
+  list_validator_economics: VALIDATOR_ECONOMICS_LIMIT_MAX,
+  get_subnet_movers: MOVERS_LIMIT_MAX,
+  get_chain_turnover: CHAIN_TURNOVER_LIMIT_MAX,
+  get_top_holders: TOP_HOLDERS_LIMIT_MAX,
+  list_accounts: ACCOUNTS_LIST_LIMIT_MAX,
+  get_subnet_event_summary: SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
+  get_chain_identity_history: CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
+};
+for (const [name, ceiling] of Object.entries(MCP_LIMIT_CEILINGS)) {
+  const tool = tools.find((entry: Row) => entry.name === name);
+  assert.ok(tool, `${name}: named in MCP_LIMIT_CEILINGS but not published`);
+  const limit = ((tool.inputSchema as Row)?.properties as Row)?.limit as Row;
+  assert.ok(limit, `${name}: has a route-limit ceiling but no limit parameter`);
+  assert.equal(
+    limit.maximum,
+    ceiling,
+    `${name}: declares limit maximum ${limit.maximum} but src/route-limits.ts says ${ceiling}`,
+  );
+}
+
+// A parameter whose description enumerates a closed set must DECLARE that set. An
+// agent cannot be expected to parse prose to avoid a guaranteed rejection, and the
+// same server already declared enums for 54 of 55 window parameters — so the misses
+// read as oversights, not as a different convention.
+const ENUM_REQUIRED: Array<[string, string]> = [
+  ["list_validator_economics", "sort"],
+  ["get_subnet_validator_economics_history", "window"],
+  ["call_rpc", "method"],
+  ["get_subnet_burn_history", "window"],
+];
+for (const [name, param] of ENUM_REQUIRED) {
+  const tool = tools.find((entry: Row) => entry.name === name);
+  assert.ok(tool, `${name}: named in ENUM_REQUIRED but not published`);
+  const node = ((tool.inputSchema as Row)?.properties as Row)?.[param] as Row;
+  assert.ok(node, `${name}: no ${param} parameter to constrain`);
+  assert.ok(
+    Array.isArray(node.enum) && node.enum.length > 0,
+    `${name}.${param}: its description names a closed set, so the schema must declare an enum`,
   );
 }
 

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -5328,7 +5328,14 @@ export function buildApiIndexArtifact(
     generated_at: generatedAt,
     primary_domain: PRIMARY_DOMAIN,
     base_path: API_BASE_PATH,
-    openapi_url: `${API_BASE_PATH}/openapi.json`,
+    // The RAW artifact, not `${API_BASE_PATH}/openapi.json` (#9460).
+    //
+    // Both routes serve the spec, but the /api/v1 one wraps it in the standard success
+    // envelope — correct per the envelope rule, and unusable as an OpenAPI document,
+    // since the result has no top-level `openapi` key. This index advertised the
+    // wrapped one while /api/v1/contracts advertised the raw one, so the two pointers
+    // disagreed and the more prominent one broke every generator that followed it.
+    openapi_url: `${ARTIFACT_BASE_PATH}/openapi.json`,
     type_definitions_url: TYPE_DEFINITIONS_PATH,
     response_envelope: {
       schema_version: SCHEMA_VERSION,

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -5328,7 +5328,7 @@ export function buildApiIndexArtifact(
     generated_at: generatedAt,
     primary_domain: PRIMARY_DOMAIN,
     base_path: API_BASE_PATH,
-    // The RAW artifact, not `${API_BASE_PATH}/openapi.json` (#9460).
+    // The RAW artifact, not `${API_BASE_PATH}/openapi.json`.
     //
     // Both routes serve the spec, but the /api/v1 one wraps it in the standard success
     // envelope — correct per the envelope rule, and unusable as an OpenAPI document,
@@ -5385,9 +5385,9 @@ export function buildApiIndexArtifact(
 }
 
 /** The 200 response schema for a route: the success envelope, narrowed to the
- *  route's own artifact component. Shared by the example registry below and the
- *  path emitter, so the example a route ships is sampled from exactly the schema
- *  that route advertises — not a second, separately-built copy of it. */
+ * route's own artifact component. Shared by the example registry below and the
+ * path emitter, so the example a route ships is sampled from exactly the schema
+ * that route advertises — not a second, separately-built copy of it. */
 function openApiResponseSchemaForRoute(entry: (typeof API_ROUTES)[number]) {
   return {
     allOf: [

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -3422,6 +3422,7 @@ export const SDL = /* GraphQL */ `
     permit_floor_cost_tao: Float
     "Floor cost plus the registration burn. Entry is two spends; publishing one understates it."
     permit_entry_cost_tao: Float
+    "The smallest stake that actually EARNS dividends here, excluding the subnet owner -- its permit is unconditional, so an owner earning on ~0 stake would report a floor of 0. Null when NO non-owner has earned on this subnet, which is a real answer (the owner is taking the dividends), not a missing one."
     earning_floor_units: Float
     earning_floor_cost_tao: Float
     earning_entry_cost_tao: Float

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -3398,6 +3398,12 @@ export const SDL = /* GraphQL */ `
     validators_earning: Int!
     emission_gate_open: Boolean
     tao_inflow_per_day: Float
+    "The validator cap in force on this day. permit_floor_alpha is the observed floor REGARDLESS of cap state, so it cannot be read without this -- and joining today's cap onto an old point is wrong for any subnet whose cap moved."
+    max_validators: Int
+    "Where max_validators came from: observed = the hyperparameter change-log recorded it at or before this day; current = the change-log does not reach this far back, so the LIVE cap is reported."
+    max_validators_source: String
+    "Whether the permit set was full on this day (validators_permitted >= max_validators). NOT the same measure as the current record's cap_binding, which counts UIDs clearing the threshold against slots -- only the permitted set survives in a daily snapshot."
+    permit_set_full: Boolean
   }
 
   type SubnetValidatorEconomicsHistory {

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -435,7 +435,7 @@ export function overlayRpcPoolEligibility(
 
 /**
  * One serve-time lane: a tier that moves on its OWN schedule, not the publish's, so
- * the built artifact can never carry its timestamp (#9460).
+ * the built artifact can never carry its timestamp.
  */
 function liveFreshnessSource({
   id,
@@ -486,7 +486,7 @@ function liveFreshnessSource({
  *
  * Three lanes here are NOT the publish's: the 15-minute surface prober, the ~3-hourly
  * economics refresh, and the per-request live chain reads. The built artifact stamps
- * only what the publish itself captured, so before #9460 this route reported a
+ * only what the publish itself captured, so before this change the route reported a
  * `native_data_as_of` from the last publish while `/economics` served a snapshot hours
  * newer and `/network/parameters` served one seconds old — and neither appeared here at
  * all. A freshness route that omits the freshest lanes cannot answer the one question it

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -18,6 +18,7 @@ import {
   okLatencyMs,
 } from "./health-probe-core.ts";
 import { spotPriceTao } from "./stake-quote.ts";
+import { NETWORK_PARAMETERS_KV_TTL } from "./network-parameters.ts";
 import { KV_ECONOMICS_CURRENT, KV_HEALTH_CURRENT } from "./kv-keys.ts";
 import { tryPostgresTier } from "../workers/postgres-tier.ts";
 
@@ -432,12 +433,78 @@ export function overlayRpcPoolEligibility(
   };
 }
 
-// Set the live health-probe freshness onto the static freshness artifact.
+/**
+ * One serve-time lane: a tier that moves on its OWN schedule, not the publish's, so
+ * the built artifact can never carry its timestamp (#9460).
+ */
+function liveFreshnessSource({
+  id,
+  lane,
+  asOf,
+  maxAgeMs,
+  path,
+  timestampField,
+  notes,
+  now,
+}: {
+  id: string;
+  lane: string;
+  asOf: unknown;
+  maxAgeMs: number;
+  path: string;
+  timestampField: string;
+  notes: string;
+  now: number;
+}): Row {
+  const parsed = typeof asOf === "string" ? Date.parse(asOf) : NaN;
+  // "missing" is a third state, distinct from stale: a lane whose store is cold has no
+  // age at all, and reporting that as stale would invent an age it does not have.
+  const status = !Number.isFinite(parsed)
+    ? "missing"
+    : now - parsed > maxAgeMs
+      ? "stale"
+      : "current";
+  return {
+    as_of: status === "missing" ? null : asOf,
+    id,
+    lane,
+    notes,
+    path,
+    required_for_publish: false,
+    // These lanes are independent of the publish, so they can never block it — but a
+    // consumer still has to be able to gate on them, which is the whole point.
+    stale_after_hours: maxAgeMs / 3_600_000,
+    stale_behavior: "warn",
+    status,
+    timestamp: status === "missing" ? null : asOf,
+    timestamp_field: timestampField,
+  };
+}
+
+/**
+ * Set the live freshness onto the static freshness artifact.
+ *
+ * Three lanes here are NOT the publish's: the 15-minute surface prober, the ~3-hourly
+ * economics refresh, and the per-request live chain reads. The built artifact stamps
+ * only what the publish itself captured, so before #9460 this route reported a
+ * `native_data_as_of` from the last publish while `/economics` served a snapshot hours
+ * newer and `/network/parameters` served one seconds old — and neither appeared here at
+ * all. A freshness route that omits the freshest lanes cannot answer the one question it
+ * exists for, and a consumer gating on it would reject data that was current.
+ */
 export function mergeFreshness(
   staticFreshness: Row | null | undefined,
   liveMeta: Row | null | undefined,
+  liveLanes: {
+    /** `captured_at` off the economics KV blob — the same field /economics returns. */
+    economicsCapturedAt?: unknown;
+    /** `queried_at` off the cached live-RPC parameters snapshot. */
+    parametersQueriedAt?: unknown;
+    now?: number;
+  } = {},
 ): Row | null {
   if (!liveMeta || !staticFreshness) return null;
+  const now = liveLanes.now ?? Date.now();
   const sources = Array.isArray(staticFreshness.sources)
     ? (staticFreshness.sources as Row[]).map((source) =>
         source.id === "surface-health"
@@ -452,13 +519,51 @@ export function mergeFreshness(
           : source,
       )
     : staticFreshness.sources;
+
+  const economics = liveFreshnessSource({
+    id: "economics-live",
+    lane: "economics",
+    asOf: liveLanes.economicsCapturedAt,
+    // The same window the serving tier itself gates on, so this route and
+    // `resolveLiveEconomics` can never disagree about whether economics is stale.
+    maxAgeMs: ECONOMICS_FRESHNESS_MAX_AGE_MS,
+    path: "/api/v1/economics",
+    timestampField: "captured_at",
+    notes:
+      "Refreshed on its own ~3h schedule, independent of the data publish. " +
+      "`as_of` is the captured_at /api/v1/economics returns for the same blob.",
+    now,
+  });
+
+  const liveRpc = liveFreshnessSource({
+    id: "chain-parameters",
+    lane: "live-rpc",
+    asOf: liveLanes.parametersQueriedAt,
+    // Read per request behind a short KV cache, so anything older than a few multiples
+    // of that TTL means the RPC reads are failing, not merely uncached.
+    maxAgeMs: NETWORK_PARAMETERS_KV_TTL * 1000 * 4,
+    path: "/api/v1/network/parameters",
+    timestampField: "queried_at",
+    notes:
+      "Read live from chain RPC per request behind a ~5 minute cache. " +
+      "`as_of` is the queried_at /api/v1/network/parameters returns.",
+    now,
+  });
+
   return {
     ...staticFreshness,
-    sources,
+    // A malformed artifact whose `sources` is not an array passes through untouched,
+    // as it always has — appending to it would turn a string into a list of characters.
+    // The summary below still carries both lanes, so they are never silently lost.
+    sources: Array.isArray(sources)
+      ? [...(sources as Row[]), economics, liveRpc]
+      : sources,
     summary: {
       ...(staticFreshness.summary as Row),
       health_probe_as_of: liveMeta.last_run_at,
       operational_probe_as_of: liveMeta.last_run_at,
+      economics_as_of: economics.as_of,
+      live_rpc_as_of: liveRpc.as_of,
     },
   };
 }

--- a/src/mcp-input-schema.ts
+++ b/src/mcp-input-schema.ts
@@ -1,0 +1,108 @@
+// Normalisation applied to every MCP tool input schema on the way out (#9460).
+//
+// ## The problem this exists to solve
+//
+// `z.int()` in Zod 4 carries JavaScript's safe-integer range as real constraints, and
+// `z.toJSONSchema` faithfully emits them:
+//
+//   z.int()            -> {"type":"integer","minimum":-9007199254740991,"maximum":9007199254740991}
+//   z.int().min(0)     -> {"type":"integer","minimum":0,"maximum":9007199254740991}
+//
+// Nobody wrote those numbers and none of them is a real bound. 198 of 287 integer
+// parameters carried one, which made the schema unable to express the one distinction a
+// caller actually needs: `netuid` is bounded (0..65535) and `block` is not, but both
+// rendered identically, so "deliberately unbounded" and "the author forgot `.max()`"
+// were indistinguishable. A generated client faithfully emits `le=9007199254740991` for
+// a netuid, and an external consumer reading the schema reported it as an unbounded
+// list parameter — reasonably, since that is what it says.
+//
+// Stripping the sentinel is what lets a real `.max()` MEAN something: after this, an
+// integer with a `maximum` has one because someone decided it should.
+//
+// Only the exact safe-integer sentinels are removed. A hand-written bound that happens
+// to be large survives, because it is not equal to these; that precision is why this
+// strips rather than rewrites.
+
+type Json = Record<string, unknown>;
+
+const INT_MAX = Number.MAX_SAFE_INTEGER;
+const INT_MIN = Number.MIN_SAFE_INTEGER;
+
+/** Every place a subschema can hide inside a JSON Schema object we emit. */
+const SUBSCHEMA_KEYS = [
+  "items",
+  "additionalProperties",
+  "not",
+  "if",
+  "then",
+  "else",
+] as const;
+const SUBSCHEMA_MAP_KEYS = [
+  "properties",
+  "patternProperties",
+  "$defs",
+] as const;
+const SUBSCHEMA_LIST_KEYS = ["anyOf", "oneOf", "allOf", "prefixItems"] as const;
+
+/**
+ * Remove Zod's implicit safe-integer bounds, recursively.
+ *
+ * Pure and non-mutating: the caller's schema object is untouched, so a schema shared
+ * between the tool registry and a validator cannot be normalised twice into something
+ * different, and a test can compare before/after.
+ */
+export function stripSentinelIntegerBounds<T>(schema: T): T {
+  if (Array.isArray(schema)) {
+    return schema.map((entry) => stripSentinelIntegerBounds(entry)) as T;
+  }
+  if (!schema || typeof schema !== "object") return schema;
+
+  const out: Json = { ...(schema as unknown as Json) };
+
+  // Only on integers: a `number` with these bounds would be a deliberate (if odd)
+  // choice, and this has no business rewriting it.
+  if (out.type === "integer") {
+    if (out.maximum === INT_MAX) delete out.maximum;
+    if (out.minimum === INT_MIN) delete out.minimum;
+    if (out.exclusiveMaximum === INT_MAX) delete out.exclusiveMaximum;
+    if (out.exclusiveMinimum === INT_MIN) delete out.exclusiveMinimum;
+  }
+
+  for (const key of SUBSCHEMA_KEYS) {
+    if (out[key] && typeof out[key] === "object") {
+      out[key] = stripSentinelIntegerBounds(out[key]);
+    }
+  }
+  for (const key of SUBSCHEMA_LIST_KEYS) {
+    if (Array.isArray(out[key])) {
+      out[key] = (out[key] as unknown[]).map((entry) =>
+        stripSentinelIntegerBounds(entry),
+      );
+    }
+  }
+  for (const key of SUBSCHEMA_MAP_KEYS) {
+    const value = out[key];
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      const mapped: Json = {};
+      for (const [name, sub] of Object.entries(value as Json)) {
+        mapped[name] = stripSentinelIntegerBounds(sub);
+      }
+      out[key] = mapped;
+    }
+  }
+
+  return out as unknown as T;
+}
+
+/**
+ * True when a schema still carries a safe-integer sentinel anywhere inside it.
+ *
+ * The CI gate (`scripts/validate-mcp.ts`) asserts this is false for every published
+ * tool, so a newly-added `z.int()` cannot reintroduce the class.
+ */
+export function hasSentinelIntegerBound(schema: unknown): boolean {
+  return (
+    JSON.stringify(schema) !==
+    JSON.stringify(stripSentinelIntegerBounds(schema))
+  );
+}

--- a/src/mcp-input-schema.ts
+++ b/src/mcp-input-schema.ts
@@ -1,12 +1,12 @@
-// Normalisation applied to every MCP tool input schema on the way out (#9460).
+// Normalisation applied to every MCP tool input schema on the way out.
 //
 // ## The problem this exists to solve
 //
 // `z.int()` in Zod 4 carries JavaScript's safe-integer range as real constraints, and
 // `z.toJSONSchema` faithfully emits them:
 //
-//   z.int()            -> {"type":"integer","minimum":-9007199254740991,"maximum":9007199254740991}
-//   z.int().min(0)     -> {"type":"integer","minimum":0,"maximum":9007199254740991}
+// z.int()            -> {"type":"integer","minimum":-9007199254740991,"maximum":9007199254740991}
+// z.int().min(0)     -> {"type":"integer","minimum":0,"maximum":9007199254740991}
 //
 // Nobody wrote those numbers and none of them is a real bound. 198 of 287 integer
 // parameters carried one, which made the schema unable to express the one distinction a

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1617,9 +1617,9 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 // The MCP server's own SemVer — the tool surface is a public contract agents
 // depend on, so it needs a version signal distinct from CONTRACT_VERSION (the
 // date-based REST/data-contract version). Bump policy (#393):
-//   - add a tool / additive field        → MINOR
-//   - change or remove a tool's I/O       → MAJOR
-//   - behavioral-only fix (no I/O change) → PATCH
+// - add a tool / additive field        → MINOR
+// - change or remove a tool's I/O       → MAJOR
+// - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
 export const MCP_SERVER_VERSION = "1.78.13";
 // Price-impact thresholds for get_stake_action_preview's plan-shaped
@@ -2317,7 +2317,7 @@ async function findCataloguedSurface(
  * Those are both correct. What was wrong is what we said when the two differ:
  * every non-callable id came back as
  *
- *   not_found: No catalogued surface with id, key, or deprecated id "…"
+ * not_found: No catalogued surface with id, key, or deprecated id "…"
  *
  * which is false. The surface IS catalogued -- the agent almost certainly got
  * that id from `list_surfaces` or `get_subnet_surfaces` moments earlier -- it
@@ -3844,10 +3844,10 @@ const LIST_SUBNETS_ENUM_MEMBERS: Record<string, readonly string[]> = {
  * 231 already reject by hand, and these four (the two below plus their `not_`
  * counterparts) silently degraded instead:
  *
- *   coverage_level / curation_level      -> matched no row -> HTTP 200 with
- *                                           subnets: [], total: 0
- *   not_coverage_level / not_curation_level -> excluded no row -> the full
- *                                           list, silently UNFILTERED
+ * coverage_level / curation_level      -> matched no row -> HTTP 200 with
+ * subnets: [], total: 0
+ * not_coverage_level / not_curation_level -> excluded no row -> the full
+ * list, silently UNFILTERED
  *
  * The `not_` pair is the closer analogue of #8804: the agent asked to exclude
  * something, got no error, and got back exactly what it excluded.
@@ -4846,7 +4846,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       args: z.infer<typeof ListValidatorEconomicsInputSchema>,
       ctx: McpCtx,
     ) {
-      // #9460: an unsupported sort is rejected, not silently answered with the
+      // an unsupported sort is rejected, not silently answered with the
       // default ranking. REST returns 400 for the same input; this is that parity.
       if (
         args?.sort != null &&
@@ -13215,7 +13215,7 @@ export function listToolDefinitions() {
       name: tool.name,
       title: tool.title,
       description: `${tool.description} ${UNTRUSTED_DATA_NOTE}`,
-      // #9460: drop Zod's implicit safe-integer bounds. They are not constraints
+      // drop Zod's implicit safe-integer bounds. They are not constraints
       // anyone chose, and while they were emitted a real `maximum` could not be told
       // apart from `z.int()`'s default — see src/mcp-input-schema.ts.
       inputSchema: stripSentinelIntegerBounds(tool.inputSchema),
@@ -14416,13 +14416,13 @@ function rpcError(id: unknown, code: number, message: string) {
  * Precedence, strongest first:
  *
  * 1. **`github:<login>`** — a GitHub identity the OAuth provider itself already
- *    validated (metagraphed#7153). A real, durable person.
+ * validated (metagraphed#7153). A real, durable person.
  * 2. **`mcp-session:<id>`** — the client-generated Streamable HTTP session id.
- *    Not a person, and deliberately not presented as one: it is a stable handle
- *    for one client's run, which is the granularity that makes "how many
- *    distinct callers" answerable at all.
+ * Not a person, and deliberately not presented as one: it is a stable handle
+ * for one client's run, which is the granularity that makes "how many
+ * distinct callers" answerable at all.
  * 3. **undefined** — no session either. `recordX`'s own anonymous-fallback
- *    constant is the single place that decision lives, so this never invents one.
+ * constant is the single place that decision lives, so this never invents one.
  *
  * Why this is worth doing and why it stops here: every anonymous caller
  * previously collapsed onto that one fallback constant, so 13,193 of 13,365

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -627,7 +627,9 @@ import {
 import {
   DEFAULT_VALIDATOR_ECONOMICS_HISTORY_WINDOW,
   VALIDATOR_ECONOMICS_HISTORY_WINDOWS,
+  VALIDATOR_ECONOMICS_SORTS,
 } from "./validator-economics.ts";
+import { stripSentinelIntegerBounds } from "./mcp-input-schema.ts";
 import {
   buildSubnetValidatorEconomicsPayload,
   buildSubnetValidatorEconomicsHistoryPayload,
@@ -4844,6 +4846,19 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       args: z.infer<typeof ListValidatorEconomicsInputSchema>,
       ctx: McpCtx,
     ) {
+      // #9460: an unsupported sort is rejected, not silently answered with the
+      // default ranking. REST returns 400 for the same input; this is that parity.
+      if (
+        args?.sort != null &&
+        !VALIDATOR_ECONOMICS_SORTS.includes(
+          args.sort as (typeof VALIDATOR_ECONOMICS_SORTS)[number],
+        )
+      ) {
+        throw toolError(
+          "invalid_params",
+          `${args.sort} is not a supported sort. Supported: ${VALIDATOR_ECONOMICS_SORTS.join(", ")}.`,
+        );
+      }
       const { data } = await buildValidatorEconomicsRankingPayload(
         ctx.env,
         {
@@ -13200,7 +13215,10 @@ export function listToolDefinitions() {
       name: tool.name,
       title: tool.title,
       description: `${tool.description} ${UNTRUSTED_DATA_NOTE}`,
-      inputSchema: tool.inputSchema,
+      // #9460: drop Zod's implicit safe-integer bounds. They are not constraints
+      // anyone chose, and while they were emitted a real `maximum` could not be told
+      // apart from `z.int()`'s default — see src/mcp-input-schema.ts.
+      inputSchema: stripSentinelIntegerBounds(tool.inputSchema),
       // outputSchema (optional) lets a client validate the structuredContent the
       // tool returns; included only when the tool declares one.
       ...(outputSchema ? { outputSchema } : {}),

--- a/src/network-parameters.ts
+++ b/src/network-parameters.ts
@@ -16,15 +16,15 @@
 // in Node's built-in crypto. Verified live against finney (bittensor 10.5.0,
 // substrate.create_storage_key("SubtensorModule", <item>)) and via raw
 // state_getStorage RPC calls, 2026-07-17:
-//   TaoWeight raw result 0x7a14ae47e17a142e -> a U64F64 fixed-point ratio
-//     (bits/2**64 = 0.18004..., matching live TaoWeight ~0.18 at the time
-//     the underlying issue was filed -- this is governance-adjustable and
-//     will drift, the fixed-point DECODING is what's verified, not the
-//     specific value).
-//   StakeThreshold raw result 0x0010a5d4e8000000 -> a plain u64 rao amount
-//     (1e12 rao = 1000 TAO exactly).
-//   PendingChildKeyCooldown raw result 0x201c000000000000 -> a plain u64
-//     block count (7200, no TAO conversion).
+// TaoWeight raw result 0x7a14ae47e17a142e -> a U64F64 fixed-point ratio
+// (bits/2**64 = 0.18004..., matching live TaoWeight ~0.18 at the time
+// the underlying issue was filed -- this is governance-adjustable and
+// will drift, the fixed-point DECODING is what's verified, not the
+// specific value).
+// StakeThreshold raw result 0x0010a5d4e8000000 -> a plain u64 rao amount
+// (1e12 rao = 1000 TAO exactly).
+// PendingChildKeyCooldown raw result 0x201c000000000000 -> a plain u64
+// block count (7200, no TAO conversion).
 
 import { blockEmissionForIssuance } from "./block-emission.ts";
 import type { FieldSources } from "./field-provenance.ts";
@@ -268,18 +268,18 @@ async function fetchStorageU128(
  * more than any other:
  *
  * - `block_emission_tao` / `block_emission_halvings` are derived from
- *   `TotalIssuance`, NEVER read from the `BlockEmission` storage item, which
- *   has been stale at 1.0 TAO since the first halving (#8747). The item exists
- *   and would look like the obvious source; publishing `storage: null` says
- *   plainly that we did not use it.
+ * `TotalIssuance`, NEVER read from the `BlockEmission` storage item, which
+ * has been stale at 1.0 TAO since the first halving (#8747). The item exists
+ * and would look like the obvious source; publishing `storage: null` says
+ * plainly that we did not use it.
  * - `emission_gate_exponent_effective` is `DEFAULT_EMISSION_GATE_EXPONENT`
- *   whenever the storage item is unset, which is its current state on finney.
- *   Without this map a caller sees `3` and has no way to learn it came from our
- *   source tree rather than the chain — the `null` beside it in
- *   `emission_gate_exponent` reads as missing data, not as the tell. It stays
- *   reconstructed even when the item IS set and the two agree: which one it is
- *   depends on chain state the caller cannot see, and a field whose kind flips
- *   per response is not a contract.
+ * whenever the storage item is unset, which is its current state on finney.
+ * Without this map a caller sees `3` and has no way to learn it came from our
+ * source tree rather than the chain — the `null` beside it in
+ * `emission_gate_exponent` reads as missing data, not as the tell. It stays
+ * reconstructed even when the item IS set and the two agree: which one it is
+ * depends on chain state the caller cannot see, and a field whose kind flips
+ * per response is not a contract.
  *
  * Everything else is one read, decoded. `stake_threshold_tao` divided by 1e9
  * and `tao_weight` decoded from U64F64 are still that single read.
@@ -350,7 +350,7 @@ export interface NetworkParameters extends NetworkParametersSnapshot {
 }
 
 /**
- * The cached snapshot ONLY — never a live RPC read (#9460).
+ * The cached snapshot ONLY — never a live RPC read.
  *
  * `/freshness` reports how current the live-RPC lane is, and it must not become a
  * reason for that lane to be queried: a freshness probe that triggers the work it is

--- a/src/network-parameters.ts
+++ b/src/network-parameters.ts
@@ -349,6 +349,34 @@ export interface NetworkParameters extends NetworkParametersSnapshot {
   field_sources: typeof NETWORK_PARAMETERS_FIELD_SOURCES;
 }
 
+/**
+ * The cached snapshot ONLY — never a live RPC read (#9460).
+ *
+ * `/freshness` reports how current the live-RPC lane is, and it must not become a
+ * reason for that lane to be queried: a freshness probe that triggers the work it is
+ * measuring would refresh `queried_at` on every call and always report "current",
+ * which is precisely a lane that cannot go stale and therefore cannot be gated on.
+ *
+ * Null when KV is unbound or cold — the caller reports `missing`, not an age.
+ */
+export async function readCachedNetworkParametersSnapshot(
+  env: Env,
+  network?: ChainNetworkId,
+): Promise<NetworkParametersSnapshot | null> {
+  const kv = env?.METAGRAPH_CONTROL;
+  if (!kv?.get) return null;
+  try {
+    return (
+      (await kv.get<NetworkParametersSnapshot>(
+        networkKvKey("network:parameters", network),
+        { type: "json" },
+      )) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
 // Query the live global governance parameters. Uses METAGRAPH_CONTROL KV
 // (300s TTL) when present; each field is independently null on its own RPC
 // failure (schema-stable, never throws) -- three parallel reads against the

--- a/src/validator-economics.ts
+++ b/src/validator-economics.ts
@@ -369,11 +369,20 @@ export function permitFloorUnits(
 // requires submitting weights each epoch. Of ACTIVE permit-holders 97.8% earn; of
 // INACTIVE ones 1.3% do. Reported beside the floor, never instead of it. Null when
 // nobody on the subnet earns.
+//
+// The subnet owner is excluded for the same reason it never sets the permit floor
+// (#9460): its permit is unconditional, so an owner earning on ~0 stake would report an
+// earning floor of 0 — "free to earn here" — and, because a 0-alpha buy cannot be priced
+// against the pool, would then drop the whole subnet out of the cross-subnet ranking as
+// unpriceable. Both were happening.
 export function earningFloorUnits(
   neurons: readonly ValidatorNeuron[],
+  ownerHotkey?: string | null,
 ): number | null {
+  const owner = ownerUid(neurons, ownerHotkey);
   let floor: number | null = null;
   for (const n of neurons) {
+    if (owner !== null && n.uid === owner) continue;
     if (!n.validatorPermit || n.dividends <= 0) continue;
     if (floor === null || n.totalStake < floor) floor = n.totalStake;
   }
@@ -593,7 +602,7 @@ export function buildValidatorEconomics(
     stakeThreshold,
     ownerHotkey,
   );
-  const earnFloor = earningFloorUnits(neurons);
+  const earnFloor = earningFloorUnits(neurons, ownerHotkey);
   const floorCost = ammCostTao(
     inputs.taoReserve ?? NaN,
     inputs.alphaReserve ?? NaN,

--- a/src/validator-economics.ts
+++ b/src/validator-economics.ts
@@ -678,6 +678,26 @@ export const VALIDATOR_ECONOMICS_SORTS = [
 ] as const;
 export type ValidatorEconomicsSort = (typeof VALIDATOR_ECONOMICS_SORTS)[number];
 
+/**
+ * Thrown when a caller names a sort key that does not exist (#9460).
+ *
+ * A distinct type rather than a bare Error so each surface can map it to its own
+ * shape — REST to a 400, MCP to `invalid_params` — without string-matching a message.
+ */
+export class UnsupportedSortError extends Error {
+  // Plain fields, not constructor parameter properties: these modules are loaded by
+  // Node's strip-only TypeScript mode, which rejects that syntax outright.
+  readonly supported: readonly string[] = VALIDATOR_ECONOMICS_SORTS;
+  readonly requested: string;
+  constructor(requested: string) {
+    super(
+      `${requested} is not a supported sort. Supported: ${VALIDATOR_ECONOMICS_SORTS.join(", ")}.`,
+    );
+    this.name = "UnsupportedSortError";
+    this.requested = requested;
+  }
+}
+
 /** Ascending for costs (cheapest first), descending for the "more is better" keys. */
 const DESCENDING_SORTS = new Set<string>([
   "tao_inflow_per_day",
@@ -723,6 +743,21 @@ export function rankValidatorEconomics(
   rows: readonly ValidatorEconomicsRow[],
   options: ValidatorEconomicsRankingOptions = {},
 ): ValidatorEconomicsRanking {
+  // An ABSENT sort takes the default; an unsupported one is rejected (#9460).
+  //
+  // These are different questions and this silently answered both with the default:
+  // asking to rank by `tao_inflow_per_day` and mistyping it returned a list ranked by
+  // cost, echoing `sort: "earning_floor_cost_tao"` back, with no error. The caller gets
+  // a plausible ranking that answers a question it did not ask — and on MCP, where the
+  // input schema is not enforced at dispatch, a model's guess landed here directly.
+  // REST already rejected the same input with a 400; the two surfaces now agree.
+  if (
+    options.sort != null &&
+    options.sort !== "" &&
+    !VALIDATOR_ECONOMICS_SORTS.includes(options.sort as ValidatorEconomicsSort)
+  ) {
+    throw new UnsupportedSortError(String(options.sort));
+  }
   const sort = VALIDATOR_ECONOMICS_SORTS.includes(
     options.sort as ValidatorEconomicsSort,
   )

--- a/src/validator-economics.ts
+++ b/src/validator-economics.ts
@@ -60,6 +60,12 @@ export type ValidatorNeuron = {
    * which would drag the median toward a floor nobody actually set.
    */
   take?: number | null;
+  /**
+   * SS58 of the hotkey at this UID. Optional for the same reason `take` is: only the
+   * owner-exception path reads it, and a caller that cannot supply it gets the
+   * pre-#9460 behaviour rather than a crash.
+   */
+  hotkey?: string | null;
 };
 
 /** How far `modelAgreement` may fall before a derived floor stops being publishable. */
@@ -216,14 +222,68 @@ function ranked(
   );
 }
 
-// The permit set the rule implies: top-k by total stake among those clearing the threshold.
+// The subnet owner's UID, when the owner hotkey is registered on its own subnet.
+//
+// Null when no owner hotkey was supplied (callers that predate #9460) or when the owner
+// holds no UID here — an owner can run its subnet without registering a neuron on it.
+export function ownerUid(
+  neurons: readonly ValidatorNeuron[],
+  ownerHotkey?: string | null,
+): number | null {
+  if (!ownerHotkey) return null;
+  for (const n of neurons)
+    if (n.hotkey && n.hotkey === ownerHotkey) return n.uid;
+  return null;
+}
+
+// Validator slots left for everyone who is not the subnet owner.
+//
+// The owner's permit is unconditional but it is still ONE OF the `maxValidators` permits
+// the subnet issues, so it comes out of the same budget. Where the cap does not bind
+// this changes nothing; where it does, ignoring it would report a floor one rank too low.
+function competitorSlots(maxValidators: number, owner: number | null): number {
+  return Math.max(0, maxValidators - (owner === null ? 0 : 1));
+}
+
+// Eligible UIDs ranked by stake, with the owner removed — the field a non-owner
+// actually competes against for the remaining slots.
+function rankedCompetitors(
+  neurons: readonly ValidatorNeuron[],
+  stakeThreshold: number,
+  owner: number | null,
+): ValidatorNeuron[] {
+  const all = ranked(neurons, stakeThreshold);
+  return owner === null ? all : all.filter((n) => n.uid !== owner);
+}
+
+// The permit set the rule implies: the subnet owner unconditionally, then top-k by total
+// stake among the remaining UIDs clearing the threshold.
+//
+// ## Why the owner is unconditional
+//
+// Measured 2026-08-05 across the 13 subnets whose agreement had fallen below the
+// publishable floor: 9 of 9 remaining residuals were the subnet owner holding a permit
+// the stake rule cannot explain — three of them at EXACTLY zero stake — and
+// over-prediction was 0 on every subnet. Modelling the owner takes all 13 to 1.0.
+//
+// The other 5 residuals present that day were transient: UIDs that had dropped below the
+// threshold but whose permit had not yet been recomputed. Permits recompute once per
+// tempo while stake moves continuously, so a snapshot always contains some. They cleared
+// on their own within the hour and are deliberately NOT modelled here — they are timing,
+// not a rule, and `modelAgreement` is what reports them.
 export function predictPermits(
   neurons: readonly ValidatorNeuron[],
   maxValidators: number,
   stakeThreshold: number,
+  ownerHotkey?: string | null,
 ): Set<number> {
+  const owner = ownerUid(neurons, ownerHotkey);
   const predicted = new Set<number>();
-  for (const n of ranked(neurons, stakeThreshold).slice(0, maxValidators)) {
+  if (owner !== null) predicted.add(owner);
+  for (const n of rankedCompetitors(neurons, stakeThreshold, owner).slice(
+    0,
+    competitorSlots(maxValidators, owner),
+  )) {
     // A zero-stake UID clears the threshold only if the threshold is itself zero, which
     // a governance change could do — do not claim a permit in that case.
     if (n.totalStake > 0) predicted.add(n.uid);
@@ -241,8 +301,14 @@ export function modelAgreement(
   neurons: readonly ValidatorNeuron[],
   maxValidators: number,
   stakeThreshold: number,
+  ownerHotkey?: string | null,
 ): ModelAgreement {
-  const predicted = predictPermits(neurons, maxValidators, stakeThreshold);
+  const predicted = predictPermits(
+    neurons,
+    maxValidators,
+    stakeThreshold,
+    ownerHotkey,
+  );
   const observed = new Set<number>();
   for (const n of neurons) if (n.validatorPermit) observed.add(n.uid);
 
@@ -269,8 +335,13 @@ export function capBinding(
   neurons: readonly ValidatorNeuron[],
   maxValidators: number,
   stakeThreshold: number,
+  ownerHotkey?: string | null,
 ): boolean {
-  return eligible(neurons, stakeThreshold).length >= maxValidators;
+  const owner = ownerUid(neurons, ownerHotkey);
+  return (
+    rankedCompetitors(neurons, stakeThreshold, owner).length >=
+    competitorSlots(maxValidators, owner)
+  );
 }
 
 // Total-stake units needed to hold a permit on this subnet.
@@ -278,11 +349,18 @@ export function permitFloorUnits(
   neurons: readonly ValidatorNeuron[],
   maxValidators: number,
   stakeThreshold: number,
+  ownerHotkey?: string | null,
 ): number {
-  if (!capBinding(neurons, maxValidators, stakeThreshold))
+  if (!capBinding(neurons, maxValidators, stakeThreshold, ownerHotkey))
     return stakeThreshold;
-  const marginal = ranked(neurons, stakeThreshold)[maxValidators - 1];
-  return Math.max(stakeThreshold, marginal.totalStake);
+  // The owner's unconditional permit is not a rank a non-owner can take, so the marginal
+  // seat is the last COMPETITOR slot — one lower than the raw cap when an owner holds one.
+  const owner = ownerUid(neurons, ownerHotkey);
+  const competitors = rankedCompetitors(neurons, stakeThreshold, owner);
+  const marginal = competitors[competitorSlots(maxValidators, owner) - 1];
+  return marginal === undefined
+    ? stakeThreshold
+    : Math.max(stakeThreshold, marginal.totalStake);
 }
 
 // Total stake held by the smallest permit-holder actually earning dividends.
@@ -403,6 +481,13 @@ export type EconomicsInputs = {
   /** Live recycle/burn cost. Entry is two spends and publishing one understates it. */
   registrationCostTao?: number | null;
   minChildkeyTakeRatio?: number | null;
+  /**
+   * The subnet owner's hotkey (#9460). The owner holds a validator permit unconditionally,
+   * so the permit model cannot reproduce the chain without it — absent, every subnet whose
+   * owner sits below the stake threshold reports a permanent model disagreement and stops
+   * publishing its floors.
+   */
+  ownerHotkey?: string | null;
 };
 
 // 12s blocks.
@@ -463,7 +548,13 @@ export function buildValidatorEconomics(
     return { ...blank, degradedReason: "no metagraph rows for this subnet" };
   }
 
-  const agreement = modelAgreement(neurons, maxValidators, stakeThreshold);
+  const ownerHotkey = inputs.ownerHotkey ?? null;
+  const agreement = modelAgreement(
+    neurons,
+    maxValidators,
+    stakeThreshold,
+    ownerHotkey,
+  );
   const composition = setComposition(neurons);
   // Composition and agreement are OBSERVED, not derived — they stay published even when
   // the model has drifted, because they are exactly what a caller needs to see why.
@@ -473,13 +564,35 @@ export function buildValidatorEconomics(
       composition,
       // Takes are observed too, and stay published for the same reason composition does.
       takes: takeDistribution(neurons),
+      // So are these four (#9460). Suppressing the FLOOR when the permit model has
+      // drifted is right — a wrong floor reads as a price. But none of these depends on
+      // the floor model:
+      //   cap_binding / uids_above_threshold  count UIDs against the live threshold
+      //   validator_slots_open                is max_validators minus observed permits
+      //   root_tao_to_clear_threshold         is threshold / tao_weight, pure arithmetic
+      // Nulling them forced every consumer to guess, and the guess is asymmetric: assume
+      // an open cap on a subnet that is actually full and the floor you compute is too low.
+      capBinding: capBinding(
+        neurons,
+        maxValidators,
+        stakeThreshold,
+        ownerHotkey,
+      ),
+      uidsAboveThreshold: eligible(neurons, stakeThreshold).length,
+      validatorSlotsOpen: Math.max(0, maxValidators - composition.permitted),
+      rootTaoToClear: rootTaoToClear(stakeThreshold, taoWeight),
       modelAgreement: agreement,
       degradedReason:
         "permit model disagrees with observed permits on this subnet",
     };
   }
 
-  const floor = permitFloorUnits(neurons, maxValidators, stakeThreshold);
+  const floor = permitFloorUnits(
+    neurons,
+    maxValidators,
+    stakeThreshold,
+    ownerHotkey,
+  );
   const earnFloor = earningFloorUnits(neurons);
   const floorCost = ammCostTao(
     inputs.taoReserve ?? NaN,
@@ -509,7 +622,7 @@ export function buildValidatorEconomics(
     permitToEarningMultiple:
       earnFloor === null || floor <= 0 ? null : earnFloor / floor,
     rootTaoToClear: rootTaoToClear(stakeThreshold, taoWeight),
-    capBinding: capBinding(neurons, maxValidators, stakeThreshold),
+    capBinding: capBinding(neurons, maxValidators, stakeThreshold, ownerHotkey),
     uidsAboveThreshold: eligible(neurons, stakeThreshold).length,
     validatorSlotsOpen: Math.max(0, maxValidators - composition.permitted),
     composition,
@@ -680,6 +793,10 @@ export function groupNeuronsByNetuid(
     const bucket = out.get(row.netuid);
     const neuron: ValidatorNeuron = {
       uid: row.uid,
+      // Rebuilt field-by-field rather than spread, so every field this module reads has
+      // to be named here — `hotkey` included, or the owner exception (#9460) silently
+      // sees an unowned subnet on the cross-subnet ranking route only.
+      hotkey: row.hotkey ?? null,
       totalStake: row.totalStake,
       validatorPermit: row.validatorPermit,
       dividends: row.dividends,
@@ -720,6 +837,42 @@ export type ValidatorEconomicsHistoryPoint = {
   validators_earning: number;
   emission_gate_open: boolean | null;
   tao_inflow_per_day: number | null;
+  /**
+   * The subnet's validator cap (#9460). Carried on every point because
+   * `permit_floor_alpha` is the observed floor REGARDLESS of cap state, so it cannot be
+   * read without knowing whether the cap was the binding constraint that day — and
+   * joining today's cap onto a historical point is silently wrong for any subnet whose
+   * cap moved inside the window, which is exactly the join a consumer was forced into.
+   *
+   * Resolved per day from the hyperparameter change-log where that reaches back far
+   * enough, and from the live cap otherwise — `max_validators_source` says which, so the
+   * approximation is never silent. Null when unknown, never 0: an unknown cap must not
+   * read as "no slots".
+   */
+  max_validators: number | null;
+  /**
+   * Where this point's `max_validators` came from.
+   *
+   * `observed` — the change-log recorded this cap at or before this day, so it is what
+   *   the subnet actually had.
+   * `current`  — the change-log does not reach this far back, so the LIVE cap is
+   *   reported. Correct unless the cap moved, which is precisely the case a consumer
+   *   has to be able to detect. The change-log began filling 2026-08-04, so older
+   *   points read `current` and become `observed` as it accumulates.
+   *
+   * Null exactly when `max_validators` is null.
+   */
+  max_validators_source: "observed" | "current" | null;
+  /**
+   * Whether the permit set was FULL on this day: `validators_permitted >= max_validators`.
+   *
+   * Deliberately NOT named `cap_binding`. The per-subnet record's `cap_binding` is a
+   * forward-looking measure over UIDs that CLEAR THE THRESHOLD (candidates against
+   * slots); only the permitted set survives in the daily snapshot, so the same name
+   * would ship a different quantity — the silent-mismatch class this module exists to
+   * avoid. Null when the cap is unknown.
+   */
+  permit_set_full: boolean | null;
 };
 
 type HistoryRow = {
@@ -728,11 +881,18 @@ type HistoryRow = {
   validator_permit: unknown;
   dividends: unknown;
   active: unknown;
+  hotkey?: unknown;
 };
 
 type HistoryEmissionRow = {
   snapshot_date: unknown;
   tao_in_emission_tao: unknown;
+};
+
+/** One `subnet_hyperparams_history` entry: a CHANGE, not a daily value. */
+type HistoryCapRow = {
+  observed_at: unknown;
+  max_validators: unknown;
 };
 
 function numeric(value: unknown): number {
@@ -752,7 +912,55 @@ function numeric(value: unknown): number {
 export function buildValidatorEconomicsHistory(
   rows: readonly HistoryRow[],
   emissionRows: readonly HistoryEmissionRow[] = [],
+  options: {
+    /** The LIVE cap, used only for days the change-log does not reach. */
+    maxValidators?: number | null;
+    /**
+     * `subnet_hyperparams_history` rows for this subnet: a change-log, so the cap in
+     * force on a given day is the newest entry at or before it, not an entry per day.
+     */
+    capHistory?: readonly HistoryCapRow[];
+    /**
+     * The subnet owner's hotkey (#9460). The owner's permit is unconditional, so its
+     * stake is not a floor anyone else can enter at — a subnet whose owner holds a
+     * permit at ~0 published `permit_floor_alpha: 0`, which reads as "free to validate",
+     * the same wrong answer the per-subnet route already fails closed on.
+     */
+    ownerHotkey?: string | null;
+  } = {},
 ): ValidatorEconomicsHistoryPoint[] {
+  const positiveCap = (value: unknown): number | null => {
+    const n = Number(value);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  };
+  const liveCap = positiveCap(options.maxValidators);
+  const ownerHotkey = options.ownerHotkey || null;
+
+  // Ascending by observation time so the newest entry at or before a day is a scan
+  // backwards from the end — a change-log, not a per-day series.
+  const capLog = [...(options.capHistory ?? [])]
+    .map((row) => ({
+      observedAt: Number(row.observed_at),
+      cap: positiveCap(row.max_validators),
+    }))
+    .filter((row) => Number.isFinite(row.observedAt) && row.cap !== null)
+    .sort((a, b) => a.observedAt - b.observedAt);
+
+  // The cap in force at the END of a day — the snapshot is taken across it, and a
+  // change landing that morning is the cap that day's permits were computed against.
+  const capForDate = (
+    date: string,
+  ): { cap: number | null; source: "observed" | "current" | null } => {
+    const endOfDay = Date.parse(`${date}T23:59:59.999Z`);
+    if (Number.isFinite(endOfDay)) {
+      for (let i = capLog.length - 1; i >= 0; i -= 1) {
+        if (capLog[i].observedAt <= endOfDay) {
+          return { cap: capLog[i].cap, source: "observed" };
+        }
+      }
+    }
+    return { cap: liveCap, source: liveCap === null ? null : "current" };
+  };
   const emissionByDate = new Map<string, number | null>();
   for (const row of emissionRows) {
     const date = String(row.snapshot_date);
@@ -795,11 +1003,18 @@ export function buildValidatorEconomicsHistory(
     const stake = numeric(row.stake_tao);
     point.permitted += 1;
     if (numeric(row.active) === 1) point.active += 1;
+    // The owner still COUNTS as permitted — that is observed truth — but its stake is
+    // not a price anyone else can pay, so it never sets a floor (#9460).
+    const isOwner =
+      ownerHotkey !== null &&
+      row.hotkey != null &&
+      String(row.hotkey) === ownerHotkey;
+    if (numeric(row.dividends) > 0) point.earning += 1;
+    if (isOwner) continue;
     if (point.permitFloor === null || stake < point.permitFloor) {
       point.permitFloor = stake;
     }
     if (numeric(row.dividends) > 0) {
-      point.earning += 1;
       if (point.earningFloor === null || stake < point.earningFloor) {
         point.earningFloor = stake;
       }
@@ -826,6 +1041,7 @@ export function buildValidatorEconomicsHistory(
       const inflow = emissionByDate.has(snapshot_date)
         ? (emissionByDate.get(snapshot_date) ?? null)
         : null;
+      const { cap, source: capSource } = capForDate(snapshot_date);
       return {
         snapshot_date,
         permit_floor_alpha: point.permitFloor,
@@ -835,6 +1051,9 @@ export function buildValidatorEconomicsHistory(
         validators_earning: point.earning,
         emission_gate_open: inflow === null ? null : inflow > 0,
         tao_inflow_per_day: inflow === null ? null : inflow * BLOCKS_PER_DAY,
+        max_validators: cap,
+        max_validators_source: capSource,
+        permit_set_full: cap === null ? null : point.permitted >= cap,
       };
     })
     .sort((a, b) => b.snapshot_date.localeCompare(a.snapshot_date));

--- a/src/validator-economics.ts
+++ b/src/validator-economics.ts
@@ -5,10 +5,10 @@
 //
 // ## The rule, read from subtensor v441 (the deployed runtime), not inferred
 //
-//   validator_permit = top max_validators by total_stake,
-//                      among UIDs with total_stake >= StakeThreshold
+// validator_permit = top max_validators by total_stake,
+// among UIDs with total_stake >= StakeThreshold
 //
-//   total_stake = alpha + tao_weight * root      <- RAW rao, NOT normalised per leg
+// total_stake = alpha + tao_weight * root      <- RAW rao, NOT normalised per leg
 //
 // `staking/stake_utils.rs:278` combines the legs; `epoch/run_epoch.rs:246-261` filters
 // on the result then takes `is_topk_nonzero`. `StakeThreshold` raw is
@@ -36,11 +36,11 @@
 //
 // ## Two refusals, each a wrong answer found while measuring
 //
-//  1. `stakeThreshold` and `taoWeight` are PARAMETERS, never constants. A module that
-//     bakes in 1000 / 0.18 keeps returning confident, wrong floors after a governance
-//     change with nothing anywhere to notice.
-//  2. Rewards accrue as alpha. Realised revenue must go through `ammProceedsTao` — a
-//     spot mark overstates, because selling drains the pool it is priced against.
+// 1. `stakeThreshold` and `taoWeight` are PARAMETERS, never constants. A module that
+// bakes in 1000 / 0.18 keeps returning confident, wrong floors after a governance
+// change with nothing anywhere to notice.
+// 2. Rewards accrue as alpha. Realised revenue must go through `ammProceedsTao` — a
+// spot mark overstates, because selling drains the pool it is priced against.
 
 /** One UID's economics, normalised away from any tier's column shape. */
 export type ValidatorNeuron = {
@@ -63,7 +63,7 @@ export type ValidatorNeuron = {
   /**
    * SS58 of the hotkey at this UID. Optional for the same reason `take` is: only the
    * owner-exception path reads it, and a caller that cannot supply it gets the
-   * pre-#9460 behaviour rather than a crash.
+   * the earlier behaviour rather than a crash.
    */
   hotkey?: string | null;
 };
@@ -224,7 +224,7 @@ function ranked(
 
 // The subnet owner's UID, when the owner hotkey is registered on its own subnet.
 //
-// Null when no owner hotkey was supplied (callers that predate #9460) or when the owner
+// Null when no owner hotkey was supplied (callers that predate ) or when the owner
 // holds no UID here — an owner can run its subnet without registering a neuron on it.
 export function ownerUid(
   neurons: readonly ValidatorNeuron[],
@@ -371,7 +371,7 @@ export function permitFloorUnits(
 // nobody on the subnet earns.
 //
 // The subnet owner is excluded for the same reason it never sets the permit floor
-// (#9460): its permit is unconditional, so an owner earning on ~0 stake would report an
+//: its permit is unconditional, so an owner earning on ~0 stake would report an
 // earning floor of 0 — "free to earn here" — and, because a 0-alpha buy cannot be priced
 // against the pool, would then drop the whole subnet out of the cross-subnet ranking as
 // unpriceable. Both were happening.
@@ -491,7 +491,7 @@ export type EconomicsInputs = {
   registrationCostTao?: number | null;
   minChildkeyTakeRatio?: number | null;
   /**
-   * The subnet owner's hotkey (#9460). The owner holds a validator permit unconditionally,
+   * The subnet owner's hotkey. The owner holds a validator permit unconditionally,
    * so the permit model cannot reproduce the chain without it — absent, every subnet whose
    * owner sits below the stake threshold reports a permanent model disagreement and stops
    * publishing its floors.
@@ -573,12 +573,12 @@ export function buildValidatorEconomics(
       composition,
       // Takes are observed too, and stay published for the same reason composition does.
       takes: takeDistribution(neurons),
-      // So are these four (#9460). Suppressing the FLOOR when the permit model has
+      // So are these four. Suppressing the FLOOR when the permit model has
       // drifted is right — a wrong floor reads as a price. But none of these depends on
       // the floor model:
-      //   cap_binding / uids_above_threshold  count UIDs against the live threshold
-      //   validator_slots_open                is max_validators minus observed permits
-      //   root_tao_to_clear_threshold         is threshold / tao_weight, pure arithmetic
+      // cap_binding / uids_above_threshold  count UIDs against the live threshold
+      // validator_slots_open                is max_validators minus observed permits
+      // root_tao_to_clear_threshold         is threshold / tao_weight, pure arithmetic
       // Nulling them forced every consumer to guess, and the guess is asymmetric: assume
       // an open cap on a subnet that is actually full and the floor you compute is too low.
       capBinding: capBinding(
@@ -688,7 +688,7 @@ export const VALIDATOR_ECONOMICS_SORTS = [
 export type ValidatorEconomicsSort = (typeof VALIDATOR_ECONOMICS_SORTS)[number];
 
 /**
- * Thrown when a caller names a sort key that does not exist (#9460).
+ * Thrown when a caller names a sort key that does not exist.
  *
  * A distinct type rather than a bare Error so each surface can map it to its own
  * shape — REST to a 400, MCP to `invalid_params` — without string-matching a message.
@@ -752,7 +752,7 @@ export function rankValidatorEconomics(
   rows: readonly ValidatorEconomicsRow[],
   options: ValidatorEconomicsRankingOptions = {},
 ): ValidatorEconomicsRanking {
-  // An ABSENT sort takes the default; an unsupported one is rejected (#9460).
+  // An ABSENT sort takes the default; an unsupported one is rejected.
   //
   // These are different questions and this silently answered both with the default:
   // asking to rank by `tao_inflow_per_day` and mistyping it returned a list ranked by
@@ -838,7 +838,7 @@ export function groupNeuronsByNetuid(
     const neuron: ValidatorNeuron = {
       uid: row.uid,
       // Rebuilt field-by-field rather than spread, so every field this module reads has
-      // to be named here — `hotkey` included, or the owner exception (#9460) silently
+      // to be named here — `hotkey` included, or the owner exception silently
       // sees an unowned subnet on the cross-subnet ranking route only.
       hotkey: row.hotkey ?? null,
       totalStake: row.totalStake,
@@ -882,7 +882,7 @@ export type ValidatorEconomicsHistoryPoint = {
   emission_gate_open: boolean | null;
   tao_inflow_per_day: number | null;
   /**
-   * The subnet's validator cap (#9460). Carried on every point because
+   * The subnet's validator cap. Carried on every point because
    * `permit_floor_alpha` is the observed floor REGARDLESS of cap state, so it cannot be
    * read without knowing whether the cap was the binding constraint that day — and
    * joining today's cap onto a historical point is silently wrong for any subnet whose
@@ -898,11 +898,11 @@ export type ValidatorEconomicsHistoryPoint = {
    * Where this point's `max_validators` came from.
    *
    * `observed` — the change-log recorded this cap at or before this day, so it is what
-   *   the subnet actually had.
+   * the subnet actually had.
    * `current`  — the change-log does not reach this far back, so the LIVE cap is
-   *   reported. Correct unless the cap moved, which is precisely the case a consumer
-   *   has to be able to detect. The change-log began filling 2026-08-04, so older
-   *   points read `current` and become `observed` as it accumulates.
+   * reported. Correct unless the cap moved, which is precisely the case a consumer
+   * has to be able to detect. The change-log began filling 2026-08-04, so older
+   * points read `current` and become `observed` as it accumulates.
    *
    * Null exactly when `max_validators` is null.
    */
@@ -965,7 +965,7 @@ export function buildValidatorEconomicsHistory(
      */
     capHistory?: readonly HistoryCapRow[];
     /**
-     * The subnet owner's hotkey (#9460). The owner's permit is unconditional, so its
+     * The subnet owner's hotkey. The owner's permit is unconditional, so its
      * stake is not a floor anyone else can enter at — a subnet whose owner holds a
      * permit at ~0 published `permit_floor_alpha: 0`, which reads as "free to validate",
      * the same wrong answer the per-subnet route already fails closed on.
@@ -1048,7 +1048,7 @@ export function buildValidatorEconomicsHistory(
     point.permitted += 1;
     if (numeric(row.active) === 1) point.active += 1;
     // The owner still COUNTS as permitted — that is observed truth — but its stake is
-    // not a price anyone else can pay, so it never sets a floor (#9460).
+    // not a price anyone else can pay, so it never sets a floor.
     const isOwner =
       ownerHotkey !== null &&
       row.hotkey != null &&

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -2273,7 +2273,7 @@ describe("coverage-depth CSV export", () => {
 // run, so limit=50 yields exactly three pages at cursors 0 / 50 / 100.
 describe("pagination Link header", () => {
   // Only the PAGINATION relations. Every API response also carries a `service-desc`
-  // pointer to the OpenAPI document (#9460), which is not part of the walk and would
+  // pointer to the OpenAPI document, which is not part of the walk and would
   // otherwise show up in every relation-set assertion below.
   const PAGINATION_RELS = new Set(["first", "prev", "next", "last"]);
   const parseLink = (value: Row) => {

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -2272,11 +2272,15 @@ describe("coverage-depth CSV export", () => {
 // here proves the wiring for all of them. The fixture sorts to a stable netuid
 // run, so limit=50 yields exactly three pages at cursors 0 / 50 / 100.
 describe("pagination Link header", () => {
+  // Only the PAGINATION relations. Every API response also carries a `service-desc`
+  // pointer to the OpenAPI document (#9460), which is not part of the walk and would
+  // otherwise show up in every relation-set assertion below.
+  const PAGINATION_RELS = new Set(["first", "prev", "next", "last"]);
   const parseLink = (value: Row) => {
     const links: Row = {};
     for (const part of String(value || "").split(",")) {
       const match = part.match(/<([^>]+)>;\s*rel="([^"]+)"/);
-      if (match) {
+      if (match && PAGINATION_RELS.has(match[2])) {
         links[match[2]] = new URL(match[1]);
       }
     }
@@ -2344,17 +2348,20 @@ describe("pagination Link header", () => {
     assert.equal(links.last.searchParams.get("cursor"), "86");
   });
 
-  test("empty result set carries no Link header", async () => {
-    const { res } = await page("netuid=999999&limit=50");
+  test("empty result set advertises no page to walk to", async () => {
+    const { res, links } = await page("netuid=999999&limit=50");
     assert.equal(res.status, 200);
     assert.equal((await res.json()).meta.pagination.total, 0);
-    assert.equal(res.headers.get("link"), null);
+    assert.deepEqual(Object.keys(links), []);
+    // The service-desc pointer still ships — it describes the API, not the page.
+    assert.match(res.headers.get("link") ?? "", /rel="service-desc"/);
   });
 
-  test("an unpaged request (no limit/cursor) carries no Link header", async () => {
-    const { res } = await page("order=asc");
+  test("an unpaged request (no limit/cursor) advertises no page to walk to", async () => {
+    const { res, links } = await page("order=asc");
     assert.equal(res.status, 200);
-    assert.equal(res.headers.get("link"), null);
+    assert.deepEqual(Object.keys(links), []);
+    assert.match(res.headers.get("link") ?? "", /rel="service-desc"/);
   });
 
   test("a HEAD request still carries the walkable Link header", async () => {

--- a/tests/contracts.test.ts
+++ b/tests/contracts.test.ts
@@ -240,7 +240,7 @@ describe("public contract registry", () => {
     assert.equal(contracts.primary_domain, "api.metagraph.sh");
     assert.equal(contracts.openapi_url, "/metagraph/openapi.json");
     assert.equal(contracts.type_definitions_url, "/metagraph/types.d.ts");
-    // #9460: the RAW artifact, matching contracts.openapi_url above. This asserted
+    // the RAW artifact, matching contracts.openapi_url above. This asserted
     // "/api/v1/openapi.json" — the enveloped route, which is not a valid OpenAPI
     // document — so the check that should have caught the broken pointer was pinning it.
     assert.equal(apiIndex.openapi_url, "/metagraph/openapi.json");

--- a/tests/contracts.test.ts
+++ b/tests/contracts.test.ts
@@ -240,7 +240,15 @@ describe("public contract registry", () => {
     assert.equal(contracts.primary_domain, "api.metagraph.sh");
     assert.equal(contracts.openapi_url, "/metagraph/openapi.json");
     assert.equal(contracts.type_definitions_url, "/metagraph/types.d.ts");
-    assert.equal(apiIndex.openapi_url, "/api/v1/openapi.json");
+    // #9460: the RAW artifact, matching contracts.openapi_url above. This asserted
+    // "/api/v1/openapi.json" — the enveloped route, which is not a valid OpenAPI
+    // document — so the check that should have caught the broken pointer was pinning it.
+    assert.equal(apiIndex.openapi_url, "/metagraph/openapi.json");
+    assert.equal(
+      apiIndex.openapi_url,
+      contracts.openapi_url,
+      "the two published pointers must not disagree",
+    );
     assert.equal(apiIndex.routes.length, API_ROUTES.length);
     assert.equal(
       apiIndex.routes.find((route: Row) => route.id === "subnets")

--- a/tests/economics-surface-parity.test.ts
+++ b/tests/economics-surface-parity.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleRequest } from "../workers/api.ts";
+import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.ts";
+import type { Row } from "./row-type.ts";
+
+// #9460. REST and MCP answer the same question about the same resource, and an
+// external consumer found them holding two different snapshots of it — economics
+// three hours and ~900 blocks apart between `GET /api/v1/economics` and the MCP
+// `get_economics` tool.
+//
+// The two paths could not have disagreed at one instant: both read one KV key. But
+// they read it through DIFFERENT code — REST via the memoized `readEconomicsCurrentKv`,
+// MCP via a second raw `readHealthKv` — and nothing anywhere asserted they agree. This
+// file is that assertion. It goes through `handleRequest` for BOTH surfaces rather than
+// calling the composers directly, because the defect was in the Worker's wiring, not in
+// either composer: a test that injects its own readers would have passed throughout.
+//
+// It matters most on MCP specifically: an agent there has no second, independent path
+// to the same data, so a stale answer is indistinguishable from a current one. The
+// external report said exactly that — it nearly shipped a conclusion that a rebuild was
+// impossible because the API looked frozen.
+
+const CAPTURED_AT = "2026-08-05T03:26:09.362Z";
+const BLOCK = 8_775_311;
+
+const ECONOMICS_BLOB = {
+  contract_version: "test-contract",
+  captured_at: CAPTURED_AT,
+  schema_version: 1,
+  network: "finney",
+  chain_state: { block: BLOCK, block_hash: "0xabc" },
+  summary: { with_economics_count: 1, subnet_count: 1 },
+  subnets: [
+    {
+      netuid: 7,
+      name: "Allways",
+      slug: "allways",
+      block: BLOCK,
+      emission_share: 1,
+      registration_allowed: true,
+      tao_in_pool_tao: 1000,
+      alpha_in_pool: 100_000,
+    },
+  ],
+};
+
+/**
+ * One env, one KV blob, both surfaces — the shape the defect lived in.
+ *
+ * `reads` counts every `economics:current` fetch so the test can also show the two
+ * surfaces are not racing two independent reads of it.
+ */
+function makeEnv() {
+  const reads: string[] = [];
+  return {
+    reads,
+    env: {
+      METAGRAPH_CONTRACT_VERSION: "test-contract",
+      METAGRAPH_CONTROL: {
+        async get(key: string) {
+          reads.push(key);
+          return key === KV_ECONOMICS_CURRENT ? ECONOMICS_BLOB : null;
+        },
+      },
+      // R2 must answer for the committed fallback path; returning nothing forces the
+      // live KV tier to be the one under test.
+      METAGRAPH_ARCHIVE: { get: async () => null },
+    } as unknown as Env,
+  };
+}
+
+async function restEconomics(env: Env) {
+  const response = await handleRequest(
+    new Request("https://api.metagraph.sh/api/v1/economics?limit=1"),
+    env,
+    {
+      waitUntil() {},
+      passThroughOnException() {},
+    } as unknown as ExecutionContext,
+  );
+  return (await response.json()) as Row;
+}
+
+async function mcpEconomics(env: Env) {
+  const response = await handleRequest(
+    new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "get_economics", arguments: { limit: 1 } },
+      }),
+    }),
+    env,
+    {
+      waitUntil() {},
+      passThroughOnException() {},
+    } as unknown as ExecutionContext,
+  );
+  const body = (await response.json()) as Row;
+  const content = (body.result as Row)?.content as Array<Row> | undefined;
+  assert.ok(
+    content?.[0]?.text,
+    `MCP returned no tool content: ${JSON.stringify(body)}`,
+  );
+  return JSON.parse(String(content[0].text)) as Row;
+}
+
+describe("economics: REST and MCP resolve one snapshot", () => {
+  test("both surfaces report the same captured_at and block", async () => {
+    const { env } = makeEnv();
+    const rest = await restEconomics(env);
+    const mcp = await mcpEconomics(env);
+
+    const restData = rest.data as Row;
+    assert.equal(
+      restData.captured_at,
+      CAPTURED_AT,
+      "REST did not serve the live KV tier — the fixture, not the assertion, is wrong",
+    );
+    assert.equal(
+      mcp.captured_at,
+      restData.captured_at,
+      "MCP and REST are holding different snapshots of the same resource",
+    );
+    assert.equal(
+      (mcp.subnets as Array<Row>)[0].block,
+      (restData.chain_state as Row).block,
+      "the block an agent would cite differs by surface",
+    );
+  });
+
+  test("both report the same tier, so neither can silently fall back alone", async () => {
+    const { env } = makeEnv();
+    const rest = await restEconomics(env);
+    const mcp = await mcpEconomics(env);
+    assert.equal((rest.meta as Row).source, "live-kv");
+    assert.equal(mcp.source, (rest.meta as Row).source);
+  });
+
+  test("a cold KV tier degrades both surfaces the same way", async () => {
+    // The failure that matters is not "both broken" but "one broken": if only one
+    // surface falls back, an agent comparing them cannot tell which is right.
+    const env = {
+      METAGRAPH_CONTRACT_VERSION: "test-contract",
+      METAGRAPH_CONTROL: { get: async () => null },
+      METAGRAPH_ARCHIVE: { get: async () => null },
+    } as unknown as Env;
+    const rest = await restEconomics(env);
+    const mcp = await mcpEconomics(env).catch((error) => ({
+      error: String(error),
+    }));
+    assert.equal(
+      rest.ok,
+      false,
+      "no tier could answer, so REST must say so rather than serve an empty snapshot",
+    );
+    assert.ok(
+      "error" in mcp || (mcp as Row).source !== "live-kv",
+      "MCP claimed the live tier while REST could not reach it",
+    );
+  });
+
+  test("the two surfaces share one read of the blob, not one each", async () => {
+    // Not a performance assertion: two independently-timed reads of one key is the
+    // structure that let the surfaces drift apart in the first place.
+    const { env, reads } = makeEnv();
+    await restEconomics(env);
+    await mcpEconomics(env);
+    const economicsReads = reads.filter((key) => key === KV_ECONOMICS_CURRENT);
+    assert.ok(
+      economicsReads.length <= 1,
+      `both surfaces re-read economics:current independently (${economicsReads.length} reads)`,
+    );
+  });
+});

--- a/tests/economics-surface-parity.test.ts
+++ b/tests/economics-surface-parity.test.ts
@@ -4,7 +4,7 @@ import { handleRequest } from "../workers/api.ts";
 import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.ts";
 import type { Row } from "./row-type.ts";
 
-// #9460. REST and MCP answer the same question about the same resource, and an
+// REST and MCP answer the same question about the same resource, and an
 // external consumer found them holding two different snapshots of it — economics
 // three hours and ~900 blocks apart between `GET /api/v1/economics` and the MCP
 // `get_economics` tool.

--- a/tests/health-serving.test.ts
+++ b/tests/health-serving.test.ts
@@ -721,6 +721,90 @@ describe("mergeFreshness", () => {
     );
     assert.equal(out.summary.health_probe_as_of, "2026-06-11T00:00:00.000Z");
   });
+
+  // #9460. The publish stamps only what IT captured, so the two freshest tiers —
+  // economics (~3h, its own schedule) and the live chain reads (per request) — never
+  // appeared here at all. A consumer gating on this route would have rejected data
+  // hours newer than the number it was reading.
+  describe("the lanes that move independently of the publish", () => {
+    const NOW = Date.parse("2026-08-05T04:00:00.000Z");
+    const base = {
+      sources: [{ id: "surface-health", as_of: null, status: "missing" }],
+      summary: {},
+    };
+    const merge = (lanes: Record<string, unknown>) =>
+      mergeFreshness(
+        base,
+        { last_run_at: "2026-08-05T03:45:00.000Z" },
+        {
+          now: NOW,
+          ...lanes,
+        },
+      ) as Row;
+
+    test("reports the economics tier with the captured_at /economics returns", () => {
+      const out = merge({ economicsCapturedAt: "2026-08-05T03:26:09.362Z" });
+      const econ = out.sources.find((s: Row) => s.id === "economics-live");
+      assert.equal(econ.lane, "economics");
+      assert.equal(econ.as_of, "2026-08-05T03:26:09.362Z");
+      assert.equal(econ.status, "current", "34 minutes old, inside the window");
+      assert.equal(out.summary.economics_as_of, "2026-08-05T03:26:09.362Z");
+    });
+
+    test("reports the live-RPC tier with the queried_at /network/parameters returns", () => {
+      const out = merge({ parametersQueriedAt: "2026-08-05T03:59:00.000Z" });
+      const rpc = out.sources.find((s: Row) => s.id === "chain-parameters");
+      assert.equal(rpc.lane, "live-rpc");
+      assert.equal(rpc.status, "current");
+      assert.equal(out.summary.live_rpc_as_of, "2026-08-05T03:59:00.000Z");
+    });
+
+    test("an economics blob past the serving window reads stale", () => {
+      // The same 8h window resolveLiveEconomics itself gates on, so this route and the
+      // serving tier can never disagree about whether economics is stale.
+      const out = merge({ economicsCapturedAt: "2026-08-04T19:00:00.000Z" });
+      assert.equal(
+        out.sources.find((s: Row) => s.id === "economics-live").status,
+        "stale",
+      );
+    });
+
+    test("a cold tier reports missing, not an age it does not have", () => {
+      const out = merge({});
+      for (const id of ["economics-live", "chain-parameters"]) {
+        const source = out.sources.find((s: Row) => s.id === id);
+        assert.equal(source.status, "missing");
+        assert.equal(source.as_of, null);
+      }
+      assert.equal(out.summary.economics_as_of, null);
+    });
+
+    test("an unparseable timestamp is missing rather than infinitely stale", () => {
+      const out = merge({ economicsCapturedAt: "not-a-date" });
+      assert.equal(
+        out.sources.find((s: Row) => s.id === "economics-live").status,
+        "missing",
+      );
+    });
+
+    test("neither lane can block a publish it is not part of", () => {
+      const out = merge({
+        economicsCapturedAt: "2026-08-05T03:26:09.362Z",
+        parametersQueriedAt: "2026-08-05T03:59:00.000Z",
+      });
+      for (const id of ["economics-live", "chain-parameters"]) {
+        const source = out.sources.find((s: Row) => s.id === id);
+        assert.equal(source.required_for_publish, false);
+        assert.equal(source.stale_behavior, "warn");
+      }
+    });
+
+    test("leaves the built sources untouched", () => {
+      const out = merge({ economicsCapturedAt: "2026-08-05T03:26:09.362Z" });
+      assert.equal(out.sources.length, 3, "one built source plus the two live");
+      assert.equal(out.sources[0].id, "surface-health");
+    });
+  });
 });
 
 describe("formatTrends", () => {

--- a/tests/health-serving.test.ts
+++ b/tests/health-serving.test.ts
@@ -722,7 +722,7 @@ describe("mergeFreshness", () => {
     assert.equal(out.summary.health_probe_as_of, "2026-06-11T00:00:00.000Z");
   });
 
-  // #9460. The publish stamps only what IT captured, so the two freshest tiers —
+  // The publish stamps only what IT captured, so the two freshest tiers —
   // economics (~3h, its own schedule) and the live chain reads (per request) — never
   // appeared here at all. A consumer gating on this route would have rejected data
   // hours newer than the number it was reading.

--- a/tests/mcp-input-schema.test.ts
+++ b/tests/mcp-input-schema.test.ts
@@ -7,7 +7,7 @@ import {
 import { listToolDefinitions } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
-// #9460. `z.int()` carries JavaScript's safe-integer range as a real constraint, so
+// `z.int()` carries JavaScript's safe-integer range as a real constraint, so
 // every integer parameter published `maximum: 9007199254740991` whether or not anyone
 // chose a bound — 198 of 287 of them. The cost was not the number itself but that it
 // made a DELIBERATE `.max()` indistinguishable from the default, so "bounded" and

--- a/tests/mcp-input-schema.test.ts
+++ b/tests/mcp-input-schema.test.ts
@@ -91,6 +91,36 @@ describe("stripSentinelIntegerBounds", () => {
     assert.deepEqual(stripSentinelIntegerBounds(once), once);
   });
 
+  test("normalises a bare array of schemas", () => {
+    // The registry hands whole objects in, but anyOf/prefixItems recurse as arrays and
+    // the entry point accepts one directly.
+    assert.deepEqual(
+      stripSentinelIntegerBounds([
+        { type: "integer", maximum: MAX },
+        { type: "string" },
+      ]),
+      [{ type: "integer" }, { type: "string" }],
+    );
+  });
+
+  test("drops the exclusive sentinels too", () => {
+    // `z.int().gt()/.lt()` emit these instead of minimum/maximum, and they carry the
+    // same safe-integer default.
+    assert.deepEqual(
+      stripSentinelIntegerBounds({
+        type: "integer",
+        exclusiveMaximum: MAX,
+        exclusiveMinimum: MIN,
+      }),
+      { type: "integer" },
+    );
+    // A real exclusive bound survives.
+    assert.deepEqual(
+      stripSentinelIntegerBounds({ type: "integer", exclusiveMaximum: 10 }),
+      { type: "integer", exclusiveMaximum: 10 },
+    );
+  });
+
   test("passes through primitives and null without throwing", () => {
     assert.equal(stripSentinelIntegerBounds(null), null);
     assert.equal(stripSentinelIntegerBounds(undefined), undefined);

--- a/tests/mcp-input-schema.test.ts
+++ b/tests/mcp-input-schema.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  hasSentinelIntegerBound,
+  stripSentinelIntegerBounds,
+} from "../src/mcp-input-schema.ts";
+import { listToolDefinitions } from "../src/mcp-server.ts";
+import type { Row } from "./row-type.ts";
+
+// #9460. `z.int()` carries JavaScript's safe-integer range as a real constraint, so
+// every integer parameter published `maximum: 9007199254740991` whether or not anyone
+// chose a bound — 198 of 287 of them. The cost was not the number itself but that it
+// made a DELIBERATE `.max()` indistinguishable from the default, so "bounded" and
+// "unbounded" rendered identically and an external consumer reasonably read an
+// unbounded list parameter off the schema.
+
+const MAX = Number.MAX_SAFE_INTEGER;
+const MIN = Number.MIN_SAFE_INTEGER;
+
+describe("stripSentinelIntegerBounds", () => {
+  test("drops the sentinel bounds Zod adds to every integer", () => {
+    assert.deepEqual(
+      stripSentinelIntegerBounds({
+        type: "integer",
+        minimum: MIN,
+        maximum: MAX,
+      }),
+      { type: "integer" },
+    );
+  });
+
+  test("keeps a bound someone actually chose", () => {
+    // The whole point: after this, a `maximum` means a decision.
+    assert.deepEqual(
+      stripSentinelIntegerBounds({ type: "integer", minimum: 0, maximum: 512 }),
+      { type: "integer", minimum: 0, maximum: 512 },
+    );
+  });
+
+  test("keeps an explicit minimum while dropping the implicit maximum", () => {
+    assert.deepEqual(
+      stripSentinelIntegerBounds({ type: "integer", minimum: 1, maximum: MAX }),
+      { type: "integer", minimum: 1 },
+    );
+  });
+
+  test("leaves non-integer types alone", () => {
+    // On a `number` these bounds would be a deliberate, if odd, choice.
+    const number = { type: "number", maximum: MAX };
+    assert.deepEqual(stripSentinelIntegerBounds(number), number);
+    const string = { type: "string", enum: ["a", "b"] };
+    assert.deepEqual(stripSentinelIntegerBounds(string), string);
+  });
+
+  test("reaches integers nested anywhere a subschema can hide", () => {
+    const out = stripSentinelIntegerBounds({
+      type: "object",
+      properties: {
+        limit: { type: "integer", maximum: MAX },
+        nested: {
+          type: "array",
+          items: { type: "integer", maximum: MAX },
+        },
+        either: {
+          anyOf: [{ type: "integer", maximum: MAX }, { type: "string" }],
+        },
+      },
+    }) as Row;
+    const props = out.properties as Row;
+    assert.equal((props.limit as Row).maximum, undefined);
+    assert.equal(
+      (((props.nested as Row).items as Row) || {}).maximum,
+      undefined,
+    );
+    assert.equal(
+      ((props.either as Row).anyOf as Array<Row>)[0].maximum,
+      undefined,
+    );
+  });
+
+  test("does not mutate its argument", () => {
+    // The registry and the validator share these objects; normalising in place would
+    // make the second read differ from the first.
+    const input = { type: "integer", maximum: MAX };
+    stripSentinelIntegerBounds(input);
+    assert.equal(input.maximum, MAX);
+  });
+
+  test("is idempotent", () => {
+    const once = stripSentinelIntegerBounds({ type: "integer", maximum: MAX });
+    assert.deepEqual(stripSentinelIntegerBounds(once), once);
+  });
+
+  test("passes through primitives and null without throwing", () => {
+    assert.equal(stripSentinelIntegerBounds(null), null);
+    assert.equal(stripSentinelIntegerBounds(undefined), undefined);
+    assert.equal(stripSentinelIntegerBounds(7), 7);
+  });
+});
+
+describe("hasSentinelIntegerBound", () => {
+  test("detects a sentinel and ignores a real bound", () => {
+    assert.equal(
+      hasSentinelIntegerBound({ type: "integer", maximum: MAX }),
+      true,
+    );
+    assert.equal(
+      hasSentinelIntegerBound({ type: "integer", maximum: 512 }),
+      false,
+    );
+  });
+});
+
+describe("the published tool registry", () => {
+  const tools = listToolDefinitions() as Array<Row>;
+
+  test("publishes no safe-integer sentinel on any of the 215 tools", () => {
+    const offenders = tools
+      .filter((tool) => hasSentinelIntegerBound(tool.inputSchema))
+      .map((tool) => tool.name);
+    assert.deepEqual(offenders, []);
+  });
+
+  test("bounds the parameters that genuinely are bounded", () => {
+    const props = (name: string) =>
+      ((tools.find((tool) => tool.name === name)?.inputSchema as Row)
+        ?.properties ?? {}) as Row;
+    // netuid is a u16 on chain, and the REST routes reject outside that range.
+    assert.equal(
+      (props("get_subnet_validator_economics").netuid as Row).maximum,
+      65535,
+    );
+    // A page size must agree with the ceiling its own route enforces.
+    assert.equal(
+      (props("list_validator_economics").limit as Row).maximum,
+      512,
+      "src/route-limits.ts is the single declaration of this",
+    );
+  });
+
+  test("declares an enum wherever the description names a closed set", () => {
+    const param = (name: string, key: string) =>
+      ((
+        (tools.find((tool) => tool.name === name)?.inputSchema as Row)
+          ?.properties as Row
+      )?.[key] ?? {}) as Row;
+    assert.deepEqual(
+      param("get_subnet_validator_economics_history", "window").enum,
+      ["7d", "30d", "90d"],
+    );
+    assert.ok(
+      Array.isArray(param("list_validator_economics", "sort").enum),
+      "REST 400s on an unsupported sort; the schema has to say which are supported",
+    );
+    assert.ok(
+      (param("call_rpc", "method").enum as string[])?.includes("system_health"),
+      "a hard allowlist spelled out in prose belongs in the schema",
+    );
+  });
+
+  test("states the fields syntax rather than leaving it to be guessed", () => {
+    const fields = ((
+      (tools.find((tool) => tool.name === "get_economics")?.inputSchema as Row)
+        ?.properties as Row
+    )?.fields ?? {}) as Row;
+    assert.ok(fields.pattern, "comma-separated identifiers, declared");
+    assert.match(String(fields.description), /[Cc]omma-separated/);
+    // The declared pattern must accept what the projection layer accepts.
+    const re = new RegExp(String(fields.pattern));
+    assert.ok(re.test("netuid,name,slug"));
+    assert.ok(!re.test('["netuid","name"]'), "not a JSON array");
+    assert.ok(!re.test("netuid.name"), "no paths");
+    assert.ok(!re.test(""), "an empty projection is an error, not everything");
+    // The pattern must accept everything parseFieldsParam accepts: it trims each
+    // segment and drops empty ones, so a tidier pattern would have clients rejecting
+    // input the server takes — the defect this whole change is about.
+    assert.ok(re.test("netuid, name"), "the parser trims");
+    assert.ok(re.test("netuid,,name"), "the parser drops empty segments");
+  });
+});

--- a/tests/network-parameters.test.ts
+++ b/tests/network-parameters.test.ts
@@ -6,6 +6,7 @@ import {
   NETWORK_PARAMETERS_RPC_TIMEOUT_MS,
   NETWORK_PARAMETERS_FIELD_SOURCES,
   loadNetworkParameters,
+  readCachedNetworkParametersSnapshot,
 } from "../src/network-parameters.ts";
 import { handleRequest } from "../workers/api.ts";
 import { mockEnv } from "./row-type.ts";
@@ -581,6 +582,63 @@ describe("GET /api/v1/network/parameters via the Worker", () => {
           );
         }
       },
+    );
+  });
+});
+
+// #9460. /freshness reports how current the live-RPC lane is, and reads the cached
+// snapshot ONLY — never falling through to chain RPC. A freshness probe that triggered
+// the work it measures would refresh `queried_at` on every call and always report
+// "current": a lane that cannot go stale, and therefore cannot be gated on.
+describe("readCachedNetworkParametersSnapshot", () => {
+  test("returns the cached snapshot without touching RPC", async () => {
+    const snapshot = {
+      queried_at: "2026-08-05T03:59:00.000Z",
+      tao_weight: 0.18,
+    };
+    let fetched = false;
+    await withFetchStub(
+      () => {
+        fetched = true;
+        throw new Error("the freshness probe must not query the chain");
+      },
+      async () => {
+        const out = await readCachedNetworkParametersSnapshot({
+          METAGRAPH_CONTROL: { get: async () => snapshot },
+        } as unknown as Env);
+        assert.equal(out?.queried_at, snapshot.queried_at);
+        assert.equal(fetched, false);
+      },
+    );
+  });
+
+  test("a cold or unbound KV is null, not an RPC read", async () => {
+    assert.equal(
+      await readCachedNetworkParametersSnapshot({} as unknown as Env),
+      null,
+      "unbound",
+    );
+    assert.equal(
+      await readCachedNetworkParametersSnapshot({
+        METAGRAPH_CONTROL: { get: async () => null },
+      } as unknown as Env),
+      null,
+      "cold",
+    );
+  });
+
+  test("a KV failure is null rather than a thrown freshness route", async () => {
+    // The caller reports `missing`; a throw here would take out the whole route over
+    // one lane's store being unreachable.
+    assert.equal(
+      await readCachedNetworkParametersSnapshot({
+        METAGRAPH_CONTROL: {
+          get: async () => {
+            throw new Error("KV down");
+          },
+        },
+      } as unknown as Env),
+      null,
     );
   });
 });

--- a/tests/network-parameters.test.ts
+++ b/tests/network-parameters.test.ts
@@ -586,7 +586,7 @@ describe("GET /api/v1/network/parameters via the Worker", () => {
   });
 });
 
-// #9460. /freshness reports how current the live-RPC lane is, and reads the cached
+// /freshness reports how current the live-RPC lane is, and reads the cached
 // snapshot ONLY — never falling through to chain RPC. A freshness probe that triggered
 // the work it measures would refresh `queried_at` on every call and always report
 // "current": a lane that cannot go stale, and therefore cannot be gated on.

--- a/tests/request-handlers-analytics.test.ts
+++ b/tests/request-handlers-analytics.test.ts
@@ -1664,7 +1664,12 @@ describe("handleGlobalIncidents", () => {
       url(p),
     );
     await json(res);
-    assert.equal(res.headers.get("link"), null);
+    // No pagination relations; the service-desc pointer every API response carries
+    // (#9460) is not one of them.
+    assert.doesNotMatch(
+      res.headers.get("link") ?? "",
+      /rel="(next|prev|first|last)"/,
+    );
   });
 });
 

--- a/tests/request-handlers-analytics.test.ts
+++ b/tests/request-handlers-analytics.test.ts
@@ -1665,7 +1665,7 @@ describe("handleGlobalIncidents", () => {
     );
     await json(res);
     // No pagination relations; the service-desc pointer every API response carries
-    // (#9460) is not one of them.
+    // is not one of them.
     assert.doesNotMatch(
       res.headers.get("link") ?? "",
       /rel="(next|prev|first|last)"/,

--- a/tests/responses-envelope.test.ts
+++ b/tests/responses-envelope.test.ts
@@ -37,7 +37,7 @@ test("envelopeResponse applies extra headers and skips null values", async () =>
     "x-skip-me": null,
   });
   // The caller's pagination link survives; the service-desc pointer is APPENDED to
-  // it rather than replacing it (#9460) — RFC 8288 carries multiple values, and
+  // it rather than replacing it — RFC 8288 carries multiple values, and
   // trading pagination away for discoverability would be a worse bargain.
   assert.match(
     res.headers.get("link") ?? "",
@@ -158,7 +158,7 @@ test("envelopeResponse: a match returns a bodiless 304, a miss returns the body"
   assert.equal(((await stale.json()) as Row).data.hello, "world");
 });
 
-// #9460. The OpenAPI spec is published and complete, but the `service-desc` Link was
+// The OpenAPI spec is published and complete, but the `service-desc` Link was
 // emitted only on `/`, and the api index advertised `/api/v1/openapi.json` — which
 // serves the spec INSIDE the success envelope, so it carries no top-level `openapi`
 // key and every generator pointed at it fails. An external integrator hand-probed

--- a/tests/responses-envelope.test.ts
+++ b/tests/responses-envelope.test.ts
@@ -36,7 +36,14 @@ test("envelopeResponse applies extra headers and skips null values", async () =>
     link: '<https://x/next>; rel="next"',
     "x-skip-me": null,
   });
-  assert.equal(res.headers.get("link"), '<https://x/next>; rel="next"');
+  // The caller's pagination link survives; the service-desc pointer is APPENDED to
+  // it rather than replacing it (#9460) — RFC 8288 carries multiple values, and
+  // trading pagination away for discoverability would be a worse bargain.
+  assert.match(
+    res.headers.get("link") ?? "",
+    /<https:\/\/x\/next>; rel="next"/,
+  );
+  assert.match(res.headers.get("link") ?? "", /rel="service-desc"/);
   assert.equal(res.headers.has("x-skip-me"), false);
 });
 
@@ -52,7 +59,13 @@ test("envelopeResponse keeps extra headers on a 304 short-circuit", async () => 
     { link: '<https://x/next>; rel="next"' },
   );
   assert.equal(res.status, 304);
-  assert.equal(res.headers.get("link"), '<https://x/next>; rel="next"');
+  assert.match(
+    res.headers.get("link") ?? "",
+    /<https:\/\/x\/next>; rel="next"/,
+  );
+  // A 304 carries it too: a conditional request is exactly when a client that already
+  // has the body is still looking for the spec.
+  assert.match(res.headers.get("link") ?? "", /rel="service-desc"/);
 });
 
 // Regression guard: the two success builders (dataResponse + envelopeResponse)
@@ -143,4 +156,34 @@ test("envelopeResponse: a match returns a bodiless 304, a miss returns the body"
   const stale = await envelopeResponse(reqWith('"stale"'), payload, "standard");
   assert.equal(stale.status, 200);
   assert.equal(((await stale.json()) as Row).data.hello, "world");
+});
+
+// #9460. The OpenAPI spec is published and complete, but the `service-desc` Link was
+// emitted only on `/`, and the api index advertised `/api/v1/openapi.json` — which
+// serves the spec INSIDE the success envelope, so it carries no top-level `openapi`
+// key and every generator pointed at it fails. An external integrator hand-probed
+// routes and reported that no spec existed. Both pointers now name the raw artifact,
+// and every API response carries one.
+test("every API response points at the OpenAPI document", async () => {
+  const payload = { data: { ok: 1 }, meta: { contract_version: "test" } };
+  const res = await envelopeResponse(reqWith(null), payload, "standard");
+  const link = res.headers.get("link") ?? "";
+  assert.match(link, /rel="service-desc"/);
+  assert.match(
+    link,
+    /\/metagraph\/openapi\.json/,
+    "the RAW artifact — the enveloped route is not a valid OpenAPI document",
+  );
+  assert.doesNotMatch(link, /\/api\/v1\/openapi\.json/);
+});
+
+test("the api index and the contracts artifact agree on where the spec is", async () => {
+  // These two pointers disagreed, and the more prominent one was the broken one.
+  const { buildApiIndexArtifact, buildContractsArtifact } =
+    await import("../src/contracts.ts");
+  const generatedAt = "2026-08-05T00:00:00.000Z";
+  const contracts = buildContractsArtifact(generatedAt);
+  const index = buildApiIndexArtifact(generatedAt, contracts) as Row;
+  assert.equal((contracts as Row).openapi_url, "/metagraph/openapi.json");
+  assert.equal(index.openapi_url, (contracts as Row).openapi_url);
 });

--- a/tests/subnet-validator-economics-route.test.ts
+++ b/tests/subnet-validator-economics-route.test.ts
@@ -126,14 +126,14 @@ describe("buildSubnetValidatorEconomicsPayload", () => {
     assert.match(sql[0], /FROM neurons WHERE netuid = \?/);
     assert.match(sql[0], /stake_tao/);
     assert.match(sql[0], /take/);
-    // The owner exception (#9460) needs the hotkey to find the owner's UID; without it
+    // The owner exception needs the hotkey to find the owner's UID; without it
     // selected, every owner-below-threshold subnet stays permanently degraded.
     assert.match(sql[0], /hotkey/);
     // A SELECT * here would drag ~20 unused columns per UID across 256 rows.
     assert.doesNotMatch(sql[0], /SELECT \*/);
   });
 
-  // #9460, end to end: the owner hotkey lives on the economics artifact and the UID it
+  // end to end: the owner hotkey lives on the economics artifact and the UID it
   // names lives in D1, so this is the one place the two tiers have to meet.
   test("threads the owner hotkey from the economics tier into the permit model", async () => {
     const neurons = [
@@ -170,7 +170,7 @@ describe("buildSubnetValidatorEconomicsPayload", () => {
   });
 
   test("publishes the model-free fields even while the floor is withheld", async () => {
-    // #9460: cap_binding, uids_above_threshold, validator_slots_open and
+    // cap_binding, uids_above_threshold, validator_slots_open and
     // root_tao_to_clear_threshold are counted off the live threshold and the observed
     // permits — none of them needs the floor model that has drifted.
     const { env } = envWith({
@@ -536,7 +536,7 @@ describe("buildValidatorEconomicsRankingPayload", () => {
     );
   });
 
-  // #9460, on the CROSS-SUBNET route: the owner exception has to reach here too, or
+  // on the CROSS-SUBNET route: the owner exception has to reach here too, or
   // every owner-below-threshold subnet lands in `excluded` and drops out of the ranking
   // entirely — which is how 13 subnets were missing from it.
   test("applies the owner exception per subnet from the economics rows", async () => {
@@ -874,7 +874,7 @@ describe("buildSubnetValidatorEconomicsHistoryPayload", () => {
     );
     assert.match(sql[0], /LIMIT \?/);
     // The owner's unconditional permit has to be identifiable to stay out of the
-    // observed floor (#9460).
+    // observed floor.
     assert.match(sql[0], /hotkey/);
     assert.equal(binds[0][0], 7);
     // The cutoff is a date string, not a timestamp — snapshot_date is TEXT.
@@ -882,7 +882,7 @@ describe("buildSubnetValidatorEconomicsHistoryPayload", () => {
     assert.equal(typeof binds[0][2], "number");
   });
 
-  // #9460: the series was not self-contained. `permit_floor_alpha` is the observed
+  // the series was not self-contained. `permit_floor_alpha` is the observed
   // floor regardless of cap state, so reading it needs the cap — which lived only on
   // the current record, making the join wrong for any subnet whose cap had moved.
   test("stamps the cap and the full-set flag onto every point", async () => {

--- a/tests/subnet-validator-economics-route.test.ts
+++ b/tests/subnet-validator-economics-route.test.ts
@@ -536,6 +536,32 @@ describe("buildValidatorEconomicsRankingPayload", () => {
     );
   });
 
+  // #9460, on the CROSS-SUBNET route: the owner exception has to reach here too, or
+  // every owner-below-threshold subnet lands in `excluded` and drops out of the ranking
+  // entirely — which is how 13 subnets were missing from it.
+  test("applies the owner exception per subnet from the economics rows", async () => {
+    const scan = [
+      scanRow(5, 0, { hotkey: "5V0", stake_tao: 5000 }),
+      scanRow(5, 9, { hotkey: "5OWNER", stake_tao: 0 }),
+    ];
+    const withoutOwner = await buildValidatorEconomicsRankingPayload(
+      rankEnv(scan).env,
+      {},
+      rankDeps([pool(5)]),
+    );
+    // Without the owner the floor is withheld, so the subnet cannot be priced and
+    // drops out of the ranking entirely — not merely flagged within it.
+    assert.deepEqual(withoutOwner.data.rows, []);
+    assert.equal((withoutOwner.data.excluded as Row[])[0]?.netuid, 5);
+    const withOwner = await buildValidatorEconomicsRankingPayload(
+      rankEnv(scan).env,
+      {},
+      rankDeps([pool(5, { owner_hotkey: "5OWNER" })]),
+    );
+    assert.equal((withOwner.data.rows as Row[])[0]?.degraded_reason, null);
+    assert.equal((withOwner.data.rows as Row[])[0]?.permit_floor_units, 1000);
+  });
+
   test("derives one row per subnet from a single grouped scan", async () => {
     const { env } = rankEnv([
       scanRow(5, 0),

--- a/tests/subnet-validator-economics-route.test.ts
+++ b/tests/subnet-validator-economics-route.test.ts
@@ -126,8 +126,65 @@ describe("buildSubnetValidatorEconomicsPayload", () => {
     assert.match(sql[0], /FROM neurons WHERE netuid = \?/);
     assert.match(sql[0], /stake_tao/);
     assert.match(sql[0], /take/);
+    // The owner exception (#9460) needs the hotkey to find the owner's UID; without it
+    // selected, every owner-below-threshold subnet stays permanently degraded.
+    assert.match(sql[0], /hotkey/);
     // A SELECT * here would drag ~20 unused columns per UID across 256 rows.
     assert.doesNotMatch(sql[0], /SELECT \*/);
+  });
+
+  // #9460, end to end: the owner hotkey lives on the economics artifact and the UID it
+  // names lives in D1, so this is the one place the two tiers have to meet.
+  test("threads the owner hotkey from the economics tier into the permit model", async () => {
+    const neurons = [
+      permitted(0, { hotkey: "5V0", stake_tao: 5000 }),
+      // The owner, holding a permit the stake rule cannot explain — SN5's shape.
+      permitted(9, { hotkey: "5OWNER", stake_tao: 0 }),
+    ];
+    const withoutOwner = await buildSubnetValidatorEconomicsPayload(
+      envWith({ neurons }).env,
+      7,
+      deps(),
+    );
+    assert.equal(
+      withoutOwner.data.degraded_reason,
+      "permit model disagrees with observed permits on this subnet",
+    );
+    assert.equal(withoutOwner.data.permit_floor_units, null);
+
+    const withOwner = await buildSubnetValidatorEconomicsPayload(
+      envWith({
+        neurons,
+        economics: economicsArtifact({ owner_hotkey: "5OWNER" }),
+      }).env,
+      7,
+      deps(),
+    );
+    assert.equal(withOwner.data.degraded_reason, null);
+    assert.equal(withOwner.data.permit_floor_units, 1000);
+    assert.equal(
+      (withOwner.data.model_agreement as Row | null)?.agreement,
+      1,
+      "the owner exception reproduces the chain exactly",
+    );
+  });
+
+  test("publishes the model-free fields even while the floor is withheld", async () => {
+    // #9460: cap_binding, uids_above_threshold, validator_slots_open and
+    // root_tao_to_clear_threshold are counted off the live threshold and the observed
+    // permits — none of them needs the floor model that has drifted.
+    const { env } = envWith({
+      neurons: [
+        permitted(0, { hotkey: "5V0", stake_tao: 5000 }),
+        permitted(9, { hotkey: "5OWNER", stake_tao: 0 }),
+      ],
+    });
+    const { data } = await buildSubnetValidatorEconomicsPayload(env, 7, deps());
+    assert.equal(data.permit_floor_units, null, "still withheld");
+    assert.equal(data.cap_binding, false);
+    assert.equal(data.uids_above_threshold, 1);
+    assert.equal(data.validator_slots_open, 62, "64 slots less 2 permits");
+    assert.equal(data.root_tao_to_clear_threshold, 1000 / 0.18);
   });
 
   test("treats a result set with no rows array as empty, not as a crash", async () => {
@@ -730,7 +787,11 @@ describe("validator-economics routing", () => {
 });
 
 describe("buildSubnetValidatorEconomicsHistoryPayload", () => {
-  function historyEnv(neuronRows: Row[], emissionRows: Row[] = []) {
+  function historyEnv(
+    neuronRows: Row[],
+    emissionRows: Row[] = [],
+    capRows: Row[] = [],
+  ) {
     const sql: string[] = [];
     const binds: unknown[][] = [];
     return {
@@ -740,13 +801,25 @@ describe("buildSubnetValidatorEconomicsHistoryPayload", () => {
         METAGRAPH_HEALTH_DB: {
           prepare(query: string) {
             sql.push(query);
-            const isEmission = /subnet_snapshots/.test(query);
+            // Three different reads share this stub, so each has to be told apart by
+            // its table — returning the neuron rows for all of them would let a
+            // broken cap query pass by accident.
+            const table = /subnet_snapshots/.test(query)
+              ? "emission"
+              : /subnet_hyperparams_history/.test(query)
+                ? "cap"
+                : "neurons";
             return {
               bind(...args: unknown[]) {
                 binds.push(args);
                 return {
                   all: async () => ({
-                    results: isEmission ? emissionRows : neuronRows,
+                    results:
+                      table === "emission"
+                        ? emissionRows
+                        : table === "cap"
+                          ? capRows
+                          : neuronRows,
                   }),
                 };
               },
@@ -774,10 +847,123 @@ describe("buildSubnetValidatorEconomicsHistoryPayload", () => {
       /FROM neuron_daily WHERE netuid = \? AND snapshot_date >= \?/,
     );
     assert.match(sql[0], /LIMIT \?/);
+    // The owner's unconditional permit has to be identifiable to stay out of the
+    // observed floor (#9460).
+    assert.match(sql[0], /hotkey/);
     assert.equal(binds[0][0], 7);
     // The cutoff is a date string, not a timestamp — snapshot_date is TEXT.
     assert.match(String(binds[0][1]), /^\d{4}-\d{2}-\d{2}$/);
     assert.equal(typeof binds[0][2], "number");
+  });
+
+  // #9460: the series was not self-contained. `permit_floor_alpha` is the observed
+  // floor regardless of cap state, so reading it needs the cap — which lived only on
+  // the current record, making the join wrong for any subnet whose cap had moved.
+  test("stamps the cap and the full-set flag onto every point", async () => {
+    const { env } = historyEnv([
+      dayRow("2026-08-01"),
+      dayRow("2026-08-01", { stake_tao: 3000 }),
+    ]);
+    const { data } = await buildSubnetValidatorEconomicsHistoryPayload(
+      env,
+      7,
+      "7d",
+      {
+        loadEconomicsRow: (async () => ({
+          row: { max_validators: 2 },
+          generatedAt: null,
+        })) as never,
+      },
+    );
+    const points = data.points as Array<Row>;
+    assert.equal(points[0].max_validators, 2);
+    assert.equal(points[0].permit_set_full, true, "2 permitted for 2 slots");
+    assert.equal(
+      points[0].max_validators_source,
+      "current",
+      "no change-log entry reaches this day, so the live cap is reported AS the live cap",
+    );
+  });
+
+  // Stamping today's cap onto an old point manufactures a transition that never
+  // happened — the reason the cap was left out of the series in the first place. The
+  // change-log is what makes it publishable: the cap in force on a day is the newest
+  // entry at or before it.
+  test("resolves the cap per day from the hyperparameter change-log", async () => {
+    const { env, sql } = historyEnv(
+      [dayRow("2026-08-01"), dayRow("2026-08-03")],
+      [],
+      [
+        // Raised from 8 to 64 on 2026-08-02.
+        { observed_at: Date.parse("2026-07-01T00:00:00Z"), max_validators: 8 },
+        { observed_at: Date.parse("2026-08-02T12:00:00Z"), max_validators: 64 },
+      ],
+    );
+    const { data } = await buildSubnetValidatorEconomicsHistoryPayload(
+      env,
+      7,
+      "30d",
+      {
+        loadEconomicsRow: (async () => ({
+          row: { max_validators: 64 },
+          generatedAt: null,
+        })) as never,
+      },
+    );
+    assert.match(sql[2], /FROM subnet_hyperparams_history/);
+    // The change-log is deliberately NOT bounded by the window: the cap on day one is
+    // whatever the last change before the window set.
+    assert.doesNotMatch(sql[2], /observed_at >= \?/);
+    const byDate = new Map(
+      (data.points as Array<Row>).map((p) => [p.snapshot_date, p]),
+    );
+    assert.equal(byDate.get("2026-08-01")?.max_validators, 8);
+    assert.equal(byDate.get("2026-08-01")?.max_validators_source, "observed");
+    assert.equal(byDate.get("2026-08-03")?.max_validators, 64);
+    assert.equal(byDate.get("2026-08-03")?.max_validators_source, "observed");
+  });
+
+  test("keeps the owner's unconditional permit out of the observed floor", async () => {
+    const { env } = historyEnv([
+      dayRow("2026-08-01", { stake_tao: 4000, hotkey: "5V0" }),
+      dayRow("2026-08-01", { stake_tao: 0, hotkey: "5OWNER" }),
+    ]);
+    const { data } = await buildSubnetValidatorEconomicsHistoryPayload(
+      env,
+      7,
+      "7d",
+      {
+        loadEconomicsRow: (async () => ({
+          row: { max_validators: 64, owner_hotkey: "5OWNER" },
+          generatedAt: null,
+        })) as never,
+      },
+    );
+    const points = data.points as Array<Row>;
+    assert.equal(
+      points[0].permit_floor_alpha,
+      4000,
+      "a 0 here reads as free to validate",
+    );
+    assert.equal(points[0].validators_permitted, 2);
+  });
+
+  test("a cold economics tier leaves the cap null rather than guessing", async () => {
+    const { env } = historyEnv([dayRow("2026-08-01")]);
+    const { data } = await buildSubnetValidatorEconomicsHistoryPayload(
+      env,
+      7,
+      "7d",
+      {
+        loadEconomicsRow: (async () => ({
+          row: null,
+          generatedAt: null,
+        })) as never,
+      },
+    );
+    const points = data.points as Array<Row>;
+    assert.equal(points[0].max_validators, null);
+    assert.equal(points[0].permit_set_full, null);
   });
 
   test("joins the emission series from subnet_snapshots", async () => {

--- a/tests/validator-economics.test.ts
+++ b/tests/validator-economics.test.ts
@@ -380,6 +380,42 @@ describe("capBinding and permitFloorUnits", () => {
 });
 
 describe("earningFloorUnits and setComposition", () => {
+  // #9460. The owner earns on an unconditional permit, so an owner sitting at ~0 stake
+  // reported an earning floor of 0 — "free to earn here". Worse downstream: a 0-alpha
+  // buy cannot be priced against the pool, so earning_floor_cost_tao came back null and
+  // the cross-subnet ranking EXCLUDED the subnet as unpriceable. Both were happening.
+  test("the owner never sets the earning floor", () => {
+    const rows = [
+      n(0, {
+        totalStake: 4000,
+        validatorPermit: true,
+        dividends: 0.5,
+        hotkey: "5V0",
+      }),
+      n(9, {
+        totalStake: 0,
+        validatorPermit: true,
+        dividends: 0.9,
+        hotkey: "5OWNER",
+      }),
+    ];
+    assert.equal(earningFloorUnits(rows), 0, "the owner's zero, unfiltered");
+    assert.equal(earningFloorUnits(rows, "5OWNER"), 4000);
+  });
+
+  test("a subnet where ONLY the owner earns has no earning floor", () => {
+    // Null, not 0: nobody a newcomer could match has earned here.
+    const rows = [
+      n(9, {
+        totalStake: 0,
+        validatorPermit: true,
+        dividends: 0.9,
+        hotkey: "5OWNER",
+      }),
+    ];
+    assert.equal(earningFloorUnits(rows, "5OWNER"), null);
+  });
+
   test("permitted, active and earning are three different counts", () => {
     assert.deepEqual(setComposition(cappedSubnet()), {
       permitted: 64,
@@ -1153,6 +1189,19 @@ describe("buildValidatorEconomicsHistory", () => {
       "current",
       "an approximation the consumer can see is not an approximation that misleads",
     );
+  });
+
+  test("an unparseable snapshot_date falls back rather than throwing", () => {
+    // snapshot_date is TEXT in D1; a malformed row must not take out the series or
+    // silently claim an observed cap it cannot place in time.
+    const points = buildValidatorEconomicsHistory([day("not-a-date")], [], {
+      capHistory: [
+        { observed_at: Date.parse("2026-08-01T00:00:00Z"), max_validators: 8 },
+      ],
+      maxValidators: 64,
+    });
+    assert.equal(points[0].max_validators, 64);
+    assert.equal(points[0].max_validators_source, "current");
   });
 
   test("ignores change-log entries that record no cap", () => {

--- a/tests/validator-economics.test.ts
+++ b/tests/validator-economics.test.ts
@@ -19,6 +19,7 @@ import {
   takeDistribution,
   buildValidatorEconomicsHistory,
   rankValidatorEconomics,
+  VALIDATOR_ECONOMICS_SORTS,
   groupNeuronsByNetuid,
   type ValidatorEconomicsRow,
   type ValidatorNeuron,
@@ -807,6 +808,43 @@ function row(
   };
 }
 
+describe("rankValidatorEconomics — an unsupported sort", () => {
+  // #9460. An unsupported sort silently became the default ranking, which was then
+  // echoed back as `sort`. Asking for `tao_inflow_per_day` and mistyping it returned a
+  // COST-ranked list, labelled honestly, with no error — a plausible answer to a
+  // question nobody asked. REST already returned 400 and GraphQL BAD_USER_INPUT; only
+  // MCP reached this, and MCP is where a model's guess lands.
+  test("is rejected rather than answered with the default", () => {
+    assert.throws(
+      () => rankValidatorEconomics([row(1)], { sort: "tao_inflow_per_dya" }),
+      (error: Error) => {
+        assert.equal(error.name, "UnsupportedSortError");
+        assert.match(error.message, /is not a supported sort/);
+        // The message names the alternatives — the caller mistyped one of five.
+        assert.match(error.message, /tao_inflow_per_day/);
+        return true;
+      },
+    );
+  });
+
+  test("an ABSENT sort still takes the default", () => {
+    // Not the same question: omitting a sort is a valid request, mistyping one is not.
+    for (const options of [{}, { sort: undefined }, { sort: "" }]) {
+      assert.equal(
+        rankValidatorEconomics([row(1)], options).sort,
+        "earning_floor_cost_tao",
+      );
+    }
+  });
+
+  test("every supported key is accepted", () => {
+    // Guards the rejection against being too eager as the set changes.
+    for (const sort of VALIDATOR_ECONOMICS_SORTS) {
+      assert.equal(rankValidatorEconomics([row(1)], { sort }).sort, sort);
+    }
+  });
+});
+
 describe("rankValidatorEconomics", () => {
   test("ranks cheapest-to-earn first by default", () => {
     const out = rankValidatorEconomics([
@@ -875,12 +913,13 @@ describe("rankValidatorEconomics", () => {
     );
   });
 
-  test("falls back to the default sort rather than erroring on an unknown one", () => {
-    // The handler rejects a bad sort before reaching here; this is the belt to
-    // that braces, so a caller that bypasses the handler still gets an ordering.
-    const out = rankValidatorEconomics([row(1)], { sort: "nonsense" });
-    assert.equal(out.sort, "earning_floor_cost_tao");
-  });
+  // Was: "falls back to the default sort rather than erroring on an unknown one",
+  // reasoning that the handler rejects a bad sort first so this is only a belt to that
+  // braces. The premise was wrong (#9460) — the MCP tool reached here with no
+  // validation at all, and the fallback turned a typo into a differently-ranked list
+  // presented as an answer. A belt that silently changes the question is worse than no
+  // belt; the rejection now lives here, where every surface passes through.
+  // Behaviour pinned in "rankValidatorEconomics — an unsupported sort" above.
 
   test("excludes an unpriceable subnet with a reason instead of ranking it first", () => {
     // A null cost sorted as 0 would put the one subnet we CANNOT price at the

--- a/tests/validator-economics.test.ts
+++ b/tests/validator-economics.test.ts
@@ -162,6 +162,109 @@ describe("predictPermits", () => {
     // Reachable only if the threshold is itself zero, which a governance change could do.
     assert.equal(predictPermits([n(0), n(1)], 2, 0).size, 0);
   });
+
+  // #9460. Shaped like SN5 on 2026-08-05: the owner holds a permit at EXACTLY zero
+  // stake, which the top-k-by-stake rule can never reproduce on its own.
+  test("grants the subnet owner a permit below the threshold", () => {
+    const rows = [
+      n(0, { totalStake: 5000, hotkey: "5A" }),
+      n(251, { totalStake: 0, hotkey: "5OWNER" }),
+    ];
+    assert.deepEqual(
+      [...predictPermits(rows, 64, 1000, "5OWNER")].sort(),
+      [0, 251],
+    );
+  });
+
+  test("without an owner hotkey the rule is unchanged", () => {
+    const rows = [
+      n(0, { totalStake: 5000, hotkey: "5A" }),
+      n(251, { totalStake: 0, hotkey: "5OWNER" }),
+    ];
+    assert.deepEqual([...predictPermits(rows, 64, 1000)], [0]);
+  });
+
+  test("an owner that holds no UID on its own subnet grants nothing", () => {
+    const rows = [n(0, { totalStake: 5000, hotkey: "5A" })];
+    assert.deepEqual([...predictPermits(rows, 64, 1000, "5ABSENT")], [0]);
+  });
+
+  test("the owner's permit comes out of the cap, not on top of it", () => {
+    // Two slots, an owner below the threshold, and two eligible competitors: the owner
+    // takes one slot, so only the STRONGER competitor gets the other.
+    const rows = [
+      n(0, { totalStake: 5000, hotkey: "5A" }),
+      n(1, { totalStake: 4000, hotkey: "5B" }),
+      n(9, { totalStake: 0, hotkey: "5OWNER" }),
+    ];
+    assert.deepEqual(
+      [...predictPermits(rows, 2, 1000, "5OWNER")].sort(),
+      [0, 9],
+    );
+  });
+
+  test("counts the owner once when it would have ranked in anyway", () => {
+    const rows = [
+      n(0, { totalStake: 9000, hotkey: "5OWNER" }),
+      n(1, { totalStake: 4000, hotkey: "5B" }),
+    ];
+    assert.deepEqual(
+      [...predictPermits(rows, 2, 1000, "5OWNER")].sort(),
+      [0, 1],
+    );
+  });
+});
+
+// #9460: the owner exception, measured. On 2026-08-05 thirteen subnets sat below the
+// publishable floor; 9 of 9 remaining residuals were the subnet owner and
+// over-prediction was 0 on every one of them. Modelling the owner takes all 13 to 1.0
+// and moves no other subnet — verified against all 128 live.
+describe("modelAgreement with the subnet owner", () => {
+  // SN68 on 2026-08-05: 5 observed permits, 4 explicable by stake, the fifth the owner.
+  function ownerResidualSubnet(): ValidatorNeuron[] {
+    const rows = [
+      n(0, { totalStake: 216.6, validatorPermit: true, hotkey: "5OWNER" }),
+    ];
+    for (let uid = 1; uid < 5; uid += 1)
+      rows.push(
+        n(uid, {
+          totalStake: 2000 + uid,
+          validatorPermit: true,
+          hotkey: `5V${uid}`,
+        }),
+      );
+    return rows;
+  }
+
+  test("an owner-only residual is a permanent, unpublishable disagreement", () => {
+    const a = modelAgreement(ownerResidualSubnet(), 64, 1000);
+    assert.equal(a.observedPermits, 5);
+    assert.equal(a.underPredicted, 1, "the owner");
+    assert.equal(a.overPredicted, 0);
+    assert.equal(a.agreement, 0.8);
+    assert.equal(a.publishable, false);
+  });
+
+  test("modelling the owner reproduces the chain exactly", () => {
+    const a = modelAgreement(ownerResidualSubnet(), 64, 1000, "5OWNER");
+    assert.equal(a.matched, 5);
+    assert.equal(a.underPredicted, 0);
+    assert.equal(a.overPredicted, 0);
+    assert.equal(a.agreement, 1);
+    assert.equal(a.publishable, true);
+  });
+
+  test("the exception never invents a permit the chain did not grant", () => {
+    // An owner registered but NOT permitted on chain must show as over-prediction
+    // rather than being quietly matched — the exception has to stay falsifiable.
+    const rows = [
+      n(0, { totalStake: 5000, validatorPermit: true, hotkey: "5A" }),
+      n(1, { totalStake: 0, validatorPermit: false, hotkey: "5OWNER" }),
+    ];
+    const a = modelAgreement(rows, 64, 1000, "5OWNER");
+    assert.equal(a.overPredicted, 1);
+    assert.equal(a.matched, 1);
+  });
 });
 
 describe("modelAgreement", () => {
@@ -229,6 +332,49 @@ describe("capBinding and permitFloorUnits", () => {
     const rows = [n(0, { totalStake: 1000 }), n(1, { totalStake: 1000 })];
     assert.equal(capBinding(rows, 2, 1000), true);
     assert.equal(permitFloorUnits(rows, 2, 1000), 1000);
+  });
+
+  // #9460. The owner's permit is unconditional but still one of `maxValidators`, so it
+  // shrinks the field a non-owner competes for. No live subnet has a binding cap today
+  // (verified across all 128 on 2026-08-05, where this changes nothing), but where one
+  // does, ignoring the owner's seat would report a floor one rank too low.
+  test("the owner's seat raises the marginal rank on a capped subnet", () => {
+    const rows = [
+      n(0, { totalStake: 5000, hotkey: "5A" }),
+      n(1, { totalStake: 4000, hotkey: "5B" }),
+      n(2, { totalStake: 3000, hotkey: "5C" }),
+      n(9, { totalStake: 0, hotkey: "5OWNER" }),
+    ];
+    // Three slots, three eligible competitors: without the owner the third slot is the
+    // marginal one and the floor is 3000. With the owner holding one, only two slots
+    // remain and the marginal competitor is the SECOND — a floor of 4000.
+    assert.equal(permitFloorUnits(rows, 3, 1000), 3000);
+    assert.equal(permitFloorUnits(rows, 3, 1000, "5OWNER"), 4000);
+  });
+
+  test("the owner's seat can make a cap bind that otherwise would not", () => {
+    const rows = [
+      n(0, { totalStake: 5000, hotkey: "5A" }),
+      n(1, { totalStake: 4000, hotkey: "5B" }),
+      n(9, { totalStake: 0, hotkey: "5OWNER" }),
+    ];
+    assert.equal(capBinding(rows, 3, 1000), false, "2 eligible < 3 slots");
+    assert.equal(
+      capBinding(rows, 3, 1000, "5OWNER"),
+      true,
+      "2 competitors for the 2 slots the owner leaves",
+    );
+  });
+
+  test("a cap the owner alone fills floors at the threshold", () => {
+    // One slot, taken by the owner: there is no marginal competitor to read a floor off,
+    // so the threshold stands rather than the lookup returning undefined.
+    const rows = [
+      n(0, { totalStake: 5000, hotkey: "5A" }),
+      n(9, { totalStake: 0, hotkey: "5OWNER" }),
+    ];
+    assert.equal(capBinding(rows, 1, 1000, "5OWNER"), true);
+    assert.equal(permitFloorUnits(rows, 1, 1000, "5OWNER"), 1000);
   });
 });
 
@@ -354,6 +500,37 @@ describe("buildValidatorEconomics", () => {
     // The observed facts survive — they are what explains the disagreement.
     assert.deepEqual(out.composition, { permitted: 2, active: 0, earning: 0 });
     assert.equal(out.modelAgreement?.publishable, false);
+  });
+
+  // #9460: which fields the drifted path is allowed to withhold. The floor depends on
+  // the model and stays null; these four are counted off the live threshold and the
+  // observed permits, so withholding them only forced consumers to guess — and the
+  // guess is asymmetric, since assuming an open cap on a full subnet under-reports the
+  // floor rather than erring safe.
+  test("publishes the fields that need no floor model when the model has drifted", () => {
+    const drifted = [
+      n(0, { totalStake: 5000, validatorPermit: true }),
+      n(1, { totalStake: 200, validatorPermit: true }),
+      n(2, { totalStake: 4000 }),
+    ];
+    const out = buildValidatorEconomics({
+      ...base,
+      neurons: drifted,
+      maxValidators: 2,
+    });
+    assert.equal(
+      out.permitFloorUnits,
+      null,
+      "the floor still is not published",
+    );
+    assert.equal(out.capBinding, true, "2 eligible for 2 slots");
+    assert.equal(out.uidsAboveThreshold, 2);
+    assert.equal(out.validatorSlotsOpen, 0, "max_validators minus permitted");
+    assert.equal(
+      out.rootTaoToClear,
+      1000 / 0.18,
+      "threshold / tao_weight is arithmetic, not a model",
+    );
   });
 
   test("keeps the unit floors when only the reserves are missing", () => {
@@ -819,6 +996,21 @@ describe("groupNeuronsByNetuid", () => {
     assert.equal(grouped.get(5)?.[0].take, 0.18);
   });
 
+  // The rebuild names every field explicitly, so a new one is dropped unless it is
+  // added there too — which would leave the owner exception working on the per-subnet
+  // route and silently disabled on the cross-subnet ranking (#9460).
+  test("carries the hotkey through so the owner exception survives grouping", () => {
+    const grouped = groupNeuronsByNetuid([
+      { netuid: 5, ...n(0, { hotkey: "5OWNER" }) },
+    ]);
+    assert.equal(grouped.get(5)?.[0].hotkey, "5OWNER");
+  });
+
+  test("a neuron scanned without a hotkey groups to an explicit null", () => {
+    const grouped = groupNeuronsByNetuid([{ netuid: 5, ...n(0) }]);
+    assert.equal(grouped.get(5)?.[0].hotkey, null);
+  });
+
   test("an empty scan groups to an empty map", () => {
     assert.equal(groupNeuronsByNetuid([]).size, 0);
   });
@@ -848,6 +1040,163 @@ describe("buildValidatorEconomicsHistory", () => {
       ["2026-08-02", "2026-08-01"],
     );
     assert.equal(points[1].validators_permitted, 2);
+  });
+
+  // #9460. `permit_floor_alpha` is the observed floor regardless of cap state, so a
+  // consumer has to test the cap per day to use it — and the cap was not in the point.
+  // Joining today's cap from the current record is silently wrong for any subnet whose
+  // cap moved inside the window.
+  test("carries the cap on every point so the floor is interpretable alone", () => {
+    const points = buildValidatorEconomicsHistory(
+      [day("2026-08-01"), day("2026-08-02")],
+      [],
+      { maxValidators: 64 },
+    );
+    assert.deepEqual(
+      points.map((p) => p.max_validators),
+      [64, 64],
+    );
+  });
+
+  test("an unknown cap is null on every point, never zero", () => {
+    // A 0 here would read as "no validator slots at all".
+    const points = buildValidatorEconomicsHistory([day("2026-08-01")]);
+    assert.equal(points[0].max_validators, null);
+    assert.equal(points[0].max_validators_source, null);
+    assert.equal(points[0].permit_set_full, null);
+  });
+
+  // The change-log is what makes the cap publishable per day. Re-running today's cap
+  // over an old snapshot would show a flat cap across a change that really happened —
+  // the same class of error the module refuses for the floor.
+  test("reads the cap in force on each day from the change-log", () => {
+    const capHistory = [
+      { observed_at: Date.parse("2026-08-02T12:00:00Z"), max_validators: 64 },
+      { observed_at: Date.parse("2026-07-01T00:00:00Z"), max_validators: 8 },
+    ];
+    const points = buildValidatorEconomicsHistory(
+      [day("2026-08-01"), day("2026-08-03")],
+      [],
+      { capHistory, maxValidators: 64 },
+    );
+    const byDate = new Map(points.map((p) => [p.snapshot_date, p]));
+    assert.equal(
+      byDate.get("2026-08-01")?.max_validators,
+      8,
+      "before the raise",
+    );
+    assert.equal(byDate.get("2026-08-03")?.max_validators, 64, "after it");
+    assert.equal(byDate.get("2026-08-01")?.max_validators_source, "observed");
+  });
+
+  test("a change landing mid-day counts for that day", () => {
+    // Permits are recomputed across the day, so the cap at its END is the one that
+    // day's set was computed against.
+    const points = buildValidatorEconomicsHistory([day("2026-08-02")], [], {
+      capHistory: [
+        { observed_at: Date.parse("2026-08-02T12:00:00Z"), max_validators: 64 },
+      ],
+    });
+    assert.equal(points[0].max_validators, 64);
+    assert.equal(points[0].max_validators_source, "observed");
+  });
+
+  test("falls back to the live cap for days the change-log predates", () => {
+    const points = buildValidatorEconomicsHistory([day("2026-06-01")], [], {
+      capHistory: [
+        { observed_at: Date.parse("2026-08-02T00:00:00Z"), max_validators: 64 },
+      ],
+      maxValidators: 32,
+    });
+    assert.equal(points[0].max_validators, 32);
+    assert.equal(
+      points[0].max_validators_source,
+      "current",
+      "an approximation the consumer can see is not an approximation that misleads",
+    );
+  });
+
+  test("ignores change-log entries that record no cap", () => {
+    // The table logs every hyperparameter, so most rows carry no max_validators.
+    const points = buildValidatorEconomicsHistory([day("2026-08-03")], [], {
+      capHistory: [
+        {
+          observed_at: Date.parse("2026-08-01T00:00:00Z"),
+          max_validators: null,
+        },
+      ],
+      maxValidators: 16,
+    });
+    assert.equal(points[0].max_validators, 16);
+    assert.equal(points[0].max_validators_source, "current");
+  });
+
+  test("a non-positive cap is treated as unknown", () => {
+    const points = buildValidatorEconomicsHistory([day("2026-08-01")], [], {
+      maxValidators: 0,
+    });
+    assert.equal(points[0].max_validators, null);
+  });
+
+  test("permit_set_full compares the permitted count against the cap", () => {
+    const rows = [
+      day("2026-08-01", { stake_tao: 9000 }),
+      day("2026-08-01", { stake_tao: 8000 }),
+    ];
+    assert.equal(
+      buildValidatorEconomicsHistory(rows, [], { maxValidators: 2 })[0]
+        .permit_set_full,
+      true,
+    );
+    assert.equal(
+      buildValidatorEconomicsHistory(rows, [], { maxValidators: 3 })[0]
+        .permit_set_full,
+      false,
+    );
+  });
+
+  // The per-subnet record fails closed when it cannot justify a floor. The series did
+  // not, so a subnet whose owner holds a permit at ~0 published `permit_floor_alpha: 0`
+  // — "free to validate", the exact wrong answer the rest of the module avoids.
+  test("the owner's unconditional permit never sets the floor", () => {
+    const rows = [
+      day("2026-08-01", { stake_tao: 4000, hotkey: "5V0" }),
+      day("2026-08-01", { stake_tao: 0, hotkey: "5OWNER" }),
+    ];
+    assert.equal(
+      buildValidatorEconomicsHistory(rows)[0].permit_floor_alpha,
+      0,
+      "without an owner the observed minimum is the owner's zero",
+    );
+    const fixed = buildValidatorEconomicsHistory(rows, [], {
+      ownerHotkey: "5OWNER",
+    })[0];
+    assert.equal(fixed.permit_floor_alpha, 4000);
+    assert.equal(
+      fixed.validators_permitted,
+      2,
+      "the owner still counts as permitted — that is observed truth",
+    );
+  });
+
+  test("the owner is excluded from the earning floor too", () => {
+    const rows = [
+      day("2026-08-01", { stake_tao: 4000, hotkey: "5V0", dividends: 0.5 }),
+      day("2026-08-01", { stake_tao: 1, hotkey: "5OWNER", dividends: 0.9 }),
+    ];
+    const p = buildValidatorEconomicsHistory(rows, [], {
+      ownerHotkey: "5OWNER",
+    })[0];
+    assert.equal(p.earning_floor_alpha, 4000);
+    assert.equal(p.validators_earning, 2, "still counted, just not a floor");
+  });
+
+  test("a row with no hotkey is never mistaken for the owner", () => {
+    const rows = [day("2026-08-01", { stake_tao: 7 })];
+    const p = buildValidatorEconomicsHistory(rows, [], {
+      ownerHotkey: "5OWNER",
+    })[0];
+    assert.equal(p.permit_floor_alpha, 7);
   });
 
   test("the permit floor is the smallest stake that ACTUALLY held a permit", () => {

--- a/tests/validator-economics.test.ts
+++ b/tests/validator-economics.test.ts
@@ -164,7 +164,7 @@ describe("predictPermits", () => {
     assert.equal(predictPermits([n(0), n(1)], 2, 0).size, 0);
   });
 
-  // #9460. Shaped like SN5 on 2026-08-05: the owner holds a permit at EXACTLY zero
+  // Shaped like SN5 on 2026-08-05: the owner holds a permit at EXACTLY zero
   // stake, which the top-k-by-stake rule can never reproduce on its own.
   test("grants the subnet owner a permit below the threshold", () => {
     const rows = [
@@ -216,7 +216,7 @@ describe("predictPermits", () => {
   });
 });
 
-// #9460: the owner exception, measured. On 2026-08-05 thirteen subnets sat below the
+// the owner exception, measured. On 2026-08-05 thirteen subnets sat below the
 // publishable floor; 9 of 9 remaining residuals were the subnet owner and
 // over-prediction was 0 on every one of them. Modelling the owner takes all 13 to 1.0
 // and moves no other subnet — verified against all 128 live.
@@ -335,7 +335,7 @@ describe("capBinding and permitFloorUnits", () => {
     assert.equal(permitFloorUnits(rows, 2, 1000), 1000);
   });
 
-  // #9460. The owner's permit is unconditional but still one of `maxValidators`, so it
+  // The owner's permit is unconditional but still one of `maxValidators`, so it
   // shrinks the field a non-owner competes for. No live subnet has a binding cap today
   // (verified across all 128 on 2026-08-05, where this changes nothing), but where one
   // does, ignoring the owner's seat would report a floor one rank too low.
@@ -380,7 +380,7 @@ describe("capBinding and permitFloorUnits", () => {
 });
 
 describe("earningFloorUnits and setComposition", () => {
-  // #9460. The owner earns on an unconditional permit, so an owner sitting at ~0 stake
+  // The owner earns on an unconditional permit, so an owner sitting at ~0 stake
   // reported an earning floor of 0 — "free to earn here". Worse downstream: a 0-alpha
   // buy cannot be priced against the pool, so earning_floor_cost_tao came back null and
   // the cross-subnet ranking EXCLUDED the subnet as unpriceable. Both were happening.
@@ -539,7 +539,7 @@ describe("buildValidatorEconomics", () => {
     assert.equal(out.modelAgreement?.publishable, false);
   });
 
-  // #9460: which fields the drifted path is allowed to withhold. The floor depends on
+  // which fields the drifted path is allowed to withhold. The floor depends on
   // the model and stays null; these four are counted off the live threshold and the
   // observed permits, so withholding them only forced consumers to guess — and the
   // guess is asymmetric, since assuming an open cap on a full subnet under-reports the
@@ -845,7 +845,7 @@ function row(
 }
 
 describe("rankValidatorEconomics — an unsupported sort", () => {
-  // #9460. An unsupported sort silently became the default ranking, which was then
+  // An unsupported sort silently became the default ranking, which was then
   // echoed back as `sort`. Asking for `tao_inflow_per_day` and mistyping it returned a
   // COST-ranked list, labelled honestly, with no error — a plausible answer to a
   // question nobody asked. REST already returned 400 and GraphQL BAD_USER_INPUT; only
@@ -951,7 +951,7 @@ describe("rankValidatorEconomics", () => {
 
   // Was: "falls back to the default sort rather than erroring on an unknown one",
   // reasoning that the handler rejects a bad sort first so this is only a belt to that
-  // braces. The premise was wrong (#9460) — the MCP tool reached here with no
+  // braces. The premise was wrong — the MCP tool reached here with no
   // validation at all, and the fallback turned a typo into a differently-ranked list
   // presented as an answer. A belt that silently changes the question is worse than no
   // belt; the rejection now lives here, where every surface passes through.
@@ -1073,7 +1073,7 @@ describe("groupNeuronsByNetuid", () => {
 
   // The rebuild names every field explicitly, so a new one is dropped unless it is
   // added there too — which would leave the owner exception working on the per-subnet
-  // route and silently disabled on the cross-subnet ranking (#9460).
+  // route and silently disabled on the cross-subnet ranking.
   test("carries the hotkey through so the owner exception survives grouping", () => {
     const grouped = groupNeuronsByNetuid([
       { netuid: 5, ...n(0, { hotkey: "5OWNER" }) },
@@ -1117,7 +1117,7 @@ describe("buildValidatorEconomicsHistory", () => {
     assert.equal(points[1].validators_permitted, 2);
   });
 
-  // #9460. `permit_floor_alpha` is the observed floor regardless of cap state, so a
+  // `permit_floor_alpha` is the observed floor regardless of cap state, so a
   // consumer has to test the cap per day to use it — and the cap was not in the point.
   // Joining today's cap from the current record is silently wrong for any subnet whose
   // cap moved inside the window.

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -3703,7 +3703,7 @@ export async function handleRequest(
     // capture through waitUntil instead of stranding it on isolate exit.
     return handleMcpRequest(request, env, {
       readArtifact,
-      // #9460: `economics:current` reads go through the SAME memo the REST routes use
+      // `economics:current` reads go through the SAME memo the REST routes use
       // (readEconomicsCurrentKv), not a second, independently-timed read of the same
       // key. Two paths reading one blob on two schedules is how an agent ends up
       // holding two different snapshots of one resource with no way to tell which is
@@ -7739,7 +7739,7 @@ async function liveHealthOverlay(
     }
     case "freshness": {
       // The economics tier and the live-RPC tier both move independently of the
-      // publish, so their timestamps exist only at serve time (#9460). Both reads are
+      // publish, so their timestamps exist only at serve time. Both reads are
       // the SAME ones the data routes make — the memoized economics blob and the
       // cached parameters snapshot — so `/freshness` can never report an `as_of` that
       // disagrees with what `/economics` or `/network/parameters` just returned.

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -311,6 +311,7 @@ import {
   writeSubnetSnapshot,
 } from "../src/health-prober.ts";
 import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.ts";
+import { readCachedNetworkParametersSnapshot } from "../src/network-parameters.ts";
 import {
   mergeFreshness,
   mergeRpcEndpoints,
@@ -7729,8 +7730,20 @@ async function liveHealthOverlay(
       break;
     }
     case "freshness": {
-      const meta = await readHealthMetaKv(env);
-      data = mergeFreshness(staticData, meta);
+      // The economics tier and the live-RPC tier both move independently of the
+      // publish, so their timestamps exist only at serve time (#9460). Both reads are
+      // the SAME ones the data routes make — the memoized economics blob and the
+      // cached parameters snapshot — so `/freshness` can never report an `as_of` that
+      // disagrees with what `/economics` or `/network/parameters` just returned.
+      const [meta, economicsBlob, parameters] = await Promise.all([
+        readHealthMetaKv(env),
+        readEconomicsCurrentKv(env),
+        readCachedNetworkParametersSnapshot(env),
+      ]);
+      data = mergeFreshness(staticData, meta, {
+        economicsCapturedAt: economicsBlob?.captured_at,
+        parametersQueriedAt: parameters?.queried_at,
+      });
       break;
     }
     case "subnet-overview": {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -3703,7 +3703,15 @@ export async function handleRequest(
     // capture through waitUntil instead of stranding it on isolate exit.
     return handleMcpRequest(request, env, {
       readArtifact,
-      readHealthKv,
+      // #9460: `economics:current` reads go through the SAME memo the REST routes use
+      // (readEconomicsCurrentKv), not a second, independently-timed read of the same
+      // key. Two paths reading one blob on two schedules is how an agent ends up
+      // holding two different snapshots of one resource with no way to tell which is
+      // current — and MCP is the surface with no second path to check against.
+      readHealthKv: ((e: Env, key: string) =>
+        key === KV_ECONOMICS_CURRENT
+          ? readEconomicsCurrentKv(e)
+          : readHealthKv(e, key)) as unknown as typeof readHealthKv,
       executionCtx: ctx,
     });
   }

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -3422,7 +3422,7 @@ const VALIDATOR_ECONOMICS_FIELD_SOURCES = {
 // The per-UID columns the derivation needs, and no more. `stake_tao` is the metagraph's
 // `total_stake` — it ALREADY contains the root leg at tao_weight, so it is passed
 // through untouched; recombining it from legs is the #9331 bug.
-// `hotkey` is here only so the owner-exception path (#9460) can find the owner's UID.
+// `hotkey` is here only so the owner-exception path can find the owner's UID.
 const VALIDATOR_ECONOMICS_NEURON_COLUMNS =
   "uid, hotkey, stake_tao, validator_permit, dividends, active, take";
 
@@ -3537,7 +3537,7 @@ export async function buildSubnetValidatorEconomicsPayload(
       hyperRow?.min_childkey_take_ratio != null
         ? Number(hyperRow.min_childkey_take_ratio)
         : null,
-    // #9460: the economics row is the only tier here that carries subnet ownership.
+    // the economics row is the only tier here that carries subnet ownership.
     ownerHotkey:
       economics?.owner_hotkey != null ? String(economics.owner_hotkey) : null,
   });
@@ -3665,7 +3665,7 @@ const VALIDATOR_ECONOMICS_HISTORY_FIELD_SOURCES = {
     kind: "reconstructed",
     storage: "SubtensorModule.SubnetTaoInEmission",
   },
-  // #9460. The cap is read live and stamped onto every point, so unlike its neighbours
+  // The cap is read live and stamped onto every point, so unlike its neighbours
   // it is NOT observed off that day's snapshot — a subnet whose cap moved inside the
   // window carries today's value on older points. That is still strictly better than
   // the join it replaces (the consumer had no cap at all), and labelling it `measured`
@@ -3703,7 +3703,7 @@ export async function buildSubnetValidatorEconomicsHistoryPayload(
         await db
           .prepare(
             // `hotkey` is selected only so the owner's unconditional permit can be kept
-            // out of the observed floor (#9460).
+            // out of the observed floor.
             "SELECT snapshot_date, hotkey, stake_tao, validator_permit, dividends, active " +
               "FROM neuron_daily WHERE netuid = ? AND snapshot_date >= ? " +
               "ORDER BY snapshot_date DESC LIMIT ?",
@@ -3726,7 +3726,7 @@ export async function buildSubnetValidatorEconomicsHistoryPayload(
     : [];
 
   // The cap travels on every point so the observed floor is interpretable without a
-  // join, and the owner is what keeps its unconditional permit out of that floor (#9460).
+  // join, and the owner is what keeps its unconditional permit out of that floor.
   //
   // The cap is resolved per day from the hyperparameter CHANGE-LOG, not stamped from the
   // live value: applying today's cap to an old snapshot manufactures a transition that
@@ -3910,7 +3910,7 @@ export async function buildValidatorEconomicsRankingPayload(
           economics?.tao_in_emission_tao != null
             ? Number(economics.tao_in_emission_tao)
             : null,
-        // #9460: same owner exception the per-subnet route applies — without it this
+        // same owner exception the per-subnet route applies — without it this
         // route drops every owner-below-threshold subnet into `excluded`.
         ownerHotkey:
           economics?.owner_hotkey != null

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -3422,14 +3422,16 @@ const VALIDATOR_ECONOMICS_FIELD_SOURCES = {
 // The per-UID columns the derivation needs, and no more. `stake_tao` is the metagraph's
 // `total_stake` — it ALREADY contains the root leg at tao_weight, so it is passed
 // through untouched; recombining it from legs is the #9331 bug.
+// `hotkey` is here only so the owner-exception path (#9460) can find the owner's UID.
 const VALIDATOR_ECONOMICS_NEURON_COLUMNS =
-  "uid, stake_tao, validator_permit, dividends, active, take";
+  "uid, hotkey, stake_tao, validator_permit, dividends, active, take";
 
 function toValidatorNeurons(
   rows: Array<Record<string, unknown>>,
 ): ValidatorNeuron[] {
   return rows.map((row) => ({
     uid: Number(row.uid),
+    hotkey: row.hotkey == null ? null : String(row.hotkey),
     totalStake: Number(row.stake_tao ?? 0),
     validatorPermit: Number(row.validator_permit) === 1,
     dividends: Number(row.dividends ?? 0),
@@ -3535,6 +3537,9 @@ export async function buildSubnetValidatorEconomicsPayload(
       hyperRow?.min_childkey_take_ratio != null
         ? Number(hyperRow.min_childkey_take_ratio)
         : null,
+    // #9460: the economics row is the only tier here that carries subnet ownership.
+    ownerHotkey:
+      economics?.owner_hotkey != null ? String(economics.owner_hotkey) : null,
   });
 
   const data = validatorEconomicsWire(
@@ -3660,6 +3665,19 @@ const VALIDATOR_ECONOMICS_HISTORY_FIELD_SOURCES = {
     kind: "reconstructed",
     storage: "SubtensorModule.SubnetTaoInEmission",
   },
+  // #9460. The cap is read live and stamped onto every point, so unlike its neighbours
+  // it is NOT observed off that day's snapshot — a subnet whose cap moved inside the
+  // window carries today's value on older points. That is still strictly better than
+  // the join it replaces (the consumer had no cap at all), and labelling it `measured`
+  // against the live storage item is what says so.
+  max_validators: {
+    kind: "measured",
+    storage: "SubtensorModule.MaxAllowedValidators",
+  },
+  permit_set_full: {
+    kind: "reconstructed",
+    storage: "SubtensorModule.ValidatorPermit",
+  },
 } as const;
 
 // GET /api/v1/subnets/{netuid}/validator-economics/history (#9326): the observed
@@ -3669,7 +3687,11 @@ export async function buildSubnetValidatorEconomicsHistoryPayload(
   env: Env,
   netuid: number,
   windowLabel: string,
+  // Same injection seam the per-subnet composer uses: the economics row is an artifact
+  // read, and a test that cannot stub it exercises only the cap-unknown path.
+  deps: { loadEconomicsRow?: typeof resolveSubnetEconomicsRow } = {},
 ): Promise<{ data: Record<string, unknown> }> {
+  const readEconomicsRow = deps.loadEconomicsRow ?? resolveSubnetEconomicsRow;
   const days = VALIDATOR_ECONOMICS_HISTORY_WINDOWS[windowLabel];
   const cutoff = new Date(Date.now() - days * 86_400_000)
     .toISOString()
@@ -3680,7 +3702,9 @@ export async function buildSubnetValidatorEconomicsHistoryPayload(
     ? ((
         await db
           .prepare(
-            "SELECT snapshot_date, stake_tao, validator_permit, dividends, active " +
+            // `hotkey` is selected only so the owner's unconditional permit can be kept
+            // out of the observed floor (#9460).
+            "SELECT snapshot_date, hotkey, stake_tao, validator_permit, dividends, active " +
               "FROM neuron_daily WHERE netuid = ? AND snapshot_date >= ? " +
               "ORDER BY snapshot_date DESC LIMIT ?",
           )
@@ -3701,6 +3725,27 @@ export async function buildSubnetValidatorEconomicsHistoryPayload(
       )?.results ?? [])
     : [];
 
+  // The cap travels on every point so the observed floor is interpretable without a
+  // join, and the owner is what keeps its unconditional permit out of that floor (#9460).
+  //
+  // The cap is resolved per day from the hyperparameter CHANGE-LOG, not stamped from the
+  // live value: applying today's cap to an old snapshot manufactures a transition that
+  // never happened. Rows before the window still matter — the cap in force on day one is
+  // whatever the last change before it set — so this is not bounded by the cutoff.
+  const capHistory = db
+    ? ((
+        await db
+          .prepare(
+            "SELECT observed_at, max_validators FROM subnet_hyperparams_history " +
+              "WHERE netuid = ? AND max_validators IS NOT NULL ORDER BY observed_at ASC",
+          )
+          .bind(netuid)
+          .all()
+      )?.results ?? [])
+    : [];
+
+  const { row: economics } = await readEconomicsRow(env, netuid);
+
   return {
     data: {
       schema_version: 1,
@@ -3709,6 +3754,17 @@ export async function buildSubnetValidatorEconomicsHistoryPayload(
       points: buildValidatorEconomicsHistory(
         neuronRows as never,
         emissionRows as never,
+        {
+          maxValidators:
+            economics?.max_validators != null
+              ? Number(economics.max_validators)
+              : null,
+          capHistory: capHistory as never,
+          ownerHotkey:
+            economics?.owner_hotkey != null
+              ? String(economics.owner_hotkey)
+              : null,
+        },
       ),
       field_sources: VALIDATOR_ECONOMICS_HISTORY_FIELD_SOURCES,
     },
@@ -3853,6 +3909,12 @@ export async function buildValidatorEconomicsRankingPayload(
         taoInEmissionPerBlock:
           economics?.tao_in_emission_tao != null
             ? Number(economics.tao_in_emission_tao)
+            : null,
+        // #9460: same owner exception the per-subnet route applies — without it this
+        // route drops every owner-below-threshold subnet into `excluded`.
+        ownerHotkey:
+          economics?.owner_hotkey != null
+            ? String(economics.owner_hotkey)
             : null,
       }),
       netuid,

--- a/workers/responses.ts
+++ b/workers/responses.ts
@@ -3,7 +3,21 @@
 // Extracted from workers/api.ts (issue #510, de-monolith). Depends only on the
 // http + storage leaf modules and the contract version; it calls nothing back
 // into api.ts, so there is no import cycle.
-import { CONTRACT_VERSION } from "../src/contracts.ts";
+import {
+  ARTIFACT_BASE_PATH,
+  CONTRACT_VERSION,
+  PRIMARY_DOMAIN,
+} from "../src/contracts.ts";
+
+/**
+ * The `service-desc` link every API response carries (#9460).
+ *
+ * Points at the RAW artifact, never `/api/v1/openapi.json`: that route wraps the spec
+ * in the standard success envelope, so it has no top-level `openapi` key and every
+ * OpenAPI tool pointed at it fails. Absolute, matching the linkset body and the `/`
+ * header, since the API and the site are different origins.
+ */
+const SERVICE_DESC_LINK = `<https://${PRIMARY_DOMAIN}${ARTIFACT_BASE_PATH}/openapi.json>; rel="service-desc"; type="application/json"`;
 import { apiHeaders, ifNoneMatchSatisfied, weakEtag } from "./http.ts";
 import type { CacheProfile } from "./http.ts";
 import { latestPointer } from "./storage.ts";
@@ -115,6 +129,21 @@ export async function envelopeResponse(
       headers.set(key, value);
     }
   }
+  // RFC 8288 pointer to the OpenAPI document, on EVERY API response (#9460).
+  //
+  // It was emitted only on `/`, so a consumer who started anywhere under /api/v1 — the
+  // normal case — got no pointer to the spec at all. An external integrator reported
+  // hand-probing routes and concluding no spec existed; it does, at this URL, and
+  // nothing they touched said so.
+  //
+  // Appended rather than set: several routes already send a pagination `Link`, and
+  // overwriting it would trade one discovery problem for a worse one. Multiple
+  // comma-separated values are exactly what the header is specified to carry.
+  const existingLink = headers.get("link");
+  headers.set(
+    "link",
+    existingLink ? `${existingLink}, ${SERVICE_DESC_LINK}` : SERVICE_DESC_LINK,
+  );
   if (ifNoneMatchSatisfied(request, etag)) {
     return new Response(null, {
       status: 304,

--- a/workers/responses.ts
+++ b/workers/responses.ts
@@ -10,7 +10,7 @@ import {
 } from "../src/contracts.ts";
 
 /**
- * The `service-desc` link every API response carries (#9460).
+ * The `service-desc` link every API response carries.
  *
  * Points at the RAW artifact, never `/api/v1/openapi.json`: that route wraps the spec
  * in the standard success envelope, so it has no top-level `openapi` key and every
@@ -129,7 +129,7 @@ export async function envelopeResponse(
       headers.set(key, value);
     }
   }
-  // RFC 8288 pointer to the OpenAPI document, on EVERY API response (#9460).
+  // RFC 8288 pointer to the OpenAPI document, on EVERY API response.
   //
   // It was emitted only on `/`, so a consumer who started anywhere under /api/v1 — the
   // normal case — got no pointer to the spec at all. An external integrator reported


### PR DESCRIPTION
Closes #9498.

Seven fixes for the defects an external consumer found while building a validator sizing model against the public API. Their chain reads reconciled perfectly against the finney archive node, so none of this is a correctness defect in what we read from chain — it is what we then say about it.

The eight commits are split by concern and readable individually. They ship together because they share plumbing (the owner hotkey reaches four call sites), shared constants (`src/route-limits.ts`), and shared test files, so splitting them would mean rewriting a change set that is verified as a whole.

### The permit model now reproduces the chain

`predictPermits` ranked by stake alone and so could never explain the subnet owner's permit, which the chain grants unconditionally. Measured across all 128 subnets: 9 of 9 remaining residuals were the owner — three at exactly zero stake — and over-prediction was 0 everywhere.

**13 subnets go from ~0.92 agreement to 1.0 and start publishing floors again. Zero regressions across the other 119, verified against live data.**

The owner's permit is unconditional but is still one of `max_validators`, so `capBinding` and `permitFloorUnits` count it as a taken seat. No subnet is cap-bound today, so that part is a no-op on current data — verified — and correct when one is.

The consumer's epoch-lag hypothesis was right about a *second* class: five non-owner residuals present that day resolved on their own within the hour. Those are timing, not a rule, and are deliberately not modelled — `model_agreement` is what reports them.

### Fields that need no model are no longer withheld

On the drifted path `cap_binding`, `uids_above_threshold`, `validator_slots_open` and `root_tao_to_clear_threshold` were nulled alongside the floor. None depends on the floor model. Note the consumer's proposed `cap_binding` formula (`permitted >= max_validators`) is **not** the right one — it is `eligible >= slots` — and adopting theirs would have produced exactly the asymmetric silent error they were guarding against.

### The history series is self-contained and fails closed

Each point now carries `max_validators`, without which `permit_floor_alpha` cannot be read at all. The cap is resolved per day from the `subnet_hyperparams_history` change-log rather than stamped from the live value — stamping today's cap on a 90-day-old point is what the schema comment rightly warned against — and `max_validators_source` names the days that fall back to it, so the approximation is never silent.

The owner is also kept out of the observed floor. The series was publishing `permit_floor_alpha: 0` for owner-at-zero subnets.

### The earning floor had the same defect, found by a test

An owner earning on ~0 stake set `earning_floor_units` to 0, and because a 0-alpha buy cannot be priced, `earning_floor_cost_tao` came back null and the cross-subnet ranking **dropped the subnet entirely** as unpriceable. One value changes network-wide: SN79 goes from 3,845,494 to null, because its only earning permit-holder is the owner taking 100% of dividends.

### `/freshness` reports the lanes that move independently of the publish

Economics (~3h) and live-RPC now appear as first-class sources in the serve-time overlay. The economics lane is gated on exactly the window `resolveLiveEconomics` uses, and both read the same cached values the data routes read, so an `as_of` here cannot contradict what `/economics` just returned. The live-RPC read is cache-only and never falls through to chain RPC — a freshness probe that triggered the work it measures could never report stale.

### MCP and REST share one economics reader

The reported 3h split was not simultaneous — 252 paired production samples across a refresh boundary, identical every time. But MCP was making its own independently-timed read of the same KV key. The regression test drives **both** surfaces through `handleRequest`, because the defect was in the Worker's wiring: a test injecting its own readers would have passed the whole time. Verified to fail without the fix.

### The MCP tool schemas describe what the server accepts

`listToolDefinitions` strips Zod's safe-integer sentinel, which is what lets a real `maximum` mean a decision; bounded params then get real bounds read from `src/route-limits.ts`. Three prose-only enums become enums, sourced from the same constants the enforcement uses. `list_validator_economics.sort` now **rejects** instead of silently ranking by the default and echoing it back.

`fields` declares a pattern and a description, deliberately as permissive as `parseFieldsParam` actually is — that parser trims segments and drops empty ones, so a tidier pattern would have clients rejecting input the server accepts.

`validate-mcp` gains three assertions that keep all of this fixed. Each was confirmed to fail against the defect it guards before being committed.

### The OpenAPI pointer resolves to a parseable document

`/api/v1` advertised `/api/v1/openapi.json`, which serves the spec inside the envelope. Both pointers now name the raw artifact, and `service-desc` ships on every API response rather than only on `/`. The test that should have caught this was pinning the broken URL.

---

**Verification:** 16,166 tests passing across 676 files · **100% patch coverage, branch-counted** (103 lines / 126 branches, 0 uncovered) · contract-drift, validate-mcp, no-hand-written-mjs, lint, format all green · rebased onto current main.

Live-data checks: the permit-model change verified against all 128 subnets (9 improved, 119 unchanged, 0 regressed, `cap_binding` and `permit_floor` unchanged everywhere); the MCP/REST parity claim verified with 252 paired production samples.