### PR TITLE
docs: say what feeds the firehose now, and that only blocks arrives

### DIFF
--- a/docs/realtime-firehose.md
+++ b/docs/realtime-firehose.md
@@ -1,30 +1,44 @@
 # Realtime chain-event firehose (#2114, ADR 0015)
 
-> **Partly historical (2026-08-04).** The ingest half of this document describes a
-> Postgres `AFTER INSERT` trigger that was retired with Postgres itself (#9426). The
-> Durable Object hub, the SSE/GraphQL/MCP fan-out and the rate-limiting design below are
-> all still live — only the row _source_ changed, from a Postgres trigger to the head
-> poller writing D1 and the lakehouse.
+> **Partly historical (2026-08-05).** The ingest half of this document — the Postgres
+> `AFTER INSERT` trigger, the `chain_firehose_outbox` table, and the box-side relay that
+> drained it — was retired with Postgres and the box (#9426). The Durable Object hub, the
+> SSE/GraphQL/MCP fan-out and the rate-limiting design below are all still live: the row
+> _source_ changed, and the hub is now fed by whatever POSTs
+> `/api/v1/internal/chain-firehose-ingest`.
+>
+> **What actually arrives today is `blocks` and nothing else** — measured on an unfiltered
+> subscription, 2026-08-05. `extrinsics`, `chain_events` and `account_events` are dark; see
+> #9583 before building on them.
 
-The `chain_firehose_outbox` table is a compact, best-effort stream source for
+The `chain_firehose_outbox` table was a compact, best-effort stream source for
 every row landing in `blocks`/`extrinsics`/`chain_events`/`account_events`
 (the last added for #4984 -- see below), decoupled from `indexer-rs`'s own
-process so downstream delivery cannot block the chain follower. See ADR 0015
+process so downstream delivery could not block the chain follower. See ADR 0015
 for why this shape was chosen over a direct push from `indexer-rs` (the
 retired `metagraphed-streamer`'s exact failure mode, documented in ADR 0014).
 
 ## How it works
 
 ```
-indexer-rs → (writes, as it always has) → Postgres
-                                              │
-                              AFTER INSERT trigger (retired Postgres, #9426)
-                                              │
-                                 INSERT chain_firehose_outbox(payload)
-                                              │
-              box-side relay (poll/claim rows, #4981/#5027, live) → Cloudflare Durable Object (#4982, live)
+TODAY
+
+  the producer → POST /api/v1/internal/chain-firehose-ingest → Cloudflare Durable Object (#4982, live)
                                                                           │
                                               SSE / WS (#4982, live) / GraphQL subs / MCP (#4983, live)
+
+  Observed 2026-08-05: only `blocks` payloads arrive. The other three topics
+  are dark — see #9583.
+
+RETIRED WITH THE BOX (#9426) — the ingest half everything below describes
+
+  indexer-rs → (writes) → Postgres
+                              │
+                  AFTER INSERT trigger
+                              │
+                 INSERT chain_firehose_outbox(payload)
+                              │
+              box-side relay (poll/claim rows, #4981/#5027)
 ```
 
 this exists. The trigger writes compact references into a normal Postgres
@@ -63,7 +77,7 @@ trigger; the row-level outbox design here is unchanged. A
 future fast-follow if outbox INSERT volume itself (not ingest-request volume)
 ever becomes the bottleneck instead.
 
-## The relay (#4981, live)
+## The relay (#4981, RETIRED with the box — historical)
 
 A new, small, self-hosted process on the indexer box polls and claims pending
 `chain_firehose_outbox` rows, groups them into `CHAIN_FIREHOSE_INGEST_BATCH_SIZE`-sized
@@ -459,11 +473,12 @@ is, on the MAIN Worker (the hub is co-located there, not on
 wrangler secret put CHAIN_FIREHOSE_SYNC_SECRET
 ```
 
-The #4981 relay is deployed and live — verified directly against the running
-infrastructure: `chain_firehose_outbox` on the indexer box's Postgres has zero
-pending rows, with the most recent row delivered within ~7s of being written.
-The ingest endpoint below can still be exercised directly to isolate the hub
-itself from the rest of the path when debugging:
+The #4981 relay was verified live in its day — `chain_firehose_outbox` on the
+indexer box's Postgres held zero pending rows, most recent delivered within ~7s
+of being written. It went with the box; the hub is now fed by whatever POSTs the
+ingest endpoint, and a live subscription shows `blocks` payloads arriving one per
+block (with only that topic — #9583). The ingest endpoint can still be exercised
+directly to isolate the hub itself from the rest of the path when debugging:
 
 ```sh
 # terminal 1: subscribe (SSE)


### PR DESCRIPTION
## Summary

`docs/realtime-firehose.md` had a banner saying the ingest half was historical, and then three places below it asserting the retired path as current: the architecture diagram drew the box-side relay as **live**, the section heading said "## The relay (#4981, live)", and a verification note said the relay "is deployed and live — verified directly against the running infrastructure: `chain_firehose_outbox` on the indexer box's Postgres has zero pending rows". That box was decommissioned 2026-08-03. A reader debugging the stream was being sent to inspect a table on a machine that is gone.

The diagram is now split into today's path and the retired one, and both relay sections are in the past tense.

## The part worth reading

While verifying what feeds the hub, I subscribed to the live stream. The fan-out is healthy — block payloads one per block, heartbeats in between:

```
: connected
id: 76
event: chain
data: {"table":"blocks","block_number":8780118,…,"extrinsic_count":30,"event_count":316}
```

But an **unfiltered** 60-second subscription (no `?topics=`, which `parseTopics` turns into "every table") returns only that one topic:

```
   5 "table":"blocks"
```

`extrinsics`, `chain_events` and `account_events` are dark. Not a sampling artifact — those same five blocks carried ~30 extrinsics and ~300 events each, so if they were publishing they'd outnumber `blocks` by two orders of magnitude. Filed as **#9583** (the producer is outside this repo, so the fix is likely infra-side); this PR puts the measurement at the top of the document so nobody builds against a stream that will never emit.

## Validation

- `npm run validate:docs` — passed (this file is in the cadence guard's scan set)
- `npx prettier --check docs/realtime-firehose.md` — clean

Docs-only.

Closes #9586