### PR TITLE
refactor(data-api): validate sync rows with zod, and say which row and field

### DIFF
--- a/src/sync-row-schemas.ts
+++ b/src/sync-row-schemas.ts
@@ -1,0 +1,331 @@
+// Zod schemas for the seven internal sync-route row shapes (#9564).
+//
+// WHAT THIS REPLACES, AND WHY. Each route used a `valid*SyncRow(row): boolean`
+// predicate driven as `rows.every(...)`, so a batch of up to 50,000 rows was
+// rejected with one sentence -- "rows must match the neuron row shape" -- and
+// the reason was discarded at the exact point it was known. The producer is the
+// poller Container, whose stdout is unreachable, so there is no second place to
+// look: the operator sees a 400 with no coordinates and a lane that stopped
+// writing. A boolean cannot carry a reason; a schema can.
+//
+// The rules here are a FAITHFUL translation, not a redesign. Every bound, byte
+// cap, allowlist and null rule below is the one the predicate applied. Nothing
+// loosens -- tests/sync-row-schemas.test.ts pins each rule against the shape it
+// rejected before.
+//
+// COLUMN ALLOWLISTS ARE DERIVED, NEVER RESTATED. Each route's permitted keys
+// come from the same *_INSERT_COLUMNS constant the writer binds, passed in by
+// the caller. Enumerating ~20 neuron columns statically here would be a second
+// source of truth for the row shape, which is precisely the drift that dropped
+// `take` and `validator_trust` from two SELECTs (#9523). A schema that
+// disagrees with the writer is worse than no schema.
+//
+// Kept out of workers/data-api.ts, and pure, for the same reason
+// src/chain-detail-sync-payload.ts is: it is testable without a Request, an Env
+// or a database.
+
+import { z } from "zod";
+
+type Row = Record<string, unknown>;
+
+/** Same encoder the predicates used: the caps are UTF-8 BYTES, not code units,
+ * so a multi-byte identity string cannot slip past a `.length` check. */
+function utf8Bytes(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+/**
+ * Floor for a plausible epoch-MILLISECOND capture stamp.
+ *
+ * Carried over verbatim from `validSyncCapturedAt`, including the reason it
+ * exists: one row reached production with a seconds-precision `captured_at`
+ * (netuid 1, uid 0, block 8,755,038 -- 1785715160 beside an `updated_at` of
+ * 1785715160521, the same instant in ms). Read as milliseconds it landed on
+ * 1970-01-21, and because these tables upsert under
+ * `captured_at <= excluded.captured_at`, a stamp 1,000x too small is
+ * permanently "older" than any correct one -- the bad row can never be
+ * corrected in place by a later capture.
+ *
+ * Rejected rather than coerced: a stamp in the wrong unit means the producer
+ * is wrong, and silently multiplying by 1000 here would hide that while
+ * inventing a capture time. A clean 400 tells the producer; a 1970 row tells
+ * nobody -- and now the 400 names the field.
+ */
+export function capturedAtMs(minCapturedAtMs: number) {
+  return z
+    .number()
+    .int("must be an epoch-millisecond integer")
+    .min(
+      minCapturedAtMs,
+      "must be an epoch-millisecond stamp (a seconds-precision value is a unit error)",
+    );
+}
+
+/** A non-empty key string within its route's UTF-8 byte cap. */
+function keyString(maxBytes: number) {
+  return z
+    .string()
+    .min(1, "must be a non-empty string")
+    .refine(
+      (v) => utf8Bytes(v) <= maxBytes,
+      `must be at most ${maxBytes} UTF-8 bytes`,
+    );
+}
+
+/** Reject any key the writer will not bind. Derived from the caller's
+ * *_INSERT_COLUMNS so the schema cannot disagree with the INSERT. */
+function onlyKnownColumns(columns: readonly string[]) {
+  const allowed = new Set(columns);
+  return (row: Row, ctx: z.RefinementCtx) => {
+    for (const key of Object.keys(row)) {
+      if (!allowed.has(key)) {
+        ctx.addIssue({
+          code: "custom",
+          path: [key],
+          message: "is not a column this route writes",
+        });
+      }
+    }
+  };
+}
+
+export interface SyncRowSchemaOptions {
+  columns: readonly string[];
+  minCapturedAtMs: number;
+}
+
+/**
+ * neurons / neuron_daily.
+ *
+ * The per-value rules are uniform across the column set rather than per-column,
+ * exactly as the predicate had them: every column is a TEXT/INTEGER/NUMERIC/
+ * BOOLEAN scalar, so a nested object or array would otherwise surface later as
+ * an opaque bind error (a 502) instead of a clean 400 here. bigint/symbol/
+ * function are deliberately NOT checked -- JSON.parse, this row's only real
+ * source, cannot produce them.
+ */
+export function neuronSyncRowSchema({
+  columns,
+  minCapturedAtMs,
+  maxNetuid,
+  maxUid,
+  maxStringBytes,
+}: SyncRowSchemaOptions & {
+  maxNetuid: number;
+  maxUid: number;
+  maxStringBytes: number;
+}) {
+  return z
+    .looseObject({
+      netuid: z.number().int().min(0).max(maxNetuid),
+      uid: z.number().int().min(0).max(maxUid),
+      captured_at: capturedAtMs(minCapturedAtMs),
+    })
+    .superRefine((row, ctx) => {
+      onlyKnownColumns(columns)(row as Row, ctx);
+      for (const [key, value] of Object.entries(row as Row)) {
+        if (typeof value === "string" && utf8Bytes(value) > maxStringBytes) {
+          ctx.addIssue({
+            code: "custom",
+            path: [key],
+            message: `must be at most ${maxStringBytes} UTF-8 bytes`,
+          });
+        }
+        if (typeof value === "number" && !Number.isFinite(value)) {
+          ctx.addIssue({
+            code: "custom",
+            path: [key],
+            message: "must be finite",
+          });
+        }
+        if (value !== null && typeof value === "object") {
+          ctx.addIssue({
+            code: "custom",
+            path: [key],
+            message: "must be a scalar, not an object or array",
+          });
+        }
+      }
+    });
+}
+
+/** subnet_hyperparams: every column is numeric-or-null (no strings at all). */
+export function subnetHyperparamsSyncRowSchema({
+  columns,
+  minCapturedAtMs,
+  maxNetuid,
+}: SyncRowSchemaOptions & { maxNetuid: number }) {
+  return z
+    .looseObject({
+      netuid: z.number().int().min(0).max(maxNetuid),
+      captured_at: capturedAtMs(minCapturedAtMs),
+    })
+    .superRefine((row, ctx) => {
+      onlyKnownColumns(columns)(row as Row, ctx);
+      for (const [key, value] of Object.entries(row as Row)) {
+        if (typeof value === "number" && !Number.isFinite(value)) {
+          ctx.addIssue({
+            code: "custom",
+            path: [key],
+            message: "must be finite",
+          });
+        }
+        if (value !== null && typeof value !== "number") {
+          ctx.addIssue({
+            code: "custom",
+            path: [key],
+            message: "must be a number or null",
+          });
+        }
+      }
+    });
+}
+
+/**
+ * account_identity.
+ *
+ * `captured_at` is only required to be finite here, NOT an epoch-ms integer --
+ * the predicate used `Number.isFinite` for this one route alone. Preserved
+ * rather than tightened: narrowing it would be a behaviour change to a write
+ * path, which belongs in its own issue with its own measurement.
+ */
+export function accountIdentitySyncRowSchema({
+  columns,
+  maxStringBytes,
+}: {
+  columns: readonly string[];
+  maxStringBytes: number;
+}) {
+  return z
+    .looseObject({
+      account: z.string().min(1, "must be a non-empty string"),
+      captured_at: z.number().finite("must be a finite number"),
+    })
+    .superRefine((row, ctx) => {
+      onlyKnownColumns(columns)(row as Row, ctx);
+      for (const [key, value] of Object.entries(row as Row)) {
+        if (key === "account" || key === "captured_at") continue;
+        if (value === null) continue;
+        if (typeof value !== "string") {
+          ctx.addIssue({
+            code: "custom",
+            path: [key],
+            message: "must be a string or null",
+          });
+          continue;
+        }
+        if (utf8Bytes(value) > maxStringBytes) {
+          ctx.addIssue({
+            code: "custom",
+            path: [key],
+            message: `must be at most ${maxStringBytes} UTF-8 bytes`,
+          });
+        }
+      }
+    });
+}
+
+/** validator_nominator_counts. */
+export function nominatorCountSyncRowSchema({
+  columns,
+  minCapturedAtMs,
+  maxKeyBytes,
+}: SyncRowSchemaOptions & { maxKeyBytes: number }) {
+  return z
+    .looseObject({
+      hotkey: keyString(maxKeyBytes),
+      nominator_count: z.number().int().min(0),
+      captured_at: capturedAtMs(minCapturedAtMs),
+    })
+    .superRefine((row, ctx) => onlyKnownColumns(columns)(row as Row, ctx));
+}
+
+/** nominator_positions. share_fraction is a dimensionless 0..1 slice. */
+export function nominatorPositionSyncRowSchema({
+  columns,
+  minCapturedAtMs,
+  maxKeyBytes,
+  maxNetuid,
+}: SyncRowSchemaOptions & { maxKeyBytes: number; maxNetuid: number }) {
+  return z
+    .looseObject({
+      coldkey: keyString(maxKeyBytes),
+      hotkey: keyString(maxKeyBytes),
+      netuid: z.number().int().min(0).max(maxNetuid),
+      share_fraction: z
+        .number()
+        .finite("must be finite")
+        .min(0)
+        .max(1, "must be a fraction between 0 and 1"),
+      captured_at: capturedAtMs(minCapturedAtMs),
+    })
+    .superRefine((row, ctx) => onlyKnownColumns(columns)(row as Row, ctx));
+}
+
+/** account_balances. Both amounts are non-negative TAO. */
+export function accountBalanceSyncRowSchema({
+  columns,
+  minCapturedAtMs,
+  maxKeyBytes,
+}: SyncRowSchemaOptions & { maxKeyBytes: number }) {
+  return z
+    .looseObject({
+      ss58: keyString(maxKeyBytes),
+      free_tao: z.number().finite("must be finite").min(0),
+      reserved_tao: z.number().finite("must be finite").min(0),
+      captured_at: capturedAtMs(minCapturedAtMs),
+    })
+    .superRefine((row, ctx) => onlyKnownColumns(columns)(row as Row, ctx));
+}
+
+/** hotkey_alpha. Composite (hotkey, netuid) identity; no netuid ceiling here,
+ * matching the predicate. */
+export function hotkeyAlphaSyncRowSchema({
+  columns,
+  minCapturedAtMs,
+  maxKeyBytes,
+}: SyncRowSchemaOptions & { maxKeyBytes: number }) {
+  return z
+    .looseObject({
+      hotkey: keyString(maxKeyBytes),
+      netuid: z.number().int().min(0),
+      total_alpha: z.number().finite("must be finite").min(0),
+      captured_at: capturedAtMs(minCapturedAtMs),
+    })
+    .superRefine((row, ctx) => onlyKnownColumns(columns)(row as Row, ctx));
+}
+
+export type SyncRowsResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * Validate a whole batch, reporting the FIRST failing row by index and field.
+ *
+ * First-failure rather than all-failures on purpose: a malformed batch is
+ * usually malformed the same way in every row, so listing 50,000 issues would
+ * bury the one fact the operator needs. The batch is still rejected whole --
+ * that semantic is unchanged, and a half-written snapshot is exactly what these
+ * routes exist to make impossible.
+ */
+export function validateSyncRows(
+  rows: unknown[],
+  schema: { safeParse(value: unknown): z.ZodSafeParseResult<unknown> },
+  shapeLabel: string,
+): SyncRowsResult {
+  if (!rows.length) {
+    return { ok: false, error: `rows must match the ${shapeLabel} row shape` };
+  }
+  for (const [index, row] of rows.entries()) {
+    const parsed = schema.safeParse(row);
+    if (parsed.success) continue;
+    // A failed parse always carries at least one issue, and zod always sets its
+    // message -- so neither is optional-chained here. Guarding them would add
+    // branches nothing can reach, and an unreachable branch on a write path is
+    // just an untested one wearing a safety costume.
+    const issue = parsed.error.issues[0]!;
+    // An empty path means the failure is the ROW itself rather than a field --
+    // a non-object, or an array where a row was expected.
+    const path = issue.path.length ? issue.path.join(".") : "row";
+    return { ok: false, error: `row ${index}: ${path} ${issue.message}` };
+  }
+  return { ok: true };
+}

--- a/tests/data-api-nominator-positions-d1.test.ts
+++ b/tests/data-api-nominator-positions-d1.test.ts
@@ -198,23 +198,29 @@ describe("POST /api/v1/internal/nominator-positions-sync", () => {
   });
 
   test("rejects a row with a bad key, netuid, captured_at, or an unknown column", async () => {
-    const bad: Row[] = [
-      positionRow({ coldkey: "" }),
-      positionRow({ coldkey: 42 }),
-      positionRow({ hotkey: "x".repeat(200) }),
-      positionRow({ netuid: -1 }),
-      positionRow({ netuid: 70_000 }),
-      positionRow({ netuid: 1.5 }),
-      positionRow({ captured_at: 0 }),
-      positionRow({ captured_at: 1.5 }),
-      positionRow({ surprise: 1 }),
+    // #9564: each rejection now names the row index and the offending FIELD,
+    // instead of one shape-level sentence for a whole batch. Asserting the
+    // field is strictly stronger than the old message -- it would catch a rule
+    // that still rejects but for the wrong reason, which the shape-level regex
+    // could not distinguish.
+    const bad: [Row, RegExp][] = [
+      [positionRow({ coldkey: "" }), /^row 0: coldkey /],
+      [positionRow({ coldkey: 42 }), /^row 0: coldkey /],
+      [positionRow({ hotkey: "x".repeat(200) }), /^row 0: hotkey /],
+      [positionRow({ netuid: -1 }), /^row 0: netuid /],
+      [positionRow({ netuid: 70_000 }), /^row 0: netuid /],
+      [positionRow({ netuid: 1.5 }), /^row 0: netuid /],
+      [positionRow({ captured_at: 0 }), /^row 0: captured_at /],
+      [positionRow({ captured_at: 1.5 }), /^row 0: captured_at /],
+      [positionRow({ surprise: 1 }), /^row 0: surprise /],
     ];
-    for (const row of bad) {
+    for (const [row, expected] of bad) {
       const response = await post({ rows: [row] });
       assert.equal(response.status, 400, JSON.stringify(row));
       assert.match(
         (await response.json<{ error: string }>()).error,
-        /nominator-position row shape/,
+        expected,
+        JSON.stringify(row),
       );
     }
     // A non-object row, and an empty batch, are the same 400.

--- a/tests/sync-row-schemas.test.ts
+++ b/tests/sync-row-schemas.test.ts
@@ -1,0 +1,335 @@
+// src/sync-row-schemas.ts (#9564) — the zod schemas that replaced the seven
+// `valid*SyncRow` boolean predicates on the internal sync routes.
+//
+// The point of the change was DIAGNOSIS, not stricter validation: a batch of up
+// to 50,000 rows used to be rejected with one sentence and no coordinates, from
+// a producer whose stdout is unreachable. So this file tests two things, and the
+// first matters more than the second:
+//
+//   1. EQUIVALENCE. Every rule the predicate enforced still rejects. A rule that
+//      silently stopped rejecting is the one regression that matters on a write
+//      path into D1 — a loosened schema does not fail loudly, it just lets a bad
+//      row through months later.
+//   2. The rejection now names the row index and the field.
+//
+// The accept-cases are as load-bearing as the reject-cases: a schema that
+// rejects everything would pass every "must reject" assertion on its own.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  accountBalanceSyncRowSchema,
+  accountIdentitySyncRowSchema,
+  hotkeyAlphaSyncRowSchema,
+  neuronSyncRowSchema,
+  nominatorCountSyncRowSchema,
+  nominatorPositionSyncRowSchema,
+  subnetHyperparamsSyncRowSchema,
+  validateSyncRows,
+} from "../src/sync-row-schemas.ts";
+
+/** Well clear of the seconds/milliseconds floor the real routes use. */
+const CAPTURED_AT = 1_785_715_160_521;
+const MIN_CAPTURED_AT = 1_600_000_000_000;
+
+function rejects(
+  schema: { safeParse(v: unknown): { success: boolean } },
+  row: unknown,
+) {
+  return !schema.safeParse(row).success;
+}
+
+describe("neuron sync rows", () => {
+  const schema = neuronSyncRowSchema({
+    columns: ["netuid", "uid", "hotkey", "stake_tao", "captured_at"],
+    minCapturedAtMs: MIN_CAPTURED_AT,
+    maxNetuid: 65_535,
+    maxUid: 65_535,
+    maxStringBytes: 512,
+  });
+  const valid = {
+    netuid: 7,
+    uid: 3,
+    hotkey: "5Hot",
+    stake_tao: 12.5,
+    captured_at: CAPTURED_AT,
+  };
+
+  test("accepts a well-formed row", () => {
+    assert.equal(schema.safeParse(valid).success, true);
+  });
+
+  test("rejects everything the predicate rejected", () => {
+    assert.ok(rejects(schema, { ...valid, netuid: -1 }), "negative netuid");
+    assert.ok(rejects(schema, { ...valid, netuid: 65_536 }), "netuid over cap");
+    assert.ok(rejects(schema, { ...valid, netuid: 1.5 }), "non-integer netuid");
+    assert.ok(rejects(schema, { ...valid, uid: -1 }), "negative uid");
+    assert.ok(rejects(schema, { ...valid, uid: 65_536 }), "uid over cap");
+    assert.ok(rejects(schema, { ...valid, unknown_col: 1 }), "unknown column");
+    assert.ok(
+      rejects(schema, { ...valid, hotkey: "x".repeat(513) }),
+      "string over the byte cap",
+    );
+    assert.ok(
+      rejects(schema, { ...valid, stake_tao: Number.POSITIVE_INFINITY }),
+      "non-finite number",
+    );
+    assert.ok(rejects(schema, { ...valid, hotkey: { a: 1 } }), "nested object");
+    assert.ok(rejects(schema, { ...valid, hotkey: [1] }), "array value");
+    assert.ok(rejects(schema, [valid]), "an array is not a row");
+  });
+
+  // The cap is UTF-8 BYTES. A `.length` check would accept this: 200 code
+  // units, 600 bytes.
+  test("measures the string cap in bytes, not code units", () => {
+    assert.ok(rejects(schema, { ...valid, hotkey: "€".repeat(200) }));
+    assert.equal(
+      schema.safeParse({ ...valid, hotkey: "€".repeat(100) }).success,
+      true,
+    );
+  });
+
+  // The rule that exists because one row reached production this way.
+  test("rejects a seconds-precision captured_at", () => {
+    assert.ok(rejects(schema, { ...valid, captured_at: 1_785_715_160 }));
+  });
+
+  test("accepts null in an optional column", () => {
+    assert.equal(schema.safeParse({ ...valid, hotkey: null }).success, true);
+  });
+});
+
+describe("subnet-hyperparams sync rows", () => {
+  const schema = subnetHyperparamsSyncRowSchema({
+    columns: ["netuid", "tempo", "captured_at"],
+    minCapturedAtMs: MIN_CAPTURED_AT,
+    maxNetuid: 65_535,
+  });
+  const valid = { netuid: 7, tempo: 360, captured_at: CAPTURED_AT };
+
+  test("accepts numeric-or-null columns and rejects the rest", () => {
+    assert.equal(schema.safeParse(valid).success, true);
+    assert.equal(schema.safeParse({ ...valid, tempo: null }).success, true);
+    // This route takes no strings at all — the predicate's distinguishing rule.
+    assert.ok(rejects(schema, { ...valid, tempo: "360" }), "string value");
+    assert.ok(rejects(schema, { ...valid, tempo: Number.NaN }), "NaN");
+    assert.ok(rejects(schema, { ...valid, netuid: 65_536 }), "netuid over cap");
+    assert.ok(rejects(schema, { ...valid, other: 1 }), "unknown column");
+  });
+});
+
+describe("account-identity sync rows", () => {
+  const schema = accountIdentitySyncRowSchema({
+    columns: ["account", "name", "captured_at"],
+    maxStringBytes: 1024,
+  });
+  const valid = { account: "5Acct", name: "tao.bot", captured_at: CAPTURED_AT };
+
+  test("accepts string-or-null columns and rejects the rest", () => {
+    assert.equal(schema.safeParse(valid).success, true);
+    assert.equal(schema.safeParse({ ...valid, name: null }).success, true);
+    assert.ok(rejects(schema, { ...valid, account: "" }), "empty account");
+    assert.ok(rejects(schema, { ...valid, name: 7 }), "numeric value");
+    assert.ok(
+      rejects(schema, { ...valid, name: "x".repeat(1025) }),
+      "string over the byte cap",
+    );
+    assert.ok(rejects(schema, { ...valid, other: "x" }), "unknown column");
+  });
+
+  // Deliberately NOT the epoch-ms floor: this one route used Number.isFinite,
+  // and preserving that is the whole point of an equivalence test.
+  test("keeps this route's looser captured_at rule", () => {
+    assert.equal(schema.safeParse({ ...valid, captured_at: 1 }).success, true);
+    assert.ok(rejects(schema, { ...valid, captured_at: "now" }));
+  });
+});
+
+describe("nominator-count sync rows", () => {
+  const schema = nominatorCountSyncRowSchema({
+    columns: ["hotkey", "nominator_count", "captured_at"],
+    minCapturedAtMs: MIN_CAPTURED_AT,
+    maxKeyBytes: 128,
+  });
+  const valid = {
+    hotkey: "5Hot",
+    nominator_count: 12,
+    captured_at: CAPTURED_AT,
+  };
+
+  test("accepts a well-formed row and rejects the predicate's cases", () => {
+    assert.equal(schema.safeParse(valid).success, true);
+    assert.ok(rejects(schema, { ...valid, hotkey: "" }), "empty hotkey");
+    assert.ok(
+      rejects(schema, { ...valid, hotkey: "x".repeat(129) }),
+      "key over cap",
+    );
+    assert.ok(
+      rejects(schema, { ...valid, nominator_count: -1 }),
+      "negative count",
+    );
+    assert.ok(
+      rejects(schema, { ...valid, nominator_count: 1.5 }),
+      "fractional count",
+    );
+    assert.ok(rejects(schema, { ...valid, other: 1 }), "unknown column");
+  });
+});
+
+describe("nominator-position sync rows", () => {
+  const schema = nominatorPositionSyncRowSchema({
+    columns: ["coldkey", "hotkey", "netuid", "share_fraction", "captured_at"],
+    minCapturedAtMs: MIN_CAPTURED_AT,
+    maxKeyBytes: 128,
+    maxNetuid: 65_535,
+  });
+  const valid = {
+    coldkey: "5Cold",
+    hotkey: "5Hot",
+    netuid: 7,
+    share_fraction: 0.25,
+    captured_at: CAPTURED_AT,
+  };
+
+  test("bounds share_fraction to a real 0..1 slice", () => {
+    assert.equal(schema.safeParse(valid).success, true);
+    assert.equal(
+      schema.safeParse({ ...valid, share_fraction: 0 }).success,
+      true,
+    );
+    assert.equal(
+      schema.safeParse({ ...valid, share_fraction: 1 }).success,
+      true,
+    );
+    assert.ok(rejects(schema, { ...valid, share_fraction: -0.1 }), "below 0");
+    assert.ok(rejects(schema, { ...valid, share_fraction: 1.1 }), "above 1");
+    assert.ok(
+      rejects(schema, { ...valid, share_fraction: Number.NaN }),
+      "NaN share",
+    );
+  });
+
+  test("requires both keys", () => {
+    assert.ok(rejects(schema, { ...valid, coldkey: "" }), "empty coldkey");
+    assert.ok(rejects(schema, { ...valid, hotkey: "" }), "empty hotkey");
+  });
+});
+
+describe("account-balance sync rows", () => {
+  const schema = accountBalanceSyncRowSchema({
+    columns: ["ss58", "free_tao", "reserved_tao", "captured_at"],
+    minCapturedAtMs: MIN_CAPTURED_AT,
+    maxKeyBytes: 128,
+  });
+  const valid = {
+    ss58: "5Acct",
+    free_tao: 10,
+    reserved_tao: 0,
+    captured_at: CAPTURED_AT,
+  };
+
+  test("requires both amounts to be non-negative and finite", () => {
+    assert.equal(schema.safeParse(valid).success, true);
+    assert.ok(rejects(schema, { ...valid, free_tao: -1 }), "negative free_tao");
+    assert.ok(
+      rejects(schema, { ...valid, reserved_tao: -1 }),
+      "negative reserved",
+    );
+    assert.ok(
+      rejects(schema, { ...valid, free_tao: Number.POSITIVE_INFINITY }),
+      "infinite free_tao",
+    );
+    assert.ok(rejects(schema, { ...valid, free_tao: "10" }), "string amount");
+  });
+});
+
+describe("hotkey-alpha sync rows", () => {
+  const schema = hotkeyAlphaSyncRowSchema({
+    columns: ["hotkey", "netuid", "total_alpha", "captured_at"],
+    minCapturedAtMs: MIN_CAPTURED_AT,
+    maxKeyBytes: 128,
+  });
+  const valid = {
+    hotkey: "5Hot",
+    netuid: 7,
+    total_alpha: 1234.5,
+    captured_at: CAPTURED_AT,
+  };
+
+  test("accepts the composite identity and rejects the predicate's cases", () => {
+    assert.equal(schema.safeParse(valid).success, true);
+    assert.ok(rejects(schema, { ...valid, netuid: -1 }), "negative netuid");
+    assert.ok(rejects(schema, { ...valid, netuid: 1.5 }), "fractional netuid");
+    assert.ok(rejects(schema, { ...valid, total_alpha: -1 }), "negative alpha");
+    assert.ok(rejects(schema, { ...valid, hotkey: "" }), "empty hotkey");
+  });
+
+  // This route deliberately has no netuid ceiling — the predicate had none, and
+  // inventing one here would be a silent narrowing of a write path.
+  test("keeps this route's absent netuid ceiling", () => {
+    assert.equal(schema.safeParse({ ...valid, netuid: 999_999 }).success, true);
+  });
+});
+
+describe("validateSyncRows reports coordinates, which is the point", () => {
+  const schema = nominatorCountSyncRowSchema({
+    columns: ["hotkey", "nominator_count", "captured_at"],
+    minCapturedAtMs: MIN_CAPTURED_AT,
+    maxKeyBytes: 128,
+  });
+  const good = { hotkey: "5Hot", nominator_count: 1, captured_at: CAPTURED_AT };
+
+  test("names the failing row index and field", () => {
+    const result = validateSyncRows(
+      [good, good, { ...good, nominator_count: -1 }],
+      schema,
+      "nominator count",
+    );
+    assert.equal(result.ok, false);
+    assert.match(
+      (result as { error: string }).error,
+      /^row 2: nominator_count /,
+      "the operator needs the index AND the field, not just a shape name",
+    );
+  });
+
+  test("names the offending key for an unknown column", () => {
+    const result = validateSyncRows(
+      [{ ...good, bogus: 1 }],
+      schema,
+      "nominator count",
+    );
+    assert.equal(result.ok, false);
+    assert.match((result as { error: string }).error, /row 0: bogus /);
+  });
+
+  // The root-path branch: when the failure is the ROW itself rather than a
+  // field, there is no path to name, so the message says so instead of
+  // printing an empty field name.
+  test("says `row` when the row itself is the problem, not a field", () => {
+    for (const bad of [null, "nope", [good], 7]) {
+      const result = validateSyncRows([bad], schema, "nominator count");
+      assert.equal(result.ok, false, JSON.stringify(bad));
+      assert.match((result as { error: string }).error, /^row 0: row /);
+    }
+  });
+
+  test("accepts a fully valid batch", () => {
+    assert.deepEqual(
+      validateSyncRows([good, good], schema, "nominator count"),
+      {
+        ok: true,
+      },
+    );
+  });
+
+  // Unchanged from the predicates: an empty batch is a client error, and the
+  // message stays the old shape-level one because there is no row to point at.
+  test("still rejects an empty batch with the shape-level message", () => {
+    const result = validateSyncRows([], schema, "nominator count");
+    assert.equal(result.ok, false);
+    assert.equal(
+      (result as { error: string }).error,
+      "rows must match the nominator count row shape",
+    );
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -17,6 +17,16 @@
 // TAO/USD index cron. Routes whose store is gone still answer exactly what
 // they answered before the deletion -- see dispatchDataApiRequest's own note
 // for why that matters to the forward gate.
+import {
+  accountBalanceSyncRowSchema,
+  accountIdentitySyncRowSchema,
+  hotkeyAlphaSyncRowSchema,
+  neuronSyncRowSchema,
+  nominatorCountSyncRowSchema,
+  nominatorPositionSyncRowSchema,
+  subnetHyperparamsSyncRowSchema,
+  validateSyncRows,
+} from "../src/sync-row-schemas.ts";
 import { spotPriceTao } from "../src/stake-quote.ts";
 import { recordExceptionEvent } from "../src/usage-telemetry.ts";
 import { isPathUnder } from "./http.ts";
@@ -477,39 +487,6 @@ function utf8Bytes(value: unknown) {
 // same trust posture as workers/request-handlers/staging.mjs's
 // validStagedNeuronRow (this payload arrives over a different transport, but
 // it's the same untrusted-until-checked shape from the same producer script).
-function validNeuronSyncRow(row: Row) {
-  if (!row || typeof row !== "object" || Array.isArray(row)) return false;
-  if (
-    !Number.isInteger(row.netuid) ||
-    row.netuid < 0 ||
-    row.netuid > NEURONS_SYNC_MAX_NETUID
-  )
-    return false;
-  if (
-    !Number.isInteger(row.uid) ||
-    row.uid < 0 ||
-    row.uid > NEURONS_SYNC_MAX_UID
-  )
-    return false;
-  if (!validSyncCapturedAt(row.captured_at)) return false;
-  for (const [key, value] of Object.entries(row)) {
-    if (!NEURON_INSERT_COLUMNS.includes(key)) return false;
-    if (
-      typeof value === "string" &&
-      utf8Bytes(value).length > NEURONS_SYNC_MAX_STRING_BYTES
-    )
-      return false;
-    if (typeof value === "number" && !Number.isFinite(value)) return false;
-    // Every column here is a TEXT/INTEGER/NUMERIC/BOOLEAN scalar (never
-    // JSONB) -- a nested object or array slipping through would only be
-    // caught later as an opaque Postgres bind error (a 502), so reject it
-    // here as a clean 400 instead. (bigint/symbol/function are NOT checked:
-    // JSON.parse, this row's only real source, can never produce them.)
-    if (value !== null && typeof value === "object") return false;
-  }
-  return true;
-}
-
 /**
  * Floor for a plausible epoch-MILLISECOND capture stamp (#9382).
  *
@@ -536,19 +513,15 @@ function validNeuronSyncRow(row: Row) {
  */
 export const SYNC_MIN_CAPTURED_AT_MS = Date.UTC(2020, 0, 1);
 
-/**
- * Whether a sync row's `captured_at` is a usable epoch-millisecond stamp.
- *
- * Rejected rather than coerced: a stamp in the wrong unit means the producer is
- * wrong, and silently multiplying by 1000 here would hide that while inventing a
- * capture time. A clean 400 tells the producer; a 1970 row tells nobody.
- */
-function validSyncCapturedAt(capturedAt: unknown): boolean {
-  return (
-    Number.isInteger(capturedAt) &&
-    (capturedAt as number) >= SYNC_MIN_CAPTURED_AT_MS
-  );
-}
+// One instance per route, each built from the SAME *_INSERT_COLUMNS the writer
+// binds, so a schema can never drift from the INSERT it guards (#9564).
+const NEURON_SYNC_ROW_SCHEMA = neuronSyncRowSchema({
+  columns: NEURON_INSERT_COLUMNS,
+  minCapturedAtMs: SYNC_MIN_CAPTURED_AT_MS,
+  maxNetuid: NEURONS_SYNC_MAX_NETUID,
+  maxUid: NEURONS_SYNC_MAX_UID,
+  maxStringBytes: NEURONS_SYNC_MAX_STRING_BYTES,
+});
 
 // captured_at is epoch ms; snapshot_date is the UTC day, matching D1's
 // rollupNeuronDaily (`date(captured_at / 1000, 'unixepoch')`).
@@ -643,11 +616,13 @@ async function handleNeuronsSync(request: Request, env: Env) {
   // -- this handler had the exact same bug, just never patched alongside
   // the backfill one.
   const validatedIncoming = incoming.map(stripClientSnapshotDate);
-  if (
-    !validatedIncoming.length ||
-    !validatedIncoming.every(validNeuronSyncRow)
-  ) {
-    return writeJson({ error: "rows must match the neuron row shape" }, 400);
+  const neuronCheck = validateSyncRows(
+    validatedIncoming,
+    NEURON_SYNC_ROW_SCHEMA,
+    "neuron",
+  );
+  if (!neuronCheck.ok) {
+    return writeJson({ error: neuronCheck.error }, 400);
   }
 
   const rows = validatedIncoming.map(coerceNeuronSyncRow);
@@ -929,11 +904,13 @@ async function handleNeuronDailyBackfill(request: Request, env: Env) {
     );
   }
   const validatedIncoming = incoming.map(stripClientSnapshotDate);
-  if (
-    !validatedIncoming.length ||
-    !validatedIncoming.every(validNeuronSyncRow)
-  ) {
-    return writeJson({ error: "rows must match the neuron row shape" }, 400);
+  const neuronCheck = validateSyncRows(
+    validatedIncoming,
+    NEURON_SYNC_ROW_SCHEMA,
+    "neuron",
+  );
+  if (!neuronCheck.ok) {
+    return writeJson({ error: neuronCheck.error }, 400);
   }
 
   const rows = validatedIncoming.map(coerceNeuronSyncRow);
@@ -1095,22 +1072,11 @@ const SUBNET_HYPERPARAMS_HISTORY_FIELDS =
 // Bounds-check one incoming row against SUBNET_HYPERPARAMS_INSERT_COLUMNS --
 // every field but netuid is null-or-finite-number; the fetch script emits 0/1
 // for the boolean-flag columns, not JSON booleans.
-function validSubnetHyperparamsSyncRow(row: Row) {
-  if (!row || typeof row !== "object" || Array.isArray(row)) return false;
-  if (
-    !Number.isInteger(row.netuid) ||
-    row.netuid < 0 ||
-    row.netuid > SUBNET_HYPERPARAMS_SYNC_MAX_NETUID
-  )
-    return false;
-  if (!validSyncCapturedAt(row.captured_at)) return false;
-  for (const [key, value] of Object.entries(row)) {
-    if (!SUBNET_HYPERPARAMS_INSERT_COLUMNS.includes(key)) return false;
-    if (typeof value === "number" && !Number.isFinite(value)) return false;
-    if (value !== null && typeof value !== "number") return false;
-  }
-  return true;
-}
+const SUBNET_HYPERPARAMS_SYNC_ROW_SCHEMA = subnetHyperparamsSyncRowSchema({
+  columns: SUBNET_HYPERPARAMS_INSERT_COLUMNS,
+  minCapturedAtMs: SYNC_MIN_CAPTURED_AT_MS,
+  maxNetuid: SUBNET_HYPERPARAMS_SYNC_MAX_NETUID,
+});
 
 // 0/1 -> boolean for the BOOLEAN columns (see NEURONS_SYNC_BOOLEAN_COLUMNS'
 // identical reasoning above); everything else passes through unchanged.
@@ -1219,11 +1185,13 @@ async function handleSubnetHyperparamsSync(request: Request, env: Env) {
       413,
     );
   }
-  if (!incoming.length || !incoming.every(validSubnetHyperparamsSyncRow)) {
-    return writeJson(
-      { error: "rows must match the subnet-hyperparams row shape" },
-      400,
-    );
+  const subnetHyperparamsCheck = validateSyncRows(
+    incoming,
+    SUBNET_HYPERPARAMS_SYNC_ROW_SCHEMA,
+    "subnet-hyperparams",
+  );
+  if (!subnetHyperparamsCheck.ok) {
+    return writeJson({ error: subnetHyperparamsCheck.error }, 400);
   }
 
   const rows = incoming.map(coerceSubnetHyperparamsSyncRow);
@@ -1359,20 +1327,10 @@ const ACCOUNT_IDENTITY_SYNC_MAX_STRING_BYTES = 1024;
 // same trust posture as staging.mjs's validStagedAccountIdentityRow. Unlike
 // validSubnetHyperparamsSyncRow, every column but account/captured_at is
 // TEXT-only, so a bare number must be actively REJECTED here, not tolerated.
-function validAccountIdentitySyncRow(row: Row) {
-  if (!row || typeof row !== "object" || Array.isArray(row)) return false;
-  if (typeof row.account !== "string" || row.account.length === 0) return false;
-  if (!Number.isFinite(row.captured_at)) return false;
-  for (const [key, value] of Object.entries(row)) {
-    if (!ACCOUNT_IDENTITY_INSERT_COLUMNS.includes(key)) return false;
-    if (key === "account" || key === "captured_at") continue;
-    if (value === null) continue;
-    if (typeof value !== "string") return false;
-    if (utf8Bytes(value).length > ACCOUNT_IDENTITY_SYNC_MAX_STRING_BYTES)
-      return false;
-  }
-  return true;
-}
+const ACCOUNT_IDENTITY_SYNC_ROW_SCHEMA = accountIdentitySyncRowSchema({
+  columns: ACCOUNT_IDENTITY_INSERT_COLUMNS,
+  maxStringBytes: ACCOUNT_IDENTITY_SYNC_MAX_STRING_BYTES,
+});
 
 // Postgres' TEXT type rejects any embedded NUL byte outright ("invalid byte
 // sequence for encoding UTF8: 0x00") -- confirmed live 2026-07-11 against a
@@ -1484,11 +1442,13 @@ async function handleAccountIdentitySync(request: Request, env: Env) {
       413,
     );
   }
-  if (!incoming.length || !incoming.every(validAccountIdentitySyncRow)) {
-    return writeJson(
-      { error: "rows must match the account-identity row shape" },
-      400,
-    );
+  const accountIdentityCheck = validateSyncRows(
+    incoming,
+    ACCOUNT_IDENTITY_SYNC_ROW_SCHEMA,
+    "account-identity",
+  );
+  if (!accountIdentityCheck.ok) {
+    return writeJson({ error: accountIdentityCheck.error }, 400);
   }
 
   // Sanitize BEFORE both the upsert and the history hash so the two stay
@@ -1605,21 +1565,11 @@ const VALIDATOR_NOMINATOR_COUNTS_SYNC_MAX_KEY_BYTES = 128;
  * discards anything that isn't -- a value this route accepted but every reader
  * silently drops is worse than a 400 the producer can actually see.
  */
-function validNominatorCountSyncRow(row: Row) {
-  if (!row || typeof row !== "object" || Array.isArray(row)) return false;
-  for (const key of Object.keys(row)) {
-    if (!VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS.includes(key)) return false;
-  }
-  if (typeof row.hotkey !== "string" || row.hotkey.length === 0) return false;
-  if (
-    utf8Bytes(row.hotkey).length > VALIDATOR_NOMINATOR_COUNTS_SYNC_MAX_KEY_BYTES
-  )
-    return false;
-  if (!Number.isInteger(row.nominator_count) || row.nominator_count < 0)
-    return false;
-  if (!validSyncCapturedAt(row.captured_at)) return false;
-  return true;
-}
+const NOMINATOR_COUNT_SYNC_ROW_SCHEMA = nominatorCountSyncRowSchema({
+  columns: VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS,
+  minCapturedAtMs: SYNC_MIN_CAPTURED_AT_MS,
+  maxKeyBytes: VALIDATOR_NOMINATOR_COUNTS_SYNC_MAX_KEY_BYTES,
+});
 
 /** Project a validated row onto the writer's exact column list and order. */
 function coerceNominatorCountSyncRow(row: Row) {
@@ -1693,11 +1643,13 @@ async function handleValidatorNominatorCountsSync(request: Request, env: Env) {
       413,
     );
   }
-  if (!incoming.length || !incoming.every(validNominatorCountSyncRow)) {
-    return writeJson(
-      { error: "rows must match the nominator count row shape" },
-      400,
-    );
+  const nominatorCountCheck = validateSyncRows(
+    incoming,
+    NOMINATOR_COUNT_SYNC_ROW_SCHEMA,
+    "nominator count",
+  );
+  if (!nominatorCountCheck.ok) {
+    return writeJson({ error: nominatorCountCheck.error }, 400);
   }
 
   const rows = incoming.map(coerceNominatorCountSyncRow);
@@ -1777,33 +1729,12 @@ const NOMINATOR_POSITIONS_SYNC_MAX_KEY_BYTES = 128;
  * hotkey's stake as this account's position. That is the one field here whose
  * garbage would read as a plausible number rather than as an error.
  */
-function validNominatorPositionSyncRow(row: Row) {
-  if (!row || typeof row !== "object" || Array.isArray(row)) return false;
-  for (const key of Object.keys(row)) {
-    if (!NOMINATOR_POSITION_INSERT_COLUMNS.includes(key)) return false;
-  }
-  for (const key of ["coldkey", "hotkey"]) {
-    const value = row[key];
-    if (typeof value !== "string" || value.length === 0) return false;
-    if (utf8Bytes(value).length > NOMINATOR_POSITIONS_SYNC_MAX_KEY_BYTES)
-      return false;
-  }
-  if (
-    !Number.isInteger(row.netuid) ||
-    row.netuid < 0 ||
-    row.netuid > NOMINATOR_POSITIONS_SYNC_MAX_NETUID
-  )
-    return false;
-  if (
-    typeof row.share_fraction !== "number" ||
-    !Number.isFinite(row.share_fraction) ||
-    row.share_fraction < 0 ||
-    row.share_fraction > 1
-  )
-    return false;
-  if (!validSyncCapturedAt(row.captured_at)) return false;
-  return true;
-}
+const NOMINATOR_POSITION_SYNC_ROW_SCHEMA = nominatorPositionSyncRowSchema({
+  columns: NOMINATOR_POSITION_INSERT_COLUMNS,
+  minCapturedAtMs: SYNC_MIN_CAPTURED_AT_MS,
+  maxKeyBytes: NOMINATOR_POSITIONS_SYNC_MAX_KEY_BYTES,
+  maxNetuid: NOMINATOR_POSITIONS_SYNC_MAX_NETUID,
+});
 
 /** Project a validated row onto the writer's exact column list and order. */
 function coerceNominatorPositionSyncRow(row: Row) {
@@ -1872,11 +1803,13 @@ async function handleNominatorPositionsSync(request: Request, env: Env) {
       413,
     );
   }
-  if (!incoming.length || !incoming.every(validNominatorPositionSyncRow)) {
-    return writeJson(
-      { error: "rows must match the nominator-position row shape" },
-      400,
-    );
+  const nominatorPositionCheck = validateSyncRows(
+    incoming,
+    NOMINATOR_POSITION_SYNC_ROW_SCHEMA,
+    "nominator-position",
+  );
+  if (!nominatorPositionCheck.ok) {
+    return writeJson({ error: nominatorPositionCheck.error }, 400);
   }
 
   const rows = incoming.map(coerceNominatorPositionSyncRow);
@@ -1967,22 +1900,11 @@ const ACCOUNT_BALANCES_SYNC_MAX_PASS_TOTAL = 10_000_000;
  * Infinity arriving as null would otherwise bind as NULL against a NOT NULL
  * column and fail the whole 25,000-row batch at the database instead of here.
  */
-function validAccountBalanceSyncRow(row: Row) {
-  if (!row || typeof row !== "object" || Array.isArray(row)) return false;
-  for (const key of Object.keys(row)) {
-    if (!ACCOUNT_BALANCE_INSERT_COLUMNS.includes(key)) return false;
-  }
-  if (typeof row.ss58 !== "string" || row.ss58.length === 0) return false;
-  if (utf8Bytes(row.ss58).length > ACCOUNT_BALANCES_SYNC_MAX_KEY_BYTES)
-    return false;
-  for (const key of ["free_tao", "reserved_tao"]) {
-    const value = row[key];
-    if (typeof value !== "number" || !Number.isFinite(value) || value < 0)
-      return false;
-  }
-  if (!validSyncCapturedAt(row.captured_at)) return false;
-  return true;
-}
+const ACCOUNT_BALANCE_SYNC_ROW_SCHEMA = accountBalanceSyncRowSchema({
+  columns: ACCOUNT_BALANCE_INSERT_COLUMNS,
+  minCapturedAtMs: SYNC_MIN_CAPTURED_AT_MS,
+  maxKeyBytes: ACCOUNT_BALANCES_SYNC_MAX_KEY_BYTES,
+});
 
 /** Project a validated row onto the writer's exact column list and order. */
 function coerceAccountBalanceSyncRow(row: Row) {
@@ -2062,11 +1984,13 @@ async function handleAccountBalancesSync(request: Request, env: Env) {
       413,
     );
   }
-  if (!incoming.length || !incoming.every(validAccountBalanceSyncRow)) {
-    return writeJson(
-      { error: "rows must match the account-balance row shape" },
-      400,
-    );
+  const accountBalanceCheck = validateSyncRows(
+    incoming,
+    ACCOUNT_BALANCE_SYNC_ROW_SCHEMA,
+    "account-balance",
+  );
+  if (!accountBalanceCheck.ok) {
+    return writeJson({ error: accountBalanceCheck.error }, 400);
   }
 
   const rows = incoming.map(coerceAccountBalanceSyncRow);
@@ -2190,27 +2114,11 @@ const HOTKEY_ALPHA_SYNC_MAX_PASS_TOTAL = 10_000_000;
  * balance columns are bounded: the composite primary key means a junk netuid
  * silently creates a parallel row rather than updating the intended one.
  */
-function validHotkeyAlphaSyncRow(row: Row) {
-  if (!row || typeof row !== "object" || Array.isArray(row)) return false;
-  for (const key of Object.keys(row)) {
-    if (!HOTKEY_ALPHA_INSERT_COLUMNS.includes(key)) return false;
-  }
-  if (typeof row.hotkey !== "string" || row.hotkey.length === 0) return false;
-  if (utf8Bytes(row.hotkey).length > HOTKEY_ALPHA_SYNC_MAX_KEY_BYTES)
-    return false;
-  if (
-    typeof row.netuid !== "number" ||
-    !Number.isInteger(row.netuid) ||
-    row.netuid < 0
-  ) {
-    return false;
-  }
-  const alpha = row.total_alpha;
-  if (typeof alpha !== "number" || !Number.isFinite(alpha) || alpha < 0)
-    return false;
-  if (!validSyncCapturedAt(row.captured_at)) return false;
-  return true;
-}
+const HOTKEY_ALPHA_SYNC_ROW_SCHEMA = hotkeyAlphaSyncRowSchema({
+  columns: HOTKEY_ALPHA_INSERT_COLUMNS,
+  minCapturedAtMs: SYNC_MIN_CAPTURED_AT_MS,
+  maxKeyBytes: HOTKEY_ALPHA_SYNC_MAX_KEY_BYTES,
+});
 
 /** Project a validated row onto the writer's exact column list and order. */
 function coerceHotkeyAlphaSyncRow(row: Row) {
@@ -2288,11 +2196,13 @@ async function handleHotkeyAlphaSync(request: Request, env: Env) {
       413,
     );
   }
-  if (!incoming.length || !incoming.every(validHotkeyAlphaSyncRow)) {
-    return writeJson(
-      { error: "rows must match the hotkey-alpha row shape" },
-      400,
-    );
+  const hotkeyAlphaCheck = validateSyncRows(
+    incoming,
+    HOTKEY_ALPHA_SYNC_ROW_SCHEMA,
+    "hotkey-alpha",
+  );
+  if (!hotkeyAlphaCheck.ok) {
+    return writeJson({ error: hotkeyAlphaCheck.error }, 400);
   }
 
   const rows = incoming.map(coerceHotkeyAlphaSyncRow);


### PR DESCRIPTION
## Summary

Seven internal sync routes validated their POST bodies with hand-written boolean predicates driven as `rows.every(...)`. A batch of up to **50,000 rows** was rejected with one sentence — `"rows must match the neuron row shape"` — and the reason was discarded at the exact point it was known.

The producer is the poller Container, whose **stdout is unreachable**. So there was no second place to look: a 400 with no coordinates and a lane that stopped writing.

A boolean cannot carry a reason. A schema can:

```
row 417: captured_at must be an epoch-millisecond stamp (a seconds-precision value is a unit error)
row 0:   bogus is not a column this route writes
row 12:  share_fraction must be a fraction between 0 and 1
```

## The eight rejection sites, all opaque

`workers/data-api.ts` — lines 650, 936, 1224, 1489, 1698, 1877, 2067, 2293, driven by the `valid*SyncRow` predicates at 480, 1098, 1362, 1608, 1780, 1970, 2193. All seven predicates and `validSyncCapturedAt` are now gone; the file previously contained **zero zod**.

## A faithful translation, not a redesign

Every bound, byte cap, allowlist and null rule is the one the predicate applied — including the two asymmetries preserved **deliberately**:

- **account-identity's `captured_at` stays `Number.isFinite`**, not the epoch-ms floor the other six use. That's what the predicate did.
- **hotkey-alpha still has no netuid ceiling.** That's what the predicate did.

Tightening either would be a silent narrowing of a write path, which belongs in its own issue with its own measurement. Both are pinned by tests so they can't drift accidentally.

## Column allowlists are derived, never restated

Each schema takes the same `*_INSERT_COLUMNS` constant the writer binds. Enumerating ~20 neuron columns inside the schema would be a second source of truth for the row shape — exactly the drift that dropped `take` and `validator_trust` from two SELECTs (#9523). **A schema that disagrees with its INSERT is worse than no schema.**

## What's untouched

The `coerce*SyncRow` normalisers. They run *after* validation and were not the defect; folding them in would widen the change across a D1 write path for no diagnostic gain. The 400 status and batch-rejected-whole semantics are unchanged.

## Tests

Equivalence is the point: every rule that rejected before still rejects. The **accept-cases carry equal weight** — a schema that rejected everything would satisfy every "must reject" assertion on its own. Includes the UTF-8-bytes-not-code-units cap (`"€".repeat(200)` is 200 code units, 600 bytes), and the seconds-precision `captured_at` rule that exists because one row reached production that way.

One existing test asserted the old opaque message and now asserts the **named field**, which is strictly stronger — it catches a rule that still rejects but for the wrong reason, which a shape-level regex could not distinguish.

Two defensive fallbacks were removed rather than annotated: a failed zod parse always carries an issue and zod always sets its message, so guarding them added branches nothing could reach. An unreachable branch on a write path is just an untested one wearing a safety costume.

## Coverage

`src/sync-row-schemas.ts` — **100% lines / branches / statements / functions**.

## Validation

```
npm run lint   npm run format:check   npm run typecheck
npm run validate   npm run scan:public-safety
npx vitest run   ->  686 files, 16,417 tests, 0 failures
```

Closes #9564