### PR TITLE
fix(events): export price_at_tx and price_basis in the CSV projection

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -29209,8 +29209,8 @@ export interface operations {
                         data?: components["schemas"]["AccountEventsArtifact"];
                     };
                     /**
-                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index
-                     *     8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,,2026-07-03T00:00:00.000Z,2
+                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index,price_at_tx,price_basis
+                     *     8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,440,2026-07-03T00:00:00.000Z,2,0.028409091,trade_exact
                      */
                     "text/csv": string;
                 };
@@ -48143,8 +48143,8 @@ export interface operations {
                         data?: components["schemas"]["SubnetEventsArtifact"];
                     };
                     /**
-                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index
-                     *     8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,,2026-07-03T00:00:00.000Z,2
+                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index,price_at_tx,price_basis
+                     *     8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,440,2026-07-03T00:00:00.000Z,2,0.028409091,trade_exact
                      */
                     "text/csv": string;
                 };

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -359,7 +359,7 @@
         }
       },
       "AccountEventsCsv": {
-        "value": "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index\r\n8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,,2026-07-03T00:00:00.000Z,2"
+        "value": "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index,price_at_tx,price_basis\r\n8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,440,2026-07-03T00:00:00.000Z,2,0.028409091,trade_exact"
       },
       "AccountExtrinsicsArtifactResponse": {
         "value": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -29209,8 +29209,8 @@ export interface operations {
                         data?: components["schemas"]["AccountEventsArtifact"];
                     };
                     /**
-                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index
-                     *     8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,,2026-07-03T00:00:00.000Z,2
+                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index,price_at_tx,price_basis
+                     *     8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,440,2026-07-03T00:00:00.000Z,2,0.028409091,trade_exact
                      */
                     "text/csv": string;
                 };
@@ -48143,8 +48143,8 @@ export interface operations {
                         data?: components["schemas"]["SubnetEventsArtifact"];
                     };
                     /**
-                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index
-                     *     8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,,2026-07-03T00:00:00.000Z,2
+                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index,price_at_tx,price_basis
+                     *     8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,440,2026-07-03T00:00:00.000Z,2,0.028409091,trade_exact
                      */
                     "text/csv": string;
                 };

--- a/src/csv-route-examples.ts
+++ b/src/csv-route-examples.ts
@@ -3,9 +3,15 @@
 // examples without contending on the csvExampleForRoute if-chain in contracts.ts.
 // Shared header/example for the two event-stream feeds (subnet + account), which
 // serialize the same formatAccountEvent row shape.
+// price_at_tx / price_basis close #9537: both are on every JSON event row and
+// were missing from this projection. The sample row now carries a real
+// alpha_amount too -- a StakeAdded with an empty alpha leg was never a shape
+// production emits, and it made the derived price columns un-illustratable.
+// price_at_tx is amount_tao / alpha_amount at rao precision (12.5 / 440,
+// resolvePriceAtTx -> roundUnit), so the example stays arithmetically true.
 const EVENTS_CSV_EXAMPLE = [
-  "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index",
-  "8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,,2026-07-03T00:00:00.000Z,2",
+  "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index,price_at_tx,price_basis",
+  "8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,440,2026-07-03T00:00:00.000Z,2,0.028409091,trade_exact",
 ].join("\r\n");
 
 export const ROUTE_CSV_EXAMPLES: Record<string, string> = {

--- a/tests/account-events.test.ts
+++ b/tests/account-events.test.ts
@@ -16,6 +16,7 @@ import {
   buildAccountTransfers,
   ACCOUNT_ACTIVITY_MODULES_WINDOW,
 } from "../src/account-events.ts";
+import { EVENTS_CSV_COLUMNS } from "../workers/request-handlers/entities.ts";
 
 test("INDEXED_EVENT_KINDS covers the core entity events", () => {
   for (const k of [
@@ -1119,4 +1120,48 @@ test("loadAccountHistory is schema-stable when no tier can answer", async () => 
   assert.deepEqual(out.days, []);
   assert.equal(out.limit, 25);
   assert.equal(out.offset, 0);
+});
+
+// #9537: EVENTS_CSV_COLUMNS is the ONLY declaration of the CSV projection for
+// all three event feeds (account, subnet, block), and it is written by hand
+// beside a row shape that grows independently. price_at_tx/price_basis were
+// added to formatAccountEvent and never to the list, so every ?format=csv
+// export silently dropped two fields the JSON contract kept publishing.
+//
+// Deriving the expectation from formatAccountEvent's own output, rather than
+// restating the column names, is the point: a restated list would have to be
+// updated by the same hand that forgot the first time.
+test("the events CSV projection covers every field formatAccountEvent emits", () => {
+  const row = formatAccountEvent({
+    block_number: 8454388,
+    event_index: 3,
+    event_kind: "StakeAdded",
+    hotkey: "5Hot",
+    coldkey: "5Cold",
+    netuid: 7,
+    uid: 3,
+    amount_tao: 12.5,
+    alpha_amount: 440,
+    observed_at: 1_751_500_800_000,
+    extrinsic_index: 2,
+  });
+  assert.ok(row);
+  const emitted = Object.keys(row);
+  const missing = emitted.filter((key) => !EVENTS_CSV_COLUMNS.includes(key));
+  assert.deepEqual(
+    missing,
+    [],
+    `formatAccountEvent emits field(s) the CSV export drops: ${missing.join(", ")}`,
+  );
+  // And nothing in the list that the row never emits -- a stale column would
+  // write a blank cell forever and read as "always null" to a consumer.
+  const orphaned = EVENTS_CSV_COLUMNS.filter((key) => !emitted.includes(key));
+  assert.deepEqual(
+    orphaned,
+    [],
+    `CSV columns with no source field: ${orphaned.join(", ")}`,
+  );
+  // The derived pair specifically, since they are what regressed.
+  assert.equal(row.price_at_tx, 0.028409091);
+  assert.equal(row.price_basis, "trade_exact");
 });

--- a/tests/account-routes.test.ts
+++ b/tests/account-routes.test.ts
@@ -4,6 +4,7 @@ import { handleRequest } from "../workers/api.ts";
 import { CHAIN_DEREGISTRATIONS_HOTKEY_PROJECTION_KEY } from "../src/chain-deregistrations-artifact.ts";
 import { DEREGISTRATIONS_DEGRADED_NOT_DERIVED } from "../src/uncurated-event-streams.ts";
 import type { Row } from "./row-type.ts";
+import { EVENTS_CSV_COLUMNS } from "../workers/request-handlers/entities.ts";
 
 const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 
@@ -81,8 +82,11 @@ test("GET /accounts/{ss58}/events rejects an unsupported query param", async () 
   assert.equal(res.status, 400);
 });
 
-const EVENTS_CSV_HEADER =
-  "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index";
+// Derived, not restated (#9537): this was the FOURTH hand-written copy of this
+// header in the suite, and every one of them agreed with the bug -- the CSV
+// export dropped price_at_tx/price_basis while the JSON contract published
+// them, and four literals all asserted the wrong thing in unison.
+const EVENTS_CSV_HEADER = EVENTS_CSV_COLUMNS.join(",");
 
 test("GET /accounts/{ss58}/events?format=csv emits a header-only CSV when cold", async () => {
   const res = await handleRequest(

--- a/tests/block-csv.test.ts
+++ b/tests/block-csv.test.ts
@@ -2,14 +2,17 @@ import assert from "node:assert/strict";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
+import { EVENTS_CSV_COLUMNS } from "../workers/request-handlers/entities.ts";
 
 // #5746: ?format=csv on the block-scoped extrinsics/events feeds, reusing the
 // unscoped/account-scoped siblings' CSV-columns constants (same row shapes).
 const REF = "8621331";
 const EXTRINSICS_CSV_HEADER =
   "extrinsic_id,block_number,signer,call_module,call_function,success";
-const EVENTS_CSV_HEADER =
-  "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index";
+// Derived, not restated (#9537): a hand-written copy of this header is exactly
+// how price_at_tx/price_basis stayed missing from the CSV export while the JSON
+// contract published them -- the literal agreed with the bug.
+const EVENTS_CSV_HEADER = EVENTS_CSV_COLUMNS.join(",");
 
 function req(path: string, init?: RequestInit) {
   return new Request(`https://api.metagraph.sh${path}`, init);

--- a/tests/subnet-events.test.ts
+++ b/tests/subnet-events.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.ts";
+import { EVENTS_CSV_COLUMNS } from "../workers/request-handlers/entities.ts";
 
 function req(path: string) {
   return new Request(`https://api.metagraph.sh${path}`);
@@ -15,8 +16,10 @@ test("GET /subnets/{netuid}/events rejects an unsupported query param", async ()
   assert.equal(res.status, 400);
 });
 
-const EVENTS_CSV_HEADER =
-  "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index";
+// Derived, not restated (#9537): a hand-written copy of this header is exactly
+// how price_at_tx/price_basis stayed missing from the CSV export while the JSON
+// contract published them -- the literal agreed with the bug.
+const EVENTS_CSV_HEADER = EVENTS_CSV_COLUMNS.join(",");
 
 test("GET /subnets/{netuid}/events?format=csv emits a header-only CSV when cold", async () => {
   const res = await handleRequest(

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -644,7 +644,15 @@ const ACCOUNT_COUNTERPARTIES_CSV_COLUMNS = [
 ];
 // Shared column order for the subnet + account event-stream feeds — the
 // formatAccountEvent row shape, stable so a CSV consumer's columns never shift.
-const EVENTS_CSV_COLUMNS = [
+//
+// This must stay COMPLETE, not merely stable: it is the only place the CSV
+// projection is declared, so a field added to formatAccountEvent and not here
+// is dropped from every ?format=csv export while the JSON contract keeps
+// publishing it. That is how price_at_tx/price_basis went missing (#9537) --
+// they were appended to the row and never to this list. Exported so
+// tests/account-events pins the two against each other; a new field belongs in
+// BOTH.
+export const EVENTS_CSV_COLUMNS = [
   "block_number",
   "event_index",
   "event_kind",
@@ -656,6 +664,10 @@ const EVENTS_CSV_COLUMNS = [
   "alpha_amount",
   "observed_at",
   "extrinsic_index",
+  // Appended, not interleaved: existing consumers' column positions are part
+  // of the stability promise above.
+  "price_at_tx",
+  "price_basis",
 ];
 // The formatIdentityHistoryEntry row shape (src/subnet-identity-history.ts):
 // one SubnetIdentitiesV3 snapshot per row, stable so a CSV consumer's columns


### PR DESCRIPTION
## Summary

`EVENTS_CSV_COLUMNS` (`workers/request-handlers/entities.ts:647`) listed 11 columns and omitted both price fields. It is the only declaration of the CSV projection, and all three event feeds share it — `handleAccountEvents` (`:4744`), subnet events (`:5534`), `handleBlockEvents` (`:6473`) — so every `?format=csv` export silently dropped data the JSON contract publishes on every row.

## Measured

```
get_account_events(ss58=5E2LP6…, kind="StakeAdded", limit=1)
  price_at_tx: 0.028416706
  price_basis: "trade_exact"
```

Neither column appeared in the CSV of that same row.

## Why these two specifically

`price_at_tx` is the per-row execution price — the field a CSV consumer doing cost-basis or fill analysis actually wants, and the reason `src/price-at-tx.ts` exists. `price_basis` is what tells them whether a null price means "no trade leg" or the root-subnet special case (`root_no_pool`); without it a null is unattributable.

Appended rather than interleaved, so existing consumers' column positions keep the stability the list's own comment promises.

## The OpenAPI example moved with it

Its sample row now carries a real `alpha_amount`. A `StakeAdded` with an empty alpha leg is not a shape production emits, and it left the two derived columns un-illustratable. The price shown is arithmetically true for that row — `12.5 / 440` at rao precision, matching `resolvePriceAtTx` → `roundUnit` — not a placeholder.

Regenerated and committed: `openapi.json`, `packages/contract/index.d.ts`, `public/metagraph/types.d.ts`. `validate:contract-drift` passes.

## The test derives, it does not restate

A restated column list would have to be updated by the same hand that forgot the first time. The new assertion in `tests/account-events.test.ts` compares `EVENTS_CSV_COLUMNS` against `formatAccountEvent`'s own output keys, **in both directions**:

- a field the row emits and the CSV drops → fails
- a column with no source field → fails (it would write a blank cell forever and read as "always null" to a consumer, which is the defect class this whole sweep is about)

Verified it fails on the unfixed code with the precise cause:

```
× the events CSV projection covers every field formatAccountEvent emits
  AssertionError: formatAccountEvent emits field(s) the CSV export drops: price_at_tx, price_basis
```

Two other test files (`tests/subnet-events.test.ts`, `tests/block-csv.test.ts`) had each hand-copied the header as a literal. **Those literals agreed with the bug**, which is why nothing caught it — both now derive from the exported constant. `tests/worker-runtime.test.ts`'s `CHAIN_EVENTS_CSV_HEADER` is a different feed (pallet/method shape) and is untouched.

## Validation

```
npm run lint            npm run format:check          npm run typecheck
npm run validate        npm run validate:contract-drift
npm run scan:public-safety
npm run build
npx vitest run tests/account-events.test.ts tests/subnet-events.test.ts \
  tests/block-csv.test.ts tests/block-events.test.ts tests/worker-runtime.test.ts
  -> 146 passed
```

Closes #9537