### PR TITLE
feat(queue): accept neurons on sync-batches, pruning per netuid

### DIFF
--- a/src/neurons-d1-write.ts
+++ b/src/neurons-d1-write.ts
@@ -277,6 +277,102 @@ export interface NeuronSnapshotWrite {
   netuidMaxCapturedAt: Map<number, number>;
 }
 
+// --- The three derivations, pure and shared ---------------------------------
+//
+// `neuron_daily` and `account_position_daily` are pure functions of the posted
+// rows, and the prune cutoff is a pure function of them too. They used to be
+// computed inline in the sync handler, which was fine while the handler was the
+// only writer. It is not any more: the queue consumer receives a message that
+// carries `rows` and nothing else (metagraphed-infra#359 is the standing reason
+// SyncBatchMessage stays one array), so it has to redo all three.
+//
+// Two implementations of a prune cutoff is two chances to compute a different
+// one, and the failure mode there is deleted rows. So there is one.
+
+/**
+ * Per-netuid max `captured_at`, the cutoff `writeNeuronSnapshotToD1` prunes on.
+ *
+ * NOT one batch-wide value: a global max would let one netuid's later capture
+ * delete rows this same write just upserted for a different, earlier-captured
+ * netuid -- its own fresh rows would satisfy `captured_at < max`.
+ *
+ * Rows with an unusable netuid or captured_at are skipped rather than seeding a
+ * NaN cutoff, which would delete every row for that netuid. Same rule, and the
+ * same reason, as `coldkeyMaxCapturedAt` in the positions lane.
+ */
+export function netuidMaxCapturedAt(rows: Row[]): Map<number, number> {
+  const cutoffs = new Map<number, number>();
+  for (const row of rows) {
+    const netuid = row?.netuid;
+    const capturedAt = row?.captured_at;
+    if (!Number.isFinite(netuid as number)) continue;
+    if (!Number.isFinite(capturedAt as number)) continue;
+    const current = cutoffs.get(netuid as number);
+    if (current == null || (capturedAt as number) > current) {
+      cutoffs.set(netuid as number, capturedAt as number);
+    }
+  }
+  return cutoffs;
+}
+
+/** The UTC day a capture belongs to, matching D1's `rollupNeuronDaily`
+ * (`date(captured_at / 1000, 'unixepoch')`). */
+export function neuronSnapshotDate(capturedAtMs: number): string {
+  return new Date(capturedAtMs).toISOString().slice(0, 10);
+}
+
+/** `neuron_daily` rows: the posted row plus its day and a write stamp. */
+export function neuronDailyRows(rows: Row[], nowMs: number): Row[] {
+  return rows.map((row) => ({
+    ...row,
+    snapshot_date: neuronSnapshotDate(row.captured_at as number),
+    updated_at: nowMs,
+  }));
+}
+
+/**
+ * `account_position_daily` rows, re-keyed by account.
+ *
+ * Rows with no hotkey are dropped: the table is keyed on `account`, so a null
+ * one has nowhere to go.
+ */
+export function neuronPositionRows(dailyRows: Row[]): Row[] {
+  return dailyRows
+    .filter((row) => row.hotkey != null)
+    .map((row) => ({
+      account: row.hotkey,
+      netuid: row.netuid,
+      snapshot_date: row.snapshot_date,
+      uid: row.uid,
+      coldkey: row.coldkey,
+      active: row.active,
+      validator_permit: row.validator_permit,
+      rank: row.rank,
+      trust: row.trust,
+      incentive: row.incentive,
+      dividends: row.dividends,
+      stake_tao: row.stake_tao,
+      emission_tao: row.emission_tao,
+      captured_at: row.captured_at,
+      updated_at: row.updated_at,
+    }));
+}
+
+/** Everything `writeNeuronSnapshotToD1` needs, derived from the rows alone --
+ * so the sync handler and the queue consumer build it the same way. */
+export function neuronSnapshotWrite(
+  rows: Row[],
+  nowMs: number,
+): NeuronSnapshotWrite {
+  const dailyRows = neuronDailyRows(rows, nowMs);
+  return {
+    rows,
+    dailyRows,
+    positionRows: neuronPositionRows(dailyRows),
+    netuidMaxCapturedAt: netuidMaxCapturedAt(rows),
+  };
+}
+
 /**
  * Write one sync batch to D1, atomically.
  *

--- a/src/sync-batch-queue.ts
+++ b/src/sync-batch-queue.ts
@@ -100,11 +100,22 @@ export const SYNC_BATCH_LANES = [
  * Lanes whose write PRUNES, and therefore may not be applied from a chunk that
  * could be missing rows for a key it names.
  *
- * `neurons` belongs here too -- it prunes per netuid -- but is not on the queue
- * yet, and listing a lane before its producer asserts completeness would reject
- * every one of its messages. It joins when it moves.
+ * A lane belongs here only once its POSTs are known to carry whole keys --
+ * listing one earlier makes every message assert something false, on the one
+ * field whose failure mode is deleted rows. `PRUNING_LANE_KEYS` says WHICH key;
+ * this says which lanes have earned the claim.
  */
-export const PRUNING_LANES: readonly string[] = ["nominator-positions"];
+export const PRUNING_LANES: readonly string[] = [
+  "nominator-positions",
+  // metagraphed-infra#357. It prunes per netuid, and it can assert
+  // key-completeness for a reason worth stating: its producer NEVER chunks.
+  // `metagraph.rs` bails -- "refusing to truncate a partial snapshot" -- if a
+  // pass exceeds its 50,000-row ceiling, and a pass is ~33,000 rows, so the
+  // whole snapshot arrives in one POST or none of it does. The packer then
+  // groups that POST by netuid, so every message really does carry every row
+  // for each netuid it names.
+  "neurons",
+];
 
 export type SyncBatchLane = (typeof SYNC_BATCH_LANES)[number];
 
@@ -163,8 +174,7 @@ export const SYNC_BATCH_MAX_BYTES = 96 * 1024;
  */
 export const PRUNING_LANE_KEYS: Readonly<Record<string, string>> = {
   "nominator-positions": "coldkey",
-  // `neurons` prunes per netuid and joins PRUNING_LANES when it moves
-  // (metagraphed-infra#357); its key is declared here at the same time.
+  neurons: "netuid",
 };
 
 /** Bytes one row costs inside the `rows` array, including its separating
@@ -204,9 +214,10 @@ export function packSyncBatchMessages(input: {
   maxRows?: number;
   /** Overridable so the "listed as pruning, no key declared" guard below is
    * reachable from a test. PRUNING_LANES and PRUNING_LANE_KEYS are deliberately
-   * NOT one list -- a lane can have a known prune key while its producer does
-   * not yet assert key-completeness, which is exactly `neurons` today -- so the
-   * mismatch is possible and the guard is not decorative. */
+   * NOT one list -- a lane can have a known prune key while its producer cannot
+   * yet guarantee whole keys per POST, and listing it before then would make
+   * every message assert something false -- so the mismatch is possible and the
+   * guard is not decorative. */
   pruningKeys?: Readonly<Record<string, string>>;
 }): SyncBatchMessage[] {
   const {

--- a/tests/data-api-neurons-d1.test.ts
+++ b/tests/data-api-neurons-d1.test.ts
@@ -1697,3 +1697,139 @@ test("a missing subnet_hyperparams table degrades apy_estimate, never the valida
   assert.equal(entry.apy_estimate, null, "only the APY opinion is lost");
   assert.equal(entry.apy_estimate_eligible_subnet_count, 0);
 });
+
+// --- routed to the sync queue (metagraphed-infra#357) -----------------------
+//
+// This lane waited on the queue because its write PRUNES: it deletes rows for a
+// netuid older than the newest captured_at it saw for that netuid. Applied to a
+// message holding only part of a netuid, that deletes rows the message never
+// carried, and no retry undoes a delete.
+//
+// What makes the claim safe is the producer, not the transport: metagraph.rs
+// bails -- "refusing to truncate a partial snapshot" -- rather than chunk above
+// its 50,000-row ceiling, and a pass is ~33,000 rows. So a POST always holds
+// every row for every netuid it names, and the packer only has to not break it.
+function queueEnv(send: (m: unknown) => Promise<void>) {
+  return env({ SYNC_BATCHES: { send }, SYNC_QUEUE_LANES: "neurons" });
+}
+
+test("neurons-sync enqueues instead of writing, and never both", async () => {
+  const sent: Record<string, unknown>[] = [];
+  const res = await postSync(
+    [syncRow(), syncRow({ uid: 1, hotkey: "5Hot7-1" })],
+    queueEnv(async (m) => {
+      sent.push(m as Record<string, unknown>);
+    }),
+  );
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.deepEqual(body.stores, ["queue"]);
+  assert.equal(body.neurons_written, 2);
+  assert.equal(sent.length, 1);
+  // The derived counts are still reported, because a caller reads them to know
+  // the snapshot was understood -- they are computed either way.
+  assert.equal(body.neuron_daily_written, 2);
+  assert.equal(body.netuids_covered, 1);
+});
+
+test("neurons-sync claims key-completeness on what it enqueues", async () => {
+  // The consumer REFUSES a neurons message without this, and a refused message
+  // is acked rather than retried -- so a missing flag drops the snapshot.
+  const sent: Record<string, unknown>[] = [];
+  await postSync(
+    [syncRow()],
+    queueEnv(async (m) => {
+      sent.push(m as Record<string, unknown>);
+    }),
+  );
+  assert.equal(sent[0]!.key_complete, true);
+  assert.equal(sent[0]!.lane, "neurons");
+  // No pass declaration: this lane has never had one, and inventing a total
+  // would mark an unproven load complete.
+  assert.equal("pass_total" in sent[0]!, false);
+});
+
+test("neurons-sync 502s when the enqueue fails, so the producer retries", async () => {
+  const res = await postSync(
+    [syncRow()],
+    queueEnv(async () => Promise.reject(new Error("over capacity"))),
+  );
+  assert.equal(res.status, 502);
+});
+
+test("the queue consumer writes a neurons message, prune included", async () => {
+  // Drives the Worker's own queue() handler against a real D1, so the writer
+  // wired into the consumer map is exercised rather than a stand-in. The prune
+  // is the part worth proving end to end: it is what made this lane wait.
+  await postSync([
+    syncRow({ uid: 0, hotkey: "5Hot7-0", captured_at: CAPTURED_AT }),
+    syncRow({ uid: 1, hotkey: "5Hot7-1", captured_at: CAPTURED_AT }),
+  ]);
+  assert.equal(count("neurons"), 2);
+
+  // A later capture naming only uid 0 must retire uid 1 -- it is the shape of a
+  // deregistration, and the reason a partial message could never be applied.
+  const acked: string[] = [];
+  await worker.queue(
+    {
+      messages: [
+        {
+          body: {
+            lane: "neurons",
+            captured_at: CAPTURED_AT + 60_000,
+            key_complete: true,
+            rows: [
+              syncRow({
+                uid: 0,
+                hotkey: "5Hot7-0",
+                captured_at: CAPTURED_AT + 60_000,
+              }),
+            ],
+          },
+          ack: () => acked.push("ack"),
+          retry: () => acked.push("retry"),
+        },
+      ],
+    } as never,
+    env(),
+    { waitUntil: (p: Promise<unknown>) => void p } as never,
+  );
+
+  assert.deepEqual(acked, ["ack"], "a written message is acked, never retried");
+  assert.equal(count("neurons"), 1, "uid 1 pruned by the later capture");
+  assert.equal(
+    one("SELECT * FROM neurons WHERE uid = 0").captured_at,
+    CAPTURED_AT + 60_000,
+  );
+  // The derived tables are redone by the consumer from the message's rows.
+  assert.equal(count("neuron_daily") > 0, true);
+});
+
+test("the consumer refuses a neurons message that does not claim key-completeness", async () => {
+  // Refused, not written: applying it would prune netuid 7 down to the one row
+  // this message happens to carry, deleting rows it never saw.
+  await postSync([
+    syncRow({ uid: 0, captured_at: CAPTURED_AT }),
+    syncRow({ uid: 1, hotkey: "5Hot7-1", captured_at: CAPTURED_AT }),
+  ]);
+  const acked: string[] = [];
+  await worker.queue(
+    {
+      messages: [
+        {
+          body: {
+            lane: "neurons",
+            captured_at: CAPTURED_AT + 60_000,
+            rows: [syncRow({ uid: 0, captured_at: CAPTURED_AT + 60_000 })],
+          },
+          ack: () => acked.push("ack"),
+          retry: () => acked.push("retry"),
+        },
+      ],
+    } as never,
+    env(),
+    { waitUntil: (p: Promise<unknown>) => void p } as never,
+  );
+  assert.deepEqual(acked, ["ack"], "unparseable is acked, not retried");
+  assert.equal(count("neurons"), 2, "nothing written, nothing pruned");
+});

--- a/tests/neurons-d1-write.test.ts
+++ b/tests/neurons-d1-write.test.ts
@@ -21,6 +21,7 @@ import {
   rowsPerStatement,
   D1_JSON_BUDGET_BYTES,
   writeNeuronSnapshotToD1,
+  netuidMaxCapturedAt,
 } from "../src/neurons-d1-write.ts";
 import { NEURON_INSERT_COLUMNS } from "../src/metagraph-neurons.ts";
 
@@ -297,5 +298,39 @@ describe("the neurons D1 write path (#9146)", () => {
     });
     assert.equal(result.statements, 0);
     assert.equal(batched(), null, "an empty write must not open a transaction");
+  });
+});
+
+describe("netuidMaxCapturedAt", () => {
+  test("takes the LATEST capture per netuid, not one batch-wide max", () => {
+    // A batch-wide max would let one netuid's later capture delete rows this
+    // same write just upserted for a different, earlier-captured netuid.
+    const cutoffs = netuidMaxCapturedAt([
+      { netuid: 7, captured_at: 100 },
+      { netuid: 7, captured_at: 300 },
+      { netuid: 8, captured_at: 200 },
+    ]);
+    assert.equal(cutoffs.get(7), 300);
+    assert.equal(cutoffs.get(8), 200);
+  });
+
+  test("skips a row with no usable netuid rather than keying on NaN", () => {
+    const cutoffs = netuidMaxCapturedAt([
+      { netuid: null, captured_at: 100 },
+      { captured_at: 100 },
+      { netuid: 7, captured_at: 100 },
+    ]);
+    assert.deepEqual([...cutoffs.keys()], [7]);
+  });
+
+  test("skips a row with no usable captured_at, which would delete everything", () => {
+    // A NaN cutoff makes `captured_at < cutoff` false for every row, but a
+    // null one binds as NULL and the comparison stops being a guard at all --
+    // either way the safe move is to not seed a cutoff from an unusable row.
+    const cutoffs = netuidMaxCapturedAt([
+      { netuid: 7, captured_at: null },
+      { netuid: 8, captured_at: "soon" },
+    ]);
+    assert.equal(cutoffs.size, 0);
   });
 });

--- a/tests/sync-batch-queue.test.ts
+++ b/tests/sync-batch-queue.test.ts
@@ -566,3 +566,67 @@ describe("enqueueSyncBatch", () => {
     );
   });
 });
+
+describe("packSyncBatchMessages: neurons (metagraphed-infra#357)", () => {
+  // neurons prunes per NETUID, and its producer never chunks: metagraph.rs
+  // bails rather than truncate a partial snapshot above its 50,000-row ceiling,
+  // and a pass is ~33,000 rows. So a POST always carries every row for every
+  // netuid it names, and the packer only has to not break that.
+  const neuronRows = (netuids: number, perNetuid: number) =>
+    Array.from({ length: netuids * perNetuid }, (_, i) => ({
+      netuid: Math.floor(i / perNetuid),
+      uid: i % perNetuid,
+      hotkey: ss58(i),
+      coldkey: ss58(100_000 + i),
+      stake_tao: 1234.5678 + i,
+      captured_at: 1_785_970_245_474,
+    }));
+
+  test("never splits a netuid across messages", () => {
+    const rows = neuronRows(129, 256);
+    const messages = packSyncBatchMessages({
+      lane: "neurons",
+      capturedAt: 1_785_970_245_474,
+      rows,
+    });
+
+    assert.equal(messages.length > 1, true, "one message could not hold 33k");
+
+    const seen = new Map<number, number>();
+    for (const [index, message] of messages.entries()) {
+      for (const row of message.rows) {
+        const netuid = row.netuid as number;
+        const previous = seen.get(netuid);
+        if (previous !== undefined) assert.equal(previous, index);
+        else seen.set(netuid, index);
+      }
+    }
+    assert.equal(seen.size, 129, "every netuid accounted for");
+  });
+
+  test("every message is accepted by the validator", () => {
+    // A neurons message without key_complete is REFUSED, and a refused message
+    // is acked rather than retried -- so a packer that forgot the flag would
+    // drop the whole snapshot silently.
+    for (const message of packSyncBatchMessages({
+      lane: "neurons",
+      capturedAt: 1_785_970_245_474,
+      rows: neuronRows(20, 256),
+    })) {
+      assert.equal(message.key_complete, true);
+      assert.equal(validSyncBatchMessage(message), true);
+    }
+  });
+
+  test("the validator refuses a neurons chunk that does not claim it", () => {
+    // Prove the guard bites: same message, flag removed.
+    const [message] = packSyncBatchMessages({
+      lane: "neurons",
+      capturedAt: 1_785_970_245_474,
+      rows: neuronRows(1, 4),
+    });
+    assert.equal(validSyncBatchMessage(message), true);
+    const { key_complete: _drop, ...unclaimed } = message!;
+    assert.equal(validSyncBatchMessage(unclaimed), false);
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -358,6 +358,8 @@ import {
   NEURON_INSERT_COLUMNS,
 } from "../src/metagraph-neurons.ts";
 import {
+  neuronSnapshotDate,
+  neuronSnapshotWrite,
   writeNeuronDailyBackfillToD1,
   writeNeuronSnapshotToD1,
 } from "../src/neurons-d1-write.ts";
@@ -539,9 +541,7 @@ const NEURON_SYNC_ROW_SCHEMA = neuronSyncRowSchema({
 
 // captured_at is epoch ms; snapshot_date is the UTC day, matching D1's
 // rollupNeuronDaily (`date(captured_at / 1000, 'unixepoch')`).
-function neuronSyncSnapshotDate(capturedAtMs: number) {
-  return new Date(capturedAtMs).toISOString().slice(0, 10);
-}
+const neuronSyncSnapshotDate = neuronSnapshotDate;
 
 // Coerce one validated row into the exact JS types each Postgres column
 // expects: 0/1 -> boolean for the BOOLEAN columns (the fetch script emits
@@ -640,46 +640,49 @@ async function handleNeuronsSync(request: Request, env: Env) {
   }
 
   const rows = validatedIncoming.map(coerceNeuronSyncRow);
-  // Per-netuid max captured_at, NOT one batch-wide value -- a global max would
-  // let one netuid's later capture prune rows this SAME request just upserted
-  // for a different, earlier-captured netuid in the same batch (the max would
-  // exceed that netuid's own captured_at, so its own just-written rows would
-  // satisfy `captured_at < max` and be deleted as if deregistered).
-  const netuidMaxCapturedAt = new Map();
-  for (const row of rows) {
-    const prev = netuidMaxCapturedAt.get(row.netuid) ?? 0;
-    if (row.captured_at > prev)
-      netuidMaxCapturedAt.set(row.netuid, row.captured_at);
-  }
+  // Derived by the SAME functions the queue consumer uses (#9636's fan-out
+  // means this snapshot can now arrive either way). Two implementations of a
+  // prune cutoff would be two chances to compute a different one, and the
+  // failure mode there is deleted rows.
+  const { dailyRows, positionRows, netuidMaxCapturedAt } = neuronSnapshotWrite(
+    rows,
+    Date.now(),
+  );
   const netuids = [...netuidMaxCapturedAt.keys()];
 
-  // Shaped ONCE, outside the transaction, so the D1 and Postgres writers put
-  // the same rows in the same shape into both stores -- two shapings would be
-  // two chances to diverge.
-  const dailyRows = rows.map((row: Row) => ({
-    ...row,
-    snapshot_date: neuronSyncSnapshotDate(row.captured_at),
-    updated_at: Date.now(),
-  }));
-  const positionRows = dailyRows
-    .filter((row: Row) => row.hotkey != null)
-    .map((row: Row) => ({
-      account: row.hotkey,
-      netuid: row.netuid,
-      snapshot_date: row.snapshot_date,
-      uid: row.uid,
-      coldkey: row.coldkey,
-      active: row.active,
-      validator_permit: row.validator_permit,
-      rank: row.rank,
-      trust: row.trust,
-      incentive: row.incentive,
-      dividends: row.dividends,
-      stake_tao: row.stake_tao,
-      emission_tao: row.emission_tao,
-      captured_at: row.captured_at,
-      updated_at: row.updated_at,
-    }));
+  // Enqueue or write, never both -- see handleHotkeyAlphaSync's own note.
+  //
+  // THE PRUNE IS WHY THIS LANE WAITED (metagraphed-infra#357). Its write
+  // DELETES rows for a netuid older than the newest captured_at it saw for that
+  // netuid, so a message missing some of a netuid's rows would delete rows it
+  // never carried. The packer groups by netuid and asserts `key_complete`
+  // because it made that true -- and it CAN, because this producer never
+  // chunks: metagraph.rs bails rather than truncate a partial snapshot, so the
+  // whole pass arrives in one POST or none of it does.
+  //
+  // No pass declaration: this lane has never had one, and inventing one would
+  // mark an unproven load complete.
+  if (syncLaneUsesQueue(env, "neurons")) {
+    try {
+      await enqueueSyncBatch(env.SYNC_BATCHES!, {
+        lane: "neurons",
+        capturedAt: rows[0]!.captured_at as number,
+        rows,
+      });
+    } catch (err) {
+      console.error("data-api neurons enqueue failed:", err);
+      await captureDataApiError(err, "neurons-sync-queue", env);
+      return writeJson({ error: "enqueue failed" }, 502);
+    }
+    return writeJson({
+      ok: true,
+      neurons_written: rows.length,
+      neuron_daily_written: dailyRows.length,
+      account_position_daily_written: positionRows.length,
+      netuids_covered: netuids.length,
+      stores: ["queue"],
+    });
+  }
 
   // D1 is the binding this path REQUIRES -- it is the only store left (#9146,
   // #9193), so the sync has to keep working with nothing else bound or the
@@ -7296,6 +7299,17 @@ export default {
               >[0],
               rows,
               pass,
+            ),
+          // Redoes both derivations from THIS message's rows, which is sound
+          // only because the message asserted `key_complete` -- the validator
+          // rejects a neurons message without it, so this writer never sees a
+          // chunk whose prune map would delete rows it did not carry.
+          neurons: (rows) =>
+            writeNeuronSnapshotToD1(
+              env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+                typeof writeNeuronSnapshotToD1
+              >[0],
+              neuronSnapshotWrite(rows, Date.now()),
             ),
           "validator-nominator-counts": (rows) =>
             writeValidatorNominatorCountsToD1(


### PR DESCRIPTION
Closes metagraphed-infra#357.

The lane that looks flat and is not. `writeNeuronSnapshotToD1` **deletes** rows for a netuid older than the newest `captured_at` it saw for that netuid — so a message holding only part of a netuid deletes rows it never carried, and no retry undoes a delete.

## The question that blocked it, answered

#357 recorded the blocker honestly as *unverified*: whether the producer's neuron chunking can split a netuid across requests.

**It cannot, because it never chunks at all.** `metagraph.rs` bails — *"refusing to truncate a partial snapshot"* — if a pass exceeds its 50,000-row ceiling, and a pass is ~33,000 rows (129 subnets × ≤256 UIDs). The whole snapshot arrives in one POST or none of it does.

That is a *stronger* guarantee than `pack_coldkey_chunks` gives the positions lane, and it is enforced by the producer rather than assumed by the consumer. With #9636's packer grouping by the lane's prune key, `neurons` joins `PRUNING_LANES` with `netuid`, and every message genuinely satisfies `key_complete` rather than merely claiming it.

## One derivation, not two

`neuron_daily`, `account_position_daily` and the prune cutoff were computed inline in the sync handler. Fine while the handler was the only writer — but the consumer receives a message carrying `rows` and nothing else (`SyncBatchMessage` stays one array; that is metagraphed-infra#359's standing constraint), so it must redo all three.

**Two implementations of a prune cutoff is two chances to compute a different one**, and the failure mode is deleted rows. They move into `src/neurons-d1-write.ts` as pure functions and both callers use them. `netuidMaxCapturedAt` skips rows with an unusable netuid or `captured_at` rather than seeding a NaN cutoff — the same rule, for the same reason, as `coldkeyMaxCapturedAt`.

## Also removed

The `if (!env.SYNC_BATCHES) return 503` guard I first wrote into the enqueue branch: `syncLaneUsesQueue` already returns false without the binding, so it was unreachable. The other three lanes use `env.SYNC_BATCHES!` for exactly that reason, and a dead branch that codecov counts is worse than no branch.

## Wired, not cut over

`SYNC_QUEUE_LANES` is unchanged, so this ships inert — a bad wiring change cannot also be a bad cutover. Cutting `neurons` over waits on `account-balances` reporting at its next tick (#9641).

## Verification

- **100% patch coverage, branch-counted**, by diff intersection across all three changed files (`workers/data-api.ts` 10/10, `src/sync-batch-queue.ts` 1/1, `src/neurons-d1-write.ts` 17/17, no uncovered branches)
- the consumer test drives the Worker's **own `queue()` handler** against a real D1 and asserts the prune retires a UID the later capture omitted — the writer wired into the consumer map, not a stand-in
- a companion test proves the guard bites: the same message without `key_complete` is refused and acked, and nothing is written or pruned
- full suite: **703 files / 16,918 tests** green
- `build`, `lint`, `format:check`, `validate:contract-drift`, `validate:mcp` clean; no generated-artifact drift