### PR TITLE
fix(queue): pack sync chunks into messages that fit, key-aware where it prunes

### DIFF
--- a/src/sync-batch-queue.ts
+++ b/src/sync-batch-queue.ts
@@ -110,8 +110,239 @@ export type SyncBatchLane = (typeof SYNC_BATCH_LANES)[number];
 
 /** Rows per message. Sized against the sink's existing per-request ceiling
  * rather than re-derived: the D1 write shape is unchanged by the transport, and
- * `json_each` already made a chunk one statement (metagraphed#9550). */
+ * `json_each` already made a chunk one statement (metagraphed#9550).
+ *
+ * THIS IS NOT THE BINDING LIMIT and never was -- see SYNC_BATCH_MAX_BYTES.
+ * A row-count ceiling cannot bound a payload whose rows differ in size by lane,
+ * and 5,000 hotkey-alpha rows is already 5x the transport's cap. It survives as
+ * a cheap sanity bound on top of the byte budget, not as the thing that makes a
+ * message deliverable. */
 export const SYNC_BATCH_MAX_ROWS = 5_000;
+
+/**
+ * The transport's hard ceiling: a Cloudflare Queues message is capped at
+ * **128 KB**, of which up to ~100 bytes is internal metadata.
+ * https://developers.cloudflare.com/queues/platform/limits/
+ */
+export const QUEUE_MESSAGE_MAX_BYTES = 128 * 1024;
+
+/**
+ * The byte budget `packSyncBatchMessages` fills, deliberately under the cap.
+ *
+ * WHY A BYTE BUDGET AND NOT A ROW COUNT (metagraphed-infra#360). The route used
+ * to hand `send()` the whole posted chunk, and the producers chunk at 25,000
+ * rows. Measured against real `hotkey_alpha` rows at 127.6 bytes each, that is
+ * 3,116 KB -- **24x over** -- so `send()` threw, the route returned 502, and the
+ * producer read that as a transient network fault, retried six times and
+ * abandoned the pass. A cut-over lane did not degrade; it stopped.
+ *
+ * Rows are not a proxy for bytes. `hotkey_alpha` carries a 48-character ss58 and
+ * three scalars; `account_balances` and `nominator_positions` carry more. One
+ * row count that is safe for the widest lane wastes most of the budget on the
+ * narrowest, and one that suits the narrowest overflows on the widest. So the
+ * packer measures.
+ *
+ * The headroom covers the envelope (`lane`, `captured_at`, `pass_total`,
+ * `key_complete`, the array brackets and commas) plus the platform's own
+ * metadata, and leaves room for a row slightly larger than any sampled -- a
+ * subnet identity with a long description, say. Cheap insurance against a
+ * failure whose signature is a stopped lane rather than an error.
+ */
+export const SYNC_BATCH_MAX_BYTES = 96 * 1024;
+
+/**
+ * Which column a pruning lane's write DELETES by, so the packer never splits
+ * one key's rows across two messages.
+ *
+ * This is the packer's half of the `key_complete` contract. The consumer
+ * refuses a pruning lane's message that does not assert key-completeness; this
+ * is what makes the assertion true rather than merely claimed. A lane in
+ * PRUNING_LANES with no entry here is a programming error and
+ * `packSyncBatchMessages` throws rather than emitting an unsafe message -- the
+ * failure it would otherwise cause is deleted rows, which no retry undoes.
+ */
+export const PRUNING_LANE_KEYS: Readonly<Record<string, string>> = {
+  "nominator-positions": "coldkey",
+  // `neurons` prunes per netuid and joins PRUNING_LANES when it moves
+  // (metagraphed-infra#357); its key is declared here at the same time.
+};
+
+/** Bytes one row costs inside the `rows` array, including its separating
+ * comma. Measured rather than estimated -- see SYNC_BATCH_MAX_BYTES. */
+function rowBytes(row: Record<string, unknown>): number {
+  return JSON.stringify(row).length + 1;
+}
+
+/**
+ * Split one posted chunk into messages that each fit the transport.
+ *
+ * ONE POST BECOMES N MESSAGES, and the pass tally does not notice, because the
+ * tally is commutative: `received_rows` accumulates and `completed_at` is
+ * stamped by whichever write closes the gap. N messages summing to the same
+ * rows land on the same answer as one message would have, in any order. That
+ * property is what makes fanning out here safe without touching the producer,
+ * the declared `pass_total`, or the publish floor.
+ *
+ * KEY-AWARE FOR PRUNING LANES. A lane whose write deletes rows for a key older
+ * than the newest `captured_at` it saw for that key cannot be applied from a
+ * message missing some of that key's rows -- it would delete rows the message
+ * never carried. So for a pruning lane the packer groups by the lane's key and
+ * places whole groups, never part of one. Every emitted message then genuinely
+ * satisfies `key_complete`, which the consumer already refuses to take on trust.
+ *
+ * A single key whose rows exceed the budget THROWS rather than being split.
+ * Splitting it would silently reintroduce exactly the deletion this guards, and
+ * a coldkey needing more than 96 KB of positions is a fact worth surfacing
+ * loudly rather than a case to quietly degrade.
+ */
+export function packSyncBatchMessages(input: {
+  lane: SyncBatchLane;
+  capturedAt: number;
+  passTotal?: number;
+  rows: Record<string, unknown>[];
+  maxBytes?: number;
+  maxRows?: number;
+  /** Overridable so the "listed as pruning, no key declared" guard below is
+   * reachable from a test. PRUNING_LANES and PRUNING_LANE_KEYS are deliberately
+   * NOT one list -- a lane can have a known prune key while its producer does
+   * not yet assert key-completeness, which is exactly `neurons` today -- so the
+   * mismatch is possible and the guard is not decorative. */
+  pruningKeys?: Readonly<Record<string, string>>;
+}): SyncBatchMessage[] {
+  const {
+    lane,
+    capturedAt,
+    passTotal,
+    rows,
+    maxBytes = SYNC_BATCH_MAX_BYTES,
+    maxRows = SYNC_BATCH_MAX_ROWS,
+    pruningKeys = PRUNING_LANE_KEYS,
+  } = input;
+  if (rows.length === 0) return [];
+
+  const prunes = PRUNING_LANES.includes(lane);
+  const keyColumn = prunes ? pruningKeys[lane] : undefined;
+  if (prunes && !keyColumn) {
+    throw new Error(
+      `sync-batches: ${lane} prunes but declares no key column; ` +
+        `add it to PRUNING_LANE_KEYS before enqueuing`,
+    );
+  }
+
+  // Groups the packer places atomically. For a non-pruning lane every row is
+  // its own group, so the same code path handles both and there is no second
+  // packing rule to keep in step with this one.
+  const groups: Record<string, unknown>[][] = [];
+  if (keyColumn) {
+    const byKey = new Map<string, Record<string, unknown>[]>();
+    for (const row of rows) {
+      const key = String(row[keyColumn]);
+      const group = byKey.get(key);
+      if (group) group.push(row);
+      else byKey.set(key, [row]);
+    }
+    groups.push(...byKey.values());
+  } else {
+    for (const row of rows) groups.push([row]);
+  }
+
+  const messages: SyncBatchMessage[] = [];
+  let current: Record<string, unknown>[] = [];
+  let currentBytes = 0;
+
+  // NEVER CALLED EMPTY, and deliberately carries no guard saying so. The empty
+  // chunk returned above, every group holds at least one row, and the in-loop
+  // call is gated on `current.length > 0` -- so an "if empty, return" here would
+  // be a branch no test could reach, which is how a file starts collecting
+  // coverage pragmas instead of reasons.
+  const flush = () => {
+    const message: SyncBatchMessage = {
+      lane,
+      captured_at: capturedAt,
+      ...(passTotal !== undefined ? { pass_total: passTotal } : {}),
+      ...(prunes ? { key_complete: true as const } : {}),
+      rows: current,
+    };
+    // THE ASSERTION THIS BUG COST US. Nothing measured the message before
+    // sending it, so an oversize payload surfaced as a 502 the producer read as
+    // a transient network fault and retried into -- a stopped lane wearing the
+    // costume of a flaky one. Measured here, at the boundary, where the failure
+    // names itself.
+    const bytes = JSON.stringify(message).length;
+    if (bytes > QUEUE_MESSAGE_MAX_BYTES) {
+      throw new Error(
+        `sync-batches: ${lane} message of ${current.length} row(s) is ` +
+          `${bytes} bytes, over the ${QUEUE_MESSAGE_MAX_BYTES}-byte transport ` +
+          `cap; lower SYNC_BATCH_MAX_BYTES`,
+      );
+    }
+    messages.push(message);
+    current = [];
+    currentBytes = 0;
+  };
+
+  for (const group of groups) {
+    const groupBytes = group.reduce((n, row) => n + rowBytes(row), 0);
+    if (groupBytes > maxBytes) {
+      throw new Error(
+        `sync-batches: ${lane} ${keyColumn ?? "row"} group of ` +
+          `${group.length} row(s) is ${groupBytes} bytes, over the ` +
+          `${maxBytes}-byte message budget; it cannot be split without ` +
+          `breaking key_complete`,
+      );
+    }
+    if (
+      current.length > 0 &&
+      (currentBytes + groupBytes > maxBytes ||
+        current.length + group.length > maxRows)
+    ) {
+      flush();
+    }
+    current.push(...group);
+    currentBytes += groupBytes;
+  }
+  flush();
+
+  return messages;
+}
+
+/** The structural slice of a Queue binding the enqueue path uses, so a test can
+ * hand it a plain object rather than stand up a binding. */
+export interface SyncBatchQueue {
+  /** Returns `unknown` rather than `void` so the real `Queue<T>` binding, whose
+   * `send` resolves a `QueueSendResponse`, satisfies this structurally. */
+  send(body: SyncBatchMessage): Promise<unknown>;
+}
+
+/**
+ * Pack one posted chunk and enqueue every message it becomes.
+ *
+ * SENT IN PARALLEL, and order does not matter: the tally is commutative, the
+ * writes are upserts, and each message of a pruning lane is independently
+ * key-complete. Nothing downstream can tell which arrived first.
+ *
+ * A PARTIAL FAILURE OVER-DELIVERS RATHER THAN UNDER-DELIVERS. If some sends
+ * succeed and one throws, the route returns 502 and the producer retries the
+ * whole chunk, so the rows that did land are written twice. That is the
+ * at-least-once overshoot metagraphed-infra#352 already accepted and documented:
+ * `received_rows` can exceed `pass_total`, `completed_at` is stamped once and
+ * never cleared, and the gate asks "did everything arrive", not "how many
+ * times". The opposite trade -- acking a partial chunk -- would mark a pass
+ * complete that never was.
+ */
+export async function enqueueSyncBatch(
+  queue: SyncBatchQueue,
+  input: {
+    lane: SyncBatchLane;
+    capturedAt: number;
+    passTotal?: number;
+    rows: Record<string, unknown>[];
+  },
+): Promise<number> {
+  const messages = packSyncBatchMessages(input);
+  await Promise.all(messages.map((message) => queue.send(message)));
+  return messages.length;
+}
 
 /**
  * Validate one message off the queue.

--- a/tests/data-api-hotkey-alpha-d1.test.ts
+++ b/tests/data-api-hotkey-alpha-d1.test.ts
@@ -27,6 +27,9 @@ import { beforeEach, describe, test } from "vitest";
 import type { Row } from "./row-type.ts";
 
 const { default: worker } = await import("../workers/data-api.ts");
+const { QUEUE_MESSAGE_MAX_BYTES } = await import(
+  "../src/sync-batch-queue.ts"
+);
 
 const SCHEMA = fs.readFileSync(
   path.join(process.cwd(), "migrations/d1/0019_hotkey_alpha.sql"),
@@ -504,5 +507,75 @@ describe("only pools some position references are stored", () => {
     assert.equal(rows().length, 1, "one stored");
     assert.equal(passes()[0]!.received_rows, 2, "two received");
     assert.ok(passes()[0]!.completed_at, "and the pass is complete");
+  });
+});
+
+describe("routed to the sync queue (metagraphed-infra#348)", () => {
+  function queueEnv(send: (m: unknown) => Promise<void>) {
+    return env({
+      SYNC_BATCHES: { send },
+      SYNC_QUEUE_LANES: "hotkey-alpha",
+    });
+  }
+
+  test("enqueues instead of writing, and never both", async () => {
+    // NO DUAL WRITE. The flag SELECTS a path; writing twice would double the
+    // D1 load the queue exists to relieve and double-count the tally.
+    const sent: Record<string, unknown>[] = [];
+    const response = await post(
+      { rows: [alphaRow(), alphaRow({ hotkey: HOTKEY_B })], pass_total: 2 },
+      SECRET,
+      queueEnv(async (m) => {
+        sent.push(m as Record<string, unknown>);
+      }),
+    );
+    assert.equal(response.status, 200);
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0]!.pass_total, 2, "the declaration rides along");
+    assert.equal(rows().length, 0, "D1 must not also have been written");
+  });
+
+  test("a chunk too large for one message is split, not dropped", async () => {
+    // metagraphed-infra#360. The route used to hand `send()` the whole posted
+    // chunk; at the producer's CHUNK_SIZE of 25,000 that is ~24x the 128 KB
+    // transport cap, so every enqueue threw, the route answered 502, and the
+    // producer retried six times and abandoned the pass. A cut-over lane did
+    // not degrade -- it stopped.
+    const big = Array.from({ length: 4_000 }, (_, i) =>
+      alphaRow({ hotkey: `5${String(i).padStart(47, "H")}`, netuid: i % 129 }),
+    );
+    const sent: Record<string, unknown>[] = [];
+    const response = await post(
+      { rows: big, pass_total: big.length },
+      SECRET,
+      queueEnv(async (m) => {
+        sent.push(m as Record<string, unknown>);
+      }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(sent.length > 1, true, "one message could not have held it");
+    for (const m of sent) {
+      assert.equal(
+        JSON.stringify(m).length <= QUEUE_MESSAGE_MAX_BYTES,
+        true,
+        "every message must fit the transport",
+      );
+    }
+    // Every row still arrives exactly once -- fanning out must not lose rows,
+    // or the tally would never close and the pass would sit incomplete.
+    const delivered = sent.flatMap((m) => m.rows as Row[]);
+    assert.equal(delivered.length, big.length);
+  });
+
+  test("502s when the enqueue fails, so the producer retries the chunk", async () => {
+    // Reporting 200 on a chunk the queue never accepted loses it silently.
+    const response = await post(
+      { rows: [alphaRow()] },
+      SECRET,
+      queueEnv(async () => Promise.reject(new Error("over capacity"))),
+    );
+    assert.equal(response.status, 502);
+    assert.equal(rows().length, 0);
   });
 });

--- a/tests/data-api-hotkey-alpha-d1.test.ts
+++ b/tests/data-api-hotkey-alpha-d1.test.ts
@@ -27,9 +27,7 @@ import { beforeEach, describe, test } from "vitest";
 import type { Row } from "./row-type.ts";
 
 const { default: worker } = await import("../workers/data-api.ts");
-const { QUEUE_MESSAGE_MAX_BYTES } = await import(
-  "../src/sync-batch-queue.ts"
-);
+const { QUEUE_MESSAGE_MAX_BYTES } = await import("../src/sync-batch-queue.ts");
 
 const SCHEMA = fs.readFileSync(
   path.join(process.cwd(), "migrations/d1/0019_hotkey_alpha.sql"),

--- a/tests/data-api-validator-nominator-counts-d1.test.ts
+++ b/tests/data-api-validator-nominator-counts-d1.test.ts
@@ -20,9 +20,7 @@ import { beforeEach, describe, test } from "vitest";
 import type { Row } from "./row-type.ts";
 
 const { default: worker } = await import("../workers/data-api.ts");
-const { QUEUE_MESSAGE_MAX_BYTES } = await import(
-  "../src/sync-batch-queue.ts"
-);
+const { QUEUE_MESSAGE_MAX_BYTES } = await import("../src/sync-batch-queue.ts");
 
 const SCHEMA = fs.readFileSync(
   path.join(process.cwd(), "migrations/d1/0012_validator_nominator_counts.sql"),
@@ -274,9 +272,13 @@ describe("routed to the sync queue (metagraphed-infra#355)", () => {
       countRow({ hotkey: `5${String(i).padStart(47, "N")}` }),
     );
     const sent: Record<string, unknown>[] = [];
-    const response = await post({ rows: big }, SECRET, queueEnv(async (m) => {
-      sent.push(m as Record<string, unknown>);
-    }));
+    const response = await post(
+      { rows: big },
+      SECRET,
+      queueEnv(async (m) => {
+        sent.push(m as Record<string, unknown>);
+      }),
+    );
 
     assert.equal(response.status, 200);
     assert.equal(sent.length > 1, true, "one message could not have held it");

--- a/tests/data-api-validator-nominator-counts-d1.test.ts
+++ b/tests/data-api-validator-nominator-counts-d1.test.ts
@@ -20,6 +20,9 @@ import { beforeEach, describe, test } from "vitest";
 import type { Row } from "./row-type.ts";
 
 const { default: worker } = await import("../workers/data-api.ts");
+const { QUEUE_MESSAGE_MAX_BYTES } = await import(
+  "../src/sync-batch-queue.ts"
+);
 
 const SCHEMA = fs.readFileSync(
   path.join(process.cwd(), "migrations/d1/0012_validator_nominator_counts.sql"),
@@ -236,5 +239,64 @@ describe("POST /api/v1/internal/validator-nominator-counts-sync", () => {
     const response = await post({ rows: [countRow()] });
     assert.equal(response.status, 502);
     assert.deepEqual(await response.json(), { error: "d1 write failed" });
+  });
+});
+
+describe("routed to the sync queue (metagraphed-infra#355)", () => {
+  function queueEnv(send: (m: unknown) => Promise<void>) {
+    return env({
+      SYNC_BATCHES: { send },
+      SYNC_QUEUE_LANES: "validator-nominator-counts",
+    });
+  }
+
+  test("enqueues instead of writing, and never both", async () => {
+    const sent: Record<string, unknown>[] = [];
+    const response = await post(
+      { rows: [countRow(), countRow({ hotkey: HOTKEY_B })] },
+      SECRET,
+      queueEnv(async (m) => {
+        sent.push(m as Record<string, unknown>);
+      }),
+    );
+    assert.equal(response.status, 200);
+    assert.equal(sent.length, 1);
+    // This lane declares no pass, so the message must not invent one --
+    // a fabricated total would mark an unproven load complete.
+    assert.equal("pass_total" in sent[0]!, false);
+    assert.equal(rows().length, 0, "D1 must not also have been written");
+  });
+
+  test("a chunk too large for one message is split, not dropped", async () => {
+    // metagraphed-infra#360: this lane's producer ceiling is 50,000 rows, which
+    // is ~49x the 128 KB transport cap.
+    const big = Array.from({ length: 4_000 }, (_, i) =>
+      countRow({ hotkey: `5${String(i).padStart(47, "N")}` }),
+    );
+    const sent: Record<string, unknown>[] = [];
+    const response = await post({ rows: big }, SECRET, queueEnv(async (m) => {
+      sent.push(m as Record<string, unknown>);
+    }));
+
+    assert.equal(response.status, 200);
+    assert.equal(sent.length > 1, true, "one message could not have held it");
+    for (const m of sent) {
+      assert.equal(JSON.stringify(m).length <= QUEUE_MESSAGE_MAX_BYTES, true);
+    }
+    assert.equal(
+      sent.flatMap((m) => m.rows as Row[]).length,
+      big.length,
+      "fanning out must not lose rows",
+    );
+  });
+
+  test("502s when the enqueue fails, so the producer retries the chunk", async () => {
+    const response = await post(
+      { rows: [countRow()] },
+      SECRET,
+      queueEnv(async () => Promise.reject(new Error("over capacity"))),
+    );
+    assert.equal(response.status, 502);
+    assert.equal(rows().length, 0);
   });
 });

--- a/tests/sync-batch-queue.test.ts
+++ b/tests/sync-batch-queue.test.ts
@@ -14,9 +14,13 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   classifySyncBatch,
+  enqueueSyncBatch,
+  packSyncBatchMessages,
+  QUEUE_MESSAGE_MAX_BYTES,
   SYNC_BATCH_LANES,
   SYNC_BATCH_MAX_ROWS,
   passTallyFor,
+  PRUNING_LANE_KEYS,
   PRUNING_LANES,
   syncLaneUsesQueue,
   validSyncBatchMessage,
@@ -273,5 +277,292 @@ describe("pruning lanes must declare key-completeness", () => {
     assert.equal(validSyncBatchMessage(OK), true);
     assert.equal(PRUNING_LANES.includes("hotkey-alpha"), false);
     assert.equal(PRUNING_LANES.includes("nominator-positions"), true);
+  });
+});
+
+// --- The transport's size cap (metagraphed-infra#360) ------------------------
+//
+// The bug this section exists for did not look like a bug. `send()` was handed
+// the whole posted chunk, the producers chunk at 25,000 rows, and a Queues
+// message is capped at 128 KB -- so every enqueue threw, the route returned 502,
+// and the producer read that as a transient network fault and retried into it.
+// A cut-over lane did not degrade. It stopped, wearing the costume of a flaky
+// one, and both lanes sat at zero completed passes until someone compared a
+// deploy timestamp against a pass table.
+//
+// So the tests that matter here are the ones that would have caught it: pack a
+// realistically-shaped chunk at the real producer size and assert the RESULT
+// fits the real cap.
+const ss58 = (n: number) => `5${String(n).padStart(47, "D")}`;
+
+/** A chunk shaped like the real thing: 25,000 rows is `CHUNK_SIZE` in both
+ * `hotkey_alpha.rs` and `account_balances.rs`, and the ss58 is what makes a row
+ * 127.6 bytes rather than the 30 a toy fixture would be. */
+const realisticChunk = (n: number, capturedAt = 1_785_970_245_474) =>
+  Array.from({ length: n }, (_, i) => ({
+    hotkey: ss58(i),
+    netuid: i % 129,
+    total_alpha: 1234.56789012 + i,
+    captured_at: capturedAt,
+  }));
+
+describe("packSyncBatchMessages", () => {
+  test("a real 25,000-row chunk becomes messages that each fit the cap", () => {
+    const rows = realisticChunk(25_000);
+
+    // THE FIXTURE MUST BE ABLE TO FAIL. If one message could hold this chunk
+    // the rest of the test proves nothing, so assert first that the payload
+    // really is over the cap -- this is the measurement the bug turned on.
+    const unsplit = JSON.stringify({
+      lane: "hotkey-alpha",
+      captured_at: 1_785_970_245_474,
+      pass_total: 47_032,
+      rows,
+    }).length;
+    assert.equal(unsplit > QUEUE_MESSAGE_MAX_BYTES * 20, true);
+
+    const messages = packSyncBatchMessages({
+      lane: "hotkey-alpha",
+      capturedAt: 1_785_970_245_474,
+      passTotal: 47_032,
+      rows,
+    });
+
+    assert.equal(messages.length > 1, true);
+    for (const message of messages) {
+      assert.equal(
+        JSON.stringify(message).length <= QUEUE_MESSAGE_MAX_BYTES,
+        true,
+      );
+      // Every message is independently valid, or the consumer acks it and the
+      // rows vanish -- a malformed message is not retried.
+      assert.equal(validSyncBatchMessage(message), true);
+    }
+  });
+
+  test("loses no row and reorders none, so the tally still sums", () => {
+    const rows = realisticChunk(5_000);
+    const messages = packSyncBatchMessages({
+      lane: "hotkey-alpha",
+      capturedAt: 1_785_970_245_474,
+      passTotal: 47_032,
+      rows,
+    });
+    const flat = messages.flatMap((m) => m.rows);
+    assert.equal(flat.length, rows.length);
+    assert.deepEqual(flat, rows);
+    // The declaration rides on every message, exactly as it rides on every
+    // POSTed chunk -- `received_rows` accumulates against one `pass_total`.
+    for (const m of messages) assert.equal(m.pass_total, 47_032);
+  });
+
+  test("carries no pass declaration when the producer made none", () => {
+    const messages = packSyncBatchMessages({
+      lane: "validator-nominator-counts",
+      capturedAt: 1_785_970_245_474,
+      rows: realisticChunk(10),
+    });
+    assert.equal(messages.length, 1);
+    assert.equal("pass_total" in messages[0]!, false);
+  });
+
+  test("returns nothing for an empty chunk rather than an empty message", () => {
+    // An empty message fails the validator, so emitting one would put a
+    // guaranteed reject on the queue.
+    assert.deepEqual(
+      packSyncBatchMessages({
+        lane: "hotkey-alpha",
+        capturedAt: 1,
+        rows: [],
+      }),
+      [],
+    );
+  });
+
+  test("refuses to emit a message over the transport cap", () => {
+    // The last line of defence, and the one whose absence cost two stopped
+    // lanes. It fires when the budget itself is wrong -- raise
+    // SYNC_BATCH_MAX_BYTES above the platform cap and the packer must refuse
+    // rather than hand `send()` something it will reject.
+    assert.throws(
+      () =>
+        packSyncBatchMessages({
+          lane: "hotkey-alpha",
+          capturedAt: 1_785_970_245_474,
+          rows: realisticChunk(25_000),
+          maxBytes: QUEUE_MESSAGE_MAX_BYTES * 100,
+        }),
+      /over the \d+-byte transport cap/,
+    );
+  });
+
+  test("throws on a single row too large for the budget", () => {
+    // A non-pruning lane has no key to group by, so the group IS one row -- and
+    // a row that cannot fit alone cannot be split at all. Better a named error
+    // than a message the transport silently refuses.
+    assert.throws(
+      () =>
+        packSyncBatchMessages({
+          lane: "hotkey-alpha",
+          capturedAt: 1,
+          rows: [{ blob: "x".repeat(5_000) }],
+          maxBytes: 1_024,
+        }),
+      /row group of 1 row\(s\) is \d+ bytes/,
+    );
+  });
+
+  test("splits on the row ceiling too, not only on bytes", () => {
+    // Tiny rows: the byte budget would never trigger, so this isolates the
+    // row-count bound.
+    const rows = Array.from({ length: 20 }, (_, i) => ({ i }));
+    const messages = packSyncBatchMessages({
+      lane: "hotkey-alpha",
+      capturedAt: 1,
+      rows,
+      maxRows: 7,
+    });
+    assert.deepEqual(
+      messages.map((m) => m.rows.length),
+      [7, 7, 6],
+    );
+  });
+});
+
+describe("packSyncBatchMessages: the pruning lanes", () => {
+  // `nominator-positions` DELETES rows for a coldkey older than the newest
+  // captured_at it saw for that coldkey. Applied to a message holding only some
+  // of a coldkey's rows, that deletes rows the message never carried -- and no
+  // retry undoes a delete. So the packer may never split a coldkey.
+  const positions = (coldkeys: number, per: number) =>
+    Array.from({ length: coldkeys * per }, (_, i) => ({
+      coldkey: ss58(Math.floor(i / per)),
+      hotkey: ss58(1000 + (i % per)),
+      netuid: i % 129,
+      alpha: 1234.5678 + i,
+      captured_at: 1_785_970_245_474,
+    }));
+
+  test("never splits a coldkey across messages", () => {
+    const rows = positions(400, 30);
+    const messages = packSyncBatchMessages({
+      lane: "nominator-positions",
+      capturedAt: 1_785_970_245_474,
+      rows,
+    });
+
+    // More than one message, or the grouping was never exercised.
+    assert.equal(messages.length > 1, true);
+
+    const seen = new Map<string, number>();
+    for (const [index, message] of messages.entries()) {
+      for (const row of message.rows) {
+        const key = row.coldkey as string;
+        const previous = seen.get(key);
+        // Every row for a coldkey must sit in the SAME message.
+        if (previous !== undefined) assert.equal(previous, index);
+        else seen.set(key, index);
+      }
+    }
+    assert.equal(seen.size, 400);
+  });
+
+  test("asserts key_complete on every message, because it made it true", () => {
+    const messages = packSyncBatchMessages({
+      lane: "nominator-positions",
+      capturedAt: 1_785_970_245_474,
+      rows: positions(50, 10),
+    });
+    for (const message of messages) {
+      assert.equal(message.key_complete, true);
+      assert.equal(validSyncBatchMessage(message), true);
+    }
+  });
+
+  test("does not claim key_complete for a lane that does not prune", () => {
+    // The flag is a claim about a property. A lane that never deletes has no
+    // such property, and asserting it anyway would make the field meaningless
+    // the day a third lane reads it.
+    const [message] = packSyncBatchMessages({
+      lane: "hotkey-alpha",
+      capturedAt: 1,
+      rows: realisticChunk(3),
+    });
+    assert.equal("key_complete" in message!, false);
+  });
+
+  test("throws on a coldkey too large to fit, rather than splitting it", () => {
+    // Degrading here would silently reintroduce the deletion the guard exists
+    // to stop, on a lane whose failure mode is lost rows.
+    assert.throws(
+      () =>
+        packSyncBatchMessages({
+          lane: "nominator-positions",
+          capturedAt: 1,
+          rows: positions(1, 2_000),
+          maxBytes: 4_096,
+        }),
+      /cannot be split without breaking key_complete/,
+    );
+  });
+
+  test("throws if a pruning lane has no declared key column", () => {
+    // Reachable because the two lists are separate on purpose: a lane can have
+    // a known prune key before its producer asserts key-completeness (`neurons`
+    // today, metagraphed-infra#357), so "in PRUNING_LANES, absent from the key
+    // map" is a state the code can really be in. Emitting an unguarded message
+    // there would delete rows it never carried.
+    assert.throws(
+      () =>
+        packSyncBatchMessages({
+          lane: "nominator-positions",
+          capturedAt: 1,
+          rows: realisticChunk(2),
+          pruningKeys: {},
+        }),
+      /prunes but declares no key column/,
+    );
+  });
+
+  test("every pruning lane declares its key, so the guard is never reached", () => {
+    // The test above proves the guard works. This one proves it should never
+    // fire in production -- a lane added to PRUNING_LANES without a key would
+    // throw on its first real chunk.
+    for (const lane of PRUNING_LANES) {
+      assert.equal(typeof PRUNING_LANE_KEYS[lane], "string");
+    }
+  });
+});
+
+describe("enqueueSyncBatch", () => {
+  test("sends every packed message and reports how many", async () => {
+    const sent: unknown[] = [];
+    const count = await enqueueSyncBatch(
+      { send: async (body) => void sent.push(body) },
+      {
+        lane: "hotkey-alpha",
+        capturedAt: 1_785_970_245_474,
+        passTotal: 47_032,
+        rows: realisticChunk(3_000),
+      },
+    );
+    assert.equal(sent.length > 1, true);
+    assert.equal(count, sent.length);
+  });
+
+  test("rejects when a send fails, so the producer retries the chunk", async () => {
+    // 502, never 200. Reporting success on a chunk the queue never accepted
+    // loses it silently, and the pass would sit incomplete forever.
+    await assert.rejects(
+      enqueueSyncBatch(
+        { send: async () => Promise.reject(new Error("over capacity")) },
+        {
+          lane: "hotkey-alpha",
+          capturedAt: 1,
+          rows: realisticChunk(10),
+        },
+      ),
+      /over capacity/,
+    );
   });
 });

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -413,6 +413,7 @@ import { createPgSql } from "../src/pg-sql.ts";
 import { recordLaneVerdict } from "../src/lane-health.ts";
 import {
   classifySyncBatch,
+  enqueueSyncBatch,
   syncLaneUsesQueue,
   validSyncBatchMessage,
   writeSyncBatch,
@@ -1672,9 +1673,9 @@ async function handleValidatorNominatorCountsSync(request: Request, env: Env) {
   // either: inventing one would mark an unproven load complete.
   if (syncLaneUsesQueue(env, "validator-nominator-counts")) {
     try {
-      await env.SYNC_BATCHES!.send({
+      await enqueueSyncBatch(env.SYNC_BATCHES!, {
         lane: "validator-nominator-counts",
-        captured_at: rows[0]!.captured_at as number,
+        capturedAt: rows[0]!.captured_at as number,
         rows,
       });
     } catch (err) {
@@ -1864,10 +1865,14 @@ async function handleNominatorPositionsSync(request: Request, env: Env) {
   // changes the transport, not the contract.
   if (syncLaneUsesQueue(env, "nominator-positions")) {
     try {
-      await env.SYNC_BATCHES!.send({
+      // key_complete is no longer asserted here -- packSyncBatchMessages
+      // groups by this lane's prune key and never splits one across messages,
+      // so it sets the flag on each message it emits BECAUSE it made the claim
+      // true. Asserting it at the call site and slicing blindly downstream is
+      // how a claim outlives the property it describes.
+      await enqueueSyncBatch(env.SYNC_BATCHES!, {
         lane: "nominator-positions",
-        captured_at: rows[0]!.captured_at as number,
-        key_complete: true,
+        capturedAt: rows[0]!.captured_at as number,
         rows,
       });
     } catch (err) {
@@ -2109,10 +2114,10 @@ async function handleAccountBalancesSync(request: Request, env: Env) {
   // that second fact is the one that caught the truncation.
   if (syncLaneUsesQueue(env, "account-balances")) {
     try {
-      await env.SYNC_BATCHES!.send({
+      await enqueueSyncBatch(env.SYNC_BATCHES!, {
         lane: "account-balances",
-        captured_at: pass?.capturedAt ?? (rows[0]!.captured_at as number),
-        ...(pass ? { pass_total: pass.expectedRows } : {}),
+        capturedAt: pass?.capturedAt ?? (rows[0]!.captured_at as number),
+        ...(pass ? { passTotal: pass.expectedRows } : {}),
         rows,
       });
     } catch (err) {
@@ -2356,10 +2361,10 @@ async function handleHotkeyAlphaSync(request: Request, env: Env) {
   // the producer's one-second sleep was standing in for.
   if (syncLaneUsesQueue(env, "hotkey-alpha")) {
     try {
-      await env.SYNC_BATCHES!.send({
+      await enqueueSyncBatch(env.SYNC_BATCHES!, {
         lane: "hotkey-alpha",
-        captured_at: rows[0]!.captured_at as number,
-        ...(pass ? { pass_total: pass.expectedRows } : {}),
+        capturedAt: rows[0]!.captured_at as number,
+        ...(pass ? { passTotal: pass.expectedRows } : {}),
         rows,
       });
     } catch (err) {


### PR DESCRIPTION
Closes metagraphed-infra#360.

The route handed `send()` the whole posted chunk. The producers chunk at `CHUNK_SIZE = 25_000`. **A Cloudflare Queues message is capped at 128 KB.**

Measured against 1,000 real `hotkey_alpha` rows from D1 — 127.6 bytes each:

| chunk | serialises to | vs the cap |
|---|---|---|
| 25,000 rows (`hotkey-alpha`, `account-balances`) | **3,116 KB** | **24x over** |
| 50,000 rows (`neurons`, `validator-nominator-counts`) | 6,232 KB | 49x over |
| ~1,026 rows | 128 KB | the real ceiling |

So `send()` threw, the route returned 502, and the producer read that as a transient network fault, retried six times with backoff, and abandoned the pass. **A cut-over lane did not degrade. It stopped**, wearing the costume of a flaky one — which is why it took comparing a deploy timestamp against a pass table to see it:

| lane | cutover deployed | newest pass |
|---|---|---|
| `hotkey-alpha` | 05:20:12Z | 05:01:38 |
| `account-balances` | 06:24:35Z | 04:38:45 |

Rolled back in #9633; this is the fix that lets the lanes be re-added.

## A byte budget, not a row count

Rows are not a proxy for bytes. `hotkey_alpha` carries a 48-character ss58 and three scalars; `account_balances` and `nominator_positions` carry more. One row count safe for the widest lane wastes most of the budget on the narrowest; one that suits the narrowest overflows on the widest.

`SYNC_BATCH_MAX_ROWS` survives as a cheap sanity bound **on top of** the byte budget, not as the thing that makes a message deliverable — 5,000 `hotkey_alpha` rows is already 5x the cap, so it never was.

## The fan-out needs no producer change

The tally is commutative: `received_rows` accumulates, `completed_at` is stamped by whichever write closes the gap. N messages summing to the same rows land on the same answer as one would have, in any order. `pass_total`, the publish floor and both producer chunk ceilings are untouched.

## Key-aware, because one lane deletes

`nominator-positions` removes rows for a coldkey older than the newest `captured_at` it saw for that coldkey. Applied to a message holding only part of a coldkey, that deletes rows the message never carried — and no retry undoes a delete.

So for a pruning lane the packer groups by the lane's key and places whole groups. **It sets `key_complete` because it made the claim true**; the call site no longer asserts it, since asserting a property upstream of the code that slices is how a claim outlives the property it describes. A single key too large to fit throws rather than being split.

`PRUNING_LANES` and `PRUNING_LANE_KEYS` are deliberately not one list — a lane can have a known prune key before its producer asserts key-completeness, which is `neurons` today (metagraphed-infra#357) — so the "listed but keyless" guard is reachable and tested rather than decorative.

## The assertion this cost us

Nothing measured the message before sending it. Now the packer does, at the boundary, so a budget set above the platform cap fails by name instead of as a 502 the producer retries into.

## Verification

- **100% patch coverage, branch-counted**, measured by diff intersection: `src/sync-batch-queue.ts` 44/44 changed statements, `workers/data-api.ts` 4/4, no uncovered branches on either
- `src/sync-batch-queue.ts` overall: 100% statements / branches / functions / lines
- the regression test packs a real 25,000-row chunk and asserts every message fits — and asserts first that the unsplit payload is over the cap, so the fixture can fail
- full suite: **703 files / 16,899 tests** green
- `build`, `lint`, `validate:contract-drift`, `validate:types`, `validate:mcp` clean; no generated-artifact drift