### PR TITLE
fix(chain-alpha-volume): give vol_mcap_ratio the denominator it needs

### DIFF
--- a/src/chain-alpha-volume-artifact.ts
+++ b/src/chain-alpha-volume-artifact.ts
@@ -33,7 +33,14 @@ interface ArtifactBucket {
  */
 export async function loadChainAlphaVolumeFromArtifact(
   env: Env | null | undefined,
-  query: { limit?: number },
+  query: {
+    limit?: number;
+    /** Passed straight to the formatter for vol_mcap_ratio (#9526). Resolved by
+     * the caller, not here: this reader's contract is "shape the artifact or
+     * decline", and reaching into the economics tier from inside it would give
+     * a second store the power to fail a read that the artifact can answer. */
+    marketCapByNetuid?: Map<number, number> | null;
+  },
   /** Which chain's projection to read (#9412). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<ReturnType<typeof buildChainAlphaVolume> | null> {
@@ -64,6 +71,7 @@ export async function loadChainAlphaVolumeFromArtifact(
     if (!Array.isArray(win?.rows)) return null;
     return buildChainAlphaVolume(win.rows as Record<string, unknown>[], {
       limit: query.limit,
+      marketCapByNetuid: query.marketCapByNetuid ?? null,
     });
   } catch {
     return null;

--- a/src/chain-alpha-volume.ts
+++ b/src/chain-alpha-volume.ts
@@ -97,10 +97,14 @@ function volumeDistribution(values: number[]): VolumeDistribution | null {
 // StakeAdded/StakeRemoved aggregate. `rows` carries at most two rows per netuid (one per kind)
 // with alpha_volume (SUM alpha_amount), tao_volume (SUM amount_tao), event_count (COUNT), and
 // last_observed (MAX observed_at) — the exact shape buildAlphaVolume's own per-subnet rows carry.
-// Each netuid's row-group is handed to buildAlphaVolume (netuid, no marketCapTao — this route has
-// no per-subnet market-cap input in scope, so vol_mcap_ratio is null on every leaderboard entry,
-// same as the D1/Postgres subnet-level route's own null-marketCapTao branch) to get that subnet's
-// full volume scorecard, then those scorecards are ranked by total_volume_tao descending (tied
+// Each netuid's row-group is handed to buildAlphaVolume with that subnet's alpha_market_cap_tao
+// from the caller's marketCapByNetuid index (#9526 — the denominator used to be out of scope here,
+// which made vol_mcap_ratio structurally null on every leaderboard entry AND in the CSV export;
+// the economics blob the subnet-level route already reads is the full subnets[] array, so the
+// chain-level fill is one read and a keyed lookup) to get that subnet's full volume scorecard.
+// A netuid absent from the index keeps a null ratio and its position — ranking is by
+// total_volume_tao, never by the ratio, so a partial index cannot distort the leaderboard.
+// Those scorecards are then ranked by total_volume_tao descending (tied
 // broken by netuid ascending). `limit` caps the leaderboard; the network rollup, subnet_count, and
 // distribution cover every subnet that had volume (the aggregate's rows) — subnets with no
 // StakeAdded/StakeRemoved events are absent from account_events and so are not represented, the
@@ -132,7 +136,16 @@ export interface ChainAlphaVolumeResult {
 
 export function buildChainAlphaVolume(
   rows: Array<Record<string, unknown>> | null | undefined,
-  { limit = CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT }: { limit?: number } = {},
+  {
+    limit = CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT,
+    marketCapByNetuid = null,
+  }: {
+    limit?: number;
+    /** alpha_market_cap_tao per netuid, for vol_mcap_ratio (#9526). Optional:
+     * omitted or missing a netuid, that subnet's ratio stays null, which is
+     * how this route read for its whole life before the index existed. */
+    marketCapByNetuid?: Map<number, number> | null;
+  } = {},
 ): ChainAlphaVolumeResult {
   const list = Array.isArray(rows) ? rows : [];
   const flooredLimit = Math.floor(Number(limit));
@@ -165,7 +178,11 @@ export function buildChainAlphaVolume(
 
   const subnets: AlphaVolumeResult[] = [];
   for (const [netuid, subnetRows] of perNetuid) {
-    subnets.push(buildAlphaVolume(subnetRows, netuid));
+    subnets.push(
+      buildAlphaVolume(subnetRows, netuid, {
+        marketCapTao: marketCapByNetuid?.get(netuid) ?? null,
+      }),
+    );
   }
   // Biggest total volume first (where market activity is concentrated), tie-broken by netuid.
   subnets.sort(

--- a/src/market-cap-index.ts
+++ b/src/market-cap-index.ts
@@ -1,0 +1,71 @@
+// Every subnet's alpha_market_cap_tao in one Map, for routes that need the
+// denominator across the whole network rather than for one subnet (#9526).
+//
+// The per-subnet twin is resolveSubnetMarketCapTao in
+// workers/request-handlers/entities.ts, which resolves exactly the same two
+// tiers and then discards all but one entry. That is the right shape for a
+// subnet route and the wrong one for a leaderboard: the economics blob is
+// ALREADY the full subnets[] array, so a chain-level caller wants one read and
+// a keyed index, not N reads.
+//
+// Live KV first, committed R2 artifact second — the same order and the same
+// staleness/contract guards resolveLiveEconomics applies, so a wedged or
+// off-contract writer falls through to the artifact rather than serving a
+// frozen denominator.
+//
+// Returns an EMPTY map, never null, when neither tier answers. Callers divide
+// by "the market cap for this netuid, if we have one"; a missing entry and an
+// empty index are the same fact to them, and vol_mcap_ratio's own guard already
+// renders both as null.
+
+import { resolveLiveEconomics } from "./health-serving.ts";
+import { KV_ECONOMICS_CURRENT } from "./kv-keys.ts";
+import { readArtifact, readHealthKv } from "../workers/storage.ts";
+import { contractVersion } from "../workers/responses.ts";
+
+type Row = Record<string, unknown>;
+
+/** Where economics.json lives when the live KV tier is cold or off-contract. */
+const ECONOMICS_ARTIFACT_PATH = "/metagraph/economics.json";
+
+/** Index the economics `subnets[]` rows by netuid, keeping only usable
+ * denominators. A zero or negative market cap is dropped rather than stored:
+ * volMcapRatio would reject it anyway, and an absent key says "no denominator"
+ * more honestly than a stored zero. */
+function indexMarketCaps(rows: unknown): Map<number, number> {
+  const index = new Map<number, number>();
+  if (!Array.isArray(rows)) return index;
+  for (const row of rows as Row[]) {
+    const netuid = Number(row?.netuid);
+    const marketCap = row?.alpha_market_cap_tao;
+    if (!Number.isInteger(netuid) || netuid < 0) continue;
+    if (typeof marketCap !== "number" || !Number.isFinite(marketCap)) continue;
+    if (marketCap <= 0) continue;
+    index.set(netuid, marketCap);
+  }
+  return index;
+}
+
+// No try/catch here on purpose. Both reads already degrade to a miss on their
+// own -- readHealthKv swallows and returns null (workers/storage.ts:490-499),
+// readArtifact reports { ok: false } on a timeout or throw -- and indexing is
+// pure. Wrapping them again would add a branch nothing can reach, and the
+// guarantee the callers actually need (an unreachable economics tier costs a
+// null ratio, never a failed leaderboard) is the one those helpers give.
+// tests/market-cap-index.test.ts pins that by exploding both bindings.
+export async function resolveMarketCapIndex(
+  env: Env | null | undefined,
+): Promise<Map<number, number>> {
+  if (!env) return new Map();
+  const live = await resolveLiveEconomics({
+    readHealthKv: (e) => readHealthKv(e, KV_ECONOMICS_CURRENT),
+    env,
+    contractVersion: contractVersion(env),
+  });
+  const liveIndex = indexMarketCaps(live?.data?.subnets);
+  if (liveIndex.size > 0) return liveIndex;
+  const artifact = await readArtifact(env, ECONOMICS_ARTIFACT_PATH);
+  return artifact.ok
+    ? indexMarketCaps((artifact.data as Row | undefined)?.subnets)
+    : new Map();
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -283,6 +283,7 @@ import { loadChainCallsFromArtifact } from "./chain-calls-artifact.ts";
 import { loadChainFeesFromArtifact } from "./chain-fees-artifact.ts";
 import { loadChainSignersFromArtifact } from "./chain-signers-artifact.ts";
 import { loadChainAlphaVolumeFromArtifact } from "./chain-alpha-volume-artifact.ts";
+import { resolveMarketCapIndex } from "./market-cap-index.ts";
 import { loadChainStakeTransfersFromArtifact } from "./chain-stake-transfers-artifact.ts";
 import { loadChainTransferPairsFromArtifact } from "./chain-transfer-pairs-artifact.ts";
 import { loadChainStakeMovesFromArtifact } from "./chain-stake-moves-artifact.ts";
@@ -5480,8 +5481,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         )) ??
         // The projection tier (#9146): the cron-recomputed lakehouse
         // aggregate, through the same builder. See
-        // src/chain-alpha-volume-artifact.ts.
-        (await loadChainAlphaVolumeFromArtifact(ctx.env, { limit })) ??
+        // src/chain-alpha-volume-artifact.ts. The market-cap index is
+        // vol_mcap_ratio's denominator (#9526); an unreachable economics tier
+        // yields an empty index and a null ratio, never a failed leaderboard.
+        (await loadChainAlphaVolumeFromArtifact(ctx.env, {
+          limit,
+          marketCapByNetuid: await resolveMarketCapIndex(ctx.env),
+        })) ??
         buildChainAlphaVolume([], { limit })
       );
     },

--- a/tests/chain-alpha-volume.test.ts
+++ b/tests/chain-alpha-volume.test.ts
@@ -69,8 +69,33 @@ describe("buildChainAlphaVolume", () => {
     assert.equal(s1.net_volume_alpha, 70);
     assert.equal(s1.sentiment_ratio, 0.5385); // 70/130 rounded to 4dp
     assert.equal(s1.sentiment, "bullish");
-    // No per-subnet marketCapTao is passed at the network level -> always null.
+    // No marketCapByNetuid index passed -> the denominator is unknown, so the
+    // ratio stays null. #9526 made the index optional, not mandatory.
     assert.equal(s1.vol_mcap_ratio, null);
+  });
+
+  // #9526: the denominator used to be out of scope at the network level, which
+  // made vol_mcap_ratio structurally null on every row and in the CSV export.
+  test("fills vol_mcap_ratio per netuid from the market-cap index, and only where the index has one", () => {
+    const data = buildChainAlphaVolume(ROWS, {
+      // netuid 3 deliberately absent: a partial index must not invent a value.
+      marketCapByNetuid: new Map([
+        [1, 1000],
+        [2, 500],
+      ]),
+    });
+    const byNetuid = new Map(data.subnets.map((s) => [s.netuid, s]));
+    // 130/1000 and 100/500, each rounded to 6dp by volMcapRatio.
+    assert.equal(byNetuid.get(1)!.vol_mcap_ratio, 0.13);
+    assert.equal(byNetuid.get(2)!.vol_mcap_ratio, 0.2);
+    assert.equal(byNetuid.get(3)!.vol_mcap_ratio, null);
+    // The ratio is never a sort key: ranking stays on total_volume_tao, so a
+    // partial index cannot reorder the leaderboard. netuid 2 has the highest
+    // ratio here and still sits second.
+    assert.deepEqual(
+      data.subnets.map((s) => s.netuid),
+      [1, 2, 3],
+    );
   });
 
   test("a subnet with only one event kind (single-sided volume) shapes correctly", () => {

--- a/tests/market-cap-index.test.ts
+++ b/tests/market-cap-index.test.ts
@@ -1,0 +1,180 @@
+// src/market-cap-index.ts (#9526) — the chain-level alpha_market_cap_tao index
+// that gives get_chain_alpha_volume's vol_mcap_ratio a denominator.
+//
+// The contract under test is deliberately forgiving in one direction and strict
+// in the other: a tier that cannot answer costs a null ratio (an empty index),
+// never a thrown read, because the leaderboard is useful without the ratio and
+// useless if the request fails. But an unusable denominator is DROPPED rather
+// than stored — a zero or negative market cap would otherwise be divided by.
+import assert from "node:assert/strict";
+import { beforeEach, test } from "vitest";
+import { resolveMarketCapIndex } from "../src/market-cap-index.ts";
+import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.ts";
+
+type Row = Record<string, unknown>;
+
+// resolveLiveEconomics accepts the blob only when it is on-contract, fresh, and
+// internally consistent (row count matches the summary, emission_share sums to
+// ~1). Build one that passes all three so the live tier is genuinely exercised
+// rather than silently falling through to the artifact.
+function liveBlob(subnets: Row[], contract: string) {
+  return {
+    contract_version: contract,
+    captured_at: new Date().toISOString(),
+    subnet_count: subnets.length,
+    subnets,
+  };
+}
+
+function subnet(netuid: number, marketCap: unknown, share: number): Row {
+  return {
+    netuid,
+    alpha_market_cap_tao: marketCap,
+    emission_share: share,
+  };
+}
+
+let kvStore: Map<string, unknown>;
+let artifactBody: Row | null;
+let artifactOk: boolean;
+
+function env() {
+  return {
+    METAGRAPH_CONTRACT_VERSION: "v1",
+    // readHealthKv reads METAGRAPH_CONTROL with { type: "json" }, so the
+    // binding hands back a parsed object, not text.
+    METAGRAPH_CONTROL: {
+      async get(key: string) {
+        const value = kvStore.get(key);
+        return value === undefined ? null : value;
+      },
+    },
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        if (!artifactOk) return null;
+        return { json: async () => artifactBody };
+      },
+    },
+  } as unknown as Env;
+}
+
+beforeEach(() => {
+  kvStore = new Map();
+  artifactBody = null;
+  artifactOk = false;
+});
+
+test("returns an empty index when there is no env at all", async () => {
+  const index = await resolveMarketCapIndex(null);
+  assert.equal(index.size, 0);
+  assert.equal(index.get(1), undefined);
+});
+
+test("indexes every usable alpha_market_cap_tao from the live KV tier", async () => {
+  kvStore.set(
+    KV_ECONOMICS_CURRENT,
+    liveBlob([subnet(1, 1000, 0.5), subnet(2, 250.5, 0.5)], "v1"),
+  );
+  const index = await resolveMarketCapIndex(env());
+  assert.equal(index.get(1), 1000);
+  assert.equal(index.get(2), 250.5);
+  assert.equal(index.size, 2);
+});
+
+// Each of these would divide into a wrong or infinite ratio, so the key is left
+// absent — vol_mcap_ratio's own guard then renders it null, which is the honest
+// "no denominator" answer rather than a fabricated number.
+test("drops rows whose market cap cannot be a denominator", async () => {
+  kvStore.set(
+    KV_ECONOMICS_CURRENT,
+    liveBlob(
+      [
+        subnet(1, 0, 0.2), // zero
+        subnet(2, -5, 0.2), // negative
+        subnet(3, null, 0.2), // absent
+        subnet(4, "1000", 0.2), // string, not a number
+        subnet(5, Number.NaN, 0.1),
+        subnet(6, 42, 0.1), // the only usable one
+      ],
+      "v1",
+    ),
+  );
+  const index = await resolveMarketCapIndex(env());
+  assert.deepEqual([...index.entries()], [[6, 42]]);
+});
+
+test("drops rows whose netuid is not a non-negative integer", async () => {
+  kvStore.set(
+    KV_ECONOMICS_CURRENT,
+    liveBlob(
+      [
+        { netuid: -1, alpha_market_cap_tao: 10, emission_share: 0.25 },
+        { netuid: 1.5, alpha_market_cap_tao: 10, emission_share: 0.25 },
+        { netuid: "x", alpha_market_cap_tao: 10, emission_share: 0.25 },
+        { netuid: 0, alpha_market_cap_tao: 10, emission_share: 0.25 },
+      ],
+      "v1",
+    ),
+  );
+  const index = await resolveMarketCapIndex(env());
+  // netuid 0 is root and a legitimate key — the guard is >= 0, not > 0.
+  assert.deepEqual([...index.entries()], [[0, 10]]);
+});
+
+test("falls back to the R2 economics artifact when the live tier is off-contract", async () => {
+  // A blob written under an older contract: resolveLiveEconomics declines it.
+  kvStore.set(
+    KV_ECONOMICS_CURRENT,
+    liveBlob([subnet(1, 999, 1)], "v0-stale-contract"),
+  );
+  artifactOk = true;
+  artifactBody = { subnets: [subnet(7, 777, 1)] };
+  const index = await resolveMarketCapIndex(env());
+  assert.equal(index.get(7), 777);
+  assert.equal(
+    index.get(1),
+    undefined,
+    "the off-contract KV blob must not win",
+  );
+});
+
+test("falls back to the artifact when the live tier has no usable rows", async () => {
+  kvStore.set(KV_ECONOMICS_CURRENT, liveBlob([subnet(1, 0, 1)], "v1"));
+  artifactOk = true;
+  artifactBody = { subnets: [subnet(3, 33, 1)] };
+  const index = await resolveMarketCapIndex(env());
+  assert.deepEqual([...index.entries()], [[3, 33]]);
+});
+
+test("returns an empty index when neither tier answers", async () => {
+  artifactOk = false;
+  const index = await resolveMarketCapIndex(env());
+  assert.equal(index.size, 0);
+});
+
+test("returns an empty index when the artifact body has no subnets array", async () => {
+  artifactOk = true;
+  artifactBody = { subnets: "not-an-array" } as unknown as Row;
+  const index = await resolveMarketCapIndex(env());
+  assert.equal(index.size, 0);
+});
+
+// The leaderboard is worth serving without a ratio and worthless if the request
+// throws, so a store that blows up degrades to "no denominator".
+test("swallows a throwing store rather than failing the leaderboard", async () => {
+  const throwing = {
+    METAGRAPH_CONTRACT_VERSION: "v1",
+    METAGRAPH_CONTROL: {
+      async get() {
+        throw new Error("kv exploded");
+      },
+    },
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        throw new Error("r2 exploded");
+      },
+    },
+  } as unknown as Env;
+  const index = await resolveMarketCapIndex(throwing);
+  assert.equal(index.size, 0);
+});

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -144,6 +144,7 @@ import { loadChainCallsFromArtifact } from "../../src/chain-calls-artifact.ts";
 import { loadChainFeesFromArtifact } from "../../src/chain-fees-artifact.ts";
 import { loadChainSignersFromArtifact } from "../../src/chain-signers-artifact.ts";
 import { loadChainAlphaVolumeFromArtifact } from "../../src/chain-alpha-volume-artifact.ts";
+import { resolveMarketCapIndex } from "../../src/market-cap-index.ts";
 import { loadChainStakeTransfersFromArtifact } from "../../src/chain-stake-transfers-artifact.ts";
 import { loadChainTransferPairsFromArtifact } from "../../src/chain-transfer-pairs-artifact.ts";
 import { loadChainStakeMovesFromArtifact } from "../../src/chain-stake-moves-artifact.ts";
@@ -1925,7 +1926,14 @@ export async function handleChainAlphaVolume(
         // per-(netuid, event_kind) aggregate from the lakehouse; the shared
         // builder owns ranking and the limit. See
         // src/chain-alpha-volume-artifact.ts.
-        (await loadChainAlphaVolumeFromArtifact(env, { limit }, network)) ??
+        // marketCapByNetuid is vol_mcap_ratio's denominator (#9526), resolved
+        // here rather than inside the reader so an unreachable economics tier
+        // costs a null ratio and not the whole leaderboard.
+        (await loadChainAlphaVolumeFromArtifact(
+          env,
+          { limit, marketCapByNetuid: await resolveMarketCapIndex(env) },
+          network,
+        )) ??
         buildChainAlphaVolume([], {
           limit,
         } as unknown as Parameters<typeof buildChainAlphaVolume>[1]);


### PR DESCRIPTION
## Summary

`get_chain_alpha_volume` published `vol_mcap_ratio` on every subnet row and never filled it — `buildChainAlphaVolume` called `buildAlphaVolume` with no `marketCapTao`, so the finite-denominator guard in `src/alpha-volume.ts:106` nulled all 20 rows. The same empty column ships in the CSV export (`src/contracts.ts:6372`, `workers/request-handlers/analytics.ts:1163`), where a consumer cannot tell "this subnet has no market cap" from "this route never computes it".

## Measurement

```
get_subnet_volume(netuid=64)   ->  vol_mcap_ratio: 0.019622
get_chain_alpha_volume()       ->  vol_mcap_ratio: null on all 20 rows
```

Same metric, same formula. The subnet route resolves the denominator via `resolveSubnetMarketCapTao` — live economics KV, R2 `economics.json` fallback — and that blob is **already the full `subnets[]` array**; the subnet route just discards all but one entry. So the chain-level fill is one read and a keyed index, not N lookups.

## What changed

- **`src/market-cap-index.ts`** (new) — `resolveMarketCapIndex(env)` returns `Map<netuid, alpha_market_cap_tao>`, applying the same tier order and the same staleness/contract guards `resolveLiveEconomics` enforces, so a wedged or off-contract writer falls through to the artifact rather than serving a frozen denominator.
- **`buildChainAlphaVolume`** takes an optional `marketCapByNetuid` and passes each subnet its own entry.
- **`loadChainAlphaVolumeFromArtifact`** passes it straight through.
- **MCP + REST handlers** resolve the index and hand it in.

## Design notes

**An unusable market cap is dropped, not stored.** Zero, negative, non-numeric, or a bad netuid → the key is absent, so `vol_mcap_ratio` stays null. A missing key reads as "no denominator", which is what it is.

**Resolved by the callers, not inside the artifact reader.** That reader's contract is "shape the artifact or decline"; reaching into the economics tier from within it would let a second store fail a read the artifact can answer. An unreachable economics tier costs a null ratio, never the leaderboard.

**Ranking is unaffected.** Subnets sort by `total_volume_tao`, tie-broken by netuid — never by the ratio — so a partial index cannot reorder the board. The test pins this with a netuid deliberately absent from the index, and asserts the order is unchanged even though the absent subnet is not last by ratio.

**No `try/catch` in the resolver.** `readHealthKv` and `readArtifact` already degrade to a miss on their own, so wrapping them adds a branch nothing can reach. The test explodes both bindings to pin the guarantee where it actually lives.

**GraphQL untouched.** Its chain-alpha-volume resolver never reached the projection tier and returns a zeroed card, so it has no rows to price. Out of scope here.

## Coverage

`src/market-cap-index.ts` — **100% lines, 100% branches, 100% statements** (9 tests, measured with `--coverage.include`).

## Validation

```
npm run lint            npm run format:check      npm run typecheck
npm run validate        npm run scan:public-safety
npx vitest run tests/market-cap-index.test.ts tests/chain-alpha-volume.test.ts \
  tests/alpha-volume.test.ts tests/chain-alpha-volume-artifact.test.ts \
  tests/subnet-alpha-volume-artifact.test.ts
  -> 91 passed
```

Rebased onto current `main`.

Closes #9526