### PR TITLE
fix(watchdog): count what an account-balances pass covered, not just when it landed

### DIFF
--- a/src/account-balances-staleness-watchdog.ts
+++ b/src/account-balances-staleness-watchdog.ts
@@ -17,10 +17,74 @@
 // producer. Watching only the artifact is what left the underlying lane's
 // absence invisible for as long as it was.
 //
-// Same shape as src/nominator-positions-staleness-watchdog.ts deliberately: one
-// MAX() read, a pure rule, a summary rather than a throw, and one exception
+// Same shape as src/nominator-positions-staleness-watchdog.ts deliberately: a
+// single read, a pure rule, a summary rather than a throw, and one exception
 // event per stale tick on the project's alert channel. Zero alerts is the
 // correct steady state.
+//
+// ## A FRESH TIMESTAMP IS NOT A COMPLETE PASS (#9530)
+//
+// This shipped watching one number, `MAX(captured_at)`, and that number cannot
+// see the failure it was next asked about. Measured on production D1,
+// 2026-08-05 06:04Z: `lane_health` carried
+// `account-balances-staleness | ok | age=0.6h`, while
+//
+//     SELECT captured_at, COUNT(*) FROM account_balances GROUP BY captured_at
+//     -- 2026-08-05T05:27:16.083Z | 147000     (one row, the whole table)
+//
+// held 147,000 accounts -- roughly 48% of the network, the committed remains of
+// a streaming pass that died partway. The stamp on those rows was genuinely
+// 36 minutes old, so the rule was applied correctly and returned the wrong
+// answer: one chunk of a pass that died at 48% looks exactly as fresh as a
+// complete pass. The alarm built to catch a DEAD lane could not see a HALF-DEAD
+// one. #9511 measured what that costs downstream -- the second-largest free
+// balance on the network, 737,821 TAO, live on chain and simply absent from the
+// ledger, so a `free_tao` ranking off this table is well-formed and quietly
+// missing its #2.
+//
+// The repair is not a tighter threshold. Truncation is only caught by a
+// threshold through the accident of enough time passing afterwards, which is
+// the bug restated, not a fix: the half-loaded table above would have been
+// reported `ok` for another eleven hours.
+//
+// ## WHAT IS COUNTED, AND WHY IT IS THIS AND NOT THE OBVIOUS TWO
+//
+// The measure added here is THE NUMBER OF ACCOUNTS THE NEWEST PASS ACTUALLY
+// WROTE, against a floor sized to the network. Two other candidates lose to it
+// on specifics rather than on taste:
+//
+//   A whole-table `COUNT(*)` floor catches the state above and nothing after
+//   it. This writer never prunes (see src/account-balances-d1-write.ts on why
+//   deleting an absent account would delete the wallets that emptied), so once
+//   a complete pass has landed, a later pass that dies at 48% CANNOT shrink the
+//   table -- it upserts half the rows to a new stamp and leaves the other half
+//   at the old one. `COUNT(*)` still reads the full network and reports fine,
+//   on exactly the failure this file exists for. That blindness arrives the
+//   moment the lane starts working, which is to say almost immediately.
+//
+//   A producer-published completeness marker (a per-pass row count or terminal
+//   sentinel, the infra-side option #9511 weighs) is the right answer for the
+//   SERVING guard and the wrong one here, for one reason: a pass that dies is a
+//   pass that never sends its marker. The watchdog would then be inferring the
+//   fault from an ABSENCE of report -- which is the staleness check it already
+//   has, and which is precisely what answered `ok` above, because the truncated
+//   pass's committed chunk was recent. A watchdog whose job is to catch a
+//   producer failing cannot take that producer's word for whether it failed;
+//   every alarm in this family reads the source or the served object directly
+//   for that reason. (This is complementary to #9511's serving guard, not a
+//   substitute: this one reports the fault, that one refuses to rank over it.)
+//
+// Counting the newest pass's own rows beats both because it measures the PASS
+// rather than the accumulation. It fires on 147,000 whether the table was empty
+// beforehand (147,000 written) or already full (147,000 refreshed out of
+// ~306,000), and it never divides by the table size, so it does not drift as
+// emptied-and-never-refunded accounts pile up carrying old stamps forever.
+//
+// COST, since this trades an index seek for a scan. `COUNT(*)` plus the
+// conditional sum is one walk of the table, ~306k rows, on a `4,34 * * * *`
+// cron -- 48 ticks a day, ~15M D1 rows read a day. That sits inside the
+// included allowance and is the price of the only signal that would have fired
+// on the case above.
 
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
@@ -47,48 +111,161 @@ import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
  */
 export const ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS = 12 * 60 * 60 * 1000;
 
+/**
+ * How many accounts a COMPLETE pass is expected to write.
+ *
+ * The producer walks System::Account -- 542,618 entries at its own last live
+ * measurement (2026-07-19), per migrations/d1/0017_account_balances.sql -- and
+ * SKIPS every account whose free and reserved are both zero, so a full pass
+ * lands the nonzero-balance subset of that, ~306,000 accounts (2026-08-05).
+ *
+ * Stated as the measurement rather than as a bound, because the floor below is
+ * what the rule actually uses and is sized so that being wrong about this
+ * number cannot make the alarm wrong in the dangerous direction.
+ */
+export const ACCOUNT_BALANCES_EXPECTED_ACCOUNTS = 306_000;
+
+/**
+ * How much of that a single pass must cover before it counts as complete.
+ *
+ * EIGHTY PERCENT, and the slack is deliberate on both sides:
+ *
+ *   It cannot false-fire on a working lane. A complete pass writes the whole
+ *   nonzero subset, so the only way to land under this floor is to not finish.
+ *   The 20% gap absorbs both ordinary churn in the account population and the
+ *   possibility that ACCOUNT_BALANCES_EXPECTED_ACCOUNTS above is an
+ *   overestimate -- if the true subset is nearer the raw 542,618, this floor is
+ *   merely slacker still, never tighter. That is the #9301 sizing rule: an
+ *   alarm that fires on a lane which is working stops being read.
+ *
+ *   It still catches the case it was built for decisively. The measured
+ *   truncation wrote 147,000, which is 48% of the expectation and 60% of the
+ *   floor -- not a near miss in either direction.
+ *
+ * The gap it does NOT catch is a pass that dies between 80% and 100%, and only
+ * while the table has never held a complete pass. Once one has, a later partial
+ * refreshes fewer rows than it and is caught here anyway.
+ */
+export const ACCOUNT_BALANCES_COVERAGE_FLOOR_RATIO = 0.8;
+
+/** The floor the rule compares against, ~244,800 rows. */
+export const ACCOUNT_BALANCES_COVERAGE_FLOOR_ROWS = Math.round(
+  ACCOUNT_BALANCES_EXPECTED_ACCOUNTS * ACCOUNT_BALANCES_COVERAGE_FLOOR_RATIO,
+);
+
+/**
+ * How far back from the newest stamp still counts as "the newest pass".
+ *
+ * TWO HOURS, and this one is bounded from both ends rather than being slack:
+ *
+ *   Too SMALL and a producer that stamps each request instead of each pass
+ *   reads as ~22 partial passes, and the alarm fires forever on a healthy lane.
+ *   Today a pass carries ONE stamp -- the 147,000 rows measured above arrived
+ *   across ~6 requests and shared a single `captured_at` to the millisecond --
+ *   so this window is pure headroom against that changing.
+ *
+ *   Too LARGE and two consecutive passes merge into one coverage count, so a
+ *   truncated pass sitting on top of the previous complete one sums to full
+ *   coverage and reports fine -- reintroducing exactly this file's bug. The
+ *   producer's `ACCOUNT_BALANCES_POLL_SECS` is 21600 (six hours), so the window
+ *   must stay well under that; two is a third of it.
+ *
+ * Overridable via ACCOUNT_BALANCES_PASS_WINDOW_MS, which must be re-sized
+ * against the poll interval if that interval ever shortens.
+ */
+export const ACCOUNT_BALANCES_PASS_WINDOW_MS = 2 * 60 * 60 * 1000;
+
+/**
+ * One read, answering both questions: how fresh the newest pass is, and how
+ * much of the network it actually covered.
+ *
+ * `covered` counts only rows stamped within ACCOUNT_BALANCES_PASS_WINDOW_MS of
+ * the newest stamp -- the rows THIS pass wrote -- rather than the whole table,
+ * which is the distinction the module header exists about. `total` is not used
+ * by the rule; it rides along free on the same walk and is what tells an
+ * operator how much older data is sitting underneath a partial pass.
+ */
+const ACCOUNT_BALANCES_COVERAGE_SQL =
+  "SELECT COUNT(*) AS total, MAX(captured_at) AS latest, " +
+  "SUM(CASE WHEN captured_at >= " +
+  "(SELECT MAX(captured_at) FROM account_balances) - ? THEN 1 ELSE 0 END) " +
+  "AS covered FROM account_balances";
+
+export type AccountBalancesStalenessReason =
+  "no_rows" | "stale" | "partial" | null;
+
 export interface AccountBalancesStalenessVerdict {
   stale: boolean;
-  reason: "no_rows" | "stale" | null;
+  reason: AccountBalancesStalenessReason;
   age_ms: number | null;
   latest_captured_at: number | null;
   threshold_ms: number;
+  /** Accounts the newest pass wrote. The coverage signal itself. */
+  covered_rows: number;
+  /** Accounts in the table across all vintages. Context, never the rule. */
+  total_rows: number;
+  coverage_floor_rows: number;
 }
 
 /** The rule alone, testable without a database or a clock. */
 export function evaluateAccountBalancesStaleness(input: {
   latestCapturedAtMs: number | null;
+  coveredRows: number;
+  totalRows: number;
   nowMs: number;
   thresholdMs: number;
+  coverageFloorRows: number;
 }): AccountBalancesStalenessVerdict {
-  const { latestCapturedAtMs, nowMs, thresholdMs } = input;
+  const {
+    latestCapturedAtMs,
+    coveredRows,
+    totalRows,
+    nowMs,
+    thresholdMs,
+    coverageFloorRows,
+  } = input;
+  const base = {
+    latest_captured_at: latestCapturedAtMs,
+    threshold_ms: thresholdMs,
+    covered_rows: coveredRows,
+    total_rows: totalRows,
+    coverage_floor_rows: coverageFloorRows,
+  };
   if (latestCapturedAtMs === null) {
     // An empty table is a stall of infinite age, not a healthy quiet one --
     // and here it is also the CUTOVER state, before the revived lane has
     // posted anything. That is exactly the condition worth alerting on: an
     // empty table means every top-holders read is still answering from the
     // frozen 2026-08-02 artifact.
-    return {
-      stale: true,
-      reason: "no_rows",
-      age_ms: null,
-      latest_captured_at: null,
-      threshold_ms: thresholdMs,
-    };
+    return { ...base, stale: true, reason: "no_rows", age_ms: null };
   }
   const age = nowMs - latestCapturedAtMs;
-  return {
-    stale: age > thresholdMs,
-    reason: age > thresholdMs ? "stale" : null,
-    age_ms: age,
-    latest_captured_at: latestCapturedAtMs,
-    threshold_ms: thresholdMs,
-  };
+  if (age > thresholdMs) {
+    // Checked BEFORE coverage: if nothing has run in half a day, the coverage
+    // number describes an old pass and the headline is that the producer
+    // stopped, not how much its last attempt managed to write.
+    return { ...base, stale: true, reason: "stale", age_ms: age };
+  }
+  if (coveredRows < coverageFloorRows) {
+    // Recent AND short -- the discrimination this rule exists for. The pass ran
+    // and did not finish, so the table is a stitched mix of vintages that reads
+    // as fresh from its MAX() alone.
+    return { ...base, stale: true, reason: "partial", age_ms: age };
+  }
+  return { ...base, stale: false, reason: null, age_ms: age };
+}
+
+/** D1 counts arrive as numbers, but a null SUM over no rows and a shim that
+ * stringifies both have to land on 0 rather than NaN -- a NaN would compare
+ * false against the floor and report the truncated table healthy. */
+function countOrZero(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
 }
 
 interface D1Like {
   prepare(sql: string): {
-    first(): Promise<unknown>;
+    bind(...values: unknown[]): { first(): Promise<unknown> };
   };
 }
 
@@ -118,25 +295,45 @@ export async function runAccountBalancesStalenessWatchdog(
   const thresholdMs =
     Number(env?.ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS) ||
     ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS;
+  const passWindowMs =
+    Number(env?.ACCOUNT_BALANCES_PASS_WINDOW_MS) ||
+    ACCOUNT_BALANCES_PASS_WINDOW_MS;
+  const coverageFloorRows =
+    Number(env?.ACCOUNT_BALANCES_COVERAGE_FLOOR_ROWS) ||
+    ACCOUNT_BALANCES_COVERAGE_FLOOR_ROWS;
 
   try {
     const row = (await db
-      .prepare("SELECT MAX(captured_at) AS latest FROM account_balances")
-      .first()) as { latest: number | null } | null;
+      .prepare(ACCOUNT_BALANCES_COVERAGE_SQL)
+      .bind(passWindowMs)
+      .first()) as {
+      latest: number | null;
+      covered: number | null;
+      total: number | null;
+    } | null;
     const verdict = evaluateAccountBalancesStaleness({
       latestCapturedAtMs: row?.latest ?? null,
+      coveredRows: countOrZero(row?.covered),
+      totalRows: countOrZero(row?.total),
       nowMs: now(),
       thresholdMs,
+      coverageFloorRows,
     });
     if (verdict.stale) {
+      // The two faults get different wording on purpose. They are read in
+      // PostHog by whoever is on the other end of the alert, and "the producer
+      // stopped" and "the producer is running and not finishing" send that
+      // person to different places.
       const age =
         verdict.age_ms === null
           ? "no rows at all"
           : `${(verdict.age_ms / 3_600_000).toFixed(1)} h old`;
+      const message =
+        verdict.reason === "partial"
+          ? `account-balances lane truncated: the newest pass covered only ${verdict.covered_rows} accounts against a floor of ${verdict.coverage_floor_rows} (${verdict.total_rows} rows in the table, newest stamp ${age}) -- the capture is RECENT and PARTIAL, so /accounts/top-holders ranks free_tao over whatever fraction landed and a real top holder the pass never reached is silently absent, not merely stale`
+          : `account-balances lane stalled: latest snapshot is ${age} (threshold ${thresholdMs / 3_600_000} h) -- /accounts/top-holders is answering from a free_tao column nothing is refreshing`;
       await record(env as never, {
-        error: new Error(
-          `account-balances lane stalled: latest snapshot is ${age} (threshold ${thresholdMs / 3_600_000} h) -- /accounts/top-holders is answering from a free_tao column nothing is refreshing`,
-        ),
+        error: new Error(message),
         route: "watchdog:account-balances-staleness",
         errorCode: "stale_lane",
       }).catch(() => false);

--- a/tests/account-balances-staleness-watchdog.test.ts
+++ b/tests/account-balances-staleness-watchdog.test.ts
@@ -11,10 +11,21 @@
 // mid-cycle reading and must stay quiet. #9301 had to correct precisely that
 // mistake on the nominator-positions watchdog after a threshold was set tighter
 // than its producer's cadence.
+//
+// The COVERAGE half (#9530) is the one edge that is not about time at all, and
+// the whole discrimination it has to make is between two ticks that a
+// timestamp cannot tell apart: half a network written recently, and a whole
+// network written recently. The production reading it was built from --
+// 147,000 rows at one 36-minute-old stamp, reported `ok` -- is asserted below
+// verbatim, because a rule that gets every synthetic case right and that one
+// wrong is the rule this file already had.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 import {
+  ACCOUNT_BALANCES_COVERAGE_FLOOR_ROWS,
+  ACCOUNT_BALANCES_EXPECTED_ACCOUNTS,
+  ACCOUNT_BALANCES_PASS_WINDOW_MS,
   ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS,
   evaluateAccountBalancesStaleness,
   runAccountBalancesStalenessWatchdog,
@@ -24,18 +35,32 @@ import * as workerConfig from "../workers/config.ts";
 
 const NOW = 1_785_800_000_000;
 const HOUR = 60 * 60_000;
+/** A pass that covered the network, so `covered` is never the thing under test
+ * unless a case says so. */
+const FULL = ACCOUNT_BALANCES_EXPECTED_ACCOUNTS;
 
-function fakeDb(latest: number | null | Error) {
+function fakeDb(
+  latest: number | null | Error,
+  covered: number = FULL,
+  total: number = FULL,
+) {
   const queries: string[] = [];
+  const binds: unknown[][] = [];
   return {
     queries,
+    binds,
     db: {
       prepare(sql: string) {
         queries.push(sql);
         return {
-          async first() {
-            if (latest instanceof Error) throw latest;
-            return { latest };
+          bind(...values: unknown[]) {
+            binds.push(values);
+            return {
+              async first() {
+                if (latest instanceof Error) throw latest;
+                return { latest, covered, total };
+              },
+            };
           },
         };
       },
@@ -43,22 +68,34 @@ function fakeDb(latest: number | null | Error) {
   };
 }
 
+/** The rule's inputs with everything healthy, so each case overrides only the
+ * one field it is about. */
+function inputs(
+  over: Partial<Parameters<typeof evaluateAccountBalancesStaleness>[0]> = {},
+) {
+  return {
+    latestCapturedAtMs: NOW - HOUR,
+    coveredRows: FULL,
+    totalRows: FULL,
+    nowMs: NOW,
+    thresholdMs: ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS,
+    coverageFloorRows: ACCOUNT_BALANCES_COVERAGE_FLOOR_ROWS,
+    ...over,
+  };
+}
+
 describe("evaluateAccountBalancesStaleness", () => {
   test("a recent pass is quiet; one past the threshold is a stall", () => {
-    const fresh = evaluateAccountBalancesStaleness({
-      latestCapturedAtMs: NOW - 2 * HOUR,
-      nowMs: NOW,
-      thresholdMs: ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS,
-    });
+    const fresh = evaluateAccountBalancesStaleness(
+      inputs({ latestCapturedAtMs: NOW - 2 * HOUR }),
+    );
     assert.equal(fresh.stale, false);
     assert.equal(fresh.reason, null);
     assert.equal(fresh.age_ms, 2 * HOUR);
 
-    const stalled = evaluateAccountBalancesStaleness({
-      latestCapturedAtMs: NOW - 13 * HOUR,
-      nowMs: NOW,
-      thresholdMs: ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS,
-    });
+    const stalled = evaluateAccountBalancesStaleness(
+      inputs({ latestCapturedAtMs: NOW - 13 * HOUR }),
+    );
     assert.equal(stalled.stale, true);
     assert.equal(stalled.reason, "stale");
     assert.equal(stalled.latest_captured_at, NOW - 13 * HOUR);
@@ -69,11 +106,9 @@ describe("evaluateAccountBalancesStaleness", () => {
     // walk plus its ~22 POSTs sit on top of that -- so a healthy lane's age
     // swings across this whole range and none of it may alert.
     for (const hours of [1, 3, 5, 6, 7]) {
-      const verdict = evaluateAccountBalancesStaleness({
-        latestCapturedAtMs: NOW - hours * HOUR,
-        nowMs: NOW,
-        thresholdMs: ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS,
-      });
+      const verdict = evaluateAccountBalancesStaleness(
+        inputs({ latestCapturedAtMs: NOW - hours * HOUR }),
+      );
       assert.equal(
         verdict.stale,
         false,
@@ -84,24 +119,102 @@ describe("evaluateAccountBalancesStaleness", () => {
 
   test("exactly at the threshold is not yet a stall", () => {
     // Strictly-greater, so a lane running exactly on cadence never flaps.
-    const verdict = evaluateAccountBalancesStaleness({
-      latestCapturedAtMs: NOW - ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS,
-      nowMs: NOW,
-      thresholdMs: ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS,
-    });
+    const verdict = evaluateAccountBalancesStaleness(
+      inputs({
+        latestCapturedAtMs: NOW - ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS,
+      }),
+    );
     assert.equal(verdict.stale, false);
   });
 
   test("an empty table is a stall of infinite age, never a healthy quiet", () => {
-    const verdict = evaluateAccountBalancesStaleness({
-      latestCapturedAtMs: null,
-      nowMs: NOW,
-      thresholdMs: ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS,
-    });
+    const verdict = evaluateAccountBalancesStaleness(
+      inputs({ latestCapturedAtMs: null, coveredRows: 0, totalRows: 0 }),
+    );
     assert.equal(verdict.stale, true);
     assert.equal(verdict.reason, "no_rows");
     assert.equal(verdict.age_ms, null);
     assert.equal(verdict.latest_captured_at, null);
+  });
+
+  test("HALF A NETWORK RECENTLY and A WHOLE NETWORK RECENTLY are told apart", () => {
+    // The acceptance criterion, and the only assertion in this file that fails
+    // against the pre-#9530 rule. Both ticks below carry an identically fresh
+    // MAX(captured_at); the ONLY difference is how many accounts the pass
+    // reached, which is exactly what a timestamp cannot express.
+    const half = evaluateAccountBalancesStaleness(
+      inputs({ coveredRows: 147_000, totalRows: 147_000 }),
+    );
+    assert.equal(half.stale, true, "a half-covered pass must not read as ok");
+    assert.equal(half.reason, "partial");
+    // Recent, not old -- the point being that it is caught WITHOUT time passing.
+    assert.equal(half.age_ms, HOUR);
+
+    const whole = evaluateAccountBalancesStaleness(inputs());
+    assert.equal(whole.stale, false);
+    assert.equal(whole.reason, null);
+    assert.equal(whole.age_ms, half.age_ms);
+  });
+
+  test("the production reading of 2026-08-05 06:04Z alerts", () => {
+    // Verbatim: 147,000 rows sharing one captured_at stamped 05:27:16.083Z,
+    // read at 06:04:48Z. lane_health said `ok | age=0.6h`.
+    const capturedAt = Date.parse("2026-08-05T05:27:16.083Z");
+    const checkedAt = Date.parse("2026-08-05T06:04:48.000Z");
+    const verdict = evaluateAccountBalancesStaleness(
+      inputs({
+        latestCapturedAtMs: capturedAt,
+        coveredRows: 147_000,
+        totalRows: 147_000,
+        nowMs: checkedAt,
+      }),
+    );
+    assert.equal(verdict.stale, true);
+    assert.equal(verdict.reason, "partial");
+    // The freshness half was never wrong -- it was answering a different
+    // question. Assert that it still reads as fresh, so the fix is provably
+    // coverage and not a quietly tightened threshold.
+    assert.ok(verdict.age_ms !== null && verdict.age_ms < HOUR);
+    assert.ok(verdict.age_ms < verdict.threshold_ms);
+  });
+
+  test("a pass exactly at the floor is complete; one row under is not", () => {
+    // Strictly-less, matching the threshold edge above, so a lane landing
+    // exactly on the floor never flaps.
+    const atFloor = evaluateAccountBalancesStaleness(
+      inputs({ coveredRows: ACCOUNT_BALANCES_COVERAGE_FLOOR_ROWS }),
+    );
+    assert.equal(atFloor.stale, false);
+    assert.equal(atFloor.reason, null);
+
+    const under = evaluateAccountBalancesStaleness(
+      inputs({ coveredRows: ACCOUNT_BALANCES_COVERAGE_FLOOR_ROWS - 1 }),
+    );
+    assert.equal(under.stale, true);
+    assert.equal(under.reason, "partial");
+  });
+
+  test("a truncated pass on top of a FULL table is caught too", () => {
+    // The steady-state failure a whole-table COUNT(*) floor is blind to: this
+    // writer never prunes, so a pass that dies at 48% leaves the table at its
+    // full size with half its rows a vintage old. `total` reads healthy;
+    // `covered` is what fires.
+    const verdict = evaluateAccountBalancesStaleness(
+      inputs({ coveredRows: 147_000, totalRows: FULL }),
+    );
+    assert.equal(verdict.stale, true);
+    assert.equal(verdict.reason, "partial");
+    assert.equal(verdict.total_rows, FULL, "the table itself is not short");
+  });
+
+  test("a stalled lane reports `stale`, not `partial`, even when also short", () => {
+    // Order matters for the operator on the other end: if nothing has run in
+    // 20 hours, "the producer stopped" is the headline and the coverage of its
+    // last attempt is a detail.
+    const verdict = evaluateAccountBalancesStaleness(
+      inputs({ latestCapturedAtMs: NOW - 20 * HOUR, coveredRows: 147_000 }),
+    );
+    assert.equal(verdict.reason, "stale");
   });
 });
 
@@ -122,7 +235,62 @@ describe("runAccountBalancesStalenessWatchdog", () => {
     assert.equal(result.ok, true);
     assert.equal(result.alerted, false);
     assert.deepEqual(recorded, []);
-    assert.match(queries[0]!, /MAX\(captured_at\).*FROM account_balances/);
+    assert.match(queries[0]!, /MAX\(captured_at\)/);
+    assert.match(queries[0]!, /FROM account_balances/);
+    // The coverage half has to be IN the read, or the rule is being handed a
+    // number nothing measured.
+    assert.match(queries[0]!, /AS covered/);
+  });
+
+  test("the read counts only the newest pass, bounded by the pass window", () => {
+    // A window that spanned the 6h poll interval would sum two consecutive
+    // passes into one coverage count, so a truncated pass landing on a
+    // complete one would report full coverage -- the bug, restored.
+    const { db, queries, binds } = fakeDb(NOW - HOUR);
+    return runAccountBalancesStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW, recordException: (async () => true) as never },
+    ).then(() => {
+      assert.deepEqual(binds[0], [ACCOUNT_BALANCES_PASS_WINDOW_MS]);
+      assert.ok(
+        ACCOUNT_BALANCES_PASS_WINDOW_MS < 6 * HOUR,
+        "the window must stay under ACCOUNT_BALANCES_POLL_SECS (21600)",
+      );
+      // Counted against the newest stamp, not against `now` -- a lane that is
+      // merely late must not also read as uncovered.
+      assert.match(
+        queries[0]!,
+        /captured_at >= \(SELECT MAX\(captured_at\) FROM account_balances\) - \?/,
+      );
+    });
+  });
+
+  test("a recent but half-covered table alerts, naming both counts", async () => {
+    const { db } = fakeDb(NOW - HOUR, 147_000, 147_000);
+    const recorded: { error?: Error; route?: string; errorCode?: string }[] =
+      [];
+    const result = await runAccountBalancesStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async (_env: never, event: never) => {
+          recorded.push(event);
+          return true;
+        }) as never,
+      },
+    );
+    assert.equal(result.alerted, true);
+    assert.equal(result.reason, "partial");
+    assert.equal(result.covered_rows, 147_000);
+    assert.equal(recorded.length, 1);
+    assert.equal(recorded[0]!.errorCode, "stale_lane");
+    const message = String(recorded[0]!.error?.message);
+    // The wording has to separate itself from the stalled case -- an operator
+    // reading this in PostHog goes to a different place for each.
+    assert.match(message, /truncated/);
+    assert.match(message, /147000/);
+    assert.match(message, /RECENT and PARTIAL/);
+    assert.doesNotMatch(message, /nothing is refreshing/);
   });
 
   test("a stalled lane records ONE exception naming the age and the route it breaks", async () => {
@@ -179,6 +347,59 @@ describe("runAccountBalancesStalenessWatchdog", () => {
     assert.equal(result.threshold_ms, HOUR);
   });
 
+  test("the env coverage-floor and pass-window overrides win over the defaults", async () => {
+    // Both exist so the numbers can follow the producer's real cadence and the
+    // network's real size without a code deploy -- the same reason the
+    // threshold above is overridable.
+    const { db, binds } = fakeDb(NOW - HOUR, 200_000, 200_000);
+    const raised = await runAccountBalancesStalenessWatchdog(
+      {
+        METAGRAPH_HEALTH_DB: db,
+        ACCOUNT_BALANCES_COVERAGE_FLOOR_ROWS: String(500_000),
+        ACCOUNT_BALANCES_PASS_WINDOW_MS: String(HOUR),
+      },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(raised.alerted, true);
+    assert.equal(raised.reason, "partial");
+    assert.equal(raised.coverage_floor_rows, 500_000);
+    assert.deepEqual(binds[0], [HOUR]);
+
+    // Lowered under the same reading, the identical tick is quiet.
+    const lowered = await runAccountBalancesStalenessWatchdog(
+      {
+        METAGRAPH_HEALTH_DB: fakeDb(NOW - HOUR, 200_000, 200_000).db,
+        ACCOUNT_BALANCES_COVERAGE_FLOOR_ROWS: String(100_000),
+      },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(lowered.alerted, false);
+    assert.equal(lowered.coverage_floor_rows, 100_000);
+  });
+
+  test("an uncountable coverage number reads as ZERO, never as covered", async () => {
+    // A null SUM over no rows, or a shim handing back something non-numeric,
+    // must not become a NaN: NaN compares false against the floor, which would
+    // report a truncated table healthy -- the exact direction of failure this
+    // change exists to remove.
+    const { db } = fakeDb(NOW - HOUR, null as unknown as number, 0);
+    const result = await runAccountBalancesStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(result.covered_rows, 0);
+    assert.equal(result.alerted, true);
+    assert.equal(result.reason, "partial");
+
+    const junk = fakeDb(NOW - HOUR, "not a number" as unknown as number, 0);
+    const nonNumeric = await runAccountBalancesStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: junk.db },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(nonNumeric.covered_rows, 0);
+    assert.equal(nonNumeric.alerted, true);
+  });
+
   test("a missing binding and a failing query degrade to summaries, never throw", async () => {
     assert.deepEqual(await runAccountBalancesStalenessWatchdog({}), {
       ok: false,
@@ -204,9 +425,11 @@ describe("runAccountBalancesStalenessWatchdog", () => {
     // yields a readable detail.
     const stringThrow = {
       prepare: () => ({
-        first: async () => {
-          throw "socket hangup";
-        },
+        bind: () => ({
+          first: async () => {
+            throw "socket hangup";
+          },
+        }),
       }),
     };
     const nonError = await runAccountBalancesStalenessWatchdog(
@@ -219,7 +442,7 @@ describe("runAccountBalancesStalenessWatchdog", () => {
 
   test("a null row and a telemetry failure never fail the tick", async () => {
     const nullRow = {
-      prepare: () => ({ first: async () => null }),
+      prepare: () => ({ bind: () => ({ first: async () => null }) }),
     };
     const empty = await runAccountBalancesStalenessWatchdog(
       { METAGRAPH_HEALTH_DB: nullRow },

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1977,9 +1977,11 @@ async function dispatchScheduled(
     // The account-balances lane's alarm (#9478) -- the SOURCE side of the
     // watchdog above rather than a replacement for it: that one asks whether
     // the served artifact is readable and current, this one asks whether the
-    // D1 table it is composed from is being written at all. Zero alerts is the
-    // correct steady state; a stale verdict records one exception under
-    // watchdog:account-balances-staleness, the project's alert channel. An
+    // D1 table it is composed from is being written at all -- and, since
+    // #9530, whether each pass COVERS the network rather than merely arriving
+    // recently. Zero alerts is the correct steady state; a stale verdict
+    // records one exception under watchdog:account-balances-staleness, the
+    // project's alert channel. An
     // EMPTY table alerts too -- until the revived lane posts, every top-holders
     // read is still answering from the frozen 2026-08-02 materialization.
     return runAccountBalancesStalenessWatchdog(


### PR DESCRIPTION
## Summary

`account-balances-staleness` structurally could not detect a truncated publish. It read one number — `MAX(captured_at)` — and reported `ok` while the table held roughly half the network.

Measured on production D1, 2026-08-05 06:04Z:

```
lane_health:  account-balances-staleness | ok | age=0.6h | checked=2026-08-05T06:04:48Z

SELECT captured_at, COUNT(*) FROM account_balances GROUP BY captured_at
-- 2026-08-05T05:27:16.083Z | 147000      (one row, the whole table)
```

147,000 accounts — ~48% of the network — at a stamp that was genuinely 36 minutes old. The rule was applied correctly and returned the wrong answer: one committed chunk of a pass that died at 48% looks exactly as fresh as a complete pass. #316's own header predicted this verbatim.

Not fixed by tightening the threshold: that catches truncation only through the accident of enough time passing afterwards, which is the bug restated. The half-loaded table above would have read `ok` for another eleven hours.

## What Changed

The watchdog's read now also counts **the accounts the newest pass actually wrote** — rows stamped within `ACCOUNT_BALANCES_PASS_WINDOW_MS` (2 h) of the newest stamp — and compares that against a floor of 80% of the ~306,000 nonzero-balance accounts a complete pass lands. A recent-but-short capture reports the new reason `partial`.

**Why the newest pass and not the whole table.** A whole-table `COUNT(*)` floor catches today's state and nothing after it. This writer never prunes, so once a complete pass has landed, a later pass that dies at 48% *cannot shrink the table* — it upserts half the rows to a new stamp and leaves the other half at the old one. `COUNT(*)` still reads the full network and reports fine, on exactly the failure the alarm exists for. That blindness arrives the moment the lane starts working.

**Why not a producer-published completeness marker** (the infra-side option #9511 weighs): a pass that dies is a pass that never sends its marker, so the watchdog would be inferring the fault from an *absence of report* — which is the staleness check it already has, and which is precisely what answered `ok` here. A watchdog whose job is to catch a producer failing cannot take that producer's word for whether it failed. That option is still the right answer for the **serving** guard; this is complementary to #9511, not a substitute — this reports the fault, that one refuses to rank over it.

Counting the pass rather than the accumulation fires on 147,000 whether the table was empty beforehand or already full, and never divides by table size, so it does not drift as emptied-and-never-refunded accounts pile up carrying old stamps forever.

**Sizing.** The 80% floor cannot false-fire on a working lane (a complete pass writes the whole nonzero subset; 147,000 is 60% of the floor, not a near miss), and if `ACCOUNT_BALANCES_EXPECTED_ACCOUNTS` is an overestimate the floor only gets slacker, never tighter — the #9301 rule. The 2 h pass window is bounded from both ends: too small and a producer that stamps per-request reads as ~22 partial passes (alerting forever on a healthy lane); too large and two consecutive passes merge into one coverage count, restoring this very bug. Six-hour `ACCOUNT_BALANCES_POLL_SECS` is the upper bound; two is a third of it. Both are env-overridable alongside the existing threshold.

**Cost.** Trades an index seek for one table walk: ~306k rows × 48 ticks/day ≈ 15M D1 rows read/day, inside the included allowance.

**No schema change.** `partial` is a `lane_health` **detail**; the verdict stays inside the published `ok`/`stale`/`unknown` enum, so there is no contract drift and no regenerated artifact.

### The acceptance criterion, asserted

`tests/account-balances-staleness-watchdog.test.ts` pins the discrimination directly — two ticks with an identically fresh `MAX(captured_at)`, differing only in coverage — plus the production reading of 2026-08-05 06:04Z verbatim, which also asserts the capture still reads as *fresh*, proving the fix is coverage and not a quietly tightened threshold.

Verified these fail without the change: neutering only the `coveredRows < coverageFloorRows` branch fails **7 of 23** tests, including both of the above. All 23 pass with it.

## Registry Safety

- [x] No linked issue — maintainer PR, filed at maintainer request.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None changed — `git status` clean after `npm run build`.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — see above.)

## Validation

- [x] `npm run lint` · `npm run format:check` · `npm run typecheck`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run validate:contract-drift`
- [x] `npm run worker:test`
- [x] `npm run build` (8/8 steps passed)
- [x] `npx vitest run` — 680 files, 16,279 tests, all passing
- [x] Patch coverage — 100% statements, 100% branches (37/37) on `src/account-balances-staleness-watchdog.ts` from its own test file alone; the `workers/api.ts` change is comment-only
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

`npm run check` was not run to completion locally (exceeded a 10-minute bound); its constituents above were run individually instead.

## Template Used

- `backend-code.md`
