### PR TITLE
feat(chain-summaries): give the governance feeds a summary sentence

### DIFF
--- a/packages/chain-summaries/dist/index.cjs
+++ b/packages/chain-summaries/dist/index.cjs
@@ -630,6 +630,61 @@ function timelockedWeightsTemplate() {
     return `${addressLabel(ctx.signer)} committed time-locked weights for ${netuid}, revealing at round ${round}.`;
   };
 }
+function callArgEntries(callArgs) {
+  if (Array.isArray(callArgs)) {
+    return callArgs.filter((a) => typeof a?.name === "string").map((a) => [a.name, a.value]);
+  }
+  if (callArgs && typeof callArgs === "object") {
+    return Object.entries(callArgs);
+  }
+  return null;
+}
+function valueLabel(value) {
+  if (value === null || value === void 0) return "none";
+  if (typeof value === "boolean") return String(value);
+  if (typeof value === "number") return fmtNumber(value);
+  if (typeof value === "string") {
+    if (value === "") return null;
+    const asNumber2 = parseNetuidLike(value);
+    if (asNumber2 !== null && /^(0x[0-9a-f]+|-?\d+)$/i.test(value.trim())) {
+      return fmtNumber(asNumber2);
+    }
+    return shortHash(value) ?? value;
+  }
+  if (Array.isArray(value)) {
+    const parts = value.map((item) => valueLabel(item));
+    if (parts.some((part) => part === null)) return null;
+    return `[${parts.join(", ")}]`;
+  }
+  return null;
+}
+function humanizeParam(name) {
+  return name.replace(/_/g, " ").trim();
+}
+function adminUtilsTemplate(callFunction) {
+  const SET_PREFIX = "sudo_set_";
+  if (!callFunction.startsWith(SET_PREFIX)) return null;
+  const param = humanizeParam(callFunction.slice(SET_PREFIX.length));
+  if (!param) return null;
+  return (callArgs) => {
+    const entries = callArgEntries(callArgs);
+    if (!entries) return null;
+    const netuid = subnetLabel(callArgValue(callArgs, "netuid"));
+    const rest = entries.filter(([name]) => name !== "netuid");
+    if (rest.length === 0) return null;
+    const rendered = rest.map(([name, value]) => {
+      const label = valueLabel(value);
+      return label === null ? null : rest.length === 1 ? label : `${humanizeParam(name)} ${label}`;
+    });
+    if (rendered.some((part) => part === null)) return null;
+    const target = netuid ? ` for ${netuid}` : "";
+    return `Set ${param}${target} to ${rendered.join(", ")}.`;
+  };
+}
+function patternTemplate(callModule, callFunction) {
+  if (callModule === "AdminUtils") return adminUtilsTemplate(callFunction);
+  return null;
+}
 function describeInner(call, ctx) {
   if (!call) return "an unrecognized call";
   const summary = summarizeCall(call.call_module, call.call_function, call.call_args, ctx);
@@ -702,7 +757,22 @@ var CALL_TEMPLATES = {
     const pages = fmtNumber(callArgValue(callArgs, "pages"));
     return pages ? `Set the node heap page allocation to ${pages}.` : "Set the node heap page allocation.";
   },
-  "System.remark": (_args, ctx) => `${addressLabel(ctx.signer)} submitted an on-chain remark.`
+  "System.remark": (_args, ctx) => `${addressLabel(ctx.signer)} submitted an on-chain remark.`,
+  // Sudo is subtensor's only root-origin pathway (it has no Council/Senate).
+  // Every observed get_sudo row is a WRAPPER whose payload is the interesting
+  // part -- a flat sentence here would say "someone used sudo" and omit what
+  // they did -- so these recurse like Utility.batch*/Proxy.proxy. The inner
+  // call is usually AdminUtils, which is why this and adminUtilsTemplate ship
+  // together: without the latter, a sudo-wrapped config change would still
+  // bottom out in describeInner's raw `module.function` fallback.
+  "Sudo.sudo": (callArgs, ctx) => `${addressLabel(ctx.signer)} executed a root call: ${describeInner(asDecodedCall(callArgValue(callArgs, "call")), ctx)}`,
+  "Sudo.sudo_unchecked_weight": (callArgs, ctx) => `${addressLabel(ctx.signer)} executed a root call: ${describeInner(asDecodedCall(callArgValue(callArgs, "call")), ctx)}`,
+  "Sudo.sudo_as": (callArgs, ctx) => {
+    const who = callArgValue(callArgs, "who");
+    return `${addressLabel(ctx.signer)} executed a root call as ${addressLabel(who)}: ${describeInner(asDecodedCall(callArgValue(callArgs, "call")), { signer: typeof who === "string" ? who : ctx.signer })}`;
+  },
+  "Sudo.set_key": (callArgs, ctx) => `${addressLabel(ctx.signer)} transferred the sudo key to ${addressLabel(callArgValue(callArgs, "new"))}.`,
+  "Sudo.remove_key": (_args, ctx) => `${addressLabel(ctx.signer)} removed the sudo key, permanently disabling root calls.`
 };
 function batchSentence(callArgs, ctx) {
   const calls = callArgValue(callArgs, "calls");
@@ -714,7 +784,7 @@ function batchSentence(callArgs, ctx) {
 }
 function summarizeCall(callModule, callFunction, callArgs, ctx = {}) {
   if (!callModule || !callFunction) return null;
-  const template = CALL_TEMPLATES[`${callModule}.${callFunction}`];
+  const template = CALL_TEMPLATES[`${callModule}.${callFunction}`] ?? patternTemplate(callModule, callFunction);
   if (!template) return null;
   try {
     return template(callArgs, ctx);

--- a/packages/chain-summaries/dist/index.js
+++ b/packages/chain-summaries/dist/index.js
@@ -628,6 +628,61 @@ function timelockedWeightsTemplate() {
     return `${addressLabel(ctx.signer)} committed time-locked weights for ${netuid}, revealing at round ${round}.`;
   };
 }
+function callArgEntries(callArgs) {
+  if (Array.isArray(callArgs)) {
+    return callArgs.filter((a) => typeof a?.name === "string").map((a) => [a.name, a.value]);
+  }
+  if (callArgs && typeof callArgs === "object") {
+    return Object.entries(callArgs);
+  }
+  return null;
+}
+function valueLabel(value) {
+  if (value === null || value === void 0) return "none";
+  if (typeof value === "boolean") return String(value);
+  if (typeof value === "number") return fmtNumber(value);
+  if (typeof value === "string") {
+    if (value === "") return null;
+    const asNumber2 = parseNetuidLike(value);
+    if (asNumber2 !== null && /^(0x[0-9a-f]+|-?\d+)$/i.test(value.trim())) {
+      return fmtNumber(asNumber2);
+    }
+    return shortHash(value) ?? value;
+  }
+  if (Array.isArray(value)) {
+    const parts = value.map((item) => valueLabel(item));
+    if (parts.some((part) => part === null)) return null;
+    return `[${parts.join(", ")}]`;
+  }
+  return null;
+}
+function humanizeParam(name) {
+  return name.replace(/_/g, " ").trim();
+}
+function adminUtilsTemplate(callFunction) {
+  const SET_PREFIX = "sudo_set_";
+  if (!callFunction.startsWith(SET_PREFIX)) return null;
+  const param = humanizeParam(callFunction.slice(SET_PREFIX.length));
+  if (!param) return null;
+  return (callArgs) => {
+    const entries = callArgEntries(callArgs);
+    if (!entries) return null;
+    const netuid = subnetLabel(callArgValue(callArgs, "netuid"));
+    const rest = entries.filter(([name]) => name !== "netuid");
+    if (rest.length === 0) return null;
+    const rendered = rest.map(([name, value]) => {
+      const label = valueLabel(value);
+      return label === null ? null : rest.length === 1 ? label : `${humanizeParam(name)} ${label}`;
+    });
+    if (rendered.some((part) => part === null)) return null;
+    const target = netuid ? ` for ${netuid}` : "";
+    return `Set ${param}${target} to ${rendered.join(", ")}.`;
+  };
+}
+function patternTemplate(callModule, callFunction) {
+  if (callModule === "AdminUtils") return adminUtilsTemplate(callFunction);
+  return null;
+}
 function describeInner(call, ctx) {
   if (!call) return "an unrecognized call";
   const summary = summarizeCall(call.call_module, call.call_function, call.call_args, ctx);
@@ -700,7 +755,22 @@ var CALL_TEMPLATES = {
     const pages = fmtNumber(callArgValue(callArgs, "pages"));
     return pages ? `Set the node heap page allocation to ${pages}.` : "Set the node heap page allocation.";
   },
-  "System.remark": (_args, ctx) => `${addressLabel(ctx.signer)} submitted an on-chain remark.`
+  "System.remark": (_args, ctx) => `${addressLabel(ctx.signer)} submitted an on-chain remark.`,
+  // Sudo is subtensor's only root-origin pathway (it has no Council/Senate).
+  // Every observed get_sudo row is a WRAPPER whose payload is the interesting
+  // part -- a flat sentence here would say "someone used sudo" and omit what
+  // they did -- so these recurse like Utility.batch*/Proxy.proxy. The inner
+  // call is usually AdminUtils, which is why this and adminUtilsTemplate ship
+  // together: without the latter, a sudo-wrapped config change would still
+  // bottom out in describeInner's raw `module.function` fallback.
+  "Sudo.sudo": (callArgs, ctx) => `${addressLabel(ctx.signer)} executed a root call: ${describeInner(asDecodedCall(callArgValue(callArgs, "call")), ctx)}`,
+  "Sudo.sudo_unchecked_weight": (callArgs, ctx) => `${addressLabel(ctx.signer)} executed a root call: ${describeInner(asDecodedCall(callArgValue(callArgs, "call")), ctx)}`,
+  "Sudo.sudo_as": (callArgs, ctx) => {
+    const who = callArgValue(callArgs, "who");
+    return `${addressLabel(ctx.signer)} executed a root call as ${addressLabel(who)}: ${describeInner(asDecodedCall(callArgValue(callArgs, "call")), { signer: typeof who === "string" ? who : ctx.signer })}`;
+  },
+  "Sudo.set_key": (callArgs, ctx) => `${addressLabel(ctx.signer)} transferred the sudo key to ${addressLabel(callArgValue(callArgs, "new"))}.`,
+  "Sudo.remove_key": (_args, ctx) => `${addressLabel(ctx.signer)} removed the sudo key, permanently disabling root calls.`
 };
 function batchSentence(callArgs, ctx) {
   const calls = callArgValue(callArgs, "calls");
@@ -712,7 +782,7 @@ function batchSentence(callArgs, ctx) {
 }
 function summarizeCall(callModule, callFunction, callArgs, ctx = {}) {
   if (!callModule || !callFunction) return null;
-  const template = CALL_TEMPLATES[`${callModule}.${callFunction}`];
+  const template = CALL_TEMPLATES[`${callModule}.${callFunction}`] ?? patternTemplate(callModule, callFunction);
   if (!template) return null;
   try {
     return template(callArgs, ctx);

--- a/packages/chain-summaries/src/chain-summaries.test.ts
+++ b/packages/chain-summaries/src/chain-summaries.test.ts
@@ -394,6 +394,192 @@ describe("summarizeCall", () => {
     expect(keys).toContain("Utility.batch_all");
     expect(keys.length).toBeGreaterThanOrEqual(20);
   });
+
+  // #9525. get_sudo and get_governance_config_changes filter to exactly the
+  // Sudo and AdminUtils pallets, and neither had a single template -- so
+  // `summary` was null on 100% of both feeds while the global >=95% coverage
+  // bar stayed green on SubtensorModule-dominated traffic.
+  //
+  // Every call_args fixture below was captured live from api.metagraph.sh
+  // (get_sudo / get_governance_config_changes, 2026-08-05), same discipline as
+  // the fixtures above.
+  describe("governance pallets (#9525)", () => {
+    const SIGNER = "5DA2vLrSXZxnT9G4Yrywx1Fpi4RXwMH1Ah7r8DTTWS7UZZBM";
+
+    it("AdminUtils.sudo_set_* renders the parameter and its new value", () => {
+      expect(
+        summarizeCall(
+          "AdminUtils",
+          "sudo_set_weights_version_key",
+          [
+            { name: "netuid", type: "NetUid", value: 107 },
+            { name: "weights_version_key", type: "u64", value: 20 },
+          ],
+          { signer: SIGNER },
+        ),
+      ).toBe("Set weights version key for SN107 to 20.");
+    });
+
+    // A multi-value setter must name every value it changed: reporting only
+    // the first would understate the call.
+    it("renders every non-netuid arg, not just the first", () => {
+      expect(
+        summarizeCall(
+          "AdminUtils",
+          "sudo_set_mechanism_emission_split",
+          [
+            { name: "netuid", value: 89 },
+            { name: "maybe_split", value: [52428, 13107] },
+          ],
+          { signer: SIGNER },
+        ),
+      ).toBe("Set mechanism emission split for SN89 to [52,428, 13,107].");
+    });
+
+    it("renders a boolean hyperparameter literally", () => {
+      expect(
+        summarizeCall(
+          "AdminUtils",
+          "sudo_set_network_registration_allowed",
+          [
+            { name: "netuid", value: 92 },
+            { name: "registration_allowed", value: false },
+          ],
+          { signer: SIGNER },
+        ),
+      ).toBe("Set network registration allowed for SN92 to false.");
+    });
+
+    it("omits the subnet clause for a network-wide setter", () => {
+      expect(
+        summarizeCall("AdminUtils", "sudo_set_tx_rate_limit", { tx_rate_limit: 1000 }, {}),
+      ).toBe("Set tx rate limit to 1,000.");
+    });
+
+    // The refusal half of the contract: a value with no faithful one-line form
+    // declines the sentence rather than half-rendering it.
+    it("declines rather than half-rendering an unstatable value", () => {
+      expect(
+        summarizeCall(
+          "AdminUtils",
+          "sudo_set_something",
+          [
+            { name: "netuid", value: 1 },
+            { name: "opaque", value: { nested: "object" } },
+          ],
+          {},
+        ),
+      ).toBeNull();
+      // No args beyond netuid: nothing to report as the new value.
+      expect(
+        summarizeCall("AdminUtils", "sudo_set_x", [{ name: "netuid", value: 1 }], {}),
+      ).toBeNull();
+      // Not a setter, so the pattern does not claim it.
+      expect(summarizeCall("AdminUtils", "some_other_call", { a: 1 }, {})).toBeNull();
+    });
+
+    // Every observed get_sudo row is a wrapper; a flat sentence would say
+    // "someone used sudo" and omit what they actually did.
+    it("Sudo.sudo recurses into the wrapped call", () => {
+      expect(
+        summarizeCall(
+          "Sudo",
+          "sudo",
+          [
+            {
+              name: "call",
+              type: "RuntimeCall",
+              value: {
+                call_module: "AdminUtils",
+                call_function: "sudo_set_weights_set_rate_limit",
+                call_args: { netuid: 6, weights_set_rate_limit: 10 },
+              },
+            },
+          ],
+          { signer: SIGNER },
+        ),
+      ).toBe(
+        `${shortHash(SIGNER)} executed a root call: Set weights set rate limit for SN6 to 10.`,
+      );
+    });
+
+    // An inner pallet with no template still names the call rather than
+    // vanishing -- describeInner's existing raw fallback.
+    it("falls back to the raw inner call name when the inner pallet has no template", () => {
+      expect(
+        summarizeCall(
+          "Sudo",
+          "sudo",
+          [
+            {
+              name: "call",
+              value: {
+                call_module: "Swap",
+                call_function: "toggle_user_liquidity",
+                call_args: { enable: true, netuid: 30 },
+              },
+            },
+          ],
+          { signer: SIGNER },
+        ),
+      ).toBe(`${shortHash(SIGNER)} executed a root call: Swap.toggle_user_liquidity`);
+    });
+
+    it("Sudo.sudo_as attributes the inner call to `who`, not the sudo key", () => {
+      const who = "5CfSg4e23Z3aTXvc2XZie8ZE1xkqRPoyVRFdWUuyyjGxJrMA";
+      expect(
+        summarizeCall(
+          "Sudo",
+          "sudo_as",
+          [
+            { name: "who", value: who },
+            {
+              name: "call",
+              value: {
+                call_module: "System",
+                call_function: "remark",
+                call_args: {},
+              },
+            },
+          ],
+          { signer: SIGNER },
+        ),
+      ).toBe(
+        `${shortHash(SIGNER)} executed a root call as ${shortHash(who)}: ${shortHash(who)} submitted an on-chain remark.`,
+      );
+    });
+
+    it("Sudo key management reads as key management, not as a wrapper", () => {
+      const next = "5CfSg4e23Z3aTXvc2XZie8ZE1xkqRPoyVRFdWUuyyjGxJrMA";
+      expect(
+        summarizeCall("Sudo", "set_key", [{ name: "new", value: next }], { signer: SIGNER }),
+      ).toBe(`${shortHash(SIGNER)} transferred the sudo key to ${shortHash(next)}.`);
+      expect(summarizeCall("Sudo", "remove_key", [], { signer: SIGNER })).toBe(
+        `${shortHash(SIGNER)} removed the sudo key, permanently disabling root calls.`,
+      );
+    });
+
+    it("Sudo.sudo_unchecked_weight recurses like Sudo.sudo", () => {
+      expect(
+        summarizeCall(
+          "Sudo",
+          "sudo_unchecked_weight",
+          [
+            {
+              name: "call",
+              value: {
+                call_module: "AdminUtils",
+                call_function: "sudo_set_tempo",
+                call_args: { netuid: 3, tempo: 360 },
+              },
+            },
+            { name: "weight", value: { ref_time: 1 } },
+          ],
+          { signer: SIGNER },
+        ),
+      ).toBe(`${shortHash(SIGNER)} executed a root call: Set tempo for SN3 to 360.`);
+    });
+  });
 });
 
 describe("summarizeEvent", () => {

--- a/packages/chain-summaries/src/chain-summaries.ts
+++ b/packages/chain-summaries/src/chain-summaries.ts
@@ -92,6 +92,96 @@ function timelockedWeightsTemplate(): CallTemplate {
   };
 }
 
+/** Every `{name, value}` pair on a call, in declaration order, regardless of
+ * which of the two valid call_args shapes decoded (see callArgValue). Null
+ * when callArgs is neither shape. */
+function callArgEntries(callArgs: unknown): Array<[string, unknown]> | null {
+  if (Array.isArray(callArgs)) {
+    return (callArgs as Array<{ name?: string | null; value?: unknown }>)
+      .filter((a) => typeof a?.name === "string")
+      .map((a) => [a.name as string, a.value]);
+  }
+  if (callArgs && typeof callArgs === "object") {
+    return Object.entries(callArgs as Record<string, unknown>);
+  }
+  return null;
+}
+
+/** A hyperparameter's new value, rendered literally. Null for anything this
+ * cannot state exactly -- a nested object has no faithful one-line form, and a
+ * half-rendered value would be exactly the guess this module refuses to make. */
+function valueLabel(value: unknown): string | null {
+  if (value === null || value === undefined) return "none";
+  if (typeof value === "boolean") return String(value);
+  if (typeof value === "number") return fmtNumber(value);
+  if (typeof value === "string") {
+    if (value === "") return null;
+    // Numeric strings (including the hex small-ints nested calls carry) read as
+    // numbers to a human, so format them as such.
+    const asNumber = parseNetuidLike(value);
+    if (asNumber !== null && /^(0x[0-9a-f]+|-?\d+)$/i.test(value.trim())) {
+      return fmtNumber(asNumber);
+    }
+    return shortHash(value) ?? value;
+  }
+  if (Array.isArray(value)) {
+    const parts = value.map((item) => valueLabel(item));
+    if (parts.some((part) => part === null)) return null;
+    return `[${parts.join(", ")}]`;
+  }
+  return null;
+}
+
+/** `sudo_set_weights_version_key` -> `weights version key`. */
+function humanizeParam(name: string): string {
+  return name.replace(/_/g, " ").trim();
+}
+
+/**
+ * AdminUtils is subtensor's root-origin hyperparameter pathway, and it is
+ * uniform by construction: every call is `sudo_set_<param>` taking a `netuid`
+ * plus that parameter's new value. That regularity is why this is derived from
+ * the decoded call rather than written out as ~80 near-identical templates --
+ * a hand-maintained list would go stale the next time the pallet gains a
+ * setter, and silently return to publishing null for it.
+ *
+ * Nothing here is inferred: the parameter name comes from the call's own
+ * decoded name and the value from its own decoded args. A value that cannot be
+ * stated exactly (valueLabel -> null) declines the whole sentence.
+ */
+function adminUtilsTemplate(callFunction: string): CallTemplate | null {
+  const SET_PREFIX = "sudo_set_";
+  if (!callFunction.startsWith(SET_PREFIX)) return null;
+  const param = humanizeParam(callFunction.slice(SET_PREFIX.length));
+  if (!param) return null;
+  return (callArgs) => {
+    const entries = callArgEntries(callArgs);
+    if (!entries) return null;
+    const netuid = subnetLabel(callArgValue(callArgs, "netuid"));
+    // Every arg except the subnet selector is part of the new value. Rendering
+    // all of them matters for the multi-value setters (e.g.
+    // sudo_set_mechanism_emission_split), where naming only the first would
+    // understate what the call actually changed.
+    const rest = entries.filter(([name]) => name !== "netuid");
+    if (rest.length === 0) return null;
+    const rendered = rest.map(([name, value]) => {
+      const label = valueLabel(value);
+      return label === null ? null : rest.length === 1 ? label : `${humanizeParam(name)} ${label}`;
+    });
+    if (rendered.some((part) => part === null)) return null;
+    const target = netuid ? ` for ${netuid}` : "";
+    return `Set ${param}${target} to ${rendered.join(", ")}.`;
+  };
+}
+
+/** Templates resolved by SHAPE rather than by exact pallet.method, for a
+ * pallet whose call set is uniform and open-ended. Consulted only after the
+ * exact-match table misses, so a hand-written template always wins. */
+function patternTemplate(callModule: string, callFunction: string): CallTemplate | null {
+  if (callModule === "AdminUtils") return adminUtilsTemplate(callFunction);
+  return null;
+}
+
 /** A wrapper call (Utility.batch*, Proxy.proxy) that recurses into its inner call(s). */
 function describeInner(call: DecodedCall | null, ctx: SummaryContext): string {
   if (!call) return "an unrecognized call";
@@ -183,6 +273,27 @@ const CALL_TEMPLATES: Record<string, CallTemplate> = {
       : "Set the node heap page allocation.";
   },
   "System.remark": (_args, ctx) => `${addressLabel(ctx.signer)} submitted an on-chain remark.`,
+  // Sudo is subtensor's only root-origin pathway (it has no Council/Senate).
+  // Every observed get_sudo row is a WRAPPER whose payload is the interesting
+  // part -- a flat sentence here would say "someone used sudo" and omit what
+  // they did -- so these recurse like Utility.batch*/Proxy.proxy. The inner
+  // call is usually AdminUtils, which is why this and adminUtilsTemplate ship
+  // together: without the latter, a sudo-wrapped config change would still
+  // bottom out in describeInner's raw `module.function` fallback.
+  "Sudo.sudo": (callArgs, ctx) =>
+    `${addressLabel(ctx.signer)} executed a root call: ${describeInner(asDecodedCall(callArgValue(callArgs, "call")), ctx)}`,
+  "Sudo.sudo_unchecked_weight": (callArgs, ctx) =>
+    `${addressLabel(ctx.signer)} executed a root call: ${describeInner(asDecodedCall(callArgValue(callArgs, "call")), ctx)}`,
+  "Sudo.sudo_as": (callArgs, ctx) => {
+    const who = callArgValue(callArgs, "who");
+    // The inner call's effective origin is `who`, not the sudo key -- same
+    // signer substitution Proxy.proxy makes for `real`.
+    return `${addressLabel(ctx.signer)} executed a root call as ${addressLabel(who)}: ${describeInner(asDecodedCall(callArgValue(callArgs, "call")), { signer: typeof who === "string" ? who : ctx.signer })}`;
+  },
+  "Sudo.set_key": (callArgs, ctx) =>
+    `${addressLabel(ctx.signer)} transferred the sudo key to ${addressLabel(callArgValue(callArgs, "new"))}.`,
+  "Sudo.remove_key": (_args, ctx) =>
+    `${addressLabel(ctx.signer)} removed the sudo key, permanently disabling root calls.`,
 };
 
 function batchSentence(callArgs: unknown, ctx: SummaryContext): string | null {
@@ -208,7 +319,8 @@ export function summarizeCall(
   ctx: SummaryContext = {},
 ): string | null {
   if (!callModule || !callFunction) return null;
-  const template = CALL_TEMPLATES[`${callModule}.${callFunction}`];
+  const template =
+    CALL_TEMPLATES[`${callModule}.${callFunction}`] ?? patternTemplate(callModule, callFunction);
   if (!template) return null;
   try {
     return template(callArgs, ctx);
@@ -416,6 +528,11 @@ export function summarizeEvent(
 
 /** Every `pallet.method` key this module can produce a sentence for -- used by the coverage script. */
 export function summarizableCallKeys(): string[] {
+  // EXACT-match keys only. AdminUtils is covered by shape instead
+  // (patternTemplate -> adminUtilsTemplate), because its call set is uniform
+  // and open-ended, so it has no finite key list to enumerate here. A coverage
+  // script reading this will understate AdminUtils rather than overstate it,
+  // which is the safe direction for a bar that fails on regressions.
   return Object.keys(CALL_TEMPLATES);
 }
 


### PR DESCRIPTION
## Summary

`get_sudo.summary` and `get_governance_config_changes.summary` were null on **100% of rows** (found by `npm run smoke:mcp`, #9455):

```
get_sudo                       rows=50 path=extrinsics  SUSPECT ALL_NULL(summary)
get_governance_config_changes  rows=50 path=extrinsics  SUSPECT ALL_NULL(summary)
```

Not a broken producer. `summarizeCall` is invoked (`src/extrinsics.ts:202`), the rows are fully decoded, and the field is honestly contracted as "null when no template matches". The problem is that both tools hard-filter to exactly the two pallets `CALL_TEMPLATES` had no entry for, so 0% coverage was arithmetically guaranteed — while the global ≥95% coverage bar stayed green on SubtensorModule-dominated traffic and could not see either tail.

```
templates before: 26
modules:          SubtensorModule, Drand, Ethereum, Commitments, MevShield,
                  Timestamp, Balances, Utility, Proxy, System
has Sudo.*: false | has AdminUtils.*: false
```

## Before / after, on rows pulled from production

| Call | Before | After |
| --- | --- | --- |
| `AdminUtils.sudo_set_weights_version_key` (netuid 107, key 20) | `null` | Set weights version key for SN107 to 20. |
| `AdminUtils.sudo_set_mechanism_emission_split` (netuid 89, `[52428, 13107]`) | `null` | Set mechanism emission split for SN89 to [52,428, 13,107]. |
| `AdminUtils.sudo_set_network_registration_allowed` (netuid 92, false) | `null` | Set network registration allowed for SN92 to false. |
| `Sudo.sudo` → `AdminUtils.sudo_set_weights_set_rate_limit` | `null` | 5DA2vL…7UZZBM executed a root call: Set weights set rate limit for SN6 to 10. |
| `Sudo.sudo` → `Swap.toggle_user_liquidity` | `null` | 5DA2vL…7UZZBM executed a root call: Swap.toggle_user_liquidity |

## AdminUtils is derived, not enumerated

Every call in that pallet is `sudo_set_<param>` taking `netuid` plus the new value. Writing ~80 near-identical templates by hand would go stale the next time the pallet gains a setter — silently returning to publishing null for it.

**Nothing is inferred.** The parameter name comes from the call's own decoded name; the value from its own decoded args. A value with no faithful one-line form (a nested object) declines the whole sentence rather than half-rendering it — the same refusal the module already makes everywhere else. Multi-value setters name *every* value they changed, because reporting only the first would understate the call.

Pattern matching is consulted **only after** the exact-match table misses, so a hand-written template always wins.

## Sudo recurses

Every observed `get_sudo` row is a wrapper; a flat sentence would say "someone used sudo" and omit what they actually did. So `Sudo.sudo` / `sudo_unchecked_weight` / `sudo_as` recurse via the existing `describeInner`, exactly like `Utility.batch*` and `Proxy.proxy`. `sudo_as` attributes the inner call to `who`, matching the signer substitution `Proxy.proxy` already makes for `real`.

The two halves ship together deliberately: without the AdminUtils templates, a sudo-wrapped config change would still bottom out in `describeInner`'s raw `module.function` fallback — which is exactly the last row of the table above, kept for an inner pallet that genuinely has no template.

`Sudo.set_key` / `remove_key` are key management rather than wrappers, and read as such.

## Notes

- `summarizableCallKeys()` still returns exact-match keys only; its doc now says so. A coverage script reading it will *understate* AdminUtils rather than overstate it — the safe direction for a bar that fails on regressions.
- Every fixture in the new tests is a real decoded `call_args` captured from `api.metagraph.sh` on 2026-08-05, same discipline as the existing fixtures.
- `packages/chain-summaries/dist/{index.js,index.cjs}` are committed (CI drift-checks them), so the rebuilt output is in this diff.

## Validation

```
npm run lint            npm run format:check      npm run typecheck
npm run validate        npm run scan:public-safety
npm run build --workspace=packages/chain-summaries
npx vitest run --root packages/chain-summaries   -> 122 passed, 1 skipped
npx vitest run tests/extrinsics.test.ts          -> 49 passed
```

Rebased onto current `main`.

Closes #9525