### PR TITLE
feat(profiles): resolve team from the subnet's subnet-team provider

### DIFF
--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -386,17 +386,42 @@ for (const surface of surfaces) {
   }
   providerIdsByNetuid.get(surface.netuid).add(surface.provider);
 }
-const derivedDescriptionByNetuid = new Map();
-// serial: accumulates into derivedDescriptionByNetuid (shared state), so unlike the
-// #2057 per-subnet write loops this is intentionally not parallelized.
-for (const subnet of mergedSubnets) {
-  if (subnet.description) continue;
-  const ids = [...(providerIdsByNetuid.get(subnet.netuid) || [])].sort(
+// A subnet's attached provider ids, subnet-team ones first, then by id so the
+// order is deterministic across builds. Shared by the derived-description pass
+// below and the team lookup, which want the same "most authoritative provider
+// for this subnet" ranking.
+function providerIdsForNetuid(netuid: number) {
+  return [...(providerIdsByNetuid.get(netuid) || [])].sort(
     (a, b) =>
       (providersById.get(a)?.kind === "subnet-team" ? 0 : 1) -
         (providersById.get(b)?.kind === "subnet-team" ? 0 : 1) ||
       a.localeCompare(b),
   );
+}
+
+// The team behind each subnet, from its attached `kind: "subnet-team"` provider
+// (#9524). Registry records carry no `team` key of their own -- the identity has
+// always lived on the provider -- so the profile artifact published team: null
+// for all 129 subnets. Only a subnet-team provider counts: any other kind is a
+// vendor or infra operator, not the team, and naming one here would be wrong
+// rather than merely absent.
+const teamByNetuid = new Map();
+for (const subnet of mergedSubnets) {
+  const teamId = providerIdsForNetuid(subnet.netuid).find(
+    (id) => providersById.get(id)?.kind === "subnet-team",
+  );
+  const name = teamId ? providersById.get(teamId)?.name : null;
+  if (typeof name === "string" && name.trim()) {
+    teamByNetuid.set(subnet.netuid, name.trim());
+  }
+}
+
+const derivedDescriptionByNetuid = new Map();
+// serial: accumulates into derivedDescriptionByNetuid (shared state), so unlike the
+// #2057 per-subnet write loops this is intentionally not parallelized.
+for (const subnet of mergedSubnets) {
+  if (subnet.description) continue;
+  const ids = providerIdsForNetuid(subnet.netuid);
   for (const id of ids) {
     const provider = providersById.get(id);
     const derived = deriveDescriptionFromNotes(
@@ -3336,7 +3361,7 @@ function buildSubnetProfile({
     github_commits_weekly: subnet.github_commits_weekly,
     github_unreachable: subnet.github_unreachable,
     project_name: subnet.name,
-    team: null,
+    team: teamByNetuid.get(subnet.netuid) ?? null,
     categories: subnet.categories || [],
     derived_categories: subnet.derived_categories || [],
     derived_description: derivedDescription,

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -1234,6 +1234,35 @@ test("public artifacts are internally consistent", () => {
     ),
     true,
   );
+  // #9524: `team` used to be a hardcoded null in the build, so every profile
+  // published it empty. Two assertions, and the second is the important one:
+  // coverage alone would pass just as well if the field were filled from the
+  // wrong provider, so pin the value to a subnet-team provider that actually
+  // claims this netuid. A team the registry does not attest is worse than null.
+  {
+    const teamProviders = (providersArtifact.providers as Row[]).filter(
+      (provider: Row) => provider.kind === "subnet-team",
+    );
+    const withTeam = (profiles.profiles as Row[]).filter(
+      (profile: Row) => profile.team,
+    );
+    assert.equal(
+      withTeam.length > (profiles.profiles as Row[]).length * 0.9,
+      true,
+      `expected >90% of profiles to resolve a team, got ${withTeam.length}/${(profiles.profiles as Row[]).length}`,
+    );
+    for (const profile of withTeam) {
+      assert.equal(
+        teamProviders.some(
+          (provider: Row) =>
+            provider.name === profile.team &&
+            (provider.netuids as number[]).includes(profile.netuid as number),
+        ),
+        true,
+        `profile ${profile.netuid} names team "${profile.team}" with no matching subnet-team provider on that netuid`,
+      );
+    }
+  }
   assert.equal(
     profileCompleteness.profiles.every(
       (profile: Row) =>


### PR DESCRIPTION
## Summary

`list_profiles.team` was null on all 129 profiles because `scripts/build-artifacts.ts` hardcoded it:

```js
project_name: subnet.name,
team: null,
```

No registry record carries a `team` key (`grep -rl '"team"' registry/` → 0 files) — the identity has always lived on the provider, as `kind: "subnet-team"`. So the field never had a producer, rather than having lost one.

The ordering that finds the right provider was already in this file, used only to pick a `derived_description` source. Extracted as `providerIdsForNetuid` and reused, so both consumers rank a subnet's providers the same way and cannot drift apart.

## Measurement

Before (production sweep, 2026-08-05):

```
list_profiles   rows=129 path=profiles  SUSPECT ALL_NULL(team)
```

After (`npm run build`, reading the generated artifact):

```
profiles: 129 | non-null team: 122
samples: 1=Macrocosmos, 2=Inference Labs, 3=One Covenant, 4=Targon, 5=Hone
null team netuids: 0, 19, 31, 73, 86, 104, 119
```

## Only a subnet-team provider counts

Any other provider kind attached to a subnet is a vendor or infra operator. Naming one as the team would be wrong rather than merely absent, so the 7 subnets with no `subnet-team` provider keep a null — including netuid 0 (root), which has no team by definition.

## The test pins the value, not just the count

A coverage threshold alone would pass equally well if the field were filled from the wrong provider. The new assertion in `tests/artifacts.test.ts` requires every non-null `team` to match a `kind: "subnet-team"` provider whose `netuids` actually includes that profile's netuid:

```
profile ${netuid} names team "${team}" with no matching subnet-team provider on that netuid
```

## Why not withdraw the field instead

`team` is **required** in the published contract — `schemas-src/routes/subnet-profile.ts:204` declares `z.string().nullable()` (nullable, not optional) and it appears in the generated OpenAPI `required` array. Dropping it is a breaking change to a field with a real, recoverable source for 94.6% of subnets.

## Scope

This recovers an identity string from reviewed registry data. It sets no health, uptime, latency or verification value, so it is outside the probe-derived-only rule. `profiles.json` is an R2-only artifact, so there is no committed derived artifact to regenerate — `git status` shows only the two source files.

## Validation

```
npm run lint            npm run format:check      npm run typecheck
npm run validate        npm run scan:public-safety
npm run build
npx vitest run tests/artifacts.test.ts tests/build-readiness.test.ts tests/contracts.test.ts
  -> 107 passed
```

Rebased onto current `main`.

Closes #9524