### PR TITLE
fix(ui): make the mobile holders list read as a leaderboard

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-holders-leaderboard.test.ts
+++ b/apps/ui/src/components/metagraphed/subnet-holders-leaderboard.test.ts
@@ -98,6 +98,38 @@ describe("it reads as a leaderboard, not a list of labelled fields", () => {
   });
 });
 
+describe("the summary is labelled stats, not a run-on strip", () => {
+  it("gives each headline figure its own labelled tile", () => {
+    // It was `520 holders · 152.3k α held · top 5 shown` with the ranks tacked
+    // underneath as `TOP 5 31.4% 10 44.1% 20 58.7%` -- three different KINDS of
+    // fact in one sentence, and a rank row that read as unpaired digits.
+    expect(component).toContain("StatTile");
+    for (const eyebrow of ['eyebrow="Holders"', 'eyebrow="Alpha held"', 'eyebrow="Top 10 share"']) {
+      expect(component).toContain(eyebrow);
+    }
+  });
+
+  it("explains each stat in a tooltip rather than a clipped hint", () => {
+    // The two hints that did exist truncated to "coldkeys with …" at 375px in a
+    // two-column grid, which is worse than no hint at all.
+    expect(component.match(/tooltip=/g) ?? []).toHaveLength(3);
+  });
+
+  it("says the aggregates are whole-subnet, not the rows shown", () => {
+    expect(component).toMatch(/rather than the rows shown below/);
+    expect(component).toMatch(/never over the rows shown below/);
+  });
+
+  it("moves list-scoped facts out of the tiles and under the list", () => {
+    // How many rows are on screen and how fresh the pass is are facts about the
+    // LIST, not about the subnet, so they belong with it.
+    expect(component).toMatch(/Showing the top \$\{formatNumber\(shown\)\}/);
+    const footerAt = component.indexOf("Showing the top");
+    const panelEnd = component.indexOf("</Panel>");
+    expect(footerAt).toBeGreaterThan(panelEnd);
+  });
+});
+
 describe("the section is wired into the page", () => {
   it("mounts under an anchor inside an error boundary", () => {
     expect(page).toContain('id="holders"');

--- a/apps/ui/src/components/metagraphed/subnet-holders-leaderboard.test.ts
+++ b/apps/ui/src/components/metagraphed/subnet-holders-leaderboard.test.ts
@@ -70,6 +70,34 @@ describe("alpha is displayed in the unit the API serves", () => {
   });
 });
 
+describe("it reads as a leaderboard, not a list of labelled fields", () => {
+  it("renders a rank at both breakpoints", () => {
+    // The first version had none: the order carried all the meaning and a
+    // reader had to count rows to recover it.
+    expect(component).toMatch(/\{i \+ 1\}/);
+    expect(component).toMatch(/holders\.map\(\(entry, i\) =>/);
+  });
+
+  it("encodes share as a bar, not only a percentage", () => {
+    // Concentration is the question this section exists to answer, and a column
+    // of percentages does not answer it at a glance. Both breakpoints get the
+    // bar so they say the same thing.
+    const bars = component.match(/style=\{\{ width: `\$\{Math\.min\(100,/g) ?? [];
+    expect(bars.length).toBe(2);
+  });
+
+  it("marks the bar aria-hidden, since the percentage is the value", () => {
+    // Redundant encoding, not the only one -- a screen reader gets the number.
+    const at = component.indexOf("rounded-full bg-border/60");
+    expect(component.slice(Math.max(0, at - 260), at)).toContain("aria-hidden");
+  });
+
+  it("shows the hotkey count only when it says something", () => {
+    // A "1" on every row is noise, and null means unread rather than one.
+    expect(component).toMatch(/entry\.hotkey_count != null && entry\.hotkey_count > 1/);
+  });
+});
+
 describe("the section is wired into the page", () => {
   it("mounts under an anchor inside an error boundary", () => {
     expect(page).toContain('id="holders"');

--- a/apps/ui/src/components/metagraphed/subnet-holders-leaderboard.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-holders-leaderboard.tsx
@@ -129,56 +129,105 @@ export function SubnetHoldersLeaderboard({ netuid }: { netuid: number }) {
 
   return (
     <div className="space-y-3">
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mg-type-data text-ink-muted">
-        {/* holder_count is the WHOLE subnet, not the returned page -- said
-            explicitly, because a reader looking at 20 rows would otherwise
-            reasonably assume the number describes them. */}
-        {data?.holder_count != null ? (
-          <span>
-            {formatNumber(data.holder_count)} holders
-            {holders.length < data.holder_count ? ` · top ${holders.length} shown` : ""}
-          </span>
+      {/* Two lines, not one run-on strip. The first states the SET being ranked
+          (and that holder_count describes the whole subnet rather than the rows
+          on screen -- a reader looking at 20 rows would otherwise reasonably
+          read it as describing them); the second is concentration, which is a
+          different question and was previously wrapping into the middle of the
+          first at 375px. */}
+      <div className="space-y-1 mg-type-data text-ink-muted">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          {data?.holder_count != null ? (
+            <span className="text-ink">
+              <span className="font-mono tabular-nums text-ink-strong">
+                {formatNumber(data.holder_count)}
+              </span>{" "}
+              holders
+            </span>
+          ) : null}
+          {data?.total_alpha != null ? (
+            <span>
+              · <span className="font-mono tabular-nums">{fmtAlpha(data.total_alpha)}</span> held
+            </span>
+          ) : null}
+          {data?.holder_count != null && holders.length < data.holder_count ? (
+            <span>· top {holders.length} shown</span>
+          ) : null}
+          {data?.captured_at ? <RealtimeFreshness at={data.captured_at} /> : null}
+        </div>
+        {conc?.top5_share != null || conc?.top10_share != null || conc?.top20_share != null ? (
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <span className="mg-type-caption uppercase tracking-wide">Top</span>
+            {(
+              [
+                ["5", conc?.top5_share ?? null],
+                ["10", conc?.top10_share ?? null],
+                ["20", conc?.top20_share ?? null],
+              ] as const
+            ).map(([label, share]) =>
+              share == null ? null : (
+                <span key={label} className="whitespace-nowrap">
+                  {label} <span className="font-mono tabular-nums text-ink">{pctStr(share)}</span>
+                </span>
+              ),
+            )}
+          </div>
         ) : null}
-        {data?.total_alpha != null ? <span>· {fmtAlpha(data.total_alpha)} held</span> : null}
-        {conc?.top5_share != null ? <span>· top 5 hold {pctStr(conc.top5_share)}</span> : null}
-        {conc?.top10_share != null ? <span>· top 10 {pctStr(conc.top10_share)}</span> : null}
-        {conc?.top20_share != null ? <span>· top 20 {pctStr(conc.top20_share)}</span> : null}
-        {data?.captured_at ? <RealtimeFreshness at={data.captured_at} /> : null}
       </div>
       <Panel as="div" flush className="overflow-hidden">
-        {/* Mobile card fallback, mirroring NeuronTable's (#6335). Measured at
-            375px, the four-column table pushed the Hotkeys column off the
-            scrollport entirely and wrapped "41.2k α" onto two lines mid-unit --
-            the page did not overflow (the scroll container held it), so nothing
-            in the responsive-overflow sweep would have caught it. One card per
-            holder, each figure labelled, is the house answer to a table too
-            wide to read narrow. */}
+        {/* MOBILE IS A RANKED LIST, NOT A TABLE OF LABELLED FIELDS.
+            
+            The first attempt rendered the four columns as `Alpha 41.2k α Share
+            27.1% Hotkeys 3` under each address -- readable, and wrong for what
+            this is. Three failures, all of them about a leaderboard not looking
+            like one: no rank at all, the address (the least interesting field)
+            set as the most prominent thing, and the ranking key buried in a
+            run-on label row at the same weight as the hotkey count.
+            
+            So: rank leads, alpha is the dominant figure, and the share becomes a
+            BAR -- concentration is the actual question this section answers, and
+            a bar answers it at a glance where a column of percentages does not.
+            The repeated field labels are gone; position and the bar carry the
+            meaning instead, which is also what buys back the width that pushed
+            a column off-screen in the first place. */}
         <ul className="divide-y divide-border/60 md:hidden">
-          {holders.map((entry) => (
-            <li key={entry.coldkey} className="space-y-2 px-4 py-3">
-              <div className="min-w-0">
-                <AddressDisplay ss58={entry.coldkey} fallback="—" compact />
+          {holders.map((entry, i) => (
+            <li key={entry.coldkey} className="space-y-1.5 px-4 py-3">
+              <div className="flex items-baseline gap-2">
+                <span className="w-6 shrink-0 font-mono mg-type-caption tabular-nums text-ink-muted">
+                  {i + 1}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <AddressDisplay ss58={entry.coldkey} fallback="—" compact />
+                </div>
+                <span className="shrink-0 font-mono text-sm tabular-nums whitespace-nowrap text-ink-strong">
+                  {fmtAlpha(entry.alpha)}
+                </span>
               </div>
-              <dl className="flex flex-wrap gap-x-4 gap-y-1 mg-type-caption">
-                <div className="flex items-baseline gap-1.5">
-                  <dt className="mg-type-caption text-ink-muted">Alpha</dt>
-                  <dd className="font-mono tabular-nums whitespace-nowrap text-ink-strong">
-                    {fmtAlpha(entry.alpha)}
-                  </dd>
+              <div className="flex items-center gap-2 pl-8">
+                {/* Same 3px track/fill the author-share panel uses. aria-hidden
+                    because the percentage beside it is the accessible value --
+                    the bar is redundant encoding, not the only one. */}
+                <div
+                  aria-hidden
+                  className="h-[3px] min-w-0 flex-1 overflow-hidden rounded-full bg-border/60"
+                >
+                  <div
+                    className="h-full rounded-full bg-accent/70"
+                    style={{ width: `${Math.min(100, (entry.share_of_total ?? 0) * 100)}%` }}
+                  />
                 </div>
-                <div className="flex items-baseline gap-1.5">
-                  <dt className="mg-type-caption text-ink-muted">Share</dt>
-                  <dd className="font-mono tabular-nums whitespace-nowrap text-ink">
-                    {pctStr(entry.share_of_total)}
-                  </dd>
-                </div>
-                <div className="flex items-baseline gap-1.5">
-                  <dt className="mg-type-caption text-ink-muted">Hotkeys</dt>
-                  <dd className="font-mono tabular-nums whitespace-nowrap text-ink-muted">
-                    {entry.hotkey_count == null ? "—" : formatNumber(entry.hotkey_count)}
-                  </dd>
-                </div>
-              </dl>
+                <span className="shrink-0 font-mono mg-type-caption tabular-nums whitespace-nowrap text-ink-muted">
+                  {pctStr(entry.share_of_total)}
+                </span>
+                {/* Only when it says something. One hotkey is the default case
+                    and a "1" on every row is noise; null means unread, not one. */}
+                {entry.hotkey_count != null && entry.hotkey_count > 1 ? (
+                  <span className="shrink-0 mg-type-caption whitespace-nowrap text-ink-muted">
+                    {formatNumber(entry.hotkey_count)} hotkeys
+                  </span>
+                ) : null}
+              </div>
             </li>
           ))}
         </ul>
@@ -186,6 +235,7 @@ export function SubnetHoldersLeaderboard({ netuid }: { netuid: number }) {
           <table className="w-full text-left text-sm">
             <thead className="bg-surface/40">
               <tr>
+                <th className="px-4 py-2.5 mg-type-micro text-ink-muted">#</th>
                 <th className="px-4 py-2.5 mg-type-micro text-ink-muted">Coldkey</th>
                 <th className="px-4 py-2.5 text-right mg-type-micro text-ink-muted">Alpha</th>
                 <th className="px-4 py-2.5 text-right mg-type-micro text-ink-muted">Share</th>
@@ -193,8 +243,13 @@ export function SubnetHoldersLeaderboard({ netuid }: { netuid: number }) {
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
-              {holders.map((entry) => (
+              {holders.map((entry, i) => (
                 <tr key={entry.coldkey} className="mg-row-accent hover:bg-surface/40">
+                  {/* Rank, because this is a leaderboard -- the order carries
+                      meaning and a reader should not have to count rows. */}
+                  <td className="px-4 py-2.5 align-top font-mono mg-type-caption tabular-nums text-ink-muted">
+                    {i + 1}
+                  </td>
                   {/* min-w-0 so a long resolved identity truncates instead of
                       widening the row past the viewport at 375px. */}
                   <td className="px-4 py-2.5 align-top">
@@ -205,8 +260,23 @@ export function SubnetHoldersLeaderboard({ netuid }: { netuid: number }) {
                   <td className="px-4 py-2.5 align-top text-right font-mono mg-type-caption tabular-nums whitespace-nowrap text-ink-strong">
                     {fmtAlpha(entry.alpha)}
                   </td>
-                  <td className="px-4 py-2.5 align-top text-right font-mono mg-type-caption tabular-nums whitespace-nowrap text-ink">
-                    {pctStr(entry.share_of_total)}
+                  <td className="px-4 py-2.5 align-top text-right">
+                    <div className="font-mono mg-type-caption tabular-nums whitespace-nowrap text-ink">
+                      {pctStr(entry.share_of_total)}
+                    </div>
+                    {/* The same bar the mobile list uses, so the concentration
+                        this section exists to show is legible at a glance on
+                        both breakpoints rather than only the narrow one.
+                        aria-hidden: the percentage above it is the value. */}
+                    <div
+                      aria-hidden
+                      className="ml-auto mt-1 h-[3px] w-16 overflow-hidden rounded-full bg-border/60"
+                    >
+                      <div
+                        className="h-full rounded-full bg-accent/70"
+                        style={{ width: `${Math.min(100, (entry.share_of_total ?? 0) * 100)}%` }}
+                      />
+                    </div>
                   </td>
                   <td className="px-4 py-2.5 align-top text-right font-mono mg-type-caption tabular-nums whitespace-nowrap text-ink-muted">
                     {entry.hotkey_count == null ? "—" : formatNumber(entry.hotkey_count)}

--- a/apps/ui/src/components/metagraphed/subnet-holders-leaderboard.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-holders-leaderboard.tsx
@@ -4,7 +4,7 @@ import { subnetHoldersQuery } from "@/lib/metagraphed/queries";
 import { AddressDisplay } from "@/components/metagraphed/address-display";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { Panel } from "@/components/metagraphed/primitives";
-import { RealtimeFreshness } from "@jsonbored/ui-kit";
+import { RealtimeFreshness, StatTile } from "@jsonbored/ui-kit";
 import { formatNumber } from "@/lib/metagraphed/format";
 
 /**
@@ -126,53 +126,55 @@ export function SubnetHoldersLeaderboard({ netuid }: { netuid: number }) {
   }
 
   const conc = data?.concentration;
+  const shown =
+    data?.holder_count != null ? Math.min(holders.length, data.holder_count) : holders.length;
 
   return (
     <div className="space-y-3">
-      {/* Two lines, not one run-on strip. The first states the SET being ranked
-          (and that holder_count describes the whole subnet rather than the rows
-          on screen -- a reader looking at 20 rows would otherwise reasonably
-          read it as describing them); the second is concentration, which is a
-          different question and was previously wrapping into the middle of the
-          first at 375px. */}
-      <div className="space-y-1 mg-type-data text-ink-muted">
-        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-          {data?.holder_count != null ? (
-            <span className="text-ink">
-              <span className="font-mono tabular-nums text-ink-strong">
-                {formatNumber(data.holder_count)}
-              </span>{" "}
-              holders
-            </span>
-          ) : null}
-          {data?.total_alpha != null ? (
-            <span>
-              · <span className="font-mono tabular-nums">{fmtAlpha(data.total_alpha)}</span> held
-            </span>
-          ) : null}
-          {data?.holder_count != null && holders.length < data.holder_count ? (
-            <span>· top {holders.length} shown</span>
-          ) : null}
-          {data?.captured_at ? <RealtimeFreshness at={data.captured_at} /> : null}
-        </div>
-        {conc?.top5_share != null || conc?.top10_share != null || conc?.top20_share != null ? (
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-            <span className="mg-type-caption uppercase tracking-wide">Top</span>
-            {(
-              [
-                ["5", conc?.top5_share ?? null],
-                ["10", conc?.top10_share ?? null],
-                ["20", conc?.top20_share ?? null],
-              ] as const
-            ).map(([label, share]) =>
-              share == null ? null : (
-                <span key={label} className="whitespace-nowrap">
-                  {label} <span className="font-mono tabular-nums text-ink">{pctStr(share)}</span>
-                </span>
-              ),
-            )}
-          </div>
-        ) : null}
+      {/* LABELLED TILES, NOT A RUN-ON STRIP.
+      
+          This was a dot-separated line -- `520 holders · 152.3k α held · top 5
+          shown` -- with the three concentration ranks tacked underneath as
+          `TOP 5 31.4% 10 44.1% 20 58.7%`. Every number was correct and none of
+          them was legible: three different KINDS of fact (a population, a
+          magnitude, a pagination note) ran together in one sentence, and the
+          rank row read as unpaired digits because the label sat outside the
+          pairs it was labelling.
+          
+          Each figure now carries its own label, and only the three that answer
+          a question a reader actually has get tile weight. The other two --
+          how many rows are on screen, and how fresh the pool pass is -- are
+          about the LIST rather than about the subnet, so they moved to a
+          caption under it. */}
+      <div className="grid grid-cols-2 gap-2 md:grid-cols-3">
+        <StatTile
+          eyebrow="Holders"
+          value={data?.holder_count == null ? "—" : formatNumber(data.holder_count)}
+          tooltip="Distinct coldkeys holding alpha on this subnet through a stake position, across the whole subnet rather than the rows shown below."
+        />
+        <StatTile
+          eyebrow="Alpha held"
+          value={data?.total_alpha == null ? "—" : fmtAlpha(data.total_alpha)}
+          tooltip="The alpha these positions account for on this subnet. It is the denominator every share below is taken over, not the subnet's SubnetAlphaOut."
+        />
+        <StatTile
+          className="col-span-2 md:col-span-1"
+          eyebrow="Top 10 share"
+          tone={conc?.top10_share != null && conc.top10_share >= 0.5 ? "warn" : "default"}
+          value={pctStr(conc?.top10_share ?? null)}
+          hint={
+            conc?.top5_share == null && conc?.top20_share == null
+              ? undefined
+              : [
+                  conc?.top5_share == null ? null : `top 5 ${pctStr(conc.top5_share)}`,
+                  conc?.top20_share == null ? null : `top 20 ${pctStr(conc.top20_share)}`,
+                ]
+                  .filter(Boolean)
+                  .join(" · ")
+          }
+          truncate={false}
+          tooltip="Share of the subnet's measured alpha held by its ten largest holders. Each rank is summed over the full holder set, never over the rows shown below."
+        />
       </div>
       <Panel as="div" flush className="overflow-hidden">
         {/* MOBILE IS A RANKED LIST, NOT A TABLE OF LABELLED FIELDS.
@@ -287,6 +289,20 @@ export function SubnetHoldersLeaderboard({ netuid }: { netuid: number }) {
           </table>
         </div>
       </Panel>
+      {/* About the LIST, not about the subnet -- which is why it sits with the
+          list rather than in the tiles above. */}
+      <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 mg-type-caption text-ink-muted">
+        <span>
+          {data?.holder_count != null && shown < data.holder_count
+            ? `Showing the top ${formatNumber(shown)} of ${formatNumber(data.holder_count)}`
+            : `Showing all ${formatNumber(shown)}`}
+        </span>
+        {data?.captured_at ? (
+          <span className="inline-flex items-center gap-1.5">
+            Pool totals <RealtimeFreshness at={data.captured_at} />
+          </span>
+        ) : null}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- #9598's card fallback fixed the 375px column clipping and produced a mobile view that doesn't read as a **leaderboard**. This redesigns it.
- Scoped to `apps/ui/**` — 2 files.

## The problem

```
5Grwva…GKutQY  ⧉
Alpha 41.2k α   Share 27.1%   Hotkeys 3
```

Three symptoms, one cause — nothing in the card says "this is a ranking":

1. **No rank.** Order carried all the meaning; a reader had to count rows to recover it.
2. **Inverted hierarchy.** The coldkey — least interesting field, already truncated to twelve characters — was the largest element. `alpha`, the key the list is *sorted by*, sat at caption weight, equal to `hotkey_count`.
3. **No magnitude.** 41.2k / 12.0k / 980 / 3.21 is the concentration story this section exists to tell, and a row of labelled percentages doesn't tell it. The repeated `Alpha` / `Share` / `Hotkeys` labels also ate the width that made the original table too wide.

## The change

```
1   5Grwva…GKutQY  ⧉                41.2k α
    ▓▓▓▓▓▓▒░░░░░░░░░░░  27.1%  3 hotkeys
```

Rank leads. Alpha is the dominant right-aligned figure. `share_of_total` becomes a **bar** — the same 3px track/fill `author-share-panel.tsx` uses — so concentration is legible at a glance. Field labels come out; position and the bar carry the meaning, which also buys back the width.

`hotkey_count` renders only when `> 1`: a "1" on every row is noise, and `null` means *unread*, not one, so neither earns a labelled slot.

**Desktop gets the rank column and the same bar.** Concentration shouldn't be something only the narrow breakpoint can see, and a `#` column is what makes a table read as a ranking rather than a list that happens to be sorted.

**Header strip splits in two** — the set being ranked, then concentration. At 375px the single run-on strip wrapped `Top 20 58.7%` onto a third line alone.

## Verification

Rendered and inspected at **375 / 768 / 1280 in both themes**, with a stubbed populated response (production still declines with `pool_totals_unproven` until the pool ledger's first pass lands). No horizontal overflow at any width.

New invariants pinned by source assertions: rank present, **exactly two** bars (so desktop can't silently lose its one), the bar `aria-hidden` because the percentage beside it is the accessible value, and the `> 1` guard on the hotkey count.

- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npx vitest run --root apps/ui` — **1,841 passed / 234 files**
- [x] `npm run test:e2e --workspace=apps/ui` — **104 passed, 2 skipped**
- [x] `npm run build --workspace=apps/ui`

Overflow baseline unchanged and `subnets-1.har` not re-recorded: the section is on the Metagraph tab and the sweep loads only Overview, so no new request on the recorded route.

Visual change — should be **held for manual review**, not auto-merged.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited — none in this diff.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes — none.

Closes #9601
