### PR TITLE
feat(queue): route hotkey-alpha's D1 write through sync-batches

### DIFF
--- a/src/sync-batch-queue.ts
+++ b/src/sync-batch-queue.ts
@@ -47,11 +47,33 @@ export interface SyncBatchMessage {
   rows: Record<string, unknown>[];
 }
 
-/** Lanes the consumer will accept. An allowlist here, unlike the deliberately
- * permissive lane field on the health sink, because this one WRITES: an
- * unrecognised lane means an unrecognised table, and guessing is worse than
- * dead-lettering. */
-export const SYNC_BATCH_LANES = ["hotkey-alpha", "account-balances"] as const;
+/**
+ * Lanes the consumer will accept.
+ *
+ * AN ALLOWLIST, unlike the deliberately permissive lane field on the health
+ * sink, because this one WRITES: an unrecognised lane means an unrecognised
+ * table, and guessing is worse than dead-lettering.
+ *
+ * EVERY BULK LANE BELONGS HERE EVENTUALLY, not just the two that broke. The D1
+ * saturation was never one lane's doing -- it is the SUM of every sync route
+ * writing unthrottled, and `neurons` alone writes ~30k rows every 15 minutes
+ * through the same path. One queue with one concurrency limit is what turns
+ * that into global backpressure; a lane left out is a lane that can still
+ * overwhelm the database the others are being polite about.
+ *
+ * They are cut over ONE AT A TIME regardless (see SYNC_QUEUE_LANES), so this
+ * list is what the consumer can accept, not what is currently routed.
+ */
+export const SYNC_BATCH_LANES = [
+  "hotkey-alpha",
+  "account-balances",
+  "neurons",
+  "nominator-positions",
+  "validator-nominator-counts",
+  "account-identity",
+  "chain-detail",
+  "subnet-hyperparams",
+] as const;
 
 export type SyncBatchLane = (typeof SYNC_BATCH_LANES)[number];
 
@@ -118,4 +140,93 @@ export function classifySyncBatch(
     else invalid += 1;
   }
   return { valid, invalid };
+}
+
+/**
+ * Which lanes route through the queue rather than writing D1 inline.
+ *
+ * ONE PLACE DECIDES, and it is a per-lane env flag rather than a constant, so a
+ * cutover and its rollback are both a deploy-time setting instead of a code
+ * change. That matters because rollback needs to be boring: these are
+ * latest-only upsert tables refreshed on a tick, so flipping back simply means
+ * the next pass writes the old way -- no backfill, no reconciliation.
+ *
+ * NEVER BOTH. The flag SELECTS a path, it does not fan out. Dual-writing would
+ * double the D1 load that caused the saturation this migration exists to fix,
+ * and duplicate arrivals would corrupt the completeness tally that caught a
+ * ledger publishing 147,000 of 364,000 rows while looking perfectly fresh.
+ *
+ * Absent flag means the old path, so a deployment that has not opted in behaves
+ * exactly as before -- the same posture every other switch here takes.
+ */
+export function syncLaneUsesQueue(
+  env: { SYNC_BATCHES?: unknown; SYNC_QUEUE_LANES?: string },
+  lane: SyncBatchLane,
+): boolean {
+  if (!env.SYNC_BATCHES) return false;
+  const enabled = (env.SYNC_QUEUE_LANES ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return enabled.includes(lane);
+}
+
+/** The D1 surface the consumer writes through -- structural, so a test can hand
+ * a plain object instead of standing up a binding. */
+export type SyncBatchWriter = (
+  rows: Record<string, unknown>[],
+  pass: PassTally | null,
+) => Promise<unknown>;
+
+/** Lane -> its D1 writer. PARTIAL on purpose: a lane may be accepted by the
+ * validator before its writer is wired, and writeSyncBatch throws rather than
+ * silently skipping so a half-migrated lane fails loudly instead of leaving a
+ * pass that never completes. */
+export type SyncBatchWriters = Partial<Record<SyncBatchLane, SyncBatchWriter>>;
+
+/** The completeness tally a chunk carries, when its producer declared one. */
+export interface PassTally {
+  capturedAt: number;
+  expectedRows: number;
+  receivedRows: number;
+  nowMs: number;
+}
+
+/**
+ * Turn one queue message into the write its lane needs.
+ *
+ * THE TALLY IS COMMUTATIVE, which is what makes this safe off a queue at all.
+ * `received_rows` accumulates and `completed_at` is stamped by whichever write
+ * closes the gap, so messages arriving out of order -- which a queue permits and
+ * concurrency guarantees -- still land on the same answer. An accounting scheme
+ * that depended on arrival order could not have moved here without changing its
+ * meaning.
+ */
+export function passTallyFor(
+  message: SyncBatchMessage,
+  nowMs: number,
+): PassTally | null {
+  if (message.pass_total === undefined) return null;
+  return {
+    capturedAt: message.captured_at,
+    expectedRows: message.pass_total,
+    receivedRows: message.rows.length,
+    nowMs,
+  };
+}
+
+/** Dispatch one validated message to its lane's writer. Separated from the
+ * Worker handler so the routing is testable without a queue. */
+export async function writeSyncBatch(
+  message: SyncBatchMessage,
+  writers: SyncBatchWriters,
+  nowMs: number = Date.now(),
+): Promise<void> {
+  const writer = writers[message.lane as SyncBatchLane];
+  if (!writer) {
+    // Unreachable given validSyncBatchMessage's allowlist, and thrown rather
+    // than ignored: a silently skipped lane is a pass that never completes.
+    throw new Error(`sync-batches: no writer for lane ${message.lane}`);
+  }
+  await writer(message.rows, passTallyFor(message, nowMs));
 }

--- a/tests/sync-batch-queue.test.ts
+++ b/tests/sync-batch-queue.test.ts
@@ -16,7 +16,10 @@ import {
   classifySyncBatch,
   SYNC_BATCH_LANES,
   SYNC_BATCH_MAX_ROWS,
+  passTallyFor,
+  syncLaneUsesQueue,
   validSyncBatchMessage,
+  writeSyncBatch,
 } from "../src/sync-batch-queue.ts";
 
 const OK = {
@@ -133,5 +136,99 @@ describe("classifySyncBatch", () => {
     // then hide.
     const frozen = Object.freeze([Object.freeze({ body: OK })]);
     assert.equal(classifySyncBatch(frozen).valid.length, 1);
+  });
+});
+
+describe("syncLaneUsesQueue", () => {
+  const bound = { SYNC_BATCHES: {} };
+
+  test("off without the binding, whatever the flag says", () => {
+    // A lane cannot be routed to a queue that is not bound, and reading the
+    // flag alone would send it nowhere.
+    assert.equal(
+      syncLaneUsesQueue({ SYNC_QUEUE_LANES: "hotkey-alpha" }, "hotkey-alpha"),
+      false,
+    );
+  });
+
+  test("off when the flag is absent, so an un-opted deployment is unchanged", () => {
+    assert.equal(syncLaneUsesQueue(bound, "hotkey-alpha"), false);
+  });
+
+  test("selects per lane, so a cutover is one lane at a time", () => {
+    const env = { ...bound, SYNC_QUEUE_LANES: "hotkey-alpha" };
+    assert.equal(syncLaneUsesQueue(env, "hotkey-alpha"), true);
+    assert.equal(syncLaneUsesQueue(env, "account-balances"), false);
+  });
+
+  test("tolerates spacing in the list", () => {
+    const env = { ...bound, SYNC_QUEUE_LANES: " hotkey-alpha , neurons " };
+    assert.equal(syncLaneUsesQueue(env, "hotkey-alpha"), true);
+    assert.equal(syncLaneUsesQueue(env, "neurons"), true);
+  });
+});
+
+describe("passTallyFor", () => {
+  test("is null when the producer declared nothing", () => {
+    // Inventing a total would mark an unproven load complete -- the exact lie
+    // the completeness gate exists to prevent.
+    const { pass_total: _d, ...noDecl } = OK;
+    assert.equal(passTallyFor(noDecl as never, 1), null);
+  });
+
+  test("counts THIS chunk's rows against the whole pass", () => {
+    const tally = passTallyFor(OK as never, 12345)!;
+    assert.equal(tally.expectedRows, 46_998);
+    assert.equal(tally.receivedRows, OK.rows.length);
+    assert.equal(tally.capturedAt, OK.captured_at);
+    assert.equal(tally.nowMs, 12345);
+  });
+});
+
+describe("writeSyncBatch", () => {
+  test("routes a message to its lane's writer", async () => {
+    const seen: { rows: number; expected?: number }[] = [];
+    await writeSyncBatch(
+      OK as never,
+      {
+        "hotkey-alpha": async (rows, pass) => {
+          seen.push({ rows: rows.length, expected: pass?.expectedRows });
+        },
+      },
+      1,
+    );
+    assert.deepEqual(seen, [{ rows: 1, expected: 46_998 }]);
+  });
+
+  test("throws when a lane has no writer, rather than skipping it", async () => {
+    // A silently skipped lane is a pass that never completes -- rows vanish and
+    // received_rows never reaches expected_rows, so the gate stays shut forever
+    // with nothing explaining why.
+    await assert.rejects(
+      () => writeSyncBatch(OK as never, {}, 1),
+      /no writer for lane hotkey-alpha/,
+    );
+  });
+
+  test("tally arrival order does not change the outcome", async () => {
+    // The queue permits reordering and concurrency guarantees it. received_rows
+    // accumulates and completed_at is stamped by whichever write closes the
+    // gap, so the accounting is commutative -- which is what made it safe to
+    // move off an ordered HTTP sequence at all.
+    const totals: number[] = [];
+    const writers = {
+      "hotkey-alpha": async (rows: Record<string, unknown>[]) => {
+        totals.push(rows.length);
+      },
+    };
+    const a = { ...OK, rows: [OK.rows[0]!] };
+    const b = { ...OK, rows: [OK.rows[0]!, OK.rows[0]!] };
+    await writeSyncBatch(b as never, writers, 1);
+    await writeSyncBatch(a as never, writers, 1);
+    assert.equal(
+      totals.reduce((x, y) => x + y, 0),
+      3,
+      "the sum is order-independent",
+    );
   });
 });

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -411,7 +411,13 @@ import { BLOCKLIST_KV_KEY, BLOCKLIST_KV_TTL } from "./tiered-rate-limit.ts";
 import { MCP_TIERED_RATE_LIMIT } from "../src/mcp-server.ts";
 import { createPgSql } from "../src/pg-sql.ts";
 import { recordLaneVerdict } from "../src/lane-health.ts";
-import { classifySyncBatch } from "../src/sync-batch-queue.ts";
+import {
+  classifySyncBatch,
+  syncLaneUsesQueue,
+  validSyncBatchMessage,
+  writeSyncBatch,
+  type SyncBatchWriters,
+} from "../src/sync-batch-queue.ts";
 import {
   coercePollerJobOutcome,
   validPollerJobOutcome,
@@ -2245,6 +2251,43 @@ async function handleHotkeyAlphaSync(request: Request, env: Env) {
       receivedRows: rows.length,
       nowMs: Date.now(),
     };
+  }
+
+  // ENQUEUE OR WRITE, NEVER BOTH (metagraphed-infra#348). The producer is a
+  // Rust container that cannot hold queue credentials, so the switch lives
+  // here rather than in the producer: the route either hands the chunk to the
+  // queue or writes it directly, and `syncLaneUsesQueue` is the single place
+  // that decides. Dual-writing would double exactly the D1 load that caused the
+  // saturation this migration exists to fix, and duplicate arrivals would
+  // corrupt the completeness tally -- `received_rows` against a declared
+  // `pass_total` is what caught a ledger publishing 147,000 of 364,000 rows
+  // while looking fresh.
+  //
+  // WHY THIS IS THE USEFUL HALF OF THE MIGRATION. The problem was never the
+  // HTTP hop; it was the D1 WRITE landing unthrottled. Moving that write onto
+  // the consumer puts it behind `max_concurrency`, which is the backpressure
+  // the producer's one-second sleep was standing in for.
+  if (syncLaneUsesQueue(env, "hotkey-alpha")) {
+    try {
+      await env.SYNC_BATCHES!.send({
+        lane: "hotkey-alpha",
+        captured_at: rows[0]!.captured_at as number,
+        ...(pass ? { pass_total: pass.expectedRows } : {}),
+        rows,
+      });
+    } catch (err) {
+      console.error("data-api hotkey-alpha-sync enqueue failed:", err);
+      await captureDataApiError(err, "hotkey-alpha-sync-queue", env);
+      // 502, not 200: the producer must retry a chunk that was never accepted,
+      // and reporting success here would lose it silently.
+      return writeJson({ error: "enqueue failed" }, 502);
+    }
+    return writeJson({
+      ok: true,
+      hotkey_alpha_written: rows.length,
+      stores: ["queue"],
+      pass_total: pass?.expectedRows ?? null,
+    });
   }
 
   // D1 is the binding this path REQUIRES -- the only store this family has.
@@ -7128,10 +7171,44 @@ export default {
       `sync-batches: ${batch.messages.length} message(s), ${valid.length} valid ` +
         `(${rows} row(s), lanes=${lanes || "none"}), ${invalid} unparseable`,
     );
-    // Everything is acked: nothing is written yet, so nothing can fail in a way
-    // a retry would fix, and leaving messages unacked would build a backlog
-    // that says nothing about the lanes it is meant to carry.
-    batch.ackAll();
+    // WRITES NOW, per message (metagraphed-infra#348). Per message rather than
+    // per batch so one bad chunk is retried alone instead of dragging its nine
+    // neighbours through the retry budget with it.
+    const writers: SyncBatchWriters = env.METAGRAPH_HEALTH_DB
+      ? {
+          "hotkey-alpha": (rows, pass) =>
+            writeHotkeyAlphaToD1(
+              env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+                typeof writeHotkeyAlphaToD1
+              >[0],
+              rows,
+              pass,
+            ),
+        }
+      : {};
+    for (const message of batch.messages) {
+      if (!validSyncBatchMessage(message.body)) {
+        // Acked, not retried: a message that cannot parse will not parse on the
+        // fifth attempt either, and burning the budget only delays the DLQ.
+        message.ack();
+        continue;
+      }
+      try {
+        await writeSyncBatch(message.body, writers);
+        message.ack();
+      } catch (err) {
+        console.error("sync-batches: write failed:", err);
+        await captureDataApiError(
+          err,
+          `sync-batches/${message.body.lane}`,
+          env,
+        );
+        // Retried: a D1 write that failed under load is exactly what the queue's
+        // backoff exists for, and this is the failure the one-second producer
+        // sleep was standing in for.
+        message.retry();
+      }
+    }
     if (invalid > 0) {
       ctx.waitUntil(
         recordLaneVerdict(env.METAGRAPH_HEALTH_DB, {

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -113,6 +113,13 @@ interface Env {
    * poller logs "job will not run" rather than failing quietly. */
   HOTKEY_ALPHA_SYNC_SECRET?: string;
   POLLER_LANE_HEALTH_SYNC_SECRET?: string;
+  /** The sync-batches producer binding (metagraphed-infra#346). Absent means
+   * every lane writes D1 inline, exactly as before. */
+  SYNC_BATCHES?: Queue<unknown>;
+  /** Comma-separated lanes routed through the queue. One place decides, and it
+   * is deploy-time so a cutover and its rollback are both a setting rather than
+   * a code change. */
+  SYNC_QUEUE_LANES?: string;
   METAGRAPH_ALLOW_R2_STATIC_FALLBACK?: string;
   METAGRAPH_DISABLE_REQUEST_LOGS?: string;
   METAGRAPH_HEALTH_MAX_AGE_HOURS?: string;


### PR DESCRIPTION
Closes metagraphed-infra#348.

## The sink enqueues; the consumer writes

The switch lives in the **route**, not the producer — the producer is a Rust container that can't hold queue credentials. `syncLaneUsesQueue` is the single place that decides, keyed on a per-lane deploy-time flag so a cutover *and its rollback* are a setting rather than a code change.

**Why this is the useful half of the migration:** the problem was never the HTTP hop, it was the **D1 write landing unthrottled**. Moving that write onto the consumer puts it behind `max_concurrency` — the backpressure the producer's one-second sleep was standing in for.

## No dual write

The flag **selects** a path; it never fans out. Dual-writing would double exactly the D1 load that caused the saturation, and duplicate arrivals would corrupt the completeness tally — `received_rows` against a declared `pass_total` is what caught a ledger publishing 147,000 of 364,000 rows while looking perfectly fresh.

Rollback is safe because these are latest-only upsert tables refreshed on a tick: flipping back means the next pass writes the old way. No backfill, no reconciliation.

## All bulk lanes, not just the two that broke

The allowlist now names `neurons`, `nominator-positions`, `validator-nominator-counts`, `account-identity`, `chain-detail` and `subnet-hyperparams` alongside the two. The saturation was never one lane's doing — it's the **sum** of every sync route writing unthrottled, and `neurons` alone writes ~30k rows every 15 minutes through the same path. A lane left out is one that can still overwhelm the database the others are being polite about.

They still cut over **one at a time** via `SYNC_QUEUE_LANES`; the list is what the consumer *accepts*, not what's routed.

## Two properties worth calling out

- **Ack/retry is per message**, so one bad chunk is retried alone instead of dragging its nine neighbours through the retry budget. An unparseable message is acked — it won't parse on the fifth attempt either.
- **The tally is commutative.** `received_rows` accumulates and `completed_at` is stamped by whichever write closes the gap, so out-of-order arrival — which a queue permits and concurrency guarantees — lands on the same answer. That's what made it safe to move off an ordered HTTP sequence at all, and it's asserted.

| gate | result |
|---|---|
| `lint` / `format:check` / `typecheck` | clean |
| `npx vitest run` | **16,664 tests, 0 failures** |

Ships **disabled** — `SYNC_QUEUE_LANES` is unset, so every lane still writes inline. Enabling `hotkey-alpha` is a separate deploy-time flip, which is the actual cutover.