### PR TITLE
fix(repo): ignore Wrangler's .dev.vars so local secrets cannot be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,15 @@ web_modules/
 .env.*
 !.env.example
 
+# Wrangler local secrets. `wrangler dev` reads these, and `--remote` uploads
+# them to the preview Worker, so they hold the same live credentials as
+# `wrangler secret put` -- the R2 SQL token, sync secrets. The patterns above
+# do NOT cover this filename, so without these lines a local dev session leaves
+# a plaintext-secret file staged by any `git add -A`.
+.dev.vars
+.dev.vars.*
+!.dev.vars.example
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 .parcel-cache


### PR DESCRIPTION
## Summary

`.gitignore` covers `.env` and `.env.*` but not `.dev.vars`, the filename Wrangler reads for local secrets. `wrangler dev --remote` uploads that file's contents to the preview Worker as secrets, so it carries the same live credentials as `wrangler secret put` — `R2_SQL_TOKEN`, the `*_SYNC_SECRET`s.

Nothing is tracked today, so this is prevention rather than cleanup. But creating the file is the documented Wrangler workflow whenever a lane needs credentials under `wrangler dev`, and this repo has several such lanes (the projection lanes read `R2_SQL_TOKEN`). Once the file exists, a routine `git add -A` stages plaintext credentials with no warning — and `scan:public-safety` passes on the current tree, so it would not catch it either.

Mirrors the `.env` block directly above it, including the `.dev.vars.*` variants (`.local`, `.production` are both standard) and an `!.dev.vars.example` negation matching the existing `!.env.example` convention.

## Verification

Confirmed the rules resolve as intended, then removed the scratch files:

```
$ git check-ignore -v .dev.vars .dev.vars.local
.gitignore:84:.dev.vars       .dev.vars
.gitignore:85:.dev.vars.*     .dev.vars.local

$ git status --porcelain | grep dev.vars.example
?? .dev.vars.example          # negation intact
```

`git ls-files | grep -i dev.vars` returns nothing, confirming no such file is currently tracked.

## Gates run

- `git diff --check` — clean
- `npm run lint` — clean
- `npm run format:check` — all matched files use Prettier code style
- `npm run scan:public-safety` — passed
- `npm run validate` — validated 129 native subnets, 129 curated overlays, 3442 surfaces, 136 providers, 2037 candidates

No `src/**` or `workers/**` lines change, so there is no patch-coverage surface. No generated artifact is touched.

Closes #9509
