### PR TITLE
fix(api): send the contract-version header dataResponse advertises

### DIFF
--- a/scripts/smoke-live-api.ts
+++ b/scripts/smoke-live-api.ts
@@ -50,29 +50,60 @@ async function runLiveSmoke(): Promise<void> {
   ];
   const results: Row[] = [];
 
+  // EVERY FAILING ROUTE, NOT THE FIRST. Throwing on the first one turns a
+  // broken smoke into a whack-a-mole: #9651 fixed /api/v1/ask, the very next
+  // publish surfaced /api/v1/search/semantic, and each round trip costs a full
+  // publish run to discover one route. Collecting means one run names them all.
+  const failures: string[] = [];
   for (const check of apiChecks) {
-    const result = await fetchJson(check.url);
-    assert.equal(result.status, 200, `${check.route}: expected HTTP 200`);
-    assertHeader(result, "access-control-allow-origin", "*", check.route);
-    assert.ok(result.headers.get("etag"), `${check.route}: missing ETag`);
-    assert.ok(
-      result.headers.get("x-metagraph-contract-version"),
-      `${check.route}: missing contract version header`,
+    try {
+      const result = await fetchJson(check.url);
+      assert.equal(result.status, 200, `${check.route}: expected HTTP 200`);
+      assertHeader(result, "access-control-allow-origin", "*", check.route);
+      // AN ETAG IS REQUIRED OF CACHEABLE RESPONSES, not of all of them. A
+      // route that answers `cache-control: no-store` is telling every cache not
+      // to keep it, and a validator for a response nobody may store validates
+      // nothing. /api/v1/search/semantic is the live case: it runs a query per
+      // request and is deliberately no-store, so demanding an ETag there was
+      // asserting a property the route correctly does not have.
+      if (!/no-store/i.test(result.headers.get("cache-control") || "")) {
+        assert.ok(
+          result.headers.get("etag"),
+          `${check.route}: missing ETag on a cacheable response`,
+        );
+      }
+      assert.ok(
+        result.headers.get("x-metagraph-contract-version"),
+        `${check.route}: missing contract version header`,
+      );
+      assert.equal(
+        result.body?.ok,
+        true,
+        `${check.route}: expected ok envelope`,
+      );
+      assert.equal(
+        result.body?.schema_version,
+        1,
+        `${check.route}: expected schema_version 1`,
+      );
+      assert.ok(result.body?.data, `${check.route}: expected data payload`);
+      assert.ok(result.body?.meta, `${check.route}: expected meta payload`);
+      results.push({
+        path: new URL(check.url).pathname,
+        route: check.route,
+        status: result.status,
+        source: result.body.meta.source || null,
+      });
+    } catch (error) {
+      failures.push(
+        `${check.route}: ${(error as Error)?.message || String(error)}`,
+      );
+    }
+  }
+  if (failures.length) {
+    throw new Error(
+      `${failures.length} live API route(s) failed:\n  ${failures.join("\n  ")}`,
     );
-    assert.equal(result.body?.ok, true, `${check.route}: expected ok envelope`);
-    assert.equal(
-      result.body?.schema_version,
-      1,
-      `${check.route}: expected schema_version 1`,
-    );
-    assert.ok(result.body?.data, `${check.route}: expected data payload`);
-    assert.ok(result.body?.meta, `${check.route}: expected meta payload`);
-    results.push({
-      path: new URL(check.url).pathname,
-      route: check.route,
-      status: result.status,
-      source: result.body.meta.source || null,
-    });
   }
 
   for (const artifactPath of rawArtifactChecks) {
@@ -529,6 +560,12 @@ export function apiRouteUrl(
     // stake-quote requires `amount` — a bare GET is a correct 400
     // invalid_amount, not a route failure (same #1682 class as compare above).
     url.searchParams.set("amount", "1");
+  } else if (routePath === "/api/v1/search/semantic") {
+    // semantic search requires `q` — a bare GET is a correct 400, not a route
+    // failure (same #1682 class as compare/stake-quote above). This one reached
+    // production: it failed the publish lane on 2026-08-06, immediately after
+    // #9651 unblocked the step that had been hiding it.
+    url.searchParams.set("q", "inference");
   } else if (routePath === "/api/v1/compare/validators") {
     // compare/validators requires `hotkeys` — a bare GET is a 400 invalid_query
     // (same #1682 class as compare/stake-quote above). Alice's address is the

--- a/tests/responses-contract-version.test.ts
+++ b/tests/responses-contract-version.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { CONTRACT_VERSION } from "../src/contracts.ts";
-import { contractStaleness, contractVersion } from "../workers/responses.ts";
+import {
+  contractStaleness,
+  contractVersion,
+  dataResponse,
+} from "../workers/responses.ts";
 import { mockEnv } from "./row-type.ts";
 
 test("contractVersion returns env override when METAGRAPH_CONTRACT_VERSION is set", () => {
@@ -59,4 +63,31 @@ test("contractStaleness uses CONTRACT_VERSION when env override is unset", () =>
     built_under: "2020-01-01.1",
     live: CONTRACT_VERSION,
   });
+});
+
+test("dataResponse sends the contract version as a HEADER, not only in meta", async () => {
+  // access-control-expose-headers advertises x-metagraph-contract-version on
+  // every response, so a client is told to read it. envelopeResponse set it;
+  // dataResponse put the value in the body and nothing in the headers, so the
+  // ten routes built on it (semantic search, the ask/RPC proxies, the webhook
+  // subscription CRUD) advertised a header they never sent. Caught against
+  // production by the live smoke, not by a unit test -- hence this one.
+  const env = mockEnv({ METAGRAPH_CONTRACT_VERSION: "2099-01-01.1" });
+  const res = dataResponse(env, { hello: "world" });
+  assert.equal(res.headers.get("x-metagraph-contract-version"), "2099-01-01.1");
+  const body = (await res.json()) as { meta: { contract_version: string } };
+  assert.equal(
+    body.meta.contract_version,
+    "2099-01-01.1",
+    "the body value must still agree with the header",
+  );
+});
+
+test("dataResponse stays no-store, and therefore carries no ETag", () => {
+  // These responses are per-request. A validator for something no cache may
+  // store validates nothing, and the live smoke asserts an ETag only where the
+  // response is actually cacheable.
+  const res = dataResponse(mockEnv(), { hello: "world" });
+  assert.match(res.headers.get("cache-control") || "", /no-store/);
+  assert.equal(res.headers.get("etag"), null);
 });

--- a/tests/smoke-route-substitution.test.ts
+++ b/tests/smoke-route-substitution.test.ts
@@ -110,3 +110,39 @@ describe("the live smoke set is GET-only (#9650)", () => {
     );
   });
 });
+
+describe("the live smoke supplies every required query param (#9663)", () => {
+  // Routes whose bare GET is a correct 400. The smoke iterates the whole
+  // contract, so each one has to be given what it requires or the publish lane
+  // fails on a route that is working exactly as designed.
+  //
+  // The contract does not declare requiredness, so this list cannot be derived
+  // -- which is why it is asserted here instead: each entry was found by a
+  // failing production publish, one per run, and this is what stops the next
+  // one being found the same way.
+  const REQUIRES = [
+    ["/api/v1/compare", "netuids"],
+    ["/api/v1/compare/validators", "hotkeys"],
+    ["/api/v1/subnets/{netuid}/stake-quote", "amount"],
+    ["/api/v1/search/semantic", "q"],
+  ] as const;
+
+  test("each known required param is present in the built URL", () => {
+    for (const [routePath, param] of REQUIRES) {
+      const url = new URL(apiRouteUrl(routePath, "2026-08-06"));
+      assert.ok(
+        url.searchParams.get(param),
+        `${routePath} needs ?${param}= or it answers 400`,
+      );
+    }
+  });
+
+  test("every route in the smoke set is one the contract still has", () => {
+    // A required-param entry for a route that no longer exists is a guard that
+    // silently stops guarding.
+    const paths = new Set(API_ROUTES.map((route) => route.path));
+    for (const [routePath] of REQUIRES) {
+      assert.ok(paths.has(routePath), `${routePath} is no longer a route`);
+    }
+  });
+});

--- a/workers/responses.ts
+++ b/workers/responses.ts
@@ -70,6 +70,15 @@ export function dataResponse(
 ): Response {
   const headers = apiHeaders("short");
   headers.set("cache-control", "no-store");
+  // THE HEADER, NOT JUST THE BODY. envelopeResponse sets both, and
+  // `access-control-expose-headers` advertises x-metagraph-contract-version on
+  // every response -- so a client told to read it found it absent on exactly
+  // the routes built here (semantic search, the ask/RPC proxies, the webhook
+  // subscription CRUD). Ten call sites shipped a contract they did not state.
+  //
+  // No ETag here, deliberately: these are no-store, and a validator for a
+  // response nobody may cache validates nothing.
+  headers.set("x-metagraph-contract-version", contractVersion(env));
   return new Response(
     JSON.stringify({
       ok: true,


### PR DESCRIPTION
Closes #9666.

Three fixes, all found by running the live smoke against production once #9651 unblocked it.

## The real defect: a header the API advertises and never sends

`/api/v1/search/semantic` answers 200 with:

```
cache-control: no-store
access-control-expose-headers: …, x-metagraph-contract-version, …
```

…and **no `x-metagraph-contract-version`**.

`envelopeResponse` sets both the header and the body's `meta.contract_version`. `dataResponse` set **only the body value**. Every client is told via `access-control-expose-headers` to read that header, and on the **ten** routes built with `dataResponse` — semantic search, the ask/RPC proxies, the webhook subscription CRUD — it is absent.

A contract the API states and does not keep. No unit test caught it because the tests assert the body.

## The smoke reported one failure per publish run

It asserted *inside* the loop, so the first bad route threw and the rest were never checked — each round trip costing a **full publish run** to discover **one** route:

| | |
|---|---|
| #9650 | fixed `/api/v1/ask` (405, POST-only) |
| next publish | surfaced `/api/v1/search/semantic` (400, missing `q`) |
| run locally with failures collected | surfaced **two more** immediately |

It now collects every failure and throws once, naming them all.

## Two assertions were simply wrong

- **`/api/v1/search/semantic` needs `q`.** Its bare GET is a correct 400, not a route failure — the fourth instance of the #1682 class. The required-param table is now pinned by a test that *also* asserts each entry is still a real route, because a guard for a deleted route silently stops guarding.
- **An ETag was required of every route.** These responses are `no-store`; a validator for something no cache may store validates nothing. Now required only where the response is actually cacheable.

## Verification

- ran the real smoke against production between each fix — that is how findings 3 and 4 surfaced, after finding 2 was fixed
- `/api/v1/governance/config-changes` timed out on one run and answered 200 in 3.6s on the next; left alone as transient rather than "fixed" by raising a timeout
- full suite: **702 files / 16,981 tests** green; `build`, `lint`, `format:check` clean