### PR TITLE
docs(mcp): record why unknown tools answer isError, not -32602

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -14846,6 +14846,32 @@ async function dispatchTool(
   const name = params?.name;
   const tool = typeof name === "string" ? TOOLS_BY_NAME.get(name) : undefined;
   if (!tool) {
+    // A DELIBERATE DIVERGENCE FROM THE SPEC'S CLASSIFICATION (#9646), decided
+    // rather than inherited -- the audit that raised it found no comment
+    // saying it had ever been considered, so here it is.
+    //
+    // MCP 2025-11-25 sorts failures into two mechanisms and puts unknown tools
+    // in the first: "Protocol Errors: Standard JSON-RPC errors for issues
+    // like: Unknown tools, Malformed requests, Server errors", with -32602 as
+    // the worked example. We answer with the second -- a tool-execution error,
+    // isError: true -- for two reasons the same section supplies.
+    //
+    // RECOVERY. "Clients SHOULD provide tool execution errors to language
+    // models to enable self-correction. Clients MAY provide protocol errors to
+    // language models, though these are less likely to result in successful
+    // recovery." An agent that guessed a tool name is precisely the case that
+    // recovers: it needs to see the name it got wrong and try another. A
+    // protocol error is the shape most likely to abort the attempt instead.
+    //
+    // ATTRIBUTION. `unknown_tool` is a real code in structuredContent.error,
+    // which is what callTool threads into $mcp_error_code and
+    // classifyMcpErrorType. Moving to a protocol error returns before that
+    // wiring, so the dimension would have to be re-threaded separately or the
+    // failure would stop being countable -- and "agents are guessing tool
+    // names" is a thing worth counting.
+    //
+    // If this is ever revisited, the cost of switching is those two things,
+    // not the code change.
     return {
       content: [{ type: "text", text: `Unknown tool: ${String(name)}` }],
       // metagraphed#7726: the one isError path that doesn't go through

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -23948,3 +23948,61 @@ describe("tools/list cursor handling (#9648)", () => {
     }
   });
 });
+
+// #9646: a deliberate divergence from the spec's classification, pinned so it
+// stays a decision rather than drifting back by accident. MCP 2025-11-25 lists
+// unknown tools under Protocol Errors (-32602); we answer with a tool-execution
+// error because the same section says clients hand those to the model for
+// self-correction, and because `unknown_tool` is what feeds $mcp_error_code.
+describe("unknown tools are a tool-execution error, deliberately (#9646)", () => {
+  const callUnknown = async () => {
+    const res = await handleMcpRequest(
+      new Request("https://api.metagraph.sh/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: "no_such_tool_anywhere", arguments: {} },
+        }),
+      }),
+      {} as unknown as Env,
+      {},
+    );
+    return (await res.json()) as Row;
+  };
+
+  test("answers isError, not a JSON-RPC protocol error", () => {
+    return callUnknown().then((body) => {
+      assert.equal(
+        "error" in body,
+        false,
+        "a protocol error here would abort the agent instead of letting it retry",
+      );
+      assert.equal((body.result as Row).isError, true);
+    });
+  });
+
+  // The attribution half: this code is what callTool threads into
+  // $mcp_error_code, so "agents are guessing tool names" stays countable.
+  test("carries the unknown_tool code the analytics path reads", async () => {
+    const body = await callUnknown();
+    assert.equal(
+      ((body.result as Row).structuredContent as Row).error.code,
+      "unknown_tool",
+    );
+  });
+
+  // The recovery half: the model has to see WHICH name failed to pick another.
+  test("names the tool that was not found", async () => {
+    const body = await callUnknown();
+    assert.match(
+      String(((body.result as Row).content as Row[])[0]!.text),
+      /no_such_tool_anywhere/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`dispatchTool` answers an unknown tool with a **tool-execution error** (`isError: true`, code `unknown_tool`) where MCP 2025-11-25 classifies unknown tools as a **protocol error** (`-32602`).

The audit that raised #9646 found **no comment saying the classification had ever been considered**, so the divergence read as an oversight. It is a decision. This writes it down where the next reader will look, and pins it so a silent drift back fails rather than merely changes behaviour.

## The spec cuts both ways, which is why this is a decision

It lists unknown tools under Protocol Errors, with `-32602` as the worked example. The same section then says:

> Clients **SHOULD** provide tool execution errors to language models to enable self-correction. Clients **MAY** provide protocol errors to language models, though these are less likely to result in successful recovery.

**Recovery.** An agent that guessed a tool name is precisely the case that recovers — it needs to see which name failed and try another. A protocol error is the shape most likely to abort the attempt instead.

**Attribution.** `unknown_tool` is a real code in `structuredContent.error`, which `callTool` threads into `$mcp_error_code` and `classifyMcpErrorType`. A protocol error returns *before* that wiring, so the dimension would have to be re-threaded separately or the failure would stop being countable — and "agents are guessing tool names" is worth counting (12 such errors in the last 14 days).

The comment states both, plus what switching would cost, so a future revisit inherits the reasoning rather than the conclusion.

## Tests

Three, pinning each half of the argument:

- the response is `isError`, **not** a protocol error — the assertion carries the reason (`"a protocol error here would abort the agent instead of letting it retry"`)
- it carries the `unknown_tool` code the analytics path reads
- it names the tool that was not found, which is what the model needs to pick another

Together they make a drift back to `-32602` fail loudly.

## No behaviour change

Documentation and tests only. The response is byte-identical.

## Validation run

```
npx vitest run <2 MCP suites>   1431 passed
npm run validate:mcp            224 tools, lifecycle + all tools/call green
npm run typecheck / lint        clean
```

Closes #9646
