### PR TITLE
fix(accounts): refuse to rank top-holders off an account_balances load that is not provably complete

### DIFF
--- a/migrations/d1/0020_account_balances_passes.sql
+++ b/migrations/d1/0020_account_balances_passes.sql
@@ -1,0 +1,60 @@
+-- Completeness marker for the account-balances lane (#9511).
+--
+-- WHY A SEPARATE TABLE RATHER THAN A COLUMN. "Is this load complete?" is not
+-- observable in `account_balances` itself, and that is the entire problem
+-- #9511 reports: 147,000 well-formed rows look exactly like 542,618
+-- well-formed rows, only fewer. A reader ranking `ORDER BY free_tao DESC`
+-- over a partial table returns the largest balances PRESENT rather than the
+-- largest that EXIST -- a well-formed leaderboard quietly missing its #2, which
+-- is what production served after the truncated pass on 2026-08-05.
+--
+-- The emptiness check the serving side has today (`results.length === 0`)
+-- cannot close this. 147,000 rows clear it.
+--
+-- WHAT THE PRODUCER'S OWN GATE DOES AND DOES NOT COVER. metagraphed-infra#316
+-- made the poller buffer its whole walk before posting anything, so a
+-- TRUNCATED SCAN now publishes nothing at all -- the failure that actually
+-- happened cannot recur. Two holes survive that fix, and this table is for
+-- them:
+--
+--   1. A FAILED POST MID-SEQUENCE. A full pass is ~15 requests. If request 7
+--      fails, requests 1-6 are already committed under a fresh captured_at and
+--      the job returns Err -- leaving exactly the partial-load-that-looks-fresh
+--      shape, from a scan that was complete.
+--   2. THE FLOOR IS 80%. A pass covering 80-99% of the keyspace clears
+--      MIN_ACCOUNT_SCAN_ROWS and publishes legitimately. That is the right
+--      call for a network that grew (an absolute floor would need editing every
+--      time it did), but "cleared the floor" is not "covers everything".
+--
+-- So the producer declares, in its FIRST request of a pass, how many rows that
+-- pass will deliver -- a number it knows because it buffers before posting --
+-- and every request adds its own row count. A pass is complete when the two
+-- agree. Nothing infers completeness; the writer states it and the arithmetic
+-- checks it.
+--
+-- ONE ROW PER PASS, keyed on the pass's own captured_at, which the producer
+-- stamps once at scan start and repeats across every chunk (see
+-- account_balances.rs). Rows accumulate as requests land, so a reader can tell
+-- "in flight" from "complete" from "abandoned" -- all three are different
+-- things, and the middle one is the one that used to be invisible.
+--
+-- NO PRUNE here either, matching the ledger it describes. A handful of rows a
+-- day is nothing, and the history is what makes "how long has this lane been
+-- landing partial passes?" answerable at all.
+CREATE TABLE IF NOT EXISTS account_balances_passes (
+  captured_at   INTEGER NOT NULL,
+  expected_rows INTEGER NOT NULL,
+  received_rows INTEGER NOT NULL DEFAULT 0,
+  -- Epoch-ms of the request that completed the pass, NULL while it is still in
+  -- flight or if it never finished. This is the column a reader keys on: it is
+  -- set exactly once, by the request that brings received_rows up to
+  -- expected_rows.
+  completed_at  INTEGER,
+  PRIMARY KEY (captured_at)
+);
+
+-- The reader's only query shape: "the newest COMPLETE pass". A partial index
+-- would be tighter, but D1/SQLite serves this fine from a small table and the
+-- ledger it guards is the thing with half a million rows, not this.
+CREATE INDEX IF NOT EXISTS idx_account_balances_passes_completed
+  ON account_balances_passes (completed_at DESC);

--- a/src/account-balances-completeness.ts
+++ b/src/account-balances-completeness.ts
@@ -1,0 +1,113 @@
+// "Is the account_balances ledger safe to rank from?" (#9511)
+//
+// THE QUESTION A ROW COUNT CANNOT ANSWER. `ORDER BY free_tao DESC LIMIT n` over
+// a partial ledger returns the largest balances PRESENT, not the largest that
+// EXIST -- a well-formed leaderboard quietly missing its #2. Production served
+// exactly that on 2026-08-05: 147,000 rows, every one correct, and the
+// second-largest free balance on the network (737,821 TAO, live on chain)
+// simply absent. The serving side's guard was `results.length === 0`, and
+// 147,000 clears it.
+//
+// Completeness is not observable in the ledger itself. 147,000 well-formed rows
+// look exactly like 554,136 well-formed rows, only fewer. So the producer
+// declares its pass size up front -- it can, because metagraphed-infra#316 made
+// it buffer the whole walk before posting anything -- and
+// `account_balances_passes` (migrations/d1/0018) tallies what actually landed.
+// This module is the reader over that tally.
+//
+// WHY NOT JUST TRUST THE PRODUCER'S OWN FLOOR. metagraphed-infra#316 already
+// refuses to publish a truncated scan, and that closes the failure that
+// actually happened. Two holes survive it, and both produce the same
+// partial-load-that-looks-fresh shape:
+//
+//   1. A POST failing mid-sequence. A pass is ~15 requests; if the 7th fails,
+//      the first six are committed under a fresh captured_at.
+//   2. The floor is 80% of the last known network size, deliberately, so a
+//      network that grew does not deadlock the lane. A pass covering 80-99%
+//      clears it and publishes.
+//
+// Neither is a producer bug. Both are why the reader needs its own answer.
+
+interface D1Like {
+  prepare(sql: string): {
+    first(): Promise<unknown>;
+  };
+}
+
+export interface AccountBalancesCompleteness {
+  /** captured_at of the newest pass that fully landed, or null if none has. */
+  capturedAt: number | null;
+  /** What that pass declared it would deliver. Null when capturedAt is null. */
+  expectedRows: number | null;
+  /** What actually landed under that stamp. */
+  receivedRows: number | null;
+  /** Why a caller may not rank yet, or null when it may. */
+  reason: "no_complete_pass" | "unavailable" | null;
+}
+
+const NONE: AccountBalancesCompleteness = {
+  capturedAt: null,
+  expectedRows: null,
+  receivedRows: null,
+  reason: "no_complete_pass",
+};
+
+/**
+ * The newest COMPLETE pass, or a decline.
+ *
+ * Keys on `completed_at IS NOT NULL` rather than on any arithmetic over the
+ * counts. The producer is at-least-once -- it re-sends a chunk on failure -- so
+ * a replayed request adds its rows again and `received_rows` can legitimately
+ * exceed `expected_rows`. An equality check would call that finished pass
+ * unfinished; the stamp is set once by whichever request closed the gap and is
+ * never cleared.
+ *
+ * Returns a DECLINE rather than throwing on a missing binding or a failed
+ * query, matching the cold-safety posture of every other tier reader here: a
+ * leaderboard that cannot prove its inputs should fall back, not 500.
+ */
+export async function latestCompleteAccountBalancesPass(
+  db: D1Like | null | undefined,
+): Promise<AccountBalancesCompleteness> {
+  if (!db?.prepare) return { ...NONE, reason: "unavailable" };
+  try {
+    const row = (await db
+      .prepare(
+        `SELECT captured_at, expected_rows, received_rows
+           FROM account_balances_passes
+          WHERE completed_at IS NOT NULL
+          ORDER BY completed_at DESC
+          LIMIT 1`,
+      )
+      .first()) as {
+      captured_at?: unknown;
+      expected_rows?: unknown;
+      received_rows?: unknown;
+    } | null;
+    const capturedAt = Number(row?.captured_at);
+    if (!row || !Number.isFinite(capturedAt) || capturedAt <= 0) return NONE;
+    return {
+      capturedAt,
+      expectedRows: Number(row.expected_rows) || null,
+      receivedRows: Number(row.received_rows) || null,
+      reason: null,
+    };
+  } catch {
+    // A table that does not exist yet (the migration is applied by hand) lands
+    // here, and it means the same thing as "no complete pass": do not rank.
+    return { ...NONE, reason: "unavailable" };
+  }
+}
+
+/**
+ * The predicate a ranking tier should gate on.
+ *
+ * Deliberately NOT "are there rows" -- that is the check #9511 is about. A
+ * caller that ranks must additionally scope its query to `capturedAt`, or it
+ * will mix the complete pass with whatever partial one landed after it.
+ */
+export function mayRankAccountBalances(
+  completeness: AccountBalancesCompleteness,
+): completeness is AccountBalancesCompleteness & { capturedAt: number } {
+  return completeness.reason === null && completeness.capturedAt !== null;
+}

--- a/src/account-balances-d1-write.ts
+++ b/src/account-balances-d1-write.ts
@@ -59,17 +59,86 @@ export const ACCOUNT_BALANCE_INSERT_COLUMNS = [
 ];
 
 /**
+ * One pass's completeness accounting, when the producer declares it.
+ *
+ * `expectedRows` is what the producer says the whole pass will deliver -- a
+ * number it knows because metagraphed-infra#316 made it buffer the walk before
+ * posting anything. `receivedRows` is what THIS request carries. The statement
+ * adds the second to a running total and stamps `completed_at` on the request
+ * that closes the gap.
+ */
+export interface AccountBalancesPass {
+  capturedAt: number;
+  expectedRows: number;
+  receivedRows: number;
+  /** Injected rather than read from the clock so a test can pin it. */
+  nowMs: number;
+}
+
+/**
+ * The statement that advances a pass's row tally, upserted on (captured_at).
+ *
+ * `completed_at` is set by whichever request brings the running total up to
+ * `expected_rows`, and never cleared afterwards -- a replayed request adds its
+ * rows again and would otherwise un-complete a finished pass. Over-counting on
+ * replay is deliberate and harmless: the reader asks "is completed_at set",
+ * never "does the count match exactly", precisely so an at-least-once producer
+ * cannot leave a complete pass looking unfinished.
+ */
+export function accountBalancesPassStatement(
+  db: D1Like,
+  pass: AccountBalancesPass,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT INTO account_balances_passes
+         (captured_at, expected_rows, received_rows, completed_at)
+       VALUES (?, ?, ?, CASE WHEN ? >= ? THEN ? ELSE NULL END)
+       ON CONFLICT (captured_at) DO UPDATE SET
+         expected_rows = excluded.expected_rows,
+         received_rows = account_balances_passes.received_rows + excluded.received_rows,
+         completed_at = COALESCE(
+           account_balances_passes.completed_at,
+           CASE
+             WHEN account_balances_passes.received_rows + excluded.received_rows
+                  >= excluded.expected_rows
+             THEN ?
+             ELSE NULL
+           END
+         )`,
+    )
+    .bind(
+      pass.capturedAt,
+      pass.expectedRows,
+      pass.receivedRows,
+      pass.receivedRows,
+      pass.expectedRows,
+      pass.nowMs,
+      pass.nowMs,
+    );
+}
+
+/**
  * Write one account-balances sync batch to D1: a latest-only upsert on (ss58),
- * nothing else.
+ * plus this pass's completeness tally when the producer declared one.
  *
  * NO PRUNE -- see this module's header and the migration's for why deleting an
  * account absent from a batch would delete the wallets that emptied. An empty
  * batch issues no statements at all rather than an empty `db.batch([])`,
  * matching writeValidatorNominatorCountsToD1's own guard.
+ *
+ * THE PASS STATEMENT IS APPENDED LAST, deliberately. batchInSlices splits a
+ * large statement list across several `db.batch()` calls, so there is no single
+ * transaction spanning all of them -- and given that, the only safe ordering is
+ * one where a mid-run failure UNDER-counts. Rows land, then the tally moves; a
+ * pass can therefore look less complete than it is, never more. The reverse
+ * would mark a pass complete over rows that never arrived, which is exactly the
+ * lie #9511 is about.
  */
 export async function writeAccountBalancesToD1(
   db: D1Like,
   rows: Row[],
+  pass?: AccountBalancesPass | null,
 ): Promise<{ statements: number }> {
   const statements: D1PreparedStatement[] = chunkStatements(
     db,
@@ -78,6 +147,7 @@ export async function writeAccountBalancesToD1(
     ["ss58"],
     rows,
   );
+  if (pass) statements.push(accountBalancesPassStatement(db, pass));
   if (statements.length) await batchInSlices(db, statements);
   return { statements: statements.length };
 }

--- a/src/top-holders-flow-tier.ts
+++ b/src/top-holders-flow-tier.ts
@@ -81,7 +81,10 @@ import { DEFAULT_CHAIN_NETWORK, chainTable } from "./chain-network.ts";
 import type { ChainNetworkId } from "./chain-network.ts";
 import { r2SqlQuery } from "./r2-sql.ts";
 import { buildTopHoldersList } from "./top-holders.ts";
-
+import {
+  latestCompleteAccountBalancesPass,
+  mayRankAccountBalances,
+} from "./account-balances-completeness.ts";
 /** Where the lane writes and the reader below gets. Under
  * `metagraph/projections/` like every other cron-recomputed card, and
  * deliberately NOT the frozen `metagraph/materialized/top-holders.json`: the
@@ -290,9 +293,38 @@ export async function topHoldersBalances(
   const db = (env as { METAGRAPH_HEALTH_DB?: D1Like } | null | undefined)
     ?.METAGRAPH_HEALTH_DB;
   if (!db?.prepare) return null;
+
+  // COMPLETENESS FIRST, ROWS SECOND (#9511). A row count cannot answer "is this
+  // ledger safe to rank from": 147,000 well-formed rows look exactly like
+  // 364,266 well-formed rows, only fewer, and `ORDER BY free_tao DESC` over the
+  // former returns the largest balances PRESENT rather than the largest that
+  // EXIST. Production served precisely that on 2026-08-05 -- a correct-looking
+  // leaderboard whose #2, 737,821 TAO live on chain, was simply absent -- and
+  // the `results.length === 0` check below cleared it without complaint.
+  //
+  // The producer declares each pass's size up front (it buffers the walk before
+  // posting, metagraphed-infra#316) and the sink tallies arrivals against it, so
+  // this asks the tally rather than guessing from the ledger.
+  // The two readers describe the same binding with different minimal shapes --
+  // this module's D1Like names bind()/all(), the completeness reader names
+  // first() -- so the cast goes through unknown rather than widening either
+  // interface to satisfy the other.
+  const completeness = await latestCompleteAccountBalancesPass(
+    db as unknown as Parameters<typeof latestCompleteAccountBalancesPass>[0],
+  );
+  if (!mayRankAccountBalances(completeness)) return null;
+
   let results: unknown[];
   try {
     const res = await db
+      // NOT scoped to the complete pass's captured_at, deliberately. This
+      // ledger never prunes, so a later PARTIAL pass only overwrites rows --
+      // it never removes an account. Once any complete pass has landed the
+      // table holds at least that whole account set, and scoping to its stamp
+      // would drop exactly the accounts a newer partial pass had refreshed:
+      // the same missing-top-holder bug, reintroduced by the guard against it.
+      // Mixed stamps mean some values are fresher than others, which is what a
+      // no-prune upsert ledger is.
       .prepare(
         "SELECT ss58, free_tao FROM account_balances" +
           " WHERE free_tao > 0 ORDER BY free_tao DESC LIMIT ?",

--- a/tests/account-balances-completeness.test.ts
+++ b/tests/account-balances-completeness.test.ts
@@ -1,0 +1,200 @@
+// The account_balances completeness gate (#9511), against a REAL SQLite
+// database built from the migration it reads.
+//
+// The bug this exists to prevent is not a crash. It is a leaderboard that is
+// entirely well-formed and quietly missing its #2: production ranked
+// `ORDER BY free_tao DESC` over 147,000 correct rows while the second-largest
+// free balance on the network (737,821 TAO, live on chain) was simply absent,
+// because the only guard was `results.length === 0` and 147,000 clears it.
+//
+// So the assertions here are about what the gate REFUSES, not what it returns.
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, describe, test } from "vitest";
+import {
+  latestCompleteAccountBalancesPass,
+  mayRankAccountBalances,
+} from "../src/account-balances-completeness.ts";
+
+const SCHEMA = fs.readFileSync(
+  path.join(process.cwd(), "migrations/d1/0020_account_balances_passes.sql"),
+  "utf8",
+);
+
+let db: InstanceType<typeof DatabaseSync>;
+
+/** The D1 shim shape this reader uses: prepare().first(). */
+function d1() {
+  return {
+    prepare(sql: string) {
+      return {
+        async first() {
+          return db.prepare(sql).get() ?? null;
+        },
+      };
+    },
+  };
+}
+
+function insertPass(
+  capturedAt: number,
+  expected: number,
+  received: number,
+  completedAt: number | null,
+) {
+  db.prepare(
+    `INSERT INTO account_balances_passes
+       (captured_at, expected_rows, received_rows, completed_at)
+     VALUES (?, ?, ?, ?)`,
+  ).run(capturedAt, expected, received, completedAt);
+}
+
+beforeEach(() => {
+  db = new DatabaseSync(":memory:");
+  db.exec(SCHEMA);
+});
+
+describe("latestCompleteAccountBalancesPass", () => {
+  test("declines while no pass has completed", async () => {
+    const result = await latestCompleteAccountBalancesPass(d1());
+    assert.equal(result.capturedAt, null);
+    assert.equal(result.reason, "no_complete_pass");
+    assert.equal(mayRankAccountBalances(result), false);
+  });
+
+  test("REFUSES a pass that is still in flight -- the 2026-08-05 shape", async () => {
+    // The exact production failure: rows landed, they are correct, and ranking
+    // over them drops real top holders. 147,000 of a declared 364,266.
+    insertPass(1_785_907_636_083, 364_266, 147_000, null);
+    const result = await latestCompleteAccountBalancesPass(d1());
+    assert.equal(result.capturedAt, null, "an unfinished pass is not rankable");
+    assert.equal(result.reason, "no_complete_pass");
+    assert.equal(mayRankAccountBalances(result), false);
+  });
+
+  test("returns the newest COMPLETE pass and permits ranking", async () => {
+    insertPass(1_785_900_000_000, 360_000, 360_000, 1_785_900_100_000);
+    const result = await latestCompleteAccountBalancesPass(d1());
+    assert.equal(result.capturedAt, 1_785_900_000_000);
+    assert.equal(result.expectedRows, 360_000);
+    assert.equal(result.receivedRows, 360_000);
+    assert.equal(result.reason, null);
+    assert.equal(mayRankAccountBalances(result), true);
+  });
+
+  test("a newer INCOMPLETE pass never supersedes an older complete one", async () => {
+    // The case that matters operationally: yesterday's pass is whole, today's
+    // died halfway. Ranking must fall back to yesterday, not to the fragment.
+    insertPass(1_785_900_000_000, 360_000, 360_000, 1_785_900_100_000);
+    insertPass(1_785_990_000_000, 364_266, 12_000, null);
+    const result = await latestCompleteAccountBalancesPass(d1());
+    assert.equal(
+      result.capturedAt,
+      1_785_900_000_000,
+      "the complete pass wins even though it is older",
+    );
+    assert.equal(mayRankAccountBalances(result), true);
+  });
+
+  test("ordering is by completion, and a replayed pass stays complete", async () => {
+    // The producer is at-least-once, so received can exceed expected. An
+    // equality check would call a finished pass unfinished; the stamp decides.
+    insertPass(1_785_900_000_000, 360_000, 360_000, 1_785_900_100_000);
+    insertPass(1_785_990_000_000, 364_266, 389_266, 1_785_990_500_000);
+    const result = await latestCompleteAccountBalancesPass(d1());
+    assert.equal(result.capturedAt, 1_785_990_000_000);
+    assert.equal(result.receivedRows, 389_266);
+    assert.equal(mayRankAccountBalances(result), true);
+  });
+
+  test("a missing binding declines rather than throwing", async () => {
+    for (const binding of [null, undefined, {} as never]) {
+      const result = await latestCompleteAccountBalancesPass(binding);
+      assert.equal(result.reason, "unavailable");
+      assert.equal(mayRankAccountBalances(result), false);
+    }
+  });
+
+  test("an absent table declines rather than throwing", async () => {
+    // The migrations here are applied by hand, so "the table does not exist
+    // yet" is a real state and means the same thing as "do not rank".
+    db.exec("DROP TABLE account_balances_passes");
+    const result = await latestCompleteAccountBalancesPass(d1());
+    assert.equal(result.reason, "unavailable");
+    assert.equal(mayRankAccountBalances(result), false);
+  });
+
+  test("an unusable captured_at is treated as no pass at all", async () => {
+    const broken = {
+      prepare: () => ({
+        first: async () => ({
+          captured_at: null,
+          expected_rows: 1,
+          received_rows: 1,
+        }),
+      }),
+    };
+    assert.equal(
+      (await latestCompleteAccountBalancesPass(broken)).reason,
+      "no_complete_pass",
+    );
+    const zero = {
+      prepare: () => ({
+        first: async () => ({
+          captured_at: 0,
+          expected_rows: 1,
+          received_rows: 1,
+        }),
+      }),
+    };
+    assert.equal(
+      (await latestCompleteAccountBalancesPass(zero)).reason,
+      "no_complete_pass",
+    );
+  });
+
+  test("null counts on a usable stamp degrade to null, not NaN", async () => {
+    const partial = {
+      prepare: () => ({
+        first: async () => ({
+          captured_at: 1_785_900_000_000,
+          expected_rows: null,
+          received_rows: null,
+        }),
+      }),
+    };
+    const result = await latestCompleteAccountBalancesPass(partial);
+    assert.equal(result.capturedAt, 1_785_900_000_000);
+    assert.equal(result.expectedRows, null);
+    assert.equal(result.receivedRows, null);
+    assert.equal(mayRankAccountBalances(result), true);
+  });
+});
+
+describe("the passes migration", () => {
+  test("declares the columns the reader and writer name", () => {
+    const cols = new Set(
+      (
+        db
+          .prepare("PRAGMA table_info(account_balances_passes)")
+          .all() as Array<{
+          name: string;
+        }>
+      ).map((c) => c.name),
+    );
+    for (const col of [
+      "captured_at",
+      "expected_rows",
+      "received_rows",
+      "completed_at",
+    ]) {
+      assert.ok(cols.has(col), `${col} missing from the migration`);
+    }
+  });
+
+  test("is keyed one row per pass", () => {
+    assert.match(SCHEMA, /PRIMARY KEY \(captured_at\)/);
+  });
+});

--- a/tests/data-api-account-balances-d1.test.ts
+++ b/tests/data-api-account-balances-d1.test.ts
@@ -30,6 +30,10 @@ const SCHEMA = fs.readFileSync(
   path.join(process.cwd(), "migrations/d1/0017_account_balances.sql"),
   "utf8",
 );
+const PASSES_SCHEMA = fs.readFileSync(
+  path.join(process.cwd(), "migrations/d1/0020_account_balances_passes.sql"),
+  "utf8",
+);
 
 const PATH = "/api/v1/internal/account-balances-sync";
 const SECRET = "test-account-balances-sync-secret";
@@ -108,9 +112,15 @@ function balanceRow(overrides: Row = {}): Row {
 const rows = () =>
   db.prepare("SELECT * FROM account_balances ORDER BY ss58").all() as Row[];
 
+const passes = () =>
+  db
+    .prepare("SELECT * FROM account_balances_passes ORDER BY captured_at")
+    .all() as Row[];
+
 beforeEach(() => {
   db = new DatabaseSync(":memory:");
   db.exec(SCHEMA);
+  db.exec(PASSES_SCHEMA);
 });
 
 describe("POST /api/v1/internal/account-balances-sync", () => {
@@ -127,6 +137,9 @@ describe("POST /api/v1/internal/account-balances-sync", () => {
       account_balances_written: 2,
       stores: ["d1"],
       d1_statements: 1,
+      // null, not absent: an undeclared pass is reported as undeclared rather
+      // than dropped, so a producer can tell the field was understood.
+      pass_total: null,
     });
     assert.equal(rows().length, 2);
     // A zero free_tao IS stored: the producer only skips an account whose free
@@ -281,6 +294,7 @@ describe("POST /api/v1/internal/account-balances-sync", () => {
       account_balances_written: 60,
       stores: ["d1"],
       d1_statements: 3,
+      pass_total: null,
     });
     assert.equal(rows().length, 60);
   });
@@ -290,5 +304,111 @@ describe("POST /api/v1/internal/account-balances-sync", () => {
     const response = await post({ rows: [balanceRow()] });
     assert.equal(response.status, 502);
     assert.deepEqual(await response.json(), { error: "d1 write failed" });
+  });
+});
+
+// --- pass completeness (#9511) ---------------------------------------------
+//
+// A partial load is indistinguishable from a complete one by inspection: 147,000
+// well-formed rows look exactly like 364,266 well-formed rows, only fewer. The
+// producer therefore declares its pass size, and these assert the accounting.
+describe("pass_total completeness accounting", () => {
+  test("a single-request pass completes immediately", async () => {
+    const response = await post({ rows: [balanceRow()], pass_total: 1 });
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      account_balances_written: 1,
+      stores: ["d1"],
+      d1_statements: 2,
+      pass_total: 1,
+    });
+    const [row] = passes();
+    assert.equal(row!.expected_rows, 1);
+    assert.equal(row!.received_rows, 1);
+    assert.ok(row!.completed_at, "a satisfied pass carries a completion stamp");
+  });
+
+  test("a multi-request pass stays incomplete until the last request lands", async () => {
+    // THE REGRESSION. Rows are present and correct after the first request, and
+    // ranking over them would drop real top holders -- which is exactly what
+    // production did on 2026-08-05.
+    await post({ rows: [balanceRow()], pass_total: 3 });
+    assert.equal(rows().length, 1);
+    assert.equal(passes()[0]!.received_rows, 1);
+    assert.equal(
+      passes()[0]!.completed_at,
+      null,
+      "one of three requests is NOT a complete pass",
+    );
+
+    await post({ rows: [balanceRow({ ss58: SS58_B })], pass_total: 3 });
+    assert.equal(passes()[0]!.received_rows, 2);
+    assert.equal(passes()[0]!.completed_at, null);
+
+    await post({ rows: [balanceRow({ ss58: "5Third" })], pass_total: 3 });
+    assert.equal(passes()[0]!.received_rows, 3);
+    assert.ok(passes()[0]!.completed_at, "the closing request stamps it");
+  });
+
+  test("a replayed request never un-completes a finished pass", async () => {
+    // The producer re-sends on failure, so received can exceed expected. The
+    // stamp is set once and must survive the overshoot.
+    await post({ rows: [balanceRow()], pass_total: 1 });
+    const stamped = passes()[0]!.completed_at;
+    await post({ rows: [balanceRow()], pass_total: 1 });
+    assert.equal(passes()[0]!.received_rows, 2, "the replay is counted");
+    assert.equal(
+      passes()[0]!.completed_at,
+      stamped,
+      "and the original completion stamp is preserved",
+    );
+  });
+
+  test("a second pass is tracked separately from the first", async () => {
+    await post({ rows: [balanceRow()], pass_total: 1 });
+    await post({
+      rows: [balanceRow({ captured_at: 1_790_000_000_000 })],
+      pass_total: 2,
+    });
+    assert.equal(passes().length, 2, "one row per captured_at");
+    assert.equal(passes()[1]!.completed_at, null, "the newer one is partial");
+  });
+
+  test("omitting pass_total writes no tally at all -- the bare-array envelope", async () => {
+    await post([balanceRow()]);
+    assert.equal(rows().length, 1);
+    assert.deepEqual(passes(), [], "an undeclared pass is not half-tracked");
+  });
+
+  test("rejects a pass_total that is absent-shaped, negative, fractional or absurd", async () => {
+    for (const bad of [0, -1, 1.5, "3", null, 10_000_001]) {
+      const response = await post({ rows: [balanceRow()], pass_total: bad });
+      assert.equal(response.status, 400, `expected 400 for ${bad}`);
+    }
+    assert.equal(rows().length, 0, "no partial write from a rejected batch");
+  });
+
+  test("rejects a pass_total smaller than the request it arrived with", async () => {
+    const response = await post({
+      rows: [balanceRow(), balanceRow({ ss58: SS58_B })],
+      pass_total: 1,
+    });
+    assert.equal(response.status, 400);
+  });
+
+  test("rejects a declared pass carrying two captured_at stamps", async () => {
+    // The tally is keyed on captured_at, so two stamps in one request would
+    // credit rows to whichever the code happened to pick -- and the reader
+    // would trust a total never delivered under that key.
+    const response = await post({
+      rows: [
+        balanceRow(),
+        balanceRow({ ss58: SS58_B, captured_at: 1_790_000_000_000 }),
+      ],
+      pass_total: 5,
+    });
+    assert.equal(response.status, 400);
+    assert.equal(rows().length, 0);
   });
 });

--- a/tests/top-holders-flow-tier.test.ts
+++ b/tests/top-holders-flow-tier.test.ts
@@ -69,15 +69,43 @@ function artifact(
   };
 }
 
-/** A D1 stub whose one statement returns `rows` (or throws). */
-function d1With(rows: unknown[] | null, opts: { throws?: boolean } = {}) {
+/**
+ * A D1 stub whose one statement returns `rows` (or throws).
+ *
+ * Also answers the completeness probe (#9511), which runs BEFORE the balance
+ * query: `topHoldersBalances` declines outright unless a pass has been recorded
+ * complete, so a stub without it would make every balance test vacuously assert
+ * the decline path. `pass` defaults to a completed one so the existing tests
+ * keep testing what they were written to test; pass `null` for the ledger state
+ * that must be refused.
+ */
+function d1With(
+  rows: unknown[] | null,
+  opts: {
+    throws?: boolean;
+    pass?: Record<string, unknown> | null;
+  } = {},
+) {
   const seen: { sql: string; params: unknown[] }[] = [];
+  const pass =
+    opts.pass === undefined
+      ? {
+          captured_at: 1_785_900_000_000,
+          expected_rows: 364_266,
+          received_rows: 364_266,
+        }
+      : opts.pass;
   return {
     seen,
     env: {
       METAGRAPH_HEALTH_DB: {
         prepare(sql: string) {
           return {
+            // The completeness reader's shape.
+            async first() {
+              seen.push({ sql, params: [] });
+              return pass;
+            },
             bind(...params: unknown[]) {
               return {
                 async all() {
@@ -336,8 +364,15 @@ describe("topHoldersBalances", () => {
     );
     // The ordering and the cap are the DATABASE's job -- there is no index on
     // free_tao, so sorting in the Worker would mean shipping every row.
-    assert.match(seen[0]!.sql, /ORDER BY free_tao DESC LIMIT \?/);
-    assert.deepEqual(seen[0]!.params, [250]);
+    // Located rather than indexed: the completeness probe (#9511) runs first,
+    // so a positional assertion here would silently start checking the wrong
+    // statement the next time a preflight is added.
+    const balanceQuery = seen.find((q) =>
+      q.sql.includes("FROM account_balances "),
+    );
+    assert.ok(balanceQuery, "the balance query ran");
+    assert.match(balanceQuery.sql, /ORDER BY free_tao DESC LIMIT \?/);
+    assert.deepEqual(balanceQuery.params, [250]);
   });
 
   test("skips unusable cells, and declines when nothing usable remains", async () => {
@@ -676,5 +711,75 @@ describe("the flow lane's cron", () => {
     assert.equal(result.ok, false);
     assert.equal(result.reason, "compute_declined");
     assert.deepEqual(puts, []);
+  });
+});
+
+// --- the completeness gate (#9511) ------------------------------------------
+describe("topHoldersBalances refuses a ledger that is not provably complete", () => {
+  const ROWS = [
+    { ss58: "5Whale", free_tao: 900_000 },
+    { ss58: "5Small", free_tao: 12 },
+  ];
+
+  test("declines when no pass has ever completed", async () => {
+    // THE REGRESSION. Rows are present and every one is correct -- production
+    // had 147,000 such rows -- and ranking over them drops the network's #2.
+    // The old guard was `results.length === 0`, which 147,000 clears.
+    const { env, seen } = d1With(ROWS, { pass: null });
+    assert.equal(await topHoldersBalances(env), null);
+    assert.equal(
+      seen.filter((q) => q.sql.includes("FROM account_balances ")).length,
+      0,
+      "and it does not even run the ranking query",
+    );
+  });
+
+  test("ranks once a pass is recorded complete", async () => {
+    const { env } = d1With(ROWS);
+    const map = await topHoldersBalances(env);
+    assert.equal(map?.size, 2);
+    assert.equal(map?.get("5Whale"), 900_000);
+  });
+
+  test("an unreadable passes table declines rather than ranking blind", async () => {
+    // The migration is applied by hand, so "the table is not there yet" is a
+    // real state -- and it means the same thing as an unfinished pass.
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            async first() {
+              throw new Error("no such table: account_balances_passes");
+            },
+            bind() {
+              return {
+                async all() {
+                  return { results: ROWS };
+                },
+              };
+            },
+          };
+        },
+      },
+    } as unknown as Env;
+    assert.equal(await topHoldersBalances(env), null);
+  });
+
+  test("the artifact leaves free_tao out of its declared sorts while refused", async () => {
+    // The end-to-end consequence: with the ledger unproven the object never
+    // claims the sort, so `?sort=free_tao` keeps answering from the frozen
+    // materialization instead of a ranking missing its top holders.
+    const { env } = d1With(ROWS, { pass: null });
+    const balances = await topHoldersBalances(env);
+    const body = buildTopHoldersFlowRows(
+      [{ coldkey: "5Whale", net_flow_7d: 1, net_flow_30d: 1, net_flow_90d: 1 }],
+      GENERATED_AT,
+      10,
+      balances,
+    );
+    assert.ok(
+      !JSON.stringify(body).includes("free_tao"),
+      "no free_tao column while the ledger is unproven",
+    );
   });
 });

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -361,6 +361,7 @@ import { writeValidatorNominatorCountsToD1 } from "../src/validator-nominator-co
 import {
   ACCOUNT_BALANCE_INSERT_COLUMNS,
   writeAccountBalancesToD1,
+  type AccountBalancesPass,
 } from "../src/account-balances-d1-write.ts";
 import {
   HOTKEY_ALPHA_INSERT_COLUMNS,
@@ -1942,6 +1943,13 @@ const ACCOUNT_BALANCES_SYNC_MAX_ROWS = 25_000;
 // An SS58 address is 48 characters; the ceiling is generous rather than exact
 // so a future address format does not silently fail the whole batch.
 const ACCOUNT_BALANCES_SYNC_MAX_KEY_BYTES = 128;
+// A ceiling on the producer's declared `pass_total` (#9511). Every account that
+// has ever held a balance measured 364,266 on 2026-08-05 against 554,136
+// System::Account entries, so ten million is roughly 27x headroom -- generous
+// enough to survive a decade of growth, tight enough that a garbage value
+// cannot declare a pass that never completes and pins the reader on an older
+// one forever.
+const ACCOUNT_BALANCES_SYNC_MAX_PASS_TOTAL = 10_000_000;
 
 /**
  * Bounds-check one incoming row against ACCOUNT_BALANCE_INSERT_COLUMNS.
@@ -2025,6 +2033,25 @@ async function handleAccountBalancesSync(request: Request, env: Env) {
       400,
     );
   }
+  // OPTIONAL, and absent on the bare-array envelope: how many rows the whole
+  // pass will deliver (#9511). The producer knows this before its first request
+  // because it buffers the walk, and it is the only way a reader can tell a
+  // complete ledger from a partial one -- 147,000 well-formed rows look exactly
+  // like 542,618 well-formed rows, only fewer.
+  const declaredTotal = Array.isArray(parsed) ? undefined : parsed?.pass_total;
+  if (
+    declaredTotal !== undefined &&
+    (!Number.isInteger(declaredTotal) ||
+      declaredTotal <= 0 ||
+      declaredTotal > ACCOUNT_BALANCES_SYNC_MAX_PASS_TOTAL)
+  ) {
+    return writeJson(
+      {
+        error: `pass_total must be a positive integer no greater than ${ACCOUNT_BALANCES_SYNC_MAX_PASS_TOTAL}`,
+      },
+      400,
+    );
+  }
   if (incoming.length > ACCOUNT_BALANCES_SYNC_MAX_ROWS) {
     return writeJson(
       { error: `at most ${ACCOUNT_BALANCES_SYNC_MAX_ROWS} rows per request` },
@@ -2039,6 +2066,39 @@ async function handleAccountBalancesSync(request: Request, env: Env) {
   }
 
   const rows = incoming.map(coerceAccountBalanceSyncRow);
+
+  // A declared pass is keyed on its own captured_at, which the producer stamps
+  // once at scan start and repeats across every chunk. Requiring exactly one
+  // here is what makes the tally meaningful: two stamps in a request would
+  // credit rows to whichever one this code happened to pick, and the reader
+  // would trust a total that was never delivered under that key.
+  let pass: AccountBalancesPass | null = null;
+  if (declaredTotal !== undefined) {
+    const stamps = new Set<number>(
+      rows.map((row: Row) => row.captured_at as number),
+    );
+    if (stamps.size !== 1) {
+      return writeJson(
+        {
+          error:
+            "a request declaring pass_total must carry exactly one captured_at",
+        },
+        400,
+      );
+    }
+    if (declaredTotal < rows.length) {
+      return writeJson(
+        { error: "pass_total cannot be smaller than this request's row count" },
+        400,
+      );
+    }
+    pass = {
+      capturedAt: [...stamps][0]!,
+      expectedRows: declaredTotal as number,
+      receivedRows: rows.length,
+      nowMs: Date.now(),
+    };
+  }
 
   // D1 is the binding this path REQUIRES -- the only store this family has.
   // Checked HERE, after validation, not at the top: a malformed body is a 400
@@ -2055,6 +2115,7 @@ async function handleAccountBalancesSync(request: Request, env: Env) {
         typeof writeAccountBalancesToD1
       >[0],
       rows,
+      pass,
     ));
   } catch (err) {
     console.error("data-api account-balances-sync D1 write failed:", err);
@@ -2067,6 +2128,9 @@ async function handleAccountBalancesSync(request: Request, env: Env) {
     account_balances_written: rows.length,
     stores: ["d1"],
     d1_statements: d1Statements,
+    // Echoed so a producer can see its declaration was understood rather than
+    // silently dropped -- the failure mode a purely optional field invites.
+    pass_total: pass?.expectedRows ?? null,
   });
 }
 


### PR DESCRIPTION
Closes #9511. Sink half; producer half is metagraphed-infra#323.

`topHoldersBalances` declines on exactly one condition — `results.length === 0`
— and a partial ledger clears it. Production demonstrated the consequence on
2026-08-05: **147,000 rows, every one correct**, and `ORDER BY free_tao DESC`
returning a well-formed leaderboard whose #2 (737,821 TAO, live on chain) was
simply absent.

Completeness is not observable in the ledger. 147,000 well-formed rows look
exactly like 364,266 well-formed rows, only fewer — so no check over
`account_balances` alone can tell them apart. The producer therefore declares
each pass's size up front, which it **can** because metagraphed-infra#316 made
it buffer the walk before posting anything.

## What's here

| | |
|---|---|
| `migrations/d1/0020_account_balances_passes.sql` | one row per pass, keyed on its `captured_at`, with a `completed_at` stamp |
| `workers/data-api.ts` | optional `pass_total` on the envelope; tallies arrivals |
| `src/account-balances-completeness.ts` | the reader + `mayRankAccountBalances` predicate |
| `src/top-holders-flow-tier.ts` | gates on it before ranking |

## Three decisions worth reading

**The gate does not scope the query to the complete pass's `captured_at`**, and
this is the subtle one. My first instinct was to scope. It's wrong: this ledger
never prunes, so a later **partial** pass only overwrites rows — it never
removes an account. Once any complete pass has landed the table holds at least
that whole account set, and scoping to its stamp would drop exactly the accounts
a newer partial pass had refreshed. That is the same missing-top-holder bug,
reintroduced by the guard against it.

**The tally statement is appended last in the batch.** `batchInSlices` spans
several `db.batch()` calls, so there is no single transaction across them — and
given that, the only safe ordering is one where a mid-run failure **under**-counts.
Rows land, then the tally moves. A pass can look less complete than it is, never
more; the reverse would mark a pass complete over rows that never arrived, which
is the exact lie this PR is about.

**Completeness keys on `completed_at IS NOT NULL`, not on `received >= expected`.**
The producer is at-least-once — it re-sends a chunk on failure — so a replay
makes `received_rows` exceed `expected_rows`. An equality check would call a
finished pass unfinished.

## Why the producer's own gate isn't enough

metagraphed-infra#316 already stops a truncated **scan** from publishing, which
closes the failure that actually happened. Two holes survive it, and both produce
the same partial-load-that-looks-fresh shape:

1. **A POST failing mid-sequence** — a pass is ~15 requests; if the 7th fails,
   the first six are already committed under a fresh `captured_at`, from a scan
   that was complete.
2. **The floor is 80%** of the last known network size, deliberately, so a
   network that grew does not deadlock the lane. A pass covering 80–99% clears it.

## Validation

- `npx vitest run` — full suite green; **70 passed** across the three touched
  suites, including `REFUSES a pass that is still in flight -- the 2026-08-05 shape`.
- `npm run test:coverage` + diff intersection on `src/**` and `workers/**`:
  **59/59 lines and branches, 100.00%**.
- `lint` · `format:check` · `typecheck` · `validate` — clean.
- `migrations/d1/0020` is already applied to the live D1 and verified against
  `sqlite_master` (renumbered from 0018 after #9493/#9512 took that slot).

`pass_total` is optional on the envelope, so this deploys safely in either order
relative to metagraphed-infra#323: an old producer simply records nothing.