### PR TITLE
fix(mcp): make the push channel real from initialize, and serve /mcp/

### DIFF
--- a/src/github-oauth.ts
+++ b/src/github-oauth.ts
@@ -202,6 +202,23 @@ export function matchesMcpApiRoute(pathname: string): boolean {
   return pathname.startsWith(MCP_API_ROUTE);
 }
 
+/**
+ * Is this the MCP endpoint itself — the path the Worker actually serves?
+ *
+ * Deliberately NARROWER than `matchesMcpApiRoute`, and the two are next to each other
+ * so the difference is visible: that one answers "would OAuthProvider claim this",
+ * which must stay a prefix; this one answers "is this the endpoint", which must not,
+ * or `/mcp/sse` would be served as MCP rather than 404ing honestly.
+ *
+ * A trailing slash IS the endpoint. `/mcp/` is what a client gets from joining a base
+ * URL, it is the same resource by every convention that matters, and OAuthProvider
+ * already treats it as the same route. Rejecting it bought nothing and cost the one
+ * client mistake most likely to be made.
+ */
+export function isMcpEndpointPath(pathname: string): boolean {
+  return pathname === MCP_API_ROUTE || pathname === `${MCP_API_ROUTE}/`;
+}
+
 export function isNonOAuthMcpRequest(request: Request): boolean {
   if (!matchesMcpApiRoute(new URL(request.url).pathname)) return false;
   const header = request.headers.get("Authorization");

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -14827,6 +14827,38 @@ function pendingMcpSessionId(body: Row | null): string | null {
   return crypto.randomUUID();
 }
 
+/**
+ * Tell the session's hub it exists, as soon as `initialize` decides to hand the id out.
+ *
+ * A session used to become known to `McpSessionHub` only via `resources/subscribe`, so
+ * `GET /mcp` and `DELETE /mcp` both failed for a session that had merely initialized —
+ * and the GET's answer is 405, which a conformant client may take as "this server has
+ * no SSE stream, ever". Such a client never re-opens the stream after subscribing, and
+ * every `notifications/resources/updated` is then delivered to nobody.
+ *
+ * Never throws: an unbound or unreachable hub leaves the session unregistered, which
+ * degrades to exactly the previous behaviour (a 405 on GET) rather than failing the
+ * initialize that a client needs in order to do anything at all.
+ */
+async function registerMcpSession(
+  env: Env,
+  sessionId: string | undefined,
+): Promise<void> {
+  if (!sessionId || !env.MCP_SESSION_HUB) return;
+  try {
+    const stub = env.MCP_SESSION_HUB.get(
+      env.MCP_SESSION_HUB.idFromName(sessionId),
+    );
+    await stub.fetch("https://mcp-session-hub.internal/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessionId }),
+    });
+  } catch {
+    // See above: a hub that cannot be reached costs the push channel, not the session.
+  }
+}
+
 const MCP_STREAM_HUB_UNAVAILABLE_RESPONSE = new Response(null, {
   status: 405,
   headers: { ...MCP_HEADERS, allow: "POST, OPTIONS" },
@@ -15090,6 +15122,15 @@ export async function handleMcpRequest(
     response,
     ctx.pendingSessionId ?? null,
   );
+  // Register the session with its hub BEFORE the id reaches the client, and only
+  // when it actually will (mintMcpSessionHeaderIfNeeded returns {} for a failed or
+  // batched initialize, so a session id the client never receives creates no state).
+  //
+  // Awaited, not deferred: the client learns the id from this response's headers and
+  // may open the GET stream on the next tick. Registering after the response is a race
+  // the client wins — which is how an initialize-then-GET could 404 against a session
+  // the server had just handed out.
+  await registerMcpSession(env, sessionHeaders["mcp-session-id"]);
   if (!response) {
     // Notification(s) only — nothing to return.
     return new Response(null, {

--- a/tests/github-oauth.test.ts
+++ b/tests/github-oauth.test.ts
@@ -6,6 +6,7 @@ import {
   handleGithubOAuthCallback,
   isAnonymousMcpRequest,
   isNonOAuthMcpRequest,
+  isMcpEndpointPath,
   matchesMcpApiRoute,
   OAUTH_PENDING_TTL_SECONDS,
   UNUSED_DEFAULT_HANDLER,
@@ -667,6 +668,23 @@ describe("isNonOAuthMcpRequest (#8643) — our own API keys must not reach OAuth
       "https://api.metagraph.sh/mcpx",
     ]) {
       expect(isNonOAuthMcpRequest(new Request(url)), url).toBe(true);
+    }
+  });
+
+  test("isMcpEndpointPath is the endpoint, not the OAuth surface", () => {
+    // Narrower than matchesMcpApiRoute on purpose: `/mcp/sse` is claimed by OAuth's
+    // prefix but is NOT the endpoint, and serving it as MCP would be worse than the
+    // 404 it gets. A trailing slash, though, IS the endpoint — that is the client
+    // mistake most likely to be made, and it now works instead of 405ing.
+    for (const [pathname, expected] of [
+      ["/mcp", true],
+      ["/mcp/", true],
+      ["/mcp/sse", false],
+      ["/mcp/message", false],
+      ["/mcpx", false],
+      ["/api/v1/subnets", false],
+    ] as Array<[string, boolean]>) {
+      expect(isMcpEndpointPath(pathname), pathname).toBe(expected);
     }
   });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1619,6 +1619,108 @@ describe("MCP transport handling", () => {
       assert.equal(res.headers.get("allow"), "POST, OPTIONS");
     });
 
+    // The sequence an MCP client actually performs, and the one that used to fail:
+    // initialize, then open the push channel with the id it just received. A session
+    // was known to the hub only from resources/subscribe, so this GET always missed —
+    // and its answer, 405, is one a conformant client may treat as "no SSE stream,
+    // ever", after which it never re-opens the channel and every
+    // notifications/resources/updated goes to nobody.
+    test("initialize registers the session, so the GET that follows it opens a stream", async () => {
+      const hub = fakeMcpSessionHubBinding();
+      const env = { MCP_SESSION_HUB: hub } as unknown as Env;
+
+      const init = await rpc(
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: { name: "t", version: "1" },
+          },
+        },
+        { env },
+      );
+      const sessionId = init.headers.get("mcp-session-id");
+      assert.ok(sessionId, "initialize must hand back a session id");
+
+      // Registered BEFORE the id reached the client — registering afterwards is a race
+      // the client wins by opening the stream on the next tick.
+      const registered = hub.calls.filter((c: Row) =>
+        String(c.url).includes("/register"),
+      );
+      assert.equal(registered.length, 1);
+      assert.equal(
+        JSON.parse(String((registered[0].init as RequestInit).body)).sessionId,
+        sessionId,
+      );
+
+      const stream = await handleMcpRequest(
+        new Request(MCP_URL, {
+          method: "GET",
+          headers: { "mcp-session-id": sessionId },
+        }),
+        env,
+      );
+      assert.equal(stream.status, 200);
+      await stream.body?.cancel();
+    });
+
+    test("an initialize that mints no session id registers nothing", async () => {
+      // Registration is driven by the header mintMcpSessionHeaderIfNeeded produced,
+      // not by "the body said initialize" — so every case it excludes (a batch, which
+      // predates the session concept; a failed negotiation) creates no hub state for
+      // an id the client never received.
+      const hub = fakeMcpSessionHubBinding();
+      const res = await rpc(
+        [
+          {
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-06-18",
+              capabilities: {},
+              clientInfo: { name: "t", version: "1" },
+            },
+          },
+        ],
+        { env: { MCP_SESSION_HUB: hub } as unknown as Env },
+      );
+      assert.equal(res.headers.get("mcp-session-id"), null);
+      assert.deepEqual(
+        hub.calls.filter((c: Row) => String(c.url).includes("/register")),
+        [],
+      );
+    });
+
+    test("an unreachable hub costs the push channel, not the initialize", async () => {
+      const hub = {
+        idFromName: (name: string) => name,
+        get: () => ({
+          fetch: async () => {
+            throw new Error("hub unreachable");
+          },
+        }),
+      };
+      const res = await rpc(
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: { name: "t", version: "1" },
+          },
+        },
+        { env: { MCP_SESSION_HUB: hub } as unknown as Env },
+      );
+      assert.equal(res.status, 200);
+      assert.ok(res.headers.get("mcp-session-id"), "the session still exists");
+    });
+
     test("with MCP_SESSION_HUB bound, forwards to the session's /stream route and streams the response through", async () => {
       const hub = fakeMcpSessionHubBinding();
       const request = new Request(MCP_URL, {
@@ -23673,4 +23775,53 @@ describe("MCP event-stream honesty (#9307)", () => {
       );
     },
   );
+});
+
+// `/mcp/` is the same endpoint as `/mcp`. A trailing slash is what a client gets from
+// joining a base URL; OAuthProvider already treats the two as one route, and the app
+// answering only the bare form is what put an otherwise-correct client on the 405 path.
+describe("the MCP endpoint tolerates a trailing slash", () => {
+  test("POST /mcp/ dispatches like POST /mcp", async () => {
+    const response = await handleRequest(
+      new Request("https://api.metagraph.sh/mcp/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/list",
+          params: {},
+        }),
+      }),
+      {} as unknown as Env,
+      {
+        waitUntil() {},
+        passThroughOnException() {},
+      } as unknown as ExecutionContext,
+    );
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as Row;
+    assert.ok(
+      Array.isArray((body.result as Row)?.tools),
+      "a trailing slash must not change the answer",
+    );
+  });
+
+  test("a deeper /mcp path is still not the endpoint", async () => {
+    // `/mcp/sse` is claimed by OAuth's prefix but is not this endpoint; serving it as
+    // MCP would be worse than the honest rejection it gets.
+    const response = await handleRequest(
+      new Request("https://api.metagraph.sh/mcp/sse", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+      }),
+      {} as unknown as Env,
+      {
+        waitUntil() {},
+        passThroughOnException() {},
+      } as unknown as ExecutionContext,
+    );
+    assert.notEqual(response.status, 200);
+  });
 });

--- a/tests/mcp-session-hub.test.ts
+++ b/tests/mcp-session-hub.test.ts
@@ -1061,3 +1061,171 @@ test("alarm: a healthy expiry captures nothing", async () => {
     globalThis.fetch = original;
   }
 });
+
+// --- /register: a session exists from `initialize`, not from `resources/subscribe` ---
+//
+// Before this, the hub learned a session only from resources/subscribe. So the
+// canonical initialize-then-GET sequence always missed, and its answer -- 405, "this
+// endpoint offers no SSE stream" -- is one a conformant client may believe forever.
+// Such a client never re-opens the stream after subscribing, and every
+// notifications/resources/updated is delivered to nobody.
+
+test("handleRegister records the session without subscribing it to anything", async () => {
+  const hub = new McpSessionHub(stubState(), mockEnv());
+  const response = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessionId: "s-1" }),
+    }),
+  );
+  assert.equal(response.status, 200);
+  assert.equal(hub.sessionId, "s-1");
+  assert.equal(
+    hub.subscribedUris.size,
+    0,
+    "registration is not a subscription",
+  );
+});
+
+test("handleRegister arms the idle alarm, so an abandoned session still reaps", async () => {
+  const state = stubState();
+  const hub = new McpSessionHub(state, mockEnv());
+  const before = Date.now();
+  await hub.fetch(
+    new Request("https://mcp-session-hub.internal/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessionId: "s-1" }),
+    }),
+  );
+  const alarm = (state.storage as unknown as { lastAlarmTime: number | null })
+    .lastAlarmTime;
+  assert.ok(
+    alarm !== null && alarm >= before + MCP_SESSION_IDLE_TTL_MS - 5_000,
+    "registering must not create state nothing will clean up",
+  );
+});
+
+test("handleRegister is idempotent for the same session id", async () => {
+  const hub = new McpSessionHub(stubState(), mockEnv());
+  const register = () =>
+    hub.fetch(
+      new Request("https://mcp-session-hub.internal/register", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sessionId: "s-1" }),
+      }),
+    );
+  assert.equal((await register()).status, 200);
+  assert.equal((await register()).status, 200);
+  assert.equal(hub.sessionId, "s-1");
+});
+
+test("handleRegister refuses a different session id on the same object", async () => {
+  // Reachable only via a hash collision on idFromName; refusing is still cheaper
+  // than letting one session's id overwrite another's.
+  const hub = new McpSessionHub(stubState(), mockEnv());
+  await hub.fetch(
+    new Request("https://mcp-session-hub.internal/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessionId: "s-1" }),
+    }),
+  );
+  const response = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessionId: "s-2" }),
+    }),
+  );
+  assert.equal(response.status, 409);
+  assert.equal(hub.sessionId, "s-1");
+});
+
+test("handleRegister rejects a missing session id rather than persisting a null", async () => {
+  const hub = new McpSessionHub(stubState(), mockEnv());
+  const response = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    }),
+  );
+  assert.equal(response.status, 400);
+  assert.equal(hub.sessionId, null);
+});
+
+test("a registered session opens a stream with NOTHING subscribed", async () => {
+  // The whole point: the GET channel is the server's side of the connection, opened
+  // once at startup. What it carries is decided later, by subscribe.
+  const hub = new McpSessionHub(stubState(), mockEnv());
+  await hub.fetch(
+    new Request("https://mcp-session-hub.internal/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessionId: "s-1" }),
+    }),
+  );
+  const response = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/stream?sessionId=s-1"),
+  );
+  assert.equal(response.status, 200);
+  await response.body?.cancel();
+});
+
+test("an unregistered session still finds no stream", async () => {
+  // Registration is what makes a stream real; a bare Durable Object name is not a
+  // session, or any UUID would open one.
+  const hub = new McpSessionHub(stubState(), mockEnv());
+  const response = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/stream?sessionId=s-unknown"),
+  );
+  assert.equal(response.status, 404);
+});
+
+test("DELETE terminates a session that only ever registered", async () => {
+  // This returned "session not found" before, so a well-behaved client could not
+  // release its hub after a bare initialize.
+  const hub = new McpSessionHub(stubState(), mockEnv());
+  await hub.fetch(
+    new Request("https://mcp-session-hub.internal/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessionId: "s-1" }),
+    }),
+  );
+  const response = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/terminate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessionId: "s-1" }),
+    }),
+  );
+  assert.equal(response.status, 200);
+  assert.equal(hub.terminated, true);
+});
+
+test("a terminated session is not resurrected by a late register", async () => {
+  const hub = new McpSessionHub(stubState(), mockEnv());
+  const register = () =>
+    hub.fetch(
+      new Request("https://mcp-session-hub.internal/register", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sessionId: "s-1" }),
+      }),
+    );
+  await register();
+  await hub.fetch(
+    new Request("https://mcp-session-hub.internal/terminate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessionId: "s-1" }),
+    }),
+  );
+  const response = await register();
+  assert.equal(response.status, 404, "the terminated gate answers first");
+  assert.equal(hub.terminated, true);
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -375,6 +375,7 @@ import { validateResponseTripwire } from "../src/response-validation-tripwire.ts
 import {
   handleAuthorizeRequest,
   handleGithubOAuthCallback,
+  isMcpEndpointPath,
 } from "../src/github-oauth.ts";
 import {
   handleSavedQueryRequest,
@@ -3714,7 +3715,11 @@ export async function handleRequest(
   // Runs before the read-only method gate (POST/DELETE would otherwise be
   // rejected there) like the RPC proxy. Artifact/KV readers are injected so
   // the MCP tools reuse the exact R2/ASSETS resolution.
-  if (url.pathname === "/mcp") {
+  // `/mcp` and `/mcp/` are the same endpoint. A trailing slash is what a client gets
+  // from joining a base URL, and rejecting it bought nothing: OAuthProvider already
+  // treats the two as one route, and the app answering only the bare form is what put
+  // an otherwise-correct client on the 405 path.
+  if (isMcpEndpointPath(url.pathname)) {
     // executionCtx is what lets tool-dispatch telemetry (#6031) drain its
     // capture through waitUntil instead of stranding it on isolate exit.
     return handleMcpRequest(request, env, {
@@ -7837,7 +7842,7 @@ function corsPreflight(request: Request) {
   } else if (url.pathname === "/api/v1/graphql") {
     // POST executes queries; GET serves the published SDL document.
     methods = "GET, POST, OPTIONS";
-  } else if (url.pathname === "/mcp") {
+  } else if (isMcpEndpointPath(url.pathname)) {
     // GET opens the bounded SSE push stream (#4983 MCP half); DELETE
     // terminates a session explicitly; POST is the stateless JSON-RPC path.
     methods = "GET, POST, DELETE, OPTIONS";

--- a/workers/mcp-session-hub.ts
+++ b/workers/mcp-session-hub.ts
@@ -126,6 +126,7 @@ export function formatMcpSseEvent(
 // route is at most a few events per session. Lifecycle is the signal worth
 // paying for; a per-event counter is not.
 const SESSION_HUB_ROUTES: Record<string, string> = {
+  "/register": "register",
   "/subscribe": "subscribe",
   "/unsubscribe": "unsubscribe",
   "/stream": "stream",
@@ -253,6 +254,9 @@ export class McpSessionHub implements DurableObject {
     }
 
     const handled = async (): Promise<Response | null> => {
+      if (url.pathname === "/register" && request.method === "POST") {
+        return this.handleRegister(request);
+      }
       if (url.pathname === "/subscribe" && request.method === "POST") {
         return this.handleSubscribe(request);
       }
@@ -280,6 +284,47 @@ export class McpSessionHub implements DurableObject {
       this.recordRoute(routeLabel, response.status < 400, startedAt);
     }
     return response;
+  }
+
+  /**
+   * Record that a session exists, without subscribing it to anything.
+   *
+   * Called once by `initialize`. Before this, a session was known to the hub only
+   * from `resources/subscribe`, so the canonical initialize-then-GET sequence always
+   * missed — and the answer to that GET is 405 ("this endpoint offers no SSE stream"),
+   * which a conformant client is entitled to believe permanently. It would then never
+   * re-open the stream after subscribing, and every `notifications/resources/updated`
+   * would be delivered to nobody. 405 was true of the request and false of the server.
+   *
+   * DELETE had the same hole: terminating a session that had only ever initialized
+   * returned "session not found", so a well-behaved client could not release its hub.
+   *
+   * Idempotent — a client may re-register a session id it already holds, and a
+   * `terminated` session stays terminated rather than being resurrected by a late call.
+   */
+  async handleRegister(request: Request): Promise<Response> {
+    const { sessionId } = (await request.json()) as { sessionId: string };
+    if (!sessionId) {
+      return new Response(JSON.stringify({ error: "sessionId is required" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    // A client-supplied id is authority only over the DO it names, which is derived
+    // from that same id -- so this can only ever register the session it IS.
+    if (this.sessionId && this.sessionId !== sessionId) {
+      return new Response(JSON.stringify({ error: "session mismatch" }), {
+        status: 409,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    this.sessionId = sessionId;
+    await this.persist();
+    await this.touch();
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
   }
 
   async handleSubscribe(request: Request): Promise<Response> {
@@ -511,11 +556,16 @@ export class McpSessionHub implements DurableObject {
 
   async handleStream(url: URL): Promise<Response> {
     const sessionId = url.searchParams.get("sessionId");
-    if (
-      !this.sessionId ||
-      (sessionId && sessionId !== this.sessionId) ||
-      this.subscribedUris.size === 0
-    ) {
+    // A registered session may hold the stream open with NOTHING subscribed. That is
+    // the ordinary shape of the transport: the GET channel is the server's side of the
+    // connection, opened once at startup, and what it carries is decided later.
+    //
+    // Requiring a subscription here made the ordering load-bearing — open the stream
+    // before subscribing and you got a 404, which the Worker surfaced as a 405 the
+    // client was entitled to treat as final. Since a stream still costs residency, the
+    // bound is unchanged: MCP_SESSION_MAX_STREAM_DURATION_MS closes it either way, and
+    // the idle alarm reaps a session nobody comes back to.
+    if (!this.sessionId || (sessionId && sessionId !== this.sessionId)) {
       return new Response(JSON.stringify({ error: "session not found" }), {
         status: 404,
         headers: { "content-type": "application/json" },


### PR DESCRIPTION
Closes #9513. The two follow-ups from #9505 that #9506 only made fail politely.

### The push channel was never available to a client that believed us

#9506 changed `GET /mcp` from 404 to 405 because 405 is what the transport sanctions for "this endpoint offers no SSE stream". That stopped the reconnect storm — and 405 is also an answer a conformant client is entitled to believe *permanently*. It would then never re-open the stream after subscribing, and every `notifications/resources/updated` would be delivered to nobody. **405 was true of the request and false of the server.**

`initialize` now registers the session with its hub, **before the id reaches the client**. The client learns the id from the response headers and may open the stream on the next tick, so registering afterwards is a race the client wins — precisely the race the production logs showed as a 404 against a session the server had just handed out.

Registration is driven by the header `mintMcpSessionHeaderIfNeeded` actually produced, not by "the body said initialize", so every case it excludes (a batch, a failed negotiation) creates no hub state for an id nobody received. An unbound or unreachable hub costs the push channel, not the initialize.

`handleStream` no longer requires a subscription. The GET channel is the server's side of the connection, opened once at startup; what it carries is decided later by subscribe. Requiring one made the ordering load-bearing, which was the bug.

**The cost bound is unchanged.** `MCP_SESSION_MAX_STREAM_DURATION_MS` still closes the stream, and the idle alarm — now armed at registration, which a test pins — still reaps a session nobody returns to. The new marginal cost is one DO fetch per initialize.

DELETE is fixed by the same change: terminating a session that had only initialized returned "session not found", so a well-behaved client could not release its hub. The logs show exactly that.

### `/mcp/` is the same endpoint as `/mcp`

A trailing slash is what a client gets from joining a base URL. OAuthProvider already treats the two as one route; the app answering only the bare form is what put an otherwise-correct client on the 405 path to begin with.

`isMcpEndpointPath` is deliberately **narrower** than `matchesMcpApiRoute` and sits beside it so the difference is visible: the OAuth predicate must stay a prefix to match the library, while the serving predicate must not, or `/mcp/sse` would be served as MCP rather than rejected.

### Deliberately not changed, and why

A genuinely nonexistent path under `/mcp` (`/mcp/sse`, `/mcpx`) answers **405** from the global read-only method gate rather than 404. Distinguishing them there means asking the gate whether a path exists, and `matchRoute` only knows the `/api/v1` table — a blanket 404 would turn correct 405s into wrong ones for every static asset POSTed to. That is a behaviour change across the whole surface to fix one status code on a path nobody meant to call.

---

**Verification:** 16,245 tests across 677 files · **100% patch coverage, branch-counted** (20 lines / 25 branches, 0 uncovered) · contract-drift, validate-mcp, lint, format green · rebased onto current main.

New tests cover the sequence that was broken end to end (initialize → GET opens a stream), that registration happens before the id is handed out, that an excluded initialize registers nothing, that an unreachable hub does not fail the initialize, that a registered session streams with nothing subscribed, that an *un*registered one still does not, that DELETE works after a bare initialize, that a terminated session is not resurrected, and that the idle alarm is armed at registration.