### PR TITLE
feat(mcp): capture agent intent via the context argument

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -3461,7 +3461,36 @@ function validateToolArguments(tool: Row, args: Row) {
       `Invalid arguments for tool ${tool.name}.`,
     );
   }
-  return args;
+  // #9642: the intent argument is analytics metadata, never tool input, so it
+  // is removed before any handler sees it -- the same contract @posthog/mcp's
+  // SDK documents ("It strips that argument before your handler runs"). Not
+  // merely a courtesy: several handlers forward their whole argument object
+  // into a query builder or an upstream call, where an unexpected key becomes
+  // a filter, a cache-key difference, or a 400 from someone else's API.
+  return splitMcpIntent(args).rest;
+}
+
+/**
+ * Separate the intent argument from the real tool arguments.
+ *
+ * ONE splitter for both readers -- the dispatch path (which must not hand it
+ * to a handler) and the telemetry path (which must not duplicate it inside
+ * `$mcp_parameters`, where it would be a second copy of free-form agent text
+ * on an event that is never sampled). Two implementations of "which key is the
+ * intent" is exactly the drift this avoids.
+ *
+ * Returns the ORIGINAL object when there is nothing to strip, so the
+ * overwhelmingly common case allocates nothing.
+ */
+export function splitMcpIntent(args: Row): { intent?: string; rest: Row } {
+  if (!args || typeof args !== "object" || !Object.hasOwn(args, MCP_INTENT_ARG))
+    return { rest: args };
+  const { [MCP_INTENT_ARG]: intent, ...rest } = args;
+  return {
+    // A non-string, or a caller sending only whitespace, is not an intent.
+    ...(typeof intent === "string" && intent.trim() ? { intent } : {}),
+    rest,
+  };
 }
 
 function requireNonNegativeInt(args: Row, key: string) {
@@ -4193,7 +4222,70 @@ export function requireFeedNetuidDependency(
   };
 }
 
-export const MCP_TOOLS: McpToolDefinition[] = [
+/**
+ * The argument an agent uses to say WHY it is calling, and the property
+ * PostHog's MCP Analytics reads it as (#9642).
+ *
+ * `context` is @posthog/mcp's own name for it, kept verbatim so an agent that
+ * already knows the convention from another instrumented server needs to learn
+ * nothing here. Verified against all 224 published schemas before choosing it:
+ * none declares `context`, `intent`, `reason` or `why`, so nothing collides.
+ */
+const MCP_INTENT_ARG = "context";
+const MCP_INTENT_ARG_SCHEMA = {
+  type: "string",
+  description:
+    "Why are you calling this tool? Briefly describe the user's goal. " +
+    "Optional, recorded for analytics only -- it does not affect the result.",
+} as const;
+
+/**
+ * Add the intent argument to one tool's published schema.
+ *
+ * OPTIONAL, WHERE THE SDK MAKES IT REQUIRED. That divergence is deliberate and
+ * is the whole reason this is hand-rolled rather than delegated: every one of
+ * these tools declares `additionalProperties: false` and is already serving
+ * live traffic, so a required argument would make the next deploy reject every
+ * call from every existing client, on every tool at once. Coverage is worth
+ * less than not breaking the public surface.
+ *
+ * NON-MUTATING. The `inputSchema` objects come from `z.toJSONSchema(...)` in
+ * the per-tool modules and several are exported and read elsewhere, so this
+ * builds new objects rather than writing into shared ones.
+ *
+ * Exported for tests only. Every registered tool currently declares both
+ * `type` and `properties`, so the two fallbacks below cannot be reached
+ * through MCP_TOOLS -- but a hand-written literal is still permitted by
+ * JsonSchemaLike, and a defensive branch nobody can exercise is one nobody can
+ * trust. Tested directly rather than annotated away.
+ */
+export function withIntentArgument(tool: McpToolDefinition): McpToolDefinition {
+  const schema = tool.inputSchema as Row;
+  return {
+    ...tool,
+    inputSchema: {
+      ...schema,
+      type: schema?.type ?? "object",
+      properties: {
+        ...((schema?.properties as Row) ?? {}),
+        [MCP_INTENT_ARG]: MCP_INTENT_ARG_SCHEMA,
+      },
+    } as JsonSchemaLike,
+  };
+}
+
+// Applied ONCE, here, rather than in listToolDefinitions() -- and that is the
+// point rather than a detail. There are two tool objects: listToolDefinitions()
+// builds what tools/list ADVERTISES, while dispatchTool validates against the
+// raw entry via TOOLS_BY_NAME, where validateToolArguments rejects any key not
+// in `properties`. Injecting into the advertise path alone would publish an
+// argument and then throw invalid_params on every call that used it -- strictly
+// worse than not offering it, because agents would start sending it. Injecting
+// upstream of both is what makes the two incapable of disagreeing.
+//
+// Once at module load, not per request: 224 shallow copies at cold start
+// against one on every tools/list.
+const MCP_TOOLS_BASE: McpToolDefinition[] = [
   {
     name: "search_subnets",
     title: "Search Bittensor subnets",
@@ -13143,6 +13235,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   },
 ];
 
+export const MCP_TOOLS: McpToolDefinition[] =
+  MCP_TOOLS_BASE.map(withIntentArgument);
+
 const TOOLS_BY_NAME = new Map(MCP_TOOLS.map((tool) => [tool.name, tool]));
 
 // JSON Schema 2020-12 output schemas for each tool's `structuredContent`. They
@@ -14413,13 +14508,23 @@ async function callTool(params: Row, ctx: McpCtx) {
       ? { errorCode: result?.structuredContent?.error?.code }
       : {}),
   });
+  // #9642: `context` is the argument an agent uses to say WHY it called, and
+  // PostHog records it as $mcp_intent. Split here rather than read in place so
+  // `parameters` below carries the real arguments only -- the intent travels
+  // as its own property, not as a second copy inside the parameter blob.
+  const { intent, rest: toolParameters } = splitMcpIntent(
+    params?.arguments as Row,
+  );
   scheduleMcpToolCallEvent(ctx, {
     toolName: typeof params?.name === "string" ? params.name : undefined,
     isError: result.isError === true,
     durationMs,
     sessionId: ctx?.sessionId,
-    parameters: params?.arguments,
+    parameters: toolParameters,
     response: result?.structuredContent,
+    // Omitted entirely when the agent said nothing, so "did not explain" stays
+    // distinguishable from "explained with an empty string".
+    ...(intent ? { intent } : {}),
     // #8963: the same structuredContent.error.code usage_event already
     // threads above, projected onto PostHog's $mcp_error_type by
     // classifyMcpErrorType inside the recorder. Omitted on success.

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -216,6 +216,27 @@ export function resolveUsageSampleRate(
 // Cap free-form string fields so a buggy caller can't ship unbounded payloads.
 const MAX_LABEL_CHARS = 256;
 
+// Agent intent is prose, not an identifier, so it needs a ceiling of its own
+// (#9642). MAX_LABEL_CHARS is sized for a tool or route name and would cut a
+// real sentence mid-clause; this is long enough for the one-or-two-sentence
+// answer the argument's description asks for, and short enough that an agent
+// pasting an entire system prompt into it cannot ship that on every call.
+const MAX_MCP_INTENT_CHARS = 1024;
+
+/**
+ * A trimmed string capped at `max`, or undefined when there is nothing to say.
+ *
+ * Separate from sanitizeLabel purely because the LIMIT differs -- the
+ * empty/non-string/trim rules are identical, and duplicating them was the
+ * alternative.
+ */
+function trimToLength(value: unknown, max: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > max ? trimmed.slice(0, max) : trimmed;
+}
+
 // ─── deployment dimensions (environment / release) ──────────────────────────
 //
 // Every event this module emits was, until now, indistinguishable from every
@@ -509,12 +530,7 @@ export function resolvePostHogHost(env: Env | null | undefined): string {
 }
 
 function sanitizeLabel(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const trimmed = value.trim();
-  if (!trimmed) return undefined;
-  return trimmed.length > MAX_LABEL_CHARS
-    ? trimmed.slice(0, MAX_LABEL_CHARS)
-    : trimmed;
+  return trimToLength(value, MAX_LABEL_CHARS);
 }
 
 // ─── $mcp_error_type projection (#8963) ────────────────────────────────────
@@ -796,6 +812,17 @@ export interface McpToolCallEvent extends McpServerIdentity {
    * when isError is true.
    */
   errorCode?: string;
+  /**
+   * The agent's own statement of WHY it made this call, taken from the
+   * `context` argument (#9642). Emitted as $mcp_intent, which is what
+   * PostHog's MCP Analytics intent view and clustering read.
+   *
+   * Free-form model output, so it is trimmed and hard-capped by the recorder
+   * rather than trusted: this rides on an event that is never sampled, and an
+   * agent that pastes a whole prompt into it would otherwise ship that
+   * verbatim on every call.
+   */
+  intent?: string;
   clientName?: string;
   clientVersion?: string;
   clientNameSource?: McpClientNameSource;
@@ -885,6 +912,23 @@ export async function recordMcpToolCallEvent(
 
     const toolName = sanitizeLabel(event.toolName);
     if (toolName !== undefined) properties["$mcp_tool_name"] = toolName;
+
+    // Agent intent (#9642). NOT sanitizeLabel: that caps at MAX_LABEL_CHARS,
+    // which is sized for identifiers like a tool or route name, and would
+    // truncate a real sentence into uselessness. This is meant to be prose,
+    // so it gets its own, longer ceiling -- but a ceiling all the same,
+    // because it is model output on an unsampled event.
+    //
+    // $mcp_intent_source is part of the wire contract rather than decoration:
+    // PostHog distinguishes an intent the agent actually stated
+    // ("context_parameter") from one a server inferred on its behalf
+    // ("inferred"). We only ever emit the former, and saying so explicitly is
+    // what stops a future inference fallback from being read as agent speech.
+    const intent = trimToLength(event.intent, MAX_MCP_INTENT_CHARS);
+    if (intent !== undefined) {
+      properties["$mcp_intent"] = intent;
+      properties["$mcp_intent_source"] = "context_parameter";
+    }
 
     // Failure classification (#8963). Emitted only on failure: an
     // $mcp_error_type on a successful call would poison every breakdown.

--- a/tests/feed-netuid-schema.test.ts
+++ b/tests/feed-netuid-schema.test.ts
@@ -61,6 +61,14 @@ describe("get_feed published inputSchema netuid dependency (#8829)", () => {
     const expected = requireFeedNetuidDependency(
       GET_FEED_MCP_TOOL.inputSchema as Record<string, unknown>,
     );
-    assert.deepEqual(tool.inputSchema, expected);
+    // #9642 adds a universal `context` argument to EVERY tool for agent-intent
+    // capture, so the registered schema is the wrapper's output plus that one
+    // property. Subtracted rather than added to the expectation, so this still
+    // asserts the wrapper's full output exactly -- including the `anyOf` that
+    // is the whole point of it -- instead of being relaxed into a partial
+    // match that would no longer notice the wrapper being dropped.
+    const actual = tool.inputSchema as Record<string, unknown>;
+    const { context: _context, ...properties } = actual.properties as Row;
+    assert.deepEqual({ ...actual, properties }, expected);
   });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -23574,11 +23574,20 @@ describe("get_coverage_depth MCP tool (#6983)", () => {
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage_depth");
     assert.ok(tool, "get_coverage_depth should be registered");
     assert.equal(typeof tool.description, "string");
-    assert.deepEqual(tool.inputSchema, {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    });
+    assert.equal(tool.inputSchema.type, "object");
+    assert.equal(tool.inputSchema.additionalProperties, false);
+    // #9642 added a universal `context` argument to every tool for agent-intent
+    // capture, so "no-arg" now means "no arguments OF ITS OWN" rather than an
+    // empty properties object. Asserted by subtraction so this keeps testing
+    // what it was written to test -- that this tool takes no input -- instead
+    // of being loosened to a shape check that would also pass if a real
+    // argument were added tomorrow.
+    assert.deepEqual(
+      Object.keys(tool.inputSchema.properties ?? {}).filter(
+        (key) => key !== "context",
+      ),
+      [],
+    );
   });
 
   test("returns the coverage-depth artifact verbatim", async () => {

--- a/tests/mcp-usage-telemetry.test.ts
+++ b/tests/mcp-usage-telemetry.test.ts
@@ -8,9 +8,12 @@ import {
 } from "../src/usage-telemetry.ts";
 import {
   handleMcpRequest,
+  listToolDefinitions,
   mcpDistinctId,
   mcpRefusalReason,
   scheduleMcpRefusalEvent,
+  splitMcpIntent,
+  withIntentArgument,
 } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
@@ -1514,5 +1517,165 @@ describe("scheduleMcpRefusalEvent guards (#9639)", () => {
         new Response(null, { status: 405 }),
       ),
     );
+  });
+});
+
+// #9642: `context` is the argument an agent uses to say WHY it called, and
+// PostHog's MCP Analytics records it as $mcp_intent. Until now the intent
+// panel read "No agent intents captured yet" because nothing ever sent one.
+describe("MCP agent intent capture (#9642)", () => {
+  const tools = () => listToolDefinitions() as Row[];
+
+  // Derived from listToolDefinitions() rather than a fixed list, so a tool
+  // registered tomorrow is covered tonight -- the same bet the enum and
+  // required gates in mcp-schema-enforcement.test.ts make.
+  test("every published tool advertises the context argument", () => {
+    const all = tools();
+    assert.ok(
+      all.length > 200,
+      `expected the full catalogue, got ${all.length}`,
+    );
+    const missing = all
+      .filter((t) => !(t.inputSchema as Row)?.properties?.context)
+      .map((t) => t.name);
+    assert.deepEqual(missing, [], "these tools cannot carry agent intent");
+  });
+
+  // THE COMPATIBILITY CONSTRAINT, pinned. PostHog's own SDK makes `context`
+  // required; doing that here would reject every call from every existing
+  // client on the next deploy, on all 224 tools at once. If someone ever
+  // "fixes" this to match the SDK, this test is what says why not.
+  test("context is optional on every tool -- never required", () => {
+    const required = tools()
+      .filter((t) =>
+        (((t.inputSchema as Row)?.required as string[]) ?? []).includes(
+          "context",
+        ),
+      )
+      .map((t) => t.name);
+    assert.deepEqual(
+      required,
+      [],
+      "a required context would break every existing client",
+    );
+  });
+
+  test("the advertised schema describes what to write", () => {
+    const schema = (tools()[0]!.inputSchema as Row).properties.context as Row;
+    assert.equal(schema.type, "string");
+    assert.match(String(schema.description), /why are you calling this tool/i);
+  });
+
+  // The trap this feature had to avoid: advertised by tools/list but rejected
+  // by validateToolArguments, which throws invalid_params for any key outside
+  // `properties` (all 224 tools are additionalProperties:false). If the two
+  // paths ever diverge again, this call starts failing.
+  test("a call carrying context is accepted, not rejected as an unknown key", async () => {
+    const payload = await callMcp(
+      {
+        ...toolCall(TOOL),
+        params: { name: TOOL, arguments: { context: "why" } },
+      },
+      CONFIGURED_ENV,
+      { executionCtx: fakeExecutionCtx() },
+    );
+    assert.equal((payload.result as Row).isError, false);
+  });
+
+  test("intent lands on $mcp_tool_call with its source, and not inside parameters", async () => {
+    const events: Row[] = [];
+    await callMcp(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "get_subnet",
+          arguments: { netuid: 64, context: "Checking SN64 for a user report" },
+        },
+      },
+      CONFIGURED_ENV,
+      {
+        executionCtx: fakeExecutionCtx(),
+        recordMcpToolCallEvent: (_env: unknown, event: Row) => {
+          events.push(event);
+          return true;
+        },
+      },
+    );
+    assert.equal(events.length, 1);
+    const event = events[0]!;
+    assert.equal(event.intent, "Checking SN64 for a user report");
+    // The real arguments survive; the intent is not duplicated among them.
+    assert.deepEqual(event.parameters, { netuid: 64 });
+  });
+
+  test("the handler never receives context", () => {
+    const { intent, rest } = splitMcpIntent({ netuid: 64, context: "why" });
+    assert.equal(intent, "why");
+    assert.deepEqual(rest, { netuid: 64 });
+    assert.equal("context" in rest, false);
+  });
+
+  // "Did not explain" must stay distinguishable from "explained with nothing",
+  // and a non-string is not an explanation.
+  test("an empty, whitespace or non-string context yields no intent", () => {
+    assert.equal(splitMcpIntent({ context: "" }).intent, undefined);
+    assert.equal(splitMcpIntent({ context: "   " }).intent, undefined);
+    assert.equal(splitMcpIntent({ context: 42 }).intent, undefined);
+    assert.equal(splitMcpIntent({ context: null }).intent, undefined);
+    // Still stripped from the arguments even when it is not usable as intent.
+    assert.deepEqual(splitMcpIntent({ netuid: 1, context: 42 }).rest, {
+      netuid: 1,
+    });
+  });
+
+  // A schema that declares neither `type` nor `properties` is legal under
+  // JsonSchemaLike (hand-written literals are still permitted) even though no
+  // registered tool is shaped that way today. The fallbacks exist for that
+  // tool; exercised here so they are known to work rather than assumed.
+  test("a schema missing type/properties still gets a well-formed one", () => {
+    const injected = withIntentArgument({
+      name: "hypothetical",
+      title: "Hypothetical",
+      description: "d",
+      inputSchema: {},
+      handler: async () => ({}),
+    });
+    const schema = injected.inputSchema as Row;
+    assert.equal(schema.type, "object");
+    assert.deepEqual(Object.keys(schema.properties as Row), ["context"]);
+  });
+
+  test("an existing schema keeps its own type and every real property", () => {
+    const injected = withIntentArgument({
+      name: "hypothetical",
+      title: "Hypothetical",
+      description: "d",
+      inputSchema: {
+        type: "object",
+        properties: { netuid: { type: "integer" } },
+        required: ["netuid"],
+        additionalProperties: false,
+      },
+      handler: async () => ({}),
+    });
+    const schema = injected.inputSchema as Row;
+    assert.equal(schema.type, "object");
+    assert.deepEqual(schema.required, ["netuid"]);
+    assert.equal(schema.additionalProperties, false);
+    assert.deepEqual(Object.keys(schema.properties as Row).sort(), [
+      "context",
+      "netuid",
+    ]);
+  });
+
+  // The common case is a call with no context at all, so it must not pay for
+  // the feature.
+  test("arguments without context are passed through untouched", () => {
+    const args = { netuid: 64 };
+    const split = splitMcpIntent(args);
+    assert.equal(split.rest, args, "same object, no copy");
+    assert.equal(split.intent, undefined);
   });
 });


### PR DESCRIPTION
## Summary

PostHog's MCP Analytics has an **agent intent** dimension — *why* a tool was called, not just which one — and we populated none of it. Its own instrumentation checklist reported it ("Few or no tool calls carry agent intent. Enable the context parameter"), and the Activity panel read "No agent intents captured yet".

14K tool calls told us `call_subnet_surface` is popular and nothing about what anyone was trying to accomplish. This adds the missing half.

## Wire contract

Per PostHog's reference (`/docs/mcp-analytics/intent`, `/docs/mcp-analytics/events`): an agent supplies a `context` string, the server records it as `$mcp_intent` with `$mcp_intent_source: "context_parameter"`, and the argument is stripped before the handler runs. We emit `$mcp_tool_call` directly rather than through `@posthog/mcp`, so this implements the same contract by hand.

Name checked before choosing it: across all 224 published schemas, **none declares `context`, `intent`, `reason` or `why`** — no collision.

## One deliberate divergence: optional, not required

The SDK makes `context` **required**. That is right for a server being instrumented on day one and wrong for this one. All 224 tools declare `additionalProperties: false` and are serving live traffic, so a required argument would reject **every call from every existing client on the next deploy**, on every tool at once.

It is optional here, and a test pins that so nobody later "fixes" it to match the SDK.

## The trap this had to avoid

There are two tool objects and they are not the same one:

- `listToolDefinitions()` builds what `tools/list` **advertises**, and already post-processes the schema (`stripSentinelIntegerBounds`) — the obvious-looking place to inject.
- `dispatchTool` **validates** against `TOOLS_BY_NAME.get(name)`, the raw `MCP_TOOLS` entry, where `validateToolArguments` throws `invalid_params` for any key outside `properties`.

Injecting into the advertise path alone would publish an argument and then reject it — agents would start sending `context` and *every call would fail*. So it is injected once at `MCP_TOOLS` construction, upstream of both, which is what makes the two incapable of disagreeing. A test drives a real call carrying `context` end-to-end, so a future divergence fails loudly.

Once at module load, not per request: 224 shallow copies at cold start against one on every `tools/list`. Non-mutating, because the `inputSchema` objects come from `z.toJSONSchema(...)` in the per-tool modules and several are exported and read elsewhere.

## Stripped before the handler

Matching the SDK's documented behaviour, and not merely as a courtesy: several handlers forward their whole argument object into a query builder or an upstream call, where an unexpected key becomes a filter, a cache-key difference, or a 400 from someone else's API.

One splitter serves both readers — the dispatch path (must not hand it to a handler) and the telemetry path (must not duplicate it inside `$mcp_parameters`, where it would be a second copy of free-form agent text on an event that is never sampled). It returns the original object when there is nothing to strip, so the common case allocates nothing.

## Bounded

`$mcp_intent` is trimmed and hard-capped at 1024 chars. `sanitizeLabel`'s 256 is sized for identifiers and would cut a sentence mid-clause; this is prose, but prose from a model on an unsampled event, so it gets a longer ceiling rather than none. `sanitizeLabel` is now expressed in terms of the same helper instead of duplicating the trim rules.

## Two existing tests updated, neither loosened

- `get_coverage_depth` "is registered as a no-arg read-only tool" — now asserts by **subtraction** (`properties` minus `context` is empty), so it still fails if a real argument is added tomorrow.
- `feed-netuid-schema` "wrapper applied" — same approach, so it still asserts the wrapper's full output including the `anyOf` that is its whole purpose, rather than degrading to a partial match that would not notice the wrapper being dropped.

## Tests

11 new cases. The catalogue-wide ones derive from `listToolDefinitions()` rather than a fixed list, so a tool registered tomorrow is covered tonight — the same bet the enum and `required` gates make. `withIntentArgument` is exported to exercise its two defensive fallbacks directly: no registered tool omits `type` or `properties`, but a hand-written literal may, and a defensive branch nobody can exercise is one nobody can trust.

## Validation run

```
npx vitest run <10 MCP/schema/telemetry suites>   1637 passed
npm run validate:mcp                              224 tools, lifecycle + all tools/call green
npm run typecheck                                 clean
npm run lint                                      clean
patch coverage (diff intersection)                100% on src/mcp-server.ts and src/usage-telemetry.ts
```

Closes #9642
