### PR TITLE
chore(queue): cut account-balances over to sync-batches

### DIFF
--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -119,7 +119,24 @@
     // Declared INSIDE this block deliberately: a second top-level "vars" key
     // would silently replace this one wholesale, which is the trap the tier-flag
     // comment above already records.
-    "SYNC_QUEUE_LANES": "hotkey-alpha",
+    //
+    // account-balances joins hotkey-alpha as of 2026-08-06. This is THE lane:
+    // `D1_ERROR: D1 DB is overloaded` aborted its pass at 147,000 of 364,000
+    // rows and took wallet-auth and tao-usd-index down with it, and it is ~8x
+    // hotkey-alpha's size, so it is the first real test of whether the queue's
+    // backpressure replaces the producer's deleted inter-chunk sleep.
+    //
+    // Cut over on evidence, not on hope: hotkey-alpha's two queued passes
+    // tallied exactly (47,032/47,032) and ran 35s/95s against 123s/177s on the
+    // old path. That is consistent with the sleep having been the dominant
+    // cost -- it is NOT proof at 364k rows, which is why this lane goes alone.
+    //
+    // ROLLBACK IS DROPPING A WORD FROM THIS STRING. These are latest-only
+    // upsert tables refreshed on a tick, so the next pass simply writes the old
+    // way. No backfill, no reconciliation. Watch account_balances_passes: an
+    // incomplete pass is the signal, and completeness is a fact the queue does
+    // not itself provide.
+    "SYNC_QUEUE_LANES": "hotkey-alpha,account-balances",
     // #9430's $exception storm guard reads this var per-Worker
     // (src/usage-telemetry.ts), and `vars` are per-config -- declaring it
     // only in wrangler.jsonc left THIS Worker's captures entirely unguarded,


### PR DESCRIPTION
Closes metagraphed-infra#350.

One word added to `SYNC_QUEUE_LANES`. That word is the cutover — #9629 wired the lane and shipped it inert on purpose, so a bad wiring change could not also be a bad cutover.

## Why this lane, and why alone

`account-balances` is the lane whose unthrottled write produced `D1_ERROR: D1 DB is overloaded. Requests queued for too long.` — aborting its pass at 147,000 of 364,000 rows and taking `wallet-auth` and `tao-usd-index` down with it, on the database everything shares.

At ~364k rows it is roughly **8x** `hotkey-alpha`, which makes it the first real test of whether queue-provided backpressure replaces the producer's inter-chunk sleep (deleted in metagraphed-infra#356).

## The evidence this is cut over on

`hotkey-alpha` has been on the queue since 04:35Z today:

| pass | tally | wall time | path |
|---|---|---|---|
| 05:01:38 | 47,032/47,032 ✅ | **95s** | queue |
| 04:40:46 | 46,965/46,965 ✅ | **35s** | queue |
| 00:05:46 | 47,041/47,041 ✅ | 177s | HTTP + 1s sleep |
| 22:50:45 | 46,998/46,998 ✅ | 123s | HTTP + 1s sleep |

Being precise about what that does and does not establish: completeness held, and throughput did not regress — consistent with the sleep having been the dominant cost. It is **not** proof at 364k rows on two passes of a much smaller lane. That is exactly why this lane goes alone rather than alongside the other two wired ones.

## Rollback

Dropping the word. These are latest-only upsert tables refreshed on a tick, so the next pass simply writes the old way — no backfill, no reconciliation.

**What to watch:** `account_balances_passes`. An incomplete pass (`received_rows` short of `expected_rows`, `completed_at` null) is the signal, and it is a fact the queue does not itself provide — a queue knows a message was delivered, not whether the whole scan arrived. That distinction is what caught the original truncation.

| gate | result |
|---|---|
| `format:check` | clean |
| `validate` | 129 subnets, 3442 surfaces |
| `scan:public-safety` | passed |
| `sync-batch-queue` suite | 23 passed |

No `src/**` or `workers/**` lines changed — config only.
