### PR TITLE
docs(workers): point HOTKEY_ALPHA_SYNC_SECRET at the one Worker that reads it

### DIFF
--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -99,8 +99,18 @@ interface Env {
   HEALTH_CHECKS_SYNC_SECRET?: string;
   /** #9502: gates POST /api/v1/internal/hotkey-alpha-sync -- the write path
    * into hotkey_alpha, the (hotkey, netuid) alpha-pool totals delegated_tao
-   * values a position against. Set via `wrangler secret put` on BOTH Workers
-   * (api.ts proxies, data-api.ts checks) and in the poller's vault. */
+   * values a position against.
+   *
+   * ONE Worker, not two: `wrangler secret put HOTKEY_ALPHA_SYNC_SECRET --name
+   * metagraphed-data-api`. api.ts only PROXIES this route -- it forwards the
+   * caller's header untouched and never reads the secret itself -- so setting
+   * it there does nothing. (The sibling comments above say "BOTH Workers"
+   * because their routes are checked in both; this one is not.)
+   *
+   * The producer needs the SAME value as `hotkey_alpha_sync_secret` in the
+   * metagraphed-infra vault. It is a shared secret with no external issuer:
+   * any high-entropy random string works, and until both sides hold it the
+   * poller logs "job will not run" rather than failing quietly. */
   HOTKEY_ALPHA_SYNC_SECRET?: string;
   METAGRAPH_ALLOW_R2_STATIC_FALLBACK?: string;
   METAGRAPH_DISABLE_REQUEST_LOGS?: string;


### PR DESCRIPTION
My own comment in #9512 sends you to the wrong place.

It said to set `HOTKEY_ALPHA_SYNC_SECRET` on **both** Workers — "api.ts proxies, data-api.ts checks". `api.ts` never reads it:

```
grep -c HOTKEY_ALPHA_SYNC_SECRET workers/api.ts
0
```

`handleHotkeyAlphaSyncProxy` calls `proxyToDataApi` and forwards the caller's header untouched; only `data-api.ts` compares it. Setting it on the public Worker does nothing. The wrong copy came from the sibling comments directly above, whose routes genuinely *are* checked in both places.

The comment now also states the question this actually caused: it's a **shared secret with no external issuer**. There is no value to look up or recover — the name exists, the value has never been generated. Any high-entropy random string works, so long as the metagraphed-infra vault's `hotkey_alpha_sync_secret` holds the same one.

Comment-only; `typecheck`, `lint`, `format:check` clean.

Closes #9519