### PR TITLE
feat(firehose): tell a subscriber when its topic has no producer

### DIFF
--- a/docs/realtime-firehose.md
+++ b/docs/realtime-firehose.md
@@ -144,7 +144,20 @@ One global instance (`idFromName("global")`) owns two endpoints:
   the WS transport instead. Both support
   `?topics=blocks,extrinsics,chain_events,account_events` (comma-separated,
   defaults to all four) to avoid forcing a client to consume the full
-  firehose.
+  firehose. **Only `blocks` has a producer today** (#204 publishes that lane
+  alone; see the banner at the top), so a filter naming only the other three
+  matches nothing. The filter still accepts all four — a producer arriving
+  later must not require a client change — but SSE sends one
+  `event: notice` frame at connect naming any requested topic that has no
+  producer:
+
+  ```
+  event: notice
+  data: {"code":"topic_not_published","topics":["chain_events"],"published":["blocks"]}
+  ```
+
+  It carries no `id:`, so it never becomes a resume point, and `EventSource`
+  clients that don't listen for `notice` ignore it (#9583).
 
 Bounded per-connection buffering: an SSE client whose `ReadableStream`
 controller falls behind (`desiredSize < 0` against a 64-frame

--- a/tests/chain-firehose-hub.test.ts
+++ b/tests/chain-firehose-hub.test.ts
@@ -45,6 +45,9 @@ import {
   validateChainFirehoseIngestPayload,
   shouldEmitAlerterUnreachable,
   ALERTER_UNREACHABLE_EVENT_WINDOW_MS,
+  CHAIN_FIREHOSE_PUBLISHED_TABLES,
+  formatChainFirehoseTopicNoticeFrame,
+  unpublishedChainFirehoseTopics,
 } from "../workers/chain-firehose-hub.ts";
 import { MCP_CHAIN_STREAM_RESOURCE_URI } from "../workers/mcp-session-hub.ts";
 import { resetModuleState } from "../src/module-state-registry.ts";
@@ -743,6 +746,71 @@ test("ChainFirehoseHub /subscribe (SSE): responds with a text/event-stream and a
   await reader.cancel();
 });
 
+test("unpublishedChainFirehoseTopics: names the topics no producer publishes (#9583)", () => {
+  assert.deepEqual(
+    unpublishedChainFirehoseTopics(new Set(["chain_events", "blocks"])),
+    ["chain_events"],
+  );
+  // Sorted, so the frame is stable regardless of the caller's ?topics= order.
+  assert.deepEqual(
+    unpublishedChainFirehoseTopics(new Set(["extrinsics", "account_events"])),
+    ["account_events", "extrinsics"],
+  );
+  // Positive control: `blocks` IS published, so a blocks-only filter is not a
+  // thwarted expectation and must produce no notice.
+  assert.ok(CHAIN_FIREHOSE_PUBLISHED_TABLES.has("blocks"));
+  assert.deepEqual(unpublishedChainFirehoseTopics(new Set(["blocks"])), []);
+  // No filter means "everything there is", which is never thwarted either.
+  assert.deepEqual(unpublishedChainFirehoseTopics(null), []);
+  assert.deepEqual(unpublishedChainFirehoseTopics(undefined), []);
+});
+
+test("formatChainFirehoseTopicNoticeFrame: an id-less notice frame (#9583)", () => {
+  const frame = formatChainFirehoseTopicNoticeFrame(["chain_events"]);
+  assert.equal(
+    frame,
+    'event: notice\ndata: {"code":"topic_not_published","topics":["chain_events"],"published":["blocks"]}\n\n',
+  );
+  // No `id:` -- a reconnecting client must not be able to resume "from" a
+  // notice, the same reason formatChainFirehoseSseResetFrame() has none.
+  assert.ok(!frame.includes("id:"));
+});
+
+test("ChainFirehoseHub /subscribe (SSE): warns a client that filtered to an unpublished topic (#9583)", async () => {
+  const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
+  const res = await hub.fetch(
+    new Request(
+      "https://chain-firehose-hub.internal/subscribe?topics=chain_events",
+    ),
+  );
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  assert.equal(decoder.decode((await reader.read()).value), ": connected\n\n");
+  assert.equal(
+    decoder.decode((await reader.read()).value),
+    formatChainFirehoseTopicNoticeFrame(["chain_events"]),
+  );
+  await reader.cancel();
+});
+
+test("ChainFirehoseHub /subscribe (SSE): no notice when the filter names a published topic (#9583)", async () => {
+  const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
+  const res = await hub.fetch(
+    new Request("https://chain-firehose-hub.internal/subscribe?topics=blocks"),
+  );
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  assert.equal(decoder.decode((await reader.read()).value), ": connected\n\n");
+  // Positive control: the same request shape with an unpublished topic emits a
+  // notice as its SECOND frame (test above), so proving there is none here
+  // means proving the next frame is real data instead.
+  hub.broadcast({ table: "blocks", block_number: 1 });
+  const second = decoder.decode((await reader.read()).value);
+  assert.ok(!second.includes("event: notice"));
+  assert.ok(second.includes("event: chain"));
+  await reader.cancel();
+});
+
 test("ChainFirehoseHub /subscribe (SSE): rejects new clients at the global connection cap", async () => {
   const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
   const responses = [];
@@ -849,6 +917,7 @@ test("ChainFirehoseHub /subscribe (SSE) -> broadcast: ?netuid= filters account_e
   const decode = async () =>
     new TextDecoder().decode((await reader.read()).value);
   await decode(); // ": connected"
+  await decode(); // #9583 notice: account_events has no producer today
 
   hub.broadcast({ table: "account_events", block_number: 1, netuid: 9 }); // wrong subnet -- filtered
   hub.broadcast({ table: "account_events", block_number: 2, netuid: 5 }); // id 2 -- matches
@@ -890,6 +959,12 @@ test("ChainFirehoseHub /subscribe (SSE) Last-Event-ID resume: replays only event
     new TextDecoder().decode((await reader.read()).value);
 
   assert.equal(await decode(), ": connected\n\n");
+  // #9583: the notice precedes the replay -- a resuming client learns the
+  // topic has no producer before it starts reading history through it.
+  assert.equal(
+    await decode(),
+    formatChainFirehoseTopicNoticeFrame(["account_events"]),
+  );
   assert.equal(
     await decode(),
     'id: 2\nevent: chain\ndata: {"table":"account_events","block_number":2,"netuid":5}\n\n',

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -80,6 +80,33 @@ export const CHAIN_FIREHOSE_TABLES = new Set([
   "account_events",
 ]);
 
+// #9583: of the four topics above, only `blocks` has a producer today. The
+// box-side relay that fed all four died with Postgres (#9426) and the head
+// poller that replaced it (#204) publishes the blocks lane alone -- decoding
+// the other three needs runtime metadata, which is the Containers indexer's
+// job (#209), and a Worker faking them from undecoded bytes would serve wrong
+// data.
+//
+// A topic filter is still ACCEPTED for all four, because a producer arriving
+// later must not require a client change. But a subscriber that asks only for
+// unpublished topics gets a well-formed stream that never emits, which is
+// indistinguishable from a quiet chain -- so say so once, at connect.
+export const CHAIN_FIREHOSE_PUBLISHED_TABLES = new Set(["blocks"]);
+
+/**
+ * Requested topics that no producer currently publishes, sorted for a stable
+ * frame. `null` (no filter) returns none: that caller asked for everything and
+ * gets everything there is, which is not a thwarted expectation.
+ */
+export function unpublishedChainFirehoseTopics(
+  topics: Set<string> | null | undefined,
+): string[] {
+  if (!topics) return [];
+  return [...topics]
+    .filter((topic) => !CHAIN_FIREHOSE_PUBLISHED_TABLES.has(topic))
+    .sort();
+}
+
 // Headroom over Postgres's 8000-byte NOTIFY payload cap (the trigger's own
 // payload is already far smaller than this -- see the trigger's comment).
 export const CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES = 16_000;
@@ -506,6 +533,20 @@ export function chainFirehoseSseResumeHasGap(
 // instead of refetching again.
 export function formatChainFirehoseSseResetFrame(): string {
   return `event: reset\ndata: {}\n\n`;
+}
+
+// #9583: sent once, at connect, when a client filtered to topics nothing
+// publishes. Its own event type so an existing client ignores it (EventSource
+// delivers only listened-for types), and no `id:` for the same reason `reset`
+// has none -- it is not a numbered event in the stream's sequence, and a
+// resuming client must not be able to resume "from" it.
+export function formatChainFirehoseTopicNoticeFrame(topics: string[]): string {
+  const payload = JSON.stringify({
+    code: "topic_not_published",
+    topics,
+    published: [...CHAIN_FIREHOSE_PUBLISHED_TABLES].sort(),
+  });
+  return `event: notice\ndata: ${payload}\n\n`;
 }
 
 // Sentry METAGRAPHED-3: state.getWebSockets() itself -- not a per-socket
@@ -1261,6 +1302,16 @@ export class ChainFirehoseHub implements DurableObject {
           entry = { controller, topics, ip: clientIp, netuid };
           this.addSseClient(entry);
           controller.enqueue(encoder.encode(": connected\n\n"));
+
+          // #9583: before any data frame, tell a client that filtered to
+          // topics nothing publishes -- otherwise the silence that follows
+          // reads as a quiet chain rather than an absent producer.
+          const unpublished = unpublishedChainFirehoseTopics(topics);
+          if (unpublished.length > 0) {
+            controller.enqueue(
+              encoder.encode(formatChainFirehoseTopicNoticeFrame(unpublished)),
+            );
+          }
 
           // #8364: Last-Event-ID resume.
           if (lastEventIdHeader !== null) {


### PR DESCRIPTION
## Summary

`?topics=` accepts all four table names, but only `blocks` has a producer. The relay that fed the other three died with Postgres (#9426), and the head poller that replaced it (#204) publishes the blocks lane alone — decoding `extrinsics`/`chain_events`/`account_events` needs runtime metadata, which is the Containers indexer's job (#209).

So `GET /api/v1/chain/stream?topics=chain_events` returns 200, opens a well-formed stream, and never emits. A client cannot distinguish that from a quiet chain, and neither can its operator.

This sends **one notice frame at connect**, before any data frame and before a `Last-Event-ID` replay:

```
event: notice
data: {"code":"topic_not_published","topics":["chain_events"],"published":["blocks"]}
```

## Why this shape

- **Still accepts all four names.** A producer arriving later must not require a client change, so this reports rather than rejects. A 400 would also break callers who pass the documented value today.
- **Its own event type.** `EventSource` dispatches only listened-for types, so every existing client ignores it — no client change is forced by this PR either.
- **No `id:`.** Same reason `formatChainFirehoseSseResetFrame()` has none: it is not a numbered event in the stream's sequence, and a resuming client must never be able to resume *from* it.
- **Fires on any unpublished topic, not only an all-unpublished filter.** `?topics=blocks,chain_events` still streams blocks; the notice names `chain_events` so the half that will never arrive is stated rather than inferred.
- **No filter means no notice.** A subscriber that asked for everything gets everything there is, which is not a thwarted expectation.

## Changes

- `workers/chain-firehose-hub.ts` — `CHAIN_FIREHOSE_PUBLISHED_TABLES`, the pure `unpublishedChainFirehoseTopics()` and `formatChainFirehoseTopicNoticeFrame()` (mirroring the existing reset-frame helper), and the emit in the SSE `start()`.
- `tests/chain-firehose-hub.test.ts` — 3 new tests; 2 existing SSE tests updated because the frame sequence for an `account_events` subscriber now carries the notice. Both changes are the behavior under test, not accommodation: the resume test now asserts the notice precedes the replay.
- `docs/realtime-firehose.md` — the `?topics=` bullet documents the notice and shows the frame.

## Validation

- `npm test` (post-build) — **689 files, 16,520 tests, all passing**
- Patch coverage proven by diff intersection, not a whole-file percentage: **51 added lines in `workers/chain-firehose-hub.ts`, 0 uncovered statements** (vitest json coverage ∩ `git diff -U0` added lines)
- `npm run lint`, `format:check`, `typecheck`, `validate:docs` — clean

Note the WS and GraphQL-subscription transports don't get the notice: their connect paths are inside the `/* v8 ignore */` Cloudflare-runtime glue this repo's plain-vitest harness cannot drive, so adding it there would be untested code. SSE is the transport the docs point a reader at, and the notice is discoverable from a single `curl -N`.

Closes #9583