### PR TITLE
fix(mcp): make the SDK envelope reproduce the handshake, and prove it

### DIFF
--- a/src/mcp-sdk-adapter.ts
+++ b/src/mcp-sdk-adapter.ts
@@ -56,7 +56,12 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { MCP_SERVER_VERSION } from "./mcp-server.ts";
+import {
+  MCP_CAPABILITIES,
+  MCP_INSTRUCTIONS,
+  MCP_REGISTRY_META,
+  MCP_SERVER_INFO,
+} from "./mcp-server.ts";
 
 /** The published tool shape, as listToolDefinitions() already emits it. */
 type PublishedTool = Record<string, unknown> & { name: string };
@@ -72,7 +77,6 @@ interface SdkServeOptions {
   tools: PublishedTool[];
   /** The single funnel every tools/call passes through. */
   dispatch: SdkToolDispatch;
-  serverName?: string;
 }
 
 /**
@@ -86,12 +90,22 @@ interface SdkServeOptions {
  */
 export async function serveWithSdk(
   request: Request,
-  { tools, dispatch, serverName = "metagraphed" }: SdkServeOptions,
+  { tools, dispatch }: SdkServeOptions,
 ): Promise<Response> {
-  const server = new Server(
-    { name: serverName, version: MCP_SERVER_VERSION },
-    { capabilities: { tools: {} } },
-  );
+  // THE HANDSHAKE IS READ FROM THE SAME CONSTANTS THE HAND-ROLLED PATH USES,
+  // not restated here. `initialize` is handled inside the SDK's Server rather
+  // than by a handler we register, so every field it reports has to arrive
+  // through this constructor -- and a second copy of the server's identity is
+  // exactly the drift this migration must not introduce.
+  //
+  // Measured against production before wiring it: our initialize returns
+  // `_meta`, `capabilities`, `instructions`, `protocolVersion` and a
+  // `serverInfo` carrying name/title/description. The SDK reproduces all of
+  // those EXCEPT `_meta`, which it drops -- see mergeInitializeMeta below.
+  const server = new Server(MCP_SERVER_INFO, {
+    capabilities: MCP_CAPABILITIES,
+    instructions: MCP_INSTRUCTIONS,
+  });
 
   // The published definitions are handed back verbatim. Any reshaping here
   // would be a second place that decides what the contract is, and the whole
@@ -130,7 +144,7 @@ export async function serveWithSdk(
     // Reading to completion here, then returning a fresh Response, makes the
     // payload independent of the objects that produced it.
     const body = await response.text();
-    return new Response(body, {
+    return new Response(mergeInitializeMeta(body), {
       status: response.status,
       headers: response.headers,
     });
@@ -162,3 +176,43 @@ export async function closeQuietly(target: {
     // Deliberately silent: see the caller.
   }
 }
+
+/**
+ * Restore the one initialize field the SDK does not carry.
+ *
+ * Our handshake reports a `_meta` registry backlink alongside `serverInfo`.
+ * The SDK's Server builds the initialize result itself and has no way to
+ * attach it, so it would silently vanish at cutover -- the kind of loss that
+ * shows up as a missing link in a client months later rather than as a failure.
+ *
+ * Narrow on purpose: it touches ONLY a result that already looks like an
+ * initialize response, leaves any other payload byte-identical, and never
+ * overwrites a `_meta` the SDK did produce. A parse failure returns the body
+ * untouched, because a shim must not be able to turn a valid response into
+ * an invalid one.
+ */
+export function mergeInitializeMeta(body: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return body;
+  }
+  const payload = parsed as Row | undefined;
+  const result = payload?.result as Row | undefined;
+  if (
+    !result ||
+    typeof result !== "object" ||
+    !result.serverInfo ||
+    !result.protocolVersion ||
+    result._meta !== undefined
+  ) {
+    return body;
+  }
+  return JSON.stringify({
+    ...payload,
+    result: { ...result, _meta: MCP_REGISTRY_META },
+  });
+}
+
+type Row = Record<string, unknown>;

--- a/tests/mcp-sdk-parity.test.ts
+++ b/tests/mcp-sdk-parity.test.ts
@@ -11,12 +11,12 @@
 // the served path.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
+import { handleMcpRequest, listToolDefinitions } from "../src/mcp-server.ts";
 import {
-  handleMcpRequest,
-  listToolDefinitions,
-  MCP_SERVER_VERSION,
-} from "../src/mcp-server.ts";
-import { closeQuietly, serveWithSdk } from "../src/mcp-sdk-adapter.ts";
+  closeQuietly,
+  mergeInitializeMeta,
+  serveWithSdk,
+} from "../src/mcp-sdk-adapter.ts";
 import type { Row } from "./row-type.ts";
 
 const MCP_HEADERS = {
@@ -93,7 +93,15 @@ describe("SDK envelope parity with the hand-rolled dispatcher (#9647)", () => {
     );
   });
 
-  test("initialize reports the same server identity and protocol", async () => {
+  // THE WHOLE PAYLOAD, not a field or two. The first version of this test
+  // compared serverInfo.version and protocolVersion and called it "identity" --
+  // which would have passed while silently dropping `instructions` (what tells
+  // a model what this server is FOR), serverInfo.title/description, and the
+  // `_meta` registry backlink. `initialize` is handled INSIDE the SDK's Server
+  // rather than by a handler we register, so every one of those fields has to
+  // arrive through the constructor or a shim, and only a whole-payload compare
+  // proves it did.
+  test("initialize is byte-identical, every field", async () => {
     const body = {
       jsonrpc: "2.0",
       id: 1,
@@ -106,13 +114,21 @@ describe("SDK envelope parity with the hand-rolled dispatcher (#9647)", () => {
     };
     const mine = (await viaHandRolled(body)).result as Row;
     const sdk = (await viaSdk(body)).result as Row;
-    assert.equal((sdk.serverInfo as Row).version, MCP_SERVER_VERSION);
-    assert.equal(
-      (sdk.serverInfo as Row).version,
-      (mine.serverInfo as Row).version,
-      "one version constant, both envelopes",
+
+    // Named first so a failure says WHICH field went missing rather than
+    // dumping two large objects at the reader.
+    assert.deepEqual(
+      Object.keys(sdk).sort(),
+      Object.keys(mine).sort(),
+      "the handshake's field set must not change",
     );
-    assert.equal(sdk.protocolVersion, mine.protocolVersion);
+    for (const key of ["instructions", "protocolVersion"]) {
+      assert.deepEqual(sdk[key], mine[key], `initialize.${key} differs`);
+    }
+    assert.deepEqual(sdk.serverInfo, mine.serverInfo);
+    assert.deepEqual(sdk.capabilities, mine.capabilities);
+    assert.deepEqual(sdk._meta, mine._meta, "the registry backlink survives");
+    assert.deepEqual(sdk, mine);
   });
 
   test("tools/call reaches the dispatch funnel with the caller's arguments", async () => {
@@ -193,5 +209,54 @@ describe("closeQuietly (#9668)", () => {
       },
     });
     assert.equal(closed, true);
+  });
+});
+
+// The shim restoring the one initialize field the SDK drops. Narrow by design:
+// a compatibility patch that can turn a valid response into an invalid one is
+// worse than the gap it closes, so every guard is exercised.
+describe("mergeInitializeMeta (#9668)", () => {
+  const initResult = (extra: Row = {}) =>
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        protocolVersion: "2025-11-25",
+        serverInfo: { name: "x" },
+        ...extra,
+      },
+    });
+
+  test("adds _meta to an initialize result that lacks it", () => {
+    const out = JSON.parse(mergeInitializeMeta(initResult())) as Row;
+    assert.ok((out.result as Row)._meta, "the registry backlink is restored");
+  });
+
+  test("never overwrites a _meta the SDK did produce", () => {
+    const out = JSON.parse(
+      mergeInitializeMeta(initResult({ _meta: { mine: true } })),
+    ) as Row;
+    assert.deepEqual((out.result as Row)._meta, { mine: true });
+  });
+
+  // Anything that is not an initialize result must come back untouched --
+  // byte-identical, not merely equivalent, since this runs on every response.
+  test("leaves a non-initialize payload byte-identical", () => {
+    for (const body of [
+      JSON.stringify({ jsonrpc: "2.0", id: 1, result: { tools: [] } }),
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        error: { code: -32602, message: "no" },
+      }),
+      JSON.stringify([{ jsonrpc: "2.0", id: 1, result: {} }]),
+      "",
+    ]) {
+      assert.equal(mergeInitializeMeta(body), body);
+    }
+  });
+
+  test("returns unparseable input unchanged rather than throwing", () => {
+    assert.equal(mergeInitializeMeta("{not json"), "{not json");
   });
 });


### PR DESCRIPTION
## Summary

Step 1 (#9668) proved the SDK envelope publishes an identical **tool catalogue**. Preparing the cutover found a gap **in that proof itself** — so this closes it before anything is wired.

## The step-1 parity test was too weak on the method that matters most

Its `initialize` assertion compared `serverInfo.version` and `protocolVersion` — two fields — under the name *"reports the same server identity and protocol"*. Measured against production, the real handshake returns five:

```
keys:       _meta, capabilities, instructions, protocolVersion, serverInfo
serverInfo: { name, title, description }
```

`instructions` is the blob that tells a model what this server is **for**. `_meta` is the registry backlink. **Both would have been dropped at cutover, and that test would have passed.** That was my miss in the previous PR.

## What the SDK carries, probed rather than assumed

`initialize` is handled *inside* the SDK's `Server`, not by a handler we register, so every field must arrive through the constructor:

| field | reproduced? |
|---|---|
| `serverInfo.name` / `title` / `description` | yes — from the `Implementation` argument |
| `instructions` | yes — from `ServerOptions` |
| `capabilities` | yes |
| `_meta` | **no — dropped** |

## The fix

The adapter builds its `Server` from `MCP_SERVER_INFO` / `MCP_CAPABILITIES` / `MCP_INSTRUCTIONS` — **the same constants the hand-rolled path reads**, not restated. A second copy of the server's identity is precisely the drift this migration exists to avoid.

`mergeInitializeMeta` restores the one field the SDK cannot, and is deliberately narrow: it touches only a payload that already looks like an initialize result, never overwrites a `_meta` the SDK produced, and returns unparseable input unchanged. **A compatibility shim that can turn a valid response into an invalid one is worse than the gap it closes.** All four guards are exercised.

## The strengthened test

Compares the **whole** initialize payload, with the field-set assertion first so a failure names what went missing rather than dumping two large objects at the reader.

Verified it catches the regression: removing the shim fails it with *"the handshake's field set must not change"*.

## Why the wiring is still not here

Deleting or bypassing the hand-rolled dispatcher in the same change that first serves through the SDK removes the only way to recover from a defect on a surface taking **14K tool calls a month**. This step found a real hole in the safety net; wiring before that net is trusted is the wrong order, and for infrastructure this is the standard — parity-proven, then flag-gated, then baked, then deleted.

Remaining, unchanged from #9647: wire `/mcp` behind a flag with the pre-dispatch gauntlet and telemetry re-attached; flip; then delete the dispatcher once it has baked through a deploy cycle.

## Validation run

```
npx vitest run tests/mcp-sdk-parity.test.ts    12 passed
npx vitest run <4 MCP suites>                1404 passed
npm run validate:mcp                          224 tools, lifecycle + all tools/call green
npm run typecheck / lint                      clean
adapter coverage                              100% statements, 100% branches
```

Closes #9670
