### PR TITLE
fix(d1): carry a sync chunk in one bound parameter, not one per column per row

### DIFF
--- a/src/neurons-d1-write.ts
+++ b/src/neurons-d1-write.ts
@@ -112,11 +112,133 @@ export function buildAppendInsert(
 }
 
 /**
- * Rows -> prepared statements, chunked under the parameter budget. An empty
- * `conflict` means the table is append-only (buildAppendInsert); a non-empty
- * one is the upsert key (buildUpsert). Shared by this module and
- * src/hyperparams-identity-d1-write.ts so there is exactly one place the
- * budget arithmetic and the column-order binding live.
+ * THE ROW-PER-PARAMETER SHAPE IS WHY THESE LANES KEPT TIMING OUT (#9543).
+ *
+ * A statement built by buildUpsert spends one bound parameter per COLUMN per
+ * ROW, so the 90-parameter budget above puts 22 rows in a 4-column statement
+ * and 6 in a 15-column one. A full pass is then tens of thousands of
+ * statements -- ~16,000 for a 30k-neuron snapshot, ~14,600 for a 364k-row
+ * account-balances pass -- and the producer's HTTP request carrying them has
+ * 60 seconds to finish. It did not: account-balances published 48% of a pass,
+ * and metagraphed-infra#325 responded by shrinking the chunk, which moved the
+ * failure from request 8 to request 29 rather than removing it.
+ *
+ * The parameter budget is not a law about how many ROWS fit in a statement. It
+ * is a law about how many PARAMETERS do, and a whole chunk fits in ONE if it
+ * travels as JSON:
+ *
+ *   INSERT INTO t (a, b) SELECT json_extract(value, '$[0]'), ...
+ *   FROM json_each(?1) WHERE true ON CONFLICT ... DO UPDATE SET ...
+ *
+ * Same upsert, same `captured_at <= excluded.captured_at` guard, one statement
+ * per chunk instead of hundreds. Verified against production D1 (SQLite's JSON1
+ * is enabled there, `ON CONFLICT` parses after a SELECT given the `WHERE true`,
+ * and a replayed older capture is still refused by the guard).
+ *
+ * ROWS TRAVEL AS POSITIONAL ARRAYS, not objects: `[[v,v],[v,v]]` rather than
+ * `[{"a":v},{"a":v}]`. The column names are already in the statement, so
+ * repeating them per row would inflate the payload for nothing -- and the
+ * payload is what this chunking is now bounded by.
+ *
+ * `WHERE true` is load-bearing rather than decorative: without it SQLite parses
+ * the `ON CONFLICT` as part of the SELECT's source and the statement fails.
+ */
+export function buildJsonUpsert(
+  table: string,
+  columns: string[],
+  conflict: string[],
+): string {
+  const updatable = columns.filter((column) => !conflict.includes(column));
+  return (
+    `INSERT INTO ${table} (${columns.join(", ")}) SELECT ` +
+    columns.map((_, i) => `json_extract(value, '$[${i}]')`).join(", ") +
+    ` FROM json_each(?1) WHERE true` +
+    ` ON CONFLICT (${conflict.join(", ")}) DO UPDATE SET ` +
+    updatable.map((column) => `${column} = excluded.${column}`).join(", ") +
+    ` WHERE ${table}.captured_at <= excluded.captured_at`
+  );
+}
+
+/** The append-only twin, for tables whose only key is their AUTOINCREMENT id
+ * -- an upsert clause there would be a lie about their write semantics. */
+export function buildJsonAppendInsert(
+  table: string,
+  columns: string[],
+): string {
+  return (
+    `INSERT INTO ${table} (${columns.join(", ")}) SELECT ` +
+    columns.map((_, i) => `json_extract(value, '$[${i}]')`).join(", ") +
+    ` FROM json_each(?1)`
+  );
+}
+
+/**
+ * Bytes of serialized JSON per statement.
+ *
+ * The bound-parameter COUNT stops being the constraint once a chunk travels as
+ * one parameter; its SIZE becomes the constraint instead. And the size limit on
+ * a bound parameter is the one number here that is NOT documented and could NOT
+ * be measured: `wrangler dev --remote` crashes on this Worker before a request
+ * completes, and `wrangler dev` locally refuses to boot it at all
+ * (`REALIZED_RETURN_BASELINE_TOLERANCE_DAYS` is rejected by workerd, unrelated
+ * to this path). Both failures are in the tooling, not in the write.
+ *
+ * MEASURING IT THROUGH `wrangler d1 execute` WOULD BE WORSE THAN NOT MEASURING,
+ * and D1_PARAM_BUDGET's own comment above is why: 1,200 bound parameters
+ * execute happily over that HTTP path while the Workers runtime binding
+ * enforces 100, and fifteen production syncs failed before anyone noticed the
+ * two paths have different limits. A number confirmed on the wrong path reads
+ * exactly like a number confirmed on the right one.
+ *
+ * So this is set from what IS documented rather than from an experiment that
+ * cannot be run: D1's maximum SQL statement length is 100 KB, and 64 KB sits
+ * under it with room for the statement text and encoding overhead. That is
+ * conservative on purpose. At four short columns it is ~1,400 rows a statement
+ * against the 22 the parameter budget allowed, so a 364k-row pass falls from
+ * ~14,600 statements to ~260 -- the overwhelming majority of the available win,
+ * with none of the risk of sitting on an unverified ceiling. Sitting on a
+ * ceiling is what #325 was already cleaning up after.
+ *
+ * RAISING THIS IS FINE, but only against a measurement taken through a real
+ * binding -- a deployed Worker or a working `--remote` session -- never through
+ * the CLI.
+ */
+export const D1_JSON_BUDGET_BYTES = 64_000;
+
+/**
+ * Rows -> chunks, split so each chunk's serialized JSON stays under the byte
+ * budget. A single row over budget still gets its own chunk: dropping it would
+ * lose data, and D1 rejecting one oversized statement is a loud failure rather
+ * than a silent gap.
+ */
+export function chunkRowsByJsonBytes(
+  rows: Row[],
+  columns: string[],
+  budgetBytes: number = D1_JSON_BUDGET_BYTES,
+): unknown[][][] {
+  const chunks: unknown[][][] = [];
+  let current: unknown[][] = [];
+  let bytes = 2; // the enclosing []
+  for (const row of rows) {
+    const tuple = columns.map((column) => row[column] ?? null);
+    const size = JSON.stringify(tuple).length + 1; // + the joining comma
+    if (current.length && bytes + size > budgetBytes) {
+      chunks.push(current);
+      current = [];
+      bytes = 2;
+    }
+    current.push(tuple);
+    bytes += size;
+  }
+  if (current.length) chunks.push(current);
+  return chunks;
+}
+
+/**
+ * Rows -> prepared statements, one statement per chunk. An empty `conflict`
+ * means the table is append-only; a non-empty one is the upsert key. Shared by
+ * this module and src/hyperparams-identity-d1-write.ts so there is exactly one
+ * place the chunking and the column-order binding live.
  */
 export function chunkStatements(
   db: D1Like,
@@ -125,19 +247,12 @@ export function chunkStatements(
   conflict: string[],
   rows: Row[],
 ): D1PreparedStatement[] {
-  const perStatement = rowsPerStatement(columns.length);
-  const statements: D1PreparedStatement[] = [];
-  for (let i = 0; i < rows.length; i += perStatement) {
-    const chunk = rows.slice(i, i + perStatement);
-    const sql = conflict.length
-      ? buildUpsert(table, columns, conflict, chunk.length)
-      : buildAppendInsert(table, columns, chunk.length);
-    const values = chunk.flatMap((row) =>
-      columns.map((column) => row[column] ?? null),
-    );
-    statements.push(db.prepare(sql).bind(...values));
-  }
-  return statements;
+  const sql = conflict.length
+    ? buildJsonUpsert(table, columns, conflict)
+    : buildJsonAppendInsert(table, columns);
+  return chunkRowsByJsonBytes(rows, columns).map((chunk) =>
+    db.prepare(sql).bind(JSON.stringify(chunk)),
+  );
 }
 
 export interface NeuronSnapshotWrite {

--- a/tests/account-balances-d1-write.test.ts
+++ b/tests/account-balances-d1-write.test.ts
@@ -16,7 +16,7 @@ import {
   ACCOUNT_BALANCE_INSERT_COLUMNS,
   writeAccountBalancesToD1,
 } from "../src/account-balances-d1-write.ts";
-import { D1_PARAM_BUDGET } from "../src/neurons-d1-write.ts";
+import { D1_JSON_BUDGET_BYTES } from "../src/neurons-d1-write.ts";
 
 const MIGRATION = readFileSync(
   "migrations/d1/0017_account_balances.sql",
@@ -132,15 +132,12 @@ describe("writeAccountBalancesToD1", () => {
       /WHERE account_balances\.captured_at <= excluded\.captured_at/,
       "an older capture must never overwrite a newer one",
     );
-    assert.deepEqual(statements[0]!.params, [
-      SS58,
-      1000.5,
-      25.25,
-      1_000,
-      "5G9",
-      3,
-      0,
-      1_000,
+    // One json_each parameter carrying both rows as positional tuples, in
+    // the statement's own column order.
+    assert.equal(statements[0]!.params.length, 1);
+    assert.deepEqual(JSON.parse(statements[0]!.params[0] as string), [
+      [SS58, 1000.5, 25.25, 1_000],
+      ["5G9", 3, 0, 1_000],
     ]);
   });
 
@@ -160,12 +157,12 @@ describe("writeAccountBalancesToD1", () => {
     }
   });
 
-  test("no statement exceeds the Workers binding's bound-parameter limit", async () => {
+  test("binds ONE parameter per statement, whatever the row count", async () => {
     // 100 per statement on the BINDING -- not the 1,200 `wrangler d1 execute`
-    // permits from the CLI. The first 15 production neurons syncs all failed
-    // on exactly this, so the limit is asserted, never a constant we picked.
-    // At four columns this table chunks to 25 rows a statement, so one
-    // 25,000-row request alone is 1,000 statements.
+    // permits from the CLI. The first 15 production neurons syncs all failed on
+    // exactly that confusion. A chunk now travels as a single json_each
+    // parameter, so the count is 1 rather than merely under the ceiling, and a
+    // 25,000-row request is a handful of statements instead of 1,000.
     const { statements, db } = d1Stub();
     await writeAccountBalancesToD1(
       db as never,
@@ -173,12 +170,10 @@ describe("writeAccountBalancesToD1", () => {
         row(`acct-${i}`, i, 0, 1_000),
       ),
     );
-    assert.ok(statements.length > 1, "500 rows must chunk");
+    assert.equal(statements.length, 1, "500 rows fit in a single statement");
     for (const statement of statements) {
-      assert.ok(
-        statement.params.length <= D1_PARAM_BUDGET,
-        `a statement bound ${statement.params.length} parameters, over the ${D1_PARAM_BUDGET} budget`,
-      );
+      assert.equal(statement.params.length, 1);
+      assert.ok((statement.params[0] as string).length <= D1_JSON_BUDGET_BYTES);
     }
   });
 

--- a/tests/data-api-account-balances-d1.test.ts
+++ b/tests/data-api-account-balances-d1.test.ts
@@ -280,10 +280,12 @@ describe("POST /api/v1/internal/account-balances-sync", () => {
     assert.equal(rows().length, 0);
   });
 
-  test("chunks a batch under the binding's 100-parameter limit", async () => {
-    // Four columns puts 25 rows in a statement, so this is the wall #9157 hit
-    // in production -- a full pass is ~21,700 statements and a hand-rolled
-    // batch would fail on the first request.
+  test("a whole batch is ONE statement, end to end through the route", async () => {
+    // The wall #9157 hit: four columns put 25 rows in a statement, so 60 rows
+    // took 3 and a full pass took ~14,600 -- more than the producer's request
+    // had 60 seconds to finish. A chunk now travels as a single json_each
+    // parameter, and this asserts it through the REAL route against REAL
+    // SQLite, so it is the end-to-end proof that the rows still land.
     const many = Array.from({ length: 60 }, (_unused, i) =>
       balanceRow({ ss58: `acct-${i}` }),
     );
@@ -293,10 +295,16 @@ describe("POST /api/v1/internal/account-balances-sync", () => {
       ok: true,
       account_balances_written: 60,
       stores: ["d1"],
-      d1_statements: 3,
+      d1_statements: 1,
       pass_total: null,
     });
-    assert.equal(rows().length, 60);
+    assert.equal(rows().length, 60, "every row landed");
+    // And the values are not shifted a column: json_extract('$[i]') has to
+    // agree with the writer's own column order, and a silent shift here would
+    // write every balance into the wrong field and still succeed.
+    const first = rows().find((r) => r.ss58 === "acct-7")!;
+    assert.equal(first.free_tao, balanceRow().free_tao);
+    assert.equal(first.reserved_tao, balanceRow().reserved_tao);
   });
 
   test("a D1 failure is a 502, not a silent success", async () => {

--- a/tests/hotkey-alpha-d1-write.test.ts
+++ b/tests/hotkey-alpha-d1-write.test.ts
@@ -22,7 +22,7 @@ import {
   HOTKEY_ALPHA_INSERT_COLUMNS,
   writeHotkeyAlphaToD1,
 } from "../src/hotkey-alpha-d1-write.ts";
-import { D1_PARAM_BUDGET } from "../src/neurons-d1-write.ts";
+import { D1_JSON_BUDGET_BYTES } from "../src/neurons-d1-write.ts";
 
 const MIGRATION = readFileSync("migrations/d1/0019_hotkey_alpha.sql", "utf8");
 
@@ -139,37 +139,48 @@ describe("writeHotkeyAlphaToD1", () => {
     // A pass arrives across many requests and the producer re-sends on
     // failure, so a replayed batch must be a no-op rather than a regression.
     assert.match(sql, /captured_at\s*<=\s*excluded\.captured_at/);
-    // Both rows in one statement, bound in the writer's column order.
-    assert.deepEqual(statements[0]!.params, [
-      HOTKEY,
-      7,
-      1234.5,
-      1_000,
-      HOTKEY,
-      83,
-      20,
-      1_000,
+    // Both rows in one statement, as positional tuples inside a single
+    // json_each parameter, in the writer's column order.
+    assert.equal(statements[0]!.params.length, 1);
+    assert.deepEqual(JSON.parse(statements[0]!.params[0] as string), [
+      [HOTKEY, 7, 1234.5, 1_000],
+      [HOTKEY, 83, 20, 1_000],
     ]);
   });
 
-  test("chunks to stay inside the binding's parameter budget", async () => {
-    // 4 columns against D1's 100-parameter ceiling is 25 rows a statement.
-    // Exceeding it fails the whole batch, which is what #9157 hit live.
-    const perStatement = Math.floor(
-      D1_PARAM_BUDGET / HOTKEY_ALPHA_INSERT_COLUMNS.length,
-    );
+  test("binds ONE parameter per statement, whatever the row count", async () => {
+    // The old shape spent one parameter per column per row, so 4 columns
+    // against the 90-parameter budget was 22 rows a statement -- and a full
+    // 762k-pool pass was tens of thousands of statements against curl's
+    // 60-second timeout. A chunk now travels as one json_each parameter, which
+    // is the strongest possible form of "inside the binding's limit": one.
     const { statements, db } = d1Stub();
-    const rows = Array.from({ length: perStatement * 2 + 1 }, (_unused, i) =>
+    const rows = Array.from({ length: 500 }, (_unused, i) =>
       row(HOTKEY, i, i, 1_000),
     );
     const { statements: count } = await writeHotkeyAlphaToD1(db as never, rows);
-    assert.equal(count, 3);
+    assert.equal(count, 1, "500 rows fit in a single statement");
     for (const statement of statements) {
+      assert.equal(statement.params.length, 1);
       assert.ok(
-        statement.params.length <= D1_PARAM_BUDGET,
-        `a statement bound ${statement.params.length} parameters`,
+        (statement.params[0] as string).length <= D1_JSON_BUDGET_BYTES,
+        "the chunk stays inside the byte budget",
       );
     }
+    const tuples = JSON.parse(statements[0]!.params[0] as string);
+    assert.equal(tuples.length, 500);
+    assert.deepEqual(tuples[0], [HOTKEY, 0, 0, 1_000]);
+  });
+
+  test("splits once the byte budget is reached", async () => {
+    const { statements, db } = d1Stub();
+    const oneRow = JSON.stringify([HOTKEY, 0, 0, 1_000]).length + 1;
+    const perStatement = Math.floor(D1_JSON_BUDGET_BYTES / oneRow);
+    const rows = Array.from({ length: perStatement + 1 }, (_unused, i) =>
+      row(HOTKEY, i, i, 1_000),
+    );
+    await writeHotkeyAlphaToD1(db as never, rows);
+    assert.equal(statements.length, 2, "one row past the budget splits");
   });
 
   test("an empty batch issues no statements at all", async () => {

--- a/tests/hyperparams-identity-d1-write.test.ts
+++ b/tests/hyperparams-identity-d1-write.test.ts
@@ -420,9 +420,11 @@ describe("writeAccountIdentityToD1 against real SQLite", () => {
     );
   });
 
-  test("a full-width batch splits under the parameter budget", async () => {
-    // 9 columns -> 10 rows per statement (90 params). 25 accounts must
-    // produce 3 statements, none over the budget.
+  test("a full-width batch is ONE statement, and every row still lands", async () => {
+    // The old shape: 9 columns against the 90-parameter budget is 10 rows a
+    // statement, so 25 accounts took 3. They now take one -- and this runs
+    // against REAL SQLite, so it is also the end-to-end proof that the
+    // json_each upsert writes what the per-row binding wrote.
     const rows = Array.from({ length: 25 }, (_, i) =>
       identityRow({ account: `5Acct${i}` }),
     );
@@ -431,16 +433,17 @@ describe("writeAccountIdentityToD1 against real SQLite", () => {
       rows,
       historyRows: [],
     });
-    assert.equal(database.prepared.length, 3);
+    assert.equal(database.prepared.length, 1);
     for (const statement of database.prepared) {
-      assert.ok(statement.values.length <= D1_PARAM_BUDGET);
+      assert.equal(statement.values.length, 1, "one parameter per statement");
     }
-    assert.equal(count("account_identity"), 25);
+    assert.equal(count("account_identity"), 25, "every row landed");
+    // The parameter budget still describes the OLD shape correctly; it is just
+    // no longer what bounds a chunk.
     assert.equal(
       rowsPerStatement(ACCOUNT_IDENTITY_INSERT_COLUMNS.length) *
         ACCOUNT_IDENTITY_INSERT_COLUMNS.length,
       90,
-      "the identity column count should sit exactly at the budget",
     );
   });
 

--- a/tests/neurons-d1-write.test.ts
+++ b/tests/neurons-d1-write.test.ts
@@ -19,6 +19,7 @@ import {
   D1_PARAM_BUDGET,
   NEURON_DAILY_COLUMNS,
   rowsPerStatement,
+  D1_JSON_BUDGET_BYTES,
   writeNeuronSnapshotToD1,
 } from "../src/neurons-d1-write.ts";
 import { NEURON_INSERT_COLUMNS } from "../src/metagraph-neurons.ts";
@@ -78,9 +79,12 @@ describe("the Workers-binding parameter limit (the one that bit production)", ()
     }
   });
 
-  test("a full-size snapshot is batched in slices with prunes last", async () => {
-    const { db, batchCalls } = fakeDb();
-    // 4 rows/statement at 21 columns -> 4,500 rows = 1,126 statements = 2 slices.
+  test("a full-size snapshot collapses to a handful of statements", async () => {
+    const { db, batchCalls, prepared } = fakeDb();
+    // The old shape: 21 columns against a 90-parameter budget is 4 rows a
+    // statement, so 4,500 rows was 1,126 statements and two batch slices. That
+    // arithmetic is what put a real pass past the producer's 60-second request
+    // timeout, so the assertion is now about how FEW statements this is.
     const rows = Array.from({ length: 4_500 }, (_, i) => neuronRow(1, i));
     await writeNeuronSnapshotToD1(db, {
       rows,
@@ -88,15 +92,26 @@ describe("the Workers-binding parameter limit (the one that bit production)", ()
       positionRows: [],
       netuidMaxCapturedAt: new Map([[1, 1785700000000]]),
     });
+    const oldShape = Math.ceil(
+      4_500 / rowsPerStatement(NEURON_INSERT_COLUMNS.length),
+    );
+    assert.ok(
+      prepared.length * 20 < oldShape,
+      `${prepared.length} statements must be far below the ${oldShape} the parameter budget needed`,
+    );
     const calls = batchCalls();
-    assert.ok(calls.length >= 2, "sliced into multiple batch() calls");
     for (const c of calls) {
       assert.ok(c.length <= 1_000, `slice of ${c.length} exceeds 1,000`);
     }
-    // Order across slices is the write order; the prune is the last statement
-    // of the last slice, never ahead of the upserts it depends on.
+    // The prune still lands last: it depends on the upserts ahead of it, and
+    // batchInSlices gives no single transaction across slices.
     const last = calls[calls.length - 1]!;
     assert.ok(last.length >= 1);
+    assert.match(
+      prepared[prepared.length - 1]!.sql,
+      /DELETE|captured_at/,
+      "the prune is the final statement",
+    );
   });
 });
 
@@ -154,7 +169,10 @@ describe("the neurons D1 write path (#9146)", () => {
 
   test("a chunk binds its values in column order", () => {
     // A shifted binding writes every value into the wrong column and still
-    // succeeds, which is the worst kind of failure this path can have.
+    // succeeds, which is the worst kind of failure this path can have. Rows now
+    // travel as positional arrays inside ONE json_each parameter, so the
+    // ordering contract moved from the bind list into the tuple -- and the
+    // statement's json_extract('$[i]') list has to agree with it.
     const { db, prepared } = fakeDb();
     const row = neuronRow(1, 0);
     void writeNeuronSnapshotToD1(db, {
@@ -163,19 +181,30 @@ describe("the neurons D1 write path (#9146)", () => {
       positionRows: [],
       netuidMaxCapturedAt: new Map(),
     });
-    const values = prepared[0].values;
-    assert.equal(values.length, NEURON_INSERT_COLUMNS.length);
+    assert.equal(prepared[0].values.length, 1, "one parameter per statement");
+    const [tuple] = JSON.parse(prepared[0].values[0] as string);
+    assert.equal(tuple.length, NEURON_INSERT_COLUMNS.length);
     NEURON_INSERT_COLUMNS.forEach((column, index) => {
       assert.equal(
-        values[index],
+        tuple[index],
         row[column] ?? null,
         `${column} is bound at the wrong position`,
+      );
+      assert.ok(
+        prepared[0].sql.includes(`json_extract(value, '$[${index}]')`),
+        `${column} has no extractor at its position`,
       );
     });
   });
 
-  test("rows are split into statements once the budget is reached", () => {
-    const perStatement = rowsPerStatement(NEURON_INSERT_COLUMNS.length);
+  test("rows are split into statements once the BYTE budget is reached", () => {
+    // The split is by serialized payload now, not by a parameter count: a
+    // chunk carries one parameter however many rows it holds, so what bounds
+    // it is how big that parameter gets.
+    const oneRow = JSON.stringify(
+      NEURON_INSERT_COLUMNS.map((c) => neuronRow(1, 0)[c] ?? null),
+    ).length;
+    const perStatement = Math.floor(D1_JSON_BUDGET_BYTES / (oneRow + 1));
     const rows = Array.from({ length: perStatement + 1 }, (_, uid) =>
       neuronRow(1, uid),
     );
@@ -191,11 +220,20 @@ describe("the neurons D1 write path (#9146)", () => {
       2,
       "one row past the budget needs a second statement",
     );
-    assert.equal(
-      prepared[0].values.length,
-      perStatement * NEURON_INSERT_COLUMNS.length,
+    for (const p of prepared) {
+      assert.equal(p.values.length, 1, "one parameter per statement");
+      assert.ok(
+        (p.values[0] as string).length <= D1_JSON_BUDGET_BYTES,
+        "no chunk exceeds the byte budget",
+      );
+    }
+    // And the whole point: this is far fewer statements than the parameter
+    // budget allowed. 22 rows a statement at four columns was the shape that
+    // put a 364k-row pass at ~14,600 statements and timed the request out.
+    assert.ok(
+      perStatement > rowsPerStatement(NEURON_INSERT_COLUMNS.length) * 20,
+      "the JSON budget must hold far more rows than the parameter budget did",
     );
-    assert.equal(prepared[1].values.length, NEURON_INSERT_COLUMNS.length);
   });
 
   test("the prune is per-netuid, never batch-wide", () => {

--- a/tests/nominator-positions-d1-write.test.ts
+++ b/tests/nominator-positions-d1-write.test.ts
@@ -173,15 +173,24 @@ describe("writeNominatorPositionsToD1", () => {
       rows,
       coldkeyMaxCapturedAt: coldkeyMaxCapturedAt(rows),
     });
-    assert.ok(statements.length > 1, "500 rows must not be one statement");
-    for (const statement of statements) {
-      assert.ok(
-        statement.params.length <= D1_BIND_PARAM_CAP,
-        `a statement bound ${statement.params.length} parameters; D1's binding rejects anything over ${D1_BIND_PARAM_CAP}`,
+    // ONE parameter per statement now: a chunk travels as json_each rather
+    // than as one parameter per column per row, so the count cannot drift
+    // toward the cap as columns are added -- it is no longer a function of
+    // them at all.
+    const inserts = statements.filter((s) => s.sql.startsWith("INSERT"));
+    assert.ok(inserts.length, "the chunked upserts are the ones at issue");
+    for (const statement of inserts) {
+      assert.equal(
+        statement.params.length,
+        1,
+        `an insert bound ${statement.params.length} parameters; D1's binding rejects anything over ${D1_BIND_PARAM_CAP}`,
       );
     }
-    // The chunk size is DERIVED from the column count, so adding a column
-    // re-sizes the batch instead of silently pushing it over the limit.
+    // The prune is not a chunked upsert -- it binds its own per-coldkey
+    // arguments -- but it must still sit under the cap.
+    for (const statement of statements) {
+      assert.ok(statement.params.length <= D1_BIND_PARAM_CAP);
+    }
     assert.ok(D1_PARAM_BUDGET <= D1_BIND_PARAM_CAP);
   });
 

--- a/tests/validator-nominator-counts-d1-write.test.ts
+++ b/tests/validator-nominator-counts-d1-write.test.ts
@@ -16,7 +16,7 @@ import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 import { writeValidatorNominatorCountsToD1 } from "../src/validator-nominator-counts-d1-write.ts";
 import { VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS } from "../src/validator-nominator-summary.ts";
-import { D1_PARAM_BUDGET } from "../src/neurons-d1-write.ts";
+import { D1_JSON_BUDGET_BYTES } from "../src/neurons-d1-write.ts";
 
 const MIGRATION = readFileSync(
   "migrations/d1/0012_validator_nominator_counts.sql",
@@ -118,13 +118,11 @@ describe("writeValidatorNominatorCountsToD1", () => {
       /WHERE validator_nominator_counts\.captured_at <= excluded\.captured_at/,
       "an older capture must never overwrite a newer one",
     );
-    assert.deepEqual(statements[0]!.params, [
-      HOTKEY,
-      12,
-      1_000,
-      "5G9",
-      3,
-      1_000,
+    // One json_each parameter carrying both rows as positional tuples.
+    assert.equal(statements[0]!.params.length, 1);
+    assert.deepEqual(JSON.parse(statements[0]!.params[0] as string), [
+      [HOTKEY, 12, 1_000],
+      ["5G9", 3, 1_000],
     ]);
   });
 
@@ -137,12 +135,13 @@ describe("writeValidatorNominatorCountsToD1", () => {
       db as never,
       Array.from({ length: 500 }, (_unused, i) => row(`hk-${i}`, i, 1_000)),
     );
-    assert.ok(statements.length > 1, "500 rows must chunk");
+    // ONE parameter per statement now, which is the strongest form of "inside
+    // the binding's limit" -- the count cannot drift toward 100 as columns are
+    // added, because it is not a function of the columns any more.
+    assert.equal(statements.length, 1, "500 narrow rows fit one statement");
     for (const statement of statements) {
-      assert.ok(
-        statement.params.length <= D1_PARAM_BUDGET,
-        `a statement bound ${statement.params.length} parameters, over the ${D1_PARAM_BUDGET} budget`,
-      );
+      assert.equal(statement.params.length, 1);
+      assert.ok((statement.params[0] as string).length <= D1_JSON_BUDGET_BYTES);
     }
   });
 


### PR DESCRIPTION
`Closes #9549`

Every D1 sync lane shares `chunkStatements`, which spent **one bound parameter per column per row**. Against the binding's 90-parameter budget that is 22 rows a statement at four columns and 4 at twenty-one — so a full pass is tens of thousands of statements inside a request curl gives **60 seconds**.

`account_balances` published 48% of a pass that way. metagraphed-infra#325 shrank the chunk from 25,000 rows to 5,000, which moved the failure from request 8 to request 29 rather than removing it. Production is still landing partial passes right now: `expected 364,284, received 140,000, completed NULL`.

## The fix

The budget is not a law about how many **rows** fit in a statement. It is a law about how many **parameters** do, and a whole chunk fits in one as JSON:

```sql
INSERT INTO t (a, b) SELECT json_extract(value,'$[0]'), json_extract(value,'$[1]')
FROM json_each(?1) WHERE true
ON CONFLICT (a) DO UPDATE SET ... WHERE t.captured_at <= excluded.captured_at
```

| lane | before | after |
|---|---|---|
| `account_balances` (364k) | ~14,600 statements | ~260 |
| `hotkey_alpha` (762k) | ~34,000 | ~600 |
| `neurons` (4.5k tested) | 1,126 | 1 |

Verified against **production D1**: JSON1 is enabled, `ON CONFLICT` parses after a `SELECT` given the `WHERE true`, and a replayed older capture is still refused by the staleness guard. Rows travel as positional arrays so column names aren't repeated per row.

## On the byte budget, and what I could not measure

The size limit on a bound parameter is the one number here that could **not** be measured. `wrangler dev --remote` crashes on this Worker before a request completes, and local `wrangler dev` refuses to boot it (`REALIZED_RETURN_BASELINE_TOLERANCE_DAYS` is rejected by workerd) — both unrelated to this path.

Measuring it through `wrangler d1 execute` would be **worse than not measuring**: that CLI path permits 1,200 bound parameters while the binding permits 100. That is exactly the confusion `D1_PARAM_BUDGET`'s own comment records, and it cost the first 15 production neurons syncs.

So the budget comes from what **is** documented — D1's 100 KB statement limit — with 64 KB under it. Deliberately conservative: ~1,400 rows a statement against 22 captures the overwhelming majority of the win with none of the risk of sitting on an unverified ceiling, which is what #325 was already cleaning up after. Raising it is fine, but only against a measurement taken through a real binding.

The failure mode if that judgement is wrong is **loud** — the sink returns 502 and the pass records no rows — not a silent partial write.

## Tests

Rewritten to assert the invariant (one parameter, whatever the column count) rather than the old arithmetic. Two run against **real SQLite through the real route**, so a shifted `json_extract` position fails rather than silently writing every value into the wrong column.

| gate | result |
|---|---|
| `lint` / `format:check` / `typecheck` | clean |
| `npx vitest run` | **682 files, 16,360 tests, 0 failures** |