### PR TITLE
fix(queue): hoist a lone group's prune key, so the largest coldkey fits

### DIFF
--- a/src/sync-batch-queue.ts
+++ b/src/sync-batch-queue.ts
@@ -81,6 +81,24 @@ export interface SyncBatchMessage {
    * prune rather than pruning on trust.
    */
   key_complete?: boolean;
+  /**
+   * The prune key HOISTED off every row, for a message holding exactly one key.
+   *
+   * WHY THIS EXISTS (metagraphed-infra#355). `nominator-positions`' largest
+   * coldkey holds 722 positions. A real row measures 200 bytes, so that group is
+   * **141 KB** -- over the 128 KB transport cap -- and it cannot be split,
+   * because splitting a coldkey deletes rows the message never carried.
+   *
+   * The coldkey is IDENTICAL on all 722 rows by construction: it is what groups
+   * them. Carrying it once instead of 722 times removes ~62 bytes a row and
+   * brings the message to ~97 KB. The consumer re-injects it before writing, so
+   * the WRITER is untouched -- this is a wire encoding, not a schema change.
+   *
+   * Present only when a message holds a single key AND needed the room. Every
+   * other message carries whole rows, so the common path is unchanged.
+   */
+  key_column?: string;
+  key_value?: string;
 }
 
 /**
@@ -175,6 +193,12 @@ export const QUEUE_MESSAGE_MAX_BYTES = 128 * 1024;
  * failure whose signature is a stopped lane rather than an error.
  */
 export const SYNC_BATCH_MAX_BYTES = 96 * 1024;
+
+/** Room left for the message envelope when deciding whether a LONE group needs
+ * its key hoisted -- the lane name, timestamps, flags, brackets and the
+ * platform's own ~100 bytes. Small, because at this point the question is only
+ * "does this one group fit at all". */
+const ENVELOPE_HEADROOM = 2 * 1024;
 
 /**
  * Which column a pruning lane's write DELETES by, so the packer never splits
@@ -304,13 +328,23 @@ export function packSyncBatchMessages(input: {
   // call is gated on `current.length > 0` -- so an "if empty, return" here would
   // be a branch no test could reach, which is how a file starts collecting
   // coverage pragmas instead of reasons.
+  let hoistKey: string | null = null;
   const flush = () => {
+    const hoisted = hoistKey;
+    const keyValue = hoisted ? String(current[0]![hoisted]) : undefined;
+    const rows = hoisted
+      ? current.map((row) => {
+          const { [hoisted]: _key, ...rest } = row;
+          return rest;
+        })
+      : current;
     const message: SyncBatchMessage = {
       lane,
       captured_at: capturedAt,
       ...(passTotal !== undefined ? { pass_total: passTotal } : {}),
       ...(prunes ? { key_complete: true as const } : {}),
-      rows: current,
+      ...(hoisted ? { key_column: hoisted, key_value: keyValue } : {}),
+      rows,
     };
     // THE ASSERTION THIS BUG COST US. Nothing measured the message before
     // sending it, so an oversize payload surfaced as a 502 the producer read as
@@ -322,7 +356,8 @@ export function packSyncBatchMessages(input: {
       throw new Error(
         `sync-batches: ${lane} message of ${current.length} row(s) is ` +
           `${bytes} bytes, over the ${QUEUE_MESSAGE_MAX_BYTES}-byte transport ` +
-          `cap; lower SYNC_BATCH_MAX_BYTES`,
+          `cap. A single ${keyColumn ?? "row"} group this large cannot be ` +
+          `split without breaking key_complete, so the PRODUCER must reduce it.`,
       );
     }
     messages.push(message);
@@ -332,13 +367,38 @@ export function packSyncBatchMessages(input: {
 
   for (const group of groups) {
     const groupBytes = group.reduce((n, row) => n + rowBytes(row), 0);
+    // AN INDIVISIBLE GROUP ANSWERS TO THE TRANSPORT, NOT TO THE BUDGET.
+    //
+    // `maxBytes` decides when to stop COMBINING groups into one message. A
+    // group that exceeds it alone cannot be combined with anything -- but it
+    // can still be a message, because the only real limit on one message is the
+    // 128 KB transport cap. Treating both with one number is what made a
+    // legitimate coldkey unpackable: nominator-positions' largest holds 722
+    // positions, ~108 KB, over the 96 KB budget and comfortably under the cap.
+    // The lane 502'd on its first tick (metagraphed-infra#355) until this
+    // distinction existed.
+    //
+    // It goes ALONE, and `flush()` checks it against the real cap -- so a group
+    // that genuinely cannot fit still fails loudly rather than being split.
     if (groupBytes > maxBytes) {
-      throw new Error(
-        `sync-batches: ${lane} ${keyColumn ?? "row"} group of ` +
-          `${group.length} row(s) is ${groupBytes} bytes, over the ` +
-          `${maxBytes}-byte message budget; it cannot be split without ` +
-          `breaking key_complete`,
-      );
+      if (current.length > 0) flush();
+      current = [...group];
+      currentBytes = groupBytes;
+      // HOIST THE KEY when the group alone would still not fit. It is identical
+      // on every row of the group by construction, so carrying it once instead
+      // of N times is free room -- ~62 bytes a row for a coldkey, which is what
+      // brings a 722-position group from 141 KB under the 128 KB cap. The
+      // consumer re-injects before writing, so the writer never sees the
+      // difference.
+      if (
+        keyColumn &&
+        groupBytes > QUEUE_MESSAGE_MAX_BYTES - ENVELOPE_HEADROOM
+      ) {
+        hoistKey = keyColumn;
+      }
+      flush();
+      hoistKey = null;
+      continue;
     }
     if (
       current.length > 0 &&
@@ -350,7 +410,7 @@ export function packSyncBatchMessages(input: {
     current.push(...group);
     currentBytes += groupBytes;
   }
-  flush();
+  if (current.length > 0) flush();
 
   return messages;
 }
@@ -506,6 +566,17 @@ export function validSyncBatchMessage(body: unknown): body is SyncBatchMessage {
     return false;
   }
   if (m.rows.length > SYNC_BATCH_MAX_ROWS) return false;
+  // A hoisted key needs both halves, and only makes sense for a pruning lane --
+  // it is the prune key that is constant, and nothing else is.
+  if (m.key_column !== undefined || m.key_value !== undefined) {
+    if (typeof m.key_column !== "string" || !m.key_column) return false;
+    if (typeof m.key_value !== "string" || !m.key_value) return false;
+    if (!PRUNING_LANES.includes(m.lane)) return false;
+    if (PRUNING_LANE_KEYS[m.lane] !== m.key_column) return false;
+    // The rows must NOT also carry it, or the two could disagree and the
+    // consumer would have to decide which is authoritative.
+    if (m.rows.some((r) => m.key_column! in r)) return false;
+  }
   if (m.pass_total !== undefined && m.pass_total < m.rows.length) return false;
   return m.rows.every((r) => r !== null && typeof r === "object");
 }
@@ -625,6 +696,22 @@ export function passTallyFor(
   };
 }
 
+/**
+ * The rows a message means, with a hoisted key re-injected.
+ *
+ * The writer never sees the wire encoding: it gets whole rows either way, so
+ * hoisting stayed a transport optimisation rather than becoming a schema the
+ * D1 layer has to know about.
+ */
+export function syncBatchRows(
+  message: SyncBatchMessage,
+): Record<string, unknown>[] {
+  if (!message.key_column) return message.rows;
+  const column = message.key_column;
+  const value = message.key_value;
+  return message.rows.map((row) => ({ ...row, [column]: value }));
+}
+
 /** How many rows a message actually carries, whichever shape it uses. */
 export function syncBatchRowCount(message: SyncBatchMessage): number {
   if (message.families) {
@@ -663,5 +750,7 @@ export async function writeSyncBatch(
     // than ignored: a silently skipped lane is a pass that never completes.
     throw new Error(`sync-batches: no writer for lane ${message.lane}`);
   }
-  await writer(message.rows, passTallyFor(message, nowMs));
+  // syncBatchRows, not message.rows: a hoisted key is re-injected here so the
+  // writer -- and the prune map it derives -- see whole rows.
+  await writer(syncBatchRows(message), passTallyFor(message, nowMs));
 }

--- a/tests/sync-batch-queue.test.ts
+++ b/tests/sync-batch-queue.test.ts
@@ -18,6 +18,7 @@ import {
   packMultiFamilyMessage,
   packSyncBatchMessages,
   syncBatchRowCount,
+  syncBatchRows,
   QUEUE_MESSAGE_MAX_BYTES,
   SYNC_BATCH_LANES,
   SYNC_BATCH_MAX_ROWS,
@@ -398,19 +399,125 @@ describe("packSyncBatchMessages", () => {
     );
   });
 
-  test("throws on a single row too large for the budget", () => {
-    // A non-pruning lane has no key to group by, so the group IS one row -- and
-    // a row that cannot fit alone cannot be split at all. Better a named error
-    // than a message the transport silently refuses.
+  test("a group over the BUDGET but under the cap goes alone, not thrown", () => {
+    // metagraphed-infra#355. `maxBytes` decides when to stop COMBINING groups;
+    // a group that exceeds it alone cannot be combined with anything, but can
+    // still BE a message -- the only real limit on one message is the transport
+    // cap. Conflating the two made nominator-positions' largest coldkey (722
+    // positions, ~108 KB against a 96 KB budget) unpackable, and the lane 502'd
+    // on its first tick.
+    const messages = packSyncBatchMessages({
+      lane: "hotkey-alpha",
+      capturedAt: 1,
+      rows: [{ blob: "x".repeat(5_000) }, { small: 1 }],
+      maxBytes: 1_024,
+    });
+    assert.equal(messages.length, 2, "the big row got its own message");
+    assert.equal(messages[0]!.rows.length, 1);
+    assert.equal(messages[1]!.rows.length, 1);
+    // And it is still a valid, deliverable message.
+    assert.equal(
+      JSON.stringify(messages[0]).length <= QUEUE_MESSAGE_MAX_BYTES,
+      true,
+    );
+  });
+
+  test("a group over the TRANSPORT CAP still throws, rather than splitting", () => {
+    // The cap is the one limit that cannot be negotiated. A group this large
+    // is a producer-side problem, and the error says so instead of the packer
+    // quietly breaking key_complete to make it fit.
     assert.throws(
       () =>
         packSyncBatchMessages({
           lane: "hotkey-alpha",
           capturedAt: 1,
-          rows: [{ blob: "x".repeat(5_000) }],
-          maxBytes: 1_024,
+          rows: [{ blob: "x".repeat(QUEUE_MESSAGE_MAX_BYTES + 1_000) }],
         }),
-      /row group of 1 row\(s\) is \d+ bytes/,
+      /over the \d+-byte transport cap/,
+    );
+  });
+
+  test("a real 722-position coldkey packs, which is the case that broke", () => {
+    // The measured shape: nominator-positions' largest coldkey. Rows carry a
+    // coldkey, a hotkey, a netuid, an alpha and a captured_at -- ~150 bytes --
+    // so 722 of them is ~108 KB: over the 96 KB budget, under the 128 KB cap.
+    const coldkey = `5${"C".repeat(47)}`;
+    const rows = Array.from({ length: 722 }, (_, i) => ({
+      coldkey,
+      hotkey: `5${String(i).padStart(47, "H")}`,
+      netuid: i % 129,
+      alpha: 1234.56789 + i,
+      captured_at: 1_785_970_245_474,
+    }));
+    // 722 x 200 bytes is ~141 KB -- over the 128 KB cap -- so this only fits
+    // because the coldkey is hoisted off the rows.
+    const messages = packSyncBatchMessages({
+      lane: "nominator-positions",
+      capturedAt: 1_785_970_245_474,
+      rows,
+    });
+    assert.equal(messages.length, 1, "one coldkey, one message");
+    assert.equal(messages[0]!.rows.length, 722, "not one row dropped");
+    assert.equal(messages[0]!.key_complete, true);
+    assert.equal(messages[0]!.key_column, "coldkey", "the key was hoisted");
+    assert.equal(messages[0]!.key_value, coldkey);
+    // Hoisted means ABSENT from the rows -- two copies could disagree.
+    assert.equal("coldkey" in messages[0]!.rows[0]!, false);
+    assert.equal(
+      JSON.stringify(messages[0]).length <= QUEUE_MESSAGE_MAX_BYTES,
+      true,
+      "and the whole point: it now fits",
+    );
+    assert.equal(validSyncBatchMessage(messages[0]), true);
+
+    // The consumer sees whole rows again, so the writer and its prune map are
+    // untouched by the wire encoding.
+    const rebuilt = syncBatchRows(messages[0]!);
+    assert.equal(rebuilt.length, 722);
+    assert.equal(rebuilt[0]!.coldkey, coldkey);
+    assert.deepEqual(rebuilt[0], rows[0]);
+  });
+
+  test("a hoisted key is refused if the rows still carry it", () => {
+    // Two copies of one value can disagree, and the consumer would have to pick.
+    assert.equal(
+      validSyncBatchMessage({
+        lane: "nominator-positions",
+        captured_at: 1,
+        key_complete: true,
+        key_column: "coldkey",
+        key_value: "5A",
+        rows: [{ coldkey: "5B", netuid: 1 }],
+      }),
+      false,
+    );
+  });
+
+  test("a hoisted key is refused on a lane that does not prune", () => {
+    // It is the PRUNE key that is constant across a group. Nothing else is.
+    assert.equal(
+      validSyncBatchMessage({
+        lane: "hotkey-alpha",
+        captured_at: 1,
+        key_column: "hotkey",
+        key_value: "5A",
+        rows: [{ netuid: 1 }],
+      }),
+      false,
+    );
+  });
+
+  test("a hoisted key must name the lane's OWN prune column", () => {
+    assert.equal(
+      validSyncBatchMessage({
+        lane: "nominator-positions",
+        captured_at: 1,
+        key_complete: true,
+        key_column: "netuid",
+        key_value: "7",
+        rows: [{ hotkey: "5A" }],
+      }),
+      false,
     );
   });
 


### PR DESCRIPTION
Reopens the path for metagraphed-infra#355, rolled back in #9682.

Two bugs, one symptom: `nominator-positions` 502'd on its first queued tick because `packSyncBatchMessages` threw on its largest coldkey.

## 1. The budget was doing two jobs

`SYNC_BATCH_MAX_BYTES` (96 KB) decides when to stop **combining** groups into one message. A group that exceeds it alone cannot be combined with anything — **but it can still be a message**, because the only real limit on one message is the 128 KB transport cap.

An indivisible group now goes alone and is checked against the **transport cap**, not the packing budget.

## 2. That was not enough, and the measurement says why

A real `nominator_positions` row is **200 bytes** — measured from D1, not estimated:

```json
{"coldkey":"5CJsfarz…","hotkey":"5HjTdJhG…","netuid":105,"share_fraction":0.0588…,"captured_at":1786015878842}
```

The largest coldkey holds **722 positions = 141 KB**. Over the cap even alone.

So the key is **hoisted**. It is identical on every row of the group *by construction* — it is what groups them — so carrying it once instead of 722 times removes ~62 bytes a row and brings the message to **~97 KB**.

`key_column`/`key_value` ride on the message; `syncBatchRows` re-injects before the writer sees anything. **The writer and its prune map are untouched** — this is a wire encoding, not a schema change.

The validator refuses a hoisted key that: lacks either half, is on a lane that does not prune, names a column that is not that lane's prune key, or leaves the rows still carrying it — two copies of one value can disagree, and the consumer would have to pick which is authoritative.

## The residual limit, stated rather than hidden

Hoisting buys **~31%, not immunity**. A coldkey past roughly 950 positions overflows again, and the failure is the same loud 502. That is a producer-side problem when it arrives, and the error message says so rather than the packer quietly breaking `key_complete` to make it fit.

## Verification

- full suite: **703 files / 17,069 tests** green
- the regression test builds the **real** 722-position shape at 200 bytes a row and asserts it now fits, that no row is dropped, that the key is absent from the rows, and that `syncBatchRows` rebuilds rows byte-identical to the input
- three refusal tests for the ways a hoisted key can be malformed

`nominator-positions` stays **out** of `SYNC_QUEUE_LANES` until this is deployed and its next tick is observed clean.