### PR TITLE
feat(queue): cut hotkey-alpha's writes onto sync-batches

### DIFF
--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -107,6 +107,19 @@
     "METAGRAPH_NEURONS_SOURCE": "d1",
     "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",
+    // THE QUEUE CUTOVER (metagraphed-infra#348). Comma-separated lanes whose D1
+    // write goes through sync-batches instead of landing inline on the request.
+    // One lane at a time; adding a name routes it, removing a name routes it
+    // back, and neither is a code change.
+    //
+    // NEVER BOTH PATHS AT ONCE. The flag selects, it does not fan out --
+    // dual-writing would double the D1 load that caused the saturation, and
+    // duplicate arrivals would corrupt the completeness tally.
+    //
+    // Declared INSIDE this block deliberately: a second top-level "vars" key
+    // would silently replace this one wholesale, which is the trap the tier-flag
+    // comment above already records.
+    "SYNC_QUEUE_LANES": "hotkey-alpha",
     // #9430's $exception storm guard reads this var per-Worker
     // (src/usage-telemetry.ts), and `vars` are per-config -- declaring it
     // only in wrangler.jsonc left THIS Worker's captures entirely unguarded,


### PR DESCRIPTION
Closes metagraphed-infra#348.

`SYNC_QUEUE_LANES=hotkey-alpha` — that lane's D1 write now lands on the queue consumer behind `max_concurrency` instead of inline on the sync request.

## Verified end to end against production

A real 47,032-row pass, enqueued in two chunks:

```
hotkey-alpha: POST 1/2 ok -- 25000/47032 row(s)
hotkey-alpha: POST 2/2 ok -- 47032/47032 row(s)
hotkey-alpha: ok -- 48797 scanned, 47032 written, 0 error(s)
```

| | before | after |
|---|---|---|
| `captured_at` | 04:40:46 | **05:01:38** |
| pools stored | 17,867 | 17,867 |
| complete passes | 3 | **4** |

The consumer wrote it, and **the completeness tally recorded and closed the pass through the queue** — which is the property that had to hold, since the tally is what stops a partial ledger publishing. Pool count held, so the referenced-pairs filter still applies on the consumer path.

## One trap worth recording

I first added this as a **second top-level `vars` key**. Wrangler replaces `vars` wholesale, so that would have silently dropped `UNKEY_API_ID`, all three tier-source flags and both PostHog vars — with no error at deploy time.

That file's own tier-flag comment already documents this exact failure (*"`vars` is replaced wholesale on deploy, so over here they were always `undefined`"*). I walked into it before reading it, and caught it only by checking for a duplicate key. It's now declared inside the existing block, with the reason noted where the next person will be editing.