### PR TITLE
fix(d1): store only the alpha pools some position actually references

### DIFF
--- a/migrations/d1/0022_nominator_positions_hotkey_netuid.sql
+++ b/migrations/d1/0022_nominator_positions_hotkey_netuid.sql
@@ -1,0 +1,22 @@
+-- The (hotkey, netuid) lookup `nominator_positions` could not serve (#9558).
+--
+-- The PRIMARY KEY is (coldkey, hotkey, netuid), so its implicit index answers
+-- "which positions does this coldkey hold" and nothing else: a lookup keyed on
+-- (hotkey, netuid) is not a prefix of it and falls back to a full scan of every
+-- position row.
+--
+-- WHAT NEEDS IT. The hotkey-alpha sink now writes only the pools some position
+-- actually references, which is a per-row EXISTS against exactly this key. At
+-- 25,000 rows a request against ~124,000 position rows, an unindexed predicate
+-- would be a scan per incoming row -- comfortably worse than the write volume
+-- it exists to avoid, which is the kind of "optimisation" that reads as a fix
+-- and measures as a regression.
+--
+-- The top-holders holdings query benefits incidentally: it drives from
+-- `nominator_positions` and looks `hotkey_alpha` up by ITS primary key, so that
+-- direction was already covered, but the reverse direction now is too.
+--
+-- COVERING, deliberately. Both columns are in the index, so the EXISTS is
+-- answered from the index alone and never touches the table.
+CREATE INDEX IF NOT EXISTS idx_nominator_positions_hotkey_netuid
+  ON nominator_positions (hotkey, netuid);

--- a/src/hotkey-alpha-d1-write.ts
+++ b/src/hotkey-alpha-d1-write.ts
@@ -50,6 +50,39 @@ export const HOTKEY_ALPHA_INSERT_COLUMNS = [
 ];
 
 /**
+ * Only pools some position actually references are stored (#9558).
+ *
+ * WHY A LEDGER SHOULD REFUSE MOST OF ITS OWN KEYSPACE. `TotalHotkeyAlpha` has
+ * ~762,577 entries. The number this table exists to serve is `delegated_tao`,
+ * which prices `nominator_positions` -- and those name **17,902** distinct
+ * (hotkey, netuid) pairs. The other 43x is written every pass, read by nothing,
+ * and was measurably harmful: bulk passes saturated D1
+ * (`D1_ERROR: D1 DB is overloaded. Requests queued for too long.`), which
+ * aborted the passes themselves and failed unrelated writers -- `wallet-auth`
+ * and `tao-usd-index` -- on the database everything shares.
+ *
+ * FILTERED IN THE STATEMENT, not in the Worker and not in the producer. In the
+ * Worker the write is already paid for by the time you could skip it; in the
+ * producer it would need to know the position set, which only the database has.
+ * As a predicate on the SELECT, a declined row costs no write at all.
+ *
+ * NOT A PRUNE. Rows already stored for a pair that later loses its positions
+ * stay -- this lane has never deleted, and `absent` carries no meaning here (the
+ * producer skips a genuine zero pool). A pair that GAINS a position is picked up
+ * on the next pass, since both lanes refresh daily.
+ *
+ * Needs migrations/d1/0022's (hotkey, netuid) index: the primary key is
+ * (coldkey, hotkey, netuid), so without it this predicate is a full scan of
+ * every position row, per incoming row.
+ */
+const REFERENCED_BY_A_POSITION =
+  "EXISTS (SELECT 1 FROM nominator_positions np" +
+  ` WHERE np.hotkey = json_extract(value, '$[${HOTKEY_ALPHA_INSERT_COLUMNS.indexOf("hotkey")}]')` +
+  ` AND np.netuid = json_extract(value, '$[${HOTKEY_ALPHA_INSERT_COLUMNS.indexOf("netuid")}]'))`;
+
+export { REFERENCED_BY_A_POSITION };
+
+/**
  * One pass's completeness accounting, when the producer declares it.
  *
  * The twin of AccountBalancesPass, and deliberately a separate type rather than
@@ -136,6 +169,7 @@ export async function writeHotkeyAlphaToD1(
     HOTKEY_ALPHA_INSERT_COLUMNS,
     ["hotkey", "netuid"],
     rows,
+    REFERENCED_BY_A_POSITION,
   );
   if (pass && statements.length) {
     statements.push(hotkeyAlphaPassStatement(db, pass));

--- a/src/neurons-d1-write.ts
+++ b/src/neurons-d1-write.ts
@@ -147,12 +147,23 @@ export function buildJsonUpsert(
   table: string,
   columns: string[],
   conflict: string[],
+  /**
+   * An optional SQL predicate on the incoming row, evaluated INSIDE the
+   * statement so a rejected row costs no D1 write at all.
+   *
+   * This is how a lane declines to store rows nothing will ever read. Filtering
+   * in the Worker instead would still pay the write; filtering in the producer
+   * would need it to know something only the database does. The predicate may
+   * reference `json_extract(value, '$[i]')` for the incoming row's columns.
+   */
+  filter?: string,
 ): string {
   const updatable = columns.filter((column) => !conflict.includes(column));
   return (
     `INSERT INTO ${table} (${columns.join(", ")}) SELECT ` +
     columns.map((_, i) => `json_extract(value, '$[${i}]')`).join(", ") +
     ` FROM json_each(?1) WHERE true` +
+    (filter ? ` AND (${filter})` : "") +
     ` ON CONFLICT (${conflict.join(", ")}) DO UPDATE SET ` +
     updatable.map((column) => `${column} = excluded.${column}`).join(", ") +
     ` WHERE ${table}.captured_at <= excluded.captured_at`
@@ -246,9 +257,12 @@ export function chunkStatements(
   columns: string[],
   conflict: string[],
   rows: Row[],
+  /** See buildJsonUpsert's own `filter`. Upsert-only: an append-only table has
+   * no key to decline a row against. */
+  filter?: string,
 ): D1PreparedStatement[] {
   const sql = conflict.length
-    ? buildJsonUpsert(table, columns, conflict)
+    ? buildJsonUpsert(table, columns, conflict, filter)
     : buildJsonAppendInsert(table, columns);
   return chunkRowsByJsonBytes(rows, columns).map((chunk) =>
     db.prepare(sql).bind(JSON.stringify(chunk)),

--- a/tests/data-api-hotkey-alpha-d1.test.ts
+++ b/tests/data-api-hotkey-alpha-d1.test.ts
@@ -36,6 +36,29 @@ const PASSES_SCHEMA = fs.readFileSync(
   path.join(process.cwd(), "migrations/d1/0021_hotkey_alpha_passes.sql"),
   "utf8",
 );
+// The write filters against nominator_positions (#9557): only pools some
+// position actually references are stored, so the sink's statement reads that
+// table and the fixture has to provide it.
+const POSITIONS_SCHEMA = fs.readFileSync(
+  path.join(process.cwd(), "migrations/d1/0011_nominator_positions.sql"),
+  "utf8",
+);
+const POSITIONS_INDEX = fs.readFileSync(
+  path.join(
+    process.cwd(),
+    "migrations/d1/0022_nominator_positions_hotkey_netuid.sql",
+  ),
+  "utf8",
+);
+
+/** Make (hotkey, netuid) referenced, so a pool for it is stored. */
+function reference(hotkey: string, netuid: number) {
+  db.prepare(
+    "INSERT OR IGNORE INTO nominator_positions" +
+      " (coldkey, hotkey, netuid, share_fraction, captured_at)" +
+      " VALUES (?, ?, ?, 1.0, 1)",
+  ).run(`5Cold${hotkey}${netuid}`, hotkey, netuid);
+}
 
 const PATH = "/api/v1/internal/hotkey-alpha-sync";
 const SECRET = "test-hotkey-alpha-sync-secret";
@@ -125,6 +148,14 @@ beforeEach(() => {
   db = new DatabaseSync(":memory:");
   db.exec(SCHEMA);
   db.exec(PASSES_SCHEMA);
+  db.exec(POSITIONS_SCHEMA);
+  db.exec(POSITIONS_INDEX);
+  // The fixtures below use HOTKEY/HOTKEY_B on the netuids alphaRow() defaults
+  // to; referencing them keeps every pre-existing assertion about what lands
+  // testing what it was written to test.
+  for (const hk of [HOTKEY, HOTKEY_B]) {
+    for (const n of [7, 8, 9, 83]) reference(hk, n);
+  }
 });
 
 describe("POST /api/v1/internal/hotkey-alpha-sync", () => {
@@ -395,5 +426,83 @@ describe("pass_total completeness accounting", () => {
     });
     assert.equal(response.status, 400);
     assert.equal(rows().length, 0);
+  });
+});
+
+// --- writing only what something reads (#9557) -------------------------------
+//
+// `TotalHotkeyAlpha` has ~762,577 entries; `nominator_positions` names 17,902
+// distinct (hotkey, netuid) pairs, and pricing those positions is the only
+// reason this table exists. The other 43x was written every pass, read by
+// nothing, and measurably harmful: the bulk volume saturated D1
+// (`D1 DB is overloaded. Requests queued for too long.`), which aborted the
+// passes AND failed unrelated writers on the same database.
+describe("only pools some position references are stored", () => {
+  test("an unreferenced pool is accepted and NOT written", async () => {
+    const orphan = "5OrphanHotkeyNothingDelegatesTo00000000000000000";
+    const response = await post({
+      rows: [
+        alphaRow({ netuid: 7 }),
+        alphaRow({ hotkey: orphan, netuid: 7, total_alpha: 999 }),
+      ],
+    });
+    // ACCEPTED, not rejected: the producer walks the whole keyspace and is
+    // right to send it. Declining is the sink's judgement about storage, not a
+    // complaint about the payload -- a 4xx here would abort a healthy pass.
+    assert.equal(response.status, 200);
+    assert.equal(((await response.json()) as Row).hotkey_alpha_written, 2);
+
+    const stored = rows();
+    assert.deepEqual(
+      stored.map((r) => r.hotkey),
+      [HOTKEY],
+      "the referenced pool landed and the orphan did not",
+    );
+  });
+
+  test("a pool becomes storable once a position references it", async () => {
+    const later = "5LaterHotkeyGainsANominator0000000000000000000000";
+    await post({ rows: [alphaRow({ hotkey: later, netuid: 7 })] });
+    assert.equal(rows().length, 0, "nothing references it yet");
+
+    // Both lanes refresh daily, so a pair that gains a position is picked up on
+    // the next pass rather than needing a backfill.
+    reference(later, 7);
+    await post({ rows: [alphaRow({ hotkey: later, netuid: 7 })] });
+    assert.equal(rows().length, 1);
+    assert.equal(rows()[0]!.hotkey, later);
+  });
+
+  test("the filter is per (hotkey, netuid), not per hotkey", async () => {
+    // A hotkey holds a SEPARATE pool on every subnet it is staked to. Filtering
+    // on the hotkey alone would store pools for subnets nothing delegates on --
+    // and, worse, the composite key means those rows are not overwrites.
+    const partial = "5PartialHotkeyOnOneSubnetOnly000000000000000000";
+    reference(partial, 7);
+    await post({
+      rows: [
+        alphaRow({ hotkey: partial, netuid: 7, total_alpha: 10 }),
+        alphaRow({ hotkey: partial, netuid: 42, total_alpha: 20 }),
+      ],
+    });
+    const stored = rows().filter((r) => r.hotkey === partial);
+    assert.deepEqual(
+      stored.map((r) => r.netuid),
+      [7],
+    );
+  });
+
+  test("the pass tally counts what ARRIVED, not what was stored", async () => {
+    // Completeness is a fact about the producer's delivery. If it counted
+    // stored rows, every pass would look short by exactly the rows the sink
+    // chose not to keep, and the gate would never open.
+    const orphan = "5AnotherOrphan000000000000000000000000000000000";
+    await post({
+      rows: [alphaRow({ netuid: 7 }), alphaRow({ hotkey: orphan, netuid: 7 })],
+      pass_total: 2,
+    });
+    assert.equal(rows().length, 1, "one stored");
+    assert.equal(passes()[0]!.received_rows, 2, "two received");
+    assert.ok(passes()[0]!.completed_at, "and the pass is complete");
   });
 });


### PR DESCRIPTION
`Closes #9558`

`TotalHotkeyAlpha` has ~762,577 entries and the sink stored every one. The only reason the table exists is to price `nominator_positions` for `delegated_tao` — and those positions name **17,902** distinct `(hotkey, netuid)` pairs.

**43× of every pass was written, read by nothing, and actively harmful.**

## The harm, measured

```
D1_ERROR: D1 DB is overloaded. Requests queued for too long.
```

Captured from `wrangler tail metagraphed-data-api`. Bulk volume saturates D1 — which aborted the passes themselves (every `account_balances` pass died in a 140k–175k band regardless of chunk size) and failed **unrelated writers on the same database**: 13 `wallet-auth/keys` writes and a `tao-usd-index` tick in one 16-minute window.

`hotkey_alpha` is the worse of the two lanes: twice the volume, one reader.

## Where the filter goes, and why

Not in the Worker — by then the write is already paid for. Not in the producer — it would need the position set, which only the database has. As a predicate on the `SELECT` inside the upsert, **a declined row costs no write at all**.

`buildJsonUpsert` gains an optional `filter`; only `hotkey_alpha` passes one.

## Three things deliberately preserved

- **Not a prune.** Rows for a pair that later loses its positions stay. This lane has never deleted, and absence carries no meaning here (the producer skips a genuine zero pool). A pair that *gains* a position is picked up next pass — both lanes refresh daily.
- **Accepted, not rejected.** An unreferenced pool returns 200. The producer walks the whole keyspace and is right to send it; declining is the sink's judgement about storage, and a 4xx would abort a healthy pass.
- **The tally counts arrivals, not stores.** Completeness is a fact about the producer's delivery. Counting stored rows would make every pass look short by exactly the rows the sink declined, and the gate would never open. There's a test for precisely this.

## The index

`nominator_positions`' primary key is `(coldkey, hotkey, netuid)`, so a `(hotkey, netuid)` lookup isn't a prefix of it and falls back to a full scan — per incoming row, at 25,000 rows a request against ~124,000 positions. Migration `0022` adds a covering index; **already applied to production D1**.

## Validation

| gate | result |
|---|---|
| `lint` / `format:check` / `typecheck` | clean |
| `npx vitest run` | **685 files, 16,401 tests, 0 failures** |

Four new tests run against **real SQLite through the real route**: an unreferenced pool is accepted and not written; a pool becomes storable once referenced; the filter is per `(hotkey, netuid)` rather than per hotkey (a hotkey holds a separate pool per subnet); and the tally counts arrivals.