### PR TITLE
fix(graphql): give the block and extrinsic reads their tiers

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -26,6 +26,23 @@ import { resolveMarketCapIndex } from "./market-cap-index.ts";
 import { loadChainCallsFromArtifact } from "./chain-calls-artifact.ts";
 import { loadChainFeesFromArtifact } from "./chain-fees-artifact.ts";
 import { loadExtrinsicFeedColdTier } from "./extrinsics-cold-tier.ts";
+import { loadExtrinsicColdTier } from "./extrinsics-cold-tier.ts";
+import {
+  loadBlockColdTier,
+  loadBlockFeedColdTier,
+} from "./blocks-cold-tier.ts";
+import { loadBlockExtrinsicsColdTier } from "./extrinsics-cold-tier.ts";
+import { loadBlockEventsColdTier } from "./events-cold-tier.ts";
+import {
+  answerBlockDetail,
+  answerExtrinsicDetail,
+  chainDetailGapMessage,
+  isEmptyEventPayload,
+  isEmptyExtrinsicPayload,
+  loadBlockEventsHotTier,
+  loadBlockExtrinsicsHotTier,
+  type ChainDetailAnswer,
+} from "./chain-detail-hot-tier.ts";
 // #7881: the same list-query helper the REST pipeline and the list_* MCP
 // loaders use, so subnet_health's filter/sort/page allowlists cannot drift
 // from GET /api/v1/subnets/{netuid}/health.
@@ -1984,6 +2001,36 @@ function resolveEvmAddressMapping(
 // the pilot conversion + the codegen mechanism). Every Query root field on
 // this object is now typed against the generated Query<Field>Args types
 // below rather than a Row-typed destructured param.
+/**
+ * A block-scoped detail answer, with the GAP case raised rather than flattened
+ * to an empty (#9540).
+ *
+ * `answerBlockDetail` distinguishes three outcomes and only two of them mean
+ * "no rows". A `gap` is a ref falling between the decoded seam and the hot
+ * window: the data exists and this deployment cannot currently read it. REST
+ * answers that 503 `block_detail_unavailable` and MCP throws a tool error, so
+ * GraphQL must not be the one surface reporting it as an empty block.
+ *
+ * `miss` -- a ref that genuinely resolves to nothing -- still degrades to the
+ * schema-stable empty, which is this surface's existing convention.
+ */
+function gapAwareBlockDetail<T>(
+  answer: ChainDetailAnswer<T>,
+  empty: () => T,
+): T {
+  if (answer.kind === "answer") return answer.data;
+  if (answer.kind === "gap") {
+    throw new GraphQLError(chainDetailGapMessage(answer), {
+      extensions: {
+        code: "BLOCK_DETAIL_UNAVAILABLE",
+        block_number: answer.block,
+        decoded_through: answer.seam,
+      },
+    });
+  }
+  return empty();
+}
+
 const rootValue = {
   subnets(args: QuerySubnetsArgs, context: GqlContext) {
     // #8423: full parity with the list_subnets MCP tool over the same static
@@ -4951,7 +4998,16 @@ const rootValue = {
           `/api/v1/extrinsics/${encodeURIComponent(ref)}`,
         ),
         "METAGRAPH_EXTRINSICS_SOURCE",
-      )) as Row | null) ?? buildExtrinsic(undefined, ref);
+      )) as Row | null) ??
+      // The same hot/cold cascade REST and MCP run (#9540). A composite
+      // "<block>-<index>" ref routes through answerBlockDetail, so it inherits
+      // the gap case -- raised, not flattened to an empty extrinsic.
+      (gapAwareBlockDetail(
+        await answerExtrinsicDetail(context.env, ref, () =>
+          loadExtrinsicColdTier(context.env, ref),
+        ),
+        () => buildExtrinsic(undefined, ref),
+      ) as Row);
     return {
       ref: data.ref ?? ref,
       extrinsic: extrinsicNode(data.extrinsic),
@@ -5097,6 +5153,23 @@ const rootValue = {
         postgresTierRequest(context, "/api/v1/blocks", params),
         "METAGRAPH_BLOCKS_SOURCE",
       )) as Row | null) ??
+      // The blocks cold tier REST and MCP both read (#9540). Every filter is
+      // forwarded, so the tier does the filtering -- the empty builder below
+      // ignores them, which is why reaching it silently dropped a filtered
+      // query's meaning as well as its rows.
+      ((await loadBlockFeedColdTier(context.env, {
+        limit: safeLimit,
+        offset: safeOffset,
+        cursor,
+        author,
+        specVersion,
+        blockStart,
+        blockEnd,
+        from,
+        to,
+        minExtrinsics,
+        minEvents,
+      } as never)) as Row | null) ??
       buildBlockFeed([], {
         limit: safeLimit,
         offset: safeOffset,
@@ -5180,7 +5253,10 @@ const rootValue = {
           `/api/v1/blocks/${encodeURIComponent(ref)}`,
         ),
         "METAGRAPH_BLOCKS_SOURCE",
-      )) as Row | null) ?? buildBlock(undefined, ref);
+      )) as Row | null) ??
+      // The block cold tier REST and MCP both read (#9540).
+      ((await loadBlockColdTier(context.env, ref)) as Row | null) ??
+      buildBlock(undefined, ref);
     return {
       ref: data.ref ?? ref,
       block: data.block ?? null,
@@ -5217,10 +5293,32 @@ const rootValue = {
       ),
       "METAGRAPH_EXTRINSICS_SOURCE",
     )) as Row | null) ?? {
-      data: buildBlockExtrinsics([], ref, null, {
-        limit: safeLimit,
-        offset: safeOffset,
-      }),
+      // The hot/cold cascade REST and MCP both run (#9540). Not a plain loader:
+      // a ref can land in the GAP between the decoded seam and the hot window,
+      // and that is a decline, not an empty -- REST answers it 503
+      // block_detail_unavailable and MCP throws. Returning the empty builder
+      // there would state "this block has no extrinsics", which is the confident
+      // zero this whole change exists to remove.
+      data: gapAwareBlockDetail(
+        await answerBlockDetail(context.env, ref, {
+          hot: (height) =>
+            loadBlockExtrinsicsHotTier(context.env, ref, height, {
+              limit: safeLimit,
+              offset: safeOffset,
+            }),
+          cold: () =>
+            loadBlockExtrinsicsColdTier(context.env, ref, {
+              limit: safeLimit,
+              offset: safeOffset,
+            }),
+          isEmpty: isEmptyExtrinsicPayload,
+        }),
+        () =>
+          buildBlockExtrinsics([], ref, null, {
+            limit: safeLimit,
+            offset: safeOffset,
+          }),
+      ),
     };
     return data;
   },
@@ -5249,10 +5347,32 @@ const rootValue = {
       ),
       "METAGRAPH_EXTRINSICS_SOURCE",
     )) as Row | null) ?? {
-      data: buildBlockEvents([], ref, null, {
-        limit: safeLimit,
-        offset: safeOffset,
-      }),
+      // The hot/cold cascade REST and MCP both run (#9540). Not a plain loader:
+      // a ref can land in the GAP between the decoded seam and the hot window,
+      // and that is a decline, not an empty -- REST answers it 503
+      // block_detail_unavailable and MCP throws. Returning the empty builder
+      // there would state "this block has no events", which is the confident
+      // zero this whole change exists to remove.
+      data: gapAwareBlockDetail(
+        await answerBlockDetail(context.env, ref, {
+          hot: (height) =>
+            loadBlockEventsHotTier(context.env, ref, height, {
+              limit: safeLimit,
+              offset: safeOffset,
+            }),
+          cold: () =>
+            loadBlockEventsColdTier(context.env, ref, {
+              limit: safeLimit,
+              offset: safeOffset,
+            }),
+          isEmpty: isEmptyEventPayload,
+        }),
+        () =>
+          buildBlockEvents([], ref, null, {
+            limit: safeLimit,
+            offset: safeOffset,
+          }),
+      ),
     };
     return data;
   },

--- a/tests/graphql-tier-cascade.test.ts
+++ b/tests/graphql-tier-cascade.test.ts
@@ -103,18 +103,6 @@ function buildResolver(
 }
 
 /**
- * Resolvers on a retired tier with no loader, that are NOT defects.
- *
- * A name belongs here only when the tier genuinely does not exist for anyone --
- * verified by the MCP twin ALSO bottoming out in an empty builder. GraphQL
- * matching MCP's empty is correct in that case; the missing data is a separate
- * question about the lane, not a wiring bug on this surface.
- *
- * Every entry needs a reason. The list must SHRINK: an entry that no longer
- * matches a broken resolver fails the test below, so a fix cannot silently
- * leave a stale exemption behind.
- */
-/**
  * Resolvers still to be wired, tracked against #9540.
  *
  * These ARE defects -- each has a loader its REST/MCP twin already calls, and
@@ -128,11 +116,6 @@ const PENDING_WIRING = new Set([
   "subnet_axon_removals",
   "subnet_events",
   "subnet_prometheus",
-  "extrinsic",
-  "blocks",
-  "block",
-  "block_extrinsics",
-  "block_events",
   "account_prometheus",
   "account_stake_flow",
   "account_registrations",
@@ -147,6 +130,18 @@ const PENDING_WIRING = new Set([
   "chain_activity",
 ]);
 
+/**
+ * Resolvers on a retired tier with no loader, that are NOT defects.
+ *
+ * A name belongs here only when the tier genuinely does not exist for anyone --
+ * verified by the MCP twin ALSO bottoming out in an empty builder. GraphQL
+ * matching MCP's empty is correct in that case; the missing data is a separate
+ * question about the lane, not a wiring bug on this surface.
+ *
+ * Every entry needs a reason. The list must SHRINK: an entry that no longer
+ * matches a broken resolver fails the test below, so a fix cannot silently
+ * leave a stale exemption behind.
+ */
 const NO_TIER_ANYWHERE: Record<string, string> = {
   chain_axon_removals:
     "get_chain_axon_removals falls to buildChainAxonRemovals([]) on MCP too -- no artifact lane exists for it",


### PR DESCRIPTION
## Summary

Five more resolvers on the retired `BLOCKS`/`EXTRINSICS` flags reached only the empty builder, so GraphQL served block 8776109 as *"no such block"* while REST and MCP returned it.

Continues #9546. `PENDING_WIRING` drops **20 → 15**.

## Wired

| Resolver | Tier |
| --- | --- |
| `blocks` | `loadBlockFeedColdTier` |
| `block` | `loadBlockColdTier` |
| `block_extrinsics` | `answerBlockDetail` (hot → cold) |
| `block_events` | `answerBlockDetail` (hot → cold) |
| `extrinsic` | `answerExtrinsicDetail` (hot → cold) |

`blocks` forwards **every filter**, which matters more than the rows alone: the empty builder ignores them, so reaching it dropped a filtered query's *meaning* as well as its result.

## The gap case is why three of these aren't plain loaders

A block ref can land in the **gap** between the decoded seam and the hot window. That is a decline, not an absence — the data exists and this deployment cannot currently read it, and the decode lane closes it within the hour.

- REST answers it `503 block_detail_unavailable` (`chainDetailGapResponse`)
- MCP throws a tool error (`chainDetailAnswerOrThrow`)

Returning the empty builder there would state "this block has no events" — the exact confident zero this whole effort is removing. `gapAwareBlockDetail` raises a `GraphQLError` with `BLOCK_DETAIL_UNAVAILABLE` plus `block_number`/`decoded_through`, so the condition is diagnosable from the response.

A genuine `miss` still degrades to the schema-stable empty — this surface's existing convention, unchanged.

## Pre-existing failure, called out

`tests/economics-surface-parity.test.ts` fails 3 tests on **clean `origin/main`** too, identically, before and after this change. Verified by hard-resetting to `origin/main`, running a full `npm run build`, and re-running: same 3.

It's an ordering dependency on the gitignored R2 fixture tree that surfaced when main's test-file count changed (682 → 685 files shifts alphabetical order, and the fixtures are populated as a side effect of an earlier-sorting file). CI shards differently and stays green. **Not introduced here** — flagged separately rather than folded into this PR.

## Validation

```
npm run lint   npm run format:check   npm run typecheck
npm run validate   npm run scan:public-safety
npx vitest run
  -> 684 passed / 685 files; the single failing file is the pre-existing one above,
     byte-identical to clean main
```

Refs #9540