### PR TITLE
test(mcp): gate required arguments, and pin offset as advisory

### DIFF
--- a/tests/mcp-schema-enforcement.test.ts
+++ b/tests/mcp-schema-enforcement.test.ts
@@ -151,6 +151,13 @@ describe("published MCP enums are enforced at runtime (#8942)", () => {
       ["get_chain_serving", { limit: 999_999 }],
       ["get_subnet_movers", { limit: 0 }],
       ["list_global_validators", { limit: "not-a-number" }],
+      // `offset` is the OTHER pagination bound and clamps the same way -- a
+      // non-numeric one resolves to 0 and the response reports `offset: 0`, so
+      // the caller can see what was used. It was left out of this pin
+      // originally, which made 9 tools look like unenforced type constraints
+      // when they were the documented leniency wearing a different name.
+      ["get_sudo", { limit: 2, offset: "not-a-number" }],
+      ["list_blocks", { limit: 2, offset: -5 }],
     ] as [string, Record<string, unknown>][]) {
       const code = await errorCode(tool, args);
       assert.notEqual(
@@ -162,4 +169,56 @@ describe("published MCP enums are enforced at runtime (#8942)", () => {
       );
     }
   }, 60_000);
+
+  // The third constraint class, and the last one without a gate. #8942's audit
+  // covered enums (zero gaps) and numeric bounds (all 101 "gaps" were the
+  // deliberate pagination clamping pinned above). `required` was never probed.
+  //
+  // Measured before writing this: 90 required arguments across every runnable
+  // tool, ZERO silently accepted when omitted. So this fixes nothing today --
+  // it is the same bet the enum test makes, that a tool registered tomorrow
+  // declares `required` and forgets its guard, and then answers a confidently
+  // empty result for a caller who supplied nothing (the #9013 shape).
+  //
+  // Derived from listToolDefinitions() like its sibling, so it needs no
+  // maintenance and a tool added tonight is covered tonight.
+  test("every required argument is rejected when omitted", async () => {
+    const silent: string[] = [];
+    let checked = 0;
+
+    for (const tool of listToolDefinitions() as Row[]) {
+      const schema = tool.inputSchema as Row;
+      const required = (schema?.required as string[]) ?? [];
+      if (required.length === 0) continue;
+      if (!(await isRunnable(tool))) continue;
+
+      for (const key of required) {
+        checked++;
+        const code = await errorCode(
+          tool.name as string,
+          baselineArgs(schema, key),
+        );
+        // Rejection is the property, not a particular code -- same reasoning as
+        // the enum test: a tool may describe the caller's mistake better than
+        // `invalid_params` does. Silent acceptance is what must never happen.
+        if (code === null) {
+          silent.push(`${tool.name}.${key} silently ACCEPTED being omitted`);
+        }
+      }
+    }
+
+    assert.ok(
+      checked > 50,
+      `expected to probe real required args, checked ${checked}`,
+    );
+    assert.deepEqual(
+      silent,
+      [],
+      "these tools publish a required argument but do not enforce it, so a " +
+        "call that omits it reaches the handler with undefined instead of " +
+        "erroring -- add a guard (requireNonNegativeInt / requireString or " +
+        "equivalent) in the handler:\n" +
+        silent.join("\n"),
+    );
+  }, 120_000);
 });


### PR DESCRIPTION
## Summary

#8942 chose per-handler guards over dispatch-level schema validation, and paid for that choice with a derived CI gate so the next unguarded argument fails in CI rather than production. **That gate covers enums only.** Two of the three constraint classes the audit named were ungated.

No runtime change — this closes gaps in the gate, not in the server.

## `required` had no gate

A tool publishing `required: ["netuid"]` that forgets `requireNonNegativeInt` reaches its handler with `undefined` and answers a confidently empty result — the exact #9013 shape the enum gate exists to prevent, one constraint class over.

**Measured before writing anything**, per #8942's own first requirement:

```
required args probed: 90 | tools skipped (not runnable): 37
SILENTLY ACCEPTED a missing required arg: 0
```

So this fixes nothing today. It's the same bet the enum test makes — that a tool registered tomorrow forgets its guard — and it's derived from `listToolDefinitions()` the same way, so a tool added tonight is covered tonight.

Verified the gate actually bites by neutering `requireNonNegativeInt`:

```
× every required argument is rejected when omitted
  get_subnet_snapshot.netuid silently ACCEPTED being omitted
  get_subnet_health.netuid silently ACCEPTED being omitted
  get_subnet_health_trends.netuid silently ACCEPTED being omitted
  …
```

## The other 9 "gaps" were `offset`, and they are deliberate

Probing every non-pagination numeric argument surfaced 9 apparent type gaps — all of them `offset`:

```
non-pagination numeric args probed: 107
SILENTLY ACCEPTED a non-numeric value: 9
   list_validator_economics.offset, get_subnet_identity_history.offset,
   get_subnet_events.offset, list_blocks.offset, list_block_extrinsics.offset,
   get_block_events.offset, list_extrinsics.offset, get_sudo.offset,
   get_governance_config_changes.offset
```

Checked against production rather than assumed: `offset` is the **other** pagination bound and clamps exactly like `limit` — and the response *reports* the effective value, so the caller can see what was used.

```
get_sudo    {limit:2, offset:"not-a-number"}  ->  {offset: 0, limit: 2}
get_sudo    {limit:2, offset:5}               ->  {offset: 5, limit: 2}
list_blocks {limit:2, offset:"xyz"}           ->  {offset: 0, limit: 2}
```

It was simply missing from the advisory pin, which named only `limit`. Now pinned, with the measurement recorded so the next person doesn't re-litigate whether those nine are defects.

## Why not dispatch-level zod enforcement

Re-measured today rather than taken on trust: enums 0 gaps, required 0 of 90, non-pagination numerics 0 of 107 once the deliberate `offset` clamping is excluded. #8942's audit found the same and recorded that a generic validator would have rejected seven tested, forgiving behaviours and changed 52 handler error messages for zero new safety. That decision stands; this makes it safe as the catalogue grows.

## Assertion style

Rejection is the property, not a particular error code — matching the reasoning the enum test already records: a tool may describe the caller's mistake better than `invalid_params` does, and insisting on one code asserts a house style rather than a safety property.

## Validation

```
npm run lint   npm run format:check   npm run typecheck
npm run validate   npm run scan:public-safety
npx vitest run tests/mcp-schema-enforcement.test.ts   -> 3 passed
```

Closes #9559