### PR TITLE
fix(data-api): read take and validator_trust back out of neuron_daily

### DIFF
--- a/src/subnet-performance.ts
+++ b/src/subnet-performance.ts
@@ -21,6 +21,16 @@ export const PERFORMANCE_READ_COLUMNS =
   "incentive, dividends, trust, consensus, validator_trust, " +
   "active, validator_permit, captured_at";
 
+// The neuron_daily columns the performance-HISTORY handler reads. Separate from
+// PERFORMANCE_READ_COLUMNS above because the two differ at both ends: history
+// groups by snapshot_date and has no use for captured_at. Single-sourced here
+// for the same reason as its sibling — the history SELECT was hand-transcribed
+// and silently omitted validator_trust, which nulled validator_trust_mean and
+// validator_trust_median on every point of every subnet (#9523).
+export const PERFORMANCE_HISTORY_READ_COLUMNS =
+  "snapshot_date, incentive, dividends, trust, consensus, validator_trust, " +
+  "active, validator_permit";
+
 // The 0..1 score columns reported as a percentile spread (not a concentration
 // scorecard — a bounded score has no "share of a total" to be unequal over, so a
 // distribution summary is the meaningful lens).

--- a/tests/data-api-neurons-d1.test.ts
+++ b/tests/data-api-neurons-d1.test.ts
@@ -1021,6 +1021,43 @@ test("GET /api/v1/subnets/:netuid/neurons/:uid/history windows on snapshot_date 
   assert.equal(allBody.window, "all");
 });
 
+// #9523. Both of the next two assert a SELECT LIST, not a builder: each handler
+// hand-transcribed its column list instead of using the shared read constant,
+// and each quietly dropped one column. The builders were already covered --
+// tests/subnet-performance.test.ts feeds validator_trust straight in -- so the
+// gap could only ever be caught by reading a real row back through the route.
+// Assert every column the builder consumes, so the next omission fails here.
+test("GET /api/v1/subnets/:netuid/neurons/:uid/history serves take (SELECT list must match NEURON_DAILY_READ_COLUMNS)", async () => {
+  insertDaily({ uid: 3, snapshot_date: dayAgo(1), take: 0.18 });
+  const res = await call(req("/api/v1/subnets/7/neurons/3/history"));
+  assert.equal(res.status, 200);
+  const point = ((await res.json()) as Row).points as Row[];
+  assert.equal(point.length, 1);
+  assert.equal(point[0].take, 0.18, "take was dropped from the SELECT list");
+  // The neighbours that were never broken, so a regression here reads as the
+  // whole projection going wrong rather than one column.
+  assert.equal(point[0].validator_trust, 0.8);
+  assert.equal(point[0].axon, "1.2.3.4:8091");
+});
+
+test("GET /api/v1/subnets/:netuid/performance/history serves validator_trust_mean/median (SELECT list must match PERFORMANCE_HISTORY_READ_COLUMNS)", async () => {
+  // Two permit-holding validators on one day: mean 0.6, median 0.6. Distinct
+  // values so a mean/median computed over an all-undefined array (the bug)
+  // cannot coincidentally match.
+  insertDaily({ uid: 0, snapshot_date: dayAgo(1), validator_trust: 0.4 });
+  insertDaily({ uid: 1, snapshot_date: dayAgo(1), validator_trust: 0.8 });
+  const res = await call(req("/api/v1/subnets/7/performance/history"));
+  assert.equal(res.status, 200);
+  const points = ((await res.json()) as Row).points as Row[];
+  assert.equal(points.length, 1);
+  assert.equal(
+    points[0].validator_trust_mean,
+    0.6,
+    "validator_trust was dropped from the SELECT list",
+  );
+  assert.equal(points[0].validator_trust_median, 0.6);
+});
+
 test("GET /api/v1/subnets/:netuid/history aggregates per day (SUM over 0/1 validator_permit)", async () => {
   insertDaily({
     uid: 0,

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -47,6 +47,7 @@ import {
 import {
   buildSubnetPerformance,
   buildSubnetPerformanceHistory,
+  PERFORMANCE_HISTORY_READ_COLUMNS,
   PERFORMANCE_HISTORY_ROW_CAP,
   PERFORMANCE_HISTORY_WINDOWS,
   DEFAULT_PERFORMANCE_HISTORY_WINDOW,
@@ -71,6 +72,7 @@ import {
   HISTORY_WINDOWS,
   DEFAULT_HISTORY_WINDOW,
   MAX_HISTORY_POINTS,
+  NEURON_DAILY_READ_COLUMNS,
 } from "../src/neuron-history.ts";
 import { buildValidatorHistory } from "../src/validator-history.ts";
 import {
@@ -5424,17 +5426,25 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
         HISTORY_WINDOWS,
         DEFAULT_HISTORY_WINDOW,
       );
+      // sql.unsafe, not the tagged form: the tag binds every interpolation as a
+      // parameter, so a column-list constant can only be threaded this way --
+      // the same reason the neurons reads above use it for NEURON_COLUMNS.
+      // Hand-transcribing the list here is what dropped `take` (#9523).
       const rows = cutoff
-        ? await sql`
-          SELECT snapshot_date, uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, consensus, incentive, dividends, emission_tao, stake_tao, registered_at_block, is_immunity_period, axon, block_number, captured_at
+        ? await sql.unsafe(
+            `SELECT ${NEURON_DAILY_READ_COLUMNS}
           FROM neuron_daily
-          WHERE netuid = ${netuid} AND uid = ${uid} AND snapshot_date >= ${cutoff}
-          ORDER BY snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`
-        : await sql`
-          SELECT snapshot_date, uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, consensus, incentive, dividends, emission_tao, stake_tao, registered_at_block, is_immunity_period, axon, block_number, captured_at
+          WHERE netuid = ? AND uid = ? AND snapshot_date >= ?
+          ORDER BY snapshot_date DESC LIMIT ?`,
+            [netuid, uid, cutoff, MAX_HISTORY_POINTS],
+          )
+        : await sql.unsafe(
+            `SELECT ${NEURON_DAILY_READ_COLUMNS}
           FROM neuron_daily
-          WHERE netuid = ${netuid} AND uid = ${uid}
-          ORDER BY snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`;
+          WHERE netuid = ? AND uid = ?
+          ORDER BY snapshot_date DESC LIMIT ?`,
+            [netuid, uid, MAX_HISTORY_POINTS],
+          );
       return json(
         buildNeuronHistory(rows, netuid, uid, {
           window: windowLabelFor(url, HISTORY_WINDOWS, DEFAULT_HISTORY_WINDOW),
@@ -5731,11 +5741,13 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
         PERFORMANCE_HISTORY_WINDOWS,
         DEFAULT_PERFORMANCE_HISTORY_WINDOW,
       );
-      const rows = await sql`
-        SELECT snapshot_date, incentive, dividends, trust, consensus, validator_permit, active
+      const rows = await sql.unsafe(
+        `SELECT ${PERFORMANCE_HISTORY_READ_COLUMNS}
         FROM neuron_daily
-        WHERE netuid = ${netuid} AND snapshot_date >= ${cutoff}
-        ORDER BY snapshot_date DESC LIMIT ${PERFORMANCE_HISTORY_ROW_CAP}`;
+        WHERE netuid = ? AND snapshot_date >= ?
+        ORDER BY snapshot_date DESC LIMIT ?`,
+        [netuid, cutoff, PERFORMANCE_HISTORY_ROW_CAP],
+      );
       return json(
         buildSubnetPerformanceHistory(rows, netuid, {
           window: windowLabelFor(


### PR DESCRIPTION
## Summary

Two `neuron_daily` handlers in `workers/data-api.ts` hand-transcribed their SELECT lists instead of using the shared read-column constants. Each dropped one column, and each dropped column is published as an always-null field:

| Route | Dropped | Published as |
| --- | --- | --- |
| `/subnets/:netuid/neurons/:uid/history` | `take` | `get_neuron_history.take` |
| `/subnets/:netuid/performance/history` | `validator_trust` | `get_subnet_performance_history.validator_trust_mean` / `_median` |

Both now interpolate a single-sourced constant through `sql.unsafe`, which is how every neighbouring neurons read already threads `NEURON_COLUMNS`. The tagged `sql` form binds interpolations as parameters, so a column-list constant cannot go through it — which is why these two were written out by hand to begin with.

`PERFORMANCE_HISTORY_READ_COLUMNS` is new and sits beside `PERFORMANCE_READ_COLUMNS`; the two differ at both ends (history groups by `snapshot_date` and has no use for `captured_at`), so it is a sibling rather than a reuse.

## Measurements that prove it

Same poller snapshot read two ways — identical `captured_at` and `block_number`, so this is not staleness:

```
get_subnet_metagraph(netuid=64)        captured_at=2026-08-05T06:21:05.918Z  block=8776182
  uid 0 -> take: 0.179995

get_neuron_history(netuid=64, uid=0)   captured_at=2026-08-05T06:21:05.918Z  block=8776182
  uid 0 -> take: null   (8/8 points)
```

The same metric, history vs non-history:

```
get_subnet_performance(netuid=64)
  validator_trust: { count: 19, mean: 0.736026, p50: 0.999893, p90: 0.999985 }

get_subnet_performance_history(netuid=64)
  validator_trust_mean: null, validator_trust_median: null   (27/27 points)
```

`trust_mean`/`consensus_mean` on those same points are populated, because `trust` and `consensus` *are* in the SELECT — so the rows are present and the tier is answering.

## Why CI did not catch it

Both builders were already covered by unit tests that feed the missing column straight in (`tests/subnet-performance.test.ts:243-290` passes `validator_trust: 0.85`), so the gap was only reachable by reading a real row back through the route. The two new tests do that against the real migrations in the existing real-SQLite harness, and assert the neighbouring columns too so a future regression reads as the whole projection failing rather than one column.

Verified they fail on the unfixed code:

```
× ...history serves take (SELECT list must match NEURON_DAILY_READ_COLUMNS)
  AssertionError: take was dropped from the SELECT list
× ...performance/history serves validator_trust_mean/median
  AssertionError: validator_trust was dropped from the SELECT list
```

## Known limit

Days written by `scripts/backfill-neuron-history.py` stay null for `take` — that script has no `take` key and #5217 chose that deliberately (take reflects current chain state only). Post-#5217 days populate.

## Out of scope

`rank` and `axon` were flagged on the same tools by the same sweep and are **not** defects — `rank` is derived from `incentive` and is null for the whole `incentive == 0` population, `axon` is null when a neuron announces no endpoint. Both verified populated for serving miners on netuid 64. Recorded on #9455.

## Validation

```
npm run lint            npm run format:check      npm run typecheck
npm run validate        npm run scan:public-safety
npx vitest run tests/data-api-neurons-d1.test.ts tests/subnet-performance.test.ts \
  tests/neuron-history.test.ts tests/subnet-performance-history-csv.test.ts tests/data-api.test.ts
  -> 233 passed
```

Rebased onto `main` @ 4d8432652.

Closes #9523