### PR TITLE
fix(test): anchor the tao-usd fixture clock, which had aged out and turned main red

### DIFF
--- a/tests/tao-usd-series.test.ts
+++ b/tests/tao-usd-series.test.ts
@@ -46,7 +46,23 @@ const SCHEMA = (() => {
   return sql.slice(start, endStmt + 1);
 })();
 
-const NOW = 1_785_979_535_000;
+// THE FIXTURE CLOCK MUST TRACK THE REAL ONE, and this was a hardcoded
+// 1_785_979_535_000 (2026-08-06T01:25:35Z) until it aged out.
+//
+// Two kinds of test share this file. The loader tests inject their own clock
+// (`now: () => NOW`) and are immune to what the wall clock says. The route,
+// GraphQL and MCP tests go through the SERVED path, which has no injection
+// point and filters against real `Date.now()` — so they seed rows at
+// `NOW - offset` and then ask a handler to select them relative to now.
+//
+// With an absolute NOW those two halves drift apart at one second per second.
+// Once the gap passed DEFAULT_TAO_USD_WINDOW (24h) every seeded row fell
+// outside the window and `point_count` went 2 → 0: three tests that had
+// passed for months began failing on 2026-08-07 and would have failed every
+// day after. Anchoring to Date.now() keeps the seeded rows a fixed distance
+// from whenever the suite actually runs, which is what the served-path tests
+// were always assuming.
+const NOW = Date.now();
 const POOLS = JSON.stringify([
   { address: "0x433a00819c771b33fa7223a5b3499b24fbcd1bbc", included: true },
   { address: "0x0000000000000000000000000000000000000002", included: false },


### PR DESCRIPTION
## main is red, and would have stayed red

Three tests in `tests/tao-usd-series.test.ts` fail on current main — the route, GraphQL and MCP cases, all on `point_count` `0 !== 2`. Not a flake: they would have failed every day from here.

## Cause

The file pinned `const NOW = 1_785_979_535_000` — **2026-08-06T01:25:35Z** — and seeded rows at `NOW - offset`. Two kinds of test share that constant:

- **Loader tests** inject their own clock (`now: () => NOW`). Immune — seeded rows and filter agree by construction.
- **Route / GraphQL / MCP tests** go through the **served** path, which has no injection point and filters against real `Date.now()`.

Those halves drift apart at one second per second. `DEFAULT_TAO_USD_WINDOW` is `24h`, so once wall-clock time passed `NOW + 24h` — **2026-08-07T01:25Z** — every seeded row fell outside the window and the count went to zero.

Anchoring `NOW` to `Date.now()` keeps the seeded rows a fixed distance from whenever the suite runs, which is what the served-path tests always assumed. The clock-injecting tests are unaffected — they pass `NOW` explicitly either way.

## Why CI didn't catch it

Last green `Validate` on main was `67fa1c254` (2026-08-06 12:45Z), before the expiry. Both runs since verified nothing:

| SHA | Validate | detail |
|---|---|---|
| `938d0c24a` | failure | `changes` **cancelled**; `test`/`ui`/`python` **skipped** |
| `b93cce21e` | cancelled | — |

Neither is an assertion failure — both are concurrency cancellations, so the suite never ran. A cancelled `Validate` on main reads as "not green" but carries no information, and the real breakage slipped through underneath. Worth a separate look at why they cancelled, since `validate.yml`'s concurrency block is written specifically to prevent cancel-in-progress on main.

## Verification

```
npx vitest run tests/tao-usd-series.test.ts   29/29 passing (was 26/29)
npx vitest run tests/                          705 files, 17088 tests, all passing
npx tsc --noEmit                               clean
npm run validate                               129 subnets, 3442 surfaces, 136 providers
npm run lint / format:check                    clean
```

## The wider class — see #9689

A sweep finds **53** hardcoded epoch-millisecond constants in `tests/`, **41 of them minted within 120 days of now** (written to mean "now", not to pin a deliberate historical date) — `POSITIONS_AT`, `PASS`, `ALPHA_AT`, `BAL_AT`, and `NOW` across six staleness-watchdog suites.

Only tao-usd has detonated. The others presumably inject clocks — but that is an assumption, not a verified fact, and **a test that passes because the calendar happens to cooperate is not a passing test**. #9689 proposes a scheduled run with an advanced system clock so these surface together rather than one per expiry morning.

Closes #9689
