### PR TITLE
fix(watchdog): count coldkeys covered on the nominator-positions lane

### DIFF
--- a/src/nominator-positions-staleness-watchdog.ts
+++ b/src/nominator-positions-staleness-watchdog.ts
@@ -8,9 +8,49 @@
 // No probe, no red check, no exception -- the failure was invisible precisely
 // because the read path degraded so gracefully.
 //
-// Same shape as src/neurons-staleness-watchdog.ts deliberately: one MAX() read,
+// Same shape as src/neurons-staleness-watchdog.ts deliberately: a single read,
 // a pure rule, a summary rather than a throw, and one exception event per stale
 // tick on the project's alert channel. Zero alerts is the correct steady state.
+//
+// ## COVERAGE IS COUNTED IN COLDKEYS HERE (#9530, #9533)
+//
+// The last of the four keyspace-scan lanes to get the coverage signal #9530
+// added after a watchdog reading one `MAX(captured_at)` reported
+// `ok | age=0.6h` over an account_balances table holding 147,000 rows -- 48% of
+// the network. A fresh timestamp says when something last landed; it cannot say
+// whether the whole thing landed.
+//
+// THE UNIT IS COLDKEYS BECAUSE THE PRUNE IS PER COLDKEY. This lane's writer
+// (src/nominator-positions-d1-write.ts) deletes the positions a coldkey's own
+// batch did not refresh, but only for coldkeys the batch CONTAINS -- an
+// unstaked position genuinely stops existing, so that prune is correct. A
+// coldkey absent from the pass entirely is left completely untouched, still
+// carrying its previous stamp. So a scan that dies partway restamps the
+// coldkeys it reached, leaves the rest behind a `MAX()` that just advanced, and
+// /accounts/{ss58}/positions answers for those with a confident, silently
+// pass-old position set.
+//
+// ROWS WOULD BE THE WRONG UNIT for the same reason it is on the neurons lane:
+// coldkeys hold wildly different numbers of positions (122,836 rows across
+// 23,668 coldkeys, so a mean of ~5 but a long tail), and a scan that died after
+// the largest delegators could show high row coverage having missed most of the
+// accounts. Coldkeys are what the scan iterates and what the prune is keyed on,
+// so they are what a partial pass is partial IN.
+//
+// MEASURED 2026-08-05, production D1: 124,817 rows over three vintages --
+// 122,836 rows / 23,668 coldkeys at the newest stamp, then 1,815/401 and 166/52
+// older. Those 453 straggler coldkeys are the prune working as designed, and
+// they are why coverage is counted over a WINDOW against an absolute floor
+// rather than as a ratio of the table (which would read 98.1% and drift down
+// forever as coldkeys stop delegating).
+//
+// The producer is the SAME 24h job that writes validator_nominator_counts --
+// both tables carried the identical `captured_at` in that reading -- so the
+// window and floor here are sized against that one scan, exactly as the sibling
+// watchdog's are.
+//
+// COST: one walk of ~125k rows on an `8,38 * * * *` cron, 48 ticks a day, so
+// ~6M D1 rows read a day.
 
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
@@ -43,48 +83,142 @@ import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
  */
 export const NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS = 30 * 60 * 60 * 1000;
 
+/**
+ * How many coldkeys a COMPLETE pass is expected to cover.
+ *
+ * 23,668, read off production D1 on 2026-08-05 as `COUNT(DISTINCT coldkey)` at
+ * the newest `captured_at` -- every coldkey the SubtensorModule::Alpha scan
+ * found holding at least one position.
+ */
+export const NOMINATOR_POSITIONS_EXPECTED_COLDKEYS = 23_668;
+
+/**
+ * How much of that a single pass must cover before it counts as complete.
+ *
+ * EIGHTY PERCENT (~18,934 coldkeys), the ratio the three sibling lanes use.
+ *
+ * The drift here runs the same direction as validator_nominator_counts and NOT
+ * the same as account_balances, because this counts coldkeys holding a position
+ * RIGHT NOW: it can genuinely shrink as delegators unstake. So a MARGINAL miss
+ * on an otherwise-healthy lane means re-measure and lower this, not hunt for a
+ * truncated pass -- a real mid-scan death lands far below, near a chunk
+ * boundary. The 453 straggler coldkeys already in the table (see the module
+ * header) are ~1.9%, nowhere near this floor.
+ *
+ * Overridable via NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS.
+ */
+export const NOMINATOR_POSITIONS_COVERAGE_FLOOR_RATIO = 0.8;
+
+/** The floor the rule compares against, ~18,934 coldkeys. */
+export const NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS = Math.round(
+  NOMINATOR_POSITIONS_EXPECTED_COLDKEYS *
+    NOMINATOR_POSITIONS_COVERAGE_FLOOR_RATIO,
+);
+
+/**
+ * How far back from the newest stamp still counts as "the newest pass".
+ *
+ * FOUR HOURS, the same as validator_nominator_counts and for the same reason:
+ * it is the SAME 24h producer scan writing both tables. Bounded from both ends
+ * -- too small and the intra-pass spread reads as several partial passes (the
+ * scan is ~4 minutes at the measured ~3,100 rows/sec, so this is three orders
+ * of magnitude of headroom); too large and two consecutive passes merge into
+ * one coverage count, letting a truncated pass on top of a complete one report
+ * full coverage and restoring the bug. A sixth of the cadence sits well clear
+ * of both.
+ *
+ * Overridable via NOMINATOR_POSITIONS_PASS_WINDOW_MS, which must be re-sized
+ * against the poll interval if that interval ever shortens.
+ */
+export const NOMINATOR_POSITIONS_PASS_WINDOW_MS = 4 * 60 * 60 * 1000;
+
+/**
+ * One read, answering both questions: how fresh the newest pass is, and how
+ * many coldkeys it actually reached.
+ *
+ * `total` is the coldkey count across ALL vintages -- context rather than the
+ * rule. Read together the pair is the diagnosis: `covered` well under `total`
+ * is a scan that died partway through the keyspace.
+ */
+const NOMINATOR_POSITIONS_COVERAGE_SQL =
+  "SELECT COUNT(DISTINCT coldkey) AS total, MAX(captured_at) AS latest, " +
+  "COUNT(DISTINCT CASE WHEN captured_at >= " +
+  "(SELECT MAX(captured_at) FROM nominator_positions) - ? THEN coldkey END) " +
+  "AS covered FROM nominator_positions";
+
+export type NominatorPositionsStalenessReason =
+  "no_rows" | "stale" | "partial" | null;
+
 export interface NominatorPositionsStalenessVerdict {
   stale: boolean;
-  reason: "no_rows" | "stale" | null;
+  reason: NominatorPositionsStalenessReason;
   age_ms: number | null;
   latest_captured_at: number | null;
   threshold_ms: number;
+  /** Coldkeys the newest pass covered. The coverage signal itself. */
+  covered_coldkeys: number;
+  /** Coldkeys in the table across all vintages. Context, never the rule. */
+  total_coldkeys: number;
+  coverage_floor_coldkeys: number;
 }
 
 /** The rule alone, testable without a database or a clock. */
 export function evaluateNominatorPositionsStaleness(input: {
   latestCapturedAtMs: number | null;
+  coveredColdkeys: number;
+  totalColdkeys: number;
   nowMs: number;
   thresholdMs: number;
+  coverageFloorColdkeys: number;
 }): NominatorPositionsStalenessVerdict {
-  const { latestCapturedAtMs, nowMs, thresholdMs } = input;
+  const {
+    latestCapturedAtMs,
+    coveredColdkeys,
+    totalColdkeys,
+    nowMs,
+    thresholdMs,
+    coverageFloorColdkeys,
+  } = input;
+  const base = {
+    latest_captured_at: latestCapturedAtMs,
+    threshold_ms: thresholdMs,
+    covered_coldkeys: coveredColdkeys,
+    total_coldkeys: totalColdkeys,
+    coverage_floor_coldkeys: coverageFloorColdkeys,
+  };
   if (latestCapturedAtMs === null) {
     // An empty table is a stall of infinite age, not a healthy quiet one --
     // and here it is also the CUTOVER state, before the revived lane has
     // posted anything. That is exactly the condition worth alerting on: an
     // empty hot tier means every positions read is still answering from the
     // frozen lakehouse export.
-    return {
-      stale: true,
-      reason: "no_rows",
-      age_ms: null,
-      latest_captured_at: null,
-      threshold_ms: thresholdMs,
-    };
+    return { ...base, stale: true, reason: "no_rows", age_ms: null };
   }
   const age = nowMs - latestCapturedAtMs;
-  return {
-    stale: age > thresholdMs,
-    reason: age > thresholdMs ? "stale" : null,
-    age_ms: age,
-    latest_captured_at: latestCapturedAtMs,
-    threshold_ms: thresholdMs,
-  };
+  if (age > thresholdMs) {
+    // Checked BEFORE coverage: if a whole pass has been missed, the coverage
+    // number describes an old one and the headline is that the producer stopped.
+    return { ...base, stale: true, reason: "stale", age_ms: age };
+  }
+  if (coveredColdkeys < coverageFloorColdkeys) {
+    // Recent AND short -- a scan that died partway through the coldkey walk,
+    // leaving the accounts it never reached behind a freshly advanced MAX().
+    return { ...base, stale: true, reason: "partial", age_ms: age };
+  }
+  return { ...base, stale: false, reason: null, age_ms: age };
+}
+
+/** A null count over no rows, or a shim that stringifies, must land on 0 rather
+ * than NaN -- a NaN compares false against the floor and would report a
+ * half-scanned keyspace healthy. */
+function countOrZero(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
 }
 
 interface D1Like {
   prepare(sql: string): {
-    first(): Promise<unknown>;
+    bind(...values: unknown[]): { first(): Promise<unknown> };
   };
 }
 
@@ -114,25 +248,44 @@ export async function runNominatorPositionsStalenessWatchdog(
   const thresholdMs =
     Number(env?.NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS) ||
     NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS;
+  const passWindowMs =
+    Number(env?.NOMINATOR_POSITIONS_PASS_WINDOW_MS) ||
+    NOMINATOR_POSITIONS_PASS_WINDOW_MS;
+  const coverageFloorColdkeys =
+    Number(env?.NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS) ||
+    NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS;
 
   try {
     const row = (await db
-      .prepare("SELECT MAX(captured_at) AS latest FROM nominator_positions")
-      .first()) as { latest: number | null } | null;
+      .prepare(NOMINATOR_POSITIONS_COVERAGE_SQL)
+      .bind(passWindowMs)
+      .first()) as {
+      latest: number | null;
+      covered: number | null;
+      total: number | null;
+    } | null;
     const verdict = evaluateNominatorPositionsStaleness({
       latestCapturedAtMs: row?.latest ?? null,
+      coveredColdkeys: countOrZero(row?.covered),
+      totalColdkeys: countOrZero(row?.total),
       nowMs: now(),
       thresholdMs,
+      coverageFloorColdkeys,
     });
     if (verdict.stale) {
+      // The two faults get different wording on purpose -- "the producer
+      // stopped" and "the producer is running and not finishing" send whoever
+      // reads the alert to different places.
       const age =
         verdict.age_ms === null
           ? "no rows at all"
           : `${(verdict.age_ms / 3_600_000).toFixed(1)} h old`;
+      const message =
+        verdict.reason === "partial"
+          ? `nominator-positions lane truncated: the newest pass covered only ${verdict.covered_coldkeys} of ${verdict.total_coldkeys} coldkeys against a floor of ${verdict.coverage_floor_coldkeys} (newest stamp ${age}) -- the capture is RECENT and PARTIAL, so /accounts/{ss58}/positions answers for every coldkey the scan never reached with a confident position set that is silently a pass old`
+          : `nominator-positions lane stalled: latest snapshot is ${age} (threshold ${thresholdMs / 3_600_000} h) -- /accounts/{ss58}/positions is answering from a ledger nothing is refreshing`;
       await record(env as never, {
-        error: new Error(
-          `nominator-positions lane stalled: latest snapshot is ${age} (threshold ${thresholdMs / 3_600_000} h) -- /accounts/{ss58}/positions is answering from a ledger nothing is refreshing`,
-        ),
+        error: new Error(message),
         route: "watchdog:nominator-positions-staleness",
         errorCode: "stale_lane",
       }).catch(() => false);

--- a/tests/nominator-positions-staleness-watchdog.test.ts
+++ b/tests/nominator-positions-staleness-watchdog.test.ts
@@ -9,6 +9,9 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 import {
+  NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS,
+  NOMINATOR_POSITIONS_EXPECTED_COLDKEYS,
+  NOMINATOR_POSITIONS_PASS_WINDOW_MS,
   NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS,
   evaluateNominatorPositionsStaleness,
   runNominatorPositionsStalenessWatchdog,
@@ -19,17 +22,32 @@ import * as workerConfig from "../workers/config.ts";
 const NOW = 1_785_800_000_000;
 const HOUR = 60 * 60_000;
 
-function fakeDb(latest: number | null | Error) {
+/** A pass that covered the keyspace, so coverage is never the thing under test
+ * unless a case says so. */
+const FULL = NOMINATOR_POSITIONS_EXPECTED_COLDKEYS;
+
+function fakeDb(
+  latest: number | null | Error,
+  covered: number = FULL,
+  total: number = FULL,
+) {
   const queries: string[] = [];
+  const binds: unknown[][] = [];
   return {
     queries,
+    binds,
     db: {
       prepare(sql: string) {
         queries.push(sql);
         return {
-          async first() {
-            if (latest instanceof Error) throw latest;
-            return { latest };
+          bind(...values: unknown[]) {
+            binds.push(values);
+            return {
+              async first() {
+                if (latest instanceof Error) throw latest;
+                return { latest, covered, total };
+              },
+            };
           },
         };
       },
@@ -37,13 +55,27 @@ function fakeDb(latest: number | null | Error) {
   };
 }
 
+/** The rule's inputs with everything healthy, so each case overrides only the
+ * one field it is about. */
+function inputs(
+  over: Partial<Parameters<typeof evaluateNominatorPositionsStaleness>[0]> = {},
+) {
+  return {
+    latestCapturedAtMs: NOW - 2 * HOUR,
+    coveredColdkeys: FULL,
+    totalColdkeys: FULL,
+    nowMs: NOW,
+    thresholdMs: NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS,
+    coverageFloorColdkeys: NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS,
+    ...over,
+  };
+}
+
 describe("evaluateNominatorPositionsStaleness", () => {
   test("a recent pass is quiet; one past the threshold is a stall", () => {
-    const fresh = evaluateNominatorPositionsStaleness({
-      latestCapturedAtMs: NOW - 2 * HOUR,
-      nowMs: NOW,
-      thresholdMs: NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS,
-    });
+    const fresh = evaluateNominatorPositionsStaleness(
+      inputs({ latestCapturedAtMs: NOW - 2 * HOUR }),
+    );
     assert.equal(fresh.stale, false);
     assert.equal(fresh.reason, null);
     assert.equal(fresh.age_ms, 2 * HOUR);
@@ -51,11 +83,9 @@ describe("evaluateNominatorPositionsStaleness", () => {
     // 31h, not 7h: the threshold moved to 30h in #9301 once the lane had a
     // real producer on a 24h tick. A 7-hour-old capture is now a HEALTHY
     // mid-cycle reading -- see the constant's own header.
-    const stalled = evaluateNominatorPositionsStaleness({
-      latestCapturedAtMs: NOW - 31 * HOUR,
-      nowMs: NOW,
-      thresholdMs: NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS,
-    });
+    const stalled = evaluateNominatorPositionsStaleness(
+      inputs({ latestCapturedAtMs: NOW - 31 * HOUR }),
+    );
     assert.equal(stalled.stale, true);
     assert.equal(stalled.reason, "stale");
     assert.equal(stalled.latest_captured_at, NOW - 31 * HOUR);
@@ -65,11 +95,9 @@ describe("evaluateNominatorPositionsStaleness", () => {
     // The regression #9301 fixed: at the old 6h threshold this lane alerted
     // for roughly three quarters of every day while working perfectly.
     for (const hours of [7, 12, 20, 23]) {
-      const verdict = evaluateNominatorPositionsStaleness({
-        latestCapturedAtMs: NOW - hours * HOUR,
-        nowMs: NOW,
-        thresholdMs: NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS,
-      });
+      const verdict = evaluateNominatorPositionsStaleness(
+        inputs({ latestCapturedAtMs: NOW - hours * HOUR }),
+      );
       assert.equal(
         verdict.stale,
         false,
@@ -80,24 +108,85 @@ describe("evaluateNominatorPositionsStaleness", () => {
 
   test("exactly at the threshold is not yet a stall", () => {
     // Strictly-greater, so a lane running exactly on cadence never flaps.
-    const verdict = evaluateNominatorPositionsStaleness({
-      latestCapturedAtMs: NOW - NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS,
-      nowMs: NOW,
-      thresholdMs: NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS,
-    });
+    const verdict = evaluateNominatorPositionsStaleness(
+      inputs({
+        latestCapturedAtMs: NOW - NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS,
+      }),
+    );
     assert.equal(verdict.stale, false);
   });
 
   test("an empty table is a stall of infinite age, never a healthy quiet", () => {
-    const verdict = evaluateNominatorPositionsStaleness({
-      latestCapturedAtMs: null,
-      nowMs: NOW,
-      thresholdMs: NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS,
-    });
+    const verdict = evaluateNominatorPositionsStaleness(
+      inputs({ latestCapturedAtMs: null }),
+    );
     assert.equal(verdict.stale, true);
     assert.equal(verdict.reason, "no_rows");
     assert.equal(verdict.age_ms, null);
     assert.equal(verdict.latest_captured_at, null);
+  });
+
+  test("HALF THE COLDKEYS RECENTLY and ALL THE COLDKEYS RECENTLY are told apart", () => {
+    // The acceptance criterion. Both ticks carry an identically fresh
+    // MAX(captured_at); the ONLY difference is how far into the coldkey walk
+    // the scan got, which is exactly what a timestamp cannot express.
+    const half = evaluateNominatorPositionsStaleness(
+      inputs({ coveredColdkeys: 11_800, totalColdkeys: FULL }),
+    );
+    assert.equal(
+      half.stale,
+      true,
+      "a half-scanned keyspace must not read as ok",
+    );
+    assert.equal(half.reason, "partial");
+    // Recent, not old -- caught WITHOUT any time passing.
+    assert.equal(half.age_ms, 2 * HOUR);
+    assert.ok(half.age_ms < half.threshold_ms);
+
+    const whole = evaluateNominatorPositionsStaleness(inputs());
+    assert.equal(whole.stale, false);
+    assert.equal(whole.reason, null);
+    assert.equal(whole.age_ms, half.age_ms);
+  });
+
+  test("the per-coldkey prune's stragglers do not count against coverage", () => {
+    // Measured 2026-08-05: 23,668 coldkeys at the newest stamp plus 453 across
+    // two older vintages, because a coldkey absent from a pass is left
+    // untouched by design. A healthy tick must stay quiet with them present --
+    // which is why the floor is absolute rather than a ratio of the table, a
+    // ratio would read 98.1% here and drift down forever.
+    const verdict = evaluateNominatorPositionsStaleness(
+      inputs({ coveredColdkeys: 23_668, totalColdkeys: 24_121 }),
+    );
+    assert.equal(verdict.stale, false);
+    assert.equal(verdict.reason, null);
+  });
+
+  test("a pass exactly at the floor is complete; one coldkey under is not", () => {
+    // Strictly-less, matching the threshold edge, so a lane landing exactly on
+    // the floor never flaps.
+    const atFloor = evaluateNominatorPositionsStaleness(
+      inputs({ coveredColdkeys: NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS }),
+    );
+    assert.equal(atFloor.stale, false);
+    assert.equal(atFloor.reason, null);
+
+    const under = evaluateNominatorPositionsStaleness(
+      inputs({
+        coveredColdkeys: NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS - 1,
+      }),
+    );
+    assert.equal(under.stale, true);
+    assert.equal(under.reason, "partial");
+  });
+
+  test("a stalled lane reports `stale`, not `partial`, even when also short", () => {
+    // If a whole 24h pass has been missed, "the producer stopped" is the
+    // headline and the coverage of its last attempt is a detail.
+    const verdict = evaluateNominatorPositionsStaleness(
+      inputs({ latestCapturedAtMs: NOW - 34 * HOUR, coveredColdkeys: 11_800 }),
+    );
+    assert.equal(verdict.reason, "stale");
   });
 });
 
@@ -118,7 +207,112 @@ describe("runNominatorPositionsStalenessWatchdog", () => {
     assert.equal(result.ok, true);
     assert.equal(result.alerted, false);
     assert.deepEqual(recorded, []);
-    assert.match(queries[0]!, /MAX\(captured_at\).*FROM nominator_positions/);
+    assert.match(queries[0]!, /MAX\(captured_at\)/);
+    assert.match(queries[0]!, /FROM nominator_positions/);
+    // The coverage half has to be IN the read, or the rule is being handed a
+    // number nothing measured. DISTINCT coldkey, not COUNT(*) -- rows would
+    // hide a scan that died after the largest delegators.
+    assert.match(queries[0]!, /COUNT\(DISTINCT coldkey\) AS total/);
+    assert.match(queries[0]!, /THEN coldkey END\) AS covered/);
+  });
+
+  test("the read counts only the newest pass, bounded by the pass window", () => {
+    // A window spanning the 24h poll interval would merge two consecutive
+    // passes into one coverage count, so a truncated pass landing on a complete
+    // one would report full coverage -- the bug, restored.
+    const { db, queries, binds } = fakeDb(NOW - HOUR);
+    return runNominatorPositionsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW, recordException: (async () => true) as never },
+    ).then(() => {
+      assert.deepEqual(binds[0], [NOMINATOR_POSITIONS_PASS_WINDOW_MS]);
+      assert.ok(
+        NOMINATOR_POSITIONS_PASS_WINDOW_MS < 24 * HOUR,
+        "the window must stay under VALIDATOR_NOMINATORS_POLL_SECS (24h)",
+      );
+      // Counted against the newest stamp, not against `now` -- a lane that is
+      // merely late must not also read as uncovered.
+      assert.match(
+        queries[0]!,
+        /captured_at >= \(SELECT MAX\(captured_at\) FROM nominator_positions\) - \?/,
+      );
+    });
+  });
+
+  test("a recent but half-scanned keyspace alerts, naming both counts", async () => {
+    const { db } = fakeDb(NOW - HOUR, 11_800, 24_121);
+    const recorded: { error?: Error; route?: string; errorCode?: string }[] =
+      [];
+    const result = await runNominatorPositionsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async (_env: never, event: never) => {
+          recorded.push(event);
+          return true;
+        }) as never,
+      },
+    );
+    assert.equal(result.alerted, true);
+    assert.equal(result.reason, "partial");
+    assert.equal(result.covered_coldkeys, 11_800);
+    assert.equal(recorded.length, 1);
+    assert.equal(recorded[0]!.errorCode, "stale_lane");
+    const message = String(recorded[0]!.error?.message);
+    // Distinct wording from the stalled case -- different place to go looking.
+    assert.match(message, /truncated/);
+    assert.match(message, /11800 of 24121 coldkeys/);
+    assert.match(message, /RECENT and PARTIAL/);
+    assert.doesNotMatch(message, /nothing is refreshing/);
+  });
+
+  test("the env coverage-floor and pass-window overrides win over the defaults", async () => {
+    const { db, binds } = fakeDb(NOW - HOUR, 20_000, 24_121);
+    const raised = await runNominatorPositionsStalenessWatchdog(
+      {
+        METAGRAPH_HEALTH_DB: db,
+        NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS: String(22_000),
+        NOMINATOR_POSITIONS_PASS_WINDOW_MS: String(HOUR),
+      },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(raised.alerted, true);
+    assert.equal(raised.reason, "partial");
+    assert.equal(raised.coverage_floor_coldkeys, 22_000);
+    assert.deepEqual(binds[0], [HOUR]);
+
+    // Lowered under the same reading, the identical tick is quiet. This is the
+    // documented remedy if the delegating population ever genuinely shrinks.
+    const lowered = await runNominatorPositionsStalenessWatchdog(
+      {
+        METAGRAPH_HEALTH_DB: fakeDb(NOW - HOUR, 20_000, 24_121).db,
+        NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS: String(15_000),
+      },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(lowered.alerted, false);
+    assert.equal(lowered.coverage_floor_coldkeys, 15_000);
+  });
+
+  test("an uncountable coverage number reads as ZERO, never as covered", async () => {
+    // A NaN would compare false against the floor and report a half-scanned
+    // keyspace healthy -- the exact direction of failure this closes.
+    const { db } = fakeDb(NOW - HOUR, null as unknown as number, 0);
+    const result = await runNominatorPositionsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(result.covered_coldkeys, 0);
+    assert.equal(result.alerted, true);
+    assert.equal(result.reason, "partial");
+
+    const junk = fakeDb(NOW - HOUR, "not a number" as unknown as number, 0);
+    const nonNumeric = await runNominatorPositionsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: junk.db },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(nonNumeric.covered_coldkeys, 0);
+    assert.equal(nonNumeric.alerted, true);
   });
 
   test("a stalled lane records ONE exception naming the age and the route it breaks", async () => {
@@ -200,9 +394,11 @@ describe("runNominatorPositionsStalenessWatchdog", () => {
     // yields a readable detail.
     const stringThrow = {
       prepare: () => ({
-        first: async () => {
-          throw "socket hangup";
-        },
+        bind: () => ({
+          first: async () => {
+            throw "socket hangup";
+          },
+        }),
       }),
     };
     const nonError = await runNominatorPositionsStalenessWatchdog(
@@ -215,7 +411,7 @@ describe("runNominatorPositionsStalenessWatchdog", () => {
 
   test("a null row and a telemetry failure never fail the tick", async () => {
     const nullRow = {
-      prepare: () => ({ first: async () => null }),
+      prepare: () => ({ bind: () => ({ first: async () => null }) }),
     };
     const empty = await runNominatorPositionsStalenessWatchdog(
       { METAGRAPH_HEALTH_DB: nullRow },


### PR DESCRIPTION
## Summary

The **last of the four** keyspace-scan lanes to get the coverage signal [#9530](https://github.com/JSONbored/metagraphed/pull/9530) added and [#9533](https://github.com/JSONbored/metagraphed/pull/9533) extended. A watchdog reading one `MAX(captured_at)` cannot tell a complete pass from a truncated one — that reported `ok | age=0.6h` over an `account_balances` table holding 48% of the network.

I swept all six watchdogs that read a bare `MAX()` and measured each against production D1. Exactly four have the keyspace-pass shape; this is the remaining one. The other two do **not** have this defect and are deliberately left alone:

| Watchdog | Keyspace-pass shape? | Status |
| --- | --- | --- |
| `account-balances` | yes | #9530 |
| `validator-nominator-counts` | yes | #9533 |
| `neurons` | yes | #9533 |
| `nominator-positions` | yes | **this PR** |
| `chain-detail` | **no** — a continuous block-tip append, not a keyspace pass; it already reads `MAX(observed_at)` *and* `MAX(block_number)`. Its completeness question is sequence gaps, a different defect. | left alone |
| `rpc-usage` | **no** — queries an Analytics Engine dataset, an event stream with no keyspace to cover. | left alone |

Measured 2026-08-05, production D1 — healthy, so **this alarm does not fire on merge**:

```
SELECT captured_at, COUNT(*), COUNT(DISTINCT coldkey) FROM nominator_positions GROUP BY captured_at
1785911726709 | 122,836 | 23,668     <- newest pass
1785798649685 |     166 |     52
1785796069582 |   1,815 |    401
```

## What Changed

### The unit is coldkeys, because the prune is per coldkey

The writer ([nominator-positions-d1-write.ts](src/nominator-positions-d1-write.ts)) deletes the positions a coldkey's own batch didn't refresh — but only for coldkeys the batch *contains*. An unstaked position genuinely stops existing, so that prune is correct. A coldkey absent from the pass entirely is left completely untouched, still carrying its previous stamp.

So a scan that dies partway restamps the coldkeys it reached, leaves the rest behind a `MAX()` that just advanced, and `/accounts/{ss58}/positions` answers for those with a confident, silently pass-old position set — the same shape as the `positions: 0` regression [#9273](https://github.com/JSONbored/metagraphed/issues/9273) exists about, but invisible to the alarm that issue produced.

**Rows would be the wrong unit**, for the same reason as on neurons: 122,836 rows across 23,668 coldkeys is a mean of ~5 with a long tail, so a scan that died after the largest delegators could show high row coverage having missed most of the accounts. Coldkeys are what the scan iterates *and* what the prune is keyed on, so they're what a partial pass is partial **in**.

### Why the floor is absolute, not a ratio

The measurement is the argument. Those 453 straggler coldkeys across two older vintages are the prune working as designed. A ratio-of-table check would read **98.1% today and drift down forever** as delegators unstake and never return — an alarm that eventually fires on a healthy lane, which is the [#9301](https://github.com/JSONbored/metagraphed/issues/9301) failure this family already had once. An absolute floor of 80% of 23,668 measured coldkeys can't drift that way. There's a test pinning that a healthy tick stays quiet with the stragglers present.

The drift here runs the same direction as `validator_nominator_counts`, not `account_balances`: this counts coldkeys holding a position *right now*, which can genuinely shrink. A **marginal** miss means re-measure and lower the floor; a real mid-scan death lands far below. Documented in the constant, with a test for the remedy path.

### Sizing

Same producer as `validator_nominator_counts` — both tables carried an identical `captured_at` in that reading — so the 4 h pass window is sized against that one 24 h scan, exactly as the sibling's is. Bounded from both ends: too small and intra-pass spread reads as several partial passes; too large and two consecutive passes merge into one coverage count, restoring the bug. Asserted in tests against the cadence.

**Cost:** one walk of ~125k rows on an `8,38 * * * *` cron — ~6M D1 rows read/day, inside the included allowance. Stated in the module header.

**No schema change.** `partial` is a `lane_health` **detail**; the verdict stays inside the published `ok`/`stale`/`unknown` enum. No contract drift, no regenerated artifacts — the diff is two files.

### Tests fail without the change

Neutering only the `coveredColdkeys < coverageFloorColdkeys` branch fails **5 of 22** tests, including the acceptance case (two ticks with identically fresh `MAX(captured_at)`, differing only in coverage). All 22 pass with it.

## Registry Safety

- [x] No linked issue — maintainer PR, filed at maintainer request (as #9530 / #9533).
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None changed — `git status` clean after `npm run build`.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — see above.)

## Validation

- [x] `npm run lint` · `format:check` · `typecheck`
- [x] `npm run validate` · `validate:schemas` · `validate:api` · `validate:openapi` · `validate:types`
- [x] `npm run validate:artifact-budgets` · `validate:docs` · `validate:intake` · `validate:workflows`
- [x] `npm run validate:contract-drift`
- [x] `npm run worker:test`
- [x] `npm run build` (8/8 steps passed)
- [x] `npx vitest run` — 682 files, 16,357 tests, all passing
- [x] Patch coverage — 100% statements, 100% branches (37/37) on the changed module, from its own test file alone
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
- [x] Rebased on `origin/main` at `6bfb2c942` (includes #9533)

## Template Used

- `backend-code.md`
