### PR TITLE
docs(validators): say why realized_return_1m reads null before its history exists

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -5634,7 +5634,7 @@ export type Validator = {
   nominator_count?: Maybe<Scalars['Int']['output']>;
   /** Realized 1-day return on staked capital: the fractional change in total_stake_tao vs the newest permitted neuron_daily snapshot within 2 days of the ~1-day-ago target date. Backward-looking over an elapsed window (captures compounding + net delegation flow), unlike the forward-looking apy_estimate; null when no permitted snapshot lands in that range (never computed against a stale far-older baseline, #8837). Mirrors realized_return_1d in the REST/MCP shape (#7228). */
   realized_return_1d?: Maybe<Scalars['Float']['output']>;
-  /** Realized 30-day return on staked capital vs the newest permitted neuron_daily snapshot within 2 days of the ~1-month-ago target date; null when no permitted snapshot lands in that range (#7228, #8837). */
+  /** Realized 30-day return on staked capital vs the newest permitted neuron_daily snapshot within 2 days of the ~1-month-ago target date; null when no permitted snapshot lands in that range (#7228, #8837). NOTE: a window can only be answered once neuron_daily holds history reaching back past it -- the table began accumulating on 2026-07-10, so this 30-day window reads null for EVERY validator until roughly 2026-08-09 and is not a defect before then (#9455). The shorter windows are unaffected. */
   realized_return_1m?: Maybe<Scalars['Float']['output']>;
   /** Realized 7-day return on staked capital vs the newest permitted neuron_daily snapshot within 2 days of the ~1-week-ago target date; null when no permitted snapshot lands in that range (#7228, #8837). */
   realized_return_1w?: Maybe<Scalars['Float']['output']>;

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -3993,7 +3993,7 @@ export const SDL = /* GraphQL */ `
     realized_return_1d: Float
     "Realized 7-day return on staked capital vs the newest permitted neuron_daily snapshot within 2 days of the ~1-week-ago target date; null when no permitted snapshot lands in that range (#7228, #8837)."
     realized_return_1w: Float
-    "Realized 30-day return on staked capital vs the newest permitted neuron_daily snapshot within 2 days of the ~1-month-ago target date; null when no permitted snapshot lands in that range (#7228, #8837)."
+    "Realized 30-day return on staked capital vs the newest permitted neuron_daily snapshot within 2 days of the ~1-month-ago target date; null when no permitted snapshot lands in that range (#7228, #8837). NOTE: a window can only be answered once neuron_daily holds history reaching back past it -- the table began accumulating on 2026-07-10, so this 30-day window reads null for EVERY validator until roughly 2026-08-09 and is not a defect before then (#9455). The shorter windows are unaffected."
     realized_return_1m: Float
     avg_validator_trust: Float
     max_validator_trust: Float

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -2321,6 +2321,17 @@ const REALIZED_RETURN_WINDOWS = { d1: 1, d7: 7, d30: 30 };
 // is missing or late, while rejecting anything older -- so a "1-day return"
 // can never be computed against a week-old baseline (the stale-baseline bug
 // this closes). Applied uniformly to all three REALIZED_RETURN_WINDOWS.
+//
+// A CONSEQUENCE WORTH STATING, because it looks exactly like a dead field
+// (#9455 filed it as one): a window is unanswerable until neuron_daily holds
+// history reaching past `days + tolerance`. The table began accumulating
+// 2026-07-10, so through early August the d30 window's bound
+// [today-32, today-30] fell entirely before the oldest row and
+// realized_return_1m was null for EVERY validator while 1d and 1w -- the same
+// query, the same code path -- returned values for ~49/50. That is the correct
+// answer, not a defect: the alternative is reaching further back, which is
+// precisely the stale baseline #8837 exists to refuse. It resolves itself once
+// the table is deep enough (~2026-08-09); nothing here needs changing for it.
 export const REALIZED_RETURN_BASELINE_TOLERANCE_DAYS = 2;
 
 // postgres.js returns BIGINT columns as strings; the D1-backed routes return them


### PR DESCRIPTION
`realized_return_1m` is null on all 50 validators while its siblings — **the identical query through the identical resolver** — are not:

```
realized_return_1d: 49/50 present
realized_return_1w: 47/50 present
realized_return_1m:  0/50 present
apy_estimate:       50/50 present
```

#9455 read that as the Postgres removal (#9429) killing the field. It isn't — 1d and 1w would have died with it.

## Actual cause

The d30 baseline is bounded to `[today-32, today-30]` (`REALIZED_RETURN_BASELINE_TOLERANCE_DAYS = 2`, #8837). `neuron_daily` holds 27 days:

```sql
SELECT MIN(snapshot_date), MAX(snapshot_date), COUNT(DISTINCT snapshot_date) FROM neuron_daily;
-- 2026-07-10 | 2026-08-05 | 27
```

Today that window is `[2026-07-04, 2026-07-06]` — entirely before the oldest row, so zero rows qualify for any hotkey.

## Why there is no code change here

**The null is correct.** Reaching further back is precisely the stale baseline #8837 exists to refuse — that was a real bug fix, and overriding it to make this field non-null would reintroduce it. There is no prune on `neuron_daily`, so it self-heals around **2026-08-09**, when the oldest row first falls inside the window. Pre-2026-07-10 neuron history does not exist anywhere to backfill from: the Postgres box is gone and the lakehouse holds blocks/extrinsics/chain_events/account_events, not neuron snapshots.

What was actually wrong is that nothing distinguished "not enough history yet" from "broken" — which is exactly why it got filed as a dead field and nearly fixed in the wrong direction. The SDL description and the constant's own comment now say so, and note that the shorter windows are unaffected.

## Follow-up worth knowing about

The 27-day floor is a hard ceiling on any longer window — a `realized_return_90d` or `_1y` would be permanently null for the same reason. `NEURON_DAILY_BACKFILL_SECRET` already exists, and a historical `get_all_metagraphs()` scan against the archive node could extend the table backwards. Worth doing if longer windows are ever wanted; disproportionate for a 4-day gap that closes itself. Noted in #9500 rather than built.

`lint` · `typecheck` · `format:check` · `validate:contract-drift` clean; `generated/graphql/types.ts` regenerated and committed.

Closes #9500