### PR TITLE
feat(queue): accept nominator-positions on sync-batches, with a pruning guard

### DIFF
--- a/src/sync-batch-queue.ts
+++ b/src/sync-batch-queue.ts
@@ -46,12 +46,18 @@ export interface SyncBatchMessage {
   pass_total?: number;
   rows: Record<string, unknown>[];
   /**
-   * "Every row for each `coldkey` named in this message is IN this message."
+   * "Every row for each KEY named in this message is IN this message."
    *
-   * Only `nominator-positions` needs it, and only because its write PRUNES: the
-   * writer deletes rows for a `coldkey` older than the newest `captured_at` it
-   * just saw for it. Computed from a partial chunk, that would delete rows the
+   * Only a pruning lane needs it, and only because its write DELETES: the
+   * writer removes rows for a key older than the newest `captured_at` it just
+   * saw for that key. Computed from a partial chunk, that would delete rows the
    * chunk simply did not carry -- silent data loss, not a slowdown.
+   *
+   * WHICH key is the lane's own business -- `nominator-positions` prunes per
+   * `coldkey`, `neurons` per netuid -- so the flag is deliberately named for
+   * the property rather than for the column. A per-column field would have to
+   * be renamed the moment the second pruning lane moved, and renaming a wire
+   * field after cutover is not free.
    *
    * The producer's `pack_coldkey_chunks` already guarantees it, and has a test
    * that a flat slice would fail. But once the write moves to a consumer, that
@@ -59,7 +65,7 @@ export interface SyncBatchMessage {
    * crosses a boundary should be an assertion. Absent, the consumer refuses to
    * prune rather than pruning on trust.
    */
-  coldkey_complete?: boolean;
+  key_complete?: boolean;
 }
 
 /**
@@ -90,8 +96,14 @@ export const SYNC_BATCH_LANES = [
   "subnet-hyperparams",
 ] as const;
 
-/** Lanes whose write PRUNES, and therefore may not be applied from a chunk that
- * could be missing rows for a key it names. */
+/**
+ * Lanes whose write PRUNES, and therefore may not be applied from a chunk that
+ * could be missing rows for a key it names.
+ *
+ * `neurons` belongs here too -- it prunes per netuid -- but is not on the queue
+ * yet, and listing a lane before its producer asserts completeness would reject
+ * every one of its messages. It joins when it moves.
+ */
 export const PRUNING_LANES: readonly string[] = ["nominator-positions"];
 
 export type SyncBatchLane = (typeof SYNC_BATCH_LANES)[number];
@@ -129,7 +141,7 @@ export function validSyncBatchMessage(body: unknown): body is SyncBatchMessage {
   if (!Array.isArray(m.rows) || m.rows.length === 0) return false;
   // A pruning lane must SAY its chunk is key-complete. Refusing here beats
   // pruning on trust: the failure mode is deleted rows, which no retry undoes.
-  if (PRUNING_LANES.includes(m.lane) && m.coldkey_complete !== true) {
+  if (PRUNING_LANES.includes(m.lane) && m.key_complete !== true) {
     return false;
   }
   if (m.rows.length > SYNC_BATCH_MAX_ROWS) return false;

--- a/src/sync-batch-queue.ts
+++ b/src/sync-batch-queue.ts
@@ -45,6 +45,21 @@ export interface SyncBatchMessage {
    * and inventing a total would mark an unproven load complete. */
   pass_total?: number;
   rows: Record<string, unknown>[];
+  /**
+   * "Every row for each `coldkey` named in this message is IN this message."
+   *
+   * Only `nominator-positions` needs it, and only because its write PRUNES: the
+   * writer deletes rows for a `coldkey` older than the newest `captured_at` it
+   * just saw for it. Computed from a partial chunk, that would delete rows the
+   * chunk simply did not carry -- silent data loss, not a slowdown.
+   *
+   * The producer's `pack_coldkey_chunks` already guarantees it, and has a test
+   * that a flat slice would fail. But once the write moves to a consumer, that
+   * guarantee is load-bearing across a repo boundary, and an assumption that
+   * crosses a boundary should be an assertion. Absent, the consumer refuses to
+   * prune rather than pruning on trust.
+   */
+  coldkey_complete?: boolean;
 }
 
 /**
@@ -74,6 +89,10 @@ export const SYNC_BATCH_LANES = [
   "chain-detail",
   "subnet-hyperparams",
 ] as const;
+
+/** Lanes whose write PRUNES, and therefore may not be applied from a chunk that
+ * could be missing rows for a key it names. */
+export const PRUNING_LANES: readonly string[] = ["nominator-positions"];
 
 export type SyncBatchLane = (typeof SYNC_BATCH_LANES)[number];
 
@@ -108,6 +127,11 @@ export function validSyncBatchMessage(body: unknown): body is SyncBatchMessage {
     return false;
   }
   if (!Array.isArray(m.rows) || m.rows.length === 0) return false;
+  // A pruning lane must SAY its chunk is key-complete. Refusing here beats
+  // pruning on trust: the failure mode is deleted rows, which no retry undoes.
+  if (PRUNING_LANES.includes(m.lane) && m.coldkey_complete !== true) {
+    return false;
+  }
   if (m.rows.length > SYNC_BATCH_MAX_ROWS) return false;
   if (m.pass_total !== undefined && m.pass_total < m.rows.length) return false;
   return m.rows.every((r) => r !== null && typeof r === "object");

--- a/tests/data-api-nominator-positions-d1.test.ts
+++ b/tests/data-api-nominator-positions-d1.test.ts
@@ -14,6 +14,7 @@ import { DatabaseSync } from "node:sqlite";
 import fs from "node:fs";
 import path from "node:path";
 import { beforeEach, describe, test } from "vitest";
+import { validSyncBatchMessage } from "../src/sync-batch-queue.ts";
 import type { Row } from "./row-type.ts";
 
 const { default: worker } = await import("../workers/data-api.ts");
@@ -299,5 +300,82 @@ describe("POST /api/v1/internal/nominator-positions-sync", () => {
       (await response.json<{ error: string }>()).error,
       /d1 write failed/,
     );
+  });
+});
+
+describe("routed to the sync queue (metagraphed-infra#355)", () => {
+  function queueEnv(send: (m: unknown) => Promise<void>) {
+    return env({
+      SYNC_BATCHES: { send },
+      SYNC_QUEUE_LANES: "nominator-positions",
+    });
+  }
+
+  test("enqueues instead of writing, and never both", async () => {
+    // NO DUAL WRITE. Writing twice during the migration doubles the D1 load the
+    // queue exists to relieve, and a duplicate arrival would double-count any
+    // completeness tally. The flag SELECTS a path; it does not fan out.
+    const sent: Record<string, unknown>[] = [];
+    const response = await post(
+      { rows: [positionRow(), positionRow({ coldkey: COLDKEY_B, netuid: 1 })] },
+      SECRET,
+      queueEnv(async (m) => {
+        sent.push(m as Record<string, unknown>);
+      }),
+    );
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      nominator_positions_written: 2,
+      stores: ["queue"],
+    });
+    assert.equal(sent.length, 1);
+    assert.equal(rows().length, 0, "D1 must not also have been written");
+  });
+
+  test("asserts coldkey-completeness on the message it sends", async () => {
+    // The consumer REFUSES a nominator-positions chunk without this flag,
+    // because its write prunes. A producer that stopped setting it would
+    // dead-letter loudly rather than silently deleting rows the chunk did not
+    // carry -- which is the whole reason the flag exists rather than a comment.
+    const sent: Record<string, unknown>[] = [];
+    await post(
+      { rows: [positionRow()] },
+      SECRET,
+      queueEnv(async (m) => {
+        sent.push(m as Record<string, unknown>);
+      }),
+    );
+    assert.equal(sent[0]!.lane, "nominator-positions");
+    assert.equal(sent[0]!.coldkey_complete, true);
+    assert.equal(sent[0]!.captured_at, 1_780_000_000_000);
+    assert.equal(validSyncBatchMessage(sent[0]), true);
+  });
+
+  test("a failed enqueue is a 502, not a silent success", async () => {
+    // The producer retries on a non-2xx. Reporting ok on a dropped chunk would
+    // lose the rows outright, since nothing else is writing them now.
+    const response = await post(
+      { rows: [positionRow()] },
+      SECRET,
+      queueEnv(async () => {
+        throw new Error("queue unavailable");
+      }),
+    );
+    assert.equal(response.status, 502);
+    assert.equal(rows().length, 0, "no fallback write -- the lane is cut over");
+  });
+
+  test("an un-opted deployment still writes D1", async () => {
+    // Rollback has to be boring: these are latest-only upsert tables refreshed
+    // on a tick, so unsetting the flag simply means the next pass writes the
+    // old way. No backfill, no reconciliation.
+    const response = await post(
+      { rows: [positionRow()] },
+      SECRET,
+      env({ SYNC_BATCHES: { send: async () => {} } }),
+    );
+    assert.equal(response.status, 200);
+    assert.equal(rows().length, 1);
   });
 });

--- a/tests/data-api-nominator-positions-d1.test.ts
+++ b/tests/data-api-nominator-positions-d1.test.ts
@@ -347,7 +347,7 @@ describe("routed to the sync queue (metagraphed-infra#355)", () => {
       }),
     );
     assert.equal(sent[0]!.lane, "nominator-positions");
-    assert.equal(sent[0]!.coldkey_complete, true);
+    assert.equal(sent[0]!.key_complete, true);
     assert.equal(sent[0]!.captured_at, 1_780_000_000_000);
     assert.equal(validSyncBatchMessage(sent[0]), true);
   });

--- a/tests/data-api-sync-queue-consumer.test.ts
+++ b/tests/data-api-sync-queue-consumer.test.ts
@@ -1,0 +1,168 @@
+// The sync queue's consumer (metagraphed-infra#347/#348/#355).
+//
+// This handler WRITES, which is why it is worth a test of its own: everything
+// above it -- the validator, the classifier, the dispatch -- is pure and tested
+// in sync-batch-queue.test.ts, but the ack/retry decision is only observable
+// here, and getting it backwards is expensive in both directions. Retrying an
+// unparseable message burns five attempts and dead-letters anyway; acking a
+// failed WRITE loses rows nothing else is producing, because a cut-over lane
+// has no second path.
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, describe, test } from "vitest";
+
+const { default: worker } = await import("../workers/data-api.ts");
+
+const SCHEMA = fs.readFileSync(
+  path.join(process.cwd(), "migrations/d1/0011_nominator_positions.sql"),
+  "utf8",
+);
+
+const COLDKEY = "5CXRfP2ekFhYQ6BCwEy5V8YyxgLmUmTNzHZTKAfTHKhKPBqE";
+const HOTKEY = "5FyVinYphF6JS5FZHzhMQffxtgbz1WxwUEBAxTRo9nABwb5g";
+
+let db: InstanceType<typeof DatabaseSync>;
+
+function d1(failing = false) {
+  return {
+    prepare(text: string) {
+      return {
+        bind(...values: unknown[]) {
+          return {
+            text,
+            values,
+            async all() {
+              return { results: db.prepare(text).all(...(values as never[])) };
+            },
+          };
+        },
+      };
+    },
+    async batch(statements: { text: string; values: unknown[] }[]) {
+      if (failing) throw new Error("D1 DB is overloaded");
+      db.exec("BEGIN");
+      try {
+        const results = statements.map((s) => ({
+          results: db.prepare(s.text).all(...(s.values as never[])),
+        }));
+        db.exec("COMMIT");
+        return results;
+      } catch (err) {
+        db.exec("ROLLBACK");
+        throw err;
+      }
+    },
+  };
+}
+
+function message(body: unknown) {
+  const calls: string[] = [];
+  return {
+    body,
+    calls,
+    ack: () => calls.push("ack"),
+    retry: () => calls.push("retry"),
+  };
+}
+
+function positionMessage(overrides: Record<string, unknown> = {}) {
+  return message({
+    lane: "nominator-positions",
+    captured_at: 1_780_000_000_000,
+    coldkey_complete: true,
+    rows: [
+      {
+        coldkey: COLDKEY,
+        hotkey: HOTKEY,
+        netuid: 18,
+        share_fraction: 0.25,
+        captured_at: 1_780_000_000_000,
+      },
+    ],
+    ...overrides,
+  });
+}
+
+async function consume(
+  messages: ReturnType<typeof message>[],
+  envOverrides: Record<string, unknown> = {},
+) {
+  await worker.queue!(
+    { messages } as never,
+    { METAGRAPH_HEALTH_DB: d1(), ...envOverrides } as never,
+    { waitUntil: () => {} } as never,
+  );
+}
+
+beforeEach(() => {
+  db = new DatabaseSync(":memory:");
+  db.exec(SCHEMA);
+});
+
+const rows = () =>
+  db.prepare("SELECT * FROM nominator_positions").all() as Record<
+    string,
+    unknown
+  >[];
+
+describe("the sync queue consumer", () => {
+  test("writes a valid message and acks it", async () => {
+    const m = positionMessage();
+    await consume([m]);
+    assert.deepEqual(m.calls, ["ack"]);
+    assert.equal(rows().length, 1);
+  });
+
+  test("acks an unparseable message rather than retrying it", async () => {
+    // It will not parse on the fifth attempt either. Acking keeps the DLQ
+    // holding things that might yet succeed rather than things that never could.
+    const m = message({ lane: "not-a-lane", captured_at: 1, rows: [{}] });
+    await consume([m]);
+    assert.deepEqual(m.calls, ["ack"]);
+  });
+
+  test("acks a pruning message that failed to assert completeness", async () => {
+    // THE DATA-LOSS GUARD, end to end. Without `coldkey_complete` the write
+    // would prune a coldkey against a chunk that may not carry all its rows.
+    // The consumer refuses instead, and nothing is written.
+    const m = positionMessage({ coldkey_complete: undefined });
+    await consume([m]);
+    assert.deepEqual(m.calls, ["ack"]);
+    assert.equal(rows().length, 0, "refused, not written");
+  });
+
+  test("retries a message whose WRITE failed", async () => {
+    // `D1_ERROR: D1 DB is overloaded` is the exact failure the producer's
+    // one-second inter-chunk sleep stood in for, and the reason deleting that
+    // sleep was safe: the queue's backoff now owns it.
+    const m = positionMessage();
+    await consume([m], { METAGRAPH_HEALTH_DB: d1(true) });
+    assert.deepEqual(m.calls, ["retry"]);
+  });
+
+  test("disposes of each message on its own merits", async () => {
+    // Per message, not per batch: one bad chunk must not drag its nine
+    // neighbours through the retry budget with it.
+    const good = positionMessage();
+    const bad = message(null);
+    await consume([good, bad]);
+    assert.deepEqual(good.calls, ["ack"]);
+    assert.deepEqual(bad.calls, ["ack"]);
+    assert.equal(rows().length, 1);
+  });
+
+  test("retries rather than dropping when no D1 binding is present", async () => {
+    // An unbound database is transient-looking from here, and a lane that is
+    // cut over has no other writer -- acking would lose the rows outright.
+    const m = positionMessage();
+    await consume([m], { METAGRAPH_HEALTH_DB: undefined });
+    assert.deepEqual(m.calls, ["retry"]);
+  });
+
+  test("an empty batch is not an error", async () => {
+    await consume([]);
+    assert.equal(rows().length, 0);
+  });
+});

--- a/tests/data-api-sync-queue-consumer.test.ts
+++ b/tests/data-api-sync-queue-consumer.test.ts
@@ -71,7 +71,7 @@ function positionMessage(overrides: Record<string, unknown> = {}) {
   return message({
     lane: "nominator-positions",
     captured_at: 1_780_000_000_000,
-    coldkey_complete: true,
+    key_complete: true,
     rows: [
       {
         coldkey: COLDKEY,
@@ -124,10 +124,10 @@ describe("the sync queue consumer", () => {
   });
 
   test("acks a pruning message that failed to assert completeness", async () => {
-    // THE DATA-LOSS GUARD, end to end. Without `coldkey_complete` the write
+    // THE DATA-LOSS GUARD, end to end. Without `key_complete` the write
     // would prune a coldkey against a chunk that may not carry all its rows.
     // The consumer refuses instead, and nothing is written.
-    const m = positionMessage({ coldkey_complete: undefined });
+    const m = positionMessage({ key_complete: undefined });
     await consume([m]);
     assert.deepEqual(m.calls, ["ack"]);
     assert.equal(rows().length, 0, "refused, not written");

--- a/tests/sync-batch-queue.test.ts
+++ b/tests/sync-batch-queue.test.ts
@@ -43,9 +43,7 @@ describe("validSyncBatchMessage", () => {
     assert.equal(validSyncBatchMessage({ ...OK, lane: "brand-new" }), false);
     for (const lane of SYNC_BATCH_LANES) {
       // A pruning lane additionally has to assert key-completeness; see below.
-      const extra = PRUNING_LANES.includes(lane)
-        ? { coldkey_complete: true }
-        : {};
+      const extra = PRUNING_LANES.includes(lane) ? { key_complete: true } : {};
       assert.equal(
         validSyncBatchMessage({ ...OK, ...extra, lane }),
         true,
@@ -256,14 +254,14 @@ describe("pruning lanes must declare key-completeness", () => {
     // retry undoes a delete. Refusing beats pruning on trust.
     assert.equal(validSyncBatchMessage(positions), false);
     assert.equal(
-      validSyncBatchMessage({ ...positions, coldkey_complete: false }),
+      validSyncBatchMessage({ ...positions, key_complete: false }),
       false,
     );
   });
 
   test("accepts it once the producer asserts completeness", () => {
     assert.equal(
-      validSyncBatchMessage({ ...positions, coldkey_complete: true }),
+      validSyncBatchMessage({ ...positions, key_complete: true }),
       true,
     );
   });

--- a/tests/sync-batch-queue.test.ts
+++ b/tests/sync-batch-queue.test.ts
@@ -17,6 +17,7 @@ import {
   SYNC_BATCH_LANES,
   SYNC_BATCH_MAX_ROWS,
   passTallyFor,
+  PRUNING_LANES,
   syncLaneUsesQueue,
   validSyncBatchMessage,
   writeSyncBatch,
@@ -41,7 +42,15 @@ describe("validSyncBatchMessage", () => {
     // lane means an unrecognised table, and a guess is worse than a DLQ entry.
     assert.equal(validSyncBatchMessage({ ...OK, lane: "brand-new" }), false);
     for (const lane of SYNC_BATCH_LANES) {
-      assert.equal(validSyncBatchMessage({ ...OK, lane }), true, lane);
+      // A pruning lane additionally has to assert key-completeness; see below.
+      const extra = PRUNING_LANES.includes(lane)
+        ? { coldkey_complete: true }
+        : {};
+      assert.equal(
+        validSyncBatchMessage({ ...OK, ...extra, lane }),
+        true,
+        lane,
+      );
     }
   });
 
@@ -230,5 +239,41 @@ describe("writeSyncBatch", () => {
       3,
       "the sum is order-independent",
     );
+  });
+});
+
+describe("pruning lanes must declare key-completeness", () => {
+  const positions = {
+    lane: "nominator-positions",
+    captured_at: 1_785_990_000_000,
+    rows: [{ coldkey: "5C", hotkey: "5H", netuid: 7, captured_at: 1 }],
+  };
+
+  test("rejects a pruning lane's chunk that does not claim completeness", () => {
+    // THE DATA-LOSS CASE. nominator_positions' write DELETES a coldkey's rows
+    // older than the max captured_at it just saw for that coldkey. Computed
+    // from a partial chunk, that deletes rows the chunk did not carry -- and no
+    // retry undoes a delete. Refusing beats pruning on trust.
+    assert.equal(validSyncBatchMessage(positions), false);
+    assert.equal(
+      validSyncBatchMessage({ ...positions, coldkey_complete: false }),
+      false,
+    );
+  });
+
+  test("accepts it once the producer asserts completeness", () => {
+    assert.equal(
+      validSyncBatchMessage({ ...positions, coldkey_complete: true }),
+      true,
+    );
+  });
+
+  test("non-pruning lanes are unaffected", () => {
+    // Only a pruning write can delete what a chunk did not carry, so requiring
+    // the flag everywhere would be ceremony that teaches people to set it
+    // reflexively -- which is how a real guarantee becomes a habit.
+    assert.equal(validSyncBatchMessage(OK), true);
+    assert.equal(PRUNING_LANES.includes("hotkey-alpha"), false);
+    assert.equal(PRUNING_LANES.includes("nominator-positions"), true);
   });
 });

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -1852,9 +1852,8 @@ async function handleNominatorPositionsSync(request: Request, env: Env) {
 
   // Enqueue or write, never both -- see handleHotkeyAlphaSync's own note.
   //
-  // `coldkey_complete` is this lane's alone, and it is not ceremony. The write
-  // below PRUNES: it deletes rows for a `coldkey` older than the newest
-  // captured_at just seen for it. Applied to a chunk missing some of those
+  // `key_complete` is not ceremony. The write below PRUNES: it deletes rows
+  // for a `coldkey` older than the newest captured_at just seen for that key. Applied to a chunk missing some of those
   // rows, that deletes rows the chunk never carried -- and no retry undoes a
   // delete. The producer's `pack_coldkey_chunks` guarantees a per-coldkey group
   // is never split, with a test a flat slice would fail; asserting it here
@@ -1868,7 +1867,7 @@ async function handleNominatorPositionsSync(request: Request, env: Env) {
       await env.SYNC_BATCHES!.send({
         lane: "nominator-positions",
         captured_at: rows[0]!.captured_at as number,
-        coldkey_complete: true,
+        key_complete: true,
         rows,
       });
     } catch (err) {
@@ -7242,7 +7241,7 @@ export default {
               pass,
             ),
           // Recomputes the prune map from THIS message's rows, which is sound
-          // only because the message asserted `coldkey_complete` -- the
+          // only because the message asserted `key_complete` -- the
           // validator rejects it otherwise, so this writer never sees a chunk
           // that could prune rows it did not carry.
           "nominator-positions": (rows) =>

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -1850,6 +1850,39 @@ async function handleNominatorPositionsSync(request: Request, env: Env) {
   const rows = incoming.map(coerceNominatorPositionSyncRow);
   const cutoffs = coldkeyMaxCapturedAt(rows);
 
+  // Enqueue or write, never both -- see handleHotkeyAlphaSync's own note.
+  //
+  // `coldkey_complete` is this lane's alone, and it is not ceremony. The write
+  // below PRUNES: it deletes rows for a `coldkey` older than the newest
+  // captured_at just seen for it. Applied to a chunk missing some of those
+  // rows, that deletes rows the chunk never carried -- and no retry undoes a
+  // delete. The producer's `pack_coldkey_chunks` guarantees a per-coldkey group
+  // is never split, with a test a flat slice would fail; asserting it here
+  // turns a cross-repo assumption into something the consumer can refuse.
+  //
+  // Note the guarantee is ALREADY load-bearing on the HTTP path -- `cutoffs`
+  // above is computed from one POSTed chunk, not the whole pass. The queue
+  // changes the transport, not the contract.
+  if (syncLaneUsesQueue(env, "nominator-positions")) {
+    try {
+      await env.SYNC_BATCHES!.send({
+        lane: "nominator-positions",
+        captured_at: rows[0]!.captured_at as number,
+        coldkey_complete: true,
+        rows,
+      });
+    } catch (err) {
+      console.error("data-api nominator-positions enqueue failed:", err);
+      await captureDataApiError(err, "nominator-positions-sync-queue", env);
+      return writeJson({ error: "enqueue failed" }, 502);
+    }
+    return writeJson({
+      ok: true,
+      nominator_positions_written: rows.length,
+      stores: ["queue"],
+    });
+  }
+
   // D1 is the binding this path REQUIRES -- the only store this family has.
   // Checked HERE, after validation, not at the top: a malformed body is a 400
   // whether or not a store happens to be bound (handleSubnetHyperparamsSync's
@@ -7168,13 +7201,15 @@ export default {
   /**
    * The bulk sync path's consumer (metagraphed-infra#347).
    *
-   * NO-OP BY DESIGN AT THIS STAGE. It validates, classifies and reports, and
-   * writes nothing. The point of a first cut is to observe the queue's real
-   * behaviour -- batch sizes, retry timing, dead-letter routing, what
-   * `max_concurrency` actually does to throughput -- against production traffic
-   * shape BEFORE any lane depends on it. Those are precisely the properties the
-   * hand-rolled retry and pacing currently substitute for, so they get measured
-   * rather than assumed.
+   * IT WRITES. The first cut deliberately did not -- it validated, classified
+   * and reported, so the queue's real behaviour (batch sizes, retry timing,
+   * dead-letter routing, what `max_concurrency` does to throughput) could be
+   * observed against production traffic shape before any lane depended on it.
+   * Those are the properties the hand-rolled retry and pacing substituted for,
+   * and measuring them first is what made deleting the pacing defensible.
+   *
+   * A lane only reaches here once SYNC_QUEUE_LANES names it, so wiring a lane
+   * and cutting it over stay separate deploys.
    *
    * A MALFORMED MESSAGE IS ACKED, NOT RETRIED. Retrying something that can
    * never parse burns five attempts and dead-letters anyway; acking it keeps
@@ -7205,6 +7240,17 @@ export default {
               >[0],
               rows,
               pass,
+            ),
+          // Recomputes the prune map from THIS message's rows, which is sound
+          // only because the message asserted `coldkey_complete` -- the
+          // validator rejects it otherwise, so this writer never sees a chunk
+          // that could prune rows it did not carry.
+          "nominator-positions": (rows) =>
+            writeNominatorPositionsToD1(
+              env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+                typeof writeNominatorPositionsToD1
+              >[0],
+              { rows, coldkeyMaxCapturedAt: coldkeyMaxCapturedAt(rows) },
             ),
           "validator-nominator-counts": (rows) =>
             writeValidatorNominatorCountsToD1(


### PR DESCRIPTION
Closes metagraphed-infra#355.

The last bulk lane to wire, and the only one whose write **deletes**.

## The guard this lane needed

`nominator_positions`' writer prunes: it removes rows for a `coldkey` older than the newest `captured_at` it just saw for that key. Applied to a chunk that is missing some of those rows, it deletes rows the chunk never carried — **and no retry undoes a delete**.

`pack_coldkey_chunks` already guarantees a per-coldkey group is never split, with a test a flat slice would fail. Worth being precise about what changed: **that guarantee is already load-bearing on the HTTP path** — the prune map is computed from one POSTed chunk, not the whole pass — so the queue changes the transport, not the contract.

What *is* new is that it now crosses a repo boundary. An assumption that crosses a boundary should be an assertion, so the message carries `key_complete`, and the consumer **refuses** a pruning chunk without it rather than pruning on trust. A producer that stopped setting it dead-letters loudly instead of quietly deleting.

The flag is scoped to `PRUNING_LANES`, not required everywhere — a mandatory field on seven lanes that cannot lose data teaches people to set it reflexively, which is how a real guarantee decays into a habit.

## The consumer was writing untested

It has performed D1 writes since #9612 with no test of its own. Everything above it is pure and covered; the **ack/retry decision is only observable in the handler**, and it is expensive backwards in both directions:

- retrying an unparseable message burns five attempts and dead-letters anyway
- acking a failed *write* loses rows outright, because a cut-over lane has no second path

Seven cases now cover it, including the data-loss guard end to end and `D1_ERROR: D1 DB is overloaded` — the exact failure the producer's one-second inter-chunk sleep stood in for, and the reason deleting that sleep was safe.

Also corrected the handler's header, which still read "NO-OP BY DESIGN AT THIS STAGE" three PRs after it started writing.

## Ships inert

`SYNC_QUEUE_LANES` still names only `hotkey-alpha`. **Wiring and cutover stay separate deploys**, so a bad wiring change cannot also be a bad cutover.

| gate | result |
|---|---|
| `lint` / `format:check` / `typecheck` | clean |
| `validate` | 129 subnets, 3442 surfaces |
| `scan:public-safety` | passed |
| affected suites | 45 passed (3 files) |
| patch coverage | 77 changed lines across both files — **0 uncovered statements, 0 uncovered branches**, measured by diff intersection |

---

**Update:** the guard's field is `key_complete`, not `coldkey_complete`. `neurons` prunes too — per netuid — so a per-column name would need renaming the moment the second pruning lane moved. `PRUNING_LANES` still lists only `nominator-positions`: listing a lane before its producer asserts completeness would reject every one of its messages.