### PR TITLE
fix(watchdog): give the neurons and validator-nominator-counts lanes a coverage signal

### DIFF
--- a/src/neurons-staleness-watchdog.ts
+++ b/src/neurons-staleness-watchdog.ts
@@ -11,6 +11,36 @@
 // exception event per tick (route watchdog:neurons-staleness), which is the
 // project's alert channel; the cron summary carries the age either way so a
 // healthy check is still legible.
+//
+// ## COVERAGE IS COUNTED IN NETUIDS HERE, NOT ROWS
+//
+// #9530 established that `MAX(captured_at)` cannot distinguish a complete pass
+// from a truncated one, after 147,000 account_balances rows -- 48% of the
+// network -- reported `ok | age=0.6h` in production. This lane has the same
+// blind spot by a DIFFERENT mechanism, and the mechanism is what picks the
+// unit.
+//
+// There is no chunked upload to truncate: NEURONS_SYNC_MAX_ROWS is 50,000 and
+// the whole metagraph is at most 129 subnets x 256 UIDs = 33,024 rows (30,103
+// measured 2026-08-05), so a pass is always ONE request. The hazard is upstream
+// of that -- the producer scans netuid by netuid over RPC, and this lane's
+// writer (src/neurons-d1-write.ts) prunes PER NETUID: it deletes the UIDs its
+// batch did not refresh, but only within the netuids the batch contains. A
+// netuid absent from the payload is left completely untouched, still carrying
+// its previous stamp. So a scan that dies at netuid 40 posts a well-formed
+// request, restamps 40 subnets, and leaves 89 serving data a pass old behind a
+// `MAX(captured_at)` that just advanced.
+//
+// ROWS WOULD BE THE WRONG UNIT for that. Subnets vary from 64 to 256 UIDs, so a
+// scan that died after the largest 60 could show high row coverage while having
+// missed more than half the network. Netuids covered is what the producer
+// actually iterates, so it is what a partial pass is partial IN. Measured
+// 2026-08-05: 129 of 129 netuids at the newest stamp, a single vintage across
+// the whole table -- the prune keeps it that way when a pass completes, which
+// is also why any vintage spread at all is a signal here.
+//
+// COST: one walk of ~30k rows on a `6,21,36,51 * * * *` cron, 96 ticks a day,
+// so ~2.9M D1 rows read a day.
 
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
@@ -20,44 +50,140 @@ import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
  * a stall. */
 export const NEURONS_STALENESS_THRESHOLD_MS = 45 * 60 * 1000;
 
+/**
+ * How many subnets a COMPLETE pass is expected to cover.
+ *
+ * 129, read off production D1 on 2026-08-05 as `COUNT(DISTINCT netuid)` at the
+ * newest stamp, and matching the 129 native subnets `npm run validate` reports
+ * from the registry -- two independent counts of the same thing.
+ */
+export const NEURONS_EXPECTED_NETUIDS = 129;
+
+/**
+ * How much of that a single pass must cover before it counts as complete.
+ *
+ * EIGHTY PERCENT (~103 subnets), the same ratio the sibling lanes use, and the
+ * slack here is doing real work rather than being copied: the subnet count is
+ * not fixed. New subnets register, and a floor sized exactly to today's 129
+ * would be a floor that has to be edited every time the network grows. Sized
+ * this way it only ever gets SLACKER as subnets are added, never tighter, which
+ * is the safe direction -- the #9301 rule that an alarm firing on a working
+ * lane stops being read.
+ *
+ * The cost of that slack is the honest one: a scan that dies in its last 20% of
+ * subnets is not caught. It is bounded, visible, and far better than the
+ * present state of not catching a scan that dies at 30%.
+ *
+ * Overridable via NEURONS_COVERAGE_FLOOR_NETUIDS -- and note this is the number
+ * to LOWER if the network ever contracts below it, not a number to chase upward
+ * as subnets are added.
+ */
+export const NEURONS_COVERAGE_FLOOR_RATIO = 0.8;
+
+/** The floor the rule compares against, ~103 subnets. */
+export const NEURONS_COVERAGE_FLOOR_NETUIDS = Math.round(
+  NEURONS_EXPECTED_NETUIDS * NEURONS_COVERAGE_FLOOR_RATIO,
+);
+
+/**
+ * How far back from the newest stamp still counts as "the newest pass".
+ *
+ * FIVE MINUTES, a third of the producer's 15-minute tick. Bounded from both
+ * ends like its siblings, but the ceiling binds much harder here because the
+ * cadence is so short: anything at or over 15 minutes would merge two ticks
+ * into one coverage count, letting a half-scanned pass sitting on a complete
+ * one report full coverage -- exactly the bug this is closing. The floor is
+ * comfortable in the other direction, since a pass arrives as a single request
+ * and therefore carries a single stamp (measured: one vintage across all 30,103
+ * rows).
+ *
+ * Overridable via NEURONS_PASS_WINDOW_MS, which must be re-sized against the
+ * poller's tick if that tick ever changes.
+ */
+export const NEURONS_PASS_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * One read, answering both questions: how fresh the newest pass is, and how
+ * many subnets it actually reached.
+ *
+ * `total` is the netuid count across ALL vintages -- context rather than the
+ * rule. Read together the pair is the diagnosis: `covered` well under `total`
+ * is a scan that died partway through the network.
+ */
+const NEURONS_COVERAGE_SQL =
+  "SELECT COUNT(DISTINCT netuid) AS total, MAX(captured_at) AS latest, " +
+  "COUNT(DISTINCT CASE WHEN captured_at >= " +
+  "(SELECT MAX(captured_at) FROM neurons) - ? THEN netuid END) AS covered " +
+  "FROM neurons";
+
+export type NeuronsStalenessReason = "no_rows" | "stale" | "partial" | null;
+
 export interface NeuronsStalenessVerdict {
   stale: boolean;
-  reason: "no_rows" | "stale" | null;
+  reason: NeuronsStalenessReason;
   age_ms: number | null;
   latest_captured_at: number | null;
   threshold_ms: number;
+  /** Subnets the newest pass covered. The coverage signal itself. */
+  covered_netuids: number;
+  /** Subnets present in the table across all vintages. Context, never the rule. */
+  total_netuids: number;
+  coverage_floor_netuids: number;
 }
 
 /** The rule alone, testable without a database or a clock. */
 export function evaluateNeuronsStaleness(input: {
   latestCapturedAtMs: number | null;
+  coveredNetuids: number;
+  totalNetuids: number;
   nowMs: number;
   thresholdMs: number;
+  coverageFloorNetuids: number;
 }): NeuronsStalenessVerdict {
-  const { latestCapturedAtMs, nowMs, thresholdMs } = input;
-  if (latestCapturedAtMs === null) {
-    // An empty table is a stall of infinite age, not a healthy quiet one.
-    return {
-      stale: true,
-      reason: "no_rows",
-      age_ms: null,
-      latest_captured_at: null,
-      threshold_ms: thresholdMs,
-    };
-  }
-  const age = nowMs - latestCapturedAtMs;
-  return {
-    stale: age > thresholdMs,
-    reason: age > thresholdMs ? "stale" : null,
-    age_ms: age,
+  const {
+    latestCapturedAtMs,
+    coveredNetuids,
+    totalNetuids,
+    nowMs,
+    thresholdMs,
+    coverageFloorNetuids,
+  } = input;
+  const base = {
     latest_captured_at: latestCapturedAtMs,
     threshold_ms: thresholdMs,
+    covered_netuids: coveredNetuids,
+    total_netuids: totalNetuids,
+    coverage_floor_netuids: coverageFloorNetuids,
   };
+  if (latestCapturedAtMs === null) {
+    // An empty table is a stall of infinite age, not a healthy quiet one.
+    return { ...base, stale: true, reason: "no_rows", age_ms: null };
+  }
+  const age = nowMs - latestCapturedAtMs;
+  if (age > thresholdMs) {
+    // Checked BEFORE coverage: if the Container has missed three ticks, the
+    // coverage number describes an old pass and the headline is that it stopped.
+    return { ...base, stale: true, reason: "stale", age_ms: age };
+  }
+  if (coveredNetuids < coverageFloorNetuids) {
+    // Recent AND short -- a scan that died partway through the netuid walk,
+    // leaving the subnets it never reached behind a freshly advanced MAX().
+    return { ...base, stale: true, reason: "partial", age_ms: age };
+  }
+  return { ...base, stale: false, reason: null, age_ms: age };
+}
+
+/** A null count over no rows, or a shim that stringifies, must land on 0 rather
+ * than NaN -- a NaN compares false against the floor and would report a
+ * half-scanned network healthy. */
+function countOrZero(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
 }
 
 interface D1Like {
   prepare(sql: string): {
-    first(): Promise<unknown>;
+    bind(...values: unknown[]): { first(): Promise<unknown> };
   };
 }
 
@@ -87,25 +213,43 @@ export async function runNeuronsStalenessWatchdog(
   const thresholdMs =
     Number(env?.NEURONS_STALENESS_THRESHOLD_MS) ||
     NEURONS_STALENESS_THRESHOLD_MS;
+  const passWindowMs =
+    Number(env?.NEURONS_PASS_WINDOW_MS) || NEURONS_PASS_WINDOW_MS;
+  const coverageFloorNetuids =
+    Number(env?.NEURONS_COVERAGE_FLOOR_NETUIDS) ||
+    NEURONS_COVERAGE_FLOOR_NETUIDS;
 
   try {
     const row = (await db
-      .prepare("SELECT MAX(captured_at) AS latest FROM neurons")
-      .first()) as { latest: number | null } | null;
+      .prepare(NEURONS_COVERAGE_SQL)
+      .bind(passWindowMs)
+      .first()) as {
+      latest: number | null;
+      covered: number | null;
+      total: number | null;
+    } | null;
     const verdict = evaluateNeuronsStaleness({
       latestCapturedAtMs: row?.latest ?? null,
+      coveredNetuids: countOrZero(row?.covered),
+      totalNetuids: countOrZero(row?.total),
       nowMs: now(),
       thresholdMs,
+      coverageFloorNetuids,
     });
     if (verdict.stale) {
+      // The two faults get different wording on purpose -- "the Container
+      // stopped" and "the Container is running and the scan is not finishing"
+      // send whoever reads the alert to different places.
       const age =
         verdict.age_ms === null
           ? "no rows at all"
           : `${(verdict.age_ms / 60_000).toFixed(1)} min old`;
+      const message =
+        verdict.reason === "partial"
+          ? `neurons lane truncated: the newest pass covered only ${verdict.covered_netuids} of ${verdict.total_netuids} subnets against a floor of ${verdict.coverage_floor_netuids} (newest stamp ${age}) -- the capture is RECENT and PARTIAL, so every route over a subnet the scan never reached is serving a pass-old metagraph behind a MAX(captured_at) that just advanced`
+          : `neurons lane stalled: latest snapshot is ${age} (threshold ${thresholdMs / 60_000} min) -- the poller Container has missed at least three ticks`;
       await record(env as never, {
-        error: new Error(
-          `neurons lane stalled: latest snapshot is ${age} (threshold ${thresholdMs / 60_000} min) -- the poller Container has missed at least three ticks`,
-        ),
+        error: new Error(message),
         route: "watchdog:neurons-staleness",
         errorCode: "stale_lane",
       }).catch(() => false);

--- a/src/validator-nominator-counts-staleness-watchdog.ts
+++ b/src/validator-nominator-counts-staleness-watchdog.ts
@@ -10,9 +10,38 @@
 //
 // Same shape as src/nominator-positions-staleness-watchdog.ts deliberately --
 // its sibling from the SAME producer scan -- and as
-// src/neurons-staleness-watchdog.ts before it: one MAX() read, a pure rule, a
+// src/neurons-staleness-watchdog.ts before it: a single read, a pure rule, a
 // summary rather than a throw, and one exception event per stale tick on the
 // project's alert channel. Zero alerts is the correct steady state.
+//
+// ## COVERAGE, because freshness alone cannot see a truncated pass
+//
+// This lane has the SAME structural blind spot #9530 fixed on
+// src/account-balances-staleness-watchdog.ts, and for the same reason rather
+// than by analogy: src/validator-nominator-counts-d1-write.ts is explicitly NO
+// PRUNE, so a chunked pass that dies partway upserts the rows it reached to a
+// new stamp and leaves the rest at the old one. `MAX(captured_at)` reads the
+// rows that DID land, reports them genuinely fresh, and says nothing about the
+// ones that did not. On account_balances that failure reached production:
+// 147,000 rows -- 48% of the network -- reported `ok | age=0.6h`.
+//
+// So this watchdog also counts the hotkeys the NEWEST pass wrote, against a
+// floor sized to the scan. Counting the pass rather than the table is the whole
+// point: with no prune, a truncated pass cannot shrink the table, so a
+// whole-table `COUNT(*)` floor reads the full population and reports fine. See
+// the account-balances module header for why a producer-published completeness
+// marker loses here too (a pass that dies never sends its marker, which puts
+// the watchdog back to inferring from an absence of report -- the check that
+// already said `ok`).
+//
+// MEASURED 2026-08-05, production D1: 112,250 rows total across three vintages
+// -- 112,245 at the newest stamp, then 1 and 4 rows at two older ones. Those
+// five stragglers are the no-prune behaviour working as designed (a hotkey the
+// latest scan did not re-send keeps its last known count), and they are why
+// coverage is counted over a WINDOW rather than an exact stamp match.
+//
+// COST: one walk of ~112k rows on a `19,49 * * * *` cron, 48 ticks a day, so
+// ~5.4M D1 rows read a day.
 
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
@@ -38,48 +67,150 @@ import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 export const VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS =
   30 * 60 * 60 * 1000;
 
+/**
+ * How many hotkeys a COMPLETE pass is expected to write.
+ *
+ * 112,245, read off production D1 on 2026-08-05 as the row count at the newest
+ * `captured_at`. The table is keyed on (hotkey) alone, so a row IS a hotkey --
+ * every hotkey the SubtensorModule::Alpha scan found with at least one
+ * nominator.
+ */
+export const VALIDATOR_NOMINATOR_COUNTS_EXPECTED_HOTKEYS = 112_245;
+
+/**
+ * How much of that a single pass must cover before it counts as complete.
+ *
+ * EIGHTY PERCENT, placed against the chunking rather than picked round: the
+ * sync route caps a request at 25,000 rows, so a full pass is ~5 requests and a
+ * death partway lands near 25k / 50k / 75k / 100k. This floor (~89,800) catches
+ * every one of those but the last, which is the right trade -- tightening it
+ * far enough to catch a 4-of-5 death would put the alarm inside the noise band
+ * of ordinary population change.
+ *
+ * THE DRIFT DIRECTION IS DIFFERENT HERE than on account_balances, and worth
+ * knowing before retuning. That lane's expectation only grows (it counts
+ * accounts that have EVER held a balance). This one counts hotkeys with a
+ * nominator RIGHT NOW, which can genuinely shrink as delegation concentrates or
+ * miners deregister. So if this ever fires MARGINALLY -- a covered count a few
+ * percent under the floor, on a lane that is otherwise healthy -- the answer is
+ * to re-measure the population and lower this, not to go hunting for a
+ * truncated pass. A death mid-scan looks nothing like that; it lands near a
+ * chunk boundary, far below.
+ *
+ * Overridable via VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS.
+ */
+export const VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_RATIO = 0.8;
+
+/** The floor the rule compares against, ~89,796 hotkeys. */
+export const VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS = Math.round(
+  VALIDATOR_NOMINATOR_COUNTS_EXPECTED_HOTKEYS *
+    VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_RATIO,
+);
+
+/**
+ * How far back from the newest stamp still counts as "the newest pass".
+ *
+ * FOUR HOURS, bounded from both ends like its account-balances counterpart but
+ * against a much slower producer. Too small and the intra-pass spread reads as
+ * several partial passes (the scan itself is ~4 minutes at the measured ~3,100
+ * rows/sec, so four hours is three orders of magnitude of headroom); too large
+ * and two consecutive passes merge into one coverage count, which would let a
+ * truncated pass sitting on a complete one report full coverage and restore the
+ * bug. VALIDATOR_NOMINATORS_POLL_SECS is 24 h, so this is a sixth of the
+ * cadence -- nowhere near able to merge two passes.
+ *
+ * Overridable via VALIDATOR_NOMINATOR_COUNTS_PASS_WINDOW_MS, which must be
+ * re-sized against the poll interval if that interval ever shortens.
+ */
+export const VALIDATOR_NOMINATOR_COUNTS_PASS_WINDOW_MS = 4 * 60 * 60 * 1000;
+
+/**
+ * One read, answering both questions: how fresh the newest pass is, and how
+ * many hotkeys it actually reached.
+ *
+ * `total` is not used by the rule -- it rides along free on the same walk and
+ * is what tells an operator how many older-vintage rows are sitting underneath
+ * a partial pass.
+ */
+const VALIDATOR_NOMINATOR_COUNTS_COVERAGE_SQL =
+  "SELECT COUNT(*) AS total, MAX(captured_at) AS latest, " +
+  "SUM(CASE WHEN captured_at >= " +
+  "(SELECT MAX(captured_at) FROM validator_nominator_counts) - ? " +
+  "THEN 1 ELSE 0 END) AS covered FROM validator_nominator_counts";
+
+export type ValidatorNominatorCountsStalenessReason =
+  "no_rows" | "stale" | "partial" | null;
+
 export interface ValidatorNominatorCountsStalenessVerdict {
   stale: boolean;
-  reason: "no_rows" | "stale" | null;
+  reason: ValidatorNominatorCountsStalenessReason;
   age_ms: number | null;
   latest_captured_at: number | null;
   threshold_ms: number;
+  /** Hotkeys the newest pass wrote. The coverage signal itself. */
+  covered_rows: number;
+  /** Hotkeys in the table across all vintages. Context, never the rule. */
+  total_rows: number;
+  coverage_floor_rows: number;
 }
 
 /** The rule alone, testable without a database or a clock. */
 export function evaluateValidatorNominatorCountsStaleness(input: {
   latestCapturedAtMs: number | null;
+  coveredRows: number;
+  totalRows: number;
   nowMs: number;
   thresholdMs: number;
+  coverageFloorRows: number;
 }): ValidatorNominatorCountsStalenessVerdict {
-  const { latestCapturedAtMs, nowMs, thresholdMs } = input;
+  const {
+    latestCapturedAtMs,
+    coveredRows,
+    totalRows,
+    nowMs,
+    thresholdMs,
+    coverageFloorRows,
+  } = input;
+  const base = {
+    latest_captured_at: latestCapturedAtMs,
+    threshold_ms: thresholdMs,
+    covered_rows: coveredRows,
+    total_rows: totalRows,
+    coverage_floor_rows: coverageFloorRows,
+  };
   if (latestCapturedAtMs === null) {
     // An empty table is a stall of infinite age, not a healthy quiet one --
     // and here it is also the CUTOVER state, before the re-enabled lane has
     // posted anything. That is exactly the condition worth alerting on: an
     // empty hot tier means every nominator_count is still being filled from
     // the frozen lakehouse mirror, or left null outright.
-    return {
-      stale: true,
-      reason: "no_rows",
-      age_ms: null,
-      latest_captured_at: null,
-      threshold_ms: thresholdMs,
-    };
+    return { ...base, stale: true, reason: "no_rows", age_ms: null };
   }
   const age = nowMs - latestCapturedAtMs;
-  return {
-    stale: age > thresholdMs,
-    reason: age > thresholdMs ? "stale" : null,
-    age_ms: age,
-    latest_captured_at: latestCapturedAtMs,
-    threshold_ms: thresholdMs,
-  };
+  if (age > thresholdMs) {
+    // Checked BEFORE coverage: if the producer has missed a whole pass, the
+    // coverage number describes an old one and the headline is that it stopped.
+    return { ...base, stale: true, reason: "stale", age_ms: age };
+  }
+  if (coveredRows < coverageFloorRows) {
+    // Recent AND short -- a pass that ran and did not finish, leaving a table
+    // that reads fresh from its MAX() alone.
+    return { ...base, stale: true, reason: "partial", age_ms: age };
+  }
+  return { ...base, stale: false, reason: null, age_ms: age };
+}
+
+/** A null SUM over no rows, or a shim that stringifies, must land on 0 rather
+ * than NaN -- a NaN compares false against the floor and would report a
+ * truncated table healthy. */
+function countOrZero(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
 }
 
 interface D1Like {
   prepare(sql: string): {
-    first(): Promise<unknown>;
+    bind(...values: unknown[]): { first(): Promise<unknown> };
   };
 }
 
@@ -109,27 +240,44 @@ export async function runValidatorNominatorCountsStalenessWatchdog(
   const thresholdMs =
     Number(env?.VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS) ||
     VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS;
+  const passWindowMs =
+    Number(env?.VALIDATOR_NOMINATOR_COUNTS_PASS_WINDOW_MS) ||
+    VALIDATOR_NOMINATOR_COUNTS_PASS_WINDOW_MS;
+  const coverageFloorRows =
+    Number(env?.VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS) ||
+    VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS;
 
   try {
     const row = (await db
-      .prepare(
-        "SELECT MAX(captured_at) AS latest FROM validator_nominator_counts",
-      )
-      .first()) as { latest: number | null } | null;
+      .prepare(VALIDATOR_NOMINATOR_COUNTS_COVERAGE_SQL)
+      .bind(passWindowMs)
+      .first()) as {
+      latest: number | null;
+      covered: number | null;
+      total: number | null;
+    } | null;
     const verdict = evaluateValidatorNominatorCountsStaleness({
       latestCapturedAtMs: row?.latest ?? null,
+      coveredRows: countOrZero(row?.covered),
+      totalRows: countOrZero(row?.total),
       nowMs: now(),
       thresholdMs,
+      coverageFloorRows,
     });
     if (verdict.stale) {
+      // The two faults get different wording on purpose -- "the producer
+      // stopped" and "the producer is running and not finishing" send whoever
+      // reads the alert to different places.
       const age =
         verdict.age_ms === null
           ? "no rows at all"
           : `${(verdict.age_ms / 3_600_000).toFixed(1)} h old`;
+      const message =
+        verdict.reason === "partial"
+          ? `validator-nominator-counts lane truncated: the newest pass reached only ${verdict.covered_rows} hotkeys against a floor of ${verdict.coverage_floor_rows} (${verdict.total_rows} rows in the table, newest stamp ${age}) -- the capture is RECENT and PARTIAL, so /validators serves a nominator_count that is silently a pass old for every hotkey the scan never got to`
+          : `validator-nominator-counts lane stalled: latest snapshot is ${age} (threshold ${thresholdMs / 3_600_000} h) -- /validators is serving nominator_count from a table nothing is refreshing`;
       await record(env as never, {
-        error: new Error(
-          `validator-nominator-counts lane stalled: latest snapshot is ${age} (threshold ${thresholdMs / 3_600_000} h) -- /validators is serving nominator_count from a table nothing is refreshing`,
-        ),
+        error: new Error(message),
         route: "watchdog:validator-nominator-counts-staleness",
         errorCode: "stale_lane",
       }).catch(() => false);

--- a/tests/neurons-staleness-watchdog.test.ts
+++ b/tests/neurons-staleness-watchdog.test.ts
@@ -2,9 +2,19 @@
 // cron wiring. The rule's edges are the point: one restarted container is a
 // missed tick by design and must NOT alert; three missed ticks is a stall and
 // MUST; and an empty table is a stall of infinite age, never a healthy quiet.
+//
+// The COVERAGE edge is not about time at all, and its unit is NETUIDS rather
+// than rows: the writer prunes per-netuid, so a scan that dies partway through
+// the netuid walk leaves the subnets it never reached completely untouched,
+// behind a MAX(captured_at) that just advanced. Rows would hide that -- subnets
+// run 64 to 256 UIDs, so a scan that died after the largest ones could show
+// high row coverage having missed half the network.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  NEURONS_COVERAGE_FLOOR_NETUIDS,
+  NEURONS_EXPECTED_NETUIDS,
+  NEURONS_PASS_WINDOW_MS,
   NEURONS_STALENESS_THRESHOLD_MS,
   evaluateNeuronsStaleness,
   runNeuronsStalenessWatchdog,
@@ -13,18 +23,32 @@ import { handleScheduled } from "../workers/api.ts";
 import * as workerConfig from "../workers/config.ts";
 
 const NOW = 1_785_800_000_000;
+/** A pass that covered the network, so coverage is never the thing under test
+ * unless a case says so. */
+const FULL = NEURONS_EXPECTED_NETUIDS;
 
-function fakeDb(latest: number | null | Error) {
+function fakeDb(
+  latest: number | null | Error,
+  covered: number = FULL,
+  total: number = FULL,
+) {
   const queries: string[] = [];
+  const binds: unknown[][] = [];
   return {
     queries,
+    binds,
     db: {
       prepare(sql: string) {
         queries.push(sql);
         return {
-          async first() {
-            if (latest instanceof Error) throw latest;
-            return { latest };
+          bind(...values: unknown[]) {
+            binds.push(values);
+            return {
+              async first() {
+                if (latest instanceof Error) throw latest;
+                return { latest, covered, total };
+              },
+            };
           },
         };
       },
@@ -32,35 +56,120 @@ function fakeDb(latest: number | null | Error) {
   };
 }
 
+/** The rule's inputs with everything healthy, so each case overrides only the
+ * one field it is about. */
+function inputs(
+  over: Partial<Parameters<typeof evaluateNeuronsStaleness>[0]> = {},
+) {
+  return {
+    latestCapturedAtMs: NOW - 5 * 60_000,
+    coveredNetuids: FULL,
+    totalNetuids: FULL,
+    nowMs: NOW,
+    thresholdMs: NEURONS_STALENESS_THRESHOLD_MS,
+    coverageFloorNetuids: NEURONS_COVERAGE_FLOOR_NETUIDS,
+    ...over,
+  };
+}
+
 describe("evaluateNeuronsStaleness", () => {
   test("one missed tick is quiet, three is a stall", () => {
-    const oneTick = evaluateNeuronsStaleness({
-      latestCapturedAtMs: NOW - 20 * 60_000,
-      nowMs: NOW,
-      thresholdMs: NEURONS_STALENESS_THRESHOLD_MS,
-    });
+    const oneTick = evaluateNeuronsStaleness(
+      inputs({ latestCapturedAtMs: NOW - 20 * 60_000 }),
+    );
     assert.equal(oneTick.stale, false);
     assert.equal(oneTick.reason, null);
     assert.equal(oneTick.age_ms, 20 * 60_000);
 
-    const stalled = evaluateNeuronsStaleness({
-      latestCapturedAtMs: NOW - 46 * 60_000,
-      nowMs: NOW,
-      thresholdMs: NEURONS_STALENESS_THRESHOLD_MS,
-    });
+    const stalled = evaluateNeuronsStaleness(
+      inputs({ latestCapturedAtMs: NOW - 46 * 60_000 }),
+    );
     assert.equal(stalled.stale, true);
     assert.equal(stalled.reason, "stale");
   });
 
   test("an empty table is a stall of infinite age", () => {
-    const verdict = evaluateNeuronsStaleness({
-      latestCapturedAtMs: null,
-      nowMs: NOW,
-      thresholdMs: NEURONS_STALENESS_THRESHOLD_MS,
-    });
+    const verdict = evaluateNeuronsStaleness(
+      inputs({ latestCapturedAtMs: null, coveredNetuids: 0, totalNetuids: 0 }),
+    );
     assert.equal(verdict.stale, true);
     assert.equal(verdict.reason, "no_rows");
     assert.equal(verdict.age_ms, null);
+  });
+
+  test("HALF THE SUBNETS RECENTLY and ALL THE SUBNETS RECENTLY are told apart", () => {
+    // The acceptance criterion. Both ticks carry an identically fresh
+    // MAX(captured_at); the ONLY difference is how far into the netuid walk the
+    // scan got, which is exactly what a timestamp cannot express.
+    const half = evaluateNeuronsStaleness(
+      inputs({ coveredNetuids: 64, totalNetuids: FULL }),
+    );
+    assert.equal(
+      half.stale,
+      true,
+      "a half-scanned network must not read as ok",
+    );
+    assert.equal(half.reason, "partial");
+    // Recent, not old -- caught WITHOUT any time passing.
+    assert.equal(half.age_ms, 5 * 60_000);
+    assert.ok(half.age_ms < half.threshold_ms);
+
+    const whole = evaluateNeuronsStaleness(inputs());
+    assert.equal(whole.stale, false);
+    assert.equal(whole.reason, null);
+    assert.equal(whole.age_ms, half.age_ms);
+  });
+
+  test("a scan that died at netuid 40 alerts, though every row it wrote is fresh", () => {
+    // The concrete mechanism: the per-netuid prune touches only the netuids in
+    // the payload, so 89 subnets keep a pass-old metagraph while MAX() advances.
+    const verdict = evaluateNeuronsStaleness(
+      inputs({ coveredNetuids: 40, totalNetuids: 129 }),
+    );
+    assert.equal(verdict.stale, true);
+    assert.equal(verdict.reason, "partial");
+    assert.equal(
+      verdict.total_netuids,
+      129,
+      "the table still knows 129 subnets",
+    );
+  });
+
+  test("a pass exactly at the floor is complete; one subnet under is not", () => {
+    // Strictly-less, matching the threshold edge, so a lane landing exactly on
+    // the floor never flaps.
+    const atFloor = evaluateNeuronsStaleness(
+      inputs({ coveredNetuids: NEURONS_COVERAGE_FLOOR_NETUIDS }),
+    );
+    assert.equal(atFloor.stale, false);
+    assert.equal(atFloor.reason, null);
+
+    const under = evaluateNeuronsStaleness(
+      inputs({ coveredNetuids: NEURONS_COVERAGE_FLOOR_NETUIDS - 1 }),
+    );
+    assert.equal(under.stale, true);
+    assert.equal(under.reason, "partial");
+  });
+
+  test("the floor only loosens as the network grows, never tightens", () => {
+    // Sized as a RATIO of a measured count rather than pinned to it, so new
+    // subnets registering can never turn a working lane into an alerting one.
+    // At 129 subnets the floor is ~80%; at 200 it is the same absolute number,
+    // which is slacker still.
+    assert.ok(NEURONS_COVERAGE_FLOOR_NETUIDS < NEURONS_EXPECTED_NETUIDS);
+    const grown = evaluateNeuronsStaleness(
+      inputs({ coveredNetuids: 200, totalNetuids: 200 }),
+    );
+    assert.equal(grown.stale, false);
+  });
+
+  test("a stalled lane reports `stale`, not `partial`, even when also short", () => {
+    // If the Container has missed three ticks, "it stopped" is the headline and
+    // the coverage of its last attempt is a detail.
+    const verdict = evaluateNeuronsStaleness(
+      inputs({ latestCapturedAtMs: NOW - 3 * 60 * 60_000, coveredNetuids: 40 }),
+    );
+    assert.equal(verdict.reason, "stale");
   });
 });
 
@@ -81,6 +190,110 @@ describe("runNeuronsStalenessWatchdog", () => {
     assert.equal(result.ok, true);
     assert.equal(result.alerted, false);
     assert.deepEqual(recorded, []);
+  });
+
+  test("the read counts subnets at the newest stamp, bounded by the pass window", () => {
+    // A window at or over the 15-minute tick would merge two passes into one
+    // coverage count, letting a half-scanned pass on top of a complete one
+    // report full coverage -- the bug this closes.
+    const { db, queries, binds } = fakeDb(NOW - 5 * 60_000);
+    return runNeuronsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW, recordException: (async () => true) as never },
+    ).then(() => {
+      assert.deepEqual(binds[0], [NEURONS_PASS_WINDOW_MS]);
+      assert.ok(
+        NEURONS_PASS_WINDOW_MS < 15 * 60_000,
+        "the window must stay under the poller's 15-minute tick",
+      );
+      // DISTINCT netuid, not COUNT(*) -- rows would hide a scan that died after
+      // the largest subnets.
+      assert.match(queries[0], /COUNT\(DISTINCT netuid\) AS total/);
+      assert.match(queries[0], /THEN netuid END\) AS covered/);
+      assert.match(
+        queries[0],
+        /captured_at >= \(SELECT MAX\(captured_at\) FROM neurons\) - \?/,
+      );
+    });
+  });
+
+  test("a recent but half-scanned network alerts, naming both counts", async () => {
+    const { db } = fakeDb(NOW - 5 * 60_000, 64, 129);
+    const recorded: { error?: Error; route?: string; errorCode?: string }[] =
+      [];
+    const result = await runNeuronsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async (_env: never, event: never) => {
+          recorded.push(event);
+          return true;
+        }) as never,
+      },
+    );
+    assert.equal(result.alerted, true);
+    assert.equal(result.reason, "partial");
+    assert.equal(result.covered_netuids, 64);
+    assert.equal(recorded.length, 1);
+    assert.equal(recorded[0].errorCode, "stale_lane");
+    const message = String(recorded[0].error?.message);
+    // Distinct wording from the stalled case -- different place to go looking.
+    assert.match(message, /truncated/);
+    assert.match(message, /64 of 129 subnets/);
+    assert.match(message, /RECENT and PARTIAL/);
+    assert.doesNotMatch(message, /missed at least three ticks/);
+  });
+
+  test("the env coverage-floor and pass-window overrides win over the defaults", async () => {
+    const { db, binds } = fakeDb(NOW - 5 * 60_000, 110, 129);
+    const raised = await runNeuronsStalenessWatchdog(
+      {
+        METAGRAPH_HEALTH_DB: db,
+        NEURONS_COVERAGE_FLOOR_NETUIDS: "120",
+        NEURONS_PASS_WINDOW_MS: "60000",
+      },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(raised.alerted, true);
+    assert.equal(raised.reason, "partial");
+    assert.equal(raised.coverage_floor_netuids, 120);
+    assert.deepEqual(binds[0], [60_000]);
+
+    // Lowered under the same reading, the identical tick is quiet.
+    const lowered = await runNeuronsStalenessWatchdog(
+      {
+        METAGRAPH_HEALTH_DB: fakeDb(NOW - 5 * 60_000, 110, 129).db,
+        NEURONS_COVERAGE_FLOOR_NETUIDS: "100",
+      },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(lowered.alerted, false);
+    assert.equal(lowered.coverage_floor_netuids, 100);
+  });
+
+  test("an uncountable coverage number reads as ZERO, never as covered", async () => {
+    // A NaN would compare false against the floor and report a half-scanned
+    // network healthy -- the exact direction of failure this closes.
+    const { db } = fakeDb(NOW - 5 * 60_000, null as unknown as number, 0);
+    const result = await runNeuronsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(result.covered_netuids, 0);
+    assert.equal(result.alerted, true);
+    assert.equal(result.reason, "partial");
+
+    const junk = fakeDb(
+      NOW - 5 * 60_000,
+      "not a number" as unknown as number,
+      0,
+    );
+    const nonNumeric = await runNeuronsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: junk.db },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(nonNumeric.covered_netuids, 0);
+    assert.equal(nonNumeric.alerted, true);
   });
 
   test("a stalled lane records ONE exception naming the age and threshold", async () => {
@@ -155,9 +368,11 @@ describe("runNeuronsStalenessWatchdog", () => {
     // yields a readable detail.
     const stringThrow = {
       prepare: () => ({
-        first: async () => {
-          throw "socket hangup";
-        },
+        bind: () => ({
+          first: async () => {
+            throw "socket hangup";
+          },
+        }),
       }),
     };
     const nonError = await runNeuronsStalenessWatchdog(
@@ -216,7 +431,11 @@ describe("handleScheduled NEURONS_STALENESS_WATCHDOG_CRON", () => {
     // statement ran. Exactly one read of the lane, and it is the right read.
     const reads = queries.filter((q: string) => q.includes("FROM neurons"));
     assert.equal(reads.length, 1);
-    assert.match(reads[0], /MAX\(captured_at\).*FROM neurons/);
+    assert.match(reads[0], /MAX\(captured_at\)/);
+    assert.match(reads[0], /FROM neurons/);
+    // The coverage half has to be IN the read, or the rule is being handed a
+    // number nothing measured.
+    assert.match(reads[0], /AS covered/);
     // The durable record is the whole point of the change: a healthy tick must be
     // recorded too, or "the watchdog stopped running" stays invisible.
     const writes = queries.filter((q: string) =>

--- a/tests/validator-nominator-counts-staleness-watchdog.test.ts
+++ b/tests/validator-nominator-counts-staleness-watchdog.test.ts
@@ -7,10 +7,20 @@
 // from the middle of the producer's 24h cycle is QUIET -- the threshold is
 // derived from that cadence rather than picked, because an alarm that fires on
 // a healthy lane is one nobody reads.
+//
+// The COVERAGE edge is not about time at all. This lane's writer is explicitly
+// NO PRUNE, so a chunked pass that dies partway upserts the hotkeys it reached
+// to a new stamp and leaves the rest at the old one -- a table that reads fresh
+// from its MAX() alone while serving a pass-old nominator_count for everything
+// the scan never got to. The production reading behind #9530 is asserted below
+// on this lane's own numbers.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 import {
+  VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS,
+  VALIDATOR_NOMINATOR_COUNTS_EXPECTED_HOTKEYS,
+  VALIDATOR_NOMINATOR_COUNTS_PASS_WINDOW_MS,
   VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS,
   evaluateValidatorNominatorCountsStaleness,
   runValidatorNominatorCountsStalenessWatchdog,
@@ -20,18 +30,32 @@ import * as workerConfig from "../workers/config.ts";
 
 const NOW = 1_785_800_000_000;
 const HOUR = 60 * 60_000;
+/** A pass that covered the scan, so coverage is never the thing under test
+ * unless a case says so. */
+const FULL = VALIDATOR_NOMINATOR_COUNTS_EXPECTED_HOTKEYS;
 
-function fakeDb(latest: number | null | Error) {
+function fakeDb(
+  latest: number | null | Error,
+  covered: number = FULL,
+  total: number = FULL,
+) {
   const queries: string[] = [];
+  const binds: unknown[][] = [];
   return {
     queries,
+    binds,
     db: {
       prepare(sql: string) {
         queries.push(sql);
         return {
-          async first() {
-            if (latest instanceof Error) throw latest;
-            return { latest };
+          bind(...values: unknown[]) {
+            binds.push(values);
+            return {
+              async first() {
+                if (latest instanceof Error) throw latest;
+                return { latest, covered, total };
+              },
+            };
           },
         };
       },
@@ -39,22 +63,34 @@ function fakeDb(latest: number | null | Error) {
   };
 }
 
+/** The rule's inputs with everything healthy, so each case overrides only the
+ * one field it is about. */
+function inputs(
+  over: Partial<
+    Parameters<typeof evaluateValidatorNominatorCountsStaleness>[0]
+  > = {},
+) {
+  return {
+    latestCapturedAtMs: NOW - 2 * HOUR,
+    coveredRows: FULL,
+    totalRows: FULL,
+    nowMs: NOW,
+    thresholdMs: VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS,
+    coverageFloorRows: VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS,
+    ...over,
+  };
+}
+
 describe("evaluateValidatorNominatorCountsStaleness", () => {
   test("a recent pass is quiet; one past the threshold is a stall", () => {
-    const fresh = evaluateValidatorNominatorCountsStaleness({
-      latestCapturedAtMs: NOW - 2 * HOUR,
-      nowMs: NOW,
-      thresholdMs: VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS,
-    });
+    const fresh = evaluateValidatorNominatorCountsStaleness(inputs());
     assert.equal(fresh.stale, false);
     assert.equal(fresh.reason, null);
     assert.equal(fresh.age_ms, 2 * HOUR);
 
-    const stalled = evaluateValidatorNominatorCountsStaleness({
-      latestCapturedAtMs: NOW - 31 * HOUR,
-      nowMs: NOW,
-      thresholdMs: VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS,
-    });
+    const stalled = evaluateValidatorNominatorCountsStaleness(
+      inputs({ latestCapturedAtMs: NOW - 31 * HOUR }),
+    );
     assert.equal(stalled.stale, true);
     assert.equal(stalled.reason, "stale");
     assert.equal(stalled.latest_captured_at, NOW - 31 * HOUR);
@@ -65,11 +101,9 @@ describe("evaluateValidatorNominatorCountsStaleness", () => {
     // 24h, so a healthy lane presents an age anywhere in [0h, 24h+scan] and
     // any threshold at or under 24h alerts on a lane that is working.
     for (const hours of [7, 12, 20, 23, 24]) {
-      const verdict = evaluateValidatorNominatorCountsStaleness({
-        latestCapturedAtMs: NOW - hours * HOUR,
-        nowMs: NOW,
-        thresholdMs: VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS,
-      });
+      const verdict = evaluateValidatorNominatorCountsStaleness(
+        inputs({ latestCapturedAtMs: NOW - hours * HOUR }),
+      );
       assert.equal(
         verdict.stale,
         false,
@@ -80,25 +114,103 @@ describe("evaluateValidatorNominatorCountsStaleness", () => {
 
   test("exactly at the threshold is not yet a stall", () => {
     // Strictly-greater, so a lane running exactly on cadence never flaps.
-    const verdict = evaluateValidatorNominatorCountsStaleness({
-      latestCapturedAtMs:
-        NOW - VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS,
-      nowMs: NOW,
-      thresholdMs: VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS,
-    });
+    const verdict = evaluateValidatorNominatorCountsStaleness(
+      inputs({
+        latestCapturedAtMs:
+          NOW - VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS,
+      }),
+    );
     assert.equal(verdict.stale, false);
   });
 
   test("an empty table is a stall of infinite age, never a healthy quiet", () => {
-    const verdict = evaluateValidatorNominatorCountsStaleness({
-      latestCapturedAtMs: null,
-      nowMs: NOW,
-      thresholdMs: VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS,
-    });
+    const verdict = evaluateValidatorNominatorCountsStaleness(
+      inputs({ latestCapturedAtMs: null, coveredRows: 0, totalRows: 0 }),
+    );
     assert.equal(verdict.stale, true);
     assert.equal(verdict.reason, "no_rows");
     assert.equal(verdict.age_ms, null);
     assert.equal(verdict.latest_captured_at, null);
+  });
+
+  test("HALF THE HOTKEYS RECENTLY and ALL THE HOTKEYS RECENTLY are told apart", () => {
+    // The acceptance criterion. Both ticks carry an identically fresh
+    // MAX(captured_at); the ONLY difference is how many hotkeys the pass
+    // reached, which is exactly what a timestamp cannot express.
+    const half = evaluateValidatorNominatorCountsStaleness(
+      inputs({ coveredRows: 54_000, totalRows: FULL }),
+    );
+    assert.equal(half.stale, true, "a half-covered pass must not read as ok");
+    assert.equal(half.reason, "partial");
+    // Recent, not old -- caught WITHOUT any time passing.
+    assert.equal(half.age_ms, 2 * HOUR);
+    assert.ok(half.age_ms < half.threshold_ms);
+
+    const whole = evaluateValidatorNominatorCountsStaleness(inputs());
+    assert.equal(whole.stale, false);
+    assert.equal(whole.reason, null);
+    assert.equal(whole.age_ms, half.age_ms);
+  });
+
+  test("a truncated pass is caught at every chunk boundary but the last", () => {
+    // The sync route caps a request at 25,000 rows, so a full pass is ~5
+    // requests and a death partway lands near these counts. The floor is placed
+    // against that grid rather than picked round.
+    for (const covered of [25_000, 50_000, 75_000]) {
+      const verdict = evaluateValidatorNominatorCountsStaleness(
+        inputs({ coveredRows: covered, totalRows: FULL }),
+      );
+      assert.equal(
+        verdict.reason,
+        "partial",
+        `a pass that died at ${covered} rows must alert`,
+      );
+    }
+    // Documented gap, asserted so it is a decision rather than a surprise: a
+    // death in the final chunk clears the floor. Tightening far enough to catch
+    // it would put the alarm inside the noise band of population change.
+    const lastChunk = evaluateValidatorNominatorCountsStaleness(
+      inputs({ coveredRows: 100_000, totalRows: FULL }),
+    );
+    assert.equal(lastChunk.stale, false);
+  });
+
+  test("the no-prune stragglers do not count against coverage", () => {
+    // Measured 2026-08-05: 112,250 rows across three vintages -- 112,245 at the
+    // newest stamp, then 1 and 4 older. Those five are the no-prune behaviour
+    // working as designed, and a healthy tick must stay quiet with them present.
+    const verdict = evaluateValidatorNominatorCountsStaleness(
+      inputs({ coveredRows: 112_245, totalRows: 112_250 }),
+    );
+    assert.equal(verdict.stale, false);
+    assert.equal(verdict.reason, null);
+  });
+
+  test("a pass exactly at the floor is complete; one row under is not", () => {
+    // Strictly-less, matching the threshold edge, so a lane landing exactly on
+    // the floor never flaps.
+    const atFloor = evaluateValidatorNominatorCountsStaleness(
+      inputs({ coveredRows: VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS }),
+    );
+    assert.equal(atFloor.stale, false);
+    assert.equal(atFloor.reason, null);
+
+    const under = evaluateValidatorNominatorCountsStaleness(
+      inputs({
+        coveredRows: VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS - 1,
+      }),
+    );
+    assert.equal(under.stale, true);
+    assert.equal(under.reason, "partial");
+  });
+
+  test("a stalled lane reports `stale`, not `partial`, even when also short", () => {
+    // If a whole pass has been missed, "the producer stopped" is the headline
+    // and the coverage of its last attempt is a detail.
+    const verdict = evaluateValidatorNominatorCountsStaleness(
+      inputs({ latestCapturedAtMs: NOW - 31 * HOUR, coveredRows: 54_000 }),
+    );
+    assert.equal(verdict.reason, "stale");
   });
 });
 
@@ -119,10 +231,11 @@ describe("runValidatorNominatorCountsStalenessWatchdog", () => {
     assert.equal(result.ok, true);
     assert.equal(result.alerted, false);
     assert.deepEqual(recorded, []);
-    assert.match(
-      queries[0]!,
-      /MAX\(captured_at\)[\s\S]*FROM validator_nominator_counts/,
-    );
+    assert.match(queries[0]!, /MAX\(captured_at\)/);
+    assert.match(queries[0]!, /FROM validator_nominator_counts/);
+    // The coverage half has to be IN the read, or the rule is being handed a
+    // number nothing measured.
+    assert.match(queries[0]!, /AS covered/);
   });
 
   test("a stalled lane records ONE exception naming the age and the route it breaks", async () => {
@@ -182,6 +295,105 @@ describe("runValidatorNominatorCountsStalenessWatchdog", () => {
     assert.equal(result.threshold_ms, HOUR);
   });
 
+  test("the read counts only the newest pass, bounded by the pass window", () => {
+    // A window spanning the 24h poll interval would sum two consecutive passes
+    // into one coverage count, so a truncated pass landing on a complete one
+    // would report full coverage -- the bug, restored.
+    const { db, queries, binds } = fakeDb(NOW - HOUR);
+    return runValidatorNominatorCountsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW, recordException: (async () => true) as never },
+    ).then(() => {
+      assert.deepEqual(binds[0], [VALIDATOR_NOMINATOR_COUNTS_PASS_WINDOW_MS]);
+      assert.ok(
+        VALIDATOR_NOMINATOR_COUNTS_PASS_WINDOW_MS < 24 * HOUR,
+        "the window must stay under VALIDATOR_NOMINATORS_POLL_SECS (24h)",
+      );
+      // Counted against the newest stamp, not against `now` -- a lane that is
+      // merely late must not also read as uncovered.
+      assert.match(
+        queries[0]!,
+        /captured_at >= \(SELECT MAX\(captured_at\) FROM validator_nominator_counts\) - \?/,
+      );
+    });
+  });
+
+  test("a recent but half-covered table alerts, naming both counts", async () => {
+    const { db } = fakeDb(NOW - HOUR, 54_000, 112_250);
+    const recorded: { error?: Error; route?: string; errorCode?: string }[] =
+      [];
+    const result = await runValidatorNominatorCountsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async (_env: never, event: never) => {
+          recorded.push(event);
+          return true;
+        }) as never,
+      },
+    );
+    assert.equal(result.alerted, true);
+    assert.equal(result.reason, "partial");
+    assert.equal(result.covered_rows, 54_000);
+    assert.equal(recorded.length, 1);
+    assert.equal(recorded[0]!.errorCode, "stale_lane");
+    const message = String(recorded[0]!.error?.message);
+    // Distinct wording from the stalled case -- different place to go looking.
+    assert.match(message, /truncated/);
+    assert.match(message, /54000 hotkeys/);
+    assert.match(message, /RECENT and PARTIAL/);
+    assert.doesNotMatch(message, /nothing is refreshing/);
+  });
+
+  test("the env coverage-floor and pass-window overrides win over the defaults", async () => {
+    const { db, binds } = fakeDb(NOW - HOUR, 100_000, 112_250);
+    const raised = await runValidatorNominatorCountsStalenessWatchdog(
+      {
+        METAGRAPH_HEALTH_DB: db,
+        VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS: String(110_000),
+        VALIDATOR_NOMINATOR_COUNTS_PASS_WINDOW_MS: String(HOUR),
+      },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(raised.alerted, true);
+    assert.equal(raised.reason, "partial");
+    assert.equal(raised.coverage_floor_rows, 110_000);
+    assert.deepEqual(binds[0], [HOUR]);
+
+    // Lowered under the same reading, the identical tick is quiet. This is the
+    // documented remedy if the hotkey population ever genuinely shrinks.
+    const lowered = await runValidatorNominatorCountsStalenessWatchdog(
+      {
+        METAGRAPH_HEALTH_DB: fakeDb(NOW - HOUR, 100_000, 112_250).db,
+        VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS: String(80_000),
+      },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(lowered.alerted, false);
+    assert.equal(lowered.coverage_floor_rows, 80_000);
+  });
+
+  test("an uncountable coverage number reads as ZERO, never as covered", async () => {
+    // A NaN would compare false against the floor and report a truncated table
+    // healthy -- the exact direction of failure this closes.
+    const { db } = fakeDb(NOW - HOUR, null as unknown as number, 0);
+    const result = await runValidatorNominatorCountsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(result.covered_rows, 0);
+    assert.equal(result.alerted, true);
+    assert.equal(result.reason, "partial");
+
+    const junk = fakeDb(NOW - HOUR, "not a number" as unknown as number, 0);
+    const nonNumeric = await runValidatorNominatorCountsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: junk.db },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(nonNumeric.covered_rows, 0);
+    assert.equal(nonNumeric.alerted, true);
+  });
+
   test("a missing binding and a failing query degrade to summaries, never throw", async () => {
     assert.deepEqual(await runValidatorNominatorCountsStalenessWatchdog({}), {
       ok: false,
@@ -207,9 +419,11 @@ describe("runValidatorNominatorCountsStalenessWatchdog", () => {
     // yields a readable detail.
     const stringThrow = {
       prepare: () => ({
-        first: async () => {
-          throw "socket hangup";
-        },
+        bind: () => ({
+          first: async () => {
+            throw "socket hangup";
+          },
+        }),
       }),
     };
     const nonError = await runValidatorNominatorCountsStalenessWatchdog(
@@ -222,7 +436,7 @@ describe("runValidatorNominatorCountsStalenessWatchdog", () => {
 
   test("a null row and a telemetry failure never fail the tick", async () => {
     const nullRow = {
-      prepare: () => ({ first: async () => null }),
+      prepare: () => ({ bind: () => ({ first: async () => null }) }),
     };
     const empty = await runValidatorNominatorCountsStalenessWatchdog(
       { METAGRAPH_HEALTH_DB: nullRow },


### PR DESCRIPTION
## Summary

[#9530](https://github.com/JSONbored/metagraphed/pull/9530) fixed a structural blind spot on `account-balances-staleness`: a watchdog judging a lane from one `MAX(captured_at)` cannot distinguish a complete pass from a truncated one. Production D1 held 147,000 rows — ~48% of the network — and `lane_health` read `ok | age=0.6h`.

Two sibling watchdogs had the same single-`MAX()` shape. **I measured both against production D1 before writing anything**, rather than assuming the remedy transfers:

```
SELECT COUNT(*), COUNT(DISTINCT captured_at), MAX(captured_at) ...
validator_nominator_counts   112,250 rows, 3 vintages  (112,245 / 1 / 4)
neurons                       30,103 rows, 1 vintage,  129 of 129 netuids at newest
```

Both are healthy right now, so **neither alarm fires on merge** — this closes the blind spot before it costs anything, rather than after.

## What Changed

### `validator_nominator_counts` — the closest case, fails identically

Its writer is explicitly **NO PRUNE** ([validator-nominator-counts-d1-write.ts:38](src/validator-nominator-counts-d1-write.ts:38)), the same chunked-upsert shape `account_balances` uses. A pass that dies partway upserts the hotkeys it reached to a new stamp and leaves the rest at the old one; `MAX()` reads the rows that *did* land and says nothing about the ones that did not.

Now counts **hotkeys the newest pass wrote** against a floor of 80% of 112,245 (measured). The 80% is placed against the sync route's 25,000-row chunking — a full pass is ~5 requests, so a death lands near 25k/50k/75k/100k, and the floor catches every one but the last. That gap is asserted as a test so it's a decision, not a surprise.

The three measured vintages are worth noting: the 1 and 4 straggler rows are the no-prune behaviour working as designed (a hotkey the latest scan didn't re-send keeps its last count). They're why coverage is counted over a **window** rather than an exact stamp match, and a test pins that a healthy tick stays quiet with them present.

### `neurons` — fails by a different mechanism, so a different unit

There is no chunked upload to truncate here: `NEURONS_SYNC_MAX_ROWS` is 50,000 and the whole metagraph is at most 129 × 256 = 33,024 rows, so a pass is always **one request**. The hazard is upstream — the producer walks netuid by netuid over RPC, and the writer prunes **per netuid**: it deletes the UIDs its batch didn't refresh, but only within netuids the batch *contains*. A netuid absent from the payload is untouched. So a scan that dies at netuid 40 posts a well-formed request, restamps 40 subnets, and leaves 89 serving a pass-old metagraph behind a `MAX()` that just advanced.

Coverage is therefore counted in **netuids, not rows**. Rows would be the wrong unit: subnets run 64 to 256 UIDs, so a scan that died after the largest ones could show high row coverage having missed more than half the network. Netuids are what the producer iterates, so they're what a partial pass is partial *in*.

### Sizing, and why it can't turn into alarm fatigue

Both floors are **ratios of a measured count**, not pinned numbers, so they only ever loosen as the network grows — the #9301 rule. Asserted directly for neurons (a 200-subnet network still passes).

The one honest asymmetry is documented in the code: `account_balances` counts accounts that have *ever* held a balance, so its expectation only grows. `validator_nominator_counts` counts hotkeys with a nominator *right now*, which can genuinely shrink. If that floor ever fires **marginally** on an otherwise-healthy lane, the remedy is to re-measure and lower it — a real truncation lands near a chunk boundary, far below. There's a test for that remedy path.

Pass windows are bounded from both ends: too small and a per-request stamp reads as several partial passes (alerting forever on a healthy lane); too large and two consecutive passes merge into one coverage count, restoring the bug. Sized to a third (neurons, 5 min vs a 15 min tick) and a sixth (vnc, 4 h vs 24 h) of each producer's cadence, asserted in tests against those cadences.

**Cost:** ~5.4M (vnc) + ~2.9M (neurons) D1 rows read/day, inside the included allowance. Stated in each module header.

**No schema change.** `partial` is a `lane_health` **detail**; both verdicts stay inside the published `ok`/`stale`/`unknown` enum. No contract drift, no regenerated artifacts — the diff is four files.

### Tests fail without the change

Neutering only the `covered < floor` branch in each module fails **12 of 42** tests, including both acceptance cases (two ticks with identically fresh `MAX(captured_at)`, differing only in coverage). All 42 pass with it.

## Registry Safety

- [x] No linked issue — maintainer PR, filed at maintainer request (same as #9530).
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None changed — `git status` clean after `npm run build`.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — see above.)

## Validation

- [x] `npm run lint` · `npm run format:check` · `npm run typecheck`
- [x] `npm run validate` · `validate:schemas` · `validate:api` · `validate:openapi` · `validate:types`
- [x] `npm run validate:artifact-budgets` · `validate:docs` · `validate:intake` · `validate:workflows`
- [x] `npm run validate:contract-drift`
- [x] `npm run worker:test`
- [x] `npm run build` (8/8 steps passed)
- [x] `npx vitest run` — 679 files, 16,318 tests, all passing
- [x] Patch coverage — 100% statements, 100% branches (37/37) on **each** changed module, from its own test file alone
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

## Template Used

- `backend-code.md`
