### PR TITLE
fix(mcp): refuse an unpaginated tools/list cursor instead of ignoring it

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -15008,6 +15008,45 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
       case "ping":
         return isNotification ? null : rpcResult(id, {});
       case "tools/list": {
+        // #9648: `cursor` was ACCEPTED AND IGNORED. A caller that paged got the
+        // whole catalogue back every time, with no `nextCursor` to terminate
+        // on -- whether that loops or merely double-counts is the client's
+        // problem to discover. Accepting a parameter and disregarding it is
+        // worse than refusing it: the request said one thing and the response
+        // quietly did another.
+        //
+        // WHY REFUSE RATHER THAN PAGINATE. Pagination is a server's choice
+        // under the spec, and taking it here would be the more damaging bug.
+        // No compliant client sends `cursor` unprompted -- it only ever comes
+        // from a `nextCursor` we issued -- so the clients that would be handed
+        // a first page are the ones that never asked to page: the scripted
+        // callers (python-requests, curl) that make up most of this surface's
+        // traffic. They would silently see 100 of 224 tools and have no way to
+        // know. Losing tool discovery to fix a cursor is a bad trade.
+        //
+        // It also would not buy what it looks like it buys: a compliant client
+        // fetches every page and puts them all in context, so paginating moves
+        // bytes around without shrinking what an agent ends up holding. The
+        // catalogue's size is a function of having 224 tools, not of how it is
+        // transferred.
+        //
+        // Only a NON-EMPTY cursor is refused. A client that sends the key with
+        // null/undefined -- or omits it, as every one does today -- is
+        // unaffected, so this cannot break a caller that is not already
+        // relying on behaviour we never had.
+        const cursor = (params as Row | undefined)?.cursor;
+        if (typeof cursor === "string" && cursor.trim()) {
+          return isNotification
+            ? null
+            : rpcError(
+                id,
+                RPC_INVALID_PARAMS,
+                "tools/list is not paginated on this server: the full tool " +
+                  "catalogue is returned in one response and no `nextCursor` " +
+                  "is ever issued, so there is no cursor to resume from. Omit " +
+                  "`cursor`.",
+              );
+        }
         const tools = listToolDefinitions();
         // Recorded for a notification too: the discovery happened either way,
         // and dropping it would undercount exactly the crawler traffic this

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -23865,3 +23865,86 @@ describe("the MCP endpoint tolerates a trailing slash", () => {
     assert.notEqual(response.status, 200);
   });
 });
+
+// #9648: `cursor` on tools/list was accepted and ignored -- the request said
+// one thing and the response quietly did another, with no `nextCursor` to
+// terminate on.
+describe("tools/list cursor handling (#9648)", () => {
+  const call = async (params?: Row) => {
+    const res = await handleMcpRequest(
+      new Request("https://api.metagraph.sh/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/list",
+          ...(params ? { params } : {}),
+        }),
+      }),
+      {} as unknown as Env,
+      {},
+    );
+    return (await res.json()) as Row;
+  };
+
+  test("the full catalogue is returned when no cursor is sent", async () => {
+    const body = await call();
+    assert.ok((body.result as Row).tools.length > 200);
+    assert.equal(
+      "nextCursor" in (body.result as Row),
+      false,
+      "no cursor is issued, so none may be advertised",
+    );
+  });
+
+  test("a non-empty cursor is refused rather than silently ignored", async () => {
+    const body = await call({ cursor: "abc" });
+    assert.equal((body.error as Row).code, -32602);
+    assert.match(String((body.error as Row).message), /not paginated/i);
+  });
+
+  // A NOTIFICATION carrying a cursor: there is no id to answer, so the refusal
+  // has nowhere to go and the response must stay empty rather than inventing
+  // an error envelope with a null id.
+  test("a notification with a cursor is dropped, not answered", async () => {
+    const res = await handleMcpRequest(
+      new Request("https://api.metagraph.sh/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "tools/list",
+          params: { cursor: "abc" },
+        }),
+      }),
+      {} as unknown as Env,
+      {},
+    );
+    assert.equal(res.status, 202);
+    assert.equal(await res.text(), "");
+  });
+
+  // The compatibility line: every client today sends no cursor, and some send
+  // the key with an empty value. Neither may start failing.
+  test("an absent, null or empty cursor is unaffected", async () => {
+    for (const params of [
+      undefined,
+      { cursor: null },
+      { cursor: "" },
+      { cursor: "   " },
+    ]) {
+      const body = await call(params as Row | undefined);
+      assert.ok(
+        (body.result as Row)?.tools?.length > 200,
+        `expected the full catalogue for ${JSON.stringify(params)}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`tools/list` accepted `cursor` and disregarded it. A caller that paged got the whole catalogue back every time, with no `nextCursor` to terminate on — whether that loops or merely double-counts was left for the client to discover. A request said one thing and the response quietly did another.

Now a non-empty `cursor` is refused with `-32602` and a message saying the catalogue is unpaginated and no `nextCursor` is ever issued.

## I corrected the issue's own reasoning before fixing it

#9648 argued that 524 KB lands in an agent's context on every handshake and that pagination would help. The first half is true; **the second does not follow.** A compliant client fetches every page and holds them all, so paginating moves the same bytes in three responses instead of one. The catalogue's size is a function of having 224 tools, not of how it is transferred. That correction is [on the issue](https://github.com/JSONbored/metagraphed/issues/9648).

## Why refusal, not pagination

Paginating would be the more damaging change:

- **No compliant client sends `cursor` unprompted** — it only ever comes from a `nextCursor` we issued.
- So the clients handed a truncated first page would be exactly the ones that never asked to page: the scripted callers (`python-requests`, `curl`) that make up most of this surface's traffic.
- They would silently see 100 of 224 tools with no way to know.

Losing tool discovery to fix a cursor is a bad trade, and per the correction it buys nothing in return.

Worth reconsidering if the catalogue grows enough that one response is genuinely unserviceable — at which point the truncation risk is worth accepting and clients will have had notice. The comment says so, so the next reader inherits the reasoning rather than the conclusion.

## Compatibility

Only a **non-empty** cursor is refused. Absent, `null`, and empty/whitespace are unaffected — which is every client today, so nothing that currently works can start failing. Pinned by a test that walks all four shapes.

The notification form is handled too: with no id to answer, the refusal has nowhere to go, so the response stays empty (202) rather than inventing an error envelope with a null id.

## Tests

Four cases: full catalogue with no cursor and no advertised `nextCursor`; a non-empty cursor refused with `-32602`; the four no-op cursor shapes unaffected; and the notification form dropped rather than answered.

Verified the refusal test catches the defect — removing the guard fails it and nothing else.

## Validation run

```
npx vitest run <3 MCP suites>       1430 passed
npm run validate:mcp                224 tools, lifecycle + all tools/call green
npm run typecheck / lint            clean
patch coverage (diff intersection)  100%
```

Closes #9648
