### PR TITLE
fix(health): treat last_ok as a high-water mark the upsert cannot wipe

### DIFF
--- a/migrations/d1/0027_surface_status_last_ok_repair.sql
+++ b/migrations/d1/0027_surface_status_last_ok_repair.sql
@@ -1,0 +1,50 @@
+-- Restore the last_ok values a degraded prior-status read wiped (#9634).
+--
+-- WHAT WAS LOST. `surface_status.last_ok` is a high-water mark: the last time a
+-- surface was seen working. The prober computes it as `ok ? runAt :
+-- (prior?.last_ok ?? null)`, and until #9522 the `prior` read resolved to
+-- nothing on every run, so every surface that was not ok on a given run had its
+-- history rewritten to NULL. #9522 fixed the read and src/observations-d1.ts
+-- now COALESCEs on write, so no further rows can be wiped -- but neither
+-- restores what was already gone.
+--
+-- Recovery only ever happened by a surface going ok again, which is precisely
+-- what a persistently-degraded surface does not do. Measured 2026-08-06:
+--
+--   status    rows  with last_ok
+--   degraded    94            9
+--   failed       8            0
+--   ok         533          533
+--
+-- and of the 93 null rows, 71 have successful probes still on record:
+-- sn-62-ridges-perfectly-solved-over-time alone has 150, the most recent
+-- 2026-08-05T20:15:10.427Z, while serving `last_ok: null` to every caller.
+--
+-- WHY surface_checks IS A SAFE SOURCE. It records one row per probe with an
+-- `ok` flag, so MAX(checked_at) WHERE ok=1 is the most recent success still
+-- retained. The raw table is pruned at 30 days (`pruneHealthHistory`), which
+-- makes this a LOWER BOUND and never an overstatement: if the true last success
+-- has aged out, every surviving ok row is older, so the value moves earlier or
+-- the surface stays null. It cannot invent a success that did not happen, and
+-- it cannot claim one more recent than the evidence.
+--
+-- IDEMPOTENT, in the same one-pass style as 0024/0025. `WHERE last_ok IS NULL`
+-- makes a re-run a no-op rather than clobbering values the prober has since
+-- written -- a live column must never be overwritten by a repair that reruns.
+-- The inner `MAX(...) IS NOT NULL` guard keeps a surface with no ok probe on
+-- record at NULL instead of writing NULL over NULL, so `changes()` reports the
+-- rows genuinely repaired.
+UPDATE surface_status
+   SET last_ok = (
+         SELECT MAX(c.checked_at)
+           FROM surface_checks c
+          WHERE c.surface_id = surface_status.surface_id
+            AND c.ok = 1
+       )
+ WHERE last_ok IS NULL
+   AND (
+         SELECT MAX(c.checked_at)
+           FROM surface_checks c
+          WHERE c.surface_id = surface_status.surface_id
+            AND c.ok = 1
+       ) IS NOT NULL;

--- a/src/observations-d1.ts
+++ b/src/observations-d1.ts
@@ -57,6 +57,27 @@ export async function runD1StatementBatches(
 // upsert. The status upsert targets BOTH conflict paths (#1005): surface_key
 // when present so a display-id rename updates the alias in place, surface_id
 // as the fallback for keyless rows.
+//
+// LAST_OK IS A HIGH-WATER MARK AND THE UPSERT TREATS IT AS ONE (#9634). Every
+// other column is overwritten with what this run measured, because that is what
+// "latest status" means. `last_ok` is the exception: it records the last time
+// the surface was seen WORKING, so a run that did not see it working has
+// observed nothing about it and must not be able to clear it.
+//
+// It could. `src/health-prober.ts` computes `last_ok_ms` as `ok ? runAt :
+// (prior?.last_ok ?? null)`, and `prior` comes from readLiveSurfaceStatus,
+// which DEGRADES TO AN EMPTY ARRAY on a missing flag, missing binding,
+// transport failure, non-2xx, or unparseable body (see that module's header).
+// With a bare `last_ok=excluded.last_ok`, one such degrade rewrote every non-ok
+// surface's history to NULL permanently -- a read-side degrade silently
+// promoted into write-side data loss. #9522 fixed the read; COALESCE is what
+// makes the write survive the NEXT time that read comes back empty, whatever
+// the reason. Recovery for the rows already wiped is migration 0027.
+//
+// COALESCE and not a WHERE guard because the two conflict paths must stay
+// column-symmetric, and because `excluded.last_ok` is authoritative whenever it
+// is non-null: an ok run supplies runAt, a non-ok run with prior supplies the
+// carried value, and only "we do not know" arrives as null.
 export async function persistProbesToD1(
   db: ObservationsDb | undefined,
   probed: Row[],
@@ -83,7 +104,8 @@ export async function persistProbesToD1(
          provider=excluded.provider, status=excluded.status,
          classification=excluded.classification, latency_ms=excluded.latency_ms,
          status_code=excluded.status_code, last_checked=excluded.last_checked,
-         last_ok=excluded.last_ok, consecutive_failures=excluded.consecutive_failures,
+         last_ok=COALESCE(excluded.last_ok, surface_status.last_ok),
+         consecutive_failures=excluded.consecutive_failures,
          updated_at=excluded.updated_at
        ON CONFLICT(surface_id) DO UPDATE SET
          surface_key=excluded.surface_key,
@@ -91,7 +113,8 @@ export async function persistProbesToD1(
          provider=excluded.provider, status=excluded.status,
          classification=excluded.classification, latency_ms=excluded.latency_ms,
          status_code=excluded.status_code, last_checked=excluded.last_checked,
-         last_ok=excluded.last_ok, consecutive_failures=excluded.consecutive_failures,
+         last_ok=COALESCE(excluded.last_ok, surface_status.last_ok),
+         consecutive_failures=excluded.consecutive_failures,
          updated_at=excluded.updated_at`,
     );
     const statements: unknown[] = [];

--- a/tests/observations-d1-sqlite.test.ts
+++ b/tests/observations-d1-sqlite.test.ts
@@ -23,6 +23,17 @@ const SCHEMA = fs.readFileSync(
   "utf8",
 );
 
+// The #9634 repair, executed rather than eyeballed: it is a correlated UPDATE
+// with a matching guard subquery, which is exactly the shape that silently
+// no-ops or over-writes when it is only read.
+const LAST_OK_REPAIR = fs.readFileSync(
+  path.join(
+    process.cwd(),
+    "migrations/d1/0027_surface_status_last_ok_repair.sql",
+  ),
+  "utf8",
+);
+
 let db: InstanceType<typeof DatabaseSync>;
 
 function d1(): ObservationsDb {
@@ -114,6 +125,162 @@ test("re-probing the same surface_key upserts in place across an id rename", asy
   assert.equal(row.status, "failed");
   assert.equal(row.consecutive_failures, 3);
   assert.equal(count("surface_checks"), 2, "raw history keeps both probes");
+});
+
+// #9634: `last_ok` is a high-water mark, so a run that did not observe the
+// surface working must not be able to clear it. The prober passes
+// `last_ok_ms: null` whenever its prior-status read came back empty --
+// readLiveSurfaceStatus degrades to [] on a missing binding, a non-2xx or an
+// unparseable body -- and a bare `last_ok=excluded.last_ok` turned that
+// read-side degrade into permanent data loss for every non-ok surface.
+// Exercised on BOTH conflict paths because they are separate SET lists.
+test("a non-ok re-probe with no prior keeps last_ok on the surface_key path (#9634)", async () => {
+  const firstOk = Date.parse("2026-08-02T10:00:00Z");
+  await persistProbesToD1(d1(), [probe({ last_ok_ms: firstOk })], firstOk);
+  const res = await persistProbesToD1(
+    d1(),
+    [
+      probe({
+        status: "degraded",
+        latency_ms: null,
+        // The prober's `ok ? runAt : (prior?.last_ok ?? null)` with no prior.
+        last_ok_ms: null,
+        consecutive_failures: 1,
+      }),
+    ],
+    firstOk + 60_000,
+  );
+  assert.equal(res.ok, true);
+  const row = db
+    .prepare("SELECT status, last_ok FROM surface_status")
+    .get() as Record<string, unknown>;
+  assert.equal(row.status, "degraded", "this run's status still lands");
+  assert.equal(row.last_ok, firstOk, "history survives a prior-read degrade");
+});
+
+test("a non-ok re-probe with no prior keeps last_ok on the surface_id path (#9634)", async () => {
+  const firstOk = Date.parse("2026-08-02T10:00:00Z");
+  // surface_key null routes the upsert through ON CONFLICT(surface_id).
+  const keyless = { surface_key: null };
+  await persistProbesToD1(
+    d1(),
+    [probe({ ...keyless, last_ok_ms: firstOk })],
+    firstOk,
+  );
+  await persistProbesToD1(
+    d1(),
+    [probe({ ...keyless, status: "failed", last_ok_ms: null })],
+    firstOk + 60_000,
+  );
+  const row = db
+    .prepare("SELECT status, last_ok FROM surface_status")
+    .get() as Record<string, unknown>;
+  assert.equal(row.status, "failed");
+  assert.equal(row.last_ok, firstOk, "history survives on the keyless path");
+});
+
+// The other half of COALESCE: a non-null excluded value is authoritative, so a
+// surface that IS working must still advance its mark rather than pin the
+// oldest success forever.
+test("an ok re-probe advances last_ok rather than holding the first value (#9634)", async () => {
+  const firstOk = Date.parse("2026-08-02T10:00:00Z");
+  const laterOk = Date.parse("2026-08-02T11:00:00Z");
+  await persistProbesToD1(d1(), [probe({ last_ok_ms: firstOk })], firstOk);
+  await persistProbesToD1(d1(), [probe({ last_ok_ms: laterOk })], laterOk);
+  const row = db.prepare("SELECT last_ok FROM surface_status").get() as Record<
+    string,
+    unknown
+  >;
+  assert.equal(row.last_ok, laterOk);
+});
+
+// A surface whose first-ever probe fails has no history to protect, and must
+// read as "never seen working" rather than inheriting anything.
+test("a first probe that fails still stores last_ok null (#9634)", async () => {
+  await persistProbesToD1(
+    d1(),
+    [probe({ status: "failed", latency_ms: null, last_ok_ms: null })],
+    1,
+  );
+  const row = db.prepare("SELECT last_ok FROM surface_status").get() as Record<
+    string,
+    unknown
+  >;
+  assert.equal(row.last_ok, null);
+});
+
+// Migration 0027 recovers the rows wiped BEFORE the COALESCE above existed.
+// The prober is the only writer, so the repair is seeded through it and then
+// the column is nulled by hand -- reproducing the wipe rather than asserting
+// against a hand-built row that might not match what the prober writes.
+test("migration 0027 restores last_ok from the surviving ok checks (#9634)", async () => {
+  const okAt = Date.parse("2026-08-02T10:00:00Z");
+  const laterAt = Date.parse("2026-08-02T11:00:00Z");
+  await persistProbesToD1(
+    d1(),
+    [probe({ checked_at_ms: okAt, last_ok_ms: okAt })],
+    okAt,
+  );
+  // A second success, so the repair has to pick the MOST RECENT one.
+  await persistProbesToD1(
+    d1(),
+    [probe({ checked_at_ms: laterAt, last_ok_ms: laterAt })],
+    laterAt,
+  );
+  // A LATER degraded probe: its check row is the newest of the three, so a
+  // repair that forgot `ok = 1` would restore this timestamp instead.
+  await persistProbesToD1(
+    d1(),
+    [
+      probe({
+        status: "degraded",
+        latency_ms: null,
+        checked_at_ms: laterAt + 60_000,
+        last_ok_ms: laterAt,
+      }),
+    ],
+    laterAt + 60_000,
+  );
+  db.exec("UPDATE surface_status SET last_ok = NULL");
+
+  db.exec(LAST_OK_REPAIR);
+
+  const row = db.prepare("SELECT last_ok FROM surface_status").get() as Record<
+    string,
+    unknown
+  >;
+  assert.equal(row.last_ok, laterAt, "restored to the newest ok check");
+});
+
+test("migration 0027 leaves a surface with no ok check null (#9634)", async () => {
+  await persistProbesToD1(
+    d1(),
+    [probe({ status: "failed", latency_ms: null, last_ok_ms: null })],
+    1,
+  );
+  db.exec(LAST_OK_REPAIR);
+  const row = db.prepare("SELECT last_ok FROM surface_status").get() as Record<
+    string,
+    unknown
+  >;
+  assert.equal(row.last_ok, null, "no evidence means no claim");
+});
+
+// Re-running a repair against a live column is the way a one-shot fix becomes a
+// recurring bug, so the guard is pinned: a value the prober has since written
+// must survive a second application unchanged.
+test("migration 0027 is idempotent and never overwrites a live last_ok (#9634)", async () => {
+  const okAt = Date.parse("2026-08-02T10:00:00Z");
+  const laterAt = Date.parse("2026-08-02T11:00:00Z");
+  await persistProbesToD1(d1(), [probe({ last_ok_ms: okAt })], okAt);
+  await persistProbesToD1(d1(), [probe({ last_ok_ms: laterAt })], laterAt);
+  db.exec(LAST_OK_REPAIR);
+  db.exec(LAST_OK_REPAIR);
+  const row = db.prepare("SELECT last_ok FROM surface_status").get() as Record<
+    string,
+    unknown
+  >;
+  assert.equal(row.last_ok, laterAt, "live value untouched by the repair");
 });
 
 test("the day rollup aggregates checks into surface_uptime_daily with the clamped ratio", async () => {


### PR DESCRIPTION
## Summary

`surface_status.last_ok` records the last time a surface was seen working — a high-water mark. The probe upsert did not treat it as one: both conflict paths set `last_ok=excluded.last_ok`, so a run that did not observe the surface working could clear the column outright.

It could, and it did. `src/health-prober.ts:554` computes `last_ok_ms` as `ok ? runAt : (prior?.last_ok ?? null)`, and `prior` comes from `readLiveSurfaceStatus`, which by its own documented contract "DEGRADES, NEVER THROWS — a flag naming no tier, no binding, a transport failure, a non-2xx, an unparseable body, or a body without a rows array all yield an empty array." A degrade on the **read** side was silently promoted into permanent data loss on the **write** side.

#9522 repaired the read so the empty-map case stopped being permanent. This makes the write survive the *next* time that read comes back empty, whatever the reason.

## Two halves

**1. `COALESCE(excluded.last_ok, surface_status.last_ok)` on both conflict paths.** The column can advance or hold, never clear. This is general rather than a patch for one cause: `excluded.last_ok` is authoritative whenever it is non-null (an ok run supplies `runAt`, a non-ok run with prior supplies the carried value), and only "we do not know" arrives as null.

**2. Migration 0027 restores what was already lost**, from the successful probes `surface_checks` still holds.

## Measured before writing (production D1, 2026-08-06)

```sql
SELECT status, COUNT(*) n, COUNT(last_ok) with_last_ok FROM surface_status GROUP BY status;
-- degraded | 94  | 9
-- failed   |  8  | 0
-- ok       | 533 | 533
```

Recovery only ever happened by a surface going ok again, which a persistently-degraded surface does not do — precisely the population an operator cares about. Of the 93 null rows, **71 are recoverable**:

```sql
SELECT ss.status, COUNT(DISTINCT ss.surface_id) surfaces,
       COUNT(DISTINCT CASE WHEN c.ok=1 THEN ss.surface_id END) recoverable
  FROM surface_status ss LEFT JOIN surface_checks c ON c.surface_id = ss.surface_id
 WHERE ss.last_ok IS NULL GROUP BY ss.status;
-- degraded | 85 | 64
-- failed   |  8 |  7
```

The worst case is not marginal:

```
surface_id                               status    last_ok  ok_probes  last ok in surface_checks
sn-62-ridges-perfectly-solved-over-time  degraded  NULL     150        2026-08-05T20:15:10.427Z
```

150 recorded successes, the most recent under a day old, served as "never seen working".

## Why `surface_checks` is a safe source

Raw checks prune at 30 days, so `MAX(checked_at) WHERE ok=1` is a **lower bound**: if the true last success has aged out, every surviving ok row is older, so the value moves earlier or the surface stays null. It cannot invent a success, and cannot claim one more recent than the evidence.

The repair is idempotent in the style of 0024/0025 — `WHERE last_ok IS NULL` makes a re-run a no-op rather than clobbering values the prober has since written.

## Tests

Seven new cases in the existing real-SQLite suite (`tests/observations-d1-sqlite.test.ts`), which executes the statements against a database built from the actual migration rather than asserting on SQL strings.

- Preservation on **both** conflict paths (`surface_key` and the keyless `surface_id` path) — they are separate SET lists, so both are exercised.
- The other half of COALESCE: an ok re-probe still **advances** the mark rather than pinning the oldest success.
- A first-ever probe that fails stores null — no history to protect, no inheritance.
- Migration 0027: restores the newest ok check (with a *later degraded* probe present, so a repair that forgot `ok = 1` would fail), leaves a surface with no ok check null, and is idempotent across two applications.

Verified the preservation tests genuinely catch the bug: reverting the SQL to `last_ok=excluded.last_ok` fails exactly those two and no others.

## Validation run

```
npx vitest run tests/observations-d1-sqlite.test.ts   18 passed
npm run typecheck                                     clean
npm run lint                                          clean
npm run validate:migrations                           27 files, prefixes unique and sequential
patch coverage (diff intersection, src/observations-d1.ts)  100%
```

## Deploy note

Migration 0027 is applied by hand against production D1, as this repo's migrations always are — merging does not run it.

Closes #9634
