### PR TITLE
fix(graphql): give every retired-tier resolver the cascade it was missing

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -25,7 +25,20 @@ import { loadChainAlphaVolumeFromArtifact } from "./chain-alpha-volume-artifact.
 import { resolveMarketCapIndex } from "./market-cap-index.ts";
 import { loadChainCallsFromArtifact } from "./chain-calls-artifact.ts";
 import { loadChainFeesFromArtifact } from "./chain-fees-artifact.ts";
+import { loadChainActivityFromArtifact } from "./chain-activity-artifact.ts";
 import { loadExtrinsicFeedColdTier } from "./extrinsics-cold-tier.ts";
+import {
+  loadAccountCounterpartiesColdTier,
+  loadAccountRegistrationsColdTier,
+  loadAccountServingColdTier,
+  loadAccountStakeFlowColdTier,
+  loadAccountStakeMovesColdTier,
+  loadAccountTransfersColdTier,
+  loadAccountWeightSettersColdTier,
+  loadCounterpartyRelationshipColdTier,
+} from "./account-feeds-cold-tier.ts";
+import { loadAccountEventsColdTier } from "./events-cold-tier.ts";
+import { loadAccountExtrinsicsColdTier } from "./extrinsics-cold-tier.ts";
 import { loadExtrinsicColdTier } from "./extrinsics-cold-tier.ts";
 import {
   loadBlockColdTier,
@@ -5837,6 +5850,14 @@ const rootValue = {
     );
     const data =
       (pg?.data as Row | undefined) ??
+      // The account cold tier REST and MCP both read (#9540); the loader
+      // returns the same { data } envelope the retired tier did.
+      ((
+        (await loadAccountStakeFlowColdTier(context.env, ss58, {
+          window: requestedWindow,
+          direction: requestedDirection,
+        })) as Row | null
+      )?.data as Row | undefined) ??
       buildAccountStakeFlow([], ss58, { window: requestedWindow });
     return {
       schema_version: data.schema_version ?? 1,
@@ -6003,6 +6024,13 @@ const rootValue = {
     );
     const data =
       (tier?.data as Row | undefined) ??
+      // The account cold tier REST and MCP both read (#9540); the loader
+      // returns the same { data } envelope the retired tier did.
+      ((
+        (await loadAccountRegistrationsColdTier(context.env, ss58, {
+          window: windowParam,
+        })) as Row | null
+      )?.data as Row | undefined) ??
       buildAccountRegistrations([], ss58, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
@@ -6123,6 +6151,13 @@ const rootValue = {
     );
     const data =
       (tier?.data as Row | undefined) ??
+      // The account cold tier REST and MCP both read (#9540); the loader
+      // returns the same { data } envelope the retired tier did.
+      ((
+        (await loadAccountServingColdTier(context.env, ss58, {
+          window: windowParam,
+        })) as Row | null
+      )?.data as Row | undefined) ??
       buildAccountServing([], ss58, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
@@ -6234,6 +6269,13 @@ const rootValue = {
     );
     const data =
       (tier?.data as Row | undefined) ??
+      // The account cold tier REST and MCP both read (#9540); the loader
+      // returns the same { data } envelope the retired tier did.
+      ((
+        (await loadAccountStakeMovesColdTier(context.env, ss58, {
+          window: windowParam,
+        })) as Row | null
+      )?.data as Row | undefined) ??
       buildAccountStakeMoves([], ss58, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
@@ -6288,6 +6330,13 @@ const rootValue = {
     );
     const data =
       (pg?.data as Row | undefined) ??
+      // The account cold tier REST and MCP both read (#9540); the loader
+      // returns the same { data } envelope the retired tier did.
+      ((
+        (await loadAccountWeightSettersColdTier(context.env, ss58, {
+          window: requestedWindow,
+        })) as Row | null
+      )?.data as Row | undefined) ??
       buildAccountWeightSetters([], ss58, { window: requestedWindow });
     return {
       schema_version: data.schema_version ?? 1,
@@ -6486,6 +6535,24 @@ const rootValue = {
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     );
     let data = tier as Row | null;
+    // The cold tiers REST and MCP both read (#9540). Two of them, because this
+    // resolver has two modes and they are not interchangeable: a counterparty
+    // argument asks about ONE relationship, and answering it from the list
+    // reader would return a different question's answer.
+    if (data == null) {
+      data = (
+        counterparty != null
+          ? await loadCounterpartyRelationshipColdTier(
+              context.env,
+              ss58,
+              counterparty,
+              { limit: limit ?? undefined },
+            )
+          : await loadAccountCounterpartiesColdTier(context.env, ss58, {
+              limit: limit ?? undefined,
+            })
+      ) as Row | null;
+    }
     if (data == null) {
       if (counterparty != null) {
         const rel = buildCounterpartyRelationship([], ss58, counterparty, {
@@ -6600,6 +6667,16 @@ const rootValue = {
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
+      // The account cold tier REST and MCP both read (#9540). Every filter is
+      // forwarded, so the tier filters -- the empty builder below ignores them.
+      ((await loadAccountTransfersColdTier(context.env, ss58, {
+        limit: safeLimit,
+        offset: safeOffset,
+        cursor,
+        direction,
+        blockStart: block_start,
+        blockEnd: block_end,
+      })) as Row | null) ??
       buildAccountTransfers([], ss58, {
         limit: safeLimit,
         offset: safeOffset,
@@ -6668,6 +6745,15 @@ const rootValue = {
         ),
         "METAGRAPH_EXTRINSICS_SOURCE",
       )) as Row | null) ??
+      // The account cold tier REST and MCP both read (#9540). Every filter is
+      // forwarded, so the tier filters -- the empty builder below ignores them.
+      ((await loadAccountExtrinsicsColdTier(context.env, ss58, {
+        limit: safeLimit,
+        offset: safeOffset,
+        cursor,
+        blockStart: block_start,
+        blockEnd: block_end,
+      })) as Row | null) ??
       buildAccountExtrinsics([], ss58, {
         limit: safeLimit,
         offset: safeOffset,
@@ -6734,6 +6820,17 @@ const rootValue = {
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
+      // The account cold tier REST and MCP both read (#9540). Every filter is
+      // forwarded, so the tier filters -- the empty builder below ignores them.
+      ((await loadAccountEventsColdTier(context.env, ss58, {
+        limit: safeLimit,
+        offset: safeOffset,
+        cursor,
+        kind,
+        netuid,
+        blockStart: block_start,
+        blockEnd: block_end,
+      })) as Row | null) ??
       buildAccountEvents([], ss58, {
         limit: safeLimit,
         offset: safeOffset,
@@ -7083,6 +7180,14 @@ const rootValue = {
         postgresTierRequest(context, "/api/v1/chain/activity", params),
         "METAGRAPH_EXTRINSICS_SOURCE",
       )) as ReturnType<typeof buildChainActivity> | null) ??
+        // The projection tier REST reads (#9540). Window-based like REST's
+        // handleChainActivity, NOT the blocks-based loadChainActivity MCP's
+        // get_chain_activity uses -- that tool takes a block count and answers a
+        // different question, so borrowing its loader would change this
+        // resolver's contract rather than fill it.
+        ((await loadChainActivityFromArtifact(context.env, {
+          window: label,
+        })) as ReturnType<typeof buildChainActivity> | null) ??
         buildChainActivity({ window: label }),
       days,
     );

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -26,6 +26,23 @@ import { resolveMarketCapIndex } from "./market-cap-index.ts";
 import { loadChainCallsFromArtifact } from "./chain-calls-artifact.ts";
 import { loadChainFeesFromArtifact } from "./chain-fees-artifact.ts";
 import { loadExtrinsicFeedColdTier } from "./extrinsics-cold-tier.ts";
+import { loadExtrinsicColdTier } from "./extrinsics-cold-tier.ts";
+import {
+  loadBlockColdTier,
+  loadBlockFeedColdTier,
+} from "./blocks-cold-tier.ts";
+import { loadBlockExtrinsicsColdTier } from "./extrinsics-cold-tier.ts";
+import { loadBlockEventsColdTier } from "./events-cold-tier.ts";
+import {
+  answerBlockDetail,
+  answerExtrinsicDetail,
+  chainDetailGapMessage,
+  isEmptyEventPayload,
+  isEmptyExtrinsicPayload,
+  loadBlockEventsHotTier,
+  loadBlockExtrinsicsHotTier,
+  type ChainDetailAnswer,
+} from "./chain-detail-hot-tier.ts";
 // #7881: the same list-query helper the REST pipeline and the list_* MCP
 // loaders use, so subnet_health's filter/sort/page allowlists cannot drift
 // from GET /api/v1/subnets/{netuid}/health.
@@ -1984,6 +2001,36 @@ function resolveEvmAddressMapping(
 // the pilot conversion + the codegen mechanism). Every Query root field on
 // this object is now typed against the generated Query<Field>Args types
 // below rather than a Row-typed destructured param.
+/**
+ * A block-scoped detail answer, with the GAP case raised rather than flattened
+ * to an empty (#9540).
+ *
+ * `answerBlockDetail` distinguishes three outcomes and only two of them mean
+ * "no rows". A `gap` is a ref falling between the decoded seam and the hot
+ * window: the data exists and this deployment cannot currently read it. REST
+ * answers that 503 `block_detail_unavailable` and MCP throws a tool error, so
+ * GraphQL must not be the one surface reporting it as an empty block.
+ *
+ * `miss` -- a ref that genuinely resolves to nothing -- still degrades to the
+ * schema-stable empty, which is this surface's existing convention.
+ */
+function gapAwareBlockDetail<T>(
+  answer: ChainDetailAnswer<T>,
+  empty: () => T,
+): T {
+  if (answer.kind === "answer") return answer.data;
+  if (answer.kind === "gap") {
+    throw new GraphQLError(chainDetailGapMessage(answer), {
+      extensions: {
+        code: "BLOCK_DETAIL_UNAVAILABLE",
+        block_number: answer.block,
+        decoded_through: answer.seam,
+      },
+    });
+  }
+  return empty();
+}
+
 const rootValue = {
   subnets(args: QuerySubnetsArgs, context: GqlContext) {
     // #8423: full parity with the list_subnets MCP tool over the same static
@@ -4951,7 +4998,16 @@ const rootValue = {
           `/api/v1/extrinsics/${encodeURIComponent(ref)}`,
         ),
         "METAGRAPH_EXTRINSICS_SOURCE",
-      )) as Row | null) ?? buildExtrinsic(undefined, ref);
+      )) as Row | null) ??
+      // The same hot/cold cascade REST and MCP run (#9540). A composite
+      // "<block>-<index>" ref routes through answerBlockDetail, so it inherits
+      // the gap case -- raised, not flattened to an empty extrinsic.
+      (gapAwareBlockDetail(
+        await answerExtrinsicDetail(context.env, ref, () =>
+          loadExtrinsicColdTier(context.env, ref),
+        ),
+        () => buildExtrinsic(undefined, ref),
+      ) as Row);
     return {
       ref: data.ref ?? ref,
       extrinsic: extrinsicNode(data.extrinsic),
@@ -5097,6 +5153,23 @@ const rootValue = {
         postgresTierRequest(context, "/api/v1/blocks", params),
         "METAGRAPH_BLOCKS_SOURCE",
       )) as Row | null) ??
+      // The blocks cold tier REST and MCP both read (#9540). Every filter is
+      // forwarded, so the tier does the filtering -- the empty builder below
+      // ignores them, which is why reaching it silently dropped a filtered
+      // query's meaning as well as its rows.
+      ((await loadBlockFeedColdTier(context.env, {
+        limit: safeLimit,
+        offset: safeOffset,
+        cursor,
+        author,
+        specVersion,
+        blockStart,
+        blockEnd,
+        from,
+        to,
+        minExtrinsics,
+        minEvents,
+      } as never)) as Row | null) ??
       buildBlockFeed([], {
         limit: safeLimit,
         offset: safeOffset,
@@ -5180,7 +5253,10 @@ const rootValue = {
           `/api/v1/blocks/${encodeURIComponent(ref)}`,
         ),
         "METAGRAPH_BLOCKS_SOURCE",
-      )) as Row | null) ?? buildBlock(undefined, ref);
+      )) as Row | null) ??
+      // The block cold tier REST and MCP both read (#9540).
+      ((await loadBlockColdTier(context.env, ref)) as Row | null) ??
+      buildBlock(undefined, ref);
     return {
       ref: data.ref ?? ref,
       block: data.block ?? null,
@@ -5217,10 +5293,32 @@ const rootValue = {
       ),
       "METAGRAPH_EXTRINSICS_SOURCE",
     )) as Row | null) ?? {
-      data: buildBlockExtrinsics([], ref, null, {
-        limit: safeLimit,
-        offset: safeOffset,
-      }),
+      // The hot/cold cascade REST and MCP both run (#9540). Not a plain loader:
+      // a ref can land in the GAP between the decoded seam and the hot window,
+      // and that is a decline, not an empty -- REST answers it 503
+      // block_detail_unavailable and MCP throws. Returning the empty builder
+      // there would state "this block has no extrinsics", which is the confident
+      // zero this whole change exists to remove.
+      data: gapAwareBlockDetail(
+        await answerBlockDetail(context.env, ref, {
+          hot: (height) =>
+            loadBlockExtrinsicsHotTier(context.env, ref, height, {
+              limit: safeLimit,
+              offset: safeOffset,
+            }),
+          cold: () =>
+            loadBlockExtrinsicsColdTier(context.env, ref, {
+              limit: safeLimit,
+              offset: safeOffset,
+            }),
+          isEmpty: isEmptyExtrinsicPayload,
+        }),
+        () =>
+          buildBlockExtrinsics([], ref, null, {
+            limit: safeLimit,
+            offset: safeOffset,
+          }),
+      ),
     };
     return data;
   },
@@ -5249,10 +5347,32 @@ const rootValue = {
       ),
       "METAGRAPH_EXTRINSICS_SOURCE",
     )) as Row | null) ?? {
-      data: buildBlockEvents([], ref, null, {
-        limit: safeLimit,
-        offset: safeOffset,
-      }),
+      // The hot/cold cascade REST and MCP both run (#9540). Not a plain loader:
+      // a ref can land in the GAP between the decoded seam and the hot window,
+      // and that is a decline, not an empty -- REST answers it 503
+      // block_detail_unavailable and MCP throws. Returning the empty builder
+      // there would state "this block has no events", which is the confident
+      // zero this whole change exists to remove.
+      data: gapAwareBlockDetail(
+        await answerBlockDetail(context.env, ref, {
+          hot: (height) =>
+            loadBlockEventsHotTier(context.env, ref, height, {
+              limit: safeLimit,
+              offset: safeOffset,
+            }),
+          cold: () =>
+            loadBlockEventsColdTier(context.env, ref, {
+              limit: safeLimit,
+              offset: safeOffset,
+            }),
+          isEmpty: isEmptyEventPayload,
+        }),
+        () =>
+          buildBlockEvents([], ref, null, {
+            limit: safeLimit,
+            offset: safeOffset,
+          }),
+      ),
     };
     return data;
   },

--- a/tests/economics-surface-parity.test.ts
+++ b/tests/economics-surface-parity.test.ts
@@ -21,7 +21,16 @@ import type { Row } from "./row-type.ts";
 // external report said exactly that — it nearly shipped a conclusion that a rebuild was
 // impossible because the API looked frozen.
 
-const CAPTURED_AT = "2026-08-05T03:26:09.362Z";
+// RELATIVE, not a literal. resolveLiveEconomics rejects a blob older than
+// ECONOMICS_FRESHNESS_MAX_AGE_MS (8h) and falls through to R2 -- which this
+// harness deliberately leaves empty so the KV tier is the one under test. A
+// hardcoded stamp therefore makes this file a time bomb: it was committed dated
+// slightly in the future, passed while wall-clock time was behind it, and went
+// permanently red 8 hours after that instant, with a `not_found` from the R2
+// fallback rather than anything resembling the freshness cause. Anchoring to
+// now keeps the blob perpetually fresh, which is the precondition of the test,
+// not its subject.
+const CAPTURED_AT = new Date(Date.now() - 60_000).toISOString();
 const BLOCK = 8_775_311;
 
 const ECONOMICS_BLOB = {

--- a/tests/graphql-tier-cascade.test.ts
+++ b/tests/graphql-tier-cascade.test.ts
@@ -103,18 +103,6 @@ function buildResolver(
 }
 
 /**
- * Resolvers on a retired tier with no loader, that are NOT defects.
- *
- * A name belongs here only when the tier genuinely does not exist for anyone --
- * verified by the MCP twin ALSO bottoming out in an empty builder. GraphQL
- * matching MCP's empty is correct in that case; the missing data is a separate
- * question about the lane, not a wiring bug on this surface.
- *
- * Every entry needs a reason. The list must SHRINK: an entry that no longer
- * matches a broken resolver fails the test below, so a fix cannot silently
- * leave a stale exemption behind.
- */
-/**
  * Resolvers still to be wired, tracked against #9540.
  *
  * These ARE defects -- each has a loader its REST/MCP twin already calls, and
@@ -128,11 +116,6 @@ const PENDING_WIRING = new Set([
   "subnet_axon_removals",
   "subnet_events",
   "subnet_prometheus",
-  "extrinsic",
-  "blocks",
-  "block",
-  "block_extrinsics",
-  "block_events",
   "account_prometheus",
   "account_stake_flow",
   "account_registrations",
@@ -147,6 +130,18 @@ const PENDING_WIRING = new Set([
   "chain_activity",
 ]);
 
+/**
+ * Resolvers on a retired tier with no loader, that are NOT defects.
+ *
+ * A name belongs here only when the tier genuinely does not exist for anyone --
+ * verified by the MCP twin ALSO bottoming out in an empty builder. GraphQL
+ * matching MCP's empty is correct in that case; the missing data is a separate
+ * question about the lane, not a wiring bug on this surface.
+ *
+ * Every entry needs a reason. The list must SHRINK: an entry that no longer
+ * matches a broken resolver fails the test below, so a fix cannot silently
+ * leave a stale exemption behind.
+ */
 const NO_TIER_ANYWHERE: Record<string, string> = {
   chain_axon_removals:
     "get_chain_axon_removals falls to buildChainAxonRemovals([]) on MCP too -- no artifact lane exists for it",

--- a/tests/graphql-tier-cascade.test.ts
+++ b/tests/graphql-tier-cascade.test.ts
@@ -94,11 +94,20 @@ function buildResolver(
     usesRetiredTier:
       /tryPostgresTier\(/.test(body) &&
       [...retired].some((flag) => body.includes(flag)),
-    // The rung: any shared cold-tier / artifact reader. `loadChainActivity` and
-    // friends do not follow the ColdTier/FromArtifact suffix convention, so
-    // match the loader prefix rather than the suffix. Comments count as body
+    // The rung: any shared cold-tier / artifact reader, OR a composer that owns
+    // the whole ladder on the resolver's behalf.
+    //
+    // Both prefixes are needed. `load*` covers the readers, but several routes
+    // reach their tier through an `answer*` composer instead --
+    // answerSubnetEvents owns the tier order and empty floor for REST, MCP and
+    // GraphQL alike, and answerBlockDetail routes a ref across the seam. Matching
+    // only `load` reported subnet_events as missing a rung it already had, which
+    // would have sent someone to "fix" a correct resolver.
+    //
+    // Suffix matching is not an option either: loadChainActivity and friends do
+    // not follow the ColdTier/FromArtifact convention. Comments count as body
     // text, which is why the brace-accurate slice above matters.
-    hasLoader: /\bload[A-Z][A-Za-z]*\s*\(/.test(body),
+    hasLoader: /\b(?:load|answer)[A-Z][A-Za-z]*\s*\(/.test(body),
   };
 }
 
@@ -112,22 +121,10 @@ function buildResolver(
  * only ever SHRINK, and the test above still fails for any resolver that is in
  * neither map. A newly-broken resolver cannot hide among them.
  */
-const PENDING_WIRING = new Set([
-  "subnet_axon_removals",
-  "subnet_events",
-  "subnet_prometheus",
-  "account_prometheus",
-  "account_stake_flow",
-  "account_registrations",
-  "account_serving",
-  "account_axon_removals",
-  "account_stake_moves",
-  "account_weight_setters",
-  "account_counterparties",
-  "account_transfers",
-  "account_extrinsics",
-  "account_events",
-  "chain_activity",
+const PENDING_WIRING = new Set<string>([
+  // Empty, and kept so the next gap has an obvious home: a resolver found
+  // broken goes here with its issue, and the staleness check below forces it
+  // back out the moment it is fixed.
 ]);
 
 /**
@@ -144,17 +141,17 @@ const PENDING_WIRING = new Set([
  */
 const NO_TIER_ANYWHERE: Record<string, string> = {
   chain_axon_removals:
-    "get_chain_axon_removals falls to buildChainAxonRemovals([]) on MCP too -- no artifact lane exists for it",
+    "get_chain_axon_removals falls to buildChainAxonRemovals([]) on MCP too -- no lane exists for it",
   chain_prometheus:
-    "get_chain_prometheus falls to buildChainPrometheus([]) on MCP too -- no artifact lane exists for it",
-  account:
-    "get_account composes from sibling readers rather than one tier loader; not a single missing rung",
-  account_entities:
-    "get_account_entities composes from sibling readers rather than one tier loader",
-  chain_identity_history:
-    "no identity-history cold tier exists on any surface; MCP's own ladder ends at the same empty",
-  subnet_identity_history:
-    "same identity-history lane as chain_identity_history",
+    "get_chain_prometheus falls to buildChainPrometheus([]) on MCP too -- no lane exists for it",
+  account_prometheus:
+    "get_account_prometheus falls to buildAccountPrometheus([]) on MCP too -- no lane exists for it",
+  account_axon_removals:
+    "get_account_axon_removals falls to buildAccountAxonRemovals([]) on MCP too -- no lane exists for it",
+  subnet_axon_removals:
+    "get_subnet_axon_removals falls to buildSubnetAxonRemovals(null) on MCP too -- no lane exists for it",
+  subnet_prometheus:
+    "get_subnet_prometheus falls to buildSubnetPrometheus(null) on MCP too -- no lane exists for it",
 };
 
 // Positive control. A pure "nothing is broken" assertion passes just as well


### PR DESCRIPTION
## Summary

Eight tier flags read `"retired"` in `wrangler.jsonc`, so `tryPostgresTier` returns null for them. A resolver whose ladder is `tryPostgresTier(...) ?? build...([])` is therefore **structurally empty in production** — it answers a schema-valid zero with an empty `errors` array, indistinguishable from "the chain has no data".

**29 resolvers were affected.** 9 landed in #9546; this closes out the remaining 20 and takes `PENDING_WIRING` to empty.

## Measured against production GraphQL

```graphql
{ blocks(limit:2){total} extrinsics(limit:2){total}
  account_events(ss58:"5E2LP6…",limit:2){event_count}
  chain_transfers{transfer_count} chain_alpha_volume(limit:2){subnet_count} }
```
```json
{"data":{"blocks":{"total":0},"extrinsics":{"total":0},"account_events":{"event_count":0},
         "chain_transfers":{"transfer_count":0},"chain_alpha_volume":{"subnet_count":0}},"errors":[]}
```

Every one of those returns real rows on REST and MCP.

## Wired to the twin's own loader, not a shape invented here

- **`blocks`** forwards every filter. That matters beyond the rows: the empty builder *ignores* them, so reaching it dropped a filtered query's **meaning** as well as its result.
- **`block_extrinsics` / `block_events` / `extrinsic`** go through the hot/cold cascade, because a ref can land in the **gap** between the decoded seam and the hot window. That is a decline, not an absence — REST answers it `503 block_detail_unavailable`, MCP throws — so `gapAwareBlockDetail` raises rather than let GraphQL be the one surface reporting it as an empty block. A genuine `miss` still degrades to the schema-stable empty.
- **`account_counterparties`** takes two readers, because its two modes are not interchangeable: a `counterparty` argument asks about **one** relationship, and answering it from the list reader would return a different question's answer.
- **`chain_activity`** takes the **window-based** artifact loader REST uses, not the blocks-based `loadChainActivity` MCP's tool uses — that tool takes a block count and answers a different question, so borrowing it would change this resolver's contract rather than fill it.
- The 9 account resolvers, `blocks`/`block`, and the rest each take the `{ data }`-enveloped or paginated cold tier their twin calls, filters forwarded.

## Six stay unwired — with evidence, not assumption

`chain_axon_removals`, `chain_prometheus`, `account_prometheus`, `account_axon_removals`, `subnet_axon_removals`, `subnet_prometheus`. Each MCP twin bottoms out in the *same* empty builder, so no tier exists on any surface and GraphQL matching that empty is correct.

## Two guard corrections — it was reporting the wrong answer in both directions

The detector matched only `load*`, so:

1. **`subnet_events` read as broken** though it was already wired through `answerSubnetEvents` — a false positive that would have sent someone to "fix" a correct resolver.
2. **Four resolvers** (`account`, `account_entities`, `chain_identity_history`, `subnet_identity_history`) sat wrongly in the no-tier list; all four reach `answer*` composers. Verified individually, not inferred from the regex.

It now matches composers too. `PENDING_WIRING` is empty and kept in place so the next gap has an obvious home — the staleness check forces an entry back out the moment it's fixed, and a resolver in neither list still fails outright.

Verified the guard still bites by removing the `chain_activity` rung:
```
× no resolver on a retired tier is left with no loader to fall back to
  AssertionError: ... so they can only answer zero:
    chain_activity
```

## Also fixes a time bomb found while running the suite

`tests/economics-surface-parity.test.ts` hardcoded `captured_at: "2026-08-05T03:26:09.362Z"`. `resolveLiveEconomics` rejects a blob older than 8h and falls through to R2 — which that harness deliberately leaves empty so the KV tier is what's under test. So the file **passed while wall-clock time was behind the stamp and went permanently red 8 hours later**, surfacing as a `not_found` from the R2 fallback with nothing resembling the freshness cause. It was 14.6h stale when found.

Anchored to `Date.now()`, since a fresh blob is the test's *precondition*, not its subject.

Swept the sibling fixtures rather than assume it was unique: every other one is deliberately ancient (≥954h, one at year 2000) and tests the *stale* path, so it stays correct forever. This was the only instance.

## Validation

```
npm run lint   npm run format:check   npm run typecheck
npm run validate   npm run scan:public-safety
npx vitest run   ->  685 files, 16,397 tests, 0 failures
```

Fully green, including the parity test that was failing on `main` before this.

Closes #9540