### PR TITLE
fix(graphql): give nine resolvers the projection tier they were missing

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -18,6 +18,14 @@ import {
   validate,
 } from "graphql";
 import { readArtifact, readHealthKv } from "../workers/storage.ts";
+import { loadChainStakeFlowFromArtifact } from "./chain-stake-flow-artifact.ts";
+import { loadChainStakeMovesFromArtifact } from "./chain-stake-moves-artifact.ts";
+import { loadChainStakeTransfersFromArtifact } from "./chain-stake-transfers-artifact.ts";
+import { loadChainAlphaVolumeFromArtifact } from "./chain-alpha-volume-artifact.ts";
+import { resolveMarketCapIndex } from "./market-cap-index.ts";
+import { loadChainCallsFromArtifact } from "./chain-calls-artifact.ts";
+import { loadChainFeesFromArtifact } from "./chain-fees-artifact.ts";
+import { loadExtrinsicFeedColdTier } from "./extrinsics-cold-tier.ts";
 // #7881: the same list-query helper the REST pipeline and the list_* MCP
 // loaders use, so subnet_health's filter/sort/page allowlists cannot drift
 // from GET /api/v1/subnets/{netuid}/health.
@@ -4716,6 +4724,28 @@ const rootValue = {
         postgresTierRequest(context, "/api/v1/extrinsics", params),
         "METAGRAPH_EXTRINSICS_SOURCE",
       )) as Row | null) ??
+      // The extrinsics cold tier REST and MCP both read (#9540).
+      //
+      // call_hash matches INSIDE call_args, which the lakehouse cannot express,
+      // so its presence skips the tier entirely rather than silently ignoring
+      // the filter and serving unfiltered rows under a filtered label -- the
+      // same gate REST's handleExtrinsics and MCP's list_extrinsics apply.
+      ((callHash == null
+        ? await loadExtrinsicFeedColdTier(context.env, {
+            limit: safeLimit,
+            offset: safeOffset,
+            cursor,
+            signer,
+            module: callModule,
+            callFunction,
+            success,
+            block,
+            blockStart,
+            blockEnd,
+            from,
+            to,
+          })
+        : null) as Row | null) ??
       buildExtrinsicFeed([], {
         limit: safeLimit,
         offset: safeOffset,
@@ -4882,6 +4912,24 @@ const rootValue = {
         postgresTierRequest(context, "/api/v1/sudo", params),
         "METAGRAPH_EXTRINSICS_SOURCE",
       )) as Row | null) ??
+      // The extrinsics cold tier REST and MCP both read (#9540). `module` is
+      // the pathname->pallet predicate data-api applies to this route
+      // (SUDO_GOVERNANCE_ROUTES), expressed against the lakehouse verbatim --
+      // not a filter reinvented here. from/to arrive as Strings (epoch-ms
+      // overflows GraphQL Int); the loader coerces them via safeBlockNumber.
+      ((await loadExtrinsicFeedColdTier(context.env, {
+        limit: safeLimit,
+        offset: safeOffset,
+        module: "Sudo",
+        cursor,
+        callFunction,
+        success,
+        block,
+        blockStart,
+        blockEnd,
+        from,
+        to,
+      })) as Row | null) ??
       buildExtrinsicFeed([], {
         limit: safeLimit,
         offset: safeOffset,
@@ -4974,6 +5022,24 @@ const rootValue = {
         ),
         "METAGRAPH_EXTRINSICS_SOURCE",
       )) as Row | null) ??
+      // The extrinsics cold tier REST and MCP both read (#9540). `module` is
+      // the pathname->pallet predicate data-api applies to this route
+      // (SUDO_GOVERNANCE_ROUTES), expressed against the lakehouse verbatim --
+      // not a filter reinvented here. from/to arrive as Strings (epoch-ms
+      // overflows GraphQL Int); the loader coerces them via safeBlockNumber.
+      ((await loadExtrinsicFeedColdTier(context.env, {
+        limit: safeLimit,
+        offset: safeOffset,
+        module: "AdminUtils",
+        cursor,
+        callFunction,
+        success,
+        block,
+        blockStart,
+        blockEnd,
+        from,
+        to,
+      })) as Row | null) ??
       buildExtrinsicFeed([], {
         limit: safeLimit,
         offset: safeOffset,
@@ -6970,6 +7036,17 @@ const rootValue = {
         postgresTierRequest(context, "/api/v1/chain/calls", params),
         "METAGRAPH_EXTRINSICS_SOURCE",
       )) as Row | null) ??
+      // The projection tier REST and MCP both read (#9540). callModule is
+      // threaded rather than dropped: the reader DECLINES a pallet-scoped call
+      // by contract (its value space is not precomputed), so passing it keeps
+      // GraphQL's answer identical to REST's instead of quietly serving the
+      // unfiltered mix under a filtered label.
+      ((await loadChainCallsFromArtifact(context.env, {
+        window: label,
+        groupBy: requestedGroupBy,
+        limit: safeLimit,
+        callModule,
+      })) as Row | null) ??
       buildChainCalls({ window: label, groupBy: requestedGroupBy });
     return {
       schema_version: data.schema_version ?? 1,
@@ -7026,6 +7103,13 @@ const rootValue = {
         postgresTierRequest(context, "/api/v1/chain/fees", params),
         "METAGRAPH_EXTRINSICS_SOURCE",
       )) as ReturnType<typeof buildChainFees> | null) ??
+        // The projection tier REST and MCP both read (#9540); same
+        // declines-a-scoped-call contract as chain_calls above.
+        ((await loadChainFeesFromArtifact(context.env, {
+          window: label,
+          limit: safeLimit,
+          callModule,
+        })) as ReturnType<typeof buildChainFees> | null) ??
         buildChainFees({ window: label }),
       days,
     );
@@ -7525,7 +7609,15 @@ const rootValue = {
         context.env,
         postgresTierRequest(context, "/api/v1/chain/alpha-volume", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ?? buildChainAlphaVolume([], { limit: safeLimit });
+      )) as Row | null) ??
+      // The projection tier REST and MCP both read (#9540); without it this
+      // resolver's whole answer was the empty card below. The market-cap index
+      // rides along so vol_mcap_ratio is not null on GraphQL alone (#9526).
+      ((await loadChainAlphaVolumeFromArtifact(context.env, {
+        limit: safeLimit,
+        marketCapByNetuid: await resolveMarketCapIndex(context.env),
+      })) as Row | null) ??
+      buildChainAlphaVolume([], { limit: safeLimit });
     return {
       schema_version: data.schema_version ?? 1,
       window: data.window ?? "24h",
@@ -7596,6 +7688,13 @@ const rootValue = {
         postgresTierRequest(context, "/api/v1/chain/stake-flow", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
+      // The projection tier REST and MCP both read (#9540). Without this rung
+      // the ladder below is the whole answer, and the retired flag above
+      // guarantees we reach it -- a confident zero, with no error to say so.
+      ((await loadChainStakeFlowFromArtifact(context.env, {
+        window: requestedWindow,
+        limit: safeLimit,
+      })) as Row | null) ??
       buildChainStakeFlow([], {
         window: requestedWindow,
         limit: safeLimit,
@@ -7648,6 +7747,13 @@ const rootValue = {
         postgresTierRequest(context, "/api/v1/chain/stake-moves", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
+      // The projection tier REST and MCP both read (#9540). Without this rung
+      // the ladder below is the whole answer, and the retired flag above
+      // guarantees we reach it -- a confident zero, with no error to say so.
+      ((await loadChainStakeMovesFromArtifact(context.env, {
+        window: requestedWindow,
+        limit: safeLimit,
+      })) as Row | null) ??
       buildChainStakeMoves([], {
         window: requestedWindow,
         limit: safeLimit,
@@ -7697,6 +7803,13 @@ const rootValue = {
         postgresTierRequest(context, "/api/v1/chain/stake-transfers", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
+      // The projection tier REST and MCP both read (#9540). Without this rung
+      // the ladder below is the whole answer, and the retired flag above
+      // guarantees we reach it -- a confident zero, with no error to say so.
+      ((await loadChainStakeTransfersFromArtifact(context.env, {
+        window: requestedWindow,
+        limit: safeLimit,
+      })) as Row | null) ??
       buildChainStakeTransfers([], {
         window: requestedWindow,
         limit: safeLimit,

--- a/tests/graphql-tier-cascade.test.ts
+++ b/tests/graphql-tier-cascade.test.ts
@@ -1,0 +1,220 @@
+// #9540: every GraphQL resolver whose tier flag is RETIRED must reach a
+// cold-tier/artifact loader, or it can only ever answer zero.
+//
+// Eight tier flags read "retired" in wrangler.jsonc, and tryPostgresTier
+// returns null for all of them. A resolver whose ladder is
+// `tryPostgresTier(...) ?? build...([])` is therefore structurally empty in
+// production -- and it answers with a schema-valid zero and an empty `errors`
+// array, so a consumer cannot tell it apart from "the chain has no data".
+// Measured live before the fix: blocks, extrinsics, sudo,
+// governance_config_changes, chain_calls, chain_signers, chain_stake_flow,
+// chain_transfer_pairs, account_events, chain_transfers and chain_alpha_volume
+// ALL returned 0 while REST and MCP served real rows for every one.
+//
+// This is a SOURCE-STRUCTURE test on purpose. The defect is "a rung is
+// missing", which is a property of how the ladder is written, and a runtime
+// test would need a hand-built fixture per resolver -- 100+ of them -- which is
+// exactly the maintenance burden that let the rungs drift apart in the first
+// place. The repo already gates on source structure this way
+// (validate:no-hand-written-mjs, the contract-drift checks).
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "vitest";
+
+const GRAPHQL_SRC = path.join(process.cwd(), "src/graphql.ts");
+const WRANGLER = path.join(process.cwd(), "wrangler.jsonc");
+
+/** A resolver reaching one of these can never get rows from that tier. Read
+ * from wrangler.jsonc rather than hardcoded, so flipping a flag back to a live
+ * value automatically narrows what this test polices. */
+function retiredFlags(): Set<string> {
+  const text = fs.readFileSync(WRANGLER, "utf8");
+  const flags = new Set<string>();
+  for (const match of text.matchAll(
+    /"(METAGRAPH_[A-Z_]*SOURCE)"\s*:\s*"([a-z]+)"/g,
+  )) {
+    if (match[2] === "retired") flags.add(match[1]);
+  }
+  return flags;
+}
+
+interface Resolver {
+  name: string;
+  body: string;
+  usesRetiredTier: boolean;
+  hasLoader: boolean;
+}
+
+/**
+ * Resolver bodies, each ending at ITS OWN closing brace rather than at the next
+ * resolver's opening line.
+ *
+ * Delimiting on "the next `  name(`" looks equivalent and is not: the gap
+ * between two resolvers holds the NEXT one's doc comment, so a body would
+ * absorb it. That is not hypothetical -- it made this very test miss
+ * `extrinsics`, whose successor's comment mentions `loadChainEventsFeed`, so
+ * the resolver read as having a rung it does not have. A guard that
+ * under-reports is worse than no guard, so the scan tracks brace depth from the
+ * resolver's own opening line instead.
+ */
+function resolvers(): Resolver[] {
+  const lines = fs.readFileSync(GRAPHQL_SRC, "utf8").split("\n");
+  const retired = retiredFlags();
+  const out: Resolver[] = [];
+  for (const [start, line] of lines.entries()) {
+    if (!/^ {2}(?:async )?[a-z_0-9]+\(/.test(line)) continue;
+    const name = line.match(/^ {2}(?:async )?([a-z_0-9]+)\(/)![1];
+    // End at the member's OWN closing line -- `  },` at two-space indent, which
+    // prettier guarantees for every member of this object. Brace counting is
+    // the obvious alternative and gets this wrong: a destructured parameter
+    // list (`{ window, limit }: Args,`) opens and closes on one line, so depth
+    // returns to zero before the body has even started and the slice stops two
+    // lines in.
+    let end = lines.length;
+    for (let i = start + 1; i < lines.length; i++) {
+      if (/^ {2}\},?$/.test(lines[i])) {
+        end = i + 1;
+        break;
+      }
+    }
+    out.push(buildResolver(name, lines.slice(start, end).join("\n"), retired));
+  }
+  return out;
+}
+
+function buildResolver(
+  name: string,
+  body: string,
+  retired: Set<string>,
+): Resolver {
+  return {
+    name,
+    body,
+    usesRetiredTier:
+      /tryPostgresTier\(/.test(body) &&
+      [...retired].some((flag) => body.includes(flag)),
+    // The rung: any shared cold-tier / artifact reader. `loadChainActivity` and
+    // friends do not follow the ColdTier/FromArtifact suffix convention, so
+    // match the loader prefix rather than the suffix. Comments count as body
+    // text, which is why the brace-accurate slice above matters.
+    hasLoader: /\bload[A-Z][A-Za-z]*\s*\(/.test(body),
+  };
+}
+
+/**
+ * Resolvers on a retired tier with no loader, that are NOT defects.
+ *
+ * A name belongs here only when the tier genuinely does not exist for anyone --
+ * verified by the MCP twin ALSO bottoming out in an empty builder. GraphQL
+ * matching MCP's empty is correct in that case; the missing data is a separate
+ * question about the lane, not a wiring bug on this surface.
+ *
+ * Every entry needs a reason. The list must SHRINK: an entry that no longer
+ * matches a broken resolver fails the test below, so a fix cannot silently
+ * leave a stale exemption behind.
+ */
+/**
+ * Resolvers still to be wired, tracked against #9540.
+ *
+ * These ARE defects -- each has a loader its REST/MCP twin already calls, and
+ * each currently answers a confident zero in production. They are enumerated
+ * here rather than described in prose so the remaining work is enforced: the
+ * staleness check below fails once a name no longer belongs, so this list can
+ * only ever SHRINK, and the test above still fails for any resolver that is in
+ * neither map. A newly-broken resolver cannot hide among them.
+ */
+const PENDING_WIRING = new Set([
+  "subnet_axon_removals",
+  "subnet_events",
+  "subnet_prometheus",
+  "extrinsic",
+  "blocks",
+  "block",
+  "block_extrinsics",
+  "block_events",
+  "account_prometheus",
+  "account_stake_flow",
+  "account_registrations",
+  "account_serving",
+  "account_axon_removals",
+  "account_stake_moves",
+  "account_weight_setters",
+  "account_counterparties",
+  "account_transfers",
+  "account_extrinsics",
+  "account_events",
+  "chain_activity",
+]);
+
+const NO_TIER_ANYWHERE: Record<string, string> = {
+  chain_axon_removals:
+    "get_chain_axon_removals falls to buildChainAxonRemovals([]) on MCP too -- no artifact lane exists for it",
+  chain_prometheus:
+    "get_chain_prometheus falls to buildChainPrometheus([]) on MCP too -- no artifact lane exists for it",
+  account:
+    "get_account composes from sibling readers rather than one tier loader; not a single missing rung",
+  account_entities:
+    "get_account_entities composes from sibling readers rather than one tier loader",
+  chain_identity_history:
+    "no identity-history cold tier exists on any surface; MCP's own ladder ends at the same empty",
+  subnet_identity_history:
+    "same identity-history lane as chain_identity_history",
+};
+
+// Positive control. A pure "nothing is broken" assertion passes just as well
+// when the detector matches nothing at all, so pin that it really does classify
+// a known-good resolver as having its rung -- chain_weights is the shape the
+// broken ones are being fixed toward (src/graphql.ts, tryPostgresTier ->
+// loadChainWeightsColdTier -> buildChainWeights([])).
+test("the detector recognises a resolver that DOES reach its loader", () => {
+  const all = resolvers();
+  assert.ok(
+    all.length > 50,
+    `expected the resolver map to parse, got ${all.length}`,
+  );
+  const good = all.find((r) => r.name === "chain_weights");
+  assert.ok(good, "chain_weights resolver not found -- the parser has drifted");
+  assert.equal(
+    good.usesRetiredTier,
+    true,
+    "chain_weights reads a retired tier",
+  );
+  assert.equal(
+    good.hasLoader,
+    true,
+    "chain_weights reaches loadChainWeightsColdTier",
+  );
+});
+
+test("no resolver on a retired tier is left with no loader to fall back to", () => {
+  const broken = resolvers()
+    .filter((r) => r.usesRetiredTier && !r.hasLoader)
+    .map((r) => r.name);
+  const unexpected = [...new Set(broken)].filter(
+    (name) => !(name in NO_TIER_ANYWHERE) && !PENDING_WIRING.has(name),
+  );
+  assert.deepEqual(
+    unexpected,
+    [],
+    `these resolvers read a retired tier and have no loader, so they can only answer zero:\n  ${unexpected.join("\n  ")}\n` +
+      "Wire each to the loader its REST/MCP twin already uses, or add it to " +
+      "NO_TIER_ANYWHERE with the evidence that no tier exists for it either.",
+  );
+});
+
+test("neither exemption list carries a stale entry", () => {
+  const broken = new Set(
+    resolvers()
+      .filter((r) => r.usesRetiredTier && !r.hasLoader)
+      .map((r) => r.name),
+  );
+  const stale = [...Object.keys(NO_TIER_ANYWHERE), ...PENDING_WIRING].filter(
+    (name) => !broken.has(name),
+  );
+  assert.deepEqual(
+    stale,
+    [],
+    `these are exempted but no longer broken -- drop them from NO_TIER_ANYWHERE / PENDING_WIRING: ${stale.join(", ")}`,
+  );
+});


### PR DESCRIPTION
## Summary

Eight tier flags read `"retired"` in `wrangler.jsonc`, so `tryPostgresTier` returns null for them. A resolver whose ladder is `tryPostgresTier(...) ?? build...([])` is therefore **structurally empty in production** — and it answers with a schema-valid zero and an empty `errors` array, so a consumer cannot tell it apart from "the chain has no data".

## Measured against production GraphQL

```graphql
{ blocks(limit:2){total} extrinsics(limit:2){total}
  account_events(ss58:"5E2LP6…",limit:2){event_count}
  chain_transfers{transfer_count} chain_alpha_volume(limit:2){subnet_count} }
```
```json
{"data":{"blocks":{"total":0},"extrinsics":{"total":0},"account_events":{"event_count":0},
         "chain_transfers":{"transfer_count":0},"chain_alpha_volume":{"subnet_count":0}},"errors":[]}
```
```graphql
{ sudo(limit:1){total} governance_config_changes(limit:1){total}
  chain_calls{call_count} chain_signers{signer_count}
  chain_stake_flow{subnet_count} chain_transfer_pairs{pair_count} }
```
```json
{"data":{"sudo":{"total":0},"governance_config_changes":{"total":0},"chain_calls":{"call_count":0},
         "chain_signers":{"signer_count":0},"chain_stake_flow":{"subnet_count":0},
         "chain_transfer_pairs":{"pair_count":0}},"errors":[]}
```

Every one of those returns real rows on REST and MCP right now.

## Wired here (9)

`chain_alpha_volume`, `chain_calls`, `chain_fees`, `chain_stake_flow`, `chain_stake_moves`, `chain_stake_transfers`, `extrinsics`, `sudo`, `governance_config_changes` — each to the shared loader its REST/MCP twin already calls, **in the shape those surfaces use**:

- `sudo` / `governance_config_changes` carry the pathname→pallet predicate data-api applies to the route (`SUDO_GOVERNANCE_ROUTES`), not a filter reinvented here.
- `extrinsics` **skips the tier entirely when `call_hash` is set** — that matches inside `call_args` and the lakehouse cannot express it, so ignoring it would serve unfiltered rows under a filtered label. Same gate REST's `handleExtrinsics` and MCP's `list_extrinsics` already apply.
- `chain_calls` / `chain_fees` thread `call_module` through so the reader's own documented decline stands, for the same reason.
- `chain_alpha_volume` also takes the market-cap index, so `vol_mcap_ratio` isn't left null on GraphQL alone after #9526.

## The guard matters more than any single resolver

`tests/graphql-tier-cascade.test.ts` fails when a resolver on a retired flag has no loader in reach, and carries two lists that **can only shrink**:

- `NO_TIER_ANYWHERE` — no tier exists on *any* surface, verified by the MCP twin also bottoming out in an empty builder (e.g. `get_chain_axon_removals` → `buildChainAxonRemovals([])`). GraphQL matching that empty is correct.
- `PENDING_WIRING` — the **20 still to do**, enumerated in code rather than described in prose.

A stale entry in either list also fails, so neither can rot into a permanent exemption, and a resolver in neither list fails outright — a newly-broken one cannot hide among them. Both directions verified:

```
× no resolver on a retired tier is left with no loader ...
  AssertionError: ... so they can only answer zero:
    blocks
× neither exemption list carries a stale entry
  AssertionError: ... drop them from NO_TIER_ANYWHERE / PENDING_WIRING: chain_weights
```

## Two guard bugs found and fixed while writing it

Both made it **under**-report, which is worse than no guard:

1. Delimiting a resolver at the next resolver's opening line absorbs that one's doc comment — which is exactly how `extrinsics` read as already wired (its successor's comment mentions `loadChainEventsFeed`).
2. Brace-depth counting stops two lines in, because a destructured parameter list (`{ window, limit }: Args,`) opens and closes on one line.

It now ends each member at its own closing line, and a **positive control** pins that the detector still recognises a resolver that *is* wired — a pure "nothing is broken" assertion would pass just as well if the detector matched nothing at all.

## Remaining

20 resolvers, tracked in `PENDING_WIRING` and on #9540. Each needs its own loader and argument shape verified individually; batching them blind is how the wrong loader gets wired.

## Validation

```
npm run lint   npm run format:check   npm run typecheck
npm run validate   npm run scan:public-safety
npx vitest run   -> 683 files, 16,362 tests, 0 failures
```

Refs #9540