### PR TITLE
fix(api): flag derived deregistration counts as the lower bound they are

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -6144,6 +6144,11 @@ export interface components {
                 reason: string;
             };
             derivation?: {
+                /**
+                 * @description True when the count is a floor rather than a measurement: some registrations in the window displaced a holder the derivation's lookback cannot name, so the real figure is higher by at least `unattributed_registrations`. Treat the value as 'at least this many', never as a total.
+                 * @example true
+                 */
+                is_lower_bound: boolean;
                 lookback_days: number;
                 method: string;
                 unattributed_registrations: number;
@@ -7450,6 +7455,11 @@ export interface components {
                 reason: string;
             };
             derivation?: {
+                /**
+                 * @description True when the count is a floor rather than a measurement: some registrations in the window displaced a holder the derivation's lookback cannot name, so the real figure is higher by at least `unattributed_registrations`. Treat the value as 'at least this many', never as a total.
+                 * @example true
+                 */
+                is_lower_bound: boolean;
                 lookback_days: number;
                 method: string;
                 unattributed_registrations: number;
@@ -11082,6 +11092,11 @@ export interface components {
             deregistrations: number;
             deregistrations_per_hotkey: number | null;
             derivation?: {
+                /**
+                 * @description True when the count is a floor rather than a measurement: some registrations in the window displaced a holder the derivation's lookback cannot name, so the real figure is higher by at least `unattributed_registrations`. Treat the value as 'at least this many', never as a total.
+                 * @example true
+                 */
+                is_lower_bound: boolean;
                 lookback_days: number;
                 method: string;
                 unattributed_registrations: number;
@@ -16267,6 +16282,7 @@ export interface operations {
                      *           "reason": "example"
                      *         },
                      *         "derivation": {
+                     *           "is_lower_bound": false,
                      *           "lookback_days": 1,
                      *           "method": "GET",
                      *           "unattributed_registrations": 1,
@@ -25314,6 +25330,7 @@ export interface operations {
                      *         "deregistrations": 1,
                      *         "deregistrations_per_hotkey": 0.5,
                      *         "derivation": {
+                     *           "is_lower_bound": false,
                      *           "lookback_days": 1,
                      *           "method": "GET",
                      *           "unattributed_registrations": 1,
@@ -29551,6 +29568,7 @@ export interface operations {
                      *           "reason": "example"
                      *         },
                      *         "derivation": {
+                     *           "is_lower_bound": false,
                      *           "lookback_days": 1,
                      *           "method": "GET",
                      *           "unattributed_registrations": 1,
@@ -35059,6 +35077,7 @@ export interface operations {
                      *           "reason": "example"
                      *         },
                      *         "derivation": {
+                     *           "is_lower_bound": false,
                      *           "lookback_days": 1,
                      *           "method": "GET",
                      *           "unattributed_registrations": 1,
@@ -49201,6 +49220,7 @@ export interface operations {
                      *         "deregistrations": 1,
                      *         "deregistrations_per_hotkey": 0.5,
                      *         "derivation": {
+                     *           "is_lower_bound": false,
                      *           "lookback_days": 1,
                      *           "method": "GET",
                      *           "unattributed_registrations": 1,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -229,6 +229,7 @@
               "reason": "example"
             },
             "derivation": {
+              "is_lower_bound": false,
               "lookback_days": 1,
               "method": "GET",
               "unattributed_registrations": 1,
@@ -2692,6 +2693,7 @@
               "reason": "example"
             },
             "derivation": {
+              "is_lower_bound": false,
               "lookback_days": 1,
               "method": "GET",
               "unattributed_registrations": 1,
@@ -8552,6 +8554,7 @@
             "deregistrations": 1,
             "deregistrations_per_hotkey": 0.5,
             "derivation": {
+              "is_lower_bound": false,
               "lookback_days": 1,
               "method": "GET",
               "unattributed_registrations": 1,
@@ -12895,6 +12898,13 @@
           "derivation": {
             "additionalProperties": false,
             "properties": {
+              "is_lower_bound": {
+                "description": "True when the count is a floor rather than a measurement: some registrations in the window displaced a holder the derivation's lookback cannot name, so the real figure is higher by at least `unattributed_registrations`. Treat the value as 'at least this many', never as a total.",
+                "examples": [
+                  true
+                ],
+                "type": "boolean"
+              },
               "lookback_days": {
                 "maximum": 9007199254740991,
                 "minimum": 0,
@@ -12918,7 +12928,8 @@
               "method",
               "lookback_days",
               "window_registrations",
-              "unattributed_registrations"
+              "unattributed_registrations",
+              "is_lower_bound"
             ],
             "type": "object"
           },
@@ -20473,6 +20484,13 @@
           "derivation": {
             "additionalProperties": false,
             "properties": {
+              "is_lower_bound": {
+                "description": "True when the count is a floor rather than a measurement: some registrations in the window displaced a holder the derivation's lookback cannot name, so the real figure is higher by at least `unattributed_registrations`. Treat the value as 'at least this many', never as a total.",
+                "examples": [
+                  true
+                ],
+                "type": "boolean"
+              },
               "lookback_days": {
                 "maximum": 9007199254740991,
                 "minimum": 0,
@@ -20496,7 +20514,8 @@
               "method",
               "lookback_days",
               "window_registrations",
-              "unattributed_registrations"
+              "unattributed_registrations",
+              "is_lower_bound"
             ],
             "type": "object"
           },
@@ -40864,6 +40883,13 @@
           "derivation": {
             "additionalProperties": false,
             "properties": {
+              "is_lower_bound": {
+                "description": "True when the count is a floor rather than a measurement: some registrations in the window displaced a holder the derivation's lookback cannot name, so the real figure is higher by at least `unattributed_registrations`. Treat the value as 'at least this many', never as a total.",
+                "examples": [
+                  true
+                ],
+                "type": "boolean"
+              },
               "lookback_days": {
                 "maximum": 9007199254740991,
                 "minimum": 0,
@@ -40887,7 +40913,8 @@
               "method",
               "lookback_days",
               "window_registrations",
-              "unattributed_registrations"
+              "unattributed_registrations",
+              "is_lower_bound"
             ],
             "type": "object"
           },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6144,6 +6144,11 @@ export interface components {
                 reason: string;
             };
             derivation?: {
+                /**
+                 * @description True when the count is a floor rather than a measurement: some registrations in the window displaced a holder the derivation's lookback cannot name, so the real figure is higher by at least `unattributed_registrations`. Treat the value as 'at least this many', never as a total.
+                 * @example true
+                 */
+                is_lower_bound: boolean;
                 lookback_days: number;
                 method: string;
                 unattributed_registrations: number;
@@ -7450,6 +7455,11 @@ export interface components {
                 reason: string;
             };
             derivation?: {
+                /**
+                 * @description True when the count is a floor rather than a measurement: some registrations in the window displaced a holder the derivation's lookback cannot name, so the real figure is higher by at least `unattributed_registrations`. Treat the value as 'at least this many', never as a total.
+                 * @example true
+                 */
+                is_lower_bound: boolean;
                 lookback_days: number;
                 method: string;
                 unattributed_registrations: number;
@@ -11082,6 +11092,11 @@ export interface components {
             deregistrations: number;
             deregistrations_per_hotkey: number | null;
             derivation?: {
+                /**
+                 * @description True when the count is a floor rather than a measurement: some registrations in the window displaced a holder the derivation's lookback cannot name, so the real figure is higher by at least `unattributed_registrations`. Treat the value as 'at least this many', never as a total.
+                 * @example true
+                 */
+                is_lower_bound: boolean;
                 lookback_days: number;
                 method: string;
                 unattributed_registrations: number;
@@ -16267,6 +16282,7 @@ export interface operations {
                      *           "reason": "example"
                      *         },
                      *         "derivation": {
+                     *           "is_lower_bound": false,
                      *           "lookback_days": 1,
                      *           "method": "GET",
                      *           "unattributed_registrations": 1,
@@ -25314,6 +25330,7 @@ export interface operations {
                      *         "deregistrations": 1,
                      *         "deregistrations_per_hotkey": 0.5,
                      *         "derivation": {
+                     *           "is_lower_bound": false,
                      *           "lookback_days": 1,
                      *           "method": "GET",
                      *           "unattributed_registrations": 1,
@@ -29551,6 +29568,7 @@ export interface operations {
                      *           "reason": "example"
                      *         },
                      *         "derivation": {
+                     *           "is_lower_bound": false,
                      *           "lookback_days": 1,
                      *           "method": "GET",
                      *           "unattributed_registrations": 1,
@@ -35059,6 +35077,7 @@ export interface operations {
                      *           "reason": "example"
                      *         },
                      *         "derivation": {
+                     *           "is_lower_bound": false,
                      *           "lookback_days": 1,
                      *           "method": "GET",
                      *           "unattributed_registrations": 1,
@@ -49201,6 +49220,7 @@ export interface operations {
                      *         "deregistrations": 1,
                      *         "deregistrations_per_hotkey": 0.5,
                      *         "derivation": {
+                     *           "is_lower_bound": false,
                      *           "lookback_days": 1,
                      *           "method": "GET",
                      *           "unattributed_registrations": 1,

--- a/schemas-src/routes/event-stream-honesty.ts
+++ b/schemas-src/routes/event-stream-honesty.ts
@@ -34,5 +34,24 @@ export const DeregistrationDerivationSchema = z
     lookback_days: z.int().min(0),
     window_registrations: z.int().min(0),
     unattributed_registrations: z.int().min(0),
+    // #9708: the same fact, machine-readable. The prose above and
+    // `unattributed_registrations` have said "lower bound" since #9307, but
+    // only to a human reading docs -- the payload published a bare count, and
+    // a bare count reads as a measurement. Measured on mainnet 2026-08-07
+    // against subnets with no free UIDs, where every registration must
+    // displace someone: SN64 published 0 deregistrations against 24
+    // registrations, SN51 0 against 26, SN120 219 against 470, SN53 287
+    // against 540. A reader took the zeros to mean "no churn" -- the opposite
+    // of the truth -- and nothing in the response contradicted them.
+    is_lower_bound: z
+      .boolean()
+      .describe(
+        "True when the count is a floor rather than a measurement: some " +
+          "registrations in the window displaced a holder the derivation's " +
+          "lookback cannot name, so the real figure is higher by at least " +
+          "`unattributed_registrations`. Treat the value as 'at least this " +
+          "many', never as a total.",
+      )
+      .meta({ examples: [true] }),
   })
   .strict();

--- a/src/deregistration-derivation.ts
+++ b/src/deregistration-derivation.ts
@@ -62,6 +62,30 @@ export interface DeregistrationDerivation {
   window_registrations: number;
   /** Of those, the ones with no observed previous holder. */
   unattributed_registrations: number;
+  /**
+   * True when the published count is a floor rather than a measurement.
+   *
+   * The prose above, the SDL description, and `unattributed_registrations`
+   * itself have all said this since #9307 -- but only to a human reading the
+   * docs. The PAYLOAD published a bare number, and a bare number reads as a
+   * measurement no matter what the documentation says. Measured on mainnet
+   * 2026-08-07, against subnets whose UIDs are full so every registration must
+   * displace someone:
+   *
+   *   SN64 Chutes    24 registrations/30d,   0 deregistrations   100% under
+   *   SN51 lium.io   26 registrations/30d,   0 deregistrations   100% under
+   *   SN120 Affine  470 registrations/30d, 219 deregistrations    53% under
+   *   SN53 engy     540 registrations/30d, 287 deregistrations    47% under
+   *
+   * Two subnets publish a literal zero while two dozen hotkeys register into a
+   * subnet with no free slots. A reader concluded "no churn, nobody
+   * registering" from that zero -- the opposite of the truth -- and the number
+   * gave them no reason to doubt it.
+   *
+   * A wrong number that looks authoritative is worse than a null, and worse
+   * than a flagged floor. This is the flag.
+   */
+  is_lower_bound: boolean;
 }
 
 /** One NeuronRegistered row as the lakehouse returns it. */

--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -1168,6 +1168,12 @@ async function computeChainDeregistrations(
       lookback_days: lookbackDays,
       window_registrations: derived.registrations,
       unattributed_registrations: derived.unattributed,
+      // #9708: say in the PAYLOAD what the docs already said in prose. Any
+      // unattributed registration displaced a holder the lookback cannot name,
+      // so every published count is a floor by at least that many events --
+      // and a bare number reads as a measurement however carefully the
+      // documentation hedges it.
+      is_lower_bound: derived.unattributed > 0,
     };
     const subnetRows = deregistrationsByNetuid(derived.events);
     windows[label] = {

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -158,6 +158,8 @@ function deregistrationProjectionEnv(): Row {
     lookback_days: 30,
     window_registrations: 8064,
     unattributed_registrations: 1726,
+    // #9708: the payload now says out loud what the docs always said.
+    is_lower_bound: true,
   };
   const bodies: Record<string, unknown> = {
     [CHAIN_DEREGISTRATIONS_PROJECTION_KEY]: {
@@ -2546,6 +2548,10 @@ describe("handleSubnetDeregistrations", () => {
     assert.equal(body.data.deregistrations, 441);
     assert.equal(body.data.distinct_deregistered_hotkeys, 432);
     assert.equal(body.data.derivation.unattributed_registrations, 1726);
+    // The floor is flagged in the payload, not only in the documentation
+    // (#9708). Two mainnet subnets published a literal 0 against two dozen
+    // registrations each, and a reader took that to mean "no churn".
+    assert.equal(body.data.derivation.is_lower_bound, true);
     assert.equal(body.data.degraded, undefined);
     await assertValidComponent("SubnetDeregistrationsArtifact", body.data);
   });
@@ -5668,6 +5674,10 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.total_deregistrations, 2);
     assert.equal(body.data.derivation.unattributed_registrations, 1726);
+    // The floor is flagged in the payload, not only in the documentation
+    // (#9708). Two mainnet subnets published a literal 0 against two dozen
+    // registrations each, and a reader took that to mean "no churn".
+    assert.equal(body.data.derivation.is_lower_bound, true);
     assert.equal(body.data.degraded, undefined);
     await assertValidComponent("AccountDeregistrationsArtifact", body.data);
   });


### PR DESCRIPTION
## Reproduced

On subnets with no free UIDs every registration must displace a holder, so deregistrations should ≈ registrations. Measured against mainnet 2026-08-07:

| subnet | regs/30d | deregs/30d | undercount |
|---|---|---|---|
| SN64 Chutes | 24 | **0** | 100% |
| SN51 lium.io | 26 | **0** | 100% |
| SN120 Affine | 470 | 219 | 53% |
| SN53 engy | 540 | 287 | 47% |

Two subnets publish a literal **zero** while two dozen hotkeys register into a subnet with no free slots.

## The count isn't wrong — the presentation is

Deregistrations are derived from UID reuse (#9307) because `NeuronDeregistered` has never been emitted on-chain. A registration onto a slot whose previous holder the lookback can't name is unattributable by construction — ~11,687 of 33,139 network registrations over 30d are exactly that.

The module prose, the SDL description, and `unattributed_registrations` have all said "lower bound" since #9307 — **to a human reading documentation.** The payload published a bare number, and a bare number reads as a measurement however carefully the docs hedge it. The reporter concluded "no churn, nobody registering" from the zeros — the opposite of the truth — and nothing in the response contradicted them.

## Fix

`derivation.is_lower_bound`, true whenever `unattributed_registrations > 0`. Declared in `schemas-src/routes/event-stream-honesty.ts` — which is `.strict()`, so it regenerates into `openapi.json` and the published types (both committed here) — and set where the derivation is built.

A wrong number that looks authoritative is worse than a null, and worse than a flagged floor.

## Not in this change

Reconciling against the `NeuronRegistered` stream when `open_slots == 0` would make the count *correct* rather than merely *honest*. That's a data-pipeline change and wants its own issue; this stops the wrong conclusion today without waiting on a backfill.

## Verification

```
npx tsc --noEmit       clean
npm run build          openapi.json + types regenerated and committed
npm run validate       129 subnets, 3442 surfaces, 136 providers
lint / format:check    clean
full suite             705 files, 17,127 tests — all passing
```

Two fixtures failed on the `.strict()` schema for lacking the new field — the correct failure — and now assert it.

Closes #9708