### PR TITLE
feat(queue): stand up sync-batches with a no-op consumer

### DIFF
--- a/src/sync-batch-queue.ts
+++ b/src/sync-batch-queue.ts
@@ -1,0 +1,121 @@
+// The bulk sync path, on a queue (metagraphed-infra#346/#347).
+//
+// WHAT THIS REPLACES, and why it is a refactor rather than a rescue. Each bulk
+// lane grew its own substitute for what a queue provides: a retry loop with
+// hand-tuned backoff, a one-second inter-chunk sleep standing in for
+// backpressure, a declared `pass_total` standing in for "did the batch set
+// drain", and a publish floor standing in for "was the scan even complete".
+// Every one was a correct local fix for the D1 saturation on 2026-08-05 --
+// `D1_ERROR: D1 DB is overloaded. Requests queued for too long.`, which aborted
+// the passes and also failed `wallet-auth` and `tao-usd-index` on the database
+// everything shares. Together they are an orchestration layer nobody designed.
+//
+// All of that machinery currently WORKS -- five consecutive complete
+// account-balances passes, a complete hotkey-alpha pass, the top-holders
+// columns live. So this replaces working code, which is exactly why it goes one
+// lane at a time behind a producer-side switch.
+//
+// NO DUAL WRITE. A lane enqueues OR posts, never both. Writing everything twice
+// during the migration doubles the load that caused the incident, and duplicate
+// arrivals corrupt the completeness tally -- `received_rows` counted against a
+// declared `pass_total` is what caught a ledger publishing 147,000 of 364,000
+// rows while looking perfectly fresh.
+//
+// WHAT THE QUEUE DOES NOT GIVE, and must not be deleted along with the
+// scaffolding it does replace:
+//
+//   * PASS COMPLETENESS. A queue knows a message was delivered. It does not
+//     know whether a producer's whole SCAN arrived, which is a different fact
+//     and the one that stopped a wrong leaderboard publishing.
+//   * THE PUBLISH FLOOR. A truncated scan is a producer-side fact the queue
+//     never sees at all.
+//
+// Both survive this migration deliberately. See metagraphed-infra#352.
+
+/** One chunk of a lane's pass, as producers enqueue it. */
+export interface SyncBatchMessage {
+  /** Which lane produced it -- `hotkey-alpha`, `account-balances`, … */
+  lane: string;
+  /** The pass this chunk belongs to, stamped once by the producer at scan
+   * start and repeated across every chunk. The completeness contract keys on
+   * it, exactly as the HTTP path's `captured_at` does. */
+  captured_at: number;
+  /** How many rows the WHOLE pass will deliver. Optional for the same reason
+   * it is optional on the sync routes: a producer may post without declaring,
+   * and inventing a total would mark an unproven load complete. */
+  pass_total?: number;
+  rows: Record<string, unknown>[];
+}
+
+/** Lanes the consumer will accept. An allowlist here, unlike the deliberately
+ * permissive lane field on the health sink, because this one WRITES: an
+ * unrecognised lane means an unrecognised table, and guessing is worse than
+ * dead-lettering. */
+export const SYNC_BATCH_LANES = ["hotkey-alpha", "account-balances"] as const;
+
+export type SyncBatchLane = (typeof SYNC_BATCH_LANES)[number];
+
+/** Rows per message. Sized against the sink's existing per-request ceiling
+ * rather than re-derived: the D1 write shape is unchanged by the transport, and
+ * `json_each` already made a chunk one statement (metagraphed#9550). */
+export const SYNC_BATCH_MAX_ROWS = 5_000;
+
+/**
+ * Validate one message off the queue.
+ *
+ * A malformed message is NOT retried -- retrying a message that can never parse
+ * burns the retry budget and then dead-letters anyway, five attempts later. The
+ * caller acks it and records it instead, so the DLQ holds things that might yet
+ * succeed rather than things that never could.
+ */
+export function validSyncBatchMessage(body: unknown): body is SyncBatchMessage {
+  const m = body as SyncBatchMessage | null;
+  if (!m || typeof m !== "object") return false;
+  if (!SYNC_BATCH_LANES.includes(m.lane as SyncBatchLane)) return false;
+  if (
+    typeof m.captured_at !== "number" ||
+    !Number.isInteger(m.captured_at) ||
+    m.captured_at <= 0
+  ) {
+    return false;
+  }
+  if (
+    m.pass_total !== undefined &&
+    (!Number.isInteger(m.pass_total) || m.pass_total <= 0)
+  ) {
+    return false;
+  }
+  if (!Array.isArray(m.rows) || m.rows.length === 0) return false;
+  if (m.rows.length > SYNC_BATCH_MAX_ROWS) return false;
+  if (m.pass_total !== undefined && m.pass_total < m.rows.length) return false;
+  return m.rows.every((r) => r !== null && typeof r === "object");
+}
+
+/** How a message was disposed of, so a batch's outcome is reportable rather
+ * than inferred from an absence of errors. */
+export interface SyncBatchOutcome {
+  acked: number;
+  /** Retried by the queue -- transient, may yet succeed. */
+  retried: number;
+  /** Acked despite failing, because retrying could not help. */
+  rejected: number;
+}
+
+/**
+ * Split a batch into what should be written, retried, and rejected.
+ *
+ * Pure, so the disposition rule is testable without a queue or a database --
+ * and the rule is the part worth testing: "retry the transient, reject the
+ * impossible" is what keeps a DLQ meaningful.
+ */
+export function classifySyncBatch(
+  messages: readonly { readonly body: unknown }[],
+): { valid: SyncBatchMessage[]; invalid: number } {
+  const valid: SyncBatchMessage[] = [];
+  let invalid = 0;
+  for (const message of messages) {
+    if (validSyncBatchMessage(message.body)) valid.push(message.body);
+    else invalid += 1;
+  }
+  return { valid, invalid };
+}

--- a/tests/sync-batch-queue.test.ts
+++ b/tests/sync-batch-queue.test.ts
@@ -1,0 +1,137 @@
+// The bulk sync path's queue contract (metagraphed-infra#347).
+//
+// The rule worth testing here is the DISPOSITION one: retry the transient,
+// reject the impossible. A DLQ is only useful if it holds messages that might
+// yet succeed; filling it with messages that could never parse turns it into a
+// second log nobody reads.
+//
+// The validator is also the last line before a WRITE, which is why its lane
+// field is an allowlist -- unlike the health sink's, which is deliberately
+// permissive so a brand-new lane can report on its first run. An unrecognised
+// lane here means an unrecognised table, and guessing is worse than
+// dead-lettering.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  classifySyncBatch,
+  SYNC_BATCH_LANES,
+  SYNC_BATCH_MAX_ROWS,
+  validSyncBatchMessage,
+} from "../src/sync-batch-queue.ts";
+
+const OK = {
+  lane: "hotkey-alpha",
+  captured_at: 1_785_970_245_474,
+  pass_total: 46_998,
+  rows: [{ hotkey: "5A", netuid: 7, total_alpha: 1.5, captured_at: 1 }],
+};
+
+describe("validSyncBatchMessage", () => {
+  test("accepts a well-formed chunk, with or without a declared pass", () => {
+    assert.equal(validSyncBatchMessage(OK), true);
+    const { pass_total: _drop, ...noDeclaration } = OK;
+    assert.equal(validSyncBatchMessage(noDeclaration), true);
+  });
+
+  test("rejects a lane it would not know where to write", () => {
+    // An allowlist on purpose: this validator guards a WRITE. An unrecognised
+    // lane means an unrecognised table, and a guess is worse than a DLQ entry.
+    assert.equal(validSyncBatchMessage({ ...OK, lane: "brand-new" }), false);
+    for (const lane of SYNC_BATCH_LANES) {
+      assert.equal(validSyncBatchMessage({ ...OK, lane }), true, lane);
+    }
+  });
+
+  test("rejects a pass_total smaller than the chunk it arrived with", () => {
+    // Same check the HTTP sink makes. A declaration under the delivered count
+    // is incoherent, and trusting it would mark a pass complete early.
+    assert.equal(
+      validSyncBatchMessage({ ...OK, pass_total: 0, rows: OK.rows }),
+      false,
+    );
+    assert.equal(
+      validSyncBatchMessage({
+        ...OK,
+        pass_total: 1,
+        rows: [OK.rows[0]!, OK.rows[0]!],
+      }),
+      false,
+    );
+  });
+
+  test("rejects empty and oversized batches", () => {
+    assert.equal(validSyncBatchMessage({ ...OK, rows: [] }), false);
+    assert.equal(
+      validSyncBatchMessage({
+        ...OK,
+        pass_total: SYNC_BATCH_MAX_ROWS + 1,
+        rows: Array.from({ length: SYNC_BATCH_MAX_ROWS + 1 }, () => ({})),
+      }),
+      false,
+    );
+  });
+
+  test("rejects a captured_at that could not key a pass", () => {
+    // The completeness contract keys on this stamp. A zero or fractional value
+    // would create a pass nothing can ever close.
+    for (const bad of [0, -1, 1.5, "now", null, undefined]) {
+      assert.equal(
+        validSyncBatchMessage({ ...OK, captured_at: bad }),
+        false,
+        String(bad),
+      );
+    }
+  });
+
+  test("rejects shapes that are not messages at all", () => {
+    for (const bad of [
+      null,
+      undefined,
+      42,
+      "msg",
+      [],
+      { lane: "hotkey-alpha" },
+    ]) {
+      assert.equal(validSyncBatchMessage(bad), false, JSON.stringify(bad));
+    }
+  });
+
+  test("rejects rows that are not objects", () => {
+    assert.equal(validSyncBatchMessage({ ...OK, rows: [1, 2] }), false);
+    assert.equal(validSyncBatchMessage({ ...OK, rows: [null] }), false);
+  });
+});
+
+describe("classifySyncBatch", () => {
+  test("splits a mixed batch without losing a message", () => {
+    const { valid, invalid } = classifySyncBatch([
+      { body: OK },
+      { body: { ...OK, lane: "nonsense" } },
+      { body: OK },
+      { body: null },
+    ]);
+    assert.equal(valid.length, 2);
+    assert.equal(invalid, 2);
+    assert.equal(valid.length + invalid, 4, "every message is accounted for");
+  });
+
+  test("an all-valid batch reports no rejects", () => {
+    const { valid, invalid } = classifySyncBatch([{ body: OK }, { body: OK }]);
+    assert.equal(valid.length, 2);
+    assert.equal(invalid, 0);
+  });
+
+  test("an empty batch is not an error", () => {
+    // Queues can deliver an empty batch on a timeout boundary; treating that as
+    // a failure would retry nothing, forever.
+    assert.deepEqual(classifySyncBatch([]), { valid: [], invalid: 0 });
+  });
+
+  test("accepts a readonly batch, as the runtime delivers it", () => {
+    // MessageBatch.messages is readonly; a signature requiring a mutable array
+    // forces a cast at the call site, which is where a real type error would
+    // then hide.
+    const frozen = Object.freeze([Object.freeze({ body: OK })]);
+    assert.equal(classifySyncBatch(frozen).valid.length, 1);
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -411,6 +411,7 @@ import { BLOCKLIST_KV_KEY, BLOCKLIST_KV_TTL } from "./tiered-rate-limit.ts";
 import { MCP_TIERED_RATE_LIMIT } from "../src/mcp-server.ts";
 import { createPgSql } from "../src/pg-sql.ts";
 import { recordLaneVerdict } from "../src/lane-health.ts";
+import { classifySyncBatch } from "../src/sync-batch-queue.ts";
 import {
   coercePollerJobOutcome,
   validPollerJobOutcome,
@@ -7096,6 +7097,51 @@ export default {
       if (typeof ctx?.waitUntil === "function") {
         ctx.waitUntil(pending);
       }
+    }
+  },
+
+  /**
+   * The bulk sync path's consumer (metagraphed-infra#347).
+   *
+   * NO-OP BY DESIGN AT THIS STAGE. It validates, classifies and reports, and
+   * writes nothing. The point of a first cut is to observe the queue's real
+   * behaviour -- batch sizes, retry timing, dead-letter routing, what
+   * `max_concurrency` actually does to throughput -- against production traffic
+   * shape BEFORE any lane depends on it. Those are precisely the properties the
+   * hand-rolled retry and pacing currently substitute for, so they get measured
+   * rather than assumed.
+   *
+   * A MALFORMED MESSAGE IS ACKED, NOT RETRIED. Retrying something that can
+   * never parse burns five attempts and dead-letters anyway; acking it keeps
+   * the DLQ holding things that might yet succeed rather than things that never
+   * could.
+   */
+  async queue(
+    batch: MessageBatch<unknown>,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<void> {
+    const { valid, invalid } = classifySyncBatch(batch.messages);
+    const rows = valid.reduce((n: number, m) => n + m.rows.length, 0);
+    const lanes = [...new Set(valid.map((m) => m.lane))].sort().join(",");
+    console.log(
+      `sync-batches: ${batch.messages.length} message(s), ${valid.length} valid ` +
+        `(${rows} row(s), lanes=${lanes || "none"}), ${invalid} unparseable`,
+    );
+    // Everything is acked: nothing is written yet, so nothing can fail in a way
+    // a retry would fix, and leaving messages unacked would build a backlog
+    // that says nothing about the lanes it is meant to carry.
+    batch.ackAll();
+    if (invalid > 0) {
+      ctx.waitUntil(
+        recordLaneVerdict(env.METAGRAPH_HEALTH_DB, {
+          lane: "sync-batches",
+          verdict: "stale",
+          age_ms: null,
+          detail: `${invalid} unparseable message(s) in a batch of ${batch.messages.length}`,
+          checked_at: Date.now(),
+        }).then(() => undefined),
+      );
     }
   },
 };

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -208,6 +208,39 @@
   // TAO/USD index (migrations/d1/0004_user_state.sql). Chain-scale data
   // (blocks/extrinsics/chain_events/...) never goes to D1; those reads live
   // in the R2 lakehouse cold tier.
+  // The bulk sync path (metagraphed-infra#346/#347). Producers enqueue chunks
+  // instead of POSTing them at a sync route; this Worker consumes and writes.
+  //
+  // WHY. Each bulk lane grew its own substitute for what a queue provides --
+  // retry loops, a 1-second inter-chunk sleep standing in for backpressure, a
+  // pass tally standing in for "did the batch set drain". Every piece was a
+  // correct local fix for the D1 saturation on 2026-08-05
+  // (`D1_ERROR: D1 DB is overloaded`, which also failed wallet-auth and
+  // tao-usd-index), and together they are an orchestration layer nobody
+  // designed.
+  //
+  // NO DUAL WRITE, ever. A lane enqueues OR posts, never both -- writing
+  // everything twice during a migration doubles exactly the load that caused
+  // the incident, and duplicate arrivals corrupt the completeness tally that
+  // stopped a partial ledger publishing a leaderboard missing its #2.
+  //
+  // max_batch_size / max_concurrency ARE the backpressure. They replace the
+  // hand-rolled sleep, and are deliberately conservative until measured against
+  // real traffic: the failure this exists to prevent is overwhelming D1, so
+  // starting slow and raising on evidence is the whole point.
+  "queues": {
+    "producers": [{ "binding": "SYNC_BATCHES", "queue": "sync-batches" }],
+    "consumers": [
+      {
+        "queue": "sync-batches",
+        "max_batch_size": 10,
+        "max_batch_timeout": 5,
+        "max_retries": 5,
+        "max_concurrency": 2,
+        "dead_letter_queue": "sync-batches-dlq",
+      },
+    ],
+  },
   "d1_databases": [
     {
       "binding": "METAGRAPH_HEALTH_DB",


### PR DESCRIPTION
First step of metagraphed-infra#346 / #347.

## What this replaces, eventually

Each bulk lane grew its own substitute for what a queue provides:

| scaffolding | stands in for |
|---|---|
| `CHUNK_POST_ATTEMPTS` + `retry_backoff` | queue retries |
| `CHUNK_POST_PAUSE_MS` (1s sleep) | **backpressure** |
| `pass_total` + `*_passes` tables | "did the batch set drain" |
| `scan_floor` / `may_publish` | "was the scan complete" |

Every one was a correct local fix for the 2026-08-05 D1 saturation — `D1_ERROR: D1 DB is overloaded`, which aborted the passes and also failed `wallet-auth` and `tao-usd-index`. Together they're an orchestration layer nobody designed.

## The consumer writes nothing yet — on purpose

It validates, classifies and reports. A first cut exists to **observe the queue's real behaviour** — batch sizes, retry timing, DLQ routing, what `max_concurrency` does to throughput — against production traffic shape *before* any lane depends on it. Those are precisely the properties the scaffolding currently substitutes for, so they get measured rather than assumed.

`max_batch_size: 10` / `max_concurrency: 2` **are** the backpressure that replaces the sleep, and start conservative deliberately: the failure this prevents is overwhelming D1, so raising them on evidence is the whole point.

## Two disposition rules worth stating

- **A malformed message is acked, not retried.** Retrying something that can never parse burns five attempts and dead-letters anyway; acking keeps the DLQ holding things that might *yet* succeed rather than things that never could.
- **The lane field is an allowlist**, unlike the health sink's deliberately permissive one — this validator guards a **write**, so an unrecognised lane means an unrecognised table, and guessing is worse than dead-lettering.

## What this does NOT delete, and won't

- **Pass completeness.** A queue knows a message was delivered, not that a producer's whole *scan* arrived. That distinction caught `account_balances` publishing 147,000 of 364,000 rows while looking perfectly fresh.
- **The publish floor.** A truncated scan is a producer-side fact the queue never sees.

Both survive deliberately; metagraphed-infra#352 makes their final form an explicit decision rather than an assumption.

| gate | result |
|---|---|
| `lint` / `format:check` / `typecheck` | clean |
| `validate` / `scan:public-safety` | pass |
| `npx vitest run` | **16,655 tests, 0 failures** |

Queues `sync-batches` and `sync-batches-dlq` are already created in the account.