### PR TITLE
feat(mcp): record the refusals that never reach dispatch

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -190,6 +190,7 @@ import {
 } from "../schemas-src/mcp-tools/get-emission-pipeline.ts";
 import {
   MCP_PROTOCOL_ROUTE_PREFIX,
+  admitMcpRefusalCapture,
   isUsageTelemetryConfigured,
   recordAiDegradedEvent,
   recordExceptionEvent,
@@ -15592,11 +15593,123 @@ async function handleMcpTerminateRequest(request: Request, env: Env) {
   return new Response(null, { status: 204, headers: MCP_HEADERS });
 }
 
+/**
+ * The refusal reason for a pre-dispatch status, or null when the status is not
+ * one this boundary refuses with.
+ *
+ * A LABEL PER STATUS, not per call site, because the call sites are what drift
+ * -- the whole point of instrumenting at the boundary is that a refusal added
+ * later needs no edit here to be counted, and `status_<n>` catches it.
+ *
+ * 429 is the one status two gates share, and they are operationally different
+ * questions: "asking too fast" is a client-pacing bug, "out of quota" is a
+ * limits conversation, and "blocked" is neither. They are split on
+ * `x-ratelimit-scope`, which tieredRateLimitHeaders already sets for exactly
+ * this purpose (#8608 added it so a 429 is actionable), rather than by
+ * threading a label up from each `return`.
+ */
+export function mcpRefusalReason(response: Response): string | null {
+  switch (response.status) {
+    case 429: {
+      const scope = response.headers.get("x-ratelimit-scope");
+      return scope === "daily-quota"
+        ? "daily_quota"
+        : scope === "blocked"
+          ? "blocked"
+          : "rate_limited";
+    }
+    case 405:
+      return "method_not_allowed";
+    case 413:
+      return "body_too_large";
+    case 400:
+      return "bad_request";
+    case 401:
+      return "unauthorized";
+    default:
+      return response.status >= 400 ? `status_${response.status}` : null;
+  }
+}
+
+/**
+ * Record a refusal that never reached a handler, without ever touching the
+ * response.
+ *
+ * Fire-and-forget through waitUntil on the same contract as
+ * scheduleToolUsageEvent: telemetry must never surface into the MCP path, so
+ * every failure here is swallowed.
+ *
+ * Exported for tests, same reasoning as admitExceptionCapture's own note: the
+ * guard branches here (an unrecognised non-2xx, the throttle holding one back,
+ * a recorder that rejects) are the entire point of the code, and every one of
+ * them is deliberately unreachable through the HTTP path -- a 3xx never leaves
+ * the MCP entry, so driving them from a Request would mean asserting on a
+ * state production cannot produce.
+ */
+export function scheduleMcpRefusalEvent(
+  request: Request,
+  env: Env,
+  deps: Row,
+  response: Response,
+) {
+  try {
+    if (!isUsageTelemetryConfigured(env)) return;
+    const reason = mcpRefusalReason(response);
+    if (reason === null) return;
+    const suppressed = admitMcpRefusalCapture(env, reason);
+    if (suppressed === null) return;
+    const record = (deps.recordUsageEvent ?? recordUsageEvent) as AnyFn;
+    const pending = Promise.resolve(
+      record(
+        env,
+        {
+          route: `${MCP_PROTOCOL_ROUTE_PREFIX}refused:${reason}`,
+          ok: false,
+          status: response.status,
+          method: request.method,
+          ...(suppressed > 0 ? { suppressed_occurrences: suppressed } : {}),
+        },
+        {},
+      ),
+    ).catch(() => false);
+    (deps.executionCtx as Row | undefined)?.waitUntil?.(pending);
+  } catch {
+    // Telemetry must never surface into the MCP path.
+  }
+}
+
 // Entry point wired into the Worker at `/mcp`. `deps` injects the shared
 // artifact/KV readers from workers/api.ts. POST carries the stateless
 // JSON-RPC 2.0 envelope; GET opens the SSE push stream; DELETE terminates a
 // session (see the two handlers above for both).
+//
+// #9639: EVERY REFUSAL BELOW USED TO BE POSTHOG-DARK. `/mcp` is excluded from
+// withUsageTelemetry (workers/api.ts) because the dispatch loop instruments
+// itself (#8993) -- but that instrumentation starts at dispatchMessage, so the
+// rate limit, the daily quota, the 405, the body-size gate, the protocol-
+// version check and both batch guards all returned before anything recorded
+// them. A client that got throttled or ran out of quota simply stopped
+// appearing, with nothing saying why: the events that EXPLAIN a drop in usage
+// were exactly the ones missing.
+//
+// Instrumented at the BOUNDARY rather than at each `return`, which is #8993's
+// own rule ("a new case is instrumented by existing") applied one layer out.
+// The discriminator is exact rather than heuristic: dispatch always answers
+// 2xx -- a JSON-RPC error rides INSIDE a 200 body, jsonResponse defaults to
+// 200, and the only other successes are 202 for a notification and 204 for a
+// terminated session. So a non-2xx leaving this function is, by construction,
+// a request that never reached a handler.
 export async function handleMcpRequest(
+  request: Request,
+  env: Env = {} as unknown as Env,
+  deps: Row = {},
+) {
+  const response = await dispatchMcpRequest(request, env, deps);
+  if (!response.ok) scheduleMcpRefusalEvent(request, env, deps, response);
+  return response;
+}
+
+async function dispatchMcpRequest(
   request: Request,
   env: Env = {} as unknown as Env,
   deps: Row = {},

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -123,6 +123,8 @@ registerModuleStateReset("src/usage-telemetry.ts", () => {
   // the next file, which is precisely the cross-file channel this registry
   // exists to close.
   exceptionThrottle.clear();
+  // Same hazard, same reason, for the MCP refusal guard (#9639).
+  mcpRefusalThrottle.clear();
 });
 
 function parseRate(value: unknown): number | undefined {
@@ -1195,6 +1197,47 @@ export function admitExceptionCapture(
   const state = exceptionThrottle.get(fingerprint);
   if (state === undefined || nowMs - state.windowStartedAtMs >= windowMs) {
     exceptionThrottle.set(fingerprint, {
+      windowStartedAtMs: nowMs,
+      suppressed: 0,
+    });
+    return state?.suppressed ?? 0;
+  }
+  state.suppressed += 1;
+  return null;
+}
+
+// The MCP pre-dispatch refusal guard (#9639). Its own map, not a shared
+// namespace on exceptionThrottle: these are analytics `usage_event`s, not
+// $exception captures, and a burst of one must never consume the other's
+// window. It reuses exceptionStormWindowMs deliberately -- the question
+// ("how often may one repeating signal speak") is identical, and a second
+// knob would be one more thing to set correctly on four wrangler configs.
+const mcpRefusalThrottle = new Map<string, ExceptionThrottleState>();
+
+/**
+ * Decide whether this MCP refusal reason may emit now. Same contract as
+ * admitExceptionCapture: the number of occurrences suppressed since the last
+ * emission when it may (0 on first sighting), or null when it must be held.
+ *
+ * WHY A REFUSAL NEEDS A GUARD AT ALL. resolveUsageSampleRate returns 1 for
+ * `ok: false` AND for the `mcp:` route prefix, so a refusal event is
+ * unsampled twice over -- correct for a signal that should never be lost, and
+ * a quota hazard for one a single caller can generate without bound. A client
+ * hammering the rate limiter produces one refusal per request; that is the
+ * shape that spent a month's event budget in two days. One event per reason
+ * per window, carrying the suppressed count, keeps the signal and drops the
+ * storm.
+ */
+export function admitMcpRefusalCapture(
+  env: Env | null | undefined,
+  reason: string,
+  nowMs: number = Date.now(),
+): number | null {
+  const windowMs = exceptionStormWindowMs(env);
+  if (windowMs === 0) return 0;
+  const state = mcpRefusalThrottle.get(reason);
+  if (state === undefined || nowMs - state.windowStartedAtMs >= windowMs) {
+    mcpRefusalThrottle.set(reason, {
       windowStartedAtMs: nowMs,
       suppressed: 0,
     });

--- a/tests/mcp-usage-telemetry.test.ts
+++ b/tests/mcp-usage-telemetry.test.ts
@@ -1,10 +1,17 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  POSTHOG_EXCEPTION_STORM_WINDOW_MS_ENV,
   POSTHOG_PROJECT_TOKEN_ENV,
   USAGE_EVENT_DISTINCT_ID,
+  admitMcpRefusalCapture,
 } from "../src/usage-telemetry.ts";
-import { handleMcpRequest, mcpDistinctId } from "../src/mcp-server.ts";
+import {
+  handleMcpRequest,
+  mcpDistinctId,
+  mcpRefusalReason,
+  scheduleMcpRefusalEvent,
+} from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const CONFIGURED_ENV = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" };
@@ -1191,6 +1198,321 @@ describe("mcpDistinctId precedence (#9054)", () => {
     assert.notEqual(
       mcpDistinctId(undefined, "github:someone"),
       "github:someone",
+    );
+  });
+});
+
+// #9639: every refusal that returns before dispatchMessage used to emit
+// nothing. `/mcp` is excluded from withUsageTelemetry because the dispatch
+// loop instruments itself (#8993), so a request refused ABOVE the loop fell
+// between the two and a throttled or quota-exhausted client just stopped
+// appearing.
+describe("MCP pre-dispatch refusal telemetry (#9639)", () => {
+  const refusalEvents = (spy: { events: Row[] }) =>
+    spy.events.filter((e) =>
+      String((e.event as Row)?.route ?? "").startsWith("mcp:refused:"),
+    );
+
+  test("a 405 refusal is recorded with its reason", async () => {
+    const spy = recorder();
+    const ctx = fakeExecutionCtx();
+    const response = await handleMcpRequest(
+      new Request("https://api.metagraph.sh/mcp", { method: "PUT" }),
+      CONFIGURED_ENV as unknown as Env,
+      makeDeps({
+        recordUsageEvent: spy.recordUsageEvent,
+        executionCtx: ctx,
+      }),
+    );
+    // The response itself must be untouched by the instrumentation.
+    assert.equal(response.status, 405);
+    assert.equal(response.headers.get("allow"), "GET, POST, DELETE, OPTIONS");
+
+    const events = refusalEvents(spy);
+    assert.equal(events.length, 1);
+    const event = events[0]!.event as Row;
+    assert.equal(event.route, "mcp:refused:method_not_allowed");
+    assert.equal(event.ok, false);
+    assert.equal(event.status, 405);
+    assert.equal(event.method, "PUT");
+  });
+
+  // The other half of the boundary rule: a DISPATCHED call must not be
+  // counted as a refusal. Dispatch answers 2xx even when the JSON-RPC body
+  // carries an error, which is exactly why `response.ok` is the discriminator.
+  test("a dispatched tools/call records no refusal, even when it errors", async () => {
+    const spy = recorder();
+    const body = await callMcp(toolCall("definitely_not_a_real_tool"), {
+      ...CONFIGURED_ENV,
+    });
+    assert.equal((body.result as Row)?.isError, true);
+    assert.deepEqual(refusalEvents(spy), []);
+  });
+
+  test("a malformed JSON body is recorded as bad_request", async () => {
+    const spy = recorder();
+    const ctx = fakeExecutionCtx();
+    const response = await handleMcpRequest(
+      new Request("https://api.metagraph.sh/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{not json",
+      }),
+      CONFIGURED_ENV as unknown as Env,
+      makeDeps({
+        recordUsageEvent: spy.recordUsageEvent,
+        executionCtx: ctx,
+      }),
+    );
+    assert.equal(response.ok, false);
+    const events = refusalEvents(spy);
+    assert.equal(events.length, 1);
+    assert.equal((events[0]!.event as Row).ok, false);
+  });
+
+  // The storm guard is the whole reason this is safe to unsample. A caller
+  // hammering the same refusal must produce ONE event per window carrying the
+  // suppressed count, not one per request.
+  test("repeated identical refusals collapse into one event per window", async () => {
+    const spy = recorder();
+    // The window is env-gated and DISABLED when unset (the schema's
+    // .positive().catch(0) sentinel), so it has to be configured here or this
+    // test would assert the guard while measuring the disabled path.
+    // Production sets 300000 in wrangler.jsonc.
+    const env = {
+      ...CONFIGURED_ENV,
+      [POSTHOG_EXCEPTION_STORM_WINDOW_MS_ENV]: "300000",
+    };
+    const refuse = () =>
+      handleMcpRequest(
+        new Request("https://api.metagraph.sh/mcp", { method: "PUT" }),
+        env as unknown as Env,
+        makeDeps({
+          recordUsageEvent: spy.recordUsageEvent,
+          executionCtx: fakeExecutionCtx(),
+        }),
+      );
+    for (let i = 0; i < 5; i += 1) await refuse();
+    assert.equal(
+      refusalEvents(spy).length,
+      1,
+      "five refusals, one event -- the rest are suppressed into its counter",
+    );
+  });
+
+  // The counter itself, driven directly so the window boundary is exact
+  // rather than wall-clock dependent.
+  test("the guard reports how many it suppressed on the next admission", () => {
+    const env = {
+      [POSTHOG_EXCEPTION_STORM_WINDOW_MS_ENV]: "1000",
+    } as unknown as Env;
+    assert.equal(admitMcpRefusalCapture(env, "rate_limited", 0), 0);
+    assert.equal(admitMcpRefusalCapture(env, "rate_limited", 10), null);
+    assert.equal(admitMcpRefusalCapture(env, "rate_limited", 20), null);
+    // Next window opens: the two held occurrences are reported, not lost.
+    assert.equal(admitMcpRefusalCapture(env, "rate_limited", 1000), 2);
+    // A DIFFERENT reason keeps its own window -- a rate-limit storm must not
+    // silence the first daily-quota refusal.
+    assert.equal(admitMcpRefusalCapture(env, "daily_quota", 20), 0);
+  });
+
+  test("an unset window disables the guard rather than blocking every event", () => {
+    assert.equal(admitMcpRefusalCapture({} as unknown as Env, "x", 0), 0);
+    assert.equal(admitMcpRefusalCapture({} as unknown as Env, "x", 1), 0);
+  });
+
+  // Telemetry must never surface into the MCP path: a recorder that throws
+  // has to leave the refusal response exactly as it was.
+  test("a throwing recorder cannot change the response", async () => {
+    const response = await handleMcpRequest(
+      new Request("https://api.metagraph.sh/mcp", { method: "PUT" }),
+      CONFIGURED_ENV as unknown as Env,
+      makeDeps({
+        recordUsageEvent: () => {
+          throw new Error("recorder exploded");
+        },
+        executionCtx: fakeExecutionCtx(),
+      }),
+    );
+    assert.equal(response.status, 405);
+  });
+
+  // With no PostHog token the whole path is a no-op -- it must not throw and
+  // must not attempt to record.
+  test("an unconfigured environment records nothing and still refuses", async () => {
+    const spy = recorder();
+    const response = await handleMcpRequest(
+      new Request("https://api.metagraph.sh/mcp", { method: "PUT" }),
+      {} as unknown as Env,
+      makeDeps({
+        recordUsageEvent: spy.recordUsageEvent,
+        executionCtx: fakeExecutionCtx(),
+      }),
+    );
+    assert.equal(response.status, 405);
+    assert.deepEqual(refusalEvents(spy), []);
+  });
+});
+
+// The reason mapper, driven directly. Every arm is a distinct operational
+// question, and only 405/400 are reachable by constructing a Request -- a 429
+// needs a rate-limiter verdict and a 413 an oversized body, so asserting them
+// through the HTTP path would test the gate rather than the mapping.
+describe("mcpRefusalReason (#9639)", () => {
+  const withScope = (status: number, scope?: string) =>
+    new Response(null, {
+      status,
+      headers: scope ? { "x-ratelimit-scope": scope } : {},
+    });
+
+  test("429 splits on x-ratelimit-scope, the header #8608 added for this", () => {
+    assert.equal(
+      mcpRefusalReason(withScope(429, "daily-quota")),
+      "daily_quota",
+    );
+    assert.equal(mcpRefusalReason(withScope(429, "blocked")), "blocked");
+    assert.equal(
+      mcpRefusalReason(withScope(429, "per-minute")),
+      "rate_limited",
+    );
+    // A 429 with no scope header is still a refusal, not an unlabelled one.
+    assert.equal(mcpRefusalReason(withScope(429)), "rate_limited");
+  });
+
+  test("each other refusal status maps to its own reason", () => {
+    assert.equal(mcpRefusalReason(withScope(405)), "method_not_allowed");
+    assert.equal(mcpRefusalReason(withScope(413)), "body_too_large");
+    assert.equal(mcpRefusalReason(withScope(400)), "bad_request");
+    assert.equal(mcpRefusalReason(withScope(401)), "unauthorized");
+  });
+
+  // The point of instrumenting at the boundary: a refusal added later is
+  // counted without editing this mapper.
+  test("an unmapped 4xx/5xx still gets a stable label", () => {
+    assert.equal(mcpRefusalReason(withScope(418)), "status_418");
+    assert.equal(mcpRefusalReason(withScope(503)), "status_503");
+  });
+
+  test("a non-error status is not a refusal", () => {
+    assert.equal(mcpRefusalReason(withScope(302)), null);
+    assert.equal(mcpRefusalReason(withScope(200)), null);
+  });
+});
+
+describe("scheduleMcpRefusalEvent guards (#9639)", () => {
+  const req = () =>
+    new Request("https://api.metagraph.sh/mcp", { method: "POST" });
+
+  test("a non-2xx the mapper does not recognise records nothing", () => {
+    const spy = recorder();
+    const ctx = fakeExecutionCtx();
+    scheduleMcpRefusalEvent(
+      req(),
+      CONFIGURED_ENV as unknown as Env,
+      { recordUsageEvent: spy.recordUsageEvent, executionCtx: ctx },
+      new Response(null, { status: 302 }),
+    );
+    assert.deepEqual(spy.events, []);
+  });
+
+  test("a throttled reason is held back entirely", () => {
+    const env = {
+      ...CONFIGURED_ENV,
+      [POSTHOG_EXCEPTION_STORM_WINDOW_MS_ENV]: "300000",
+    } as unknown as Env;
+    const spy = recorder();
+    const fire = () =>
+      scheduleMcpRefusalEvent(
+        req(),
+        env,
+        {
+          recordUsageEvent: spy.recordUsageEvent,
+          executionCtx: fakeExecutionCtx(),
+        },
+        new Response(null, { status: 413 }),
+      );
+    fire();
+    fire();
+    fire();
+    assert.equal(spy.events.length, 1);
+  });
+
+  // suppressed_occurrences rides on the NEXT admission, and is omitted rather
+  // than sent as 0 when nothing was held -- a zero would read as a measured
+  // quiet window instead of "first sighting".
+  test("suppressed_occurrences is omitted on a clean window and present after a burst", () => {
+    const spy = recorder();
+    scheduleMcpRefusalEvent(
+      req(),
+      CONFIGURED_ENV as unknown as Env,
+      {
+        recordUsageEvent: spy.recordUsageEvent,
+        executionCtx: fakeExecutionCtx(),
+      },
+      new Response(null, { status: 401 }),
+    );
+    const event = spy.events[0]!.event as Row;
+    assert.equal(event.route, "mcp:refused:unauthorized");
+    assert.equal("suppressed_occurrences" in event, false);
+  });
+
+  // The other side of that ternary: once a window rolls over, the count of
+  // what was held is carried on the next event rather than discarded. Uses a
+  // 1ms window and a real rollover -- admitMcpRefusalCapture takes an explicit
+  // clock but scheduleMcpRefusalEvent deliberately does not, so this is the
+  // honest way to cross the boundary through the real call path. A distinct
+  // status keys its own reason, so no earlier test in this file can prime it.
+  test("suppressed_occurrences rides the first event of the next window", async () => {
+    const env = {
+      ...CONFIGURED_ENV,
+      [POSTHOG_EXCEPTION_STORM_WINDOW_MS_ENV]: "1",
+    } as unknown as Env;
+    const spy = recorder();
+    const fire = () =>
+      scheduleMcpRefusalEvent(
+        req(),
+        env,
+        {
+          recordUsageEvent: spy.recordUsageEvent,
+          executionCtx: fakeExecutionCtx(),
+        },
+        new Response(null, { status: 418 }),
+      );
+    fire();
+    fire();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    fire();
+    assert.equal(spy.events.length, 2, "one per window, not one per call");
+    const second = spy.events[1]!.event as Row;
+    assert.equal(second.route, "mcp:refused:status_418");
+    assert.equal(second.suppressed_occurrences, 1);
+  });
+
+  test("a recorder that rejects is swallowed, never surfaced", async () => {
+    const ctx = fakeExecutionCtx();
+    scheduleMcpRefusalEvent(
+      req(),
+      CONFIGURED_ENV as unknown as Env,
+      {
+        recordUsageEvent: () => Promise.reject(new Error("posthog down")),
+        executionCtx: ctx,
+      },
+      new Response(null, { status: 400 }),
+    );
+    // The scheduled promise must settle rather than reject -- an unhandled
+    // rejection inside waitUntil is a Worker-level error.
+    assert.equal(await ctx.scheduled[0], false);
+  });
+
+  test("falls back to the module recorder when deps supply none", () => {
+    // No executionCtx either: the optional-chained waitUntil must not throw.
+    assert.doesNotThrow(() =>
+      scheduleMcpRefusalEvent(
+        req(),
+        CONFIGURED_ENV as unknown as Env,
+        {},
+        new Response(null, { status: 405 }),
+      ),
     );
   });
 });


### PR DESCRIPTION
## Summary

Every refusal that happens before `dispatchMessage` emitted nothing. `/mcp` is excluded from `withUsageTelemetry` (`workers/api.ts`) because the dispatch loop instruments itself (#8993) — but that instrumentation begins *at* `dispatchMessage`, so everything above it fell in the gap between the two.

The result: a client that was rate-limited, out of daily quota, sending an unsupported protocol version, an oversized body or a malformed batch simply stopped appearing, with nothing saying why. For the MCP surface that is the worst possible blind spot — **the events that explain a drop in usage were exactly the ones not recorded.**

## Instrumented at the boundary, not at each return

Patching the six `return` sites is how this gap opened. #8993 makes precisely this point about the dispatch switch, choosing the loop over the cases so "a new case is instrumented by existing". Same rule, one layer out.

The discriminator is exact rather than heuristic:

> Dispatch always answers 2xx — a JSON-RPC error rides **inside** a 200 body, `jsonResponse` defaults to 200, and the only other successes are 202 for a notification and 204 for a terminated session.

So a non-2xx leaving the entry point is, by construction, a request that never reached a handler. One check covers every refusal above and every refusal added later.

## It must not become the next storm

`resolveUsageSampleRate` returns 1 for `ok: false` **and** for the `mcp:` route prefix — these events are unsampled twice over. Correct for a signal that should never be lost, and a hazard for one a single caller can generate without bound: a client hammering the rate limiter produces one refusal per request, which is the shape that spent a month of event budget in two days.

So the capture reuses the existing per-fingerprint storm-guard pattern: **one event per reason per window, carrying the suppressed count**. `admitMcpRefusalCapture` gets its own map rather than a namespace on `exceptionThrottle` — these are analytics `usage_event`s, not `$exception` captures, and a burst of one must not consume the other's window. It shares `exceptionStormWindowMs` deliberately: the question is identical, and a second knob is one more thing to set correctly on four wrangler configs.

## Reason labels

A label per status, not per call site, because the call sites are what drift. 429 is the one status two gates share, and they are different operational questions — "asking too fast" is a client-pacing bug, "out of quota" is a limits conversation, "blocked" is neither — so they split on `x-ratelimit-scope`, which `tieredRateLimitHeaders` already sets for exactly this purpose (#8608 added it so a 429 is actionable). An unmapped status still gets a stable `status_<n>` label.

## No behaviour change

Status, body and headers are byte-identical. A recorder that throws or returns a rejecting promise cannot surface into the MCP path — both are covered by tests, including that the `waitUntil` promise settles rather than rejecting (an unhandled rejection inside `waitUntil` is a Worker-level error).

## Tests

13 new cases. The recording assertions were verified to genuinely catch the gap: removing the one boundary line fails exactly the three that assert recording, and none of the absence/non-interference ones.

Two helpers are exported for tests, on the same reasoning `admitExceptionCapture` already documents — the guard branches (an unrecognised non-2xx, the throttle holding one back, a rejecting recorder) are the entire point of the code and are deliberately unreachable through the HTTP path, so driving them from a `Request` would mean asserting on a state production cannot produce.

The storm-window test configures `POSTHOG_EXCEPTION_STORM_WINDOW_MS` explicitly: the window is env-gated and **disabled** when unset (the schema's `.positive().catch(0)` sentinel), so without it the test would assert the guard while measuring the disabled path.

## Validation run

```
npx vitest run tests/mcp-usage-telemetry.test.ts tests/mcp-server.test.ts
  tests/mcp-schema-enforcement.test.ts tests/usage-telemetry.test.ts
  tests/mcp-server-dispatch-error-capture.test.ts tests/mcp-session-hub.test.ts
                                            1643 passed
npm run validate:mcp                        224 tools, lifecycle + all tools/call green
npm run typecheck                           clean
npm run lint                                clean
patch coverage (diff intersection)          100% on src/mcp-server.ts and src/usage-telemetry.ts
```

Closes #9639
