### PR TITLE
fix(ci): smoke only the GET routes, so one POST route stops failing publish

### DIFF
--- a/scripts/smoke-live-api.ts
+++ b/scripts/smoke-live-api.ts
@@ -556,8 +556,23 @@ export function liveSmokeApiRoutes(
   // Fixture detail is a live, R2-only detail route whose path requires a
   // currently published surface id. The smoke runner derives that id from the
   // fixture index when the deployment does not supply an explicit override.
+  //
+  // GET ROUTES ONLY (#9650). Every check below asserts a CACHEABLE READ
+  // CONTRACT -- 200, `access-control-allow-origin`, an ETag, a contract-version
+  // header -- and a route with a body has none of those by design. Until #9101
+  // registered /api/v1/ask as POST, every route in the contract was a GET, so
+  // fetching all of them was the same thing as fetching the read surface. It is
+  // not any more: the runner's plain GET drew 405 from that one route and
+  // failed the publish lane on every run from 2026-08-02, taking
+  // `webhooks:dispatch` -- which runs later in the same job -- down with it.
+  //
+  // Skipping rather than POSTing is deliberate. A smoke POST to a grounded-RAG
+  // endpoint would invoke the AI binding on every publish, to assert response
+  // properties that endpoint does not promise.
   return API_ROUTES.filter(
-    (route) => route.id !== "fixture-detail" || fixtureSurfaceId,
+    (route) =>
+      (route.method ?? "GET") === "GET" &&
+      (route.id !== "fixture-detail" || fixtureSurfaceId),
   );
 }
 

--- a/tests/smoke-route-substitution.test.ts
+++ b/tests/smoke-route-substitution.test.ts
@@ -73,3 +73,40 @@ describe("smoke route substitution", () => {
     assert.equal(fixtureSurfaceIdFromIndex({ data: { fixtures: [] } }), null);
   });
 });
+
+describe("the live smoke set is GET-only (#9650)", () => {
+  test("no route with a body is smoked", () => {
+    // Every check in the runner asserts a CACHEABLE READ CONTRACT -- 200, CORS,
+    // an ETag, a contract-version header -- so a route with a request body has
+    // nothing the assertions are about. The runner fetches with a plain GET, so
+    // including one draws 405 and fails the whole publish lane.
+    //
+    // This is not hypothetical. Until #9101 registered /api/v1/ask as POST,
+    // every route in the contract was a GET, so "all routes" and "the read
+    // surface" were the same set. Publishing broke on 2026-08-02 and stayed
+    // broken for four days, taking `webhooks:dispatch` -- later in the same
+    // job -- with it.
+    for (const route of liveSmokeApiRoutes("7:subnet-api:new_v2")) {
+      assert.equal(
+        route.method ?? "GET",
+        "GET",
+        `${route.path} is ${route.method}; the smoke runner only issues GET`,
+      );
+    }
+  });
+
+  test("and the contract does still carry a non-GET route, or this proves nothing", () => {
+    // A filter with nothing to filter passes forever. Assert the input set
+    // really does contain the case being excluded.
+    assert.equal(
+      API_ROUTES.some((route) => (route.method ?? "GET") !== "GET"),
+      true,
+      "no non-GET route in the contract -- this guard is now vacuous",
+    );
+    assert.equal(
+      liveSmokeApiRoutes("7:subnet-api:new_v2").length < API_ROUTES.length,
+      true,
+      "the smoke set must be strictly smaller than the contract",
+    );
+  });
+});


### PR DESCRIPTION
Closes #9650.

`Publish Cloudflare Backend` has failed its **Smoke live API** step on every run since 2026-08-02 — four consecutive failures (08-03 schedule, 08-04 push, 08-04 schedule, 08-05 schedule). Last success: **2026-08-02**.

```
AssertionError [ERR_ASSERTION]: /api/v1/ask: expected HTTP 200
405 !== 200
    at runLiveSmoke (scripts/smoke-live-api.ts:55:12)
```

`liveSmokeApiRoutes()` returned **all of `API_ROUTES`** and the runner fetches each with a plain GET. `/api/v1/ask` is `POST`, so it answers 405.

It is the **only** non-GET route in the contract — 1 of 199 — registered by #9101 on **2026-08-02**, the same day the lane last went green. Every route was a GET before that, so "all routes" and "the read surface" had always been the same set, and the runner's assumption had never been wrong.

## What it cost

The step runs in the `publish` job **before** `npm run webhooks:dispatch` (line 384), so **webhook subscribers have received nothing since 2026-08-02**.

The R2/KV writes happen earlier in the job and did land, so the served data is not as stale as the run's own `🔴 R2/KV may go stale` alert implies — but the webhook side is genuinely dead, and the lane has been red for four days.

## Why skip rather than POST

Every check asserts a **cacheable read contract** — 200, `access-control-allow-origin`, an `ETag`, `x-metagraph-contract-version` — and a route with a request body promises none of them. A smoke POST to a grounded-RAG endpoint would also invoke the AI binding on every publish, to assert properties that endpoint does not have.

## The guard

Two tests, **both verified to fail with the filter removed**:

1. no route in the smoke set has a method other than GET
2. the contract still *has* a non-GET route, and the smoke set is strictly smaller than it

The second exists because a filter with nothing to filter passes forever — it would have gone vacuous the day `/ask` changed method, which is exactly the shape of the bug being fixed.

## Verification

- full suite: **703 files / 16,948 tests** green
- `build`, `lint`, `format:check`, `tsc` clean; no generated-artifact drift
- the next scheduled publish (~09:5xZ daily) is the real check