### PR TITLE
feat(graphql): serve subnet_holders, so the third surface answers what REST does

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2800,6 +2800,8 @@ export type Query = {
   subnet_health_trends: SubnetHealthTrends;
   /** One subnet's daily history from the neuron_daily rollup over a 7d/30d/90d/1y/all window (default 30d): neuron count, validator count, total stake (TAO), and total emission (TAO) per snapshot_date, newest first. A subnet with no daily rollup resolves to a schema-stable empty series (point_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/history. */
   subnet_history: SubnetHistory;
+  /** Who OWNS a subnet's alpha: the top coldkeys by alpha held on that netuid, each with its share of the subnet total and how many hotkeys it holds through, plus whole-subnet aggregates (distinct holder count, total measured alpha, top5/top10/top20 concentration). The reverse index of account_positions, which reads the same ledger one coldkey (one account) at a time, and distinct from subnet_concentration: that card is computed off registered UIDs' stake, while this one includes alpha staked to UNREGISTERED hotkeys. Ranked in ALPHA, not TAO. limit caps the rows (default 20, max 100); the aggregates are always computed over the FULL holder set, so holder_count is not the length of what you got back. TWO STATES DECLINE rather than answer, both with an empty holders list, a degraded block and NULL counts: pool_totals_unproven while the pool ledger has no complete pass, and root_not_in_alpha_map for netuid 0, which the chain's Alpha map does not cover. An empty holders list WITHOUT a degraded block is therefore a measurement. Mainnet only. Mirrors GET /api/v1/subnets/{netuid}/holders. */
+  subnet_holders: SubnetHolders;
   /** One subnet's live on-chain hyperparameters (latest snapshot only). The hyperparameters block is null when the subnet has no captured row -- a schema-stable card, never a GraphQL error, matching the Query.block ref-lookup convention. Mirrors GET /api/v1/subnets/{netuid}/hyperparameters. */
   subnet_hyperparameters?: Maybe<SubnetHyperparameters>;
   /** One subnet's append-only hyperparameter-change history, newest first, one entry per observed change. Forward-only: entries exist only from when the diff-on-change write started. A subnet with no recorded changes resolves to an empty entry list, never null. Mirrors GET /api/v1/subnets/{netuid}/hyperparameters/history. */
@@ -3907,6 +3909,12 @@ export type QuerySubnet_HistoryArgs = {
 };
 
 
+export type QuerySubnet_HoldersArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  netuid: Scalars['Int']['input'];
+};
+
+
 export type QuerySubnet_HyperparametersArgs = {
   netuid: Scalars['Int']['input'];
 };
@@ -4902,6 +4910,44 @@ export type SubnetHistoryPoint = {
   total_emission_alpha?: Maybe<Scalars['Float']['output']>;
   total_stake_alpha?: Maybe<Scalars['Float']['output']>;
   validator_count?: Maybe<Scalars['Int']['output']>;
+};
+
+/** One coldkey's holding of a subnet's alpha, including alpha staked to hotkeys that hold no UID on that subnet. */
+export type SubnetHolder = {
+  __typename?: 'SubnetHolder';
+  /** ALPHA, not TAO. Within one subnet alpha is already a common unit, so there is no price conversion and none of its staleness -- multiply by the subnet's alpha_price_tao for TAO. */
+  alpha: Scalars['Float']['output'];
+  coldkey: Scalars['String']['output'];
+  /** Distinct hotkeys this coldkey holds the subnet's alpha through -- registered on it or not, which is the part a neurons-sourced view misses. */
+  hotkey_count?: Maybe<Scalars['Int']['output']>;
+  /** This holder's alpha over the subnet's FULL measured total, so it means the same thing at limit 5 and limit 100. Null when the total is zero. */
+  share_of_total?: Maybe<Scalars['Float']['output']>;
+};
+
+export type SubnetHolders = {
+  __typename?: 'SubnetHolders';
+  /** The pool pass every row was valued against. */
+  captured_at?: Maybe<Scalars['String']['output']>;
+  concentration?: Maybe<SubnetHoldersConcentration>;
+  /** Present ONLY on a decline. Its absence is what says the ranking is real -- an empty holders list with no degraded block means the subnet genuinely has no measured holders. */
+  degraded?: Maybe<DegradedInfo>;
+  /** Distinct coldkeys holding this subnet's alpha -- the whole set, never the returned page's length. */
+  holder_count?: Maybe<Scalars['Int']['output']>;
+  holders: Array<SubnetHolder>;
+  limit?: Maybe<Scalars['Int']['output']>;
+  netuid: Scalars['Int']['output'];
+  /** When the positions ledger itself was last written, which advances on a different cadence than the pool totals. */
+  positions_captured_at?: Maybe<Scalars['String']['output']>;
+  schema_version: Scalars['Int']['output'];
+  total_alpha?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Concentration of a subnet's alpha, each rank summed over the top N of the FULL holder set rather than the returned page. */
+export type SubnetHoldersConcentration = {
+  __typename?: 'SubnetHoldersConcentration';
+  top5_share?: Maybe<Scalars['Float']['output']>;
+  top10_share?: Maybe<Scalars['Float']['output']>;
+  top20_share?: Maybe<Scalars['Float']['output']>;
 };
 
 /** Per-subnet neuron-registration activity over a window (#5720). Zeroed card (0 counts) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/registrations. */
@@ -6125,6 +6171,9 @@ export type ResolversTypes = ResolversObject<{
   SubnetHealthTrends: ResolverTypeWrapper<SubnetHealthTrends>;
   SubnetHistory: ResolverTypeWrapper<SubnetHistory>;
   SubnetHistoryPoint: ResolverTypeWrapper<SubnetHistoryPoint>;
+  SubnetHolder: ResolverTypeWrapper<SubnetHolder>;
+  SubnetHolders: ResolverTypeWrapper<SubnetHolders>;
+  SubnetHoldersConcentration: ResolverTypeWrapper<SubnetHoldersConcentration>;
   SubnetHyperparameters: ResolverTypeWrapper<SubnetHyperparameters>;
   SubnetHyperparamsHistory: ResolverTypeWrapper<SubnetHyperparamsHistory>;
   SubnetIdentityHistory: ResolverTypeWrapper<SubnetIdentityHistory>;
@@ -6442,6 +6491,9 @@ export type ResolversParentTypes = ResolversObject<{
   SubnetHealthTrends: SubnetHealthTrends;
   SubnetHistory: SubnetHistory;
   SubnetHistoryPoint: SubnetHistoryPoint;
+  SubnetHolder: SubnetHolder;
+  SubnetHolders: SubnetHolders;
+  SubnetHoldersConcentration: SubnetHoldersConcentration;
   SubnetHyperparameters: SubnetHyperparameters;
   SubnetHyperparamsHistory: SubnetHyperparamsHistory;
   SubnetIdentityHistory: SubnetIdentityHistory;
@@ -8669,6 +8721,7 @@ export type QueryResolvers<ContextType = GqlContext, ParentType extends Resolver
   subnet_health_percentiles?: Resolver<ResolversTypes['SubnetHealthPercentiles'], ParentType, ContextType, RequireFields<QuerySubnet_Health_PercentilesArgs, 'netuid'>>;
   subnet_health_trends?: Resolver<ResolversTypes['SubnetHealthTrends'], ParentType, ContextType, RequireFields<QuerySubnet_Health_TrendsArgs, 'netuid'>>;
   subnet_history?: Resolver<ResolversTypes['SubnetHistory'], ParentType, ContextType, RequireFields<QuerySubnet_HistoryArgs, 'netuid'>>;
+  subnet_holders?: Resolver<ResolversTypes['SubnetHolders'], ParentType, ContextType, RequireFields<QuerySubnet_HoldersArgs, 'netuid'>>;
   subnet_hyperparameters?: Resolver<Maybe<ResolversTypes['SubnetHyperparameters']>, ParentType, ContextType, RequireFields<QuerySubnet_HyperparametersArgs, 'netuid'>>;
   subnet_hyperparameters_history?: Resolver<ResolversTypes['SubnetHyperparamsHistory'], ParentType, ContextType, RequireFields<QuerySubnet_Hyperparameters_HistoryArgs, 'netuid'>>;
   subnet_identity_history?: Resolver<ResolversTypes['SubnetIdentityHistory'], ParentType, ContextType, RequireFields<QuerySubnet_Identity_HistoryArgs, 'netuid'>>;
@@ -9225,6 +9278,32 @@ export type SubnetHistoryPointResolvers<ContextType = GqlContext, ParentType ext
   total_emission_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   total_stake_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   validator_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+}>;
+
+export type SubnetHolderResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetHolder'] = ResolversParentTypes['SubnetHolder']> = ResolversObject<{
+  alpha?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  coldkey?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  hotkey_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  share_of_total?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+}>;
+
+export type SubnetHoldersResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetHolders'] = ResolversParentTypes['SubnetHolders']> = ResolversObject<{
+  captured_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  concentration?: Resolver<Maybe<ResolversTypes['SubnetHoldersConcentration']>, ParentType, ContextType>;
+  degraded?: Resolver<Maybe<ResolversTypes['DegradedInfo']>, ParentType, ContextType>;
+  holder_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  holders?: Resolver<Array<ResolversTypes['SubnetHolder']>, ParentType, ContextType>;
+  limit?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  positions_captured_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  total_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+}>;
+
+export type SubnetHoldersConcentrationResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetHoldersConcentration'] = ResolversParentTypes['SubnetHoldersConcentration']> = ResolversObject<{
+  top5_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  top10_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  top20_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;
 
 export type SubnetHyperparametersResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetHyperparameters'] = ResolversParentTypes['SubnetHyperparameters']> = ResolversObject<{
@@ -10193,6 +10272,9 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   SubnetHealthTrends?: SubnetHealthTrendsResolvers<ContextType>;
   SubnetHistory?: SubnetHistoryResolvers<ContextType>;
   SubnetHistoryPoint?: SubnetHistoryPointResolvers<ContextType>;
+  SubnetHolder?: SubnetHolderResolvers<ContextType>;
+  SubnetHolders?: SubnetHoldersResolvers<ContextType>;
+  SubnetHoldersConcentration?: SubnetHoldersConcentrationResolvers<ContextType>;
   SubnetHyperparameters?: SubnetHyperparametersResolvers<ContextType>;
   SubnetHyperparamsHistory?: SubnetHyperparamsHistoryResolvers<ContextType>;
   SubnetIdentityHistory?: SubnetIdentityHistoryResolvers<ContextType>;

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -304,6 +304,8 @@ export const SDL = /* GraphQL */ `
     ): SubnetPerformanceHistory!
     "Per-subnet stake and emission concentration over the current neurons snapshot: raw-UID and per-entity Gini/HHI/Nakamoto/top-K share for stake and emission, validator-only stake concentration, and a uids-per-entity Sybil signal; a subnet with no neurons resolves to a schema-stable zeroed card (metric blocks null), never null. Mirrors GET /api/v1/subnets/{netuid}/concentration."
     subnet_concentration(netuid: Int!): SubnetConcentration!
+    "Who OWNS a subnet's alpha: the top coldkeys by alpha held on that netuid, each with its share of the subnet total and how many hotkeys it holds through, plus whole-subnet aggregates (distinct holder count, total measured alpha, top5/top10/top20 concentration). The reverse index of account_positions, which reads the same ledger one coldkey (one account) at a time, and distinct from subnet_concentration: that card is computed off registered UIDs' stake, while this one includes alpha staked to UNREGISTERED hotkeys. Ranked in ALPHA, not TAO. limit caps the rows (default 20, max 100); the aggregates are always computed over the FULL holder set, so holder_count is not the length of what you got back. TWO STATES DECLINE rather than answer, both with an empty holders list, a degraded block and NULL counts: pool_totals_unproven while the pool ledger has no complete pass, and root_not_in_alpha_map for netuid 0, which the chain's Alpha map does not cover. An empty holders list WITHOUT a degraded block is therefore a measurement. Mainnet only. Mirrors GET /api/v1/subnets/{netuid}/holders."
+    subnet_holders(netuid: Int!, limit: Int): SubnetHolders!
     "Per-subnet per-day stake and emission concentration trend from the neuron_daily rollup over a 7d/30d/90d window (default 30d): each day's stake/emission Gini, Nakamoto coefficient, and top-10% share, newest first; a subnet with no daily rollup resolves to a schema-stable empty series (point_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/concentration/history."
     subnet_concentration_history(
       netuid: Int!
@@ -2790,6 +2792,41 @@ export const SDL = /* GraphQL */ `
     deregistrations: Int!
     deregistrations_per_hotkey: Float
     derivation: DeregistrationDerivation
+    degraded: DegradedInfo
+  }
+
+  "One coldkey's holding of a subnet's alpha, including alpha staked to hotkeys that hold no UID on that subnet."
+  type SubnetHolder {
+    coldkey: String!
+    "ALPHA, not TAO. Within one subnet alpha is already a common unit, so there is no price conversion and none of its staleness -- multiply by the subnet's alpha_price_tao for TAO."
+    alpha: Float!
+    "This holder's alpha over the subnet's FULL measured total, so it means the same thing at limit 5 and limit 100. Null when the total is zero."
+    share_of_total: Float
+    "Distinct hotkeys this coldkey holds the subnet's alpha through -- registered on it or not, which is the part a neurons-sourced view misses."
+    hotkey_count: Int
+  }
+
+  "Concentration of a subnet's alpha, each rank summed over the top N of the FULL holder set rather than the returned page."
+  type SubnetHoldersConcentration {
+    top5_share: Float
+    top10_share: Float
+    top20_share: Float
+  }
+
+  type SubnetHolders {
+    schema_version: Int!
+    netuid: Int!
+    limit: Int
+    "Distinct coldkeys holding this subnet's alpha -- the whole set, never the returned page's length."
+    holder_count: Int
+    total_alpha: Float
+    concentration: SubnetHoldersConcentration
+    "The pool pass every row was valued against."
+    captured_at: String
+    "When the positions ledger itself was last written, which advances on a different cadence than the pool totals."
+    positions_captured_at: String
+    holders: [SubnetHolder!]!
+    "Present ONLY on a decline. Its absence is what says the ranking is real -- an empty holders list with no degraded block means the subnet genuinely has no measured holders."
     degraded: DegradedInfo
   }
 

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -295,6 +295,12 @@ import {
   TOP_HOLDERS_LIMIT_MAX,
   TOP_HOLDERS_SORTS,
 } from "./top-holders.ts";
+import {
+  buildSubnetHolders,
+  loadSubnetHolders,
+  SUBNET_HOLDERS_LIMIT_DEFAULT,
+  SUBNET_HOLDERS_LIMIT_MAX,
+} from "./subnet-holders.ts";
 import { loadTopHoldersFromArtifact } from "./top-holders-artifact.ts";
 import { loadTopHoldersFlowTier } from "./top-holders-flow-tier.ts";
 import { composeLeaderboardsData } from "../workers/request-handlers/analytics-routes.ts";
@@ -1148,6 +1154,9 @@ export const FIELD_COMPLEXITY = {
   subnet_performance_history: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_concentration: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_concentration_history: RELATIONSHIP_FIELD_COMPLEXITY,
+  // #9595: two D1 statements, both bounded -- the ranked page by `limit` and the
+  // aggregate to a single row -- so it costs what its siblings do.
+  subnet_holders: RELATIONSHIP_FIELD_COMPLEXITY,
   neuron: RELATIONSHIP_FIELD_COMPLEXITY,
   neuron_history: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -2718,6 +2727,43 @@ const rootValue = {
       consensus: data.consensus ?? null,
       validator_trust: data.validator_trust ?? null,
     };
+  },
+
+  async subnet_holders(
+    { netuid, limit }: { netuid: number; limit?: number | null },
+    context: GqlContext,
+  ) {
+    // #9595. Reads the SAME loader REST and MCP do rather than a resolver-local
+    // query -- the defect this surface has a history of is a field that answers
+    // a confident zero off a tier its siblings stopped using, and one shared
+    // loader is what makes that impossible rather than merely unlikely.
+    //
+    // The limit is VALIDATED, not clamped: REST returns 400 on an over-ceiling
+    // limit, and a GraphQL field that silently substituted a different number
+    // would answer a question the caller did not ask.
+    if (
+      limit != null &&
+      (!Number.isInteger(limit) ||
+        limit < 1 ||
+        limit > SUBNET_HOLDERS_LIMIT_MAX)
+    ) {
+      throw new GraphQLError(
+        `limit must be an integer between 1 and ${SUBNET_HOLDERS_LIMIT_MAX}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const safeLimit = limit ?? SUBNET_HOLDERS_LIMIT_DEFAULT;
+    const read = await loadSubnetHolders(
+      context.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
+        typeof loadSubnetHolders
+      >[0],
+      netuid,
+      { limit: safeLimit },
+    );
+    // buildSubnetHolders already returns the decline shape (empty holders, a
+    // degraded block, null counts), so there is nothing to translate here -- and
+    // nothing that could turn a decline into a zero on the way through.
+    return buildSubnetHolders(read, netuid, { limit: safeLimit });
   },
 
   async subnet_concentration(

--- a/tests/graphql-subnet-holders.test.ts
+++ b/tests/graphql-subnet-holders.test.ts
@@ -1,0 +1,272 @@
+// The `subnet_holders` GraphQL field (#9595).
+//
+// The point of this file is CROSS-SURFACE AGREEMENT, not that the resolver
+// returns plausible JSON. GraphQL is the surface with a history of quietly
+// disagreeing with its siblings here: #9540 found eleven resolvers answering a
+// schema-valid `0` with an empty `errors` array while REST and MCP served real
+// rows for every one of them, because each had a ladder whose only rung was a
+// retired tier. A consumer cannot tell that apart from "the chain has no data".
+//
+// So the central assertion below runs the SAME database through the REST
+// handler and through this resolver and requires the two payloads to match
+// field for field. A resolver-local query that drifted from the shared loader
+// would still pass every shape check and fail that one.
+//
+// The decline path gets the same treatment for the same reason. `holders: []`
+// with a `degraded` block and `holders: []` without one are opposite claims —
+// "we cannot rank this" versus "nobody holds any" — and GraphQL is exactly
+// where that distinction has been lost before.
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, describe, test } from "vitest";
+import { FIELD_COMPLEXITY, SDL, handleGraphQLRequest } from "../src/graphql.ts";
+import { SUBNET_HOLDERS_LIMIT_MAX } from "../src/subnet-holders.ts";
+import { handleRequest } from "../workers/api.ts";
+import type { Row } from "./row-type.ts";
+
+const MIGRATIONS = [
+  "0011_nominator_positions.sql",
+  "0019_hotkey_alpha.sql",
+  "0021_hotkey_alpha_passes.sql",
+  "0022_nominator_positions_hotkey_netuid.sql",
+  "0023_nominator_positions_netuid.sql",
+].map((file) =>
+  fs.readFileSync(path.join(process.cwd(), "migrations/d1", file), "utf8"),
+);
+
+const NETUID = 74;
+const PASS = 1_785_900_000_000;
+const POSITIONS_AT = 1_785_953_674_407;
+const ck = (n: number) => `5Coldkey${String(n).padStart(40, "0")}`;
+const hk = (n: number) => `5Hotkey0${String(n).padStart(40, "0")}`;
+
+let db: InstanceType<typeof DatabaseSync>;
+
+function d1() {
+  return {
+    prepare(text: string) {
+      const run = (values: unknown[]) => ({
+        async all() {
+          return { results: db.prepare(text).all(...(values as never[])) };
+        },
+        async first() {
+          return db.prepare(text).get(...(values as never[])) ?? null;
+        },
+      });
+      return { bind: (...values: unknown[]) => run(values), ...run([]) };
+    },
+  };
+}
+
+const env = () => ({ METAGRAPH_HEALTH_DB: d1() }) as unknown as Env;
+
+async function gql(query: string, e: Env = env()) {
+  const res = await handleGraphQLRequest(
+    new Request("https://api.metagraph.sh/api/v1/graphql", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query }),
+    }),
+    e,
+  );
+  return (await res.json()) as Row;
+}
+
+/** The same five holders the REST suite uses: 250/200/150/100/50 on a 1,000
+ * alpha pool, inserted out of rank order. */
+function fiveHolders() {
+  db.prepare(
+    `INSERT INTO hotkey_alpha_passes
+       (captured_at, expected_rows, received_rows, completed_at)
+     VALUES (?, ?, ?, ?)`,
+  ).run(PASS, 1, 1, PASS + 1000);
+  db.prepare(
+    `INSERT INTO hotkey_alpha (hotkey, netuid, total_alpha, captured_at)
+     VALUES (?, ?, ?, ?)`,
+  ).run(hk(1), NETUID, 1000, PASS);
+  for (const [coldkey, fraction] of [
+    [ck(3), 0.15],
+    [ck(1), 0.25],
+    [ck(5), 0.05],
+    [ck(2), 0.2],
+    [ck(4), 0.1],
+  ] as [string, number][]) {
+    db.prepare(
+      `INSERT INTO nominator_positions
+         (coldkey, hotkey, netuid, share_fraction, captured_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(coldkey, hk(1), NETUID, fraction, POSITIONS_AT);
+  }
+}
+
+const FULL_QUERY = (netuid: number, limit?: number) => `{
+  subnet_holders(netuid: ${netuid}${limit === undefined ? "" : `, limit: ${limit}`}) {
+    schema_version
+    netuid
+    limit
+    holder_count
+    total_alpha
+    concentration { top5_share top10_share top20_share }
+    captured_at
+    positions_captured_at
+    holders { coldkey alpha share_of_total hotkey_count }
+    degraded { reason }
+  }
+}`;
+
+beforeEach(() => {
+  db = new DatabaseSync(":memory:");
+  for (const schema of MIGRATIONS) db.exec(schema);
+});
+
+describe("subnet_holders agrees with REST over the same database", () => {
+  test("the ranking is field-for-field identical", async () => {
+    fiveHolders();
+    const viaGraphql = ((await gql(FULL_QUERY(NETUID, 3))).data as Row)
+      .subnet_holders as Row;
+
+    const restRes = await handleRequest(
+      new Request(
+        `https://api.metagraph.sh/api/v1/subnets/${NETUID}/holders?limit=3`,
+      ),
+      env(),
+      {} as unknown as ExecutionContext,
+    );
+    const viaRest = ((await restRes.json()) as Row).data as Row;
+
+    // GraphQL types `degraded` as an object and REST omits the key entirely on a
+    // healthy read, so that one field is compared separately below; everything
+    // else must match exactly.
+    assert.equal(viaGraphql.degraded, null);
+    assert.equal(viaRest.degraded, undefined);
+    const { degraded: _g, ...gqlRest } = viaGraphql;
+    const { degraded: _r, ...restRest } = viaRest;
+    assert.deepEqual(gqlRest, restRest);
+    // And the numbers are the ones the fixture describes, so a matching pair of
+    // wrong answers cannot pass.
+    assert.equal(viaGraphql.holder_count, 5);
+    assert.equal(viaGraphql.total_alpha, 750);
+    assert.deepEqual(
+      (viaGraphql.holders as Row[]).map((h) => [h.coldkey, h.alpha]),
+      [
+        [ck(1), 250],
+        [ck(2), 200],
+        [ck(3), 150],
+      ],
+    );
+  });
+
+  test("the aggregates stay whole-subnet under a smaller limit", async () => {
+    fiveHolders();
+    const card = ((await gql(FULL_QUERY(NETUID, 2))).data as Row)
+      .subnet_holders as Row;
+    assert.equal((card.holders as Row[]).length, 2);
+    assert.equal(card.holder_count, 5);
+    // top5 over the FULL set is the whole 750, not the 450 the page carries.
+    assert.equal((card.concentration as Row).top5_share, 1);
+  });
+
+  test("an absent limit takes the shared default", async () => {
+    fiveHolders();
+    const card = ((await gql(FULL_QUERY(NETUID))).data as Row)
+      .subnet_holders as Row;
+    assert.equal(card.limit, 20);
+    assert.equal((card.holders as Row[]).length, 5);
+  });
+});
+
+describe("subnet_holders declines rather than answering zero", () => {
+  test("an unproven pool ledger carries a reason, not an empty ranking", async () => {
+    // Rows exist and would rank perfectly well — that is the danger. An empty
+    // list with no reason would read as "nobody holds this subnet's alpha".
+    const card = ((await gql(FULL_QUERY(NETUID))).data as Row)
+      .subnet_holders as Row;
+    assert.deepEqual(card.holders, []);
+    assert.deepEqual(card.degraded, { reason: "pool_totals_unproven" });
+    assert.equal(card.holder_count, null);
+    assert.equal(card.total_alpha, null);
+    assert.deepEqual(card.concentration, {
+      top5_share: null,
+      top10_share: null,
+      top20_share: null,
+    });
+  });
+
+  test("root declines with its own reason", async () => {
+    fiveHolders();
+    const card = ((await gql(FULL_QUERY(0))).data as Row).subnet_holders as Row;
+    assert.deepEqual(card.degraded, { reason: "root_not_in_alpha_map" });
+  });
+
+  test("no D1 binding declines rather than erroring", async () => {
+    const body = await gql(FULL_QUERY(NETUID), {} as Env);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(((body.data as Row).subnet_holders as Row).degraded, {
+      reason: "unavailable",
+    });
+  });
+
+  test("a declined read is still a schema-valid non-null card", async () => {
+    // The field is `SubnetHolders!`, so a decline that returned null would
+    // surface as a GraphQL error and take the whole query down with it.
+    const body = await gql(`{ subnet_holders(netuid: ${NETUID}) { netuid } }`);
+    assert.equal(body.errors, undefined);
+    assert.equal(((body.data as Row).subnet_holders as Row).netuid, NETUID);
+  });
+});
+
+describe("subnet_holders validates its limit rather than clamping", () => {
+  // REST returns 400 on an over-ceiling limit. A GraphQL field that silently
+  // substituted a different number would answer a question nobody asked.
+  test.each([0, -1, SUBNET_HOLDERS_LIMIT_MAX + 1])(
+    "limit %i is a BAD_USER_INPUT error",
+    async (limit) => {
+      const body = await gql(FULL_QUERY(NETUID, limit));
+      const errors = body.errors as Row[];
+      assert.equal(Array.isArray(errors), true);
+      assert.match(String(errors[0].message), /limit must be an integer/);
+      assert.equal(
+        (errors[0].extensions as Row)?.code,
+        "BAD_USER_INPUT",
+        "the code is what a client branches on",
+      );
+    },
+  );
+
+  test("the ceiling itself is accepted", async () => {
+    fiveHolders();
+    const card = (
+      (await gql(FULL_QUERY(NETUID, SUBNET_HOLDERS_LIMIT_MAX))).data as Row
+    ).subnet_holders as Row;
+    assert.equal(card.limit, SUBNET_HOLDERS_LIMIT_MAX);
+  });
+});
+
+describe("the field is declared and priced", () => {
+  test("the SDL exposes it with both arguments", () => {
+    assert.match(
+      SDL,
+      /subnet_holders\(netuid: Int!, limit: Int\): SubnetHolders!/,
+    );
+    assert.match(SDL, /type SubnetHolders \{/);
+    assert.match(SDL, /type SubnetHolder \{/);
+  });
+
+  test("it carries a complexity cost", () => {
+    // An unpriced field is free to the depth/complexity limiter, so a query can
+    // fan out across subnets without ever tripping the budget.
+    assert.equal(typeof FIELD_COMPLEXITY.subnet_holders, "number");
+    assert.equal(
+      FIELD_COMPLEXITY.subnet_holders,
+      FIELD_COMPLEXITY.subnet_concentration,
+      "it costs what its per-subnet siblings do",
+    );
+  });
+
+  test("the SDL documents that an empty list without a reason is a measurement", () => {
+    // The one sentence a consumer has to read to use this field correctly.
+    assert.match(SDL, /empty holders list WITHOUT a degraded block/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `subnet_holders(netuid: Int!, limit: Int): SubnetHolders!` — the GraphQL half of #9557, which shipped REST + MCP only.
- Resolves through `loadSubnetHolders` / `buildSubnetHolders`, the same two functions the other surfaces call.

## What Changed

**Why a shared loader and not a resolver-local query.** #9540 found **eleven** resolvers answering a schema-valid `0` with an empty `errors` array while REST and MCP served real rows for the same query — each had a ladder whose only rung was a retired tier, and a consumer cannot tell that apart from "the chain has no data". A missing field is louder than a wrong one, but the cure is the same: one loader, so the tier cascade physically cannot differ between surfaces.

**The test that carries the weight** runs one database through the REST handler and through this resolver and requires the two payloads to match field for field:

```ts
const { degraded: _g, ...gqlRest } = viaGraphql;
const { degraded: _r, ...restRest } = viaRest;
assert.deepEqual(gqlRest, restRest);
```

A resolver that had quietly grown its own query would pass every shape assertion and fail that one. The fixture's numbers are asserted separately, so a matching pair of *wrong* answers cannot pass either.

**Two behaviours carry across intact**, both the kind a hand-written resolver drops:

- **A decline is not an empty ranking.** `holders: []` with a `degraded` block and `holders: []` without one are opposite claims. The field is `SubnetHolders!`, so a decline is a card rather than a GraphQL error that takes the whole query down — asserted directly.
- **The aggregates are whole-subnet.** `holder_count`, `total_alpha` and the three concentration shares are computed over the full holder set and then sliced, so they do not move when `limit` does. Asserted at `limit: 2` over five holders, where a page-local `top5_share` would read `1.0` and look perfectly reasonable.

**`limit` is validated, not clamped.** REST returns 400 on an over-ceiling limit; a field that silently substituted a different number would answer a question the caller did not ask. `BAD_USER_INPUT`, matching how the window arguments already behave. `0`, `-1` and `MAX + 1` are each asserted, and the ceiling itself is asserted accepted.

**Priced in `FIELD_COMPLEXITY`** at its per-subnet siblings' cost — an unpriced field is free to the depth/complexity limiter, so a query could fan it out across subnets without tripping the budget. Asserted equal to `subnet_concentration` rather than to a literal, so the two move together.

The SDL sentence a consumer has to read — *"an empty holders list WITHOUT a degraded block"* is a measurement — is itself asserted present, so it cannot be edited away silently.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (`generated/graphql/types.ts` is `npm run build` output).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented — the SDL addition is the change; no REST route or OpenAPI surface moves.

## Validation

- [x] `npm run build` (8/8 steps passed)
- [x] `npx tsc --noEmit` · `npm run lint` · `npm run format:check`
- [x] `npm run validate:api` — 191 routes
- [x] `npm run validate:contract-drift`
- [x] `npm run validate:docs`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
- [x] `npx vitest run tests/graphql-subnet-holders.test.ts` — 14 passed
- [x] `npx vitest run tests/graphql-subnet-holders.test.ts tests/graphql-tier-cascade.test.ts tests/graphql.test.ts` — **1,097 passed** (the #9540 tier-cascade guard included; this resolver reaches no `tryPostgresTier` rung at all)

**Patch coverage: 100% statements (5/5), 100% branches (8/8)**, measured by intersecting `coverage-final.json` with the diff's added lines across `src/**` and `workers/**`. `npm run test:coverage` (full unsharded suite) was not run locally; CI owns that.

## Template Used

- `backend-code.md`

Closes #9595
