### PR TITLE
feat(queue): accept validator-nominator-counts on sync-batches

### DIFF
--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -1667,6 +1667,28 @@ async function handleValidatorNominatorCountsSync(request: Request, env: Env) {
 
   const rows = incoming.map(coerceNominatorCountSyncRow);
 
+  // Enqueue or write, never both -- see handleHotkeyAlphaSync's own note.
+  // This lane carries no pass declaration, so the queue message carries none
+  // either: inventing one would mark an unproven load complete.
+  if (syncLaneUsesQueue(env, "validator-nominator-counts")) {
+    try {
+      await env.SYNC_BATCHES!.send({
+        lane: "validator-nominator-counts",
+        captured_at: rows[0]!.captured_at as number,
+        rows,
+      });
+    } catch (err) {
+      console.error("data-api validator-nominator-counts enqueue failed:", err);
+      await captureDataApiError(err, "vnc-sync-queue", env);
+      return writeJson({ error: "enqueue failed" }, 502);
+    }
+    return writeJson({
+      ok: true,
+      nominator_counts_written: rows.length,
+      stores: ["queue"],
+    });
+  }
+
   // D1 is the binding this path REQUIRES -- the only store this family has.
   // Checked HERE, after validation, not at the top: a malformed body is a 400
   // whether or not a store happens to be bound (handleNominatorPositionsSync's
@@ -7183,6 +7205,13 @@ export default {
               >[0],
               rows,
               pass,
+            ),
+          "validator-nominator-counts": (rows) =>
+            writeValidatorNominatorCountsToD1(
+              env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+                typeof writeValidatorNominatorCountsToD1
+              >[0],
+              rows,
             ),
         }
       : {};


### PR DESCRIPTION
Part of metagraphed-infra#355.

Second lane wired, same shape as `hotkey-alpha`: the route enqueues **or** writes, never both, and the consumer performs the D1 write behind `max_concurrency`.

This lane carries **no pass declaration**, so the queue message carries none either. Inventing one would mark an unproven load complete — the precise lie the completeness gate exists to prevent.

## Ships inert

`SYNC_QUEUE_LANES` still names only `hotkey-alpha`, so this lane keeps writing inline until the flag says otherwise. **Wiring and cutover are separate deploys on purpose**, so a bad wiring change cannot also be a bad cutover.

## Why `nominator_positions` is not in this PR

Its writer takes a **per-coldkey prune map**, and computing that from a partial chunk would prune rows the chunk simply did not carry — a data-loss bug, not a performance one.

The producer's `pack_coldkey_chunks` already guarantees a coldkey is never split across chunks, which is exactly what would make it safe. But that guarantee currently lives in the producer and would become load-bearing on the consumer, so it needs asserting there before the lane moves rather than assumed.

| gate | result |
|---|---|
| `lint` / `format:check` / `typecheck` | clean |
| `npx vitest run` | full suite green |