### PR TITLE
fix(health): answer the prober's continuity read so last_ok survives a run

### DIFF
--- a/src/health-prober.ts
+++ b/src/health-prober.ts
@@ -35,7 +35,6 @@ import {
   upsertSubnetSnapshotsToD1,
   type ObservationsDb,
 } from "./observations-d1.ts";
-import { tryPostgresTier } from "../workers/postgres-tier.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import {
@@ -61,6 +60,7 @@ import {
 } from "./endpoint-reliability.ts";
 import { emptyStatusCounts } from "./endpoint-score.ts";
 import type { ObservationsReadDb } from "./analytics-live.ts";
+import { readLiveSurfaceStatus } from "./health-status-live.ts";
 export const OPERATIONAL_SURFACES_PATH = "/metagraph/operational-surfaces.json";
 
 type Row = Record<string, unknown>;
@@ -501,25 +501,21 @@ export async function runHealthProber(
   }
 
   // Prior status (last_ok + consecutive_failures) for continuity + the breaker.
-  // D1 retirement: this used to read D1's own surface_status directly; now
-  // reuses the same Postgres-backed internal endpoint resolveLiveHealth's
-  // KV-cold fallback calls (workers/data-api.ts's
-  // /api/v1/internal/health-status-live), with since=0 so it returns every
-  // tracked surface regardless of freshness — this read needs the LAST known
-  // row per surface for continuity even if it's stale, unlike the serving
-  // fallback which deliberately filters to fresh rows only.
+  // since=0 so it returns every tracked surface regardless of freshness — this
+  // read needs the LAST known row per surface for continuity even if it's
+  // stale, unlike the serving fallback which deliberately filters to fresh
+  // rows only.
+  //
+  // #9522: this went through tryPostgresTier until the route it asks for was
+  // actually implemented AND the flag gate stopped swallowing it. Both halves
+  // were broken — see src/health-status-live.ts for why the fix is a direct
+  // service-binding call rather than a wider flag. While it resolved to null,
+  // every line below that reads `prior` silently took its absent branch: any
+  // surface not ok THIS run had last_ok rewritten to null, and the failure
+  // streak restarted at 1, holding it under the pool breaker's threshold.
   const priorStatus = new Map<unknown, Row>();
-  const priorRows = await tryPostgresTier(
-    env,
-    new Request(
-      "https://api.metagraph.sh/api/v1/internal/health-status-live?since=0",
-    ),
-    "METAGRAPH_HEALTH_SOURCE",
-  );
-  if (Array.isArray(priorRows?.rows)) {
-    for (const row of priorRows.rows as Row[]) {
-      priorStatus.set(row.surface_key || row.surface_id, row);
-    }
+  for (const row of await readLiveSurfaceStatus(env, 0)) {
+    priorStatus.set(row.surface_key || row.surface_id, row);
   }
 
   const probed = await mapLimit(surfaces, concurrency, async (surface) => {

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -26,6 +26,7 @@ import {
   comparePoolEndpoints,
   endpointScoreBreakdown,
 } from "./endpoint-score.ts";
+import { readLiveSurfaceStatus } from "./health-status-live.ts";
 
 type Row = Record<string, unknown>;
 
@@ -2006,15 +2007,12 @@ export async function resolveLiveHealth({
   const currentTime = typeof now === "function" ? now() : Date.now();
   const freshnessCutoff = currentTime - D1_HEALTH_FALLBACK_MAX_AGE_MS;
   if (env) {
-    const pg = await tryPostgresTier(
-      env,
-      new Request(
-        `https://api.metagraph.sh/api/v1/internal/health-status-live?since=${freshnessCutoff}`,
-      ),
-      "METAGRAPH_HEALTH_SOURCE",
-    );
-    if (Array.isArray(pg?.rows) && pg.rows.length) {
-      return liveFromStatusRows(pg.rows as Row[]);
+    // #9522: same route, same previously-dead read as the prober's continuity
+    // load — see src/health-status-live.ts. A freshness cutoff here rather
+    // than 0, because a stale row is worth CARRYING FORWARD but not SERVING.
+    const rows = await readLiveSurfaceStatus(env, freshnessCutoff);
+    if (rows.length) {
+      return liveFromStatusRows(rows);
     }
   }
   return null;

--- a/src/health-status-live.ts
+++ b/src/health-status-live.ts
@@ -1,0 +1,83 @@
+// The probe-status continuity read: every surface_status row the prober needs
+// to carry last_ok and the failure streak across runs (#9522).
+//
+// WHY THIS IS A DIRECT SERVICE-BINDING CALL AND NOT tryPostgresTier.
+//
+// Both callers used to route this through tryPostgresTier(...,
+// "METAGRAPH_HEALTH_SOURCE"), which resolved to null on every run: that flag
+// reads "d1" in production, and tryPostgresTier only forwards "d1" for the
+// three flags in DATA_API_D1_FLAGS. Adding this one to that set would have
+// fixed the read and broken something else -- the flag is shared with
+// /api/v1/health/trends, /api/v1/incidents and /api/v1/internal/compare-health,
+// none of which data-api implements, so each of those would start forwarding,
+// take a non-2xx, and emit a capturePostgresTierFallback exception on every
+// request. That is a per-flag switch being asked to do a per-route job.
+//
+// This route is internal and service-binding-only, so it does not need the
+// public proxy layer's flag gate at all -- the same argument
+// data-api's subnet-identity-sync handler already makes for calling
+// env.DATA_API.fetch() directly.
+//
+// THE FLAG STILL GATES THE READ, just not through DATA_API_D1_FLAGS. A
+// deployment that has not pointed METAGRAPH_HEALTH_SOURCE at a tier must not
+// have this reach for one -- both callers' suites pin that ("never reaches
+// Postgres when the flag is off"), and it is the right contract: an unset flag
+// means no probe-status tier exists here, not "try anyway". What changed is
+// only that "d1" now names a tier that answers.
+//
+// DEGRADES, NEVER THROWS. A flag naming no tier, no binding, a transport
+// failure, a non-2xx, an unparseable body, or a body without a rows array all
+// yield an empty array -- which is exactly the state that existed before this
+// route answered. A prober run that cannot read prior state should still
+// probe; it just cannot carry continuity forward that run.
+
+type Row = Record<string, unknown>;
+
+interface ServiceBinding {
+  fetch(request: Request): Promise<Response>;
+}
+
+/** Flag values that name a tier able to answer this route: the D1 dispatcher
+ * (production since the box was retired) and the legacy Postgres one. Anything
+ * else -- unset, "retired", a typo -- means there is nothing to ask. */
+const TIERS_THAT_ANSWER = new Set(["d1", "postgres"]);
+
+/**
+ * surface_status rows whose `last_checked` is at or after `sinceMs`.
+ *
+ * Pass 0 for "every tracked surface regardless of age" — what continuity
+ * wants, since a stale row is precisely the one worth carrying forward. The
+ * serving fallback passes a real freshness cutoff instead, because a stale row
+ * is not worth SERVING.
+ */
+export async function readLiveSurfaceStatus(
+  env: Env | null | undefined,
+  sinceMs: number,
+): Promise<Row[]> {
+  if (!env) return [];
+  if (!TIERS_THAT_ANSWER.has(String(env.METAGRAPH_HEALTH_SOURCE))) return [];
+  const dataApi = (env as { DATA_API?: ServiceBinding } | null | undefined)
+    ?.DATA_API;
+  if (!dataApi?.fetch) return [];
+  const since =
+    Number.isFinite(sinceMs) && sinceMs > 0 ? Math.floor(sinceMs) : 0;
+  let response: Response;
+  try {
+    response = await dataApi.fetch(
+      new Request(
+        `https://api.metagraph.sh/api/v1/internal/health-status-live?since=${since}`,
+      ),
+    );
+  } catch {
+    return [];
+  }
+  if (!response.ok) return [];
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return [];
+  }
+  const rows = (body as { rows?: unknown } | null)?.rows;
+  return Array.isArray(rows) ? (rows as Row[]) : [];
+}

--- a/tests/data-api-health-status-d1.test.ts
+++ b/tests/data-api-health-status-d1.test.ts
@@ -1,0 +1,250 @@
+// GET /api/v1/internal/health-status-live (#9522), exercised END TO END
+// against a REAL SQLite database through the real Worker fetch handler --
+// same harness and rationale as tests/data-api-hotkey-alpha-d1.test.ts.
+//
+// This route is the prober's own continuity read, and it did not exist. Two
+// callers in the main Worker have always requested it -- src/health-prober.ts
+// with since=0 for the last known row per surface, src/health-serving.ts with
+// a freshness cutoff for its KV-cold serving fallback -- and both got null on
+// every call, because nothing answered the path AND the flag that gates the
+// forward was not in DATA_API_D1_FLAGS.
+//
+// The consequence was not a missing field but a broken invariant: with an
+// empty prior map the prober rewrote last_ok to null for every surface that
+// was not ok this run, and restarted consecutive_failures at 1 -- capping it
+// under the pool breaker's threshold of 2, so `sustained-down` eviction could
+// never fire. Measured in production D1 before the fix: 0 of 109
+// degraded/failed rows carried a last_ok while 85 had ok=1 rows in
+// surface_checks, and consecutive_failures was 0 or 1 across all 635 rows.
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, test } from "vitest";
+import type { Row } from "./row-type.ts";
+
+const { default: worker } = await import("../workers/data-api.ts");
+
+// surface_status lives in the observations migration, alongside surface_checks.
+const OBSERVATIONS_SCHEMA = fs.readFileSync(
+  path.join(process.cwd(), "migrations/d1/0002_observations.sql"),
+  "utf8",
+);
+
+const PATH = "/api/v1/internal/health-status-live";
+
+let db: InstanceType<typeof DatabaseSync>;
+
+function d1() {
+  return {
+    prepare(text: string) {
+      return {
+        bind(...values: unknown[]) {
+          return {
+            text,
+            values,
+            async all() {
+              return { results: db.prepare(text).all(...(values as never[])) };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+function env(overrides: Record<string, unknown> = {}): Env {
+  return {
+    METAGRAPH_HEALTH_DB: d1(),
+    // What production runs. "postgres" would forward through the legacy tier;
+    // "d1" is the value that was silently not forwarding.
+    METAGRAPH_HEALTH_SOURCE: "d1",
+    ...overrides,
+  } as unknown as Env;
+}
+
+function get(query = "", envOverride?: Env) {
+  return worker.fetch(
+    new Request(`https://d${PATH}${query}`),
+    envOverride ?? env(),
+    {} as unknown as ExecutionContext,
+  );
+}
+
+function insertStatus(overrides: Row = {}) {
+  const row: Row = {
+    surface_id: "sn7-api",
+    surface_key: "srf-sn7apikey000000",
+    netuid: 7,
+    kind: "subnet-api",
+    url: "https://example.com/api",
+    provider: "example",
+    status: "failed",
+    classification: "dead",
+    latency_ms: null,
+    status_code: null,
+    last_checked: 50_000,
+    last_ok: 1_000,
+    consecutive_failures: 2,
+    updated_at: 50_000,
+    ...overrides,
+  };
+  db.prepare(
+    `INSERT INTO surface_status (surface_id, surface_key, netuid, kind, url,
+       provider, status, classification, latency_ms, status_code, last_checked,
+       last_ok, consecutive_failures, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    ...([
+      row.surface_id,
+      row.surface_key,
+      row.netuid,
+      row.kind,
+      row.url,
+      row.provider,
+      row.status,
+      row.classification,
+      row.latency_ms,
+      row.status_code,
+      row.last_checked,
+      row.last_ok,
+      row.consecutive_failures,
+      row.updated_at,
+    ] as never[]),
+  );
+}
+
+beforeEach(() => {
+  db = new DatabaseSync(":memory:");
+  db.exec(OBSERVATIONS_SCHEMA);
+});
+
+test("serves the columns both callers read, including last_ok and the failure streak", async () => {
+  insertStatus();
+  const res = await get("?since=0");
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as { rows: Row[] };
+  assert.equal(body.rows.length, 1);
+  const row = body.rows[0];
+  // The two the prober needs for continuity -- the whole reason for the route.
+  assert.equal(row.last_ok, 1_000);
+  assert.equal(row.consecutive_failures, 2);
+  // The rest is what liveFromStatusRows projects for the serving overlay; a
+  // column dropped here silently degrades that fallback instead of failing it.
+  assert.equal(row.surface_id, "sn7-api");
+  assert.equal(row.surface_key, "srf-sn7apikey000000");
+  assert.equal(row.netuid, 7);
+  assert.equal(row.kind, "subnet-api");
+  assert.equal(row.provider, "example");
+  assert.equal(row.url, "https://example.com/api");
+  assert.equal(row.status, "failed");
+  assert.equal(row.classification, "dead");
+  assert.equal(row.last_checked, 50_000);
+});
+
+// since=0 is the prober's call: it wants the last known row per surface even
+// when that row is stale, because staleness is exactly what continuity spans.
+test("since=0 returns every tracked surface regardless of age", async () => {
+  insertStatus({
+    surface_id: "fresh",
+    surface_key: "k-fresh",
+    last_checked: 9_000_000,
+  });
+  insertStatus({
+    surface_id: "ancient",
+    surface_key: "k-ancient",
+    last_checked: 1,
+  });
+  const body = (await (await get("?since=0")).json()) as { rows: Row[] };
+  assert.deepEqual(
+    body.rows.map((r) => r.surface_id),
+    ["ancient", "fresh"],
+    "ordered by surface_id so the response is stable run to run",
+  );
+});
+
+// A freshness cutoff is health-serving.ts's call: it deliberately wants only
+// rows recent enough to serve, unlike the prober.
+test("since filters on last_checked", async () => {
+  insertStatus({
+    surface_id: "fresh",
+    surface_key: "k-fresh",
+    last_checked: 9_000_000,
+  });
+  insertStatus({
+    surface_id: "stale",
+    surface_key: "k-stale",
+    last_checked: 1,
+  });
+  const body = (await (await get("?since=100000")).json()) as { rows: Row[] };
+  assert.deepEqual(
+    body.rows.map((r) => r.surface_id),
+    ["fresh"],
+  );
+});
+
+// An absent or unparseable `since` must not become NaN in the comparison --
+// that would filter everything out and silently reproduce the empty prior map
+// this route exists to fix.
+test("a missing or unparseable since is treated as 0, not NaN", async () => {
+  insertStatus({ last_checked: 5 });
+  assert.equal(
+    ((await (await get()).json()) as { rows: Row[] }).rows.length,
+    1,
+    "no since param",
+  );
+  assert.equal(
+    ((await (await get("?since=not-a-number")).json()) as { rows: Row[] }).rows
+      .length,
+    1,
+    "unparseable since",
+  );
+});
+
+test("an empty table is an empty row set, not an error", async () => {
+  const res = await get("?since=0");
+  assert.equal(res.status, 200);
+  assert.deepEqual((await res.json()) as unknown, { rows: [] });
+});
+
+test("declines with 503 when the D1 binding is absent", async () => {
+  const res = await get("?since=0", {
+    METAGRAPH_HEALTH_SOURCE: "d1",
+  } as unknown as Env);
+  assert.equal(res.status, 503);
+});
+
+// Under "postgres" this route is the legacy tier's to answer, so the D1
+// matcher must decline rather than shadow it.
+test("does not claim the route when the flag says postgres", async () => {
+  insertStatus();
+  const res = await get(
+    "?since=0",
+    env({ METAGRAPH_HEALTH_SOURCE: "postgres" }),
+  );
+  assert.notEqual(res.status, 200);
+});
+
+// A failing query answers an opaque 502 that leaks no DB detail -- the same
+// envelope the neurons and hyperparams D1 blocks use. It matters here because
+// the caller reads a non-2xx as "this tier declines" and carries on with an
+// empty prior map, which is the pre-fix behaviour: degraded, not broken.
+test("a failing query is an opaque 502, never a leaked DB error", async () => {
+  const exploding = {
+    METAGRAPH_HEALTH_DB: {
+      prepare() {
+        throw new Error("no such table: surface_status");
+      },
+    },
+    METAGRAPH_HEALTH_SOURCE: "d1",
+  } as unknown as Env;
+  const res = await get("?since=0", exploding);
+  assert.equal(res.status, 502);
+  const body = (await res.json()) as Row;
+  assert.equal(body.error, "data query failed");
+  assert.equal(
+    JSON.stringify(body).includes("surface_status"),
+    false,
+    "the underlying DB error must not reach the response",
+  );
+});

--- a/tests/health-prober.test.ts
+++ b/tests/health-prober.test.ts
@@ -217,12 +217,20 @@ function makeDb({ priorStatus = [] as unknown[] } = {}) {
 // /api/v1/internal/health-checks-sync (whose `probed` body is the new
 // observation point for consecutive_failures/etc, replacing the old D1
 // INSERT-statement inspection).
-function makeProberEnv({ priorStatus = [] as unknown[] } = {}) {
+// healthSource is a parameter, not a constant, because the flag VALUE is what
+// #9522 turned on: production has read "d1" since the box was retired, and
+// tryPostgresTier only forwards "d1" for flags listed in DATA_API_D1_FLAGS.
+// Every continuity test below ran under "postgres", which forwards, so they
+// all passed while production silently resolved the prior read to null.
+function makeProberEnv({
+  priorStatus = [] as unknown[],
+  healthSource = "postgres",
+} = {}) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const posted: any[][] = [];
   return {
     env: mockEnv({
-      METAGRAPH_HEALTH_SOURCE: "postgres",
+      METAGRAPH_HEALTH_SOURCE: healthSource,
       HEALTH_CHECKS_SYNC_SECRET: "test-secret",
       DATA_API: {
         async fetch(request: Row) {
@@ -597,6 +605,45 @@ describe("runHealthProber", () => {
     // re-keys onto the rename-stable identity, not the display id/slug.
     const apiRow = posted[0].find((r) => r.surface_id === "sn7-api");
     assert.equal(apiRow.surface_key, "srf-sn7apikey000000");
+    assert.equal(apiRow.consecutive_failures, 3);
+  });
+
+  // #9522. The two assertions above are the same ones the suite already made
+  // under METAGRAPH_HEALTH_SOURCE="postgres". Production has read "d1" since
+  // the box was retired, and "d1" only forwards for flags in
+  // DATA_API_D1_FLAGS -- which this one was not in. So the prior read returned
+  // null on every real run: last_ok was rewritten to null for any surface that
+  // was not ok THIS run, and consecutive_failures restarted at 1, capping it
+  // below the breaker's threshold of 2 forever.
+  //
+  // Measured in production D1 before the fix: 0 of 109 degraded/failed rows
+  // carried a last_ok though 85 of them had ok=1 rows in surface_checks, and
+  // consecutive_failures was 0 or 1 across all 635 rows.
+  test("carries prior last_ok and the failure streak under the d1 flag production actually runs", async () => {
+    const { env, posted } = makeProberEnv({
+      healthSource: "d1",
+      priorStatus: [
+        {
+          surface_id: "sn7-api",
+          surface_key: "srf-sn7apikey000000",
+          last_ok: 1000,
+          consecutive_failures: 2,
+        },
+      ],
+    });
+    await runHealthProber(env, FAKE_CTX, {
+      now: () => 50000,
+      kv: makeKv(),
+      loadSurfaces: async () => SURFACES,
+      probeSurface: probeImpl,
+      probeOptions: {},
+    });
+    const apiRow = posted[0].find((r) => r.surface_id === "sn7-api");
+    // Carried forward, not wiped: this surface failed THIS run but was healthy
+    // at t=1000, and "when was it last up" is the whole point of the column.
+    assert.equal(apiRow.last_ok_ms, 1000);
+    // 2 -> 3 crosses POOL_SUSTAINED_DOWN_FAILURES, so `sustained-down`
+    // eviction becomes reachable. Pinned at 1 before this fix.
     assert.equal(apiRow.consecutive_failures, 3);
   });
 

--- a/tests/health-status-live.test.ts
+++ b/tests/health-status-live.test.ts
@@ -1,0 +1,148 @@
+// src/health-status-live.ts (#9522) — the probe-status continuity read.
+//
+// This helper exists because the previous route through tryPostgresTier could
+// not be fixed without collateral: METAGRAPH_HEALTH_SOURCE is shared with
+// /api/v1/health/trends, /api/v1/incidents and /api/v1/internal/compare-health,
+// none of which data-api implements, so adding it to DATA_API_D1_FLAGS would
+// have made all three forward, take a non-2xx, and emit a
+// capturePostgresTierFallback exception per request.
+//
+// So the contract has two halves and both are pinned below: the flag still
+// decides WHETHER to ask, and every failure mode answers with an empty array
+// rather than throwing — a prober run that cannot read prior state must still
+// probe.
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { readLiveSurfaceStatus } from "../src/health-status-live.ts";
+
+type Row = Record<string, unknown>;
+
+const ROWS = [{ surface_id: "a", last_ok: 1000, consecutive_failures: 2 }];
+
+function env(overrides: Record<string, unknown> = {}) {
+  const calls: string[] = [];
+  const base = {
+    METAGRAPH_HEALTH_SOURCE: "d1",
+    DATA_API: {
+      async fetch(request: Request) {
+        calls.push(request.url);
+        return new Response(JSON.stringify({ rows: ROWS }), { status: 200 });
+      },
+    },
+    ...overrides,
+  } as unknown as Env;
+  return { env: base, calls };
+}
+
+test("returns the rows the route serves", async () => {
+  const { env: e, calls } = env();
+  assert.deepEqual(await readLiveSurfaceStatus(e, 0), ROWS);
+  assert.equal(calls.length, 1);
+});
+
+test("asks for every surface when since is 0, and filters when it is not", async () => {
+  const { env: e, calls } = env();
+  await readLiveSurfaceStatus(e, 0);
+  assert.equal(new URL(calls[0]).searchParams.get("since"), "0");
+  await readLiveSurfaceStatus(e, 12_345);
+  assert.equal(new URL(calls[1]).searchParams.get("since"), "12345");
+});
+
+// A NaN or negative cutoff must collapse to 0 (everything), never into the
+// query string, where it would filter the whole table out and silently
+// reproduce the empty prior map this route exists to fix.
+test("normalizes an unusable since to 0 rather than passing it through", async () => {
+  const { env: e, calls } = env();
+  await readLiveSurfaceStatus(e, Number.NaN);
+  await readLiveSurfaceStatus(e, -5);
+  await readLiveSurfaceStatus(e, 9.9);
+  assert.deepEqual(
+    calls.map((url) => new URL(url).searchParams.get("since")),
+    ["0", "0", "9"],
+  );
+});
+
+// --- the flag still gates the read -----------------------------------------
+
+test("does not reach the tier when the flag names none", async () => {
+  for (const value of [undefined, "", "retired", "postgress"]) {
+    const { env: e, calls } = env({ METAGRAPH_HEALTH_SOURCE: value });
+    assert.deepEqual(await readLiveSurfaceStatus(e, 0), [], String(value));
+    assert.equal(calls.length, 0, `must not call DATA_API for ${value}`);
+  }
+});
+
+test("reaches the tier for both flag values that name one", async () => {
+  for (const value of ["d1", "postgres"]) {
+    const { env: e, calls } = env({ METAGRAPH_HEALTH_SOURCE: value });
+    assert.deepEqual(await readLiveSurfaceStatus(e, 0), ROWS, value);
+    assert.equal(calls.length, 1);
+  }
+});
+
+// --- every failure mode degrades to an empty array -------------------------
+
+test("returns empty with no env at all", async () => {
+  assert.deepEqual(await readLiveSurfaceStatus(null, 0), []);
+  assert.deepEqual(await readLiveSurfaceStatus(undefined, 0), []);
+});
+
+test("returns empty when the service binding is absent", async () => {
+  const { env: e } = env({ DATA_API: undefined });
+  assert.deepEqual(await readLiveSurfaceStatus(e, 0), []);
+});
+
+test("returns empty when the binding has no fetch", async () => {
+  const { env: e } = env({ DATA_API: {} });
+  assert.deepEqual(await readLiveSurfaceStatus(e, 0), []);
+});
+
+test("returns empty when the fetch throws", async () => {
+  const { env: e } = env({
+    DATA_API: {
+      async fetch() {
+        throw new Error("binding exploded");
+      },
+    },
+  });
+  assert.deepEqual(await readLiveSurfaceStatus(e, 0), []);
+});
+
+test("returns empty on a non-2xx", async () => {
+  const { env: e } = env({
+    DATA_API: {
+      async fetch() {
+        return new Response("nope", { status: 503 });
+      },
+    },
+  });
+  assert.deepEqual(await readLiveSurfaceStatus(e, 0), []);
+});
+
+test("returns empty on an unparseable body", async () => {
+  const { env: e } = env({
+    DATA_API: {
+      async fetch() {
+        return new Response("not json", { status: 200 });
+      },
+    },
+  });
+  assert.deepEqual(await readLiveSurfaceStatus(e, 0), []);
+});
+
+test("returns empty when the body carries no rows array", async () => {
+  for (const body of ["null", "{}", '{"rows":null}', '{"rows":"nope"}']) {
+    const { env: e } = env({
+      DATA_API: {
+        async fetch() {
+          return new Response(body, { status: 200 });
+        },
+      },
+    });
+    assert.deepEqual(
+      (await readLiveSurfaceStatus(e, 0)) as Row[],
+      [],
+      `body ${body}`,
+    );
+  }
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -6169,6 +6169,53 @@ function accountIdentityServedFromD1(env: Env) {
   return env.METAGRAPH_ACCOUNT_IDENTITY_SOURCE !== "postgres";
 }
 
+function healthStatusServedFromD1(env: Env) {
+  return env.METAGRAPH_HEALTH_SOURCE !== "postgres";
+}
+
+// Every column liveFromStatusRows projects (src/health-serving.ts:1918-1936)
+// plus consecutive_failures, which only the prober reads. Kept as one list
+// because both consumers of this route want the whole surface_status row --
+// the serving overlay to render it, the prober to carry it forward.
+const HEALTH_STATUS_LIVE_D1_READ_COLUMNS =
+  "surface_id, surface_key, netuid, kind, provider, url, status, " +
+  "classification, latency_ms, status_code, last_checked, last_ok, " +
+  "consecutive_failures";
+
+// GET /api/v1/internal/health-status-live?since=<epoch_ms>
+//
+// The route two callers in the main Worker have always requested and nothing
+// ever answered (#9522): src/health-prober.ts asks with since=0 for the LAST
+// known row per surface, and src/health-serving.ts asks with a freshness
+// cutoff for its KV-cold serving fallback. Without it, tryPostgresTier
+// returned null on every call, so the prober's prior map was empty and it
+// rewrote last_ok to null and reset consecutive_failures on every run --
+// which in turn made the pool's sustained-down breaker (threshold 2)
+// unreachable.
+//
+// `since` filters on last_checked, the column that records when the row was
+// written; since=0 (or absent/unparseable) returns everything, which is what
+// "the last known row, however stale" means for the prober's continuity read.
+function matchHealthStatusD1Route(
+  url: URL,
+  env: Env,
+): NeuronsD1RouteHandler | null {
+  if (!healthStatusServedFromD1(env)) return null;
+  if (url.pathname !== "/api/v1/internal/health-status-live") return null;
+  return async (sql) => {
+    const since = Number(url.searchParams.get("since"));
+    const cutoff = Number.isFinite(since) && since > 0 ? since : 0;
+    const rows = await sql.unsafe(
+      `SELECT ${HEALTH_STATUS_LIVE_D1_READ_COLUMNS}
+       FROM surface_status
+       WHERE last_checked >= ?
+       ORDER BY surface_id ASC`,
+      [cutoff],
+    );
+    return json({ rows });
+  };
+}
+
 function d1TierCold() {
   return json({ error: "d1 tier cold: no sync has landed yet" }, 503);
 }
@@ -6652,6 +6699,28 @@ async function dispatchDataApiRequest(
           );
         } catch (err) {
           console.error("data-api neurons D1 query failed:", err);
+          await captureDataApiError(err, maskRouteParams(url.pathname), env);
+          return json({ error: "data query failed" }, 502);
+        }
+      }
+    }
+
+    // Probe status on D1 (#9522) -- the internal continuity read the prober
+    // and the health-serving fallback have both always called. Same envelope
+    // as the neurons block above.
+    {
+      const healthStatusD1Handler = matchHealthStatusD1Route(url, env);
+      if (healthStatusD1Handler) {
+        if (!env.METAGRAPH_HEALTH_DB) {
+          return json({ error: "d1 binding unavailable" }, 503);
+        }
+        try {
+          return await healthStatusD1Handler(
+            createD1Sql(env.METAGRAPH_HEALTH_DB),
+            env,
+          );
+        } catch (err) {
+          console.error("data-api health-status D1 query failed:", err);
           await captureDataApiError(err, maskRouteParams(url.pathname), env);
           return json({ error: "data query failed" }, 502);
         }


### PR DESCRIPTION
## Summary

`/api/v1/internal/health-status-live` had **two callers and no implementation**. `src/health-prober.ts:513` asked for it with `since=0` to carry prior state forward; `src/health-serving.ts:2012` asked with a freshness cutoff for its KV-cold fallback. Both got `null` on every call.

The visible symptom was `list_endpoint_incidents.last_ok` null on all 143 incidents (found by `npm run smoke:mcp`, #9455). The more serious consequence was silent.

## Two things followed from the empty prior map

**1. `last_ok` was wiped for every non-ok surface.** The carry-forward at `src/health-prober.ts:557` reads `prior?.last_ok`; with `prior` always `undefined`, a surface not ok *this run* was written with `last_ok = null` regardless of history.

```
SELECT status, COUNT(*) n, COUNT(last_ok) with_ok FROM surface_status GROUP BY status
  degraded  rows=104  with_last_ok=0
  failed    rows=5    with_last_ok=0
  ok        rows=526  with_last_ok=526
```

Not because they never succeeded — `surface_checks` still holds their successful probes:

```
degraded  surfaces=104  ever_ok_in_checks=81
failed    surfaces=5    ever_ok_in_checks=4
```

**85 of 109 unhealthy surfaces had recorded successes and a null `last_ok`.**

**2. The pool's sustained-down breaker could never fire.** `consecutive_failures` rebuilt from the same empty map, so it capped at 1. Eviction needs `>= 2` (`src/health-serving.ts:44-50`, used at `:396-400`):

```
consecutive_failures=0  rows=629
consecutive_failures=1  rows=6
```

No row in production has ever reached 2, so a persistently dead `subtensor-rpc`/`subtensor-wss` endpoint stayed `pool_eligible` indefinitely — the exact failure the breaker exists to prevent.

## Why not just add the flag to `DATA_API_D1_FLAGS`

That was the obvious one-line fix and it would have caused a regression. `METAGRAPH_HEALTH_SOURCE` reads `"d1"` in production but is **shared** with `/api/v1/health/trends`, `/api/v1/incidents` and `/api/v1/internal/compare-health` — none of which `data-api` implements. Widening the flag makes all three start forwarding, take a non-2xx, and fire `capturePostgresTierFallback` → **a PostHog exception per request**.

`DATA_API_D1_FLAGS` is a per-flag switch being asked to do a per-route job. This route is internal and service-binding-only, so it does not need the public proxy's flag gate at all — the same argument `data-api`'s `subnet-identity-sync` handler already makes for calling `env.DATA_API.fetch()` directly.

**The flag still decides *whether* to ask.** An unset or non-tier value reads no tier — both suites already pinned that ("never reaches Postgres when the flag is off"), and it stays true. What changed is only that `"d1"` now names a tier that answers.

## What changed

- `workers/data-api.ts` — implements `GET /api/v1/internal/health-status-live` over D1 `surface_status`, which already carries `last_ok` and `consecutive_failures` (`migrations/d1/0002_observations.sql:52-67`). `?since=` filters on `last_checked`; `0`/absent/unparseable returns everything.
- `src/health-status-live.ts` (new) — `readLiveSurfaceStatus(env, sinceMs)`. Degrades to `[]` on every failure mode: a prober run that cannot read prior state should still probe.
- `src/health-prober.ts`, `src/health-serving.ts` — both use it.

## Why CI did not catch it

The prober's continuity behaviour **was** tested — but only under `METAGRAPH_HEALTH_SOURCE="postgres"`, which forwards. Production has read `"d1"` since the box was retired, so the suite passed while the real run resolved the read to null. The new case runs the same assertions under `"d1"`, and fails on the unfixed code:

```
× carries prior last_ok and the failure streak under the d1 flag production actually runs
  AssertionError: Expected values to be strictly equal
```

## Coverage

`src/health-status-live.ts` — **100% lines / branches / statements** (12 tests).
`workers/data-api.ts` — **100% of changed statements** (20/20), measured by diff intersection, not whole-file.

## Known limit

`last_ok` stays null for the 24 surfaces with no successful probe on record. That is the correct encoding of "never seen healthy", not a gap.

Note `registry/verification/surface-health.json` is **not** a usable substitute source — 624 of its 625 rows carry the identical timestamp `2026-08-02T07:00:56.015Z` (the rollup's own generation stamp), so joining against it would publish a fabricated last-success time for endpoints down for weeks.

## Validation

```
npm run lint            npm run format:check      npm run typecheck
npm run validate        npm run scan:public-safety
npx vitest run tests/health-prober.test.ts tests/health-serving.test.ts \
  tests/health-status-live.test.ts tests/data-api-health-status-d1.test.ts \
  tests/data-api.test.ts tests/data-api-neurons-d1.test.ts
  -> 450 passed
```

Closes #9522