### PR TITLE
chore(queue): re-cut account-balances over, now that messages fit

### DIFF
--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -120,31 +120,32 @@
     // would silently replace this one wholesale, which is the trap the tier-flag
     // comment above already records.
     //
-    // EMPTY, ROLLED BACK 2026-08-06 (metagraphed-infra#360). Every enqueue
-    // exceeds the 128 KB Queues message cap by ~24x: the route hands `send()`
-    // the whole posted chunk and the producer chunks at CHUNK_SIZE = 25_000,
-    // which is 3,116 KB at a measured 127.6 bytes/row. `send()` throws, the
-    // route returns 502, and the producer retries 6x and abandons the pass --
-    // so a cut-over lane does not degrade, it STOPS.
+    // account-balances, re-cut over 2026-08-06 after the fan-out landed
+    // (metagraphed-infra#360, #9636). Before it, the route handed `send()` the
+    // whole posted chunk: at CHUNK_SIZE = 25_000 that is 3,116 KB against a
+    // 128 KB cap, so every enqueue would have thrown. The packer now splits one
+    // POST into byte-budgeted messages, key-aware where the lane prunes.
     //
-    // Both lanes had completed ZERO passes while named here. The earlier
-    // "cut over on evidence" note cited hotkey-alpha passes at 04:40 and 05:01
-    // as queued; #9619 -- the commit that first added the name -- did not
-    // deploy until 05:20:12Z, so those two ran on the inline path. THE DEPLOY
-    // TIMESTAMP IS THE CHECK, not the pass table: a pass row proves a lane is
-    // healthy, not which path carried it.
+    // THE BIG LANE GOES FIRST HERE, reversing the epic's small-lane-first rule,
+    // and the reason is the timers. `HOTKEY_ALPHA_POLL_SECS` is 86400, so
+    // cutting the cheap lane over buys no signal until ~05:00 tomorrow.
+    // `ACCOUNT_BALANCES_POLL_SECS` is 21600 and its last pass was 04:38, so it
+    // reports around 10:38 today. The transport shape is already proven by
+    // tests that pack a real 25,000-row chunk; what is NOT proven is D1 under
+    // queue concurrency, and only this lane can answer that.
     //
-    // Re-adding a lane requires the fan-out in #360 first, and that split must
-    // be KEY-AWARE -- nominator-positions asserts `key_complete`, and a naive
-    // slice can split a coldkey across sub-messages, which is exactly the
-    // delete-what-you-did-not-carry bug the guard exists to stop.
+    // WHAT "NO PASS YET" MEANS HERE. These lanes are timers, not streams. An
+    // absence of rows is not a failure until it exceeds the interval -- reading
+    // one as the other is what turned a preventive rollback into a reported
+    // incident earlier today. Judge this cutover at 10:38, not before.
     //
     // ROLLBACK IS DROPPING A WORD FROM THIS STRING. These are latest-only
     // upsert tables refreshed on a tick, so the next pass simply writes the old
     // way. No backfill, no reconciliation. Watch account_balances_passes: an
-    // incomplete pass is the signal, and completeness is a fact the queue does
-    // not itself provide.
-    "SYNC_QUEUE_LANES": "",
+    // INCOMPLETE pass is the signal -- received_rows short of expected_rows with
+    // a null completed_at -- and completeness is a fact the queue does not
+    // itself provide.
+    "SYNC_QUEUE_LANES": "account-balances",
     // #9430's $exception storm guard reads this var per-Worker
     // (src/usage-telemetry.ts), and `vars` are per-config -- declaring it
     // only in wrangler.jsonc left THIS Worker's captures entirely unguarded,


### PR DESCRIPTION
Closes metagraphed-infra#350.

One word back in `SYNC_QUEUE_LANES`, after #9636 made the enqueue survivable. The route used to hand `send()` the whole posted chunk — **3,116 KB at `CHUNK_SIZE = 25_000` against a 128 KB cap** — so the packer landing first is what makes this a cutover rather than a repeat of #9630.

## The big lane goes first, reversing the epic's rule

Not for throughput — for the timers.

| lane | `*_POLL_SECS` | last pass | next tick |
|---|---|---|---|
| `hotkey-alpha` | 86400 (24h) | 05:01:38 | ~05:00 **tomorrow** |
| `account-balances` | 21600 (6h) | 04:38:45 | **~10:38 today** |

The small-lane-first rule existed to prove the transport shape cheaply. That is now proven by tests that pack a real 25,000-row chunk and assert every message fits the cap. What remains unproven is **D1 under queue concurrency** — and only the 364k-row lane can answer that. The cheap lane has nothing left to teach that is worth 20 hours of wall time.

## What "no pass yet" means

These lanes are timers, not streams. **An absence of rows is not a failure until it exceeds the interval** — reading one as the other is what turned a preventive rollback into a reported incident earlier today (metagraphed-infra#360). This cutover is judged at ~10:38, not before.

## What to check when it ticks

- a new `account_balances_passes` row with `captured_at` > this deploy, `received_rows == expected_rows`, `completed_at` non-null
- no `D1_ERROR: D1 DB is overloaded` — this is the lane whose unthrottled write caused that, and its 1s inter-chunk sleep is still in place (metagraphed-infra#351), so this run tests the queue's `max_concurrency: 2` bound with the old pacing still on
- `received_rows` may *exceed* `expected_rows` if a message is retried; that is the documented at-least-once overshoot (metagraphed-infra#352), not a fault

## Verification

- `vitest tests/sync-batch-queue.test.ts tests/data-api-account-balances-d1.test.ts` — 63 passed
- config-only; no generated artifact depends on this var
- rollback stays one word