### PR TITLE
feat(api): give hotkey_alpha a D1 sink so delegated_tao has a pool total

### DIFF
--- a/migrations/d1/0019_hotkey_alpha.sql
+++ b/migrations/d1/0019_hotkey_alpha.sql
@@ -1,0 +1,70 @@
+-- The (hotkey, netuid) alpha-pool ledger (#9502) -- the input `delegated_tao`
+-- needs and neither store has.
+--
+-- WHY THIS TABLE HAS TO EXIST. `nominator_positions.share_fraction` is
+-- dimensionless: a coldkey's slice of a (hotkey, netuid) alpha POOL. Valuing a
+-- position needs that pool's total, and the only stake figure in D1 is
+-- `neurons.stake_tao`, which exists solely for hotkeys holding a UID on that
+-- exact subnet. A delegate accrues alpha on every subnet it is staked to,
+-- registered there or not, so the join misses most of the ledger. Measured
+-- against production 2026-08-05 (#9502):
+--
+--   distinct hotkeys in nominator_positions        13,724
+--   ...present in neurons at all                      979
+--   ...present on the matching (hotkey, netuid)        512
+--   position rows that price                28,902/126,508  (22.8%)
+--   coldkeys that price                       6,673/24,121  (27.7%)
+--
+-- `validator_nominator_counts` -- the sibling output of the same Alpha scan --
+-- holds 112,250 hotkeys against `neurons`' 21,635, which is the same fact seen
+-- from the other side.
+--
+-- WHY A LABEL WAS NOT ENOUGH. The per-account route already reports the gap
+-- honestly (`degraded.reason: positions_unpriceable`,
+-- src/account-nominator-positions.ts). A per-row label cannot rescue a
+-- RANKING, though: recomputing the leaderboard from those three tables puts an
+-- account the frozen snapshot ranks at 81,185 TAO at 0 and drops another out of
+-- the payload entirely. A leaderboard confidently wrong about who the top
+-- holders are is worse than the frozen one it would replace, which is why
+-- #9492 left the column alone rather than shipping it.
+--
+-- THE INPUT IS ON CHAIN. `SubtensorModule::TotalHotkeyAlpha(hotkey, netuid)
+-- -> u64` (alpha in rao), probed live 2026-08-05 and populated;
+-- `TotalHotkeyShares` sits alongside it as the denominator share_fraction is
+-- already computed against. Neither D1 nor the lakehouse carries either --
+-- `chain.total_hotkey_alpha` / `chain.hotkey_alpha` do not exist, and
+-- `chain.neurons` has the same registered-only hole.
+--
+-- SHAPE MIRRORS 0017_account_balances.sql, including its prune posture: the
+-- producer skips a zero pool rather than writing a zero row, so "absent from
+-- the batch" says nothing about a pool's size and a prune would delete exactly
+-- the hotkeys that emptied. Upsert-only on (hotkey, netuid), never deleting.
+--
+-- `total_alpha` is REAL and holds ALPHA, not TAO: converting to TAO needs the
+-- subnet's alpha price, which lives in `subnet_snapshots` on a daily cadence
+-- and is the reader's business, not the writer's. Storing the served unit the
+-- producer measured keeps this column one hop from the chain -- the same rule
+-- 0015_subnet_burn_history.sql's `burn_tao` follows.
+--
+-- A genuine zero is a real pool size, so this column is NOT NULL and a missing
+-- read is an absent ROW, never a zero one -- the distinction #9414 and the
+-- burn-history migration both turn on.
+CREATE TABLE IF NOT EXISTS hotkey_alpha (
+  hotkey      TEXT    NOT NULL,
+  netuid      INTEGER NOT NULL,
+  total_alpha REAL    NOT NULL,
+  -- Epoch MILLISECONDS, like every other captured_at in this database. #9382 is
+  -- the standing reminder of what a seconds value does here: read as ms it
+  -- lands in 1970, and a staleness guard then pins the row permanently.
+  captured_at INTEGER NOT NULL,
+  PRIMARY KEY (hotkey, netuid)
+);
+
+-- The serving read: price one coldkey's positions, which are looked up by the
+-- (hotkey, netuid) pairs those positions name.
+CREATE INDEX IF NOT EXISTS idx_hotkey_alpha_netuid
+  ON hotkey_alpha (netuid, hotkey);
+
+-- The staleness watchdog scans by capture time across every hotkey.
+CREATE INDEX IF NOT EXISTS idx_hotkey_alpha_captured
+  ON hotkey_alpha (captured_at);

--- a/src/hotkey-alpha-d1-write.ts
+++ b/src/hotkey-alpha-d1-write.ts
@@ -1,0 +1,73 @@
+// The hotkey-alpha sync write path, against D1 (#9502).
+//
+// `delegated_tao`'s missing input. A coldkey's `nominator_positions.share_fraction`
+// is a dimensionless slice of a (hotkey, netuid) alpha POOL, and nothing in
+// either store held that pool's total: `neurons.stake_tao` covers only hotkeys
+// registered on that exact subnet, which is 512 of the 13,724 (hotkey, netuid)
+// pairs the positions actually name. migrations/d1/0019_hotkey_alpha.sql is the
+// table; this module is the writer.
+//
+// SHAPE MIRRORS src/account-balances-d1-write.ts exactly, including the prune
+// posture -- the producer skips a zero pool rather than writing a zero row, so
+// "absent from this batch" says nothing about a pool's size and a prune would
+// delete exactly the hotkeys that emptied. Upsert-only, never deleting.
+//
+// The one structural difference is the KEY: a composite (hotkey, netuid) rather
+// than a single column. chunkStatements takes the conflict target as a list
+// precisely so this needs no fork -- the same D1_PARAM_BUDGET arithmetic
+// applies, at 4 columns to 25 rows a statement.
+//
+// The trailing `captured_at <= excluded.captured_at` guard buildUpsert appends
+// is load-bearing here for the same reason it is on the balances lane: a full
+// pass arrives across many requests and the producer re-sends on failure, so a
+// replayed or out-of-order batch must be a no-op rather than a regression to an
+// older pool size.
+
+import {
+  batchInSlices,
+  chunkStatements,
+  type D1Like,
+  type D1PreparedStatement,
+} from "./neurons-d1-write.ts";
+
+type Row = Record<string, unknown>;
+
+/**
+ * The writer's exact column list and order, and the single source the route's
+ * validator, the migration's drift test and the producer's payload all agree
+ * against.
+ *
+ * `total_alpha` is ALPHA, not TAO. Converting needs the subnet's alpha price
+ * (daily, from `subnet_snapshots`) and belongs to the reader that prices a
+ * position, not to this write path -- storing the unit the producer measured
+ * keeps the column one hop from the chain.
+ */
+export const HOTKEY_ALPHA_INSERT_COLUMNS = [
+  "hotkey",
+  "netuid",
+  "total_alpha",
+  "captured_at",
+];
+
+/**
+ * Write one hotkey-alpha sync batch to D1: a latest-only upsert on
+ * (hotkey, netuid), nothing else.
+ *
+ * NO PRUNE -- see this module's header and the migration's. An empty batch
+ * issues no statements at all rather than an empty `db.batch([])`, matching
+ * writeAccountBalancesToD1's own guard.
+ */
+export async function writeHotkeyAlphaToD1(
+  db: D1Like,
+  rows: Row[],
+): Promise<{ statements: number }> {
+  const statements: D1PreparedStatement[] = chunkStatements(
+    db,
+    "hotkey_alpha",
+    HOTKEY_ALPHA_INSERT_COLUMNS,
+    ["hotkey", "netuid"],
+    rows,
+  );
+  if (statements.length) await batchInSlices(db, statements);
+  return { statements: statements.length };
+}

--- a/tests/data-api-hotkey-alpha-d1.test.ts
+++ b/tests/data-api-hotkey-alpha-d1.test.ts
@@ -1,0 +1,282 @@
+// The hotkey-alpha sync lane (#9502), exercised END TO END against a REAL
+// SQLite database through the real Worker fetch handler -- same harness and
+// rationale as tests/data-api-account-balances-d1.test.ts.
+//
+// This table is the input `delegated_tao` could not be computed without. A
+// coldkey's `nominator_positions.share_fraction` is a dimensionless slice of a
+// (hotkey, netuid) alpha POOL, and the only stake figure in D1 --
+// `neurons.stake_tao` -- exists solely for hotkeys registered on that exact
+// subnet: 512 of the 13,724 pairs the positions actually name, so 22.8% of
+// position rows priced. Recomputing the leaderboard from that join ranks an
+// account the frozen snapshot puts at 81,185 TAO at 0, which is why the column
+// waited for this rather than shipping a per-row label on a ranking.
+//
+// What matters here is the write CONTRACT, and it differs from the balances
+// lane in exactly one structural way: the key is COMPOSITE. A hotkey holds a
+// separate pool on every subnet it is staked to, so (hotkey, netuid) is the
+// identity and a same-hotkey/different-netuid row must INSERT rather than
+// overwrite. The sibling Alpha scan is ~762,577 entries, past any single
+// request body, so a pass arrives across many requests -- which is why there is
+// no prune and why the captured_at guard, not request ordering, is what keeps a
+// replay safe.
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, describe, test } from "vitest";
+import type { Row } from "./row-type.ts";
+
+const { default: worker } = await import("../workers/data-api.ts");
+
+const SCHEMA = fs.readFileSync(
+  path.join(process.cwd(), "migrations/d1/0019_hotkey_alpha.sql"),
+  "utf8",
+);
+
+const PATH = "/api/v1/internal/hotkey-alpha-sync";
+const SECRET = "test-hotkey-alpha-sync-secret";
+const HOTKEY = "5FyVinYphF6JS5FZHzhMQffxtgbz1WxwUEBAxTRo9nABwb5g";
+const HOTKEY_B = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+let db: InstanceType<typeof DatabaseSync>;
+
+function d1() {
+  return {
+    prepare(text: string) {
+      return {
+        bind(...values: unknown[]) {
+          return {
+            text,
+            values,
+            async all() {
+              return { results: db.prepare(text).all(...(values as never[])) };
+            },
+          };
+        },
+      };
+    },
+    async batch(statements: { text: string; values: unknown[] }[]) {
+      db.exec("BEGIN");
+      try {
+        const results = statements.map((statement) => ({
+          results: db
+            .prepare(statement.text)
+            .all(...(statement.values as never[])),
+        }));
+        db.exec("COMMIT");
+        return results;
+      } catch (err) {
+        db.exec("ROLLBACK");
+        throw err;
+      }
+    },
+  };
+}
+
+function env(overrides: Record<string, unknown> = {}): Env {
+  return {
+    METAGRAPH_HEALTH_DB: d1(),
+    HOTKEY_ALPHA_SYNC_SECRET: SECRET,
+    ...overrides,
+  } as unknown as Env;
+}
+
+function post(body: unknown, token: string | null = SECRET, envOverride?: Env) {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (token !== null) headers["x-hotkey-alpha-sync-token"] = token;
+  return worker.fetch(
+    new Request(`https://d${PATH}`, {
+      method: "POST",
+      headers,
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    }),
+    envOverride ?? env(),
+    {} as unknown as ExecutionContext,
+  );
+}
+
+function alphaRow(overrides: Row = {}): Row {
+  return {
+    hotkey: HOTKEY,
+    netuid: 7,
+    total_alpha: 1234.5,
+    captured_at: 1_780_000_000_000,
+    ...overrides,
+  };
+}
+
+const rows = () =>
+  db
+    .prepare("SELECT * FROM hotkey_alpha ORDER BY hotkey, netuid")
+    .all() as Row[];
+
+beforeEach(() => {
+  db = new DatabaseSync(":memory:");
+  db.exec(SCHEMA);
+});
+
+describe("POST /api/v1/internal/hotkey-alpha-sync", () => {
+  test("writes a batch to D1 and reports what it did", async () => {
+    const response = await post({
+      rows: [alphaRow(), alphaRow({ hotkey: HOTKEY_B, total_alpha: 0 })],
+    });
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      hotkey_alpha_written: 2,
+      stores: ["d1"],
+      d1_statements: 1,
+    });
+    assert.equal(rows().length, 2);
+    // A zero pool IS stored. The producer skips an unread pool, so a zero that
+    // arrives is a measured emptiness, not a placeholder -- the distinction
+    // the NOT NULL column exists to preserve.
+    assert.equal(rows()[1]!.total_alpha, 0);
+  });
+
+  test("the same hotkey on two subnets is two rows, not an overwrite", async () => {
+    // The whole reason this table exists: a delegate accrues alpha on every
+    // subnet it is staked to. A single-column key would collapse those pools
+    // into one and misprice every position on all but the last-written subnet.
+    await post({
+      rows: [
+        alphaRow({ netuid: 7, total_alpha: 100 }),
+        alphaRow({ netuid: 83, total_alpha: 250 }),
+      ],
+    });
+    assert.equal(rows().length, 2);
+    assert.deepEqual(
+      rows().map((r) => [r.netuid, r.total_alpha]),
+      [
+        [7, 100],
+        [83, 250],
+      ],
+    );
+  });
+
+  test("a newer capture updates in place; an older one is ignored", async () => {
+    // Real epoch-ms throughout: validSyncCapturedAt rejects a toy value like
+    // 2000 outright, which is the guard #9382 exists for -- a seconds-scale
+    // number read as ms lands in 1970 and pins the row permanently.
+    const older = 1_780_000_000_000;
+    const newer = 1_781_000_000_000;
+    await post({ rows: [alphaRow({ total_alpha: 100, captured_at: older })] });
+    await post({ rows: [alphaRow({ total_alpha: 300, captured_at: newer })] });
+    assert.equal(rows()[0]!.total_alpha, 300);
+    // A pass arrives across many requests and the producer re-sends on
+    // failure, so a replayed or out-of-order batch must be a no-op rather than
+    // a regression to an older pool size.
+    await post({ rows: [alphaRow({ total_alpha: 999, captured_at: older })] });
+    assert.equal(rows()[0]!.total_alpha, 300);
+    assert.equal(rows()[0]!.captured_at, newer);
+  });
+
+  test("accepts a bare array as well as {rows:[...]}", async () => {
+    const response = await post([alphaRow()]);
+    assert.equal(response.status, 200);
+    assert.equal(rows().length, 1);
+  });
+
+  test("rejects a missing or wrong token before reading the body", async () => {
+    assert.equal((await post({ rows: [alphaRow()] }, null)).status, 401);
+    assert.equal((await post({ rows: [alphaRow()] }, "wrong")).status, 401);
+    assert.equal(rows().length, 0);
+  });
+
+  test("503s when the route is not provisioned", async () => {
+    const response = await post(
+      { rows: [alphaRow()] },
+      SECRET,
+      env({ HOTKEY_ALPHA_SYNC_SECRET: undefined }),
+    );
+    assert.equal(response.status, 503);
+  });
+
+  test("400s on a body that is not JSON or not a row list", async () => {
+    assert.equal((await post("not json")).status, 400);
+    assert.equal((await post({ nope: 1 })).status, 400);
+    assert.equal((await post({ rows: [] })).status, 400);
+  });
+
+  test("rejects a row carrying a key outside the writer's column list", async () => {
+    // An unknown key means the producer and the writer disagree about the
+    // shape; accepting it would silently drop the field.
+    const response = await post({ rows: [alphaRow({ extra: 1 })] });
+    assert.equal(response.status, 400);
+    assert.equal(rows().length, 0);
+  });
+
+  test("rejects a negative, non-finite or non-numeric alpha", async () => {
+    // A NaN or Infinity arriving as null would bind as NULL against a NOT NULL
+    // column and fail the whole batch at the database rather than here.
+    for (const bad of [-1, "1234.5", null, undefined]) {
+      const response = await post({ rows: [alphaRow({ total_alpha: bad })] });
+      assert.equal(response.status, 400, String(bad));
+    }
+    assert.equal(
+      (
+        await post(
+          `{"rows":[{"hotkey":"${HOTKEY}","netuid":7,"total_alpha":1e999,"captured_at":1780000000000}]}`,
+        )
+      ).status,
+      400,
+      "Infinity",
+    );
+    assert.equal(rows().length, 0);
+  });
+
+  test("rejects a junk netuid rather than creating a parallel row", async () => {
+    // netuid is half the primary key, so a non-integer or negative value
+    // silently creates a second row for the same pool instead of updating it.
+    for (const bad of [-1, 1.5, "7", null]) {
+      const response = await post({ rows: [alphaRow({ netuid: bad })] });
+      assert.equal(response.status, 400, String(bad));
+    }
+    assert.equal(rows().length, 0);
+  });
+
+  test("rejects an empty or oversized hotkey", async () => {
+    assert.equal(
+      (await post({ rows: [alphaRow({ hotkey: "" })] })).status,
+      400,
+    );
+    assert.equal(
+      (await post({ rows: [alphaRow({ hotkey: "5".repeat(200) })] })).status,
+      400,
+    );
+    assert.equal(rows().length, 0);
+  });
+
+  test("rejects a captured_at the staleness guard cannot trust", async () => {
+    for (const bad of [0, -1, "1780000000000", null]) {
+      const response = await post({ rows: [alphaRow({ captured_at: bad })] });
+      assert.equal(response.status, 400, String(bad));
+    }
+    assert.equal(rows().length, 0);
+  });
+
+  test("503s when D1 is unbound, and only AFTER validating the body", async () => {
+    // A malformed body is a 400 whether or not a store happens to be bound.
+    const unbound = env({ METAGRAPH_HEALTH_DB: undefined });
+    assert.equal((await post({ nope: 1 }, SECRET, unbound)).status, 400);
+    assert.equal(
+      (await post({ rows: [alphaRow()] }, SECRET, unbound)).status,
+      503,
+    );
+  });
+
+  test("502s when the D1 write throws", async () => {
+    const exploding = env({
+      METAGRAPH_HEALTH_DB: {
+        prepare: () => ({ bind: () => ({}) }),
+        batch: async () => {
+          throw new Error("d1 exploded");
+        },
+      },
+    });
+    const response = await post({ rows: [alphaRow()] }, SECRET, exploding);
+    assert.equal(response.status, 502);
+  });
+});

--- a/tests/hotkey-alpha-d1-write.test.ts
+++ b/tests/hotkey-alpha-d1-write.test.ts
@@ -1,0 +1,194 @@
+// The hotkey-alpha D1 write path (#9502) and the schema it writes into.
+//
+// Two things are checked here and they fail in different ways. The MIGRATION
+// check is anti-drift: a column the writer binds but the table lacks makes D1
+// reject the whole batch, and a column the table has but the writer never
+// sends is a permanently-NULL field that reads like real data -- the same
+// guarantee 0017's tests/account-balances-d1-write.test.ts makes for its table.
+// The WRITER checks are about the composite key and the staleness guard: this
+// lane posts a ~762k-row pass across many requests, so a chunk that overran the
+// binding's parameter limit would fail the whole batch, and a replayed request
+// must never walk a pool total backwards.
+//
+// The composite key is what separates this lane from every sibling. A hotkey
+// holds a SEPARATE alpha pool on every subnet it is staked to, so collapsing
+// (hotkey, netuid) to (hotkey) would misprice every position on all but the
+// last-written subnet -- and mispricing is the exact failure #9502 exists to
+// avoid, not a smaller version of it.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  HOTKEY_ALPHA_INSERT_COLUMNS,
+  writeHotkeyAlphaToD1,
+} from "../src/hotkey-alpha-d1-write.ts";
+import { D1_PARAM_BUDGET } from "../src/neurons-d1-write.ts";
+
+const MIGRATION = readFileSync("migrations/d1/0019_hotkey_alpha.sql", "utf8");
+
+const HOTKEY = "5FyVinYphF6JS5FZHzhMQffxtgbz1WxwUEBAxTRo9nABwb5g";
+
+/** Column names of one CREATE TABLE block, in declaration order. */
+function tableColumns(table: string): string[] {
+  const match = MIGRATION.match(
+    new RegExp(`CREATE TABLE IF NOT EXISTS ${table} \\(([\\s\\S]*?)\\n\\);`),
+  );
+  assert.ok(match, `no CREATE TABLE for ${table} in the migration`);
+  return match[1]
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(
+      (line) =>
+        line &&
+        !line.startsWith("--") &&
+        !line.startsWith("PRIMARY KEY") &&
+        !line.startsWith("CHECK"),
+    )
+    .map((line) => line.split(/\s+/)[0]);
+}
+
+/** Records every prepared statement and its bindings, in order. */
+function d1Stub() {
+  const statements: { sql: string; params: unknown[] }[] = [];
+  const batches: number[] = [];
+  const db = {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          const entry = { sql, params };
+          statements.push(entry);
+          return entry as never;
+        },
+      };
+    },
+    async batch(slice: unknown[]) {
+      batches.push(slice.length);
+      return [];
+    },
+  };
+  return { statements, batches, db };
+}
+
+function row(hotkey: string, netuid: number, alpha: number, at: number) {
+  return { hotkey, netuid, total_alpha: alpha, captured_at: at };
+}
+
+describe("the hotkey_alpha D1 schema matches its writer", () => {
+  test("the migration parser actually finds columns", () => {
+    // A regex that silently matched nothing would make every comparison below
+    // vacuously pass -- the way a source-scanning check stops checking.
+    assert.equal(tableColumns("hotkey_alpha").length, 4);
+  });
+
+  test("the table holds exactly the columns the sync binds", () => {
+    assert.deepEqual(
+      tableColumns("hotkey_alpha").sort(),
+      [...HOTKEY_ALPHA_INSERT_COLUMNS].sort(),
+    );
+  });
+
+  test("the upsert key is one row per (hotkey, netuid) pool", () => {
+    // NOT (hotkey) alone. A delegate accrues alpha on every subnet it is
+    // staked to; a single-column key would collapse those pools into one.
+    assert.match(
+      MIGRATION,
+      /PRIMARY KEY \(hotkey, netuid\)/,
+      "the PRIMARY KEY must be the same key the writer declares as its conflict target",
+    );
+  });
+
+  test("total_alpha is REAL, so a pool total is numeric", () => {
+    // The one thing TEXT would silently break: "9" outranking "10" wherever a
+    // priced position is compared.
+    assert.match(MIGRATION, /total_alpha\s+REAL\s+NOT NULL/);
+  });
+
+  test("the column stores ALPHA, and the migration says so", () => {
+    // Storing TAO here would need the subnet's daily alpha price at WRITE
+    // time, freezing a conversion the reader should make. Pinned because the
+    // unit is invisible in the column name.
+    assert.match(MIGRATION, /ALPHA, not TAO/);
+  });
+
+  test("both serving reads have an index to seek", () => {
+    // Pricing a coldkey's positions looks up by (netuid, hotkey); the
+    // staleness watchdog scans by capture time. Without either, both are full
+    // scans of a ~762k-row table.
+    assert.match(
+      MIGRATION,
+      /idx_hotkey_alpha_netuid\s+ON hotkey_alpha \(netuid, hotkey\)/,
+    );
+    assert.match(
+      MIGRATION,
+      /idx_hotkey_alpha_captured\s+ON hotkey_alpha \(captured_at\)/,
+    );
+  });
+});
+
+describe("writeHotkeyAlphaToD1", () => {
+  test("upserts on the composite key with the staleness guard", async () => {
+    const { statements, db } = d1Stub();
+    const { statements: count } = await writeHotkeyAlphaToD1(db as never, [
+      row(HOTKEY, 7, 1234.5, 1_000),
+      row(HOTKEY, 83, 20, 1_000),
+    ]);
+    assert.equal(count, 1);
+    const sql = statements[0]!.sql;
+    assert.match(sql, /INSERT INTO hotkey_alpha/);
+    assert.match(sql, /ON CONFLICT\s*\(hotkey, netuid\)/);
+    // A pass arrives across many requests and the producer re-sends on
+    // failure, so a replayed batch must be a no-op rather than a regression.
+    assert.match(sql, /captured_at\s*<=\s*excluded\.captured_at/);
+    // Both rows in one statement, bound in the writer's column order.
+    assert.deepEqual(statements[0]!.params, [
+      HOTKEY,
+      7,
+      1234.5,
+      1_000,
+      HOTKEY,
+      83,
+      20,
+      1_000,
+    ]);
+  });
+
+  test("chunks to stay inside the binding's parameter budget", async () => {
+    // 4 columns against D1's 100-parameter ceiling is 25 rows a statement.
+    // Exceeding it fails the whole batch, which is what #9157 hit live.
+    const perStatement = Math.floor(
+      D1_PARAM_BUDGET / HOTKEY_ALPHA_INSERT_COLUMNS.length,
+    );
+    const { statements, db } = d1Stub();
+    const rows = Array.from({ length: perStatement * 2 + 1 }, (_unused, i) =>
+      row(HOTKEY, i, i, 1_000),
+    );
+    const { statements: count } = await writeHotkeyAlphaToD1(db as never, rows);
+    assert.equal(count, 3);
+    for (const statement of statements) {
+      assert.ok(
+        statement.params.length <= D1_PARAM_BUDGET,
+        `a statement bound ${statement.params.length} parameters`,
+      );
+    }
+  });
+
+  test("an empty batch issues no statements at all", async () => {
+    // Not an empty db.batch([]), which D1 rejects.
+    const { statements, batches, db } = d1Stub();
+    const { statements: count } = await writeHotkeyAlphaToD1(db as never, []);
+    assert.equal(count, 0);
+    assert.deepEqual(statements, []);
+    assert.deepEqual(batches, []);
+  });
+
+  test("never issues a DELETE -- this lane does not prune", async () => {
+    // The producer skips a zero pool rather than writing a zero row, so
+    // "absent from the batch" says nothing about a pool's size. A prune would
+    // delete exactly the hotkeys that emptied.
+    const { statements, db } = d1Stub();
+    await writeHotkeyAlphaToD1(db as never, [row(HOTKEY, 7, 1, 1_000)]);
+    for (const statement of statements) {
+      assert.doesNotMatch(statement.sql, /DELETE/i);
+    }
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -3041,6 +3041,20 @@ async function handleAccountBalancesSyncProxy(request: Request, env: Env) {
   });
 }
 
+// Proxies POST /api/v1/internal/hotkey-alpha-sync -- the write path into
+// hotkey_alpha (#9502), the (hotkey, netuid) alpha-pool totals delegated_tao
+// needs to value a position. Same DATA_API service binding as the other
+// internal sync routes above.
+async function handleHotkeyAlphaSyncProxy(request: Request, env: Env) {
+  return proxyToDataApi(request, env, {
+    code: "hotkey_alpha_sync_unavailable",
+    notBoundMessage:
+      "The hotkey-alpha sync tier is not bound to this deployment.",
+    unreadableMessage:
+      "The hotkey-alpha sync tier returned an unreadable response.",
+  });
+}
+
 // --- POST /api/v1/internal/emission-gate-sync (#8748/#8750 restored) --------
 // The persistence half of the emission-gate sampling lane, moved off the
 // decommissioned box's Postgres onto D1. scripts/sample-emission-gate.ts (now
@@ -3819,6 +3833,11 @@ export async function handleRequest(
   // account-balances job POSTs here. Same DATA_API service binding.
   if (url.pathname === "/api/v1/internal/account-balances-sync") {
     return handleAccountBalancesSyncProxy(request, env);
+  }
+  // The write path into hotkey_alpha (#9502) -- the poller's TotalHotkeyAlpha
+  // scan POSTs here. Same DATA_API service binding.
+  if (url.pathname === "/api/v1/internal/hotkey-alpha-sync") {
+    return handleHotkeyAlphaSyncProxy(request, env);
   }
   // The write path into the emission-gate history tables on D1 (#8748/#8750,
   // box decommission) -- sample-emission-gate.yml's 10-minute schedule POSTs

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -362,6 +362,10 @@ import {
   ACCOUNT_BALANCE_INSERT_COLUMNS,
   writeAccountBalancesToD1,
 } from "../src/account-balances-d1-write.ts";
+import {
+  HOTKEY_ALPHA_INSERT_COLUMNS,
+  writeHotkeyAlphaToD1,
+} from "../src/hotkey-alpha-d1-write.ts";
 import { VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS } from "../src/validator-nominator-counts-staleness-watchdog.ts";
 import { writeChainDetailToD1 } from "../src/chain-detail-d1-write.ts";
 import {
@@ -2061,6 +2065,166 @@ async function handleAccountBalancesSync(request: Request, env: Env) {
   return writeJson({
     ok: true,
     account_balances_written: rows.length,
+    stores: ["d1"],
+    d1_statements: d1Statements,
+  });
+}
+
+// --- POST /api/v1/internal/hotkey-alpha-sync (#9502) ----------------------
+//
+// The (hotkey, netuid) alpha-pool ledger `delegated_tao` needs. A staker's
+// `nominator_positions.share_fraction` is a dimensionless slice of a pool, and
+// nothing in either store held the pool total to value it against:
+// `neurons.stake_tao` covers only hotkeys registered on that exact subnet,
+// which is 512 of the 13,724 (hotkey, netuid) pairs the positions name, so
+// only 22.8% of position rows and 27.7% of staking accounts priced at all
+// (#9502).
+//
+// Recomputing the leaderboard from that join is not a staleness problem that
+// a label fixes: it puts an account the frozen snapshot ranks at 81,185 TAO at
+// 0 and drops another out of the payload entirely. A ranking cannot carry a
+// per-row degraded flag the way the per-account route does, which is why the
+// column waited for this table rather than shipping wrong.
+//
+// The producer reads `SubtensorModule::TotalHotkeyAlpha(hotkey, netuid)`
+// directly, the same posture as account-balances above: a direct state read
+// cannot drift, event-replay can.
+//
+// A FULL PASS DOES NOT FIT ONE REQUEST -- the sibling Alpha scan is ~762,577
+// entries -- so this takes the same {rows:[...]} shape, the same token gate,
+// and the same flat chunking as account-balances: rows are keyed on
+// (hotkey, netuid) and this lane never prunes, so a row may land in any
+// request in any order.
+const HOTKEY_ALPHA_SYNC_TOKEN_HEADER = "x-hotkey-alpha-sync-token";
+const HOTKEY_ALPHA_SYNC_MAX_BODY_BYTES = 8_000_000;
+const HOTKEY_ALPHA_SYNC_MAX_ROWS = 25_000;
+const HOTKEY_ALPHA_SYNC_MAX_KEY_BYTES = 128;
+
+/**
+ * Bounds-check one incoming row against HOTKEY_ALPHA_INSERT_COLUMNS.
+ *
+ * `total_alpha` must be finite and NON-NEGATIVE: a negative alpha pool is not
+ * a thing the chain can hold, and a NaN or Infinity arriving as null would
+ * bind as NULL against a NOT NULL column and fail the whole batch at the
+ * database rather than here, where the producer can see it. A genuine 0 IS
+ * accepted -- an emptied pool is a real measurement, and the producer's own
+ * skip rule is what keeps those out, not this validator.
+ *
+ * `netuid` is bounded to a non-negative integer for the same reason the
+ * balance columns are bounded: the composite primary key means a junk netuid
+ * silently creates a parallel row rather than updating the intended one.
+ */
+function validHotkeyAlphaSyncRow(row: Row) {
+  if (!row || typeof row !== "object" || Array.isArray(row)) return false;
+  for (const key of Object.keys(row)) {
+    if (!HOTKEY_ALPHA_INSERT_COLUMNS.includes(key)) return false;
+  }
+  if (typeof row.hotkey !== "string" || row.hotkey.length === 0) return false;
+  if (utf8Bytes(row.hotkey).length > HOTKEY_ALPHA_SYNC_MAX_KEY_BYTES)
+    return false;
+  if (
+    typeof row.netuid !== "number" ||
+    !Number.isInteger(row.netuid) ||
+    row.netuid < 0
+  ) {
+    return false;
+  }
+  const alpha = row.total_alpha;
+  if (typeof alpha !== "number" || !Number.isFinite(alpha) || alpha < 0)
+    return false;
+  if (!validSyncCapturedAt(row.captured_at)) return false;
+  return true;
+}
+
+/** Project a validated row onto the writer's exact column list and order. */
+function coerceHotkeyAlphaSyncRow(row: Row) {
+  const out: Row = {};
+  for (const col of HOTKEY_ALPHA_INSERT_COLUMNS) out[col] = row[col];
+  return out;
+}
+
+async function handleHotkeyAlphaSync(request: Request, env: Env) {
+  if (!env.HOTKEY_ALPHA_SYNC_SECRET) {
+    return writeJson(
+      { error: "hotkey-alpha sync is not provisioned on this deployment" },
+      503,
+    );
+  }
+  const provided = request.headers.get(HOTKEY_ALPHA_SYNC_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, env.HOTKEY_ALPHA_SYNC_SECRET)) {
+    return writeJson(
+      { error: `provide a valid ${HOTKEY_ALPHA_SYNC_TOKEN_HEADER} header` },
+      401,
+    );
+  }
+
+  const raw = await request.text();
+  if (utf8Bytes(raw).length > HOTKEY_ALPHA_SYNC_MAX_BODY_BYTES) {
+    return writeJson(
+      { error: `body exceeds ${HOTKEY_ALPHA_SYNC_MAX_BODY_BYTES} bytes` },
+      413,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return writeJson({ error: "body must be JSON" }, 400);
+  }
+  const incoming = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.rows)
+      ? parsed.rows
+      : null;
+  if (!incoming) {
+    return writeJson(
+      {
+        error:
+          "body must be a JSON array of hotkey-alpha rows (or {rows:[...]})",
+      },
+      400,
+    );
+  }
+  if (incoming.length > HOTKEY_ALPHA_SYNC_MAX_ROWS) {
+    return writeJson(
+      { error: `at most ${HOTKEY_ALPHA_SYNC_MAX_ROWS} rows per request` },
+      413,
+    );
+  }
+  if (!incoming.length || !incoming.every(validHotkeyAlphaSyncRow)) {
+    return writeJson(
+      { error: "rows must match the hotkey-alpha row shape" },
+      400,
+    );
+  }
+
+  const rows = incoming.map(coerceHotkeyAlphaSyncRow);
+
+  // D1 is the binding this path REQUIRES -- the only store this family has.
+  // Checked HERE, after validation, not at the top: a malformed body is a 400
+  // whether or not a store happens to be bound (handleAccountBalancesSync's
+  // own 400-before-503 reasoning).
+  if (!env.METAGRAPH_HEALTH_DB) {
+    return writeJson({ error: "d1 binding unavailable" }, 503);
+  }
+
+  let d1Statements: number;
+  try {
+    ({ statements: d1Statements } = await writeHotkeyAlphaToD1(
+      env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+        typeof writeHotkeyAlphaToD1
+      >[0],
+      rows,
+    ));
+  } catch (err) {
+    console.error("data-api hotkey-alpha-sync D1 write failed:", err);
+    await captureDataApiError(err, "hotkey-alpha-sync-d1", env);
+    return writeJson({ error: "d1 write failed" }, 502);
+  }
+
+  return writeJson({
+    ok: true,
+    hotkey_alpha_written: rows.length,
     stores: ["d1"],
     d1_statements: d1Statements,
   });
@@ -6185,6 +6349,12 @@ async function dispatchDataApiRequest(
       url.pathname === "/api/v1/internal/account-balances-sync"
     ) {
       return handleAccountBalancesSync(request, env);
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/internal/hotkey-alpha-sync"
+    ) {
+      return handleHotkeyAlphaSync(request, env);
     }
     if (
       request.method === "POST" &&

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -97,6 +97,11 @@ interface Env {
    */
   ETH_RPC_URL?: string;
   HEALTH_CHECKS_SYNC_SECRET?: string;
+  /** #9502: gates POST /api/v1/internal/hotkey-alpha-sync -- the write path
+   * into hotkey_alpha, the (hotkey, netuid) alpha-pool totals delegated_tao
+   * values a position against. Set via `wrangler secret put` on BOTH Workers
+   * (api.ts proxies, data-api.ts checks) and in the poller's vault. */
+  HOTKEY_ALPHA_SYNC_SECRET?: string;
   METAGRAPH_ALLOW_R2_STATIC_FALLBACK?: string;
   METAGRAPH_DISABLE_REQUEST_LOGS?: string;
   METAGRAPH_HEALTH_MAX_AGE_HOURS?: string;


### PR DESCRIPTION
## The missing input

`delegated_tao` can't be rebuilt from what D1 holds, and #9502 measured why it's structural rather than stale. A staker's `nominator_positions.share_fraction` is a **dimensionless** slice of a `(hotkey, netuid)` alpha pool. Valuing it needs that pool's total — and the only stake figure in D1, `neurons.stake_tao`, exists solely for hotkeys *registered on that exact subnet*. A delegate accrues alpha on every subnet it's staked to:

| | |
|---|---|
| distinct hotkeys in `nominator_positions` | 13,724 |
| …present in `neurons` at all | 979 |
| …present on the matching `(hotkey, netuid)` | **512** |
| position rows that price | **28,902 / 126,508 (22.8%)** |
| staking accounts that price | **6,673 / 24,121 (27.7%)** |

A per-row label can't rescue a *ranking*. The per-account route already reports this honestly (`degraded.reason: positions_unpriceable`), but recomputing the leaderboard from those three tables ranks an account the frozen snapshot puts at **81,185 TAO at 0**, and drops another out of the payload entirely. Confidently wrong about who the top holders are is worse than frozen — which is why #9492 left the column alone rather than shipping it.

`SubtensorModule::TotalHotkeyAlpha(hotkey, netuid) -> u64` is the input, probed live and populated. Neither store carries it.

## This PR

The landing zone, mirroring #9483's shape for `account_balances`:

- `migrations/d1/0019_hotkey_alpha.sql` — **applied to production D1**, since the table has to exist before the route can accept a row.
- `src/hotkey-alpha-d1-write.ts` — reuses `chunkStatements`/`batchInSlices`, so D1's 100-bound-parameter limit stays enforced in exactly one place (4 columns → 25 rows a statement).
- `POST /api/v1/internal/hotkey-alpha-sync` behind its own token, plus the main-Worker proxy.

**The composite key is the one structural difference from every sibling lane.** A hotkey holds a separate pool per subnet, so `(hotkey, netuid)` is the identity; collapsing it to `(hotkey)` would misprice every position on all but the last-written subnet — the exact failure this exists to prevent, not a smaller version of it. There's a test for precisely that.

**No prune**, same reasoning as the balances lane: the producer skips a zero pool rather than writing a zero row, so "absent from the batch" says nothing about a pool's size and a prune would delete the hotkeys that emptied. The `captured_at <= excluded.captured_at` guard — not request ordering — is what makes a replay safe across a ~762k-row multi-request pass.

**`total_alpha` stores ALPHA, not TAO.** Converting needs the subnet's daily alpha price; that's the reader's job. Pinned by a test, because the unit is invisible in the column name.

## What this does NOT do

It does not flip `delegated_tao` live. That needs the producer POSTing rows, which is the infra half (#9502's second bullet) — and per its own warning, that scan needs the `alpha_scan_floor()` guard, since the sibling Alpha scan is ~762,577 entries and needed `storage_page_size` raised to 1000 to finish at all. A truncated pass looks complete and publishes real-looking totals that are merely too low — exactly what just happened to `account_balances` at 147,000 rows.

## Validation

- `lint` · `typecheck` · `format:check` · `scan:public-safety` — clean
- `validate` exit 0 · `build` exit 0 · `validate:migrations` — 19 files, unique and sequential
- `npx vitest run` — **679 files / 16,221 tests passed**

24 new tests: a real-SQLite end-to-end pass through the Worker fetch handler (composite-key insert vs overwrite, the replay guard with real epoch-ms, every rejection path including a junk `netuid` that would fork a parallel row), plus schema-vs-writer drift and the parameter budget.

Closes #9502