### PR TITLE
fix(ci): diff the PR head, and stop firing when the prose already agrees

### DIFF
--- a/scripts/validate-contract-doc-sync.ts
+++ b/scripts/validate-contract-doc-sync.ts
@@ -130,9 +130,32 @@ export interface ContractDocDrift {
 }
 
 /**
+ * Does this bullet already say what the new description says? True when the
+ * prose carries every claim the description GAINED and none of the ones it
+ * LOST -- which is agreement, not staleness, and must not be reported as drift.
+ *
+ * #9575: without this the gate fired on 47 entries of #9573, a PR that
+ * corrected src/contracts.ts to match bullets that ALREADY said D1. The only
+ * way to satisfy it was to edit a line that was right, which is the token-edit
+ * failure mode the claim vector exists to avoid. Checking agreement is what the
+ * gate is for; "was the bullet edited" was only ever a proxy for it.
+ */
+function bulletAlreadyAgrees(
+  bulletText: string,
+  gained: string[],
+  lost: string[],
+): boolean {
+  const bulletTokens = claimVector(bulletText);
+  return (
+    gained.every((token) => bulletTokens.includes(token)) &&
+    lost.every((token) => !bulletTokens.includes(token))
+  );
+}
+
+/**
  * Pure decision function (unit-tested). Drift is: the entry existed at the base,
- * its claim vector changed, it has a bullet, and that bullet is byte-identical
- * to the base's.
+ * its claim vector changed, it has a bullet, that bullet is byte-identical to
+ * the base's, AND the bullet does not already agree with the new claims.
  */
 export function evaluateContractDocSync({
   baseDescriptions,
@@ -162,11 +185,15 @@ export function evaluateContractDocSync({
     if (!headBullet || !baseBullet) continue;
     if (headBullet.text !== baseBullet.text) continue;
 
+    const gained = after.filter((token) => !before.includes(token));
+    const lost = before.filter((token) => !after.includes(token));
+    if (bulletAlreadyAgrees(headBullet.text, gained, lost)) continue;
+
     drift.push({
       path: entryPath,
       docLine: headBullet.line,
-      gained: after.filter((token) => !before.includes(token)),
-      lost: before.filter((token) => !after.includes(token)),
+      gained,
+      lost,
     });
   }
   return { drift, ok: drift.length === 0 };
@@ -212,16 +239,33 @@ export function resolveDiffBase({
   return null;
 }
 
-function readAtBase(baseRef: string, filePath: string): string | null {
+/**
+ * Which commit the HEAD side is read from: the explicit head ref when one was
+ * supplied, or `null` meaning "the working tree". Exported so the choice itself
+ * is unit-tested -- it is the whole of the #9575 fix.
+ */
+export function headReadRef(explicitHead: string | undefined): string | null {
+  return explicitHead ? explicitHead : null;
+}
+
+function readAtRef(ref: string, filePath: string): string | null {
   try {
-    return git(["show", `${baseRef}:${filePath}`]);
+    return git(["show", `${ref}:${filePath}`]);
   } catch {
     return null;
   }
 }
 
 async function main(): Promise<void> {
-  const headRef = valueAfter("--head-sha") || process.env.HEAD_SHA || "HEAD";
+  // An EXPLICIT head ref (CI always passes the PR head SHA) is read from git;
+  // only a local run with none falls back to the working tree. #9575: reading
+  // the head side from the working tree on a PR compares the merge base against
+  // the MERGE COMMIT, so every contract change that landed on the base branch
+  // since the fork point is diffed as though this PR made it -- #9574 inherited
+  // 47 entries from two PRs it had nothing to do with. Same reason
+  // validate-client-sdk-sync.ts diffs fork-point -> HEAD_SHA with explicit refs.
+  const explicitHead = valueAfter("--head-sha") || process.env.HEAD_SHA;
+  const headRef = explicitHead || "HEAD";
   const baseRef = resolveDiffBase({
     explicitBase: valueAfter("--base-sha") || process.env.BASE_SHA,
     baseRef: valueAfter("--base-ref") || process.env.BASE_REF || "main",
@@ -237,11 +281,9 @@ async function main(): Promise<void> {
     return;
   }
 
-  // Base from git, head from the working tree: on a PR the checkout is the merge
-  // commit, and locally this is what makes an uncommitted doc edit count.
-  const baseArtifacts = readAtBase(baseRef, ARTIFACT_CATALOG_PATH);
-  const baseRoutes = readAtBase(baseRef, ROUTE_INDEX_PATH);
-  const baseDoc = readAtBase(baseRef, DOC_PATH);
+  const baseArtifacts = readAtRef(baseRef, ARTIFACT_CATALOG_PATH);
+  const baseRoutes = readAtRef(baseRef, ROUTE_INDEX_PATH);
+  const baseDoc = readAtRef(baseRef, DOC_PATH);
   if (baseArtifacts === null || baseRoutes === null || baseDoc === null) {
     console.log(
       `ℹ Contract↔doc sync: a tracked file is absent at ${baseRef.slice(0, 9)} — gate skipped.`,
@@ -249,9 +291,24 @@ async function main(): Promise<void> {
     return;
   }
 
-  const headDoc = await fs.readFile(path.join(repoRoot, DOC_PATH), "utf8");
-  const readHead = async (filePath: string): Promise<unknown> =>
-    JSON.parse(await fs.readFile(path.join(repoRoot, filePath), "utf8"));
+  // With an explicit head ref, read that commit; otherwise the working tree, so
+  // a local run still sees an uncommitted doc edit.
+  const headSource = headReadRef(explicitHead);
+  const readHeadText = async (filePath: string): Promise<string | null> =>
+    headSource
+      ? readAtRef(headSource, filePath)
+      : await fs.readFile(path.join(repoRoot, filePath), "utf8");
+
+  const headDoc = await readHeadText(DOC_PATH);
+  const headArtifacts = await readHeadText(ARTIFACT_CATALOG_PATH);
+  const headRoutes = await readHeadText(ROUTE_INDEX_PATH);
+  if (headDoc === null || headArtifacts === null || headRoutes === null) {
+    console.log(
+      `ℹ Contract↔doc sync: a tracked file is absent at ${headRef.slice(0, 9)} — gate skipped.`,
+    );
+    return;
+  }
+  const readHead = (contents: string): unknown => JSON.parse(contents);
 
   const drift = [
     evaluateContractDocSync({
@@ -260,7 +317,7 @@ async function main(): Promise<void> {
         "artifacts",
       ),
       headDescriptions: descriptionsFromCatalog(
-        await readHead(ARTIFACT_CATALOG_PATH),
+        readHead(headArtifacts),
         "artifacts",
       ),
       baseDoc,
@@ -271,10 +328,7 @@ async function main(): Promise<void> {
         JSON.parse(baseRoutes),
         "routes",
       ),
-      headDescriptions: descriptionsFromCatalog(
-        await readHead(ROUTE_INDEX_PATH),
-        "routes",
-      ),
+      headDescriptions: descriptionsFromCatalog(readHead(headRoutes), "routes"),
       baseDoc,
       headDoc,
     }),

--- a/tests/validate-contract-doc-sync.test.ts
+++ b/tests/validate-contract-doc-sync.test.ts
@@ -12,6 +12,7 @@ import {
   descriptionsFromCatalog,
   docBulletFor,
   evaluateContractDocSync,
+  headReadRef,
   resolveDiffBase,
 } from "../scripts/validate-contract-doc-sync.ts";
 
@@ -227,6 +228,71 @@ describe("evaluateContractDocSync", () => {
       headDoc: DOC_WITH_STALE_BULLET,
     });
     expect(result.ok).toBe(true);
+  });
+});
+
+describe("head-side source (#9575)", () => {
+  it("reads the explicit head ref when CI supplies one", () => {
+    // On a pull_request the checkout is the MERGE commit, so reading the
+    // working tree would diff the base branch's own changes as this PR's.
+    expect(headReadRef("abc123")).toBe("abc123");
+  });
+
+  it("falls back to the working tree locally, so an uncommitted edit counts", () => {
+    expect(headReadRef(undefined)).toBe(null);
+    expect(headReadRef("")).toBe(null);
+  });
+});
+
+describe("bullet already agrees (#9575)", () => {
+  // A description corrected to match prose that was already right: the bullet
+  // says D1, the description finally does too. Editing the bullet to satisfy a
+  // gate would degrade a correct line.
+  const correctBullet =
+    "- `/metagraph/x.json`: served live from the `neurons` D1 tier.";
+  const staleDescription = "Served live from the Postgres-backed neurons tier.";
+  const fixedDescription = "Served live from the neurons D1 tier.";
+
+  it("does not fire when the bullet already carries the gained claims", () => {
+    // Positive control: the claim vector really did move (postgres -> d1), so
+    // the pre-#9575 rule would have reported drift here.
+    expect(claimVector(staleDescription)).toContain("postgres");
+    expect(claimVector(fixedDescription)).toContain("d1");
+
+    const result = evaluateContractDocSync({
+      baseDescriptions: new Map([["/metagraph/x.json", staleDescription]]),
+      headDescriptions: new Map([["/metagraph/x.json", fixedDescription]]),
+      baseDoc: correctBullet,
+      headDoc: correctBullet,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("still fires when the bullet keeps a claim the description dropped", () => {
+    const staleBullet =
+      "- `/metagraph/x.json`: not live — answers from the frozen materialization.";
+    const result = evaluateContractDocSync({
+      baseDescriptions: new Map([["/metagraph/x.json", STALE_DESCRIPTION]]),
+      headDescriptions: new Map([["/metagraph/x.json", LIVE_DESCRIPTION]]),
+      baseDoc: staleBullet,
+      headDoc: staleBullet,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.drift[0].lost).toContain("not-live");
+  });
+
+  it("still fires when the bullet is missing a claim the description gained", () => {
+    const thinBullet = "- `/metagraph/x.json`: the top-holder leaderboard.";
+    const result = evaluateContractDocSync({
+      baseDescriptions: new Map([["/metagraph/x.json", staleDescription]]),
+      headDescriptions: new Map([
+        ["/metagraph/x.json", "Served from the frozen lakehouse export."],
+      ]),
+      baseDoc: thinBullet,
+      headDoc: thinBullet,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.drift[0].gained).toContain("lakehouse");
   });
 });
 


### PR DESCRIPTION
## Summary

Two defects in the gate #9567 added, both hit by the first PR that followed it: [#9574](https://github.com/JSONbored/metagraphed/pull/9574) changes no contract description at all, and the gate failed it with **47 entries**.

**1. The head side was read from the working tree.** The base side is read at the merge base via `git show`, the head side was `fs.readFile`. On a `pull_request` the checkout is the *merge commit* — base branch plus the PR — so every contract change that landed on main since the fork point was diffed as though this PR made it. #9574 forked before #9567 and #9573 merged and inherited both. `validate-client-sdk-sync.ts`, the gate this was modeled on, avoids exactly this by diffing `fork-point → HEAD_SHA` with explicit refs.

Now: read the head side at `HEAD_SHA` / `--head-sha` when one is supplied (CI always supplies it), and fall back to the working tree only for a local run, where seeing an uncommitted doc edit is the point.

**2. It fired when the doc bullet was already correct.** Every one of those 47 was `+d1 -postgres` — #9573 corrected `src/contracts.ts` to match bullets that *already said D1*. "Did the bullet change" made a correct line the obstacle, and the only way to green was to degrade it. That is the token-edit failure mode the claim vector was chosen to avoid.

Now: an entry whose head bullet carries every claim the description **gained** and none of the ones it **lost** is agreement, not staleness, and is skipped.

## Effect, measured

Replaying #9573's range (`86a28c24a → main`) under the old rule and the new one:

| | Entries reported |
| --- | --- |
| Before | 47 — all false |
| After | **4 — all real** |

The 4 survivors are a genuine miss in my own #9573: it rewrote the identity-history descriptions to "frozen lakehouse export of subnet_identity_history" while `docs/backend-artifact-contracts.md:124/196/283/333` still call it a D1 tier served live. Fixed separately in #9579 — this PR is the gate only.

The #9545 case the gate was built for still fires: its bullet said "not live" and lacked `declines`/`unproven`, so the bullet neither changed nor agreed.

## Changes

- `scripts/validate-contract-doc-sync.ts` — `headReadRef()` (exported so the choice itself is tested) and `bulletAlreadyAgrees()`; `readAtBase` generalized to `readAtRef`, and the head side now skips with a notice if a tracked file is absent at that ref rather than throwing.
- `tests/validate-contract-doc-sync.test.ts` — 5 new cases (21 total): explicit head ref vs working tree, the already-agrees skip with a positive control that the claim vector really moved, and both directions that must still fire (bullet keeps a dropped claim / lacks a gained one).

## Validation

- `npx vitest run` on the gate's tests plus `pipeline-validator-parity`, `workflow-observability`, `script-utils` — **93 passed** (the parity test is the one #9567 tripped)
- `npm run lint`, `format:check`, `typecheck`, `validate:docs` — clean
- Ran the CLI both ways: clean tree passes; `BASE_SHA=86a28c24a HEAD_SHA=<main>` reproduces the #9574 scenario and now reports the 4 real entries instead of 47

Closes #9575
