### PR TITLE
fix(api): proxy poller-lane-health-sync, so the route is actually reachable

### DIFF
--- a/workers/api.ts
+++ b/workers/api.ts
@@ -3091,6 +3091,26 @@ async function handleHotkeyAlphaSyncProxy(request: Request, env: Env) {
   });
 }
 
+// Proxies POST /api/v1/internal/poller-lane-health-sync -- the poller's own
+// tick outcomes (#9599). NOT a data lane: this is the DIAGNOSTIC channel, and
+// it exists because hotkey_alpha failed 95 seconds into every run for ten hours
+// with nothing anywhere able to say so.
+//
+// THIS FILE IS THE FOURTH PLACE A SYNC ROUTE MUST BE REGISTERED, and the one
+// that is easiest to miss: the route can be complete and deployed in data-api
+// and still 404, because api.metagraph.sh is fronted by THIS Worker and it
+// forwards only the paths it names. That is exactly how #9600 shipped a route
+// nothing could reach.
+async function handlePollerLaneHealthSyncProxy(request: Request, env: Env) {
+  return proxyToDataApi(request, env, {
+    code: "poller_lane_health_sync_unavailable",
+    notBoundMessage:
+      "The poller lane-health sink is not bound to this deployment.",
+    unreadableMessage:
+      "The poller lane-health sink returned an unreadable response.",
+  });
+}
+
 // --- POST /api/v1/internal/emission-gate-sync (#8748/#8750 restored) --------
 // The persistence half of the emission-gate sampling lane, moved off the
 // decommissioned box's Postgres onto D1. scripts/sample-emission-gate.ts (now
@@ -3881,6 +3901,11 @@ export async function handleRequest(
   // scan POSTs here. Same DATA_API service binding.
   if (url.pathname === "/api/v1/internal/hotkey-alpha-sync") {
     return handleHotkeyAlphaSyncProxy(request, env);
+  }
+  // The poller's own tick outcomes (#9599) -- the diagnostic channel, not a
+  // data lane. Same DATA_API service binding.
+  if (url.pathname === "/api/v1/internal/poller-lane-health-sync") {
+    return handlePollerLaneHealthSyncProxy(request, env);
   }
   // The write path into the emission-gate history tables on D1 (#8748/#8750,
   // box decommission) -- sample-emission-gate.yml's 10-minute schedule POSTs


### PR DESCRIPTION
Closes #9605

#9600 shipped `POST /api/v1/internal/poller-lane-health-sync`, merged it, and deployed it. The route still 404s.

`api.metagraph.sh` is fronted by the **main** Worker, which forwards only the internal paths it explicitly names — each with its own `*Proxy` helper over the `DATA_API` service binding. The handler was complete and live in `data-api` and simply unreachable.

## A sync route has four registration points, not three

| # | place | silent when omitted? |
|---|---|---|
| 1 | handler in `data-api.ts` | yes |
| 2 | path match in `data-api.ts` | yes |
| 3 | secret on both Workers | yes — 503 |
| 4 | **proxy in `api.ts`** | yes — **404 on deployed code** |

The fourth is the nastiest signal: a route whose code you can point at in the deployed bundle, returning 404. Same shape as `hotkey-alpha` shipping absent from two of three poller wiring lists and presenting as an empty table.

## What it cost

The observability work from #9599 had been **inert since it merged** — the poller reported every tick, every report 404'd, and `hotkey_alpha`, the lane that motivated the whole thing, was still unobservable.

| gate | result |
|---|---|
| `lint` / `format:check` / `typecheck` | clean |
| `npx vitest run` | **16,564 tests, 0 failures** |

Worth a follow-up: the poller-lane-wiring guard in metagraphed-infra catches the three-place omission on that side. Nothing yet catches this four-place one, and it has now cost a full cycle.