### PR TITLE
feat(ui): add the search-resolve query and types

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.test.ts
@@ -16,6 +16,7 @@ import {
   normalizeSubnetGaps,
   validateNextCursor,
   normalizeFreshnessSources,
+  searchResolveQuery,
 } from "./queries";
 
 // These tests lock the canonical-only reads after #1756 collapsed the redundant

--- a/apps/ui/src/lib/metagraphed/queries.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.test.ts
@@ -793,3 +793,32 @@ describe("validateNextCursor", () => {
     });
   });
 });
+
+describe("searchResolveQuery (metagraphed-infra#362)", () => {
+  it("keys on the raw query, network-scoped like every other read", () => {
+    // The key carries the network because the same string can resolve on
+    // testnet as well -- the route is in LIVE_CHAIN_ROUTE_PATHS precisely
+    // because a checksum means the same thing on every chain.
+    expect(searchResolveQuery("0xabc").queryKey).toEqual([
+      "metagraphed",
+      { network: "mainnet" },
+      "search-resolve",
+      "0xabc",
+    ]);
+  });
+
+  it("never runs on an empty or whitespace query", () => {
+    // The route would answer with an empty `matches`, but a request per
+    // keystroke-that-is-only-spaces is a request for nothing.
+    expect(searchResolveQuery("").enabled).toBe(false);
+    expect(searchResolveQuery("   ").enabled).toBe(false);
+    expect(searchResolveQuery("7").enabled).toBe(true);
+  });
+
+  it("caches forever, because the answer is a pure function of the query", () => {
+    // Unlike every other query here, nothing on the server can change this
+    // result: the same string resolves to the same destinations always. A
+    // finite staleTime would re-request an answer that cannot have moved.
+    expect(searchResolveQuery("7").staleTime).toBe(Infinity);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -184,6 +184,7 @@ import type {
   RpcEndpointsSummary,
   RpcUsage,
   SchemaInfo,
+  SearchResolveResponse,
   SemanticSearchResponse,
   Subnet,
   SubnetAxonRemovals,
@@ -9013,6 +9014,30 @@ export const searchQuery = (q: string, limit = 20) =>
 // Response is a single object with `results` nested inside (not a bare list or
 // a { <collection>: T[] } wrapper), so this builds directly on apiFetch rather
 // than the fetchList list-unwrapping helper.
+/**
+ * What did the user paste (metagraphed-infra#362)?
+ *
+ * Deliberately SEPARATE from semanticSearchQuery and safe to run alongside it:
+ * this route is deterministic, needs no AI binding, and answers from the shape
+ * of the query alone -- so an explorer's most common search never waits on, or
+ * pays for, an embedding.
+ *
+ * `staleTime: Infinity` because the answer is a pure function of the query. The
+ * same string resolves to the same destinations forever; there is nothing on
+ * the server that can change it.
+ */
+export const searchResolveQuery = (q: string) =>
+  queryOptions({
+    queryKey: k("search-resolve", q),
+    queryFn: ({ signal }) =>
+      apiFetch<SearchResolveResponse>("/api/v1/search/resolve", {
+        params: { q },
+        signal,
+      }),
+    enabled: q.trim().length > 0,
+    staleTime: Infinity,
+  });
+
 export const semanticSearchQuery = (q: string, limit = 10, types?: string[]) =>
   queryOptions({
     queryKey: k("search-semantic", q, limit, types ?? []),

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -3966,6 +3966,33 @@ export interface SemanticSearchResult {
 }
 
 /** /api/v1/search/semantic response envelope. */
+/** One place a pasted query could lead (metagraphed-infra#362). */
+export interface ResolvedIdentifier {
+  kind: "account" | "block" | "extrinsic" | "evm-account" | "subnet" | "neuron";
+  value: string;
+  api_path: string;
+  ui_path: string;
+  /**
+   * Whether this is the ONLY reading of the input.
+   *
+   * `false` means another kind matches the same shape -- a 64-hex string is a
+   * block hash OR an extrinsic hash, a small integer is a netuid AND a block
+   * height -- so the UI must show the alternatives rather than navigate. It is
+   * NOT a claim that the entity exists; the route looks nothing up.
+   */
+  exact: boolean;
+}
+
+/** What the user pasted, resolved to chain entities. */
+export interface SearchResolveResponse {
+  query: string;
+  matches: ResolvedIdentifier[];
+  match_count: number;
+  /** Exactly one candidate, and it is exact -- the only case where navigating
+   * straight there is correct. */
+  unambiguous: boolean;
+}
+
 export interface SemanticSearchResponse {
   query: string;
   count: number;


### PR DESCRIPTION
Part of #9674, ahead of the component change.

#9672 shipped `GET /api/v1/search/resolve`. This adds the client half — `searchResolveQuery` plus the `ResolvedIdentifier` / `SearchResolveResponse` types — **without touching a component**, so it goes through the normal gate rather than being held for manual review alongside a visual diff.

## `staleTime: Infinity`, which nothing else here uses

The answer is a **pure function of the query**: the same string resolves to the same destinations forever, and nothing on the server can change it. Any finite `staleTime` would re-request an answer that cannot have moved.

## Deliberately separate from `semanticSearchQuery`

They are independent and meant to run side by side. Resolve is deterministic and needs no AI binding; semantic needs both. **An explorer's most common search must never wait on — or fail because of — the embedding path.**

## Verification

- `apps/ui` lib tests: **142 files / 1,146 passed**
- three new tests: the query key (network-scoped, as `k()` builds it), that it never fires on whitespace, and the `staleTime: Infinity` rationale
- **`apps/ui` typecheck: 0 errors**
- no component touched, so no visual diff and no screenshot table

### A correction to an earlier revision of this description

I first described four `apps/ui` type errors as pre-existing. They were not defects at all — `apps/ui` typechecks against `@jsonbored/metagraphed` and `@jsonbored/ui-kit`, and neither workspace had been built in this worktree, so `ApiSchema<"PartnershipMetadata">` and friends resolved against absent declarations. Building both clears all of them. Nothing in the codebase needed fixing; my checkout did.

The component wiring — and the decisions already settled for it — is #9674.