### PR TITLE
feat(queue): accept chain-detail's four row families in one message

### DIFF
--- a/src/sync-batch-queue.ts
+++ b/src/sync-batch-queue.ts
@@ -46,6 +46,21 @@ export interface SyncBatchMessage {
   pass_total?: number;
   rows: Record<string, unknown>[];
   /**
+   * Several row families that must land in ONE write (metagraphed-infra#359).
+   *
+   * `chain-detail` posts blocks, extrinsics, chain events and account events
+   * together because a block and its extrinsics landing separately is a
+   * readable-but-wrong state -- the drill-down shows a block with no calls. One
+   * `rows` array cannot express that, and splitting the lane into four messages
+   * would let the four retry independently, which is exactly the property the
+   * single POST exists to prevent.
+   *
+   * OPTIONAL, AND MUTUALLY EXCLUSIVE WITH `rows`. Every existing lane carries
+   * one array and is untouched by this; only a lane that declares `families`
+   * uses it, so widening the wire format costs the other lanes nothing.
+   */
+  families?: Record<string, Record<string, unknown>[]>;
+  /**
    * "Every row for each KEY named in this message is IN this message."
    *
    * Only a pruning lane needs it, and only because its write DELETES: the
@@ -172,6 +187,29 @@ export const SYNC_BATCH_MAX_BYTES = 96 * 1024;
  * `packSyncBatchMessages` throws rather than emitting an unsafe message -- the
  * failure it would otherwise cause is deleted rows, which no retry undoes.
  */
+/**
+ * Lanes whose write covers SEVERAL row families that must land together
+ * (metagraphed-infra#359).
+ *
+ * An allowlist rather than "any lane may send families", for the same reason
+ * SYNC_BATCH_LANES is one: the consumer has to know how to write what arrives,
+ * and a family name it does not recognise is a table it would have to guess at.
+ */
+export const MULTI_FAMILY_LANES: readonly string[] = ["chain-detail"];
+
+/** The family names each multi-family lane may send. A name outside this list
+ * is refused rather than written to a guessed table. */
+export const MULTI_FAMILY_LANE_ROW_FAMILIES: Readonly<
+  Record<string, readonly string[]>
+> = {
+  "chain-detail": [
+    "blockRows",
+    "extrinsicRows",
+    "chainEventRows",
+    "accountEventRows",
+  ],
+};
+
 export const PRUNING_LANE_KEYS: Readonly<Record<string, string>> = {
   "nominator-positions": "coldkey",
   neurons: "netuid",
@@ -317,6 +355,59 @@ export function packSyncBatchMessages(input: {
   return messages;
 }
 
+/**
+ * Pack one multi-family chunk (metagraphed-infra#359).
+ *
+ * ALL FAMILIES IN ONE MESSAGE OR NONE. Splitting them by byte budget the way
+ * `packSyncBatchMessages` splits rows would defeat the point: a block and its
+ * extrinsics arriving in two messages can retry independently, and the
+ * intermediate state -- a block whose drill-down shows no calls -- is readable
+ * and wrong. So an oversize chunk THROWS rather than degrading into the split
+ * this shape exists to prevent.
+ *
+ * That is a real constraint, not a hypothetical: the producer batches 2 blocks
+ * per POST at ~350-662 KiB, which is over the 128 KB cap. The producer has to
+ * post smaller batches for this lane to move -- and a loud error at the
+ * boundary is how that gets discovered, rather than a silently split write.
+ */
+export function packMultiFamilyMessage(input: {
+  lane: SyncBatchLane;
+  capturedAt: number;
+  passTotal?: number;
+  families: Record<string, Record<string, unknown>[]>;
+  maxBytes?: number;
+}): SyncBatchMessage {
+  const {
+    lane,
+    capturedAt,
+    passTotal,
+    families,
+    maxBytes = SYNC_BATCH_MAX_BYTES,
+  } = input;
+  const message: SyncBatchMessage = {
+    lane,
+    captured_at: capturedAt,
+    ...(passTotal !== undefined ? { pass_total: passTotal } : {}),
+    families,
+  } as SyncBatchMessage;
+  // `rows` is absent by construction here; the validator refuses a message
+  // carrying both, so the type's required `rows` is deliberately not set.
+  delete (message as { rows?: unknown }).rows;
+
+  const bytes = JSON.stringify(message).length;
+  if (bytes > maxBytes) {
+    const counts = Object.entries(families)
+      .map(([name, rows]) => `${name}=${rows.length}`)
+      .join(", ");
+    throw new Error(
+      `sync-batches: ${lane} multi-family message is ${bytes} bytes (${counts}), ` +
+        `over the ${maxBytes}-byte budget; these families must land together, ` +
+        `so the PRODUCER must post a smaller batch rather than this splitting them`,
+    );
+  }
+  return message;
+}
+
 /** The structural slice of a Queue binding the enqueue path uses, so a test can
  * hand it a plain object rather than stand up a binding. */
 export interface SyncBatchQueue {
@@ -379,6 +470,34 @@ export function validSyncBatchMessage(body: unknown): body is SyncBatchMessage {
     (!Number.isInteger(m.pass_total) || m.pass_total <= 0)
   ) {
     return false;
+  }
+  // A multi-family message carries `families` INSTEAD of `rows`. Accepting both
+  // would leave the writer to guess which one is authoritative, and a lane that
+  // sent both would write one of them silently.
+  if (m.families !== undefined) {
+    if (m.rows !== undefined) return false;
+    if (!MULTI_FAMILY_LANES.includes(m.lane)) return false;
+    const families = m.families as Record<string, unknown> | null;
+    if (!families || typeof families !== "object" || Array.isArray(families)) {
+      return false;
+    }
+    const names = Object.keys(families);
+    if (names.length === 0) return false;
+    const expected = MULTI_FAMILY_LANE_ROW_FAMILIES[m.lane];
+    let total = 0;
+    for (const name of names) {
+      if (expected && !expected.includes(name)) return false;
+      const rows = families[name];
+      if (!Array.isArray(rows)) return false;
+      if (!rows.every((r) => r !== null && typeof r === "object")) return false;
+      total += rows.length;
+    }
+    // The row ceiling is on the WHOLE message, not per family: the transport
+    // caps the payload, and four families of 5,000 is 20,000 rows in one
+    // message however it is spelled.
+    if (total === 0 || total > SYNC_BATCH_MAX_ROWS) return false;
+    if (m.pass_total !== undefined && m.pass_total < total) return false;
+    return true;
   }
   if (!Array.isArray(m.rows) || m.rows.length === 0) return false;
   // A pruning lane must SAY its chunk is key-complete. Refusing here beats
@@ -456,11 +575,22 @@ export type SyncBatchWriter = (
   pass: PassTally | null,
 ) => Promise<unknown>;
 
+/** A multi-family lane's writer. Separate from SyncBatchWriter rather than a
+ * union, so a lane cannot be wired to the wrong one by accident: the type says
+ * which shape it consumes. */
+export type SyncBatchFamilyWriter = (
+  families: Record<string, Record<string, unknown>[]>,
+  pass: PassTally | null,
+) => Promise<unknown>;
+
 /** Lane -> its D1 writer. PARTIAL on purpose: a lane may be accepted by the
  * validator before its writer is wired, and writeSyncBatch throws rather than
  * silently skipping so a half-migrated lane fails loudly instead of leaving a
  * pass that never completes. */
 export type SyncBatchWriters = Partial<Record<SyncBatchLane, SyncBatchWriter>>;
+export type SyncBatchFamilyWriters = Partial<
+  Record<SyncBatchLane, SyncBatchFamilyWriter>
+>;
 
 /** The completeness tally a chunk carries, when its producer declared one. */
 export interface PassTally {
@@ -488,9 +618,22 @@ export function passTallyFor(
   return {
     capturedAt: message.captured_at,
     expectedRows: message.pass_total,
-    receivedRows: message.rows.length,
+    // A multi-family message delivers the SUM of its families. Counting only
+    // `rows` there would credit zero and the pass would never close.
+    receivedRows: syncBatchRowCount(message),
     nowMs,
   };
+}
+
+/** How many rows a message actually carries, whichever shape it uses. */
+export function syncBatchRowCount(message: SyncBatchMessage): number {
+  if (message.families) {
+    return Object.values(message.families).reduce(
+      (n, rows) => n + rows.length,
+      0,
+    );
+  }
+  return message.rows?.length ?? 0;
 }
 
 /** Dispatch one validated message to its lane's writer. Separated from the
@@ -499,7 +642,21 @@ export async function writeSyncBatch(
   message: SyncBatchMessage,
   writers: SyncBatchWriters,
   nowMs: number = Date.now(),
+  familyWriters: SyncBatchFamilyWriters = {},
 ): Promise<void> {
+  if (message.families) {
+    const familyWriter = familyWriters[message.lane as SyncBatchLane];
+    if (!familyWriter) {
+      throw new Error(
+        `sync-batches: no family writer for lane ${message.lane}`,
+      );
+    }
+    // ONE CALL, so the families land in one D1 batch -- which is the entire
+    // reason they travel together. Writing them in a loop here would restore
+    // the split the message shape exists to prevent.
+    await familyWriter(message.families, passTallyFor(message, nowMs));
+    return;
+  }
   const writer = writers[message.lane as SyncBatchLane];
   if (!writer) {
     // Unreachable given validSyncBatchMessage's allowlist, and thrown rather

--- a/tests/sync-batch-queue.test.ts
+++ b/tests/sync-batch-queue.test.ts
@@ -15,7 +15,9 @@ import { describe, test } from "vitest";
 import {
   classifySyncBatch,
   enqueueSyncBatch,
+  packMultiFamilyMessage,
   packSyncBatchMessages,
+  syncBatchRowCount,
   QUEUE_MESSAGE_MAX_BYTES,
   SYNC_BATCH_LANES,
   SYNC_BATCH_MAX_ROWS,
@@ -628,5 +630,171 @@ describe("packSyncBatchMessages: neurons (metagraphed-infra#357)", () => {
     assert.equal(validSyncBatchMessage(message), true);
     const { key_complete: _drop, ...unclaimed } = message!;
     assert.equal(validSyncBatchMessage(unclaimed), false);
+  });
+});
+
+describe("multi-family messages (metagraphed-infra#359)", () => {
+  // chain-detail posts four row families in one request because they must land
+  // in one write: a block whose drill-down shows no calls is readable and
+  // wrong. `rows` cannot express that, and four independent messages would let
+  // the families retry apart -- exactly the state the single POST prevents.
+  const families = (n: number) => ({
+    blockRows: Array.from({ length: n }, (_, i) => ({ number: i })),
+    extrinsicRows: Array.from({ length: n }, (_, i) => ({ hash: `0x${i}` })),
+    chainEventRows: [{ kind: "x" }],
+    accountEventRows: [{ account: "5A" }],
+  });
+
+  test("carries families instead of rows, and validates", () => {
+    const m = packMultiFamilyMessage({
+      lane: "chain-detail",
+      capturedAt: 1_785_970_245_474,
+      families: families(2),
+    });
+    assert.equal("rows" in m, false, "families REPLACE rows, never accompany");
+    assert.equal(validSyncBatchMessage(m), true);
+    assert.deepEqual(Object.keys(m.families!).sort(), [
+      "accountEventRows",
+      "blockRows",
+      "chainEventRows",
+      "extrinsicRows",
+    ]);
+  });
+
+  test("the row count is the SUM, so the pass tally can close", () => {
+    // Counting only `rows` would credit zero and a declared pass would never
+    // reach its total.
+    const m = packMultiFamilyMessage({
+      lane: "chain-detail",
+      capturedAt: 1,
+      passTotal: 6,
+      families: families(2),
+    });
+    assert.equal(syncBatchRowCount(m), 6);
+    assert.equal(passTallyFor(m, 0)!.receivedRows, 6);
+  });
+
+  test("refuses a message carrying BOTH shapes", () => {
+    // Which one is authoritative? Accepting both leaves the writer to guess,
+    // and a lane sending both would have one silently dropped.
+    assert.equal(
+      validSyncBatchMessage({
+        lane: "chain-detail",
+        captured_at: 1,
+        rows: [{ a: 1 }],
+        families: families(1),
+      }),
+      false,
+    );
+  });
+
+  test("refuses families from a lane that does not declare them", () => {
+    assert.equal(
+      validSyncBatchMessage({
+        lane: "hotkey-alpha",
+        captured_at: 1,
+        families: { blockRows: [{ a: 1 }] },
+      }),
+      false,
+    );
+  });
+
+  test("refuses a family name the consumer would have to guess a table for", () => {
+    assert.equal(
+      validSyncBatchMessage({
+        lane: "chain-detail",
+        captured_at: 1,
+        families: { mysteryRows: [{ a: 1 }] },
+      }),
+      false,
+    );
+  });
+
+  test("refuses an empty family set, and non-array families", () => {
+    for (const bad of [{}, { blockRows: "nope" }, { blockRows: [1, 2] }]) {
+      assert.equal(
+        validSyncBatchMessage({
+          lane: "chain-detail",
+          captured_at: 1,
+          families: bad,
+        }),
+        false,
+        JSON.stringify(bad),
+      );
+    }
+  });
+
+  test("THROWS rather than splitting an oversize chunk", () => {
+    // The families must land together, so there is no correct way to split
+    // them here. The producer has to post a smaller batch -- and this error is
+    // how that gets discovered, instead of a silently split write.
+    assert.throws(
+      () =>
+        packMultiFamilyMessage({
+          lane: "chain-detail",
+          capturedAt: 1,
+          families: families(5_000),
+        }),
+      /must land together/,
+    );
+  });
+
+  test("the producer's CURRENT batch does not fit, and that is the finding", () => {
+    // chain-detail batches 2 blocks per POST at ~350-662 KiB (workers/data-api.ts
+    // header). The cap is 128 KB. So this lane cannot be cut over until the
+    // producer posts smaller batches -- asserting it here means the constraint
+    // is recorded in the code rather than rediscovered at cutover.
+    const bigBatch = {
+      blockRows: [{ number: 1, blob: "x".repeat(200_000) }],
+      extrinsicRows: [],
+      chainEventRows: [],
+      accountEventRows: [],
+    };
+    assert.throws(
+      () =>
+        packMultiFamilyMessage({
+          lane: "chain-detail",
+          capturedAt: 1,
+          families: bigBatch,
+        }),
+      /over the \d+-byte budget/,
+    );
+  });
+
+  test("writeSyncBatch routes a family message to the family writer", async () => {
+    const seen: Record<string, unknown>[] = [];
+    await writeSyncBatch(
+      packMultiFamilyMessage({
+        lane: "chain-detail",
+        capturedAt: 1,
+        families: families(1),
+      }),
+      {},
+      1,
+      {
+        "chain-detail": async (f) => {
+          seen.push(f as Record<string, unknown>);
+        },
+      },
+    );
+    assert.equal(seen.length, 1, "ONE call -- one D1 batch, not four writes");
+    assert.equal((seen[0]!.blockRows as unknown[]).length, 1);
+  });
+
+  test("throws when no family writer is wired, rather than skipping", async () => {
+    // A silently skipped lane is a pass that never completes.
+    await assert.rejects(
+      writeSyncBatch(
+        packMultiFamilyMessage({
+          lane: "chain-detail",
+          capturedAt: 1,
+          families: families(1),
+        }),
+        {},
+        1,
+        {},
+      ),
+      /no family writer for lane chain-detail/,
+    );
   });
 });

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -416,6 +416,8 @@ import { recordLaneVerdict } from "../src/lane-health.ts";
 import {
   classifySyncBatch,
   enqueueSyncBatch,
+  packMultiFamilyMessage,
+  type SyncBatchFamilyWriters,
   syncLaneUsesQueue,
   validSyncBatchMessage,
   writeSyncBatch,
@@ -798,6 +800,43 @@ async function handleChainDetailSync(request: Request, env: Env) {
   // ordering, and the same reason, as handleNeuronsSync above.
   if (!env.METAGRAPH_HEALTH_DB) {
     return writeJson({ error: "d1 binding unavailable" }, 503);
+  }
+
+  // Enqueue or write, never both -- see handleHotkeyAlphaSync's own note.
+  //
+  // FOUR FAMILIES, ONE MESSAGE (metagraphed-infra#359). blocks, extrinsics,
+  // chain events and account events are posted together because they must land
+  // together: a block whose drill-down shows no calls is readable and wrong.
+  // packMultiFamilyMessage refuses to split them, so an oversize batch throws
+  // here rather than silently becoming the split this shape exists to prevent.
+  if (syncLaneUsesQueue(env, "chain-detail")) {
+    try {
+      await env.SYNC_BATCHES!.send(
+        packMultiFamilyMessage({
+          lane: "chain-detail",
+          capturedAt: Date.now(),
+          families: {
+            blockRows: batch.rows.blockRows,
+            extrinsicRows: batch.rows.extrinsicRows,
+            chainEventRows: batch.rows.chainEventRows,
+            accountEventRows: batch.rows.accountEventRows,
+          },
+        }),
+      );
+    } catch (err) {
+      console.error("data-api chain-detail enqueue failed:", err);
+      await captureDataApiError(err, "chain-detail-sync-queue", env);
+      return writeJson({ error: "enqueue failed" }, 502);
+    }
+    return writeJson({
+      ok: true,
+      blocks_written: batch.rows.blockRows.length,
+      extrinsics_written: batch.rows.extrinsicRows.length,
+      chain_events_written: batch.rows.chainEventRows.length,
+      account_events_written: batch.rows.accountEventRows.length,
+      head: batch.rows.head,
+      stores: ["queue"],
+    });
   }
 
   let statements: number;
@@ -7271,6 +7310,25 @@ export default {
     // WRITES NOW, per message (metagraphed-infra#348). Per message rather than
     // per batch so one bad chunk is retried alone instead of dragging its nine
     // neighbours through the retry budget with it.
+    // ONE CALL per message, so the four families land in a single D1 batch --
+    // writeChainDetailToD1 already does that, which is why this is a straight
+    // hand-off rather than four writes.
+    const familyWriters: SyncBatchFamilyWriters = env.METAGRAPH_HEALTH_DB
+      ? {
+          "chain-detail": (families) =>
+            writeChainDetailToD1(
+              env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+                typeof writeChainDetailToD1
+              >[0],
+              {
+                blockRows: families.blockRows ?? [],
+                extrinsicRows: families.extrinsicRows ?? [],
+                chainEventRows: families.chainEventRows ?? [],
+                accountEventRows: families.accountEventRows ?? [],
+              } as Parameters<typeof writeChainDetailToD1>[1],
+            ),
+        }
+      : {};
     const writers: SyncBatchWriters = env.METAGRAPH_HEALTH_DB
       ? {
           "hotkey-alpha": (rows, pass) =>
@@ -7328,7 +7386,7 @@ export default {
         continue;
       }
       try {
-        await writeSyncBatch(message.body, writers);
+        await writeSyncBatch(message.body, writers, Date.now(), familyWriters);
         message.ack();
       } catch (err) {
         console.error("sync-batches: write failed:", err);


### PR DESCRIPTION
Closes metagraphed-infra#359.

`chain-detail` posts blocks, extrinsics, chain events and account events in **one** request because they must land in **one** write: a block whose drill-down shows no calls is readable and wrong. `SyncBatchMessage` carried a single `rows` array, so this lane had no shape to move in.

## Widened, not split

The issue offered one-message-per-family or a family map. **The first loses the property the four are posted together for** — four messages retry independently — so it is rejected on that basis rather than chosen for being easiest.

`families` is **optional and mutually exclusive with `rows`**:

- every existing lane carries one array and is untouched — widening costs them nothing
- only a lane in `MULTI_FAMILY_LANES` may send families, and only the names in `MULTI_FAMILY_LANE_ROW_FAMILIES`, so an unrecognised family is **refused** rather than written to a guessed table
- a message carrying **both** shapes is refused — accepting both would leave the writer to guess which is authoritative and silently drop one

## The row count is the sum

`passTallyFor` counts families as well as rows. Counting only `rows` would credit zero and a declared pass would never close.

## It throws rather than splitting

`packMultiFamilyMessage` refuses an oversize chunk instead of degrading into the split the shape exists to prevent.

**That constraint bites today, and a test says so.** The producer batches 2 blocks per POST at **~350–662 KiB** against a **128 KB** cap — so this lane cannot be cut over until the producer posts smaller batches.

Shipped **wired and inert** (`SYNC_QUEUE_LANES` does not name it), with the blocker recorded in a test rather than left to be rediscovered at cutover. That follow-up belongs on the producer side.

## On the Workflows alternative

metagraphed-infra#363 flags Workflows as a candidate here, and a step boundary would also give atomicity. This is the smaller change: it is contained to a shape three lanes already ignore, adds no new platform primitive, and does not block a Workflows evaluation later — if that lands, this becomes one fewer reason to need it.

## Verification

- full suite: **703 files / 17,065 tests** green
- 11 new tests covering: families replacing rows, the summed tally, refusal of both-shapes / foreign lanes / unknown family names / empty and non-array families, the throw-not-split rule, single-call dispatch to the family writer, and a loud throw when no family writer is wired