### PR TITLE
feat(watchdog): read lane_health, so a stale lane reaches somebody

### DIFF
--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -114,6 +114,23 @@ export const LANE_ALARM_MIN_CADENCE_SAMPLES = 3;
 export const LANE_ALARM_SILENCE_INTERVALS = 3;
 export const LANE_ALARM_MIN_SILENCE_MS = 90 * 60 * 1000;
 
+/**
+ * How old a lane's newest verdict may be before the lane stops counting as one.
+ *
+ * THE SAME SEVEN DAYS the cadence window reads, and this exists because of a
+ * state found while retiring two lanes: a RETIRED lane's last row sits in
+ * `lane_health` forever, and if that row said `stale`, `staleLanes()` keeps
+ * returning it for the life of the table. Without this guard the alarm would
+ * re-raise a lane that no longer exists, every tick, until retention expired it
+ * 90 days later -- an alarm about nothing, which is how alarms get muted.
+ *
+ * A lane that has written nothing in a week is residue, not an outage. It is
+ * also uncalibratable by construction, since the cadence estimate reads the
+ * same window -- so this guard and that one agree by sharing the constant
+ * rather than by two numbers that must be kept equal.
+ */
+export const LANE_ALARM_MAX_VERDICT_AGE_MS = LANE_ALARM_CADENCE_WINDOW_MS;
+
 /** Title prefix. The dedup key: stable across ticks, and greppable by a human. */
 export const LANE_ALARM_TITLE_PREFIX = "alarm(lane): ";
 
@@ -225,6 +242,8 @@ export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
 
   const stale = staleLanes(latest);
   for (const record of stale) {
+    // Residue, not an outage: see LANE_ALARM_MAX_VERDICT_AGE_MS.
+    if (nowMs - record.checked_at > LANE_ALARM_MAX_VERDICT_AGE_MS) continue;
     const run = runs[record.lane];
     // No run row for a lane whose newest verdict IS stale means the two reads
     // disagree -- a verdict landed between them. Treat the newest verdict as

--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -1,0 +1,604 @@
+// The READER for lane_health -- the half of #9330/#9340 that was never built.
+//
+// Every staleness watchdog in this repo writes a verdict every tick, and
+// src/lane-health.ts is emphatic about why: PostHog `$exception` is a
+// notification, and "did anyone get paged" is a different question from "was
+// anything stale overnight". That was right, and the durable record has worked
+// perfectly ever since. What nobody noticed is that answering the second
+// question still requires somebody to ASK it.
+//
+// Measured on the 2026-08-06 metagraph outage: `neurons-staleness` recorded 112
+// consecutive `stale` verdicts across 28 hours. Every one landed. The verdict
+// was correct, the reason string named the fault, and GET /api/v1/self-health
+// served `stale_lane_count` publicly the entire time. Nobody looked, because
+// every path to that record is a PULL. Three other lanes were also stale at the
+// moment this was written -- `metagraph`, `subnet-snapshot`, and
+// `top-holders-staleness`, the last of them by 102 hours -- and each had been
+// invisible for exactly the same reason.
+//
+// So this is the push. It reads what the watchdogs already wrote and opens a
+// GitHub issue, which is where this project's maintainer actually works.
+//
+// ## Why GitHub and not another notifier
+//
+// GITHUB_TOKEN is already provisioned on this Worker. No Discord, Slack,
+// Telegram, or Resend credential is -- checked against `wrangler secret list`,
+// not assumed -- so every other channel would mean provisioning a new external
+// dependency to report that an external dependency stopped reporting.
+//
+// An issue is also the right SHAPE. It is durable, it deduplicates against
+// itself, it carries the diagnosis in a form you can reply to, and closing it
+// on recovery keeps the open-issue count honest rather than accumulating alarm
+// residue. This is a Worker cron calling the GitHub API -- not a GitHub Action.
+//
+// ## Two faults, one reader
+//
+// A lane can fail in two ways and only the first was ever detectable:
+//
+//   STALE   -- the watchdog ran and said the lane is behind.
+//   SILENT  -- the watchdog itself stopped running, so the newest verdict is
+//              old and still says `ok`. `staleLanes()` reports nothing, because
+//              nothing it can see is stale. This is strictly worse than the
+//              first fault and had no detector at all.
+//
+// Silence is measured against each lane's OWN observed cadence rather than a
+// table of expected intervals, because such a table is a second place to
+// remember to edit -- see [feedback] "size a watchdog to its producer". The
+// cadences here really do span three orders of magnitude (`tao-usd-index` is
+// every minute, `top-holders-flow` is daily), so one shared constant could only
+// ever be wrong for most of them.
+
+import {
+  loadLatestLaneHealth,
+  staleLanes,
+  type LaneHealthDb,
+  type LaneHealthRecord,
+} from "./lane-health.ts";
+import { recordLaneVerdict } from "./lane-health.ts";
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+
+/**
+ * How long a lane must stay stale before it earns an issue.
+ *
+ * ONE HOUR. The single most important number here, and it is a floor on noise
+ * rather than on latency: the #9301 rule is that an alarm which fires on a
+ * working lane stops being read, and several lanes in this repo flick stale for
+ * one tick during a deploy or an eviction. `chain-detail` did it 64 times in
+ * the day this was written while being fundamentally healthy.
+ *
+ * An hour is comfortably longer than any single lane's tick, so a one-tick blip
+ * can never reach it, and comfortably shorter than the outages that actually
+ * matter -- the three that motivated this were 4 hours, 28 hours, and 102
+ * hours. Overridable via LANE_ALARM_MIN_STALE_MS.
+ */
+export const LANE_ALARM_MIN_STALE_MS = 60 * 60 * 1000;
+
+/**
+ * How many issues one tick may open.
+ *
+ * FOUR. A platform-wide outage takes every lane stale at once, and the useful
+ * report of that is not twenty issues -- it is the first few, plus the fact
+ * that there were twenty, which the summary carries either way. The cap also
+ * bounds the blast radius of a bug in this file, which is worth having in
+ * something whose whole job is to act on its own without supervision.
+ */
+export const LANE_ALARM_MAX_OPENS_PER_TICK = 4;
+
+/**
+ * How much history the cadence estimate reads.
+ *
+ * SEVEN DAYS: enough for a daily lane to show ~7 samples, and bounded so this
+ * query does not get slower every day the table grows (retention is 90 days).
+ */
+export const LANE_ALARM_CADENCE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * How many ticks a lane must have written before its cadence is trusted.
+ *
+ * THREE, giving two gaps to average. Below that the estimate is one
+ * measurement, and a wrong cadence here produces exactly the false alarm the
+ * hour-long floor above exists to prevent. A lane with too little history is
+ * reported as uncalibrated rather than guessed at.
+ */
+export const LANE_ALARM_MIN_CADENCE_SAMPLES = 3;
+
+/**
+ * How many missed ticks count as silence, and the floor under that.
+ *
+ * THREE INTERVALS, matching the threshold every staleness watchdog in this repo
+ * already uses for its own lane ("one restart is routine, two could be an
+ * unlucky pair, three is a stall"). The 90-minute floor keeps a fast lane --
+ * `tao-usd-index` ticks every minute, so three intervals is three minutes --
+ * from alarming on a deploy.
+ */
+export const LANE_ALARM_SILENCE_INTERVALS = 3;
+export const LANE_ALARM_MIN_SILENCE_MS = 90 * 60 * 1000;
+
+/** Title prefix. The dedup key: stable across ticks, and greppable by a human. */
+export const LANE_ALARM_TITLE_PREFIX = "alarm(lane): ";
+
+/** One issue per lane, forever, reopened only if the lane breaks again. */
+export function laneAlarmTitle(lane: string): string {
+  return `${LANE_ALARM_TITLE_PREFIX}${lane}`;
+}
+
+/** Which of the two faults an alarm is about. */
+export type LaneAlarmKind = "stale" | "silent";
+
+export interface LaneAlarm {
+  lane: string;
+  kind: LaneAlarmKind;
+  /** When the fault started: the first tick of the stale run, or the last
+   * verdict written before the lane went quiet. */
+  since: number;
+  /** Consecutive stale ticks. Always 0 for `silent` -- there were none. */
+  ticks: number;
+  /** The watchdog's own reason string, verbatim. Null when it wrote none. */
+  detail: string | null;
+  /** How far behind the lane itself was, as the watchdog measured it. */
+  age_ms: number | null;
+  /** The lane's own observed tick interval, when there was enough history. */
+  cadence_ms: number | null;
+}
+
+/**
+ * The current unbroken stale run per lane.
+ *
+ * Everything since that lane's most recent NON-stale verdict, which is what
+ * "has been stale for an hour" has to mean -- a lane that flickers ok/stale is
+ * not an hour-long outage, and `MIN(checked_at) WHERE verdict='stale'` would
+ * call it one for as long as the table remembers.
+ *
+ * COALESCE to 0 handles the lane that has never once been healthy, which is not
+ * hypothetical: `subnet-snapshot` and `top-holders-staleness` each had zero `ok`
+ * verdicts in the five days before this was written.
+ */
+export const LANE_STALE_RUN_SQL =
+  "SELECT lane, MIN(checked_at) AS since, COUNT(*) AS ticks " +
+  "FROM lane_health h WHERE verdict = 'stale' AND checked_at > COALESCE(" +
+  "(SELECT MAX(checked_at) FROM lane_health x " +
+  "WHERE x.lane = h.lane AND x.verdict <> 'stale'), 0) GROUP BY lane";
+
+/**
+ * Each lane's observed cadence, as a mean gap.
+ *
+ * A mean rather than a median because it needs no window function and no sort:
+ * one GROUP BY over a bounded window, where `(last - first) / (n - 1)` is the
+ * mean gap by construction. A median would be more robust to a single long
+ * outage, but the consumer multiplies this by three and floors it at 90
+ * minutes, so that robustness would buy nothing a human could measure.
+ */
+export const LANE_CADENCE_SQL =
+  "SELECT lane, COUNT(*) AS n, MIN(checked_at) AS first, MAX(checked_at) AS last " +
+  "FROM lane_health WHERE checked_at > ? GROUP BY lane";
+
+/** Mean gap between ticks, or null when there is not enough history to say. */
+export function laneCadenceMs(sample: {
+  n: number;
+  first: number;
+  last: number;
+}): number | null {
+  if (sample.n < LANE_ALARM_MIN_CADENCE_SAMPLES) return null;
+  const span = sample.last - sample.first;
+  if (span <= 0) return null;
+  return Math.round(span / (sample.n - 1));
+}
+
+/** How long a lane may stay quiet before the silence is itself the fault. */
+export function laneSilenceThresholdMs(cadenceMs: number): number {
+  return Math.max(
+    cadenceMs * LANE_ALARM_SILENCE_INTERVALS,
+    LANE_ALARM_MIN_SILENCE_MS,
+  );
+}
+
+export interface LaneAlarmPlanInput {
+  /** Newest verdict per lane, from loadLatestLaneHealth. */
+  latest: Record<string, LaneHealthRecord>;
+  /** Current unbroken stale runs, keyed by lane. */
+  runs: Record<string, { since: number; ticks: number }>;
+  /** Observed cadence per lane, keyed by lane. Null where uncalibrated. */
+  cadence: Record<string, number | null>;
+  /** Lanes that already have an open alarm issue. */
+  openAlarms: Record<string, number>;
+  nowMs: number;
+  minStaleMs: number;
+}
+
+export interface LaneAlarmPlan {
+  /** Alarms to raise, worst first, capped. */
+  open: LaneAlarm[];
+  /** Lanes that recovered and whose issue should close. Never carries a null
+   * record: an entry only exists because a record said `ok`. */
+  close: { lane: string; issue: number; record: LaneHealthRecord }[];
+  /** Alarms that qualified but lost to the per-tick cap. Reported, not dropped. */
+  suppressed: number;
+}
+
+/**
+ * Decide what to open and what to close. Pure: no clock, no database, no
+ * network, so every branch below is reachable from a test.
+ */
+export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
+  const { latest, runs, cadence, openAlarms, nowMs, minStaleMs } = input;
+  const qualified: LaneAlarm[] = [];
+
+  const stale = staleLanes(latest);
+  for (const record of stale) {
+    const run = runs[record.lane];
+    // No run row for a lane whose newest verdict IS stale means the two reads
+    // disagree -- a verdict landed between them. Treat the newest verdict as
+    // the start rather than inventing a duration.
+    const since = run?.since ?? record.checked_at;
+    if (nowMs - since < minStaleMs) continue;
+    qualified.push({
+      lane: record.lane,
+      kind: "stale",
+      since,
+      ticks: run?.ticks ?? 1,
+      detail: record.detail,
+      age_ms: record.age_ms,
+      cadence_ms: cadence[record.lane] ?? null,
+    });
+  }
+
+  for (const record of Object.values(latest)) {
+    // A lane already alarming as STALE is not also alarming as SILENT. The
+    // watchdog said so itself; that it then stopped saying so is the same
+    // outage, and two issues for one fault is the noise this is trying to end.
+    if (record.verdict === "stale") continue;
+    const cadenceMs = cadence[record.lane] ?? null;
+    if (cadenceMs === null) continue;
+    const quietFor = nowMs - record.checked_at;
+    if (quietFor < laneSilenceThresholdMs(cadenceMs)) continue;
+    qualified.push({
+      lane: record.lane,
+      kind: "silent",
+      since: record.checked_at,
+      ticks: 0,
+      detail: record.detail,
+      age_ms: record.age_ms,
+      cadence_ms: cadenceMs,
+    });
+  }
+
+  // Worst first, so the per-tick cap keeps the longest-running faults rather
+  // than whichever lane sorts first alphabetically.
+  qualified.sort((a, b) => a.since - b.since);
+  const fresh = qualified.filter((alarm) => !(alarm.lane in openAlarms));
+  const open = fresh.slice(0, LANE_ALARM_MAX_OPENS_PER_TICK);
+
+  const close: LaneAlarmPlan["close"] = [];
+  for (const [lane, issue] of Object.entries(openAlarms)) {
+    const record = latest[lane] ?? null;
+    // Only `ok` closes. A lane that went `unknown` has not recovered -- the
+    // watchdog could not evaluate it -- and closing on an absence of
+    // measurement is the confident-wrong-answer this repo avoids everywhere
+    // else. A lane with no record at all keeps its issue for the same reason.
+    if (record?.verdict !== "ok") continue;
+    close.push({ lane, issue, record });
+  }
+
+  return { open, close, suppressed: fresh.length - open.length };
+}
+
+function humanDuration(ms: number): string {
+  if (ms < 60_000) return `${Math.max(0, Math.round(ms / 1000))}s`;
+  if (ms < 3_600_000) return `${(ms / 60_000).toFixed(0)} min`;
+  if (ms < 172_800_000) return `${(ms / 3_600_000).toFixed(1)}h`;
+  return `${(ms / 86_400_000).toFixed(1)} days`;
+}
+
+/**
+ * The issue body. Written to be actionable without opening anything else:
+ * which lane, which fault, how long, what the watchdog said, and the query that
+ * shows the history.
+ */
+export function laneAlarmIssueBody(alarm: LaneAlarm, nowMs: number): string {
+  const forHow = humanDuration(nowMs - alarm.since);
+  const opening =
+    alarm.kind === "stale"
+      ? `\`${alarm.lane}\` has reported **stale** on every tick for **${forHow}** (${alarm.ticks} consecutive verdicts).`
+      : `\`${alarm.lane}\` has written **no verdict at all** for **${forHow}**. Its watchdog appears to have stopped running -- the last verdict it did write said \`${alarm.detail ?? "ok"}\`, so nothing else will report this.`;
+  const lines = [
+    opening,
+    "",
+    "| | |",
+    "| --- | --- |",
+    `| fault | \`${alarm.kind}\` |`,
+    `| since | ${new Date(alarm.since).toISOString()} |`,
+  ];
+  if (alarm.age_ms !== null) {
+    lines.push(`| lane was behind by | ${humanDuration(alarm.age_ms)} |`);
+  }
+  if (alarm.cadence_ms !== null) {
+    lines.push(`| observed cadence | ${humanDuration(alarm.cadence_ms)} |`);
+  }
+  if (alarm.detail) {
+    lines.push(`| watchdog said | \`${alarm.detail}\` |`);
+  }
+  lines.push(
+    "",
+    "```sql",
+    `SELECT datetime(checked_at/1000,'unixepoch') at, verdict, detail`,
+    `FROM lane_health WHERE lane = '${alarm.lane}'`,
+    `ORDER BY checked_at DESC LIMIT 40;`,
+    "```",
+    "",
+    "Closed automatically on the first `ok` verdict. Opened by the lane-health",
+    "reader (`src/lane-alarm.ts`); the record it reads is also served at",
+    "`GET /api/v1/self-health`.",
+  );
+  return lines.join("\n");
+}
+
+/** The recovery comment. States what recovered and how long it was out. */
+export function laneAlarmRecoveryComment(
+  lane: string,
+  record: LaneHealthRecord,
+): string {
+  const detail = record.detail ? ` (\`${record.detail}\`)` : "";
+  return (
+    `\`${lane}\` reported **ok** at ${new Date(record.checked_at).toISOString()}${detail}. ` +
+    `Closing automatically.`
+  );
+}
+
+interface D1Like extends LaneHealthDb {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      run(): Promise<unknown>;
+      first(): Promise<unknown>;
+      all?(): Promise<{ results?: unknown[] } | null>;
+    };
+    all?(): Promise<{ results?: unknown[] } | null>;
+  };
+}
+
+function toInt(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Current stale runs, keyed by lane. `{}` on any failure -- a reader that
+ * throws is a reader that stops reading. */
+export async function loadLaneStaleRuns(
+  db: D1Like | null | undefined,
+): Promise<Record<string, { since: number; ticks: number }>> {
+  if (!db?.prepare) return {};
+  try {
+    const result = await db.prepare(LANE_STALE_RUN_SQL).all?.();
+    const rows = (result?.results ?? []) as Record<string, unknown>[];
+    const out: Record<string, { since: number; ticks: number }> = {};
+    for (const row of rows) {
+      const lane = row.lane == null ? "" : String(row.lane);
+      if (!lane) continue;
+      out[lane] = { since: toInt(row.since), ticks: toInt(row.ticks) };
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** Each lane's observed cadence, keyed by lane. Null where uncalibrated. */
+export async function loadLaneCadence(
+  db: D1Like | null | undefined,
+  sinceMs: number,
+): Promise<Record<string, number | null>> {
+  if (!db?.prepare) return {};
+  try {
+    const result = await db.prepare(LANE_CADENCE_SQL).bind(sinceMs).all?.();
+    const rows = (result?.results ?? []) as Record<string, unknown>[];
+    const out: Record<string, number | null> = {};
+    for (const row of rows) {
+      const lane = row.lane == null ? "" : String(row.lane);
+      if (!lane) continue;
+      out[lane] = laneCadenceMs({
+        n: toInt(row.n),
+        first: toInt(row.first),
+        last: toInt(row.last),
+      });
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** The GitHub calls this needs, as one injectable seam. */
+export interface LaneAlarmGitHub {
+  listOpen(): Promise<Record<string, number>>;
+  open(alarm: LaneAlarm, title: string, body: string): Promise<number | null>;
+  close(issue: number, comment: string): Promise<boolean>;
+}
+
+const GITHUB_API = "https://api.github.com";
+
+/** The real GitHub client. Every call returns a value rather than throwing, so
+ * one failed request costs one alarm and not the tick. */
+export function laneAlarmGitHub(
+  token: string,
+  repo: string,
+  fetchImpl: typeof fetch = fetch,
+): LaneAlarmGitHub {
+  const headers = {
+    authorization: `Bearer ${token}`,
+    accept: "application/vnd.github+json",
+    "user-agent": "metagraphed-lane-alarm",
+    "content-type": "application/json",
+  };
+  return {
+    async listOpen() {
+      const response = await fetchImpl(
+        `${GITHUB_API}/repos/${repo}/issues?state=open&per_page=100`,
+        { headers },
+      );
+      if (!response.ok) return {};
+      const issues = (await response.json()) as {
+        number?: number;
+        title?: string;
+        pull_request?: unknown;
+      }[];
+      const out: Record<string, number> = {};
+      for (const issue of Array.isArray(issues) ? issues : []) {
+        // The issues endpoint returns pull requests too, and a PR whose title
+        // happens to match would be closed as though it were an alarm.
+        if (issue.pull_request) continue;
+        const title = issue.title ?? "";
+        if (!title.startsWith(LANE_ALARM_TITLE_PREFIX)) continue;
+        const lane = title.slice(LANE_ALARM_TITLE_PREFIX.length).trim();
+        if (lane && typeof issue.number === "number") out[lane] = issue.number;
+      }
+      return out;
+    },
+    async open(_alarm, title, body) {
+      const response = await fetchImpl(`${GITHUB_API}/repos/${repo}/issues`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ title, body }),
+      });
+      if (!response.ok) return null;
+      const created = (await response.json()) as { number?: number };
+      return typeof created.number === "number" ? created.number : null;
+    },
+    async close(issue, comment) {
+      // Comment first: a close that lands without its reason is an issue whose
+      // history says only that something changed its mind.
+      await fetchImpl(`${GITHUB_API}/repos/${repo}/issues/${issue}/comments`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ body: comment }),
+      }).catch(() => null);
+      const response = await fetchImpl(
+        `${GITHUB_API}/repos/${repo}/issues/${issue}`,
+        {
+          method: "PATCH",
+          headers,
+          body: JSON.stringify({ state: "closed", state_reason: "completed" }),
+        },
+      );
+      return response.ok;
+    },
+  };
+}
+
+export interface LaneAlarmDeps {
+  github?: LaneAlarmGitHub | null;
+  now?: () => number;
+  recordException?: typeof recordExceptionEvent;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * One reader tick.
+ *
+ * Returns a summary rather than throwing, matching the watchdog family it
+ * reads: a tick that cannot run is one missed report, not an outage.
+ */
+export async function runLaneAlarm(
+  env: Record<string, unknown> | null | undefined,
+  deps: LaneAlarmDeps = {},
+): Promise<Record<string, unknown>> {
+  const now = deps.now ?? Date.now;
+  const record = deps.recordException ?? recordExceptionEvent;
+  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
+
+  const token = typeof env?.GITHUB_TOKEN === "string" ? env.GITHUB_TOKEN : "";
+  const repo =
+    typeof env?.LANE_ALARM_REPO === "string" && env.LANE_ALARM_REPO
+      ? env.LANE_ALARM_REPO
+      : "JSONbored/metagraphed";
+  const github =
+    deps.github ??
+    (token ? laneAlarmGitHub(token, repo, deps.fetchImpl ?? fetch) : null);
+
+  const nowMs = now();
+  const minStaleMs =
+    Number(env?.LANE_ALARM_MIN_STALE_MS) || LANE_ALARM_MIN_STALE_MS;
+
+  const [latest, runs, cadence] = await Promise.all([
+    loadLatestLaneHealth(db),
+    loadLaneStaleRuns(db),
+    loadLaneCadence(db, nowMs - LANE_ALARM_CADENCE_WINDOW_MS),
+  ]);
+
+  // Read the open alarms BEFORE planning: without them every tick would open a
+  // duplicate of every alarm still outstanding, which is the failure that makes
+  // an alerting system get muted.
+  const openAlarms = github ? await github.listOpen().catch(() => null) : null;
+  if (github && openAlarms === null) {
+    // Deliberately NOT falling back to `{}`. An unreadable issue list is
+    // indistinguishable from "no alarms are open", and acting on that
+    // assumption opens a duplicate of everything currently outstanding.
+    return {
+      ok: false,
+      reason: "issue_list_unavailable",
+      lanes: Object.keys(latest).length,
+    };
+  }
+
+  const plan = laneAlarmPlan({
+    latest,
+    runs,
+    cadence,
+    openAlarms: openAlarms ?? {},
+    nowMs,
+    minStaleMs,
+  });
+
+  let opened = 0;
+  let closed = 0;
+  for (const alarm of plan.open) {
+    const body = laneAlarmIssueBody(alarm, nowMs);
+    // PostHog stays a second channel rather than the only one. It is recorded
+    // for every alarm, including the ones the cap suppressed below, so a
+    // working capture path still sees the full picture.
+    await record(env as never, {
+      error: new Error(
+        `lane ${alarm.lane} is ${alarm.kind}: ${humanDuration(nowMs - alarm.since)}`,
+      ),
+      route: "watchdog:lane-alarm",
+      errorCode: alarm.kind === "stale" ? "lane_stale" : "lane_silent",
+    }).catch(() => false);
+    if (!github) continue;
+    const number = await github
+      .open(alarm, laneAlarmTitle(alarm.lane), body)
+      .catch(() => null);
+    if (number !== null) opened += 1;
+  }
+  // Guarded as a whole rather than per entry: with no client there are no open
+  // alarms to have recovered, so the loop body is unreachable, not skipped.
+  if (github) {
+    for (const entry of plan.close) {
+      const ok = await github
+        .close(entry.issue, laneAlarmRecoveryComment(entry.lane, entry.record))
+        .catch(() => false);
+      if (ok) closed += 1;
+    }
+  }
+
+  await recordLaneVerdict(db, {
+    lane: "lane-alarm",
+    // The READER is ok whenever it ran. Whether the lanes it read are ok is the
+    // `alarming` count, and conflating the two would make this row report the
+    // platform's health instead of its own -- at which point a silent reader
+    // and a healthy platform look identical.
+    verdict: "ok",
+    age_ms: null,
+    detail: `${plan.open.length} alarming, ${plan.close.length} recovered, ${Object.keys(latest).length} lanes`,
+    checked_at: nowMs,
+  });
+
+  return {
+    ok: true,
+    lanes: Object.keys(latest).length,
+    alarming: plan.open.length,
+    recovered: plan.close.length,
+    suppressed: plan.suppressed,
+    opened,
+    closed,
+    delivered: Boolean(github),
+  };
+}

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -1,0 +1,930 @@
+// The lane-health READER (src/lane-alarm.ts).
+//
+// The load-bearing properties are all about restraint, because an alerting
+// system's failure mode is being muted rather than being wrong:
+//
+//   * a lane must be stale CONTINUOUSLY to alarm -- a flicker must not,
+//   * an alarm must not be re-opened while its issue is still open,
+//   * an unreadable issue list must NOT be read as "nothing is open",
+//   * and only an `ok` verdict closes -- `unknown` is not recovery.
+//
+// The silence detector gets the same scrutiny from the other direction: it must
+// fire for a watchdog that stopped writing while its last verdict said `ok`,
+// which is the fault that had no detector at all before this file.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  LANE_ALARM_MAX_OPENS_PER_TICK,
+  LANE_ALARM_MIN_STALE_MS,
+  LANE_ALARM_TITLE_PREFIX,
+  LANE_CADENCE_SQL,
+  LANE_STALE_RUN_SQL,
+  laneAlarmGitHub,
+  laneAlarmIssueBody,
+  laneAlarmPlan,
+  laneAlarmRecoveryComment,
+  laneAlarmTitle,
+  laneCadenceMs,
+  laneSilenceThresholdMs,
+  loadLaneCadence,
+  loadLaneStaleRuns,
+  runLaneAlarm,
+  type LaneAlarm,
+  type LaneAlarmGitHub,
+} from "../src/lane-alarm.ts";
+import type { LaneHealthRecord } from "../src/lane-health.ts";
+
+const NOW = 1_785_800_000_000;
+const HOUR = 60 * 60 * 1000;
+
+function record(over: Partial<LaneHealthRecord> = {}): LaneHealthRecord {
+  return {
+    lane: "neurons-staleness",
+    verdict: "stale",
+    age_ms: 4 * HOUR,
+    detail: "partial",
+    checked_at: NOW - 1000,
+    ...over,
+  };
+}
+
+/** A D1 double: returns rows, or throws however asked. */
+function fakeDb(rows: Record<string, unknown>[] | Error = []) {
+  const calls: { sql: string; values: unknown[] }[] = [];
+  const answer = () => {
+    if (rows instanceof Error) throw rows;
+    return { results: rows };
+  };
+  return {
+    calls,
+    prepare(sql: string) {
+      return {
+        bind(...values: unknown[]) {
+          calls.push({ sql, values });
+          return {
+            run: async () => ({}),
+            first: async () => null,
+            all: async () => answer(),
+          };
+        },
+        all: async () => {
+          calls.push({ sql, values: [] });
+          return answer();
+        },
+      };
+    },
+  };
+}
+
+describe("laneCadenceMs", () => {
+  test("averages the gaps between ticks", () => {
+    // 5 verdicts spanning 60 minutes = 4 gaps of 15 minutes.
+    assert.equal(
+      laneCadenceMs({ n: 5, first: NOW - 60 * 60_000, last: NOW }),
+      15 * 60_000,
+    );
+  });
+
+  test("refuses to guess from too little history", () => {
+    // Two samples is one gap, and a wrong cadence produces exactly the false
+    // alarm the design is trying to avoid. Uncalibrated is the honest answer.
+    assert.equal(laneCadenceMs({ n: 2, first: NOW - 60_000, last: NOW }), null);
+  });
+
+  test("refuses a zero-width span", () => {
+    // Every verdict at the same instant: a real table state on the first tick
+    // after a deploy, and a cadence of 0 would make the silence threshold 0.
+    assert.equal(laneCadenceMs({ n: 5, first: NOW, last: NOW }), null);
+  });
+});
+
+describe("laneSilenceThresholdMs", () => {
+  test("three intervals for a slow lane", () => {
+    assert.equal(laneSilenceThresholdMs(24 * HOUR), 72 * HOUR);
+  });
+
+  test("floors a fast lane, so a deploy is not an outage", () => {
+    // tao-usd-index ticks every minute; three intervals would be 3 minutes.
+    assert.equal(laneSilenceThresholdMs(60_000), 90 * 60_000);
+  });
+});
+
+describe("laneAlarmPlan", () => {
+  const base = {
+    latest: {},
+    runs: {},
+    cadence: {},
+    openAlarms: {},
+    nowMs: NOW,
+    minStaleMs: LANE_ALARM_MIN_STALE_MS,
+  };
+
+  test("alarms on a lane stale for longer than the threshold", () => {
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: { a: record({ lane: "a" }) },
+      runs: { a: { since: NOW - 28 * HOUR, ticks: 112 } },
+      cadence: { a: 15 * 60_000 },
+    });
+    assert.equal(plan.open.length, 1);
+    assert.deepEqual(
+      {
+        lane: plan.open[0].lane,
+        kind: plan.open[0].kind,
+        ticks: plan.open[0].ticks,
+        cadence: plan.open[0].cadence_ms,
+      },
+      { lane: "a", kind: "stale", ticks: 112, cadence: 15 * 60_000 },
+    );
+  });
+
+  test("a one-tick flicker never reaches the threshold", () => {
+    // chain-detail did this 64 times in one day while being healthy. If a blip
+    // could alarm, the alarm would be muted within a week.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: { a: record({ lane: "a" }) },
+      runs: { a: { since: NOW - 60_000, ticks: 1 } },
+    });
+    assert.deepEqual(plan.open, []);
+  });
+
+  test("dates a stale lane from its newest verdict when no run row exists", () => {
+    // The two reads are separate queries; a verdict can land between them.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: { a: record({ lane: "a", checked_at: NOW - 3 * HOUR }) },
+      runs: {},
+    });
+    assert.equal(plan.open.length, 1);
+    assert.equal(plan.open[0].since, NOW - 3 * HOUR);
+    assert.equal(plan.open[0].ticks, 1);
+    assert.equal(plan.open[0].cadence_ms, null);
+  });
+
+  test("alarms on a SILENT lane whose last verdict said ok", () => {
+    // The fault with no detector: staleLanes() sees nothing, because nothing it
+    // can see is stale. The watchdog simply stopped writing.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: {
+        a: record({
+          lane: "a",
+          verdict: "ok",
+          detail: null,
+          checked_at: NOW - 6 * HOUR,
+        }),
+      },
+      cadence: { a: 30 * 60_000 },
+    });
+    assert.equal(plan.open.length, 1);
+    assert.equal(plan.open[0].kind, "silent");
+    assert.equal(plan.open[0].ticks, 0);
+  });
+
+  test("a lane inside its own cadence is not silent", () => {
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: {
+        a: record({ lane: "a", verdict: "ok", checked_at: NOW - 20 * 60_000 }),
+      },
+      cadence: { a: 15 * 60_000 },
+    });
+    assert.deepEqual(plan.open, []);
+  });
+
+  test("an uncalibrated lane is never called silent", () => {
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: {
+        a: record({
+          lane: "a",
+          verdict: "ok",
+          checked_at: NOW - 40 * 24 * HOUR,
+        }),
+      },
+      cadence: {},
+    });
+    assert.deepEqual(plan.open, []);
+  });
+
+  test("a stale lane raises one alarm, not two", () => {
+    // It is also, by definition, not writing recently -- but "stale" and "then
+    // it stopped saying so" are one outage.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: { a: record({ lane: "a", checked_at: NOW - 9 * HOUR }) },
+      runs: { a: { since: NOW - 9 * HOUR, ticks: 30 } },
+      cadence: { a: 15 * 60_000 },
+    });
+    assert.equal(plan.open.length, 1);
+    assert.equal(plan.open[0].kind, "stale");
+  });
+
+  test("an `unknown` verdict is never STALE, but can still go silent", () => {
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: {
+        a: record({
+          lane: "a",
+          verdict: "unknown",
+          checked_at: NOW - 9 * HOUR,
+        }),
+      },
+      cadence: { a: 15 * 60_000 },
+    });
+    // staleLanes() excludes `unknown`, so this cannot be a stale alarm. It is
+    // 9 hours past a 15-minute cadence, though, so the silence detector still
+    // reaches it -- which is the point: "the watchdog cannot evaluate this lane
+    // and has now stopped trying" is exactly what needs reporting.
+    assert.equal(plan.open.length, 1);
+    assert.equal(plan.open[0].kind, "silent");
+  });
+
+  test("does not re-open a lane that already has an issue", () => {
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: { a: record({ lane: "a" }) },
+      runs: { a: { since: NOW - 28 * HOUR, ticks: 112 } },
+      openAlarms: { a: 4242 },
+    });
+    assert.deepEqual(plan.open, []);
+    assert.equal(plan.suppressed, 0);
+  });
+
+  test("caps a platform-wide outage, and reports what it capped", () => {
+    const latest: Record<string, LaneHealthRecord> = {};
+    const runs: Record<string, { since: number; ticks: number }> = {};
+    for (let i = 0; i < 9; i += 1) {
+      const lane = `lane-${i}`;
+      latest[lane] = record({ lane });
+      // Descending start times, so the WORST are not the ones sorted first.
+      runs[lane] = { since: NOW - (2 + i) * HOUR, ticks: 10 };
+    }
+    const plan = laneAlarmPlan({ ...base, latest, runs });
+    assert.equal(plan.open.length, LANE_ALARM_MAX_OPENS_PER_TICK);
+    assert.equal(plan.suppressed, 9 - LANE_ALARM_MAX_OPENS_PER_TICK);
+    // Oldest-first: the longest-running fault must survive the cap.
+    assert.equal(plan.open[0].lane, "lane-8");
+  });
+
+  test("closes an issue when its lane reports ok", () => {
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: { a: record({ lane: "a", verdict: "ok" }) },
+      openAlarms: { a: 77 },
+    });
+    assert.deepEqual(
+      plan.close.map((c) => ({ lane: c.lane, issue: c.issue })),
+      [{ lane: "a", issue: 77 }],
+    );
+  });
+
+  test("does NOT close on `unknown` -- absence of measurement is not recovery", () => {
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: { a: record({ lane: "a", verdict: "unknown" }) },
+      openAlarms: { a: 77 },
+    });
+    assert.deepEqual(plan.close, []);
+  });
+
+  test("does NOT close a lane that has no record at all", () => {
+    const plan = laneAlarmPlan({ ...base, openAlarms: { a: 77 } });
+    assert.deepEqual(plan.close, []);
+  });
+
+  test("does not close a lane that is still stale", () => {
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: { a: record({ lane: "a" }) },
+      runs: { a: { since: NOW - 28 * HOUR, ticks: 112 } },
+      openAlarms: { a: 77 },
+    });
+    assert.deepEqual(plan.close, []);
+  });
+});
+
+describe("laneAlarmIssueBody", () => {
+  function alarm(over: Partial<LaneAlarm> = {}): LaneAlarm {
+    return {
+      lane: "neurons-staleness",
+      kind: "stale",
+      since: NOW - 28 * HOUR,
+      ticks: 112,
+      detail: "partial",
+      age_ms: 4 * HOUR,
+      cadence_ms: 15 * 60_000,
+      ...over,
+    };
+  }
+
+  test("a stale body names the duration, the tick count, and the reason", () => {
+    const body = laneAlarmIssueBody(alarm(), NOW);
+    assert.match(body, /reported \*\*stale\*\* on every tick/);
+    assert.match(body, /28\.0h/);
+    assert.match(body, /112 consecutive verdicts/);
+    assert.match(body, /watchdog said \| `partial`/);
+    assert.match(body, /observed cadence \| 15 min/);
+    assert.match(body, /lane was behind by \| 4\.0h/);
+    assert.match(body, /FROM lane_health WHERE lane = 'neurons-staleness'/);
+  });
+
+  test("a silent body says the watchdog stopped, and what it last said", () => {
+    const body = laneAlarmIssueBody(
+      alarm({ kind: "silent", ticks: 0, detail: "ok", age_ms: null }),
+      NOW,
+    );
+    assert.match(body, /no verdict at all/);
+    assert.match(body, /appears to have stopped running/);
+    assert.doesNotMatch(body, /lane was behind by/);
+  });
+
+  test("a silent lane that never wrote a detail still reads correctly", () => {
+    const body = laneAlarmIssueBody(
+      alarm({ kind: "silent", detail: null, cadence_ms: null }),
+      NOW,
+    );
+    assert.match(body, /last verdict it did write said `ok`/);
+    assert.doesNotMatch(body, /observed cadence/);
+    assert.doesNotMatch(body, /watchdog said/);
+  });
+
+  test("renders every duration scale", () => {
+    assert.match(
+      laneAlarmIssueBody(alarm({ since: NOW - 30_000 }), NOW),
+      /30s/,
+    );
+    assert.match(
+      laneAlarmIssueBody(alarm({ since: NOW - 20 * 60_000 }), NOW),
+      /20 min/,
+    );
+    assert.match(
+      laneAlarmIssueBody(alarm({ since: NOW - 5 * HOUR }), NOW),
+      /5\.0h/,
+    );
+    assert.match(
+      laneAlarmIssueBody(alarm({ since: NOW - 102 * HOUR }), NOW),
+      /4\.3 days/,
+    );
+  });
+
+  test("never renders a negative duration from a clock that disagrees", () => {
+    // `since` comes from D1 and `now` from the Worker; they are different
+    // clocks, and "-3s" in an alarm reads as a bug in the alarm.
+    assert.match(laneAlarmIssueBody(alarm({ since: NOW + 3000 }), NOW), /0s/);
+  });
+});
+
+describe("laneAlarmRecoveryComment", () => {
+  test("states the recovery time and the verdict detail", () => {
+    const comment = laneAlarmRecoveryComment(
+      "a",
+      record({ verdict: "ok", detail: "129 of 129 netuids" }),
+    );
+    assert.match(comment, /reported \*\*ok\*\*/);
+    assert.match(comment, /129 of 129 netuids/);
+  });
+
+  test("reads cleanly when the watchdog wrote no detail", () => {
+    const comment = laneAlarmRecoveryComment(
+      "a",
+      record({ verdict: "ok", detail: null }),
+    );
+    assert.match(comment, /Closing automatically\.$/);
+  });
+});
+
+describe("loadLaneStaleRuns / loadLaneCadence", () => {
+  test("read the current run and the observed cadence", async () => {
+    const db = fakeDb([{ lane: "a", since: 10, ticks: 5 }]);
+    assert.deepEqual(await loadLaneStaleRuns(db), {
+      a: { since: 10, ticks: 5 },
+    });
+    assert.equal(db.calls[0].sql, LANE_STALE_RUN_SQL);
+
+    const cadenceDb = fakeDb([
+      { lane: "a", n: 5, first: NOW - 60 * 60_000, last: NOW },
+    ]);
+    assert.deepEqual(await loadLaneCadence(cadenceDb, NOW - 7 * 24 * HOUR), {
+      a: 15 * 60_000,
+    });
+    assert.equal(cadenceDb.calls[0].sql, LANE_CADENCE_SQL);
+    assert.deepEqual(cadenceDb.calls[0].values, [NOW - 7 * 24 * HOUR]);
+  });
+
+  test("skip a row with no lane name rather than keying on an empty string", async () => {
+    assert.deepEqual(
+      await loadLaneStaleRuns(fakeDb([{ since: 1, ticks: 1 }])),
+      {},
+    );
+    assert.deepEqual(await loadLaneCadence(fakeDb([{ n: 5 }]), 0), {});
+  });
+
+  test("coerce an unreadable count to zero rather than NaN", async () => {
+    // A NaN cadence compares false against every threshold, which would report
+    // a dead watchdog healthy -- the same class of bug as #9530's NaN coverage.
+    assert.deepEqual(
+      await loadLaneStaleRuns(fakeDb([{ lane: "a", since: "x", ticks: null }])),
+      { a: { since: 0, ticks: 0 } },
+    );
+  });
+
+  test("treat a driver that answers with no rows key as empty", async () => {
+    // D1 shims and older bindings have both answered `{}` and `null` here; a
+    // reader that trusted `.results` would throw on the first such tick.
+    const shim = {
+      prepare: () => ({
+        bind: () => ({
+          run: async () => ({}),
+          first: async () => null,
+          all: async () => null,
+        }),
+        all: async () => ({}),
+      }),
+    };
+    assert.deepEqual(await loadLaneStaleRuns(shim), {});
+    assert.deepEqual(await loadLaneCadence(shim, 0), {});
+  });
+
+  test("return empty on a missing binding or a failing query", async () => {
+    assert.deepEqual(await loadLaneStaleRuns(null), {});
+    assert.deepEqual(await loadLaneCadence(undefined, 0), {});
+    assert.deepEqual(
+      await loadLaneStaleRuns(fakeDb(new Error("no such table"))),
+      {},
+    );
+    assert.deepEqual(await loadLaneCadence(fakeDb(new Error("boom")), 0), {});
+  });
+});
+
+describe("laneAlarmGitHub", () => {
+  function client(handler: (url: string, init?: RequestInit) => unknown) {
+    const seen: { url: string; init?: RequestInit }[] = [];
+    const impl = (async (url: string, init?: RequestInit) => {
+      seen.push({ url, init });
+      const out = handler(url, init);
+      return out ?? { ok: true, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+    return { seen, gh: laneAlarmGitHub("t0ken", "o/r", impl) };
+  }
+
+  test("lists only open lane alarms, keyed by lane", async () => {
+    const { gh, seen } = client(() => ({
+      ok: true,
+      json: async () => [
+        { number: 1, title: `${LANE_ALARM_TITLE_PREFIX}neurons-staleness` },
+        { number: 2, title: "feat: unrelated" },
+        // A PR whose title matches would otherwise be closed as an alarm.
+        {
+          number: 3,
+          title: `${LANE_ALARM_TITLE_PREFIX}metagraph`,
+          pull_request: {},
+        },
+        { number: 4, title: LANE_ALARM_TITLE_PREFIX },
+        { number: null, title: `${LANE_ALARM_TITLE_PREFIX}ghost` },
+        { title: `${LANE_ALARM_TITLE_PREFIX}nameless` },
+        {},
+      ],
+    }));
+    assert.deepEqual(await gh.listOpen(), { "neurons-staleness": 1 });
+    assert.match(
+      seen[0].url,
+      /\/repos\/o\/r\/issues\?state=open&per_page=100$/,
+    );
+  });
+
+  test("an error or a non-array body lists nothing", async () => {
+    const bad = client(() => ({ ok: false, json: async () => [] }));
+    assert.deepEqual(await bad.gh.listOpen(), {});
+    const odd = client(() => ({
+      ok: true,
+      json: async () => ({ message: "nope" }),
+    }));
+    assert.deepEqual(await odd.gh.listOpen(), {});
+  });
+
+  test("opens an issue and returns its number", async () => {
+    const { gh, seen } = client(() => ({
+      ok: true,
+      json: async () => ({ number: 99 }),
+    }));
+    const alarm = {
+      lane: "a",
+      kind: "stale" as const,
+      since: NOW,
+      ticks: 1,
+      detail: null,
+      age_ms: null,
+      cadence_ms: null,
+    };
+    assert.equal(await gh.open(alarm, "t", "b"), 99);
+    assert.equal(seen[0].init?.method, "POST");
+    assert.deepEqual(JSON.parse(String(seen[0].init?.body)), {
+      title: "t",
+      body: "b",
+    });
+  });
+
+  test("a rejected or numberless create reports null rather than a false success", async () => {
+    const denied = client(() => ({ ok: false, json: async () => ({}) }));
+    const alarm = {
+      lane: "a",
+      kind: "stale" as const,
+      since: NOW,
+      ticks: 1,
+      detail: null,
+      age_ms: null,
+      cadence_ms: null,
+    };
+    assert.equal(await denied.gh.open(alarm, "t", "b"), null);
+    const odd = client(() => ({ ok: true, json: async () => ({}) }));
+    assert.equal(await odd.gh.open(alarm, "t", "b"), null);
+  });
+
+  test("comments before it closes, so the history carries the reason", async () => {
+    const { gh, seen } = client(() => ({ ok: true, json: async () => ({}) }));
+    assert.equal(await gh.close(12, "recovered"), true);
+    assert.match(seen[0].url, /\/issues\/12\/comments$/);
+    assert.equal(seen[1].init?.method, "PATCH");
+    assert.deepEqual(JSON.parse(String(seen[1].init?.body)), {
+      state: "closed",
+      state_reason: "completed",
+    });
+  });
+
+  test("still closes when the comment fails", async () => {
+    // The close is the point. A dropped comment is a worse issue history, not
+    // an alarm left open forever.
+    let first = true;
+    const { gh } = client(() => {
+      if (first) {
+        first = false;
+        throw new Error("comment rejected");
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    assert.equal(await gh.close(12, "recovered"), true);
+  });
+
+  test("reports a failed close rather than counting it", async () => {
+    const { gh } = client((url) =>
+      url.endsWith("/comments")
+        ? { ok: true, json: async () => ({}) }
+        : { ok: false, json: async () => ({}) },
+    );
+    assert.equal(await gh.close(12, "recovered"), false);
+  });
+});
+
+describe("runLaneAlarm", () => {
+  /** A GitHub double that records what it was asked to do. */
+  function fakeGitHub(open: Record<string, number> = {}): LaneAlarmGitHub & {
+    opened: string[];
+    closed: number[];
+  } {
+    const opened: string[] = [];
+    const closed: number[] = [];
+    return {
+      opened,
+      closed,
+      listOpen: async () => open,
+      open: async (alarm) => {
+        opened.push(alarm.lane);
+        return 100 + opened.length;
+      },
+      close: async (issue) => {
+        closed.push(issue);
+        return true;
+      },
+    };
+  }
+
+  /** A D1 double answering each of the three reads with its own rows. */
+  function healthDb(rows: {
+    latest?: Record<string, unknown>[];
+    runs?: Record<string, unknown>[];
+    cadence?: Record<string, unknown>[];
+  }) {
+    const written: Record<string, unknown>[] = [];
+    return {
+      written,
+      prepare(sql: string) {
+        const answer = async () => {
+          if (sql === LANE_STALE_RUN_SQL) return { results: rows.runs ?? [] };
+          if (sql === LANE_CADENCE_SQL) return { results: rows.cadence ?? [] };
+          return { results: rows.latest ?? [] };
+        };
+        return {
+          bind(...values: unknown[]) {
+            return {
+              run: async () => {
+                if (sql.startsWith("INSERT")) {
+                  written.push({ sql, values });
+                }
+                return {};
+              },
+              first: async () => null,
+              all: answer,
+            };
+          },
+          all: answer,
+        };
+      },
+    };
+  }
+
+  const env = { GITHUB_TOKEN: "t", METAGRAPH_HEALTH_DB: null as unknown };
+
+  test("opens an issue for a lane stale past the threshold, and records its own tick", async () => {
+    const db = healthDb({
+      latest: [
+        {
+          lane: "neurons-staleness",
+          verdict: "stale",
+          age_ms: 4 * HOUR,
+          detail: "partial",
+          checked_at: NOW - 1000,
+        },
+      ],
+      runs: [{ lane: "neurons-staleness", since: NOW - 28 * HOUR, ticks: 112 }],
+      cadence: [
+        {
+          lane: "neurons-staleness",
+          n: 100,
+          first: NOW - 25 * HOUR,
+          last: NOW,
+        },
+      ],
+    });
+    const github = fakeGitHub();
+    const out = await runLaneAlarm(
+      { ...env, METAGRAPH_HEALTH_DB: db },
+      { github, now: () => NOW, recordException: async () => true },
+    );
+    assert.equal(out.ok, true);
+    assert.equal(out.alarming, 1);
+    assert.equal(out.opened, 1);
+    assert.deepEqual(github.opened, ["neurons-staleness"]);
+    // The reader's own verdict, so a reader that stops is itself visible.
+    assert.equal(db.written.length, 1);
+    assert.deepEqual(db.written[0].values, [
+      "lane-alarm",
+      "ok",
+      null,
+      "1 alarming, 0 recovered, 1 lanes",
+      NOW,
+    ]);
+  });
+
+  test("closes the issue once the lane reports ok", async () => {
+    const db = healthDb({
+      latest: [
+        {
+          lane: "neurons-staleness",
+          verdict: "ok",
+          age_ms: 60_000,
+          detail: null,
+          checked_at: NOW - 1000,
+        },
+      ],
+    });
+    const github = fakeGitHub({ "neurons-staleness": 4242 });
+    const out = await runLaneAlarm(
+      { ...env, METAGRAPH_HEALTH_DB: db },
+      { github, now: () => NOW, recordException: async () => true },
+    );
+    assert.equal(out.recovered, 1);
+    assert.equal(out.closed, 1);
+    assert.deepEqual(github.closed, [4242]);
+  });
+
+  test("an unreadable issue list stops the tick rather than duplicating every alarm", async () => {
+    // The single most damaging thing this could do: treat a failed list as
+    // "nothing is open" and re-open every outstanding alarm, every tick.
+    const db = healthDb({
+      latest: [
+        {
+          lane: "a",
+          verdict: "stale",
+          age_ms: 1,
+          detail: null,
+          checked_at: NOW,
+        },
+      ],
+      runs: [{ lane: "a", since: NOW - 28 * HOUR, ticks: 100 }],
+    });
+    const github = fakeGitHub();
+    github.listOpen = async () => {
+      throw new Error("502 from github");
+    };
+    const out = await runLaneAlarm(
+      { ...env, METAGRAPH_HEALTH_DB: db },
+      { github, now: () => NOW },
+    );
+    assert.deepEqual(out, {
+      ok: false,
+      reason: "issue_list_unavailable",
+      lanes: 1,
+    });
+    assert.deepEqual(github.opened, []);
+  });
+
+  test("still records the alarm when no token is configured", async () => {
+    // Notification degrades to PostHog alone; the tick still runs and the
+    // durable verdict still lands.
+    const db = healthDb({
+      latest: [
+        {
+          lane: "a",
+          verdict: "stale",
+          age_ms: 1,
+          detail: null,
+          checked_at: NOW,
+        },
+      ],
+      runs: [{ lane: "a", since: NOW - 28 * HOUR, ticks: 100 }],
+    });
+    const seen: unknown[] = [];
+    const out = await runLaneAlarm(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: async (_env, payload) => {
+          seen.push(payload);
+          return true;
+        },
+      },
+    );
+    assert.equal(out.ok, true);
+    assert.equal(out.delivered, false);
+    assert.equal(out.opened, 0);
+    assert.equal(seen.length, 1);
+  });
+
+  test("counts a rejected create as not opened", async () => {
+    const db = healthDb({
+      latest: [
+        {
+          lane: "a",
+          verdict: "stale",
+          age_ms: 1,
+          detail: null,
+          checked_at: NOW,
+        },
+      ],
+      runs: [{ lane: "a", since: NOW - 28 * HOUR, ticks: 100 }],
+    });
+    const github = fakeGitHub();
+    github.open = async () => {
+      throw new Error("rate limited");
+    };
+    const out = await runLaneAlarm(
+      { ...env, METAGRAPH_HEALTH_DB: db },
+      { github, now: () => NOW, recordException: async () => true },
+    );
+    assert.equal(out.alarming, 1);
+    assert.equal(out.opened, 0);
+  });
+
+  test("counts a rejected close as not closed", async () => {
+    const db = healthDb({
+      latest: [
+        { lane: "a", verdict: "ok", age_ms: 1, detail: null, checked_at: NOW },
+      ],
+    });
+    const github = fakeGitHub({ a: 5 });
+    github.close = async () => {
+      throw new Error("rate limited");
+    };
+    const out = await runLaneAlarm(
+      { ...env, METAGRAPH_HEALTH_DB: db },
+      { github, now: () => NOW, recordException: async () => true },
+    );
+    assert.equal(out.recovered, 1);
+    assert.equal(out.closed, 0);
+  });
+
+  test("honours an overridden threshold and repo", async () => {
+    const db = healthDb({
+      latest: [
+        {
+          lane: "a",
+          verdict: "stale",
+          age_ms: 1,
+          detail: null,
+          checked_at: NOW,
+        },
+      ],
+      runs: [{ lane: "a", since: NOW - 90 * 60_000, ticks: 6 }],
+    });
+    const calls: string[] = [];
+    const out = await runLaneAlarm(
+      {
+        GITHUB_TOKEN: "t",
+        LANE_ALARM_REPO: "o/other",
+        LANE_ALARM_MIN_STALE_MS: 2 * HOUR,
+        METAGRAPH_HEALTH_DB: db,
+      },
+      {
+        now: () => NOW,
+        recordException: async () => true,
+        fetchImpl: (async (url: string) => {
+          calls.push(String(url));
+          return { ok: true, json: async () => [] };
+        }) as unknown as typeof fetch,
+      },
+    );
+    // 90 minutes is under the overridden 2-hour threshold.
+    assert.equal(out.alarming, 0);
+    assert.match(calls[0], /\/repos\/o\/other\/issues/);
+  });
+
+  test("builds its own GitHub client from the ambient fetch when given none", async () => {
+    // The wiring the cron actually uses: no deps at all beyond the clock.
+    const db = healthDb({
+      latest: [
+        {
+          lane: "a",
+          verdict: "ok",
+          age_ms: 1,
+          detail: null,
+          checked_at: NOW - 40 * HOUR,
+        },
+      ],
+      cadence: [
+        { lane: "a", n: 50, first: NOW - 50 * HOUR, last: NOW - 40 * HOUR },
+      ],
+    });
+    const calls: string[] = [];
+    const original = globalThis.fetch;
+    globalThis.fetch = (async (url: string) => {
+      calls.push(String(url));
+      return {
+        ok: true,
+        json: async () => (calls.length === 1 ? [] : { number: 7 }),
+      };
+    }) as unknown as typeof fetch;
+    try {
+      const out = await runLaneAlarm(
+        { ...env, METAGRAPH_HEALTH_DB: db },
+        { now: () => NOW, recordException: async () => true },
+      );
+      // Silent, not stale -- so this also exercises the `lane_silent` code.
+      assert.equal(out.alarming, 1);
+      assert.equal(out.opened, 1);
+    } finally {
+      globalThis.fetch = original;
+    }
+    assert.match(
+      calls[0],
+      /\/repos\/JSONbored\/metagraphed\/issues\?state=open/,
+    );
+  });
+
+  test("reports a missing binding rather than throwing", async () => {
+    assert.deepEqual(await runLaneAlarm({}), {
+      ok: false,
+      reason: "d1 binding unavailable",
+    });
+    assert.deepEqual(await runLaneAlarm(null), {
+      ok: false,
+      reason: "d1 binding unavailable",
+    });
+  });
+
+  test("survives a telemetry sink that rejects", async () => {
+    const db = healthDb({
+      latest: [
+        {
+          lane: "a",
+          verdict: "stale",
+          age_ms: 1,
+          detail: null,
+          checked_at: NOW,
+        },
+      ],
+      runs: [{ lane: "a", since: NOW - 28 * HOUR, ticks: 100 }],
+    });
+    const out = await runLaneAlarm(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: async () => {
+          throw new Error("posthog is down");
+        },
+      },
+    );
+    assert.equal(out.ok, true);
+    assert.equal(out.alarming, 1);
+  });
+});
+
+describe("laneAlarmTitle", () => {
+  test("is the dedup key, and is stable across ticks", () => {
+    assert.equal(
+      laneAlarmTitle("neurons-staleness"),
+      `${LANE_ALARM_TITLE_PREFIX}neurons-staleness`,
+    );
+  });
+});

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -241,6 +241,21 @@ describe("laneAlarmPlan", () => {
     assert.equal(plan.open[0].kind, "silent");
   });
 
+  test("ignores a RETIRED lane whose last verdict is a week old", () => {
+    // A retired lane's final row sits in lane_health until retention expires
+    // it. If that row said `stale`, staleLanes() keeps returning it -- and the
+    // alarm would re-raise a lane that no longer exists for 90 days.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: { a: record({ lane: "a", checked_at: NOW - 9 * 24 * HOUR }) },
+      runs: { a: { since: NOW - 30 * 24 * HOUR, ticks: 4000 } },
+    });
+    assert.deepEqual(plan.open, []);
+    // And it cannot come back as `silent` either: the cadence read looks at the
+    // same window, so a lane with nothing in it is uncalibrated.
+    assert.equal(plan.suppressed, 0);
+  });
+
   test("does not re-open a lane that already has an issue", () => {
     const plan = laneAlarmPlan({
       ...base,

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -394,6 +394,7 @@ import { sampleEmissionGate } from "../src/emission-gate-sampler.ts";
 import { checkEmissionDrift } from "../src/emission-drift-check.ts";
 import { refreshLiveEconomics } from "../src/live-economics-refresh.ts";
 import { runNeuronsStalenessWatchdog } from "../src/neurons-staleness-watchdog.ts";
+import { runLaneAlarm } from "../src/lane-alarm.ts";
 import { runNominatorPositionsStalenessWatchdog } from "../src/nominator-positions-staleness-watchdog.ts";
 import { runProjectionStalenessWatchdog } from "../src/projection-staleness-watchdog.ts";
 import { runValidatorNominatorCountsStalenessWatchdog } from "../src/validator-nominator-counts-staleness-watchdog.ts";
@@ -468,6 +469,7 @@ import {
   EXTRINSICS_FEED_PATH_PATTERN,
   ACCOUNT_EVENTS_ROLLUP_CRON,
   FRESHNESS_WATCHDOG_CRON,
+  LANE_ALARM_CRON,
   LAKEHOUSE_SEAM_CRON,
   SAFE_MODE_WATCHDOG_CRON,
   EMISSION_GATE_SAMPLE_CRON,
@@ -2028,6 +2030,7 @@ function cronLabel(cron: string): string {
   if (cron === ABUSE_SCAN_CRON) return "abuse-scan";
   if (cron === UPGRADE_RADAR_CRON) return "upgrade-radar";
   if (cron === FRESHNESS_WATCHDOG_CRON) return "freshness-watchdog";
+  if (cron === LANE_ALARM_CRON) return "lane-alarm";
   if (cron === LAKEHOUSE_SEAM_CRON) return "lakehouse-seam-watchdog";
   if (cron === SAFE_MODE_WATCHDOG_CRON) return "safe-mode-watchdog";
   if (cron === PROJECTION_LANES_CRON) return "projection-lanes";
@@ -2321,6 +2324,13 @@ async function dispatchScheduled(
     );
     const body = (await response.json()) as Row;
     return { ok: response.ok, status: response.status, body };
+  }
+  if (cron === LANE_ALARM_CRON) {
+    // The reader for everything the watchdogs below write. Every other branch
+    // in this dispatcher produces a verdict; this is the only one that CONSUMES
+    // them, which is why a 28-hour outage could sit in lane_health with a
+    // correct verdict on every tick and reach nobody (#9330/#9340).
+    return runLaneAlarm(env as unknown as Record<string, unknown>);
   }
   if (cron === NEURONS_STALENESS_WATCHDOG_CRON) {
     // The neurons live lane's alarm. Zero alerts is the correct steady state;

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -321,6 +321,21 @@ export const TAO_USD_INDEX_CRON = "* * * * *";
  * for four days (#9650).
  */
 export const WEBHOOK_DISPATCH_CRON = "29,59 * * * *";
+
+/**
+ * The lane-health READER's tick (#9330/#9340's missing half).
+ *
+ * TWICE HOURLY at :28 and :58, which are two of the four minutes left free on
+ * this Worker's hourly grid. Both sit near the end of a half hour, after the
+ * watchdogs that write at :02/:04/:06/:08/:14/:21/:22/:23 and their
+ * second-half twins -- so a tick reads verdicts written minutes ago rather
+ * than a half-hour-old picture.
+ *
+ * The cadence is not a latency decision. An alarm needs LANE_ALARM_MIN_STALE_MS
+ * (one hour) of continuous staleness before it fires at all, so reading twice
+ * an hour costs nothing against the threshold and halves the requests.
+ */
+export const LANE_ALARM_CRON = "28,58 * * * *";
 // Trend windows for /api/v1/subnets/{netuid}/health/trends and
 // /api/v1/health/trends.
 export const RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN =

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -831,6 +831,12 @@
       // id is content-addressed, so a tick over an unchanged snapshot costs one
       // KV read -- see WEBHOOK_DISPATCH_CRON in workers/config.ts.
       "29,59 * * * *",
+      // 28,58 = twice-hourly lane-health READER (#9330/#9340). Every other
+      // cron on this list produces a verdict; this is the one that reads them.
+      // Without it a stale lane is recorded correctly and reaches nobody --
+      // measured at 112 consecutive correct `stale` verdicts across a 28-hour
+      // metagraph outage -- see LANE_ALARM_CRON in workers/config.ts.
+      "28,58 * * * *",
       // 18 = hourly network-wide concentration rollup (#9628). The only free
       // minute on the hourly grid; hourly rather than daily so the
       // self-backfill of the days already in neuron_daily drains in a working


### PR DESCRIPTION
Closes #9697.

Every staleness watchdog in this repo **writes** a verdict every tick. **Nothing reads them.**

Measured on the 2026-08-06 metagraph outage: `neurons-staleness` recorded **112 consecutive `stale` verdicts across 28 hours**. Every one landed, every reason string named the fault, and `GET /api/v1/self-health` served `stale_lane_count` publicly the whole time. Nobody looked, because **every path to that record is a pull**. Three other lanes were also stale as this was written — `metagraph`, `subnet-snapshot`, and `top-holders-staleness`, the last by **102 hours** — each invisible for the same reason.

#9330/#9340 were right that a durable record beats a second notifier. What they left out is that answering *"was anything stale overnight"* still needs somebody to **ask**.

## The push

A twice-hourly Worker cron (`28,58`) reads what the watchdogs wrote and opens a GitHub issue.

`GITHUB_TOKEN` is already provisioned on this Worker. No Discord, Slack, Telegram, or Resend credential is — checked against `wrangler secret list`, not assumed — so **any other channel means provisioning a new external dependency in order to report that an external dependency stopped reporting.**

It closes the issue on the first `ok` verdict, so the open-issue count stays honest rather than accumulating alarm residue.

## Two faults, and only one was ever detectable

| | |
| --- | --- |
| **stale** | the watchdog ran and said the lane is behind. |
| **silent** | the watchdog *itself* stopped, so the newest verdict is old and still says `ok`. `staleLanes()` reports nothing — nothing it can see is stale. Strictly worse, and it had **no detector at all**. |

Silence is measured against each lane's **own observed cadence**, read from its history. The cadences here span three orders of magnitude (`tao-usd-index` every minute, `top-holders-flow` daily), so one shared constant could only ever be wrong for most of them — and a table of expected intervals is a second place to remember to edit.

## Restraint is the design

An alerting system fails by being **muted**, so:

- **one hour of continuous staleness** before anything fires. `chain-detail` flicked stale 64 times in one day while fundamentally healthy.
- **four issues per tick maximum.** A platform-wide outage is not twenty issues; the count is in the summary either way.
- **an unreadable issue list aborts the tick** rather than defaulting to `{}`. That default would re-open every outstanding alarm on every tick — precisely how an alarm gets muted. This is the single most damaging thing this code could do, and it has its own test.
- **only `ok` closes.** `unknown` is not recovery; closing on an absence of measurement is the confident-wrong-answer this repo avoids everywhere else.

## Verification

- **49 tests. 100% statements, 100% branches, 100% functions, 100% lines** on `src/lane-alarm.ts`
- two dead branches found by the coverage run and **deleted** rather than annotated — a `!entry.record` guard the type already made impossible, and a per-entry client check that was unreachable because a null client means an empty close list
- `validate:workflows`, `validate:private-boundary`, `validate:no-hand-written-mjs`, `validate:module-state-resets` pass
- `tests/api-coverage.test.ts` (328 tests) passes with the new cron registered
- Worker cron only. No GitHub Actions.

## What it will do on its first tick

Open four issues, for the four lanes that are stale right now. That is the correct output, and the reason this is worth having.