### PR TITLE
feat(observability): give the poller's job outcomes a queryable sink

### DIFF
--- a/src/poller-lane-health.ts
+++ b/src/poller-lane-health.ts
@@ -1,0 +1,139 @@
+// The poller's own job outcomes, made queryable (metagraphed-infra#343 phase 1).
+//
+// WHAT THIS FIXES, precisely. On 2026-08-05 `hotkey_alpha` held zero rows for
+// about ten hours. It was never slow and never stuck: it failed **95 seconds**
+// into every run -- its publish floor was larger than the map it guarded -- and
+// then slept 24 hours. Nothing anywhere reported that, because:
+//
+//   * `wrangler tail` on the poller shows nothing during a scan. The job only
+//     logs once it starts POSTing, so a failure BEFORE that point is silent.
+//   * `lane_health` held only WATCHDOG verdicts, and watchdogs are Worker-side.
+//     Its silence about `hotkey-alpha` meant "no watchdog ran", not "the lane is
+//     fine" -- an absence that reads exactly like health.
+//   * Every staleness watchdog keys on `MAX(captured_at)`, and a table that has
+//     NEVER held a row has no timestamp to age. A lane that has never once
+//     succeeded is invisible to the exact mechanism built to catch lanes that
+//     stopped.
+//
+// Hours went into inferring the cause from row counts. Running the job locally
+// answered it in 95 seconds. The difference was not diagnosis skill, it was
+// having somewhere to look.
+//
+// SO THE PRODUCER REPORTS, rather than the reader inferring. `log_job_outcome`
+// in the poller already computes everything needed -- scanned, written, errors,
+// elapsed, and whether the tick succeeded -- and only printed it. It now posts
+// here, and a failed tick becomes a row.
+//
+// WHY THIS IS NOT JUST ANOTHER NOTIFICATION. src/lane-health.ts's own header
+// makes the argument and it applies unchanged: a notification answers "was
+// anyone paged", a row answers "was anything broken overnight". This is the
+// second question, for the half of the system D1 could not see.
+//
+// A REPORT IS NOT A MEASUREMENT OF ITSELF. A lane that never runs at all still
+// writes nothing here -- exactly like the watchdogs it complements. That gap is
+// closed by `neverSucceededLanes` below, which asks which lanes are EXPECTED and
+// have no successful tick, rather than waiting for a lane to tell on itself.
+
+import type { LaneVerdict } from "./lane-health.ts";
+
+/** The poller lanes that are expected to report. Absence from `lane_health` is
+ * only meaningful against a list of what SHOULD be there -- see
+ * neverSucceededLanes. Mirrors POLLER_ONLY in metagraphed-infra's
+ * Dockerfile.poller; the wiring guard there keeps that list honest. */
+export const EXPECTED_POLLER_LANES = [
+  "account-balances",
+  "account-identity",
+  "chain-detail",
+  "hotkey-alpha",
+  "metagraph",
+  "subnet-hyperparams",
+  "validator-nominators",
+] as const;
+
+/** One reported tick, in the shape the poller posts. */
+export interface PollerJobOutcome {
+  lane: string;
+  /** `ok` when the tick completed, `stale` when it failed. `unknown` is not
+   * used here: the producer always knows which happened, unlike a watchdog that
+   * may be unable to evaluate at all. */
+  verdict: LaneVerdict;
+  /** How long the tick took. Named for lane_health's column rather than for
+   * what it measures, so one table answers one question. */
+  age_ms: number | null;
+  /** The job's own message, kept verbatim -- this is the line that would
+   * otherwise have gone to a container stderr nobody can read. */
+  detail: string | null;
+  checked_at: number;
+}
+
+const MAX_DETAIL_CHARS = 2_000;
+
+/**
+ * Validate one reported outcome.
+ *
+ * DELIBERATELY PERMISSIVE ABOUT `lane`. A new poller lane must be able to
+ * report on its FIRST run, before anyone has added it to a list here -- the
+ * alternative is that the newest lane, which is the one most likely to be
+ * broken, is the one that cannot tell you. `EXPECTED_POLLER_LANES` is used for
+ * the absence check, not as an allowlist for writes.
+ */
+export function validPollerJobOutcome(
+  row: unknown,
+): row is Record<string, unknown> {
+  const r = row as Record<string, unknown> | null;
+  if (!r || typeof r !== "object") return false;
+  if (typeof r.lane !== "string" || !r.lane || r.lane.length > 64) return false;
+  if (r.verdict !== "ok" && r.verdict !== "stale" && r.verdict !== "unknown") {
+    return false;
+  }
+  if (
+    r.age_ms != null &&
+    (typeof r.age_ms !== "number" || !Number.isFinite(r.age_ms) || r.age_ms < 0)
+  ) {
+    return false;
+  }
+  if (r.detail != null && typeof r.detail !== "string") return false;
+  if (
+    typeof r.checked_at !== "number" ||
+    !Number.isInteger(r.checked_at) ||
+    r.checked_at <= 0
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/** Project a validated row onto the lane_health record shape, truncating the
+ * detail. An error message can carry a whole decode dump; the first couple of
+ * thousand characters are the triage value and the rest is table growth. */
+export function coercePollerJobOutcome(
+  row: Record<string, unknown>,
+): PollerJobOutcome {
+  const detail = typeof row.detail === "string" ? row.detail : null;
+  return {
+    lane: row.lane as string,
+    verdict: row.verdict as LaneVerdict,
+    age_ms: typeof row.age_ms === "number" ? Math.round(row.age_ms) : null,
+    detail: detail ? detail.slice(0, MAX_DETAIL_CHARS) : null,
+    checked_at: row.checked_at as number,
+  };
+}
+
+/**
+ * Which expected lanes have NEVER reported a successful tick.
+ *
+ * THE QUESTION NO STALENESS WATCHDOG CAN ASK. They all key on how old the newest
+ * success is, so a lane with zero successes has no age and produces no verdict --
+ * `hotkey-alpha` was invisible for ten hours for exactly this reason. Asking
+ * which lanes are missing from a set of successes inverts it: absence becomes
+ * the signal instead of the blind spot.
+ *
+ * Pure, so the rule is testable without a database.
+ */
+export function neverSucceededLanes(
+  succeeded: Iterable<string>,
+  expected: readonly string[] = EXPECTED_POLLER_LANES,
+): string[] {
+  const seen = new Set(succeeded);
+  return expected.filter((lane) => !seen.has(lane));
+}

--- a/tests/poller-lane-health.test.ts
+++ b/tests/poller-lane-health.test.ts
@@ -1,0 +1,121 @@
+// Poller job outcomes reaching a queryable sink (metagraphed-infra#343 phase 1).
+//
+// THE INCIDENT THIS IS SIZED AGAINST. `hotkey_alpha` held zero rows for ~10
+// hours. It failed 95 seconds into every run and slept 24 hours, and nothing
+// reported it: the job only logs once it starts POSTing, so a failure before
+// that is silent; `lane_health` held watchdog verdicts only; and every
+// staleness watchdog keys on MAX(captured_at), which a never-successful lane
+// does not have.
+//
+// So the assertions below are mostly about ABSENCE being detectable, which is
+// the property that was missing rather than the one that was wrong.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  coercePollerJobOutcome,
+  EXPECTED_POLLER_LANES,
+  neverSucceededLanes,
+  validPollerJobOutcome,
+} from "../src/poller-lane-health.ts";
+
+const OK = {
+  lane: "hotkey-alpha",
+  verdict: "ok",
+  age_ms: 95_600,
+  detail: null,
+  checked_at: 1_785_960_000_000,
+};
+
+describe("validPollerJobOutcome", () => {
+  test("accepts a well-formed outcome", () => {
+    assert.equal(validPollerJobOutcome(OK), true);
+    assert.equal(validPollerJobOutcome({ ...OK, verdict: "stale" }), true);
+    assert.equal(validPollerJobOutcome({ ...OK, age_ms: null }), true);
+  });
+
+  test("accepts a lane nobody has listed yet", () => {
+    // A NEW lane must be able to report on its first run. The newest lane is
+    // the one most likely to be broken, so an allowlist here would silence
+    // exactly the case this exists for -- which is what happened to
+    // hotkey-alpha, absent from two of three wiring lists.
+    assert.equal(validPollerJobOutcome({ ...OK, lane: "brand-new" }), true);
+  });
+
+  test("rejects shapes that would land as junk", () => {
+    for (const bad of [
+      null,
+      "not an object",
+      { ...OK, lane: "" },
+      { ...OK, lane: "x".repeat(65) },
+      { ...OK, verdict: "fine" },
+      { ...OK, age_ms: -1 },
+      { ...OK, age_ms: Number.NaN },
+      { ...OK, detail: 42 },
+      { ...OK, checked_at: 0 },
+      { ...OK, checked_at: 1.5 },
+      { ...OK, checked_at: "yesterday" },
+    ]) {
+      assert.equal(validPollerJobOutcome(bad), false, JSON.stringify(bad));
+    }
+  });
+});
+
+describe("coercePollerJobOutcome", () => {
+  test("keeps the job's own message verbatim", () => {
+    // This string is the whole point: it is the line that otherwise goes to a
+    // container stderr nobody can read. The real one read "scan ended at 48779
+    // entries, under the 76257 floor".
+    const detail =
+      "scan ended at 48779 entries, under the 76257 floor (0 decode error(s))";
+    assert.equal(
+      coercePollerJobOutcome({ ...OK, verdict: "stale", detail }).detail,
+      detail,
+    );
+  });
+
+  test("truncates a runaway detail rather than growing the table", () => {
+    const row = coercePollerJobOutcome({ ...OK, detail: "x".repeat(10_000) });
+    assert.equal(row.detail!.length, 2_000);
+  });
+
+  test("rounds a fractional elapsed, and preserves null", () => {
+    assert.equal(coercePollerJobOutcome({ ...OK, age_ms: 95.6 }).age_ms, 96);
+    assert.equal(coercePollerJobOutcome({ ...OK, age_ms: null }).age_ms, null);
+  });
+});
+
+describe("neverSucceededLanes", () => {
+  test("names a lane that has never once succeeded", () => {
+    // THE REGRESSION. hotkey-alpha ran, failed, and left no successful tick for
+    // ten hours. No staleness watchdog could see it, because there was no
+    // captured_at to age -- absence was the signal and nothing was reading it.
+    const succeeded = EXPECTED_POLLER_LANES.filter((l) => l !== "hotkey-alpha");
+    assert.deepEqual(neverSucceededLanes(succeeded), ["hotkey-alpha"]);
+  });
+
+  test("is quiet when every expected lane has succeeded", () => {
+    assert.deepEqual(neverSucceededLanes(EXPECTED_POLLER_LANES), []);
+  });
+
+  test("names ALL missing lanes, not just the first", () => {
+    assert.deepEqual(neverSucceededLanes(["metagraph"]).length, 6);
+  });
+
+  test("an unexpected lane reporting does not mask a missing one", () => {
+    // A lane nobody expected is not evidence about the ones we do expect.
+    const succeeded = ["some-future-lane", ...EXPECTED_POLLER_LANES].filter(
+      (l) => l !== "chain-detail",
+    );
+    assert.deepEqual(neverSucceededLanes(succeeded), ["chain-detail"]);
+  });
+
+  test("an empty success set names every expected lane", () => {
+    // The cold-start shape, and the one that must not read as healthy: nothing
+    // has reported, so everything is unproven.
+    assert.deepEqual(
+      neverSucceededLanes([]),
+      [...EXPECTED_POLLER_LANES],
+      "no reports means no lane is proven, not that all are fine",
+    );
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -410,6 +410,11 @@ import {
 import { BLOCKLIST_KV_KEY, BLOCKLIST_KV_TTL } from "./tiered-rate-limit.ts";
 import { MCP_TIERED_RATE_LIMIT } from "../src/mcp-server.ts";
 import { createPgSql } from "../src/pg-sql.ts";
+import { recordLaneVerdict } from "../src/lane-health.ts";
+import {
+  coercePollerJobOutcome,
+  validPollerJobOutcome,
+} from "../src/poller-lane-health.ts";
 import {
   createSessionToken,
   createTriggerToken,
@@ -2273,6 +2278,87 @@ async function handleHotkeyAlphaSync(request: Request, env: Env) {
     // silently dropped -- the failure mode a purely optional field invites.
     pass_total: pass?.expectedRows ?? null,
   });
+}
+
+// --- POST /api/v1/internal/poller-lane-health-sync -------------------------
+//
+// The poller reporting its OWN job outcomes (metagraphed-infra#343 phase 1).
+// See src/poller-lane-health.ts for why: `hotkey_alpha` failed 95 seconds into
+// every run for ten hours and nothing anywhere said so, because container
+// stderr has no queryable destination and every staleness watchdog keys on a
+// MAX(captured_at) that a never-successful lane does not have.
+//
+// SMALL BODY, NO PASS ACCOUNTING. This is one row per tick, not a bulk load, so
+// it needs none of the chunking or completeness machinery the data lanes carry.
+const POLLER_LANE_HEALTH_TOKEN_HEADER = "x-poller-lane-health-sync-token";
+const POLLER_LANE_HEALTH_MAX_BODY_BYTES = 64_000;
+const POLLER_LANE_HEALTH_MAX_ROWS = 50;
+
+async function handlePollerLaneHealthSync(request: Request, env: Env) {
+  if (!env.POLLER_LANE_HEALTH_SYNC_SECRET) {
+    return writeJson(
+      {
+        error: "poller lane-health sync is not provisioned on this deployment",
+      },
+      503,
+    );
+  }
+  const provided = request.headers.get(POLLER_LANE_HEALTH_TOKEN_HEADER) || "";
+  if (
+    !provided ||
+    !timingSafeEqual(provided, env.POLLER_LANE_HEALTH_SYNC_SECRET)
+  ) {
+    return writeJson(
+      { error: `provide a valid ${POLLER_LANE_HEALTH_TOKEN_HEADER} header` },
+      401,
+    );
+  }
+
+  const raw = await request.text();
+  if (utf8Bytes(raw).length > POLLER_LANE_HEALTH_MAX_BODY_BYTES) {
+    return writeJson(
+      { error: `body exceeds ${POLLER_LANE_HEALTH_MAX_BODY_BYTES} bytes` },
+      413,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return writeJson({ error: "body must be JSON" }, 400);
+  }
+  const incoming = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.rows)
+      ? parsed.rows
+      : null;
+  if (!incoming) {
+    return writeJson(
+      { error: "body must be a JSON array of outcomes (or {rows:[...]})" },
+      400,
+    );
+  }
+  if (incoming.length > POLLER_LANE_HEALTH_MAX_ROWS) {
+    return writeJson(
+      { error: `at most ${POLLER_LANE_HEALTH_MAX_ROWS} rows per request` },
+      413,
+    );
+  }
+  if (!incoming.length || !incoming.every(validPollerJobOutcome)) {
+    return writeJson({ error: "rows must match the outcome shape" }, 400);
+  }
+  if (!env.METAGRAPH_HEALTH_DB) {
+    return writeJson({ error: "d1 binding unavailable" }, 503);
+  }
+
+  // recordLaneVerdict swallows its own failures by design -- an alarm whose
+  // recording can break the alarm is worse than the bug. So the count of rows
+  // that actually landed is reported rather than assumed.
+  let written = 0;
+  for (const row of incoming.map(coercePollerJobOutcome)) {
+    if (await recordLaneVerdict(env.METAGRAPH_HEALTH_DB, row)) written += 1;
+  }
+  return writeJson({ ok: true, lane_health_written: written, stores: ["d1"] });
 }
 
 // --- POST /api/v1/internal/subnet-identity-sync (#4832 gap-closure) -------
@@ -6478,6 +6564,12 @@ async function dispatchDataApiRequest(
       url.pathname === "/api/v1/internal/hotkey-alpha-sync"
     ) {
       return handleHotkeyAlphaSync(request, env);
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/internal/poller-lane-health-sync"
+    ) {
+      return handlePollerLaneHealthSync(request, env);
     }
     if (
       request.method === "POST" &&

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -112,6 +112,7 @@ interface Env {
    * any high-entropy random string works, and until both sides hold it the
    * poller logs "job will not run" rather than failing quietly. */
   HOTKEY_ALPHA_SYNC_SECRET?: string;
+  POLLER_LANE_HEALTH_SYNC_SECRET?: string;
   METAGRAPH_ALLOW_R2_STATIC_FALLBACK?: string;
   METAGRAPH_DISABLE_REQUEST_LOGS?: string;
   METAGRAPH_HEALTH_MAX_AGE_HOURS?: string;


### PR DESCRIPTION
`Closes #9599` — Phase 1 of metagraphed-infra#343.

`hotkey_alpha` held **0 rows for ~10 hours** today. It failed **95 seconds** into every run and slept 24 hours. Nothing reported it.

## Three blind spots, all hit at once

| | why it was silent |
|---|---|
| `wrangler tail` on the poller | the job only logs once it starts POSTing — a failure *before* that produces no line |
| `lane_health` | held only **watchdog** verdicts (Worker-side), so silence about `hotkey-alpha` meant "no watchdog ran" — an absence that reads like health |
| every staleness watchdog | keys on `MAX(captured_at)`; a lane that has **never** succeeded has no timestamp to age, so the mechanism for catching *stopped* lanes cannot see one that never *started* |

Hours went into inferring the cause from row counts, across four wrong theories. Running the job locally answered it in **95 seconds**. The difference wasn't diagnosis — it was having somewhere to look.

## What this adds

**`POST /api/v1/internal/poller-lane-health-sync`.** `log_job_outcome` already computes scanned/written/errors/elapsed and only printed them; now a failed tick becomes a row carrying the job's own message verbatim — the line that otherwise went to unreadable container stderr. The real one read *"scan ended at 48779 entries, under the 76257 floor"*, and that single string would have ended the investigation immediately.

**`neverSucceededLanes`.** A lane that never runs still writes nothing here — same gap as the watchdogs. So this asks which **expected** lanes have no successful tick, inverting it: absence becomes the signal.

## One deliberate design choice

The write path is **permissive about lane names**. A new lane must be able to report on its first run — the newest lane is the one most likely to be broken, and an allowlist would silence exactly the case this exists for. Not hypothetical: `hotkey-alpha` shipped missing from two of three wiring lists.

Detail is truncated at 2,000 chars (an error can carry a whole decode dump), and `recordLaneVerdict` keeps its existing swallow-failures posture — an alarm whose recording breaks the alarm is worse than the bug.

| gate | result |
|---|---|
| `lint` / `format:check` / `typecheck` | clean |
| `validate` / `scan:public-safety` | pass |
| `npx vitest run` | **692 files, 16,555 tests, 0 failures** |

**Follow-up, not in this PR:** the producer side in metagraphed-infra, plus `POLLER_LANE_HEALTH_SYNC_SECRET` on both Workers. The route returns 503 "not provisioned" until then, matching the sibling sync routes.