### PR TITLE
fix(mcp): stop answering /mcp/ with an OAuth challenge nobody can complete

### DIFF
--- a/scripts/validate-mcp.ts
+++ b/scripts/validate-mcp.ts
@@ -1470,11 +1470,20 @@ assert.equal(
 const unknownTool = await call("not_a_real_tool", {});
 assert.equal(unknownTool.isError, true, "unknown tools must return isError");
 
+// 405, not 400: the Streamable HTTP transport names 405 as the sanctioned "this
+// endpoint offers no SSE stream", and a conformant client treats it as POST-only
+// and carries on. Any other non-2xx is a transport error that starts a reconnect
+// loop — which is what every client opening the push channel used to hit.
 const getWithoutSession = await mcpRaw(null, { method: "GET" });
 assert.equal(
   getWithoutSession.status,
-  400,
-  "GET /mcp without an Mcp-Session-Id header must be rejected with 400",
+  405,
+  "GET /mcp without an Mcp-Session-Id header must answer 405, not a transport error",
+);
+assert.equal(
+  getWithoutSession.headers.get("allow"),
+  "POST, DELETE, OPTIONS",
+  "a 405 must say which methods the endpoint does take",
 );
 
 const A_SESSION_ID = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
@@ -1639,8 +1648,8 @@ const postTerminateStream = await mcpRaw(null, {
 });
 assert.equal(
   postTerminateStream.status,
-  404,
-  "GET /mcp after DELETE must find no such session",
+  405,
+  "GET /mcp after DELETE must report no stream on offer, the same 405 way an unregistered session does",
 );
 
 // --- MCP per-subnet status subscription lifecycle (#6034) ------------------

--- a/src/github-oauth.ts
+++ b/src/github-oauth.ts
@@ -179,8 +179,31 @@ export function buildOAuthProviderOptions(
  * discovery endpoints, and /mcp with a genuine OAuth Bearer -- still needs the
  * real oauthProvider.fetch() dispatch.
  */
+/**
+ * Does OAuthProvider consider this path part of the MCP API surface?
+ *
+ * This has to be asked exactly the way the library asks it. `matchApiRoute`
+ * (@cloudflare/workers-oauth-provider) matches a path-style `apiRoute` with
+ * `url.pathname.startsWith(route)`, so `/mcp` claims `/mcp/`, `/mcp/sse` and even
+ * `/mcpx` — not just `/mcp`.
+ *
+ * The bypass below used `!==` against the same constant. One character narrower than
+ * the library, and every request that fell into the gap was handed to
+ * `oauthProvider.fetch`, matched `isApiRequest` by prefix, and was answered by
+ * `handleApiRequest`'s no-Authorization branch: an anonymous **401** with a
+ * `WWW-Authenticate: Bearer realm="OAuth"` challenge, before `apiHandler` ever ran.
+ *
+ * A trailing slash was therefore enough to make an unauthenticated MCP client believe
+ * the server required OAuth — and, because the discovery documents it points at are
+ * live and complete, to start a flow it cannot finish unattended. Exported so the two
+ * sides are one declaration and cannot drift apart again.
+ */
+export function matchesMcpApiRoute(pathname: string): boolean {
+  return pathname.startsWith(MCP_API_ROUTE);
+}
+
 export function isNonOAuthMcpRequest(request: Request): boolean {
-  if (new URL(request.url).pathname !== MCP_API_ROUTE) return false;
+  if (!matchesMcpApiRoute(new URL(request.url).pathname)) return false;
   const header = request.headers.get("Authorization");
   if (!header?.startsWith("Bearer ")) return true;
   return header.slice("Bearer ".length).startsWith(MG_API_KEY_TAG);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -14862,7 +14862,12 @@ async function handleMcpStreamRequest(request: Request, env: Env) {
           "(metagraph://chain/stream or metagraph://subnet/{netuid}/status), " +
           "then GET with that session id. Every other MCP method is POST.",
       ),
-      400,
+      // 405, for the same reason as the no-subscription branch below: a client
+      // opening the push channel before it has a session is doing the ordinary
+      // thing, and the transport's answer for "no stream here" is 405, not a 400
+      // that reads as a protocol violation. The message is unchanged.
+      405,
+      { allow: "POST, DELETE, OPTIONS" },
     );
   }
   if (!env.MCP_SESSION_HUB) {
@@ -14894,7 +14899,20 @@ async function handleMcpStreamRequest(request: Request, env: Env) {
               "before opening the GET stream. If the session has since expired, " +
               "re-run initialize and subscribe again.",
       ),
-      upstream.status === 409 ? 409 : 404,
+      // 405, not 404, for the no-subscription case. The Streamable HTTP transport
+      // names 405 as the sanctioned "this endpoint offers no SSE stream", and a
+      // conformant client treats it as "fine, POST-only" and moves on; ANY other
+      // non-2xx is a transport error that tears the connection down.
+      //
+      // The canonical initialize-then-GET sequence always lands here, because a
+      // session is only registered with the hub by resources/subscribe. So every
+      // spec-following client took a transport error within a second of connecting
+      // and began reconnecting — which is the churn that then walked into the
+      // OAuth-route 401 (see matchesMcpApiRoute in src/github-oauth.ts).
+      //
+      // 409 keeps its own status: a stream IS on offer there, just already taken.
+      upstream.status === 409 ? 409 : 405,
+      upstream.status === 409 ? undefined : { allow: "POST, DELETE, OPTIONS" },
     );
   }
   return new Response(upstream.body, {

--- a/tests/github-oauth.test.ts
+++ b/tests/github-oauth.test.ts
@@ -6,6 +6,7 @@ import {
   handleGithubOAuthCallback,
   isAnonymousMcpRequest,
   isNonOAuthMcpRequest,
+  matchesMcpApiRoute,
   OAUTH_PENDING_TTL_SECONDS,
   UNUSED_DEFAULT_HANDLER,
 } from "../src/github-oauth.ts";
@@ -646,6 +647,44 @@ describe("isNonOAuthMcpRequest (#8643) — our own API keys must not reach OAuth
         headers: { Authorization: "Bearer mg_abcdefghijklmnop" },
       });
       expect(isNonOAuthMcpRequest(request), url).toBe(false);
+    }
+  });
+
+  // The inverse of the case above, and the one nothing pinned. OAuthProvider's
+  // matchApiRoute matches a path-style apiRoute with `startsWith`, so `/mcp` claims
+  // `/mcp/`, `/mcp/sse` and `/mcpx`. This predicate used `!==` against the same
+  // constant — one character narrower — and every path in the gap was handed to
+  // oauthProvider.fetch, which answered an anonymous 401 with a
+  // `WWW-Authenticate: Bearer realm="OAuth"` challenge before the app ever ran.
+  // Reproduced against production: POST /mcp -> 200, POST /mcp/ -> 401. A trailing
+  // slash was enough to tell an unauthenticated client it needed OAuth.
+  test("diverts every path OAuthProvider would claim by prefix, not just /mcp exactly", () => {
+    for (const url of [
+      "https://api.metagraph.sh/mcp",
+      "https://api.metagraph.sh/mcp/",
+      "https://api.metagraph.sh/mcp/sse",
+      "https://api.metagraph.sh/mcp/message",
+      "https://api.metagraph.sh/mcpx",
+    ]) {
+      expect(isNonOAuthMcpRequest(new Request(url)), url).toBe(true);
+    }
+  });
+
+  test("matchesMcpApiRoute agrees with OAuthProvider's startsWith, so the two cannot drift", () => {
+    // If this ever disagrees with matchApiRoute, the gap reopens as a 401.
+    const claimedByLibrary = (pathname: string) => pathname.startsWith("/mcp");
+    for (const pathname of [
+      "/mcp",
+      "/mcp/",
+      "/mcp/sse",
+      "/mcpx",
+      "/api/v1/subnets",
+      "/authorize",
+      "/",
+    ]) {
+      expect(matchesMcpApiRoute(pathname), pathname).toBe(
+        claimedByLibrary(pathname),
+      );
     }
   });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1580,19 +1580,24 @@ describe("MCP transport handling", () => {
   });
 
   describe("GET /mcp — the SSE push stream (#4983 MCP half)", () => {
-    test("without an Mcp-Session-Id header, rejects with 400", async () => {
+    // 405, not 400. The Streamable HTTP transport names 405 as the sanctioned
+    // "this endpoint offers no SSE stream": a conformant client reads it as
+    // "POST-only, fine" and carries on, where any other non-2xx is a transport
+    // error that tears the connection down and starts a reconnect loop.
+    test("without an Mcp-Session-Id header, answers 405 rather than a transport error", async () => {
       const res = await rpc(null, { method: "GET" });
-      assert.equal(res.status, 400);
+      assert.equal(res.status, 405);
+      assert.equal(res.headers.get("allow"), "POST, DELETE, OPTIONS");
       assert.equal(res.body.error.code, -32600);
       assert.match(res.body.error.message, /Mcp-Session-Id/);
     });
 
-    test("with a malformed Mcp-Session-Id header, rejects with 400", async () => {
+    test("with a malformed Mcp-Session-Id header, answers 405", async () => {
       const res = await rpc(null, {
         method: "GET",
         headers: { "mcp-session-id": "has a space" },
       });
-      assert.equal(res.status, 400);
+      assert.equal(res.status, 405);
     });
 
     test("with an unrecognized MCP-Protocol-Version header, rejects with 400 before checking the session", async () => {
@@ -1642,7 +1647,7 @@ describe("MCP transport handling", () => {
     // by resources/subscribe. These pin the message actually being actionable.
     test("a bare GET (no session) says this is not a browsable URL", async () => {
       const res = await rpc(null, { method: "GET" });
-      assert.equal(res.status, 400);
+      assert.equal(res.status, 405);
       assert.match(res.body.error.message, /not a browsable endpoint/);
     });
 
@@ -1691,7 +1696,11 @@ describe("MCP transport handling", () => {
       assert.match(body.error.message, /already open/);
     });
 
-    test("a 404 from the session hub (unknown/terminated session) passes through as 404", async () => {
+    // The canonical initialize-then-GET sequence ALWAYS lands here, because a
+    // session is only registered with the hub by resources/subscribe. Answering it
+    // with 404 made every spec-following client take a transport error within a
+    // second of connecting; 405 is the transport's own word for "no stream here".
+    test("an unregistered session answers 405, not a transport error", async () => {
       const hub = fakeMcpSessionHubBinding({
         "/stream": () => new Response(null, { status: 404 }),
       });
@@ -1702,7 +1711,8 @@ describe("MCP transport handling", () => {
       const response = await handleMcpRequest(request, {
         MCP_SESSION_HUB: hub,
       } as unknown as Env);
-      assert.equal(response.status, 404);
+      assert.equal(response.status, 405);
+      assert.equal(response.headers.get("allow"), "POST, DELETE, OPTIONS");
       const body = (await response.json()) as Row;
       assert.match(
         body.error.message,


### PR DESCRIPTION
Closes #9505. This is the last open item from #9498 — the one I could not diagnose without logs.

### The bypass was one character narrower than the surface it guards

`OAuthProvider.matchApiRoute` matches a path-style `apiRoute` with `pathname.startsWith(route)`, so `/mcp` claims `/mcp/`, `/mcp/sse` and `/mcpx`. `isNonOAuthMcpRequest` tested `!==` against the same constant.

Everything in that gap went to `oauthProvider.fetch`, matched `isApiRequest` by prefix, and got the no-`Authorization` branch: an anonymous **401** with `WWW-Authenticate: Bearer realm="OAuth"`, before the app handler ran. Reproduced against production, no credentials sent:

```
POST /mcp      -> 200
POST /mcp/     -> 401  www-authenticate: Bearer realm="OAuth", error="invalid_token"
POST /mcp/sse  -> 401
POST /mcpx     -> 401
```

A trailing slash was enough to tell an unauthenticated client the server required OAuth — and the discovery documents that 401 points at are live and complete, so the client believes it and starts a flow it cannot finish unattended. REST was untouched because no `/api/v1/**` path starts with `/mcp`, which is exactly why the two surfaces behaved so differently in the report.

Both sides now read one exported `matchesMcpApiRoute`, so they cannot drift apart again — that drift was the whole bug. `workers/api.ts` serves only `/mcp` exactly, so the widened bypass exposes nothing new: `/mcp/` and friends now fall through to the app's ordinary 404 instead of a 401 that misstates why.

### The churn that walked into it

`GET /mcp` answered **400** without a session and **404** with an unregistered one — and since a session is only registered by `resources/subscribe`, the canonical initialize-then-GET sequence *always* landed on one. The Streamable HTTP transport names **405** as the sanctioned "this endpoint offers no SSE stream", which a conformant client accepts silently; anything else is a transport error. So every client opening the push channel took one within a second of connecting, tore down, and reconnected — until a reconnect used a trailing slash.

Confirmed in production Workers logs: session `fe127df2-…` initialised (200), `notifications/initialized` (202), `GET /mcp` → **404**, `DELETE /mcp` → **404**, while its POSTs kept returning 200 because dispatch is stateless. That is the reported "two or three calls would succeed, then the session died".

Both branches now answer 405 with `allow: POST, DELETE, OPTIONS`. **409 keeps its own status** — a stream is on offer there, just already taken. The explanatory bodies are unchanged; they were already good.

### Why nothing caught it

The existing test asserted only that `/authorize`, `/oauth/token` and `/api/v1/subnets` are NOT diverted. The inverse — that everything OAuthProvider claims by prefix IS — was pinned nowhere, which is how a predicate could sit one character off the library it mirrors. Both directions are now covered, plus a test asserting the matcher agrees with `startsWith` case by case. Verified to fail against the old predicate.

### Ruled out along the way

Rate limiting (anonymous MCP is 100/60s, rejects 429/403 with `retry-after`, never 401 — and is *more* generous than REST's 60/60s; 100 anonymous calls all returned 200), session lifecycle (POST dispatch is stateless — a fabricated session id returns a full `tools/list`), per-tool auth (fails as MCP tool errors, never HTTP 401), and split deployments (single 100% version).

---

**Verification:** 16,198 tests passing across 677 files · **100% patch coverage, branch-counted** · contract-drift, validate-mcp, lint, format green · rebased onto main after #9499 merged.

`scripts/validate-mcp.ts` gains the `allow`-header assertion and its two status expectations move with the behaviour.