### PR TITLE
feat(mcp): describe every published tool parameter

### DIFF
--- a/schemas-src/mcp-tools/account-balance.ts
+++ b/schemas-src/mcp-tools/account-balance.ts
@@ -4,13 +4,12 @@
 // reuse. Modeled fresh, matching the hand-written literal it replaces
 // field-for-field.
 import { z } from "zod";
+import { ss58Schema } from "./shared.ts";
 import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
-
-const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 
 export const GetAccountBalanceInputSchema = z
   .object({
-    ss58: Ss58Schema,
+    ss58: ss58Schema(),
     // #8700: which chain to read. These routes answer from live storage, and
     // the storage keys are twox128 hashes of pallet+item names — identical on
     // every chain running the same runtime — so the endpoint is the only thing

--- a/schemas-src/mcp-tools/account-delegation.ts
+++ b/schemas-src/mcp-tools/account-delegation.ts
@@ -6,13 +6,12 @@
 // looseness (neither the hand-written subnets items nor their nested
 // entries items declare a `required` array).
 import { z } from "zod";
+import { netuidSchema, ss58Schema } from "./shared.ts";
 import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
-
-const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 
 export const GetAccountChildrenInputSchema = z
   .object({
-    ss58: Ss58Schema,
+    ss58: ss58Schema(),
     // #8700: which chain to read. These routes answer from live storage, and
     // the storage keys are twox128 hashes of pallet+item names — identical on
     // every chain running the same runtime — so the endpoint is the only thing
@@ -34,7 +33,7 @@ const ChildEntrySchema = z
 
 const ChildSubnetSchema = z
   .object({
-    netuid: z.int().optional(),
+    netuid: netuidSchema().optional(),
     entries: z.array(ChildEntrySchema).optional(),
   })
   .strict();
@@ -55,7 +54,7 @@ export type GetAccountChildrenOutput = z.infer<
 
 export const GetAccountParentsInputSchema = z
   .object({
-    ss58: Ss58Schema,
+    ss58: ss58Schema(),
     // #8700: which chain to read. These routes answer from live storage, and
     // the storage keys are twox128 hashes of pallet+item names — identical on
     // every chain running the same runtime — so the endpoint is the only thing
@@ -77,7 +76,7 @@ const ParentEntrySchema = z
 
 const ParentSubnetSchema = z
   .object({
-    netuid: z.int().optional(),
+    netuid: netuidSchema().optional(),
     entries: z.array(ParentEntrySchema).optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/account-extrinsics.ts
+++ b/schemas-src/mcp-tools/account-extrinsics.ts
@@ -8,17 +8,22 @@
 // hand-written JSON Schema for now and EXTRINSIC_ITEM itself has no Zod
 // equivalent yet.
 import { z } from "zod";
-
-const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+import {
+  blockBoundSchema,
+  keysetCursorSchema,
+  limitSchema,
+  offsetSchema,
+  ss58Schema,
+} from "./shared.ts";
 
 export const GetAccountExtrinsicsInputSchema = z
   .object({
-    ss58: Ss58Schema,
-    block_start: z.int().min(0).optional(),
-    block_end: z.int().min(0).optional(),
-    limit: z.int().min(1).max(1000).optional(),
-    offset: z.int().min(0).optional(),
-    cursor: z.string().optional(),
+    ss58: ss58Schema(),
+    block_start: blockBoundSchema("first").optional(),
+    block_end: blockBoundSchema("last").optional(),
+    limit: limitSchema(1000).optional(),
+    offset: offsetSchema().optional(),
+    cursor: keysetCursorSchema().optional(),
   })
   .strict();
 export type GetAccountExtrinsicsInput = z.infer<

--- a/schemas-src/mcp-tools/account-footprints.ts
+++ b/schemas-src/mcp-tools/account-footprints.ts
@@ -13,8 +13,7 @@
 // false) with every field in their own `required` array -- modeled here
 // with the SAME strictness, not the usual item-level looseness.
 import { z } from "zod";
-
-const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+import { netuidSchema, ss58Schema, windowSchema } from "./shared.ts";
 
 // Symbolic in each hand-written original (src/account-*.ts's own
 // *_WINDOWS/DEFAULT_*_WINDOW constants), cross-checked against the actual
@@ -25,8 +24,8 @@ const WEIGHT_SETTERS_WINDOWS_2 = ["7d", "30d"] as const;
 
 export const GetAccountStakeMovesInputSchema = z
   .object({
-    ss58: Ss58Schema,
-    window: z.enum(FOOTPRINT_WINDOWS_3).optional(),
+    ss58: ss58Schema(),
+    window: windowSchema(FOOTPRINT_WINDOWS_3).optional(),
   })
   .strict();
 export type GetAccountStakeMovesInput = z.infer<
@@ -35,7 +34,7 @@ export type GetAccountStakeMovesInput = z.infer<
 
 const StakeMovesSubnetSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     movements: z.int(),
     first_moved_at: z.string().nullable(),
     last_moved_at: z.string().nullable(),
@@ -61,8 +60,8 @@ export type GetAccountStakeMovesOutput = z.infer<
 
 export const GetAccountAxonRemovalsInputSchema = z
   .object({
-    ss58: Ss58Schema,
-    window: z.enum(FOOTPRINT_WINDOWS_3).optional(),
+    ss58: ss58Schema(),
+    window: windowSchema(FOOTPRINT_WINDOWS_3).optional(),
   })
   .strict();
 export type GetAccountAxonRemovalsInput = z.infer<
@@ -71,7 +70,7 @@ export type GetAccountAxonRemovalsInput = z.infer<
 
 const AxonRemovalsSubnetSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     removals: z.int(),
     first_removed_at: z.string().nullable(),
     last_removed_at: z.string().nullable(),
@@ -96,8 +95,8 @@ export type GetAccountAxonRemovalsOutput = z.infer<
 
 export const GetAccountPrometheusInputSchema = z
   .object({
-    ss58: Ss58Schema,
-    window: z.enum(FOOTPRINT_WINDOWS_3).optional(),
+    ss58: ss58Schema(),
+    window: windowSchema(FOOTPRINT_WINDOWS_3).optional(),
   })
   .strict();
 export type GetAccountPrometheusInput = z.infer<
@@ -106,7 +105,7 @@ export type GetAccountPrometheusInput = z.infer<
 
 const PrometheusSubnetSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     announcements: z.int(),
     first_announced_at: z.string().nullable(),
     last_announced_at: z.string().nullable(),
@@ -131,8 +130,8 @@ export type GetAccountPrometheusOutput = z.infer<
 
 export const GetAccountRegistrationsInputSchema = z
   .object({
-    ss58: Ss58Schema,
-    window: z.enum(FOOTPRINT_WINDOWS_3).optional(),
+    ss58: ss58Schema(),
+    window: windowSchema(FOOTPRINT_WINDOWS_3).optional(),
   })
   .strict();
 export type GetAccountRegistrationsInput = z.infer<
@@ -141,7 +140,7 @@ export type GetAccountRegistrationsInput = z.infer<
 
 const RegistrationsSubnetSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     registrations: z.int(),
     first_registered_at: z.string().nullable(),
     last_registered_at: z.string().nullable(),
@@ -166,8 +165,8 @@ export type GetAccountRegistrationsOutput = z.infer<
 
 export const GetAccountWeightSettersInputSchema = z
   .object({
-    ss58: Ss58Schema,
-    window: z.enum(WEIGHT_SETTERS_WINDOWS_2).optional(),
+    ss58: ss58Schema(),
+    window: windowSchema(WEIGHT_SETTERS_WINDOWS_2).optional(),
   })
   .strict();
 export type GetAccountWeightSettersInput = z.infer<
@@ -176,7 +175,7 @@ export type GetAccountWeightSettersInput = z.infer<
 
 const WeightSettersSubnetSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     weight_sets: z.int(),
     first_set_at: z.string().nullable(),
     last_set_at: z.string().nullable(),
@@ -201,8 +200,8 @@ export type GetAccountWeightSettersOutput = z.infer<
 
 export const GetAccountServingInputSchema = z
   .object({
-    ss58: Ss58Schema,
-    window: z.enum(FOOTPRINT_WINDOWS_3).optional(),
+    ss58: ss58Schema(),
+    window: windowSchema(FOOTPRINT_WINDOWS_3).optional(),
   })
   .strict();
 export type GetAccountServingInput = z.infer<
@@ -211,7 +210,7 @@ export type GetAccountServingInput = z.infer<
 
 const ServingSubnetSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     announcements: z.int(),
     first_served_at: z.string().nullable(),
     last_served_at: z.string().nullable(),
@@ -236,8 +235,8 @@ export type GetAccountServingOutput = z.infer<
 
 export const GetAccountDeregistrationsInputSchema = z
   .object({
-    ss58: Ss58Schema,
-    window: z.enum(FOOTPRINT_WINDOWS_3).optional(),
+    ss58: ss58Schema(),
+    window: windowSchema(FOOTPRINT_WINDOWS_3).optional(),
   })
   .strict();
 export type GetAccountDeregistrationsInput = z.infer<
@@ -246,7 +245,7 @@ export type GetAccountDeregistrationsInput = z.infer<
 
 const DeregistrationsSubnetSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     deregistrations: z.int(),
     first_deregistered_at: z.string().nullable(),
     last_deregistered_at: z.string().nullable(),

--- a/schemas-src/mcp-tools/account-history.ts
+++ b/schemas-src/mcp-tools/account-history.ts
@@ -4,18 +4,33 @@
 // reuse. Modeled fresh, matching the hand-written literal it replaces
 // field-for-field.
 import { z } from "zod";
-
-const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+import {
+  keysetCursorSchema,
+  limitSchema,
+  netuidSchema,
+  offsetSchema,
+  ss58Schema,
+} from "./shared.ts";
 
 export const GetAccountHistoryInputSchema = z
   .object({
-    ss58: Ss58Schema,
-    netuid: z.int().min(0).optional(),
-    from: z.string().optional(),
-    to: z.string().optional(),
-    limit: z.int().min(1).max(1000).optional(),
-    offset: z.int().min(0).optional(),
-    cursor: z.string().optional(),
+    ss58: ss58Schema(),
+    netuid: netuidSchema().optional(),
+    from: z
+      .string()
+      .optional()
+      .describe(
+        "Inclusive start of the range. A block height on chain tools, an ISO-8601 date on time-series ones.",
+      ),
+    to: z
+      .string()
+      .optional()
+      .describe(
+        "Inclusive end of the range. A block height on chain tools, an ISO-8601 date on time-series ones; an EVM address on decode_evm_call.",
+      ),
+    limit: limitSchema(1000).optional(),
+    offset: offsetSchema().optional(),
+    cursor: keysetCursorSchema().optional(),
   })
   .strict();
 export type GetAccountHistoryInput = z.infer<
@@ -27,7 +42,7 @@ export type GetAccountHistoryInput = z.infer<
 const AccountHistoryDaySchema = z
   .object({
     day: z.string().nullable().optional(),
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     event_count: z.int().nullable().optional(),
     event_kinds: z.array(z.string()).optional(),
     first_block: z.int().nullable().optional(),

--- a/schemas-src/mcp-tools/account-identity.ts
+++ b/schemas-src/mcp-tools/account-identity.ts
@@ -4,12 +4,16 @@
 // routes -- no existing Zod schema to reuse. Modeled fresh, matching each
 // hand-written literal field-for-field.
 import { z } from "zod";
-
-const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+import {
+  keysetCursorSchema,
+  limitSchema,
+  offsetSchema,
+  ss58Schema,
+} from "./shared.ts";
 
 export const GetAccountIdentityInputSchema = z
   .object({
-    ss58: Ss58Schema,
+    ss58: ss58Schema(),
   })
   .strict();
 export type GetAccountIdentityInput = z.infer<
@@ -37,10 +41,10 @@ export type GetAccountIdentityOutput = z.infer<
 
 export const GetAccountIdentityHistoryInputSchema = z
   .object({
-    ss58: Ss58Schema,
-    limit: z.int().min(1).max(1000).optional(),
-    offset: z.int().min(0).optional(),
-    cursor: z.string().optional(),
+    ss58: ss58Schema(),
+    limit: limitSchema(1000).optional(),
+    offset: offsetSchema().optional(),
+    cursor: keysetCursorSchema().optional(),
   })
   .strict();
 export type GetAccountIdentityHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/account-portfolio.ts
+++ b/schemas-src/mcp-tools/account-portfolio.ts
@@ -10,13 +10,15 @@
 // {type:"object"}), so reusing them here would be a real tightening the
 // issue's wire-compatibility constraint doesn't require.
 import { z } from "zod";
-import { OpenObjectArraySchema, OpenObjectSchema } from "./shared.ts";
-
-const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+import {
+  OpenObjectArraySchema,
+  OpenObjectSchema,
+  ss58Schema,
+} from "./shared.ts";
 
 export const GetAccountPortfolioInputSchema = z
   .object({
-    ss58: Ss58Schema,
+    ss58: ss58Schema(),
   })
   .strict();
 export type GetAccountPortfolioInput = z.infer<
@@ -45,7 +47,7 @@ export type GetAccountPortfolioOutput = z.infer<
 
 export const GetAccountPositionsInputSchema = z
   .object({
-    ss58: Ss58Schema,
+    ss58: ss58Schema(),
   })
   .strict();
 export type GetAccountPositionsInput = z.infer<
@@ -68,8 +70,15 @@ export type GetAccountPositionsOutput = z.infer<
 
 export const GetAccountSnapshotInputSchema = z
   .object({
-    ss58: Ss58Schema,
-    recent_events_limit: z.int().min(1).max(1000).optional(),
+    ss58: ss58Schema(),
+    recent_events_limit: z
+      .int()
+      .min(1)
+      .max(1000)
+      .optional()
+      .describe(
+        "How many recent events to embed. Clamped to the tool's ceiling rather than rejected.",
+      ),
   })
   .strict();
 export type GetAccountSnapshotInput = z.infer<

--- a/schemas-src/mcp-tools/account-position-history.ts
+++ b/schemas-src/mcp-tools/account-position-history.ts
@@ -4,15 +4,18 @@
 // schema to reuse. Modeled fresh, matching the hand-written literal it
 // replaces field-for-field.
 import { z } from "zod";
-import { OpenObjectArraySchema } from "./shared.ts";
-
-const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+import {
+  OpenObjectArraySchema,
+  netuidSchema,
+  ss58Schema,
+  windowSchema,
+} from "./shared.ts";
 
 export const GetAccountPositionHistoryInputSchema = z
   .object({
-    ss58: Ss58Schema,
-    netuid: z.int().min(0),
-    window: z.enum(["7d", "30d", "90d", "1y", "all"]).optional(),
+    ss58: ss58Schema(),
+    netuid: netuidSchema(),
+    window: windowSchema(["7d", "30d", "90d", "1y", "all"]).optional(),
   })
   .strict();
 export type GetAccountPositionHistoryInput = z.infer<
@@ -23,7 +26,7 @@ export const GetAccountPositionHistoryOutputSchema = z
   .object({
     schema_version: z.int().optional(),
     ss58: z.string(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable().optional(),
     point_count: z.int(),
     points: OpenObjectArraySchema,

--- a/schemas-src/mcp-tools/account-root-claim.ts
+++ b/schemas-src/mcp-tools/account-root-claim.ts
@@ -4,13 +4,12 @@
 // reuse. Modeled fresh, matching the hand-written literal it replaces
 // field-for-field.
 import { z } from "zod";
+import { netuidSchema, ss58Schema } from "./shared.ts";
 import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
-
-const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 
 export const GetAccountRootClaimInputSchema = z
   .object({
-    ss58: Ss58Schema,
+    ss58: ss58Schema(),
     // #8700: which chain to read. These routes answer from live storage, and
     // the storage keys are twox128 hashes of pallet+item names — identical on
     // every chain running the same runtime — so the endpoint is the only thing
@@ -31,7 +30,7 @@ const RootClaimTypeSchema = z
 
 const RootClaimEntrySchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     claimable_rate: z.number(),
     claimed: z.string(),
     threshold: z.number(),

--- a/schemas-src/mcp-tools/account-stake-flow.ts
+++ b/schemas-src/mcp-tools/account-stake-flow.ts
@@ -9,8 +9,12 @@
 // breakdown array) -- the two were never the same contract. Modeled fresh,
 // matching the hand-written literal it replaces field-for-field.
 import { z } from "zod";
-
-const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+import {
+  kindSchema,
+  netuidSchema,
+  ss58Schema,
+  windowSchema,
+} from "./shared.ts";
 
 // Symbolic in the hand-written original (src/stake-flow.ts's
 // STAKE_FLOW_WINDOWS/STAKE_FLOW_DIRECTIONS), cross-checked against the
@@ -20,9 +24,9 @@ const ACCOUNT_STAKE_FLOW_DIRECTIONS = ["all", "in", "out"] as const;
 
 export const GetAccountStakeFlowInputSchema = z
   .object({
-    ss58: Ss58Schema,
-    window: z.enum(ACCOUNT_STAKE_FLOW_WINDOWS).optional(),
-    direction: z.enum(ACCOUNT_STAKE_FLOW_DIRECTIONS).optional(),
+    ss58: ss58Schema(),
+    window: windowSchema(ACCOUNT_STAKE_FLOW_WINDOWS).optional(),
+    direction: kindSchema(ACCOUNT_STAKE_FLOW_DIRECTIONS).optional(),
   })
   .strict();
 export type GetAccountStakeFlowInput = z.infer<
@@ -33,7 +37,7 @@ export type GetAccountStakeFlowInput = z.infer<
 // search-subnets.ts's same note from the pilot batch).
 const AccountStakeFlowSubnetSchema = z
   .object({
-    netuid: z.int().optional(),
+    netuid: netuidSchema().optional(),
     staked_tao: z.unknown().optional(),
     unstaked_tao: z.unknown().optional(),
     net_flow_tao: z.unknown().optional(),

--- a/schemas-src/mcp-tools/account-summary.ts
+++ b/schemas-src/mcp-tools/account-summary.ts
@@ -8,9 +8,16 @@
 // shared ACCOUNT_EVENT_ITEM/ACCOUNT_REGISTRATION_ITEM object literals
 // src/mcp-server.ts's objectItems() wraps) field-for-field.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
-
-const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+import {
+  OpenObjectSchema,
+  blockBoundSchema,
+  keysetCursorSchema,
+  kindStringSchema,
+  limitSchema,
+  netuidSchema,
+  offsetSchema,
+  ss58Schema,
+} from "./shared.ts";
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
@@ -21,7 +28,7 @@ const AccountEventItemSchema = z
     event_kind: z.string().nullable().optional(),
     hotkey: z.string().nullable().optional(),
     coldkey: z.string().nullable().optional(),
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     uid: z.int().nullable().optional(),
     amount_tao: z.unknown().optional(),
     alpha_amount: z.unknown().optional(),
@@ -32,7 +39,7 @@ const AccountEventItemSchema = z
 
 const AccountRegistrationItemSchema = z
   .object({
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     uid: z.int().nullable().optional(),
     stake_tao: z.unknown().optional(),
     validator_permit: z.boolean().optional(),
@@ -51,7 +58,7 @@ const AccountLabelItemSchema = z
 
 export const GetAccountInputSchema = z
   .object({
-    ss58: Ss58Schema,
+    ss58: ss58Schema(),
   })
   .strict();
 export type GetAccountInput = z.infer<typeof GetAccountInputSchema>;
@@ -84,7 +91,7 @@ export type GetAccountOutput = z.infer<typeof GetAccountOutputSchema>;
 
 export const GetAccountEntitiesInputSchema = z
   .object({
-    ss58: Ss58Schema,
+    ss58: ss58Schema(),
   })
   .strict();
 export type GetAccountEntitiesInput = z.infer<
@@ -100,7 +107,7 @@ export const GetAccountEntitiesOutputSchema = z
     ownership_ties: z.array(
       z
         .object({
-          netuid: z.int().nullable().optional(),
+          netuid: netuidSchema().nullable().optional(),
           role: z.string().optional(),
           block_number: z.int().nullable().optional(),
           observed_at: z.string().nullable().optional(),
@@ -115,14 +122,14 @@ export type GetAccountEntitiesOutput = z.infer<
 
 export const GetAccountEventsInputSchema = z
   .object({
-    ss58: Ss58Schema,
-    kind: z.string().optional(),
-    netuid: z.int().min(0).optional(),
-    block_start: z.int().min(0).optional(),
-    block_end: z.int().min(0).optional(),
-    limit: z.int().min(1).max(1000).optional(),
-    offset: z.int().min(0).optional(),
-    cursor: z.string().optional(),
+    ss58: ss58Schema(),
+    kind: kindStringSchema().optional(),
+    netuid: netuidSchema().optional(),
+    block_start: blockBoundSchema("first").optional(),
+    block_end: blockBoundSchema("last").optional(),
+    limit: limitSchema(1000).optional(),
+    offset: offsetSchema().optional(),
+    cursor: keysetCursorSchema().optional(),
   })
   .strict();
 export type GetAccountEventsInput = z.infer<typeof GetAccountEventsInputSchema>;
@@ -144,7 +151,7 @@ export type GetAccountEventsOutput = z.infer<
 
 export const GetAccountSubnetsInputSchema = z
   .object({
-    ss58: Ss58Schema,
+    ss58: ss58Schema(),
   })
   .strict();
 export type GetAccountSubnetsInput = z.infer<

--- a/schemas-src/mcp-tools/account-transfers.ts
+++ b/schemas-src/mcp-tools/account-transfers.ts
@@ -4,19 +4,31 @@
 // covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
 // matching each hand-written literal field-for-field.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import {
+  OpenObjectSchema,
+  blockBoundSchema,
+  keysetCursorSchema,
+  limitSchema,
+  offsetSchema,
+  ss58Schema,
+} from "./shared.ts";
 
 const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 
 export const GetAccountTransfersInputSchema = z
   .object({
-    ss58: Ss58Schema,
-    direction: z.enum(["all", "sent", "received"]).optional(),
-    block_start: z.int().min(0).optional(),
-    block_end: z.int().min(0).optional(),
-    limit: z.int().min(1).max(1000).optional(),
-    offset: z.int().min(0).optional(),
-    cursor: z.string().optional(),
+    ss58: ss58Schema(),
+    direction: z
+      .enum(["all", "sent", "received"])
+      .optional()
+      .describe(
+        "Which side of the flow to include: everything, only outgoing, or only incoming.",
+      ),
+    block_start: blockBoundSchema("first").optional(),
+    block_end: blockBoundSchema("last").optional(),
+    limit: limitSchema(1000).optional(),
+    offset: offsetSchema().optional(),
+    cursor: keysetCursorSchema().optional(),
   })
   .strict();
 export type GetAccountTransfersInput = z.infer<
@@ -54,9 +66,11 @@ export type GetAccountTransfersOutput = z.infer<
 
 export const GetAccountCounterpartiesInputSchema = z
   .object({
-    ss58: Ss58Schema,
-    counterparty: Ss58Schema.optional(),
-    limit: z.int().min(1).max(100).optional(),
+    ss58: ss58Schema(),
+    counterparty: Ss58Schema.optional().describe(
+      "The other SS58 account in the transfer pair — results are restricted to flows between the subject account and this one.",
+    ),
+    limit: limitSchema(100).optional(),
   })
   .strict();
 export type GetAccountCounterpartiesInput = z.infer<

--- a/schemas-src/mcp-tools/accounts-leaderboards.ts
+++ b/schemas-src/mcp-tools/accounts-leaderboards.ts
@@ -4,7 +4,7 @@
 // schema to reuse. Modeled fresh, matching each hand-written literal
 // field-for-field.
 import { z } from "zod";
-import { OpenObjectArraySchema } from "./shared.ts";
+import { OpenObjectArraySchema, limitSchema, sortSchema } from "./shared.ts";
 
 // Symbolic in the hand-written originals (src/accounts-list.ts's
 // ACCOUNTS_LIST_SORTS/*_LIMIT_*, src/top-holders.ts's TOP_HOLDERS_SORTS/
@@ -30,8 +30,8 @@ const TOP_HOLDERS_SORTS = [
 
 export const ListAccountsInputSchema = z
   .object({
-    sort: z.enum(ACCOUNTS_LIST_SORTS).optional(),
-    limit: z.int().min(1).max(100).optional(),
+    sort: sortSchema(ACCOUNTS_LIST_SORTS).optional(),
+    limit: limitSchema(100).optional(),
   })
   .strict();
 export type ListAccountsInput = z.infer<typeof ListAccountsInputSchema>;
@@ -70,8 +70,8 @@ export type ListAccountsOutput = z.infer<typeof ListAccountsOutputSchema>;
 
 export const GetTopHoldersInputSchema = z
   .object({
-    sort: z.enum(TOP_HOLDERS_SORTS).optional(),
-    limit: z.int().min(1).max(100).optional(),
+    sort: sortSchema(TOP_HOLDERS_SORTS).optional(),
+    limit: limitSchema(100).optional(),
   })
   .strict();
 export type GetTopHoldersInput = z.infer<typeof GetTopHoldersInputSchema>;

--- a/schemas-src/mcp-tools/agent-catalog-resources.ts
+++ b/schemas-src/mcp-tools/agent-catalog-resources.ts
@@ -6,11 +6,11 @@
 // array). Neither mirrors an existing schemas-src/routes/ REST schema --
 // modeled fresh, matching each hand-written literal field-for-field.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import { OpenObjectSchema, netuidSchema } from "./shared.ts";
 
 export const GetAgentCatalogInputSchema = z
   .object({
-    netuid: z.int().min(0).optional(),
+    netuid: netuidSchema().optional(),
   })
   .strict();
 export type GetAgentCatalogInput = z.infer<typeof GetAgentCatalogInputSchema>;

--- a/schemas-src/mcp-tools/ai-discovery.ts
+++ b/schemas-src/mcp-tools/ai-discovery.ts
@@ -4,7 +4,7 @@
 // existing schemas-src/routes/ REST schema -- modeled fresh, matching
 // each hand-written literal field-for-field.
 import { z } from "zod";
-import { OpenObjectArraySchema } from "./shared.ts";
+import { OpenObjectArraySchema, limitSchema, netuidSchema } from "./shared.ts";
 
 // Symbolic in the hand-written original (src/health-serving.ts's
 // ECONOMIC_BOARD_SPECS[].key), cross-checked against the actual runtime
@@ -29,8 +29,11 @@ const SemanticTypeSchema = z
 
 export const FindSubnetOpportunitiesInputSchema = z
   .object({
-    board: z.enum(ECONOMIC_LEADERBOARD_BOARDS).optional(),
-    limit: z.int().min(1).max(100).optional(),
+    board: z
+      .enum(ECONOMIC_LEADERBOARD_BOARDS)
+      .optional()
+      .describe("Which leaderboard to return."),
+    limit: limitSchema(100).optional(),
   })
   .strict();
 export type FindSubnetOpportunitiesInput = z.infer<
@@ -39,7 +42,7 @@ export type FindSubnetOpportunitiesInput = z.infer<
 
 const EconomicBoardEntrySchema = z
   .object({
-    netuid: z.int().optional(),
+    netuid: netuidSchema().optional(),
     slug: z.string().nullable().optional(),
     name: z.string().nullable().optional(),
   })
@@ -67,9 +70,13 @@ export type FindSubnetOpportunitiesOutput = z.infer<
 
 export const SemanticSearchInputSchema = z
   .object({
-    query: z.string(),
-    limit: z.int().min(1).max(20).optional(),
-    type: SemanticTypeSchema,
+    query: z
+      .string()
+      .describe(
+        "The request payload or search text this surface expects. Shape depends on the surface; see its schema.",
+      ),
+    limit: limitSchema(20).optional(),
+    type: SemanticTypeSchema.describe("Which entity kind to search over."),
   })
   .strict();
 export type SemanticSearchInput = z.infer<typeof SemanticSearchInputSchema>;
@@ -78,7 +85,7 @@ const SemanticSearchResultItemSchema = z
   .object({
     score: z.unknown().optional(),
     type: z.string().nullable().optional(),
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     slug: z.string().nullable().optional(),
     title: z.string().nullable().optional(),
     subtitle: z.string().nullable().optional(),
@@ -98,8 +105,12 @@ export type SemanticSearchOutput = z.infer<typeof SemanticSearchOutputSchema>;
 
 export const AskInputSchema = z
   .object({
-    question: z.string(),
-    type: SemanticTypeSchema,
+    question: z
+      .string()
+      .describe(
+        "A natural-language question. Answered from indexed registry content with citations, not from model recall.",
+      ),
+    type: SemanticTypeSchema.describe("Which entity kind to search over."),
   })
   .strict();
 export type AskInput = z.infer<typeof AskInputSchema>;
@@ -109,7 +120,7 @@ const AskCitationItemSchema = z
     ref: z.unknown().optional(),
     score: z.number().optional(),
     title: z.string().nullable().optional(),
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     slug: z.string().nullable().optional(),
     url: z.string().nullable().optional(),
   })
@@ -128,8 +139,12 @@ export type AskOutput = z.infer<typeof AskOutputSchema>;
 
 export const FindSubnetForTaskInputSchema = z
   .object({
-    task: z.string(),
-    limit: z.int().min(1).max(20).optional(),
+    task: z
+      .string()
+      .describe(
+        "Describe the task in plain language; subnets are ranked by how well their published capabilities match it.",
+      ),
+    limit: limitSchema(20).optional(),
   })
   .strict();
 export type FindSubnetForTaskInput = z.infer<

--- a/schemas-src/mcp-tools/ai-integration.ts
+++ b/schemas-src/mcp-tools/ai-integration.ts
@@ -8,12 +8,19 @@ import {
   OpenArraySchema,
   OpenObjectArraySchema,
   OpenObjectSchema,
+  netuidSchema,
+  surfaceIdSchema,
 } from "./shared.ts";
 
 export const HowDoICallInputSchema = z
   .object({
-    netuid: z.int().min(0).optional(),
-    subnet: z.string().optional(),
+    netuid: netuidSchema().optional(),
+    subnet: z
+      .string()
+      .optional()
+      .describe(
+        "A subnet by slug (`chutes`) or chain name. Use `netuid` instead when you have the numeric id.",
+      ),
   })
   .strict();
 export type HowDoICallInput = z.infer<typeof HowDoICallInputSchema>;
@@ -24,7 +31,7 @@ export type HowDoICallInput = z.infer<typeof HowDoICallInputSchema>;
 // as-is.
 export const HowDoICallOutputSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     name: z.string().nullable().optional(),
     slug: z.string().nullable().optional(),
     integration_readiness: z.unknown().optional(),
@@ -41,8 +48,8 @@ export type HowDoICallOutput = z.infer<typeof HowDoICallOutputSchema>;
 
 export const VerifyIntegrationInputSchema = z
   .object({
-    surface_id: z.string().optional(),
-    netuid: z.int().min(0).optional(),
+    surface_id: surfaceIdSchema().optional(),
+    netuid: netuidSchema().optional(),
   })
   .strict();
 export type VerifyIntegrationInput = z.infer<
@@ -57,7 +64,7 @@ export const VerifyIntegrationOutputSchema = z
   .object({
     surface_id: z.string(),
     surface_key: z.string().nullable().optional(),
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     kind: z.string().optional(),
     url: z.string().optional(),
     provider: z.string().nullable().optional(),
@@ -77,19 +84,47 @@ export type VerifyIntegrationOutput = z.infer<
 
 export const CallSubnetSurfaceInputSchema = z
   .object({
-    surface_id: z.string(),
+    surface_id: surfaceIdSchema(),
     query: z
       .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
-      .optional(),
-    path: z.string().optional(),
-    method: z.enum(["GET", "HEAD", "POST", "PUT"]).optional(),
+      .optional()
+      .describe(
+        "Query-string parameters to append, as a flat object of " +
+          "string/number/boolean values. Nested objects and arrays are not " +
+          "supported — encode them into `path` or `body` instead.",
+      ),
+    path: z
+      .string()
+      .optional()
+      .describe(
+        "Path appended to the surface's base URL, e.g. `/v1/status`. Leading slash optional.",
+      ),
+    method: z
+      .enum(["GET", "HEAD", "POST", "PUT"])
+      .optional()
+      .describe("HTTP method to use for the call."),
     // Branch order (object, then string) mirrors the hand-written original's
     // `type: ["object", "string"]`.
-    body: z.union([OpenObjectSchema, z.string()]).optional(),
-    content_type: z.string().optional(),
+    body: z
+      .union([OpenObjectSchema, z.string()])
+      .optional()
+      .describe(
+        "Request body: an object (sent as JSON) or a pre-serialized string.",
+      ),
+    content_type: z
+      .string()
+      .optional()
+      .describe(
+        "Overrides the Content-Type header. Defaults to `application/json` when the body is an object.",
+      ),
     // Branch order (string, then object) mirrors the hand-written original's
     // `type: ["string", "object"]` -- the reverse of `body` above.
-    credential: z.union([z.string(), OpenObjectSchema]).optional(),
+    credential: z
+      .union([z.string(), OpenObjectSchema])
+      .optional()
+      .describe(
+        "Secret for an authenticated surface: a bearer token string, or an object of header/query values. Sent to the surface and never stored unless you use store_surface_credential.",
+      ),
   })
   .strict();
 export type CallSubnetSurfaceInput = z.infer<
@@ -127,13 +162,22 @@ export type CallSubnetSurfaceOutput = z.infer<
 
 export const StoreSurfaceCredentialInputSchema = z
   .object({
-    surface_id: z.string(),
+    surface_id: surfaceIdSchema(),
     // Same two shapes call_subnet_surface accepts in-band: a single opaque
     // string for bearer/api-key/basic schemes, or a {name: value} bundle
     // for scheme:signature. Branch order (string, then object) mirrors
     // CallSubnetSurfaceInputSchema's `credential`.
-    credential: z.union([z.string(), OpenObjectSchema]),
-    ttl_seconds: z.int().min(60).max(7_776_000).optional(),
+    credential: z
+      .union([z.string(), OpenObjectSchema])
+      .describe(
+        "Secret for an authenticated surface: a bearer token string, or an object of header/query values. Sent to the surface and never stored unless you use store_surface_credential.",
+      ),
+    ttl_seconds: z
+      .int()
+      .min(60)
+      .max(7_776_000)
+      .optional()
+      .describe("How long the stored credential remains valid, in seconds."),
   })
   .strict();
 export type StoreSurfaceCredentialInput = z.infer<
@@ -169,7 +213,7 @@ export type ListSurfaceCredentialsOutput = z.infer<
 
 export const DeleteSurfaceCredentialInputSchema = z
   .object({
-    surface_id: z.string(),
+    surface_id: surfaceIdSchema(),
   })
   .strict();
 export type DeleteSurfaceCredentialInput = z.infer<

--- a/schemas-src/mcp-tools/blocks.ts
+++ b/schemas-src/mcp-tools/blocks.ts
@@ -8,23 +8,59 @@ import {
   AccountEventItemSchema,
   ExtrinsicItemSchema,
   OpenObjectSchema,
+  blockBoundSchema,
+  keysetCursorSchema,
+  limitSchema,
+  offsetSchema,
 } from "./shared.ts";
 
 const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 
 export const ListBlocksInputSchema = z
   .object({
-    author: Ss58Schema.optional(),
-    spec_version: z.int().min(0).optional(),
-    block_start: z.int().min(0).optional(),
-    block_end: z.int().min(0).optional(),
-    from: z.int().min(0).optional(),
-    to: z.int().min(0).optional(),
-    min_extrinsics: z.int().min(0).optional(),
-    min_events: z.int().min(0).optional(),
-    limit: z.int().min(1).max(100).optional(),
-    offset: z.int().min(0).optional(),
-    cursor: z.string().optional(),
+    author: Ss58Schema.optional().describe(
+      "Restrict to blocks authored by this SS58 validator hotkey. Only populated below the decode watermark; recent head blocks may not carry an author yet.",
+    ),
+    spec_version: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Restrict to blocks running this runtime spec version — the number that changes at a runtime upgrade.",
+      ),
+    block_start: blockBoundSchema("first").optional(),
+    block_end: blockBoundSchema("last").optional(),
+    from: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive start of the range. A block height on chain tools, an ISO-8601 date on time-series ones.",
+      ),
+    to: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive end of the range. A block height on chain tools, an ISO-8601 date on time-series ones; an EVM address on decode_evm_call.",
+      ),
+    min_extrinsics: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive lower bound on a block's extrinsic count; quieter blocks are excluded.",
+      ),
+    min_events: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive lower bound on a block's event count; quieter blocks are excluded.",
+      ),
+    limit: limitSchema(100).optional(),
+    offset: offsetSchema().optional(),
+    cursor: keysetCursorSchema().optional(),
   })
   .strict();
 export type ListBlocksInput = z.infer<typeof ListBlocksInputSchema>;
@@ -58,7 +94,11 @@ export type ListBlocksOutput = z.infer<typeof ListBlocksOutputSchema>;
 
 export const GetBlockInputSchema = z
   .object({
-    ref: z.string(),
+    ref: z
+      .string()
+      .describe(
+        "Block reference: either a block NUMBER or a 0x-prefixed block HASH. Both forms are accepted and resolve to the same block.",
+      ),
   })
   .strict();
 export type GetBlockInput = z.infer<typeof GetBlockInputSchema>;
@@ -76,9 +116,13 @@ export type GetBlockOutput = z.infer<typeof GetBlockOutputSchema>;
 
 export const ListBlockExtrinsicsInputSchema = z
   .object({
-    ref: z.string(),
-    limit: z.int().min(1).max(100).optional(),
-    offset: z.int().min(0).optional(),
+    ref: z
+      .string()
+      .describe(
+        "Block reference: either a block NUMBER or a 0x-prefixed block HASH. Both forms are accepted and resolve to the same block.",
+      ),
+    limit: limitSchema(100).optional(),
+    offset: offsetSchema().optional(),
   })
   .strict();
 export type ListBlockExtrinsicsInput = z.infer<
@@ -102,9 +146,13 @@ export type ListBlockExtrinsicsOutput = z.infer<
 
 export const GetBlockEventsInputSchema = z
   .object({
-    ref: z.string(),
-    limit: z.int().min(1).max(1000).optional(),
-    offset: z.int().min(0).optional(),
+    ref: z
+      .string()
+      .describe(
+        "Block reference: either a block NUMBER or a 0x-prefixed block HASH. Both forms are accepted and resolve to the same block.",
+      ),
+    limit: limitSchema(1000).optional(),
+    offset: offsetSchema().optional(),
   })
   .strict();
 export type GetBlockEventsInput = z.infer<typeof GetBlockEventsInputSchema>;

--- a/schemas-src/mcp-tools/catalog-detail.ts
+++ b/schemas-src/mcp-tools/catalog-detail.ts
@@ -5,18 +5,23 @@
 // existing schemas-src/routes/ REST schema -- modeled fresh, matching each
 // hand-written literal field-for-field.
 import { z } from "zod";
-import { OpenArraySchema, OpenObjectSchema } from "./shared.ts";
+import {
+  OpenArraySchema,
+  OpenObjectSchema,
+  netuidSchema,
+  surfaceIdSchema,
+} from "./shared.ts";
 
 export const ListSubnetApisInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type ListSubnetApisInput = z.infer<typeof ListSubnetApisInputSchema>;
 
 export const ListSubnetApisOutputSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     service_count: z.int(),
     services: z.array(OpenObjectSchema),
     operational_observed_at: z.string().nullable().optional(),
@@ -27,7 +32,7 @@ export type ListSubnetApisOutput = z.infer<typeof ListSubnetApisOutputSchema>;
 
 export const GetApiSchemaInputSchema = z
   .object({
-    surface_id: z.string(),
+    surface_id: surfaceIdSchema(),
   })
   .strict();
 export type GetApiSchemaInput = z.infer<typeof GetApiSchemaInputSchema>;
@@ -47,7 +52,7 @@ export type GetApiSchemaOutput = z.infer<typeof GetApiSchemaOutputSchema>;
 
 export const GetFixtureInputSchema = z
   .object({
-    surface_id: z.string(),
+    surface_id: surfaceIdSchema(),
   })
   .strict();
 export type GetFixtureInput = z.infer<typeof GetFixtureInputSchema>;
@@ -64,8 +69,17 @@ export type GetFixtureOutput = z.infer<typeof GetFixtureOutputSchema>;
 
 export const GetProviderDetailInputSchema = z
   .object({
-    slug: z.string(),
-    include_endpoints: z.boolean().optional(),
+    slug: z
+      .string()
+      .describe(
+        "The registry slug — lowercase, hyphenated (`chutes`), not the display name. Slugs are stable across renames.",
+      ),
+    include_endpoints: z
+      .boolean()
+      .optional()
+      .describe(
+        "When true, embed each provider's endpoints instead of counts alone.",
+      ),
   })
   .strict();
 export type GetProviderDetailInput = z.infer<

--- a/schemas-src/mcp-tools/chain-calls-fees.ts
+++ b/schemas-src/mcp-tools/chain-calls-fees.ts
@@ -7,15 +7,26 @@
 // symbolic *_WINDOWS import), backed by the shared parseAnalyticsWindow()
 // runtime helper -- modeled the same way here, no shared constant.
 import { z } from "zod";
+import { limitSchema, sortSchema, windowSchema } from "./shared.ts";
 
 const WINDOWS_2 = ["7d", "30d"] as const;
 
 export const GetChainCallsInputSchema = z
   .object({
-    window: z.enum(WINDOWS_2).optional(),
-    group_by: z.enum(["module", "module_function"]).optional(),
-    limit: z.int().min(1).max(100).optional(),
-    call_module: z.string().optional(),
+    window: windowSchema(WINDOWS_2).optional(),
+    group_by: z
+      .enum(["module", "module_function"])
+      .optional()
+      .describe(
+        "How to bucket the counts: by pallet, or by pallet and call together.",
+      ),
+    limit: limitSchema(100).optional(),
+    call_module: z
+      .string()
+      .optional()
+      .describe(
+        "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
+      ),
   })
   .strict();
 export type GetChainCallsInput = z.infer<typeof GetChainCallsInputSchema>;
@@ -46,10 +57,15 @@ export type GetChainCallsOutput = z.infer<typeof GetChainCallsOutputSchema>;
 
 export const GetChainSignersInputSchema = z
   .object({
-    window: z.enum(WINDOWS_2).optional(),
-    sort: z.enum(["tx_count", "total_fee_tao"]).optional(),
-    limit: z.int().min(1).max(100).optional(),
-    call_module: z.string().optional(),
+    window: windowSchema(WINDOWS_2).optional(),
+    sort: sortSchema(["tx_count", "total_fee_tao"]).optional(),
+    limit: limitSchema(100).optional(),
+    call_module: z
+      .string()
+      .optional()
+      .describe(
+        "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
+      ),
   })
   .strict();
 export type GetChainSignersInput = z.infer<typeof GetChainSignersInputSchema>;
@@ -79,9 +95,14 @@ export type GetChainSignersOutput = z.infer<typeof GetChainSignersOutputSchema>;
 
 export const GetChainFeesInputSchema = z
   .object({
-    window: z.enum(WINDOWS_2).optional(),
-    limit: z.int().min(1).max(100).optional(),
-    call_module: z.string().optional(),
+    window: windowSchema(WINDOWS_2).optional(),
+    limit: limitSchema(100).optional(),
+    call_module: z
+      .string()
+      .optional()
+      .describe(
+        "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
+      ),
   })
   .strict();
 export type GetChainFeesInput = z.infer<typeof GetChainFeesInputSchema>;

--- a/schemas-src/mcp-tools/chain-events-activity.ts
+++ b/schemas-src/mcp-tools/chain-events-activity.ts
@@ -8,13 +8,19 @@
 // the shared parseAnalyticsWindow() runtime helper rather than an
 // Object.hasOwn() check -- modeled the same way here, no shared constant.
 import { z } from "zod";
+import { keysetCursorSchema, limitSchema, windowSchema } from "./shared.ts";
 import { McpNetworkSchema } from "../shared.ts";
 
 const WINDOWS_2 = ["7d", "30d"] as const;
 
 export const GetChainActivityInputSchema = z
   .object({
-    blocks: z.int().min(1).max(5000).optional(),
+    blocks: z
+      .int()
+      .min(1)
+      .max(5000)
+      .optional()
+      .describe("How many trailing blocks to cover, ending at the chain head."),
     // #8700: which chain's decoded history to aggregate. The same published
     // finney/test enum every network-aware tool takes, so one vocabulary
     // covers the whole surface.
@@ -46,13 +52,34 @@ export type GetChainActivityOutput = z.infer<
 
 export const ListChainEventsInputSchema = z
   .object({
-    pallet: z.string().optional(),
-    method: z.string().optional(),
-    block: z.int().min(0).optional(),
-    extrinsic: z.int().min(0).optional(),
-    cursor: z.string().optional(),
-    before: z.int().min(0).optional(),
-    limit: z.int().min(1).max(200).optional(),
+    pallet: z
+      .string()
+      .optional()
+      .describe(
+        "Restrict to events emitted by this pallet, by runtime name (`SubtensorModule`). Case-sensitive.",
+      ),
+    method: z.string().optional().describe("HTTP method to use for the call."),
+    block: z
+      .int()
+      .min(0)
+      .optional()
+      .describe("Restrict to this exact block height."),
+    extrinsic: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Restrict to one extrinsic's events by its index within the block. Requires `block`.",
+      ),
+    cursor: keysetCursorSchema().optional(),
+    before: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Legacy cursor: return rows strictly BEFORE this block height. Prefer `cursor` where a tool offers one.",
+      ),
+    limit: limitSchema(200).optional(),
     network: McpNetworkSchema.optional(),
   })
   .strict();
@@ -92,7 +119,7 @@ export type ListChainEventsOutput = z.infer<typeof ListChainEventsOutputSchema>;
 
 export const GetNetworkActivityInputSchema = z
   .object({
-    window: z.enum(WINDOWS_2).optional(),
+    window: windowSchema(WINDOWS_2).optional(),
   })
   .strict();
 export type GetNetworkActivityInput = z.infer<

--- a/schemas-src/mcp-tools/chain-events.ts
+++ b/schemas-src/mcp-tools/chain-events.ts
@@ -4,11 +4,12 @@
 // covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
 // matching each hand-written literal field-for-field.
 import { z } from "zod";
+import { keysetCursorSchema, limitSchema } from "./shared.ts";
 import { McpNetworkSchema } from "../shared.ts";
 
 export const GetBlockChainEventsInputSchema = z
   .object({
-    block_number: z.int().min(0),
+    block_number: z.int().min(0).describe("The block height to read."),
     // #8700: which chain's history to read. The same published finney/test
     // enum every network-aware tool takes.
     network: McpNetworkSchema.optional(),
@@ -55,9 +56,13 @@ export type GetBlockChainEventsOutput = z.infer<
 
 export const GetExtrinsicChainEventsInputSchema = z
   .object({
-    ref: z.string(),
-    limit: z.int().min(1).max(200).optional(),
-    cursor: z.string().optional(),
+    ref: z
+      .string()
+      .describe(
+        "Block reference: either a block NUMBER or a 0x-prefixed block HASH. Both forms are accepted and resolve to the same block.",
+      ),
+    limit: limitSchema(200).optional(),
+    cursor: keysetCursorSchema().optional(),
     network: McpNetworkSchema.optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/chain-identity-history.ts
+++ b/schemas-src/mcp-tools/chain-identity-history.ts
@@ -4,12 +4,18 @@
 // reuse. Modeled fresh, matching the hand-written literal it replaces
 // field-for-field.
 import { z } from "zod";
-
-const CHAIN_IDENTITY_HISTORY_LIMIT_MAX = 200;
+import {
+  CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
+  CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
+} from "../../src/route-limits.ts";
+import { limitSchema, netuidSchema } from "./shared.ts";
 
 export const GetChainIdentityHistoryInputSchema = z
   .object({
-    limit: z.int().min(1).max(CHAIN_IDENTITY_HISTORY_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
+      CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
+    ).optional(),
   })
   .strict();
 export type GetChainIdentityHistoryInput = z.infer<
@@ -20,7 +26,7 @@ export type GetChainIdentityHistoryInput = z.infer<
 // search-subnets.ts's same note from the pilot batch).
 const ChainIdentityChangeSchema = z
   .object({
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     block_number: z.int().nullable().optional(),
     observed_at: z.string().nullable().optional(),
     subnet_name: z.string().nullable().optional(),

--- a/schemas-src/mcp-tools/chain-leaderboards.ts
+++ b/schemas-src/mcp-tools/chain-leaderboards.ts
@@ -16,7 +16,12 @@
 // exception: a flat setters leaderboard with no network/distribution
 // rollup, using the usual objectItems() item-level looseness instead.
 import { z } from "zod";
-import { DistributionStatsSchema } from "./shared.ts";
+import {
+  DistributionStatsSchema,
+  limitSchema,
+  netuidSchema,
+  windowSchema,
+} from "./shared.ts";
 
 const WINDOWS_2 = ["7d", "30d"] as const;
 const WINDOWS_3 = ["7d", "30d", "90d"] as const;
@@ -24,8 +29,8 @@ const LIMIT_MAX_100 = 100;
 
 export const GetChainTurnoverInputSchema = z
   .object({
-    window: z.enum(WINDOWS_3).optional(),
-    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+    window: windowSchema(WINDOWS_3).optional(),
+    limit: limitSchema(LIMIT_MAX_100).optional(),
   })
   .strict();
 export type GetChainTurnoverInput = z.infer<typeof GetChainTurnoverInputSchema>;
@@ -43,7 +48,7 @@ const ChainTurnoverNetworkSchema = z
 
 const ChainTurnoverSubnetSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     validators_start: z.int(),
     validators_end: z.int(),
     validators_entered: z.int(),
@@ -72,8 +77,8 @@ export type GetChainTurnoverOutput = z.infer<
 
 export const GetChainStakeFlowInputSchema = z
   .object({
-    window: z.enum(WINDOWS_2).optional(),
-    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+    window: windowSchema(WINDOWS_2).optional(),
+    limit: limitSchema(LIMIT_MAX_100).optional(),
   })
   .strict();
 export type GetChainStakeFlowInput = z.infer<
@@ -96,7 +101,7 @@ const ChainStakeFlowNetworkSchema = z
 
 const ChainStakeFlowSubnetSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     total_staked_tao: z.number(),
     total_unstaked_tao: z.number(),
     net_flow_tao: z.number(),
@@ -124,7 +129,7 @@ export type GetChainStakeFlowOutput = z.infer<
 
 export const GetChainAlphaVolumeInputSchema = z
   .object({
-    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+    limit: limitSchema(LIMIT_MAX_100).optional(),
   })
   .strict();
 export type GetChainAlphaVolumeInput = z.infer<
@@ -154,7 +159,7 @@ const ChainAlphaVolumeNetworkSchema = z
 const ChainAlphaVolumeSubnetSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string(),
     buy_volume_alpha: z.unknown().optional(),
     sell_volume_alpha: z.unknown().optional(),
@@ -188,8 +193,8 @@ export type GetChainAlphaVolumeOutput = z.infer<
 
 export const GetChainWeightsInputSchema = z
   .object({
-    window: z.enum(WINDOWS_2).optional(),
-    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+    window: windowSchema(WINDOWS_2).optional(),
+    limit: limitSchema(LIMIT_MAX_100).optional(),
   })
   .strict();
 export type GetChainWeightsInput = z.infer<typeof GetChainWeightsInputSchema>;
@@ -204,7 +209,7 @@ const ChainWeightsNetworkSchema = z
 
 const ChainWeightsSubnetSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     distinct_setters: z.int(),
     weight_sets: z.int(),
     sets_per_setter: z.number(),
@@ -226,8 +231,8 @@ export type GetChainWeightsOutput = z.infer<typeof GetChainWeightsOutputSchema>;
 
 export const GetChainWeightSettersInputSchema = z
   .object({
-    window: z.enum(WINDOWS_2).optional(),
-    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+    window: windowSchema(WINDOWS_2).optional(),
+    limit: limitSchema(LIMIT_MAX_100).optional(),
   })
   .strict();
 export type GetChainWeightSettersInput = z.infer<
@@ -264,8 +269,8 @@ export type GetChainWeightSettersOutput = z.infer<
 
 export const GetChainStakeMovesInputSchema = z
   .object({
-    window: z.enum(WINDOWS_2).optional(),
-    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+    window: windowSchema(WINDOWS_2).optional(),
+    limit: limitSchema(LIMIT_MAX_100).optional(),
   })
   .strict();
 export type GetChainStakeMovesInput = z.infer<
@@ -282,7 +287,7 @@ const ChainStakeMovesNetworkSchema = z
 
 const ChainStakeMovesSubnetSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     distinct_movers: z.int(),
     movements: z.int(),
     movements_per_mover: z.number(),
@@ -306,8 +311,8 @@ export type GetChainStakeMovesOutput = z.infer<
 
 export const GetChainStakeTransfersInputSchema = z
   .object({
-    window: z.enum(WINDOWS_2).optional(),
-    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+    window: windowSchema(WINDOWS_2).optional(),
+    limit: limitSchema(LIMIT_MAX_100).optional(),
   })
   .strict();
 export type GetChainStakeTransfersInput = z.infer<
@@ -324,7 +329,7 @@ const ChainStakeTransfersNetworkSchema = z
 
 const ChainStakeTransfersSubnetSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     distinct_senders: z.int(),
     transfers: z.int(),
     transfers_per_sender: z.number(),
@@ -348,8 +353,8 @@ export type GetChainStakeTransfersOutput = z.infer<
 
 export const GetChainAxonRemovalsInputSchema = z
   .object({
-    window: z.enum(WINDOWS_2).optional(),
-    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+    window: windowSchema(WINDOWS_2).optional(),
+    limit: limitSchema(LIMIT_MAX_100).optional(),
   })
   .strict();
 export type GetChainAxonRemovalsInput = z.infer<
@@ -366,7 +371,7 @@ const ChainAxonRemovalsNetworkSchema = z
 
 const ChainAxonRemovalsSubnetSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     distinct_removers: z.int(),
     removals: z.int(),
     removals_per_remover: z.number(),
@@ -390,8 +395,8 @@ export type GetChainAxonRemovalsOutput = z.infer<
 
 export const GetChainServingInputSchema = z
   .object({
-    window: z.enum(WINDOWS_2).optional(),
-    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+    window: windowSchema(WINDOWS_2).optional(),
+    limit: limitSchema(LIMIT_MAX_100).optional(),
   })
   .strict();
 export type GetChainServingInput = z.infer<typeof GetChainServingInputSchema>;
@@ -406,7 +411,7 @@ const ChainServingNetworkSchema = z
 
 const ChainServingSubnetSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     distinct_servers: z.int(),
     announcements: z.int(),
     announcements_per_server: z.number(),
@@ -428,8 +433,8 @@ export type GetChainServingOutput = z.infer<typeof GetChainServingOutputSchema>;
 
 export const GetChainPrometheusInputSchema = z
   .object({
-    window: z.enum(WINDOWS_2).optional(),
-    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+    window: windowSchema(WINDOWS_2).optional(),
+    limit: limitSchema(LIMIT_MAX_100).optional(),
   })
   .strict();
 export type GetChainPrometheusInput = z.infer<
@@ -446,7 +451,7 @@ const ChainPrometheusNetworkSchema = z
 
 const ChainPrometheusSubnetSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     distinct_exporters: z.int(),
     announcements: z.int(),
     announcements_per_exporter: z.number(),

--- a/schemas-src/mcp-tools/chain-registrations.ts
+++ b/schemas-src/mcp-tools/chain-registrations.ts
@@ -16,15 +16,21 @@
 // strict items. Modeled as-is, not "fixed" to match its sibling -- the epic's
 // wire-compatibility mandate preserves what shipped, not what's consistent.
 import { z } from "zod";
-import { DistributionStatsSchema, OpenObjectSchema } from "./shared.ts";
+import {
+  DistributionStatsSchema,
+  OpenObjectSchema,
+  limitSchema,
+  netuidSchema,
+  windowSchema,
+} from "./shared.ts";
 
 const WINDOWS_2 = ["7d", "30d"] as const;
 const LIMIT_MAX_100 = 100;
 
 export const GetChainRegistrationsInputSchema = z
   .object({
-    window: z.enum(WINDOWS_2).optional(),
-    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+    window: windowSchema(WINDOWS_2).optional(),
+    limit: limitSchema(LIMIT_MAX_100).optional(),
   })
   .strict();
 export type GetChainRegistrationsInput = z.infer<
@@ -46,7 +52,7 @@ const ChainRegistrationsNetworkSchema = z
 // get_chain_deregistrations's strict items below.
 const ChainRegistrationsSubnetSchema = z
   .object({
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     distinct_registrants: z.int().nullable().optional(),
     registrations: z.int().nullable().optional(),
     registrations_per_registrant: z.number().nullable().optional(),
@@ -73,8 +79,8 @@ export type GetChainRegistrationsOutput = z.infer<
 
 export const GetChainDeregistrationsInputSchema = z
   .object({
-    window: z.enum(WINDOWS_2).optional(),
-    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+    window: windowSchema(WINDOWS_2).optional(),
+    limit: limitSchema(LIMIT_MAX_100).optional(),
   })
   .strict();
 export type GetChainDeregistrationsInput = z.infer<
@@ -91,7 +97,7 @@ const ChainDeregistrationsNetworkSchema = z
 
 const ChainDeregistrationsSubnetSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     distinct_deregistered_hotkeys: z.int(),
     deregistrations: z.int(),
     deregistrations_per_hotkey: z.number(),

--- a/schemas-src/mcp-tools/chain-scorecards.ts
+++ b/schemas-src/mcp-tools/chain-scorecards.ts
@@ -7,7 +7,7 @@
 // `{type:["object","null"]}` fields with no declared shape, which stay
 // untyped open objects here too (not "improved" with a guessed shape).
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import { OpenObjectSchema, netuidSchema } from "./shared.ts";
 
 export const GetChainConcentrationInputSchema = z.object({}).strict();
 export type GetChainConcentrationInput = z.infer<
@@ -64,7 +64,7 @@ export type GetChainIdleStakeInput = z.infer<
 
 const ChainIdleStakeSubnetSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     neuron_count: z.int(),
     idle_neuron_count: z.int(),
     idle_stake_alpha: z.number(),

--- a/schemas-src/mcp-tools/chain-transfers.ts
+++ b/schemas-src/mcp-tools/chain-transfers.ts
@@ -8,6 +8,7 @@
 // NULLABLE enum (`type:["string","null"], enum:[...windows, null]`) --
 // `z.enum(...).nullable()`, not `.optional()`.
 import { z } from "zod";
+import { limitSchema, sortSchema, windowSchema } from "./shared.ts";
 
 const WINDOWS_2 = ["7d", "30d"] as const;
 
@@ -24,8 +25,8 @@ const ChainTransferPartySchema = z
 
 export const GetChainTransfersInputSchema = z
   .object({
-    window: z.enum(WINDOWS_2).optional(),
-    limit: z.int().min(1).max(100).optional(),
+    window: windowSchema(WINDOWS_2).optional(),
+    limit: limitSchema(100).optional(),
   })
   .strict();
 export type GetChainTransfersInput = z.infer<
@@ -52,9 +53,9 @@ export type GetChainTransfersOutput = z.infer<
 
 export const GetChainTransferPairsInputSchema = z
   .object({
-    window: z.enum(WINDOWS_2).optional(),
-    sort: z.enum(["volume", "count"]).optional(),
-    limit: z.int().min(1).max(100).optional(),
+    window: windowSchema(WINDOWS_2).optional(),
+    sort: sortSchema(["volume", "count"]).optional(),
+    limit: limitSchema(100).optional(),
   })
   .strict();
 export type GetChainTransferPairsInput = z.infer<

--- a/schemas-src/mcp-tools/compare-subnets.ts
+++ b/schemas-src/mcp-tools/compare-subnets.ts
@@ -9,8 +9,17 @@ const COMPARE_DIMENSIONS = ["structure", "economics", "health"] as const;
 
 export const CompareSubnetsInputSchema = z
   .object({
-    netuids: z.array(z.int().min(0)).min(1).max(128),
-    dimensions: z.array(z.enum(COMPARE_DIMENSIONS)).optional(),
+    netuids: z
+      .array(z.int().min(0))
+      .min(1)
+      .max(128)
+      .describe(
+        "Subnet ids to include, as an array of integers. Omit for every subnet.",
+      ),
+    dimensions: z
+      .array(z.enum(COMPARE_DIMENSIONS))
+      .optional()
+      .describe("Which breakdown dimensions to return, as an array of names."),
   })
   .strict();
 export type CompareSubnetsInput = z.infer<typeof CompareSubnetsInputSchema>;

--- a/schemas-src/mcp-tools/curation-and-gaps.ts
+++ b/schemas-src/mcp-tools/curation-and-gaps.ts
@@ -10,7 +10,16 @@
 // notes shape, see shared.ts's NotesFieldSchema) -- a genuine difference,
 // preserved as-is.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import {
+  OpenObjectSchema,
+  fieldsStringSchema,
+  kindSchema,
+  limitSchema,
+  netuidSchema,
+  numericCursorSchema,
+  orderSchema,
+  sortSchema,
+} from "./shared.ts";
 
 const COVERAGE_LEVELS = ["native-only", "manifested", "probed"] as const;
 const CURATION_LEVELS = [
@@ -30,14 +39,19 @@ const CURATION_SORT_FIELDS = [
 
 export const ListCurationInputSchema = z
   .object({
-    netuid: z.int().min(0).optional(),
-    coverage_level: z.enum(COVERAGE_LEVELS).optional(),
-    curation_level: z.enum(CURATION_LEVELS).optional(),
-    sort: z.enum(CURATION_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    netuid: netuidSchema().optional(),
+    coverage_level: z
+      .enum(COVERAGE_LEVELS)
+      .optional()
+      .describe(
+        "How much of the subnet is covered: on-chain data only, a manifest, or actively probed surfaces.",
+      ),
+    curation_level: kindSchema(CURATION_LEVELS).optional(),
+    sort: sortSchema(CURATION_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListCurationInput = z.infer<typeof ListCurationInputSchema>;
@@ -68,14 +82,19 @@ const GAPS_SORT_FIELDS = [
 
 export const ListGapsInputSchema = z
   .object({
-    netuid: z.int().min(0).optional(),
-    coverage_level: z.enum(COVERAGE_LEVELS).optional(),
-    curation_level: z.enum(CURATION_LEVELS).optional(),
-    sort: z.enum(GAPS_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    netuid: netuidSchema().optional(),
+    coverage_level: z
+      .enum(COVERAGE_LEVELS)
+      .optional()
+      .describe(
+        "How much of the subnet is covered: on-chain data only, a manifest, or actively probed surfaces.",
+      ),
+    curation_level: kindSchema(CURATION_LEVELS).optional(),
+    sort: sortSchema(GAPS_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListGapsInput = z.infer<typeof ListGapsInputSchema>;

--- a/schemas-src/mcp-tools/endpoint-pools-and-provider.ts
+++ b/schemas-src/mcp-tools/endpoint-pools-and-provider.ts
@@ -11,7 +11,18 @@
 // REQUIRED (a path param, not a filter), unlike every other filter in this
 // file.
 import { z } from "zod";
-import { OpenObjectSchema, NotesFieldSchema } from "./shared.ts";
+import {
+  NotesFieldSchema,
+  OpenObjectSchema,
+  fieldsStringSchema,
+  kindSchema,
+  limitSchema,
+  netuidSchema,
+  numericCursorSchema,
+  orderSchema,
+  providerSlugSchema,
+  sortSchema,
+} from "./shared.ts";
 
 const POOL_KINDS = ["subtensor-rpc", "subtensor-wss", "archive"] as const;
 const POOL_SORT_FIELDS = [
@@ -23,17 +34,42 @@ const POOL_SORT_FIELDS = [
 
 export const ListEndpointPoolsInputSchema = z
   .object({
-    id: z.string().optional(),
-    kind: z.enum(POOL_KINDS).optional(),
-    min_eligible_count: z.number().optional(),
-    max_eligible_count: z.number().optional(),
-    min_endpoint_count: z.number().optional(),
-    max_endpoint_count: z.number().optional(),
-    sort: z.enum(POOL_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    id: z
+      .string()
+      .optional()
+      .describe(
+        "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
+      ),
+    kind: kindSchema(POOL_KINDS).optional(),
+    min_eligible_count: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive lower bound on pool-eligible endpoint count; rows below it are excluded.",
+      ),
+    max_eligible_count: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive upper bound on pool-eligible endpoint count; rows above it are excluded.",
+      ),
+    min_endpoint_count: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive lower bound on endpoint count; rows below it are excluded.",
+      ),
+    max_endpoint_count: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive upper bound on endpoint count; rows above it are excluded.",
+      ),
+    sort: sortSchema(POOL_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListEndpointPoolsInput = z.infer<
@@ -91,17 +127,23 @@ const INCIDENT_SORT_FIELDS = [
 
 export const ListEndpointIncidentsInputSchema = z
   .object({
-    netuid: z.int().min(0).optional(),
-    kind: z.enum(SURFACE_KINDS).optional(),
-    provider: z.string().optional(),
-    status: z.enum(HEALTH_STATUSES).optional(),
-    severity: z.enum(INCIDENT_SEVERITIES).optional(),
-    state: z.enum(INCIDENT_STATES).optional(),
-    sort: z.enum(INCIDENT_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    netuid: netuidSchema().optional(),
+    kind: kindSchema(SURFACE_KINDS).optional(),
+    provider: providerSlugSchema().optional(),
+    status: kindSchema(HEALTH_STATUSES).optional(),
+    severity: z
+      .enum(INCIDENT_SEVERITIES)
+      .optional()
+      .describe("How serious the incident is."),
+    state: z
+      .enum(INCIDENT_STATES)
+      .optional()
+      .describe("The incident's lifecycle state."),
+    sort: sortSchema(INCIDENT_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListEndpointIncidentsInput = z.infer<
@@ -156,22 +198,62 @@ const ENDPOINT_SORT_FIELDS = [
 
 export const ListProviderEndpointsInputSchema = z
   .object({
-    slug: z.string().regex(/^[a-z0-9-]+$/),
-    kind: z.enum(SURFACE_KINDS).optional(),
-    layer: z.enum(ENDPOINT_LAYERS).optional(),
-    netuid: z.int().min(0).optional(),
-    publication_state: z.enum(ENDPOINT_PUBLICATION_STATES).optional(),
-    status: z.enum(HEALTH_STATUSES).optional(),
-    pool_eligible: z.boolean().optional(),
-    min_latency_ms: z.number().optional(),
-    max_latency_ms: z.number().optional(),
-    min_score: z.number().optional(),
-    max_score: z.number().optional(),
-    sort: z.enum(ENDPOINT_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    slug: z
+      .string()
+      .regex(/^[a-z0-9-]+$/)
+      .describe(
+        "The registry slug — lowercase, hyphenated (`chutes`), not the display name. Slugs are stable across renames.",
+      ),
+    kind: kindSchema(SURFACE_KINDS).optional(),
+    layer: z
+      .enum(ENDPOINT_LAYERS)
+      .optional()
+      .describe(
+        "Which layer of the stack the endpoint belongs to: the Bittensor base chain, a data or docs provider, or a subnet's own app.",
+      ),
+    netuid: netuidSchema().optional(),
+    publication_state: z
+      .enum(ENDPOINT_PUBLICATION_STATES)
+      .optional()
+      .describe(
+        "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
+      ),
+    status: kindSchema(HEALTH_STATUSES).optional(),
+    pool_eligible: z
+      .boolean()
+      .optional()
+      .describe(
+        "Restrict to endpoints that are (or are not) eligible for the public RPC pool.",
+      ),
+    min_latency_ms: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive lower bound on probe latency in milliseconds; rows below it are excluded.",
+      ),
+    max_latency_ms: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive upper bound on probe latency in milliseconds; rows above it are excluded.",
+      ),
+    min_score: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive lower bound on endpoint score; rows below it are excluded.",
+      ),
+    max_score: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive upper bound on endpoint score; rows above it are excluded.",
+      ),
+    sort: sortSchema(ENDPOINT_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListProviderEndpointsInput = z.infer<

--- a/schemas-src/mcp-tools/endpoints-catalog.ts
+++ b/schemas-src/mcp-tools/endpoints-catalog.ts
@@ -5,7 +5,17 @@
 // schema -- modeled fresh, matching each hand-written literal
 // field-for-field.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import {
+  OpenObjectSchema,
+  fieldsStringSchema,
+  kindSchema,
+  limitSchema,
+  netuidSchema,
+  numericCursorSchema,
+  orderSchema,
+  providerSlugSchema,
+  sortSchema,
+} from "./shared.ts";
 
 const SURFACE_KINDS = [
   "archive",
@@ -53,24 +63,59 @@ const ENDPOINT_SORT_FIELDS = [
 
 export const ListEndpointsInputSchema = z
   .object({
-    kind: z.enum(SURFACE_KINDS).optional(),
-    layer: z.enum(ENDPOINT_LAYERS).optional(),
-    netuid: z.int().min(0).optional(),
-    provider: z.string().optional(),
-    publication_state: z.enum(ENDPOINT_PUBLICATION_STATES).optional(),
-    status: z.enum(HEALTH_STATUSES).optional(),
-    pool_eligible: z.boolean().optional(),
-    min_latency_ms: z.number().optional(),
-    max_latency_ms: z.number().optional(),
-    min_score: z.number().optional(),
-    max_score: z.number().optional(),
-    sort: z.enum(ENDPOINT_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
+    kind: kindSchema(SURFACE_KINDS).optional(),
+    layer: z
+      .enum(ENDPOINT_LAYERS)
+      .optional()
+      .describe(
+        "Which layer of the stack the endpoint belongs to: the Bittensor base chain, a data or docs provider, or a subnet's own app.",
+      ),
+    netuid: netuidSchema().optional(),
+    provider: providerSlugSchema().optional(),
+    publication_state: z
+      .enum(ENDPOINT_PUBLICATION_STATES)
+      .optional()
+      .describe(
+        "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
+      ),
+    status: kindSchema(HEALTH_STATUSES).optional(),
+    pool_eligible: z
+      .boolean()
+      .optional()
+      .describe(
+        "Restrict to endpoints that are (or are not) eligible for the public RPC pool.",
+      ),
+    min_latency_ms: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive lower bound on probe latency in milliseconds; rows below it are excluded.",
+      ),
+    max_latency_ms: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive upper bound on probe latency in milliseconds; rows above it are excluded.",
+      ),
+    min_score: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive lower bound on endpoint score; rows below it are excluded.",
+      ),
+    max_score: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive upper bound on endpoint score; rows above it are excluded.",
+      ),
+    sort: sortSchema(ENDPOINT_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
     // Ceiling is MAX_LIMIT (workers/request-params.ts:21); a literal here
     // because schemas-src/ imports from neither src/ nor workers/.
-    limit: z.int().min(1).max(1000).optional(),
-    cursor: z.int().min(0).optional(),
+    limit: limitSchema(1000).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListEndpointsInput = z.infer<typeof ListEndpointsInputSchema>;
@@ -93,7 +138,7 @@ export type ListEndpointsOutput = z.infer<typeof ListEndpointsOutputSchema>;
 
 export const GetSubnetEndpointsInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetEndpointsInput = z.infer<
@@ -102,7 +147,7 @@ export type GetSubnetEndpointsInput = z.infer<
 
 export const GetSubnetEndpointsOutputSchema = z
   .object({
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     endpoints: z.array(OpenObjectSchema).optional(),
     generated_at: z.string().nullable().optional(),
     schema_version: z.union([z.string(), z.int()]).nullable().optional(),

--- a/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
+++ b/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
@@ -9,7 +9,18 @@
 // mirror an existing schemas-src/routes/ REST schema -- modeled fresh,
 // matching each hand-written literal field-for-field.
 import { z } from "zod";
-import { OpenObjectSchema, NotesFieldSchema } from "./shared.ts";
+import {
+  NotesFieldSchema,
+  OpenObjectSchema,
+  fieldsStringSchema,
+  kindSchema,
+  limitSchema,
+  netuidSchema,
+  numericCursorSchema,
+  orderSchema,
+  querySchema,
+  sortSchema,
+} from "./shared.ts";
 
 const SURFACE_KINDS = [
   "archive",
@@ -52,17 +63,33 @@ const EVIDENCE_SORT_FIELDS = [
 
 export const ListEnrichmentEvidenceInputSchema = z
   .object({
-    q: z.string().optional(),
-    netuid: z.int().min(0).optional(),
-    lane: z.enum(LANES).optional(),
-    evidence_action: z.enum(EVIDENCE_ACTIONS).optional(),
-    direct_submission_kinds: z.enum(SURFACE_KINDS).optional(),
-    missing_kinds: z.enum(SURFACE_KINDS).optional(),
-    sort: z.enum(EVIDENCE_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    q: querySchema().optional(),
+    netuid: netuidSchema().optional(),
+    lane: z
+      .enum(LANES)
+      .optional()
+      .describe("Which contribution lane the item belongs to."),
+    evidence_action: z
+      .enum(EVIDENCE_ACTIONS)
+      .optional()
+      .describe("What the evidence is asking a contributor to do."),
+    direct_submission_kinds: z
+      .enum(SURFACE_KINDS)
+      .optional()
+      .describe(
+        "Restrict to subnets where surfaces of this kind a contributor can submit directly. One kind per call; see this parameter's enum.",
+      ),
+    missing_kinds: z
+      .enum(SURFACE_KINDS)
+      .optional()
+      .describe(
+        "Restrict to subnets where surfaces of this kind the subnet is MISSING. One kind per call; see this parameter's enum.",
+      ),
+    sort: sortSchema(EVIDENCE_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListEnrichmentEvidenceInput = z.infer<
@@ -108,15 +135,23 @@ const PRIORITY_SORT_FIELDS = [
 
 export const ListReviewGapsInputSchema = z
   .object({
-    netuid: z.int().min(0).optional(),
-    curation_level: z.enum(CURATION_LEVELS).optional(),
-    missing_kinds: z.enum(SURFACE_KINDS).optional(),
-    review_state: z.string().optional(),
-    sort: z.enum(PRIORITY_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    netuid: netuidSchema().optional(),
+    curation_level: kindSchema(CURATION_LEVELS).optional(),
+    missing_kinds: z
+      .enum(SURFACE_KINDS)
+      .optional()
+      .describe(
+        "Restrict to subnets where surfaces of this kind the subnet is MISSING. One kind per call; see this parameter's enum.",
+      ),
+    review_state: z
+      .string()
+      .optional()
+      .describe("Where the item sits in maintainer review."),
+    sort: sortSchema(PRIORITY_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListReviewGapsInput = z.infer<typeof ListReviewGapsInputSchema>;
@@ -185,25 +220,64 @@ const TARGET_SORT_FIELDS = [
 
 export const ListReviewEnrichmentTargetsInputSchema = z
   .object({
-    q: z.string().optional(),
-    netuid: z.int().min(0).optional(),
-    target_type: z.enum(TARGET_TYPES).optional(),
-    target_action: z.enum(TARGET_ACTIONS).optional(),
-    kind: z.enum(SURFACE_KINDS).optional(),
-    lane: z.enum(LANES).optional(),
-    evidence_action: z.enum(EVIDENCE_ACTIONS).optional(),
-    identity_level: z.enum(IDENTITY_LEVELS).optional(),
-    profile_level: z.enum(PROFILE_LEVELS).optional(),
-    submission_route: z.enum(SUBMISSION_ROUTES).optional(),
-    auto_review_candidate: z.enum(BOOLEAN_STRINGS).optional(),
-    manual_review_required: z.enum(BOOLEAN_STRINGS).optional(),
-    missing_kinds: z.enum(SURFACE_KINDS).optional(),
-    reason_codes: z.string().optional(),
-    sort: z.enum(TARGET_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    q: querySchema().optional(),
+    netuid: netuidSchema().optional(),
+    target_type: z
+      .enum(TARGET_TYPES)
+      .optional()
+      .describe("What kind of enrichment target this is."),
+    target_action: z
+      .enum(TARGET_ACTIONS)
+      .optional()
+      .describe("What the target is asking a contributor to do."),
+    kind: kindSchema(SURFACE_KINDS).optional(),
+    lane: z
+      .enum(LANES)
+      .optional()
+      .describe("Which contribution lane the item belongs to."),
+    evidence_action: z
+      .enum(EVIDENCE_ACTIONS)
+      .optional()
+      .describe("What the evidence is asking a contributor to do."),
+    identity_level: z
+      .enum(IDENTITY_LEVELS)
+      .optional()
+      .describe("How complete the subnet's published identity is."),
+    profile_level: z
+      .enum(PROFILE_LEVELS)
+      .optional()
+      .describe(
+        "How complete the subnet's profile is, from directory-only upward.",
+      ),
+    submission_route: z
+      .enum(SUBMISSION_ROUTES)
+      .optional()
+      .describe("How a contribution for this gap should be submitted."),
+    auto_review_candidate: z
+      .enum(BOOLEAN_STRINGS)
+      .optional()
+      .describe("Restrict to items eligible for automated review."),
+    manual_review_required: z
+      .enum(BOOLEAN_STRINGS)
+      .optional()
+      .describe("Restrict to items that do (or do not) need a human reviewer."),
+    missing_kinds: z
+      .enum(SURFACE_KINDS)
+      .optional()
+      .describe(
+        "Restrict to subnets where surfaces of this kind the subnet is MISSING. One kind per call; see this parameter's enum.",
+      ),
+    reason_codes: z
+      .string()
+      .optional()
+      .describe(
+        "Comma-separated reason codes to filter by; an item matches if it carries any of them.",
+      ),
+    sort: sortSchema(TARGET_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListReviewEnrichmentTargetsInput = z.infer<

--- a/schemas-src/mcp-tools/enrichment-queue-and-candidates.ts
+++ b/schemas-src/mcp-tools/enrichment-queue-and-candidates.ts
@@ -8,7 +8,18 @@
 // REST schema -- modeled fresh, matching each hand-written literal
 // field-for-field.
 import { z } from "zod";
-import { OpenObjectSchema, NotesFieldSchema } from "./shared.ts";
+import {
+  NotesFieldSchema,
+  OpenObjectSchema,
+  fieldsStringSchema,
+  kindSchema,
+  limitSchema,
+  netuidSchema,
+  numericCursorSchema,
+  orderSchema,
+  querySchema,
+  sortSchema,
+} from "./shared.ts";
 
 const SURFACE_KINDS = [
   "archive",
@@ -81,23 +92,58 @@ const QUEUE_SORT_FIELDS = [
 
 export const ListEnrichmentQueueInputSchema = z
   .object({
-    q: z.string().optional(),
-    netuid: z.int().min(0).optional(),
-    lane: z.enum(LANES).optional(),
-    evidence_action: z.enum(EVIDENCE_ACTIONS).optional(),
-    identity_level: z.enum(IDENTITY_LEVELS).optional(),
-    curation_level: z.enum(CURATION_LEVELS).optional(),
-    profile_level: z.enum(PROFILE_LEVELS).optional(),
-    direct_submission_kinds: z.enum(SURFACE_KINDS).optional(),
-    missing_kinds: z.enum(SURFACE_KINDS).optional(),
-    manual_review_required: z.enum(BOOLEAN_STRINGS).optional(),
-    reason_codes: z.string().optional(),
-    review_state: z.string().optional(),
-    sort: z.enum(QUEUE_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    q: querySchema().optional(),
+    netuid: netuidSchema().optional(),
+    lane: z
+      .enum(LANES)
+      .optional()
+      .describe("Which contribution lane the item belongs to."),
+    evidence_action: z
+      .enum(EVIDENCE_ACTIONS)
+      .optional()
+      .describe("What the evidence is asking a contributor to do."),
+    identity_level: z
+      .enum(IDENTITY_LEVELS)
+      .optional()
+      .describe("How complete the subnet's published identity is."),
+    curation_level: kindSchema(CURATION_LEVELS).optional(),
+    profile_level: z
+      .enum(PROFILE_LEVELS)
+      .optional()
+      .describe(
+        "How complete the subnet's profile is, from directory-only upward.",
+      ),
+    direct_submission_kinds: z
+      .enum(SURFACE_KINDS)
+      .optional()
+      .describe(
+        "Restrict to subnets where surfaces of this kind a contributor can submit directly. One kind per call; see this parameter's enum.",
+      ),
+    missing_kinds: z
+      .enum(SURFACE_KINDS)
+      .optional()
+      .describe(
+        "Restrict to subnets where surfaces of this kind the subnet is MISSING. One kind per call; see this parameter's enum.",
+      ),
+    manual_review_required: z
+      .enum(BOOLEAN_STRINGS)
+      .optional()
+      .describe("Restrict to items that do (or do not) need a human reviewer."),
+    reason_codes: z
+      .string()
+      .optional()
+      .describe(
+        "Comma-separated reason codes to filter by; an item matches if it carries any of them.",
+      ),
+    review_state: z
+      .string()
+      .optional()
+      .describe("Where the item sits in maintainer review."),
+    sort: sortSchema(QUEUE_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListEnrichmentQueueInput = z.infer<
@@ -142,17 +188,35 @@ const ADAPTER_CANDIDATES_SORT_FIELDS = [
 
 export const ListAdapterCandidatesInputSchema = z
   .object({
-    netuid: z.int().min(0).optional(),
-    curation_level: z.enum(CURATION_LEVELS).optional(),
-    candidate_api_kinds: z.enum(SURFACE_KINDS).optional(),
-    operational_kinds: z.enum(SURFACE_KINDS).optional(),
-    recommended_adapter_kind: z.enum(RECOMMENDED_ADAPTER_KINDS).optional(),
-    reason_codes: z.string().optional(),
-    sort: z.enum(ADAPTER_CANDIDATES_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    netuid: netuidSchema().optional(),
+    curation_level: kindSchema(CURATION_LEVELS).optional(),
+    candidate_api_kinds: z
+      .enum(SURFACE_KINDS)
+      .optional()
+      .describe(
+        "Restrict to subnets where surfaces of this kind exist as unreviewed API candidates. One kind per call; see this parameter's enum.",
+      ),
+    operational_kinds: z
+      .enum(SURFACE_KINDS)
+      .optional()
+      .describe(
+        "Restrict to subnets where surfaces of this kind are operational. One kind per call; see this parameter's enum.",
+      ),
+    recommended_adapter_kind: z
+      .enum(RECOMMENDED_ADAPTER_KINDS)
+      .optional()
+      .describe("Which adapter shape suits this surface."),
+    reason_codes: z
+      .string()
+      .optional()
+      .describe(
+        "Comma-separated reason codes to filter by; an item matches if it carries any of them.",
+      ),
+    sort: sortSchema(ADAPTER_CANDIDATES_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListAdapterCandidatesInput = z.infer<

--- a/schemas-src/mcp-tools/evm.ts
+++ b/schemas-src/mcp-tools/evm.ts
@@ -16,8 +16,13 @@ const H160Schema = z.string().regex(/^0x[0-9a-fA-F]{40}$/);
 
 export const DecodeEvmCallInputSchema = z
   .object({
-    to: H160Schema,
-    input: z.string().regex(/^0x[0-9a-fA-F]*$/),
+    to: H160Schema.describe(
+      "Inclusive end of the range. A block height on chain tools, an ISO-8601 date on time-series ones; an EVM address on decode_evm_call.",
+    ),
+    input: z
+      .string()
+      .regex(/^0x[0-9a-fA-F]*$/)
+      .describe("ABI-encoded EVM call data (0x-prefixed) to decode."),
   })
   .strict();
 export type DecodeEvmCallInput = z.infer<typeof DecodeEvmCallInputSchema>;
@@ -35,7 +40,9 @@ export type DecodeEvmCallOutput = z.infer<typeof DecodeEvmCallOutputSchema>;
 
 export const GetEvmAddressMappingInputSchema = z
   .object({
-    h160: H160Schema,
+    h160: H160Schema.describe(
+      "A 20-byte EVM address (0x-prefixed, 40 hex characters) to resolve to its SS58 mirror.",
+    ),
     // #8700: which chain to read. These routes answer from live storage, and
     // the storage keys are twox128 hashes of pallet+item names — identical on
     // every chain running the same runtime — so the endpoint is the only thing

--- a/schemas-src/mcp-tools/extrinsics.ts
+++ b/schemas-src/mcp-tools/extrinsics.ts
@@ -3,7 +3,12 @@
 // schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
 // reuse. Modeled fresh, matching each hand-written literal field-for-field.
 import { z } from "zod";
-import { limitSchema, offsetSchema } from "./shared.ts";
+import {
+  blockBoundSchema,
+  keysetCursorSchema,
+  limitSchema,
+  offsetSchema,
+} from "./shared.ts";
 
 /**
  * Page-size ceiling for the extrinsics feeds and the two fixed-call_module feeds
@@ -21,19 +26,55 @@ const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 
 export const ListExtrinsicsInputSchema = z
   .object({
-    block: z.int().min(0).optional(),
-    signer: Ss58Schema.optional(),
-    call_module: z.string().optional(),
-    call_function: z.string().optional(),
-    call_hash: z.string().optional(),
-    success: z.boolean().optional(),
-    block_start: z.int().min(0).optional(),
-    block_end: z.int().min(0).optional(),
-    from: z.int().min(0).optional(),
-    to: z.int().min(0).optional(),
+    block: z
+      .int()
+      .min(0)
+      .optional()
+      .describe("Restrict to this exact block height."),
+    signer: Ss58Schema.optional().describe(
+      "Restrict to extrinsics signed by this SS58 account. Unsigned (inherent) extrinsics never match.",
+    ),
+    call_module: z
+      .string()
+      .optional()
+      .describe(
+        "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
+      ),
+    call_function: z
+      .string()
+      .optional()
+      .describe(
+        "Restrict to one call within the pallet (`add_stake`). Case-sensitive; pair with `call_module` to disambiguate.",
+      ),
+    call_hash: z
+      .string()
+      .optional()
+      .describe("Restrict to the extrinsic with this 0x-prefixed hash."),
+    success: z
+      .boolean()
+      .optional()
+      .describe(
+        "Restrict to successful (`true`) or failed (`false`) extrinsics. Omit for both.",
+      ),
+    block_start: blockBoundSchema("first").optional(),
+    block_end: blockBoundSchema("last").optional(),
+    from: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive start of the range. A block height on chain tools, an ISO-8601 date on time-series ones.",
+      ),
+    to: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive end of the range. A block height on chain tools, an ISO-8601 date on time-series ones; an EVM address on decode_evm_call.",
+      ),
     limit: limitSchema(EXTRINSICS_LIMIT_MAX).optional(),
     offset: offsetSchema().optional(),
-    cursor: z.string().optional(),
+    cursor: keysetCursorSchema().optional(),
   })
   .strict();
 export type ListExtrinsicsInput = z.infer<typeof ListExtrinsicsInputSchema>;
@@ -52,7 +93,11 @@ export type ListExtrinsicsOutput = z.infer<typeof ListExtrinsicsOutputSchema>;
 
 export const GetExtrinsicInputSchema = z
   .object({
-    ref: z.string(),
+    ref: z
+      .string()
+      .describe(
+        "Block reference: either a block NUMBER or a 0x-prefixed block HASH. Both forms are accepted and resolve to the same block.",
+      ),
   })
   .strict();
 export type GetExtrinsicInput = z.infer<typeof GetExtrinsicInputSchema>;

--- a/schemas-src/mcp-tools/feed.ts
+++ b/schemas-src/mcp-tools/feed.ts
@@ -6,6 +6,7 @@
 // symbolic in the hand-written original (src/feeds.ts's own exports),
 // cross-checked against the actual runtime source at the time of writing.
 import { z } from "zod";
+import { kindSchema, limitSchema, netuidSchema } from "./shared.ts";
 
 // Single source of truth for get_feed kind enums (input + output) and the
 // runtime requireKind allow-list in src/feed-mcp.ts.
@@ -22,12 +23,27 @@ const FEED_MAX_ITEMS = 50;
 
 export const GetFeedInputSchema = z
   .object({
-    kind: z.enum(FEED_KINDS),
-    netuid: z.int().min(0).optional(),
-    tag: z.string().optional(),
-    since: z.string().optional(),
-    until: z.string().optional(),
-    limit: z.int().min(1).max(FEED_MAX_ITEMS).optional(),
+    kind: kindSchema(FEED_KINDS),
+    netuid: netuidSchema().optional(),
+    tag: z
+      .string()
+      .optional()
+      .describe(
+        "Restrict the feed to items carrying this tag. Exact match against the item's own tags.",
+      ),
+    since: z
+      .string()
+      .optional()
+      .describe(
+        "ISO-8601 timestamp; only items at or after this instant are returned.",
+      ),
+    until: z
+      .string()
+      .optional()
+      .describe(
+        "ISO-8601 timestamp; only items at or before this instant are returned.",
+      ),
+    limit: limitSchema(FEED_MAX_ITEMS).optional(),
   })
   .strict();
 export type GetFeedInput = z.infer<typeof GetFeedInputSchema>;
@@ -46,7 +62,7 @@ const FeedItemSchema = z
 export const GetFeedOutputSchema = z
   .object({
     kind: z.enum(FEED_KINDS),
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     filters: z
       .object({
         tag: z.string().nullable().optional(),

--- a/schemas-src/mcp-tools/find-subnets-by-capability.ts
+++ b/schemas-src/mcp-tools/find-subnets-by-capability.ts
@@ -4,12 +4,17 @@
 // response. Modeled field-for-field from the hand-written literals this
 // replaces, same as search-subnets.ts in the pilot batch.
 import { z } from "zod";
+import { limitSchema, netuidSchema, numericCursorSchema } from "./shared.ts";
 
 export const FindSubnetsByCapabilityInputSchema = z
   .object({
-    capability: z.string(),
-    cursor: z.int().min(0).optional(),
-    limit: z.int().min(1).max(50).optional(),
+    capability: z
+      .string()
+      .describe(
+        "A capability keyword to match against subnet descriptions and surfaces, e.g. `inference` or `storage`.",
+      ),
+    cursor: numericCursorSchema().optional(),
+    limit: limitSchema(50).optional(),
   })
   .strict();
 export type FindSubnetsByCapabilityInput = z.infer<
@@ -18,7 +23,7 @@ export type FindSubnetsByCapabilityInput = z.infer<
 
 const FindSubnetsByCapabilityResultItemSchema = z
   .object({
-    netuid: z.int().optional(),
+    netuid: netuidSchema().optional(),
     slug: z.string().optional(),
     name: z.string().nullable().optional(),
     categories: z.array(z.unknown()).optional(),

--- a/schemas-src/mcp-tools/get-adapter.ts
+++ b/schemas-src/mcp-tools/get-adapter.ts
@@ -4,7 +4,7 @@
 // schemas-src/routes/ REST schema -- modeled fresh, matching the
 // hand-written literal field-for-field.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import { OpenObjectSchema, netuidSchema } from "./shared.ts";
 
 // `notes: {type:["array","string","null"], items:{type:"string"}}` -- this
 // batch's shared.ts predates the NotesFieldSchema helper hoisted in batch 10
@@ -17,7 +17,12 @@ const NotesFieldSchema = z
 
 export const GetAdapterInputSchema = z
   .object({
-    slug: z.string().regex(/^[a-z0-9-]+$/),
+    slug: z
+      .string()
+      .regex(/^[a-z0-9-]+$/)
+      .describe(
+        "The registry slug — lowercase, hyphenated (`chutes`), not the display name. Slugs are stable across renames.",
+      ),
   })
   .strict();
 export type GetAdapterInput = z.infer<typeof GetAdapterInputSchema>;
@@ -29,7 +34,7 @@ export const GetAdapterOutputSchema = z
     generated_at: z.string().nullable().optional(),
     slug: z.string(),
     subnet: z.string().nullable().optional(),
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     notes: NotesFieldSchema,
     snapshot: OpenObjectSchema.nullable().optional(),
     extensions: OpenObjectSchema.nullable().optional(),

--- a/schemas-src/mcp-tools/get-alert-trigger.ts
+++ b/schemas-src/mcp-tools/get-alert-trigger.ts
@@ -3,11 +3,20 @@
 // covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
 // matching the hand-written literal it replaces field-for-field.
 import { z } from "zod";
+import { netuidSchema } from "./shared.ts";
 
 export const GetAlertTriggerInputSchema = z
   .object({
-    id: z.string(),
-    owner_token: z.string(),
+    id: z
+      .string()
+      .describe(
+        "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
+      ),
+    owner_token: z
+      .string()
+      .describe(
+        "The secret token issued when the alert was created. Required to read it back; it is not recoverable if lost.",
+      ),
   })
   .strict();
 export type GetAlertTriggerInput = z.infer<typeof GetAlertTriggerInputSchema>;
@@ -17,7 +26,7 @@ export const GetAlertTriggerOutputSchema = z
     id: z.string(),
     name: z.string().nullable().optional(),
     table_filter: z.string().nullable().optional(),
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     event_kind: z.string().nullable().optional(),
     account: z.string().nullable().optional(),
     min_amount_tao: z.number().nullable().optional(),

--- a/schemas-src/mcp-tools/get-chain-concentration-history.ts
+++ b/schemas-src/mcp-tools/get-chain-concentration-history.ts
@@ -7,7 +7,10 @@ export const GetChainConcentrationHistoryInputSchema = z
   .object({
     window: z
       .enum(CHAIN_CONCENTRATION_HISTORY_WINDOWS as [string, ...string[]])
-      .optional(),
+      .optional()
+      .describe(
+        "Trailing time window to aggregate over, ending at the latest data point rather than a calendar boundary. Options are per-tool; see this parameter's enum.",
+      ),
   })
   .strict();
 export type GetChainConcentrationHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/get-chain-holders.ts
+++ b/schemas-src/mcp-tools/get-chain-holders.ts
@@ -1,21 +1,26 @@
 // get_chain_holders (#9607): every subnet ranked by alpha-ownership
 // concentration, mirroring GET /api/v1/chain/holders.
 import { z } from "zod";
-import { CHAIN_HOLDERS_LIMIT_MAX } from "../../src/route-limits.ts";
+import { limitSchema, netuidSchema, sortSchema } from "./shared.ts";
+import {
+  CHAIN_HOLDERS_LIMIT_DEFAULT,
+  CHAIN_HOLDERS_LIMIT_MAX,
+} from "../../src/route-limits.ts";
 
 export const GetChainHoldersInputSchema = z
   .object({
-    sort: z
-      .enum([
-        "top1_share",
-        "top5_share",
-        "top10_share",
-        "top20_share",
-        "holder_count",
-        "total_alpha",
-      ])
-      .optional(),
-    limit: z.int().min(1).max(CHAIN_HOLDERS_LIMIT_MAX).optional(),
+    sort: sortSchema([
+      "top1_share",
+      "top5_share",
+      "top10_share",
+      "top20_share",
+      "holder_count",
+      "total_alpha",
+    ]).optional(),
+    limit: limitSchema(
+      CHAIN_HOLDERS_LIMIT_MAX,
+      CHAIN_HOLDERS_LIMIT_DEFAULT,
+    ).optional(),
   })
   .strict();
 export type GetChainHoldersInput = z.infer<typeof GetChainHoldersInputSchema>;
@@ -39,7 +44,7 @@ export const GetChainHoldersOutputSchema = z
     subnets: z.array(
       z
         .object({
-          netuid: z.int(),
+          netuid: netuidSchema(),
           holder_count: z.int().nullable(),
           total_alpha: z.number().nullable(),
           top1_share: z.number().nullable(),

--- a/schemas-src/mcp-tools/get-domain-summary.ts
+++ b/schemas-src/mcp-tools/get-domain-summary.ts
@@ -31,7 +31,10 @@ const DOMAIN_TAGS = [
 
 export const GetDomainSummaryInputSchema = z
   .object({
-    domain: z.enum(DOMAIN_TAGS).optional(),
+    domain: z
+      .enum(DOMAIN_TAGS)
+      .optional()
+      .describe("The subnet's primary domain of use."),
   })
   .strict();
 export type GetDomainSummaryInput = z.infer<typeof GetDomainSummaryInputSchema>;

--- a/schemas-src/mcp-tools/get-economics-trends.ts
+++ b/schemas-src/mcp-tools/get-economics-trends.ts
@@ -5,12 +5,13 @@
 // hardcoded from src/neuron-history.ts's HISTORY_WINDOWS at the time of
 // writing (mirrors get-subnet-turnover.ts's same precedent this batch).
 import { z } from "zod";
+import { windowSchema } from "./shared.ts";
 
 const HISTORY_WINDOWS = ["7d", "30d", "90d", "1y", "all"] as const;
 
 export const GetEconomicsTrendsInputSchema = z
   .object({
-    window: z.enum(HISTORY_WINDOWS).optional(),
+    window: windowSchema(HISTORY_WINDOWS).optional(),
   })
   .strict();
 export type GetEconomicsTrendsInput = z.infer<

--- a/schemas-src/mcp-tools/get-economics.ts
+++ b/schemas-src/mcp-tools/get-economics.ts
@@ -11,7 +11,15 @@
 // constraint means NOT tightening beyond what already shipped, even though
 // the real per-row data happens to satisfy the deeper REST schema too.
 import { z } from "zod";
-import { fieldsSchema, netuidSchema, offsetSchema } from "./shared.ts";
+import {
+  fieldsSchema,
+  limitSchema,
+  netuidSchema,
+  offsetSchema,
+  orderSchema,
+  querySchema,
+  sortSchema,
+} from "./shared.ts";
 
 const ECONOMICS_SORT_FIELDS = [
   "alpha_fdv_tao",
@@ -40,15 +48,18 @@ const ECONOMICS_SORT_FIELDS = [
 export const GetEconomicsInputSchema = z
   .object({
     netuid: netuidSchema().optional(),
-    registration_allowed: z.enum(["true", "false"]).optional(),
-    q: z.string().optional(),
-    sort: z.enum(ECONOMICS_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
+    registration_allowed: z
+      .enum(["true", "false"])
+      .optional()
+      .describe("Restrict to subnets currently accepting registrations."),
+    q: querySchema().optional(),
+    sort: sortSchema(ECONOMICS_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
     // `sort` and `order` were enums while this was a bare string with no stated
     // format anywhere — comma-separated? a JSON array? — so the one parameter an agent
     // could not guess was the only one left undocumented.
     fields: fieldsSchema().optional(),
-    limit: z.int().min(1).max(1000).optional(),
+    limit: limitSchema(1000).optional(),
     cursor: offsetSchema().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/get-emission-changes.ts
+++ b/schemas-src/mcp-tools/get-emission-changes.ts
@@ -1,12 +1,19 @@
 // get_emission_changes (#9615): the emission-gate change log, mirroring
 // GET /api/v1/chain/governance/emission-changes.
 import { z } from "zod";
-import { EMISSION_CHANGES_LIMIT_MAX } from "../../src/route-limits.ts";
+import { kindSchema, limitSchema } from "./shared.ts";
+import {
+  EMISSION_CHANGES_LIMIT_DEFAULT,
+  EMISSION_CHANGES_LIMIT_MAX,
+} from "../../src/route-limits.ts";
 
 export const GetEmissionChangesInputSchema = z
   .object({
-    kind: z.enum(["param", "subnet", "flow"]).optional(),
-    limit: z.int().min(1).max(EMISSION_CHANGES_LIMIT_MAX).optional(),
+    kind: kindSchema(["param", "subnet", "flow"]).optional(),
+    limit: limitSchema(
+      EMISSION_CHANGES_LIMIT_MAX,
+      EMISSION_CHANGES_LIMIT_DEFAULT,
+    ).optional(),
   })
   .strict();
 export type GetEmissionChangesInput = z.infer<

--- a/schemas-src/mcp-tools/get-emission-pipeline-history.ts
+++ b/schemas-src/mcp-tools/get-emission-pipeline-history.ts
@@ -1,14 +1,18 @@
 // get_emission_pipeline_history (#9625): one subnet's pipeline decomposition
 // over time, mirroring GET /api/v1/subnets/{netuid}/emission-pipeline/history.
 import { z } from "zod";
+import { netuidSchema } from "./shared.ts";
 import { PIPELINE_HISTORY_WINDOWS } from "../../src/route-limits.ts";
 
 export const GetPipelineHistoryInputSchema = z
   .object({
-    netuid: z.int().min(0).max(65535),
+    netuid: netuidSchema(),
     window: z
       .enum(PIPELINE_HISTORY_WINDOWS as [string, ...string[]])
-      .optional(),
+      .optional()
+      .describe(
+        "Trailing time window to aggregate over, ending at the latest data point rather than a calendar boundary. Options are per-tool; see this parameter's enum.",
+      ),
   })
   .strict();
 export type GetPipelineHistoryInput = z.infer<
@@ -18,7 +22,7 @@ export type GetPipelineHistoryInput = z.infer<
 export const GetPipelineHistoryOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable(),
     point_count: z.int().nullable(),
     distinct_observations: z.int().nullable(),

--- a/schemas-src/mcp-tools/get-emission-pipeline.ts
+++ b/schemas-src/mcp-tools/get-emission-pipeline.ts
@@ -12,13 +12,14 @@
 // together and there is exactly one place to fix — which is the whole point of
 // not keeping a second copy here.
 import { z } from "zod";
+import { netuidSchema } from "./shared.ts";
 import { EMISSION_PIPELINE_BODY } from "../routes/emission-pipeline.ts";
 
 export const GetEmissionPipelineInputSchema = z
   .object({
     // Narrows the per-subnet rows only; the aggregate and the identity checks
     // stay network-wide, matching ?netuid= on the REST route.
-    netuid: z.int().min(0).optional(),
+    netuid: netuidSchema().optional(),
   })
   .strict();
 export type GetEmissionPipelineInput = z.infer<

--- a/schemas-src/mcp-tools/get-failure-reasons.ts
+++ b/schemas-src/mcp-tools/get-failure-reasons.ts
@@ -1,13 +1,19 @@
 // get_failure_reasons (#9622): why surfaces fail and whether the mix is
 // changing, mirroring GET /api/v1/health/failure-reasons.
 import { z } from "zod";
+import { kindStringSchema, netuidSchema } from "./shared.ts";
 import { FAILURE_REASONS_WINDOWS } from "../../src/route-limits.ts";
 
 export const GetFailureReasonsInputSchema = z
   .object({
-    window: z.enum(FAILURE_REASONS_WINDOWS as [string, ...string[]]).optional(),
-    netuid: z.int().min(0).max(65535).optional(),
-    kind: z.string().optional(),
+    window: z
+      .enum(FAILURE_REASONS_WINDOWS as [string, ...string[]])
+      .optional()
+      .describe(
+        "Trailing time window to aggregate over, ending at the latest data point rather than a calendar boundary. Options are per-tool; see this parameter's enum.",
+      ),
+    netuid: netuidSchema().optional(),
+    kind: kindStringSchema().optional(),
   })
   .strict();
 export type GetFailureReasonsInput = z.infer<
@@ -18,7 +24,7 @@ export const GetFailureReasonsOutputSchema = z
   .object({
     schema_version: z.int().optional(),
     window: z.string().nullable(),
-    netuid: z.int().nullable(),
+    netuid: netuidSchema().nullable(),
     kind: z.string().nullable(),
     days_covered: z.int().nullable(),
     oldest_day: z.string().nullable(),

--- a/schemas-src/mcp-tools/get-global-incidents.ts
+++ b/schemas-src/mcp-tools/get-global-incidents.ts
@@ -3,7 +3,16 @@
 // pilot routes -- no existing Zod schema to reuse. Modeled fresh, shallow,
 // from the hand-written literal it replaces.
 import { z } from "zod";
-import { OpenObjectArraySchema, OpenObjectSchema } from "./shared.ts";
+import {
+  OpenObjectArraySchema,
+  OpenObjectSchema,
+  limitSchema,
+  netuidSchema,
+  numericCursorSchema,
+  orderSchema,
+  sortSchema,
+  windowSchema,
+} from "./shared.ts";
 
 // Symbolic in the hand-written original (src/contracts.ts's
 // API_QUERY_COLLECTIONS.incidents.sort_fields), cross-checked against the
@@ -17,12 +26,12 @@ const GLOBAL_INCIDENTS_SORT_FIELDS = [
 
 export const GetGlobalIncidentsInputSchema = z
   .object({
-    window: z.enum(["7d", "30d"]).optional(),
-    netuid: z.int().min(0).optional(),
-    sort: z.enum(GLOBAL_INCIDENTS_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    window: windowSchema(["7d", "30d"]).optional(),
+    netuid: netuidSchema().optional(),
+    sort: sortSchema(GLOBAL_INCIDENTS_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type GetGlobalIncidentsInput = z.infer<

--- a/schemas-src/mcp-tools/get-health-history.ts
+++ b/schemas-src/mcp-tools/get-health-history.ts
@@ -7,7 +7,18 @@
 // .sort_fields at the time of writing (mirrors the pilot batch's
 // ECONOMICS_SORT_FIELDS precedent -- not cross-imported).
 import { z } from "zod";
-import { OpenObjectArraySchema, OpenObjectSchema } from "./shared.ts";
+import {
+  OpenObjectArraySchema,
+  OpenObjectSchema,
+  fieldsStringSchema,
+  kindSchema,
+  limitSchema,
+  netuidSchema,
+  numericCursorSchema,
+  orderSchema,
+  providerSlugSchema,
+  sortSchema,
+} from "./shared.ts";
 
 const SURFACE_KIND = [
   "archive",
@@ -55,17 +66,28 @@ const HEALTH_SURFACE_SORT_FIELDS = [
 
 export const GetHealthHistoryInputSchema = z
   .object({
-    date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
-    netuid: z.int().min(0).optional(),
-    kind: z.enum(SURFACE_KIND).optional(),
-    provider: z.string().optional(),
-    status: z.enum(HEALTH_STATUS).optional(),
-    classification: z.enum(HEALTH_CLASSIFICATION).optional(),
-    sort: z.enum(HEALTH_SURFACE_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(1000).optional(),
-    cursor: z.int().min(0).optional(),
+    date: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .describe("A single UTC day, `YYYY-MM-DD`."),
+    netuid: netuidSchema().optional(),
+    kind: kindSchema(SURFACE_KIND).optional(),
+    provider: providerSlugSchema().optional(),
+    status: z
+      .enum(HEALTH_STATUS)
+      .optional()
+      .describe("Restrict to rows with this health status."),
+    classification: z
+      .enum(HEALTH_CLASSIFICATION)
+      .optional()
+      .describe(
+        "Why a probe ended as it did — the reason behind the status, not the status itself.",
+      ),
+    sort: sortSchema(HEALTH_SURFACE_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(1000).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type GetHealthHistoryInput = z.infer<typeof GetHealthHistoryInputSchema>;

--- a/schemas-src/mcp-tools/get-registry-leaderboards.ts
+++ b/schemas-src/mcp-tools/get-registry-leaderboards.ts
@@ -5,7 +5,7 @@
 // from src/health-serving.ts's LEADERBOARD_BOARDS (base 6 boards +
 // ECONOMIC_BOARD_SPECS's 6 keys) at the time of writing.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import { OpenObjectSchema, limitSchema } from "./shared.ts";
 
 const LEADERBOARD_BOARDS = [
   "healthiest",
@@ -24,8 +24,11 @@ const LEADERBOARD_BOARDS = [
 
 export const GetRegistryLeaderboardsInputSchema = z
   .object({
-    board: z.enum(LEADERBOARD_BOARDS).optional(),
-    limit: z.int().min(1).max(100).optional(),
+    board: z
+      .enum(LEADERBOARD_BOARDS)
+      .optional()
+      .describe("Which leaderboard to return."),
+    limit: limitSchema(100).optional(),
   })
   .strict();
 export type GetRegistryLeaderboardsInput = z.infer<

--- a/schemas-src/mcp-tools/get-stake-action-preview.ts
+++ b/schemas-src/mcp-tools/get-stake-action-preview.ts
@@ -7,14 +7,20 @@
 // replaces, which (unlike most tools in this batch) already declared its
 // own outputSchema inline rather than via TOOL_OUTPUT_SCHEMAS.
 import { z } from "zod";
+import { kindSchema, netuidSchema } from "./shared.ts";
 
 const STAKE_QUOTE_DIRECTIONS = ["stake", "unstake"] as const;
 
 export const GetStakeActionPreviewInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    amount: z.number().gt(0),
-    direction: z.enum(STAKE_QUOTE_DIRECTIONS).optional(),
+    netuid: netuidSchema(),
+    amount: z
+      .number()
+      .gt(0)
+      .describe(
+        "Amount to quote, in TAO when staking and in alpha when unstaking. Must be greater than 0.",
+      ),
+    direction: kindSchema(STAKE_QUOTE_DIRECTIONS).optional(),
   })
   .strict();
 export type GetStakeActionPreviewInput = z.infer<
@@ -30,7 +36,7 @@ const EstimatedOutSchema = z
 
 export const GetStakeActionPreviewOutputSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     direction: z.string(),
     amount: z.number(),
     summary: z.string(),

--- a/schemas-src/mcp-tools/get-subnet-concentration-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-concentration-history.ts
@@ -4,13 +4,14 @@
 // Zod schema to reuse. Modeled fresh, shallow, from the hand-written
 // literal it replaces.
 import { z } from "zod";
+import { netuidSchema, windowSchema } from "./shared.ts";
 
 const CONCENTRATION_HISTORY_WINDOWS = ["7d", "30d", "90d"] as const;
 
 export const GetSubnetConcentrationHistoryInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    window: z.enum(CONCENTRATION_HISTORY_WINDOWS).optional(),
+    netuid: netuidSchema(),
+    window: windowSchema(CONCENTRATION_HISTORY_WINDOWS).optional(),
   })
   .strict();
 export type GetSubnetConcentrationHistoryInput = z.infer<
@@ -35,7 +36,7 @@ const ConcentrationHistoryPointSchema = z
 export const GetSubnetConcentrationHistoryOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable().optional(),
     point_count: z.int(),
     points: z.array(ConcentrationHistoryPointSchema),

--- a/schemas-src/mcp-tools/get-subnet-concentration.ts
+++ b/schemas-src/mcp-tools/get-subnet-concentration.ts
@@ -3,11 +3,11 @@
 // schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
 // reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import { OpenObjectSchema, netuidSchema } from "./shared.ts";
 
 export const GetSubnetConcentrationInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetConcentrationInput = z.infer<
@@ -17,7 +17,7 @@ export type GetSubnetConcentrationInput = z.infer<
 export const GetSubnetConcentrationOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     neuron_count: z.int(),
     entity_count: z.int().optional(),
     uids_per_entity: z.number().nullable().optional(),

--- a/schemas-src/mcp-tools/get-subnet-detail.ts
+++ b/schemas-src/mcp-tools/get-subnet-detail.ts
@@ -9,12 +9,12 @@
 // look-but-don't-reuse finding as get-network-health.ts/get-economics.ts in
 // the pilot batch).
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import { OpenObjectSchema, netuidSchema } from "./shared.ts";
 import { McpNetworkSchema } from "../shared.ts";
 
 export const GetSubnetDetailInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
     network: McpNetworkSchema.optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/get-subnet-economics.ts
+++ b/schemas-src/mcp-tools/get-subnet-economics.ts
@@ -4,11 +4,11 @@
 // SubnetEconomicsSchema (schemas-src/shared.ts) or EconomicsArtifactSchema.
 // Modeled fresh, shallow, from the hand-written literal it replaces.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import { OpenObjectSchema, netuidSchema } from "./shared.ts";
 
 export const GetSubnetEconomicsInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetEconomicsInput = z.infer<
@@ -17,7 +17,7 @@ export type GetSubnetEconomicsInput = z.infer<
 
 export const GetSubnetEconomicsOutputSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     source: z.string().nullable().optional(),
     captured_at: z.string().nullable().optional(),
     summary: OpenObjectSchema.nullable().optional(),

--- a/schemas-src/mcp-tools/get-subnet-event-summary.ts
+++ b/schemas-src/mcp-tools/get-subnet-event-summary.ts
@@ -7,10 +7,18 @@
 // src/account-events.ts's SUBNET_EVENT_SUMMARY_WINDOWS at the time of
 // writing.
 import { z } from "zod";
-import { OpenObjectArraySchema } from "./shared.ts";
+import {
+  SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
+  SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
+} from "../../src/route-limits.ts";
+import {
+  OpenObjectArraySchema,
+  limitSchema,
+  netuidSchema,
+  windowSchema,
+} from "./shared.ts";
 
 const SUBNET_EVENT_SUMMARY_WINDOWS = ["7d", "30d", "90d"] as const;
-const SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX = 50;
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
@@ -46,9 +54,12 @@ const EventKindSummarySchema = z
 
 export const GetSubnetEventSummaryInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    window: z.enum(SUBNET_EVENT_SUMMARY_WINDOWS).optional(),
-    limit: z.int().min(1).max(SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX).optional(),
+    netuid: netuidSchema(),
+    window: windowSchema(SUBNET_EVENT_SUMMARY_WINDOWS).optional(),
+    limit: limitSchema(
+      SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
+      SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
+    ).optional(),
   })
   .strict();
 export type GetSubnetEventSummaryInput = z.infer<
@@ -58,7 +69,7 @@ export type GetSubnetEventSummaryInput = z.infer<
 export const GetSubnetEventSummaryOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable(),
     observed_at: z.string().nullable().optional(),
     total_events: z.int(),

--- a/schemas-src/mcp-tools/get-subnet-events.ts
+++ b/schemas-src/mcp-tools/get-subnet-events.ts
@@ -7,16 +7,24 @@
 // schema_version optional too. Modeled fresh instead, matching the
 // hand-written literal it replaces field-for-field.
 import { z } from "zod";
+import {
+  blockBoundSchema,
+  keysetCursorSchema,
+  kindStringSchema,
+  limitSchema,
+  netuidSchema,
+  offsetSchema,
+} from "./shared.ts";
 
 export const GetSubnetEventsInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    kind: z.string().optional(),
-    block_start: z.int().min(0).optional(),
-    block_end: z.int().min(0).optional(),
-    limit: z.int().min(1).max(1000).optional(),
-    offset: z.int().min(0).optional(),
-    cursor: z.string().optional(),
+    netuid: netuidSchema(),
+    kind: kindStringSchema().optional(),
+    block_start: blockBoundSchema("first").optional(),
+    block_end: blockBoundSchema("last").optional(),
+    limit: limitSchema(1000).optional(),
+    offset: offsetSchema().optional(),
+    cursor: keysetCursorSchema().optional(),
   })
   .strict();
 export type GetSubnetEventsInput = z.infer<typeof GetSubnetEventsInputSchema>;
@@ -30,7 +38,7 @@ const AccountEventItemSchema = z
     event_kind: z.string().nullable().optional(),
     hotkey: z.string().nullable().optional(),
     coldkey: z.string().nullable().optional(),
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     uid: z.int().nullable().optional(),
     amount_tao: z.unknown().optional(),
     alpha_amount: z.unknown().optional(),
@@ -42,7 +50,7 @@ const AccountEventItemSchema = z
 export const GetSubnetEventsOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     event_count: z.int(),
     limit: z.int().nullable().optional(),
     offset: z.int().nullable().optional(),

--- a/schemas-src/mcp-tools/get-subnet-health-incidents.ts
+++ b/schemas-src/mcp-tools/get-subnet-health-incidents.ts
@@ -3,13 +3,14 @@
 // schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
 // reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
 import { z } from "zod";
+import { netuidSchema, windowSchema } from "./shared.ts";
 
 const HEALTH_WINDOWS = ["7d", "30d"] as const;
 
 export const GetSubnetHealthIncidentsInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    window: z.enum(HEALTH_WINDOWS).optional(),
+    netuid: netuidSchema(),
+    window: windowSchema(HEALTH_WINDOWS).optional(),
   })
   .strict();
 export type GetSubnetHealthIncidentsInput = z.infer<
@@ -43,7 +44,7 @@ const GetSubnetHealthIncidentsSurfaceSchema = z
 export const GetSubnetHealthIncidentsOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable().optional(),
     observed_at: z.string().nullable().optional(),
     source: z.string().nullable().optional(),

--- a/schemas-src/mcp-tools/get-subnet-health-percentiles.ts
+++ b/schemas-src/mcp-tools/get-subnet-health-percentiles.ts
@@ -3,13 +3,14 @@
 // of schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
 // reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
 import { z } from "zod";
+import { netuidSchema, windowSchema } from "./shared.ts";
 
 const HEALTH_WINDOWS = ["7d", "30d"] as const;
 
 export const GetSubnetHealthPercentilesInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    window: z.enum(HEALTH_WINDOWS).optional(),
+    netuid: netuidSchema(),
+    window: windowSchema(HEALTH_WINDOWS).optional(),
   })
   .strict();
 export type GetSubnetHealthPercentilesInput = z.infer<
@@ -38,7 +39,7 @@ const GetSubnetHealthPercentilesSurfaceSchema = z
 export const GetSubnetHealthPercentilesOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable().optional(),
     observed_at: z.string().nullable().optional(),
     source: z.string().nullable().optional(),

--- a/schemas-src/mcp-tools/get-subnet-health-trends.ts
+++ b/schemas-src/mcp-tools/get-subnet-health-trends.ts
@@ -3,11 +3,11 @@
 // schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
 // reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import { OpenObjectSchema, netuidSchema } from "./shared.ts";
 
 export const GetSubnetHealthTrendsInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetHealthTrendsInput = z.infer<
@@ -17,7 +17,7 @@ export type GetSubnetHealthTrendsInput = z.infer<
 export const GetSubnetHealthTrendsOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     observed_at: z.string().nullable().optional(),
     source: z.string().nullable().optional(),
     windows: OpenObjectSchema,

--- a/schemas-src/mcp-tools/get-subnet-health.ts
+++ b/schemas-src/mcp-tools/get-subnet-health.ts
@@ -3,11 +3,11 @@
 // schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
 // reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import { OpenObjectSchema, netuidSchema } from "./shared.ts";
 
 export const GetSubnetHealthInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetHealthInput = z.infer<typeof GetSubnetHealthInputSchema>;
@@ -17,7 +17,7 @@ export type GetSubnetHealthInput = z.infer<typeof GetSubnetHealthInputSchema>;
 const GetSubnetHealthSurfaceSchema = z
   .object({
     surface_id: z.string().optional(),
-    netuid: z.int().optional(),
+    netuid: netuidSchema().optional(),
     kind: z.string().nullable().optional(),
     status: z.string().optional(),
     latency_ms: z.int().nullable().optional(),
@@ -28,7 +28,7 @@ const GetSubnetHealthSurfaceSchema = z
 
 export const GetSubnetHealthOutputSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     summary: OpenObjectSchema,
     operational_observed_at: z.string().nullable().optional(),
     surfaces: z.array(GetSubnetHealthSurfaceSchema),

--- a/schemas-src/mcp-tools/get-subnet-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-history.ts
@@ -7,13 +7,14 @@
 // (require the key) the existing contract in different ways -- modeled
 // fresh instead, matching the original exactly.
 import { z } from "zod";
+import { netuidSchema, windowSchema } from "./shared.ts";
 
 const HISTORY_WINDOWS = ["7d", "30d", "90d", "1y", "all"] as const;
 
 export const GetSubnetHistoryInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    window: z.enum(HISTORY_WINDOWS).optional(),
+    netuid: netuidSchema(),
+    window: windowSchema(HISTORY_WINDOWS).optional(),
   })
   .strict();
 export type GetSubnetHistoryInput = z.infer<typeof GetSubnetHistoryInputSchema>;
@@ -33,7 +34,7 @@ const SubnetHistoryPointSchema = z
 export const GetSubnetHistoryOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable().optional(),
     point_count: z.int(),
     points: z.array(SubnetHistoryPointSchema),

--- a/schemas-src/mcp-tools/get-subnet-holders.ts
+++ b/schemas-src/mcp-tools/get-subnet-holders.ts
@@ -6,12 +6,19 @@
 // output is read by a model, so it stays permissive about extra keys and states
 // only the fields a caller may rely on.
 import { z } from "zod";
-import { SUBNET_HOLDERS_LIMIT_MAX } from "../../src/route-limits.ts";
+import { limitSchema, netuidSchema } from "./shared.ts";
+import {
+  SUBNET_HOLDERS_LIMIT_DEFAULT,
+  SUBNET_HOLDERS_LIMIT_MAX,
+} from "../../src/route-limits.ts";
 
 export const GetSubnetHoldersInputSchema = z
   .object({
-    netuid: z.int().min(0).max(65535),
-    limit: z.int().min(1).max(SUBNET_HOLDERS_LIMIT_MAX).optional(),
+    netuid: netuidSchema(),
+    limit: limitSchema(
+      SUBNET_HOLDERS_LIMIT_MAX,
+      SUBNET_HOLDERS_LIMIT_DEFAULT,
+    ).optional(),
   })
   .strict();
 export type GetSubnetHoldersInput = z.infer<typeof GetSubnetHoldersInputSchema>;
@@ -19,7 +26,7 @@ export type GetSubnetHoldersInput = z.infer<typeof GetSubnetHoldersInputSchema>;
 export const GetSubnetHoldersOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     limit: z.int().nullable(),
     // Whole-subnet, never bounded by the returned page.
     holder_count: z.int().nullable(),

--- a/schemas-src/mcp-tools/get-subnet-hyperparams.ts
+++ b/schemas-src/mcp-tools/get-subnet-hyperparams.ts
@@ -4,11 +4,17 @@
 // covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
 // shallow, from the hand-written literals they replace.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import {
+  OpenObjectSchema,
+  keysetCursorSchema,
+  limitSchema,
+  netuidSchema,
+  offsetSchema,
+} from "./shared.ts";
 
 export const GetSubnetHyperparamsInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetHyperparamsInput = z.infer<
@@ -18,7 +24,7 @@ export type GetSubnetHyperparamsInput = z.infer<
 export const GetSubnetHyperparamsOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     captured_at: z.string().nullable().optional(),
     block_number: z.int().nullable().optional(),
     hyperparameters: OpenObjectSchema.nullable().optional(),
@@ -30,10 +36,10 @@ export type GetSubnetHyperparamsOutput = z.infer<
 
 export const GetSubnetHyperparamsHistoryInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    limit: z.int().min(1).max(1000).optional(),
-    offset: z.int().min(0).optional(),
-    cursor: z.string().optional(),
+    netuid: netuidSchema(),
+    limit: limitSchema(1000).optional(),
+    offset: offsetSchema().optional(),
+    cursor: keysetCursorSchema().optional(),
   })
   .strict();
 export type GetSubnetHyperparamsHistoryInput = z.infer<
@@ -54,7 +60,7 @@ const HyperparamsHistoryEntrySchema = z
 export const GetSubnetHyperparamsHistoryOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     entry_count: z.int(),
     limit: z.int().nullable().optional(),
     offset: z.int().nullable().optional(),

--- a/schemas-src/mcp-tools/get-subnet-identity-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-identity-history.ts
@@ -17,13 +17,19 @@
 // here as nullable (still required -- the key itself is always present),
 // matching real behavior.
 import { z } from "zod";
+import {
+  keysetCursorSchema,
+  limitSchema,
+  netuidSchema,
+  offsetSchema,
+} from "./shared.ts";
 
 export const GetSubnetIdentityHistoryInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    limit: z.int().min(1).max(1000).optional(),
-    offset: z.int().min(0).optional(),
-    cursor: z.string().optional(),
+    netuid: netuidSchema(),
+    limit: limitSchema(1000).optional(),
+    offset: offsetSchema().optional(),
+    cursor: keysetCursorSchema().optional(),
   })
   .strict();
 export type GetSubnetIdentityHistoryInput = z.infer<
@@ -51,7 +57,7 @@ const SubnetIdentityHistoryEntrySchema = z
 export const GetSubnetIdentityHistoryOutputSchema = z
   .object({
     schema_version: z.int(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     entry_count: z.int(),
     limit: z.int().nullable().optional(),
     offset: z.int().nullable().optional(),

--- a/schemas-src/mcp-tools/get-subnet-idle-stake.ts
+++ b/schemas-src/mcp-tools/get-subnet-idle-stake.ts
@@ -3,10 +3,11 @@
 // schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
 // reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
 import { z } from "zod";
+import { netuidSchema } from "./shared.ts";
 
 export const GetSubnetIdleStakeInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetIdleStakeInput = z.infer<
@@ -16,7 +17,7 @@ export type GetSubnetIdleStakeInput = z.infer<
 export const GetSubnetIdleStakeOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     captured_at: z.string().nullable().optional(),
     neuron_count: z.int(),
     idle_neuron_count: z.int(),

--- a/schemas-src/mcp-tools/get-subnet-lease.ts
+++ b/schemas-src/mcp-tools/get-subnet-lease.ts
@@ -4,11 +4,12 @@
 // no existing Zod schema to reuse. Modeled fresh, shallow, from the
 // hand-written literals they replace.
 import { z } from "zod";
+import { netuidSchema } from "./shared.ts";
 import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
 
 export const GetSubnetLeaseInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
     // #8700: which chain to read. These routes answer from live storage, and
     // the storage keys are twox128 hashes of pallet+item names — identical on
     // every chain running the same runtime — so the endpoint is the only thing
@@ -26,7 +27,7 @@ const LeaseDetailSchema = z
     hotkey: z.string().optional(),
     emissions_share_percent: z.int().optional(),
     end_block: z.int().nullable().optional(),
-    netuid: z.int().optional(),
+    netuid: netuidSchema().optional(),
     cost_tao: z.number().optional(),
     accumulated_dividends_alpha: z.number().nullable().optional(),
   })
@@ -35,7 +36,7 @@ const LeaseDetailSchema = z
 export const GetSubnetLeaseOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     leased: z.boolean().nullable(),
     lease: LeaseDetailSchema.nullable().optional(),
     queried_at: z.string().nullable().optional(),
@@ -47,7 +48,7 @@ export type GetSubnetLeaseOutput = z.infer<typeof GetSubnetLeaseOutputSchema>;
 
 export const GetSubnetLeaseHistoryInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetLeaseHistoryInput = z.infer<
@@ -66,7 +67,7 @@ const LeaseEventSchema = z
 export const GetSubnetLeaseHistoryOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     count: z.int(),
     lease_events: z.array(LeaseEventSchema),
   })

--- a/schemas-src/mcp-tools/get-subnet-metagraph.ts
+++ b/schemas-src/mcp-tools/get-subnet-metagraph.ts
@@ -3,12 +3,21 @@
 // schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
 // reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
 import { z } from "zod";
-import { NeuronFieldsInputSchema, OpenObjectArraySchema } from "./shared.ts";
+import {
+  NeuronFieldsInputSchema,
+  OpenObjectArraySchema,
+  netuidSchema,
+} from "./shared.ts";
 
 export const GetSubnetMetagraphInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    validator_permit: z.boolean().optional(),
+    netuid: netuidSchema(),
+    validator_permit: z
+      .boolean()
+      .optional()
+      .describe(
+        "Restrict to neurons that hold (`true`) or lack (`false`) a validator permit.",
+      ),
     // #9082: narrow each returned row to these fields. Omit for the full
     // row. Valid names are NeuronSchema's own, so this enum cannot drift
     // from what the route can project.
@@ -22,7 +31,7 @@ export type GetSubnetMetagraphInput = z.infer<
 export const GetSubnetMetagraphOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     neuron_count: z.int(),
     captured_at: z.string().nullable().optional(),
     block_number: z.int().nullable().optional(),

--- a/schemas-src/mcp-tools/get-subnet-movers.ts
+++ b/schemas-src/mcp-tools/get-subnet-movers.ts
@@ -7,16 +7,25 @@
 // cross-imported, to avoid a runtime dependency for what is purely a wire-
 // schema enum).
 import { z } from "zod";
+import {
+  MOVERS_LIMIT_DEFAULT,
+  MOVERS_LIMIT_MAX,
+} from "../../src/route-limits.ts";
+import {
+  limitSchema,
+  netuidSchema,
+  sortSchema,
+  windowSchema,
+} from "./shared.ts";
 
 const MOVERS_WINDOW_KEYS = ["7d", "30d", "90d"] as const;
 const MOVERS_SORTS = ["stake", "emission", "validators", "neurons"] as const;
-const MOVERS_LIMIT_MAX = 100;
 
 export const GetSubnetMoversInputSchema = z
   .object({
-    window: z.enum(MOVERS_WINDOW_KEYS).optional(),
-    sort: z.enum(MOVERS_SORTS).optional(),
-    limit: z.int().min(1).max(MOVERS_LIMIT_MAX).optional(),
+    window: windowSchema(MOVERS_WINDOW_KEYS).optional(),
+    sort: sortSchema(MOVERS_SORTS).optional(),
+    limit: limitSchema(MOVERS_LIMIT_MAX, MOVERS_LIMIT_DEFAULT).optional(),
   })
   .strict();
 export type GetSubnetMoversInput = z.infer<typeof GetSubnetMoversInputSchema>;
@@ -25,7 +34,7 @@ export type GetSubnetMoversInput = z.infer<typeof GetSubnetMoversInputSchema>;
 // search-subnets.ts's same note from the pilot batch).
 const GetSubnetMoverItemSchema = z
   .object({
-    netuid: z.int().optional(),
+    netuid: netuidSchema().optional(),
     stake_start_alpha: z.unknown().optional(),
     stake_end_alpha: z.unknown().optional(),
     stake_delta_alpha: z.unknown().optional(),

--- a/schemas-src/mcp-tools/get-subnet-ownership-conviction.ts
+++ b/schemas-src/mcp-tools/get-subnet-ownership-conviction.ts
@@ -5,11 +5,12 @@
 // Zod schema to reuse. Modeled fresh, shallow, from the hand-written
 // literals they replace.
 import { z } from "zod";
+import { netuidSchema } from "./shared.ts";
 import { FieldSourcesSchema } from "../shared.ts";
 
 export const GetSubnetOwnershipHistoryInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetOwnershipHistoryInput = z.infer<
@@ -18,7 +19,7 @@ export type GetSubnetOwnershipHistoryInput = z.infer<
 
 const OwnershipChangeSchema = z
   .object({
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     old_coldkey: z.string().nullable().optional(),
     new_coldkey: z.string().nullable().optional(),
     block_number: z.int().nullable().optional(),
@@ -29,7 +30,7 @@ const OwnershipChangeSchema = z
 export const GetSubnetOwnershipHistoryOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     count: z.int(),
     ownership_changes: z.array(OwnershipChangeSchema),
   })
@@ -40,7 +41,7 @@ export type GetSubnetOwnershipHistoryOutput = z.infer<
 
 export const GetSubnetConvictionInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetConvictionInput = z.infer<
@@ -59,7 +60,7 @@ const ConvictionLeaderboardEntrySchema = z
 export const GetSubnetConvictionOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     queried_at_block: z.int().nullable().optional(),
     unlock_rate: z.int().nullable().optional(),
     maturity_rate: z.int().nullable().optional(),

--- a/schemas-src/mcp-tools/get-subnet-performance-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-performance-history.ts
@@ -4,14 +4,14 @@
 // schema to reuse. Modeled fresh, shallow, from the hand-written literal it
 // replaces.
 import { z } from "zod";
-import { OpenObjectArraySchema } from "./shared.ts";
+import { OpenObjectArraySchema, netuidSchema, windowSchema } from "./shared.ts";
 
 const PERFORMANCE_HISTORY_WINDOWS = ["7d", "30d", "90d"] as const;
 
 export const GetSubnetPerformanceHistoryInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    window: z.enum(PERFORMANCE_HISTORY_WINDOWS).optional(),
+    netuid: netuidSchema(),
+    window: windowSchema(PERFORMANCE_HISTORY_WINDOWS).optional(),
   })
   .strict();
 export type GetSubnetPerformanceHistoryInput = z.infer<
@@ -21,7 +21,7 @@ export type GetSubnetPerformanceHistoryInput = z.infer<
 export const GetSubnetPerformanceHistoryOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable(),
     point_count: z.int(),
     points: OpenObjectArraySchema,

--- a/schemas-src/mcp-tools/get-subnet-performance.ts
+++ b/schemas-src/mcp-tools/get-subnet-performance.ts
@@ -3,11 +3,11 @@
 // schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
 // reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import { OpenObjectSchema, netuidSchema } from "./shared.ts";
 
 export const GetSubnetPerformanceInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetPerformanceInput = z.infer<
@@ -17,7 +17,7 @@ export type GetSubnetPerformanceInput = z.infer<
 export const GetSubnetPerformanceOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     neuron_count: z.int(),
     validator_count: z.int().optional(),
     active_count: z.int().optional(),

--- a/schemas-src/mcp-tools/get-subnet-recycled-burn.ts
+++ b/schemas-src/mcp-tools/get-subnet-recycled-burn.ts
@@ -9,11 +9,12 @@
 // this tool's existing required set. Modeled fresh instead, matching each
 // hand-written literal exactly.
 import { z } from "zod";
+import { netuidSchema, windowSchema } from "./shared.ts";
 import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
 
 export const GetSubnetRecycledInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
     // #8700: which chain to read. These routes answer from live storage, and
     // the storage keys are twox128 hashes of pallet+item names — identical on
     // every chain running the same runtime — so the endpoint is the only thing
@@ -28,7 +29,7 @@ export type GetSubnetRecycledInput = z.infer<
 export const GetSubnetRecycledOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     recycled_tao: z.number().nullable().optional(),
     queried_at: z.string().nullable(),
     // #9104 provenance, mirroring the REST artifact field for field.
@@ -41,7 +42,7 @@ export type GetSubnetRecycledOutput = z.infer<
 
 export const GetSubnetBurnInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
     // #8700: which chain to read. These routes answer from live storage, and
     // the storage keys are twox128 hashes of pallet+item names — identical on
     // every chain running the same runtime — so the endpoint is the only thing
@@ -54,7 +55,7 @@ export type GetSubnetBurnInput = z.infer<typeof GetSubnetBurnInputSchema>;
 export const GetSubnetBurnOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     burn_tao: z.number().nullable().optional(),
     queried_at: z.string().nullable(),
     // #9104 provenance, mirroring the REST artifact field for field.
@@ -91,8 +92,8 @@ export type GetChainBurnOutput = z.infer<typeof GetChainBurnOutputSchema>;
 // #9402: one subnet's registration-cost series.
 export const GetSubnetBurnHistoryInputSchema = z
   .object({
-    netuid: z.int().min(0).max(65535),
-    window: z.enum(["24h", "7d", "30d", "90d"]).optional(),
+    netuid: netuidSchema(),
+    window: windowSchema(["24h", "7d", "30d", "90d"]).optional(),
   })
   .strict();
 export type GetSubnetBurnHistoryInput = z.infer<
@@ -102,7 +103,7 @@ export type GetSubnetBurnHistoryInput = z.infer<
 export const GetSubnetBurnHistoryOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable(),
     point_count: z.int(),
     current_burn_tao: z.number().nullable(),

--- a/schemas-src/mcp-tools/get-subnet-snapshot.ts
+++ b/schemas-src/mcp-tools/get-subnet-snapshot.ts
@@ -4,13 +4,26 @@
 // schemas-src schema to reuse. Modeled fresh, shallow, from the hand-written
 // literal it replaces.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import { OpenObjectSchema, netuidSchema } from "./shared.ts";
 
 export const GetSubnetSnapshotInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    top_validators_limit: z.int().min(1).optional(),
-    recent_events_limit: z.int().min(1).max(1000).optional(),
+    netuid: netuidSchema(),
+    top_validators_limit: z
+      .int()
+      .min(1)
+      .optional()
+      .describe(
+        "How many top validators to include in the embedded validator list.",
+      ),
+    recent_events_limit: z
+      .int()
+      .min(1)
+      .max(1000)
+      .optional()
+      .describe(
+        "How many recent events to embed. Clamped to the tool's ceiling rather than rejected.",
+      ),
   })
   .strict();
 export type GetSubnetSnapshotInput = z.infer<
@@ -19,7 +32,7 @@ export type GetSubnetSnapshotInput = z.infer<
 
 export const GetSubnetSnapshotOutputSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     hyperparameters: OpenObjectSchema,
     concentration: OpenObjectSchema,
     performance: OpenObjectSchema,

--- a/schemas-src/mcp-tools/get-subnet-stake-flow.ts
+++ b/schemas-src/mcp-tools/get-subnet-stake-flow.ts
@@ -6,15 +6,16 @@
 // STAKE_FLOW_WINDOWS/STAKE_FLOW_DIRECTIONS at the time of writing (mirrors
 // the pilot batch's ECONOMICS_SORT_FIELDS precedent -- not cross-imported).
 import { z } from "zod";
+import { kindSchema, netuidSchema, windowSchema } from "./shared.ts";
 
 const STAKE_FLOW_WINDOWS = ["7d", "30d", "90d"] as const;
 const STAKE_FLOW_DIRECTIONS = ["all", "in", "out"] as const;
 
 export const GetSubnetStakeFlowInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    window: z.enum(STAKE_FLOW_WINDOWS).optional(),
-    direction: z.enum(STAKE_FLOW_DIRECTIONS).optional(),
+    netuid: netuidSchema(),
+    window: windowSchema(STAKE_FLOW_WINDOWS).optional(),
+    direction: kindSchema(STAKE_FLOW_DIRECTIONS).optional(),
   })
   .strict();
 export type GetSubnetStakeFlowInput = z.infer<
@@ -24,7 +25,7 @@ export type GetSubnetStakeFlowInput = z.infer<
 export const GetSubnetStakeFlowOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable(),
     total_staked_tao: z.unknown(),
     total_unstaked_tao: z.unknown(),

--- a/schemas-src/mcp-tools/get-subnet-stake-quote.ts
+++ b/schemas-src/mcp-tools/get-subnet-stake-quote.ts
@@ -17,14 +17,20 @@
 // bucket-(a)-equivalent improvement in the PR body, not silently dropped.
 import { SubnetStakeQuoteArtifactSchema } from "../routes/stake-quote.ts";
 import { z } from "zod";
+import { kindSchema, netuidSchema } from "./shared.ts";
 
 const STAKE_QUOTE_DIRECTIONS = ["stake", "unstake"] as const;
 
 export const GetSubnetStakeQuoteInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    amount: z.number().gt(0),
-    direction: z.enum(STAKE_QUOTE_DIRECTIONS).optional(),
+    netuid: netuidSchema(),
+    amount: z
+      .number()
+      .gt(0)
+      .describe(
+        "Amount to quote, in TAO when staking and in alpha when unstaking. Must be greater than 0.",
+      ),
+    direction: kindSchema(STAKE_QUOTE_DIRECTIONS).optional(),
   })
   .strict();
 export type GetSubnetStakeQuoteInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-surface-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-surface-history.ts
@@ -1,12 +1,19 @@
 // get_subnet_surface_history (#9612): one subnet's surface audit trail,
 // mirroring GET /api/v1/subnets/{netuid}/surface-history.
 import { z } from "zod";
-import { SURFACE_HISTORY_LIMIT_MAX } from "../../src/route-limits.ts";
+import { limitSchema, netuidSchema } from "./shared.ts";
+import {
+  SURFACE_HISTORY_LIMIT_DEFAULT,
+  SURFACE_HISTORY_LIMIT_MAX,
+} from "../../src/route-limits.ts";
 
 export const GetSubnetSurfaceHistoryInputSchema = z
   .object({
-    netuid: z.int().min(0).max(65535),
-    limit: z.int().min(1).max(SURFACE_HISTORY_LIMIT_MAX).optional(),
+    netuid: netuidSchema(),
+    limit: limitSchema(
+      SURFACE_HISTORY_LIMIT_MAX,
+      SURFACE_HISTORY_LIMIT_DEFAULT,
+    ).optional(),
   })
   .strict();
 export type GetSubnetSurfaceHistoryInput = z.infer<
@@ -16,7 +23,7 @@ export type GetSubnetSurfaceHistoryInput = z.infer<
 export const GetSubnetSurfaceHistoryOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     limit: z.int().nullable(),
     change_count: z.int(),
     surface_count: z.int(),

--- a/schemas-src/mcp-tools/get-subnet-trajectory.ts
+++ b/schemas-src/mcp-tools/get-subnet-trajectory.ts
@@ -2,11 +2,11 @@
 // "Mirrors" claim in its description and no covered REST route to reuse.
 // Modeled fresh, shallow, from the hand-written literal it replaces.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import { OpenObjectSchema, netuidSchema } from "./shared.ts";
 
 export const GetSubnetTrajectoryInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetTrajectoryInput = z.infer<
@@ -16,7 +16,7 @@ export type GetSubnetTrajectoryInput = z.infer<
 export const GetSubnetTrajectoryOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     point_count: z.int(),
     points: z.array(OpenObjectSchema),
     deltas: OpenObjectSchema.optional(),

--- a/schemas-src/mcp-tools/get-subnet-turnover.ts
+++ b/schemas-src/mcp-tools/get-subnet-turnover.ts
@@ -6,15 +6,20 @@
 // writing (mirrors the pilot batch's ECONOMICS_SORT_FIELDS precedent -- not
 // cross-imported).
 import { z } from "zod";
-import { OpenObjectArraySchema } from "./shared.ts";
+import { OpenObjectArraySchema, netuidSchema, windowSchema } from "./shared.ts";
 
 const HISTORY_WINDOWS = ["7d", "30d", "90d", "1y", "all"] as const;
 
 export const GetSubnetTurnoverInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    window: z.enum(HISTORY_WINDOWS).optional(),
-    changes: z.boolean().optional(),
+    netuid: netuidSchema(),
+    window: windowSchema(HISTORY_WINDOWS).optional(),
+    changes: z
+      .boolean()
+      .optional()
+      .describe(
+        "When true, return only entries that changed rather than every entry.",
+      ),
   })
   .strict();
 export type GetSubnetTurnoverInput = z.infer<
@@ -35,7 +40,7 @@ const TurnoverChangesSchema = z
 export const GetSubnetTurnoverOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable().optional(),
     start_date: z.string().nullable().optional(),
     end_date: z.string().nullable().optional(),

--- a/schemas-src/mcp-tools/get-subnet-uptime.ts
+++ b/schemas-src/mcp-tools/get-subnet-uptime.ts
@@ -3,15 +3,26 @@
 // covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
 // shallow, from the hand-written literal it replaces.
 import { z } from "zod";
-import { OpenObjectArraySchema, OpenObjectSchema } from "./shared.ts";
+import {
+  OpenObjectArraySchema,
+  OpenObjectSchema,
+  netuidSchema,
+  windowSchema,
+} from "./shared.ts";
 
 const UPTIME_WINDOWS = ["90d", "1y"] as const;
 
 export const GetSubnetUptimeInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    window: z.enum(UPTIME_WINDOWS).optional(),
-    min_samples: z.int().min(0).optional(),
+    netuid: netuidSchema(),
+    window: windowSchema(UPTIME_WINDOWS).optional(),
+    min_samples: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Drop rows computed from fewer than this many samples, so a thin sample cannot look like a trend.",
+      ),
   })
   .strict();
 export type GetSubnetUptimeInput = z.infer<typeof GetSubnetUptimeInputSchema>;
@@ -19,7 +30,7 @@ export type GetSubnetUptimeInput = z.infer<typeof GetSubnetUptimeInputSchema>;
 export const GetSubnetUptimeOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable(),
     observed_at: z.string().nullable().optional(),
     surfaces: OpenObjectArraySchema,

--- a/schemas-src/mcp-tools/get-subnet-validator-economics.ts
+++ b/schemas-src/mcp-tools/get-subnet-validator-economics.ts
@@ -10,8 +10,16 @@ import {
   ValidatorEconomicsRankingArtifactSchema,
   SubnetValidatorEconomicsHistoryArtifactSchema,
 } from "../routes/validator-economics.ts";
-import { limitSchema, netuidSchema, offsetSchema } from "./shared.ts";
-import { VALIDATOR_ECONOMICS_LIMIT_MAX } from "../../src/route-limits.ts";
+import {
+  limitSchema,
+  netuidSchema,
+  offsetSchema,
+  sortSchema,
+} from "./shared.ts";
+import {
+  VALIDATOR_ECONOMICS_LIMIT_DEFAULT,
+  VALIDATOR_ECONOMICS_LIMIT_MAX,
+} from "../../src/route-limits.ts";
 import {
   VALIDATOR_ECONOMICS_HISTORY_WINDOWS,
   VALIDATOR_ECONOMICS_SORTS,
@@ -42,12 +50,25 @@ export const ListValidatorEconomicsInputSchema = z
     // ranked by the default, echoing that default back as `sort`. A model that guessed
     // got a plausible list answering a question nobody asked. Read from the same
     // constant the ranking and the REST validator use.
-    sort: z.enum(VALIDATOR_ECONOMICS_SORTS).optional(),
+    sort: sortSchema(VALIDATOR_ECONOMICS_SORTS).optional(),
     // Was unbounded while the mirrored route rejected anything over 512.
-    limit: limitSchema(VALIDATOR_ECONOMICS_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      VALIDATOR_ECONOMICS_LIMIT_MAX,
+      VALIDATOR_ECONOMICS_LIMIT_DEFAULT,
+    ).optional(),
     offset: offsetSchema().optional(),
-    emission_gate_open: z.boolean().optional(),
-    cap_binding: z.boolean().optional(),
+    emission_gate_open: z
+      .boolean()
+      .optional()
+      .describe(
+        "Restrict to subnets whose emission gate is open (`true`) or closed (`false`).",
+      ),
+    cap_binding: z
+      .boolean()
+      .optional()
+      .describe(
+        "Restrict to subnets where the validator cap is actually binding (`true`).",
+      ),
   })
   .strict();
 export type ListValidatorEconomicsInput = z.infer<
@@ -74,7 +95,10 @@ export const GetSubnetValidatorEconomicsHistoryInputSchema = z
           ...string[],
         ],
       )
-      .optional(),
+      .optional()
+      .describe(
+        "Trailing time window to aggregate over, ending at the latest data point rather than a calendar boundary. Options are per-tool; see this parameter's enum.",
+      ),
   })
   .strict();
 export type GetSubnetValidatorEconomicsHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-volume-ohlc.ts
+++ b/schemas-src/mcp-tools/get-subnet-volume-ohlc.ts
@@ -9,10 +9,11 @@
 // routes -- no existing Zod schema to reuse either. Both modeled fresh,
 // shallow, from the hand-written literals they replace.
 import { z } from "zod";
+import { netuidSchema } from "./shared.ts";
 
 export const GetSubnetVolumeInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetVolumeInput = z.infer<typeof GetSubnetVolumeInputSchema>;
@@ -20,7 +21,7 @@ export type GetSubnetVolumeInput = z.infer<typeof GetSubnetVolumeInputSchema>;
 export const GetSubnetVolumeOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string(),
     buy_volume_alpha: z.unknown().optional(),
     sell_volume_alpha: z.unknown().optional(),
@@ -43,9 +44,17 @@ const MAX_OHLC_WINDOW_DAYS = 365;
 
 export const GetSubnetOhlcInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    interval: z.enum(OHLC_INTERVALS).optional(),
-    days: z.int().min(1).max(MAX_OHLC_WINDOW_DAYS).optional(),
+    netuid: netuidSchema(),
+    interval: z
+      .enum(OHLC_INTERVALS)
+      .optional()
+      .describe("Bucket size for the returned series."),
+    days: z
+      .int()
+      .min(1)
+      .max(MAX_OHLC_WINDOW_DAYS)
+      .optional()
+      .describe("How many trailing days to cover, ending today (UTC)."),
   })
   .strict();
 export type GetSubnetOhlcInput = z.infer<typeof GetSubnetOhlcInputSchema>;
@@ -69,7 +78,7 @@ const OhlcCandleSchema = z
 export const GetSubnetOhlcOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     interval: z.string(),
     candles: z.array(OhlcCandleSchema),
     root_excluded: z.boolean(),

--- a/schemas-src/mcp-tools/get-subnet-weight-setters.ts
+++ b/schemas-src/mcp-tools/get-subnet-weight-setters.ts
@@ -3,13 +3,14 @@
 // schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
 // reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
 import { z } from "zod";
+import { netuidSchema, windowSchema } from "./shared.ts";
 
 const SUBNET_WEIGHT_SETTERS_WINDOWS = ["7d", "30d"] as const;
 
 export const GetSubnetWeightSettersInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    window: z.enum(SUBNET_WEIGHT_SETTERS_WINDOWS).optional(),
+    netuid: netuidSchema(),
+    window: windowSchema(SUBNET_WEIGHT_SETTERS_WINDOWS).optional(),
   })
   .strict();
 export type GetSubnetWeightSettersInput = z.infer<
@@ -36,7 +37,7 @@ const WeightSetterSchema = z
 export const GetSubnetWeightSettersOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable(),
     observed_at: z.string().nullable().optional(),
     distinct_setters: z.int(),

--- a/schemas-src/mcp-tools/get-subnet-weights.ts
+++ b/schemas-src/mcp-tools/get-subnet-weights.ts
@@ -3,13 +3,14 @@
 // covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
 // shallow, from the hand-written literal it replaces.
 import { z } from "zod";
+import { netuidSchema, windowSchema } from "./shared.ts";
 
 const SUBNET_WEIGHTS_WINDOWS = ["7d", "30d"] as const;
 
 export const GetSubnetWeightsInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    window: z.enum(SUBNET_WEIGHTS_WINDOWS).optional(),
+    netuid: netuidSchema(),
+    window: windowSchema(SUBNET_WEIGHTS_WINDOWS).optional(),
   })
   .strict();
 export type GetSubnetWeightsInput = z.infer<typeof GetSubnetWeightsInputSchema>;
@@ -17,7 +18,7 @@ export type GetSubnetWeightsInput = z.infer<typeof GetSubnetWeightsInputSchema>;
 export const GetSubnetWeightsOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable(),
     observed_at: z.string().nullable().optional(),
     distinct_setters: z.int(),

--- a/schemas-src/mcp-tools/get-subnet-yield-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-yield-history.ts
@@ -3,14 +3,14 @@
 // schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
 // reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
 import { z } from "zod";
-import { OpenObjectArraySchema } from "./shared.ts";
+import { OpenObjectArraySchema, netuidSchema, windowSchema } from "./shared.ts";
 
 const YIELD_HISTORY_WINDOWS = ["7d", "30d", "90d"] as const;
 
 export const GetSubnetYieldHistoryInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    window: z.enum(YIELD_HISTORY_WINDOWS).optional(),
+    netuid: netuidSchema(),
+    window: windowSchema(YIELD_HISTORY_WINDOWS).optional(),
   })
   .strict();
 export type GetSubnetYieldHistoryInput = z.infer<
@@ -20,7 +20,7 @@ export type GetSubnetYieldHistoryInput = z.infer<
 export const GetSubnetYieldHistoryOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable(),
     point_count: z.int(),
     points: OpenObjectArraySchema,

--- a/schemas-src/mcp-tools/get-subnet-yield.ts
+++ b/schemas-src/mcp-tools/get-subnet-yield.ts
@@ -3,11 +3,11 @@
 // covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
 // shallow, from the hand-written literal it replaces.
 import { z } from "zod";
-import { OpenObjectArraySchema } from "./shared.ts";
+import { OpenObjectArraySchema, netuidSchema } from "./shared.ts";
 
 export const GetSubnetYieldInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetYieldInput = z.infer<typeof GetSubnetYieldInputSchema>;
@@ -15,7 +15,7 @@ export type GetSubnetYieldInput = z.infer<typeof GetSubnetYieldInputSchema>;
 export const GetSubnetYieldOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     captured_at: z.string().nullable().optional(),
     block_number: z.int().nullable().optional(),
     neuron_count: z.int(),

--- a/schemas-src/mcp-tools/get-subnet.ts
+++ b/schemas-src/mcp-tools/get-subnet.ts
@@ -13,10 +13,11 @@
 // constraint (deep-typing them would accept LESS than the original, a
 // regression, not an improvement).
 import { z } from "zod";
+import { netuidSchema } from "./shared.ts";
 
 export const GetSubnetInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetInput = z.infer<typeof GetSubnetInputSchema>;
@@ -25,7 +26,7 @@ const OpenObjectSchema = z.object({}).passthrough();
 
 export const GetSubnetOutputSchema = z
   .object({
-    netuid: z.int(),
+    netuid: netuidSchema(),
     name: z.string().nullable().optional(),
     slug: z.string().nullable().optional(),
     status: z.string().nullable().optional(),

--- a/schemas-src/mcp-tools/get-tao-usd.ts
+++ b/schemas-src/mcp-tools/get-tao-usd.ts
@@ -1,8 +1,9 @@
 // get_tao_usd (#9609): the TAO/USD index, mirroring GET /api/v1/network/tao-usd.
 import { z } from "zod";
+import { windowSchema } from "./shared.ts";
 
 export const GetTaoUsdInputSchema = z
-  .object({ window: z.enum(["1h", "24h", "7d", "30d"]).optional() })
+  .object({ window: windowSchema(["1h", "24h", "7d", "30d"]).optional() })
   .strict();
 export type GetTaoUsdInput = z.infer<typeof GetTaoUsdInputSchema>;
 

--- a/schemas-src/mcp-tools/get-webhook-subscription.ts
+++ b/schemas-src/mcp-tools/get-webhook-subscription.ts
@@ -8,7 +8,11 @@ import { OpenObjectSchema } from "./shared.ts";
 
 export const GetWebhookSubscriptionInputSchema = z
   .object({
-    id: z.string(),
+    id: z
+      .string()
+      .describe(
+        "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
+      ),
   })
   .strict();
 export type GetWebhookSubscriptionInput = z.infer<

--- a/schemas-src/mcp-tools/governance-feeds.ts
+++ b/schemas-src/mcp-tools/governance-feeds.ts
@@ -8,26 +8,57 @@
 // identical JSON Schema and the diff-audit script already treats them as
 // equal (see list_accounts/get_top_holders in #8070).
 import { z } from "zod";
-import { limitSchema, offsetSchema } from "./shared.ts";
+import {
+  blockBoundSchema,
+  keysetCursorSchema,
+  limitSchema,
+  offsetSchema,
+} from "./shared.ts";
 import { EXTRINSICS_LIMIT_MAX } from "./extrinsics.ts";
 import { ExtrinsicItemSchema } from "./shared.ts";
 import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
 
 export const GetSudoInputSchema = z
   .object({
-    block: z.int().min(0).optional(),
-    call_function: z.string().optional(),
-    success: z.boolean().optional(),
-    block_start: z.int().min(0).optional(),
-    block_end: z.int().min(0).optional(),
-    from: z.int().min(0).optional(),
-    to: z.int().min(0).optional(),
+    block: z
+      .int()
+      .min(0)
+      .optional()
+      .describe("Restrict to this exact block height."),
+    call_function: z
+      .string()
+      .optional()
+      .describe(
+        "Restrict to one call within the pallet (`add_stake`). Case-sensitive; pair with `call_module` to disambiguate.",
+      ),
+    success: z
+      .boolean()
+      .optional()
+      .describe(
+        "Restrict to successful (`true`) or failed (`false`) extrinsics. Omit for both.",
+      ),
+    block_start: blockBoundSchema("first").optional(),
+    block_end: blockBoundSchema("last").optional(),
+    from: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive start of the range. A block height on chain tools, an ISO-8601 date on time-series ones.",
+      ),
+    to: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive end of the range. A block height on chain tools, an ISO-8601 date on time-series ones; an EVM address on decode_evm_call.",
+      ),
     // Both feeds say "same filters as list_extrinsics" and were modelled on it,
     // but dropped its `.max(100)` — declaring unbounded while the tier they forward to
     // caps at 100. A copy-paste omission, not a wider ceiling.
     limit: limitSchema(EXTRINSICS_LIMIT_MAX).optional(),
     offset: offsetSchema().optional(),
-    cursor: z.string().optional(),
+    cursor: keysetCursorSchema().optional(),
   })
   .strict();
 export type GetSudoInput = z.infer<typeof GetSudoInputSchema>;
@@ -67,19 +98,45 @@ export type GetSudoKeyOutput = z.infer<typeof GetSudoKeyOutputSchema>;
 
 export const GetGovernanceConfigChangesInputSchema = z
   .object({
-    block: z.int().min(0).optional(),
-    call_function: z.string().optional(),
-    success: z.boolean().optional(),
-    block_start: z.int().min(0).optional(),
-    block_end: z.int().min(0).optional(),
-    from: z.int().min(0).optional(),
-    to: z.int().min(0).optional(),
+    block: z
+      .int()
+      .min(0)
+      .optional()
+      .describe("Restrict to this exact block height."),
+    call_function: z
+      .string()
+      .optional()
+      .describe(
+        "Restrict to one call within the pallet (`add_stake`). Case-sensitive; pair with `call_module` to disambiguate.",
+      ),
+    success: z
+      .boolean()
+      .optional()
+      .describe(
+        "Restrict to successful (`true`) or failed (`false`) extrinsics. Omit for both.",
+      ),
+    block_start: blockBoundSchema("first").optional(),
+    block_end: blockBoundSchema("last").optional(),
+    from: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive start of the range. A block height on chain tools, an ISO-8601 date on time-series ones.",
+      ),
+    to: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive end of the range. A block height on chain tools, an ISO-8601 date on time-series ones; an EVM address on decode_evm_call.",
+      ),
     // Both feeds say "same filters as list_extrinsics" and were modelled on it,
     // but dropped its `.max(100)` — declaring unbounded while the tier they forward to
     // caps at 100. A copy-paste omission, not a wider ceiling.
     limit: limitSchema(EXTRINSICS_LIMIT_MAX).optional(),
     offset: offsetSchema().optional(),
-    cursor: z.string().optional(),
+    cursor: keysetCursorSchema().optional(),
   })
   .strict();
 export type GetGovernanceConfigChangesInput = z.infer<

--- a/schemas-src/mcp-tools/list-subnets.ts
+++ b/schemas-src/mcp-tools/list-subnets.ts
@@ -11,6 +11,13 @@
 // constrained on the wire, and only those reuse a shared enum.
 import { z } from "zod";
 import {
+  limitSchema,
+  netuidSchema,
+  numericCursorSchema,
+  orderSchema,
+  sortSchema,
+} from "./shared.ts";
+import {
   CoverageLevelSchema,
   CurationLevelSchema,
   McpNetworkSchema,
@@ -22,42 +29,181 @@ const LIST_SUBNETS_SORT_FIELDS = [
   "surface_count",
   "name",
 ] as const;
-const LIST_SUBNETS_ORDERS = ["asc", "desc"] as const;
 
 export const ListSubnetsInputSchema = z
   .object({
-    cursor: z.int().min(0).optional(),
-    limit: z.int().min(1).max(100).optional(),
-    status: z.string().optional(),
-    subnet_type: z.string().optional(),
-    domain: z.string().optional(),
-    not_status: z.string().optional(),
-    not_subnet_type: z.string().optional(),
-    not_domain: z.string().optional(),
-    coverage_level: CoverageLevelSchema.optional(),
-    not_coverage_level: CoverageLevelSchema.optional(),
-    curation_level: CurationLevelSchema.optional(),
-    not_curation_level: CurationLevelSchema.optional(),
-    min_readiness: z.int().min(0).max(100).optional(),
-    max_readiness: z.int().min(0).max(100).optional(),
-    min_surface_count: z.int().min(0).optional(),
-    max_surface_count: z.int().min(0).optional(),
-    min_block: z.number().optional(),
-    max_block: z.number().optional(),
-    min_candidate_count: z.int().min(0).optional(),
-    max_candidate_count: z.int().min(0).optional(),
-    min_mechanism_count: z.int().min(0).optional(),
-    max_mechanism_count: z.int().min(0).optional(),
-    min_participant_count: z.int().min(0).optional(),
-    max_participant_count: z.int().min(0).optional(),
-    min_probed_surface_count: z.int().min(0).optional(),
-    max_probed_surface_count: z.int().min(0).optional(),
-    min_tempo: z.int().min(0).optional(),
-    max_tempo: z.int().min(0).optional(),
-    min_netuid: z.int().min(0).optional(),
-    max_netuid: z.int().min(0).optional(),
-    sort: z.enum(LIST_SUBNETS_SORT_FIELDS).optional(),
-    order: z.enum(LIST_SUBNETS_ORDERS).optional(),
+    cursor: numericCursorSchema().optional(),
+    limit: limitSchema(100).optional(),
+    status: z
+      .string()
+      .optional()
+      .describe("Restrict to rows with this health status."),
+    subnet_type: z
+      .string()
+      .optional()
+      .describe("Root subnet or an application subnet."),
+    domain: z
+      .string()
+      .optional()
+      .describe("The subnet's primary domain of use."),
+    not_status: z
+      .string()
+      .optional()
+      .describe(
+        "EXCLUDE rows with this status. Applied after any positive `status` filter, so the two can be combined.",
+      ),
+    not_subnet_type: z
+      .string()
+      .optional()
+      .describe(
+        "EXCLUDE rows with this subnet type. Applied after any positive `subnet_type` filter, so the two can be combined.",
+      ),
+    not_domain: z
+      .string()
+      .optional()
+      .describe(
+        "EXCLUDE rows with this domain. Applied after any positive `domain` filter, so the two can be combined.",
+      ),
+    coverage_level: CoverageLevelSchema.optional().describe(
+      "How much of the subnet is covered: on-chain data only, a manifest, or actively probed surfaces.",
+    ),
+    not_coverage_level: CoverageLevelSchema.optional().describe(
+      "EXCLUDE rows with this coverage level. Applied after any positive `coverage_level` filter, so the two can be combined.",
+    ),
+    curation_level: CurationLevelSchema.optional().describe(
+      "How the record entered the registry — native chain data, discovered candidate, community submission, or machine-derived.",
+    ),
+    not_curation_level: CurationLevelSchema.optional().describe(
+      "EXCLUDE rows with this curation level. Applied after any positive `curation_level` filter, so the two can be combined.",
+    ),
+    min_readiness: z
+      .int()
+      .min(0)
+      .max(100)
+      .optional()
+      .describe(
+        "Inclusive lower bound on readiness score; rows below it are excluded.",
+      ),
+    max_readiness: z
+      .int()
+      .min(0)
+      .max(100)
+      .optional()
+      .describe(
+        "Inclusive upper bound on readiness score; rows above it are excluded.",
+      ),
+    min_surface_count: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive lower bound on surface count; rows below it are excluded.",
+      ),
+    max_surface_count: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive upper bound on surface count; rows above it are excluded.",
+      ),
+    min_block: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive lower bound on block height; rows below it are excluded.",
+      ),
+    max_block: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive upper bound on block height; rows above it are excluded.",
+      ),
+    min_candidate_count: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive lower bound on candidate surface count; rows below it are excluded.",
+      ),
+    max_candidate_count: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive upper bound on candidate surface count; rows above it are excluded.",
+      ),
+    min_mechanism_count: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive lower bound on mechanism count; rows below it are excluded.",
+      ),
+    max_mechanism_count: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive upper bound on mechanism count; rows above it are excluded.",
+      ),
+    min_participant_count: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive lower bound on participant count; rows below it are excluded.",
+      ),
+    max_participant_count: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive upper bound on participant count; rows above it are excluded.",
+      ),
+    min_probed_surface_count: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive lower bound on probed surface count; rows below it are excluded.",
+      ),
+    max_probed_surface_count: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive upper bound on probed surface count; rows above it are excluded.",
+      ),
+    min_tempo: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive lower bound on subnet tempo; rows below it are excluded.",
+      ),
+    max_tempo: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive upper bound on subnet tempo; rows above it are excluded.",
+      ),
+    min_netuid: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive lower bound on subnet id; rows below it are excluded.",
+      ),
+    max_netuid: z
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Inclusive upper bound on subnet id; rows above it are excluded.",
+      ),
+    sort: sortSchema(LIST_SUBNETS_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
     network: McpNetworkSchema.optional(),
   })
   .strict();
@@ -67,7 +213,7 @@ export type ListSubnetsInput = z.infer<typeof ListSubnetsInputSchema>;
 // search-subnets.ts's same note).
 const ListSubnetsRowSchema = z
   .object({
-    netuid: z.int().optional(),
+    netuid: netuidSchema().optional(),
     slug: z.string().nullable().optional(),
     title: z.string().nullable().optional(),
     subnet_type: z.string().nullable().optional(),

--- a/schemas-src/mcp-tools/neurons.ts
+++ b/schemas-src/mcp-tools/neurons.ts
@@ -8,12 +8,15 @@ import {
   NeuronFieldsInputSchema,
   OpenObjectArraySchema,
   OpenObjectSchema,
+  netuidSchema,
+  uidSchema,
+  windowSchema,
 } from "./shared.ts";
 
 export const GetNeuronInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    uid: z.int().min(0),
+    netuid: netuidSchema(),
+    uid: uidSchema(),
     // #9082: narrow each returned row to these fields. Omit for the full
     // row. Valid names are NeuronSchema's own, so this enum cannot drift
     // from what the route can project.
@@ -25,7 +28,7 @@ export type GetNeuronInput = z.infer<typeof GetNeuronInputSchema>;
 export const GetNeuronOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     captured_at: z.string().nullable().optional(),
     block_number: z.int().nullable().optional(),
     neuron: OpenObjectSchema.nullable(),
@@ -35,9 +38,9 @@ export type GetNeuronOutput = z.infer<typeof GetNeuronOutputSchema>;
 
 export const GetNeuronHistoryInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    uid: z.int().min(0),
-    window: z.enum(["7d", "30d", "90d", "1y", "all"]).optional(),
+    netuid: netuidSchema(),
+    uid: uidSchema(),
+    window: windowSchema(["7d", "30d", "90d", "1y", "all"]).optional(),
   })
   .strict();
 export type GetNeuronHistoryInput = z.infer<typeof GetNeuronHistoryInputSchema>;
@@ -45,7 +48,7 @@ export type GetNeuronHistoryInput = z.infer<typeof GetNeuronHistoryInputSchema>;
 export const GetNeuronHistoryOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     uid: z.int(),
     window: z.string().nullable().optional(),
     point_count: z.int(),

--- a/schemas-src/mcp-tools/profiles.ts
+++ b/schemas-src/mcp-tools/profiles.ts
@@ -13,7 +13,17 @@
 // subnetType,curationLevel,profileLevel} and the "profiles" query
 // collection's sort_fields at the time of writing.
 import { z } from "zod";
-import { OpenObjectArraySchema, OpenObjectSchema } from "./shared.ts";
+import {
+  OpenObjectArraySchema,
+  OpenObjectSchema,
+  fieldsStringSchema,
+  limitSchema,
+  netuidSchema,
+  numericCursorSchema,
+  orderSchema,
+  querySchema,
+  sortSchema,
+} from "./shared.ts";
 
 const SUBNET_TYPE = ["root", "application"] as const;
 const CURATION_LEVEL = [
@@ -46,25 +56,44 @@ const PROFILES_SORT_FIELDS = [
 
 export const ListProfilesInputSchema = z
   .object({
-    netuid: z.int().min(0).optional(),
-    subnet_type: z.enum(SUBNET_TYPE).optional(),
-    curation_level: z.enum(CURATION_LEVEL).optional(),
-    review_state: z.string().optional(),
-    confidence: z.enum(["low", "medium", "high"]).optional(),
-    profile_level: z.enum(PROFILE_LEVEL).optional(),
-    q: z.string().optional(),
-    sort: z.enum(PROFILES_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(1000).optional(),
-    cursor: z.int().min(0).optional(),
+    netuid: netuidSchema().optional(),
+    subnet_type: z
+      .enum(SUBNET_TYPE)
+      .optional()
+      .describe("Root subnet or an application subnet."),
+    curation_level: z
+      .enum(CURATION_LEVEL)
+      .optional()
+      .describe(
+        "How the record entered the registry — native chain data, discovered candidate, community submission, or machine-derived.",
+      ),
+    review_state: z
+      .string()
+      .optional()
+      .describe("Where the item sits in maintainer review."),
+    confidence: z
+      .enum(["low", "medium", "high"])
+      .optional()
+      .describe("How confident the machine assessment is."),
+    profile_level: z
+      .enum(PROFILE_LEVEL)
+      .optional()
+      .describe(
+        "How complete the subnet's profile is, from directory-only upward.",
+      ),
+    q: querySchema().optional(),
+    sort: sortSchema(PROFILES_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(1000).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListProfilesInput = z.infer<typeof ListProfilesInputSchema>;
 
 export const GetSubnetProfileInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetProfileInput = z.infer<typeof GetSubnetProfileInputSchema>;

--- a/schemas-src/mcp-tools/query-tools.ts
+++ b/schemas-src/mcp-tools/query-tools.ts
@@ -24,8 +24,14 @@ import { OpenObjectSchema } from "./shared.ts";
 
 export const QueryGraphqlInputSchema = z
   .object({
-    query: z.string(),
-    variables: OpenObjectSchema.optional(),
+    query: z
+      .string()
+      .describe(
+        "The request payload or search text this surface expects. Shape depends on the surface; see its schema.",
+      ),
+    variables: OpenObjectSchema.optional().describe(
+      "GraphQL variables for the query, as an object.",
+    ),
   })
   .strict();
 export type QueryGraphqlInput = z.infer<typeof QueryGraphqlInputSchema>;
@@ -48,8 +54,14 @@ const SAVED_QUERY_IDS = [
 
 export const RunSavedQueryInputSchema = z
   .object({
-    query_id: z.enum(SAVED_QUERY_IDS),
-    params: OpenObjectSchema.optional(),
+    query_id: z
+      .enum(SAVED_QUERY_IDS)
+      .describe(
+        "Which saved query template to run. See this parameter's enum for the available ids.",
+      ),
+    params: OpenObjectSchema.optional().describe(
+      "Positional or named parameters for the RPC method, matching what that method expects.",
+    ),
   })
   .strict();
 export type RunSavedQueryInput = z.infer<typeof RunSavedQueryInputSchema>;

--- a/schemas-src/mcp-tools/registry-catalogs-1.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-1.ts
@@ -9,7 +9,17 @@
 // mcp-server.ts. None mirror an existing schemas-src/routes/ REST schema --
 // modeled fresh, matching each hand-written literal field-for-field.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import {
+  OpenObjectSchema,
+  fieldsStringSchema,
+  kindSchema,
+  limitSchema,
+  netuidSchema,
+  numericCursorSchema,
+  orderSchema,
+  providerSlugSchema,
+  sortSchema,
+} from "./shared.ts";
 
 // Symbolic in each hand-written original (src/contracts.ts's QUERY_ENUMS /
 // API_QUERY_COLLECTIONS.*.sort_fields), cross-checked against the actual
@@ -31,14 +41,24 @@ const PROVIDER_SORT_FIELDS = ["authority", "id", "kind", "name"] as const;
 
 export const ListProvidersInputSchema = z
   .object({
-    id: z.string().optional(),
-    kind: z.enum(PROVIDER_KINDS).optional(),
-    authority: z.enum(PROVIDER_AUTHORITIES).optional(),
-    sort: z.enum(PROVIDER_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    id: z
+      .string()
+      .optional()
+      .describe(
+        "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
+      ),
+    kind: kindSchema(PROVIDER_KINDS).optional(),
+    authority: z
+      .enum(PROVIDER_AUTHORITIES)
+      .optional()
+      .describe(
+        "Who asserts this record: the operator, the community, a provider, or the registry's own probes.",
+      ),
+    sort: sortSchema(PROVIDER_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListProvidersInput = z.infer<typeof ListProvidersInputSchema>;
@@ -85,15 +105,20 @@ const SURFACE_SORT_FIELDS = [
 
 export const ListSurfacesInputSchema = z
   .object({
-    netuid: z.int().min(0).optional(),
-    kind: z.enum(SURFACE_KINDS).optional(),
-    provider: z.string().optional(),
-    id: z.string().optional(),
-    sort: z.enum(SURFACE_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    netuid: netuidSchema().optional(),
+    kind: kindSchema(SURFACE_KINDS).optional(),
+    provider: providerSlugSchema().optional(),
+    id: z
+      .string()
+      .optional()
+      .describe(
+        "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
+      ),
+    sort: sortSchema(SURFACE_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListSurfacesInput = z.infer<typeof ListSurfacesInputSchema>;
@@ -135,17 +160,28 @@ const CANDIDATES_SORT_FIELDS = [
 
 export const ListCandidatesInputSchema = z
   .object({
-    netuid: z.int().min(0).optional(),
-    kind: z.enum(SURFACE_KINDS).optional(),
-    provider: z.string().optional(),
-    state: z.enum(CANDIDATE_STATES).optional(),
-    id: z.string().optional(),
-    confidence: z.enum(CONFIDENCE_LEVELS).optional(),
-    sort: z.enum(CANDIDATES_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(1000).optional(),
-    cursor: z.int().min(0).optional(),
+    netuid: netuidSchema().optional(),
+    kind: kindSchema(SURFACE_KINDS).optional(),
+    provider: providerSlugSchema().optional(),
+    state: z
+      .enum(CANDIDATE_STATES)
+      .optional()
+      .describe("The incident's lifecycle state."),
+    id: z
+      .string()
+      .optional()
+      .describe(
+        "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
+      ),
+    confidence: z
+      .enum(CONFIDENCE_LEVELS)
+      .optional()
+      .describe("How confident the machine assessment is."),
+    sort: sortSchema(CANDIDATES_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(1000).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListCandidatesInput = z.infer<typeof ListCandidatesInputSchema>;

--- a/schemas-src/mcp-tools/registry-catalogs-2.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-2.ts
@@ -16,7 +16,18 @@
 // list_rpc_endpoints' `fields`/`cursor` inputs are `oneOf` unions (string-or-
 // array, integer-or-string) unlike every other tool's single-type fields.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import {
+  OpenObjectSchema,
+  fieldsStringSchema,
+  kindSchema,
+  limitSchema,
+  netuidSchema,
+  numericCursorSchema,
+  orderSchema,
+  providerSlugSchema,
+  querySchema,
+  sortSchema,
+} from "./shared.ts";
 
 const CLAIM_SORT_FIELDS = [
   "claim",
@@ -27,12 +38,12 @@ const CLAIM_SORT_FIELDS = [
 
 export const ListEvidenceInputSchema = z
   .object({
-    q: z.string().optional(),
-    sort: z.enum(CLAIM_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    q: querySchema().optional(),
+    sort: sortSchema(CLAIM_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListEvidenceInput = z.infer<typeof ListEvidenceInputSchema>;
@@ -100,24 +111,75 @@ const ENDPOINT_SORT_FIELDS = [
 
 export const ListRpcEndpointsInputSchema = z
   .object({
-    kind: z.enum(SURFACE_KINDS).optional(),
-    layer: z.enum(ENDPOINT_LAYERS).optional(),
-    netuid: z.int().min(0).optional(),
-    provider: z.string().optional(),
-    publication_state: z.enum(ENDPOINT_PUBLICATION_STATES).optional(),
-    status: z.enum(HEALTH_STATUSES).optional(),
-    pool_eligible: z.boolean().optional(),
-    min_latency_ms: z.number().optional(),
-    max_latency_ms: z.number().optional(),
-    min_score: z.number().optional(),
-    max_score: z.number().optional(),
-    sort: z.enum(ENDPOINT_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.union([z.string(), z.array(z.string())]).optional(),
+    kind: kindSchema(SURFACE_KINDS).optional(),
+    layer: z
+      .enum(ENDPOINT_LAYERS)
+      .optional()
+      .describe(
+        "Which layer of the stack the endpoint belongs to: the Bittensor base chain, a data or docs provider, or a subnet's own app.",
+      ),
+    netuid: netuidSchema().optional(),
+    provider: providerSlugSchema().optional(),
+    publication_state: z
+      .enum(ENDPOINT_PUBLICATION_STATES)
+      .optional()
+      .describe(
+        "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
+      ),
+    status: kindSchema(HEALTH_STATUSES).optional(),
+    pool_eligible: z
+      .boolean()
+      .optional()
+      .describe(
+        "Restrict to endpoints that are (or are not) eligible for the public RPC pool.",
+      ),
+    min_latency_ms: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive lower bound on probe latency in milliseconds; rows below it are excluded.",
+      ),
+    max_latency_ms: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive upper bound on probe latency in milliseconds; rows above it are excluded.",
+      ),
+    min_score: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive lower bound on endpoint score; rows below it are excluded.",
+      ),
+    max_score: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive upper bound on endpoint score; rows above it are excluded.",
+      ),
+    sort: sortSchema(ENDPOINT_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    // Both `fields` and `cursor` are UNIONS here, unlike everywhere else, so
+    // neither can take a shared builder -- the sentence has to say which forms
+    // are accepted rather than assume one.
+    fields: z
+      .union([z.string(), z.array(z.string())])
+      .describe(
+        "Row fields to project. Accepts either a comma-separated string " +
+          "(`id,url,status`) or an array of bare names. Omit for the full row.",
+      )
+      .optional(),
     // Ceiling is MAX_LIMIT (workers/request-params.ts:21); a literal here
     // because schemas-src/ imports from neither src/ nor workers/.
-    limit: z.int().min(1).max(1000).optional(),
-    cursor: z.union([z.int().min(0), z.string()]).optional(),
+    limit: limitSchema(1000).optional(),
+    cursor: z
+      .union([z.int().min(0), z.string()])
+      .describe(
+        "Page cursor. Accepts either a numeric row offset or the opaque " +
+          "`next_cursor` token from the previous response; pass a token back " +
+          "verbatim, since its contents are not stable.",
+      )
+      .optional(),
   })
   .strict();
 export type ListRpcEndpointsInput = z.infer<typeof ListRpcEndpointsInputSchema>;
@@ -157,17 +219,42 @@ const POOL_SORT_FIELDS = [
 
 export const ListRpcPoolsInputSchema = z
   .object({
-    id: z.string().optional(),
-    kind: z.enum(POOL_KINDS).optional(),
-    min_eligible_count: z.number().optional(),
-    max_eligible_count: z.number().optional(),
-    min_endpoint_count: z.number().optional(),
-    max_endpoint_count: z.number().optional(),
-    sort: z.enum(POOL_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    id: z
+      .string()
+      .optional()
+      .describe(
+        "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
+      ),
+    kind: kindSchema(POOL_KINDS).optional(),
+    min_eligible_count: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive lower bound on pool-eligible endpoint count; rows below it are excluded.",
+      ),
+    max_eligible_count: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive upper bound on pool-eligible endpoint count; rows above it are excluded.",
+      ),
+    min_endpoint_count: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive lower bound on endpoint count; rows below it are excluded.",
+      ),
+    max_endpoint_count: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive upper bound on endpoint count; rows above it are excluded.",
+      ),
+    sort: sortSchema(POOL_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListRpcPoolsInput = z.infer<typeof ListRpcPoolsInputSchema>;
@@ -199,12 +286,12 @@ const SOURCE_SORT_FIELDS = ["id", "kind", "path", "record_count"] as const;
 
 export const ListSourceSnapshotsInputSchema = z
   .object({
-    q: z.string().optional(),
-    sort: z.enum(SOURCE_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    q: querySchema().optional(),
+    sort: sortSchema(SOURCE_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListSourceSnapshotsInput = z.infer<
@@ -259,17 +346,36 @@ const PROFILE_SORT_FIELDS = [
 
 export const ListProfileCompletenessInputSchema = z
   .object({
-    netuid: z.int().min(0).optional(),
-    profile_level: z.enum(PROFILE_LEVELS).optional(),
-    confidence: z.enum(CONFIDENCE_LEVELS).optional(),
-    identity_level: z.enum(IDENTITY_LEVELS).optional(),
-    identity_promotion_kinds: z.enum(SURFACE_KINDS).optional(),
-    native_name_quality: z.enum(NATIVE_NAME_QUALITIES).optional(),
-    sort: z.enum(PROFILE_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    netuid: netuidSchema().optional(),
+    profile_level: z
+      .enum(PROFILE_LEVELS)
+      .optional()
+      .describe(
+        "How complete the subnet's profile is, from directory-only upward.",
+      ),
+    confidence: z
+      .enum(CONFIDENCE_LEVELS)
+      .optional()
+      .describe("How confident the machine assessment is."),
+    identity_level: z
+      .enum(IDENTITY_LEVELS)
+      .optional()
+      .describe("How complete the subnet's published identity is."),
+    identity_promotion_kinds: z
+      .enum(SURFACE_KINDS)
+      .optional()
+      .describe(
+        "Restrict to subnets where surfaces of this kind would promote the subnet's identity. One kind per call; see this parameter's enum.",
+      ),
+    native_name_quality: z
+      .enum(NATIVE_NAME_QUALITIES)
+      .optional()
+      .describe("Whether the on-chain name is real, a placeholder, or empty."),
+    sort: sortSchema(PROFILE_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListProfileCompletenessInput = z.infer<

--- a/schemas-src/mcp-tools/registry-summary-gaps.ts
+++ b/schemas-src/mcp-tools/registry-summary-gaps.ts
@@ -6,7 +6,16 @@
 // array). None mirror an existing schemas-src/routes/ REST schema --
 // modeled fresh, matching each hand-written literal field-for-field.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import {
+  OpenObjectSchema,
+  fieldsStringSchema,
+  kindSchema,
+  limitSchema,
+  netuidSchema,
+  numericCursorSchema,
+  orderSchema,
+  sortSchema,
+} from "./shared.ts";
 
 export const RegistrySummaryInputSchema = z.object({}).strict();
 export type RegistrySummaryInput = z.infer<typeof RegistrySummaryInputSchema>;
@@ -52,15 +61,28 @@ const AGENT_READINESS_STATUSES = [
 
 export const ListEnrichmentTargetsInputSchema = z
   .object({
-    limit: z.int().min(1).max(50).optional(),
-    tier: z.enum(COVERAGE_DEPTH_TIERS).optional(),
-    severity: z.enum(COVERAGE_DEPTH_SEVERITIES).optional(),
+    limit: limitSchema(50).optional(),
+    tier: z
+      .enum(COVERAGE_DEPTH_TIERS)
+      .optional()
+      .describe("How agent-ready the subnet is."),
+    severity: z
+      .enum(COVERAGE_DEPTH_SEVERITIES)
+      .optional()
+      .describe("How serious the incident is."),
     gap_code: z
       .string()
       .regex(/^[a-z0-9-]+$/)
-      .optional(),
-    agent_status: z.enum(AGENT_READINESS_STATUSES).optional(),
-    netuid: z.int().min(0).optional(),
+      .optional()
+      .describe(
+        "The machine-readable gap identifier (`missing-openapi`), lowercase " +
+          "and hyphenated — not the human-readable label shown beside it.",
+      ),
+    agent_status: z
+      .enum(AGENT_READINESS_STATUSES)
+      .optional()
+      .describe("How usable the subnet is to an agent right now."),
+    netuid: netuidSchema().optional(),
   })
   .strict();
 export type ListEnrichmentTargetsInput = z.infer<
@@ -70,7 +92,7 @@ export type ListEnrichmentTargetsInput = z.infer<
 const EnrichmentTargetItemSchema = z
   .object({
     rank: z.int().nullable().optional(),
-    netuid: z.int().optional(),
+    netuid: netuidSchema().optional(),
     slug: z.string().nullable().optional(),
     name: z.string().nullable().optional(),
     tier: z.string().optional(),
@@ -103,7 +125,7 @@ export type ListEnrichmentTargetsOutput = z.infer<
 
 export const GetSubnetGapsInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetGapsInput = z.infer<typeof GetSubnetGapsInputSchema>;
@@ -113,7 +135,7 @@ export const GetSubnetGapsOutputSchema = z
     schema_version: z.int().optional(),
     contract_version: z.string().nullable().optional(),
     generated_at: z.string().nullable().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     slug: z.string().nullable().optional(),
     name: z.string().nullable().optional(),
     priorities: z.array(OpenObjectSchema),
@@ -162,15 +184,23 @@ const GAP_PRIORITY_SORT_FIELDS = [
 
 export const ListSubnetGapsInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    curation_level: z.enum(CURATION_LEVELS).optional(),
-    missing_kinds: z.enum(SURFACE_KINDS).optional(),
-    review_state: z.string().optional(),
-    sort: z.enum(GAP_PRIORITY_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    netuid: netuidSchema(),
+    curation_level: kindSchema(CURATION_LEVELS).optional(),
+    missing_kinds: z
+      .enum(SURFACE_KINDS)
+      .optional()
+      .describe(
+        "Restrict to subnets where surfaces of this kind the subnet is MISSING. One kind per call; see this parameter's enum.",
+      ),
+    review_state: z
+      .string()
+      .optional()
+      .describe("Where the item sits in maintainer review."),
+    sort: sortSchema(GAP_PRIORITY_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListSubnetGapsInput = z.infer<typeof ListSubnetGapsInputSchema>;
@@ -178,7 +208,7 @@ export type ListSubnetGapsInput = z.infer<typeof ListSubnetGapsInputSchema>;
 export const ListSubnetGapsOutputSchema = z
   .object({
     generated_at: z.string().nullable().optional(),
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     priorities: z.array(OpenObjectSchema),
     total: z.int().optional(),
     returned: z.int().optional(),

--- a/schemas-src/mcp-tools/rpc-tools.ts
+++ b/schemas-src/mcp-tools/rpc-tools.ts
@@ -9,7 +9,8 @@
 // declare real item-level required fields -- preserved exactly, not loosened
 // to match this epic's usual item-shape convention.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import { McpNetworkSchema } from "../shared.ts";
+import { OpenObjectSchema, limitSchema, windowSchema } from "./shared.ts";
 import {
   SAFE_RPC_METHODS,
   SAFE_RPC_STATE_QUERY_METHODS,
@@ -69,7 +70,7 @@ const RpcUsageBucketItemSchema = z
 
 export const GetRpcUsageInputSchema = z
   .object({
-    window: z.enum(["7d", "30d"]).optional(),
+    window: windowSchema(["7d", "30d"]).optional(),
   })
   .strict();
 export type GetRpcUsageInput = z.infer<typeof GetRpcUsageInputSchema>;
@@ -118,7 +119,7 @@ export type GetRpcUsageOutput = z.infer<typeof GetRpcUsageOutputSchema>;
 
 export const GetBestRpcEndpointInputSchema = z
   .object({
-    limit: z.int().min(1).max(10).optional(),
+    limit: limitSchema(10).optional(),
   })
   .strict();
 export type GetBestRpcEndpointInput = z.infer<
@@ -156,14 +157,25 @@ export const CallRpcInputSchema = z
     // to read English to avoid a guaranteed rejection — and `call_subnet_surface.method`
     // right beside it already declared its enum. Read from the same sets the proxy
     // enforces, so a method added there cannot be missing here.
-    method: z.enum(
-      [...SAFE_RPC_METHODS, ...SAFE_RPC_STATE_QUERY_METHODS].sort() as [
-        string,
-        ...string[],
-      ],
-    ),
-    params: z.array(z.unknown()).optional(),
-    network: z.enum(["finney", "test"]).optional(),
+    method: z
+      .enum(
+        [...SAFE_RPC_METHODS, ...SAFE_RPC_STATE_QUERY_METHODS].sort() as [
+          string,
+          ...string[],
+        ],
+      )
+      .describe(
+        "The JSON-RPC method to call. Restricted to a read-only allowlist — " +
+          "the enum is the complete set, and it is the same set the proxy " +
+          "enforces, so anything absent here is refused rather than forwarded.",
+      ),
+    params: z
+      .array(z.unknown())
+      .optional()
+      .describe(
+        "Positional or named parameters for the RPC method, matching what that method expects.",
+      ),
+    network: McpNetworkSchema.optional(),
   })
   .strict();
 export type CallRpcInput = z.infer<typeof CallRpcInputSchema>;

--- a/schemas-src/mcp-tools/search-documents.ts
+++ b/schemas-src/mcp-tools/search-documents.ts
@@ -11,21 +11,34 @@
 // schemas-src/routes/ REST schema -- modeled fresh, matching each
 // hand-written literal field-for-field.
 import { z } from "zod";
-import { OpenObjectSchema, NotesFieldSchema } from "./shared.ts";
+import {
+  NotesFieldSchema,
+  OpenObjectSchema,
+  fieldsStringSchema,
+  limitSchema,
+  netuidSchema,
+  numericCursorSchema,
+  orderSchema,
+  querySchema,
+  sortSchema,
+} from "./shared.ts";
 
 const DOCUMENT_TYPES = ["subnet", "surface", "provider"] as const;
 const DOCUMENT_SORT_FIELDS = ["netuid", "slug", "title", "type"] as const;
 
 export const ListSearchIndexInputSchema = z
   .object({
-    q: z.string().optional(),
-    type: z.enum(DOCUMENT_TYPES).optional(),
-    netuid: z.int().min(0).optional(),
-    sort: z.enum(DOCUMENT_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    q: querySchema().optional(),
+    type: z
+      .enum(DOCUMENT_TYPES)
+      .optional()
+      .describe("Which entity kind to search over."),
+    netuid: netuidSchema().optional(),
+    sort: sortSchema(DOCUMENT_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListSearchIndexInput = z.infer<typeof ListSearchIndexInputSchema>;
@@ -48,14 +61,17 @@ export type ListSearchIndexOutput = z.infer<typeof ListSearchIndexOutputSchema>;
 
 export const ListSearchInputSchema = z
   .object({
-    q: z.string().optional(),
-    type: z.enum(DOCUMENT_TYPES).optional(),
-    netuid: z.int().min(0).optional(),
-    sort: z.enum(DOCUMENT_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    q: querySchema().optional(),
+    type: z
+      .enum(DOCUMENT_TYPES)
+      .optional()
+      .describe("Which entity kind to search over."),
+    netuid: netuidSchema().optional(),
+    sort: sortSchema(DOCUMENT_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListSearchInput = z.infer<typeof ListSearchInputSchema>;

--- a/schemas-src/mcp-tools/search-subnets.ts
+++ b/schemas-src/mcp-tools/search-subnets.ts
@@ -9,12 +9,17 @@
 // tightening here, only relocating where the schema is defined (#7863's own
 // "hard wire-compatibility constraint").
 import { z } from "zod";
+import { limitSchema, netuidSchema, numericCursorSchema } from "./shared.ts";
 
 export const SearchSubnetsInputSchema = z
   .object({
-    query: z.string(),
-    cursor: z.int().min(0).optional(),
-    limit: z.int().min(1).max(50).optional(),
+    query: z
+      .string()
+      .describe(
+        "The request payload or search text this surface expects. Shape depends on the surface; see its schema.",
+      ),
+    cursor: numericCursorSchema().optional(),
+    limit: limitSchema(50).optional(),
   })
   .strict();
 export type SearchSubnetsInput = z.infer<typeof SearchSubnetsInputSchema>;
@@ -24,7 +29,7 @@ export type SearchSubnetsInput = z.infer<typeof SearchSubnetsInputSchema>;
 // the wire level even though the real handler always sets all five.
 const SearchSubnetsResultItemSchema = z
   .object({
-    netuid: z.int().optional(),
+    netuid: netuidSchema().optional(),
     slug: z.string().optional(),
     title: z.string().nullable().optional(),
     description: z.string().nullable().optional(),

--- a/schemas-src/mcp-tools/shared.ts
+++ b/schemas-src/mcp-tools/shared.ts
@@ -22,20 +22,275 @@ import { MAX_OFFSET } from "../../workers/request-params.ts";
 // publishes, so an MCP tool can no longer advertise a ceiling its own route rejects.
 // `scripts/validate-mcp.ts` asserts the two agree.
 
+// DESCRIPTIONS BELONG ON THE PRIMITIVE, NOT IN THE TOOL PARAGRAPH (#9645).
+// Measured before writing these: of 773 published tool parameters, exactly ONE
+// carried a `description` — `fields`, below, the only one of these primitives
+// that had one. The guidance was not missing, it was in prose inside each
+// tool's own description, where a client cannot render it per field, a model
+// filling one argument does not attend to it, and nothing checks it against
+// the schema. Put on the shared primitive rather than at ~260 call sites, so
+// one sentence covers every tool and the wording cannot drift between them.
+
 /**
  * A subnet id. Bounded because it genuinely is: `netuid` is a u16 on chain, and
  * `isU16Netuid` is what the REST routes reject against.
  */
-export const netuidSchema = () => z.int().min(0).max(65535);
+export const netuidSchema = () =>
+  z
+    .int()
+    .min(0)
+    .max(65535)
+    .describe(
+      "Subnet id (netuid), 0-65535. 0 is the root subnet, which is special: " +
+        "it has no AMM pool and is emission-ineligible.",
+    );
 
-/** A page size, capped at the mirrored route's own ceiling. */
-export const limitSchema = (max: number) => z.int().min(1).max(max);
+/**
+ * A page size, capped at the mirrored route's own ceiling.
+ *
+ * `fallback` is the value the handler uses when the argument is omitted, and
+ * passing it is what puts the documented default INTO the contract rather than
+ * only in the tool's prose. Deliberately NOT a Zod `.default()`: that would
+ * substitute the value during parse, and these handlers own that decision —
+ * they clamp an out-of-range limit and fall back on a missing or malformed
+ * one, forgiving behaviour tests/mcp-schema-enforcement.test.ts pins on
+ * purpose (#8942). Declaring the default without applying it keeps the
+ * published contract honest and the runtime behaviour untouched.
+ */
+export const limitSchema = (max: number, fallback?: number) => {
+  const schema = z.int().min(1).max(max);
+  return fallback === undefined
+    ? schema.describe(`Maximum rows to return (1-${max}).`)
+    : schema
+        .describe(
+          `Maximum rows to return (1-${max}). Defaults to ${fallback} when omitted; ` +
+            "a larger value is clamped to the ceiling rather than rejected.",
+        )
+        .meta({ default: fallback });
+};
 
 /**
  * A page offset. `MAX_OFFSET` is the deep-paging bound every paginated route already
  * clamps to — previously declared as unbounded here and silently clamped there.
  */
-export const offsetSchema = () => z.int().min(0).max(MAX_OFFSET);
+export const offsetSchema = () =>
+  z
+    .int()
+    .min(0)
+    .max(MAX_OFFSET)
+    .describe(
+      `Rows to skip before the first returned row (0-${MAX_OFFSET}). ` +
+        "Defaults to 0; a non-numeric value resolves to 0 and the response reports it.",
+    );
+
+/**
+ * An SS58 address. The pattern is the one 26 tool modules each declared
+ * privately; hoisted so the regex and the sentence explaining it live once.
+ *
+ * Not narrowed to a network prefix: these routes accept any well-formed SS58,
+ * and the chain is what rejects an address valid in shape but belonging to no
+ * account.
+ */
+export const SS58_PATTERN = /^[1-9A-HJ-NP-Za-km-z]{47,48}$/;
+export const ss58Schema = () =>
+  z
+    .string()
+    .regex(SS58_PATTERN)
+    .describe(
+      "An SS58 account address (47-48 base58 characters). Coldkey or hotkey " +
+        "depending on the tool — see the tool description for which this expects.",
+    );
+
+/**
+ * Sort direction. 31 of the 32 `order` parameters are this exact pair and mean
+ * the same thing on every one of them.
+ */
+export const orderSchema = () =>
+  z
+    .enum(["asc", "desc"])
+    .describe(
+      "Sort direction for the chosen sort key: `asc` smallest-first, " +
+        "`desc` largest-first.",
+    );
+
+// --- Descriptions for families whose VALUES are per-tool ---------------------
+//
+// `window`, `sort` and `kind` do not share one enum — 7, 31 and 5 distinct
+// value sets respectively — so they cannot share a builder. What they do share
+// is the MEANING of the parameter, and that is the part no caller could read
+// anywhere. Each wrapper takes the tool's own enum and attaches the sentence;
+// the published `enum` still carries the values, so nothing is duplicated or
+// able to drift.
+
+/**
+ * A trailing aggregation window. Says the two things the enum cannot: that it
+ * is trailing and ends now, not a calendar period, and that the option set is
+ * per-tool.
+ */
+export const windowSchema = <T extends readonly [string, ...string[]]>(
+  values: T,
+) =>
+  z
+    .enum(values)
+    .describe(
+      "Trailing time window to aggregate over, ending at the latest data " +
+        "point rather than a calendar boundary. Options are per-tool; see this " +
+        "parameter's enum.",
+    );
+
+/** Which column the result is ranked by. Values are per-tool. */
+export const sortSchema = <T extends readonly [string, ...string[]]>(
+  values: T,
+) =>
+  z
+    .enum(values)
+    .describe(
+      "Column to rank the result by; pair with `order` for direction. " +
+        "Options are per-tool; see this parameter's enum.",
+    );
+
+/**
+ * A block height bound. Inclusive on both ends, which is the one thing a
+ * caller cannot infer from the name and gets wrong by one row.
+ */
+export const blockBoundSchema = (edge: "first" | "last") =>
+  z
+    .int()
+    .min(0)
+    .describe(
+      `Inclusive ${edge} block height of the range to read. ` +
+        "Omit for an unbounded end.",
+    );
+
+/**
+ * A free-text search query. Substring/keyword, not a query language — worth
+ * saying, because an agent that assumes operators will silently get no match.
+ */
+export const querySchema = () =>
+  z
+    .string()
+    .describe(
+      "Free-text search terms, matched as case-insensitive substrings. " +
+        "Not a query language: operators, quotes and wildcards are matched literally.",
+    );
+
+/**
+ * A page cursor. TWO kinds, and conflating them is the mistake this pair
+ * exists to prevent: 32 of the 47 `cursor` parameters are a numeric row
+ * offset and 14 are an opaque keyset token. They page differently and only
+ * one of them is safe across an inserting table, so they get different
+ * sentences rather than one vague shared one.
+ */
+export const numericCursorSchema = () =>
+  z
+    .int()
+    .min(0)
+    .describe(
+      "Row offset to resume from — the numeric position of the first row to " +
+        "return, not an opaque token. Rows inserted since the previous page " +
+        "shift it, so prefer the keyset cursor where a tool offers one.",
+    );
+
+export const keysetCursorSchema = () =>
+  z
+    .string()
+    .describe(
+      "Opaque pagination token: pass back the `next_cursor` from the previous " +
+        "response verbatim. Its contents are not stable and must not be parsed " +
+        "or constructed. Stable across inserts, unlike a row offset.",
+    );
+
+/**
+ * The `fields=` projection as a bare string. Same syntax as `fieldsSchema()`
+ * but without the regex, for the tools whose handler accepts a looser form —
+ * the sentence is what was missing on all 26 of them.
+ */
+export const fieldsStringSchema = () =>
+  z
+    .string()
+    .describe(
+      "Comma-separated row field names to project, e.g. `netuid,name,slug`. " +
+        "Bare identifiers only — not a JSON array, no paths or indices. " +
+        "Omit for the full row.",
+    );
+
+/**
+ * A `kind` filter. Like `window`/`sort`, the value sets are per-tool (surface
+ * kinds, pool kinds, feed kinds …), so only the meaning is shared.
+ */
+export const kindSchema = <T extends readonly [string, ...string[]]>(
+  values: T,
+) =>
+  z
+    .enum(values)
+    .describe(
+      "Restrict the result to this kind. Options are per-tool; see this " +
+        "parameter's enum.",
+    );
+
+/**
+ * A `kind` filter whose accepted values are NOT a closed set — the handler
+ * matches against whatever the underlying rows carry, so there is no enum to
+ * publish. Says so, because an unmatched value returns an empty result rather
+ * than an error, which reads as "no data" instead of "wrong filter".
+ */
+export const kindStringSchema = () =>
+  z
+    .string()
+    .describe(
+      "Restrict the result to this kind, matched exactly against the value " +
+        "the rows carry. Open set, so a value nothing matches yields an empty " +
+        "result rather than an error. Omit for every kind.",
+    );
+
+/**
+ * A provider slug. Says it is the slug rather than the display name, which is
+ * the mistake the parameter invites — `npm run providers:list` prints them.
+ */
+export const providerSlugSchema = () =>
+  z
+    .string()
+    .describe(
+      "Restrict to one provider, by SLUG (`opentensor-foundation`), not " +
+        "display name. Unknown slugs yield an empty result, not an error.",
+    );
+
+/** A surface id, the stable key a surface keeps across renames. */
+export const surfaceIdSchema = () =>
+  z
+    .string()
+    .describe(
+      "The surface's stable id (`sn-64-chutes-subnet-api`), as returned by " +
+        "the surface-listing tools. Stable across renames, unlike the name.",
+    );
+
+/**
+ * A hotkey or coldkey the caller must pick. Distinct from `ss58Schema()` only
+ * in that the tools using it name the ROLE in the parameter, so the sentence
+ * says which one rather than deferring to the tool description.
+ */
+export const accountKeySchema = (role: "hotkey" | "coldkey") =>
+  z
+    .string()
+    .regex(SS58_PATTERN)
+    .describe(
+      role === "hotkey"
+        ? "The neuron/validator SS58 hotkey — the key that holds a UID and " +
+            "sets weights, not the coldkey that owns the funds."
+        : "The owning SS58 coldkey — the key that holds balances and " +
+            "delegations, not the hotkey that serves on a subnet.",
+    );
+
+/** A neuron's position within one subnet. */
+export const uidSchema = () =>
+  z
+    .int()
+    .min(0)
+    .describe(
+      "Neuron UID: a slot number within ONE subnet, not a global id. The same " +
+        "UID on another netuid is a different neuron, and a UID is reused " +
+        "after deregistration.",
+    );
 
 /**
  * The accepted `fields` syntax, which was documented NOWHERE a caller could see it:
@@ -171,4 +426,9 @@ export const NEURON_FIELD_NAMES = Object.keys(NeuronSchema.shape) as [
 export const NeuronFieldsInputSchema = z
   .array(z.enum(NEURON_FIELD_NAMES))
   .min(1)
+  .describe(
+    "Narrow each returned neuron row to these fields. An ARRAY of names, " +
+      "unlike the comma-separated string `fields` takes elsewhere. Omit for " +
+      "the full row; the enum lists every projectable field.",
+  )
   .optional();

--- a/schemas-src/mcp-tools/subnet-activity.ts
+++ b/schemas-src/mcp-tools/subnet-activity.ts
@@ -12,14 +12,17 @@
 // src/subnet-*.ts WINDOWS constant at the time of writing (all seven
 // verified identical).
 import { z } from "zod";
+import { netuidSchema } from "./shared.ts";
 
 const ACTIVITY_WINDOWS = ["7d", "30d"] as const;
 const ActivityWindowSchema = z.enum(ACTIVITY_WINDOWS).optional();
 
 const ActivityInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    window: ActivityWindowSchema,
+    netuid: netuidSchema(),
+    window: ActivityWindowSchema.describe(
+      "Trailing time window to aggregate over, ending at the latest data point rather than a calendar boundary. Options are per-tool; see this parameter's enum.",
+    ),
   })
   .strict();
 
@@ -30,7 +33,7 @@ export type GetSubnetRegistrationsInput = z.infer<
 export const GetSubnetRegistrationsOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable(),
     observed_at: z.string().nullable().optional(),
     distinct_registrants: z.int(),
@@ -49,7 +52,7 @@ export type GetSubnetStakeMovesInput = z.infer<
 export const GetSubnetStakeMovesOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable(),
     observed_at: z.string().nullable().optional(),
     distinct_movers: z.int(),
@@ -68,7 +71,7 @@ export type GetSubnetStakeTransfersInput = z.infer<
 export const GetSubnetStakeTransfersOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable(),
     observed_at: z.string().nullable().optional(),
     distinct_senders: z.int(),
@@ -87,7 +90,7 @@ export type GetSubnetAxonRemovalsInput = z.infer<
 export const GetSubnetAxonRemovalsOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable(),
     observed_at: z.string().nullable().optional(),
     distinct_removers: z.int(),
@@ -104,7 +107,7 @@ export type GetSubnetServingInput = z.infer<typeof GetSubnetServingInputSchema>;
 export const GetSubnetServingOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable(),
     observed_at: z.string().nullable().optional(),
     distinct_servers: z.int(),
@@ -123,7 +126,7 @@ export type GetSubnetPrometheusInput = z.infer<
 export const GetSubnetPrometheusOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable(),
     observed_at: z.string().nullable().optional(),
     distinct_exporters: z.int(),
@@ -142,7 +145,7 @@ export type GetSubnetDeregistrationsInput = z.infer<
 export const GetSubnetDeregistrationsOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     window: z.string().nullable(),
     observed_at: z.string().nullable().optional(),
     distinct_deregistered_hotkeys: z.int(),

--- a/schemas-src/mcp-tools/subnet-registry-lists.ts
+++ b/schemas-src/mcp-tools/subnet-registry-lists.ts
@@ -9,7 +9,18 @@
 // mcp-server.ts. None mirror an existing schemas-src/routes/ REST schema --
 // modeled fresh, matching each hand-written literal field-for-field.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import {
+  OpenObjectSchema,
+  fieldsStringSchema,
+  kindSchema,
+  limitSchema,
+  netuidSchema,
+  numericCursorSchema,
+  orderSchema,
+  providerSlugSchema,
+  querySchema,
+  sortSchema,
+} from "./shared.ts";
 
 const SURFACE_KINDS = [
   "archive",
@@ -30,7 +41,7 @@ const SURFACE_KINDS = [
 
 export const GetSubnetCandidatesInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetCandidatesInput = z.infer<
@@ -39,7 +50,7 @@ export type GetSubnetCandidatesInput = z.infer<
 
 export const GetSubnetCandidatesOutputSchema = z
   .object({
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     candidates: z.array(OpenObjectSchema).optional(),
     generated_at: z.string().nullable().optional(),
     schema_version: z.union([z.string(), z.int()]).nullable().optional(),
@@ -70,17 +81,28 @@ const CANDIDATES_SORT_FIELDS = [
 
 export const ListSubnetCandidatesInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    kind: z.enum(SURFACE_KINDS).optional(),
-    provider: z.string().optional(),
-    state: z.enum(CANDIDATE_STATES).optional(),
-    id: z.string().optional(),
-    confidence: z.enum(CONFIDENCE_LEVELS).optional(),
-    sort: z.enum(CANDIDATES_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    netuid: netuidSchema(),
+    kind: kindSchema(SURFACE_KINDS).optional(),
+    provider: providerSlugSchema().optional(),
+    state: z
+      .enum(CANDIDATE_STATES)
+      .optional()
+      .describe("The incident's lifecycle state."),
+    id: z
+      .string()
+      .optional()
+      .describe(
+        "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
+      ),
+    confidence: z
+      .enum(CONFIDENCE_LEVELS)
+      .optional()
+      .describe("How confident the machine assessment is."),
+    sort: sortSchema(CANDIDATES_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListSubnetCandidatesInput = z.infer<
@@ -90,7 +112,7 @@ export type ListSubnetCandidatesInput = z.infer<
 export const ListSubnetCandidatesOutputSchema = z
   .object({
     generated_at: z.string().nullable().optional(),
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     candidates: z.array(OpenObjectSchema),
     total: z.int().optional(),
     returned: z.int().optional(),
@@ -107,7 +129,7 @@ export type ListSubnetCandidatesOutput = z.infer<
 
 export const GetSubnetEvidenceInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetEvidenceInput = z.infer<
@@ -116,7 +138,7 @@ export type GetSubnetEvidenceInput = z.infer<
 
 export const GetSubnetEvidenceOutputSchema = z
   .object({
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     claims: z.array(OpenObjectSchema).optional(),
     generated_at: z.string().nullable().optional(),
     schema_version: z.union([z.string(), z.int()]).nullable().optional(),
@@ -135,13 +157,13 @@ const CLAIM_SORT_FIELDS = [
 
 export const ListSubnetEvidenceInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    q: z.string().optional(),
-    sort: z.enum(CLAIM_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    netuid: netuidSchema(),
+    q: querySchema().optional(),
+    sort: sortSchema(CLAIM_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListSubnetEvidenceInput = z.infer<
@@ -151,7 +173,7 @@ export type ListSubnetEvidenceInput = z.infer<
 export const ListSubnetEvidenceOutputSchema = z
   .object({
     generated_at: z.string().nullable().optional(),
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     claims: z.array(OpenObjectSchema),
     total: z.int().optional(),
     returned: z.int().optional(),
@@ -168,7 +190,7 @@ export type ListSubnetEvidenceOutput = z.infer<
 
 export const GetSubnetSurfacesInputSchema = z
   .object({
-    netuid: z.int().min(0),
+    netuid: netuidSchema(),
   })
   .strict();
 export type GetSubnetSurfacesInput = z.infer<
@@ -177,7 +199,7 @@ export type GetSubnetSurfacesInput = z.infer<
 
 export const GetSubnetSurfacesOutputSchema = z
   .object({
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     surfaces: z.array(OpenObjectSchema).optional(),
     generated_at: z.string().nullable().optional(),
     schema_version: z.union([z.string(), z.int()]).nullable().optional(),

--- a/schemas-src/mcp-tools/subnet-scoped-lists.ts
+++ b/schemas-src/mcp-tools/subnet-scoped-lists.ts
@@ -16,7 +16,17 @@
 // list_subnet_surfaces/list_subnet_health have no `fields` projection param
 // at all, unlike every other list_* tool in this epic.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import {
+  OpenObjectSchema,
+  fieldsStringSchema,
+  kindSchema,
+  limitSchema,
+  netuidSchema,
+  numericCursorSchema,
+  orderSchema,
+  providerSlugSchema,
+  sortSchema,
+} from "./shared.ts";
 
 const SURFACE_KINDS = [
   "archive",
@@ -65,22 +75,57 @@ const ENDPOINT_SORT_FIELDS = [
 
 export const ListSubnetEndpointsInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    kind: z.enum(SURFACE_KINDS).optional(),
-    layer: z.enum(ENDPOINT_LAYERS).optional(),
-    provider: z.string().optional(),
-    publication_state: z.enum(ENDPOINT_PUBLICATION_STATES).optional(),
-    status: z.enum(HEALTH_STATUSES).optional(),
-    pool_eligible: z.enum(BOOLEAN_STRINGS).optional(),
-    min_latency_ms: z.number().optional(),
-    max_latency_ms: z.number().optional(),
-    min_score: z.number().optional(),
-    max_score: z.number().optional(),
-    sort: z.enum(ENDPOINT_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    fields: z.string().optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    netuid: netuidSchema(),
+    kind: kindSchema(SURFACE_KINDS).optional(),
+    layer: z
+      .enum(ENDPOINT_LAYERS)
+      .optional()
+      .describe(
+        "Which layer of the stack the endpoint belongs to: the Bittensor base chain, a data or docs provider, or a subnet's own app.",
+      ),
+    provider: providerSlugSchema().optional(),
+    publication_state: z
+      .enum(ENDPOINT_PUBLICATION_STATES)
+      .optional()
+      .describe(
+        "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
+      ),
+    status: kindSchema(HEALTH_STATUSES).optional(),
+    pool_eligible: z
+      .enum(BOOLEAN_STRINGS)
+      .optional()
+      .describe(
+        "Restrict to endpoints that are (or are not) eligible for the public RPC pool.",
+      ),
+    min_latency_ms: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive lower bound on probe latency in milliseconds; rows below it are excluded.",
+      ),
+    max_latency_ms: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive upper bound on probe latency in milliseconds; rows above it are excluded.",
+      ),
+    min_score: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive lower bound on endpoint score; rows below it are excluded.",
+      ),
+    max_score: z
+      .number()
+      .optional()
+      .describe(
+        "Inclusive upper bound on endpoint score; rows above it are excluded.",
+      ),
+    sort: sortSchema(ENDPOINT_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListSubnetEndpointsInput = z.infer<
@@ -90,7 +135,7 @@ export type ListSubnetEndpointsInput = z.infer<
 export const ListSubnetEndpointsOutputSchema = z
   .object({
     generated_at: z.string().nullable().optional(),
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     endpoints: z.array(OpenObjectSchema),
     total: z.int().optional(),
     returned: z.int().optional(),
@@ -115,14 +160,19 @@ const SURFACE_SORT_FIELDS = [
 
 export const ListSubnetSurfacesInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    kind: z.enum(SURFACE_KINDS).optional(),
-    provider: z.string().optional(),
-    id: z.string().optional(),
-    sort: z.enum(SURFACE_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    netuid: netuidSchema(),
+    kind: kindSchema(SURFACE_KINDS).optional(),
+    provider: providerSlugSchema().optional(),
+    id: z
+      .string()
+      .optional()
+      .describe(
+        "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
+      ),
+    sort: sortSchema(SURFACE_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListSubnetSurfacesInput = z.infer<
@@ -132,7 +182,7 @@ export type ListSubnetSurfacesInput = z.infer<
 export const ListSubnetSurfacesOutputSchema = z
   .object({
     generated_at: z.string().nullable().optional(),
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     surfaces: z.array(OpenObjectSchema),
     total: z.int().optional(),
     returned: z.int().optional(),
@@ -176,15 +226,20 @@ const HEALTH_SORT_FIELDS = [
 
 export const ListSubnetHealthInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    kind: z.enum(SURFACE_KINDS).optional(),
-    provider: z.string().optional(),
-    status: z.enum(HEALTH_STATUSES).optional(),
-    classification: z.enum(HEALTH_CLASSIFICATIONS).optional(),
-    sort: z.enum(HEALTH_SORT_FIELDS).optional(),
-    order: z.enum(["asc", "desc"]).optional(),
-    limit: z.int().min(1).max(100).optional(),
-    cursor: z.int().min(0).optional(),
+    netuid: netuidSchema(),
+    kind: kindSchema(SURFACE_KINDS).optional(),
+    provider: providerSlugSchema().optional(),
+    status: kindSchema(HEALTH_STATUSES).optional(),
+    classification: z
+      .enum(HEALTH_CLASSIFICATIONS)
+      .optional()
+      .describe(
+        "Why a probe ended as it did — the reason behind the status, not the status itself.",
+      ),
+    sort: sortSchema(HEALTH_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    limit: limitSchema(100).optional(),
+    cursor: numericCursorSchema().optional(),
   })
   .strict();
 export type ListSubnetHealthInput = z.infer<typeof ListSubnetHealthInputSchema>;
@@ -192,7 +247,7 @@ export type ListSubnetHealthInput = z.infer<typeof ListSubnetHealthInputSchema>;
 export const ListSubnetHealthOutputSchema = z
   .object({
     generated_at: z.string().nullable().optional(),
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     surfaces: z.array(OpenObjectSchema),
     total: z.int().optional(),
     returned: z.int().optional(),

--- a/schemas-src/mcp-tools/validators.ts
+++ b/schemas-src/mcp-tools/validators.ts
@@ -6,11 +6,19 @@
 // matching each hand-written literal field-for-field.
 import { z } from "zod";
 import {
-  limitSchema,
   NeuronFieldsInputSchema,
   OpenObjectArraySchema,
+  accountKeySchema,
+  limitSchema,
+  netuidSchema,
+  offsetSchema,
+  sortSchema,
+  windowSchema,
 } from "./shared.ts";
-import { GLOBAL_VALIDATOR_LIMIT_MAX } from "../../src/route-limits.ts";
+import {
+  GLOBAL_VALIDATOR_LIMIT_DEFAULT,
+  GLOBAL_VALIDATOR_LIMIT_MAX,
+} from "../../src/route-limits.ts";
 
 // Mirrors workers/config.ts's SS58_ADDRESS_PATTERN (inlined rather than
 // cross-imported from workers/, matching this directory's existing
@@ -20,9 +28,30 @@ const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 
 export const ListSubnetValidatorsInputSchema = z
   .object({
-    netuid: z.int().min(0),
-    limit: z.int().min(1).optional(),
-    min_stake_tao: z.number().min(0).optional(),
+    netuid: netuidSchema(),
+    // NOT limitSchema(): that helper takes the mirrored route's ceiling, and
+    // this parameter has none to take. It is an MCP-only post-filter applied
+    // after the loader returns (see this tool's handler), so the REST route
+    // enforces nothing here and the subnet's own validator set is the bound.
+    // Publishing an invented `maximum` would advertise a constraint the
+    // handler does not apply -- the same defect as declaring a ceiling a route
+    // rejects, in reverse. Described, deliberately unbounded.
+    limit: z
+      .int()
+      .min(1)
+      .describe(
+        "Keep only the highest-stake N validators. Applied after the set is " +
+          "fetched, so it trims the response rather than the query, and has " +
+          "no fixed ceiling: the subnet's own validator count is the bound.",
+      )
+      .optional(),
+    min_stake_tao: z
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        "Drop rows whose stake is below this many TAO. Applied after the set is fetched.",
+      ),
     // #9082: narrow each returned row to these fields. Omit for the full
     // row. Valid names are NeuronSchema's own, so this enum cannot drift
     // from what the route can project.
@@ -36,7 +65,7 @@ export type ListSubnetValidatorsInput = z.infer<
 export const ListSubnetValidatorsOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int(),
+    netuid: netuidSchema(),
     validator_count: z.int(),
     captured_at: z.string().nullable().optional(),
     block_number: z.int().nullable().optional(),
@@ -62,12 +91,15 @@ const GLOBAL_VALIDATOR_SORTS = [
 
 export const ListGlobalValidatorsInputSchema = z
   .object({
-    sort: z.enum(GLOBAL_VALIDATOR_SORTS).optional(),
+    sort: sortSchema(GLOBAL_VALIDATOR_SORTS).optional(),
     // Was a hardcoded 100 while this tool's own description — interpolated from
     // GLOBAL_VALIDATOR_LIMIT_MAX — said "max 2000", and the handler clamped to 2000.
     // The tool advertised 2000 in prose, 100 in schema, and served 2000. Now the
     // constant is the only declaration, as src/route-limits.ts intended.
-    limit: limitSchema(GLOBAL_VALIDATOR_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      GLOBAL_VALIDATOR_LIMIT_MAX,
+      GLOBAL_VALIDATOR_LIMIT_DEFAULT,
+    ).optional(),
   })
   .strict();
 export type ListGlobalValidatorsInput = z.infer<
@@ -78,7 +110,7 @@ export type ListGlobalValidatorsInput = z.infer<
 // search-subnets.ts's same note from the pilot batch).
 const GlobalValidatorSubnetItemSchema = z
   .object({
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     uid: z.int().nullable().optional(),
     stake_tao: z.unknown().optional(),
     emission_tao: z.unknown().optional(),
@@ -121,7 +153,7 @@ export type ListGlobalValidatorsOutput = z.infer<
 
 export const GetValidatorDetailInputSchema = z
   .object({
-    hotkey: Ss58Schema,
+    hotkey: accountKeySchema("hotkey"),
   })
   .strict();
 export type GetValidatorDetailInput = z.infer<
@@ -155,8 +187,14 @@ const COMPARE_VALIDATORS_MAX = 16;
 
 export const CompareValidatorsInputSchema = z
   .object({
-    hotkeys: z.array(Ss58Schema).min(1).max(COMPARE_VALIDATORS_MAX),
-    netuid: z.int().min(0).optional(),
+    hotkeys: z
+      .array(Ss58Schema)
+      .min(1)
+      .max(COMPARE_VALIDATORS_MAX)
+      .describe(
+        "SS58 hotkeys to compare, as an array. Each is a validator/neuron key, not a coldkey.",
+      ),
+    netuid: netuidSchema().optional(),
   })
   .strict();
 export type CompareValidatorsInput = z.infer<
@@ -166,7 +204,7 @@ export type CompareValidatorsInput = z.infer<
 export const CompareValidatorsOutputSchema = z
   .object({
     schema_version: z.int().optional(),
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     validator_count: z.int(),
     validators: OpenObjectArraySchema,
   })
@@ -187,12 +225,12 @@ const NOMINATOR_SORTS = [
 
 export const GetValidatorNominatorsInputSchema = z
   .object({
-    hotkey: Ss58Schema,
-    window: z.enum(NOMINATOR_WINDOWS).optional(),
-    sort: z.enum(NOMINATOR_SORTS).optional(),
-    limit: z.int().min(1).max(100).optional(),
-    offset: z.int().min(0).optional(),
-    coldkey: Ss58Schema.optional(),
+    hotkey: accountKeySchema("hotkey"),
+    window: windowSchema(NOMINATOR_WINDOWS).optional(),
+    sort: sortSchema(NOMINATOR_SORTS).optional(),
+    limit: limitSchema(100).optional(),
+    offset: offsetSchema().optional(),
+    coldkey: accountKeySchema("coldkey").optional(),
   })
   .strict();
 export type GetValidatorNominatorsInput = z.infer<
@@ -230,11 +268,11 @@ export type GetValidatorNominatorsOutput = z.infer<
 
 export const GetValidatorHistoryInputSchema = z
   .object({
-    hotkey: Ss58Schema,
-    window: z.enum(["7d", "30d", "90d", "1y", "all"]).optional(),
+    hotkey: accountKeySchema("hotkey"),
+    window: windowSchema(["7d", "30d", "90d", "1y", "all"]).optional(),
     // #9383: scopes the series to one subnet and switches the points to the
     // per-subnet shape (vTrust, consensus, dividends, take, native alpha).
-    netuid: z.int().min(0).max(65535).optional(),
+    netuid: netuidSchema().optional(),
   })
   .strict();
 export type GetValidatorHistoryInput = z.infer<
@@ -250,7 +288,7 @@ const ValidatorHistoryPointSchema = z
     // unscoped series, because vTrust/consensus/dividends/take are per-subnet
     // facts and a cross-subnet average of them is a number the chain never
     // computes -- see subnetScopedFields in src/validator-history.ts.
-    netuid: z.int().nullable().optional(),
+    netuid: netuidSchema().nullable().optional(),
     uid: z.int().nullable().optional(),
     stake_alpha: z.number().nullable().optional(),
     emission_alpha: z.number().nullable().optional(),

--- a/schemas-src/shared.ts
+++ b/schemas-src/shared.ts
@@ -22,7 +22,17 @@ export type CoverageLevel = z.infer<typeof CoverageLevelSchema>;
 // not have to learn that the RPC lane says "test" while a data lane says
 // "testnet". Only the tools whose artifact is actually published per-network
 // (list_subnets, get_subnet_detail) take this; everything else stays mainnet.
-export const McpNetworkSchema = z.enum(["finney", "test"]);
+// #9645: described here rather than at each of the 18 tools that accept it —
+// the two names are chain names, not environment names, and "test" reads as a
+// staging copy of mainnet when it is a separate chain with its own subnets,
+// its own netuids and its own history.
+export const McpNetworkSchema = z
+  .enum(["finney", "test"])
+  .describe(
+    "Which Bittensor chain to read: `finney` is mainnet (the default when " +
+      "omitted), `test` is testnet. They are separate chains — a netuid on one " +
+      "is unrelated to the same netuid on the other.",
+  );
 export type McpNetwork = z.infer<typeof McpNetworkSchema>;
 
 export const CurationLevelSchema = z.enum([

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -15756,12 +15756,20 @@ export function scheduleMcpRefusalEvent(
   env: Env,
   deps: Row,
   response: Response,
+  /** Injectable clock, mirroring admitMcpRefusalCapture's own `nowMs`. Only a
+   * test passes it. Without it the storm window can only be crossed by real
+   * elapsed time, which made the "next window carries the suppressed count"
+   * case a wall-clock race: two calls meant to share a window straddled it
+   * whenever the event loop scheduled them more than the window apart. A
+   * throttle is exactly the kind of code whose boundary must be asserted
+   * deterministically rather than slept at. */
+  nowMs: number = Date.now(),
 ) {
   try {
     if (!isUsageTelemetryConfigured(env)) return;
     const reason = mcpRefusalReason(response);
     if (reason === null) return;
-    const suppressed = admitMcpRefusalCapture(env, reason);
+    const suppressed = admitMcpRefusalCapture(env, reason, nowMs);
     if (suppressed === null) return;
     const record = (deps.recordUsageEvent ?? recordUsageEvent) as AnyFn;
     const pending = Promise.resolve(

--- a/tests/mcp-input-schema.test.ts
+++ b/tests/mcp-input-schema.test.ts
@@ -208,3 +208,74 @@ describe("the published tool registry", () => {
     assert.ok(re.test("netuid,,name"), "the parser drops empty segments");
   });
 });
+
+// #9645: the shared input primitives in schemas-src/mcp-tools/shared.ts carry
+// the sentence explaining each parameter, so every tool that uses one inherits
+// it. Measured before the change: exactly ONE of 773 published parameters had a
+// `description`.
+//
+// Derived from listToolDefinitions() rather than a fixed tool list, so a tool
+// registered tomorrow is covered tonight -- the same construction the enum and
+// `required` gates in mcp-schema-enforcement.test.ts use. That is what makes
+// this a gate rather than a snapshot: a new tool that hand-rolls
+// `netuid: z.int()` instead of `netuidSchema()` fails here.
+describe("shared input parameters publish their own description (#9645)", () => {
+  const params = () => {
+    const rows: Array<{ tool: string; name: string; schema: Row }> = [];
+    for (const tool of listToolDefinitions() as Row[]) {
+      const props = (tool.inputSchema as Row)?.properties ?? {};
+      for (const [name, schema] of Object.entries(props)) {
+        rows.push({ tool: tool.name as string, name, schema: schema as Row });
+      }
+    }
+    return rows;
+  };
+
+  // EVERY parameter, not a named list. The families were migrated onto shared
+  // builders and the long tail was written per name, so there is no residue to
+  // exempt -- and a whitelist would quietly stop covering whatever came next.
+  test("every published tool parameter carries a description", () => {
+    const rows = params();
+    assert.ok(
+      rows.length > 700,
+      `expected the full surface, got ${rows.length}`,
+    );
+    const missing = rows
+      .filter((p) => !String(p.schema.description ?? "").trim())
+      .map((p) => `${p.tool}.${p.name}`);
+    assert.deepEqual(
+      missing,
+      [],
+      "add the sentence to the shared builder in schemas-src/mcp-tools/shared.ts, " +
+        "or inline where the parameter's meaning is genuinely tool-specific",
+    );
+  });
+
+  // netuid is a u16 on chain. Before the shared builder, 95 of them published
+  // no upper bound at all and several published no lower bound either, so the
+  // schema permitted values the route rejects.
+  test("every `netuid` parameter is bounded to the chain's own u16 range", () => {
+    const rows = params().filter((p) => p.name === "netuid");
+    const wrong = rows
+      .filter((p) => p.schema.minimum !== 0 || p.schema.maximum !== 65535)
+      .map((p) => `${p.tool}: [${p.schema.minimum}, ${p.schema.maximum}]`);
+    assert.deepEqual(wrong, []);
+  });
+
+  // A declared default must be a real default, not a plausible one: it is read
+  // off the same `*_LIMIT_DEFAULT` constant in src/route-limits.ts that the
+  // handler uses, so the published contract and the runtime cannot disagree.
+  test("a declared limit default sits inside the declared range", () => {
+    const rows = params().filter(
+      (p) => p.name === "limit" && p.schema.default !== undefined,
+    );
+    assert.ok(rows.length > 0, "expected some limits to declare a default");
+    for (const p of rows) {
+      const d = p.schema.default as number;
+      assert.ok(
+        Number.isInteger(d) && d >= 1 && d <= (p.schema.maximum as number),
+        `${p.tool}.limit default ${d} outside 1..${p.schema.maximum}`,
+      );
+    }
+  });
+});

--- a/tests/mcp-usage-telemetry.test.ts
+++ b/tests/mcp-usage-telemetry.test.ts
@@ -1460,18 +1460,20 @@ describe("scheduleMcpRefusalEvent guards (#9639)", () => {
   });
 
   // The other side of that ternary: once a window rolls over, the count of
-  // what was held is carried on the next event rather than discarded. Uses a
-  // 1ms window and a real rollover -- admitMcpRefusalCapture takes an explicit
-  // clock but scheduleMcpRefusalEvent deliberately does not, so this is the
-  // honest way to cross the boundary through the real call path. A distinct
-  // status keys its own reason, so no earlier test in this file can prime it.
-  test("suppressed_occurrences rides the first event of the next window", async () => {
+  // what was held is carried on the next event rather than discarded.
+  //
+  // Driven by an INJECTED clock, not a sleep. The first version of this test
+  // used a 1ms window and a 20ms wait, and flaked roughly two runs in three:
+  // the two calls meant to share a window straddled it whenever the event loop
+  // scheduled them more than a millisecond apart. A throttle's boundary is
+  // exactly the thing that has to be asserted deterministically.
+  test("suppressed_occurrences rides the first event of the next window", () => {
     const env = {
       ...CONFIGURED_ENV,
-      [POSTHOG_EXCEPTION_STORM_WINDOW_MS_ENV]: "1",
+      [POSTHOG_EXCEPTION_STORM_WINDOW_MS_ENV]: "1000",
     } as unknown as Env;
     const spy = recorder();
-    const fire = () =>
+    const fire = (at: number) =>
       scheduleMcpRefusalEvent(
         req(),
         env,
@@ -1480,15 +1482,22 @@ describe("scheduleMcpRefusalEvent guards (#9639)", () => {
           executionCtx: fakeExecutionCtx(),
         },
         new Response(null, { status: 418 }),
+        at,
       );
-    fire();
-    fire();
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    fire();
+    fire(0);
+    fire(10);
+    fire(20);
+    fire(1000);
     assert.equal(spy.events.length, 2, "one per window, not one per call");
+    const first = spy.events[0]!.event as Row;
     const second = spy.events[1]!.event as Row;
-    assert.equal(second.route, "mcp:refused:status_418");
-    assert.equal(second.suppressed_occurrences, 1);
+    assert.equal(first.route, "mcp:refused:status_418");
+    assert.equal(
+      "suppressed_occurrences" in first,
+      false,
+      "first sighting held nothing back",
+    );
+    assert.equal(second.suppressed_occurrences, 2);
   });
 
   test("a recorder that rejects is swallowed, never surfaced", async () => {


### PR DESCRIPTION
## Summary

Measured on production `tools/list` before starting: of **773 published tool parameters, exactly ONE carried a `description`** and **none declared a `default`**.

The guidance was never missing — it was prose inside each tool's own description (median 568 characters), which does explain the parameters. The problem is where it lives: a client cannot render a paragraph per field, a model filling one argument does not attend to it, and nothing can check it against the schema. `limit` is the sharpest case — the paragraphs promise a default and no schema declared one, so prose and contract were free to drift with nothing noticing.

**773 of 773 are now described.**

## Two mechanisms, chosen per parameter

**Shared builders** where a name means the same thing everywhere. `schemas-src/mcp-tools/shared.ts` already held `netuidSchema`/`limitSchema`/`fieldsSchema` — and `fieldsSchema` was the *one* described parameter, which is the pattern this extends. One sentence covers every tool that uses it, so the wording cannot drift between them.

**Written per name** for the long tail — 128 names at under two uses each. `id` means a different entity on each of its nine tools; `to`/`from` are block heights on some tools and dates on others. One shared sentence across those would be filler that merely *looks* answered.

## The sentences carry what the name and enum cannot

- **`window`** — trailing, ending at the latest data point rather than a calendar boundary.
- **`cursor`** — split into two builders: 32 of the 47 are a numeric row offset, 14 are an opaque keyset token. They page differently, only one survives an insert, and a token must be passed back verbatim. One shared sentence would have been wrong for half of them.
- **`uid`** — a slot within *one* subnet, not a global id, and reused after deregistration.
- **`network`** — `finney` and `test` are separate chains, so a netuid on one is unrelated to the same netuid on the other.
- **every `min_*`/`max_*`** — states that the bound is inclusive, the detail that gets guessed wrong and silently returns an off-by-one set.
- **`call_rpc.method`** — the enum is the complete read-only allowlist, and it is the same set the proxy enforces, so anything absent is refused rather than forwarded.

## `default`, from the single source of truth

`limit` declares its default wherever `src/route-limits.ts` pairs a `*_LIMIT_MAX` with a `*_LIMIT_DEFAULT` — read off the same constant the handler uses, so contract and runtime cannot disagree.

Declared with `.meta()` rather than Zod's `.default()`, deliberately: a Zod default substitutes the value during parse, and these handlers own that decision. They clamp an out-of-range limit and fall back on a missing or malformed one — behaviour `tests/mcp-schema-enforcement.test.ts` pins on purpose (#8942).

## Cleanups this surfaced

- **Three tools redeclared a route limit locally** (`const MOVERS_LIMIT_MAX = 100`) instead of importing it, so the single source in `src/route-limits.ts` had three silent copies. Values matched; the duplicates are gone.
- **11 dead private `Ss58Schema` constants** the migration made unused.
- **`netuid` normalised on the OUTPUT side.** Output schemas never pass through `stripSentinelIntegerBounds`, so they published Zod's safe-integer sentinel (±2^53) as the range for a u16 — the noise that makes a deliberate bound indistinguishable from no bound, which is the defect #8942 removed from inputs.

## A flaky test this work exposed, fixed properly

The #9639 throttle's "suppressed count rides the next window" case used a 1ms window and a real sleep. It failed **about two runs in three** under load: the two calls meant to share a window straddled it whenever the event loop scheduled them more than a millisecond apart.

`scheduleMcpRefusalEvent` now takes an injectable clock — the same way `admitMcpRefusalCapture` already did — and the boundary is asserted rather than slept at. Verified 3/3 in isolation and in the full suite.

## Verified against the published schema, not by inspection

Every pass was checked by diffing `listToolDefinitions()` output against production's current `tools/list`:

```
described:               773/773 (100%)   [was 1/773]
with default:              9/773          [was 0/773]
constraint regressions:        0
parameters added/removed:      0
```

Two existing tests were updated and **neither was loosened** — both assert by subtraction, so they still fail if a real parameter is added (`get_coverage_depth` "no-arg") or if the wrapper is dropped (`feed-netuid-schema`).

## The gate

`tests/mcp-input-schema.test.ts` asserts **every** parameter carries a description, derived from `listToolDefinitions()` — not a whitelist, which would quietly stop covering whatever came next. Plus: every `netuid` is bounded to the chain's own u16 range, and a declared limit default sits inside its declared range. A new tool that hand-rolls `netuid: z.int()` fails in CI.

## Validation run

```
npx vitest run <10 MCP/schema/telemetry suites>   1640 passed
npm run validate:mcp                              224 tools, lifecycle + all tools/call green
npm run validate                                  129 subnets, 3442 surfaces
npm run typecheck                                 clean
npm run lint                                      clean (0 unused-var errors)
patch coverage (diff intersection, src/)          100%
```

Closes #9645
Closes #9652
