### PR TITLE
feat(mcp): give every published tool parameter a worked example

### DIFF
--- a/schemas-src/mcp-tools/account-history.ts
+++ b/schemas-src/mcp-tools/account-history.ts
@@ -21,13 +21,15 @@ export const GetAccountHistoryInputSchema = z
       .optional()
       .describe(
         "Inclusive start of the range. A block height on chain tools, an ISO-8601 date on time-series ones.",
-      ),
+      )
+      .meta({ examples: [8700000] }),
     to: z
       .string()
       .optional()
       .describe(
         "Inclusive end of the range. A block height on chain tools, an ISO-8601 date on time-series ones; an EVM address on decode_evm_call.",
-      ),
+      )
+      .meta({ examples: [8783000] }),
     limit: limitSchema(1000).optional(),
     offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),

--- a/schemas-src/mcp-tools/account-portfolio.ts
+++ b/schemas-src/mcp-tools/account-portfolio.ts
@@ -78,7 +78,8 @@ export const GetAccountSnapshotInputSchema = z
       .optional()
       .describe(
         "How many recent events to embed. Clamped to the tool's ceiling rather than rejected.",
-      ),
+      )
+      .meta({ examples: [10] }),
   })
   .strict();
 export type GetAccountSnapshotInput = z.infer<

--- a/schemas-src/mcp-tools/account-transfers.ts
+++ b/schemas-src/mcp-tools/account-transfers.ts
@@ -23,7 +23,8 @@ export const GetAccountTransfersInputSchema = z
       .optional()
       .describe(
         "Which side of the flow to include: everything, only outgoing, or only incoming.",
-      ),
+      )
+      .meta({ examples: ["all"] }),
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
     limit: limitSchema(1000).optional(),
@@ -67,9 +68,11 @@ export type GetAccountTransfersOutput = z.infer<
 export const GetAccountCounterpartiesInputSchema = z
   .object({
     ss58: ss58Schema(),
-    counterparty: Ss58Schema.optional().describe(
-      "The other SS58 account in the transfer pair — results are restricted to flows between the subject account and this one.",
-    ),
+    counterparty: Ss58Schema.optional()
+      .describe(
+        "The other SS58 account in the transfer pair — results are restricted to flows between the subject account and this one.",
+      )
+      .meta({ examples: ["5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F"] }),
     limit: limitSchema(100).optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/ai-discovery.ts
+++ b/schemas-src/mcp-tools/ai-discovery.ts
@@ -32,7 +32,8 @@ export const FindSubnetOpportunitiesInputSchema = z
     board: z
       .enum(ECONOMIC_LEADERBOARD_BOARDS)
       .optional()
-      .describe("Which leaderboard to return."),
+      .describe("Which leaderboard to return.")
+      .meta({ examples: [ECONOMIC_LEADERBOARD_BOARDS[0]] }),
     limit: limitSchema(100).optional(),
   })
   .strict();
@@ -74,9 +75,12 @@ export const SemanticSearchInputSchema = z
       .string()
       .describe(
         "The request payload or search text this surface expects. Shape depends on the surface; see its schema.",
-      ),
+      )
+      .meta({ examples: ["inference"] }),
     limit: limitSchema(20).optional(),
-    type: SemanticTypeSchema.describe("Which entity kind to search over."),
+    type: SemanticTypeSchema.describe("Which entity kind to search over.").meta(
+      { examples: ["subnet"] },
+    ),
   })
   .strict();
 export type SemanticSearchInput = z.infer<typeof SemanticSearchInputSchema>;
@@ -109,8 +113,11 @@ export const AskInputSchema = z
       .string()
       .describe(
         "A natural-language question. Answered from indexed registry content with citations, not from model recall.",
-      ),
-    type: SemanticTypeSchema.describe("Which entity kind to search over."),
+      )
+      .meta({ examples: ["Which subnets expose a public inference API?"] }),
+    type: SemanticTypeSchema.describe("Which entity kind to search over.").meta(
+      { examples: ["subnet"] },
+    ),
   })
   .strict();
 export type AskInput = z.infer<typeof AskInputSchema>;
@@ -143,7 +150,8 @@ export const FindSubnetForTaskInputSchema = z
       .string()
       .describe(
         "Describe the task in plain language; subnets are ranked by how well their published capabilities match it.",
-      ),
+      )
+      .meta({ examples: ["summarise long documents"] }),
     limit: limitSchema(20).optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/ai-integration.ts
+++ b/schemas-src/mcp-tools/ai-integration.ts
@@ -20,7 +20,8 @@ export const HowDoICallInputSchema = z
       .optional()
       .describe(
         "A subnet by slug (`chutes`) or chain name. Use `netuid` instead when you have the numeric id.",
-      ),
+      )
+      .meta({ examples: ["chutes"] }),
   })
   .strict();
 export type HowDoICallInput = z.infer<typeof HowDoICallInputSchema>;
@@ -92,17 +93,20 @@ export const CallSubnetSurfaceInputSchema = z
         "Query-string parameters to append, as a flat object of " +
           "string/number/boolean values. Nested objects and arrays are not " +
           "supported — encode them into `path` or `body` instead.",
-      ),
+      )
+      .meta({ examples: ["inference"] }),
     path: z
       .string()
       .optional()
       .describe(
         "Path appended to the surface's base URL, e.g. `/v1/status`. Leading slash optional.",
-      ),
+      )
+      .meta({ examples: ["/v1/status"] }),
     method: z
       .enum(["GET", "HEAD", "POST", "PUT"])
       .optional()
-      .describe("HTTP method to use for the call."),
+      .describe("HTTP method to use for the call.")
+      .meta({ examples: ["GET"] }),
     // Branch order (object, then string) mirrors the hand-written original's
     // `type: ["object", "string"]`.
     body: z
@@ -110,13 +114,15 @@ export const CallSubnetSurfaceInputSchema = z
       .optional()
       .describe(
         "Request body: an object (sent as JSON) or a pre-serialized string.",
-      ),
+      )
+      .meta({ examples: [{ prompt: "hello" }] }),
     content_type: z
       .string()
       .optional()
       .describe(
         "Overrides the Content-Type header. Defaults to `application/json` when the body is an object.",
-      ),
+      )
+      .meta({ examples: ["application/json"] }),
     // Branch order (string, then object) mirrors the hand-written original's
     // `type: ["string", "object"]` -- the reverse of `body` above.
     credential: z
@@ -124,7 +130,8 @@ export const CallSubnetSurfaceInputSchema = z
       .optional()
       .describe(
         "Secret for an authenticated surface: a bearer token string, or an object of header/query values. Sent to the surface and never stored unless you use store_surface_credential.",
-      ),
+      )
+      .meta({ examples: ["Bearer <token>"] }),
   })
   .strict();
 export type CallSubnetSurfaceInput = z.infer<
@@ -171,13 +178,15 @@ export const StoreSurfaceCredentialInputSchema = z
       .union([z.string(), OpenObjectSchema])
       .describe(
         "Secret for an authenticated surface: a bearer token string, or an object of header/query values. Sent to the surface and never stored unless you use store_surface_credential.",
-      ),
+      )
+      .meta({ examples: ["Bearer <token>"] }),
     ttl_seconds: z
       .int()
       .min(60)
       .max(7_776_000)
       .optional()
-      .describe("How long the stored credential remains valid, in seconds."),
+      .describe("How long the stored credential remains valid, in seconds.")
+      .meta({ examples: [3600] }),
   })
   .strict();
 export type StoreSurfaceCredentialInput = z.infer<

--- a/schemas-src/mcp-tools/blocks.ts
+++ b/schemas-src/mcp-tools/blocks.ts
@@ -18,16 +18,19 @@ const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 
 export const ListBlocksInputSchema = z
   .object({
-    author: Ss58Schema.optional().describe(
-      "Restrict to blocks authored by this SS58 validator hotkey. Only populated below the decode watermark; recent head blocks may not carry an author yet.",
-    ),
+    author: Ss58Schema.optional()
+      .describe(
+        "Restrict to blocks authored by this SS58 validator hotkey. Only populated below the decode watermark; recent head blocks may not carry an author yet.",
+      )
+      .meta({ examples: ["5CS3g6nVJM6ouns8n9buN9CzFf2C1YDHVcVGRcxoirKs2xbV"] }),
     spec_version: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Restrict to blocks running this runtime spec version — the number that changes at a runtime upgrade.",
-      ),
+      )
+      .meta({ examples: [441] }),
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
     from: z
@@ -36,28 +39,32 @@ export const ListBlocksInputSchema = z
       .optional()
       .describe(
         "Inclusive start of the range. A block height on chain tools, an ISO-8601 date on time-series ones.",
-      ),
+      )
+      .meta({ examples: [8700000] }),
     to: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive end of the range. A block height on chain tools, an ISO-8601 date on time-series ones; an EVM address on decode_evm_call.",
-      ),
+      )
+      .meta({ examples: [8783000] }),
     min_extrinsics: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive lower bound on a block's extrinsic count; quieter blocks are excluded.",
-      ),
+      )
+      .meta({ examples: [5] }),
     min_events: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive lower bound on a block's event count; quieter blocks are excluded.",
-      ),
+      )
+      .meta({ examples: [20] }),
     limit: limitSchema(100).optional(),
     offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
@@ -98,7 +105,8 @@ export const GetBlockInputSchema = z
       .string()
       .describe(
         "Block reference: either a block NUMBER or a 0x-prefixed block HASH. Both forms are accepted and resolve to the same block.",
-      ),
+      )
+      .meta({ examples: ["8783000", "0x9f1e...c3"] }),
   })
   .strict();
 export type GetBlockInput = z.infer<typeof GetBlockInputSchema>;
@@ -120,7 +128,8 @@ export const ListBlockExtrinsicsInputSchema = z
       .string()
       .describe(
         "Block reference: either a block NUMBER or a 0x-prefixed block HASH. Both forms are accepted and resolve to the same block.",
-      ),
+      )
+      .meta({ examples: ["8783000", "0x9f1e...c3"] }),
     limit: limitSchema(100).optional(),
     offset: offsetSchema().optional(),
   })
@@ -150,7 +159,8 @@ export const GetBlockEventsInputSchema = z
       .string()
       .describe(
         "Block reference: either a block NUMBER or a 0x-prefixed block HASH. Both forms are accepted and resolve to the same block.",
-      ),
+      )
+      .meta({ examples: ["8783000", "0x9f1e...c3"] }),
     limit: limitSchema(1000).optional(),
     offset: offsetSchema().optional(),
   })

--- a/schemas-src/mcp-tools/catalog-detail.ts
+++ b/schemas-src/mcp-tools/catalog-detail.ts
@@ -73,13 +73,15 @@ export const GetProviderDetailInputSchema = z
       .string()
       .describe(
         "The registry slug — lowercase, hyphenated (`chutes`), not the display name. Slugs are stable across renames.",
-      ),
+      )
+      .meta({ examples: ["chutes"] }),
     include_endpoints: z
       .boolean()
       .optional()
       .describe(
         "When true, embed each provider's endpoints instead of counts alone.",
-      ),
+      )
+      .meta({ examples: [true] }),
   })
   .strict();
 export type GetProviderDetailInput = z.infer<

--- a/schemas-src/mcp-tools/chain-calls-fees.ts
+++ b/schemas-src/mcp-tools/chain-calls-fees.ts
@@ -19,14 +19,16 @@ export const GetChainCallsInputSchema = z
       .optional()
       .describe(
         "How to bucket the counts: by pallet, or by pallet and call together.",
-      ),
+      )
+      .meta({ examples: ["module"] }),
     limit: limitSchema(100).optional(),
     call_module: z
       .string()
       .optional()
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
-      ),
+      )
+      .meta({ examples: ["SubtensorModule"] }),
   })
   .strict();
 export type GetChainCallsInput = z.infer<typeof GetChainCallsInputSchema>;
@@ -65,7 +67,8 @@ export const GetChainSignersInputSchema = z
       .optional()
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
-      ),
+      )
+      .meta({ examples: ["SubtensorModule"] }),
   })
   .strict();
 export type GetChainSignersInput = z.infer<typeof GetChainSignersInputSchema>;
@@ -102,7 +105,8 @@ export const GetChainFeesInputSchema = z
       .optional()
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
-      ),
+      )
+      .meta({ examples: ["SubtensorModule"] }),
   })
   .strict();
 export type GetChainFeesInput = z.infer<typeof GetChainFeesInputSchema>;

--- a/schemas-src/mcp-tools/chain-events-activity.ts
+++ b/schemas-src/mcp-tools/chain-events-activity.ts
@@ -20,7 +20,8 @@ export const GetChainActivityInputSchema = z
       .min(1)
       .max(5000)
       .optional()
-      .describe("How many trailing blocks to cover, ending at the chain head."),
+      .describe("How many trailing blocks to cover, ending at the chain head.")
+      .meta({ examples: [1200] }),
     // #8700: which chain's decoded history to aggregate. The same published
     // finney/test enum every network-aware tool takes, so one vocabulary
     // covers the whole surface.
@@ -57,20 +58,27 @@ export const ListChainEventsInputSchema = z
       .optional()
       .describe(
         "Restrict to events emitted by this pallet, by runtime name (`SubtensorModule`). Case-sensitive.",
-      ),
-    method: z.string().optional().describe("HTTP method to use for the call."),
+      )
+      .meta({ examples: ["SubtensorModule"] }),
+    method: z
+      .string()
+      .optional()
+      .describe("HTTP method to use for the call.")
+      .meta({ examples: ["set_weights"] }),
     block: z
       .int()
       .min(0)
       .optional()
-      .describe("Restrict to this exact block height."),
+      .describe("Restrict to this exact block height.")
+      .meta({ examples: [8783000] }),
     extrinsic: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Restrict to one extrinsic's events by its index within the block. Requires `block`.",
-      ),
+      )
+      .meta({ examples: [14] }),
     cursor: keysetCursorSchema().optional(),
     before: z
       .int()
@@ -78,7 +86,8 @@ export const ListChainEventsInputSchema = z
       .optional()
       .describe(
         "Legacy cursor: return rows strictly BEFORE this block height. Prefer `cursor` where a tool offers one.",
-      ),
+      )
+      .meta({ examples: [8783000] }),
     limit: limitSchema(200).optional(),
     network: McpNetworkSchema.optional(),
   })

--- a/schemas-src/mcp-tools/chain-events.ts
+++ b/schemas-src/mcp-tools/chain-events.ts
@@ -9,7 +9,11 @@ import { McpNetworkSchema } from "../shared.ts";
 
 export const GetBlockChainEventsInputSchema = z
   .object({
-    block_number: z.int().min(0).describe("The block height to read."),
+    block_number: z
+      .int()
+      .min(0)
+      .describe("The block height to read.")
+      .meta({ examples: [8783000] }),
     // #8700: which chain's history to read. The same published finney/test
     // enum every network-aware tool takes.
     network: McpNetworkSchema.optional(),
@@ -60,7 +64,8 @@ export const GetExtrinsicChainEventsInputSchema = z
       .string()
       .describe(
         "Block reference: either a block NUMBER or a 0x-prefixed block HASH. Both forms are accepted and resolve to the same block.",
-      ),
+      )
+      .meta({ examples: ["8783000", "0x9f1e...c3"] }),
     limit: limitSchema(200).optional(),
     cursor: keysetCursorSchema().optional(),
     network: McpNetworkSchema.optional(),

--- a/schemas-src/mcp-tools/compare-subnets.ts
+++ b/schemas-src/mcp-tools/compare-subnets.ts
@@ -15,11 +15,13 @@ export const CompareSubnetsInputSchema = z
       .max(128)
       .describe(
         "Subnet ids to include, as an array of integers. Omit for every subnet.",
-      ),
+      )
+      .meta({ examples: [[64, 8, 1]] }),
     dimensions: z
       .array(z.enum(COMPARE_DIMENSIONS))
       .optional()
-      .describe("Which breakdown dimensions to return, as an array of names."),
+      .describe("Which breakdown dimensions to return, as an array of names.")
+      .meta({ examples: [COMPARE_DIMENSIONS[0]] }),
   })
   .strict();
 export type CompareSubnetsInput = z.infer<typeof CompareSubnetsInputSchema>;

--- a/schemas-src/mcp-tools/curation-and-gaps.ts
+++ b/schemas-src/mcp-tools/curation-and-gaps.ts
@@ -45,7 +45,8 @@ export const ListCurationInputSchema = z
       .optional()
       .describe(
         "How much of the subnet is covered: on-chain data only, a manifest, or actively probed surfaces.",
-      ),
+      )
+      .meta({ examples: [COVERAGE_LEVELS[0]] }),
     curation_level: kindSchema(CURATION_LEVELS).optional(),
     sort: sortSchema(CURATION_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
@@ -88,7 +89,8 @@ export const ListGapsInputSchema = z
       .optional()
       .describe(
         "How much of the subnet is covered: on-chain data only, a manifest, or actively probed surfaces.",
-      ),
+      )
+      .meta({ examples: [COVERAGE_LEVELS[0]] }),
     curation_level: kindSchema(CURATION_LEVELS).optional(),
     sort: sortSchema(GAPS_SORT_FIELDS).optional(),
     order: orderSchema().optional(),

--- a/schemas-src/mcp-tools/endpoint-pools-and-provider.ts
+++ b/schemas-src/mcp-tools/endpoint-pools-and-provider.ts
@@ -39,32 +39,37 @@ export const ListEndpointPoolsInputSchema = z
       .optional()
       .describe(
         "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
-      ),
+      )
+      .meta({ examples: ["sn-64-chutes-subnet-api"] }),
     kind: kindSchema(POOL_KINDS).optional(),
     min_eligible_count: z
       .number()
       .optional()
       .describe(
         "Inclusive lower bound on pool-eligible endpoint count; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [1] }),
     max_eligible_count: z
       .number()
       .optional()
       .describe(
         "Inclusive upper bound on pool-eligible endpoint count; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [10] }),
     min_endpoint_count: z
       .number()
       .optional()
       .describe(
         "Inclusive lower bound on endpoint count; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [1] }),
     max_endpoint_count: z
       .number()
       .optional()
       .describe(
         "Inclusive upper bound on endpoint count; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [10] }),
     sort: sortSchema(POOL_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
@@ -134,11 +139,13 @@ export const ListEndpointIncidentsInputSchema = z
     severity: z
       .enum(INCIDENT_SEVERITIES)
       .optional()
-      .describe("How serious the incident is."),
+      .describe("How serious the incident is.")
+      .meta({ examples: [INCIDENT_SEVERITIES[0]] }),
     state: z
       .enum(INCIDENT_STATES)
       .optional()
-      .describe("The incident's lifecycle state."),
+      .describe("The incident's lifecycle state.")
+      .meta({ examples: [INCIDENT_STATES[0]] }),
     sort: sortSchema(INCIDENT_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
@@ -203,52 +210,60 @@ export const ListProviderEndpointsInputSchema = z
       .regex(/^[a-z0-9-]+$/)
       .describe(
         "The registry slug — lowercase, hyphenated (`chutes`), not the display name. Slugs are stable across renames.",
-      ),
+      )
+      .meta({ examples: ["chutes"] }),
     kind: kindSchema(SURFACE_KINDS).optional(),
     layer: z
       .enum(ENDPOINT_LAYERS)
       .optional()
       .describe(
         "Which layer of the stack the endpoint belongs to: the Bittensor base chain, a data or docs provider, or a subnet's own app.",
-      ),
+      )
+      .meta({ examples: [ENDPOINT_LAYERS[0]] }),
     netuid: netuidSchema().optional(),
     publication_state: z
       .enum(ENDPOINT_PUBLICATION_STATES)
       .optional()
       .describe(
         "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
-      ),
+      )
+      .meta({ examples: [ENDPOINT_PUBLICATION_STATES[0]] }),
     status: kindSchema(HEALTH_STATUSES).optional(),
     pool_eligible: z
       .boolean()
       .optional()
       .describe(
         "Restrict to endpoints that are (or are not) eligible for the public RPC pool.",
-      ),
+      )
+      .meta({ examples: [true] }),
     min_latency_ms: z
       .number()
       .optional()
       .describe(
         "Inclusive lower bound on probe latency in milliseconds; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [50] }),
     max_latency_ms: z
       .number()
       .optional()
       .describe(
         "Inclusive upper bound on probe latency in milliseconds; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [500] }),
     min_score: z
       .number()
       .optional()
       .describe(
         "Inclusive lower bound on endpoint score; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [50] }),
     max_score: z
       .number()
       .optional()
       .describe(
         "Inclusive upper bound on endpoint score; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [100] }),
     sort: sortSchema(ENDPOINT_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),

--- a/schemas-src/mcp-tools/endpoints-catalog.ts
+++ b/schemas-src/mcp-tools/endpoints-catalog.ts
@@ -69,7 +69,8 @@ export const ListEndpointsInputSchema = z
       .optional()
       .describe(
         "Which layer of the stack the endpoint belongs to: the Bittensor base chain, a data or docs provider, or a subnet's own app.",
-      ),
+      )
+      .meta({ examples: [ENDPOINT_LAYERS[0]] }),
     netuid: netuidSchema().optional(),
     provider: providerSlugSchema().optional(),
     publication_state: z
@@ -77,38 +78,44 @@ export const ListEndpointsInputSchema = z
       .optional()
       .describe(
         "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
-      ),
+      )
+      .meta({ examples: [ENDPOINT_PUBLICATION_STATES[0]] }),
     status: kindSchema(HEALTH_STATUSES).optional(),
     pool_eligible: z
       .boolean()
       .optional()
       .describe(
         "Restrict to endpoints that are (or are not) eligible for the public RPC pool.",
-      ),
+      )
+      .meta({ examples: [true] }),
     min_latency_ms: z
       .number()
       .optional()
       .describe(
         "Inclusive lower bound on probe latency in milliseconds; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [50] }),
     max_latency_ms: z
       .number()
       .optional()
       .describe(
         "Inclusive upper bound on probe latency in milliseconds; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [500] }),
     min_score: z
       .number()
       .optional()
       .describe(
         "Inclusive lower bound on endpoint score; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [50] }),
     max_score: z
       .number()
       .optional()
       .describe(
         "Inclusive upper bound on endpoint score; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [100] }),
     sort: sortSchema(ENDPOINT_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),

--- a/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
+++ b/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
@@ -68,23 +68,27 @@ export const ListEnrichmentEvidenceInputSchema = z
     lane: z
       .enum(LANES)
       .optional()
-      .describe("Which contribution lane the item belongs to."),
+      .describe("Which contribution lane the item belongs to.")
+      .meta({ examples: [LANES[0]] }),
     evidence_action: z
       .enum(EVIDENCE_ACTIONS)
       .optional()
-      .describe("What the evidence is asking a contributor to do."),
+      .describe("What the evidence is asking a contributor to do.")
+      .meta({ examples: [EVIDENCE_ACTIONS[0]] }),
     direct_submission_kinds: z
       .enum(SURFACE_KINDS)
       .optional()
       .describe(
         "Restrict to subnets where surfaces of this kind a contributor can submit directly. One kind per call; see this parameter's enum.",
-      ),
+      )
+      .meta({ examples: [SURFACE_KINDS[0]] }),
     missing_kinds: z
       .enum(SURFACE_KINDS)
       .optional()
       .describe(
         "Restrict to subnets where surfaces of this kind the subnet is MISSING. One kind per call; see this parameter's enum.",
-      ),
+      )
+      .meta({ examples: [SURFACE_KINDS[0]] }),
     sort: sortSchema(EVIDENCE_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
@@ -142,11 +146,13 @@ export const ListReviewGapsInputSchema = z
       .optional()
       .describe(
         "Restrict to subnets where surfaces of this kind the subnet is MISSING. One kind per call; see this parameter's enum.",
-      ),
+      )
+      .meta({ examples: [SURFACE_KINDS[0]] }),
     review_state: z
       .string()
       .optional()
-      .describe("Where the item sits in maintainer review."),
+      .describe("Where the item sits in maintainer review.")
+      .meta({ examples: ["pending"] }),
     sort: sortSchema(PRIORITY_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
@@ -225,54 +231,65 @@ export const ListReviewEnrichmentTargetsInputSchema = z
     target_type: z
       .enum(TARGET_TYPES)
       .optional()
-      .describe("What kind of enrichment target this is."),
+      .describe("What kind of enrichment target this is.")
+      .meta({ examples: [TARGET_TYPES[0]] }),
     target_action: z
       .enum(TARGET_ACTIONS)
       .optional()
-      .describe("What the target is asking a contributor to do."),
+      .describe("What the target is asking a contributor to do.")
+      .meta({ examples: [TARGET_ACTIONS[0]] }),
     kind: kindSchema(SURFACE_KINDS).optional(),
     lane: z
       .enum(LANES)
       .optional()
-      .describe("Which contribution lane the item belongs to."),
+      .describe("Which contribution lane the item belongs to.")
+      .meta({ examples: [LANES[0]] }),
     evidence_action: z
       .enum(EVIDENCE_ACTIONS)
       .optional()
-      .describe("What the evidence is asking a contributor to do."),
+      .describe("What the evidence is asking a contributor to do.")
+      .meta({ examples: [EVIDENCE_ACTIONS[0]] }),
     identity_level: z
       .enum(IDENTITY_LEVELS)
       .optional()
-      .describe("How complete the subnet's published identity is."),
+      .describe("How complete the subnet's published identity is.")
+      .meta({ examples: [IDENTITY_LEVELS[0]] }),
     profile_level: z
       .enum(PROFILE_LEVELS)
       .optional()
       .describe(
         "How complete the subnet's profile is, from directory-only upward.",
-      ),
+      )
+      .meta({ examples: [PROFILE_LEVELS[0]] }),
     submission_route: z
       .enum(SUBMISSION_ROUTES)
       .optional()
-      .describe("How a contribution for this gap should be submitted."),
+      .describe("How a contribution for this gap should be submitted.")
+      .meta({ examples: [SUBMISSION_ROUTES[0]] }),
     auto_review_candidate: z
       .enum(BOOLEAN_STRINGS)
       .optional()
-      .describe("Restrict to items eligible for automated review."),
+      .describe("Restrict to items eligible for automated review.")
+      .meta({ examples: [BOOLEAN_STRINGS[0]] }),
     manual_review_required: z
       .enum(BOOLEAN_STRINGS)
       .optional()
-      .describe("Restrict to items that do (or do not) need a human reviewer."),
+      .describe("Restrict to items that do (or do not) need a human reviewer.")
+      .meta({ examples: [BOOLEAN_STRINGS[0]] }),
     missing_kinds: z
       .enum(SURFACE_KINDS)
       .optional()
       .describe(
         "Restrict to subnets where surfaces of this kind the subnet is MISSING. One kind per call; see this parameter's enum.",
-      ),
+      )
+      .meta({ examples: [SURFACE_KINDS[0]] }),
     reason_codes: z
       .string()
       .optional()
       .describe(
         "Comma-separated reason codes to filter by; an item matches if it carries any of them.",
-      ),
+      )
+      .meta({ examples: ["stale-evidence"] }),
     sort: sortSchema(TARGET_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),

--- a/schemas-src/mcp-tools/enrichment-queue-and-candidates.ts
+++ b/schemas-src/mcp-tools/enrichment-queue-and-candidates.ts
@@ -97,48 +97,57 @@ export const ListEnrichmentQueueInputSchema = z
     lane: z
       .enum(LANES)
       .optional()
-      .describe("Which contribution lane the item belongs to."),
+      .describe("Which contribution lane the item belongs to.")
+      .meta({ examples: [LANES[0]] }),
     evidence_action: z
       .enum(EVIDENCE_ACTIONS)
       .optional()
-      .describe("What the evidence is asking a contributor to do."),
+      .describe("What the evidence is asking a contributor to do.")
+      .meta({ examples: [EVIDENCE_ACTIONS[0]] }),
     identity_level: z
       .enum(IDENTITY_LEVELS)
       .optional()
-      .describe("How complete the subnet's published identity is."),
+      .describe("How complete the subnet's published identity is.")
+      .meta({ examples: [IDENTITY_LEVELS[0]] }),
     curation_level: kindSchema(CURATION_LEVELS).optional(),
     profile_level: z
       .enum(PROFILE_LEVELS)
       .optional()
       .describe(
         "How complete the subnet's profile is, from directory-only upward.",
-      ),
+      )
+      .meta({ examples: [PROFILE_LEVELS[0]] }),
     direct_submission_kinds: z
       .enum(SURFACE_KINDS)
       .optional()
       .describe(
         "Restrict to subnets where surfaces of this kind a contributor can submit directly. One kind per call; see this parameter's enum.",
-      ),
+      )
+      .meta({ examples: [SURFACE_KINDS[0]] }),
     missing_kinds: z
       .enum(SURFACE_KINDS)
       .optional()
       .describe(
         "Restrict to subnets where surfaces of this kind the subnet is MISSING. One kind per call; see this parameter's enum.",
-      ),
+      )
+      .meta({ examples: [SURFACE_KINDS[0]] }),
     manual_review_required: z
       .enum(BOOLEAN_STRINGS)
       .optional()
-      .describe("Restrict to items that do (or do not) need a human reviewer."),
+      .describe("Restrict to items that do (or do not) need a human reviewer.")
+      .meta({ examples: [BOOLEAN_STRINGS[0]] }),
     reason_codes: z
       .string()
       .optional()
       .describe(
         "Comma-separated reason codes to filter by; an item matches if it carries any of them.",
-      ),
+      )
+      .meta({ examples: ["stale-evidence"] }),
     review_state: z
       .string()
       .optional()
-      .describe("Where the item sits in maintainer review."),
+      .describe("Where the item sits in maintainer review.")
+      .meta({ examples: ["pending"] }),
     sort: sortSchema(QUEUE_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
@@ -195,23 +204,27 @@ export const ListAdapterCandidatesInputSchema = z
       .optional()
       .describe(
         "Restrict to subnets where surfaces of this kind exist as unreviewed API candidates. One kind per call; see this parameter's enum.",
-      ),
+      )
+      .meta({ examples: [SURFACE_KINDS[0]] }),
     operational_kinds: z
       .enum(SURFACE_KINDS)
       .optional()
       .describe(
         "Restrict to subnets where surfaces of this kind are operational. One kind per call; see this parameter's enum.",
-      ),
+      )
+      .meta({ examples: [SURFACE_KINDS[0]] }),
     recommended_adapter_kind: z
       .enum(RECOMMENDED_ADAPTER_KINDS)
       .optional()
-      .describe("Which adapter shape suits this surface."),
+      .describe("Which adapter shape suits this surface.")
+      .meta({ examples: [RECOMMENDED_ADAPTER_KINDS[0]] }),
     reason_codes: z
       .string()
       .optional()
       .describe(
         "Comma-separated reason codes to filter by; an item matches if it carries any of them.",
-      ),
+      )
+      .meta({ examples: ["stale-evidence"] }),
     sort: sortSchema(ADAPTER_CANDIDATES_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),

--- a/schemas-src/mcp-tools/evm.ts
+++ b/schemas-src/mcp-tools/evm.ts
@@ -18,11 +18,12 @@ export const DecodeEvmCallInputSchema = z
   .object({
     to: H160Schema.describe(
       "Inclusive end of the range. A block height on chain tools, an ISO-8601 date on time-series ones; an EVM address on decode_evm_call.",
-    ),
+    ).meta({ examples: ["0x1234567890abcdef1234567890abcdef12345678"] }),
     input: z
       .string()
       .regex(/^0x[0-9a-fA-F]*$/)
-      .describe("ABI-encoded EVM call data (0x-prefixed) to decode."),
+      .describe("ABI-encoded EVM call data (0x-prefixed) to decode.")
+      .meta({ examples: ["0xa9059cbb0000000000000000000000001234"] }),
   })
   .strict();
 export type DecodeEvmCallInput = z.infer<typeof DecodeEvmCallInputSchema>;
@@ -42,7 +43,7 @@ export const GetEvmAddressMappingInputSchema = z
   .object({
     h160: H160Schema.describe(
       "A 20-byte EVM address (0x-prefixed, 40 hex characters) to resolve to its SS58 mirror.",
-    ),
+    ).meta({ examples: ["0x1234567890abcdef1234567890abcdef12345678"] }),
     // #8700: which chain to read. These routes answer from live storage, and
     // the storage keys are twox128 hashes of pallet+item names — identical on
     // every chain running the same runtime — so the endpoint is the only thing

--- a/schemas-src/mcp-tools/extrinsics.ts
+++ b/schemas-src/mcp-tools/extrinsics.ts
@@ -30,32 +30,43 @@ export const ListExtrinsicsInputSchema = z
       .int()
       .min(0)
       .optional()
-      .describe("Restrict to this exact block height."),
-    signer: Ss58Schema.optional().describe(
-      "Restrict to extrinsics signed by this SS58 account. Unsigned (inherent) extrinsics never match.",
-    ),
+      .describe("Restrict to this exact block height.")
+      .meta({ examples: [8783000] }),
+    signer: Ss58Schema.optional()
+      .describe(
+        "Restrict to extrinsics signed by this SS58 account. Unsigned (inherent) extrinsics never match.",
+      )
+      .meta({ examples: ["5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F"] }),
     call_module: z
       .string()
       .optional()
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
-      ),
+      )
+      .meta({ examples: ["SubtensorModule"] }),
     call_function: z
       .string()
       .optional()
       .describe(
         "Restrict to one call within the pallet (`add_stake`). Case-sensitive; pair with `call_module` to disambiguate.",
-      ),
+      )
+      .meta({ examples: ["add_stake"] }),
     call_hash: z
       .string()
       .optional()
-      .describe("Restrict to the extrinsic with this 0x-prefixed hash."),
+      .describe("Restrict to the extrinsic with this 0x-prefixed hash.")
+      .meta({
+        examples: [
+          "0x9f1e2d3c4b5a69788796a5b4c3d2e1f009182736455463728190abcdef012345",
+        ],
+      }),
     success: z
       .boolean()
       .optional()
       .describe(
         "Restrict to successful (`true`) or failed (`false`) extrinsics. Omit for both.",
-      ),
+      )
+      .meta({ examples: [true] }),
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
     from: z
@@ -64,14 +75,16 @@ export const ListExtrinsicsInputSchema = z
       .optional()
       .describe(
         "Inclusive start of the range. A block height on chain tools, an ISO-8601 date on time-series ones.",
-      ),
+      )
+      .meta({ examples: [8700000] }),
     to: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive end of the range. A block height on chain tools, an ISO-8601 date on time-series ones; an EVM address on decode_evm_call.",
-      ),
+      )
+      .meta({ examples: [8783000] }),
     limit: limitSchema(EXTRINSICS_LIMIT_MAX).optional(),
     offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
@@ -97,7 +110,8 @@ export const GetExtrinsicInputSchema = z
       .string()
       .describe(
         "Block reference: either a block NUMBER or a 0x-prefixed block HASH. Both forms are accepted and resolve to the same block.",
-      ),
+      )
+      .meta({ examples: ["8783000", "0x9f1e...c3"] }),
   })
   .strict();
 export type GetExtrinsicInput = z.infer<typeof GetExtrinsicInputSchema>;

--- a/schemas-src/mcp-tools/feed.ts
+++ b/schemas-src/mcp-tools/feed.ts
@@ -30,19 +30,22 @@ export const GetFeedInputSchema = z
       .optional()
       .describe(
         "Restrict the feed to items carrying this tag. Exact match against the item's own tags.",
-      ),
+      )
+      .meta({ examples: ["incident"] }),
     since: z
       .string()
       .optional()
       .describe(
         "ISO-8601 timestamp; only items at or after this instant are returned.",
-      ),
+      )
+      .meta({ examples: ["2026-08-01T00:00:00Z"] }),
     until: z
       .string()
       .optional()
       .describe(
         "ISO-8601 timestamp; only items at or before this instant are returned.",
-      ),
+      )
+      .meta({ examples: ["2026-08-06T00:00:00Z"] }),
     limit: limitSchema(FEED_MAX_ITEMS).optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/find-subnets-by-capability.ts
+++ b/schemas-src/mcp-tools/find-subnets-by-capability.ts
@@ -12,7 +12,8 @@ export const FindSubnetsByCapabilityInputSchema = z
       .string()
       .describe(
         "A capability keyword to match against subnet descriptions and surfaces, e.g. `inference` or `storage`.",
-      ),
+      )
+      .meta({ examples: ["inference"] }),
     cursor: numericCursorSchema().optional(),
     limit: limitSchema(50).optional(),
   })

--- a/schemas-src/mcp-tools/get-adapter.ts
+++ b/schemas-src/mcp-tools/get-adapter.ts
@@ -22,7 +22,8 @@ export const GetAdapterInputSchema = z
       .regex(/^[a-z0-9-]+$/)
       .describe(
         "The registry slug — lowercase, hyphenated (`chutes`), not the display name. Slugs are stable across renames.",
-      ),
+      )
+      .meta({ examples: ["chutes"] }),
   })
   .strict();
 export type GetAdapterInput = z.infer<typeof GetAdapterInputSchema>;

--- a/schemas-src/mcp-tools/get-alert-trigger.ts
+++ b/schemas-src/mcp-tools/get-alert-trigger.ts
@@ -11,12 +11,14 @@ export const GetAlertTriggerInputSchema = z
       .string()
       .describe(
         "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
-      ),
+      )
+      .meta({ examples: ["sn-64-chutes-subnet-api"] }),
     owner_token: z
       .string()
       .describe(
         "The secret token issued when the alert was created. Required to read it back; it is not recoverable if lost.",
-      ),
+      )
+      .meta({ examples: ["mg_alert_..."] }),
   })
   .strict();
 export type GetAlertTriggerInput = z.infer<typeof GetAlertTriggerInputSchema>;

--- a/schemas-src/mcp-tools/get-chain-concentration-history.ts
+++ b/schemas-src/mcp-tools/get-chain-concentration-history.ts
@@ -10,7 +10,8 @@ export const GetChainConcentrationHistoryInputSchema = z
       .optional()
       .describe(
         "Trailing time window to aggregate over, ending at the latest data point rather than a calendar boundary. Options are per-tool; see this parameter's enum.",
-      ),
+      )
+      .meta({ examples: [CHAIN_CONCENTRATION_HISTORY_WINDOWS[0]] }),
   })
   .strict();
 export type GetChainConcentrationHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/get-domain-summary.ts
+++ b/schemas-src/mcp-tools/get-domain-summary.ts
@@ -34,7 +34,8 @@ export const GetDomainSummaryInputSchema = z
     domain: z
       .enum(DOMAIN_TAGS)
       .optional()
-      .describe("The subnet's primary domain of use."),
+      .describe("The subnet's primary domain of use.")
+      .meta({ examples: [DOMAIN_TAGS[0]] }),
   })
   .strict();
 export type GetDomainSummaryInput = z.infer<typeof GetDomainSummaryInputSchema>;

--- a/schemas-src/mcp-tools/get-economics.ts
+++ b/schemas-src/mcp-tools/get-economics.ts
@@ -51,7 +51,8 @@ export const GetEconomicsInputSchema = z
     registration_allowed: z
       .enum(["true", "false"])
       .optional()
-      .describe("Restrict to subnets currently accepting registrations."),
+      .describe("Restrict to subnets currently accepting registrations.")
+      .meta({ examples: ["true"] }),
     q: querySchema().optional(),
     sort: sortSchema(ECONOMICS_SORT_FIELDS).optional(),
     order: orderSchema().optional(),

--- a/schemas-src/mcp-tools/get-emission-pipeline-history.ts
+++ b/schemas-src/mcp-tools/get-emission-pipeline-history.ts
@@ -12,7 +12,8 @@ export const GetPipelineHistoryInputSchema = z
       .optional()
       .describe(
         "Trailing time window to aggregate over, ending at the latest data point rather than a calendar boundary. Options are per-tool; see this parameter's enum.",
-      ),
+      )
+      .meta({ examples: [PIPELINE_HISTORY_WINDOWS[0]] }),
   })
   .strict();
 export type GetPipelineHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/get-failure-reasons.ts
+++ b/schemas-src/mcp-tools/get-failure-reasons.ts
@@ -11,7 +11,8 @@ export const GetFailureReasonsInputSchema = z
       .optional()
       .describe(
         "Trailing time window to aggregate over, ending at the latest data point rather than a calendar boundary. Options are per-tool; see this parameter's enum.",
-      ),
+      )
+      .meta({ examples: [FAILURE_REASONS_WINDOWS[0]] }),
     netuid: netuidSchema().optional(),
     kind: kindStringSchema().optional(),
   })

--- a/schemas-src/mcp-tools/get-health-history.ts
+++ b/schemas-src/mcp-tools/get-health-history.ts
@@ -69,20 +69,23 @@ export const GetHealthHistoryInputSchema = z
     date: z
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}$/)
-      .describe("A single UTC day, `YYYY-MM-DD`."),
+      .describe("A single UTC day, `YYYY-MM-DD`.")
+      .meta({ examples: ["2026-08-05"] }),
     netuid: netuidSchema().optional(),
     kind: kindSchema(SURFACE_KIND).optional(),
     provider: providerSlugSchema().optional(),
     status: z
       .enum(HEALTH_STATUS)
       .optional()
-      .describe("Restrict to rows with this health status."),
+      .describe("Restrict to rows with this health status.")
+      .meta({ examples: [HEALTH_STATUS[0]] }),
     classification: z
       .enum(HEALTH_CLASSIFICATION)
       .optional()
       .describe(
         "Why a probe ended as it did — the reason behind the status, not the status itself.",
-      ),
+      )
+      .meta({ examples: [HEALTH_CLASSIFICATION[0]] }),
     sort: sortSchema(HEALTH_SURFACE_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),

--- a/schemas-src/mcp-tools/get-registry-leaderboards.ts
+++ b/schemas-src/mcp-tools/get-registry-leaderboards.ts
@@ -27,7 +27,8 @@ export const GetRegistryLeaderboardsInputSchema = z
     board: z
       .enum(LEADERBOARD_BOARDS)
       .optional()
-      .describe("Which leaderboard to return."),
+      .describe("Which leaderboard to return.")
+      .meta({ examples: [LEADERBOARD_BOARDS[0]] }),
     limit: limitSchema(100).optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/get-stake-action-preview.ts
+++ b/schemas-src/mcp-tools/get-stake-action-preview.ts
@@ -19,7 +19,8 @@ export const GetStakeActionPreviewInputSchema = z
       .gt(0)
       .describe(
         "Amount to quote, in TAO when staking and in alpha when unstaking. Must be greater than 0.",
-      ),
+      )
+      .meta({ examples: [10] }),
     direction: kindSchema(STAKE_QUOTE_DIRECTIONS).optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/get-subnet-metagraph.ts
+++ b/schemas-src/mcp-tools/get-subnet-metagraph.ts
@@ -17,11 +17,12 @@ export const GetSubnetMetagraphInputSchema = z
       .optional()
       .describe(
         "Restrict to neurons that hold (`true`) or lack (`false`) a validator permit.",
-      ),
+      )
+      .meta({ examples: [true] }),
     // #9082: narrow each returned row to these fields. Omit for the full
     // row. Valid names are NeuronSchema's own, so this enum cannot drift
     // from what the route can project.
-    fields: NeuronFieldsInputSchema,
+    fields: NeuronFieldsInputSchema.meta({ examples: ["netuid,name,slug"] }),
   })
   .strict();
 export type GetSubnetMetagraphInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-snapshot.ts
+++ b/schemas-src/mcp-tools/get-subnet-snapshot.ts
@@ -15,7 +15,8 @@ export const GetSubnetSnapshotInputSchema = z
       .optional()
       .describe(
         "How many top validators to include in the embedded validator list.",
-      ),
+      )
+      .meta({ examples: [10] }),
     recent_events_limit: z
       .int()
       .min(1)
@@ -23,7 +24,8 @@ export const GetSubnetSnapshotInputSchema = z
       .optional()
       .describe(
         "How many recent events to embed. Clamped to the tool's ceiling rather than rejected.",
-      ),
+      )
+      .meta({ examples: [10] }),
   })
   .strict();
 export type GetSubnetSnapshotInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-stake-quote.ts
+++ b/schemas-src/mcp-tools/get-subnet-stake-quote.ts
@@ -29,7 +29,8 @@ export const GetSubnetStakeQuoteInputSchema = z
       .gt(0)
       .describe(
         "Amount to quote, in TAO when staking and in alpha when unstaking. Must be greater than 0.",
-      ),
+      )
+      .meta({ examples: [10] }),
     direction: kindSchema(STAKE_QUOTE_DIRECTIONS).optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/get-subnet-turnover.ts
+++ b/schemas-src/mcp-tools/get-subnet-turnover.ts
@@ -19,7 +19,8 @@ export const GetSubnetTurnoverInputSchema = z
       .optional()
       .describe(
         "When true, return only entries that changed rather than every entry.",
-      ),
+      )
+      .meta({ examples: [true] }),
   })
   .strict();
 export type GetSubnetTurnoverInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-uptime.ts
+++ b/schemas-src/mcp-tools/get-subnet-uptime.ts
@@ -22,7 +22,8 @@ export const GetSubnetUptimeInputSchema = z
       .optional()
       .describe(
         "Drop rows computed from fewer than this many samples, so a thin sample cannot look like a trend.",
-      ),
+      )
+      .meta({ examples: [10] }),
   })
   .strict();
 export type GetSubnetUptimeInput = z.infer<typeof GetSubnetUptimeInputSchema>;

--- a/schemas-src/mcp-tools/get-subnet-validator-economics.ts
+++ b/schemas-src/mcp-tools/get-subnet-validator-economics.ts
@@ -62,13 +62,15 @@ export const ListValidatorEconomicsInputSchema = z
       .optional()
       .describe(
         "Restrict to subnets whose emission gate is open (`true`) or closed (`false`).",
-      ),
+      )
+      .meta({ examples: [true] }),
     cap_binding: z
       .boolean()
       .optional()
       .describe(
         "Restrict to subnets where the validator cap is actually binding (`true`).",
-      ),
+      )
+      .meta({ examples: [true] }),
   })
   .strict();
 export type ListValidatorEconomicsInput = z.infer<
@@ -98,7 +100,10 @@ export const GetSubnetValidatorEconomicsHistoryInputSchema = z
       .optional()
       .describe(
         "Trailing time window to aggregate over, ending at the latest data point rather than a calendar boundary. Options are per-tool; see this parameter's enum.",
-      ),
+      )
+      .meta({
+        examples: [Object.keys(VALIDATOR_ECONOMICS_HISTORY_WINDOWS)[0]],
+      }),
   })
   .strict();
 export type GetSubnetValidatorEconomicsHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-volume-ohlc.ts
+++ b/schemas-src/mcp-tools/get-subnet-volume-ohlc.ts
@@ -48,13 +48,15 @@ export const GetSubnetOhlcInputSchema = z
     interval: z
       .enum(OHLC_INTERVALS)
       .optional()
-      .describe("Bucket size for the returned series."),
+      .describe("Bucket size for the returned series.")
+      .meta({ examples: [OHLC_INTERVALS[0]] }),
     days: z
       .int()
       .min(1)
       .max(MAX_OHLC_WINDOW_DAYS)
       .optional()
-      .describe("How many trailing days to cover, ending today (UTC)."),
+      .describe("How many trailing days to cover, ending today (UTC).")
+      .meta({ examples: [7, 30] }),
   })
   .strict();
 export type GetSubnetOhlcInput = z.infer<typeof GetSubnetOhlcInputSchema>;

--- a/schemas-src/mcp-tools/get-webhook-subscription.ts
+++ b/schemas-src/mcp-tools/get-webhook-subscription.ts
@@ -12,7 +12,8 @@ export const GetWebhookSubscriptionInputSchema = z
       .string()
       .describe(
         "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
-      ),
+      )
+      .meta({ examples: ["sn-64-chutes-subnet-api"] }),
   })
   .strict();
 export type GetWebhookSubscriptionInput = z.infer<

--- a/schemas-src/mcp-tools/governance-feeds.ts
+++ b/schemas-src/mcp-tools/governance-feeds.ts
@@ -24,19 +24,22 @@ export const GetSudoInputSchema = z
       .int()
       .min(0)
       .optional()
-      .describe("Restrict to this exact block height."),
+      .describe("Restrict to this exact block height.")
+      .meta({ examples: [8783000] }),
     call_function: z
       .string()
       .optional()
       .describe(
         "Restrict to one call within the pallet (`add_stake`). Case-sensitive; pair with `call_module` to disambiguate.",
-      ),
+      )
+      .meta({ examples: ["add_stake"] }),
     success: z
       .boolean()
       .optional()
       .describe(
         "Restrict to successful (`true`) or failed (`false`) extrinsics. Omit for both.",
-      ),
+      )
+      .meta({ examples: [true] }),
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
     from: z
@@ -45,14 +48,16 @@ export const GetSudoInputSchema = z
       .optional()
       .describe(
         "Inclusive start of the range. A block height on chain tools, an ISO-8601 date on time-series ones.",
-      ),
+      )
+      .meta({ examples: [8700000] }),
     to: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive end of the range. A block height on chain tools, an ISO-8601 date on time-series ones; an EVM address on decode_evm_call.",
-      ),
+      )
+      .meta({ examples: [8783000] }),
     // Both feeds say "same filters as list_extrinsics" and were modelled on it,
     // but dropped its `.max(100)` — declaring unbounded while the tier they forward to
     // caps at 100. A copy-paste omission, not a wider ceiling.
@@ -102,19 +107,22 @@ export const GetGovernanceConfigChangesInputSchema = z
       .int()
       .min(0)
       .optional()
-      .describe("Restrict to this exact block height."),
+      .describe("Restrict to this exact block height.")
+      .meta({ examples: [8783000] }),
     call_function: z
       .string()
       .optional()
       .describe(
         "Restrict to one call within the pallet (`add_stake`). Case-sensitive; pair with `call_module` to disambiguate.",
-      ),
+      )
+      .meta({ examples: ["add_stake"] }),
     success: z
       .boolean()
       .optional()
       .describe(
         "Restrict to successful (`true`) or failed (`false`) extrinsics. Omit for both.",
-      ),
+      )
+      .meta({ examples: [true] }),
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
     from: z
@@ -123,14 +131,16 @@ export const GetGovernanceConfigChangesInputSchema = z
       .optional()
       .describe(
         "Inclusive start of the range. A block height on chain tools, an ISO-8601 date on time-series ones.",
-      ),
+      )
+      .meta({ examples: [8700000] }),
     to: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive end of the range. A block height on chain tools, an ISO-8601 date on time-series ones; an EVM address on decode_evm_call.",
-      ),
+      )
+      .meta({ examples: [8783000] }),
     // Both feeds say "same filters as list_extrinsics" and were modelled on it,
     // but dropped its `.max(100)` — declaring unbounded while the tier they forward to
     // caps at 100. A copy-paste omission, not a wider ceiling.

--- a/schemas-src/mcp-tools/list-subnets.ts
+++ b/schemas-src/mcp-tools/list-subnets.ts
@@ -37,45 +37,59 @@ export const ListSubnetsInputSchema = z
     status: z
       .string()
       .optional()
-      .describe("Restrict to rows with this health status."),
+      .describe("Restrict to rows with this health status.")
+      .meta({ examples: ["ok"] }),
     subnet_type: z
       .string()
       .optional()
-      .describe("Root subnet or an application subnet."),
+      .describe("Root subnet or an application subnet.")
+      .meta({ examples: ["application"] }),
     domain: z
       .string()
       .optional()
-      .describe("The subnet's primary domain of use."),
+      .describe("The subnet's primary domain of use.")
+      .meta({ examples: ["inference"] }),
     not_status: z
       .string()
       .optional()
       .describe(
         "EXCLUDE rows with this status. Applied after any positive `status` filter, so the two can be combined.",
-      ),
+      )
+      .meta({ examples: ["unknown"] }),
     not_subnet_type: z
       .string()
       .optional()
       .describe(
         "EXCLUDE rows with this subnet type. Applied after any positive `subnet_type` filter, so the two can be combined.",
-      ),
+      )
+      .meta({ examples: ["root"] }),
     not_domain: z
       .string()
       .optional()
       .describe(
         "EXCLUDE rows with this domain. Applied after any positive `domain` filter, so the two can be combined.",
-      ),
-    coverage_level: CoverageLevelSchema.optional().describe(
-      "How much of the subnet is covered: on-chain data only, a manifest, or actively probed surfaces.",
-    ),
-    not_coverage_level: CoverageLevelSchema.optional().describe(
-      "EXCLUDE rows with this coverage level. Applied after any positive `coverage_level` filter, so the two can be combined.",
-    ),
-    curation_level: CurationLevelSchema.optional().describe(
-      "How the record entered the registry — native chain data, discovered candidate, community submission, or machine-derived.",
-    ),
-    not_curation_level: CurationLevelSchema.optional().describe(
-      "EXCLUDE rows with this curation level. Applied after any positive `curation_level` filter, so the two can be combined.",
-    ),
+      )
+      .meta({ examples: ["media"] }),
+    coverage_level: CoverageLevelSchema.optional()
+      .describe(
+        "How much of the subnet is covered: on-chain data only, a manifest, or actively probed surfaces.",
+      )
+      .meta({ examples: [CoverageLevelSchema.options[0]] }),
+    not_coverage_level: CoverageLevelSchema.optional()
+      .describe(
+        "EXCLUDE rows with this coverage level. Applied after any positive `coverage_level` filter, so the two can be combined.",
+      )
+      .meta({ examples: [CoverageLevelSchema.options[0]] }),
+    curation_level: CurationLevelSchema.optional()
+      .describe(
+        "How the record entered the registry — native chain data, discovered candidate, community submission, or machine-derived.",
+      )
+      .meta({ examples: [CurationLevelSchema.options[0]] }),
+    not_curation_level: CurationLevelSchema.optional()
+      .describe(
+        "EXCLUDE rows with this curation level. Applied after any positive `curation_level` filter, so the two can be combined.",
+      )
+      .meta({ examples: [CurationLevelSchema.options[0]] }),
     min_readiness: z
       .int()
       .min(0)
@@ -83,7 +97,8 @@ export const ListSubnetsInputSchema = z
       .optional()
       .describe(
         "Inclusive lower bound on readiness score; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [50] }),
     max_readiness: z
       .int()
       .min(0)
@@ -91,117 +106,134 @@ export const ListSubnetsInputSchema = z
       .optional()
       .describe(
         "Inclusive upper bound on readiness score; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [100] }),
     min_surface_count: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive lower bound on surface count; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [1] }),
     max_surface_count: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive upper bound on surface count; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [20] }),
     min_block: z
       .number()
       .optional()
       .describe(
         "Inclusive lower bound on block height; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [8700000] }),
     max_block: z
       .number()
       .optional()
       .describe(
         "Inclusive upper bound on block height; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [8783000] }),
     min_candidate_count: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive lower bound on candidate surface count; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [1] }),
     max_candidate_count: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive upper bound on candidate surface count; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [20] }),
     min_mechanism_count: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive lower bound on mechanism count; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [1] }),
     max_mechanism_count: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive upper bound on mechanism count; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [8] }),
     min_participant_count: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive lower bound on participant count; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [1] }),
     max_participant_count: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive upper bound on participant count; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [256] }),
     min_probed_surface_count: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive lower bound on probed surface count; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [1] }),
     max_probed_surface_count: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive upper bound on probed surface count; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [20] }),
     min_tempo: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive lower bound on subnet tempo; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [99] }),
     max_tempo: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive upper bound on subnet tempo; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [360] }),
     min_netuid: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive lower bound on subnet id; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [1] }),
     max_netuid: z
       .int()
       .min(0)
       .optional()
       .describe(
         "Inclusive upper bound on subnet id; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [128] }),
     sort: sortSchema(LIST_SUBNETS_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     network: McpNetworkSchema.optional(),

--- a/schemas-src/mcp-tools/neurons.ts
+++ b/schemas-src/mcp-tools/neurons.ts
@@ -20,7 +20,7 @@ export const GetNeuronInputSchema = z
     // #9082: narrow each returned row to these fields. Omit for the full
     // row. Valid names are NeuronSchema's own, so this enum cannot drift
     // from what the route can project.
-    fields: NeuronFieldsInputSchema,
+    fields: NeuronFieldsInputSchema.meta({ examples: ["netuid,name,slug"] }),
   })
   .strict();
 export type GetNeuronInput = z.infer<typeof GetNeuronInputSchema>;

--- a/schemas-src/mcp-tools/profiles.ts
+++ b/schemas-src/mcp-tools/profiles.ts
@@ -60,27 +60,32 @@ export const ListProfilesInputSchema = z
     subnet_type: z
       .enum(SUBNET_TYPE)
       .optional()
-      .describe("Root subnet or an application subnet."),
+      .describe("Root subnet or an application subnet.")
+      .meta({ examples: [SUBNET_TYPE[0]] }),
     curation_level: z
       .enum(CURATION_LEVEL)
       .optional()
       .describe(
         "How the record entered the registry — native chain data, discovered candidate, community submission, or machine-derived.",
-      ),
+      )
+      .meta({ examples: [CURATION_LEVEL[0]] }),
     review_state: z
       .string()
       .optional()
-      .describe("Where the item sits in maintainer review."),
+      .describe("Where the item sits in maintainer review.")
+      .meta({ examples: ["pending"] }),
     confidence: z
       .enum(["low", "medium", "high"])
       .optional()
-      .describe("How confident the machine assessment is."),
+      .describe("How confident the machine assessment is.")
+      .meta({ examples: ["low"] }),
     profile_level: z
       .enum(PROFILE_LEVEL)
       .optional()
       .describe(
         "How complete the subnet's profile is, from directory-only upward.",
-      ),
+      )
+      .meta({ examples: [PROFILE_LEVEL[0]] }),
     q: querySchema().optional(),
     sort: sortSchema(PROFILES_SORT_FIELDS).optional(),
     order: orderSchema().optional(),

--- a/schemas-src/mcp-tools/query-tools.ts
+++ b/schemas-src/mcp-tools/query-tools.ts
@@ -28,10 +28,11 @@ export const QueryGraphqlInputSchema = z
       .string()
       .describe(
         "The request payload or search text this surface expects. Shape depends on the surface; see its schema.",
-      ),
-    variables: OpenObjectSchema.optional().describe(
-      "GraphQL variables for the query, as an object.",
-    ),
+      )
+      .meta({ examples: ["inference"] }),
+    variables: OpenObjectSchema.optional()
+      .describe("GraphQL variables for the query, as an object.")
+      .meta({ examples: [{ netuid: 64 }] }),
   })
   .strict();
 export type QueryGraphqlInput = z.infer<typeof QueryGraphqlInputSchema>;
@@ -58,10 +59,13 @@ export const RunSavedQueryInputSchema = z
       .enum(SAVED_QUERY_IDS)
       .describe(
         "Which saved query template to run. See this parameter's enum for the available ids.",
-      ),
-    params: OpenObjectSchema.optional().describe(
-      "Positional or named parameters for the RPC method, matching what that method expects.",
-    ),
+      )
+      .meta({ examples: [SAVED_QUERY_IDS[0]] }),
+    params: OpenObjectSchema.optional()
+      .describe(
+        "Positional or named parameters for the RPC method, matching what that method expects.",
+      )
+      .meta({ examples: [[]] }),
   })
   .strict();
 export type RunSavedQueryInput = z.infer<typeof RunSavedQueryInputSchema>;

--- a/schemas-src/mcp-tools/registry-catalogs-1.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-1.ts
@@ -46,14 +46,16 @@ export const ListProvidersInputSchema = z
       .optional()
       .describe(
         "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
-      ),
+      )
+      .meta({ examples: ["sn-64-chutes-subnet-api"] }),
     kind: kindSchema(PROVIDER_KINDS).optional(),
     authority: z
       .enum(PROVIDER_AUTHORITIES)
       .optional()
       .describe(
         "Who asserts this record: the operator, the community, a provider, or the registry's own probes.",
-      ),
+      )
+      .meta({ examples: [PROVIDER_AUTHORITIES[0]] }),
     sort: sortSchema(PROVIDER_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
@@ -113,7 +115,8 @@ export const ListSurfacesInputSchema = z
       .optional()
       .describe(
         "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
-      ),
+      )
+      .meta({ examples: ["sn-64-chutes-subnet-api"] }),
     sort: sortSchema(SURFACE_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
@@ -166,17 +169,20 @@ export const ListCandidatesInputSchema = z
     state: z
       .enum(CANDIDATE_STATES)
       .optional()
-      .describe("The incident's lifecycle state."),
+      .describe("The incident's lifecycle state.")
+      .meta({ examples: [CANDIDATE_STATES[0]] }),
     id: z
       .string()
       .optional()
       .describe(
         "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
-      ),
+      )
+      .meta({ examples: ["sn-64-chutes-subnet-api"] }),
     confidence: z
       .enum(CONFIDENCE_LEVELS)
       .optional()
-      .describe("How confident the machine assessment is."),
+      .describe("How confident the machine assessment is.")
+      .meta({ examples: [CONFIDENCE_LEVELS[0]] }),
     sort: sortSchema(CANDIDATES_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),

--- a/schemas-src/mcp-tools/registry-catalogs-2.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-2.ts
@@ -117,7 +117,8 @@ export const ListRpcEndpointsInputSchema = z
       .optional()
       .describe(
         "Which layer of the stack the endpoint belongs to: the Bittensor base chain, a data or docs provider, or a subnet's own app.",
-      ),
+      )
+      .meta({ examples: [ENDPOINT_LAYERS[0]] }),
     netuid: netuidSchema().optional(),
     provider: providerSlugSchema().optional(),
     publication_state: z
@@ -125,38 +126,44 @@ export const ListRpcEndpointsInputSchema = z
       .optional()
       .describe(
         "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
-      ),
+      )
+      .meta({ examples: [ENDPOINT_PUBLICATION_STATES[0]] }),
     status: kindSchema(HEALTH_STATUSES).optional(),
     pool_eligible: z
       .boolean()
       .optional()
       .describe(
         "Restrict to endpoints that are (or are not) eligible for the public RPC pool.",
-      ),
+      )
+      .meta({ examples: [true] }),
     min_latency_ms: z
       .number()
       .optional()
       .describe(
         "Inclusive lower bound on probe latency in milliseconds; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [50] }),
     max_latency_ms: z
       .number()
       .optional()
       .describe(
         "Inclusive upper bound on probe latency in milliseconds; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [500] }),
     min_score: z
       .number()
       .optional()
       .describe(
         "Inclusive lower bound on endpoint score; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [50] }),
     max_score: z
       .number()
       .optional()
       .describe(
         "Inclusive upper bound on endpoint score; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [100] }),
     sort: sortSchema(ENDPOINT_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     // Both `fields` and `cursor` are UNIONS here, unlike everywhere else, so
@@ -168,7 +175,8 @@ export const ListRpcEndpointsInputSchema = z
         "Row fields to project. Accepts either a comma-separated string " +
           "(`id,url,status`) or an array of bare names. Omit for the full row.",
       )
-      .optional(),
+      .optional()
+      .meta({ examples: ["netuid,name,slug"] }),
     // Ceiling is MAX_LIMIT (workers/request-params.ts:21); a literal here
     // because schemas-src/ imports from neither src/ nor workers/.
     limit: limitSchema(1000).optional(),
@@ -179,7 +187,8 @@ export const ListRpcEndpointsInputSchema = z
           "`next_cursor` token from the previous response; pass a token back " +
           "verbatim, since its contents are not stable.",
       )
-      .optional(),
+      .optional()
+      .meta({ examples: [0] }),
   })
   .strict();
 export type ListRpcEndpointsInput = z.infer<typeof ListRpcEndpointsInputSchema>;
@@ -224,32 +233,37 @@ export const ListRpcPoolsInputSchema = z
       .optional()
       .describe(
         "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
-      ),
+      )
+      .meta({ examples: ["sn-64-chutes-subnet-api"] }),
     kind: kindSchema(POOL_KINDS).optional(),
     min_eligible_count: z
       .number()
       .optional()
       .describe(
         "Inclusive lower bound on pool-eligible endpoint count; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [1] }),
     max_eligible_count: z
       .number()
       .optional()
       .describe(
         "Inclusive upper bound on pool-eligible endpoint count; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [10] }),
     min_endpoint_count: z
       .number()
       .optional()
       .describe(
         "Inclusive lower bound on endpoint count; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [1] }),
     max_endpoint_count: z
       .number()
       .optional()
       .describe(
         "Inclusive upper bound on endpoint count; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [10] }),
     sort: sortSchema(POOL_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
@@ -352,25 +366,30 @@ export const ListProfileCompletenessInputSchema = z
       .optional()
       .describe(
         "How complete the subnet's profile is, from directory-only upward.",
-      ),
+      )
+      .meta({ examples: [PROFILE_LEVELS[0]] }),
     confidence: z
       .enum(CONFIDENCE_LEVELS)
       .optional()
-      .describe("How confident the machine assessment is."),
+      .describe("How confident the machine assessment is.")
+      .meta({ examples: [CONFIDENCE_LEVELS[0]] }),
     identity_level: z
       .enum(IDENTITY_LEVELS)
       .optional()
-      .describe("How complete the subnet's published identity is."),
+      .describe("How complete the subnet's published identity is.")
+      .meta({ examples: [IDENTITY_LEVELS[0]] }),
     identity_promotion_kinds: z
       .enum(SURFACE_KINDS)
       .optional()
       .describe(
         "Restrict to subnets where surfaces of this kind would promote the subnet's identity. One kind per call; see this parameter's enum.",
-      ),
+      )
+      .meta({ examples: [SURFACE_KINDS[0]] }),
     native_name_quality: z
       .enum(NATIVE_NAME_QUALITIES)
       .optional()
-      .describe("Whether the on-chain name is real, a placeholder, or empty."),
+      .describe("Whether the on-chain name is real, a placeholder, or empty.")
+      .meta({ examples: [NATIVE_NAME_QUALITIES[0]] }),
     sort: sortSchema(PROFILE_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),

--- a/schemas-src/mcp-tools/registry-summary-gaps.ts
+++ b/schemas-src/mcp-tools/registry-summary-gaps.ts
@@ -65,11 +65,13 @@ export const ListEnrichmentTargetsInputSchema = z
     tier: z
       .enum(COVERAGE_DEPTH_TIERS)
       .optional()
-      .describe("How agent-ready the subnet is."),
+      .describe("How agent-ready the subnet is.")
+      .meta({ examples: [COVERAGE_DEPTH_TIERS[0]] }),
     severity: z
       .enum(COVERAGE_DEPTH_SEVERITIES)
       .optional()
-      .describe("How serious the incident is."),
+      .describe("How serious the incident is.")
+      .meta({ examples: [COVERAGE_DEPTH_SEVERITIES[0]] }),
     gap_code: z
       .string()
       .regex(/^[a-z0-9-]+$/)
@@ -77,11 +79,13 @@ export const ListEnrichmentTargetsInputSchema = z
       .describe(
         "The machine-readable gap identifier (`missing-openapi`), lowercase " +
           "and hyphenated — not the human-readable label shown beside it.",
-      ),
+      )
+      .meta({ examples: ["missing-openapi"] }),
     agent_status: z
       .enum(AGENT_READINESS_STATUSES)
       .optional()
-      .describe("How usable the subnet is to an agent right now."),
+      .describe("How usable the subnet is to an agent right now.")
+      .meta({ examples: [AGENT_READINESS_STATUSES[0]] }),
     netuid: netuidSchema().optional(),
   })
   .strict();
@@ -191,11 +195,13 @@ export const ListSubnetGapsInputSchema = z
       .optional()
       .describe(
         "Restrict to subnets where surfaces of this kind the subnet is MISSING. One kind per call; see this parameter's enum.",
-      ),
+      )
+      .meta({ examples: [SURFACE_KINDS[0]] }),
     review_state: z
       .string()
       .optional()
-      .describe("Where the item sits in maintainer review."),
+      .describe("Where the item sits in maintainer review.")
+      .meta({ examples: ["pending"] }),
     sort: sortSchema(GAP_PRIORITY_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),

--- a/schemas-src/mcp-tools/rpc-tools.ts
+++ b/schemas-src/mcp-tools/rpc-tools.ts
@@ -168,13 +168,15 @@ export const CallRpcInputSchema = z
         "The JSON-RPC method to call. Restricted to a read-only allowlist — " +
           "the enum is the complete set, and it is the same set the proxy " +
           "enforces, so anything absent here is refused rather than forwarded.",
-      ),
+      )
+      .meta({ examples: [...SAFE_RPC_METHODS] }),
     params: z
       .array(z.unknown())
       .optional()
       .describe(
         "Positional or named parameters for the RPC method, matching what that method expects.",
-      ),
+      )
+      .meta({ examples: [[]] }),
     network: McpNetworkSchema.optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/search-documents.ts
+++ b/schemas-src/mcp-tools/search-documents.ts
@@ -32,7 +32,8 @@ export const ListSearchIndexInputSchema = z
     type: z
       .enum(DOCUMENT_TYPES)
       .optional()
-      .describe("Which entity kind to search over."),
+      .describe("Which entity kind to search over.")
+      .meta({ examples: [DOCUMENT_TYPES[0]] }),
     netuid: netuidSchema().optional(),
     sort: sortSchema(DOCUMENT_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
@@ -65,7 +66,8 @@ export const ListSearchInputSchema = z
     type: z
       .enum(DOCUMENT_TYPES)
       .optional()
-      .describe("Which entity kind to search over."),
+      .describe("Which entity kind to search over.")
+      .meta({ examples: [DOCUMENT_TYPES[0]] }),
     netuid: netuidSchema().optional(),
     sort: sortSchema(DOCUMENT_SORT_FIELDS).optional(),
     order: orderSchema().optional(),

--- a/schemas-src/mcp-tools/search-subnets.ts
+++ b/schemas-src/mcp-tools/search-subnets.ts
@@ -17,7 +17,8 @@ export const SearchSubnetsInputSchema = z
       .string()
       .describe(
         "The request payload or search text this surface expects. Shape depends on the surface; see its schema.",
-      ),
+      )
+      .meta({ examples: ["inference"] }),
     cursor: numericCursorSchema().optional(),
     limit: limitSchema(50).optional(),
   })

--- a/schemas-src/mcp-tools/shared.ts
+++ b/schemas-src/mcp-tools/shared.ts
@@ -43,7 +43,8 @@ export const netuidSchema = () =>
     .describe(
       "Subnet id (netuid), 0-65535. 0 is the root subnet, which is special: " +
         "it has no AMM pool and is emission-ineligible.",
-    );
+    )
+    .meta({ examples: [64, 0] });
 
 /**
  * A page size, capped at the mirrored route's own ceiling.
@@ -60,13 +61,15 @@ export const netuidSchema = () =>
 export const limitSchema = (max: number, fallback?: number) => {
   const schema = z.int().min(1).max(max);
   return fallback === undefined
-    ? schema.describe(`Maximum rows to return (1-${max}).`)
+    ? schema
+        .describe(`Maximum rows to return (1-${max}).`)
+        .meta({ examples: [Math.min(20, max)] })
     : schema
         .describe(
           `Maximum rows to return (1-${max}). Defaults to ${fallback} when omitted; ` +
             "a larger value is clamped to the ceiling rather than rejected.",
         )
-        .meta({ default: fallback });
+        .meta({ default: fallback, examples: [fallback] });
 };
 
 /**
@@ -81,7 +84,8 @@ export const offsetSchema = () =>
     .describe(
       `Rows to skip before the first returned row (0-${MAX_OFFSET}). ` +
         "Defaults to 0; a non-numeric value resolves to 0 and the response reports it.",
-    );
+    )
+    .meta({ examples: [0, 100] });
 
 /**
  * An SS58 address. The pattern is the one 26 tool modules each declared
@@ -99,7 +103,8 @@ export const ss58Schema = () =>
     .describe(
       "An SS58 account address (47-48 base58 characters). Coldkey or hotkey " +
         "depending on the tool — see the tool description for which this expects.",
-    );
+    )
+    .meta({ examples: ["5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F"] });
 
 /**
  * Sort direction. 31 of the 32 `order` parameters are this exact pair and mean
@@ -111,7 +116,8 @@ export const orderSchema = () =>
     .describe(
       "Sort direction for the chosen sort key: `asc` smallest-first, " +
         "`desc` largest-first.",
-    );
+    )
+    .meta({ examples: ["desc"] });
 
 // --- Descriptions for families whose VALUES are per-tool ---------------------
 //
@@ -136,7 +142,8 @@ export const windowSchema = <T extends readonly [string, ...string[]]>(
       "Trailing time window to aggregate over, ending at the latest data " +
         "point rather than a calendar boundary. Options are per-tool; see this " +
         "parameter's enum.",
-    );
+    )
+    .meta({ examples: [values[0]] });
 
 /** Which column the result is ranked by. Values are per-tool. */
 export const sortSchema = <T extends readonly [string, ...string[]]>(
@@ -147,7 +154,8 @@ export const sortSchema = <T extends readonly [string, ...string[]]>(
     .describe(
       "Column to rank the result by; pair with `order` for direction. " +
         "Options are per-tool; see this parameter's enum.",
-    );
+    )
+    .meta({ examples: [values[0]] });
 
 /**
  * A block height bound. Inclusive on both ends, which is the one thing a
@@ -160,7 +168,8 @@ export const blockBoundSchema = (edge: "first" | "last") =>
     .describe(
       `Inclusive ${edge} block height of the range to read. ` +
         "Omit for an unbounded end.",
-    );
+    )
+    .meta({ examples: [8783000] });
 
 /**
  * A free-text search query. Substring/keyword, not a query language — worth
@@ -172,7 +181,8 @@ export const querySchema = () =>
     .describe(
       "Free-text search terms, matched as case-insensitive substrings. " +
         "Not a query language: operators, quotes and wildcards are matched literally.",
-    );
+    )
+    .meta({ examples: ["inference", "text embedding"] });
 
 /**
  * A page cursor. TWO kinds, and conflating them is the mistake this pair
@@ -189,7 +199,8 @@ export const numericCursorSchema = () =>
       "Row offset to resume from — the numeric position of the first row to " +
         "return, not an opaque token. Rows inserted since the previous page " +
         "shift it, so prefer the keyset cursor where a tool offers one.",
-    );
+    )
+    .meta({ examples: [0, 100] });
 
 export const keysetCursorSchema = () =>
   z
@@ -198,7 +209,8 @@ export const keysetCursorSchema = () =>
       "Opaque pagination token: pass back the `next_cursor` from the previous " +
         "response verbatim. Its contents are not stable and must not be parsed " +
         "or constructed. Stable across inserts, unlike a row offset.",
-    );
+    )
+    .meta({ examples: ["eyJiIjo4NzgzMDAwLCJpIjo0fQ"] });
 
 /**
  * The `fields=` projection as a bare string. Same syntax as `fieldsSchema()`
@@ -212,7 +224,8 @@ export const fieldsStringSchema = () =>
       "Comma-separated row field names to project, e.g. `netuid,name,slug`. " +
         "Bare identifiers only — not a JSON array, no paths or indices. " +
         "Omit for the full row.",
-    );
+    )
+    .meta({ examples: ["netuid,name,slug"] });
 
 /**
  * A `kind` filter. Like `window`/`sort`, the value sets are per-tool (surface
@@ -226,7 +239,8 @@ export const kindSchema = <T extends readonly [string, ...string[]]>(
     .describe(
       "Restrict the result to this kind. Options are per-tool; see this " +
         "parameter's enum.",
-    );
+    )
+    .meta({ examples: [values[0]] });
 
 /**
  * A `kind` filter whose accepted values are NOT a closed set — the handler
@@ -241,7 +255,8 @@ export const kindStringSchema = () =>
       "Restrict the result to this kind, matched exactly against the value " +
         "the rows carry. Open set, so a value nothing matches yields an empty " +
         "result rather than an error. Omit for every kind.",
-    );
+    )
+    .meta({ examples: ["subnet-api"] });
 
 /**
  * A provider slug. Says it is the slug rather than the display name, which is
@@ -253,7 +268,8 @@ export const providerSlugSchema = () =>
     .describe(
       "Restrict to one provider, by SLUG (`opentensor-foundation`), not " +
         "display name. Unknown slugs yield an empty result, not an error.",
-    );
+    )
+    .meta({ examples: ["opentensor-foundation"] });
 
 /** A surface id, the stable key a surface keeps across renames. */
 export const surfaceIdSchema = () =>
@@ -262,7 +278,8 @@ export const surfaceIdSchema = () =>
     .describe(
       "The surface's stable id (`sn-64-chutes-subnet-api`), as returned by " +
         "the surface-listing tools. Stable across renames, unlike the name.",
-    );
+    )
+    .meta({ examples: ["sn-64-chutes-subnet-api"] });
 
 /**
  * A hotkey or coldkey the caller must pick. Distinct from `ss58Schema()` only
@@ -279,7 +296,10 @@ export const accountKeySchema = (role: "hotkey" | "coldkey") =>
             "sets weights, not the coldkey that owns the funds."
         : "The owning SS58 coldkey — the key that holds balances and " +
             "delegations, not the hotkey that serves on a subnet.",
-    );
+    )
+    .meta({
+      examples: ["5CS3g6nVJM6ouns8n9buN9CzFf2C1YDHVcVGRcxoirKs2xbV"],
+    });
 
 /** A neuron's position within one subnet. */
 export const uidSchema = () =>
@@ -290,7 +310,8 @@ export const uidSchema = () =>
       "Neuron UID: a slot number within ONE subnet, not a global id. The same " +
         "UID on another netuid is a different neuron, and a UID is reused " +
         "after deregistration.",
-    );
+    )
+    .meta({ examples: [0, 128] });
 
 /**
  * The accepted `fields` syntax, which was documented NOWHERE a caller could see it:
@@ -315,7 +336,8 @@ export const fieldsSchema = () =>
       "Comma-separated row field names to project, e.g. `netuid,name,slug`. " +
         "Bare identifiers only — not a JSON array, no paths or indices. " +
         "An unknown name is rejected rather than ignored.",
-    );
+    )
+    .meta({ examples: ["netuid,name,slug"] });
 
 // Bare `{type:"object"}` (hand-written, no `properties`/`additionalProperties`
 // declared -- JSON Schema's own default for an omitted additionalProperties

--- a/schemas-src/mcp-tools/subnet-activity.ts
+++ b/schemas-src/mcp-tools/subnet-activity.ts
@@ -22,7 +22,7 @@ const ActivityInputSchema = z
     netuid: netuidSchema(),
     window: ActivityWindowSchema.describe(
       "Trailing time window to aggregate over, ending at the latest data point rather than a calendar boundary. Options are per-tool; see this parameter's enum.",
-    ),
+    ).meta({ examples: [ACTIVITY_WINDOWS[0]] }),
   })
   .strict();
 

--- a/schemas-src/mcp-tools/subnet-registry-lists.ts
+++ b/schemas-src/mcp-tools/subnet-registry-lists.ts
@@ -87,17 +87,20 @@ export const ListSubnetCandidatesInputSchema = z
     state: z
       .enum(CANDIDATE_STATES)
       .optional()
-      .describe("The incident's lifecycle state."),
+      .describe("The incident's lifecycle state.")
+      .meta({ examples: [CANDIDATE_STATES[0]] }),
     id: z
       .string()
       .optional()
       .describe(
         "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
-      ),
+      )
+      .meta({ examples: ["sn-64-chutes-subnet-api"] }),
     confidence: z
       .enum(CONFIDENCE_LEVELS)
       .optional()
-      .describe("How confident the machine assessment is."),
+      .describe("How confident the machine assessment is.")
+      .meta({ examples: [CONFIDENCE_LEVELS[0]] }),
     sort: sortSchema(CANDIDATES_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),

--- a/schemas-src/mcp-tools/subnet-scoped-lists.ts
+++ b/schemas-src/mcp-tools/subnet-scoped-lists.ts
@@ -82,45 +82,52 @@ export const ListSubnetEndpointsInputSchema = z
       .optional()
       .describe(
         "Which layer of the stack the endpoint belongs to: the Bittensor base chain, a data or docs provider, or a subnet's own app.",
-      ),
+      )
+      .meta({ examples: [ENDPOINT_LAYERS[0]] }),
     provider: providerSlugSchema().optional(),
     publication_state: z
       .enum(ENDPOINT_PUBLICATION_STATES)
       .optional()
       .describe(
         "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
-      ),
+      )
+      .meta({ examples: [ENDPOINT_PUBLICATION_STATES[0]] }),
     status: kindSchema(HEALTH_STATUSES).optional(),
     pool_eligible: z
       .enum(BOOLEAN_STRINGS)
       .optional()
       .describe(
         "Restrict to endpoints that are (or are not) eligible for the public RPC pool.",
-      ),
+      )
+      .meta({ examples: [BOOLEAN_STRINGS[0]] }),
     min_latency_ms: z
       .number()
       .optional()
       .describe(
         "Inclusive lower bound on probe latency in milliseconds; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [50] }),
     max_latency_ms: z
       .number()
       .optional()
       .describe(
         "Inclusive upper bound on probe latency in milliseconds; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [500] }),
     min_score: z
       .number()
       .optional()
       .describe(
         "Inclusive lower bound on endpoint score; rows below it are excluded.",
-      ),
+      )
+      .meta({ examples: [50] }),
     max_score: z
       .number()
       .optional()
       .describe(
         "Inclusive upper bound on endpoint score; rows above it are excluded.",
-      ),
+      )
+      .meta({ examples: [100] }),
     sort: sortSchema(ENDPOINT_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
@@ -168,7 +175,8 @@ export const ListSubnetSurfacesInputSchema = z
       .optional()
       .describe(
         "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
-      ),
+      )
+      .meta({ examples: ["sn-64-chutes-subnet-api"] }),
     sort: sortSchema(SURFACE_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -235,7 +243,8 @@ export const ListSubnetHealthInputSchema = z
       .optional()
       .describe(
         "Why a probe ended as it did — the reason behind the status, not the status itself.",
-      ),
+      )
+      .meta({ examples: [HEALTH_CLASSIFICATIONS[0]] }),
     sort: sortSchema(HEALTH_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     limit: limitSchema(100).optional(),

--- a/schemas-src/mcp-tools/validators.ts
+++ b/schemas-src/mcp-tools/validators.ts
@@ -44,18 +44,20 @@ export const ListSubnetValidatorsInputSchema = z
           "fetched, so it trims the response rather than the query, and has " +
           "no fixed ceiling: the subnet's own validator count is the bound.",
       )
-      .optional(),
+      .optional()
+      .meta({ examples: [20] }),
     min_stake_tao: z
       .number()
       .min(0)
       .optional()
       .describe(
         "Drop rows whose stake is below this many TAO. Applied after the set is fetched.",
-      ),
+      )
+      .meta({ examples: [1000] }),
     // #9082: narrow each returned row to these fields. Omit for the full
     // row. Valid names are NeuronSchema's own, so this enum cannot drift
     // from what the route can project.
-    fields: NeuronFieldsInputSchema,
+    fields: NeuronFieldsInputSchema.meta({ examples: ["netuid,name,slug"] }),
   })
   .strict();
 export type ListSubnetValidatorsInput = z.infer<
@@ -193,7 +195,10 @@ export const CompareValidatorsInputSchema = z
       .max(COMPARE_VALIDATORS_MAX)
       .describe(
         "SS58 hotkeys to compare, as an array. Each is a validator/neuron key, not a coldkey.",
-      ),
+      )
+      .meta({
+        examples: [["5CS3g6nVJM6ouns8n9buN9CzFf2C1YDHVcVGRcxoirKs2xbV"]],
+      }),
     netuid: netuidSchema().optional(),
   })
   .strict();

--- a/schemas-src/shared.ts
+++ b/schemas-src/shared.ts
@@ -32,7 +32,8 @@ export const McpNetworkSchema = z
     "Which Bittensor chain to read: `finney` is mainnet (the default when " +
       "omitted), `test` is testnet. They are separate chains — a netuid on one " +
       "is unrelated to the same netuid on the other.",
-  );
+  )
+  .meta({ examples: ["finney"] });
 export type McpNetwork = z.infer<typeof McpNetworkSchema>;
 
 export const CurationLevelSchema = z.enum([

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -4237,6 +4237,13 @@ const MCP_INTENT_ARG_SCHEMA = {
   description:
     "Why are you calling this tool? Briefly describe the user's goal. " +
     "Optional, recorded for analytics only -- it does not affect the result.",
+  // A worked example, because "describe the user's goal" is exactly the kind
+  // of instruction a model satisfies with one vague word. It shows the shape
+  // that is useful in the intent view: the user's actual objective, not a
+  // restatement of the tool name.
+  examples: [
+    "Checking whether SN64's API is healthy before recommending it to a user",
+  ],
 } as const;
 
 /**

--- a/tests/mcp-input-schema.test.ts
+++ b/tests/mcp-input-schema.test.ts
@@ -338,3 +338,89 @@ describe("published output schemas are normalised like inputs (#9654)", () => {
     assert.deepEqual([...new Set(offenders)], []);
   });
 });
+
+// #9655: `examples` was 0/773. A description says what a parameter means; an
+// example says what a valid value LOOKS like, which is the part a model gets
+// wrong on an SS58 address, a block hash or a comma-separated projection.
+describe("every published tool parameter carries an example (#9655)", () => {
+  const params = () => {
+    const rows: Array<{ tool: string; name: string; schema: Row }> = [];
+    for (const tool of listToolDefinitions() as Row[]) {
+      const props = (tool.inputSchema as Row)?.properties ?? {};
+      for (const [name, schema] of Object.entries(props)) {
+        rows.push({ tool: tool.name as string, name, schema: schema as Row });
+      }
+    }
+    return rows;
+  };
+
+  test("no parameter is published without one", () => {
+    const rows = params();
+    assert.ok(
+      rows.length > 700,
+      `expected the full surface, got ${rows.length}`,
+    );
+    const missing = rows
+      .filter(
+        (p) => !Array.isArray(p.schema.examples) || !p.schema.examples.length,
+      )
+      .map((p) => `${p.tool}.${p.name}`);
+    assert.deepEqual(
+      missing,
+      [],
+      "add .meta({ examples: [...] }) -- on the shared builder in " +
+        "schemas-src/mcp-tools/shared.ts where the parameter is a shared one",
+    );
+  });
+
+  // THE FAILURE MODE THAT MATTERS. An example outside its own enum is worse
+  // than none: it reads as authoritative and is guaranteed to be rejected.
+  // The generated ones are derived from each tool's own value list precisely
+  // so this cannot happen, and this is what proves it stays that way.
+  test("no example falls outside its own enum", () => {
+    const offenders = params()
+      .filter((p) => Array.isArray(p.schema.enum))
+      .filter((p) =>
+        ((p.schema.examples as unknown[]) ?? []).some(
+          (e) => !(p.schema.enum as unknown[]).includes(e),
+        ),
+      )
+      .map((p) => `${p.tool}.${p.name}`);
+    assert.deepEqual(offenders, []);
+  });
+
+  test("no example is null or undefined", () => {
+    const offenders = params()
+      .filter((p) =>
+        (p.schema.examples as unknown[]).some(
+          (e) => e === null || e === undefined,
+        ),
+      )
+      .map((p) => `${p.tool}.${p.name}`);
+    assert.deepEqual(offenders, []);
+  });
+
+  // An integer example outside a declared bound would be the numeric twin of
+  // the enum case above.
+  test("a numeric example sits inside its declared bounds", () => {
+    const offenders: string[] = [];
+    for (const p of params()) {
+      const { minimum, maximum } = p.schema as {
+        minimum?: number;
+        maximum?: number;
+      };
+      for (const e of (p.schema.examples as unknown[]) ?? []) {
+        if (typeof e !== "number") continue;
+        if (
+          (minimum !== undefined && e < minimum) ||
+          (maximum !== undefined && e > maximum)
+        ) {
+          offenders.push(
+            `${p.tool}.${p.name}=${e} outside [${minimum}, ${maximum}]`,
+          );
+        }
+      }
+    }
+    assert.deepEqual(offenders, []);
+  });
+});


### PR DESCRIPTION
## Summary

`examples` was declared on **0 of 773** published tool parameters. Now **773/773**.

#9645 gave every parameter a `description` — what it means. This is the other half — what a valid value *looks like*. They are not redundant, and the gap between them is where a model actually fails:

| parameter | description says | example shows |
|---|---|---|
| `ss58` | "47-48 base58 characters" | `5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F` |
| `ref` | "a block NUMBER or a 0x-prefixed HASH" | `8783000` — that a bare number is accepted at all |
| `fields` | "comma-separated row field names" | `netuid,name,slug` — not `["netuid","name"]` |
| `slug` | "lowercase, hyphenated" | `chutes` — not the display name |

Values are **real ones from this chain and registry**, not placeholders: netuid 64 is a live subnet, the SS58s are keys seen in production, 8783000 is a recent height. A placeholder teaches shape and nothing else.

## The failure mode this is designed against

**An example outside its own enum is worse than no example** — it reads as authoritative and is guaranteed to be rejected.

So every enum example is **derived from that tool's own value list** (`values[0]`, `CONST[0]`) rather than written as a literal. An example generated from the set it belongs to cannot fall outside it. Where a name means the same thing everywhere, the example rides the shared builder in `schemas-src/mcp-tools/shared.ts`, so one value covers every tool that uses it.

## The gate earned its place immediately

It caught a hand-written example that was wrong: `get_chain_activity.blocks` had `7200`, above that tool's own `maximum` of 5000. Invisible without the check, and exactly the numeric twin of the enum case.

## Mechanism

Zod 4's `.meta({ examples: [...] })` emits the JSON Schema keyword and **merges** with an existing `.meta()`, so `limit`'s declared `default` from #9645 survives alongside it. Verified before starting rather than assumed.

One correction made mid-way: an early pass added examples at call sites that already inherit them from a builder — 145 redundant overrides, four of which referenced a symbol the file does not import. Removed; the builders are the single source.

## Verified against the live published schema

```
examples:                    773/773 (100%)   [was 0/773]
descriptions:                773/773          (unchanged)
examples outside their enum:       0
null/empty examples:               0
numeric examples out of bounds:    0
constraint changes:                0
```

## The gate

Four assertions, all derived from `listToolDefinitions()` so a tool added tomorrow is covered tonight: every parameter has an example; none falls outside its own enum; none is null; and no numeric example sits outside its declared bounds.

## Validation run

```
npx vitest run <6 MCP/schema suites>   1457 passed
npm run validate:mcp                   224 tools, lifecycle + all tools/call green
npm run typecheck                      clean
npm run lint                           clean
patch coverage (diff intersection)     100%
```

Closes #9657
