### PR TITLE
feat(neon): give the store a writer and a lane, before anything reads it

### DIFF
--- a/src/neon-write.ts
+++ b/src/neon-write.ts
@@ -1,0 +1,297 @@
+// Bulk writes into Neon (metagraphed-infra#336), the write half the pilot never
+// had.
+//
+// THE PILOT SHIPPED A READ AND NO WRITER. Neon took one load on 2026-08-05
+// 19:35 and froze there, while `GET /api/v1/accounts/{ss58}/subnets/{netuid}/
+// history` was already reading it -- so that route served a two-day-old
+// snapshot until metagraphed#9705 unbound Hyperdrive. Nothing checked the pair,
+// because a store with no writer looks exactly like a store with a slow one
+// until you read its MAX().
+//
+// So this file exists before any read moves back, and the rule it encodes is:
+// a lane is not on Neon until a producer tick has been observed landing in it.
+//
+// ## Why this is NOT `src/neurons-d1-write.ts` with a different runner
+//
+// `createPgSql` is deliberately interface-compatible with `createD1Sql`, and
+// that is enough for the READ path -- a route moves store by being handed a
+// different `sql`. The WRITE path cannot follow, because its SQL is not
+// portable: D1 caps a statement at 100 bound parameters, so the bulk writes
+// there smuggle whole chunks through a single JSON parameter and unpack them
+// with `json_each` / `json_extract`. That is a workaround for a limit Postgres
+// does not have.
+//
+// Postgres takes 65,535 parameters per statement, so the honest form -- a plain
+// multi-row `INSERT ... VALUES` -- is both simpler and faster here. At 22
+// columns that is 2,978 rows in one statement against D1's four.
+//
+// ## Best-effort, and never in front of the D1 write
+//
+// Every function here returns a result rather than throwing. During dual-write
+// the D1 write is still the one the routes read, so a Neon failure must cost a
+// mirror and a lane verdict -- not the pass. That inverts once a lane's read
+// moves, and the invariant that makes the inversion safe is the lane verdict
+// this records on every attempt: metagraphed#9698 reads it, so a Neon store
+// that stops accepting writes surfaces the same way any other lane does.
+
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+
+/**
+ * Postgres' hard ceiling on bound parameters in one statement.
+ *
+ * 65,535 -- the wire protocol counts them in an int16. Exceeding it is a
+ * protocol error rather than a slow query, so this is a real bound and not a
+ * tuning knob, which is why it is stated here rather than folded into a
+ * chunk-size constant somebody could later "optimise".
+ */
+export const PG_PARAM_LIMIT = 65_535;
+
+/**
+ * How much of that ceiling one statement may use.
+ *
+ * EIGHTY PERCENT. The headroom is not superstition: a chunk sized exactly to
+ * the limit leaves no room for a column being added to the write, and adding a
+ * column is the single most likely future edit to these tables. At 80% a 22-
+ * column write can gain five more columns before the chunk size has to change.
+ */
+export const PG_PARAM_BUDGET = Math.floor(PG_PARAM_LIMIT * 0.8);
+
+/** How many rows of `columnCount` columns fit in one statement. Never zero --
+ * a single row always gets its own statement, even if it is somehow wider than
+ * the budget, so the caller gets a Postgres error naming the real problem
+ * rather than an empty write that silently succeeded. */
+export function rowsPerPgStatement(columnCount: number): number {
+  if (columnCount <= 0) return 1;
+  return Math.max(1, Math.floor(PG_PARAM_BUDGET / columnCount));
+}
+
+/**
+ * `($1, $2, $3), ($4, $5, $6), ...` for `rowCount` rows of `columnCount`.
+ *
+ * The numbering IS the contract. Postgres placeholders are 1-based and
+ * positional, and an off-by-one does not throw -- it binds the value to the
+ * wrong column, which is a wrong row written confidently. Exported so a test
+ * can assert the built text directly, which is cheaper than discovering it
+ * from a wrong answer in production.
+ */
+export function pgValuesClause(rowCount: number, columnCount: number): string {
+  const groups: string[] = [];
+  for (let row = 0; row < rowCount; row += 1) {
+    const params: string[] = [];
+    for (let col = 0; col < columnCount; col += 1) {
+      params.push(`$${row * columnCount + col + 1}`);
+    }
+    groups.push(`(${params.join(", ")})`);
+  }
+  return groups.join(", ");
+}
+
+/**
+ * A multi-row upsert.
+ *
+ * `conflict` names the natural key; the columns that are NOT part of it get
+ * `DO UPDATE`. An empty `conflict` means a plain append, which is what the
+ * history tables want.
+ *
+ * `guard` is an optional `WHERE` on the DO UPDATE -- the Postgres spelling of
+ * the out-of-order protection `buildUpsert` applies in D1: an older capture
+ * arriving after a newer one must be a no-op, not a regression. Two lanes here
+ * retry, so an out-of-order arrival is a real event and not a hypothetical.
+ */
+export function buildPgUpsert(
+  table: string,
+  columns: readonly string[],
+  conflict: readonly string[],
+  rowCount: number,
+  guard?: string,
+): string {
+  const head =
+    `INSERT INTO ${table} (${columns.join(", ")}) VALUES ` +
+    pgValuesClause(rowCount, columns.length);
+  if (conflict.length === 0) return head;
+  const updates = columns
+    .filter((column) => !conflict.includes(column))
+    .map((column) => `${column} = EXCLUDED.${column}`);
+  if (updates.length === 0) {
+    // Every column is part of the key, so there is nothing an update could
+    // change. DO NOTHING rather than an empty SET, which is a syntax error.
+    return `${head} ON CONFLICT (${conflict.join(", ")}) DO NOTHING`;
+  }
+  const where = guard ? ` WHERE ${guard}` : "";
+  return (
+    `${head} ON CONFLICT (${conflict.join(", ")}) DO UPDATE SET ` +
+    `${updates.join(", ")}${where}`
+  );
+}
+
+/** Rows -> a flat parameter list, in the column order given. `undefined` is
+ * normalised to null: `pg` rejects undefined, and a row that is merely missing
+ * a key is an ordinary shape here rather than an error. */
+export function pgFlatValues(
+  rows: readonly Record<string, unknown>[],
+  columns: readonly string[],
+): unknown[] {
+  const values: unknown[] = [];
+  for (const row of rows) {
+    for (const column of columns) {
+      const value = row[column];
+      values.push(value === undefined ? null : value);
+    }
+  }
+  return values;
+}
+
+/** The one method this needs from `PgSql`, so a test can hand a plain
+ * function and a caller can hand the real runner. */
+export interface PgUnsafe {
+  unsafe(text: string, values?: unknown[]): Promise<unknown>;
+}
+
+export interface NeonWriteResult {
+  ok: boolean;
+  /** Rows this call attempted. Reported even on failure, because "how much did
+   * not land" is the triage question. */
+  rows: number;
+  statements: number;
+  reason?: string;
+}
+
+/**
+ * Write `rows` into `table`, chunked to fit Postgres' parameter ceiling.
+ *
+ * STOPS AT THE FIRST FAILED CHUNK, unlike the poller's chunked POST, and the
+ * difference is not an inconsistency. There, each chunk was a whole set of
+ * netuids and the sink pruned per netuid, so chunk 4 did not depend on chunk 3.
+ * Here every chunk is part of one logical write into one table, and continuing
+ * past a failure would leave a partial state that the row count reports as
+ * nearly complete. The count of what did land is in the result either way.
+ */
+export async function writeRowsToNeon(
+  sql: PgUnsafe | null | undefined,
+  table: string,
+  columns: readonly string[],
+  rows: readonly Record<string, unknown>[],
+  conflict: readonly string[] = [],
+  guard?: string,
+): Promise<NeonWriteResult> {
+  if (!sql?.unsafe)
+    return { ok: false, rows: 0, statements: 0, reason: "unbound" };
+  if (rows.length === 0) return { ok: true, rows: 0, statements: 0 };
+  if (columns.length === 0) {
+    return { ok: false, rows: 0, statements: 0, reason: "no_columns" };
+  }
+  const perStatement = rowsPerPgStatement(columns.length);
+  let written = 0;
+  let statements = 0;
+  for (let i = 0; i < rows.length; i += perStatement) {
+    const chunk = rows.slice(i, i + perStatement);
+    const text = buildPgUpsert(table, columns, conflict, chunk.length, guard);
+    try {
+      await sql.unsafe(text, pgFlatValues(chunk, columns));
+    } catch (error) {
+      return {
+        ok: false,
+        rows: written,
+        statements,
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
+    written += chunk.length;
+    statements += 1;
+  }
+  return { ok: true, rows: written, statements };
+}
+
+/**
+ * Record one Neon write's outcome as a lane verdict.
+ *
+ * THIS IS THE INVARIANT THE PILOT WAS MISSING. A store with no lane is
+ * invisible to metagraphed#9698's reader, and a frozen Neon serving 200 OK with
+ * plausible rows is indistinguishable from a healthy one -- which is exactly
+ * how a two-day-old snapshot reached the public API unnoticed.
+ *
+ * `age_ms` is deliberately null: this is a write outcome, and there is no
+ * meaningful "how far behind" to report from inside a single write. Inventing
+ * one would put a fabricated number in the column triage reads.
+ */
+export async function recordNeonWriteVerdict(
+  db: LaneHealthDb | null | undefined,
+  lane: string,
+  result: NeonWriteResult,
+  nowMs: number,
+): Promise<boolean> {
+  return recordLaneVerdict(db, {
+    lane: `neon:${lane}`,
+    verdict: result.ok ? "ok" : "stale",
+    age_ms: null,
+    detail: result.ok
+      ? `${result.rows} row(s) in ${result.statements} statement(s)`
+      : `${result.rows} row(s) written before failure: ${result.reason ?? "unknown"}`,
+    checked_at: nowMs,
+  });
+}
+
+/**
+ * Which lanes dual-write into Neon, read from the environment.
+ *
+ * A COMMA LIST, DEFAULTING TO EMPTY, so this file changes nothing until a lane
+ * is named. That matters more than usual here: the pilot's failure was a store
+ * being used before it was ready, and a flag that defaults ON would repeat it
+ * on the deploy that introduced the flag.
+ *
+ * Same shape as SYNC_QUEUE_LANES, so the two cutovers are read the same way.
+ */
+export function neonDualWriteLanes(
+  env: Record<string, unknown> | null | undefined,
+): Set<string> {
+  const raw = env?.NEON_DUAL_WRITE_LANES;
+  if (typeof raw !== "string" || raw.trim() === "") return new Set();
+  return new Set(
+    raw
+      .split(",")
+      .map((lane) => lane.trim())
+      .filter((lane) => lane.length > 0),
+  );
+}
+
+/**
+ * Which lanes READ from Neon. A separate flag from the write list, on purpose.
+ *
+ * THE CONFLATION IS WHAT BROKE THE PILOT. The read gate used to be "is
+ * HYPERDRIVE bound", so binding the config for a WRITE pilot silently moved a
+ * READ -- and `GET /api/v1/accounts/{ss58}/subnets/{netuid}/history` began
+ * serving a store nothing had ever written to. "The binding exists" and "this
+ * route should read Neon" are different questions and now have different
+ * answers.
+ *
+ * Defaults to empty, so the binding can come back for the writer without any
+ * read following it.
+ */
+export function neonReadLanes(
+  env: Record<string, unknown> | null | undefined,
+): Set<string> {
+  const raw = env?.NEON_READ_LANES;
+  if (typeof raw !== "string" || raw.trim() === "") return new Set();
+  return new Set(
+    raw
+      .split(",")
+      .map((lane) => lane.trim())
+      .filter((lane) => lane.length > 0),
+  );
+}
+
+/** Whether `lane`'s reads should be served from Neon on this deployment. */
+export function neonReadEnabled(
+  env: Record<string, unknown> | null | undefined,
+  lane: string,
+): boolean {
+  return neonReadLanes(env).has(lane);
+}
+
+/** Whether `lane` should mirror into Neon on this deployment. */
+export function neonDualWriteEnabled(
+  env: Record<string, unknown> | null | undefined,
+  lane: string,
+): boolean {
+  return neonDualWriteLanes(env).has(lane);
+}

--- a/src/neurons-neon-write.ts
+++ b/src/neurons-neon-write.ts
@@ -1,0 +1,169 @@
+// The neurons lane's Neon mirror (metagraphed-infra#336).
+//
+// Three tables move together because ONE handler produces all three:
+// `handleNeuronsSync` parses the posted metagraph into `neurons`, then derives
+// `neuron_daily` and `account_position_daily` from it. Mirroring at that point
+// costs one extra pass over rows already in memory, and mirroring anywhere else
+// would mean re-deriving them.
+//
+// ## The ordering is the point
+//
+// This runs AFTER the D1 write returns, never instead of it and never in front
+// of it. The pilot broke by doing the opposite -- a read moved to Neon while
+// nothing wrote to it, so `GET /api/v1/accounts/{ss58}/subnets/{netuid}/history`
+// served a two-day-old snapshot until metagraphed#9705 unbound Hyperdrive.
+//
+// While dual-writing, D1 is still the store every route reads. So a Neon
+// failure must cost a mirror and a lane verdict, and nothing else. Nothing here
+// throws.
+//
+// ## What makes the eventual read-cutover safe
+//
+// A lane verdict on EVERY attempt. metagraphed#9698's reader turns a Neon store
+// that stops accepting writes into a GitHub issue within the hour -- which is
+// the check that did not exist when a frozen database was serving the public
+// API. Do not move a read onto a table here until its `neon:` lane has been
+// green across several producer ticks.
+
+import {
+  neonDualWriteEnabled,
+  recordNeonWriteVerdict,
+  writeRowsToNeon,
+  type NeonWriteResult,
+} from "./neon-write.ts";
+import {
+  ACCOUNT_POSITION_DAILY_COLUMNS,
+  NEURON_DAILY_COLUMNS,
+} from "./neurons-d1-write.ts";
+import { NEURON_INSERT_COLUMNS } from "./metagraph-neurons.ts";
+import {
+  createPgSql,
+  type HyperdriveLike,
+  type WaitUntilLike,
+} from "./pg-sql.ts";
+import type { LaneHealthDb } from "./lane-health.ts";
+
+/** The lane name this mirror answers to in NEON_DUAL_WRITE_LANES. */
+export const NEURONS_NEON_LANE = "neurons";
+
+type Row = Record<string, unknown>;
+
+/**
+ * One table's mirror plan: where the rows go, in what column order, and on
+ * what key they collide.
+ *
+ * The conflict keys match Neon's own primary keys, read off the live database
+ * rather than assumed -- `neurons_pkey (netuid, uid)` and
+ * `account_position_daily_pkey (account, netuid, snapshot_date)`. An ON CONFLICT
+ * naming columns without a matching unique index is a runtime error, not a
+ * slower query.
+ */
+interface MirrorPlan {
+  table: string;
+  columns: readonly string[];
+  conflict: readonly string[];
+  guard?: string;
+}
+
+export const NEURON_MIRROR_PLANS: Readonly<Record<string, MirrorPlan>> = {
+  neurons: {
+    table: "neurons",
+    columns: NEURON_INSERT_COLUMNS,
+    conflict: ["netuid", "uid"],
+    // The out-of-order protection D1's own upsert applies. A retried chunk can
+    // arrive after a newer pass, and without this it would overwrite fresher
+    // rows with older ones -- silently, since both writes succeed.
+    guard: "neurons.captured_at < EXCLUDED.captured_at",
+  },
+  neuron_daily: {
+    table: "neuron_daily",
+    columns: NEURON_DAILY_COLUMNS,
+    conflict: ["netuid", "uid", "snapshot_date"],
+  },
+  account_position_daily: {
+    table: "account_position_daily",
+    columns: ACCOUNT_POSITION_DAILY_COLUMNS,
+    conflict: ["account", "netuid", "snapshot_date"],
+  },
+};
+
+export interface NeuronMirrorInput {
+  rows: Row[];
+  dailyRows: Row[];
+  positionRows: Row[];
+}
+
+export interface NeuronMirrorOutcome {
+  /** False when the lane is not enabled, or Hyperdrive is unbound. Distinct
+   * from a failed attempt: "we did not try" is not "we tried and it broke". */
+  attempted: boolean;
+  results: Record<string, NeonWriteResult>;
+}
+
+export interface NeuronMirrorDeps {
+  /** Injectable runner, so a test asserts the statements without a database. */
+  sql?: { unsafe(text: string, values?: unknown[]): Promise<unknown> } | null;
+  laneHealthDb?: LaneHealthDb | null;
+  now?: () => number;
+}
+
+/**
+ * Mirror one snapshot into Neon. Never throws.
+ *
+ * The three writes run in sequence rather than in parallel: they share one
+ * Hyperdrive connection, and `neurons` is the table a read would move to first,
+ * so it goes first and a failure below it still leaves the most important table
+ * current.
+ */
+export async function mirrorNeuronSnapshotToNeon(
+  env: Record<string, unknown> | null | undefined,
+  ctx: WaitUntilLike | null | undefined,
+  input: NeuronMirrorInput,
+  deps: NeuronMirrorDeps = {},
+): Promise<NeuronMirrorOutcome> {
+  const empty: NeuronMirrorOutcome = { attempted: false, results: {} };
+  if (!neonDualWriteEnabled(env, NEURONS_NEON_LANE)) return empty;
+
+  const hyperdrive = env?.HYPERDRIVE as HyperdriveLike | undefined;
+  const sql =
+    deps.sql ??
+    (hyperdrive?.connectionString && ctx ? createPgSql(hyperdrive, ctx) : null);
+  // Enabled but unbound is a MISCONFIGURATION, not a quiet no-op: somebody
+  // named the lane and the binding is missing, and that deserves a verdict
+  // rather than silence. It is recorded under the lane so #9698 reports it.
+  const laneDb =
+    deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as LaneHealthDb | undefined);
+  const now = deps.now ?? Date.now;
+  if (!sql) {
+    await recordNeonWriteVerdict(
+      laneDb,
+      NEURONS_NEON_LANE,
+      { ok: false, rows: 0, statements: 0, reason: "hyperdrive unbound" },
+      now(),
+    );
+    return { attempted: true, results: {} };
+  }
+
+  // Keyed by the same names as NEURON_MIRROR_PLANS, so the loop below indexes
+  // it without a fallback -- a `?? []` there would silently mirror nothing if
+  // the two ever drifted apart, which is the opposite of what should happen.
+  const byTable: Record<keyof typeof NEURON_MIRROR_PLANS, Row[]> = {
+    neurons: input.rows,
+    neuron_daily: input.dailyRows,
+    account_position_daily: input.positionRows,
+  };
+  const results: Record<string, NeonWriteResult> = {};
+  for (const [name, plan] of Object.entries(NEURON_MIRROR_PLANS)) {
+    const result = await writeRowsToNeon(
+      sql,
+      plan.table,
+      plan.columns,
+      byTable[name],
+      plan.conflict,
+      plan.guard,
+    );
+    results[name] = result;
+    await recordNeonWriteVerdict(laneDb, name, result, now());
+  }
+  return { attempted: true, results };
+}

--- a/tests/neon-write.test.ts
+++ b/tests/neon-write.test.ts
@@ -1,0 +1,439 @@
+// Bulk writes into Neon (src/neon-write.ts, metagraphed-infra#336).
+//
+// The load-bearing properties, all of them shaped by how the pilot broke:
+//
+//   * PLACEHOLDER NUMBERING. Postgres binds positionally and an off-by-one does
+//     not throw -- it writes the wrong column, confidently. The built text is
+//     asserted directly for that reason.
+//   * A FAILED WRITE MUST SAY HOW MUCH LANDED, because "3 of 4 chunks" and
+//     "0 of 4" are different outages.
+//   * EVERY ATTEMPT RECORDS A LANE VERDICT. A store with no lane is invisible
+//     to #9698's reader, which is exactly how a frozen Neon served the public
+//     API for two days.
+//   * THE FLAG DEFAULTS OFF. A flag defaulting on would repeat the pilot's
+//     failure on the very deploy that introduced it.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  buildPgUpsert,
+  neonDualWriteEnabled,
+  neonDualWriteLanes,
+  neonReadEnabled,
+  neonReadLanes,
+  PG_PARAM_BUDGET,
+  PG_PARAM_LIMIT,
+  pgFlatValues,
+  pgValuesClause,
+  recordNeonWriteVerdict,
+  rowsPerPgStatement,
+  writeRowsToNeon,
+} from "../src/neon-write.ts";
+
+const NOW = 1_785_800_000_000;
+
+/** A Postgres runner double: records every statement, or fails on demand. */
+function fakeSql(failOn: number | null = null) {
+  const calls: { text: string; values: unknown[] }[] = [];
+  return {
+    calls,
+    async unsafe(text: string, values: unknown[] = []) {
+      calls.push({ text, values });
+      if (failOn !== null && calls.length === failOn) {
+        throw new Error("duplicate key value violates unique constraint");
+      }
+      return [];
+    },
+  };
+}
+
+describe("pgValuesClause", () => {
+  test("numbers placeholders across rows, 1-based and continuous", () => {
+    // The contract. A wrong number here binds a value to the wrong column
+    // rather than failing, so this is asserted as text.
+    assert.equal(pgValuesClause(3, 2), "($1, $2), ($3, $4), ($5, $6)");
+  });
+
+  test("a single row of a single column is `($1)`", () => {
+    assert.equal(pgValuesClause(1, 1), "($1)");
+  });
+
+  test("no rows produces no groups", () => {
+    assert.equal(pgValuesClause(0, 4), "");
+  });
+});
+
+describe("rowsPerPgStatement", () => {
+  test("fills the budget without exceeding the protocol ceiling", () => {
+    const columns = 22;
+    const rows = rowsPerPgStatement(columns);
+    assert.ok(rows * columns <= PG_PARAM_BUDGET);
+    assert.ok(
+      rows * columns > PG_PARAM_BUDGET - columns,
+      "must not waste room",
+    );
+    // And comfortably inside the real wire limit, with the headroom intact.
+    assert.ok(rows * columns < PG_PARAM_LIMIT);
+  });
+
+  test("beats D1's batching by three orders of magnitude", () => {
+    // The reason this file exists rather than reusing neurons-d1-write.ts:
+    // D1 caps a statement at 100 parameters, so a 22-column write gets four
+    // rows. The JSON smuggling there is a workaround for a limit Postgres
+    // does not have.
+    assert.ok(rowsPerPgStatement(22) > 2_000);
+  });
+
+  test("never returns zero, whatever it is handed", () => {
+    // A zero would write nothing and report success. A row wider than the
+    // budget instead gets its own statement, so Postgres names the real
+    // problem.
+    assert.equal(rowsPerPgStatement(0), 1);
+    assert.equal(rowsPerPgStatement(-5), 1);
+    assert.equal(rowsPerPgStatement(PG_PARAM_BUDGET * 2), 1);
+  });
+});
+
+describe("buildPgUpsert", () => {
+  const columns = ["netuid", "uid", "stake_tao"] as const;
+
+  test("a plain append when nothing conflicts", () => {
+    assert.equal(
+      buildPgUpsert("neurons", columns, [], 2),
+      "INSERT INTO neurons (netuid, uid, stake_tao) VALUES ($1, $2, $3), ($4, $5, $6)",
+    );
+  });
+
+  test("updates exactly the non-key columns", () => {
+    assert.equal(
+      buildPgUpsert("neurons", columns, ["netuid", "uid"], 1),
+      "INSERT INTO neurons (netuid, uid, stake_tao) VALUES ($1, $2, $3) " +
+        "ON CONFLICT (netuid, uid) DO UPDATE SET stake_tao = EXCLUDED.stake_tao",
+    );
+  });
+
+  test("DO NOTHING when every column is part of the key", () => {
+    // An empty SET is a syntax error, and this shape is reachable: a pure
+    // membership table has no non-key columns.
+    assert.equal(
+      buildPgUpsert("t", ["a", "b"], ["a", "b"], 1),
+      "INSERT INTO t (a, b) VALUES ($1, $2) ON CONFLICT (a, b) DO NOTHING",
+    );
+  });
+
+  test("carries the out-of-order guard onto the update", () => {
+    // The Postgres spelling of what buildUpsert does in D1: an older capture
+    // arriving after a newer one must be a no-op, not a regression. Two lanes
+    // here retry, so this is a real event.
+    const sql = buildPgUpsert(
+      "neurons",
+      columns,
+      ["netuid", "uid"],
+      1,
+      "neurons.captured_at < EXCLUDED.captured_at",
+    );
+    assert.ok(
+      sql.endsWith(" WHERE neurons.captured_at < EXCLUDED.captured_at"),
+    );
+  });
+});
+
+describe("pgFlatValues", () => {
+  test("flattens in column order, not key order", () => {
+    // Row key order is whatever the producer happened to build; the parameter
+    // order must follow the COLUMN list or every value lands one column off.
+    assert.deepEqual(
+      pgFlatValues(
+        [
+          { b: 2, a: 1 },
+          { a: 3, b: 4 },
+        ],
+        ["a", "b"],
+      ),
+      [1, 2, 3, 4],
+    );
+  });
+
+  test("normalises a missing key to null rather than undefined", () => {
+    // `pg` rejects undefined outright. A row missing an optional column is an
+    // ordinary shape here, not an error.
+    assert.deepEqual(pgFlatValues([{ a: 1 }], ["a", "b"]), [1, null]);
+  });
+
+  test("keeps a real zero and a real false", () => {
+    // The `?? null` mistake this repo keeps catching: zero and false are
+    // measurements, and erasing them loses exactly the rows worth having.
+    assert.deepEqual(pgFlatValues([{ a: 0, b: false }], ["a", "b"]), [
+      0,
+      false,
+    ]);
+  });
+});
+
+describe("writeRowsToNeon", () => {
+  test("writes one statement when the rows fit", async () => {
+    const sql = fakeSql();
+    const result = await writeRowsToNeon(
+      sql,
+      "neurons",
+      ["netuid", "uid"],
+      [
+        { netuid: 1, uid: 2 },
+        { netuid: 1, uid: 3 },
+      ],
+      ["netuid", "uid"],
+    );
+    assert.deepEqual(result, { ok: true, rows: 2, statements: 1 });
+    assert.equal(sql.calls.length, 1);
+    assert.deepEqual(sql.calls[0].values, [1, 2, 1, 3]);
+  });
+
+  test("chunks to the parameter budget", async () => {
+    const sql = fakeSql();
+    const columns = Array.from({ length: 22 }, (_, i) => `c${i}`);
+    const perStatement = rowsPerPgStatement(columns.length);
+    const rows = Array.from({ length: perStatement + 5 }, () =>
+      Object.fromEntries(columns.map((c) => [c, 1])),
+    );
+    const result = await writeRowsToNeon(sql, "t", columns, rows);
+    assert.equal(result.statements, 2);
+    assert.equal(result.rows, rows.length);
+    for (const call of sql.calls) {
+      assert.ok(call.values.length <= PG_PARAM_BUDGET);
+    }
+  });
+
+  test("stops at the first failed chunk and says how much landed", async () => {
+    // Unlike the poller's chunked POST, where each chunk was an independent
+    // set of netuids. Here every chunk is part of one write into one table, so
+    // continuing would leave a partial state the row count calls nearly whole.
+    const sql = fakeSql(2);
+    const columns = Array.from({ length: 22 }, (_, i) => `c${i}`);
+    const perStatement = rowsPerPgStatement(columns.length);
+    const rows = Array.from({ length: perStatement * 3 }, () =>
+      Object.fromEntries(columns.map((c) => [c, 1])),
+    );
+    const result = await writeRowsToNeon(sql, "t", columns, rows);
+    assert.equal(result.ok, false);
+    assert.equal(result.rows, perStatement, "the first chunk did land");
+    assert.equal(result.statements, 1);
+    assert.match(String(result.reason), /unique constraint/);
+    assert.equal(
+      sql.calls.length,
+      2,
+      "it stopped rather than trying the third",
+    );
+  });
+
+  test("an unbound runner is reported, not thrown", async () => {
+    // During dual-write the D1 write is the one routes read, so a Neon problem
+    // must cost a mirror and a lane verdict -- never the pass.
+    assert.deepEqual(await writeRowsToNeon(null, "t", ["a"], [{ a: 1 }]), {
+      ok: false,
+      rows: 0,
+      statements: 0,
+      reason: "unbound",
+    });
+    assert.deepEqual(
+      await writeRowsToNeon({} as never, "t", ["a"], [{ a: 1 }]),
+      { ok: false, rows: 0, statements: 0, reason: "unbound" },
+    );
+  });
+
+  test("no rows is a success that touched nothing", async () => {
+    const sql = fakeSql();
+    assert.deepEqual(await writeRowsToNeon(sql, "t", ["a"], []), {
+      ok: true,
+      rows: 0,
+      statements: 0,
+    });
+    assert.equal(sql.calls.length, 0);
+  });
+
+  test("no columns is a refusal, not an empty INSERT", async () => {
+    const sql = fakeSql();
+    const result = await writeRowsToNeon(sql, "t", [], [{ a: 1 }]);
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "no_columns");
+    assert.equal(sql.calls.length, 0);
+  });
+
+  test("a non-Error rejection still produces a readable reason", async () => {
+    const sql = {
+      async unsafe() {
+        throw "connection terminated";
+      },
+    };
+    const result = await writeRowsToNeon(sql, "t", ["a"], [{ a: 1 }]);
+    assert.equal(result.reason, "connection terminated");
+  });
+});
+
+describe("recordNeonWriteVerdict", () => {
+  function spy() {
+    const rows: Record<string, unknown>[] = [];
+    return {
+      rows,
+      db: {
+        prepare(sql: string) {
+          return {
+            bind(...values: unknown[]) {
+              return {
+                async run() {
+                  if (sql.startsWith("INSERT")) {
+                    rows.push({
+                      lane: values[0],
+                      verdict: values[1],
+                      age_ms: values[2],
+                      detail: values[3],
+                    });
+                  }
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("a successful write records ok, namespaced by store", async () => {
+    // The lane name carries the STORE, so `neon:neurons` and the D1 lane can
+    // both be stale independently and be told apart in one glance at the table.
+    const s = spy();
+    await recordNeonWriteVerdict(
+      s.db,
+      "neurons",
+      { ok: true, rows: 30_109, statements: 11 },
+      NOW,
+    );
+    assert.equal(s.rows[0].lane, "neon:neurons");
+    assert.equal(s.rows[0].verdict, "ok");
+    assert.equal(s.rows[0].detail, "30109 row(s) in 11 statement(s)");
+  });
+
+  test("a failed write records stale and how much landed first", async () => {
+    const s = spy();
+    await recordNeonWriteVerdict(
+      s.db,
+      "neurons",
+      { ok: false, rows: 2_978, statements: 1, reason: "deadlock detected" },
+      NOW,
+    );
+    assert.equal(s.rows[0].verdict, "stale");
+    assert.match(
+      String(s.rows[0].detail),
+      /2978 row\(s\) written before failure/,
+    );
+    assert.match(String(s.rows[0].detail), /deadlock detected/);
+  });
+
+  test("age_ms is null rather than a fabricated number", async () => {
+    // A write outcome has no meaningful "how far behind". Inventing one puts a
+    // made-up value in the column triage reads.
+    const s = spy();
+    await recordNeonWriteVerdict(
+      s.db,
+      "x",
+      { ok: true, rows: 1, statements: 1 },
+      NOW,
+    );
+    assert.equal(s.rows[0].age_ms, null);
+  });
+
+  test("names the reason as unknown rather than omitting it", async () => {
+    const s = spy();
+    await recordNeonWriteVerdict(
+      s.db,
+      "x",
+      { ok: false, rows: 0, statements: 0 },
+      NOW,
+    );
+    assert.match(String(s.rows[0].detail), /unknown/);
+  });
+
+  test("a missing sink is reported, never thrown", async () => {
+    assert.equal(
+      await recordNeonWriteVerdict(
+        null,
+        "x",
+        { ok: true, rows: 0, statements: 0 },
+        NOW,
+      ),
+      false,
+    );
+  });
+});
+
+describe("neonDualWriteLanes", () => {
+  test("defaults to nothing, so the flag's own deploy changes nothing", () => {
+    // The pilot's failure was a store used before it was ready. A flag that
+    // defaulted on would repeat it on the deploy that introduced the flag.
+    assert.deepEqual([...neonDualWriteLanes(undefined)], []);
+    assert.deepEqual([...neonDualWriteLanes(null)], []);
+    assert.deepEqual([...neonDualWriteLanes({})], []);
+    assert.deepEqual(
+      [...neonDualWriteLanes({ NEON_DUAL_WRITE_LANES: "" })],
+      [],
+    );
+    assert.deepEqual(
+      [...neonDualWriteLanes({ NEON_DUAL_WRITE_LANES: "  " })],
+      [],
+    );
+    assert.deepEqual([...neonDualWriteLanes({ NEON_DUAL_WRITE_LANES: 7 })], []);
+  });
+
+  test("reads a comma list, tolerating spacing and empties", () => {
+    assert.deepEqual(
+      [
+        ...neonDualWriteLanes({
+          NEON_DUAL_WRITE_LANES: " neurons , ,neuron_daily ",
+        }),
+      ],
+      ["neurons", "neuron_daily"],
+    );
+  });
+
+  test("enables exactly the lanes named", () => {
+    const env = { NEON_DUAL_WRITE_LANES: "neurons" };
+    assert.equal(neonDualWriteEnabled(env, "neurons"), true);
+    assert.equal(neonDualWriteEnabled(env, "neuron_daily"), false);
+    assert.equal(neonDualWriteEnabled({}, "neurons"), false);
+  });
+});
+
+describe("neonReadLanes", () => {
+  test("is a SEPARATE flag from the write list", () => {
+    // The conflation is what broke the pilot: the read gate was "is HYPERDRIVE
+    // bound", so binding the config for a WRITE pilot silently moved a READ
+    // onto a store nothing had ever written to.
+    const env = { NEON_DUAL_WRITE_LANES: "neurons" };
+    assert.equal(neonDualWriteEnabled(env, "neurons"), true);
+    assert.equal(neonReadEnabled(env, "neurons"), false);
+  });
+
+  test("defaults to empty, so a binding alone moves nothing", () => {
+    assert.deepEqual([...neonReadLanes(undefined)], []);
+    assert.deepEqual([...neonReadLanes(null)], []);
+    assert.deepEqual([...neonReadLanes({})], []);
+    assert.deepEqual([...neonReadLanes({ NEON_READ_LANES: "" })], []);
+    assert.deepEqual([...neonReadLanes({ NEON_READ_LANES: 7 })], []);
+  });
+
+  test("reads a comma list, tolerating spacing and empties", () => {
+    assert.deepEqual(
+      [
+        ...neonReadLanes({
+          NEON_READ_LANES: " account_position_daily , ,neurons ",
+        }),
+      ],
+      ["account_position_daily", "neurons"],
+    );
+    assert.equal(
+      neonReadEnabled(
+        { NEON_READ_LANES: "account_position_daily" },
+        "account_position_daily",
+      ),
+      true,
+    );
+  });
+});

--- a/tests/neurons-neon-write.test.ts
+++ b/tests/neurons-neon-write.test.ts
@@ -1,0 +1,267 @@
+// The neurons lane's Neon mirror (src/neurons-neon-write.ts, infra#336).
+//
+// What these pin, and why each one is here rather than being obvious:
+//
+//   * OFF BY DEFAULT. The pilot broke because a store was used before it was
+//     ready; a mirror that ran on the deploy introducing it would repeat that.
+//   * NEVER THROWS. During dual-write, D1 is the store every route reads, so a
+//     Neon failure must cost a mirror and a lane verdict -- not the pass.
+//   * A VERDICT ON EVERY ATTEMPT, including the misconfiguration. A store with
+//     no lane is invisible to #9698's reader, which is exactly how a frozen
+//     Neon served the public API for two days.
+//   * THE CONFLICT KEYS MATCH NEON'S REAL PRIMARY KEYS. An ON CONFLICT naming
+//     columns with no unique index behind them is a runtime error.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  mirrorNeuronSnapshotToNeon,
+  NEURON_MIRROR_PLANS,
+  NEURONS_NEON_LANE,
+} from "../src/neurons-neon-write.ts";
+
+const NOW = 1_785_800_000_000;
+
+function fakeSql(failOnTable: string | null = null) {
+  const calls: { text: string; values: unknown[] }[] = [];
+  return {
+    calls,
+    async unsafe(text: string, values: unknown[] = []) {
+      calls.push({ text, values });
+      if (failOnTable && text.includes(`INTO ${failOnTable} `)) {
+        throw new Error("relation does not exist");
+      }
+      return [];
+    },
+  };
+}
+
+function laneSpy() {
+  const rows: Record<string, unknown>[] = [];
+  return {
+    rows,
+    db: {
+      prepare(sql: string) {
+        return {
+          bind(...values: unknown[]) {
+            return {
+              async run() {
+                if (sql.startsWith("INSERT")) {
+                  rows.push({
+                    lane: values[0],
+                    verdict: values[1],
+                    detail: values[3],
+                  });
+                }
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+const input = {
+  rows: [{ netuid: 1, uid: 0, captured_at: 5 }],
+  dailyRows: [{ netuid: 1, uid: 0, snapshot_date: "2026-08-07" }],
+  positionRows: [{ account: "5A", netuid: 1, snapshot_date: "2026-08-07" }],
+};
+
+const ctx = { waitUntil() {} };
+
+describe("NEURON_MIRROR_PLANS", () => {
+  test("conflict keys match the primary keys read off the live database", () => {
+    // Verified 2026-08-07 against pg_index on green-dawn-75468244:
+    //   neurons_pkey                (netuid, uid)
+    //   account_position_daily_pkey (account, netuid, snapshot_date)
+    assert.deepEqual(NEURON_MIRROR_PLANS.neurons.conflict, ["netuid", "uid"]);
+    assert.deepEqual(NEURON_MIRROR_PLANS.account_position_daily.conflict, [
+      "account",
+      "netuid",
+      "snapshot_date",
+    ]);
+  });
+
+  test("only `neurons` carries the out-of-order guard", () => {
+    // It is the one table a retried chunk can regress: the daily tables are
+    // keyed by snapshot_date, so a late arrival lands on its own day rather
+    // than overwriting a newer one.
+    assert.match(
+      String(NEURON_MIRROR_PLANS.neurons.guard),
+      /captured_at < EXCLUDED\.captured_at/,
+    );
+    assert.equal(NEURON_MIRROR_PLANS.neuron_daily.guard, undefined);
+    assert.equal(NEURON_MIRROR_PLANS.account_position_daily.guard, undefined);
+  });
+});
+
+describe("mirrorNeuronSnapshotToNeon", () => {
+  test("does nothing at all unless the lane is named", async () => {
+    const sql = fakeSql();
+    const spy = laneSpy();
+    for (const env of [
+      undefined,
+      null,
+      {},
+      { NEON_DUAL_WRITE_LANES: "other" },
+    ]) {
+      const out = await mirrorNeuronSnapshotToNeon(env, ctx, input, {
+        sql,
+        laneHealthDb: spy.db,
+      });
+      assert.deepEqual(out, { attempted: false, results: {} });
+    }
+    assert.equal(sql.calls.length, 0);
+    assert.equal(
+      spy.rows.length,
+      0,
+      "a lane that did not run writes no verdict",
+    );
+  });
+
+  test("writes all three tables in order, neurons first", async () => {
+    // `neurons` is the table a read would move to first, so a failure below it
+    // still leaves the most important one current.
+    const sql = fakeSql();
+    const spy = laneSpy();
+    const out = await mirrorNeuronSnapshotToNeon(
+      { NEON_DUAL_WRITE_LANES: NEURONS_NEON_LANE },
+      ctx,
+      input,
+      { sql, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.equal(out.attempted, true);
+    assert.deepEqual(
+      sql.calls.map((c) => c.text.match(/INTO (\w+)/)?.[1]),
+      ["neurons", "neuron_daily", "account_position_daily"],
+    );
+    assert.equal(out.results.neurons.rows, 1);
+    assert.equal(out.results.account_position_daily.rows, 1);
+  });
+
+  test("records one verdict per table, namespaced by store", async () => {
+    const spy = laneSpy();
+    await mirrorNeuronSnapshotToNeon(
+      { NEON_DUAL_WRITE_LANES: NEURONS_NEON_LANE },
+      ctx,
+      input,
+      { sql: fakeSql(), laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.deepEqual(
+      spy.rows.map((r) => r.lane),
+      ["neon:neurons", "neon:neuron_daily", "neon:account_position_daily"],
+    );
+    assert.ok(spy.rows.every((r) => r.verdict === "ok"));
+  });
+
+  test("a failing table is reported and does not stop the others", async () => {
+    // The mirror is best-effort per table. A missing `neuron_daily` must not
+    // cost `account_position_daily` its refresh, and each gets its own verdict
+    // so the reader names the table rather than the lane.
+    const spy = laneSpy();
+    const out = await mirrorNeuronSnapshotToNeon(
+      { NEON_DUAL_WRITE_LANES: NEURONS_NEON_LANE },
+      ctx,
+      input,
+      { sql: fakeSql("neuron_daily"), laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.equal(out.results.neurons.ok, true);
+    assert.equal(out.results.neuron_daily.ok, false);
+    assert.equal(out.results.account_position_daily.ok, true);
+    const verdicts = Object.fromEntries(
+      spy.rows.map((r) => [r.lane, r.verdict]),
+    );
+    assert.equal(verdicts["neon:neuron_daily"], "stale");
+    assert.equal(verdicts["neon:account_position_daily"], "ok");
+  });
+
+  test("enabled with no binding is a MISCONFIGURATION, and says so", async () => {
+    // Not a quiet no-op. Somebody named the lane and the binding is missing;
+    // silence there is how a store nobody writes to goes unnoticed.
+    const spy = laneSpy();
+    const out = await mirrorNeuronSnapshotToNeon(
+      { NEON_DUAL_WRITE_LANES: NEURONS_NEON_LANE },
+      ctx,
+      input,
+      { sql: null, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.deepEqual(out, { attempted: true, results: {} });
+    assert.equal(spy.rows.length, 1);
+    assert.equal(spy.rows[0].lane, "neon:neurons");
+    assert.equal(spy.rows[0].verdict, "stale");
+    assert.match(String(spy.rows[0].detail), /hyperdrive unbound/);
+  });
+
+  test("a bound Hyperdrive with no ctx is also unbound, not a crash", async () => {
+    // createPgSql parks its teardown on ctx.waitUntil. Without one there is
+    // nowhere to return the connection, so this declines rather than leaking.
+    const spy = laneSpy();
+    const out = await mirrorNeuronSnapshotToNeon(
+      {
+        NEON_DUAL_WRITE_LANES: NEURONS_NEON_LANE,
+        HYPERDRIVE: { connectionString: "postgres://x" },
+      },
+      null,
+      input,
+      { laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.equal(out.attempted, true);
+    assert.match(String(spy.rows[0].detail), /hyperdrive unbound/);
+  });
+
+  test("builds a real runner from a bound Hyperdrive, and reports its failure", async () => {
+    // The wiring the Worker actually uses: no injected sql, a real binding, a
+    // real ctx. The connection string is deliberately unreachable, so this also
+    // pins that a Neon that will not accept writes becomes a lane verdict
+    // rather than an exception escaping into the sync handler.
+    const spy = laneSpy();
+    const out = await mirrorNeuronSnapshotToNeon(
+      {
+        NEON_DUAL_WRITE_LANES: NEURONS_NEON_LANE,
+        HYPERDRIVE: { connectionString: "postgresql://u:p@127.0.0.1:1/none" },
+        METAGRAPH_HEALTH_DB: spy.db,
+      },
+      ctx,
+      input,
+    );
+    assert.equal(out.attempted, true);
+    assert.equal(out.results.neurons.ok, false, "an unreachable origin fails");
+    // Recorded through env.METAGRAPH_HEALTH_DB, with no injected sink and no
+    // injected clock -- the defaults the cron path relies on.
+    assert.equal(spy.rows.length, 3);
+    assert.ok(spy.rows.every((r) => r.verdict === "stale"));
+  });
+
+  test("an empty snapshot is a clean no-op per table", async () => {
+    const sql = fakeSql();
+    const out = await mirrorNeuronSnapshotToNeon(
+      { NEON_DUAL_WRITE_LANES: NEURONS_NEON_LANE },
+      ctx,
+      { rows: [], dailyRows: [], positionRows: [] },
+      { sql, laneHealthDb: laneSpy().db, now: () => NOW },
+    );
+    assert.equal(sql.calls.length, 0);
+    assert.ok(Object.values(out.results).every((r) => r.ok && r.rows === 0));
+  });
+
+  test("survives a lane sink that cannot be written to", async () => {
+    // D1 migrations here are applied by hand, so "no such table: lane_health"
+    // is a state this must survive on the day the migration lands late.
+    const out = await mirrorNeuronSnapshotToNeon(
+      { NEON_DUAL_WRITE_LANES: NEURONS_NEON_LANE },
+      ctx,
+      input,
+      {
+        sql: fakeSql(),
+        laneHealthDb: {
+          prepare() {
+            throw new Error("no such table: lane_health");
+          },
+        } as never,
+        now: () => NOW,
+      },
+    );
+    assert.equal(out.attempted, true);
+    assert.equal(out.results.neurons.ok, true);
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -363,6 +363,8 @@ import {
   writeNeuronDailyBackfillToD1,
   writeNeuronSnapshotToD1,
 } from "../src/neurons-d1-write.ts";
+import { mirrorNeuronSnapshotToNeon } from "../src/neurons-neon-write.ts";
+import { neonReadEnabled } from "../src/neon-write.ts";
 import {
   writeAccountIdentityToD1,
   writeSubnetHyperparamsToD1,
@@ -581,7 +583,11 @@ function neuronsServedFromD1(env: Env) {
   return env.METAGRAPH_NEURONS_SOURCE !== "postgres";
 }
 
-async function handleNeuronsSync(request: Request, env: Env) {
+async function handleNeuronsSync(
+  request: Request,
+  env: Env,
+  ctx?: ExecutionContext,
+) {
   if (!env.NEURONS_SYNC_SECRET) {
     return writeJson(
       { error: "neurons sync is not provisioned on this deployment" },
@@ -715,18 +721,39 @@ async function handleNeuronsSync(request: Request, env: Env) {
     return writeJson({ error: "d1 write failed" }, 502);
   }
 
-  // #9193: the Postgres half of #9157's dual write is gone with the box, so the
-  // D1 write above IS the sync. Body unchanged from the D1-only branch this
-  // replaces -- `stores` stays reported rather than inferred, so a reader can
-  // still see which stores this snapshot actually reached.
+  // THE NEON MIRROR (metagraphed-infra#336), and it runs AFTER the D1 write
+  // returns, never instead of it and never in front of it.
+  //
+  // That ordering is the whole lesson of how the pilot broke: a read moved to
+  // Neon while nothing wrote to it, so a public route served a two-day-old
+  // snapshot. During dual-write, D1 is still the store every route reads, so a
+  // Neon failure must cost a mirror and a lane verdict -- not the pass. It
+  // reports its own outcome and cannot throw.
+  //
+  // Off unless NEON_DUAL_WRITE_LANES names the lane, so the deploy that
+  // introduces this changes nothing.
+  const neon = await mirrorNeuronSnapshotToNeon(
+    env as unknown as Record<string, unknown>,
+    ctx,
+    {
+      rows,
+      dailyRows,
+      positionRows,
+    },
+  );
+
+  // `stores` stays REPORTED rather than inferred, so a reader can see which
+  // stores this snapshot actually reached -- which is precisely the question
+  // nobody could answer while Neon was frozen.
   return writeJson({
     ok: true,
     neurons_written: rows.length,
     neuron_daily_written: dailyRows.length,
     account_position_daily_written: positionRows.length,
     netuids_covered: netuids.length,
-    stores: ["d1"],
+    stores: neon.attempted ? ["d1", "neon"] : ["d1"],
     d1_statements: d1Statements,
+    neon: neon.attempted ? neon.results : undefined,
   });
 }
 
@@ -6631,7 +6658,7 @@ async function dispatchDataApiRequest(
       request.method === "POST" &&
       url.pathname === "/api/v1/internal/neurons-sync"
     ) {
-      return handleNeuronsSync(request, env);
+      return handleNeuronsSync(request, env, ctx);
     }
     if (
       request.method === "POST" &&
@@ -6914,19 +6941,29 @@ async function dispatchDataApiRequest(
         if (!env.METAGRAPH_HEALTH_DB) {
           return json({ error: "d1 binding unavailable" }, 503);
         }
-        // `account_position_daily` lives in Neon (metagraphed-infra#336). The
-        // handler is unchanged -- it is written against a tagged template, and
-        // createPgSql is interface-compatible with createD1Sql -- so the store
-        // moves by choosing a runner, not by rewriting a query.
+        // `account_position_daily` can be served from Neon
+        // (metagraphed-infra#336). The handler is unchanged -- it is written
+        // against a tagged template, and createPgSql is interface-compatible
+        // with createD1Sql -- so the store moves by choosing a runner, not by
+        // rewriting a query.
         //
-        // FALLS BACK TO D1 WHEN THE BINDING IS ABSENT, which is what makes this
-        // reversible without a deploy: the D1 table is still written and still
-        // current, so unbinding HYPERDRIVE restores the previous behaviour
-        // exactly. That is deliberate for a first migration and should be
-        // removed once the D1 write is retired, or it becomes a fallback ladder
-        // hiding a dead dependency.
+        // THE GATE IS AN EXPLICIT FLAG, NOT THE BINDING'S PRESENCE, and that
+        // change is the whole lesson of metagraphed#9704. It used to read
+        // `env.HYPERDRIVE && ...`, so binding Hyperdrive for a WRITE pilot
+        // silently moved this READ onto a store nothing had ever written to --
+        // and it served a two-day-old snapshot until the binding was pulled.
+        //
+        // "The binding exists" and "this route should read Neon" are different
+        // questions. NEON_READ_LANES answers the second one, defaults to empty,
+        // and must not name a lane until that lane's `neon:` verdict has been
+        // green across several producer ticks.
         const store =
-          env.HYPERDRIVE && positionHistoryServedFromNeon(url)
+          env.HYPERDRIVE &&
+          neonReadEnabled(
+            env as unknown as Record<string, unknown>,
+            "account_position_daily",
+          ) &&
+          positionHistoryServedFromNeon(url)
             ? createPgSql(env.HYPERDRIVE, ctx)
             : createD1Sql(env.METAGRAPH_HEALTH_DB);
         try {

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -105,6 +105,13 @@
     // flipping one side alone is the split-brain this pins shut -- the main
     // Worker would stop forwarding while this one kept serving D1.
     "METAGRAPH_NEURONS_SOURCE": "d1",
+    // metagraphed-infra#336. Both EMPTY on purpose: this deploy introduces the
+    // Neon mirror and changes nothing. The order they are turned on in is
+    // fixed -- name a lane here, watch its `neon:` lane in lane_health go green
+    // across several producer ticks, and only then name it in NEON_READ_LANES.
+    // Never the other way round; that is exactly what #9704 was.
+    "NEON_DUAL_WRITE_LANES": "",
+    "NEON_READ_LANES": "",
     "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",
     // THE QUEUE CUTOVER (metagraphed-infra#348). Comma-separated lanes whose D1
@@ -340,35 +347,33 @@
   // Never add `localConnectionString` here: Neon's own guide suggests it and it
   // would commit a live password to a public repository. Use `.dev.vars`, which
   // IS gitignored, for local work.
-  // UNBOUND 2026-08-07. The Neon pilot (metagraphed-infra#336) moved a READ
-  // without ever building a WRITE, and the two facts were never checked
-  // together.
+  // REBOUND 2026-08-07, with the two questions finally separated.
   //
-  // GET /api/v1/accounts/{ss58}/subnets/{netuid}/history reads Neon whenever
-  // this binding exists (see positionHistoryServedFromNeon in
-  // workers/data-api.ts). Neon's account_position_daily got ONE load on
-  // 2026-08-05 at 19:35 and nothing has written to it since, while the D1
-  // dual-write kept running. So the route served a snapshot that was two days
-  // old and getting older, and would have gone on doing that indefinitely.
+  // It was unbound hours earlier (#9704) because the Neon pilot moved a READ
+  // without ever building a WRITE: `account_position_daily` got ONE load on
+  // 2026-08-05 at 19:35, nothing wrote to it after, and
+  // GET /api/v1/accounts/{ss58}/subnets/{netuid}/history served a snapshot two
+  // days old and aging -- 26 points to 08-05 where D1 had 27 rows to 08-07.
   //
-  // Measured before unbinding, two accounts picked from the table itself:
+  // THE BINDING WAS NEVER THE PROBLEM. The read gate was
+  // `env.HYPERDRIVE && ...`, so a connection provisioned for a WRITE pilot
+  // silently moved a public route's read. "This Worker can reach Neon" and
+  // "this route should read Neon" are different questions, and they now have
+  // different answers:
   //
-  //   5C4hrjU8...t87s netuid 102   served 10 points to 2026-08-05
-  //                                D1 has 11 rows  to 2026-08-07
-  //   5C4ipx9Y...sw9bD netuid  80   served 26 points to 2026-08-05
-  //                                D1 has 27 rows  to 2026-08-07
+  //   NEON_DUAL_WRITE_LANES  which lanes MIRROR into Neon after their D1 write
+  //   NEON_READ_LANES        which lanes are SERVED from Neon
   //
-  // The code was written for exactly this rollback -- "unbinding HYPERDRIVE
-  // restores the previous behaviour exactly" -- so this is the intended
-  // control, not a workaround. Rebind it when a writer exists and its
-  // freshness has a watchdog, which is what let this run unnoticed: no lane in
-  // lane_health covers this route's store.
-  //
-  // The Hyperdrive config (metagraphed-neon,
-  // 8a09dc673733497f987434f59689287e) and the Neon project are both left in
-  // place. Nothing is lost by unbinding; the read simply goes back to the
-  // store that is current.
-  "hyperdrive": [],
+  // Both empty at this commit, so rebinding moves nothing. The order is fixed:
+  // name a lane in the write list, watch its `neon:` verdict in lane_health go
+  // green across several producer ticks -- metagraphed#9698 reads those, which
+  // is the check that did not exist -- and only then name it in the read list.
+  "hyperdrive": [
+    {
+      "binding": "HYPERDRIVE",
+      "id": "8a09dc673733497f987434f59689287e",
+    },
+  ],
   // Wallet-login challenge nonces (ADR 0021, #6835, src/wallet-auth.ts) --
   // the SAME namespace id as the main Worker's own METAGRAPH_CONTROL binding
   // (wrangler.jsonc), bound under the same name here so both Workers read/


### PR DESCRIPTION
Closes #9711. Phase 0 of metagraphed-infra#336 — **nothing moves here.**

## What #9704 actually was

The read gate was `env.HYPERDRIVE && positionHistoryServedFromNeon(url)`. A connection provisioned for a **write** pilot silently moved a **public route's read** onto a store nothing had ever written to, and it served a two-day-old snapshot until the binding was pulled.

Two questions were sharing one answer. They now have their own:

| question | answer |
| --- | --- |
| can this Worker reach Neon? | the `HYPERDRIVE` binding |
| should this lane **mirror** into Neon? | `NEON_DUAL_WRITE_LANES` |
| should this lane be **served** from Neon? | `NEON_READ_LANES` |

**Both flags default empty**, so this deploy changes nothing — `HYPERDRIVE` is rebound for the writer and moves no read with it. A flag defaulting *on* would repeat the pilot's failure on the deploy that introduced it.

## The writer, and why it is not the D1 one with a different runner

`createPgSql` is interface-compatible with `createD1Sql`, which is enough for the **read** path. The **write** path's SQL is not portable: D1 caps a statement at 100 bound parameters, so its bulk writes smuggle whole chunks through one JSON parameter and unpack them with `json_each`. Postgres takes **65,535**, so the honest form — a plain multi-row `INSERT` — is simpler *and* denser: **2,978 rows per statement at 22 columns, against D1's four.**

The placeholder numbering is asserted as **text**, because Postgres binds positionally and an off-by-one does not throw — it writes the wrong column, confidently.

## The lane

Every Neon write records a `neon:<table>` verdict, **including the enabled-but-unbound misconfiguration**. That is the check that did not exist: a frozen Neon serving 200 OK with plausible rows was indistinguishable from a healthy one, and no lane in `lane_health` covered the store. #9698's reader now turns a Neon that stops accepting writes into an issue within the hour.

## The mirror

`src/neurons-neon-write.ts` mirrors all three tables `handleNeuronsSync` already produces — `neurons`, `neuron_daily`, `account_position_daily` — because that handler is the one place they exist fully built.

It runs **after** the D1 write returns, never in front of it. While dual-writing, D1 is the store every route reads, so a Neon failure costs a mirror and a verdict and nothing else. Nothing throws. `neurons` goes first, since it is the table a read would move to first.

Conflict keys are **read off the live database** rather than assumed: `neurons_pkey (netuid, uid)`, `account_position_daily_pkey (account, netuid, snapshot_date)`. Only `neurons` carries the out-of-order guard — the daily tables are keyed by `snapshot_date`, so a late arrival lands on its own day.

## The order this exists to enforce

`NEON_DUAL_WRITE_LANES` → watch the `neon:` verdict stay green across several producer ticks → **only then** `NEON_READ_LANES`. Never the other way round.

## Verification

- **100% statements, branches, functions, lines** on both new modules
- full suite: **709 files, 17,191 tests**, green
- two dead branches found by the coverage run and **deleted** rather than annotated