### PR TITLE
fix(health): carry a probe's error onto the served rpc endpoint row

### DIFF
--- a/src/health-prober.ts
+++ b/src/health-prober.ts
@@ -586,6 +586,16 @@ export async function runHealthProber(
       checked_at_ms: runAt,
       last_ok_ms: lastOkMs,
       consecutive_failures: consecutiveFailures,
+      // #9538: the probe core has produced this since #255 (unsafe URL, unsafe
+      // redirect target, transport throw) and this row dropped it, so the only
+      // `error` a served endpoint could ever show was whatever a local build's
+      // probe cache baked -- absent in CI, hence null on every row in
+      // production even mid-outage. Not written to D1: surface_checks and
+      // surface_status have no error column, and KV is the live serving path
+      // for the RPC pool, so carrying it here and through the pool row is the
+      // whole fix. persistProbesToD1 binds explicit columns, so the extra
+      // field on this object is inert for that writer.
+      error: base.error ?? null,
     };
   });
 
@@ -718,6 +728,10 @@ async function persistToKv(
       archive_support: row.archive_support,
       last_ok: iso(row.last_ok_ms),
       consecutive_failures: row.consecutive_failures,
+      // #9538: carried so the serving overlay has something to show. Null on a
+      // healthy endpoint, which is the honest value -- what it must never be is
+      // null on a failing one purely because the pool row could not express it.
+      error: (row.error as string | null) ?? null,
       pool_eligible: row.status === "ok",
       // Null when the window holds no samples for this surface -- a new endpoint has
       // no record, and inventing a neutral score for it would let it tie a proven one.

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -265,6 +265,12 @@ export function mergeRpcEndpoints(
       classification: live.classification,
       latency_ms: live.latency_ms,
       archive_support: live.archive_support ?? endpoint.archive_support,
+      // #9538: overlaid UNCONDITIONALLY, including back to null. A `?? endpoint.error`
+      // fallback would leave a recovered endpoint wearing the error string from
+      // whichever sweep last failed it -- the same drift `by_status` is recomputed
+      // below to avoid. The live row is the whole truth about this observation:
+      // if it reports no error, there is no error.
+      error: (live.error as string | null) ?? null,
       health_source: "probe-derived",
       health_stale: false,
       // observed_at is when this status was observed, i.e. the sweep time. rpc-pool

--- a/tests/health-prober.test.ts
+++ b/tests/health-prober.test.ts
@@ -492,6 +492,60 @@ describe("runHealthProber", () => {
     assert.equal(meta.last_run_at, new Date(50000).toISOString());
   });
 
+  // #9538: the probe core has produced `error` since #255, and the probed row
+  // dropped it -- so the RPC pool row the serving overlay reads had nothing to
+  // carry, and list_rpc_endpoints.error could never be non-null on the live
+  // path no matter what a probe found.
+  test("carries a failing RPC probe's error onto the pool row, and null when it is healthy", async () => {
+    const failingRpc = async (input: Row) =>
+      input.kind === "subtensor-rpc"
+        ? {
+            status: "failed",
+            classification: "dead",
+            latency_ms: null,
+            status_code: null,
+            error: "connect ECONNREFUSED 10.0.0.1:9944",
+          }
+        : {
+            status: "ok",
+            classification: "live",
+            latency_ms: 5,
+            status_code: 200,
+          };
+    const { env } = makeProberEnv();
+    const kv = makeKv();
+    await runHealthProber(env, FAKE_CTX, {
+      now: () => 50000,
+      kv,
+      loadSurfaces: async () => SURFACES,
+      probeSurface: failingRpc,
+      probeOptions: {},
+    });
+    const pool = kv.json(KV_HEALTH_RPC_POOL);
+    assert.equal(pool.endpoints.length, 1);
+    assert.equal(pool.endpoints[0].status, "failed");
+    assert.equal(
+      pool.endpoints[0].error,
+      "connect ECONNREFUSED 10.0.0.1:9944",
+      "the probe's reason must reach the pool row",
+    );
+
+    // A healthy probe reports no error, and the field must be present-and-null
+    // rather than absent -- the overlay reads it unconditionally.
+    const okKv = makeKv();
+    await runHealthProber(env, FAKE_CTX, {
+      now: () => 50000,
+      kv: okKv,
+      loadSurfaces: async () => SURFACES,
+      probeSurface: probeImpl,
+      probeOptions: {},
+    });
+    const okPool = okKv.json(KV_HEALTH_RPC_POOL);
+    assert.equal(okPool.endpoints[0].status, "ok");
+    assert.equal(okPool.endpoints[0].error, null);
+    assert.ok("error" in okPool.endpoints[0]);
+  });
+
   test("folds unrecognized probe status into unknown in global status_counts", async () => {
     const kv = makeKv();
     const { env } = makeProberEnv();

--- a/tests/health-serving.test.ts
+++ b/tests/health-serving.test.ts
@@ -149,6 +149,51 @@ describe("mergeRpcEndpoints", () => {
     assert.equal(merged.endpoints.find((e: Row) => e.id === "b").status, "ok"); // no live → static
   });
 
+  // #9538: `error` reached the served row from the STATIC build only, so a live
+  // failing endpoint published error: null while reporting status: "failed" --
+  // a consumer could not tell "no errors" from "errors dropped".
+  test("overlays the live probe error, and clears a stale one on recovery", () => {
+    const stat = {
+      schema_version: 1,
+      generated_at: "old",
+      summary: { total: 2 },
+      endpoints: [
+        // A stale error baked by an earlier build, on an endpoint that is now ok.
+        { id: "a", status: "failed", error: "connect ETIMEDOUT" },
+        { id: "b", status: "ok", error: null },
+      ],
+    };
+    const live = {
+      last_run_at: "r",
+      generated_at: "g",
+      endpoints: [
+        {
+          id: "a",
+          status: "ok",
+          classification: null,
+          latency_ms: 12,
+          error: null,
+        },
+        {
+          id: "b",
+          status: "failed",
+          classification: "dead",
+          latency_ms: null,
+          error: "probe threw",
+        },
+      ],
+    };
+    const merged = mergeRpcEndpoints(stat, live) as Row;
+    const a = merged.endpoints.find((e: Row) => e.id === "a");
+    const b = merged.endpoints.find((e: Row) => e.id === "b");
+    // Recovered: the stale build-time string must NOT survive the overlay.
+    assert.equal(a.status, "ok");
+    assert.equal(a.error, null);
+    // Newly failing: the live reason reaches the caller.
+    assert.equal(b.status, "failed");
+    assert.equal(b.error, "probe threw");
+  });
+
   test("recomputes summary.by_status and archive_supported_count from the post-overlay endpoints, never the stale static build", () => {
     // Reproduces a live discrepancy: the static build's summary said 4 "degraded"
     // (the state at the last full artifact rebuild), but a later live sweep


### PR DESCRIPTION
## Summary

`list_rpc_endpoints.error` is null on every row. That is currently *correct* — all 9 endpoints are healthy — and it was ruled a false positive during the #9455 sweep triage on exactly that basis. The ruling holds for the observed nulls. The latent gap behind it does not: **the field could not have been non-null even during an outage.**

## Where the value was lost

The probe core has produced `error` since #255 (`src/health-probe-core.ts:191`, set at `:217` unsafe URL, `:252` unsafe redirect target, `:290` transport throw). The probed row built in `runHealthProber` (`src/health-prober.ts:576-590`) never copied it off the probe result.

Nothing downstream could carry what was already gone:

- the KV rpc-pool row (`:709-730`) had no error to publish
- `mergeRpcEndpoints` (`src/health-serving.ts:259-275`) had none to overlay

So the only non-null `error` a served endpoint could ever show was whatever the **static build** baked from a local probe cache (`scripts/lib/endpoint-artifacts.ts:82` ← `scripts/probes-smoke.ts`) — which a CI or production build does not have.

**Correction to the issue as filed:** I originally wrote that `error` was "persisted to D1". It is not — `migrations/d1/0002_observations.sql` has no `error` column on either `surface_checks` or `surface_status`. It was dropped a step earlier than I said. [Noted on the issue](https://github.com/JSONbored/metagraphed/issues/9538#issuecomment-5189009070); it makes the fix simpler, not harder.

## Scope: no migration

KV is the live serving path for the RPC pool, so carrying the value from the probe result → pool row → overlay is the whole fix. `persistProbesToD1` binds explicit columns, so the extra field on the probed row is inert for that writer, and the Postgres mirror route has been retired since #9193.

## The overlay clears, it does not just set

`error` is overlaid **unconditionally, including back to null**. A `?? endpoint.error` fallback would leave a recovered endpoint wearing the error string from whichever sweep last failed it — the same drift `by_status` is recomputed in that function to avoid. The live row is the whole truth about the observation: if it reports no error, there is no error.

The recovery direction is the half a naive test would miss, so it is asserted explicitly.

## Tests

Both hops, each verified to fail on the unfixed code:

```
× carries a failing RPC probe's error onto the pool row, and null when it is healthy
  AssertionError: the probe's reason must reach the pool row
× overlays the live probe error, and clears a stale one on recovery
  AssertionError: Expected values to be strictly equal
```

The healthy case also asserts `"error" in row` — present-and-null, not absent — because the overlay reads it unconditionally.

## House rules

Health stays probe-derived. This moves a probe-computed value to the surface; it does not author one.

## Validation

```
npm run lint            npm run format:check      npm run typecheck
npm run validate        npm run scan:public-safety
npx vitest run tests/health-prober.test.ts tests/health-serving.test.ts \
  tests/health-status-live.test.ts tests/rpc-endpoints-mcp.test.ts
  -> 295 passed
```

Closes #9538