### PR TITLE
fix(accounts): unbind HYPERDRIVE, so position history stops serving 2026-08-05

### DIFF
--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -340,12 +340,35 @@
   // Never add `localConnectionString` here: Neon's own guide suggests it and it
   // would commit a live password to a public repository. Use `.dev.vars`, which
   // IS gitignored, for local work.
-  "hyperdrive": [
-    {
-      "binding": "HYPERDRIVE",
-      "id": "8a09dc673733497f987434f59689287e",
-    },
-  ],
+  // UNBOUND 2026-08-07. The Neon pilot (metagraphed-infra#336) moved a READ
+  // without ever building a WRITE, and the two facts were never checked
+  // together.
+  //
+  // GET /api/v1/accounts/{ss58}/subnets/{netuid}/history reads Neon whenever
+  // this binding exists (see positionHistoryServedFromNeon in
+  // workers/data-api.ts). Neon's account_position_daily got ONE load on
+  // 2026-08-05 at 19:35 and nothing has written to it since, while the D1
+  // dual-write kept running. So the route served a snapshot that was two days
+  // old and getting older, and would have gone on doing that indefinitely.
+  //
+  // Measured before unbinding, two accounts picked from the table itself:
+  //
+  //   5C4hrjU8...t87s netuid 102   served 10 points to 2026-08-05
+  //                                D1 has 11 rows  to 2026-08-07
+  //   5C4ipx9Y...sw9bD netuid  80   served 26 points to 2026-08-05
+  //                                D1 has 27 rows  to 2026-08-07
+  //
+  // The code was written for exactly this rollback -- "unbinding HYPERDRIVE
+  // restores the previous behaviour exactly" -- so this is the intended
+  // control, not a workaround. Rebind it when a writer exists and its
+  // freshness has a watchdog, which is what let this run unnoticed: no lane in
+  // lane_health covers this route's store.
+  //
+  // The Hyperdrive config (metagraphed-neon,
+  // 8a09dc673733497f987434f59689287e) and the Neon project are both left in
+  // place. Nothing is lost by unbinding; the read simply goes back to the
+  // store that is current.
+  "hyperdrive": [],
   // Wallet-login challenge nonces (ADR 0021, #6835, src/wallet-auth.ts) --
   // the SAME namespace id as the main Worker's own METAGRAPH_CONTROL binding
   // (wrangler.jsonc), bound under the same name here so both Workers read/


### PR DESCRIPTION
Closes #9704.

`GET /api/v1/accounts/{ss58}/subnets/{netuid}/history` reads **Neon** whenever `HYPERDRIVE` is bound (`positionHistoryServedFromNeon`, `workers/data-api.ts`).

Neon's `account_position_daily` got **one load, on 2026-08-05 at 19:35**, and **nothing has written to it since**. The D1 dual-write kept running. The route has served a two-day-old snapshot and would have gone on aging indefinitely.

## Measured before unbinding, two accounts picked from the table itself

| account / netuid | served | D1 |
| --- | --- | --- |
| `5C4hrjU8…t87s` / 102 | 10 points to **2026-08-05** | 11 rows to **2026-08-07** |
| `5C4ipx9Y…w9bD` / 80 | 26 points to **2026-08-05** | 27 rows to **2026-08-07** |

Whole-table: Neon **803,697** rows to 2026-08-05; D1 **833,963** to 2026-08-07 — **30,266 behind**.

`neurons` in Neon is frozen the same way (`MAX(captured_at) = 2026-08-05 19:20:21` against D1's `2026-08-07 04:35:23`), but no route reads it, so nothing surfaced.

## Why it ran unnoticed

**No lane in `lane_health` covers this route's store.** Every staleness watchdog here watches a D1 table or an R2 artifact; the one route whose store moved has none — and its 200 OK with plausible-looking rows is indistinguishable from a healthy answer.

The move was also read-first: the binding and the read path both landed, and *"does anything write to the new store"* was never a separate check. That is the shape #9605 already named — a merged port PR is not a cutover.

## Why unbinding is the right control

The code was written for it, in as many words:

> **FALLS BACK TO D1 WHEN THE BINDING IS ABSENT**, which is what makes this reversible without a deploy … unbinding HYPERDRIVE restores the previous behaviour exactly.

This is the intended rollback, not a workaround. The Hyperdrive config (`metagraphed-neon`) and the Neon project are both left in place — nothing is lost by unbinding, and the read goes back to the store that is current.

**Rebind when a writer exists *and* its freshness has a watchdog.** The full "what should move to Neon" analysis is on metagraphed-infra#336.

## Verification

- `tests/data-api.test.ts` + `tests/data-api-neurons-d1.test.ts`: 177 passing
- config-only; one word of diff plus the note explaining it