### PR TITLE
fix(mcp): say when a call_module scope was declined, not measured

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -10002,7 +10002,11 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "Fetch the extrinsic call-mix breakdown over a 7d or 30d window: each " +
       "call_module (or call_module/call_function with group_by=module_function) " +
       "by count and share of all extrinsics. Optionally scope to one pallet via " +
-      "call_module. Use it to see which pallets and calls dominate on-chain traffic " +
+      "call_module -- but note that scope is NOT precomputed: a call_module " +
+      "request is declined rather than approximated, and comes back empty with " +
+      "degraded.reason = call_module_scope_not_precomputed, which is NOT a " +
+      "measurement of zero. Use list_extrinsics (call_module filter) to count a " +
+      "single pallet. Use it to see which pallets and calls dominate on-chain traffic " +
       "before drilling into specific blocks (get_block) or extrinsics " +
       "(list_extrinsics). Mirrors GET /api/v1/chain/calls.",
     inputSchema: z.toJSONSchema(GetChainCallsInputSchema, {
@@ -10046,13 +10050,16 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           limit,
           callModule,
         })) ??
-        buildChainCalls({
-          window: label,
-          groupBy,
-          observedAt: await mcpObservedAt(ctx),
-          total: 0,
-          rows: [],
-        })
+        markChainCallsScopeDeclined(
+          buildChainCalls({
+            window: label,
+            groupBy,
+            observedAt: await mcpObservedAt(ctx),
+            total: 0,
+            rows: [],
+          }),
+          callModule,
+        )
       );
     },
   },
@@ -14107,6 +14114,42 @@ function scheduleTraceSpan(
  * replaces made missing data look measured.
  */
 export const MCP_DEGRADED_REASON = "tier_unavailable";
+
+/**
+ * A `call_module`-scoped request that reached the empty floor did NOT measure
+ * zero -- it was declined (#9536).
+ *
+ * The projection lane does not precompute a pallet scope on purpose: its value
+ * space is unbounded, and filtering the stored top-N would answer with an empty
+ * slice that looks authoritative (`AdminUtils` and `Sudo` are nowhere near the
+ * top by count). So declining is right. Rendering the decline as
+ * `total_extrinsics: 0` is not: measured live, get_chain_calls(call_module:
+ * "AdminUtils") reported zero for a 30d window in which
+ * get_governance_config_changes listed four AdminUtils extrinsics.
+ *
+ * REST already says so with the `x-metagraph-degraded` header
+ * (markPostgresTierFallbackResponse). MCP has no headers, and its
+ * `markMcpTierDegraded` chokepoint cannot see this: it fires on a change to the
+ * fallback GENERATION, and tryPostgresTier returns null at its `!forwards`
+ * guard without recording one. So the handler labels its own answer, which is
+ * the case that chokepoint's own comment carves out -- a specific reason beats
+ * the generic `tier_unavailable`, and MCP must not be the one surface that
+ * cannot say why a zero is untrustworthy.
+ *
+ * Unscoped calls are untouched: their zero is a real measurement.
+ */
+export const CHAIN_CALLS_SCOPE_DECLINED = "call_module_scope_not_precomputed";
+
+export function markChainCallsScopeDeclined<T>(
+  card: T,
+  callModule: string | null | undefined,
+): T {
+  if (typeof callModule !== "string" || callModule.length === 0) return card;
+  return {
+    ...(card as Record<string, unknown>),
+    degraded: { reason: CHAIN_CALLS_SCOPE_DECLINED },
+  } as T;
+}
 
 export function markMcpTierDegraded(
   data: unknown,

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -13272,6 +13272,37 @@ describe("MCP economics + metagraph data tools", () => {
     assert.deepEqual(out.calls, []);
   });
 
+  // #9536: a call_module scope is DECLINED (the lane does not precompute an
+  // unbounded value space, and filtering the stored top-N would answer with an
+  // authoritative-looking empty slice -- AdminUtils and Sudo are nowhere near
+  // the top by count). Declining is right; rendering the decline as
+  // total_extrinsics: 0 is not. Measured live: call_module "AdminUtils"
+  // reported zero over a 30d window in which get_governance_config_changes
+  // listed four AdminUtils extrinsics.
+  test("get_chain_calls labels a declined call_module scope instead of reporting zero", async () => {
+    const scoped = await callTool("get_chain_calls", {
+      window: "7d",
+      call_module: "AdminUtils",
+    });
+    const out = scoped.body.result.structuredContent;
+    assert.equal(out.call_count, 0);
+    assert.equal(
+      out.degraded?.reason,
+      "call_module_scope_not_precomputed",
+      "a declined scope must not read as a measurement of zero",
+    );
+
+    // An UNSCOPED empty is a real measurement and must stay unlabelled --
+    // marking it would make every cold read look like a declined one.
+    const unscoped = await callTool("get_chain_calls", { window: "7d" });
+    assert.equal(unscoped.body.result.structuredContent.call_count, 0);
+    assert.equal(
+      unscoped.body.result.structuredContent.degraded,
+      undefined,
+      "an unscoped zero is measured, not declined",
+    );
+  });
+
   test("get_chain_calls rejects invalid window and group_by params", async () => {
     const window = await callTool("get_chain_calls", { window: "90d" });
     assert.equal(window.body.result.isError, true);


### PR DESCRIPTION
## Summary

`get_chain_calls` with a `call_module` filter answered `total_extrinsics: 0, calls: []` with nothing to distinguish it from "this pallet has no extrinsics".

## Measured

```
get_chain_calls(call_module="AdminUtils", group_by="module_function", window="30d")
  -> {"total_extrinsics":0,"call_count":0,"calls":[]}

get_governance_config_changes(limit=4)
  -> AdminUtils.sudo_set_weights_version_key at block 8768093, 2026-08-04
     (+3 more AdminUtils extrinsics in the same window)
```

Same pallet, same window: one endpoint says zero, the other lists the rows.

## The decline is correct and stays

`src/projection-lanes.ts:417-422` is explicit: the scope is not precomputed because its value space is unbounded, so the reader declines rather than approximates.

Filtering the stored rows instead would be **worse**, not better — the lane keeps the top `CHAIN_CALLS_LIMIT_MAX` by count, and `AdminUtils`/`Sudo` are nowhere near it. A client-side filter would return an empty slice that *also* reads as zero, with the added problem of looking authoritative.

## Only the rendering was wrong

REST already labels this path with the `x-metagraph-degraded` header (`markPostgresTierFallbackResponse`).

MCP has no headers, and its `markMcpTierDegraded` chokepoint **cannot see this case**: it fires on a change to the fallback *generation*, and `tryPostgresTier` returns null at its `!forwards` guard without ever calling `markPostgresTierFallback()`. The artifact decline doesn't bump it either.

So the handler labels its own answer with a specific reason — the case that chokepoint's own comment carves out:

> A handler that already labelled its OWN answer knows more than this chokepoint does (#9273) … Overwriting it would make MCP the one surface that cannot report why a zero is untrustworthy, when REST and GraphQL both can.

`degraded: { reason: "call_module_scope_not_precomputed" }` — specific, not the generic `tier_unavailable`.

## Both directions are pinned

An **unscoped** empty stays unlabelled, because that zero *is* a measurement — marking it would make every cold read look like a declined one. The test asserts both, and was verified to fail on the unfixed code:

```
× get_chain_calls labels a declined call_module scope instead of reporting zero
  AssertionError: a declined scope must not read as a measurement of zero
```

## Description

The tool now states that the scope is declined rather than approximated, that the empty result is not a measurement of zero, and points at `list_extrinsics` (which *does* filter by `call_module`) for counting a single pallet.

## Validation

```
npm run lint   npm run format:check   npm run typecheck
npm run validate   npm run scan:public-safety
npx vitest run   -> 682 files, 16,360 tests, 0 failures
```

Closes #9536