### PR TITLE
fix(watchdog): alarm the hotkey-alpha pool ledger, which shipped without one

### DIFF
--- a/src/hotkey-alpha-staleness-watchdog.ts
+++ b/src/hotkey-alpha-staleness-watchdog.ts
@@ -1,0 +1,312 @@
+// The alarm for the hotkey-alpha pool ledger (#9576).
+//
+// The twin of src/account-balances-staleness-watchdog.ts, and the ledger that
+// went without one. #9502 listed a staleness watchdog in its own shape; #9512
+// landed the table and the writer and the watchdog never followed. Measured
+// 2026-08-05: `hotkey_alpha` held 0 rows, `hotkey_alpha_passes` held 0 passes,
+// and `lane_health` had never carried a row for this lane -- so the ledger three
+// surfaces depend on was empty, and the only way to learn that was to query it
+// by hand.
+//
+// WHY AN EMPTY LEDGER IS QUIET HERE RATHER THAN LOUD. Every reader of this table
+// declines deliberately when it cannot prove a complete pass:
+// `/accounts/top-holders` falls back to the frozen 2026-08-02 materialization
+// for `delegated_tao`/`total_tao` (#9545), and
+// `/api/v1/subnets/{netuid}/holders` answers `degraded.reason:
+// pool_totals_unproven` (#9557). Those declines are correct -- they are what
+// stops a partial pool ledger producing a plausible wrong ranking. But from
+// outside, a correct decline and a producer that died a month ago are the same
+// response. That is precisely the state #9478's watchdog was built after: the
+// previous silently-dead lane was found by a caller reading a timestamp.
+//
+// The reasoning about WHAT to count is inherited from
+// src/account-balances-staleness-watchdog.ts and deliberately not re-derived
+// here. Both points hold for this ledger unchanged:
+//
+//   - A whole-table `COUNT(*)` floor goes blind the moment one complete pass
+//     lands. This writer never prunes either (migrations/d1/0019 says why: the
+//     producer skips a genuine zero pool, so absence carries no meaning), so a
+//     later pass that dies partway upserts some rows to a new stamp and leaves
+//     the rest at the old one -- the row count never drops.
+//   - The producer's own completeness marker (`hotkey_alpha_passes`) is the
+//     right input for the SERVING gate and the wrong one for the alarm: a pass
+//     that dies is a pass that never writes its `completed_at`, so keying on it
+//     would infer the fault from an absence of report, which is the staleness
+//     check this already has.
+//
+// So the rule counts the rows the NEWEST pass wrote, against a floor.
+//
+// ## THE FLOOR IS DERIVED, NOT DECLARED -- the one real divergence from the twin
+//
+// #9478 could state its expectation as a constant (~306,000 nonzero accounts)
+// because the producer's population is the network's. This sink's population is
+// not: #9560 narrowed it to store only the pools some position actually
+// REFERENCES, so a complete pass lands the ~17,902 distinct (hotkey, netuid)
+// pairs `nominator_positions` names -- not the ~762,577 `TotalHotkeyAlpha`
+// entries the producer walks. That number moves with the position ledger, so a
+// constant here would rot silently in whichever direction positions drift, and
+// the dangerous direction (a floor that has quietly grown too low to fire) is
+// invisible.
+//
+// Reading it from `nominator_positions` in the same statement makes the floor
+// track the sink's own predicate by construction -- the expectation and the
+// filter are then the same fact rather than two copies of it. It is cheap
+// because #9558 added the (hotkey, netuid) index that makes the DISTINCT an
+// index-only walk.
+//
+// AND AN EMPTY POSITION LEDGER SKIPS THE COVERAGE CLAUSE rather than dividing by
+// nothing. A floor of zero would mark every pass complete, including no pass at
+// all; and `nominator_positions` already has its own alarm
+// (`nominator-positions-staleness`), so restating its verdict here would put two
+// lanes' names on one fault and send whoever reads it to the wrong producer.
+
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+
+/**
+ * How old the pool ledger may get before this is a stall.
+ *
+ * FORTY-EIGHT HOURS, four times the twin's twelve, because the producer behind
+ * it runs four times less often: `HOTKEY_ALPHA_POLL_SECS` defaults to 86400
+ * (24 h) against `account_balances`' 21600 (6 h). Two full cadences of slack, so
+ * it cannot fire until a pass has genuinely been skipped -- and the pass itself
+ * is a full TotalHotkeyAlpha walk that is buffered end to end before anything is
+ * posted, so a healthy lane's age swings across the whole 24 h interval plus the
+ * walk.
+ *
+ * This is the #9301 sizing rule: a six-hour bound was once set against a 24-hour
+ * producer and alerted for three quarters of every day on a lane that was
+ * working, which is how an alarm stops being read.
+ *
+ * Overridable via HOTKEY_ALPHA_STALENESS_THRESHOLD_MS so the number can follow
+ * the Container's cadence without a code deploy.
+ */
+export const HOTKEY_ALPHA_STALENESS_THRESHOLD_MS = 48 * 60 * 60 * 1000;
+
+/**
+ * How much of the referenced pool set a single pass must cover to count.
+ *
+ * EIGHTY PERCENT, the twin's ratio and for its reasons: a complete pass writes
+ * every referenced pair, so the only way under this floor is to not finish, and
+ * the 20% gap absorbs ordinary churn between the two ledgers' capture times --
+ * `nominator_positions` and `hotkey_alpha` refresh on their own clocks, so the
+ * pairs one names and the pools the other stored are never a same-instant match.
+ */
+export const HOTKEY_ALPHA_COVERAGE_FLOOR_RATIO = 0.8;
+
+/**
+ * How far back from the newest stamp still counts as "the newest pass".
+ *
+ * SIX HOURS. The producer stamps a pass ONCE at scan start and repeats that
+ * stamp across every chunk (migrations/d1/0021_hotkey_alpha_passes.sql), so
+ * today a pass is a single `captured_at` and this window is pure headroom
+ * against that changing. It is bounded above by the 24 h poll interval -- two
+ * consecutive passes must never merge into one coverage count, or a truncated
+ * pass sitting on a complete one sums to full coverage and reports fine, which
+ * is the bug reintroduced. Six is a quarter of the interval.
+ */
+export const HOTKEY_ALPHA_PASS_WINDOW_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * One read answering three questions: how fresh the newest pass is, how many
+ * rows it wrote, and how many pools the position ledger currently references.
+ *
+ * `covered` counts only rows stamped within HOTKEY_ALPHA_PASS_WINDOW_MS of the
+ * newest stamp -- what THIS pass wrote -- rather than the whole table. `total`
+ * rides along free and tells an operator how much older data sits underneath a
+ * partial pass; it is never the rule.
+ */
+const HOTKEY_ALPHA_COVERAGE_SQL =
+  "SELECT (SELECT COUNT(*) FROM hotkey_alpha) AS total," +
+  " (SELECT MAX(captured_at) FROM hotkey_alpha) AS latest," +
+  " (SELECT SUM(CASE WHEN captured_at >=" +
+  " (SELECT MAX(captured_at) FROM hotkey_alpha) - ? THEN 1 ELSE 0 END)" +
+  " FROM hotkey_alpha) AS covered," +
+  " (SELECT COUNT(*) FROM (SELECT DISTINCT hotkey, netuid" +
+  " FROM nominator_positions)) AS referenced";
+
+export type HotkeyAlphaStalenessReason = "no_rows" | "stale" | "partial" | null;
+
+export interface HotkeyAlphaStalenessVerdict {
+  stale: boolean;
+  reason: HotkeyAlphaStalenessReason;
+  age_ms: number | null;
+  latest_captured_at: number | null;
+  threshold_ms: number;
+  /** Pool totals the newest pass wrote. The coverage signal itself. */
+  covered_rows: number;
+  /** Pool totals across all vintages. Context, never the rule. */
+  total_rows: number;
+  /** Distinct (hotkey, netuid) pairs `nominator_positions` names right now. */
+  referenced_pairs: number;
+  /** The derived floor, or null when there is nothing to derive it from. */
+  coverage_floor_rows: number | null;
+}
+
+/** The rule alone, testable without a database or a clock. */
+export function evaluateHotkeyAlphaStaleness(input: {
+  latestCapturedAtMs: number | null;
+  coveredRows: number;
+  totalRows: number;
+  referencedPairs: number;
+  nowMs: number;
+  thresholdMs: number;
+  coverageFloorRatio: number;
+}): HotkeyAlphaStalenessVerdict {
+  const {
+    latestCapturedAtMs,
+    coveredRows,
+    totalRows,
+    referencedPairs,
+    nowMs,
+    thresholdMs,
+    coverageFloorRatio,
+  } = input;
+  // Null rather than 0 when nothing references a pool: "we did not measure a
+  // floor" and "the floor is zero" reach opposite conclusions about the same
+  // pass, and only the first is true.
+  const coverageFloorRows =
+    referencedPairs > 0
+      ? Math.round(referencedPairs * coverageFloorRatio)
+      : null;
+  const base = {
+    latest_captured_at: latestCapturedAtMs,
+    threshold_ms: thresholdMs,
+    covered_rows: coveredRows,
+    total_rows: totalRows,
+    referenced_pairs: referencedPairs,
+    coverage_floor_rows: coverageFloorRows,
+  };
+  if (latestCapturedAtMs === null) {
+    // An empty table is a stall of infinite age, not a healthy quiet one. It is
+    // also the state this lane has been in since the sink shipped, with every
+    // reader declining and nothing saying why.
+    return { ...base, stale: true, reason: "no_rows", age_ms: null };
+  }
+  const age = nowMs - latestCapturedAtMs;
+  if (age > thresholdMs) {
+    // Checked BEFORE coverage: if nothing has run in two days, the coverage
+    // number describes an old pass and the headline is that the producer
+    // stopped, not how much its last attempt wrote.
+    return { ...base, stale: true, reason: "stale", age_ms: age };
+  }
+  if (coverageFloorRows !== null && coveredRows < coverageFloorRows) {
+    // Recent AND short -- the discrimination this rule exists for. A pool total
+    // that never arrived prices every position naming it against nothing, so
+    // the holders it feeds come out merely too LOW rather than absent.
+    return { ...base, stale: true, reason: "partial", age_ms: age };
+  }
+  // Reached with coverageFloorRows null when the position ledger is empty: the
+  // freshness verdict still stands on its own, and the coverage clause is
+  // declined rather than answered against a floor of nothing.
+  return { ...base, stale: false, reason: null, age_ms: age };
+}
+
+/** D1 counts arrive as numbers, but a null SUM over no rows and a shim that
+ * stringifies both have to land on 0 rather than NaN -- a NaN would compare
+ * false against the floor and report a truncated ledger healthy. */
+function countOrZero(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+interface D1Like {
+  prepare(sql: string): {
+    bind(...values: unknown[]): { first(): Promise<unknown> };
+  };
+}
+
+export interface HotkeyAlphaStalenessDeps {
+  /** Injectable durable sink, so a test can assert the verdict was RECORDED and
+   * not merely notified. */
+  laneHealthDb?: LaneHealthDb | null;
+  now?: () => number;
+  /** Telemetry seam for tests; defaults to the real recordExceptionEvent. */
+  recordException?: typeof recordExceptionEvent;
+}
+
+/**
+ * One watchdog tick. Returns a summary rather than throwing, matching the
+ * watchdog family: a tick that cannot run is one missed report, not an outage,
+ * and a cron that throws is a cron nobody can read the result of.
+ */
+export async function runHotkeyAlphaStalenessWatchdog(
+  env: Record<string, unknown> | null | undefined,
+  deps: HotkeyAlphaStalenessDeps = {},
+): Promise<Record<string, unknown>> {
+  const now = deps.now ?? Date.now;
+  const record = deps.recordException ?? recordExceptionEvent;
+  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
+
+  const thresholdMs =
+    Number(env?.HOTKEY_ALPHA_STALENESS_THRESHOLD_MS) ||
+    HOTKEY_ALPHA_STALENESS_THRESHOLD_MS;
+  const passWindowMs =
+    Number(env?.HOTKEY_ALPHA_PASS_WINDOW_MS) || HOTKEY_ALPHA_PASS_WINDOW_MS;
+  const coverageFloorRatio =
+    Number(env?.HOTKEY_ALPHA_COVERAGE_FLOOR_RATIO) ||
+    HOTKEY_ALPHA_COVERAGE_FLOOR_RATIO;
+
+  try {
+    const row = (await db
+      .prepare(HOTKEY_ALPHA_COVERAGE_SQL)
+      .bind(passWindowMs)
+      .first()) as {
+      latest: number | null;
+      covered: number | null;
+      total: number | null;
+      referenced: number | null;
+    } | null;
+    const verdict = evaluateHotkeyAlphaStaleness({
+      latestCapturedAtMs: row?.latest ?? null,
+      coveredRows: countOrZero(row?.covered),
+      totalRows: countOrZero(row?.total),
+      referencedPairs: countOrZero(row?.referenced),
+      nowMs: now(),
+      thresholdMs,
+      coverageFloorRatio,
+    });
+    if (verdict.stale) {
+      // The three faults get different wording on purpose. They are read in
+      // PostHog by whoever is on the other end, and "never started", "stopped"
+      // and "running but not finishing" send that person to different places.
+      const age =
+        verdict.age_ms === null
+          ? "no rows at all"
+          : `${(verdict.age_ms / 3_600_000).toFixed(1)} h old`;
+      const message =
+        verdict.reason === "partial"
+          ? `hotkey-alpha lane truncated: the newest pass wrote only ${verdict.covered_rows} pool totals against a floor of ${verdict.coverage_floor_rows} derived from the ${verdict.referenced_pairs} (hotkey, netuid) pairs nominator_positions references (${verdict.total_rows} rows in the table, newest stamp ${age}) -- the capture is RECENT and PARTIAL, so every position naming a pool the pass never reached prices against nothing and its holder is UNDERSTATED rather than missing`
+          : `hotkey-alpha lane ${verdict.reason === "no_rows" ? "has never landed a pass" : "stalled"}: ${age} (threshold ${thresholdMs / 3_600_000} h) -- /accounts/top-holders is answering delegated_tao/total_tao from the frozen 2026-08-02 materialization and /subnets/{netuid}/holders is declining every request with pool_totals_unproven`;
+      await record(env as never, {
+        error: new Error(message),
+        route: "watchdog:hotkey-alpha-staleness",
+        errorCode: "stale_lane",
+      }).catch(() => false);
+    }
+    // The DURABLE record, written every tick rather than only when stale
+    // (#9330/#9340). PostHog stays the notification path; it is not the record,
+    // because a dropped $exception is indistinguishable from a lane that was
+    // fine. Writing every tick is also what makes "the watchdog stopped
+    // running" visible at all. Never throws -- see recordLaneVerdict.
+    await recordLaneVerdict(
+      deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as never),
+      {
+        lane: "hotkey-alpha-staleness",
+        verdict: verdict.stale ? "stale" : "ok",
+        age_ms: verdict.age_ms,
+        detail: verdict.reason ?? null,
+        checked_at: now(),
+      },
+    );
+    // `ok` describes whether the TICK ran, not whether the lane is fresh.
+    return { ok: true, alerted: verdict.stale, ...verdict };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "query_failed",
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/tests/hotkey-alpha-staleness-watchdog.test.ts
+++ b/tests/hotkey-alpha-staleness-watchdog.test.ts
@@ -1,0 +1,555 @@
+// The hotkey-alpha pool ledger's alarm (#9576) and its cron wiring.
+//
+// The case this file exists for is the one production was actually in when the
+// watchdog was written: `hotkey_alpha` held 0 rows, `hotkey_alpha_passes` held
+// 0 passes, and every reader of the ledger answered 200. `/accounts/top-holders`
+// served `delegated_tao` off the frozen 2026-08-02 materialization and
+// `/subnets/{netuid}/holders` returned `pool_totals_unproven` — both correct,
+// both indistinguishable from a producer that died weeks ago. So an EMPTY table
+// alerting is asserted first and hardest.
+//
+// The threshold's edge matters differently here than on the twin lane. This
+// producer polls every 24 h against `account_balances`' 6 h, so a 20-hour-old
+// capture is a HEALTHY mid-cycle reading and must stay silent — the mistake
+// #9301 had to correct on the nominator-positions watchdog after a bound was set
+// tighter than its producer's cadence and alerted for three quarters of the day.
+//
+// And the coverage floor is DERIVED rather than declared, which is the real
+// divergence from #9478 and the thing worth testing directly: since #9560 the
+// sink stores only the pools some position references, so the expectation is
+// whatever `nominator_positions` currently names. A floor read from the wrong
+// place is an alarm that is quietly too low to fire, and nothing about a passing
+// tick would say so.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  HOTKEY_ALPHA_COVERAGE_FLOOR_RATIO,
+  HOTKEY_ALPHA_PASS_WINDOW_MS,
+  HOTKEY_ALPHA_STALENESS_THRESHOLD_MS,
+  evaluateHotkeyAlphaStaleness,
+  runHotkeyAlphaStalenessWatchdog,
+} from "../src/hotkey-alpha-staleness-watchdog.ts";
+import { handleScheduled } from "../workers/api.ts";
+import * as workerConfig from "../workers/config.ts";
+
+const NOW = 1_785_800_000_000;
+const HOUR = 60 * 60_000;
+/** Distinct (hotkey, netuid) pairs the position ledger names — the measured
+ * production figure the floor is derived from (#9560). */
+const REFERENCED = 17_902;
+/** A pass that covered every referenced pool, so `covered` is never the thing
+ * under test unless a case says so. */
+const FULL = REFERENCED;
+
+function fakeDb(
+  latest: number | null | Error,
+  covered: number = FULL,
+  total: number = FULL,
+  referenced: number = REFERENCED,
+) {
+  const queries: string[] = [];
+  const binds: unknown[][] = [];
+  return {
+    queries,
+    binds,
+    db: {
+      prepare(sql: string) {
+        queries.push(sql);
+        return {
+          bind(...values: unknown[]) {
+            binds.push(values);
+            return {
+              async first() {
+                if (latest instanceof Error) throw latest;
+                return { latest, covered, total, referenced };
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+/** The rule's inputs with everything healthy, so each case overrides only the
+ * one field it is about. */
+function inputs(
+  over: Partial<Parameters<typeof evaluateHotkeyAlphaStaleness>[0]> = {},
+) {
+  return {
+    latestCapturedAtMs: NOW - HOUR,
+    coveredRows: FULL,
+    totalRows: FULL,
+    referencedPairs: REFERENCED,
+    nowMs: NOW,
+    thresholdMs: HOTKEY_ALPHA_STALENESS_THRESHOLD_MS,
+    coverageFloorRatio: HOTKEY_ALPHA_COVERAGE_FLOOR_RATIO,
+    ...over,
+  };
+}
+
+describe("evaluateHotkeyAlphaStaleness", () => {
+  test("an empty ledger is a stall of infinite age, never a healthy quiet", () => {
+    // The exact production state on 2026-08-05: the sink had shipped, no pass
+    // had ever landed, and nothing anywhere said so.
+    const verdict = evaluateHotkeyAlphaStaleness(
+      inputs({ latestCapturedAtMs: null, coveredRows: 0, totalRows: 0 }),
+    );
+    assert.equal(verdict.stale, true);
+    assert.equal(verdict.reason, "no_rows");
+    assert.equal(verdict.age_ms, null);
+    assert.equal(verdict.latest_captured_at, null);
+  });
+
+  test("a recent pass is quiet; one past the threshold is a stall", () => {
+    const fresh = evaluateHotkeyAlphaStaleness(
+      inputs({ latestCapturedAtMs: NOW - 2 * HOUR }),
+    );
+    assert.equal(fresh.stale, false);
+    assert.equal(fresh.reason, null);
+    assert.equal(fresh.age_ms, 2 * HOUR);
+
+    const stalled = evaluateHotkeyAlphaStaleness(
+      inputs({ latestCapturedAtMs: NOW - 49 * HOUR }),
+    );
+    assert.equal(stalled.stale, true);
+    assert.equal(stalled.reason, "stale");
+  });
+
+  test("a capture from the middle of the producer's 24h cycle is quiet", () => {
+    // HOTKEY_ALPHA_POLL_SECS defaults to 86400, and the buffered
+    // TotalHotkeyAlpha walk sits on top of that — so a healthy lane's age swings
+    // across this whole range and none of it may alert.
+    for (const hours of [1, 6, 12, 20, 24, 30, 47]) {
+      assert.equal(
+        evaluateHotkeyAlphaStaleness(
+          inputs({ latestCapturedAtMs: NOW - hours * HOUR }),
+        ).stale,
+        false,
+        `${hours}h into a 24h cycle must not alert`,
+      );
+    }
+  });
+
+  test("exactly at the threshold is not yet a stall", () => {
+    // Strictly-greater, so a lane running exactly on cadence never flaps.
+    assert.equal(
+      evaluateHotkeyAlphaStaleness(
+        inputs({
+          latestCapturedAtMs: NOW - HOTKEY_ALPHA_STALENESS_THRESHOLD_MS,
+        }),
+      ).stale,
+      false,
+    );
+  });
+
+  test("a recent but short pass is partial, not fresh", () => {
+    // The discrimination a timestamp cannot make: a pass that ran an hour ago
+    // and wrote a third of the pools reads as perfectly fresh from MAX() alone.
+    const verdict = evaluateHotkeyAlphaStaleness(
+      inputs({ coveredRows: Math.round(REFERENCED / 3) }),
+    );
+    assert.equal(verdict.stale, true);
+    assert.equal(verdict.reason, "partial");
+    assert.equal(verdict.coverage_floor_rows, Math.round(REFERENCED * 0.8));
+  });
+
+  test("staleness is decided before coverage", () => {
+    // Both faults present: the headline must be that the producer stopped, not
+    // how much its last attempt managed to write two days ago.
+    const verdict = evaluateHotkeyAlphaStaleness(
+      inputs({ latestCapturedAtMs: NOW - 60 * HOUR, coveredRows: 1 }),
+    );
+    assert.equal(verdict.reason, "stale");
+  });
+
+  test("the floor tracks the position ledger rather than a constant", () => {
+    // The #9560 divergence from the twin. The same 14,000-row pass is complete
+    // against a small position ledger and truncated against a grown one — a
+    // hardcoded expectation would call both the same.
+    const small = evaluateHotkeyAlphaStaleness(
+      inputs({ referencedPairs: 15_000, coveredRows: 14_000 }),
+    );
+    assert.equal(small.stale, false);
+    assert.equal(small.coverage_floor_rows, 12_000);
+
+    const grown = evaluateHotkeyAlphaStaleness(
+      inputs({ referencedPairs: 40_000, coveredRows: 14_000 }),
+    );
+    assert.equal(grown.stale, true);
+    assert.equal(grown.reason, "partial");
+    assert.equal(grown.coverage_floor_rows, 32_000);
+  });
+
+  test("exactly at the floor is complete", () => {
+    assert.equal(
+      evaluateHotkeyAlphaStaleness(
+        inputs({ coveredRows: Math.round(REFERENCED * 0.8) }),
+      ).stale,
+      false,
+    );
+  });
+
+  test("an empty position ledger declines the coverage clause, not the tick", () => {
+    // A floor of zero would mark every pass complete, including no pass at all.
+    // `nominator_positions` has its own alarm; this one must not restate it and
+    // send the reader to the wrong producer.
+    const verdict = evaluateHotkeyAlphaStaleness(
+      inputs({ referencedPairs: 0, coveredRows: 0 }),
+    );
+    assert.equal(verdict.coverage_floor_rows, null);
+    assert.equal(verdict.stale, false);
+    assert.equal(verdict.reason, null);
+    // The freshness half still stands on its own.
+    assert.equal(
+      evaluateHotkeyAlphaStaleness(
+        inputs({
+          referencedPairs: 0,
+          coveredRows: 0,
+          latestCapturedAtMs: NOW - 60 * HOUR,
+        }),
+      ).reason,
+      "stale",
+    );
+  });
+
+  test("total_rows is carried as context and never used as the rule", () => {
+    // A table full of old vintages under a short new pass still reports partial.
+    const verdict = evaluateHotkeyAlphaStaleness(
+      inputs({ coveredRows: 100, totalRows: 500_000 }),
+    );
+    assert.equal(verdict.reason, "partial");
+    assert.equal(verdict.total_rows, 500_000);
+  });
+});
+
+describe("runHotkeyAlphaStalenessWatchdog", () => {
+  const noopRecord = async () => true as never;
+
+  test("reads the lane once, bound to the pass window", async () => {
+    const { db, queries, binds } = fakeDb(NOW - HOUR);
+    const result = await runHotkeyAlphaStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW, recordException: noopRecord },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, false);
+    const reads = queries.filter((q) => q.includes("FROM hotkey_alpha"));
+    assert.equal(reads.length, 1);
+    // Both ledgers are read in the one statement — the floor is derived, not
+    // fetched separately, so the two cannot be read at different moments.
+    assert.match(reads[0], /FROM nominator_positions/);
+    assert.deepEqual(binds[0], [HOTKEY_ALPHA_PASS_WINDOW_MS]);
+  });
+
+  test("an empty ledger alerts and names both affected surfaces", async () => {
+    const messages: string[] = [];
+    const { db } = fakeDb(null, 0, 0, REFERENCED);
+    const result = await runHotkeyAlphaStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async (_env: unknown, arg: { error: Error }) => {
+          messages.push(arg.error.message);
+          return true;
+        }) as never,
+      },
+    );
+    assert.equal(result.alerted, true);
+    assert.equal(result.reason, "no_rows");
+    assert.equal(messages.length, 1);
+    assert.match(messages[0], /has never landed a pass/);
+    // The message has to say what is DEGRADED, not just that a table is empty —
+    // that is the difference between an alert someone acts on and one they mute.
+    assert.match(messages[0], /top-holders/);
+    assert.match(messages[0], /pool_totals_unproven/);
+  });
+
+  test("a truncated pass gets its own wording, not the stall wording", async () => {
+    const messages: string[] = [];
+    const { db } = fakeDb(NOW - HOUR, 500, 500, REFERENCED);
+    await runHotkeyAlphaStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async (_env: unknown, arg: { error: Error }) => {
+          messages.push(arg.error.message);
+          return true;
+        }) as never,
+      },
+    );
+    assert.match(messages[0], /truncated/);
+    // The consequence is UNDERSTATEMENT here, not absence — the fact that
+    // separates this ledger's partial failure from the balance ledger's.
+    assert.match(messages[0], /UNDERSTATED/);
+    assert.match(messages[0], /17902|17,902/);
+  });
+
+  test("a stalled lane gets the stall wording", async () => {
+    const messages: string[] = [];
+    const { db } = fakeDb(NOW - 60 * HOUR);
+    await runHotkeyAlphaStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async (_env: unknown, arg: { error: Error }) => {
+          messages.push(arg.error.message);
+          return true;
+        }) as never,
+      },
+    );
+    assert.match(messages[0], /stalled/);
+    assert.match(messages[0], /60\.0 h old/);
+  });
+
+  test("a healthy tick records no exception", async () => {
+    let called = 0;
+    const { db } = fakeDb(NOW - HOUR);
+    await runHotkeyAlphaStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async () => {
+          called += 1;
+          return true;
+        }) as never,
+      },
+    );
+    assert.equal(called, 0);
+  });
+
+  test("a failing telemetry post does not fail the tick", async () => {
+    // The alert is the notification path, not the record — a dropped $exception
+    // must not also lose the lane_health verdict behind it.
+    const { db } = fakeDb(null, 0, 0);
+    const result = await runHotkeyAlphaStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async () => {
+          throw new Error("posthog down");
+        }) as never,
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, true);
+  });
+
+  test("env overrides the threshold, window and ratio", async () => {
+    const { db, binds } = fakeDb(NOW - 3 * HOUR, 100, 100, 1000);
+    const result = await runHotkeyAlphaStalenessWatchdog(
+      {
+        METAGRAPH_HEALTH_DB: db,
+        HOTKEY_ALPHA_STALENESS_THRESHOLD_MS: 2 * HOUR,
+        HOTKEY_ALPHA_PASS_WINDOW_MS: 90_000,
+        HOTKEY_ALPHA_COVERAGE_FLOOR_RATIO: 0.5,
+      },
+      { now: () => NOW, recordException: noopRecord },
+    );
+    assert.equal(result.threshold_ms, 2 * HOUR);
+    assert.equal(result.reason, "stale");
+    assert.deepEqual(binds[0], [90_000]);
+  });
+
+  test("a null SUM lands on 0 rather than NaN", async () => {
+    // NaN would compare false against the floor and report a truncated ledger
+    // healthy — the quiet direction, which is the one that matters.
+    const { db } = fakeDb(NOW - HOUR, null as unknown as number, 0, REFERENCED);
+    const result = await runHotkeyAlphaStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW, recordException: noopRecord },
+    );
+    assert.equal(result.covered_rows, 0);
+    assert.equal(result.reason, "partial");
+  });
+
+  test("a missing row object is treated as an empty ledger", async () => {
+    const db = {
+      prepare: () => ({ bind: () => ({ first: async () => null }) }),
+    };
+    const result = await runHotkeyAlphaStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW, recordException: noopRecord },
+    );
+    assert.equal(result.reason, "no_rows");
+  });
+
+  test("no D1 binding is a missed report, not a throw", async () => {
+    assert.deepEqual(await runHotkeyAlphaStalenessWatchdog({}), {
+      ok: false,
+      reason: "d1 binding unavailable",
+    });
+    assert.deepEqual(await runHotkeyAlphaStalenessWatchdog(null), {
+      ok: false,
+      reason: "d1 binding unavailable",
+    });
+  });
+
+  test("a failing query is a missed report, not a throw", async () => {
+    const { db } = fakeDb(new Error("D1_ERROR: no such table"));
+    const result = await runHotkeyAlphaStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW, recordException: noopRecord },
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "query_failed");
+    assert.match(String(result.detail), /no such table/);
+  });
+
+  test("a non-Error throw still reports a detail", async () => {
+    const db = {
+      prepare: () => ({
+        bind: () => ({
+          first: async () => {
+            throw "string rejection";
+          },
+        }),
+      }),
+    };
+    const result = await runHotkeyAlphaStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW, recordException: noopRecord },
+    );
+    assert.equal(result.reason, "query_failed");
+    assert.equal(result.detail, "string rejection");
+  });
+
+  test("defaults are used when no deps are injected", async () => {
+    // Exercises the `deps.now ?? Date.now` / `deps.recordException ?? …` arms,
+    // which a fully-injected test never reaches.
+    const { db } = fakeDb(Date.now());
+    const result = await runHotkeyAlphaStalenessWatchdog({
+      METAGRAPH_HEALTH_DB: db,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, false);
+  });
+
+  test("the verdict is written to lane_health under its own name", async () => {
+    const lanes: Record<string, unknown>[] = [];
+    const { db } = fakeDb(NOW - HOUR);
+    await runHotkeyAlphaStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: noopRecord,
+        laneHealthDb: {
+          prepare: (sql: string) => ({
+            bind: (...values: unknown[]) => {
+              lanes.push({ sql, values });
+              return { run: async () => ({}) };
+            },
+          }),
+        } as never,
+      },
+    );
+    // Written EVERY tick, not only when stale: a dropped exception is otherwise
+    // indistinguishable from a lane that was fine (#9330/#9340). Asserted by
+    // SHAPE rather than by count — recordLaneVerdict's own statement sequence is
+    // its business, and a bare length check would have to be bumped whenever it
+    // changes while saying nothing about which lane was recorded.
+    // The INSERT specifically: recordLaneVerdict also prunes this lane's expired
+    // rows on the way through, and that DELETE binds the same lane name.
+    const named = lanes.filter(
+      (call) =>
+        String(call.sql).startsWith("INSERT INTO lane_health") &&
+        (call.values as unknown[]).includes("hotkey-alpha-staleness"),
+    );
+    assert.equal(
+      named.length,
+      1,
+      "exactly one verdict, carrying this lane's own name",
+    );
+    assert.ok((named[0].values as unknown[]).includes("ok"));
+  });
+});
+
+describe("the cron string is unique and wired", () => {
+  test("no other cron in workers/config.ts shares the literal string", () => {
+    // Dispatch keys on the LITERAL cron string, so a duplicate silently routes
+    // this lane into another branch entirely.
+    const crons = Object.entries(workerConfig)
+      .filter(([key]) => key.endsWith("_CRON"))
+      .map(([, value]) => value);
+    const mine = workerConfig.HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON;
+    assert.equal(
+      crons.filter((cron) => cron === mine).length,
+      1,
+      `${mine} is declared by more than one lane`,
+    );
+  });
+
+  test("it stays off the */5 and */15 grids", () => {
+    // Both grids fire on every minute divisible by 5, so a watchdog sharing one
+    // contends with the raw-capture and probe lanes on the same tick.
+    const minute = Number(
+      workerConfig.HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON.split(" ")[0],
+    );
+    assert.equal(Number.isInteger(minute), true);
+    assert.notEqual(minute % 5, 0);
+  });
+
+  test("wrangler.jsonc declares the trigger", () => {
+    // A cron the Worker dispatches on but wrangler never fires is dead code —
+    // and the failure is silent, since the branch simply never runs.
+    const raw = readFileSync(
+      new URL("../wrangler.jsonc", import.meta.url),
+      "utf8",
+    )
+      .replace(/^\s*\/\/.*$/gm, "")
+      .replace(/,(\s*[}\]])/g, "$1");
+    const parsed = JSON.parse(raw) as { triggers?: { crons?: string[] } };
+    assert.ok(
+      parsed.triggers?.crons?.includes(
+        workerConfig.HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON,
+      ),
+    );
+  });
+
+  test("handleScheduled dispatches to the watchdog and returns its summary", async () => {
+    const { db, queries } = fakeDb(Date.now());
+    const result = (await handleScheduled(
+      {
+        cron: workerConfig.HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON,
+      } as unknown as ScheduledController,
+      { METAGRAPH_HEALTH_DB: db } as unknown as Parameters<
+        typeof handleScheduled
+      >[1],
+      {} as unknown as ExecutionContext,
+    )) as { ok: boolean; alerted: boolean };
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, false);
+    const reads = queries.filter((q: string) =>
+      q.includes("FROM hotkey_alpha"),
+    );
+    assert.equal(reads.length, 1);
+  });
+
+  test("it does not swallow the neighbouring lane's cron", async () => {
+    // This branch is checked immediately BEFORE the account-balances watchdog,
+    // so a mistake here — a copied constant, a stray `||` — routes that lane
+    // into this one and silences it while both crons keep firing. Dispatch keys
+    // on the literal string and nothing else proves the two stay distinct.
+    const { db, queries } = fakeDb(Date.now());
+    const result = (await handleScheduled(
+      {
+        cron: workerConfig.ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON,
+      } as unknown as ScheduledController,
+      { METAGRAPH_HEALTH_DB: db } as unknown as Parameters<
+        typeof handleScheduled
+      >[1],
+      {} as unknown as ExecutionContext,
+    )) as { ok: boolean };
+    assert.equal(result.ok, true);
+    // The neighbour read ITS table, and this lane's read never happened.
+    assert.equal(
+      queries.filter((q: string) => q.includes("FROM account_balances")).length,
+      1,
+    );
+    assert.equal(
+      queries.filter((q: string) => q.includes("FROM hotkey_alpha")).length,
+      0,
+    );
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -372,6 +372,7 @@ import { runNominatorPositionsStalenessWatchdog } from "../src/nominator-positio
 import { runProjectionStalenessWatchdog } from "../src/projection-staleness-watchdog.ts";
 import { runValidatorNominatorCountsStalenessWatchdog } from "../src/validator-nominator-counts-staleness-watchdog.ts";
 import { runAccountBalancesStalenessWatchdog } from "../src/account-balances-staleness-watchdog.ts";
+import { runHotkeyAlphaStalenessWatchdog } from "../src/hotkey-alpha-staleness-watchdog.ts";
 import {
   readChainDetailHead,
   runChainDetailStalenessWatchdog,
@@ -454,6 +455,7 @@ import {
   TOP_HOLDERS_FLOW_CRON,
   TOP_HOLDERS_STALENESS_WATCHDOG_CRON,
   ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON,
+  HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON,
   LIVE_ECONOMICS_REFRESH_CRON,
   PROJECTION_LANES_CRON,
   FRESHNESS_WATCHDOG_STATE_KEY,
@@ -1644,6 +1646,8 @@ function cronLabel(cron: string): string {
     return "chain-detail-staleness-watchdog";
   if (cron === TOP_HOLDERS_STALENESS_WATCHDOG_CRON)
     return "top-holders-staleness-watchdog";
+  if (cron === HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON)
+    return "hotkey-alpha-staleness-watchdog";
   if (cron === ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON)
     return "account-balances-staleness-watchdog";
   if (cron === TOP_HOLDERS_FLOW_CRON) return "top-holders-flow";
@@ -1986,6 +1990,19 @@ async function dispatchScheduled(
     // UNREADABLE or EMPTY artifact alerts too -- that is the condition where
     // the route silently answers 200 with an empty leaderboard.
     return runTopHoldersStalenessWatchdog(
+      env as unknown as Record<string, unknown>,
+    );
+  }
+  if (cron === HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON) {
+    // The pool ledger's alarm (#9576) -- the twin of the watchdog above, for
+    // the OTHER table the holdings columns are composed from. `hotkey_alpha`
+    // shipped in #9512 without one, and the cost is that its readers all
+    // decline QUIETLY: /accounts/top-holders falls back to the frozen
+    // 2026-08-02 materialization and /subnets/{netuid}/holders answers
+    // pool_totals_unproven, both of which are correct and both of which look
+    // identical to a producer that died. An EMPTY table alerts, because that is
+    // the state the lane has been in since the sink landed.
+    return runHotkeyAlphaStalenessWatchdog(
       env as unknown as Record<string, unknown>,
     );
   }

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -229,6 +229,17 @@ export const TOP_HOLDERS_STALENESS_WATCHDOG_CRON = "22,52 * * * *";
 // */15 probe grids -- dispatch keys on the LITERAL cron string, so this must be
 // unique here as well as matching a wrangler.jsonc `triggers.crons` entry.
 export const ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON = "4,34 * * * *";
+// #9576: the same alarm for the OTHER ledger the top-holders holdings columns
+// are composed from. `hotkey_alpha` shipped in #9512 without one, so an empty
+// pool ledger was invisible -- every reader declines correctly and quietly, and
+// a correct decline looks exactly like a producer that died a month ago.
+// HOURLY rather than twice-hourly, and against a 48-hour threshold: the poller's
+// HOTKEY_ALPHA_POLL_SECS defaults to 86400 against account_balances' 21600, so a
+// finer cadence would only re-report the same 24-hour-old pass. Minute 54 ticks
+// on none of the crons in this file and stays off the */5 and */15 grids --
+// dispatch keys on the LITERAL cron string, so it must be unique here as well as
+// matching a wrangler.jsonc `triggers.crons` entry.
+export const HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON = "54 * * * *";
 // #9146: scheduled projections -- recompute the windowed-aggregate artifacts
 // (every lane in src/projection-lanes.ts's PROJECTION_LANES) from the
 // lakehouse. These routes cannot

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -883,6 +883,12 @@
       // visible without waiting for the publish path to notice. See
       // ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON in workers/config.ts.
       "4,34 * * * *",
+      // 54 = the hotkey-alpha staleness watchdog (#9576): the same source-side
+      // alarm for the OTHER ledger the holdings columns are composed from,
+      // which shipped in #9512 without one. Hourly rather than twice-hourly,
+      // because its producer polls every 24h against account_balances' 6h. See
+      // HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON in workers/config.ts.
+      "54 * * * *",
     ],
   },
   // Per-client abuse control for the read-only RPC proxy (an abuse prerequisite


### PR DESCRIPTION
## Summary

- `hotkey_alpha` shipped in #9512 without the staleness watchdog #9502 listed in its own shape. This adds it.
- Measured against production 2026-08-05: the ledger held **0 rows**, `hotkey_alpha_passes` held **0 passes**, and `lane_health` had never carried a row for this lane. Nothing anywhere reported it.

## What Changed

**Why an empty ledger was silent.** Every reader declines deliberately when it cannot prove a complete pass — `/accounts/top-holders` falls back to the frozen 2026-08-02 materialization for `delegated_tao`/`total_tao` (#9545), `/subnets/{netuid}/holders` answers `pool_totals_unproven` (#9557). Those declines are *correct*; they are what stops a partial pool ledger producing a plausible wrong ranking. But from outside, a correct decline and a producer that died a month ago are the same 200. The last silently-dead lane was found by a caller reading a timestamp — the thing #9478's watchdog exists about.

**Mirrors `src/account-balances-staleness-watchdog.ts`**: one read, a pure rule, a summary rather than a throw, `recordLaneVerdict` every tick, a PostHog exception only when stale. Its reasoning about *what* to count is inherited rather than re-derived — this writer also never prunes, so `COUNT(*)` goes blind the moment one complete pass lands, and a pass that dies is a pass that never posts its completion marker.

Three things differ, all traceable to the producer:

| | Twin (#9478) | Here |
|---|---|---|
| Threshold | 12 h | **48 h** — `HOTKEY_ALPHA_POLL_SECS` is 86400 vs `account_balances`' 21600, and the pass is a buffered whole-map walk on top |
| Coverage floor | constant (~306,000 accounts) | **derived** from `nominator_positions` |
| Empty upstream | n/a | **declines the coverage clause** rather than dividing by nothing |

**The derived floor is the real divergence.** #9560 narrowed the sink to store only the pools some position actually references, so a complete pass lands the ~17,902 distinct `(hotkey, netuid)` pairs `nominator_positions` names — not the ~762,577 `TotalHotkeyAlpha` entries the producer walks. That number moves with the position ledger, so a constant would rot silently, and the dangerous direction (a floor quietly too low to fire) is invisible from a passing tick. Reading it in the same statement makes the expectation and the sink's filter the same fact rather than two copies of it. Cheap since #9558 indexed `(hotkey, netuid)`.

**An empty position ledger declines the coverage clause.** A floor of zero marks every pass complete, including no pass at all — and `nominator_positions` has its own alarm, so restating its verdict here would put two lanes' names on one fault and send the reader to the wrong producer. The freshness half still stands on its own.

**Cron:** hourly on minute `54` — collides with nothing in `workers/config.ts` or `wrangler.jsonc`, and stays off the `*/5` and `*/15` grids. Hourly rather than twice-hourly because a finer cadence against a 24 h producer only re-reports the same pass.

**Ordering:** the branch is checked immediately *before* the account-balances one, with a test asserting the neighbour's cron still reaches its own lane — dispatch keys on the literal cron string, so a copied constant would silence a working watchdog while both crons kept firing.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented — none here; this adds no route and no contract surface.

## Validation

- [x] `npm run build` (8/8 steps passed)
- [x] `npx tsc --noEmit` · `npm run lint` · `npm run format:check`
- [x] `npm run validate`
- [x] `npm run validate:api` — 191 routes
- [x] `npm run validate:contract-drift`
- [x] `npm run validate:docs`
- [x] `npm run validate:workflows` — 23 workflow files
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
- [x] `npx vitest run tests/hotkey-alpha-staleness-watchdog.test.ts` — 29 passed
- [x] `npx vitest run tests/account-balances-staleness-watchdog.test.ts tests/hotkey-alpha-staleness-watchdog.test.ts tests/lane-health.test.ts` — 70 passed (the neighbour and the shared sink still green after the dispatch reorder)

**Patch coverage: 100% statements (41/41), 100% branches (47/47)**, measured by intersecting `coverage-final.json` with the diff's added lines across `src/**` and `workers/**`. `npm run test:coverage` (full unsharded suite) was not run locally; CI owns that.

Rebased onto `235a146a3`.

## Template Used

- `backend-code.md`

Closes #9576
