### PR TITLE
fix(mcp): default list_candidates' limit, which returned 7.5 MB unbounded

### DIFF
--- a/src/candidates-mcp.ts
+++ b/src/candidates-mcp.ts
@@ -2,6 +2,10 @@
 // Applies the same list-query transforms as the REST route over the baked
 // /metagraph/candidates.json artifact (mirrors gaps-mcp.ts for GET /api/v1/gaps).
 
+import {
+  CANDIDATES_LIMIT_DEFAULT,
+  CANDIDATES_LIMIT_MAX,
+} from "./route-limits.ts";
 import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
@@ -100,14 +104,22 @@ export function candidatesQueryUrl(
       typeof limit !== "number" ||
       !Number.isInteger(limit) ||
       limit < 1 ||
-      limit > 1000
+      limit > CANDIDATES_LIMIT_MAX
     ) {
       throw candidatesMcpError(
         "invalid_params",
-        "limit must be an integer between 1 and 1000.",
+        `limit must be an integer between 1 and ${CANDIDATES_LIMIT_MAX}.`,
       );
     }
     url.searchParams.set("limit", String(limit));
+  } else {
+    // DEFAULTED, because absent used to mean unbounded (#9700). This tool
+    // takes no required arguments, so `list_candidates {}` is the obvious
+    // first call -- and it returned 7,537,056 bytes, ~1.9M tokens, roughly ten
+    // context windows. Not a big answer: no usable answer. The envelope still
+    // carries `total` and `next_cursor`, so the whole catalog is reachable by
+    // paging rather than by accident.
+    url.searchParams.set("limit", String(CANDIDATES_LIMIT_DEFAULT));
   }
   if (args?.cursor !== undefined) {
     const cursor = args.cursor;

--- a/src/route-limits.ts
+++ b/src/route-limits.ts
@@ -180,3 +180,23 @@ export const PIPELINE_HISTORY_WINDOWS = Object.keys(
   PIPELINE_HISTORY_WINDOW_DAYS,
 );
 export const DEFAULT_PIPELINE_HISTORY_WINDOW = "30d";
+
+/**
+ * `list_candidates` (MCP) -- the network-wide candidate-surface catalog.
+ *
+ * A DEFAULT, not just a ceiling, and the MCP tool is the reason. With no
+ * `limit` the loader forwarded none, so the route served every row: measured
+ * 2026-08-07 at **7,537,056 bytes for 2,037 candidates** -- roughly 1.9M
+ * tokens, about ten times a 200K context window. An agent calling
+ * list_candidates while exploring (the obvious first move, since it takes no
+ * required arguments) did not get a large answer, it got no usable answer at
+ * all. `limit: 10` returns 37,850 bytes, so the data was never the problem.
+ *
+ * Deliberately narrower than the REST route, which still serves unbounded:
+ * a browser can stream 7.5 MB and a context window cannot, so the surface with
+ * the hard constraint is the one that carries the default. `total` and
+ * `next_cursor` ride in the envelope either way, so the full set stays
+ * reachable by paging -- it is no longer reachable by accident.
+ */
+export const CANDIDATES_LIMIT_DEFAULT = 20;
+export const CANDIDATES_LIMIT_MAX = 1000;

--- a/tests/candidates-mcp.test.ts
+++ b/tests/candidates-mcp.test.ts
@@ -12,6 +12,7 @@ import {
   loadCandidatesList,
 } from "../src/candidates-mcp.ts";
 import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
+import { CANDIDATES_LIMIT_DEFAULT } from "../src/route-limits.ts";
 import type { Row } from "./row-type.ts";
 
 type CandidatesCtx = Parameters<typeof loadCandidatesList>[0];
@@ -142,6 +143,29 @@ describe("candidates-mcp (#7889)", () => {
   test("candidatesQueryUrl trims and forwards a fields projection", () => {
     const url = candidatesQueryUrl({ fields: " id,confidence " });
     assert.equal(url.searchParams.get("fields"), "id,confidence");
+  });
+
+  // THE BUG THIS TOOL SHIPPED WITH (#9700). `limit` was forwarded only when the
+  // caller passed one, so an absent limit meant unbounded -- and this tool has
+  // no required arguments, making `list_candidates {}` the obvious first call.
+  // Measured against production 2026-08-07: 7,537,056 bytes for 2,037 rows,
+  // roughly 1.9M tokens, about ten 200K context windows. Not a large answer;
+  // no usable answer. `limit: 10` returned 37,850 bytes, so the volume was
+  // never the data's fault.
+  test("an absent limit is defaulted, not left unbounded", () => {
+    const url = candidatesQueryUrl({});
+    assert.equal(
+      url.searchParams.get("limit"),
+      String(CANDIDATES_LIMIT_DEFAULT),
+      "no limit must mean the default, never the whole catalog",
+    );
+  });
+
+  test("an explicit limit still wins over the default", () => {
+    assert.equal(
+      candidatesQueryUrl({ limit: 7 }).searchParams.get("limit"),
+      "7",
+    );
   });
 
   test("candidatesQueryUrl rejects a non-numeric limit", () => {


### PR DESCRIPTION
## The bug

`list_candidates` takes **no required arguments**, so `list_candidates {}` is the obvious first call for an agent exploring the registry. Measured against production 2026-08-07:

| call | bytes | ~tokens |
|---|---|---|
| `list_candidates {}` | **7,537,056** | ~1.9M — about **10×** a 200K context window |
| `list_candidates {"limit":10}` | 37,850 | ~9k |

The agent doesn't get a large answer. It gets no usable answer, and loses its context in the process.

`candidatesQueryUrl` forwarded `limit` only when the caller passed one, so absent meant unbounded.

## Fix

`CANDIDATES_LIMIT_DEFAULT = 20` in `route-limits.ts` — the single source that already feeds the published `maximum` and the prose, so the default can't drift from what the handler enforces.

**Deliberately narrower than the REST route**, which still serves unbounded: a browser can stream 7.5 MB and a context window cannot, so the surface with the hard constraint carries the default. `total` and `next_cursor` ride in the envelope either way — the full catalog stays reachable by paging, and stops being reachable by accident.

## Tests

Two new, both asserting the thing that was broken rather than around it: an absent limit forwards the default, and an explicit limit still wins.

## Wider class — #9700

Of the 88 tools exposing a `limit`, **79 have no default**. This is the one where unbounded is catastrophic rather than merely large. Census over the 98 zero-argument tools: p50 299 ms, p90 1,741 ms, p99 9,209 ms; `list_validator_economics` 680,944 B, `list_extrinsics` 140,332 B at 9.2 s.

## Verification

```
npx tsc --noEmit       clean
lint / format:check    clean
candidates-mcp         34/34 passing
full suite             17,089 passing
```

One unrelated failure appeared in a parallel run (`artifacts.test.ts` R2 dedup); it passes in isolation both with and without this change — same parallel-flake class as the earlier `network-routing` one, not caused here.

Closes #9700