### PR TITLE
fix(ci): report Actions script failures to PostHog instead of dropping them

### DIFF
--- a/.github/workflows/discover-testnet-surfaces.yml
+++ b/.github/workflows/discover-testnet-surfaces.yml
@@ -50,6 +50,8 @@ jobs:
         run: npm ci
 
       - name: Probe testnet subnet surfaces
+        env:
+          POSTHOG_PROJECT_TOKEN: ${{ secrets.POSTHOG_PROJECT_TOKEN }}
         run: |
           node scripts/discover-testnet-surfaces.ts --out testnet-discovery.json | tee discovery.log
           {

--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -120,6 +120,13 @@ jobs:
           # build falls back to the committed seed -- never a failure.
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # scripts/build.ts spawns its child steps with `...process.env`, so
+          # this reaches the two instrumented steps in the production build
+          # list: native-snapshot (refresh-native-snapshot.ts) and
+          # refresh-og-image. Both are tolerant-by-design -- they log a warning
+          # and let the publish continue -- which is exactly why they need this:
+          # a silently-degrading step is invisible without it.
+          POSTHOG_PROJECT_TOKEN: ${{ secrets.POSTHOG_PROJECT_TOKEN }}
 
       # Belt-and-suspenders for Finding 1: the build just re-snapshotted adapters
       # from live GitHub metadata. Refuse to publish if any degraded to broken

--- a/.github/workflows/refresh-economics.yml
+++ b/.github/workflows/refresh-economics.yml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Refresh native chain snapshot (tolerant)
         run: node scripts/refresh-native-snapshot.ts
+        env:
+          POSTHOG_PROJECT_TOKEN: ${{ secrets.POSTHOG_PROJECT_TOKEN }}
 
       - name: Publish live economics (KV)
         run: npm run economics:refresh
@@ -72,6 +74,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           METAGRAPH_KV_NAMESPACE_ID: ${{ secrets.METAGRAPH_KV_NAMESPACE_ID }}
           METAGRAPH_ALLOW_KV_WRITE: "1"
+          POSTHOG_PROJECT_TOKEN: ${{ secrets.POSTHOG_PROJECT_TOKEN }}
 
       - name: Notify on failure
         if: failure() && env.METAGRAPH_ALERT_WEBHOOK_URL != ''

--- a/.github/workflows/refresh-metagraph.yml
+++ b/.github/workflows/refresh-metagraph.yml
@@ -75,3 +75,4 @@ jobs:
         env:
           METAGRAPH_NEURONS_JSON: dist/metagraph-neurons.json
           NEURONS_SYNC_SECRET: ${{ secrets.NEURONS_SYNC_SECRET }}
+          POSTHOG_PROJECT_TOKEN: ${{ secrets.POSTHOG_PROJECT_TOKEN }}

--- a/scripts/sync-neurons.ts
+++ b/scripts/sync-neurons.ts
@@ -27,6 +27,12 @@
 // makes chunking safe: splitting one snapshot across N requests cannot make an
 // earlier chunk's rows look stale to a later chunk's prune.
 
+import {
+  initObservability,
+  endSessionAndFlush,
+  captureFatalAndExit,
+} from "./observability.ts";
+
 const SYNC_URL =
   process.env.NEURONS_SYNC_URL ||
   "https://api.metagraph.sh/api/v1/internal/neurons-sync";
@@ -141,10 +147,26 @@ async function main(): Promise<void> {
 // runs the sync only when invoked directly, not on import.
 const { fileURLToPath } = await import("node:url");
 if (process.argv[1] && process.argv[1] === fileURLToPath(import.meta.url)) {
-  main().catch((err) => {
-    console.error(
-      `sync-neurons failed: ${err instanceof Error ? err.message : err}`,
-    );
-    process.exitCode = 1;
-  });
+  // Inside the direct-invocation guard, not at module scope: initObservability
+  // registers process-level crash handlers, and importing this file for the
+  // chunker (tests/sync-neurons.test.ts) must not install them.
+  initObservability("sync-neurons");
+  main()
+    .then(async () => {
+      await endSessionAndFlush();
+    })
+    .catch(async (err) => {
+      console.error(
+        `sync-neurons failed: ${err instanceof Error ? err.message : err}`,
+      );
+      // Explicit capture required here (not left to observability.ts's
+      // process-level uncaughtException/unhandledRejection handlers): Node
+      // stops considering a promise "unhandled" once something calls
+      // .catch() on it, which this script already did before those handlers
+      // would ever see it. Same reason discover-testnet-surfaces.ts calls it
+      // directly. This replaces the previous `process.exitCode = 1`:
+      // captureFatalAndExit exits 1 itself, and does so with or without a
+      // POSTHOG_PROJECT_TOKEN, so the failing exit status is unchanged.
+      await captureFatalAndExit(err);
+    });
 }

--- a/scripts/validate-workflows.ts
+++ b/scripts/validate-workflows.ts
@@ -1,6 +1,13 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { repoRoot } from "./lib.ts";
+import {
+  OBSERVABILITY_TOKEN_ENV,
+  buildStepScripts,
+  instrumentedScripts,
+  stepsMissingObservabilityToken,
+  workflowSteps,
+} from "./workflow-observability.ts";
 
 const workflowRoot = path.join(repoRoot, ".github/workflows");
 const workflows = (await fs.readdir(workflowRoot))
@@ -18,6 +25,39 @@ const errors: string[] = [];
 // exempt a future workflow that SHOULD have a checkout) is the correct fix, not a decorative
 // checkout added purely to satisfy this check.
 const NO_CHECKOUT_BY_DESIGN = new Set(["ui-preview-deploy.yml"]);
+
+// Both halves of the observability rule are DERIVED (see
+// scripts/workflow-observability.ts): which scripts are instrumented, and
+// which scripts each workflow step reaches. Nothing here is hand-listed.
+const scriptSources = await readScriptSources(path.join(repoRoot, "scripts"));
+const instrumented = instrumentedScripts(scriptSources);
+const packageJson = JSON.parse(
+  await fs.readFile(path.join(repoRoot, "package.json"), "utf8"),
+) as { scripts?: Record<string, string> };
+const buildSteps = buildStepScripts(
+  scriptSources.get("scripts/build.ts") ?? "",
+);
+const observabilityContext = {
+  npmScripts: packageJson.scripts ?? {},
+  buildStepScripts: buildSteps,
+  instrumented,
+};
+
+// Guards against this rule passing VACUOUSLY, which is the same failure mode
+// it exists to catch. If either derivation silently returns nothing -- the
+// import specifier in observability.ts's consumers changes, or build.ts stops
+// declaring steps as nodeStep(...) -- every workflow trivially satisfies the
+// rule and the regression walks straight back in. Fail instead of pass.
+check(
+  instrumented.size > 0,
+  "scripts/workflow-observability.ts",
+  "found no scripts importing ./observability.ts -- the instrumentation scan is broken, so the workflow token rule below proves nothing",
+);
+check(
+  [...buildSteps.production].some((script) => instrumented.has(script)),
+  "scripts/workflow-observability.ts",
+  "scripts/build.ts's productionSteps() no longer declares any instrumented script as a nodeStep() -- either the step list moved (so the publish build is no longer checked) or the instrumentation was dropped",
+);
 
 for (const workflow of workflows) {
   const content = await fs.readFile(path.join(workflowRoot, workflow), "utf8");
@@ -61,6 +101,18 @@ for (const workflow of workflows) {
     workflow,
     "missing checkout action",
   );
+  // A step that runs an instrumented script without the token gets
+  // initObservability()'s early return: no client, no capture, no complaint.
+  for (const { step, scripts } of stepsMissingObservabilityToken(
+    content,
+    observabilityContext,
+  )) {
+    check(
+      false,
+      workflow,
+      `step "${step}" runs ${scripts.join(", ")} (instrumented via scripts/observability.ts) without ${OBSERVABILITY_TOKEN_ENV} in scope -- its error reporting would silently no-op`,
+    );
+  }
   for (const match of content.matchAll(/uses:\s+([^\s#]+)/g)) {
     const actionRef = match[1].replace(/^['"]|['"]$/g, "");
     if (actionRef.startsWith("./") || actionRef.startsWith("docker://")) {
@@ -290,6 +342,23 @@ function check(condition: unknown, workflow: string, message: string): void {
   }
 }
 
+/** Every .ts/.mjs/.js file under scripts/, keyed by repo-relative path. */
+async function readScriptSources(dir: string): Promise<Map<string, string>> {
+  const sources = new Map<string, string>();
+  for (const entry of await fs.readdir(dir, {
+    withFileTypes: true,
+    recursive: true,
+  })) {
+    if (!/\.(?:ts|mjs|js)$/.test(entry.name)) continue;
+    const full = path.join(entry.parentPath, entry.name);
+    sources.set(
+      path.relative(repoRoot, full).split(path.sep).join("/"),
+      await fs.readFile(full, "utf8"),
+    );
+  }
+  return sources;
+}
+
 function workflowJobBlock(content: string, jobName: string): string {
   const match = content.match(
     new RegExp(
@@ -298,37 +367,6 @@ function workflowJobBlock(content: string, jobName: string): string {
     ),
   );
   return match?.[0] || "";
-}
-
-/**
- * Every `- name:` step in a workflow, as {name, block}.
- *
- * Enumerated rather than looked up by literal, so a rule can select steps by
- * what they DO -- which upload carries the token -- instead of by what they are
- * called. Names are prose and get rewritten; the contract should not move with
- * them. Quoted names are unwrapped, since YAML requires quoting once a name
- * contains a colon.
- */
-function workflowSteps(content: string): { name: string; block: string }[] {
-  const steps: { name: string; block: string }[] = [];
-  // Six spaces is the indent a step sits at inside jobs.<id>.steps. Written as {6}
-  // rather than as literal spaces so the count is readable and cannot be miscounted
-  // by eye -- which is exactly what no-regex-spaces is for.
-  const marker = /^ {6}- name: (.+)$/gm;
-  const starts: { name: string; index: number }[] = [];
-  for (const m of content.matchAll(marker)) {
-    starts.push({
-      name: m[1].trim().replace(/^["'](.*)["']$/, "$1"),
-      index: m.index ?? 0,
-    });
-  }
-  for (const [i, step] of starts.entries()) {
-    steps.push({
-      name: step.name,
-      block: content.slice(step.index, starts[i + 1]?.index),
-    });
-  }
-  return steps;
 }
 
 /** Whether an upload sends Codecov the owner-prefixed branch it requires from

--- a/scripts/workflow-observability.ts
+++ b/scripts/workflow-observability.ts
@@ -1,0 +1,237 @@
+// Keeps GitHub Actions' error reporting from silently rotting back off.
+//
+// scripts/observability.ts is the only place in the tree with real PostHog
+// flush semantics (captureExceptionImmediate + shutdown on the fatal path),
+// but initObservability() RETURNS EARLY when POSTHOG_PROJECT_TOKEN is unset.
+// That is the right behavior for a local run -- and it is exactly why the
+// instrumentation was dead in CI for as long as it was: every instrumented
+// script ran in Actions with the var absent, so every one of them was a
+// no-op, and nothing anywhere said so. A missing env line looks identical to
+// a working one until the day you need the error report.
+//
+// So the pairing is enforced rather than documented: a workflow step that
+// reaches an instrumented script must have POSTHOG_PROJECT_TOKEN in scope.
+// Both halves are derived from the tree, never hand-listed -- a script that
+// gains an `import ... from "./observability.ts"` tomorrow is covered the
+// moment it does, with no list to remember to update.
+//
+// The two indirections that make this worth computing instead of grepping:
+//
+//  1. `npm run <name>` hides the script path behind package.json.
+//  2. scripts/build.ts is a step RUNNER, and it has two step lists. Only
+//     productionSteps() includes the instrumented native-snapshot and
+//     refresh-og-image; localSteps() includes neither. Which one runs is
+//     decided by METAGRAPH_PRODUCTION_BUILD, so a plain `npm run build` in
+//     validate.yml genuinely does not need the token and must not be flagged
+//     -- treating both lists alike would have failed nine honest steps.
+//
+// The functions here are pure (they take sources, not paths) so the rule can
+// be tested against synthetic workflows -- including the NEGATIVE case, that
+// it actually fails a step missing the var. A guard that has only ever been
+// watched passing is not a guard.
+
+export const OBSERVABILITY_TOKEN_ENV = "POSTHOG_PROJECT_TOKEN";
+export const PRODUCTION_BUILD_ENV = "METAGRAPH_PRODUCTION_BUILD";
+
+// `import { ... } from "./observability.ts"` in any spacing/multi-line form.
+const OBSERVABILITY_IMPORT = /from\s+"\.\/observability\.ts"/;
+const SCRIPT_PATH = /scripts\/[\w.-]+\.(?:ts|mjs|js)/g;
+const NPM_RUN = /npm\s+run\s+([\w:-]+)/g;
+// scripts/build.ts declares its child steps as nodeStep("name", "scripts/x.ts").
+// Parsed from that declaration rather than by scanning build.ts for any script
+// path, so a path merely MENTIONED in a comment is not mistaken for a step.
+const BUILD_NODE_STEP = /nodeStep\(\s*"[^"]*"\s*,\s*"(scripts\/[\w.-]+\.ts)"/g;
+
+export type ReachContext = {
+  /** package.json's `scripts` map, for resolving `npm run <name>`. */
+  npmScripts: Record<string, string>;
+  /** script path -> the scripts it spawns as children. */
+  spawnedBy: Map<string, Set<string>>;
+};
+
+/** The scripts that import scripts/observability.ts, keyed by repo-relative path. */
+export function instrumentedScripts(
+  scriptSources: Map<string, string>,
+): Set<string> {
+  const instrumented = new Set<string>();
+  for (const [scriptPath, source] of scriptSources) {
+    if (scriptPath.endsWith("scripts/observability.ts")) continue;
+    if (OBSERVABILITY_IMPORT.test(source)) instrumented.add(scriptPath);
+  }
+  return instrumented;
+}
+
+/**
+ * scripts/build.ts's two step lists, read from the functions that declare
+ * them. Kept separate because only the production list runs instrumented
+ * scripts -- see the header.
+ */
+export function buildStepScripts(buildSource: string): {
+  local: Set<string>;
+  production: Set<string>;
+} {
+  return {
+    local: nodeStepScripts(functionBody(buildSource, "localSteps")),
+    production: nodeStepScripts(functionBody(buildSource, "productionSteps")),
+  };
+}
+
+function nodeStepScripts(source: string): Set<string> {
+  const scripts = new Set<string>();
+  for (const [, scriptPath] of source.matchAll(BUILD_NODE_STEP)) {
+    scripts.add(scriptPath);
+  }
+  return scripts;
+}
+
+/** A top-level `function name(): Step[] { ... }` body, to its closing brace at column 0. */
+function functionBody(source: string, name: string): string {
+  const start = source.indexOf(`function ${name}(`);
+  if (start === -1) return "";
+  const end = source.indexOf("\n}", start);
+  return end === -1 ? source.slice(start) : source.slice(start, end);
+}
+
+/**
+ * Every script a shell command reaches: named directly, reached through
+ * `npm run <name>`, or spawned as a child by a script that is itself reached.
+ */
+export function scriptsReachedBy(
+  command: string,
+  ctx: ReachContext,
+): Set<string> {
+  const reached = new Set<string>();
+  const commands = [command];
+  const seenNpmScripts = new Set<string>();
+  while (commands.length > 0) {
+    const current = commands.pop() as string;
+    for (const [scriptPath] of current.matchAll(SCRIPT_PATH)) {
+      reached.add(scriptPath);
+    }
+    for (const [, name] of current.matchAll(NPM_RUN)) {
+      // Guarded against an npm script that (directly or in a cycle) runs
+      // itself -- resolution must terminate, not stack-overflow CI.
+      if (seenNpmScripts.has(name)) continue;
+      seenNpmScripts.add(name);
+      const body = ctx.npmScripts[name];
+      if (body) commands.push(body);
+    }
+  }
+  const pending = [...reached];
+  while (pending.length > 0) {
+    const script = pending.pop() as string;
+    for (const child of ctx.spawnedBy.get(script) ?? []) {
+      if (reached.has(child)) continue;
+      reached.add(child);
+      pending.push(child);
+    }
+  }
+  return reached;
+}
+
+/**
+ * Every `- name:` step in a workflow, as {name, block, index}.
+ *
+ * Enumerated rather than looked up by literal, so a rule can select steps by
+ * what they DO -- which upload carries the token -- instead of by what they are
+ * called. Names are prose and get rewritten; the contract should not move with
+ * them. Quoted names are unwrapped, since YAML requires quoting once a name
+ * contains a colon.
+ */
+export function workflowSteps(
+  content: string,
+): { name: string; block: string; index: number }[] {
+  const steps: { name: string; block: string; index: number }[] = [];
+  // Six spaces is the indent a step sits at inside jobs.<id>.steps. Written as {6}
+  // rather than as literal spaces so the count is readable and cannot be miscounted
+  // by eye -- which is exactly what no-regex-spaces is for.
+  const marker = /^ {6}- name: (.+)$/gm;
+  const starts: { name: string; index: number }[] = [];
+  for (const m of content.matchAll(marker)) {
+    starts.push({
+      name: m[1].trim().replace(/^["'](.*)["']$/, "$1"),
+      index: m.index ?? 0,
+    });
+  }
+  for (const [i, step] of starts.entries()) {
+    steps.push({
+      name: step.name,
+      index: step.index,
+      block: content.slice(step.index, starts[i + 1]?.index),
+    });
+  }
+  return steps;
+}
+
+/** Each job's byte range, so a step can be resolved to the job that encloses it. */
+function jobRanges(content: string): { start: number; end: number }[] {
+  const starts: number[] = [];
+  for (const m of content.matchAll(/^ {2}[A-Za-z0-9_-]+:$/gm)) {
+    starts.push(m.index ?? 0);
+  }
+  return starts.map((start, i) => ({
+    start,
+    end: starts[i + 1] ?? content.length,
+  }));
+}
+
+/**
+ * Whether `name` is set for a step, at any of the three levels GitHub merges:
+ * the step's own `env:` (keys at 10 spaces), the enclosing job's (6), or the
+ * workflow's (2). Hoisting a var to the job is a legitimate way to set it --
+ * publish-cloudflare.yml already does exactly that with
+ * METAGRAPH_PRODUCTION_BUILD -- so a rule that only looked at the step would
+ * be wrong about the repo as it already stands.
+ */
+function envInScope(
+  name: string,
+  content: string,
+  step: { block: string; index: number },
+): boolean {
+  if (step.block.includes(`${name}:`)) return true;
+  if (new RegExp(String.raw`^ {2}${name}:`, "m").test(content)) return true;
+  const job = jobRanges(content).find(
+    (range) => step.index >= range.start && step.index < range.end,
+  );
+  if (!job) return false;
+  return new RegExp(String.raw`^ {6}${name}:`, "m").test(
+    content.slice(job.start, job.end),
+  );
+}
+
+/**
+ * Steps that reach an instrumented script without POSTHOG_PROJECT_TOKEN in
+ * scope -- i.e. steps whose error reporting would silently do nothing.
+ */
+export function stepsMissingObservabilityToken(
+  content: string,
+  ctx: {
+    npmScripts: Record<string, string>;
+    buildStepScripts: { local: Set<string>; production: Set<string> };
+    instrumented: Set<string>;
+  },
+): { step: string; scripts: string[] }[] {
+  const missing: { step: string; scripts: string[] }[] = [];
+  for (const step of workflowSteps(content)) {
+    const spawnedBy = new Map([
+      [
+        "scripts/build.ts",
+        envInScope(PRODUCTION_BUILD_ENV, content, step)
+          ? ctx.buildStepScripts.production
+          : ctx.buildStepScripts.local,
+      ],
+    ]);
+    const scripts = [
+      ...scriptsReachedBy(step.block, {
+        npmScripts: ctx.npmScripts,
+        spawnedBy,
+      }),
+    ]
+      .filter((scriptPath) => ctx.instrumented.has(scriptPath))
+      .sort();
+    if (scripts.length === 0) continue;
+    if (envInScope(OBSERVABILITY_TOKEN_ENV, content, step)) continue;
+    missing.push({ step: step.name, scripts });
+  }
+  return missing;
+}

--- a/tests/sync-neurons.test.ts
+++ b/tests/sync-neurons.test.ts
@@ -1,7 +1,17 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { gunzipSync } from "node:zlib";
 import { describe, test } from "vitest";
 import { chunkRows, MAX_ROWS_PER_REQUEST } from "../scripts/sync-neurons.ts";
 import type { Row } from "./row-type.ts";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
 
 function row(uid: number, extra: Row = {}): Row {
   return {
@@ -93,5 +103,118 @@ describe("chunkRows", () => {
 
   test("an empty snapshot yields no requests", () => {
     assert.deepEqual(chunkRows([]), []);
+  });
+});
+
+// End-to-end proof that the observability wiring actually reports, run as a
+// real subprocess against a stand-in PostHog ingest endpoint.
+//
+// Asserting the import, or that the workflow sets the var, would not have
+// caught the bug this replaces: initObservability() returns early without
+// POSTHOG_PROJECT_TOKEN, so a script can import the helper, call it, and still
+// report nothing. The only convincing evidence is an exception arriving over
+// the wire -- so that is what is asserted.
+//
+// spawn(), not execFileSync(): the sink has to answer the request while the
+// child runs, and execFileSync would block this process's event loop and
+// deadlock against its own server.
+describe("failure reporting (#9505)", () => {
+  function startSink() {
+    const events: Record<string, unknown>[] = [];
+    const server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk) => chunks.push(chunk as Buffer));
+      req.on("end", () => {
+        const raw = Buffer.concat(chunks);
+        let text: string;
+        try {
+          // posthog-node gzips its batch payloads.
+          text = gunzipSync(raw).toString("utf8");
+        } catch {
+          text = raw.toString("utf8");
+        }
+        try {
+          const body = JSON.parse(text) as {
+            batch?: Record<string, unknown>[];
+          };
+          events.push(...(body.batch ?? []));
+        } catch {
+          /* a body we cannot parse is simply not an event */
+        }
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ status: 1 }));
+      });
+    });
+    return new Promise<{
+      port: number;
+      events: Record<string, unknown>[];
+      close: () => Promise<void>;
+    }>((resolve) => {
+      server.listen(0, "127.0.0.1", () =>
+        resolve({
+          port: (server.address() as { port: number }).port,
+          events,
+          close: () => new Promise<void>((done) => server.close(() => done())),
+        }),
+      );
+    });
+  }
+
+  /** Run sync-neurons.ts with no NEURONS_SYNC_SECRET, which fails immediately. */
+  function runFailing(env: Record<string, string>) {
+    return new Promise<number | null>((resolve) => {
+      const child = spawn(process.execPath, ["scripts/sync-neurons.ts"], {
+        cwd: repoRoot,
+        stdio: "ignore",
+        env: {
+          ...process.env,
+          NEURONS_SYNC_SECRET: "",
+          POSTHOG_PROJECT_TOKEN: "",
+          ...env,
+        },
+      });
+      child.on("close", (code) => resolve(code));
+    });
+  }
+
+  test("a failed sync sends a $exception tagged with the component, and still exits non-zero", async () => {
+    const sink = await startSink();
+    const code = await runFailing({
+      POSTHOG_PROJECT_TOKEN: "phc_test_token",
+      POSTHOG_HOST: `http://127.0.0.1:${sink.port}`,
+    });
+    await sink.close();
+
+    assert.equal(code, 1, "a failed sync must still fail the workflow step");
+    const exceptions = sink.events.filter(
+      (event) => event.event === "$exception",
+    );
+    assert.equal(exceptions.length, 1, "expected exactly one exception event");
+    const properties = exceptions[0].properties as Record<string, unknown>;
+    assert.equal(exceptions[0].distinct_id, "metagraphed-infra");
+    assert.equal(
+      properties.component,
+      "sync-neurons",
+      "the event must say which script produced it",
+    );
+    const detail = (
+      properties.$exception_list as { type: string; value: string }[]
+    )[0];
+    assert.equal(detail.type, "Error");
+    assert.match(detail.value, /NEURONS_SYNC_SECRET is required/);
+  });
+
+  // The pre-fix production state. Exit status must be identical either way --
+  // the reporting is additive, and a box/local run without a token must not
+  // start behaving differently from one with it.
+  test("without the token it reports nothing and the exit status is unchanged", async () => {
+    const sink = await startSink();
+    const code = await runFailing({
+      POSTHOG_HOST: `http://127.0.0.1:${sink.port}`,
+    });
+    await sink.close();
+
+    assert.equal(code, 1);
+    assert.deepEqual(sink.events, []);
   });
 });

--- a/tests/workflow-observability.test.ts
+++ b/tests/workflow-observability.test.ts
@@ -1,0 +1,299 @@
+// Tests for the rule that keeps GitHub Actions' error reporting wired up
+// (scripts/workflow-observability.ts, enforced by scripts/validate-workflows.ts).
+//
+// The rule exists because initObservability() returns early without
+// POSTHOG_PROJECT_TOKEN: for a long stretch every instrumented script ran in
+// Actions with the var absent, so every one of them was a silent no-op. The
+// point of these tests is therefore NOT "the rule runs" -- it is that the rule
+// FAILS a workflow that forgets the var. A guard only ever observed passing is
+// indistinguishable from the no-op it replaced, which is the exact defect
+// being fixed here.
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import {
+  OBSERVABILITY_TOKEN_ENV,
+  buildStepScripts,
+  instrumentedScripts,
+  scriptsReachedBy,
+  stepsMissingObservabilityToken,
+} from "../scripts/workflow-observability.ts";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+function readScriptSources(): Map<string, string> {
+  const sources = new Map<string, string>();
+  for (const entry of readdirSync(path.join(repoRoot, "scripts"), {
+    withFileTypes: true,
+    recursive: true,
+  })) {
+    if (!/\.(?:ts|mjs|js)$/.test(entry.name)) continue;
+    const full = path.join(entry.parentPath, entry.name);
+    sources.set(
+      path.relative(repoRoot, full).split(path.sep).join("/"),
+      readFileSync(full, "utf8"),
+    );
+  }
+  return sources;
+}
+
+function realContext() {
+  const scriptSources = readScriptSources();
+  const packageJson = JSON.parse(
+    readFileSync(path.join(repoRoot, "package.json"), "utf8"),
+  ) as { scripts?: Record<string, string> };
+  return {
+    npmScripts: packageJson.scripts ?? {},
+    buildStepScripts: buildStepScripts(
+      scriptSources.get("scripts/build.ts") ?? "",
+    ),
+    instrumented: instrumentedScripts(scriptSources),
+  };
+}
+
+// A step that runs an instrumented script, with no env block at all.
+const UNINSTRUMENTED_WORKFLOW = `name: Example
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync to D1
+        run: node scripts/sync-neurons.ts
+`;
+
+const SYNTHETIC_CONTEXT = {
+  npmScripts: {
+    build: "node scripts/build.ts",
+    "economics:refresh": "node scripts/refresh-economics.ts --write",
+    loops: "npm run loops",
+  },
+  buildStepScripts: {
+    local: new Set(["scripts/build-artifacts.ts"]),
+    production: new Set([
+      "scripts/build-artifacts.ts",
+      "scripts/refresh-og-image.ts",
+    ]),
+  },
+  instrumented: new Set([
+    "scripts/sync-neurons.ts",
+    "scripts/refresh-economics.ts",
+    "scripts/refresh-og-image.ts",
+  ]),
+};
+
+function withStepEnv(workflow: string, line: string): string {
+  return workflow.replace(
+    "        run: node scripts/sync-neurons.ts",
+    `        env:\n          ${line}\n        run: node scripts/sync-neurons.ts`,
+  );
+}
+
+describe("stepsMissingObservabilityToken", () => {
+  // THE test. Everything else is a refinement of this one.
+  test("flags a step that runs an instrumented script with no token in scope", () => {
+    const missing = stepsMissingObservabilityToken(
+      UNINSTRUMENTED_WORKFLOW,
+      SYNTHETIC_CONTEXT,
+    );
+    assert.deepEqual(missing, [
+      { step: "Sync to D1", scripts: ["scripts/sync-neurons.ts"] },
+    ]);
+  });
+
+  test("a step-level env satisfies it", () => {
+    const workflow = withStepEnv(
+      UNINSTRUMENTED_WORKFLOW,
+      `${OBSERVABILITY_TOKEN_ENV}: \${{ secrets.${OBSERVABILITY_TOKEN_ENV} }}`,
+    );
+    assert.deepEqual(
+      stepsMissingObservabilityToken(workflow, SYNTHETIC_CONTEXT),
+      [],
+    );
+  });
+
+  test("a job-level env satisfies it (hoisting is legitimate, not a violation)", () => {
+    const workflow = UNINSTRUMENTED_WORKFLOW.replace(
+      "    runs-on: ubuntu-latest",
+      `    runs-on: ubuntu-latest\n    env:\n      ${OBSERVABILITY_TOKEN_ENV}: x`,
+    );
+    assert.deepEqual(
+      stepsMissingObservabilityToken(workflow, SYNTHETIC_CONTEXT),
+      [],
+    );
+  });
+
+  test("a workflow-level env satisfies it", () => {
+    const workflow = UNINSTRUMENTED_WORKFLOW.replace(
+      "jobs:",
+      `env:\n  ${OBSERVABILITY_TOKEN_ENV}: x\n\njobs:`,
+    );
+    assert.deepEqual(
+      stepsMissingObservabilityToken(workflow, SYNTHETIC_CONTEXT),
+      [],
+    );
+  });
+
+  test("a step running only uninstrumented scripts is not flagged", () => {
+    const workflow = UNINSTRUMENTED_WORKFLOW.replace(
+      "node scripts/sync-neurons.ts",
+      "node scripts/r2-manifest.ts --write",
+    );
+    assert.deepEqual(
+      stepsMissingObservabilityToken(workflow, SYNTHETIC_CONTEXT),
+      [],
+    );
+  });
+
+  // The distinction that cost nine false failures when the rule first ran:
+  // `npm run build` reaches instrumented scripts ONLY in production mode.
+  test("`npm run build` is flagged only when METAGRAPH_PRODUCTION_BUILD is in scope", () => {
+    const local = UNINSTRUMENTED_WORKFLOW.replace(
+      "node scripts/sync-neurons.ts",
+      "npm run build",
+    );
+    assert.deepEqual(
+      stepsMissingObservabilityToken(local, SYNTHETIC_CONTEXT),
+      [],
+      "a plain validate-lane build runs no instrumented step and must not be flagged",
+    );
+
+    const production = local.replace(
+      "    runs-on: ubuntu-latest",
+      '    runs-on: ubuntu-latest\n    env:\n      METAGRAPH_PRODUCTION_BUILD: "1"',
+    );
+    assert.deepEqual(
+      stepsMissingObservabilityToken(production, SYNTHETIC_CONTEXT),
+      [{ step: "Sync to D1", scripts: ["scripts/refresh-og-image.ts"] }],
+      "the production build DOES run an instrumented step and must be flagged",
+    );
+  });
+});
+
+describe("scriptsReachedBy", () => {
+  test("resolves a script named directly", () => {
+    assert.ok(
+      scriptsReachedBy("node scripts/sync-neurons.ts", {
+        npmScripts: SYNTHETIC_CONTEXT.npmScripts,
+        spawnedBy: new Map(),
+      }).has("scripts/sync-neurons.ts"),
+    );
+  });
+
+  test("resolves a script hidden behind `npm run <name>`", () => {
+    assert.ok(
+      scriptsReachedBy("npm run economics:refresh", {
+        npmScripts: SYNTHETIC_CONTEXT.npmScripts,
+        spawnedBy: new Map(),
+      }).has("scripts/refresh-economics.ts"),
+    );
+  });
+
+  test("resolves scripts a reached runner spawns as children", () => {
+    const reached = scriptsReachedBy("npm run build", {
+      npmScripts: SYNTHETIC_CONTEXT.npmScripts,
+      spawnedBy: new Map([
+        ["scripts/build.ts", new Set(["scripts/refresh-og-image.ts"])],
+      ]),
+    });
+    assert.ok(reached.has("scripts/build.ts"));
+    assert.ok(reached.has("scripts/refresh-og-image.ts"));
+  });
+
+  test("terminates on a self-referential npm script instead of hanging CI", () => {
+    assert.deepEqual(
+      [
+        ...scriptsReachedBy("npm run loops", {
+          npmScripts: SYNTHETIC_CONTEXT.npmScripts,
+          spawnedBy: new Map(),
+        }),
+      ],
+      [],
+    );
+  });
+});
+
+describe("derivation from the real tree", () => {
+  // Guards against the whole rule passing vacuously -- the same failure mode
+  // it exists to catch. validate-workflows.ts fails on these too; asserting
+  // them here means a break shows up as a named test, not as one line in a
+  // validator's output.
+  test("the instrumented-script scan finds the known importers", () => {
+    const { instrumented } = realContext();
+    assert.ok(instrumented.size > 0, "scan returned nothing");
+    for (const expected of [
+      "scripts/sync-neurons.ts",
+      "scripts/refresh-economics.ts",
+      "scripts/refresh-native-snapshot.ts",
+      "scripts/discover-testnet-surfaces.ts",
+      "scripts/refresh-og-image.ts",
+    ]) {
+      assert.ok(
+        instrumented.has(expected),
+        `${expected} imports scripts/observability.ts but was not detected`,
+      );
+    }
+    assert.ok(
+      !instrumented.has("scripts/observability.ts"),
+      "the helper itself is not a consumer of itself",
+    );
+  });
+
+  test("build.ts's production step list carries instrumented scripts and the local one does not", () => {
+    const { buildStepScripts: steps, instrumented } = realContext();
+    const inProduction = [...steps.production].filter((s) =>
+      instrumented.has(s),
+    );
+    assert.ok(
+      inProduction.length > 0,
+      "no instrumented script in productionSteps() -- `npm run build` would stop being checked",
+    );
+    assert.deepEqual(
+      [...steps.local].filter((s) => instrumented.has(s)),
+      [],
+      "localSteps() must stay free of instrumented scripts, or the validate lane needs the token too",
+    );
+  });
+
+  test("every committed workflow has the token wired for the scripts it runs", () => {
+    const ctx = realContext();
+    const workflowRoot = path.join(repoRoot, ".github/workflows");
+    const offenders: string[] = [];
+    for (const name of readdirSync(workflowRoot)) {
+      if (!/\.ya?ml$/.test(name)) continue;
+      const content = readFileSync(path.join(workflowRoot, name), "utf8");
+      for (const { step, scripts } of stepsMissingObservabilityToken(
+        content,
+        ctx,
+      )) {
+        offenders.push(`${name}: "${step}" runs ${scripts.join(", ")}`);
+      }
+    }
+    assert.deepEqual(offenders, []);
+  });
+
+  // Positive control for the test above: it must be capable of failing.
+  // Without this, a bug that made every workflow parse as zero steps would
+  // leave that assertion passing on nothing.
+  test("...and that sweep would catch a workflow that dropped the token", () => {
+    const ctx = realContext();
+    const stripped = readFileSync(
+      path.join(repoRoot, ".github/workflows/refresh-metagraph.yml"),
+      "utf8",
+    )
+      .split("\n")
+      .filter((line) => !line.includes(`${OBSERVABILITY_TOKEN_ENV}:`))
+      .join("\n");
+    assert.deepEqual(stepsMissingObservabilityToken(stripped, ctx), [
+      { step: "Sync to D1", scripts: ["scripts/sync-neurons.ts"] },
+    ]);
+  });
+});


### PR DESCRIPTION
## What

`scripts/observability.ts` holds the only real PostHog flush semantics in the repo
(`captureExceptionImmediate` + awaited `shutdown()`), but `initObservability()` returns early
when `POSTHOG_PROJECT_TOKEN` is unset — and **no workflow set it** (zero `POSTHOG` strings
anywhere in `.github/`). Every instrumented script running in Actions built no client, registered
no crash handler, and captured nothing. A missing env line looks exactly like a working one until
you need the error report.

This sets the token on the steps that actually reach an instrumented script, instruments
`sync-neurons.ts`, and enforces the pairing so it cannot rot back off.

## The steps that were silent

Two indirections hid them, which is why this needed resolving rather than grepping:

| Workflow | Step | Instrumented script(s) | Reached via |
| --- | --- | --- | --- |
| `publish-cloudflare.yml` | Prepare reviewed publish artifacts | `refresh-native-snapshot.ts`, `refresh-og-image.ts` | `npm run build` → `build.ts` **production** step list |
| `discover-testnet-surfaces.yml` | Probe testnet subnet surfaces | `discover-testnet-surfaces.ts` | direct |
| `refresh-economics.yml` | native snapshot; live economics | `refresh-native-snapshot.ts`, `refresh-economics.ts` | direct; `npm run economics:refresh` |
| `refresh-metagraph.yml` | Sync to D1 | `sync-neurons.ts` | direct (newly instrumented) |

The `publish-cloudflare` pair is the sharpest case: both scripts are **tolerant by design** — they
log a warning and let the publish proceed. A silently degrading step is precisely what needs
reporting, and precisely what was reporting nothing.

`build.ts` has two step lists and only `productionSteps()` includes those two, gated on
`METAGRAPH_PRODUCTION_BUILD`. A plain `npm run build` in the validate lane genuinely runs neither
and correctly needs no token — modelling both lists alike would have failed nine honest steps.

## Correcting a premise

The audit that prompted this described `refresh-metagraph.yml` as "the 15-minute neurons lane."
It is not, as of 2026-08-03: its schedule is retired and it is `workflow_dispatch` only — the
poller Container drives that lane. Instrumenting `sync-neurons.ts` is still right (a manual
fallback is exactly when you want error visibility, and it saved the lane once already), but it
is a dispatch-only path, not a 15-minute one.

## Proof it actually reports

`initObservability` no-ops without the var, so "the YAML line is present" proves nothing. Three
independent checks:

**1. Live dry run.** `sync-neurons.ts` forced to fail against a stand-in ingest endpoint, with
the token set, sends a real gzipped `$exception`:

```
event            : $exception
distinct_id      : metagraphed-infra
component        : sync-neurons
exception type   : Error
exception message: NEURONS_SYNC_SECRET is required: the shared secret for POST /api/v1/internal/neurons-sync.
has stacktrace   : true
EXIT_CODE=1
```

Without the token: `requests received: 0`, `EXIT_CODE=1`. The exit status is identical either
way, so replacing `process.exitCode = 1` with `captureFatalAndExit` changed no behavior beyond
the reporting.

**2. That dry run is a committed test.** `tests/sync-neurons.test.ts` runs it as a subprocess
against a local sink (`spawn`, not `execFileSync` — the sink must answer while the child runs).
Removing the `initObservability()` call fails it:

```
× a failed sync sends a $exception tagged with the component, and still exits non-zero
```

**3. Every YAML line added is load-bearing.** Deleting each one and re-running
`validate:workflows`:

| Removed from | Offending steps detected |
| --- | --- |
| `refresh-metagraph.yml` | 1 |
| `discover-testnet-surfaces.yml` | 1 |
| `refresh-economics.yml` | 2 |
| `publish-cloudflare.yml` | 1 |

## The guard

New rule in `validate:workflows` (`scripts/workflow-observability.ts`): a step reaching an
instrumented script must have the token in scope — step, job, or workflow level, since hoisting
is legitimate and `publish-cloudflare.yml` already hoists `METAGRAPH_PRODUCTION_BUILD`.

Both halves are **derived from the tree**, never hand-listed: which scripts import the helper,
and which scripts a step reaches. A script that gains the import tomorrow is covered the moment
it does.

The rule fails if either derivation returns nothing. A guard that passes vacuously is the same
defect it exists to catch, so it refuses to pass on an empty scan rather than reporting success.

## Cost

Measured, not assumed — the July bill was ~$650 (~$163 events, ~$148 error tracking), and error
tracking has its own 100K/month free tier.

Runs in the last 30 days: `publish-cloudflare` 599, `refresh-economics` 74, `refresh-metagraph`
21, `discover-testnet-surfaces` 4 — **698 total**.

Absolute ceiling if *every* run emitted an exception from *every* instrumented script it runs:
**~1,400 events/month, ≈1.4% of the error-tracking free tier.** Realistically far below that,
since these emit only on an actual failure (the tolerant scripts only on a real chain/render
failure), and 125 of those 698 runs failed for reasons in *other* steps, which emit nothing.

Worth stating plainly: the `POSTHOG_EXCEPTION_STORM_WINDOW_MS` guard lives in
`src/usage-telemetry.ts` and covers the **Worker** path, not this one. It doesn't need to — a
short-lived batch script can emit at most a couple of events per run, so volume is structurally
bounded by run count in a way a request-serving Worker's is not.

## Secret

Requires a repository secret named exactly **`POSTHOG_PROJECT_TOKEN`** — the same PostHog project
API token the Worker holds as a wrangler secret (`src/usage-telemetry.ts` reads the identically
named var). It did not exist when this work started; it was added during review, and the maintainer has
confirmed the value is the PostHog project token. So this ships live rather than inert. All four
workflows are repo-level (no `environment:`), so a plain repository secret is the correct scope.

## Scope

`scripts/` and `.github/` are outside `codecov/patch`'s `src/**`+`workers/**` scope, so no patch
coverage is claimed. No `src/`/`workers/` files are touched, so no schema regeneration applies.

Closes #9507

