### PR TITLE
fix(mcp): strip Zod's safe-integer sentinel from output schemas too

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -13871,8 +13871,21 @@ const TOOL_OUTPUT_SCHEMAS = {
 
 export function listToolDefinitions() {
   return MCP_TOOLS.map((tool: Row) => {
-    const outputSchema =
-      tool.outputSchema || (TOOL_OUTPUT_SCHEMAS as Row)[tool.name];
+    // NORMALISED HERE, not at the spread below (#9654). The sentinel is a Zod
+    // artifact of `z.int()`, not a property of which side of the call a schema
+    // describes, so it landed on 1,083 of 1,083 output integer fields while
+    // inputs were clean -- `total`, `count`, `limit`, `next_cursor`, every
+    // block height. The spec says clients SHOULD validate structured results
+    // against this schema, so it is read, and it was telling them a row count
+    // is bounded by 2^53 because nobody chose anything.
+    //
+    // Not a loosening: stripSentinelIntegerBounds removes only values EQUAL to
+    // the safe-integer sentinels, so a deliberate `.max()` survives. It also
+    // passes a non-object straight through, which is what keeps the
+    // absent-schema case below unchanged rather than adding a branch to it.
+    const outputSchema = stripSentinelIntegerBounds(
+      tool.outputSchema || (TOOL_OUTPUT_SCHEMAS as Row)[tool.name],
+    );
     return {
       name: tool.name,
       title: tool.title,
@@ -13883,6 +13896,7 @@ export function listToolDefinitions() {
       inputSchema: stripSentinelIntegerBounds(tool.inputSchema),
       // outputSchema (optional) lets a client validate the structuredContent the
       // tool returns; included only when the tool declares one.
+      //
       ...(outputSchema ? { outputSchema } : {}),
       // Behaviour hints (#8964): closed-world read-only by default; the 20
       // tools that leave our infrastructure are named in

--- a/tests/mcp-input-schema.test.ts
+++ b/tests/mcp-input-schema.test.ts
@@ -279,3 +279,62 @@ describe("shared input parameters publish their own description (#9645)", () => 
     }
   });
 });
+
+// #9654: the sentinel is an artifact of `z.int()`, not of which side of the
+// call a schema describes, so it was on every OUTPUT integer field while
+// inputs were clean -- 1,083 of them, against the 287 input parameters that
+// motivated stripping it in the first place. The spec says clients SHOULD
+// validate structured results against this schema, so it is read.
+describe("published output schemas are normalised like inputs (#9654)", () => {
+  const MAX = Number.MAX_SAFE_INTEGER;
+  const MIN = Number.MIN_SAFE_INTEGER;
+
+  /** Every integer subschema anywhere in a published schema, however nested. */
+  const integers = (node: unknown, out: Row[] = []): Row[] => {
+    if (Array.isArray(node)) {
+      for (const entry of node) integers(entry, out);
+      return out;
+    }
+    if (!node || typeof node !== "object") return out;
+    const row = node as Row;
+    if (row.type === "integer") out.push(row);
+    for (const value of Object.values(row)) integers(value, out);
+    return out;
+  };
+
+  test("no output integer field carries the safe-integer sentinel", () => {
+    const offenders: string[] = [];
+    let checked = 0;
+    for (const tool of listToolDefinitions() as Row[]) {
+      if (!tool.outputSchema) continue;
+      for (const schema of integers(tool.outputSchema)) {
+        checked += 1;
+        if (
+          schema.maximum === MAX ||
+          schema.minimum === MIN ||
+          schema.exclusiveMaximum === MAX ||
+          schema.exclusiveMinimum === MIN
+        ) {
+          offenders.push(tool.name as string);
+        }
+      }
+    }
+    // Guards the guard: a walker that found nothing would pass vacuously.
+    assert.ok(checked > 500, `expected many output integers, saw ${checked}`);
+    assert.deepEqual([...new Set(offenders)], []);
+  });
+
+  // The same assertion inputs already carry, restated here so both sides are
+  // pinned in one place -- they are normalised by the same call now.
+  test("no input parameter carries the safe-integer sentinel", () => {
+    const offenders: string[] = [];
+    for (const tool of listToolDefinitions() as Row[]) {
+      for (const schema of integers(tool.inputSchema)) {
+        if (schema.maximum === MAX || schema.minimum === MIN) {
+          offenders.push(tool.name as string);
+        }
+      }
+    }
+    assert.deepEqual([...new Set(offenders)], []);
+  });
+});


### PR DESCRIPTION
## Summary

`stripSentinelIntegerBounds` ran on every tool's `inputSchema` and **no tool's `outputSchema`**. The sentinel is an artifact of `z.int()`, not a property of which side of the call a schema describes — so the defect #8942 removed from inputs was still fully present on outputs, and larger by count.

## Measured on production `tools/list`

```
OUTPUT integer fields          1,083
  carrying the +/-2^53 sentinel  1,083   (100%)
  carrying a real maximum            0

INPUT  integer fields            297
  carrying the sentinel              0   (already stripped)
```

`total`, `count`, `limit`, `cursor`, `next_cursor`, every block height and every `netuid` published:

```json
{ "type": "integer", "minimum": -9007199254740991, "maximum": 9007199254740991 }
```

## Why it matters on the output side

The spec is explicit that this schema is read and acted on:

> Servers **MUST** provide structured results that conform to this schema. Clients **SHOULD** validate structured results against this schema.

So clients were being told a row count is bounded by 2^53 because nobody chose anything — and, exactly as `src/mcp-input-schema.ts`'s own header argues for inputs, a deliberate bound would be indistinguishable from Zod's default if one were ever added.

## Normalised at the computation site, not the spread

```ts
const outputSchema = stripSentinelIntegerBounds(
  tool.outputSchema || (TOOL_OUTPUT_SCHEMAS as Row)[tool.name],
);
```

`stripSentinelIntegerBounds` passes a non-object straight through, so the absent-schema case needs no branch of its own and the `...(outputSchema ? { outputSchema } : {})` line below stays exactly as it was — one changed expression rather than a new conditional to cover. (The first attempt normalised at the spread and added an unreachable `: {}` branch; this avoids it entirely.)

## Not a loosening

Only values **equal** to the safe-integer sentinels are removed, so a deliberate `.max()` survives — that precision is why the helper strips rather than rewrites. Measured above: no output integer field carries a real `maximum` today, so nothing is lost either way. And no JSON number past 2^53 round-trips through a JavaScript client reliably, which is why Zod emits the range in the first place rather than anyone having asserted it.

The helper was already recursive over `items` / `anyOf` / `oneOf` / `allOf` / `properties` / `patternProperties` / `$defs`, and already pure and non-mutating, so nested output shapes are covered without touching it.

## Tests

A gate over every integer subschema in every published `outputSchema`, however nested, plus the matching input-side assertion so both are pinned in one place. The output test counts what it walked and asserts it saw >500 fields, because a walker that found nothing would pass vacuously.

Verified the gate catches the defect: reverting the one-line change fails it and nothing else.

## Validation run

```
npx vitest run <4 MCP/schema suites>   1379 passed
npm run validate:mcp                   224 tools, lifecycle + all tools/call green
npm run typecheck                      clean
npm run lint                           clean
patch coverage (diff intersection)     100%
live check: 1,083 output integer fields, 0 sentinel-bounded (was 1,083)
```

Closes #9654
