### PR TITLE
feat(mcp): serve completion/complete, so prompt and template arguments autocomplete

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -13983,6 +13983,10 @@ export function listToolDefinitions() {
 // the generated server-card so the two can never drift.
 export const MCP_CAPABILITIES = {
   tools: { listChanged: false },
+  // #9686: completion/complete is served for prompt arguments and
+  // resource-template variables. An empty object is how the spec declares a
+  // capability that carries no sub-options.
+  completions: {},
   // subscribe: true (#4983 MCP half + #6034) -- metagraph://chain/stream and
   // metagraph://subnet/{netuid}/status are subscribable
   // (isSubscribableMcpResourceUri); every other resource is a static R2
@@ -14172,6 +14176,113 @@ async function listAllResources(ctx: McpCtx) {
     );
   }
   return out;
+}
+
+// ─── completion/complete (#9686) ───────────────────────────────────────────
+//
+// Argument autocompletion for prompt arguments and resource-template
+// variables. Before this, an agent filling in `netuid` on a prompt or
+// `{slug}` on metagraph://provider/{slug} had two options: guess, or call a
+// list tool first and read the result. Both are worse than the server simply
+// saying which values exist -- it already knows, and the answer is the same
+// registry data the resource list is built from.
+//
+// SCOPE IS NARROWER THAN IT LOOKS, and that is the spec's doing rather than
+// ours: `ref` is only ever `ref/prompt` or `ref/resource`. There is no
+// `ref/tool`, so this does nothing for the 224 tools -- it covers the six
+// prompts and four resource templates. Worth having, not worth overselling.
+//
+// The spec caps a response at 100 values, so `total`/`hasMore` carry the rest.
+const MCP_COMPLETION_PAGE_SIZE = 100;
+
+/**
+ * Which registry column, if any, completes this (ref, argument) pair.
+ *
+ * Returns null for everything else -- `task` and `ss58` are free text, and a
+ * completion list for them would be a guess dressed as an answer.
+ */
+function mcpCompletionSource(ref: Row, argumentName: string): string | null {
+  const type = ref?.type;
+  if (type === "ref/prompt") {
+    // Every prompt that takes a netuid takes the same netuid.
+    return argumentName === "netuid" ? "netuid" : null;
+  }
+  if (type !== "ref/resource") return null;
+  // Matched on the TEMPLATE's variable, not a parsed uri: the client sends the
+  // uriTemplate (with `{netuid}` still in it), not a concrete resource uri.
+  const uri = String(ref.uri ?? "");
+  if (uri.startsWith("metagraph://subnet/") && argumentName === "netuid") {
+    return "netuid";
+  }
+  if (uri.startsWith("metagraph://provider/") && argumentName === "slug") {
+    return "slug";
+  }
+  if (uri.startsWith("metagraph://schema/") && argumentName === "surface_id") {
+    return "surface_id";
+  }
+  return null;
+}
+
+/** Every candidate value for one source, in registry order. */
+async function mcpCompletionCandidates(
+  source: string,
+  ctx: McpCtx,
+): Promise<string[]> {
+  if (source === "netuid") {
+    const subnets = await loadArtifactData(
+      ctx,
+      "/metagraph/subnets.json",
+    ).catch(() => null);
+    return ((subnets?.subnets || []) as Row[])
+      .filter((s) => typeof s.netuid === "number")
+      .map((s) => String(s.netuid));
+  }
+  if (source === "slug") {
+    const providers = await loadArtifactData(
+      ctx,
+      "/metagraph/providers.json",
+    ).catch(() => null);
+    return ((providers?.providers || []) as Row[])
+      .map((p) => String(p.slug ?? ""))
+      .filter(Boolean);
+  }
+  const schemas = await loadArtifactData(
+    ctx,
+    "/metagraph/schemas/index.json",
+  ).catch(() => null);
+  return ((schemas?.schemas || []) as Row[])
+    .map((s) => String(s.surface_id ?? s.id ?? ""))
+    .filter(Boolean);
+}
+
+/**
+ * Answer completion/complete.
+ *
+ * An unknown ref or an argument with no source completes to nothing rather
+ * than erroring: the spec models completion as best-effort, and a client
+ * probing an argument we cannot complete has done nothing wrong.
+ */
+async function completeArgument(params: Row, ctx: McpCtx) {
+  const argument = (params?.argument ?? {}) as Row;
+  const source = mcpCompletionSource(
+    (params?.ref ?? {}) as Row,
+    String(argument.name ?? ""),
+  );
+  if (!source) return { completion: { values: [], total: 0, hasMore: false } };
+
+  // Prefix match, case-insensitive. `netuid` is numeric so a prefix is what a
+  // caller typing "6" means; slugs and surface ids are typed left to right too.
+  const typed = String(argument.value ?? "").toLowerCase();
+  const all = (await mcpCompletionCandidates(source, ctx)).filter((v) =>
+    v.toLowerCase().startsWith(typed),
+  );
+  return {
+    completion: {
+      values: all.slice(0, MCP_COMPLETION_PAGE_SIZE),
+      total: all.length,
+      hasMore: all.length > MCP_COMPLETION_PAGE_SIZE,
+    },
+  };
 }
 
 function decodeResourceCursor(cursor: unknown) {
@@ -15189,6 +15300,13 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
           : rpcResult(id, { prompts: listPromptDefinitions() });
       case "prompts/get":
         return isNotification ? null : rpcResult(id, getPrompt(params));
+      // #9686. Declared in MCP_CAPABILITIES as `completions`, so a client that
+      // reads the handshake knows to offer it rather than discovering it by
+      // trying.
+      case "completion/complete":
+        return isNotification
+          ? null
+          : rpcResult(id, await completeArgument(params, ctx));
       case "notifications/initialized":
       case "notifications/cancelled":
         return null;

--- a/tests/mcp-completion.test.ts
+++ b/tests/mcp-completion.test.ts
@@ -1,0 +1,427 @@
+// completion/complete — argument autocompletion (#9686).
+//
+// Before this, an agent filling in `netuid` on a prompt, or `{slug}` on
+// metagraph://provider/{slug}, had to guess or call a list tool and read the
+// result. The server already knows the answer; this is it saying so.
+//
+// WHAT THESE TESTS ARE CAREFUL ABOUT. Completion returns a list, and an empty
+// list is a valid answer for an argument we cannot complete — which means a
+// broken implementation that returns nothing for EVERYTHING also passes every
+// "did it refuse?" assertion. So each completable case asserts real values
+// came back, and the not-completable cases assert emptiness separately.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleMcpRequest, MCP_CAPABILITIES } from "../src/mcp-server.ts";
+import type { Row } from "./row-type.ts";
+
+/** Registry fixtures, injected the way the artifact readers expect. */
+const SUBNETS = {
+  subnets: [
+    { netuid: 1, name: "Apex" },
+    { netuid: 6, name: "Infinite Games" },
+    { netuid: 64, name: "Chutes" },
+    { netuid: 65, name: "Sixty-five" },
+  ],
+};
+const PROVIDERS = {
+  // The last row has no slug, for the same reason the schemas fixture has a
+  // row with no id: these are generated artifacts, and a row that identifies
+  // nothing must contribute nothing rather than an empty-string suggestion.
+  providers: [
+    { slug: "chutes" },
+    { slug: "chutes-labs" },
+    { slug: "opentensor" },
+    { name: "Unslugged Provider" },
+  ],
+};
+const SCHEMAS = {
+  // The third row has NEITHER key. The index is a generated artifact, so a row
+  // that identifies nothing is a real possibility, and completing to an empty
+  // string would offer the caller a value that resolves to no resource.
+  schemas: [
+    { surface_id: "sn-64-chutes-openapi" },
+    { id: "sn-6-openapi" },
+    { content_type: "application/json" },
+  ],
+};
+
+const deps = {
+  readArtifact: async (_env: unknown, path: string) => {
+    if (path.includes("subnets.json")) return { ok: true, data: SUBNETS };
+    if (path.includes("providers.json")) return { ok: true, data: PROVIDERS };
+    if (path.includes("schemas/index.json")) return { ok: true, data: SCHEMAS };
+    return null;
+  },
+};
+
+/** Drive one JSON-RPC message against the served path. */
+async function rpc(body: unknown, injected: Row = deps) {
+  const res = await handleMcpRequest(
+    new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify(body),
+    }),
+    {} as unknown as Env,
+    injected,
+  );
+  return (await res.json()) as Row;
+}
+
+/** Complete against a specific injected registry — used for the degraded cases. */
+async function completeWith(ref: Row, name: string, injected: Row) {
+  const body = await rpc(
+    {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "completion/complete",
+      params: { ref, argument: { name, value: "" } },
+    },
+    injected,
+  );
+  assert.ok(!body.error, `completion errored: ${JSON.stringify(body.error)}`);
+  return (body.result as Row).completion as Row;
+}
+
+async function complete(ref: Row, name: string, value = "") {
+  const res = await handleMcpRequest(
+    new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "completion/complete",
+        params: { ref, argument: { name, value } },
+      }),
+    }),
+    {} as unknown as Env,
+    deps,
+  );
+  const body = (await res.json()) as Row;
+  assert.ok(!body.error, `completion errored: ${JSON.stringify(body.error)}`);
+  return (body.result as Row).completion as Row;
+}
+
+describe("completion/complete (#9686)", () => {
+  test("the capability is declared, so clients know to offer it", () => {
+    assert.deepEqual((MCP_CAPABILITIES as Row).completions, {});
+  });
+
+  test("a prompt's netuid argument completes from the registry", async () => {
+    const c = await complete(
+      { type: "ref/prompt", name: "integrate_with_subnet" },
+      "netuid",
+    );
+    assert.deepEqual(c.values, ["1", "6", "64", "65"]);
+    assert.equal(c.total, 4);
+    assert.equal(c.hasMore, false);
+  });
+
+  // The case that makes completion worth having: a caller who has typed "6"
+  // should see 6 and 64 and 65, not all 129 subnets.
+  test("typing narrows by prefix", async () => {
+    const c = await complete(
+      { type: "ref/prompt", name: "integrate_with_subnet" },
+      "netuid",
+      "6",
+    );
+    assert.deepEqual(c.values, ["6", "64", "65"]);
+    assert.equal(c.total, 3);
+  });
+
+  test("a resource template's netuid variable completes the same way", async () => {
+    for (const uri of [
+      "metagraph://subnet/{netuid}",
+      "metagraph://subnet/{netuid}/status",
+    ]) {
+      const c = await complete({ type: "ref/resource", uri }, "netuid");
+      assert.deepEqual(c.values, ["1", "6", "64", "65"], uri);
+    }
+  });
+
+  test("provider slugs complete, case-insensitively", async () => {
+    const c = await complete(
+      { type: "ref/resource", uri: "metagraph://provider/{slug}" },
+      "slug",
+      "CHUT",
+    );
+    assert.deepEqual(c.values, ["chutes", "chutes-labs"]);
+  });
+
+  test("a provider row with no slug is dropped, not offered as empty", async () => {
+    const c = await complete(
+      { type: "ref/resource", uri: "metagraph://provider/{slug}" },
+      "slug",
+    );
+    assert.deepEqual(c.values, ["chutes", "chutes-labs", "opentensor"]);
+    assert.equal(c.total, 3, "the slugless row did not become a value");
+  });
+
+  // The schemas index uses `surface_id` on some rows and `id` on others; the
+  // resource list already tolerates both, so completion must too or it would
+  // silently omit half the catalogue.
+  test("surface ids complete from either key, and an id-less row is dropped", async () => {
+    const c = await complete(
+      { type: "ref/resource", uri: "metagraph://schema/{surface_id}" },
+      "surface_id",
+    );
+    // Both keyed rows present; the third fixture row (neither key) contributes
+    // nothing rather than an empty-string suggestion that resolves to no
+    // resource. `total` is the assertion that proves it was dropped and not
+    // merely sorted to the front.
+    assert.deepEqual(c.values.sort(), ["sn-6-openapi", "sn-64-chutes-openapi"]);
+    assert.equal(c.total, 2, "the row with neither key did not become a value");
+  });
+
+  describe("arguments with no meaningful completion answer empty", () => {
+    for (const [label, ref, name] of [
+      [
+        "free-text task",
+        { type: "ref/prompt", name: "find_subnet_for_task" },
+        "task",
+      ],
+      [
+        "an ss58 address",
+        { type: "ref/prompt", name: "audit_account_history" },
+        "ss58",
+      ],
+      [
+        "an unknown ref type",
+        { type: "ref/tool", name: "get_subnet" },
+        "netuid",
+      ],
+      [
+        "an unknown resource",
+        { type: "ref/resource", uri: "metagraph://nope/{x}" },
+        "x",
+      ],
+    ] as Array<[string, Row, string]>) {
+      test(label, async () => {
+        const c = await complete(ref, name);
+        assert.deepEqual(c.values, []);
+        assert.equal(c.total, 0);
+        assert.equal(c.hasMore, false);
+      });
+    }
+  });
+
+  test("a prefix that matches nothing is empty, not an error", async () => {
+    const c = await complete(
+      { type: "ref/prompt", name: "integrate_with_subnet" },
+      "netuid",
+      "zzz",
+    );
+    assert.deepEqual(c.values, []);
+    assert.equal(c.total, 0);
+  });
+
+  // The spec caps a completion response at 100 values. Beyond that the count
+  // has to ride on `total`/`hasMore`, or a client paging through them cannot
+  // tell a full page from the end of the list.
+  test("more than 100 matches are capped, with the real count on total", async () => {
+    const many = {
+      providers: Array.from({ length: 150 }, (_, i) => ({ slug: `p${i}` })),
+    };
+    const res = await handleMcpRequest(
+      new Request("https://api.metagraph.sh/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "completion/complete",
+          params: {
+            ref: { type: "ref/resource", uri: "metagraph://provider/{slug}" },
+            argument: { name: "slug", value: "p" },
+          },
+        }),
+      }),
+      {} as unknown as Env,
+      { readArtifact: async () => ({ ok: true, data: many }) },
+    );
+    const c = ((await res.json()) as Row).result.completion as Row;
+    assert.equal((c.values as string[]).length, 100);
+    assert.equal(c.total, 150);
+    assert.equal(c.hasMore, true);
+  });
+
+  // EVERY SOURCE HAS ITS OWN READ, so every source has its own failure path.
+  // The netuid case below is not evidence about the other two: they call
+  // different artifacts through different `.catch` handlers, and an
+  // autocomplete that 500s on a cold providers.json is exactly as broken as
+  // one that 500s on subnets.json.
+  describe("a degraded registry completes to nothing, per source", () => {
+    const cases: Array<[string, Row, string]> = [
+      [
+        "netuid",
+        { type: "ref/prompt", name: "integrate_with_subnet" },
+        "netuid",
+      ],
+      [
+        "slug",
+        { type: "ref/resource", uri: "metagraph://provider/{slug}" },
+        "slug",
+      ],
+      [
+        "surface_id",
+        { type: "ref/resource", uri: "metagraph://schema/{surface_id}" },
+        "surface_id",
+      ],
+    ];
+
+    for (const [label, ref, name] of cases) {
+      test(`${label}: the read throws`, async () => {
+        const c = await completeWith(ref, name, {
+          readArtifact: async () => {
+            throw new Error("R2 is down");
+          },
+        });
+        assert.deepEqual(c.values, []);
+      });
+
+      test(`${label}: the artifact is unreadable`, async () => {
+        const c = await completeWith(ref, name, {
+          readArtifact: async () => ({
+            ok: false,
+            code: "artifact_unavailable",
+          }),
+        });
+        assert.deepEqual(c.values, []);
+      });
+
+      // A published artifact whose collection key is absent — the shape the
+      // `|| []` fallback exists for. Without it this would throw on .map.
+      test(`${label}: the artifact has no rows`, async () => {
+        const c = await completeWith(ref, name, {
+          readArtifact: async () => ({ ok: true, data: {} }),
+        });
+        assert.deepEqual(c.values, []);
+      });
+    }
+  });
+
+  // Malformed-but-parseable params. A client that omits a field should get an
+  // empty completion, never a crash — completion sits in an editor's keystroke
+  // path, so it is called with half-built input by construction.
+  describe("incomplete params complete to nothing", () => {
+    for (const [label, params] of [
+      ["no params at all", undefined],
+      ["no ref", { argument: { name: "netuid", value: "6" } }],
+      [
+        "a resource ref with no uri",
+        { ref: { type: "ref/resource" }, argument: { name: "netuid" } },
+      ],
+      [
+        "no argument",
+        { ref: { type: "ref/prompt", name: "integrate_with_subnet" } },
+      ],
+      [
+        "an argument with no name",
+        {
+          ref: { type: "ref/prompt", name: "integrate_with_subnet" },
+          argument: {},
+        },
+      ],
+    ] as Array<[string, Row | undefined]>) {
+      test(label, async () => {
+        const body = await rpc({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "completion/complete",
+          ...(params ? { params } : {}),
+        });
+        assert.ok(!body.error, label);
+        assert.deepEqual((body.result.completion as Row).values, []);
+      });
+    }
+
+    // An argument with a name but no `value` is the very first keystroke —
+    // it must list everything, not nothing.
+    test("an argument with no value lists every candidate", async () => {
+      const body = await rpc({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "completion/complete",
+        params: {
+          ref: { type: "ref/prompt", name: "integrate_with_subnet" },
+          argument: { name: "netuid" },
+        },
+      });
+      assert.deepEqual((body.result.completion as Row).values, [
+        "1",
+        "6",
+        "64",
+        "65",
+      ]);
+    });
+  });
+
+  // Sent without an id. A conforming client always sends one, but the dispatch
+  // loop treats every method uniformly and this is the branch that says so.
+  test("as a notification it is answered 202 with no body", async () => {
+    const res = await handleMcpRequest(
+      new Request("https://api.metagraph.sh/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "completion/complete",
+          params: {
+            ref: { type: "ref/prompt", name: "integrate_with_subnet" },
+            argument: { name: "netuid", value: "" },
+          },
+        }),
+      }),
+      {} as unknown as Env,
+      deps,
+    );
+    assert.equal(res.status, 202);
+    assert.equal(await res.text(), "");
+  });
+
+  // A registry read that fails must not take the method down with it — an
+  // autocomplete that 500s is worse than one that returns nothing.
+  test("an unreadable registry completes to nothing rather than erroring", async () => {
+    const res = await handleMcpRequest(
+      new Request("https://api.metagraph.sh/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "completion/complete",
+          params: {
+            ref: { type: "ref/prompt", name: "integrate_with_subnet" },
+            argument: { name: "netuid", value: "" },
+          },
+        }),
+      }),
+      {} as unknown as Env,
+      {
+        readArtifact: async () => {
+          throw new Error("R2 is down");
+        },
+      },
+    );
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as Row;
+    assert.ok(!body.error);
+    assert.deepEqual((body.result.completion as Row).values, []);
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -363,7 +363,7 @@ describe("MCP JSON-RPC lifecycle", () => {
     assert.equal(res.body.result.tools.length, MCP_TOOLS.length);
   });
 
-  test("initialize advertises tools + resources + prompts capabilities", async () => {
+  test("initialize advertises tools + resources + prompts + completions", async () => {
     const res = await rpc({
       jsonrpc: "2.0",
       id: 1,
@@ -376,6 +376,10 @@ describe("MCP JSON-RPC lifecycle", () => {
       // subscribable; see resources/subscribe's own tests below.
       resources: { subscribe: true, listChanged: false },
       prompts: { listChanged: false },
+      // #9686: completion/complete for prompt arguments and resource-template
+      // variables. An empty object is the spec's shape for a capability with
+      // no sub-options -- it is a declaration, not a placeholder.
+      completions: {},
     });
   });
 


### PR DESCRIPTION
## Summary

`completion/complete` answered `-32601 Unknown method`, and `completions` was never declared in the handshake. MCP 2025-11-25 defines it as argument autocompletion — and this server already holds the answers it asks for. Until now an agent filling in a `netuid` had to guess, or call a list tool and read the result first.

## Scope, stated plainly

`ref` is only ever `ref/prompt` or `ref/resource`. **There is no `ref/tool`**, so this covers the six prompts and four resource templates — not the 224 tools. Real, and smaller than "argument autocompletion" sounds.

| variable | where | source |
|---|---|---|
| `netuid` | `integrate_with_subnet`, `check_health_and_fallbacks`, `evaluate_subnet_before_staking`, `metagraph://subnet/{netuid}`, `…/status` | registry subnets |
| `slug` | `metagraph://provider/{slug}` | registry providers |
| `surface_id` | `metagraph://schema/{surface_id}` | schema index |

`task` and `ss58` are free text — a completion list for them would be a guess dressed as an answer, so they return empty.

Prefix-matched case-insensitively, capped at the spec's 100 values with the real count on `total`/`hasMore`.

## What the tests are careful about

Completion returns a list, and **an empty list is a valid answer** — which means an implementation that returns nothing for *everything* passes every "did it refuse?" assertion. So each completable case asserts real values came back, and the empty cases are asserted separately.

**Every source has its own read, so every source has its own failure tests.** An earlier draft tested the degraded-registry path only for `netuid` and treated that as evidence about all three. It isn't: they call different artifacts through different `.catch` handlers, and an autocomplete that 500s on a cold `providers.json` is exactly as broken as one that 500s on `subnets.json`. Now all three cover: read throws, artifact unreadable, artifact present but no rows.

**Malformed params are the normal case, not an edge.** Completion sits in an editor's keystroke path, so it gets called with half-built input by construction. A missing `ref`, `uri`, `argument` or `name` completes to nothing; an argument with a name but *no value* lists everything — that's the first keystroke, and answering it with nothing would be wrong.

A row that identifies nothing (a provider with no `slug`, a schema entry with neither `surface_id` nor `id`) is dropped rather than offered as an empty string that resolves to no resource.

## Verification

```
npx tsc --noEmit                 clean
npm run lint / format:check      clean
npm run validate                 129 subnets, 3442 surfaces, 136 providers
npm run test:coverage            98.88% statements / 97.69% branches overall
patch coverage (diff ∩ lcov)     36/36 statements, 47/47 branches — 100%
```

A pre-existing exact-equality gate on `initialize` capabilities caught the new `completions` declaration on first run — working as designed; updated there with the reason.

Closes #9686
