### PR TITLE
feat(mcp): serve /mcp through the SDK envelope behind a flag, at parity

### DIFF
--- a/src/mcp-sdk-adapter.ts
+++ b/src/mcp-sdk-adapter.ts
@@ -1,150 +1,256 @@
-// Step 1 of the @modelcontextprotocol/sdk migration (#9647): the envelope,
-// served by the SDK, over the tools we already have.
+// Step 2 of the @modelcontextprotocol/sdk migration (#9647): the SDK owns the
+// ENVELOPE, src/mcp-server.ts still owns every METHOD.
 //
-// NOT WIRED TO PRODUCTION, AND DELIBERATELY TEMPORARY. `/mcp` still answers
-// from src/mcp-server.ts's hand-rolled dispatcher, so for now two envelopes
-// exist for one contract. That duplication is the cost of proving the port
-// before trusting it, and it is not meant to survive: #9647 step 4 deletes the
-// hand-rolled dispatcher once the flag has been on through a full deploy
-// cycle. If this file and that one are both still here after that, one of them
-// is dead code.
+// NOT YET SERVED BY DEFAULT. `/mcp` reaches this only when
+// `MCP_SDK_ENVELOPE` is set (see mcpSdkEnvelopeEnabled in mcp-server.ts);
+// unset, the hand-rolled path answers exactly as before. The flag exists so
+// the swap can be proved in production traffic and reverted with a config
+// change rather than a deploy, on a surface answering ~14K tool calls a month.
+// #9647 step 4 deletes the hand-rolled envelope once it has baked.
 //
-// The duplication earns its keep by being checkable:
-// tests/mcp-sdk-parity.test.ts drives both implementations with the same
-// requests and asserts the published responses match. A migration whose first
-// observable step is a cutover has no way to be wrong quietly, and this one is
-// answering 14K tool calls a month.
+// ## Total delegation, which is the whole design
 //
-// ## Why the migration is happening at all
+// Every JSON-RPC method -- INCLUDING `initialize` and `ping`, which the SDK
+// registers for itself -- is routed back into dispatchMessage() through
+// `fallbackRequestHandler`. Nothing about what a method returns is restated
+// here. That matters for three reasons, each of which was a real bug in the
+// partial-delegation version of this file:
 //
-// Both reasons the hand-rolled dispatcher's header gives were measured and
-// neither survived:
+//   telemetry   dispatchMessage's `finally` emits scheduleMcpProtocolUsageEvent
+//               for EVERY method (#8993). A method the SDK answered internally
+//               would be a method that silently stopped being counted --
+//               `initialize` most of all, which carries the client
+//               attribution (#8994) and the session identity (#9054).
+//   validation  setRequestHandler() wraps a handler in a zod parse of the
+//               SDK's own request schema. Registering one for `initialize`
+//               would REJECT a sloppy handshake we accept today (ours
+//               negotiates a missing protocolVersion; the SDK's schema
+//               requires it) and would answer with zod's text. Stricter
+//               validation is not a behaviour-neutral port.
+//   drift       one funnel is the property the whole instrumentation story
+//               rests on. Two places that answer methods is the shape that
+//               goes wrong quietly.
 //
-//   bundle   73.3 KB gzipped for core Server + the web-standard transport,
-//            bundled for workerd with zero Node imports. The 5.9 MB installed
-//            figure is the stdio/Express trees, which a web-standard build
-//            never reaches.
-//   hot path 0.28 ms to construct + connect + dispatch per request with a
-//            224-tool catalogue of our shape, warmed, against a ~140 ms p50
-//            tool call.
+// removeRequestHandler / removeNotificationHandler are public API on the SDK's
+// Protocol, so this needs no private-state access to achieve it.
 //
-// What it buys is spec drift becoming a dependency bump. One audit found four
-// conformance items (#9646, #9648, plus `icons` and `execution.taskSupport`
-// unemitted); every future revision is hand-work while we own the envelope.
+// ## Why there are no response shims
 //
-// ## The constraint that shapes this file
+// An earlier draft of this migration needed two: one to restore the
+// `initialize` `_meta` the SDK dropped, and one to strip the `MCP error -N: `
+// prefix McpError bakes into its message. Total delegation removes the first
+// (our own initialize result is returned verbatim, `_meta` included) and
+// JsonRpcFailure removes the second -- the SDK serialises `code`/`message`
+// off whatever is thrown, so a plain Error carrying a numeric `code` produces
+// a byte-identical error object. McpError is a convenience class, not the
+// contract. Measured, both ways, in tests/mcp-sdk-parity.test.ts.
 //
-// The web-standard transport REFUSES REUSE -- "Stateless transport cannot be
-// reused across requests. Create a new transport per request." So there is no
-// long-lived server object to hold; each request builds its own. That is the
-// 0.28 ms above, and it is why `serveWithSdk` takes the tool list as an
-// argument rather than closing over a module-level singleton: a per-request
-// object that reads module state is the shape that goes wrong when one request
-// mutates it.
+// ## What the SDK is actually being trusted with
 //
-// ## What must NOT change in the port
+// The envelope, and only the envelope: JSON-RPC parse + shape validation,
+// batch fan-out and response correlation, 202-on-notification, and the
+// JSON/SSE framing choice. Those are the parts that track spec revisions, and
+// the parts a hand-rolled implementation has to re-derive every time the spec
+// moves. Everything metagraphed-specific -- the rate limit, the cost-weighted
+// quota, the body cap, the batch ceiling, session minting -- runs BEFORE this
+// in dispatchMcpRequest and is untouched.
 //
-// The dispatcher is the single chokepoint for usage_event, $mcp_tool_call,
-// trace spans, $exception, pre-dispatch refusals (#9639) and agent intent
-// (#9642). #8993's rule -- instrument the loop, not the cases -- depends on
-// there being one loop we own. That still holds here: we own the
-// CallToolRequestSchema handler, so `dispatch` below is the same funnel under
-// a different envelope, and step 2 re-attaches the telemetry to it.
+// ## The constraint that shapes the per-request construction
+//
+// The web-standard transport refuses reuse ("Stateless transport cannot be
+// reused across requests"), so each request builds its own Server and
+// transport. That is 0.28 ms measured against a ~140 ms p50 tool call, and it
+// is why `dispatch` arrives as an argument rather than being read from module
+// state: a per-request object that reads module state is the shape that goes
+// wrong when one request mutates it.
+//
+// ## No import from mcp-server.ts, on purpose
+//
+// Everything metagraphed-specific -- the server identity, the capabilities,
+// the instructions, the dispatch funnel -- arrives as an ARGUMENT. That keeps
+// this module a generic "serve JSON-RPC through the MCP SDK" envelope with no
+// knowledge of this project, and it keeps mcp-server.ts (which imports this)
+// out of an import cycle. A 16K-line hub module in a cycle with the thing it
+// calls is a bundler problem waiting to happen on the hottest public path we
+// have.
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
-import {
-  MCP_CAPABILITIES,
-  MCP_INSTRUCTIONS,
-  MCP_REGISTRY_META,
-  MCP_SERVER_INFO,
-} from "./mcp-server.ts";
 
-/** The published tool shape, as listToolDefinitions() already emits it. */
-type PublishedTool = Record<string, unknown> & { name: string };
+type Row = Record<string, unknown>;
 
-/** What a tools/call must resolve to -- the same result object dispatchTool returns. */
-type SdkToolDispatch = (
-  name: string,
-  args: Record<string, unknown> | undefined,
-) => Promise<Record<string, unknown>>;
+/** JSON-RPC 2.0's own internal-error code, not a choice this project makes. */
+const RPC_INTERNAL_ERROR = -32603;
 
-interface SdkServeOptions {
-  /** Already-published definitions; this module does no shaping of its own. */
-  tools: PublishedTool[];
-  /** The single funnel every tools/call passes through. */
-  dispatch: SdkToolDispatch;
+/**
+ * The methods the SDK registers a handler for and that we take back.
+ *
+ * Hand-listed because removeRequestHandler takes a method name and the
+ * registry itself is private. That makes the list a drift risk -- an SDK
+ * upgrade adding a handler would silently recapture that method and stop it
+ * being instrumented -- so tests/mcp-sdk-parity.test.ts asserts by reflection
+ * that NOTHING remains registered after these run. The production path uses
+ * only public API; the gate proves the list is complete.
+ */
+const SDK_REGISTERED_REQUEST_METHODS = ["initialize", "ping"];
+
+/** Same, for notifications: Server registers one and Protocol two. */
+const SDK_REGISTERED_NOTIFICATION_METHODS = [
+  "notifications/initialized",
+  "notifications/cancelled",
+  "notifications/progress",
+];
+
+/**
+ * A JSON-RPC error, thrown so the SDK serialises it verbatim.
+ *
+ * The SDK's Protocol builds an error response from `code` (when it is a safe
+ * integer), `message`, and `data` (when present) off whatever the handler
+ * threw. So this reproduces our rpcError() output exactly -- unlike McpError,
+ * whose constructor rewrites the message to `MCP error ${code}: ${message}`.
+ */
+export class JsonRpcFailure extends Error {
+  readonly code: number;
+  readonly data?: unknown;
+
+  constructor(code: number, message: string, data?: unknown) {
+    super(message);
+    this.name = "JsonRpcFailure";
+    this.code = code;
+    this.data = data;
+  }
 }
 
 /**
- * Answer one MCP request through the SDK.
- *
- * A fresh Server and transport per call, because the transport requires it.
- * The body is read to completion and re-wrapped before either is closed, so
- * the returned Response does not depend on objects that no longer exist -- and
- * nothing outlives the request, which on Workers would mean sharing it with
- * the next caller.
+ * One dispatched JSON-RPC message, in dispatchMessage()'s own shape: a
+ * response object for a request, or null for a notification.
  */
+export type SdkDispatch = (message: Row) => Promise<Row | null>;
+
+/**
+ * Turn dispatchMessage()'s response object into what an SDK handler must
+ * return -- the bare `result` -- or throw the error it reported.
+ *
+ * Exported for the parity test: this is the one place the two envelopes'
+ * conventions are translated, so it is the one place a mistranslation could
+ * hide.
+ */
+export function unwrapDispatchResponse(response: Row | null): unknown {
+  const error = response?.error as Row | undefined;
+  if (error) {
+    throw new JsonRpcFailure(
+      error.code as number,
+      error.message as string,
+      error.data,
+    );
+  }
+  if (response && "result" in response) return response.result;
+  // Unreachable through dispatchMessage, which answers every request with a
+  // result or an error. Not left to fall through as `undefined`: an SDK
+  // handler returning undefined publishes `{"result":undefined}`, which
+  // JSON.stringify drops, producing a response with neither result nor error
+  // -- a malformed JSON-RPC reply. Failing loudly is the lesser harm.
+  throw new JsonRpcFailure(RPC_INTERNAL_ERROR, "Internal error.");
+}
+
+export interface SdkServeOptions {
+  /** The server identity the SDK reports; ours, not restated here. */
+  serverInfo: { name: string; version: string } & Row;
+  /** What assertRequestHandlerCapability checks registrations against. */
+  capabilities: Row;
+  /** The model-facing description of what this server is for. */
+  instructions?: string;
+  /** The single funnel every method passes through. */
+  dispatch: SdkDispatch;
+}
+
+/** Answer one MCP request through the SDK, dispatching every method to `dispatch`. */
 export async function serveWithSdk(
   request: Request,
-  { tools, dispatch }: SdkServeOptions,
+  { serverInfo, capabilities, instructions, dispatch }: SdkServeOptions,
 ): Promise<Response> {
-  // THE HANDSHAKE IS READ FROM THE SAME CONSTANTS THE HAND-ROLLED PATH USES,
-  // not restated here. `initialize` is handled inside the SDK's Server rather
-  // than by a handler we register, so every field it reports has to arrive
-  // through this constructor -- and a second copy of the server's identity is
-  // exactly the drift this migration must not introduce.
+  // The handshake constants are passed through even though our own dispatch is
+  // what answers `initialize`: `capabilities` is what the SDK's
+  // assertRequestHandlerCapability checks against, and a second copy of the
+  // server's identity is exactly the drift this migration must not introduce.
+  const server = new Server(serverInfo, { capabilities, instructions });
+
+  // Take back everything the SDK claimed, so the fallbacks below see all of it.
+  for (const method of SDK_REGISTERED_REQUEST_METHODS) {
+    server.removeRequestHandler(method);
+  }
+  for (const method of SDK_REGISTERED_NOTIFICATION_METHODS) {
+    server.removeNotificationHandler(method);
+  }
+
+  // Rebuilt rather than forwarded: the SDK hands a handler its PARSED request,
+  // and dispatchMessage takes a whole JSON-RPC message. `jsonrpc` is restated
+  // because a message that reached a handler has already been validated as
+  // 2.0 by the transport.
+  server.fallbackRequestHandler = async (req) =>
+    unwrapDispatchResponse(
+      await dispatch({
+        jsonrpc: "2.0",
+        id: (req as Row).id,
+        method: req.method,
+        params: (req as Row).params,
+      }),
+    ) as never;
+
+  // Notifications are dispatched for their SIDE EFFECT ONLY -- the protocol
+  // usage event dispatchMessage emits in its `finally`. The return value is
+  // discarded because a notification has no reply by definition, but dropping
+  // the CALL would drop the telemetry, which for an id-less message is the
+  // only signal that can ever exist (#8995).
   //
-  // Measured against production before wiring it: our initialize returns
-  // `_meta`, `capabilities`, `instructions`, `protocolVersion` and a
-  // `serverInfo` carrying name/title/description. The SDK reproduces all of
-  // those EXCEPT `_meta`, which it drops -- see mergeInitializeMeta below.
-  const server = new Server(MCP_SERVER_INFO, {
-    capabilities: MCP_CAPABILITIES,
-    instructions: MCP_INSTRUCTIONS,
-  });
-
-  // The published definitions are handed back verbatim. Any reshaping here
-  // would be a second place that decides what the contract is, and the whole
-  // point of the parity test is that there is only one.
-  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
-
-  server.setRequestHandler(CallToolRequestSchema, async (req) => {
-    const { name, arguments: args } = req.params;
-    return (await dispatch(
-      name,
-      args as Record<string, unknown> | undefined,
-    )) as never;
-  });
+  // AWAITED BEFORE THE RESPONSE, via this array. The SDK's Protocol dispatches
+  // a notification fire-and-forget -- `Promise.resolve().then(() =>
+  // handler(n))`, never awaited -- so on Workers the 202 would return while
+  // the handler was still mid-flight, and the request context would be torn
+  // down with the telemetry write unfinished. Measured: at response time the
+  // dispatch had started and not completed. The hand-rolled path awaits it, so
+  // without this the flag would quietly stop counting every
+  // notifications/initialized the server receives.
+  const pendingNotifications: Array<Promise<unknown>> = [];
+  server.fallbackNotificationHandler = async (notification) => {
+    // Pushed synchronously, before the first await, so the promise is visible
+    // to the drain below however the SDK schedules this handler.
+    const pending = dispatch({
+      jsonrpc: "2.0",
+      method: notification.method,
+      params: (notification as Row).params,
+    });
+    pendingNotifications.push(pending);
+    await pending;
+  };
 
   const transport = new WebStandardStreamableHTTPServerTransport({
-    // Stateless: no session id. The one stateful path (resources/subscribe,
-    // ADR 0015) stays on McpSessionHub and is out of scope for this step.
+    // Stateless: session minting stays in dispatchMcpRequest, which registers
+    // the id with McpSessionHub before it reaches the client. Letting the
+    // transport mint one too would create a second id the hub never heard of.
     sessionIdGenerator: undefined,
     // A BARE JSON BODY, not an SSE frame. Both are legal for Streamable HTTP,
     // but the hand-rolled dispatcher answers `{"jsonrpc":...}` directly and
     // this migration is an envelope swap, not a transport change -- a client
     // parsing our responses today must not have to learn `event: message\n
-    // data: ` to keep working. The parity test compares payloads, so without
-    // this the framing difference would be invisible there and visible to
-    // callers, which is the wrong way round.
+    // data: ` to keep working.
     enableJsonResponse: true,
   });
 
   try {
     await server.connect(transport);
     const response = await transport.handleRequest(request);
-    // BUFFERED BEFORE TEARDOWN, and the ordering is the whole point. The
-    // response body is written by the transport; closing it first truncates
-    // whatever has not been flushed, which reads downstream as an empty body
-    // and parses as "Unexpected end of JSON input" -- how this was found.
-    // Reading to completion here, then returning a fresh Response, makes the
-    // payload independent of the objects that produced it.
+    // Drain the fire-and-forget notification handlers before answering (see
+    // pendingNotifications above). allSettled, not all: a telemetry write that
+    // rejects must not become the caller's response.
+    await Promise.allSettled(pendingNotifications);
+    // BUFFERED BEFORE TEARDOWN, and the ordering is the whole point. The body
+    // is written by the transport; closing it first truncates whatever has not
+    // been flushed, which reads downstream as an empty body and parses as
+    // "Unexpected end of JSON input" -- how this was found. Reading to
+    // completion here makes the payload independent of the objects that
+    // produced it.
     const body = await response.text();
-    return new Response(mergeInitializeMeta(body), {
+    return new Response(body || null, {
       status: response.status,
       headers: response.headers,
     });
@@ -164,8 +270,7 @@ export async function serveWithSdk(
  *
  * Extracted so the swallow is reachable from a test. It only fires when a
  * close() rejects, which the happy path never does -- and a guard nobody can
- * exercise is a guard nobody can trust. Tested with a rejecting closer rather
- * than annotated away.
+ * exercise is a guard nobody can trust.
  */
 export async function closeQuietly(target: {
   close?: () => Promise<unknown>;
@@ -177,42 +282,8 @@ export async function closeQuietly(target: {
   }
 }
 
-/**
- * Restore the one initialize field the SDK does not carry.
- *
- * Our handshake reports a `_meta` registry backlink alongside `serverInfo`.
- * The SDK's Server builds the initialize result itself and has no way to
- * attach it, so it would silently vanish at cutover -- the kind of loss that
- * shows up as a missing link in a client months later rather than as a failure.
- *
- * Narrow on purpose: it touches ONLY a result that already looks like an
- * initialize response, leaves any other payload byte-identical, and never
- * overwrites a `_meta` the SDK did produce. A parse failure returns the body
- * untouched, because a shim must not be able to turn a valid response into
- * an invalid one.
- */
-export function mergeInitializeMeta(body: string): string {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(body);
-  } catch {
-    return body;
-  }
-  const payload = parsed as Row | undefined;
-  const result = payload?.result as Row | undefined;
-  if (
-    !result ||
-    typeof result !== "object" ||
-    !result.serverInfo ||
-    !result.protocolVersion ||
-    result._meta !== undefined
-  ) {
-    return body;
-  }
-  return JSON.stringify({
-    ...payload,
-    result: { ...result, _meta: MCP_REGISTRY_META },
-  });
-}
-
-type Row = Record<string, unknown>;
+/** Exported for the completeness gate in tests/mcp-sdk-parity.test.ts. */
+export const SDK_RECLAIMED_METHODS = {
+  requests: SDK_REGISTERED_REQUEST_METHODS,
+  notifications: SDK_REGISTERED_NOTIFICATION_METHODS,
+};

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -36,6 +36,7 @@
 // a dedicated ADR amendment with its own consent model, not as an incremental
 // tool addition.
 import { loadSubnetWeightSettersColdTier } from "./subnet-weight-setters-loader.ts";
+import { serveWithSdk } from "./mcp-sdk-adapter.ts";
 import { z } from "zod";
 import {
   SearchSubnetsInputSchema,
@@ -14975,6 +14976,24 @@ async function dispatchTool(
   }
 }
 
+/**
+ * Is this a JSON-RPC 2.0 message this server will route?
+ *
+ * Extracted from dispatchMessage's own guard (#9647) so there is exactly one
+ * definition. serveMcpThroughSdk needs the same answer BEFORE handing a
+ * request to the SDK, and two copies of "well-formed" is precisely how the two
+ * envelopes would start disagreeing about what a malformed request is.
+ */
+export function isDispatchableJsonRpcMessage(message: unknown): boolean {
+  const row = message as Row | null;
+  return (
+    row !== null &&
+    typeof row === "object" &&
+    row.jsonrpc === JSONRPC_VERSION &&
+    typeof row.method === "string"
+  );
+}
+
 // Dispatch a single JSON-RPC message. Returns the response object for requests,
 // or null for notifications (no id).
 async function dispatchMessage(message: Row, ctx: McpCtx) {
@@ -14985,12 +15004,7 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
     message.id === null;
   const id = isNotification ? null : message.id;
 
-  if (
-    message === null ||
-    typeof message !== "object" ||
-    message.jsonrpc !== JSONRPC_VERSION ||
-    typeof message.method !== "string"
-  ) {
+  if (!isDispatchableJsonRpcMessage(message)) {
     if (isNotification) return null;
     return rpcError(id, RPC_INVALID_REQUEST, "Invalid JSON-RPC request.");
   }
@@ -15877,6 +15891,112 @@ export function scheduleMcpRefusalEvent(
   }
 }
 
+/**
+ * Is `/mcp` answering through @modelcontextprotocol/sdk (#9647)?
+ *
+ * DEFAULT OFF, and deliberately a runtime flag rather than a build constant:
+ * the point of shipping the SDK envelope dark is that turning it on -- and
+ * more importantly turning it back off -- is a `wrangler secret put` away
+ * rather than a deploy, on the surface with the most external callers.
+ *
+ * Accepts only the exact string "1", not any truthy value. A flag whose off
+ * state depends on a variable being unset is one stray empty-string binding
+ * away from silently enabling itself.
+ */
+export function mcpSdkEnvelopeEnabled(env: Env): boolean {
+  return (env as unknown as Row)?.MCP_SDK_ENVELOPE === "1";
+}
+
+/**
+ * Is every message in this request body one the SDK envelope may handle?
+ *
+ * A batch qualifies only if ALL its members do -- the SDK rejects a mixed
+ * batch wholesale, so routing one there because most of it was fine is how the
+ * valid members would get dropped. Empty arrays never reach this (the batch
+ * guard above answers them).
+ */
+function jsonRpcBodyIsDispatchable(body: Row | Row[]): boolean {
+  return Array.isArray(body)
+    ? body.every(isDispatchableJsonRpcMessage)
+    : isDispatchableJsonRpcMessage(body);
+}
+
+/**
+ * Serve one already-gauntleted MCP request through the SDK envelope.
+ *
+ * Everything metagraphed-specific has ALREADY RUN by the time this is called:
+ * the tiered rate limit, the cost-weighted quota, the 64 KB body cap, the
+ * protocol-version header check and both batch guards. This is only the
+ * envelope -- JSON-RPC framing, batch correlation, 202-on-notification -- with
+ * every method still answered by dispatchMessage.
+ */
+async function serveMcpThroughSdk(
+  request: Request,
+  body: Row | Row[],
+  ctx: McpCtx,
+  env: Env,
+) {
+  // The single message's response, captured on the way past so session minting
+  // can read it without parsing the SDK's serialized body back into an object.
+  // Left null for a batch, which is what mintMcpSessionHeaderIfNeeded already
+  // expects: a batched initialize mints no session.
+  let single: Row | null = null;
+  const isBatch = Array.isArray(body);
+
+  const sdkResponse = await serveWithSdk(
+    // REBUILT, not forwarded: readLimitedMcpBody has already consumed the
+    // original stream, so the transport would find an empty body on it.
+    new Request(request.url, {
+      method: "POST",
+      headers: {
+        // NORMALIZED, and this is the one place the SDK is deliberately
+        // overruled. Its transport 406s any POST whose Accept header does not
+        // literally contain BOTH "application/json" and "text/event-stream".
+        // The spec does tell clients to send that, but this server has never
+        // required it, and most of its traffic is scripted callers (curl,
+        // python-requests) that send `*/*` -- which fails a substring test.
+        // Enforcing it at the same moment we swap envelopes would present as
+        // "the migration broke every script", so the guarantee is stated on
+        // the caller's behalf: we do accept both, and answer JSON.
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }),
+    {
+      serverInfo: MCP_SERVER_INFO,
+      capabilities: MCP_CAPABILITIES,
+      instructions: MCP_INSTRUCTIONS,
+      dispatch: async (message) => {
+        const response = await dispatchMessage(message, ctx);
+        if (!isBatch) single = response;
+        return response;
+      },
+    },
+  );
+
+  const sessionHeaders = mintMcpSessionHeaderIfNeeded(
+    body,
+    single,
+    ctx.pendingSessionId ?? null,
+  );
+  // Awaited before the id reaches the client, for the same reason as the
+  // hand-rolled path: the client may open the GET stream on the next tick, and
+  // registering after the response is a race the client wins.
+  await registerMcpSession(env, sessionHeaders["mcp-session-id"]);
+
+  // MCP_HEADERS overlaid rather than appended. The transport sets a bare
+  // `content-type: application/json` on a JSON reply and NOTHING on a 202, so
+  // without this the CORS headers, the charset and `cache-control: no-store`
+  // would all silently disappear the moment the flag flipped -- a caching
+  // change and a browser-client breakage, neither of them anything to do with
+  // JSON-RPC.
+  return new Response(sdkResponse.body, {
+    status: sdkResponse.status,
+    headers: { ...MCP_HEADERS, ...sessionHeaders },
+  });
+}
+
 // Entry point wired into the Worker at `/mcp`. `deps` injects the shared
 // artifact/KV readers from workers/api.ts. POST carries the stateless
 // JSON-RPC 2.0 envelope; GET opens the SSE push stream; DELETE terminates a
@@ -15983,6 +16103,12 @@ async function dispatchMcpRequest(
 
   // Legacy JSON-RPC batch (array). MCP 2025-06-18 removed batching, but cap
   // older-client compatibility so one HTTP request cannot fan out unboundedly.
+  //
+  // HOISTED OUT of the dispatch branch below (#9647) so both envelopes are
+  // capped by it. The SDK's transport fans a batch out with no ceiling of its
+  // own, so leaving this inside the hand-rolled branch would have made the
+  // flag that swaps envelopes also silently remove the fan-out bound -- a
+  // resource limit quietly becoming conditional on an unrelated flag.
   if (Array.isArray(body)) {
     if (body.length === 0) {
       return jsonResponse(
@@ -16000,6 +16126,37 @@ async function dispatchMcpRequest(
         400,
       );
     }
+  }
+
+  // THE SDK ONLY EVER SEES WELL-FORMED MESSAGES (#9647). Its transport parses
+  // every member against its own JSON-RPC schema first and, on any failure,
+  // answers `400 -32700 Parse error: Invalid JSON-RPC message` for the WHOLE
+  // request. That differs from this server three ways, and each one is a
+  // regression rather than a preference:
+  //
+  //   classification  a well-formed JSON body that is not a valid JSON-RPC
+  //                   message is Invalid Request (-32600), not Parse error
+  //                   (-32700) -- the spec reserves -32700 for JSON that did
+  //                   not parse. We answer -32600; the SDK answers -32700.
+  //   status          ours rides inside a 200 (a JSON-RPC error is a
+  //                   successful HTTP exchange). The SDK's 400 would also make
+  //                   every malformed request start emitting the #9639 refusal
+  //                   event, quietly changing what that metric counts.
+  //   batch           ours answers the VALID members of a mixed batch and
+  //                   reports an error only for the bad one. The SDK rejects
+  //                   the entire batch, so a client with one bad member
+  //                   silently loses the results of its good ones.
+  //
+  // Rather than shim any of that back afterwards, malformed input simply never
+  // reaches the SDK: it is answered by dispatchMessage below, which is the
+  // funnel being KEPT (step 4 deletes the envelope, not this). One cheap
+  // predicate, shared with dispatchMessage itself, makes the flag
+  // behaviour-neutral by construction instead of by inspection.
+  if (mcpSdkEnvelopeEnabled(env) && jsonRpcBodyIsDispatchable(body)) {
+    return serveMcpThroughSdk(request, body, ctx, env);
+  }
+
+  if (Array.isArray(body)) {
     // Dispatch independent batch members concurrently (#2060): JSON-RPC 2.0
     // correlates responses by `id`, not position, and the handlers are read-only
     // over D1/artifacts with no shared mutable `ctx` state, so a batch's

--- a/tests/mcp-sdk-parity.test.ts
+++ b/tests/mcp-sdk-parity.test.ts
@@ -1,108 +1,106 @@
 // Proves the SDK envelope answers what the hand-rolled one answers (#9647).
 //
-// This is the entire justification for step 1 existing as its own PR. The
-// migration is an ENVELOPE SWAP: no tool's behaviour, schema or error shape is
-// meant to change. That claim is either falsifiable or it is a hope, and these
-// tests are what make it falsifiable -- both implementations are driven with
-// the same requests and their published output compared, so a port that
-// changes a response fails here rather than in production.
+// This is the entire justification for the migration shipping behind a flag
+// instead of as a cutover. The claim is that swapping envelopes changes no
+// response: same results, same error codes, same error TEXT, same status, same
+// headers. That claim is either falsifiable or it is a hope.
 //
-// `/mcp` still answers from src/mcp-server.ts. Nothing in this file touches
-// the served path.
+// So these tests drive the REAL SERVED PATH both ways -- handleMcpRequest with
+// MCP_SDK_ENVELOPE unset, then the same request with it set to "1" -- and
+// compare what comes back. An earlier version of this file compared the
+// adapter against the dispatcher through a stub `dispatch`, which proved the
+// adapter could route a method but proved nothing about the wiring around it:
+// the session headers, the CORS headers, the batch guards and the Accept
+// normalization all live in serveMcpThroughSdk and none of them were covered.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { handleMcpRequest, listToolDefinitions } from "../src/mcp-server.ts";
+import {
+  handleMcpRequest,
+  listToolDefinitions,
+  mcpSdkEnvelopeEnabled,
+} from "../src/mcp-server.ts";
 import {
   closeQuietly,
-  mergeInitializeMeta,
+  JsonRpcFailure,
+  SDK_RECLAIMED_METHODS,
   serveWithSdk,
+  unwrapDispatchResponse,
 } from "../src/mcp-sdk-adapter.ts";
 import type { Row } from "./row-type.ts";
 
-const MCP_HEADERS = {
-  "content-type": "application/json",
-  accept: "application/json, text/event-stream",
-};
+const HAND_ROLLED = {} as unknown as Env;
+const SDK = { MCP_SDK_ENVELOPE: "1" } as unknown as Env;
 
-const post = (body: unknown) =>
+const post = (body: unknown, headers: Row = {}) =>
   new Request("https://api.metagraph.sh/mcp", {
     method: "POST",
-    headers: MCP_HEADERS,
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      ...(headers as Record<string, string>),
+    },
     body: JSON.stringify(body),
   });
 
-/** The current server's answer. */
-async function viaHandRolled(body: unknown): Promise<Row> {
-  const res = await handleMcpRequest(post(body), {} as unknown as Env, {});
-  return (await res.json()) as Row;
+/** Everything a caller can observe: status, body, and the headers we set. */
+async function observe(body: unknown, env: Env, headers: Row = {}) {
+  const res = await handleMcpRequest(post(body, headers), env, {});
+  const text = await res.text();
+  const sessionId = res.headers.get("mcp-session-id");
+  return {
+    status: res.status,
+    body: text ? JSON.parse(text) : null,
+    contentType: res.headers.get("content-type"),
+    cors: res.headers.get("access-control-allow-origin"),
+    cacheControl: res.headers.get("cache-control"),
+    // NORMALIZED, not compared: a minted session id is fresh per request, so
+    // comparing the values would fail on every initialize and prove nothing.
+    // What must match is WHETHER one was minted -- session minting reads the
+    // dispatched response, which the SDK path has to capture on its way past
+    // rather than parse back out of a serialized body, and getting that wrong
+    // would silently cost every caller its identity (#9054).
+    sessionMinted: sessionId ? "<minted>" : null,
+  };
 }
 
 /**
- * The SDK's answer.
+ * The core assertion: one request, both envelopes, no observable difference.
  *
- * Parsed as a bare JSON body, deliberately: the adapter sets
- * `enableJsonResponse` so the transport answers the same shape the hand-rolled
- * dispatcher does. If that is ever dropped, the transport falls back to SSE
- * framing (`event: message\ndata: {...}`) and this parse fails -- which is the
- * correct outcome, because a client parsing our responses today would fail the
- * same way.
+ * Returns the shared observation so a caller can additionally assert what the
+ * response actually WAS -- parity with a broken answer is still broken, and a
+ * comparison-only test passes happily when both sides regress together.
  */
-async function viaSdk(
-  body: unknown,
-  dispatch = passthroughDispatch,
-): Promise<Row> {
-  const res = await serveWithSdk(post(body), {
-    tools: listToolDefinitions() as Array<
-      Record<string, unknown> & { name: string }
-    >,
-    dispatch,
-  });
-  return (await res.json()) as Row;
+async function assertParity(body: unknown, headers: Row = {}) {
+  const mine = await observe(body, HAND_ROLLED, headers);
+  const sdk = await observe(body, SDK, headers);
+  assert.deepEqual(sdk, mine);
+  return mine;
 }
 
-/** Stands in for dispatchTool; step 2 replaces it with the real funnel. */
-let dispatched: Array<{ name: string; args: unknown }> = [];
-const passthroughDispatch = async (
-  name: string,
-  args?: Record<string, unknown>,
-) => {
-  dispatched.push({ name, args });
-  return { content: [{ type: "text", text: `ok:${name}` }], isError: false };
-};
-
-describe("SDK envelope parity with the hand-rolled dispatcher (#9647)", () => {
-  test("tools/list publishes the identical catalogue", async () => {
-    const mine = await viaHandRolled({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "tools/list",
-    });
-    const sdk = await viaSdk({ jsonrpc: "2.0", id: 1, method: "tools/list" });
-
-    const a = (mine.result as Row).tools as Row[];
-    const b = (sdk.result as Row).tools as Row[];
-    assert.ok(a.length > 200, `expected the full catalogue, got ${a.length}`);
-    assert.equal(b.length, a.length, "tool count must match");
-
-    // Compared whole, not sampled: a per-tool diff is exactly the thing that
-    // would be missed by checking three of 224.
-    assert.deepEqual(
-      JSON.parse(JSON.stringify(b)),
-      JSON.parse(JSON.stringify(a)),
-      "every published field of every tool must survive the envelope swap",
-    );
+// WITHOUT THIS, EVERY PARITY TEST ABOVE IS VACUOUS. They compare two envs and
+// assert no difference -- which is exactly what a flag that never reads would
+// also produce. This is the test that says the second env really does take the
+// other path.
+describe("the envelope flag (#9647)", () => {
+  test('is off unless MCP_SDK_ENVELOPE is exactly "1"', () => {
+    assert.equal(mcpSdkEnvelopeEnabled(SDK), true, "the parity fixture is on");
+    assert.equal(mcpSdkEnvelopeEnabled(HAND_ROLLED), false);
+    // A flag whose off state depends on a variable being unset is one stray
+    // empty-string binding away from enabling itself in production.
+    for (const value of ["", "0", "true", "yes", " 1", 1, null, undefined]) {
+      assert.equal(
+        mcpSdkEnvelopeEnabled({ MCP_SDK_ENVELOPE: value } as unknown as Env),
+        false,
+        `MCP_SDK_ENVELOPE=${JSON.stringify(value)} must not enable the SDK path`,
+      );
+    }
+    assert.equal(mcpSdkEnvelopeEnabled(undefined as unknown as Env), false);
   });
+});
 
-  // THE WHOLE PAYLOAD, not a field or two. The first version of this test
-  // compared serverInfo.version and protocolVersion and called it "identity" --
-  // which would have passed while silently dropping `instructions` (what tells
-  // a model what this server is FOR), serverInfo.title/description, and the
-  // `_meta` registry backlink. `initialize` is handled INSIDE the SDK's Server
-  // rather than by a handler we register, so every one of those fields has to
-  // arrive through the constructor or a shim, and only a whole-payload compare
-  // proves it did.
-  test("initialize is byte-identical, every field", async () => {
-    const body = {
+describe("SDK envelope parity on the served path (#9647)", () => {
+  test("initialize: every field, plus the registry backlink", async () => {
+    const seen = await assertParity({
       jsonrpc: "2.0",
       id: 1,
       method: "initialize",
@@ -111,71 +109,509 @@ describe("SDK envelope parity with the hand-rolled dispatcher (#9647)", () => {
         capabilities: {},
         clientInfo: { name: "parity", version: "1" },
       },
-    };
-    const mine = (await viaHandRolled(body)).result as Row;
-    const sdk = (await viaSdk(body)).result as Row;
-
-    // Named first so a failure says WHICH field went missing rather than
-    // dumping two large objects at the reader.
-    assert.deepEqual(
-      Object.keys(sdk).sort(),
-      Object.keys(mine).sort(),
-      "the handshake's field set must not change",
-    );
-    for (const key of ["instructions", "protocolVersion"]) {
-      assert.deepEqual(sdk[key], mine[key], `initialize.${key} differs`);
-    }
-    assert.deepEqual(sdk.serverInfo, mine.serverInfo);
-    assert.deepEqual(sdk.capabilities, mine.capabilities);
-    assert.deepEqual(sdk._meta, mine._meta, "the registry backlink survives");
-    assert.deepEqual(sdk, mine);
+    });
+    const result = (seen.body as Row).result as Row;
+    // Asserted positively, not just compared: `instructions` is what tells a
+    // model what this server is for, and `_meta` is the registry backlink.
+    // Both were dropped by an earlier draft of the adapter and a
+    // comparison-only test would have gone green once both sides lost them.
+    assert.ok(result.instructions, "instructions survive the envelope");
+    assert.ok(result._meta, "the registry backlink survives");
+    assert.ok((result.serverInfo as Row).name);
+    assert.equal(seen.sessionMinted, "<minted>", "initialize mints a session");
   });
 
-  test("tools/call reaches the dispatch funnel with the caller's arguments", async () => {
-    dispatched = [];
-    const sdk = await viaSdk({
+  // The value, not just its presence -- and on the SDK path specifically. The
+  // id is minted before dispatch so $mcp_initialize can carry it (#8994), then
+  // read back out of the captured response; a path that captured the wrong
+  // thing would still produce SOME header, so its shape gets asserted too.
+  test("the minted session id is well-formed on both paths", async () => {
+    const body = {
       jsonrpc: "2.0",
       id: 1,
-      method: "tools/call",
-      params: { name: "get_subnet", arguments: { netuid: 64 } },
-    });
-    assert.deepEqual(dispatched, [
-      { name: "get_subnet", args: { netuid: 64 } },
-    ]);
-    assert.equal((sdk.result as Row).isError, false);
+      method: "initialize",
+      params: { protocolVersion: "2025-11-25", capabilities: {} },
+    };
+    for (const env of [HAND_ROLLED, SDK]) {
+      const res = await handleMcpRequest(post(body), env, {});
+      const id = res.headers.get("mcp-session-id");
+      assert.ok(id, "a session id was handed back");
+      assert.match(String(id), /^[\x21-\x7E]{1,128}$/);
+    }
   });
 
-  // The property step 2 depends on: ONE funnel. If the SDK path ever dispatched
-  // somewhere else, the telemetry #8993/#9639/#9642 hang off that single point
-  // would silently stop covering it.
-  test("every tools/call goes through the funnel exactly once", async () => {
-    dispatched = [];
-    for (const name of ["get_subnet", "get_economics", "list_subnets"]) {
-      await viaSdk({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "tools/call",
-        params: { name, arguments: {} },
-      });
-    }
-    assert.equal(dispatched.length, 3);
-    assert.deepEqual(
-      dispatched.map((d) => d.name),
-      ["get_subnet", "get_economics", "list_subnets"],
+  // A FAILED initialize must mint nothing -- an id the client never received
+  // would be a session the hub is holding for nobody.
+  test("a refused request mints no session on either path", async () => {
+    const seen = await assertParity({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "no/such/method",
+    });
+    assert.equal(seen.sessionMinted, null);
+  });
+
+  test("initialize still negotiates a handshake with no protocolVersion", async () => {
+    // The SDK's InitializeRequestSchema REQUIRES params.protocolVersion, so
+    // registering a handler for it would reject this with zod's text. Total
+    // delegation is what keeps it working, and this is the case that proves
+    // the delegation is total rather than merely configured.
+    const seen = await assertParity({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    });
+    assert.ok(
+      ((seen.body as Row).result as Row).protocolVersion,
+      "a sloppy handshake is still negotiated, not refused",
     );
   });
 
-  // Nothing may outlive its request: on Workers an object that survives is
-  // shared with the next caller. Re-running the same request must be clean,
-  // which is also what the transport's own reuse ban is protecting.
-  test("a fresh server and transport per request, with no bleed between them", async () => {
-    const body = { jsonrpc: "2.0", id: 1, method: "tools/list" };
-    const first = await viaSdk(body);
-    const second = await viaSdk(body);
+  test("ping", async () => {
+    const seen = await assertParity({ jsonrpc: "2.0", id: 2, method: "ping" });
+    assert.deepEqual((seen.body as Row).result, {});
+  });
+
+  test("tools/list publishes the identical catalogue", async () => {
+    const seen = await assertParity({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/list",
+    });
+    const tools = ((seen.body as Row).result as Row).tools as Row[];
+    assert.equal(
+      tools.length,
+      listToolDefinitions().length,
+      "the full catalogue, not a page",
+    );
+    assert.ok(tools.length > 200, `expected 200+ tools, saw ${tools.length}`);
+  });
+
+  test("prompts/list and resources/templates/list", async () => {
+    await assertParity({ jsonrpc: "2.0", id: 4, method: "prompts/list" });
+    await assertParity({
+      jsonrpc: "2.0",
+      id: 5,
+      method: "resources/templates/list",
+    });
+  });
+
+  // ERROR TEXT, not just the code. This is the assertion that would have
+  // failed against McpError, whose constructor rewrites every message to
+  // `MCP error -32601: ...`. Parity on the code alone would have passed while
+  // every error string on a public surface silently changed.
+  test("an unknown method: same code AND same message", async () => {
+    const seen = await assertParity({
+      jsonrpc: "2.0",
+      id: 6,
+      method: "no/such/method",
+    });
+    const error = (seen.body as Row).error as Row;
+    assert.equal(error.code, -32601);
+    assert.equal(error.message, "Unknown method: no/such/method");
+  });
+
+  test("a refused tools/list cursor keeps its code and its explanation", async () => {
+    const seen = await assertParity({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/list",
+      params: { cursor: "eyJvIjoxMDB9" },
+    });
+    const error = (seen.body as Row).error as Row;
+    assert.equal(error.code, -32602);
+    assert.match(String(error.message), /not paginated/);
+  });
+
+  test("a notification is answered 202 with no body", async () => {
+    const seen = await assertParity({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+    assert.equal(seen.status, 202);
+    assert.equal(seen.body, null);
+  });
+
+  test("a batch keeps its order and drops its notifications", async () => {
+    const seen = await assertParity([
+      { jsonrpc: "2.0", id: 1, method: "ping" },
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+      { jsonrpc: "2.0", id: 2, method: "prompts/list" },
+    ]);
+    const responses = seen.body as Row[];
+    assert.equal(responses.length, 2, "the notification produced no response");
     assert.deepEqual(
-      (second.result as Row).tools,
-      (first.result as Row).tools,
-      "a reused-transport error would surface as a failed second request",
+      responses.map((r) => r.id),
+      [1, 2],
+    );
+  });
+
+  // The batch ceiling was HOISTED so both envelopes share it (the SDK's
+  // transport fans out with no bound of its own). If it ever slips back inside
+  // the hand-rolled branch, the flag becomes a way to turn off a resource
+  // limit, and this is what says so.
+  test("the batch ceiling applies to both envelopes", async () => {
+    const seen = await assertParity(
+      Array.from({ length: 11 }, (_, i) => ({
+        jsonrpc: "2.0",
+        id: i,
+        method: "ping",
+      })),
+    );
+    assert.equal(seen.status, 400);
+    assert.match(String(((seen.body as Row).error as Row).message), /maximum/);
+  });
+
+  test("an empty batch is refused identically", async () => {
+    const seen = await assertParity([]);
+    assert.equal(seen.status, 400);
+  });
+
+  // Most callers of this surface are scripts sending `*/*`, which fails the
+  // SDK transport's literal substring test for both media types. Normalizing
+  // the rebuilt request is what stops the migration presenting as "every
+  // script broke", so it gets a test of its own rather than riding on the
+  // default headers every other case here sends.
+  test("a caller sending Accept: */* is not 406'd", async () => {
+    const seen = await assertParity(
+      { jsonrpc: "2.0", id: 8, method: "ping" },
+      { accept: "*/*" },
+    );
+    assert.equal(seen.status, 200);
+    assert.deepEqual((seen.body as Row).result, {});
+  });
+
+  test("a caller sending no Accept header at all is not 406'd", async () => {
+    // Built by hand rather than through post(), which always supplies a
+    // conformant Accept -- passing `{}` for the overrides would have left the
+    // default in place and tested nothing.
+    const bare = () =>
+      new Request("https://api.metagraph.sh/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 9, method: "ping" }),
+      });
+    assert.equal(bare().headers.get("accept"), null, "the fixture is bare");
+    for (const env of [HAND_ROLLED, SDK]) {
+      const res = await handleMcpRequest(bare(), env, {});
+      assert.equal(res.status, 200);
+      assert.deepEqual(((await res.json()) as Row).result, {});
+    }
+  });
+
+  // tools/call, through the real dispatcher. Every one of these answers
+  // isError rather than a JSON-RPC error (SEP-1303, and #9646 for the unknown
+  // tool), which makes them the cases where a divergence would be least
+  // visible: the transport-level envelope is identical either way and the
+  // difference would be buried in the result body.
+  test("tools/call results, including both failure shapes", async () => {
+    for (const params of [
+      { name: "get_agent_catalog", arguments: {} },
+      { name: "nope", arguments: {} },
+      { name: "get_subnet", arguments: { netuid: "not-a-number" } },
+    ]) {
+      const seen = await assertParity({
+        jsonrpc: "2.0",
+        id: 11,
+        method: "tools/call",
+        params,
+      });
+      assert.ok((seen.body as Row).result, `${params.name} answered a result`);
+    }
+  });
+
+  // EVERY CASE BELOW WAS A MEASURED DIVERGENCE before the dispatchable-message
+  // gate (#9647). The SDK transport answers all of them
+  // `400 -32700 Parse error: Invalid JSON-RPC message`; this server answers
+  // -32600 inside a 200, or 202 for an id-less one. Left ungated, flipping the
+  // flag would have changed the error code, the HTTP status and -- for the
+  // mixed batch -- whether the valid members ran at all.
+  describe("malformed input never reaches the SDK", () => {
+    for (const [label, body] of [
+      ["a wrong jsonrpc version", { jsonrpc: "1.0", id: 1, method: "ping" }],
+      ["a missing method", { jsonrpc: "2.0", id: 1 }],
+      ["a non-string method", { jsonrpc: "2.0", id: 1, method: 5 }],
+    ] as Array<[string, unknown]>) {
+      test(`${label} stays -32600 inside a 200`, async () => {
+        const seen = await assertParity(body);
+        assert.equal(seen.status, 200);
+        assert.equal((seen.body as Row).error.code, -32600);
+        assert.equal(
+          (seen.body as Row).error.message,
+          "Invalid JSON-RPC request.",
+        );
+      });
+    }
+
+    for (const [label, body] of [
+      ["a null body", null],
+      ["a scalar body", 42],
+    ] as Array<[string, unknown]>) {
+      test(`${label} stays 202`, async () => {
+        const seen = await assertParity(body);
+        assert.equal(seen.status, 202);
+        assert.equal(seen.body, null);
+      });
+    }
+
+    // The one that loses data rather than merely relabelling it.
+    test("a mixed batch still answers its valid members", async () => {
+      const seen = await assertParity([
+        { jsonrpc: "2.0", id: 1, method: "ping" },
+        { jsonrpc: "1.0", id: 2, method: "ping" },
+      ]);
+      assert.equal(seen.status, 200);
+      const responses = seen.body as Row[];
+      assert.deepEqual(responses[0], {
+        jsonrpc: "2.0",
+        id: 1,
+        result: {},
+      });
+      assert.equal((responses[1].error as Row).code, -32600);
+    });
+
+    test("a body that is not JSON at all is refused identically", async () => {
+      const res = await Promise.all(
+        [HAND_ROLLED, SDK].map(async (env) => {
+          const r = await handleMcpRequest(
+            new Request("https://api.metagraph.sh/mcp", {
+              method: "POST",
+              headers: {
+                "content-type": "application/json",
+                accept: "application/json, text/event-stream",
+              },
+              body: "{not json",
+            }),
+            env,
+            {},
+          );
+          return { status: r.status, body: await r.text() };
+        }),
+      );
+      assert.deepEqual(res[1], res[0]);
+      assert.equal(res[0].status, 400);
+    });
+  });
+
+  // The headers the transport does NOT set. It emits a bare
+  // `content-type: application/json` and nothing at all on a 202, so without
+  // the MCP_HEADERS overlay the CORS header and `cache-control: no-store`
+  // would vanish the moment the flag flipped -- a caching change and a
+  // browser-client breakage with nothing to do with JSON-RPC.
+  test("CORS and cache-control survive both envelopes", async () => {
+    for (const body of [
+      { jsonrpc: "2.0", id: 10, method: "ping" },
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+    ]) {
+      const seen = await assertParity(body);
+      assert.equal(seen.cors, "*");
+      assert.equal(seen.cacheControl, "no-store");
+      assert.equal(seen.contentType, "application/json; charset=utf-8");
+    }
+  });
+});
+
+// INVISIBLE TO A RESPONSE COMPARISON, which is why it gets its own test. The
+// SDK's Protocol dispatches notifications fire-and-forget, so the 202 returns
+// while the handler is still running; on Workers the request context is then
+// torn down with the telemetry write unfinished. Every parity test above
+// passes either way -- the HTTP response is identical -- and the only symptom
+// would have been notifications/initialized quietly disappearing from PostHog
+// after the flag flipped.
+describe("a notification's dispatch completes before the response (#9647)", () => {
+  test("the funnel has finished, not merely started, when serveWithSdk resolves", async () => {
+    const events: string[] = [];
+    await serveWithSdk(
+      new Request("https://x/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+        }),
+      }),
+      {
+        serverInfo: { name: "n", version: "1" },
+        capabilities: { tools: {} },
+        dispatch: async (message) => {
+          events.push(`start:${message.method}`);
+          // Stands in for the PostHog write dispatchMessage's `finally` makes:
+          // a real await, so "started" and "finished" are distinguishable.
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          events.push(`done:${message.method}`);
+          return null;
+        },
+      },
+    );
+    assert.deepEqual(events, [
+      "start:notifications/initialized",
+      "done:notifications/initialized",
+    ]);
+  });
+
+  test("a rejecting notification dispatch never becomes the response", async () => {
+    const res = await serveWithSdk(
+      new Request("https://x/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+        }),
+      }),
+      {
+        serverInfo: { name: "n", version: "1" },
+        capabilities: { tools: {} },
+        dispatch: async () => {
+          throw new Error("telemetry backend is down");
+        },
+      },
+    );
+    assert.equal(res.status, 202, "the caller still gets its 202");
+  });
+});
+
+// A method the SDK still owns is a method dispatchMessage never sees, and so a
+// method that silently stops being counted -- initialize most of all, which
+// carries the client attribution (#8994) and the session identity (#9054).
+// The adapter reclaims them by name through public API; this proves the list
+// is COMPLETE, by reflection, so an SDK upgrade that registers a new handler
+// fails here instead of quietly going dark in PostHog.
+describe("the SDK owns no method (#9647)", () => {
+  test("nothing remains registered after the reclaim", async () => {
+    const seen: string[] = [];
+    await serveWithSdk(
+      new Request("https://x/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+      }),
+      {
+        serverInfo: { name: "reflect", version: "1" },
+        capabilities: {
+          tools: {},
+          resources: { subscribe: true },
+          prompts: {},
+        },
+        dispatch: async (message) => {
+          seen.push(String(message.method));
+          return { jsonrpc: "2.0", id: message.id, result: {} };
+        },
+      },
+    );
+    assert.deepEqual(seen, ["ping"], "ping reached our funnel, not the SDK's");
+
+    // The reflective half: build the same Server the adapter builds, reclaim
+    // the same names, and assert the SDK's own registries are empty. Reaching
+    // into private state is right here and wrong in production -- a gate may
+    // know more about its dependency than the code it guards.
+    const { Server } =
+      await import("@modelcontextprotocol/sdk/server/index.js");
+    const probe = new Server(
+      { name: "reflect", version: "1" },
+      {
+        capabilities: {
+          tools: {},
+          resources: { subscribe: true },
+          prompts: {},
+        },
+      },
+    ) as unknown as {
+      _requestHandlers: Map<string, unknown>;
+      _notificationHandlers: Map<string, unknown>;
+      removeRequestHandler: (m: string) => void;
+      removeNotificationHandler: (m: string) => void;
+    };
+    for (const m of SDK_RECLAIMED_METHODS.requests) {
+      probe.removeRequestHandler(m);
+    }
+    for (const m of SDK_RECLAIMED_METHODS.notifications) {
+      probe.removeNotificationHandler(m);
+    }
+    assert.deepEqual(
+      [...probe._requestHandlers.keys()],
+      [],
+      "the SDK still answers a request method our funnel never sees",
+    );
+    assert.deepEqual(
+      [...probe._notificationHandlers.keys()],
+      [],
+      "the SDK still absorbs a notification our funnel never counts",
+    );
+  });
+});
+
+// The one place the two envelopes' conventions are translated, and so the one
+// place a mistranslation could hide.
+describe("unwrapDispatchResponse (#9647)", () => {
+  test("returns the result of a successful response", () => {
+    assert.deepEqual(
+      unwrapDispatchResponse({ jsonrpc: "2.0", id: 1, result: { ok: true } }),
+      { ok: true },
+    );
+  });
+
+  test("returns a falsy result rather than mistaking it for an error", () => {
+    // `result: {}` is what ping answers; an `if (response.result)` test would
+    // have thrown on it.
+    assert.deepEqual(
+      unwrapDispatchResponse({ jsonrpc: "2.0", id: 1, result: {} }),
+      {},
+    );
+  });
+
+  test("throws the error verbatim, with no prefix added", () => {
+    assert.throws(
+      () =>
+        unwrapDispatchResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          error: { code: -32602, message: "Invalid params." },
+        }),
+      (error: JsonRpcFailure) => {
+        assert.equal(error.code, -32602);
+        assert.equal(error.message, "Invalid params.");
+        return true;
+      },
+    );
+  });
+
+  test("carries `data` through when the error has one", () => {
+    assert.throws(
+      () =>
+        unwrapDispatchResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          error: { code: -32602, message: "no", data: { field: "netuid" } },
+        }),
+      (error: JsonRpcFailure) => {
+        assert.deepEqual(error.data, { field: "netuid" });
+        return true;
+      },
+    );
+  });
+
+  // A handler returning undefined publishes `{"result":undefined}`, which
+  // JSON.stringify drops -- a reply with neither result nor error. Unreachable
+  // through dispatchMessage, and deliberately loud rather than silent.
+  test("refuses to publish a response that is neither", () => {
+    assert.throws(
+      () => unwrapDispatchResponse(null),
+      (error: JsonRpcFailure) => {
+        assert.equal(error.code, -32603);
+        assert.equal(error.message, "Internal error.");
+        return true;
+      },
     );
   });
 });
@@ -209,54 +645,5 @@ describe("closeQuietly (#9668)", () => {
       },
     });
     assert.equal(closed, true);
-  });
-});
-
-// The shim restoring the one initialize field the SDK drops. Narrow by design:
-// a compatibility patch that can turn a valid response into an invalid one is
-// worse than the gap it closes, so every guard is exercised.
-describe("mergeInitializeMeta (#9668)", () => {
-  const initResult = (extra: Row = {}) =>
-    JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      result: {
-        protocolVersion: "2025-11-25",
-        serverInfo: { name: "x" },
-        ...extra,
-      },
-    });
-
-  test("adds _meta to an initialize result that lacks it", () => {
-    const out = JSON.parse(mergeInitializeMeta(initResult())) as Row;
-    assert.ok((out.result as Row)._meta, "the registry backlink is restored");
-  });
-
-  test("never overwrites a _meta the SDK did produce", () => {
-    const out = JSON.parse(
-      mergeInitializeMeta(initResult({ _meta: { mine: true } })),
-    ) as Row;
-    assert.deepEqual((out.result as Row)._meta, { mine: true });
-  });
-
-  // Anything that is not an initialize result must come back untouched --
-  // byte-identical, not merely equivalent, since this runs on every response.
-  test("leaves a non-initialize payload byte-identical", () => {
-    for (const body of [
-      JSON.stringify({ jsonrpc: "2.0", id: 1, result: { tools: [] } }),
-      JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        error: { code: -32602, message: "no" },
-      }),
-      JSON.stringify([{ jsonrpc: "2.0", id: 1, result: {} }]),
-      "",
-    ]) {
-      assert.equal(mergeInitializeMeta(body), body);
-    }
-  });
-
-  test("returns unparseable input unchanged rather than throwing", () => {
-    assert.equal(mergeInitializeMeta("{not json"), "{not json");
   });
 });


### PR DESCRIPTION
## Summary

Routes `/mcp` through `@modelcontextprotocol/sdk`'s `Server` + `WebStandardStreamableHTTPServerTransport` behind a **default-off** `MCP_SDK_ENVELOPE` flag. Nothing changes in production until the flag is set; the point of shipping it dark is that flipping it — and flipping it back — is a config change rather than a deploy, on the surface with the most external callers.

The SDK takes the **envelope only**: JSON-RPC parse, batch fan-out and correlation, 202-on-notification, JSON/SSE framing. Every method still resolves through `dispatchMessage`, so the single instrumentation chokepoint (#8993, #8994, #9054, #9639, #9642) is untouched.

## Total delegation

`initialize` and `ping` are reclaimed with `removeRequestHandler`, so **no** method is answered by the SDK. Three reasons, each of which was a real defect in the partial-delegation draft:

- **telemetry** — `dispatchMessage`'s `finally` emits the protocol usage event for every method. A method the SDK answered internally is a method that silently stops being counted, `initialize` most of all.
- **validation** — `setRequestHandler` wraps a handler in a zod parse of the SDK's own schema. Registering one for `initialize` would reject a handshake with no `protocolVersion` that we negotiate today, and answer with zod's text.
- **drift** — one funnel is the property the whole instrumentation story rests on.

## Six divergences, zero response shims

Found by running the SDK, not reading it:

| Divergence | Resolution |
|---|---|
| `initialize._meta` (registry backlink) dropped | total delegation returns our result verbatim |
| A thrown handler leaks its message as `-32603` | `dispatchMessage` returns, never throws |
| `McpError` rewrites text to `MCP error -N: …` | `JsonRpcFailure` carries a `code` the SDK serialises as-is |
| Transport 406s any `Accept` lacking both media types | normalized on the rebuilt request |
| Transport sets a bare `content-type`, nothing on 202 | `MCP_HEADERS` overlaid — CORS and `no-store` survive |
| Malformed input → `400 -32700` for the whole request | gated: the SDK never sees a bad message |

The `Accept` one would have presented as *"the migration broke every script"* — most traffic here is `curl`/`python-requests` sending `*/*`, which fails the transport's literal substring test.

The malformed-input one loses data rather than relabelling it: a batch with one bad member currently answers the valid ones, where the SDK rejects the batch whole. Ours is also the more spec-correct classification, since `-32700` is reserved for JSON that did not parse. So malformed input is routed away from the SDK rather than shimmed back.

The batch ceiling moves out of the hand-rolled branch so both envelopes share it — the transport fans out with no bound of its own, and a flag that swaps envelopes must not also remove a resource limit.

`mergeInitializeMeta` is **deleted**, not left behind: total delegation makes it unreachable.

## Verification

- `tests/mcp-sdk-parity.test.ts` — 32 tests driving the **real served path** (`handleMcpRequest`, flag off then on) across every method, both `tools/call` failure shapes, malformed input, batches, headers and status codes. The previous version compared the adapter against the dispatcher through a stub, which proved nothing about the wiring around it.
- A **flag test** guards the whole file against passing vacuously — two envs that both take the hand-rolled path would compare equal too.
- Sabotage-checked: altering the error text, the `Accept` normalization, and the header overlay each fail the harness.

```
npx tsc --noEmit                 clean
npm run validate                 129 subnets, 3442 surfaces, 136 providers
npx vitest run tests/            703 files, 17014 tests, all passing
patch coverage (diff ∩ v8)       statements 42/42, branches 20/20 — 100%
```

## Not in scope

Deleting the hand-rolled envelope (#9647 step 4) stays open until the flag has been on through a full deploy cycle.

Closes #9676
Refs #9647

---

### Update: a seventh divergence, found reviewing my own diff

**The SDK dispatches notifications fire-and-forget.** `Protocol._onnotification` runs the handler as `Promise.resolve().then(() => handler(n))` and never awaits it, so the 202 returns while the handler is mid-flight — and on Workers the request context is then torn down with the telemetry write unfinished.

Measured: at response time the dispatch had **started and not completed**.

This is invisible to a response comparison — every parity test above passes either way, because the HTTP response is byte-identical. The only symptom would have been `notifications/initialized` quietly disappearing from PostHog some time after the flag flipped, with nothing pointing at the cause.

Fixed by draining pending notification dispatches before answering (`allSettled`, so a failing telemetry write can never become the caller's response), with two tests: one asserting the funnel *finished* rather than merely started, one asserting a rejecting dispatch still yields a 202. Both sabotage-checked.

### And an eighth gap — in my own harness

`observe()` compared status, body, `content-type`, CORS and `cache-control`, but **not `mcp-session-id`**. Session minting reads the dispatched response, which the SDK path has to capture on its way past rather than parse back out of a serialized body — so getting it wrong would have cost every caller its identity (#9054) with nothing in the suite objecting.

Now asserted three ways: that a successful `initialize` mints on both paths, that the id is well-formed (`[\x21-\x7E]{1,128}`), and that a refused request mints nothing — an id the client never received would be a session the hub holds for nobody. Sabotage-checked by breaking the capture: three tests fail.
