### PR TITLE
fix(d1): guard the history append against the committed latest hash

### DIFF
--- a/src/hyperparams-identity-d1-write.ts
+++ b/src/hyperparams-identity-d1-write.ts
@@ -17,6 +17,7 @@
 // place owns that arithmetic.
 import {
   batchInSlices,
+  buildLatestHashGuard,
   chunkStatements,
   type D1Like,
   type D1PreparedStatement,
@@ -109,12 +110,20 @@ export async function writeSubnetHyperparamsToD1(
     statements.push(db.prepare(buildHyperparamsPrune(netuids)).bind());
   }
   statements.push(
+    // Guarded against the committed latest hash, not just against the JS diff
+    // above -- see buildLatestHashGuard (metagraphed-infra#358).
     ...chunkStatements(
       db,
       "subnet_hyperparams_history",
       SUBNET_HYPERPARAMS_HISTORY_COLUMNS,
       [],
       historyRows,
+      buildLatestHashGuard(
+        "subnet_hyperparams_history",
+        SUBNET_HYPERPARAMS_HISTORY_COLUMNS,
+        "netuid",
+        "hyperparams_hash",
+      ),
     ),
   );
   if (statements.length) await batchInSlices(db, statements);
@@ -146,12 +155,20 @@ export async function writeAccountIdentityToD1(
       ["account"],
       rows,
     ),
+    // As above (metagraphed-infra#358). This lane needs it MORE: it has no
+    // block_number, so there is no column set a unique constraint could use.
     ...chunkStatements(
       db,
       "account_identity_history",
       ACCOUNT_IDENTITY_HISTORY_COLUMNS,
       [],
       historyRows,
+      buildLatestHashGuard(
+        "account_identity_history",
+        ACCOUNT_IDENTITY_HISTORY_COLUMNS,
+        "account",
+        "identity_hash",
+      ),
     ),
   ];
   if (statements.length) await batchInSlices(db, statements);

--- a/src/neurons-d1-write.ts
+++ b/src/neurons-d1-write.ts
@@ -175,11 +175,67 @@ export function buildJsonUpsert(
 export function buildJsonAppendInsert(
   table: string,
   columns: string[],
+  /** See buildLatestHashGuard. A predicate on the incoming row, evaluated
+   * INSIDE the statement -- which for an append-only table is the only place a
+   * concurrency-safe one can live. */
+  guard?: string,
 ): string {
   return (
     `INSERT INTO ${table} (${columns.join(", ")}) SELECT ` +
     columns.map((_, i) => `json_extract(value, '$[${i}]')`).join(", ") +
-    ` FROM json_each(?1)`
+    ` FROM json_each(?1)` +
+    (guard ? ` WHERE ${guard}` : "")
+  );
+}
+
+/**
+ * "Append this row only if the key's LATEST recorded hash is not already it."
+ *
+ * THE RACE THIS CLOSES (metagraphed-infra#358). These history appends were a
+ * read-modify-write: SELECT the group-wise MAX(id) hash per key, diff in JS,
+ * INSERT what moved. Safe only because the HTTP path is sequential. Two chunks
+ * arriving concurrently -- which a queue consumer at `max_concurrency: 2`
+ * guarantees -- both read the same pre-change latest, both see a diff, and both
+ * append. The result is a duplicate history row for a single change, and
+ * because these tables are append-only it never self-heals.
+ *
+ * Evaluating the test inside the INSERT moves it from a snapshot read to
+ * committed state at write time: the second of two concurrent appends sees the
+ * first and inserts nothing.
+ *
+ * WHY NOT A UNIQUE CONSTRAINT, which is the obvious fix. There is no column set
+ * that expresses this. `(key, hash)` forbids a value going A -> B -> A, which
+ * is a real history and losing it is worse than the duplicate. `(netuid,
+ * block_number)` works for hyperparams but `account_identity_history` carries
+ * no block. `(key, observed_at)` does not dedupe at all, since `observed_at` is
+ * each request's own clock. A constraint would also need a hand-applied D1
+ * migration, leaving a window where the deploy runs without its guard.
+ *
+ * The JS diff stays, demoted from authority to optimisation: it avoids
+ * attempting rows that certainly have not changed, and this catches the
+ * concurrent case it cannot see.
+ */
+export function buildLatestHashGuard(
+  table: string,
+  columns: string[],
+  keyColumn: string,
+  hashColumn: string,
+): string {
+  const keyIndex = columns.indexOf(keyColumn);
+  const hashIndex = columns.indexOf(hashColumn);
+  if (keyIndex < 0 || hashIndex < 0) {
+    throw new Error(
+      `${table}: guard needs ${keyColumn} and ${hashColumn} in its columns`,
+    );
+  }
+  const incomingKey = `json_extract(value, '$[${keyIndex}]')`;
+  const incomingHash = `json_extract(value, '$[${hashIndex}]')`;
+  // Compared against the LATEST row rather than against any row, so a value
+  // that returns to an earlier one is still recorded.
+  return (
+    `NOT EXISTS (SELECT 1 FROM ${table} h WHERE h.id = ` +
+    `(SELECT MAX(id) FROM ${table} WHERE ${keyColumn} = ${incomingKey}) ` +
+    `AND h.${hashColumn} = ${incomingHash})`
   );
 }
 
@@ -257,13 +313,15 @@ export function chunkStatements(
   columns: string[],
   conflict: string[],
   rows: Row[],
-  /** See buildJsonUpsert's own `filter`. Upsert-only: an append-only table has
-   * no key to decline a row against. */
+  /** See buildJsonUpsert's own `filter` for the upsert case, and
+   * buildLatestHashGuard for the append-only one -- an append-only table has no
+   * conflict target, so its predicate is the only thing that can decline a row
+   * against committed state. */
   filter?: string,
 ): D1PreparedStatement[] {
   const sql = conflict.length
     ? buildJsonUpsert(table, columns, conflict, filter)
-    : buildJsonAppendInsert(table, columns);
+    : buildJsonAppendInsert(table, columns, filter);
   return chunkRowsByJsonBytes(rows, columns).map((chunk) =>
     db.prepare(sql).bind(JSON.stringify(chunk)),
   );

--- a/tests/hyperparams-identity-d1-write.test.ts
+++ b/tests/hyperparams-identity-d1-write.test.ts
@@ -471,3 +471,101 @@ describe("writeAccountIdentityToD1 against real SQLite", () => {
     }
   });
 });
+
+describe("the history append is guarded against the committed latest hash", () => {
+  // metagraphed-infra#358. These appends were a read-modify-write -- SELECT the
+  // group-wise MAX(id) hash, diff in JS, INSERT what moved -- safe only because
+  // the HTTP path is sequential. Two chunks arriving concurrently, which a queue
+  // consumer at max_concurrency 2 guarantees, both read the same pre-change
+  // latest and both append. These tables are append-only, so the duplicate
+  // never self-heals.
+  const database = () => d1() as never;
+
+  test("a second append of the same hash is a no-op, not a duplicate", async () => {
+    await writeAccountIdentityToD1(database(), {
+      rows: [identityRow({ account: "5Alice" })],
+      historyRows: [
+        identityHistoryRow({ account: "5Alice", identity_hash: "h1" }),
+      ],
+    });
+    assert.equal(count("account_identity_history"), 1);
+
+    // The racing writer: it read the same pre-change latest, so its JS diff
+    // also concluded "changed". The statement itself must decline it.
+    await writeAccountIdentityToD1(database(), {
+      rows: [identityRow({ account: "5Alice" })],
+      historyRows: [
+        identityHistoryRow({ account: "5Alice", identity_hash: "h1" }),
+      ],
+    });
+    assert.equal(
+      count("account_identity_history"),
+      1,
+      "the duplicate must not land",
+    );
+  });
+
+  test("a value returning to an earlier one is still recorded", async () => {
+    // The reason this is a guard and not a UNIQUE (account, identity_hash):
+    // A -> B -> A is a real history, and a constraint would silently drop the
+    // second A -- losing a change that actually happened, which is worse than
+    // the duplicate it prevents.
+    for (const hash of ["h1", "h2", "h1"]) {
+      await writeAccountIdentityToD1(database(), {
+        rows: [identityRow({ account: "5Alice" })],
+        historyRows: [
+          identityHistoryRow({ account: "5Alice", identity_hash: hash }),
+        ],
+      });
+    }
+    assert.equal(count("account_identity_history"), 3);
+    assert.deepEqual(
+      (
+        db
+          .prepare(
+            "SELECT identity_hash FROM account_identity_history ORDER BY id",
+          )
+          .all() as Row[]
+      ).map((r) => r.identity_hash),
+      ["h1", "h2", "h1"],
+    );
+  });
+
+  test("one account's repeat does not block another's first append", async () => {
+    await writeAccountIdentityToD1(database(), {
+      rows: [identityRow({ account: "5Alice" })],
+      historyRows: [
+        identityHistoryRow({ account: "5Alice", identity_hash: "h1" }),
+      ],
+    });
+    // Same batch: a repeat for Alice and a genuine first for Bob. The guard is
+    // per row, so the repeat must not suppress the neighbour.
+    await writeAccountIdentityToD1(database(), {
+      rows: [
+        identityRow({ account: "5Alice" }),
+        identityRow({ account: "5Bob" }),
+      ],
+      historyRows: [
+        identityHistoryRow({ account: "5Alice", identity_hash: "h1" }),
+        identityHistoryRow({ account: "5Bob", identity_hash: "hb" }),
+      ],
+    });
+    assert.equal(count("account_identity_history"), 2);
+    assert.equal(
+      one("SELECT * FROM account_identity_history WHERE account = '5Bob'")
+        .identity_hash,
+      "hb",
+    );
+  });
+
+  test("the same rule holds for hyperparams, which prunes as well as appends", async () => {
+    for (const hash of ["hp1", "hp1"]) {
+      await writeSubnetHyperparamsToD1(database(), {
+        rows: [hyperparamsRow({ netuid: 8 })],
+        netuids: [8],
+        historyRows: [historyRow({ netuid: 8, hyperparams_hash: hash })],
+      });
+    }
+    assert.equal(count("subnet_hyperparams_history"), 1);
+  });
+});

--- a/tests/neurons-d1-write.test.ts
+++ b/tests/neurons-d1-write.test.ts
@@ -22,6 +22,8 @@ import {
   D1_JSON_BUDGET_BYTES,
   writeNeuronSnapshotToD1,
   netuidMaxCapturedAt,
+  buildLatestHashGuard,
+  buildJsonAppendInsert,
 } from "../src/neurons-d1-write.ts";
 import { NEURON_INSERT_COLUMNS } from "../src/metagraph-neurons.ts";
 
@@ -332,5 +334,45 @@ describe("netuidMaxCapturedAt", () => {
       { netuid: 8, captured_at: "soon" },
     ]);
     assert.equal(cutoffs.size, 0);
+  });
+});
+
+describe("buildLatestHashGuard", () => {
+  const COLUMNS = ["account", "observed_at", "name", "identity_hash"];
+
+  test("compares against the LATEST row, not against any row", () => {
+    // The whole reason this is a guard and not a UNIQUE (key, hash): matching
+    // any row would forbid a value returning to an earlier one, which is a real
+    // history. Matching the latest one only forbids the duplicate.
+    const sql = buildLatestHashGuard(
+      "account_identity_history",
+      COLUMNS,
+      "account",
+      "identity_hash",
+    );
+    assert.match(sql, /MAX\(id\)/);
+    assert.match(sql, /json_extract\(value, '\$\[0\]'\)/, "keyed on account");
+    assert.match(sql, /json_extract\(value, '\$\[3\]'\)/, "hash at its index");
+  });
+
+  test("throws when a column it needs is not in the statement", () => {
+    // A guard built against the wrong column list would silently compare
+    // json_extract(value, '$[-1]') -- NULL -- and never suppress anything.
+    assert.throws(
+      () => buildLatestHashGuard("t", COLUMNS, "netuid", "identity_hash"),
+      /guard needs netuid and identity_hash/,
+    );
+    assert.throws(
+      () => buildLatestHashGuard("t", COLUMNS, "account", "nope"),
+      /guard needs account and nope/,
+    );
+  });
+
+  test("an append with no guard is unconditional, as it was", () => {
+    // The neurons history tables append every row; only the two diff-and-append
+    // lanes need the guard, so the unguarded form must stay exactly as it was.
+    const sql = buildJsonAppendInsert("neuron_daily", ["netuid", "uid"]);
+    assert.equal(sql.includes("WHERE"), false);
+    assert.match(sql, /FROM json_each\(\?1\)$/);
   });
 });


### PR DESCRIPTION
Closes metagraphed-infra#358.

`account-identity` and `subnet-hyperparams` append to append-only history tables through a **read-modify-write**: `SELECT` the group-wise `MAX(id)` hash per key, diff in JS, `INSERT` what moved. Safe only because the HTTP path is sequential.

A queue consumer runs at `max_concurrency: 2`. Two chunks of one pass that both touch a changed key each read the same pre-change latest, each see a diff, and each append — **a duplicate history row for a single change**. The tables are append-only, so it never self-heals.

## Why not the uniqueness constraint this issue preferred

There is no column set that expresses the rule:

| candidate | why it fails |
|---|---|
| `(key, hash)` | forbids a value going **A → B → A**, which is a real history — losing it is worse than the duplicate it prevents |
| `(netuid, block_number)` | works for hyperparams; `account_identity_history` **has no block** |
| `(key, observed_at)` | does not dedupe at all — `observed_at` is each request's own clock, so two concurrent requests differ by construction |

A constraint would also need a **hand-applied D1 migration**, leaving a window where the deploy runs against a table without its guard.

## What this does instead

Moves the test *into* the insert:

```sql
INSERT INTO t (...) SELECT ... FROM json_each(?1)
WHERE NOT EXISTS (
  SELECT 1 FROM t h
  WHERE h.id = (SELECT MAX(id) FROM t WHERE key = <incoming key>)
    AND h.hash = <incoming hash>
)
```

"Is this key's latest hash already the incoming one?" is now evaluated **at write time against committed state**, inside the same implicit transaction as the write. The second of two concurrent appends sees the first and inserts nothing.

Compared against the **latest** row rather than against any row, so A → B → A still records all three.

The JS diff stays, demoted from authority to optimisation: it avoids attempting rows that certainly have not changed, and this catches the concurrent case it cannot see. `max_concurrency` stays at 2 — the race is *removed* rather than scheduled around.

## Verification

- **100% patch coverage**, branch-counted, by diff intersection
- **the guard tests were verified to fail with the guard removed** — three of the four do. The fourth asserts A → B → A still records, so it correctly passes both ways. (My first removal attempt silently didn't apply and all four still passed; that near-miss is exactly why this check is worth running rather than assuming.)
- full suite: **703 files / 16,943 tests** green
- `build`, `lint`, `format:check` clean; no generated-artifact drift

Neither lane is routed yet (`SYNC_QUEUE_LANES` does not name them) and neither has a consumer writer, so this is a pre-cutover fix, not a live defect — it also tightens the existing HTTP path, which had the same race under any concurrent producer.