### PR TITLE
feat(pg): add a D1Runner-shaped Postgres adapter for the analytics modules

### DIFF
--- a/src/pg-sql.ts
+++ b/src/pg-sql.ts
@@ -96,3 +96,55 @@ export function createPgSql(
   sql.unsafe = (text: string, values: unknown[] = []) => run(text, values);
   return sql;
 }
+
+/**
+ * A `D1Runner`-shaped adapter over Postgres.
+ *
+ * `D1Runner` is `(sql, params) => Promise<Row[]>`, and four analytics modules
+ * (`movers`, `turnover`, `chain-turnover`, `concentration`) already take one as
+ * a parameter rather than reaching for a binding. That injection is what makes
+ * moving them a matter of handing over a different runner instead of editing
+ * their queries -- the same property `createPgSql` gives the tagged-template
+ * routes.
+ *
+ * THE TRANSLATION IS THE WHOLE RISK. Those modules write SQLite's positional
+ * `?`, and Postgres needs `$1, $2, ...` numbered in the same order. Getting it
+ * wrong does not throw: it binds a value to the wrong column and returns a
+ * confident wrong answer. So `toPositionalPlaceholders` is exported and
+ * asserted directly rather than trusted through a query that happens to pass.
+ */
+export function toPositionalPlaceholders(sql: string): string {
+  let n = 0;
+  let out = "";
+  let quote: string | null = null;
+  for (let i = 0; i < sql.length; i += 1) {
+    const ch = sql[i]!;
+    // A `?` inside a string literal is data, not a placeholder. SQLite escapes
+    // a quote by doubling it, and since the doubled pair reads as close-then-
+    // open the state ends up correct either way.
+    if (quote) {
+      if (ch === quote) quote = null;
+      out += ch;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      out += ch;
+      continue;
+    }
+    out += ch === "?" ? `$${(n += 1)}` : ch;
+  }
+  return out;
+}
+
+/** Build a D1Runner backed by Hyperdrive. Callers pass this where they would
+ * otherwise pass the D1-backed runner; the modules themselves are untouched. */
+export function createPgD1Runner(
+  hyperdrive: HyperdriveLike,
+  ctx: WaitUntilLike,
+  clientFactory?: (connectionString: string) => Client,
+): (sql: string, params: unknown[]) => Promise<PgSqlRows> {
+  const sql = createPgSql(hyperdrive, ctx, clientFactory);
+  return (text: string, params: unknown[] = []) =>
+    sql.unsafe(toPositionalPlaceholders(text), params);
+}

--- a/tests/pg-sql.test.ts
+++ b/tests/pg-sql.test.ts
@@ -11,7 +11,12 @@
 // that a query ran.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { createPgSql, pgStatementText } from "../src/pg-sql.ts";
+import {
+  createPgD1Runner,
+  createPgSql,
+  pgStatementText,
+  toPositionalPlaceholders,
+} from "../src/pg-sql.ts";
 
 /** A `pg` Client stand-in that records what it was asked to do. */
 function fakeClient(rows: Record<string, unknown>[] = []) {
@@ -190,5 +195,95 @@ describe("createPgSql", () => {
       () => client as never,
     );
     assert.deepEqual(await sql`SELECT 1`, []);
+  });
+});
+
+describe("toPositionalPlaceholders", () => {
+  test("numbers each ? in order", () => {
+    assert.equal(
+      toPositionalPlaceholders(
+        "SELECT * FROM t WHERE a = ? AND b = ? ORDER BY c LIMIT ?",
+      ),
+      "SELECT * FROM t WHERE a = $1 AND b = $2 ORDER BY c LIMIT $3",
+    );
+  });
+
+  test("leaves a ? inside a string literal alone", () => {
+    // THE CASE THAT SILENTLY CORRUPTS. Renumbering a `?` that is data shifts
+    // every placeholder after it, so values bind one column off -- and the
+    // query still runs.
+    assert.equal(
+      toPositionalPlaceholders(
+        "SELECT ? WHERE label = 'why? really' AND b = ?",
+      ),
+      "SELECT $1 WHERE label = 'why? really' AND b = $2",
+    );
+  });
+
+  test("handles a doubled quote inside a literal", () => {
+    // SQLite escapes a quote by doubling it. Read as close-then-open the state
+    // still lands correct, which this pins rather than leaves to luck.
+    assert.equal(
+      toPositionalPlaceholders("SELECT ? WHERE s = 'it''s ok' AND t = ?"),
+      "SELECT $1 WHERE s = 'it''s ok' AND t = $2",
+    );
+  });
+
+  test("handles double-quoted identifiers", () => {
+    assert.equal(
+      toPositionalPlaceholders('SELECT "od?d" FROM t WHERE a = ?'),
+      'SELECT "od?d" FROM t WHERE a = $1',
+    );
+  });
+
+  test("a statement with no placeholders is unchanged", () => {
+    const s = "SELECT count(*) FROM neuron_daily";
+    assert.equal(toPositionalPlaceholders(s), s);
+  });
+
+  test("placeholder count is preserved exactly", () => {
+    // The property that actually has to hold at any width: n placeholders in,
+    // n numbered placeholders out, numbered 1..n with no gaps or repeats.
+    const sql = "a=? b=? c=? d=? e=? f=? g=? h=? i=? j=? k=?";
+    const out = toPositionalPlaceholders(sql);
+    assert.deepEqual(
+      out.match(/\$\d+/g),
+      Array.from({ length: 11 }, (_, i) => `$${i + 1}`),
+    );
+    assert.equal(out.includes("?"), false);
+  });
+});
+
+describe("createPgD1Runner", () => {
+  test("translates and binds, so an injected module needs no change", async () => {
+    const { client, calls } = fakeClient([{ n: 1 }]);
+    const { ctx } = ctxSpy();
+    const run = createPgD1Runner(
+      { connectionString: "postgres://x" },
+      ctx,
+      () => client as never,
+    );
+    const rows = await run(
+      "SELECT * FROM neuron_daily WHERE netuid = ? AND snapshot_date >= ?",
+      [64, "2026-08-01"],
+    );
+    assert.deepEqual(rows, [{ n: 1 }]);
+    assert.equal(
+      calls[0]!.text,
+      "SELECT * FROM neuron_daily WHERE netuid = $1 AND snapshot_date >= $2",
+    );
+    assert.deepEqual(calls[0]!.values, [64, "2026-08-01"]);
+  });
+
+  test("defaults params, matching the D1Runner contract", async () => {
+    const { client, calls } = fakeClient();
+    const { ctx } = ctxSpy();
+    const run = createPgD1Runner(
+      { connectionString: "postgres://x" },
+      ctx,
+      () => client as never,
+    );
+    await run("SELECT 1", []);
+    assert.deepEqual(calls[0]!.values, []);
   });
 });


### PR DESCRIPTION
Closes #9603 — groundwork for Neon Stage 2 (`neuron_daily`), metagraphed-infra#336.

## Why separate from the cutover

`neuron_daily`'s 31 read sites are two shapes:

| shape | sites | how it moves |
|---|---|---|
| tagged template in `data-api.ts` | 20 | already covered by `createPgSql` (#9592) |
| `D1Runner` parameter in `movers` / `turnover` / `chain-turnover` / `concentration` | 11 | needs this adapter |

Those four modules already take a `D1Runner` **as a parameter**, so moving them is handing over a different runner — not editing their queries. **No call site is switched in this PR.** This retires the translation risk on its own so the cutover is pure wiring.

## The risk, and the case that silently corrupts

SQLite uses positional `?`; Postgres needs `$1, $2, …` in the same order. Getting it wrong **does not throw** — it binds a value to the wrong column and returns a confident wrong answer.

The subtle one is a `?` **inside a string literal**:

```sql
SELECT ? WHERE label = 'why? really' AND b = ?
```

A naive replace renumbers the literal's `?` and shifts every placeholder after it — values bind one column off, and the query still runs. So the translator tracks quote state, including SQLite's doubled-quote escape (`'it''s ok'`) and double-quoted identifiers, each with its own test.

Also asserted: **count preservation at width** — 11 placeholders in, `$1..$11` out, no gaps, no repeats, and no `?` surviving.

| gate | result |
|---|---|
| `lint` / `format:check` / `typecheck` | clean |
| `npx vitest run` | **16,563 tests, 0 failures** (18 in `pg-sql`) |