### PR TITLE
fix(queue): roll SYNC_QUEUE_LANES back to empty, so the stopped lanes write again

### DIFF
--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -120,23 +120,31 @@
     // would silently replace this one wholesale, which is the trap the tier-flag
     // comment above already records.
     //
-    // account-balances joins hotkey-alpha as of 2026-08-06. This is THE lane:
-    // `D1_ERROR: D1 DB is overloaded` aborted its pass at 147,000 of 364,000
-    // rows and took wallet-auth and tao-usd-index down with it, and it is ~8x
-    // hotkey-alpha's size, so it is the first real test of whether the queue's
-    // backpressure replaces the producer's deleted inter-chunk sleep.
+    // EMPTY, ROLLED BACK 2026-08-06 (metagraphed-infra#360). Every enqueue
+    // exceeds the 128 KB Queues message cap by ~24x: the route hands `send()`
+    // the whole posted chunk and the producer chunks at CHUNK_SIZE = 25_000,
+    // which is 3,116 KB at a measured 127.6 bytes/row. `send()` throws, the
+    // route returns 502, and the producer retries 6x and abandons the pass --
+    // so a cut-over lane does not degrade, it STOPS.
     //
-    // Cut over on evidence, not on hope: hotkey-alpha's two queued passes
-    // tallied exactly (47,032/47,032) and ran 35s/95s against 123s/177s on the
-    // old path. That is consistent with the sleep having been the dominant
-    // cost -- it is NOT proof at 364k rows, which is why this lane goes alone.
+    // Both lanes had completed ZERO passes while named here. The earlier
+    // "cut over on evidence" note cited hotkey-alpha passes at 04:40 and 05:01
+    // as queued; #9619 -- the commit that first added the name -- did not
+    // deploy until 05:20:12Z, so those two ran on the inline path. THE DEPLOY
+    // TIMESTAMP IS THE CHECK, not the pass table: a pass row proves a lane is
+    // healthy, not which path carried it.
+    //
+    // Re-adding a lane requires the fan-out in #360 first, and that split must
+    // be KEY-AWARE -- nominator-positions asserts `key_complete`, and a naive
+    // slice can split a coldkey across sub-messages, which is exactly the
+    // delete-what-you-did-not-carry bug the guard exists to stop.
     //
     // ROLLBACK IS DROPPING A WORD FROM THIS STRING. These are latest-only
     // upsert tables refreshed on a tick, so the next pass simply writes the old
     // way. No backfill, no reconciliation. Watch account_balances_passes: an
     // incomplete pass is the signal, and completeness is a fact the queue does
     // not itself provide.
-    "SYNC_QUEUE_LANES": "hotkey-alpha,account-balances",
+    "SYNC_QUEUE_LANES": "",
     // #9430's $exception storm guard reads this var per-Worker
     // (src/usage-telemetry.ts), and `vars` are per-config -- declaring it
     // only in wrangler.jsonc left THIS Worker's captures entirely unguarded,


### PR DESCRIPTION
Closes metagraphed-infra#361.

Both cut-over lanes have completed **zero** passes. Not slowly, not partially — zero.

## What is wrong

The route hands `send()` the whole posted chunk:

```ts
await env.SYNC_BATCHES!.send({ lane: "hotkey-alpha", captured_at, ...pass, rows });
```

The producer chunks at `CHUNK_SIZE = 25_000`. **A Cloudflare Queues message is capped at 128 KB.** Measured against 1,000 real `hotkey_alpha` rows from D1 — 127.6 bytes/row compact:

| chunk | message | vs cap |
|---|---|---|
| 25,000 rows (`hotkey-alpha`, `account-balances`) | **3,116 KB** | **24x over** |
| 50,000 rows (`neurons`, `validator-nominator-counts`) | 6,232 KB | 49x over |
| 1,026 rows | 128 KB | the real ceiling |

`send()` throws → route returns 502 `enqueue failed` → the producer reads that as a transient network fault, retries 6x with backoff (`CHUNK_POST_ATTEMPTS`), and abandons the pass.

**So a cut-over lane does not degrade. It stops.**

| lane | cutover deployed | newest pass |
|---|---|---|
| `hotkey-alpha` | 05:20:12Z | 05:01:38 |
| `account-balances` | 06:24:35Z | 04:38:45 |

Poller is alive — `lane_health` carries rows at 07:36Z.

## The comment this replaces was wrong, and that is the useful part

It cited hotkey-alpha's 04:40 and 05:01 passes as proof the queue carried them. **#9619 — the commit that first put the name in this string — deployed at 05:20:12Z.** Both passes ran on the inline path.

A pass row proves a lane is healthy, not which path carried it. The deploy timestamp is the check, and it now sits in the config beside the flag rather than waiting to be rediscovered.

## Why this is safe

Exactly what the config already promised: latest-only upsert tables refreshed on a tick, so the next pass writes the old way. No backfill, no reconciliation.

Re-adding a lane is gated on metagraphed-infra#360 — and that fan-out must be **key-aware**, because `nominator-positions` asserts `key_complete` and a naive slice can split a coldkey across sub-messages, which is the delete-what-you-did-not-carry bug the guard exists to stop.

## Verification

- `vitest tests/sync-batch-queue.test.ts tests/data-api-account-balances-d1.test.ts tests/data-api-nominator-positions-d1.test.ts` — 63 passed (no test pins the deployed flag string; each builds its own env)
- config-only change; no generated artifact depends on this var