### PR TITLE
fix(api): answer 404 for a path that is not a route, instead of 405 for everything

### DIFF
--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -4037,3 +4037,109 @@ describe("inverse contract coverage (dispatched ⊆ contracted)", () => {
     });
   }
 });
+
+// The read-only method gate answers 405 ("this resource exists, but not with that
+// method") only for paths that exist. It used to answer 405 for everything, which sent
+// an MCP client hunting for a method that would work on a route that was never there.
+//
+// The distinction is resolved by asking the ROUTER — a list of "paths that exist"
+// maintained beside the dispatch would be a second copy of the routing table, and two
+// copies of one route disagreeing by a single character is the bug that started this.
+describe("non-GET methods: 405 for a real route, 404 for a path that is not one", () => {
+  const post = (path: string) =>
+    handleRequest(
+      req(path, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      }),
+      createLocalArtifactEnv() as unknown as Env,
+      {},
+    );
+
+  test("a read route that exists answers 405 and says what it takes", async () => {
+    // Deliberately spans all three kinds of surface: a declarative API route, a
+    // Worker-generated singleton in no route table, and the api index itself. A
+    // hand-kept registry would have had to know about each; the router already does.
+    for (const path of [
+      "/api/v1/subnets",
+      "/api/v1/freshness",
+      "/api/v1",
+      "/health",
+      "/og.png",
+      "/.well-known/api-catalog",
+    ]) {
+      const res = await post(path);
+      assert.equal(res.status, 405, path);
+      assert.equal(res.headers.get("allow"), "GET, HEAD, OPTIONS", path);
+    }
+  });
+
+  test("a path that is not a route at all answers 404", async () => {
+    for (const path of [
+      "/mcp/sse",
+      "/mcpx",
+      "/api/v1/nope",
+      "/nope",
+      "/api/v1/subnets/9999999/nope",
+    ]) {
+      const res = await post(path);
+      assert.equal(res.status, 404, path);
+      assert.equal(
+        res.headers.get("allow"),
+        null,
+        `${path}: allow names what a resource accepts, and this one does not exist`,
+      );
+      assert.equal((await res.json()).error.code, "not_found", path);
+    }
+  });
+
+  test("the existence probe is not counted as a call", async () => {
+    // The probe re-enters the router; if it charged usage, every bot POST to a
+    // nonexistent path would bill twice and pollute the rollup.
+    const recorded: unknown[] = [];
+    const env = {
+      ...(createLocalArtifactEnv() as unknown as Record<string, unknown>),
+      METAGRAPH_USAGE: {
+        writeDataPoint: (point: unknown) => recorded.push(point),
+      },
+    } as unknown as Env;
+    await handleRequest(
+      req("/api/v1/nope", { method: "POST", body: "{}" }),
+      env,
+      {},
+    );
+    assert.ok(
+      recorded.length <= 1,
+      `one request must not produce ${recorded.length} usage rows`,
+    );
+  });
+
+  test("OPTIONS still preflights rather than falling into the gate", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets", { method: "OPTIONS" }),
+      createLocalArtifactEnv() as unknown as Env,
+      {},
+    );
+    assert.equal(res.status, 204);
+    assert.equal(
+      res.headers.get("access-control-allow-methods"),
+      "GET, HEAD, OPTIONS",
+    );
+  });
+
+  test("a write route is unaffected — it returns before the gate", async () => {
+    // /api/v1/graphql takes POST; reaching the gate at all would break it.
+    const res = await handleRequest(
+      req("/api/v1/graphql", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ query: "{ __typename }" }),
+      }),
+      createLocalArtifactEnv() as unknown as Env,
+      {},
+    );
+    assert.notEqual(res.status, 405);
+    assert.notEqual(res.status, 404);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -14,7 +14,15 @@ type Row = Record<string, any>;
 // call sites here sometimes pass a real Workers-runtime ExecutionContext,
 // sometimes {} (e.g. handleScheduled's default), so a full ExecutionContext
 // isn't required to satisfy every caller.
-type Ctx = { waitUntil?: (promise: Promise<unknown>) => void };
+type Ctx = {
+  waitUntil?: (promise: Promise<unknown>) => void;
+  /**
+   * Set only by the method gate's own existence probe (see `pathResolves`). It
+   * suppresses the side effects a real request has -- usage rollup, rate-limit charge --
+   * so asking "does this path exist" cannot be mistaken for someone having called it.
+   */
+  methodProbe?: boolean;
+};
 // The Cache API (`caches.default`) isn't in the generated Env/global types --
 // it's a Workers-runtime global, not an Env binding.
 const globalWithCaches = globalThis as unknown as { caches?: Row };
@@ -3566,7 +3574,10 @@ export async function handleRequest(
   // request including keyless ones, which is the opposite of this being free.
   // A malformed `mg_` bearer counts as keyed and is a rounding error against
   // the question being asked.
-  if (url.pathname === "/api/v1" || url.pathname.startsWith("/api/v1/")) {
+  if (
+    !ctx.methodProbe &&
+    (url.pathname === "/api/v1" || url.pathname.startsWith("/api/v1/"))
+  ) {
     const authHeader = request.headers.get("authorization") || "";
     recordUsageRollup(
       env,
@@ -3892,14 +3903,38 @@ export async function handleRequest(
   }
 
   if (!["GET", "HEAD"].includes(request.method)) {
+    // 405 says "this resource exists, but not with that method", so it is only true of
+    // a path that exists. Every write route has already returned by here, so anything
+    // still in flight is either a read surface being called wrongly (405) or a path
+    // that is not a surface at all (404) -- and answering 404 with 405 sent an MCP
+    // client hunting for a method that would work on a route that was never there.
+    //
+    // Resolved by ASKING THE ROUTER, not by mirroring it. A list of "paths that exist"
+    // maintained beside the dispatch is a second copy of the routing table, and the
+    // 401 this whole thread began with was two copies of one route disagreeing by a
+    // single character. The probe re-enters as HEAD -- read-only by definition, no
+    // body to serialise, and it passes this gate on the first check, so it cannot
+    // recurse -- with `methodProbe` set so it charges nobody's rate limit and counts
+    // as nobody's usage.
+    const probe = await handleRequest(
+      new Request(url.toString(), {
+        method: "HEAD",
+        headers: request.headers,
+      }),
+      env,
+      { ...ctx, methodProbe: true },
+    );
+    if (probe.status === 404) {
+      // No `allow` here on purpose: it names the methods a resource accepts, and this
+      // one does not exist to accept any.
+      return errorResponse("not_found", "No route matched this path.", 404);
+    }
     return errorResponse(
       "method_not_allowed",
       "Only GET, HEAD, and OPTIONS are supported.",
       405,
       {},
-      {
-        allow: "GET, HEAD, OPTIONS",
-      },
+      { allow: allowedMethodsForPath(url.pathname) },
     );
   }
 
@@ -7844,9 +7879,15 @@ async function liveHealthOverlay(
   return data ? { data } : null;
 }
 
-function corsPreflight(request: Request) {
-  const url = new URL(request.url);
-  const headers = apiHeaders("short");
+/**
+ * Which methods a path accepts.
+ *
+ * One declaration, two consumers: the CORS preflight below, and the read-only method
+ * gate's `allow` header. They answered the same question from two copies before, which
+ * is how a route could advertise one method set to a browser and another to a client.
+ */
+function allowedMethodsForPath(pathname: string): string {
+  const url = { pathname };
   let methods = "GET, HEAD, OPTIONS";
   if (url.pathname.startsWith("/rpc/")) {
     methods = "POST, OPTIONS";
@@ -7879,7 +7920,16 @@ function corsPreflight(request: Request) {
   } else if (url.pathname === "/api/v1/watch/tokens") {
     methods = "POST, OPTIONS";
   }
-  headers.set("access-control-allow-methods", methods);
+  return methods;
+}
+
+function corsPreflight(request: Request) {
+  const url = new URL(request.url);
+  const headers = apiHeaders("short");
+  headers.set(
+    "access-control-allow-methods",
+    allowedMethodsForPath(url.pathname),
+  );
   headers.set(
     "access-control-allow-headers",
     `content-type, if-none-match, authorization, mcp-session-id, mcp-protocol-version, ` +


### PR DESCRIPTION
Closes #9518. The last item from the MCP transport thread (#9505, #9513).

405 means "this resource exists, but not with that method". The gate returned it to every non-GET request that reached it, so a client that mistyped a path was told to go looking for a method that would work on a route that was never there. That is how this thread started: `/mcp/sse` answering 405 reads as a real endpoint being called incorrectly rather than as a typo.

```
POST /api/v1/subnets   405  allow: GET, HEAD, OPTIONS     unchanged, correct
POST /health           405  allow: GET, HEAD, OPTIONS     unchanged, correct
POST /mcp/sse          404                                was 405
POST /mcpx             404                                was 405
POST /api/v1/nope      404                                was 405
```

### How existence is decided — by asking the router, not mirroring it

The obvious implementation is a set of "paths that exist" kept beside the dispatch. That is a second copy of the routing table, and it would have to cover three sources: `API_ROUTES`, the raw-artifact table, and the **twelve Worker-generated singletons that live in no table at all** — `/`, `/health`, `/og`, `/og.png`, `/api/v1/icon`, `/api/v1/events`, `/.well-known/api-catalog`, `/.well-known/mcp/server-card.json`, `/.well-known/agent-tools/{index,openai,anthropic}.json`.

The 401 that opened this thread was two copies of one route disagreeing by a single character. Adding a third copy to fix the second would be the same mistake with better intentions.

So the gate re-enters the router with the same URL as **HEAD** and reads the status. HEAD is read-only by definition, serialises no body, and passes this gate on its first check so it cannot recurse. It carries `ctx.methodProbe`, which suppresses the usage rollup — without it a single bot POST to a nonexistent path would bill twice and pollute the rollup. That is the only pre-gate side effect; there is no rate-limit charge this early.

Exact by construction, and it cannot drift, because the thing being asked *is* the dispatch.

### Also deduplicated

`corsPreflight` already owned a pathname → methods map while the gate hardcoded its own `"GET, HEAD, OPTIONS"` — two answers to one question. Both now read `allowedMethodsForPath`, so a route cannot advertise one method set to a browser preflight and another to a client receiving a 405.

The 404 carries no `allow` header: it names the methods a resource accepts, and this one does not exist to accept any.

---

**Verification:** 16,275 tests across 677 files · **100% patch coverage, branch-counted** (10 lines / 6 branches, 0 uncovered) · contract-drift, validate-mcp, lint, format green · rebased onto current main.

Tests span all three kinds of surface deliberately — a declarative API route, a Worker-generated singleton in no table, and the api index — because a hand-kept registry would have had to know about each and the router already does. Also pinned: the probe is not counted as a call, OPTIONS still preflights rather than falling into the gate, and a write route (`/api/v1/graphql` POST) still returns before the gate. Verified to fail against the old unconditional 405.