### PR TITLE
feat(queue): accept account-balances on sync-batches

### DIFF
--- a/tests/data-api-account-balances-d1.test.ts
+++ b/tests/data-api-account-balances-d1.test.ts
@@ -22,6 +22,7 @@ import { DatabaseSync } from "node:sqlite";
 import fs from "node:fs";
 import path from "node:path";
 import { beforeEach, describe, test } from "vitest";
+import { validSyncBatchMessage } from "../src/sync-batch-queue.ts";
 import type { Row } from "./row-type.ts";
 
 const { default: worker } = await import("../workers/data-api.ts");
@@ -418,5 +419,99 @@ describe("pass_total completeness accounting", () => {
     });
     assert.equal(response.status, 400);
     assert.equal(rows().length, 0);
+  });
+});
+
+describe("routed to the sync queue (metagraphed-infra#350)", () => {
+  function queueEnv(send: (m: unknown) => Promise<void>) {
+    return env({
+      SYNC_BATCHES: { send },
+      SYNC_QUEUE_LANES: "account-balances",
+    });
+  }
+
+  test("enqueues instead of writing, and never both", async () => {
+    // NO DUAL WRITE. This is the lane whose unthrottled write saturated D1 in
+    // the first place; writing it twice during the migration would double the
+    // load the queue exists to relieve.
+    const sent: Record<string, unknown>[] = [];
+    const response = await post(
+      { rows: [balanceRow(), balanceRow({ ss58: SS58_B })] },
+      SECRET,
+      queueEnv(async (m) => {
+        sent.push(m as Record<string, unknown>);
+      }),
+    );
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      account_balances_written: 2,
+      stores: ["queue"],
+      pass_total: null,
+    });
+    assert.equal(sent.length, 1);
+    assert.equal(rows().length, 0, "D1 must not also have been written");
+    assert.equal(passes().length, 0);
+  });
+
+  test("carries a declared pass through to the queue", async () => {
+    // A queue knows a message was DELIVERED. It does not know whether the
+    // producer's whole scan arrived -- a different fact, and the one that caught
+    // this ledger publishing 147,000 of 364,000 rows while looking fresh. The
+    // declaration has to survive the transport or the tally means nothing.
+    const sent: Record<string, unknown>[] = [];
+    const response = await post(
+      { pass_total: 364_000, rows: [balanceRow()] },
+      SECRET,
+      queueEnv(async (m) => {
+        sent.push(m as Record<string, unknown>);
+      }),
+    );
+    assert.equal(response.status, 200);
+    assert.equal(
+      ((await response.json()) as Row).pass_total,
+      364_000,
+      "echoed, so a producer sees its declaration was understood",
+    );
+    assert.equal(sent[0]!.pass_total, 364_000);
+    assert.equal(sent[0]!.captured_at, 1_780_000_000_000);
+    assert.equal(validSyncBatchMessage(sent[0]), true);
+  });
+
+  test("an undeclared chunk enqueues without inventing a total", async () => {
+    // Inventing one would mark an unproven load complete -- the precise lie the
+    // completeness gate exists to prevent.
+    const sent: Record<string, unknown>[] = [];
+    await post(
+      { rows: [balanceRow()] },
+      SECRET,
+      queueEnv(async (m) => {
+        sent.push(m as Record<string, unknown>);
+      }),
+    );
+    assert.equal("pass_total" in sent[0]!, false);
+    assert.equal(validSyncBatchMessage(sent[0]), true);
+  });
+
+  test("a failed enqueue is a 502, not a silent success", async () => {
+    const response = await post(
+      { rows: [balanceRow()] },
+      SECRET,
+      queueEnv(async () => {
+        throw new Error("queue unavailable");
+      }),
+    );
+    assert.equal(response.status, 502);
+    assert.equal(rows().length, 0, "no fallback write -- the lane is cut over");
+  });
+
+  test("an un-opted deployment still writes D1", async () => {
+    const response = await post(
+      { rows: [balanceRow()] },
+      SECRET,
+      env({ SYNC_BATCHES: { send: async () => {} } }),
+    );
+    assert.equal(response.status, 200);
+    assert.equal(rows().length, 1);
   });
 });

--- a/tests/data-api-sync-queue-consumer.test.ts
+++ b/tests/data-api-sync-queue-consumer.test.ts
@@ -15,10 +15,19 @@ import { beforeEach, describe, test } from "vitest";
 
 const { default: worker } = await import("../workers/data-api.ts");
 
-const SCHEMA = fs.readFileSync(
-  path.join(process.cwd(), "migrations/d1/0011_nominator_positions.sql"),
-  "utf8",
-);
+const SCHEMA =
+  fs.readFileSync(
+    path.join(process.cwd(), "migrations/d1/0011_nominator_positions.sql"),
+    "utf8",
+  ) +
+  fs.readFileSync(
+    path.join(process.cwd(), "migrations/d1/0017_account_balances.sql"),
+    "utf8",
+  ) +
+  fs.readFileSync(
+    path.join(process.cwd(), "migrations/d1/0020_account_balances_passes.sql"),
+    "utf8",
+  );
 
 const COLDKEY = "5CXRfP2ekFhYQ6BCwEy5V8YyxgLmUmTNzHZTKAfTHKhKPBqE";
 const HOTKEY = "5FyVinYphF6JS5FZHzhMQffxtgbz1WxwUEBAxTRo9nABwb5g";
@@ -107,7 +116,45 @@ const rows = () =>
     unknown
   >[];
 
+const balances = () =>
+  db.prepare("SELECT * FROM account_balances").all() as Record<
+    string,
+    unknown
+  >[];
+
 describe("the sync queue consumer", () => {
+  test("writes account-balances and credits its declared pass", async () => {
+    // The lane whose truncation started all of this. The tally has to survive
+    // the transport: a queue knows a message arrived, not whether the whole
+    // scan did, and only the second fact catches a short pass.
+    const m = message({
+      lane: "account-balances",
+      captured_at: 1_780_000_000_000,
+      pass_total: 2,
+      rows: [
+        {
+          ss58: COLDKEY,
+          free_tao: 1000.5,
+          reserved_tao: 25.25,
+          captured_at: 1_780_000_000_000,
+        },
+      ],
+    });
+    await consume([m]);
+    assert.deepEqual(m.calls, ["ack"]);
+    assert.equal(balances().length, 1);
+    const pass = db
+      .prepare("SELECT * FROM account_balances_passes")
+      .all()[0] as Record<string, unknown>;
+    assert.equal(pass.expected_rows, 2);
+    assert.equal(pass.received_rows, 1);
+    assert.equal(
+      pass.completed_at,
+      null,
+      "one of two rows delivered is not a complete pass",
+    );
+  });
+
   test("writes a valid message and acks it", async () => {
     const m = positionMessage();
     await consume([m]);

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -2095,6 +2095,39 @@ async function handleAccountBalancesSync(request: Request, env: Env) {
     };
   }
 
+  // Enqueue or write, never both -- see handleHotkeyAlphaSync's own note.
+  //
+  // THE LANE THAT CAUSED THE INCIDENT. `D1_ERROR: D1 DB is overloaded` aborted
+  // this pass at 147,000 of 364,000 rows, and took `wallet-auth` and
+  // `tao-usd-index` down with it on the database everything shares. It is
+  // therefore the real test of whether queue-provided backpressure replaces the
+  // producer's one-second inter-chunk sleep -- which is why it moves last of
+  // the simple lanes, after the cheap ones proved the shape.
+  //
+  // The declared pass rides along unchanged. A queue knows a message was
+  // delivered; it does not know whether a producer's whole SCAN arrived, and
+  // that second fact is the one that caught the truncation.
+  if (syncLaneUsesQueue(env, "account-balances")) {
+    try {
+      await env.SYNC_BATCHES!.send({
+        lane: "account-balances",
+        captured_at: pass?.capturedAt ?? (rows[0]!.captured_at as number),
+        ...(pass ? { pass_total: pass.expectedRows } : {}),
+        rows,
+      });
+    } catch (err) {
+      console.error("data-api account-balances enqueue failed:", err);
+      await captureDataApiError(err, "account-balances-sync-queue", env);
+      return writeJson({ error: "enqueue failed" }, 502);
+    }
+    return writeJson({
+      ok: true,
+      account_balances_written: rows.length,
+      stores: ["queue"],
+      pass_total: pass?.expectedRows ?? null,
+    });
+  }
+
   // D1 is the binding this path REQUIRES -- the only store this family has.
   // Checked HERE, after validation, not at the top: a malformed body is a 400
   // whether or not a store happens to be bound (handleNominatorPositionsSync's
@@ -7250,6 +7283,14 @@ export default {
                 typeof writeNominatorPositionsToD1
               >[0],
               { rows, coldkeyMaxCapturedAt: coldkeyMaxCapturedAt(rows) },
+            ),
+          "account-balances": (rows, pass) =>
+            writeAccountBalancesToD1(
+              env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+                typeof writeAccountBalancesToD1
+              >[0],
+              rows,
+              pass,
             ),
           "validator-nominator-counts": (rows) =>
             writeValidatorNominatorCountsToD1(


### PR DESCRIPTION
Closes metagraphed-infra#350.

**The lane that caused the incident.** `D1_ERROR: D1 DB is overloaded. Requests queued for too long.` aborted this pass at 147,000 of 364,000 rows and took `wallet-auth` and `tao-usd-index` down with it, on the database everything shares.

That makes it the real test of whether queue-provided backpressure replaces the producer's one-second inter-chunk sleep — and why it moves **last** of the simple lanes, after the cheap ones proved the shape rather than first because it hurt most.

## The declared pass rides along unchanged

A queue knows a message was **delivered**. It does not know whether a producer's whole **scan** arrived. Those are different facts, and only the second one caught this ledger publishing 147,000 of 364,000 rows while looking perfectly fresh. So `pass_total` survives the transport, `received_rows` still accumulates, and `completed_at` is still stamped by whichever write closes the gap — which is safe out of order because that tally is commutative.

## Ships inert

`SYNC_QUEUE_LANES` still names only `hotkey-alpha`. **Wiring and cutover stay separate deploys**, so a bad wiring change cannot also be a bad cutover.

## The three lanes not in this PR, and why

Each was examined and each has a real blocker, filed rather than deferred silently:

| lane | blocker | issue |
|---|---|---|
| `neurons` | **also prunes**, per netuid. `key_complete` (from #9627) is the guard; what is unverified is whether its producer chunking guarantees a netuid is never split | metagraphed-infra#357 |
| `account-identity`, `subnet-hyperparams` | their write is a **read-modify-write** against an append-only history table. Safe only because the HTTP path is sequential; at `max_concurrency: 2` two chunks can both append for one change | metagraphed-infra#358 |
| `chain-detail` | posts **four row families** in one request, written together for atomicity. The message shape carries one | metagraphed-infra#359 |

None is a wiring change, which is why none is here.

| gate | result |
|---|---|
| `lint` / `format:check` / `typecheck` | clean |
| `scan:public-safety` | passed |
| affected suites | 71 passed (4 files) |
| patch coverage | 41 changed lines — **0 uncovered statements, 0 uncovered branches**, measured by diff intersection |
