### PR TITLE
fix(queue): roll nominator-positions back — its largest coldkey exceeds the budget

### DIFF
--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -138,7 +138,20 @@
     // lane on its own. That is why this does not violate the epic's
     // one-lane-at-a-time rule so much as satisfy its reason.
     //
-    // nominator-positions IS THE ONE TO WATCH. It PRUNES per coldkey, so a
+    // nominator-positions IS ROLLED BACK, 12:5xZ, and the reason is a real
+    // measurement rather than caution. Its largest coldkey holds 722 positions;
+    // at ~150 bytes a row that is ~108 KB, and SYNC_BATCH_MAX_BYTES is 96 KB.
+    // packSyncBatchMessages CORRECTLY refuses to split a coldkey -- doing so
+    // would delete rows the message never carried -- so it throws, the route
+    // 502s, and the producer logs `post nominator_positions: sync POST failed:
+    // curl: (22) ... error: 502`. Observed at 12:47Z.
+    //
+    // The packer is right and the budget is wrong: 96 KB is the budget for
+    // COMBINING groups, but a single indivisible group only has to fit the
+    // 128 KB transport. Fixed separately; this lane rejoins after that.
+    //
+    // The original note, still true, on why it is the one to watch: it PRUNES
+    // per coldkey, so a
     // message missing rows for a coldkey it names deletes rows it never
     // carried, and no retry undoes a delete. Three things have to hold at once:
     // pack_coldkey_chunks never splits a coldkey across POSTs (producer,
@@ -157,7 +170,7 @@
     // INCOMPLETE pass is the signal -- received_rows short of expected_rows with
     // a null completed_at -- and completeness is a fact the queue does not
     // itself provide.
-    "SYNC_QUEUE_LANES": "account-balances,hotkey-alpha,validator-nominator-counts,nominator-positions",
+    "SYNC_QUEUE_LANES": "account-balances,hotkey-alpha,validator-nominator-counts",
     // #9430's $exception storm guard reads this var per-Worker
     // (src/usage-telemetry.ts), and `vars` are per-config -- declaring it
     // only in wrangler.jsonc left THIS Worker's captures entirely unguarded,


### PR DESCRIPTION
**Rolling one lane back on a measurement.**

`nominator-positions`' largest coldkey holds **722 positions**. At ~150 bytes a row that is **~108 KB**, and `SYNC_BATCH_MAX_BYTES` is **96 KB**.

`packSyncBatchMessages` **correctly refuses to split a coldkey** — splitting one would delete rows the message never carried, which is the entire reason the guard exists — so it throws, the route returns 502, and the producer logs:

```
post nominator_positions: sync POST failed: curl: (22) The requested URL returned error: 502
```

Observed at **12:47Z**, one tick after the cutover.

## The packer is right; the budget is wrong

96 KB is the budget for **combining** groups into a message. A single **indivisible** group has a different constraint: it only has to fit the **128 KB transport**. Treating both with one number is what made a legitimate 108 KB coldkey unpackable.

Fixing that is a separate change — this lane rejoins after it.

## The other two stay

`hotkey-alpha` and `validator-nominator-counts` do **not** prune, so neither has an indivisible group and both split freely. Only the pruning lane has this constraint, which is why only it comes back out.

## What this validates

The guard did exactly its job: it refused rather than silently splitting, and the failure surfaced as a loud 502 on the first tick instead of as deleted rows discovered later. That is the trade the `key_complete` design was making.