### PR TITLE
fix(oauth): require S256 PKCE, so an omitted method cannot select plain

### DIFF
--- a/src/github-oauth.ts
+++ b/src/github-oauth.ts
@@ -134,6 +134,23 @@ export function buildOAuthProviderOptions(
     authorizeEndpoint: "/authorize",
     tokenEndpoint: "/oauth/token",
     clientRegistrationEndpoint: "/oauth/register",
+    // S256 ONLY (#9637). OAuth 2.1 removes `plain`, and the MCP authorization
+    // spec requires S256, but the library's default is permissive in BOTH
+    // directions and this option is the single switch for both:
+    //
+    //   :1172  code_challenge_methods_supported: allowPlainPKCE !== false
+    //            ? ["plain", "S256"] : ["S256"]
+    //   :2963  const codeChallengeMethod =
+    //            url.searchParams.get("code_challenge_method") || "plain"
+    //   :2970  reject plain ONLY when allowPlainPKCE === false
+    //
+    // Line 2963 is the one that matters: a client sending `code_challenge`
+    // and no method is handed `plain` silently -- RFC 7636's default, which
+    // OAuth 2.1 dropped. Under `plain` the challenge IS the verifier, so
+    // anyone who can see the authorization request can redeem an intercepted
+    // code and PKCE protects nothing. Unset, we advertised the weaker method
+    // and defaulted to it.
+    allowPlainPKCE: false,
     scopesSupported: ["profile"],
     resourceMetadata: {
       resource_name: "metagraphed",

--- a/tests/github-oauth.test.ts
+++ b/tests/github-oauth.test.ts
@@ -98,6 +98,17 @@ describe("buildOAuthProviderOptions", () => {
     assert.equal(options.defaultHandler, defaultHandler);
   });
 
+  // #9637: asserted as an explicit `false`, not merely "not true". The
+  // library branches on `allowPlainPKCE !== false` for the advertised metadata
+  // and on `=== false` for the runtime rejection, so `undefined` -- the value
+  // this option had before -- takes the permissive side of BOTH. A test that
+  // accepted any falsy value would pass on exactly the state being fixed.
+  test("requires S256 PKCE: plain is disallowed explicitly (#9637)", () => {
+    const defaultHandler = { fetch: async () => new Response("default") };
+    const options = buildOAuthProviderOptions(defaultHandler);
+    assert.equal(options.allowPlainPKCE, false);
+  });
+
   test("apiHandler.fetch delegates to the given defaultHandler unchanged", async () => {
     const calls: unknown[][] = [];
     const defaultHandler = {


### PR DESCRIPTION
## Summary

The MCP OAuth server advertised `plain` as a supported PKCE method, and — more seriously — **selected it by default when a client omitted `code_challenge_method` entirely**. OAuth 2.1 removes `plain`; the MCP authorization spec requires S256.

## Measured on production before the change

```
$ curl -s https://api.metagraph.sh/.well-known/oauth-authorization-server
{"issuer":"https://api.metagraph.sh", ...
 "code_challenge_methods_supported":["plain","S256"], ...}
```

## One unset option, two permissive defaults

`buildOAuthProviderOptions` (`src/github-oauth.ts`) never set `allowPlainPKCE`, and `@cloudflare/workers-oauth-provider` branches on it twice, with **different comparisons**:

```js
:1172  code_challenge_methods_supported: this.options.allowPlainPKCE !== false ? ["plain","S256"] : ["S256"]
:2963  const codeChallengeMethod = url.searchParams.get("code_challenge_method") || "plain"
:2970  if (codeChallengeMethod === "plain" && this.provider.options.allowPlainPKCE === false) throw ...
```

`undefined` takes the permissive side of both. Line 2963 is the sharp edge: a client that sends `code_challenge` but no method was handed `plain` silently — it is not limited to a client that deliberately asks for the weaker method.

Under `plain`, `code_challenge == code_verifier`. PKCE exists so that intercepting an authorization code is not enough to redeem it; with `plain`, anyone who can observe the authorization request already has the verifier. It existed only for clients that could not compute SHA-256.

## Compatibility

Stated rather than assumed: the MCP authorization spec requires S256, and the major MCP clients send it explicitly. A client omitting `code_challenge_method` starts failing — the intended outcome, since such a client has no working PKCE protection today.

## Test

Asserts an explicit `false`, not merely "not true". Because the library uses `!== false` in one place and `=== false` in the other, `undefined` — the value being fixed — is falsy and would satisfy a loose assertion. The test would otherwise pass on exactly the broken state.

## Rest of the OAuth surface verified while measuring this

- RFC 9728 protected-resource metadata answers at both `/.well-known/oauth-protected-resource` and the path-scoped `/.well-known/oauth-protected-resource/mcp`, each with the correct `resource` value.
- The 401 challenge carries `WWW-Authenticate: Bearer realm="OAuth", resource_metadata=".../mcp", error="invalid_token"`.
- RFC 8414 authorization-server metadata and RFC 7591 dynamic client registration are live.

`plain` PKCE was the one nonconformance found.

## Validation run

```
npm run typecheck                          clean
npm run lint                               clean
npx vitest run tests/github-oauth.test.ts  41 passed
```

Closes #9637
