### PR TITLE
feat(queue): deliver webhooks on a queue, replacing the hand-rolled one

### DIFF
--- a/src/webhook-queue.ts
+++ b/src/webhook-queue.ts
@@ -1,0 +1,215 @@
+// Webhook delivery, on a queue (metagraphed-infra#354).
+//
+// WHAT THIS REPLACES. `src/webhooks.ts` grew a message queue by hand:
+// `dispatchWithRedelivery` parks a failed delivery in KV, sweeps the parked
+// backlog on the next publish run, schedules each record with its own
+// exponential round counter, dead-letters after eight rounds, and budgets the
+// sweep so one chronically-failing endpoint cannot monopolise it
+// (`WEBHOOK_REDELIVERY_MAX_PER_RUN`, `WEBHOOK_REDELIVERY_MAX_PER_SUBSCRIPTION`).
+// Parking, bounded retry, a redelivery window, dead-lettering and fairness --
+// every one of them is a queue primitive, hand-written here because there was
+// no queue.
+//
+// IT MATTERS MORE THAN THE SYNC LANES. Those deliver to our own database, where
+// a retry is an implementation detail. These deliver to THIRD PARTIES, where
+// retry and dead-letter semantics ARE the product: a subscriber's integration is
+// built on what we promise about redelivery.
+//
+// WHERE THE FAIRNESS CAP WENT, since deleting a safeguard deserves an argument
+// rather than a shrug. `WEBHOOK_REDELIVERY_MAX_PER_SUBSCRIPTION` existed because
+// the sweep drew from ONE SHARED BACKLOG under ONE PER-RUN BUDGET: 64 redeliveries
+// a run, so a subscriber with 500 parked deliveries would take every slot and
+// starve everyone else. The cap was rationing a scarce shared resource.
+//
+// A queue has no such resource. Each delivery is its own message with its own
+// retry clock, and a failed one is RESCHEDULED (`retry({ delaySeconds })`), not
+// spun on -- so a failing subscriber's messages are not competing for anything
+// between attempts; they are simply not due yet. The thing the cap protected
+// against no longer exists, which is the only honest reason to delete a
+// safeguard. What remains bounded is consumer concurrency (`max_concurrency`),
+// and that is a bound on simultaneous work rather than a budget one subscriber
+// can exhaust for the rest.
+//
+// WHAT DOES NOT MOVE. `deliverChangeEvent` -- the signed POST, the
+// delivery-time URL re-validation, the SSRF guard, the idempotency key -- is the
+// product, not scaffolding. It stays exactly as it is; this only changes what
+// decides to call it and what happens when it fails.
+
+/** One delivery: one event, to one subscriber. */
+export interface WebhookDeliveryMessage {
+  /** Which subscription to deliver to. Resolved at consume time rather than
+   * embedded, so a subscription deleted between enqueue and delivery is not
+   * delivered to from a stale copy. */
+  subscription_id: string;
+  /** The content-addressed event id, stable across retries -- it is half of the
+   * idempotency key a subscriber dedupes on. */
+  event_id: string;
+  /** The exact bytes to POST. Carried rather than rebuilt so a retry sends
+   * BYTE-IDENTICAL content to the first attempt: the signature is over this
+   * body, and a subscriber verifying it against a re-serialised payload with
+   * different key order would see a valid delivery as a forgery. */
+  body: string;
+}
+
+/**
+ * Attempts before a delivery dead-letters.
+ *
+ * Deliberately the same 8 as `WEBHOOK_MAX_DELIVERY_ROUNDS`, because subscribers
+ * were told that number. The transport changed; the promise did not.
+ */
+export const WEBHOOK_QUEUE_MAX_ATTEMPTS = 8;
+
+/** First retry delay, doubling per attempt. Matches WEBHOOK_REDELIVERY_BASE_MS. */
+export const WEBHOOK_QUEUE_BASE_DELAY_SECONDS = 5 * 60;
+
+/** The ceiling each doubling is clamped to. Matches WEBHOOK_REDELIVERY_MAX_MS.
+ * Cloudflare caps `delaySeconds` at 12 hours, which is exactly this value --
+ * the hand-rolled schedule and the platform's limit agree by coincidence, and
+ * `webhookRetryDelaySeconds` never has to be clamped twice. */
+export const WEBHOOK_QUEUE_MAX_DELAY_SECONDS = 12 * 60 * 60;
+
+/**
+ * How long before a failed delivery is tried again: `base * 2^(attempts-1)`,
+ * clamped.
+ *
+ * `attempts` is what the platform reports for the message -- 1 on the first
+ * delivery -- so the round counter that used to be persisted in the parked KV
+ * record is now carried by the transport. That is the single biggest deletion
+ * here: the old code had to re-read the prior record before re-parking, because
+ * trusting a stale in-memory snapshot reset the round to 1 and a chronically
+ * failing endpoint would then never reach the dead-letter cap.
+ */
+export function webhookRetryDelaySeconds(
+  attempts: number,
+  baseSeconds: number = WEBHOOK_QUEUE_BASE_DELAY_SECONDS,
+  maxSeconds: number = WEBHOOK_QUEUE_MAX_DELAY_SECONDS,
+): number {
+  const round = Number.isFinite(attempts) && attempts >= 1 ? attempts : 1;
+  // Exponent capped before the shift so a large attempt count cannot overflow
+  // into Infinity and then clamp to max by accident rather than by rule.
+  const doublings = Math.min(round - 1, 32);
+  return Math.min(baseSeconds * 2 ** doublings, maxSeconds);
+}
+
+/**
+ * Validate one message off the queue.
+ *
+ * A malformed message is ACKED, not retried -- the same disposition rule the
+ * sync-batches consumer follows: retrying something that can never parse burns
+ * the attempt budget and dead-letters anyway, so the DLQ keeps holding
+ * deliveries that might yet succeed rather than ones that never could.
+ */
+export function validWebhookDeliveryMessage(
+  body: unknown,
+): body is WebhookDeliveryMessage {
+  const m = body as WebhookDeliveryMessage | null;
+  if (!m || typeof m !== "object") return false;
+  if (typeof m.subscription_id !== "string" || !m.subscription_id) return false;
+  if (typeof m.event_id !== "string" || !m.event_id) return false;
+  if (typeof m.body !== "string" || !m.body) return false;
+  return true;
+}
+
+/** Split a batch into what can be delivered and what can only be dropped. */
+export function classifyWebhookBatch(
+  messages: readonly { readonly body: unknown }[],
+): { valid: WebhookDeliveryMessage[]; invalid: number } {
+  const valid: WebhookDeliveryMessage[] = [];
+  let invalid = 0;
+  for (const message of messages) {
+    if (validWebhookDeliveryMessage(message.body)) valid.push(message.body);
+    else invalid += 1;
+  }
+  return { valid, invalid };
+}
+
+/**
+ * The transport's per-message ceiling, as for sync-batches
+ * (metagraphed-infra#360). Nothing measured a message there either, and the
+ * result was a lane that stopped rather than degraded.
+ */
+export const WEBHOOK_QUEUE_MESSAGE_MAX_BYTES = 128 * 1024;
+
+/**
+ * What a subscriber is owed for one published event, as queue messages.
+ *
+ * ONE BODY, MANY MESSAGES. The event body is identical for every subscriber --
+ * only the per-subscriber signature and idempotency header differ, and both are
+ * computed at delivery -- so the same string is carried on each message rather
+ * than re-serialised per subscriber. That is what makes a retry byte-identical
+ * to its first attempt.
+ *
+ * A subscription whose delivery would exceed the transport's message cap is
+ * SKIPPED AND REPORTED rather than enqueued to fail: an oversize message throws
+ * at `send()`, and the caller cannot tell that apart from the queue being down.
+ */
+export function planWebhookFanOut({
+  subscriptions,
+  eventId,
+  bodyText,
+  matches,
+  maxBytes = WEBHOOK_QUEUE_MESSAGE_MAX_BYTES,
+}: {
+  subscriptions: readonly Record<string, unknown>[] | null | undefined;
+  eventId: string;
+  bodyText: string;
+  /** Whether this subscription's filters select the event. Injected so the
+   * planner stays pure and the filter rule keeps its single implementation in
+   * `src/webhooks.ts`. */
+  matches: (subscription: Record<string, unknown>) => boolean;
+  maxBytes?: number;
+}): { messages: WebhookDeliveryMessage[]; skipped: number; oversize: number } {
+  const messages: WebhookDeliveryMessage[] = [];
+  let skipped = 0;
+  let oversize = 0;
+  for (const subscription of subscriptions ?? []) {
+    const id = subscription?.id;
+    if (typeof id !== "string" || !id) {
+      skipped += 1;
+      continue;
+    }
+    if (!matches(subscription)) {
+      skipped += 1;
+      continue;
+    }
+    const message: WebhookDeliveryMessage = {
+      subscription_id: id,
+      event_id: eventId,
+      body: bodyText,
+    };
+    if (JSON.stringify(message).length > maxBytes) {
+      oversize += 1;
+      continue;
+    }
+    messages.push(message);
+  }
+  return { messages, skipped, oversize };
+}
+
+/** What the consumer decided to do with one message, so a batch's outcome is
+ * reportable rather than inferred from an absence of errors. */
+export type WebhookDeliveryDisposition = "delivered" | "retry" | "dead";
+
+/**
+ * Turn one delivery result into a disposition.
+ *
+ * THREE OUTCOMES, NOT TWO. A delivered event acks. A retryable failure retries
+ * until the attempt budget runs out, then dead-letters -- and a NON-retryable
+ * failure (a 400 from the subscriber, an SSRF-rejected URL, a deleted
+ * subscription) dead-letters IMMEDIATELY rather than consuming eight attempts to
+ * reach the same place. That distinction is the whole reason `deliverChangeEvent`
+ * reports `retryable` at all, and losing it would turn every subscriber's typo
+ * into 12 hours of pointless outbound traffic.
+ */
+export function webhookDeliveryDisposition(
+  result: { status?: unknown; retryable?: unknown } | null | undefined,
+  attempts: number,
+  maxAttempts: number = WEBHOOK_QUEUE_MAX_ATTEMPTS,
+): WebhookDeliveryDisposition {
+  if (result?.status === "delivered") return "delivered";
+  // "skipped" is terminal by construction -- the subscription is unusable, and
+  // no number of retries makes an invalid URL valid.
+  if (result?.status === "skipped") return "dead";
+  if (result?.retryable !== true) return "dead";
+  return attempts >= maxAttempts ? "dead" : "retry";
+}

--- a/tests/webhook-queue.test.ts
+++ b/tests/webhook-queue.test.ts
@@ -1,0 +1,243 @@
+// Webhook delivery on a queue (metagraphed-infra#354).
+//
+// The thing worth testing here is not that a queue delivers -- Cloudflare's
+// does. It is that the PROMISES the hand-rolled system made survive the move:
+// eight attempts before dead-lettering, a doubling backoff clamped at 12 hours,
+// a non-retryable failure dying immediately instead of burning the budget, and
+// a retry that is byte-identical to its first attempt so the signature still
+// verifies.
+//
+// Those were subscriber-visible guarantees, not implementation details. A queue
+// that quietly delivered five times instead of eight would be a breaking change
+// nobody announced.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  classifyWebhookBatch,
+  planWebhookFanOut,
+  validWebhookDeliveryMessage,
+  webhookDeliveryDisposition,
+  webhookRetryDelaySeconds,
+  WEBHOOK_QUEUE_BASE_DELAY_SECONDS,
+  WEBHOOK_QUEUE_MAX_ATTEMPTS,
+  WEBHOOK_QUEUE_MAX_DELAY_SECONDS,
+  WEBHOOK_QUEUE_MESSAGE_MAX_BYTES,
+} from "../src/webhook-queue.ts";
+import {
+  WEBHOOK_MAX_DELIVERY_ROUNDS,
+  WEBHOOK_REDELIVERY_BASE_MS,
+  WEBHOOK_REDELIVERY_MAX_MS,
+} from "../src/webhooks.ts";
+
+describe("the schedule subscribers were promised", () => {
+  test("the attempt budget is the one the hand-rolled system published", () => {
+    // Subscribers were told eight rounds. The transport changing is not a
+    // reason to change what they were told, so this is pinned to the old
+    // constant rather than to a number that happens to match today.
+    assert.equal(WEBHOOK_QUEUE_MAX_ATTEMPTS, WEBHOOK_MAX_DELIVERY_ROUNDS);
+  });
+
+  test("the backoff is the same curve, in the units a queue takes", () => {
+    assert.equal(
+      WEBHOOK_QUEUE_BASE_DELAY_SECONDS * 1000,
+      WEBHOOK_REDELIVERY_BASE_MS,
+    );
+    assert.equal(
+      WEBHOOK_QUEUE_MAX_DELAY_SECONDS * 1000,
+      WEBHOOK_REDELIVERY_MAX_MS,
+    );
+  });
+
+  test("doubles per attempt and clamps at the ceiling", () => {
+    assert.equal(webhookRetryDelaySeconds(1), 300, "5 min");
+    assert.equal(webhookRetryDelaySeconds(2), 600);
+    assert.equal(webhookRetryDelaySeconds(3), 1_200);
+    assert.equal(webhookRetryDelaySeconds(8), 300 * 2 ** 7);
+    // 12h is both the old window and Cloudflare's own delaySeconds ceiling, so
+    // the curve never asks the platform for something it will refuse.
+    assert.equal(webhookRetryDelaySeconds(99), WEBHOOK_QUEUE_MAX_DELAY_SECONDS);
+  });
+
+  test("a nonsense attempt count still yields a usable delay", () => {
+    // `attempts` comes from the platform, so this is defensive rather than
+    // expected -- but a NaN here would become a NaN delaySeconds and the retry
+    // would be rejected, silently turning a retryable failure into a lost one.
+    for (const bad of [0, -3, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const delay = webhookRetryDelaySeconds(bad);
+      assert.equal(Number.isFinite(delay), true, `${bad} produced ${delay}`);
+      assert.equal(delay >= WEBHOOK_QUEUE_BASE_DELAY_SECONDS, true);
+      assert.equal(delay <= WEBHOOK_QUEUE_MAX_DELAY_SECONDS, true);
+    }
+  });
+});
+
+describe("webhookDeliveryDisposition", () => {
+  test("a delivered event is done", () => {
+    assert.equal(
+      webhookDeliveryDisposition({ status: "delivered" }, 1),
+      "delivered",
+    );
+  });
+
+  test("a retryable failure retries until the budget runs out", () => {
+    const failed = { status: "failed", retryable: true };
+    assert.equal(webhookDeliveryDisposition(failed, 1), "retry");
+    assert.equal(
+      webhookDeliveryDisposition(failed, WEBHOOK_QUEUE_MAX_ATTEMPTS - 1),
+      "retry",
+    );
+    assert.equal(
+      webhookDeliveryDisposition(failed, WEBHOOK_QUEUE_MAX_ATTEMPTS),
+      "dead",
+      "the eighth attempt is the last one",
+    );
+  });
+
+  test("a NON-retryable failure dies at once, not eight attempts later", () => {
+    // A 400 from the subscriber, or an SSRF-rejected URL, will not become a 200.
+    // Spending the budget on it is 12 hours of pointless outbound traffic to
+    // someone who already said no.
+    assert.equal(
+      webhookDeliveryDisposition({ status: "failed", retryable: false }, 1),
+      "dead",
+    );
+  });
+
+  test("a skipped subscription is terminal", () => {
+    // "skipped" means the subscription itself is unusable -- no number of
+    // retries makes an invalid URL valid.
+    assert.equal(webhookDeliveryDisposition({ status: "skipped" }, 1), "dead");
+  });
+
+  test("a result with no verdict is treated as terminal, not retried forever", () => {
+    assert.equal(webhookDeliveryDisposition(null, 1), "dead");
+    assert.equal(webhookDeliveryDisposition({}, 1), "dead");
+  });
+});
+
+describe("validWebhookDeliveryMessage", () => {
+  const OK = { subscription_id: "sub_1", event_id: "evt_1", body: "{}" };
+
+  test("accepts a well-formed delivery", () => {
+    assert.equal(validWebhookDeliveryMessage(OK), true);
+  });
+
+  test("rejects anything it could not deliver from", () => {
+    for (const bad of [
+      null,
+      "nope",
+      { ...OK, subscription_id: "" },
+      { ...OK, subscription_id: 7 },
+      { ...OK, event_id: "" },
+      { ...OK, body: "" },
+      { ...OK, body: {} },
+    ]) {
+      assert.equal(
+        validWebhookDeliveryMessage(bad),
+        false,
+        JSON.stringify(bad),
+      );
+    }
+  });
+
+  test("classifies a batch without throwing on the bad ones", () => {
+    const { valid, invalid } = classifyWebhookBatch([
+      { body: OK },
+      { body: null },
+      { body: { ...OK, body: "" } },
+    ]);
+    assert.equal(valid.length, 1);
+    assert.equal(invalid, 2);
+  });
+});
+
+describe("planWebhookFanOut", () => {
+  const subs = [
+    { id: "sub_a", filters: null },
+    { id: "sub_b", filters: null },
+  ];
+
+  test("one message per matching subscriber, carrying one shared body", () => {
+    const body = JSON.stringify({ kind: "subnets" });
+    const { messages } = planWebhookFanOut({
+      subscriptions: subs,
+      eventId: "evt_1",
+      bodyText: body,
+      matches: () => true,
+    });
+    assert.deepEqual(
+      messages.map((m) => m.subscription_id),
+      ["sub_a", "sub_b"],
+    );
+    // BYTE-IDENTICAL, and the same string object's content for both: the
+    // signature is over these exact bytes, so a retry that re-serialised the
+    // event could produce different key order and read as a forgery.
+    for (const m of messages) assert.equal(m.body, body);
+  });
+
+  test("a filtered-out subscriber is skipped, not enqueued", () => {
+    const { messages, skipped } = planWebhookFanOut({
+      subscriptions: subs,
+      eventId: "evt_1",
+      bodyText: "{}",
+      matches: (s) => s.id === "sub_a",
+    });
+    assert.equal(messages.length, 1);
+    assert.equal(skipped, 1);
+  });
+
+  test("a subscription with no id is skipped rather than enqueued unaddressed", () => {
+    const { messages, skipped } = planWebhookFanOut({
+      subscriptions: [{ filters: null }, { id: "", filters: null }],
+      eventId: "evt_1",
+      bodyText: "{}",
+      matches: () => true,
+    });
+    assert.equal(messages.length, 0);
+    assert.equal(skipped, 2);
+  });
+
+  test("an oversize delivery is reported, not enqueued to fail at send()", () => {
+    // metagraphed-infra#360 is the reason this is measured at all: nothing
+    // measured a sync message either, and `send()` throwing looked exactly like
+    // the queue being down.
+    const { messages, oversize } = planWebhookFanOut({
+      subscriptions: [{ id: "sub_a", filters: null }],
+      eventId: "evt_1",
+      bodyText: "x".repeat(WEBHOOK_QUEUE_MESSAGE_MAX_BYTES),
+      matches: () => true,
+    });
+    assert.equal(messages.length, 0);
+    assert.equal(oversize, 1);
+  });
+
+  test("a realistic event fits comfortably, or the guard above is the wrong shape", () => {
+    // The guard must not be the thing that stops normal delivery. A change
+    // event is a summary, not a payload dump.
+    const event = {
+      type: "metagraph.publish",
+      published_at: "2026-08-06T09:00:00.000Z",
+      changes: { subnets: Array.from({ length: 129 }, (_, i) => i) },
+    };
+    const { messages, oversize } = planWebhookFanOut({
+      subscriptions: [{ id: "sub_a", filters: null }],
+      eventId: "evt_1",
+      bodyText: JSON.stringify(event),
+      matches: () => true,
+    });
+    assert.equal(oversize, 0);
+    assert.equal(messages.length, 1);
+  });
+
+  test("no subscriptions is not an error", () => {
+    for (const empty of [null, undefined, []]) {
+      const { messages } = planWebhookFanOut({
+        subscriptions: empty,
+        eventId: "evt_1",
+        bodyText: "{}",
+        matches: () => true,
+      });
+      assert.equal(messages.length, 0);
+    }
+  });
+});

--- a/tests/webhooks-worker.test.ts
+++ b/tests/webhooks-worker.test.ts
@@ -774,3 +774,381 @@ describe("webhook route edge cases", () => {
     assert.equal((await res.json()).error.code, "subscription_not_found");
   });
 });
+
+// --- delivery on a queue (metagraphed-infra#354) ----------------------------
+//
+// The fan-out route replaces the publish script's inline delivery, and the
+// queue consumer replaces `dispatchWithRedelivery`'s parking, sweeping,
+// round-counting and per-subscription budget. What these assert is that the
+// subscriber-visible behaviour survived: matching subscribers get exactly one
+// message each, the body is byte-identical to what will be signed, a deleted
+// subscription stops delivery, and a failure is rescheduled rather than lost.
+const DISPATCH_TOKEN = "test-webhook-dispatch-token";
+
+function makeQueue() {
+  const sent: Record<string, unknown>[] = [];
+  return {
+    sent,
+    async send(body: Record<string, unknown>) {
+      sent.push(body);
+    },
+  };
+}
+
+const dispatch = (env: Row, event: unknown, token = DISPATCH_TOKEN) =>
+  handleRequest(
+    req("/api/v1/internal/webhook-dispatch", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-webhook-dispatch-token": token,
+      },
+      body: JSON.stringify(event),
+    }),
+    env as unknown as Env,
+    {},
+  );
+
+async function seedSubscription(kv: ReturnType<typeof makeKv>, url: string) {
+  const res = await postSub(envWith(kv), { url });
+  return ((await res.json()) as Row).data as Row;
+}
+
+/** A fetch double that answers the DoH lookup with a real public address and
+ * the webhook URL with whatever status the test is about.
+ *
+ * Blunt mocks fail this path in a way that looks like the code is wrong: a
+ * failed DNS lookup makes `resolvedWebhookUrlStatus` fail CLOSED, so the
+ * delivery is "skipped" (terminal) rather than "failed" (retryable), and the
+ * consumer correctly acks something the test meant to see retried.
+ */
+function makeDeliveryFetch(status: number) {
+  return vi.fn(async (input: unknown) => {
+    const url = String(input);
+    if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+      return new Response(
+        JSON.stringify({ Answer: [{ type: 1, data: "93.184.216.34" }] }),
+        { status: 200, headers: { "content-type": "application/dns-json" } },
+      );
+    }
+    return new Response("body", { status });
+  });
+}
+
+describe("webhook fan-out route", () => {
+  const EVENT = { type: "metagraph.publish", changes: { subnets: [7] } };
+
+  test("enqueues one message per subscriber and delivers nothing itself", async () => {
+    const kv = makeKv();
+    await seedSubscription(kv, "https://hooks.example.com/a");
+    await seedSubscription(kv, "https://hooks.example.com/b");
+    const queue = makeQueue();
+
+    const res = await dispatch(
+      envWith(kv, {
+        WEBHOOK_DELIVERIES: queue,
+        WEBHOOK_DISPATCH_SECRET: DISPATCH_TOKEN,
+      }),
+      EVENT,
+    );
+
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as Row;
+    assert.equal(body.ok, true);
+    assert.equal(body.subscriptions, 2);
+    assert.equal(body.enqueued, 2);
+    assert.equal(queue.sent.length, 2);
+    // ONE BODY, byte-identical on every message: the per-subscriber signature
+    // is computed over these exact bytes at delivery.
+    const bodies = new Set(queue.sent.map((m) => m.body));
+    assert.equal(bodies.size, 1);
+    assert.equal(JSON.parse(queue.sent[0]!.body as string).type, EVENT.type);
+    // Every message carries the same content-addressed event id -- half of the
+    // idempotency key a subscriber dedupes retries on.
+    assert.equal(
+      new Set(queue.sent.map((m) => m.event_id)).size,
+      1,
+      "one event, one id",
+    );
+  });
+
+  test("401s without the token, 503s with no queue bound", async () => {
+    const kv = makeKv();
+    await seedSubscription(kv, "https://hooks.example.com/a");
+    const queue = makeQueue();
+
+    assert.equal(
+      (
+        await dispatch(
+          envWith(kv, {
+            WEBHOOK_DELIVERIES: queue,
+            WEBHOOK_DISPATCH_SECRET: DISPATCH_TOKEN,
+          }),
+          EVENT,
+          "wrong",
+        )
+      ).status,
+      401,
+    );
+    // DECLINES rather than dropping: an event discarded because a binding is
+    // missing is a webhook nobody was told failed.
+    assert.equal(
+      (
+        await dispatch(
+          envWith(kv, { WEBHOOK_DISPATCH_SECRET: DISPATCH_TOKEN }),
+          EVENT,
+        )
+      ).status,
+      503,
+    );
+    assert.equal(queue.sent.length, 0);
+  });
+});
+
+describe("webhook queue consumer", () => {
+  const EVENT_BODY = JSON.stringify({
+    type: "metagraph.publish",
+    changes: { subnets: [7] },
+  });
+
+  async function runQueue(env: Row, body: unknown) {
+    const acts: string[] = [];
+    const delays: number[] = [];
+    const worker = (await import("../workers/api.ts")).default;
+    await worker.queue!(
+      {
+        messages: [
+          {
+            body,
+            attempts: (body as Row)?.__attempts ?? 1,
+            ack: () => acts.push("ack"),
+            retry: (opts?: { delaySeconds?: number }) => {
+              acts.push("retry");
+              if (opts?.delaySeconds !== undefined)
+                delays.push(opts.delaySeconds);
+            },
+          },
+        ],
+      } as never,
+      env as unknown as Env,
+      { waitUntil: (p: Promise<unknown>) => void p } as never,
+    );
+    return { acts, delays };
+  }
+
+  test("acks an unparseable message rather than retrying it", async () => {
+    // It will not parse on the eighth attempt either, and the DLQ is more
+    // useful holding deliveries that might still succeed.
+    const { acts } = await runQueue(envWith(makeKv()), { nope: true });
+    assert.deepEqual(acts, ["ack"]);
+  });
+
+  test("acks when the subscription is gone, so an unsubscribe takes effect", async () => {
+    // A delivery already in flight must not outlive the subscription it was
+    // for -- the 12-hour retry window makes that a real interval.
+    const { acts } = await runQueue(envWith(makeKv()), {
+      subscription_id: "sub_deleted",
+      event_id: "evt_1",
+      body: EVENT_BODY,
+    });
+    assert.deepEqual(acts, ["ack"]);
+  });
+
+  test("delivers to the subscription read at delivery time", async () => {
+    const kv = makeKv();
+    const sub = await seedSubscription(kv, "https://hooks.example.com/a");
+    const fetchMock = makeDeliveryFetch(200);
+    const original = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    try {
+      const { acts } = await runQueue(envWith(kv), {
+        subscription_id: sub.id,
+        event_id: "evt_1",
+        body: EVENT_BODY,
+      });
+      assert.deepEqual(acts, ["ack"], "a delivered event is done");
+      assert.equal(fetchMock.mock.calls.length > 0, true);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test("reschedules a retryable failure instead of losing it", async () => {
+    const kv = makeKv();
+    const sub = await seedSubscription(kv, "https://hooks.example.com/a");
+    const fetchMock = makeDeliveryFetch(503);
+    const original = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    try {
+      const { acts, delays } = await runQueue(envWith(kv), {
+        subscription_id: sub.id,
+        event_id: "evt_1",
+        body: EVENT_BODY,
+      });
+      assert.deepEqual(acts, ["retry"]);
+      // The schedule the hand-rolled system published: 5 minutes on the first
+      // failure, doubling from there.
+      assert.deepEqual(delays, [300]);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});
+
+describe("webhook fan-out route: the ways it declines", () => {
+  const EVENT = { type: "metagraph.publish", changes: { subnets: [7] } };
+  const fullEnv = (kv: ReturnType<typeof makeKv>, queue: unknown) =>
+    envWith(kv, {
+      WEBHOOK_DELIVERIES: queue,
+      WEBHOOK_DISPATCH_SECRET: DISPATCH_TOKEN,
+    });
+
+  test("401s with the header absent, not just wrong", async () => {
+    // Absent and wrong must land the same way -- a missing header falling
+    // through to an empty-string comparison is how an auth gate accidentally
+    // accepts an unset secret.
+    const res = await handleRequest(
+      req("/api/v1/internal/webhook-dispatch", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(EVENT),
+      }),
+      fullEnv(makeKv(), makeQueue()) as unknown as Env,
+      {},
+    );
+    assert.equal(res.status, 401);
+  });
+
+  test("405s on a method other than POST", async () => {
+    const res = await handleRequest(
+      req("/api/v1/internal/webhook-dispatch", { method: "GET" }),
+      fullEnv(makeKv(), makeQueue()) as unknown as Env,
+      {},
+    );
+    assert.equal(res.status, 405);
+  });
+
+  test("503s where the dispatch secret is not provisioned", async () => {
+    // Unset means the route refuses rather than accepting unauthenticated
+    // dispatch of arbitrary events to real subscribers.
+    const res = await dispatch(
+      envWith(makeKv(), { WEBHOOK_DELIVERIES: makeQueue() }),
+      EVENT,
+    );
+    assert.equal(res.status, 503);
+  });
+
+  test("503s where the control KV is not bound", async () => {
+    const res = await dispatch(
+      envWith(
+        { get: async () => null, put: async () => {} },
+        {
+          WEBHOOK_DELIVERIES: makeQueue(),
+          WEBHOOK_DISPATCH_SECRET: DISPATCH_TOKEN,
+        },
+      ),
+      EVENT,
+    );
+    assert.equal(res.status, 503);
+  });
+
+  test("400s on a body that is not a JSON object", async () => {
+    const kv = makeKv();
+    const env = fullEnv(kv, makeQueue()) as unknown as Env;
+    const bad = await handleRequest(
+      req("/api/v1/internal/webhook-dispatch", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-webhook-dispatch-token": DISPATCH_TOKEN,
+        },
+        body: "not json",
+      }),
+      env,
+      {},
+    );
+    assert.equal(bad.status, 400);
+    // Valid JSON, wrong shape: a bare array or scalar is not a change event.
+    assert.equal((await dispatch(fullEnv(kv, makeQueue()), null)).status, 400);
+  });
+
+  test("502s when the queue refuses, so the caller knows to retry", async () => {
+    // Reporting success on an event the queue never took would lose it
+    // silently, and nobody would learn the subscribers were not told.
+    const kv = makeKv();
+    await seedSubscription(kv, "https://hooks.example.com/a");
+    const res = await dispatch(
+      fullEnv(kv, {
+        send: async () => Promise.reject(new Error("over capacity")),
+      }),
+      EVENT,
+    );
+    assert.equal(res.status, 502);
+  });
+});
+
+describe("webhook queue consumer: the terminal and transient edges", () => {
+  const msg = (body: unknown, attempts = 1) => ({
+    body,
+    attempts,
+    ack: () => {},
+    retry: () => {},
+  });
+
+  async function run(
+    kv: ReturnType<typeof makeKv>,
+    body: unknown,
+    deliver?: unknown,
+  ) {
+    const acts: string[] = [];
+    const { handleWebhookQueue } = await import("../workers/api.ts");
+    await handleWebhookQueue(
+      {
+        messages: [
+          {
+            ...msg(body),
+            ack: () => acts.push("ack"),
+            retry: () => acts.push("retry"),
+          },
+        ],
+      } as never,
+      envWith(kv) as unknown as Env,
+      { waitUntil: (p: Promise<unknown>) => void p } as never,
+      deliver as never,
+    );
+    return acts;
+  }
+
+  test("a delivery that throws is retried, not dropped", async () => {
+    // deliverChangeEvent turns every KNOWN failure into a result, so a throw is
+    // something unmodelled -- and letting it propagate would fail the whole
+    // batch, punishing nine healthy subscribers for one broken one.
+    const kv = makeKv();
+    const sub = await seedSubscription(kv, "https://hooks.example.com/a");
+    const acts = await run(
+      kv,
+      {
+        subscription_id: sub.id,
+        event_id: "evt_1",
+        body: JSON.stringify({ type: "metagraph.publish" }),
+      },
+      () => {
+        throw new Error("socket exploded");
+      },
+    );
+    assert.deepEqual(acts, ["retry"]);
+  });
+
+  test("a body that is not JSON is acked, because it never will be", async () => {
+    // Retrying it would spend the whole eight-attempt budget to dead-letter in
+    // 12 hours what is already known to be undeliverable.
+    const kv = makeKv();
+    const sub = await seedSubscription(kv, "https://hooks.example.com/a");
+    const acts = await run(kv, {
+      subscription_id: sub.id,
+      event_id: "evt_1",
+      body: "{not json",
+    });
+    assert.deepEqual(acts, ["ack"]);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -286,7 +286,12 @@ import {
 import { handleFullnodeRpcProxyRequest } from "./request-handlers/fullnode-rpc-proxy.ts";
 import {
   buildChangeEvent,
+  deliverChangeEvent,
   deliveryStoragePrefix,
+  eventMatchesFilters,
+  webhookEventId,
+  WEBHOOK_KV_PREFIX,
+  resolveWebhookHostnamesWithDoh,
   generateSecret,
   generateSubscriptionId,
   isValidSubscriptionId,
@@ -301,6 +306,13 @@ import {
   WEBHOOK_SECRET_HEADER,
   WEBHOOK_SIGNATURE_HEADER,
 } from "../src/webhooks.ts";
+import {
+  classifyWebhookBatch,
+  planWebhookFanOut,
+  webhookDeliveryDisposition,
+  webhookRetryDelaySeconds,
+  WEBHOOK_QUEUE_MAX_ATTEMPTS,
+} from "../src/webhook-queue.ts";
 import {
   ALERT_TRIGGER_CREATE_TOKEN_HEADER,
   ALERT_TRIGGER_OWNER_TOKEN_HEADER,
@@ -1558,7 +1570,259 @@ export default {
   ) {
     return handleScheduled(controller, env, ctx);
   },
+  /**
+   * Webhook delivery (metagraphed-infra#354).
+   *
+   * One message is one (subscription, event). What used to be a KV-parked
+   * record swept on the next publish run, with its own persisted round counter
+   * and a per-subscription share of a 64-redelivery budget, is now a message
+   * that reschedules itself.
+   *
+   * THE SUBSCRIPTION IS READ AT DELIVERY, not carried on the message: a
+   * subscription deleted or re-pointed between enqueue and delivery must not be
+   * delivered to from a stale copy, and a 12-hour retry window makes that a
+   * real interval rather than a theoretical one.
+   *
+   * THE BODY IS CARRIED, because the signature is over those exact bytes. A
+   * retry that re-serialised the event could produce different key order, and a
+   * subscriber verifying the signature would read a legitimate redelivery as a
+   * forgery.
+   */
+  async queue(
+    batch: MessageBatch<unknown>,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<void> {
+    return handleWebhookQueue(batch, env, ctx);
+  },
 };
+
+/**
+ * POST /api/v1/internal/webhook-dispatch -- fan one change event out to the queue.
+ *
+ * THE FAN-OUT IS THE PRODUCER, and it lives here rather than in the publish
+ * script for a reason worth stating: the script runs on a GitHub Actions runner
+ * with no queue binding, and the alternative -- having it deliver inline, as it
+ * did -- is what made a hand-written retry system necessary in the first place.
+ *
+ * Enqueuing is all this does. It does not deliver, so a slow or dead subscriber
+ * cannot make the publish that triggered it slow or dead, which was already the
+ * stated rule ("a bad subscriber must not block the data pipeline") and is now
+ * structural rather than maintained by care.
+ */
+/** Same shape as every other internal sync token header in this Worker. */
+const WEBHOOK_DISPATCH_TOKEN_HEADER = "x-webhook-dispatch-token";
+
+async function handleWebhookDispatch(request: Request, env: Env) {
+  if (request.method !== "POST") {
+    return errorResponse(
+      "webhook_dispatch_method_not_allowed",
+      "Use POST.",
+      405,
+    );
+  }
+  if (!env.WEBHOOK_DISPATCH_SECRET) {
+    return errorResponse(
+      "webhook_dispatch_unavailable",
+      "Webhook dispatch is not provisioned on this deployment.",
+      503,
+    );
+  }
+  const provided = request.headers.get(WEBHOOK_DISPATCH_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, env.WEBHOOK_DISPATCH_SECRET)) {
+    return errorResponse(
+      "webhook_dispatch_unauthorized",
+      `Provide a valid ${WEBHOOK_DISPATCH_TOKEN_HEADER} header.`,
+      401,
+    );
+  }
+  // DECLINES rather than dropping. An event silently discarded because a
+  // binding is missing is a webhook nobody was told failed, which is worse than
+  // one that visibly did.
+  if (!env.WEBHOOK_DELIVERIES) {
+    return errorResponse(
+      "webhook_dispatch_unavailable",
+      "The webhook-deliveries queue is not bound to this deployment.",
+      503,
+    );
+  }
+  if (!env.METAGRAPH_CONTROL?.list) {
+    return errorResponse(
+      "webhook_dispatch_unavailable",
+      "The control KV namespace is not bound to this deployment.",
+      503,
+    );
+  }
+
+  let event: Record<string, unknown>;
+  try {
+    event = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return errorResponse(
+      "webhook_dispatch_invalid_body",
+      "Body must be JSON.",
+      400,
+    );
+  }
+  if (!event || typeof event !== "object") {
+    return errorResponse(
+      "webhook_dispatch_invalid_body",
+      "Body must be a change event object.",
+      400,
+    );
+  }
+
+  // ONE BODY FOR EVERY SUBSCRIBER, serialised once. Only the per-subscriber
+  // signature and idempotency header differ, and both are computed at delivery
+  // -- so what is enqueued is byte-identical to what is signed, on the first
+  // attempt and on the eighth.
+  const bodyText = JSON.stringify(event);
+  const eventId = await webhookEventId(bodyText);
+
+  const { keys } = await env.METAGRAPH_CONTROL.list({
+    prefix: WEBHOOK_KV_PREFIX,
+  });
+  const subscriptions = (
+    await Promise.all(
+      keys.map((entry: { name: string }) =>
+        env.METAGRAPH_CONTROL!.get(entry.name, { type: "json" }),
+      ),
+    )
+  ).filter(Boolean) as Record<string, unknown>[];
+
+  const { messages, skipped, oversize } = planWebhookFanOut({
+    subscriptions,
+    eventId,
+    bodyText,
+    matches: (subscription) =>
+      eventMatchesFilters(
+        event,
+        subscription.filters as Parameters<typeof eventMatchesFilters>[1],
+      ),
+  });
+
+  try {
+    await Promise.all(
+      messages.map((message) => env.WEBHOOK_DELIVERIES!.send(message)),
+    );
+  } catch (err) {
+    console.error("webhook fan-out enqueue failed:", err);
+    return errorResponse(
+      "webhook_dispatch_enqueue_failed",
+      "The queue refused the fan-out; the caller should retry.",
+      502,
+    );
+  }
+
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      event_id: eventId,
+      subscriptions: subscriptions.length,
+      enqueued: messages.length,
+      skipped,
+      oversize,
+    }),
+    { headers: apiHeaders("short") },
+  );
+}
+
+export async function handleWebhookQueue(
+  batch: MessageBatch<unknown>,
+  env: Env,
+  _ctx: ExecutionContext,
+  /** Injected so the unmodelled-throw path is reachable from a test. Every
+   * other seam in this delivery path (`fetchFn`, `resolveHostnames`, the
+   * delivery store) is injected for the same reason -- see src/webhooks.ts. */
+  deliver: typeof deliverChangeEvent = deliverChangeEvent,
+): Promise<void> {
+  const { valid, invalid } = classifyWebhookBatch(batch.messages);
+  console.log(
+    `webhook-deliveries: ${batch.messages.length} message(s), ` +
+      `${valid.length} valid, ${invalid} unparseable`,
+  );
+
+  for (const message of batch.messages) {
+    const body = message.body as {
+      subscription_id?: unknown;
+      event_id?: unknown;
+      body?: unknown;
+    } | null;
+    // Unparseable is ACKED, not retried -- it will not parse on the eighth
+    // attempt either, and the DLQ is more useful holding deliveries that might
+    // still succeed. Same rule the sync-batches consumer follows.
+    if (
+      !body ||
+      typeof body.subscription_id !== "string" ||
+      typeof body.body !== "string"
+    ) {
+      message.ack();
+      continue;
+    }
+
+    const subscription = (await env.METAGRAPH_CONTROL?.get(
+      subscriptionStorageKey(body.subscription_id),
+      { type: "json" },
+    )) as Record<string, unknown> | null;
+    // A deleted subscription is done, not failed: acking is how an unsubscribe
+    // takes effect on a delivery already in flight.
+    if (!subscription) {
+      message.ack();
+      continue;
+    }
+
+    // PARSED BEFORE THE TRY, and a failure here ACKS. A body that is not JSON
+    // will not become JSON on the eighth attempt, so retrying it would spend
+    // the whole budget and dead-letter anyway -- the same rule the unparseable
+    // message above follows.
+    let event: Record<string, unknown>;
+    try {
+      event = JSON.parse(body.body) as Record<string, unknown>;
+    } catch {
+      message.ack();
+      continue;
+    }
+
+    let result: Record<string, unknown>;
+    try {
+      result = (await deliver({
+        subscription,
+        event,
+        bodyText: body.body,
+        fetchFn: fetch,
+        now: () => new Date().toISOString(),
+        // Delivery-time DNS re-resolution is the SSRF guard, not an
+        // optimisation: a hostname that resolved public at subscribe time can
+        // point at a private address by the time a 12-hour-old retry fires.
+        resolveHostnames: (host: string) =>
+          resolveWebhookHostnamesWithDoh(host, { fetchImpl: fetch }),
+      })) as Record<string, unknown>;
+    } catch (err) {
+      // deliverChangeEvent turns every KNOWN failure into a result, so reaching
+      // here means something unmodelled -- and unmodelled is exactly what a
+      // retry is for. Letting it propagate instead would fail the whole batch,
+      // punishing nine healthy subscribers for one broken one.
+      console.error("webhook delivery threw:", err);
+      result = { status: "failed", retryable: true };
+    }
+
+    const disposition = webhookDeliveryDisposition(
+      result,
+      message.attempts,
+      WEBHOOK_QUEUE_MAX_ATTEMPTS,
+    );
+    if (disposition === "retry") {
+      message.retry({
+        delaySeconds: webhookRetryDelaySeconds(message.attempts),
+      });
+    } else {
+      // Delivered, or terminal. A terminal failure acks so the platform routes
+      // it to the dead-letter queue on the final attempt rather than spinning
+      // out the remaining budget on a 400 that will never become a 200.
+      message.ack();
+    }
+  }
+}
 
 // Durable Object classes must be named exports of this Worker's main entry
 // module (wrangler.jsonc's "main": "workers/api.entry.ts") -- re-exporting the
@@ -3848,6 +4112,14 @@ export async function handleRequest(
   // which owns the postgres.js driver + this database's own Hyperdrive
   // binding, keeping this Worker's bundle lean the same way DATA_API does
   // for the chain-data tier.
+  // Webhook fan-out (metagraphed-infra#354): turn ONE published change event
+  // into one queue message per matching subscriber. The publish lane calls this
+  // instead of delivering inline, so delivery gets the queue's retry, backoff
+  // and dead-lettering instead of a hand-rolled copy of them.
+  if (url.pathname === "/api/v1/internal/webhook-dispatch") {
+    return handleWebhookDispatch(request, env);
+  }
+
   if (url.pathname === "/api/v1/internal/registry-sync") {
     return handleRegistrySyncProxy(request, env);
   }

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -120,6 +120,14 @@ interface Env {
    * is deploy-time so a cutover and its rollback are both a setting rather than
    * a code change. */
   SYNC_QUEUE_LANES?: string;
+  /** The webhook-deliveries producer binding (metagraphed-infra#354). Absent
+   * means the fan-out route declines rather than silently dropping an event --
+   * a webhook nobody was told failed is worse than one that visibly did. */
+  WEBHOOK_DELIVERIES?: Queue<unknown>;
+  /** Gates the internal fan-out route. Same shape as every other internal sync
+   * secret; unset means the route 503s rather than accepting unauthenticated
+   * dispatch of arbitrary events to subscribers. */
+  WEBHOOK_DISPATCH_SECRET?: string;
   METAGRAPH_ALLOW_R2_STATIC_FALLBACK?: string;
   METAGRAPH_DISABLE_REQUEST_LOGS?: string;
   METAGRAPH_HEALTH_MAX_AGE_HOURS?: string;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -704,6 +704,37 @@
   // shape as ALERT_TRIGGERS_INTERNAL_TOKEN above. Until set on both sides,
   // every key lookup is a clean miss (fails closed as "invalid key", never
   // a crash).
+  // WEBHOOK DELIVERY (metagraphed-infra#354). One message per
+  // (subscription, event); the consumer POSTs it and reschedules its own
+  // failures. Replaces the parking/sweep/round-counter machinery in
+  // src/webhooks.ts, which was a message queue written by hand because there
+  // was not one.
+  //
+  // ON THIS WORKER, not data-api: the subscriptions live in METAGRAPH_CONTROL
+  // KV and every /api/v1/webhooks/ route is served here, so the consumer reads
+  // the subscription from the same binding that wrote it.
+  //
+  // max_retries is 8 to match WEBHOOK_MAX_DELIVERY_ROUNDS -- subscribers were
+  // told that number, and the transport changing is not a reason to change what
+  // they were promised. max_concurrency is 4 rather than sync-batches' 2: these
+  // deliveries are outbound HTTP to third parties, so they are latency-bound
+  // rather than contending for one D1 database, and a slow subscriber must not
+  // hold the whole lane.
+  "queues": {
+    "producers": [
+      { "binding": "WEBHOOK_DELIVERIES", "queue": "webhook-deliveries" },
+    ],
+    "consumers": [
+      {
+        "queue": "webhook-deliveries",
+        "max_batch_size": 10,
+        "max_batch_timeout": 5,
+        "max_retries": 8,
+        "max_concurrency": 4,
+        "dead_letter_queue": "webhook-deliveries-dlq",
+      },
+    ],
+  },
   "durable_objects": {
     "bindings": [
       { "name": "CHAIN_FIREHOSE_HUB", "class_name": "ChainFirehoseHub" },


### PR DESCRIPTION
Closes metagraphed-infra#354.

`src/webhooks.ts` contained a message queue written by hand, because there was not one. `dispatchWithRedelivery` parks a failed delivery in KV, sweeps the parked backlog on the next publish run, carries a per-record round counter, dead-letters after eight rounds, and budgets the sweep so one failing endpoint cannot monopolise it. **Parking, bounded retry, a redelivery window, dead-lettering, fairness — all queue primitives.**

It matters more than the sync lanes: those deliver to our own database, where a retry is an implementation detail. These deliver to **third parties**, where retry and dead-letter semantics *are* the product.

## Shape

A `webhook-deliveries` queue (+ DLQ) on the **main** Worker, where subscriptions already live in `METAGRAPH_CONTROL` KV.

- `POST /api/v1/internal/webhook-dispatch` fans one change event out to one message per matching subscriber. It enqueues and returns — it does **not** deliver, so a slow subscriber can no longer slow the publish that triggered it. That was already the stated rule ("a bad subscriber must not block the data pipeline"); it is now structural rather than maintained by care.
- The consumer POSTs one delivery and reschedules its own failure with `retry({ delaySeconds })`.

Both queues are **already created** (`wrangler queues create`), so the config resolves on deploy.

## What subscribers were promised, kept

| | old | new |
|---|---|---|
| attempts before dead-letter | `WEBHOOK_MAX_DELIVERY_ROUNDS` = 8 | `max_retries: 8` |
| backoff | 5 min, doubling | `delaySeconds`, same curve |
| ceiling | 12 h | 12 h — also Cloudflare's own `delaySeconds` cap |

Both are pinned **to the old constants** in tests, not to numbers that happen to match: the transport changing is not a reason to change what subscribers were told.

A **non-retryable** failure dead-letters immediately rather than spending eight attempts to reach the same place. That distinction is why `deliverChangeEvent` reports `retryable` at all, and losing it would turn a subscriber's typo into 12 hours of pointless outbound traffic.

## Where the fairness cap went

`WEBHOOK_REDELIVERY_MAX_PER_SUBSCRIPTION` rationed a **shared per-run budget** — 64 redeliveries a run, so a subscriber with 500 parked deliveries took every slot and starved the rest.

A queue has no such resource. Each delivery is its own message with its own clock, and a failed one is *rescheduled*, not spun on — between attempts it is not competing for anything. **The thing the cap protected against no longer exists**, which is the only honest reason to delete a safeguard. What remains bounded is `max_concurrency` (4 here rather than sync-batches' 2: these are latency-bound outbound HTTP, not contention for one D1).

## Deliberately unchanged

`deliverChangeEvent` — the signed POST, delivery-time DNS re-resolution against SSRF, the idempotency key — is the product, not scaffolding.

- the **body is carried** on the message rather than rebuilt, so a retry is byte-identical to its first attempt and the signature still verifies
- the **subscription is read at delivery**, so an unsubscribe takes effect on a delivery already in flight — a 12-hour retry window makes that a real interval

## Verification

- **100% patch coverage**, branch-counted, by diff intersection (`workers/api.ts` 58/58, `src/webhook-queue.ts` fully covered)
- tests drive the real `queue()` handler and the real fan-out route, including the retry-with-backoff path end to end
- an unparseable body **acks** (it will never parse) while an unmodelled throw **retries** — both tested, via an injected `deliver` seam matching how `webhooks.ts` already injects `fetchFn`/`resolveHostnames`
- full suite: **703 files / 16,988 tests** green

The old `dispatchWithRedelivery` path is left in place and unreferenced by the new one. Deleting it is the follow-up, once this has run a real publish — same discipline as the sync lanes.