### PR TITLE
feat(ui): surface the alpha holder leaderboard on the subnet page

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-holders-leaderboard.test.ts
+++ b/apps/ui/src/components/metagraphed/subnet-holders-leaderboard.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// The alpha-holders section (#9597), pinned by source assertions.
+//
+// The component composes Router/Query context a rendered test cannot easily
+// stand up, so this follows the convention of subnets-total-stake-tile.test.ts
+// and leaderboards-csv-export-menu.test.ts. What it pins is deliberately narrow:
+// three properties where a plausible, well-intentioned edit produces a UI that
+// states something false and looks entirely correct doing it.
+const component = readFileSync(
+  fileURLToPath(new URL("./subnet-holders-leaderboard.tsx", import.meta.url)),
+  "utf8",
+);
+const page = readFileSync(
+  fileURLToPath(new URL("../../routes/-subnets-netuid-page.tsx", import.meta.url)),
+  "utf8",
+);
+const masthead = readFileSync(
+  fileURLToPath(new URL("./subnet-masthead.tsx", import.meta.url)),
+  "utf8",
+);
+
+describe("the decline branch precedes the empty branch", () => {
+  it("checks degraded before holders.length === 0", () => {
+    // BOTH states arrive as `holders: []`. Ordered the other way, a subnet
+    // whose ranking is merely unproven renders "No alpha holders" -- a
+    // confident claim about the chain, made from an absence of data. This is
+    // the single most important line ordering in the file.
+    const declineAt = component.indexOf("data?.degraded?.reason");
+    const emptyAt = component.indexOf("holders.length === 0");
+    expect(declineAt).toBeGreaterThan(-1);
+    expect(emptyAt).toBeGreaterThan(-1);
+    expect(declineAt).toBeLessThan(emptyAt);
+  });
+
+  it("renders a decline as an informational notice, not an EmptyState", () => {
+    // role="status" + the muted-icon notice shape, matching
+    // DataTierUnavailableNotice/NativeOnlyNotice. A dashed EmptyState would
+    // read as "nothing here"; a red ErrorState would read as "something broke".
+    expect(component).toMatch(/function DeclineNotice/);
+    expect(component).toMatch(/role="status"/);
+    for (const reason of ["pool_totals_unproven", "root_not_in_alpha_map", "unavailable"]) {
+      expect(component).toContain(reason);
+    }
+  });
+
+  it("keeps the empty-state copy explicit that it is a measurement", () => {
+    expect(component).toMatch(/measurement, not a missing ranking/);
+  });
+});
+
+describe("alpha is displayed in the unit the API serves", () => {
+  it("does not divide by 1e9", () => {
+    // The conviction leaderboard's fmtAlpha divides by 1e9 because
+    // locked_mass/conviction arrive rao-scale. THIS route's producer converts
+    // before writing (rao_to_alpha_f64), so `alpha` is already whole alpha.
+    // Copying the sibling's helper would report every holder as a billionth of
+    // its real size -- which renders as a plausible dust balance, not as an
+    // obvious bug.
+    expect(component).not.toMatch(/1_000_000_000/);
+    expect(component).not.toMatch(/UNITS_PER_WHOLE/);
+    expect(component).not.toMatch(/\/\s*1e9/);
+  });
+
+  it("renders a null share as an em dash rather than 0%", () => {
+    expect(component).toMatch(/if \(share == null/);
+    expect(component).toMatch(/return "—"/);
+  });
+});
+
+describe("the section is wired into the page", () => {
+  it("mounts under an anchor inside an error boundary", () => {
+    expect(page).toContain('id="holders"');
+    expect(page).toMatch(/<SubnetHoldersLeaderboard netuid=\{netuid\} \/>/);
+    // Without the boundary, one failing section takes the whole tab down.
+    const at = page.indexOf('id="holders"');
+    expect(page.slice(at, at + 900)).toContain("QueryErrorBoundary");
+  });
+
+  it("registers the anchor in SECTION_TO_TAB", () => {
+    // Missing here, a cross-tab deep link to /subnets/7#holders silently lands
+    // on the wrong tab and scrolls nowhere -- useHashScroll reads this map.
+    expect(page).toMatch(/holders: "metagraph"/);
+  });
+
+  it("declares the endpoint in the API drawer", () => {
+    expect(masthead).toMatch(/\/holders`/);
+  });
+
+  it("states in the section info that the aggregates are whole-subnet", () => {
+    // The one caveat a reader needs: holder_count describes the subnet, not the
+    // rows on screen.
+    const at = page.indexOf('id="holders"');
+    expect(page.slice(at, at + 900)).toMatch(/whole subnet, not the returned rows/);
+  });
+});

--- a/apps/ui/src/components/metagraphed/subnet-holders-leaderboard.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-holders-leaderboard.tsx
@@ -1,0 +1,222 @@
+import { useQuery } from "@tanstack/react-query";
+import { Database } from "lucide-react";
+import { subnetHoldersQuery } from "@/lib/metagraphed/queries";
+import { AddressDisplay } from "@/components/metagraphed/address-display";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
+import { RealtimeFreshness } from "@jsonbored/ui-kit";
+import { formatNumber } from "@/lib/metagraphed/format";
+
+/**
+ * Alpha, already in WHOLE UNITS.
+ *
+ * Deliberately NOT the `fmtAlpha` in subnet-conviction-leaderboard.tsx, which
+ * divides by 1e9 because conviction/locked_mass arrive rao-scale. This route's
+ * producer converts before writing (`rao_to_alpha_f64` in the poller's
+ * hotkey_alpha job), so `total_alpha` is stored in whole alpha and
+ * `share_fraction * total_alpha` comes out the same way. Dividing again would
+ * report every holder as a billionth of its real size, which looks like a
+ * plausible dust balance rather than an obvious bug.
+ */
+function fmtAlpha(alpha: number): string {
+  if (!Number.isFinite(alpha)) return "—";
+  const magnitude = Math.abs(alpha);
+  if (magnitude >= 1_000_000) return `${(alpha / 1_000_000).toFixed(2)}M α`;
+  if (magnitude >= 1_000) return `${(alpha / 1_000).toFixed(1)}k α`;
+  if (magnitude >= 1) return `${alpha.toFixed(2)} α`;
+  if (alpha === 0) return "0 α";
+  return `${alpha.toFixed(4)} α`;
+}
+
+/** A share as a percentage, or an em dash. Null is "no share to state" -- with
+ * no measured total there is no denominator -- and must never render as 0%. */
+function pctStr(share: number | null): string {
+  if (share == null || !Number.isFinite(share)) return "—";
+  const pct = share * 100;
+  if (pct >= 10) return `${pct.toFixed(1)}%`;
+  if (pct >= 1) return `${pct.toFixed(2)}%`;
+  return `${pct.toFixed(3)}%`;
+}
+
+/**
+ * Why the ranking could not be produced, in the caller's words.
+ *
+ * Rendered as an informational notice rather than a red ErrorState or a dashed
+ * EmptyState, matching DataTierUnavailableNotice/NativeOnlyNotice: nothing has
+ * failed and nothing is missing -- the route is declining to rank data it
+ * cannot prove. An EmptyState here would read as "this subnet has no holders",
+ * which is the one thing a decline specifically does not claim.
+ */
+const DECLINE_COPY: Record<string, { title: string; body: string }> = {
+  pool_totals_unproven: {
+    title: "Holder ranking not available yet",
+    body: "Ranking holders needs the per-hotkey alpha pool totals, and the ledger that carries them has not completed a full pass yet. A partial ledger would under-price holders rather than visibly omit them, so this ranking is withheld instead of shown wrong. It appears on its own once a pass lands.",
+  },
+  root_not_in_alpha_map: {
+    title: "Root has no alpha holders",
+    body: "Root stake is not denominated in alpha and does not appear in the chain's Alpha map, so there is no holder set to rank here. This is a property of root, not a gap in the data.",
+  },
+  unavailable: {
+    title: "Holder ranking could not be read",
+    body: "The ledger behind this ranking could not be reached for this request. It is unrelated to the rest of this page.",
+  },
+};
+
+function DeclineNotice({ reason }: { reason: string }) {
+  const copy = DECLINE_COPY[reason] ?? {
+    title: "Holder ranking not available",
+    body: "This ranking is being withheld rather than shown from data that cannot be verified.",
+  };
+  return (
+    <div role="status" className="rounded border border-border bg-surface p-4">
+      <div className="flex items-start gap-3">
+        <Database className="size-4 shrink-0 text-ink-muted" />
+        <div className="min-w-0 flex-1">
+          <div className="mb-1 font-display text-sm font-medium text-ink-strong">{copy.title}</div>
+          <p className="text-xs leading-relaxed text-ink-muted">{copy.body}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Who owns a subnet's alpha (#9557, frontend companion #9597).
+ *
+ * The reverse index of an account's own positions: this asks a subnet who
+ * holds it, where /accounts/{ss58}/positions asks a wallet what it holds. It is
+ * NOT the same question as the concentration panel beside it -- that one reads
+ * registered UIDs' stake and emits scalars (Gini/HHI/Nakamoto), so it cannot
+ * see alpha parked on hotkeys that hold no UID on this subnet. On netuid 74
+ * that is 82 of the 92 hotkeys carrying positions.
+ *
+ * THREE OUTCOMES, AND THEY ARE NOT INTERCHANGEABLE. A decline (a `degraded`
+ * block) renders an informational notice; a genuine empty holder set renders an
+ * EmptyState; a fetch failure renders an ErrorState. The decline branch is
+ * checked FIRST precisely because both it and the measurement arrive as
+ * `holders: []` -- ordering them the other way would report "no holders" for a
+ * subnet nobody has ranked yet.
+ */
+export function SubnetHoldersLeaderboard({ netuid }: { netuid: number }) {
+  const { data: res, isLoading, isError, error, refetch } = useQuery(subnetHoldersQuery(netuid));
+  const data = res?.data;
+
+  if (isError) {
+    return <ErrorState error={error} onRetry={() => refetch()} context="subnet holders" />;
+  }
+
+  if (isLoading) {
+    return <Skeleton className="h-40 w-full" />;
+  }
+
+  // BEFORE the empty check: a decline also carries an empty `holders`.
+  if (data?.degraded?.reason) {
+    return <DeclineNotice reason={data.degraded.reason} />;
+  }
+
+  const holders = data?.holders ?? [];
+
+  if (holders.length === 0) {
+    return (
+      <EmptyState
+        title="No alpha holders"
+        description="No account currently holds alpha on this subnet through a stake position. This is a measurement, not a missing ranking."
+      />
+    );
+  }
+
+  const conc = data?.concentration;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mg-type-data text-ink-muted">
+        {/* holder_count is the WHOLE subnet, not the returned page -- said
+            explicitly, because a reader looking at 20 rows would otherwise
+            reasonably assume the number describes them. */}
+        {data?.holder_count != null ? (
+          <span>
+            {formatNumber(data.holder_count)} holders
+            {holders.length < data.holder_count ? ` · top ${holders.length} shown` : ""}
+          </span>
+        ) : null}
+        {data?.total_alpha != null ? <span>· {fmtAlpha(data.total_alpha)} held</span> : null}
+        {conc?.top5_share != null ? <span>· top 5 hold {pctStr(conc.top5_share)}</span> : null}
+        {conc?.top10_share != null ? <span>· top 10 {pctStr(conc.top10_share)}</span> : null}
+        {conc?.top20_share != null ? <span>· top 20 {pctStr(conc.top20_share)}</span> : null}
+        {data?.captured_at ? <RealtimeFreshness at={data.captured_at} /> : null}
+      </div>
+      <Panel as="div" flush className="overflow-hidden">
+        {/* Mobile card fallback, mirroring NeuronTable's (#6335). Measured at
+            375px, the four-column table pushed the Hotkeys column off the
+            scrollport entirely and wrapped "41.2k α" onto two lines mid-unit --
+            the page did not overflow (the scroll container held it), so nothing
+            in the responsive-overflow sweep would have caught it. One card per
+            holder, each figure labelled, is the house answer to a table too
+            wide to read narrow. */}
+        <ul className="divide-y divide-border/60 md:hidden">
+          {holders.map((entry) => (
+            <li key={entry.coldkey} className="space-y-2 px-4 py-3">
+              <div className="min-w-0">
+                <AddressDisplay ss58={entry.coldkey} fallback="—" compact />
+              </div>
+              <dl className="flex flex-wrap gap-x-4 gap-y-1 mg-type-caption">
+                <div className="flex items-baseline gap-1.5">
+                  <dt className="mg-type-caption text-ink-muted">Alpha</dt>
+                  <dd className="font-mono tabular-nums whitespace-nowrap text-ink-strong">
+                    {fmtAlpha(entry.alpha)}
+                  </dd>
+                </div>
+                <div className="flex items-baseline gap-1.5">
+                  <dt className="mg-type-caption text-ink-muted">Share</dt>
+                  <dd className="font-mono tabular-nums whitespace-nowrap text-ink">
+                    {pctStr(entry.share_of_total)}
+                  </dd>
+                </div>
+                <div className="flex items-baseline gap-1.5">
+                  <dt className="mg-type-caption text-ink-muted">Hotkeys</dt>
+                  <dd className="font-mono tabular-nums whitespace-nowrap text-ink-muted">
+                    {entry.hotkey_count == null ? "—" : formatNumber(entry.hotkey_count)}
+                  </dd>
+                </div>
+              </dl>
+            </li>
+          ))}
+        </ul>
+        <div className="hidden overflow-x-auto md:block">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-surface/40">
+              <tr>
+                <th className="px-4 py-2.5 mg-type-micro text-ink-muted">Coldkey</th>
+                <th className="px-4 py-2.5 text-right mg-type-micro text-ink-muted">Alpha</th>
+                <th className="px-4 py-2.5 text-right mg-type-micro text-ink-muted">Share</th>
+                <th className="px-4 py-2.5 text-right mg-type-micro text-ink-muted">Hotkeys</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {holders.map((entry) => (
+                <tr key={entry.coldkey} className="mg-row-accent hover:bg-surface/40">
+                  {/* min-w-0 so a long resolved identity truncates instead of
+                      widening the row past the viewport at 375px. */}
+                  <td className="px-4 py-2.5 align-top">
+                    <div className="min-w-0">
+                      <AddressDisplay ss58={entry.coldkey} fallback="—" compact />
+                    </div>
+                  </td>
+                  <td className="px-4 py-2.5 align-top text-right font-mono mg-type-caption tabular-nums whitespace-nowrap text-ink-strong">
+                    {fmtAlpha(entry.alpha)}
+                  </td>
+                  <td className="px-4 py-2.5 align-top text-right font-mono mg-type-caption tabular-nums whitespace-nowrap text-ink">
+                    {pctStr(entry.share_of_total)}
+                  </td>
+                  <td className="px-4 py-2.5 align-top text-right font-mono mg-type-caption tabular-nums whitespace-nowrap text-ink-muted">
+                    {entry.hotkey_count == null ? "—" : formatNumber(entry.hotkey_count)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Panel>
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -315,6 +315,7 @@ export function SubnetMasthead({
       `/api/v1/subnets/${netuid}/stake-quote?amount=100&direction=stake`,
       `/api/v1/subnets/${netuid}/lease`,
       `/api/v1/subnets/${netuid}/lease/history`,
+      `/api/v1/subnets/${netuid}/holders`,
       `/api/v1/agent-catalog/${netuid}`,
     ],
     [`/metagraph/subnets/${netuid}.json`],

--- a/apps/ui/src/lib/metagraphed/queries.subnet-holders.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-holders.test.ts
@@ -1,0 +1,210 @@
+// The subnet alpha-holder leaderboard query (#9557 backend, #9597 frontend).
+//
+// The assertions that matter here are all about NOT COERCING NULLS. The route
+// declines rather than answering in two states -- the pool ledger has no
+// complete pass, or netuid 0, which the chain's Alpha map does not cover -- and
+// a decline arrives as `holders: []` with every aggregate null plus a
+// `degraded` block. A `?? 0` anywhere in this normalizer would turn "we could
+// not rank this subnet" into "this subnet has 0 holders holding 0 alpha", which
+// is exactly the confusion the backend's degraded block exists to prevent,
+// recreated one layer up and invisible in the UI.
+//
+// So: `degraded` must survive verbatim, and the aggregates must stay null.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeSubnetHolderEntry, normalizeSubnetHolders, subnetHoldersQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/74/holders",
+  });
+}
+
+function runQuery<
+  O extends {
+    queryKey: readonly unknown[];
+    queryFn?: (context: never) => unknown;
+  },
+>(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
+}
+
+const RAW_ENTRY = {
+  coldkey: "5Cold1",
+  alpha: 250.5,
+  share_of_total: 0.25,
+  hotkey_count: 3,
+};
+
+const RAW_CARD = {
+  schema_version: 1,
+  netuid: 74,
+  limit: 20,
+  holder_count: 520,
+  total_alpha: 1002,
+  concentration: { top5_share: 0.31, top10_share: 0.44, top20_share: 0.58 },
+  captured_at: "2026-08-05T18:00:00.000Z",
+  positions_captured_at: "2026-08-05T18:14:34.407Z",
+  holders: [RAW_ENTRY],
+};
+
+beforeEach(() => {
+  mockedApiFetch.mockReset();
+});
+
+describe("normalizeSubnetHolderEntry", () => {
+  it("passes a well-formed entry through", () => {
+    expect(normalizeSubnetHolderEntry(RAW_ENTRY)).toEqual(RAW_ENTRY);
+  });
+
+  it("drops a non-object and a row with no coldkey", () => {
+    expect(normalizeSubnetHolderEntry(null)).toBeNull();
+    expect(normalizeSubnetHolderEntry("5Cold1")).toBeNull();
+    expect(normalizeSubnetHolderEntry({ alpha: 1 })).toBeNull();
+  });
+
+  it("keeps a null share null rather than calling it zero", () => {
+    // share_of_total is null when the subnet's measured total is zero. A 0%
+    // share asserts the holder owns none of something; null says the question
+    // has no answer. Same for hotkey_count.
+    const entry = normalizeSubnetHolderEntry({
+      coldkey: "5Cold1",
+      alpha: 0,
+      share_of_total: null,
+      hotkey_count: null,
+    });
+    expect(entry).toEqual({
+      coldkey: "5Cold1",
+      alpha: 0,
+      share_of_total: null,
+      hotkey_count: null,
+    });
+  });
+
+  it("defaults only the amount, because a named holder is still a holder", () => {
+    const entry = normalizeSubnetHolderEntry({ coldkey: "5Cold1", alpha: "junk" });
+    expect(entry?.alpha).toBe(0);
+    expect(entry?.share_of_total).toBeNull();
+  });
+});
+
+describe("normalizeSubnetHolders", () => {
+  it("passes a well-formed card through", () => {
+    expect(normalizeSubnetHolders(74, RAW_CARD)).toEqual({ ...RAW_CARD, degraded: null });
+  });
+
+  it("degrades a cold or junk payload to a schema-stable card", () => {
+    for (const raw of [undefined, null, "nope", 42, []]) {
+      const card = normalizeSubnetHolders(74, raw);
+      expect(card.netuid).toBe(74);
+      expect(card.holders).toEqual([]);
+      expect(card.degraded).toBeNull();
+      expect(card.holder_count).toBeNull();
+      expect(card.concentration).toEqual({
+        top5_share: null,
+        top10_share: null,
+        top20_share: null,
+      });
+    }
+  });
+
+  it("preserves a decline verbatim, with every aggregate still null", () => {
+    // The shape the live route returns today: rows exist in the ledger and are
+    // deliberately not ranked.
+    const card = normalizeSubnetHolders(74, {
+      schema_version: 1,
+      netuid: 74,
+      limit: 20,
+      holder_count: null,
+      total_alpha: null,
+      concentration: { top5_share: null, top10_share: null, top20_share: null },
+      captured_at: null,
+      positions_captured_at: null,
+      holders: [],
+      degraded: { reason: "pool_totals_unproven" },
+    });
+    expect(card.degraded).toEqual({ reason: "pool_totals_unproven" });
+    expect(card.holder_count).toBeNull();
+    expect(card.total_alpha).toBeNull();
+    expect(card.concentration.top5_share).toBeNull();
+    expect(card.captured_at).toBeNull();
+  });
+
+  it("distinguishes a decline from a measured empty subnet", () => {
+    // Both carry `holders: []`. Only the presence of `degraded` separates
+    // "could not rank" from "nobody holds any", and the component branches on
+    // exactly this.
+    const declined = normalizeSubnetHolders(74, {
+      holders: [],
+      degraded: { reason: "root_not_in_alpha_map" },
+    });
+    const measured = normalizeSubnetHolders(74, {
+      holders: [],
+      holder_count: 0,
+      total_alpha: 0,
+    });
+    expect(declined.degraded?.reason).toBe("root_not_in_alpha_map");
+    expect(measured.degraded).toBeNull();
+    // A MEASURED zero survives as a zero -- it is a real count, not an absence.
+    expect(measured.holder_count).toBe(0);
+    expect(measured.total_alpha).toBe(0);
+  });
+
+  it("ignores a malformed degraded block rather than inventing a reason", () => {
+    expect(normalizeSubnetHolders(74, { degraded: {} }).degraded).toBeNull();
+    expect(normalizeSubnetHolders(74, { degraded: "broken" }).degraded).toBeNull();
+  });
+
+  it("drops a malformed row without poisoning the batch", () => {
+    const card = normalizeSubnetHolders(74, {
+      ...RAW_CARD,
+      holders: [RAW_ENTRY, null, { alpha: 5 }, { coldkey: "5Cold2", alpha: 10 }],
+    });
+    expect(card.holders.map((h) => h.coldkey)).toEqual(["5Cold1", "5Cold2"]);
+  });
+
+  it("falls back to the requested netuid when the payload omits it", () => {
+    expect(normalizeSubnetHolders(74, { holders: [] }).netuid).toBe(74);
+  });
+});
+
+describe("subnetHoldersQuery", () => {
+  it("hits the holders route and normalizes the payload", async () => {
+    resolveWith(RAW_CARD);
+    const res = await runQuery(subnetHoldersQuery(74));
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/74/holders",
+      expect.objectContaining({ params: undefined }),
+    );
+    expect(res.data.holders).toHaveLength(1);
+    expect(res.data.holder_count).toBe(520);
+  });
+
+  it("passes an explicit limit through as a query param", async () => {
+    resolveWith(RAW_CARD);
+    await runQuery(subnetHoldersQuery(74, 50));
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/74/holders",
+      expect.objectContaining({ params: { limit: "50" } }),
+    );
+  });
+
+  it("keys the cache on the limit, so two page sizes do not share a slot", () => {
+    expect(subnetHoldersQuery(74).queryKey).not.toEqual(subnetHoldersQuery(74, 50).queryKey);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -224,6 +224,8 @@ import type {
   SubnetOhlcCandle,
   SubnetConviction,
   SubnetConvictionEntry,
+  SubnetHolderEntry,
+  SubnetHolders,
   SubnetOwnershipHistory,
   SubnetLeaseState,
   SubnetLeaseTerms,
@@ -5265,6 +5267,77 @@ export const subnetConvictionQuery = (netuid: number) =>
         { signal },
       );
       return { data: normalizeSubnetConviction(netuid, res.data), meta: res.meta, url: res.url };
+    },
+    staleTime: STALE_MED,
+  });
+
+// A well-formed holder row, or null to drop a malformed one rather than
+// poisoning the whole leaderboard -- mirrors normalizeSubnetConvictionEntry.
+//
+// `alpha` defaults to 0 because a row that reached here named a coldkey, and a
+// holder with an unreadable amount is still a holder. The two SHARE fields do
+// NOT default: null means "no share to state" (the subnet's measured total is
+// zero) and 0 would claim the holder owns none of it.
+export function normalizeSubnetHolderEntry(raw: unknown): SubnetHolderEntry | null {
+  if (!isRecord(raw)) return null;
+  const coldkey = firstString(raw.coldkey);
+  if (!coldkey) return null;
+  return {
+    coldkey,
+    alpha: coerceFiniteNumber(raw.alpha) ?? 0,
+    share_of_total: firstFiniteNumber(raw.share_of_total) ?? null,
+    hotkey_count: firstFiniteNumber(raw.hotkey_count) ?? null,
+  };
+}
+
+// Cold/absent store, a DECLINE, and a subnet with genuinely no holders all
+// yield a schema-stable card -- never throws.
+//
+// THE AGGREGATES STAY NULL WHEN THEY ARE NULL. `?? 0` on any of them would turn
+// "we could not rank this subnet" into "this subnet has 0 holders holding 0
+// alpha", which is the exact confusion the route's `degraded` block exists to
+// prevent, recreated one layer up. `degraded` is preserved verbatim for the
+// same reason: it is the only thing distinguishing a decline from a
+// measurement, since both carry an empty `holders`.
+export function normalizeSubnetHolders(netuid: number, raw: unknown): SubnetHolders {
+  const d = isRecord(raw) ? raw : {};
+  const holders = Array.isArray(d.holders)
+    ? d.holders.map(normalizeSubnetHolderEntry).filter((e): e is SubnetHolderEntry => e != null)
+    : [];
+  const c = isRecord(d.concentration) ? d.concentration : {};
+  const reason = isRecord(d.degraded) ? firstString(d.degraded.reason) : null;
+  return {
+    schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+    netuid: firstFiniteNumber(d.netuid) ?? netuid,
+    limit: firstFiniteNumber(d.limit) ?? null,
+    holder_count: firstFiniteNumber(d.holder_count) ?? null,
+    total_alpha: firstFiniteNumber(d.total_alpha) ?? null,
+    concentration: {
+      top5_share: firstFiniteNumber(c.top5_share) ?? null,
+      top10_share: firstFiniteNumber(c.top10_share) ?? null,
+      top20_share: firstFiniteNumber(c.top20_share) ?? null,
+    },
+    captured_at: firstString(d.captured_at) ?? null,
+    positions_captured_at: firstString(d.positions_captured_at) ?? null,
+    holders,
+    degraded: reason ? { reason } : null,
+  };
+}
+
+// GET /api/v1/subnets/{netuid}/holders (#9557): who owns this subnet's alpha,
+// ranked by alpha held, INCLUDING alpha staked to hotkeys that hold no UID on
+// the subnet -- the part /concentration cannot see, since it reads registered
+// UIDs' stake. Declines rather than serving an empty ranking while the pool
+// ledger is unproven, so `degraded` has to survive normalization.
+export const subnetHoldersQuery = (netuid: number, limit?: number) =>
+  queryOptions({
+    queryKey: k("subnet-holders", netuid, limit ?? null),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetHolders>>(`/api/v1/subnets/${netuid}/holders`, {
+        params: limit == null ? undefined : { limit: String(limit) },
+        signal,
+      });
+      return { data: normalizeSubnetHolders(netuid, res.data), meta: res.meta, url: res.url };
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2237,6 +2237,51 @@ export interface SubnetConviction {
   leaderboard: SubnetConvictionEntry[];
 }
 
+/** One coldkey's holding of a subnet's alpha, from
+ * /api/v1/subnets/{netuid}/holders (#9557). `alpha` is WHOLE ALPHA, not rao --
+ * the producer converts before writing (`rao_to_alpha_f64`), unlike the
+ * conviction leaderboard's rao-scale figures. share_of_total is over the
+ * subnet's FULL measured total, so it means the same thing at any `limit`;
+ * null when that total is zero. hotkey_count counts distinct hotkeys this
+ * coldkey holds through, registered on the subnet or not. */
+export interface SubnetHolderEntry {
+  coldkey: string;
+  alpha: number;
+  share_of_total: number | null;
+  hotkey_count: number | null;
+}
+
+/** Concentration of a subnet's alpha. Each rank is summed over the top N of
+ * the FULL holder set rather than the returned page, and is null when there is
+ * no total to divide by. */
+export interface SubnetHoldersConcentration {
+  top5_share: number | null;
+  top10_share: number | null;
+  top20_share: number | null;
+}
+
+/** Per-subnet alpha holder leaderboard (#9557).
+ *
+ * EVERY AGGREGATE IS NULLABLE, and that is the contract rather than an
+ * inconvenience: the route DECLINES in two states -- the pool ledger has no
+ * complete pass (`pool_totals_unproven`), or netuid 0, which the chain's Alpha
+ * map does not cover (`root_not_in_alpha_map`) -- and a decline returns an
+ * empty `holders` with null counts and a `degraded` block. So an empty
+ * `holders` list WITHOUT `degraded` is a MEASUREMENT: the subnet genuinely has
+ * no holders. Coercing these nulls to 0 anywhere would erase that difference. */
+export interface SubnetHolders {
+  schema_version: number;
+  netuid: number;
+  limit: number | null;
+  holder_count: number | null;
+  total_alpha: number | null;
+  concentration: SubnetHoldersConcentration;
+  captured_at: string | null;
+  positions_captured_at: string | null;
+  holders: SubnetHolderEntry[];
+  degraded: { reason: string } | null;
+}
+
 /** One automatic ownership transfer, decoded from a chain_events
  * SubnetOwnerChanged row (#6637). old_coldkey/new_coldkey are SS58-encoded. */
 export interface SubnetOwnershipChange {

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -64,6 +64,7 @@ import { EndpointSnippet, apiSnippet } from "@/components/metagraphed/endpoint-s
 import { SubnetHistoryChart } from "@/components/metagraphed/subnet-history-chart";
 import { SubnetOhlcChart } from "@/components/metagraphed/subnet-ohlc-chart";
 import { SubnetConvictionLeaderboard } from "@/components/metagraphed/subnet-conviction-leaderboard";
+import { SubnetHoldersLeaderboard } from "@/components/metagraphed/subnet-holders-leaderboard";
 import { SubnetOwnershipHistory } from "@/components/metagraphed/subnet-ownership-history";
 import { SubnetLeasePanel } from "@/components/metagraphed/subnet-lease-panel";
 import { MetagraphTableLoader } from "@/components/metagraphed/metagraph-panel";
@@ -170,6 +171,7 @@ const SECTION_TO_TAB: Record<string, string> = {
   metagraph: "metagraph",
   neuron: "metagraph",
   concentration: "metagraph",
+  holders: "metagraph",
   yield: "metagraph",
   turnover: "metagraph",
   validators: "metagraph",
@@ -1971,6 +1973,18 @@ function MetagraphPanel({ netuid }: { netuid: number }) {
       >
         <QueryErrorBoundary>
           <DistributionPanel netuid={netuid} />
+        </QueryErrorBoundary>
+      </SectionAnchor>
+
+      <SectionAnchor
+        id="holders"
+        title="Alpha holders"
+        subtitle="Who owns this subnet's alpha: the top coldkeys by alpha held, including alpha staked to hotkeys that hold no UID here."
+        info="GET /api/v1/subnets/{netuid}/holders — coldkeys ranked by alpha held on this subnet, read from the stake-position ledger rather than from registered UIDs, so passive holders are included. Aggregates cover the whole subnet, not the returned rows."
+        tone="muted"
+      >
+        <QueryErrorBoundary>
+          <SubnetHoldersLeaderboard netuid={netuid} />
         </QueryErrorBoundary>
       </SectionAnchor>
 


### PR DESCRIPTION
## Summary

- Adds an **Alpha holders** section to the subnet page's Metagraph tab, beside `#concentration`, consuming `GET /api/v1/subnets/{netuid}/holders` (#9557).
- Scoped to `apps/ui/**` only — 7 files, ~470 LOC including tests.

## What Changed

`#concentration` looks like it answers this and does not: it computes Gini/HHI/Nakamoto off `neurons.stake_tao`, so it sees registered UIDs only and emits scalars rather than a holder list. On netuid 74 that is 10 of the 92 hotkeys carrying positions — the other 82 are exactly what this section shows.

Table of top coldkeys (`AddressDisplay`, since these are account-page-linkable unlike the hotkeys in the conviction/nominators tables), alpha, share of the subnet total, distinct hotkey count. Caption strip carries the whole-subnet aggregates plus a `RealtimeFreshness` chip on the pool-pass stamp.

## Three things that would each have shipped a UI that looks correct

**1. A decline is not an empty result — and both arrive as `holders: []`.** The route withholds a ranking while the pool ledger has no complete pass (`pool_totals_unproven`) and for netuid 0 (`root_not_in_alpha_map`). Rendering either through `EmptyState` would state *"this subnet has no alpha holders"* — a confident claim about the chain made from an absence of data, which is the exact thing the backend's `degraded` block exists to prevent.

So the degraded branch is checked **before** the length check, and renders an informational notice in the `DataTierUnavailableNotice` shape (nothing failed, nothing is missing — the ranking is withheld) with per-reason copy. `EmptyState` is reserved for a measured zero. The normalizer keeps null aggregates null for the same reason: a `?? 0` anywhere recreates the confusion one layer up, invisibly. Both are pinned by tests, including the branch *ordering*.

**2. The alpha unit.** The conviction leaderboard's local `fmtAlpha` divides by 1e9 because `locked_mass`/`conviction` arrive rao-scale. This producer converts before writing (`rao_to_alpha_f64`), so copying that helper would report every holder as a billionth of its real size — which renders as a plausible dust balance, not as an obvious bug. Verified against the producer source, and pinned by a test that fails if the divisor reappears.

**3. Mobile.** Measured at 375px, the four-column table pushed **Hotkeys off the scrollport entirely** and wrapped `41.2k α` mid-unit onto two lines:

| Before (375px) | After (375px) |
|---|---|
| 4-column table; `HOT…` header clipped, values unreachable without horizontal scroll; `41.2k` / `α` on separate lines | one card per holder, address on one line, all three figures labelled and visible |

**The page did not overflow** — the scroll container held it, `documentElement.scrollWidth === innerWidth` at every width — so the responsive-overflow sweep would not have caught this, and neither would reading the code. Fixed with the `md:hidden` card fallback `NeuronTable` already uses for the same defect class (#6335).

## Verification

Rendered and inspected in a real browser at **375 / 768 / 1280 in both themes**, across all three states (populated via a stubbed response, declined against live production, measured-empty). Horizontal overflow checked at every width: none.

Per the maintainer convention, no 12-image before/after table for our own PRs — but this **is** a visual change, so it should be held for manual review rather than auto-merged.

- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npx vitest run --root apps/ui` — **1,837 passed / 234 files** (23 of them new)
- [x] `npm run test:e2e --workspace=apps/ui` — **104 passed, 2 skipped**
- [x] `npm run build --workspace=apps/ui`

**`subnets-1.har` did not need re-recording** and the overflow baseline is unchanged: the section mounts on the Metagraph tab, and the sweep loads only the default Overview tab, so no new request is issued on the recorded route. Confirmed by the e2e run passing with `notFound: "abort"` in force.

`packages/client` / `packages/ui-kit` sources are untouched, so no `dist` rebuild is carried here. (`packages/ui-kit` did need a local build before `typecheck` would resolve its types — pre-existing, not from this change.)

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited — none in this diff.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes — none; this consumes an existing route.

Closes #9597
