### PR TITLE
feat(mcp): declare format where it is true, and fix two wrong descriptions

### DIFF
--- a/schemas-src/mcp-tools/ai-integration.ts
+++ b/schemas-src/mcp-tools/ai-integration.ts
@@ -101,7 +101,10 @@ export const CallSubnetSurfaceInputSchema = z
       .describe(
         "Path appended to the surface's base URL, e.g. `/v1/status`. Leading slash optional.",
       )
-      .meta({ examples: ["/v1/status"] }),
+      // uri-reference, not uri: this is a RELATIVE path resolved against the
+      // surface's own base URL, so `uri` (which wants a scheme) would be the
+      // wrong assertion (#9659).
+      .meta({ format: "uri-reference", examples: ["/v1/status"] }),
     method: z
       .enum(["GET", "HEAD", "POST", "PUT"])
       .optional()

--- a/schemas-src/mcp-tools/evm.ts
+++ b/schemas-src/mcp-tools/evm.ts
@@ -16,8 +16,13 @@ const H160Schema = z.string().regex(/^0x[0-9a-fA-F]{40}$/);
 
 export const DecodeEvmCallInputSchema = z
   .object({
+    // #9645 gave every `to` the shared range-bound sentence, which is right on
+    // the fifteen tools where `to` IS a range bound and wrong here: this one is
+    // the call's destination address. A shared name is not a shared meaning.
     to: H160Schema.describe(
-      "Inclusive end of the range. A block height on chain tools, an ISO-8601 date on time-series ones; an EVM address on decode_evm_call.",
+      "The contract address the call is directed at: a 20-byte EVM address, " +
+        "0x-prefixed, 40 hex characters. Not a range bound, despite the name " +
+        "it shares with the block/date bounds on other tools.",
     ).meta({ examples: ["0x1234567890abcdef1234567890abcdef12345678"] }),
     input: z
       .string()

--- a/schemas-src/mcp-tools/feed.ts
+++ b/schemas-src/mcp-tools/feed.ts
@@ -32,20 +32,34 @@ export const GetFeedInputSchema = z
         "Restrict the feed to items carrying this tag. Exact match against the item's own tags.",
       )
       .meta({ examples: ["incident"] }),
+    // TWO ACCEPTED FORMS, and the bare-date one is not shorthand for midnight
+    // on both bounds -- `parseSinceParam` (src/feeds.ts) resolves a date to the
+    // START of that UTC day for `since` and to its LAST instant for `until`,
+    // deliberately, so `?until=DATE` keeps that whole day instead of dropping
+    // everything after its midnight tick. That asymmetry is invisible from the
+    // parameter name and is the thing a caller gets wrong.
+    //
+    // Neither gets `format: "date-time"` for the same reason: the parser takes
+    // a bare calendar date too, so declaring date-time would advertise a
+    // constraint narrower than the handler's and reject input it accepts.
     since: z
       .string()
       .optional()
       .describe(
-        "ISO-8601 timestamp; only items at or after this instant are returned.",
+        "Lower bound, inclusive. Either an ISO calendar date (`2026-08-01`) or " +
+          "an ISO date-time with an explicit UTC/offset designator " +
+          "(`2026-08-01T12:00:00Z`). A bare date means the START of that UTC day.",
       )
-      .meta({ examples: ["2026-08-01T00:00:00Z"] }),
+      .meta({ examples: ["2026-08-01T00:00:00Z", "2026-08-01"] }),
     until: z
       .string()
       .optional()
       .describe(
-        "ISO-8601 timestamp; only items at or before this instant are returned.",
+        "Upper bound, inclusive. Either an ISO calendar date (`2026-08-06`) or " +
+          "an ISO date-time with an explicit UTC/offset designator. A bare date " +
+          "means the END of that UTC day, so the whole day is kept.",
       )
-      .meta({ examples: ["2026-08-06T00:00:00Z"] }),
+      .meta({ examples: ["2026-08-06T23:59:59Z", "2026-08-06"] }),
     limit: limitSchema(FEED_MAX_ITEMS).optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/get-health-history.ts
+++ b/schemas-src/mcp-tools/get-health-history.ts
@@ -66,11 +66,17 @@ const HEALTH_SURFACE_SORT_FIELDS = [
 
 export const GetHealthHistoryInputSchema = z
   .object({
+    // `format` as an ANNOTATION, keeping the existing pattern as the enforced
+    // part (#9659). Not `z.iso.date()`: that emits a full calendar-validity
+    // pattern which rejects 2026-02-30, while the handler's own gate is
+    // DAY_PATTERN -- the shape only. Publishing the stricter pattern would make
+    // a generated client refuse input this server accepts, the same defect as
+    // declaring a page-size ceiling a route does not enforce.
     date: z
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}$/)
       .describe("A single UTC day, `YYYY-MM-DD`.")
-      .meta({ examples: ["2026-08-05"] }),
+      .meta({ format: "date", examples: ["2026-08-05"] }),
     netuid: netuidSchema().optional(),
     kind: kindSchema(SURFACE_KIND).optional(),
     provider: providerSlugSchema().optional(),

--- a/schemas-src/mcp-tools/get-webhook-subscription.ts
+++ b/schemas-src/mcp-tools/get-webhook-subscription.ts
@@ -8,12 +8,23 @@ import { OpenObjectSchema } from "./shared.ts";
 
 export const GetWebhookSubscriptionInputSchema = z
   .object({
+    // A UUID v4, and the handler ENFORCES it -- `src/webhooks.ts` mints it with
+    // crypto.randomUUID() and validates the shape before using it as a KV key,
+    // refusing anything else with "Argument `id` must be a valid subscription
+    // id (UUID v4)". So the pattern is PUBLISHED here, unlike `date` above
+    // which is annotation-only: this one is a real constraint (#9659).
+    //
+    // #9645's shared `id` sentence was wrong on both counts: there is no list
+    // tool to get it from -- it is returned once, at creation -- and an unknown
+    // id is an error, not an empty result.
     id: z
-      .string()
+      .uuidv4()
       .describe(
-        "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
+        "The subscription's id, a UUID v4, as returned when the subscription " +
+          "was created. There is no listing tool: an id that was not kept " +
+          "cannot be recovered. A malformed id is rejected outright.",
       )
-      .meta({ examples: ["sn-64-chutes-subnet-api"] }),
+      .meta({ examples: ["3f2a1c6e-9b7d-4e21-8c5a-2d4f6b8e0a13"] }),
   })
   .strict();
 export type GetWebhookSubscriptionInput = z.infer<

--- a/tests/mcp-input-schema.test.ts
+++ b/tests/mcp-input-schema.test.ts
@@ -424,3 +424,65 @@ describe("every published tool parameter carries an example (#9655)", () => {
     assert.deepEqual(offenders, []);
   });
 });
+
+// #9659: `format` is a small, specific keyword and the temptation is to spray
+// it. These three are the ones that are TRUE; the gate exists to keep the next
+// one honest rather than to grow the count.
+describe("published formats are vetted, not invented (#9659)", () => {
+  // Each entry records WHY it is allowed, because that is the part a reviewer
+  // needs and the part that rots.
+  const VETTED: Record<string, string> = {
+    date: "annotation only -- the handler gates on DAY_PATTERN (shape), so the stricter calendar pattern is deliberately NOT published",
+    uuid: "enforced -- src/webhooks.ts validates UUID v4 before using the id as a KV key",
+    "uri-reference":
+      "a relative path resolved against the surface's base URL; `uri` would wrongly demand a scheme",
+  };
+
+  const formatted = () => {
+    const rows: Array<{ tool: string; name: string; schema: Row }> = [];
+    for (const tool of listToolDefinitions() as Row[]) {
+      const props = (tool.inputSchema as Row)?.properties ?? {};
+      for (const [name, schema] of Object.entries(props)) {
+        if ((schema as Row).format) {
+          rows.push({ tool: tool.name as string, name, schema: schema as Row });
+        }
+      }
+    }
+    return rows;
+  };
+
+  test("no unvetted format reaches the published schema", () => {
+    const unknown = formatted()
+      .filter((p) => !((p.schema.format as string) in VETTED))
+      .map((p) => `${p.tool}.${p.name} -> ${p.schema.format}`);
+    assert.deepEqual(
+      unknown,
+      [],
+      "a format asserts something about the VALUE -- add it here with the " +
+        "reason the handler makes it true, or drop it",
+    );
+  });
+
+  // The distinction the whole change turns on: a `format` the handler does not
+  // enforce must not arrive with a pattern narrower than the handler's own
+  // gate, or a generated client refuses input the server takes.
+  test("the date format stays annotation-only over the handler's own pattern", () => {
+    const date = formatted().find((p) => p.schema.format === "date");
+    assert.ok(date, "expected a date-formatted parameter");
+    assert.equal(
+      date.schema.pattern,
+      "^\\d{4}-\\d{2}-\\d{2}$",
+      "must remain the shape-only pattern the handler gates on",
+    );
+  });
+
+  test("the uuid format publishes the pattern the handler enforces", () => {
+    const uuid = formatted().find((p) => p.schema.format === "uuid");
+    assert.ok(uuid, "expected a uuid-formatted parameter");
+    assert.match(
+      String(uuid.schema.pattern),
+      /4\[0-9a-fA-F\]\{3\}/,
+      "v4-specific, matching what src/webhooks.ts accepts",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`format` was declared on **0 of 773** parameters. Unlike `description` (#9645) and `examples` (#9657), the honest answer here is **not "all 773"** — `format` asserts something specific about a value, and inventing one is worse than leaving it off.

Auditing the 163 free-form string parameters, **three** warrant it:

| parameter | format | why it is true |
|---|---|---|
| `get_health_history.date` | `date` | handler gates on `DAY_PATTERN` (`YYYY-MM-DD`) |
| `get_webhook_subscription.id` | `uuid` | `src/webhooks.ts` mints with `crypto.randomUUID()` and validates v4 before using it as a KV key |
| `call_subnet_surface.path` | `uri-reference` | relative to the surface's base URL — `uri` would wrongly demand a scheme |

## The two cases are opposites, deliberately

**`date` is annotation-only.** `z.iso.date()` emits a calendar-validity pattern rejecting `2026-02-30`, while the handler's gate is the *shape* alone. Publishing the stricter pattern would make a generated client refuse input this server accepts — the same defect as declaring a page-size ceiling a route does not enforce. So the format rides `.meta()` and the existing pattern stays the enforced part.

**`uuid` gets its pattern published**, because the handler really does check v4.

That distinction is the whole point of the change, and the gate asserts both halves.

## What `format` must not be used for

The remaining 160 free-form strings are domain identifiers — `ss58`, `slug`, `surface_id`, `provider`, `call_module`. No JSON Schema format describes any of them; `pattern` already does, on 26.

## `since` / `until` deliberately get no `date-time`

They look like the obvious candidates and they are the trap. `parseSinceParam` (`src/feeds.ts:729`) accepts **either** an ISO calendar date **or** an ISO date-time — and a bare date is not midnight on both bounds: it resolves to the **start** of that UTC day for `since` and the **last instant** for `until`, so `?until=DATE` keeps the whole named day.

Declaring `date-time` would reject a form the handler documents and accepts. Their descriptions now state both forms and the asymmetry, which #9645 had understated as "ISO-8601 timestamp".

## Two descriptions #9645 got wrong

Both from applying a shared sentence to a name whose meaning is not shared:

- **`decode_evm_call.to`** got "Inclusive end of the range…". It is the call's **destination address**.
- **`get_webhook_subscription.id`** got "as returned by the corresponding list tool… an unknown id yields an empty result". Both halves are wrong: there is **no listing tool** (the id is returned once, at creation) and a malformed id is **rejected outright**.

Those are mine from the previous PR, and they are the kind of error a shared-builder sweep produces — worth naming rather than quietly patching.

## The gate

Fails any **unvetted** format: an allowlist carrying the reason each one is true, so the next has to be justified rather than assumed. Plus explicit assertions that `date` stays annotation-only over the handler's own pattern, and that `uuid` keeps the v4-specific one.

## Verified

```
descriptions:            773/773  (unchanged)
formats published:             3  (was 0)
constraint regressions:        0
```

```
npx vitest run <5 MCP/schema suites>   1406 passed
npm run validate:mcp                   224 tools, lifecycle + all tools/call green
npm run typecheck / lint               clean
```

Closes #9659
