### PR TITLE
test: run the suite in the future, so expiring fixtures fail on demand

### DIFF
--- a/.github/workflows/check-clock-skew.yml
+++ b/.github/workflows/check-clock-skew.yml
@@ -1,0 +1,79 @@
+name: Check Clock Skew
+
+# Time bombs in the test suite, detonated on purpose (#9689).
+#
+# On 2026-08-07 three tests in tests/tao-usd-series.test.ts began failing and
+# would have failed every day after. Nothing about them had changed: the file
+# pinned an absolute `NOW`, seeded rows at `NOW - offset`, and asked a SERVED
+# handler -- which has no clock injection point -- to select them relative to
+# real Date.now(). Those drift apart one second per second, and once the gap
+# passed the route's 24h window every seeded row fell outside it. Main went red
+# for a reason no diff explained.
+#
+# That class is invisible to an ordinary run, because an ordinary run happens
+# today and today the calendar still cooperates. Running the suite in the
+# FUTURE is what makes the calendar stop cooperating on demand.
+#
+# The first pass of this found three more, on staggered timers — an analytics
+# fixture with one day left, a github-signals retention window with ~30, and a
+# self-health rollup with ~90. Each would have turned main red on a different
+# morning, one at a time, with nothing in the failing diff to explain it.
+#
+# (Prose here avoids the literal string "u"+"ses:" — validate-workflows.ts
+# scans the whole file for action refs, comments included, so a word ending in
+# it reads as an unpinned action.)
+#
+# WHY BOTH HORIZONS. 30d catches the near fuses while there is still time to
+# fix them calmly; 90d catches the long ones. They are separate jobs so the
+# summary says WHICH horizon broke -- "fails at 90d but not 30d" is the useful
+# half of the signal, and a single combined run would lose it.
+#
+# Reads nothing external and needs no secrets: it is the repo's own suite with
+# one environment variable set (tests/setup/clock-skew.ts, a no-op when unset).
+on:
+  schedule:
+    # Weekly. These fuses burn in days-to-months, so a daily run would spend CI
+    # minutes to learn the same thing seven times; the 30d horizon leaves ample
+    # margin at this cadence.
+    - cron: "23 5 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-clock-skew
+  cancel-in-progress: false
+
+jobs:
+  skew:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      # Both horizons always report. Without this, a 30d failure would cancel
+      # the 90d job and hide whether the fuse is near or far.
+      fail-fast: false
+      matrix:
+        days: [30, 90]
+    name: suite at +${{ matrix.days }}d
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.2
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Run the suite as if it were +${{ matrix.days }} days from now
+        env:
+          TEST_CLOCK_SKEW_DAYS: ${{ matrix.days }}
+        run: npx vitest run tests/

--- a/src/github-signals-core.ts
+++ b/src/github-signals-core.ts
@@ -248,10 +248,31 @@ export async function fetchRepoSignals(
     fetchReleases(owner, repo, options),
   ]);
   if (!metaRes.ok) {
+    // AGED AGAINST THIS RUN'S OWN TICK, not against whenever this particular
+    // repo happened to be reached (#9689). `capturedAt` is the run's tick time
+    // -- its own docstring above says it exists so this window "actually
+    // measures age" -- and captureGithubSignals already threads it into every
+    // call. Reading the global clock here instead meant two things:
+    //
+    //   1. Within one run, repos processed later were aged against a later
+    //      now. A repo sitting exactly on the 30-day boundary could be
+    //      retained or dropped depending on where it fell in the fan-out.
+    //   2. An injected clock was ignored at this one call site, which is what
+    //      made tests/github-signals-sync.test.ts time-dependent: it pins
+    //      `now: () => TICK_MS` and seeds captured_at relative to it, then had
+    //      the comparison silently read the real clock. The test would have
+    //      started failing ~30 days after TICK_MS.
+    //
+    // The `?? Date.now()` keeps the direct callers that pass no capturedAt
+    // (none in this repo today) on the previous behaviour rather than
+    // treating a missing tick as time zero.
+    const agedAt = options.capturedAt
+      ? Date.parse(options.capturedAt)
+      : Date.now();
     if (
       previousEntry &&
       previousEntry.captured_at &&
-      Date.now() - Date.parse(previousEntry.captured_at) <= RETENTION_MS
+      agedAt - Date.parse(previousEntry.captured_at) <= RETENTION_MS
     ) {
       return { ...previousEntry, owner, repo, unreachable: true };
     }

--- a/tests/analytics-live-d1-sqlite.test.ts
+++ b/tests/analytics-live-d1-sqlite.test.ts
@@ -278,6 +278,9 @@ test("an all() result that is neither an array nor { results } yields zero rows"
 function seedSnapshot(over: Record<string, unknown> = {}) {
   const row = {
     netuid: 8,
+    // Pinned ON PURPOSE: loadSubnetTrajectory's test asserts this exact string
+    // back out, and it reads every snapshot rather than a recent window. The
+    // one caller that IS window-scoped overrides it — see TODAY below.
     snapshot_date: "2026-08-01",
     completeness_score: 70,
     surface_count: 5,
@@ -415,7 +418,17 @@ test("loadLeaderboardD1Rows executes all four reads against a real database", as
     status: "ok",
     latency_ms: 25,
   });
-  seedSnapshot({ netuid: 3, completeness_score: 50 });
+  // TODAY, not the pinned default. loadLeaderboardD1Rows reads growth with
+  // `WHERE snapshot_date >= sevenDaysAgo`, computed from the real clock — so a
+  // fixed date only satisfies it until it ages past seven days. The default
+  // "2026-08-01" was already 6 days old when #9689 found this: the
+  // growthSamples assertion below had one day left before it started failing
+  // every run, for a reason nothing in the diff would have explained.
+  seedSnapshot({
+    netuid: 3,
+    completeness_score: 50,
+    snapshot_date: new Date().toISOString().slice(0, 10),
+  });
   seedUptimeDay({ surface_id: "u1", netuid: 3, samples: 10, ok_count: 9 });
 
   const out = await loadLeaderboardD1Rows(readDb());

--- a/tests/self-health-mcp.test.ts
+++ b/tests/self-health-mcp.test.ts
@@ -362,9 +362,19 @@ describe("self-health-mcp", () => {
       // The live regression: REST returned seven days per component while this loader
       // returned days: [] and uptime_90d: null for all three, because #9153 gave the
       // cold tier to the route and not to us.
+      // DAYS RELATIVE TO NOW (#9689). The cold-tier loader filters to a
+      // trailing 90 calendar days off `Date.now()`, and nothing threads a
+      // clock into loadSelfHealth, so pinned days slide out of the window as
+      // the calendar moves: "2026-08-01"/"2026-08-02" would have started
+      // returning days: [] around 2026-10-30 and failed every run after.
+      // What this test asserts is PARITY -- that the rollup comes back at all
+      // -- not which dates it carries, so anchoring them keeps the assertion
+      // and drops the expiry.
+      const asDay = (daysAgo: number) =>
+        new Date(Date.now() - daysAgo * 86_400_000).toISOString().slice(0, 10);
       const { env, restore } = coldTierEnv([
-        { day: "2026-08-01", component: "api", checks: 1440, ok_count: 1439 },
-        { day: "2026-08-02", component: "api", checks: 482, ok_count: 482 },
+        { day: asDay(2), component: "api", checks: 1440, ok_count: 1439 },
+        { day: asDay(1), component: "api", checks: 482, ok_count: 482 },
       ]);
       try {
         const result = (await loadSelfHealth({

--- a/tests/setup/clock-skew.ts
+++ b/tests/setup/clock-skew.ts
@@ -1,0 +1,81 @@
+// Run the suite as if it were N days from now, to make time bombs go off on
+// demand instead of on whatever morning they expire (#9689).
+//
+// ## What this is for
+//
+// On 2026-08-07 three tests in tests/tao-usd-series.test.ts started failing
+// and would have failed every day after. Nothing about them had changed: the
+// file pinned an absolute `NOW`, seeded rows at `NOW - offset`, and then asked
+// a SERVED handler — which has no clock injection point — to select them
+// relative to real `Date.now()`. Those two drift apart one second per second,
+// and once the gap passed the route's 24h window every seeded row fell outside
+// it.
+//
+// That class of defect is invisible to a normal run, because a normal run
+// happens today, and today the calendar still cooperates. A sweep found 53
+// hardcoded epoch constants under tests/, 41 of them minted within 120 days of
+// when they were written — i.e. written to mean "now". Most inject a clock and
+// are fine. Which ones is not something anyone should be inferring by hand.
+//
+// So: set TEST_CLOCK_SKEW_DAYS and the whole suite runs in the future. A test
+// that only passes because of what the wall clock says today fails there.
+//
+// ## Why a Date subclass rather than vi.useFakeTimers()
+//
+// Fake timers replace setTimeout/setInterval/queueMicrotask as well, which
+// this suite genuinely uses — several files await real timers, and the MCP
+// notification drain in src/mcp-sdk-adapter.ts depends on real microtask
+// ordering. Freezing or virtualising those would fail tests for reasons that
+// have nothing to do with the calendar, which is the opposite of what a
+// time-bomb detector is worth having. Shifting the CLOCK while leaving timers
+// alone is the narrow change: `Date.now()` and `new Date()` move, everything
+// about scheduling stays exactly as it was.
+//
+// ## Unset means untouched
+//
+// With no TEST_CLOCK_SKEW_DAYS this file installs nothing and returns before
+// touching a global. The normal suite is byte-for-byte unaffected — a guard
+// that perturbs the run it is guarding is worse than no guard.
+const raw = process.env.TEST_CLOCK_SKEW_DAYS;
+
+if (raw) {
+  const days = Number(raw);
+  if (!Number.isFinite(days)) {
+    throw new Error(
+      `TEST_CLOCK_SKEW_DAYS must be a number, got ${JSON.stringify(raw)}.`,
+    );
+  }
+
+  const offsetMs = days * 86_400_000;
+  const RealDate = Date;
+  const realNow = RealDate.now;
+
+  // Subclassed rather than patched in place: `new Date()` with no arguments
+  // must shift, while every explicit form (`new Date(ms)`, `new Date(iso)`,
+  // `new Date(y, m, d)`) must not. A test that pins an expected ISO string
+  // builds it explicitly, and rewriting those would make the guard report
+  // failures it had itself caused.
+  class SkewedDate extends RealDate {
+    constructor(...args: ConstructorParameters<typeof Date> | []) {
+      if (args.length === 0) {
+        super(realNow() + offsetMs);
+      } else {
+        super(...args);
+      }
+    }
+
+    static now(): number {
+      return realNow() + offsetMs;
+    }
+  }
+
+  globalThis.Date = SkewedDate as unknown as DateConstructor;
+
+  // Announced once per worker. A run whose whole purpose is "pretend it is
+  // later" must say so in its output, or a failure it surfaces reads as a
+  // mystery regression rather than an expiry.
+  console.log(
+    `[clock-skew] running as if ${days} day(s) from now — ` +
+      `${new RealDate(realNow() + offsetMs).toISOString()}`,
+  );
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -56,7 +56,14 @@ export default defineConfig({
     // leak into the next one when the module registry is shared. A no-op under
     // per-file isolation; required by `isolate: false`. See
     // src/module-state-registry.ts.
-    setupFiles: ["tests/setup/reset-module-state.ts"],
+    // clock-skew.ts is FIRST and is a no-op unless TEST_CLOCK_SKEW_DAYS is set
+    // (#9689). It shifts Date only — never the timers — so an ordinary run is
+    // byte-for-byte unaffected, and a skewed run makes expiring fixtures fail
+    // on demand rather than on whatever morning they age out.
+    setupFiles: [
+      "tests/setup/clock-skew.ts",
+      "tests/setup/reset-module-state.ts",
+    ],
     // Vitest's 5s default is too tight for THIS suite under file parallelism,
     // and the gap was papered over by putting the real number on one npm
     // script. Measured on a 12-core machine during a full parallel run that


### PR DESCRIPTION
#9689 fixed one expiring fixture and proposed a guard for the class. This is the guard, plus the three more it immediately found.

## The guard

`tests/setup/clock-skew.ts`, wired first in vitest's `setupFiles`. With `TEST_CLOCK_SKEW_DAYS` unset it installs nothing and returns before touching a global — an ordinary run is byte-for-byte unaffected. Set it, and the whole suite runs as if it were N days from now.

**A `Date` subclass, not `vi.useFakeTimers()`.** Fake timers also replace `setTimeout`/`setInterval`/`queueMicrotask`, which this suite genuinely uses — several files await real timers, and the MCP notification drain depends on real microtask ordering. Virtualising those would fail tests for reasons that have nothing to do with the calendar, which is the opposite of what a time-bomb detector is worth having. Shifting the clock while leaving scheduling alone is the narrow change. `new Date()` with no arguments shifts; every explicit form (`new Date(ms)`, `new Date(iso)`) does not, so a test that pins an expected ISO string still gets it.

Proved against the original bomb: restoring the old hardcoded `NOW` and running at +2d fails exactly the three tao-usd tests, and nothing else.

## What it found on the first pass

Three more, on staggered timers — each would have turned main red on a different morning, with nothing in the failing diff to explain it:

| file | fuse | cause |
|---|---|---|
| `analytics-live-d1-sqlite` | **~1 day** | `snapshot_date: "2026-08-01"` against `WHERE snapshot_date >= sevenDaysAgo` — already 6 days old |
| `github-signals-sync` | ~30 days | see below — a **source** bug |
| `self-health-mcp` | ~90 days | pinned rollup days against a trailing-90-day cutoff |

### `github-signals-sync` is a source bug, not a test bug

`src/github-signals-core.ts` read the **global** `Date.now()` to age the 30-day last-good retention window, while `github-signals-sync.ts` resolves an injectable clock (`deps.now ?? Date.now`) and threads its tick down as `capturedAt` — whose own docstring says it exists *"so the 30-day last-good retention window actually measures age."*

Two consequences, one of them live in production:

1. **Within a single run, repos processed later were aged against a later `now`.** A repo sitting on the 30-day boundary could be retained or dropped depending on where it landed in the fan-out.
2. An injected clock was ignored at that one call site, which is what made the test time-dependent.

Fixed by aging against the run's own tick (`capturedAt`), falling back to `Date.now()` for callers that pass none.

## Verification

```
suite at +0d      705 files, 17088 tests — all passing
suite at +90d     705 files, 17088 tests — all passing
suite at +400d    17088 passing
```

A first +400d run showed 2 failures in `network-routing.test.ts`; they do not reproduce in isolation (20/20 at +400d) nor on a repeat full run, so that is ordering/parallel flake rather than a clock bomb. Noted, not chased.

## CI

`.github/workflows/check-clock-skew.yml` — weekly, plus `workflow_dispatch`. A 2-job matrix at **+30d** and **+90d** with `fail-fast: false`, so the summary says *which* horizon broke; "fails at 90d but not 30d" is the useful half of the signal, and one combined run would lose it. No secrets — it is the repo's own suite with one environment variable set.

## Minor: the workflow validator scans comments

`scripts/validate-workflows.ts` matches `/uses:\s+([^\s#]+)/g` across the whole file, comments included, so the word "fuses:" in prose read as an unpinned action ref. It over-matches (fail-safe — it can never fail *open*), so this PR just rewords rather than loosening a security gate. Worth tightening to skip comment lines separately.

---

## Verification

```
npx tsc --noEmit                          clean
npm run lint / format:check               clean
npm run validate:workflows                24 workflow files
npm run validate                          129 subnets, 3442 surfaces, 136 providers
npm run test:coverage                     706 files, 17099 tests — all passing
patch coverage (diff ∩ lcov)              1/1 statements, 2/2 branches — 100%
TEST_CLOCK_SKEW_DAYS=90  vitest run       all passing
TEST_CLOCK_SKEW_DAYS=400 vitest run       all passing
```

Closes #9692
