### PR TITLE
fix(api): emit the fields three sort enums advertise but no row carried

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -8413,6 +8413,7 @@ export interface components {
                 candidate_count: number;
                 coverage_level: components["schemas"]["CoverageLevel"];
                 curation: components["schemas"]["CurationMetadata"];
+                curation_level?: components["schemas"]["CurationLevel"];
                 description?: string | null;
                 gap_count?: number;
                 gaps: components["schemas"]["Gaps"];
@@ -9139,6 +9140,7 @@ export interface components {
             gaps: {
                 coverage_level: components["schemas"]["CoverageLevel"];
                 curation_level: components["schemas"]["CurationLevel"];
+                gap_count?: number;
                 gap_priority?: number;
                 /** @enum {string} */
                 gap_severity?: "critical" | "warning" | "info";
@@ -10389,6 +10391,7 @@ export interface components {
                 last_ok: string | null;
                 latency_ms?: number | null;
                 latest_block?: number | null;
+                layer?: string;
                 method_tested?: string | null;
                 methods_supported?: {
                     [key: string]: boolean;
@@ -10396,10 +10399,13 @@ export interface components {
                 netuid?: number;
                 network: components["schemas"]["BittensorNetwork"];
                 observed_at: string | null;
+                pool_eligible?: boolean;
                 provider: string;
                 public_safe?: boolean;
+                publication_state?: string;
                 rate_limit_notes?: string | null;
                 rpc_method_count?: number | null;
+                score?: number;
                 source_urls?: string[];
                 status: components["schemas"]["HealthStatus"];
                 subnet_name?: string;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -26221,6 +26221,9 @@
                 "curation": {
                   "$ref": "#/components/schemas/CurationMetadata"
                 },
+                "curation_level": {
+                  "$ref": "#/components/schemas/CurationLevel"
+                },
                 "description": {
                   "anyOf": [
                     {
@@ -30567,6 +30570,11 @@
                 },
                 "curation_level": {
                   "$ref": "#/components/schemas/CurationLevel"
+                },
+                "gap_count": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
                 },
                 "gap_priority": {
                   "maximum": 9007199254740991,
@@ -37050,6 +37058,9 @@
                     }
                   ]
                 },
+                "layer": {
+                  "type": "string"
+                },
                 "method_tested": {
                   "anyOf": [
                     {
@@ -37100,11 +37111,17 @@
                     }
                   ]
                 },
+                "pool_eligible": {
+                  "type": "boolean"
+                },
                 "provider": {
                   "type": "string"
                 },
                 "public_safe": {
                   "type": "boolean"
+                },
+                "publication_state": {
+                  "type": "string"
                 },
                 "rate_limit_notes": {
                   "anyOf": [
@@ -37127,6 +37144,9 @@
                       "type": "null"
                     }
                   ]
+                },
+                "score": {
+                  "type": "number"
                 },
                 "source_urls": {
                   "items": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -8413,6 +8413,7 @@ export interface components {
                 candidate_count: number;
                 coverage_level: components["schemas"]["CoverageLevel"];
                 curation: components["schemas"]["CurationMetadata"];
+                curation_level?: components["schemas"]["CurationLevel"];
                 description?: string | null;
                 gap_count?: number;
                 gaps: components["schemas"]["Gaps"];
@@ -9139,6 +9140,7 @@ export interface components {
             gaps: {
                 coverage_level: components["schemas"]["CoverageLevel"];
                 curation_level: components["schemas"]["CurationLevel"];
+                gap_count?: number;
                 gap_priority?: number;
                 /** @enum {string} */
                 gap_severity?: "critical" | "warning" | "info";
@@ -10389,6 +10391,7 @@ export interface components {
                 last_ok: string | null;
                 latency_ms?: number | null;
                 latest_block?: number | null;
+                layer?: string;
                 method_tested?: string | null;
                 methods_supported?: {
                     [key: string]: boolean;
@@ -10396,10 +10399,13 @@ export interface components {
                 netuid?: number;
                 network: components["schemas"]["BittensorNetwork"];
                 observed_at: string | null;
+                pool_eligible?: boolean;
                 provider: string;
                 public_safe?: boolean;
+                publication_state?: string;
                 rate_limit_notes?: string | null;
                 rpc_method_count?: number | null;
+                score?: number;
                 source_urls?: string[];
                 status: components["schemas"]["HealthStatus"];
                 subnet_name?: string;

--- a/schemas-src/routes/curation-gaps.ts
+++ b/schemas-src/routes/curation-gaps.ts
@@ -42,6 +42,7 @@ export const CurationEntrySchema = z
     slug: z.string(),
     name: z.string(),
     coverage_level: CoverageLevelSchema,
+    curation_level: CurationLevelSchema.optional(),
     surface_count: z.int().min(0),
     candidate_count: z.int().min(0),
     gap_count: z.int().min(0).optional(),
@@ -89,6 +90,10 @@ export const GapsEntrySchema = z
     name: z.string(),
     coverage_level: CoverageLevelSchema,
     curation_level: CurationLevelSchema,
+    // Optional for the same reason CurationEntrySchema's is: the route serves a
+    // baked artifact, so an artifact published before #9710 has no such key and
+    // a required field would reject a body that is otherwise exactly correct.
+    gap_count: z.int().min(0).optional(),
     gaps: GapsSchema,
     gap_severity: z.enum(["critical", "warning", "info"]).optional(),
     gap_priority: z.int().min(0).optional(),

--- a/schemas-src/routes/providers-rpc.ts
+++ b/schemas-src/routes/providers-rpc.ts
@@ -165,6 +165,14 @@ const RpcEndpointSchema = z
     source_urls: z.array(z.url()).optional(),
     last_checked: z.string().nullable().optional(),
     error: z.string().nullable().optional(),
+    // #9710: the four the shared `endpoints` sort enum advertises. Optional
+    // because the route serves a baked artifact -- one published before #9710
+    // carries none of them, and a required field would reject a body that is
+    // otherwise exactly right.
+    layer: z.string().optional(),
+    publication_state: z.string().optional(),
+    pool_eligible: z.boolean().optional(),
+    score: z.number().optional(),
   })
   .strict();
 

--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -982,6 +982,13 @@ const curationIndex = mergedSubnets.map((subnet) => ({
   candidate_count: subnet.candidate_count,
   coverage_level: subnet.coverage_level,
   curation: subnet.curation,
+  // #9710: flattened alongside the nested `curation` block, not instead of it.
+  // The collection's sort enum advertises `curation_level`, and sortRows does a
+  // flat row[key] lookup -- so with the level reachable only at `curation.level`
+  // every row sank to "missing" and `?sort=curation_level` returned the list
+  // untouched while meta.pagination.sort echoed the field back. The gaps row
+  // below has always flattened it; this is the sibling catching up.
+  curation_level: subnet.curation.level,
   gap_count: subnet.gaps.missing_kinds.length,
   gaps: subnet.gaps,
   name: subnet.name,
@@ -995,6 +1002,13 @@ const gapsIndex = mergedSubnets.map((subnet) => {
   return {
     coverage_level: subnet.coverage_level,
     curation_level: subnet.curation.level,
+    // #9710: the collection's sort enum has always advertised `gap_count`, and
+    // the row never carried it -- so `?sort=gap_count` was accepted, echoed
+    // back in meta.pagination.sort, and returned rows in natural netuid order.
+    // A silent no-op that announces itself as a ranking is worse than a
+    // rejected parameter. Same expression the curation row above uses, off the
+    // same array this block already has in hand.
+    gap_count: missingKinds.length,
     gaps: subnet.gaps,
     // #1757: per-gap-row severity + priority derived from the EXISTING backend
     // weighted model (the high-value identity/interface kinds reviewPriorityScore

--- a/scripts/lib/endpoint-artifacts.ts
+++ b/scripts/lib/endpoint-artifacts.ts
@@ -53,6 +53,23 @@ export function buildRpcEndpointArtifact({
         health,
         monitored: true,
       });
+      // #9710: layer/publication_state/pool_eligible/score are advertised in
+      // this collection's sort enum -- /api/v1/endpoints and /api/v1/rpc/
+      // endpoints share one queryCollection config -- but only the resource
+      // artifact below ever emitted them. sortRows resolves row[key] flat, so
+      // on the RPC route all four sank every row to "missing" and returned the
+      // list in its natural provider/id order while echoing the requested sort.
+      // Computed from the SAME helpers the resource artifact uses, on the same
+      // monitored:true footing this builder already assumes for health.
+      const poolEligibility = endpointPoolEligibility({
+        ...surface,
+        status: health.status || "unknown",
+      });
+      const scoreBreakdown = endpointScoreBreakdown({
+        ...surface,
+        ...health,
+        status: health.status || "unknown",
+      });
       return {
         id: surface.id,
         netuid: surface.netuid,
@@ -60,12 +77,20 @@ export function buildRpcEndpointArtifact({
         subnet_name: surface.subnet_name,
         chain: "bittensor",
         network: "finney",
+        layer: endpointLayer(surface.kind),
         kind: surface.kind,
         url: surface.url,
         provider: surface.provider,
         authority: surface.authority,
         auth_required: surface.auth_required,
         public_safe: surface.public_safe,
+        publication_state: endpointPublicationState({
+          monitored: true,
+          poolEligible: poolEligibility.eligible,
+          surface,
+        }),
+        pool_eligible: poolEligibility.eligible,
+        score: scoreBreakdown.score,
         archive_support: health.archive_support ?? null,
         latest_block: health.latest_block ?? null,
         methods_supported: health.methods_supported || null,

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -37,6 +37,7 @@ import {
   R2_STAGING_RELATIVE_ROOT,
   artifactStorageTierForRelativePath,
 } from "../src/artifact-storage.ts";
+import { API_QUERY_COLLECTIONS, API_ROUTES } from "../src/contracts.ts";
 import {
   type GithubSignalEntry,
   githubSignalsForSubnet,
@@ -924,12 +925,80 @@ async function validateR2OnlyArtifactsStayOutOfPublicGit(): Promise<void> {
   }
 }
 
+// Every field a list route advertises in its `sort` enum must exist on the rows
+// that route serves (#9710).
+//
+// workers/list-query.ts sorts with a FLAT `row[key]` lookup and deliberately
+// sinks rows whose value is null/undefined to the end. Those two together mean
+// a sort field no row carries is not an error and not a no-op the caller can
+// see: every row sinks, the original order survives, `meta.pagination.sort`
+// echoes the field back, and the response says it is ranked when it is not. A
+// wrong answer that announces itself as the right one.
+//
+// Four collections were shipping that way when this check was written -- gaps
+// (`gap_count`), curation (`curation_level`, reachable only at `curation.level`),
+// rpc-endpoints (`layer`/`publication_state`/`pool_eligible`/`score`, emitted by
+// the sibling resource artifact but not this one), and health-subnets (`name`,
+// tracked separately: those rows are written by the live prober cron, not by a
+// build artifact, so the fix does not live here -- #9715).
+//
+// Driven off the contract rather than a hand-kept list, so a collection added
+// later is covered the day it is added.
+async function validateAdvertisedSortFieldsExist(): Promise<void> {
+  const collections = API_QUERY_COLLECTIONS as Record<string, Row>;
+  for (const apiRoute of API_ROUTES as Row[]) {
+    const collectionName = apiRoute.query_collection as string | null;
+    const artifactRelative = String(apiRoute.artifact_path || "").replace(
+      /^\/metagraph\//,
+      "",
+    );
+    // A templated artifact path needs a concrete id to read; the same collection
+    // is reached through an untemplated sibling route, which this loop covers.
+    if (
+      !collectionName ||
+      !artifactRelative ||
+      artifactRelative.includes("{")
+    ) {
+      continue;
+    }
+    const collection = collections[collectionName];
+    const sortFields = (collection?.sort_fields as string[]) || [];
+    if (sortFields.length === 0) continue;
+
+    const artifactFullPath = artifactPathForRelative(artifactRelative);
+    // Not every contract artifact is produced by THIS build (some are published
+    // by other lanes). Absent is not a failure here -- the freshness gates own
+    // that question.
+    if (!existsSync(artifactFullPath)) continue;
+
+    const artifact = await readJson(artifactFullPath);
+    const rows = artifact[collection.data_key as string];
+    if (!Array.isArray(rows) || rows.length === 0) continue;
+
+    const present = new Set<string>();
+    for (const row of rows as Row[]) {
+      if (row && typeof row === "object" && !Array.isArray(row)) {
+        for (const key of Object.keys(row)) present.add(key);
+      }
+    }
+    for (const field of sortFields) {
+      assert(
+        present.has(field),
+        `${apiRoute.path}: sort enum advertises "${field}", but no row in ` +
+          `${artifactRelative} carries that key — the sort would silently ` +
+          `return the list unordered while meta echoes the field back`,
+      );
+    }
+  }
+}
+
 async function validateGeneratedArtifacts(
   nativeSnapshot: Row,
   overlays: Row[],
   candidates: Row[],
 ): Promise<void> {
   await validateR2OnlyArtifactsStayOutOfPublicGit();
+  await validateAdvertisedSortFieldsExist();
 
   const providersArtifact = await readArtifactJson("providers.json");
   const subnetsArtifact = await readArtifactJson("subnets.json");

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -31,6 +31,7 @@ import {
 } from "../scripts/lib.ts";
 import {
   CONTRACT_VERSION,
+  API_QUERY_COLLECTIONS,
   API_ROUTES,
   PRIMARY_DOMAIN,
 } from "../src/contracts.ts";
@@ -2430,6 +2431,78 @@ test("Worker API serves public artifact envelopes", async () => {
   const body = await response.json();
   assert.equal(body.ok, true);
   assert.equal(body.data.subnet.netuid, 7);
+});
+
+// #9710. workers/list-query.ts sorts with a flat `row[key]` lookup and sinks
+// rows whose value is null/undefined to the end. A sort field that NO row
+// carries therefore fails silently in the worst available way: every row sinks,
+// the original order survives untouched, `meta.pagination.sort` echoes the field
+// back, and the caller reads a list that says it is ranked and is not.
+//
+// Four collections shipped that way — gaps (`gap_count`), curation
+// (`curation_level`, reachable only at the nested `curation.level`),
+// rpc-endpoints (`layer`/`publication_state`/`pool_eligible`/`score`, computed
+// for the sibling resource artifact and not this one), and health-subnets
+// (`name`, whose rows are written by the live prober cron rather than a build
+// artifact — tracked separately in #9715, hence the exemption below).
+//
+// Driven off the contract, not a hand-kept list, so a collection added later is
+// covered on the day it is added rather than the day someone remembers to.
+const SORT_FIELDS_WITHOUT_A_BUILT_ROW: Record<string, string[]> = {
+  // Written by the health prober into KV, not by this build. See #9715.
+  "/api/v1/health": ["name"],
+};
+
+test("every advertised sort field exists on the rows that route serves", () => {
+  const collections = API_QUERY_COLLECTIONS as Record<string, Row>;
+  let checked = 0;
+
+  for (const apiRoute of API_ROUTES as Row[]) {
+    const collectionName = apiRoute.query_collection as string | null;
+    const relative = String(apiRoute.artifact_path || "").replace(
+      /^\/metagraph\//,
+      "",
+    );
+    // A templated path needs a concrete id to read. Every such collection is
+    // also reached through an untemplated sibling route, which this loop covers.
+    if (!collectionName || !relative || relative.includes("{")) continue;
+
+    const collection = collections[collectionName];
+    const sortFields = (collection?.sort_fields as string[]) || [];
+    if (sortFields.length === 0) continue;
+    if (!existsSync(artifactFilePath(relative))) continue;
+
+    const rows = readArtifact(relative)[collection.data_key as string];
+    if (!Array.isArray(rows) || rows.length === 0) continue;
+
+    const present = new Set<string>();
+    for (const row of rows as Row[]) {
+      if (row && typeof row === "object" && !Array.isArray(row)) {
+        for (const key of Object.keys(row)) present.add(key);
+      }
+    }
+
+    const exempt = new Set(
+      SORT_FIELDS_WITHOUT_A_BUILT_ROW[apiRoute.path as string] || [],
+    );
+    for (const field of sortFields) {
+      if (exempt.has(field)) continue;
+      checked += 1;
+      assert.ok(
+        present.has(field),
+        `${apiRoute.path}: sort enum advertises "${field}", but no row in ` +
+          `${relative} carries that key — sorting by it would return the list ` +
+          `unordered while meta.pagination.sort echoes the field back`,
+      );
+    }
+  }
+
+  // A pass over zero fields proves nothing. If the contract shape ever changes
+  // such that nothing matches, this fails rather than going quietly green.
+  assert.ok(
+    checked > 50,
+    `expected to check well over 50 advertised sort fields, checked ${checked}`,
+  );
 });
 
 function readArtifact(relativePath: string): Row {

--- a/tests/endpoint-artifacts.test.ts
+++ b/tests/endpoint-artifacts.test.ts
@@ -116,6 +116,56 @@ describe("buildRpcEndpointArtifact", () => {
     assert.deepEqual(artifact.summary.by_status, { ok: 1, unknown: 1 });
     assert.equal(artifact.summary.archive_supported_count, 1);
   });
+
+  // #9710: /api/v1/endpoints and /api/v1/rpc/endpoints share ONE
+  // queryCollection config, so both advertise layer/publication_state/
+  // pool_eligible/score in the same sort enum -- and only the resource artifact
+  // emitted them. workers/list-query.ts sorts on a flat row[key] and sinks
+  // null/undefined to the end, so on the RPC route all four sank every row and
+  // the response came back in its natural provider/id order while
+  // meta.pagination.sort echoed the requested field. These assert the values,
+  // not just the keys: a null placeholder would sort exactly as badly.
+  test("emits the pool/score fields its sort enum advertises", () => {
+    const artifact = buildRpcEndpointArtifact({
+      surfaces: [
+        rpcSurface({ id: "healthy", provider: "alpha" }),
+        rpcSurface({ id: "gated", provider: "beta", auth_required: true }),
+      ],
+      healthSurfaces: [
+        {
+          surface_id: "healthy",
+          status: "ok",
+          classification: "live",
+          archive_support: true,
+          latest_block: 100,
+          latency_ms: 50,
+          last_ok: GENERATED_AT,
+        },
+      ],
+      generatedAt: GENERATED_AT,
+      contractVersion: CONTRACT,
+      source: "unit",
+    });
+
+    const [healthy, gated] = artifact.endpoints as Row[];
+
+    // Probing OK + public + unauthenticated + base-layer is the whole
+    // eligibility rule, so this one clears it and scores above zero.
+    assert.equal(healthy.layer, "bittensor-base");
+    assert.equal(healthy.pool_eligible, true);
+    assert.equal(healthy.publication_state, "pool-eligible");
+    assert.ok(
+      (healthy.score as number) > 0,
+      `expected a positive score, got ${healthy.score}`,
+    );
+
+    // Same surface behind auth: ineligible, and it must still carry the keys —
+    // absent is what made the sort inert in the first place.
+    assert.equal(gated.pool_eligible, false);
+    assert.equal(gated.publication_state, "monitored");
+    assert.equal(gated.layer, "bittensor-base");
+    assert.equal(typeof gated.score, "number");
+  });
 });
 
 // --- buildEndpointResourceArtifact ------------------------------------------


### PR DESCRIPTION
## Summary

`sortRows` in `workers/list-query.ts` resolves a sort with a flat `row[key]` lookup, and deliberately sinks rows whose value is null/undefined to the end so incomplete rows don't float to the top. Those two behaviours together mean a sort field that **no** row carries is neither rejected nor honoured — every row sinks, the original order survives untouched, and `meta.pagination.sort` echoes the field back. The response says it is ranked and it is not.

Found while fixing `list_gaps` (#9710), which was reported as a `sort`/`fields` inconsistency. The reported half — `fields=gap_count` returning `invalid_params` — turned out to be the honest half; the silent half was the bug.

## What was measured

Probed every unparameterized list route on production: each advertised sort field against the union of keys over the **fully paged** collection, then confirmed inertness by checking `order=asc` and `order=desc` return identical bodies.

| Route | Dead sort fields | Where the field already existed |
|---|---|---|
| `/api/v1/gaps` | `gap_count` | `missingKinds` is computed one line above |
| `/api/v1/curation` | `curation_level` | nested at `curation.level`; the gaps sibling already flattens it |
| `/api/v1/rpc/endpoints` | `layer`, `publication_state`, `pool_eligible`, `score` | shares one `queryCollection` with `/api/v1/endpoints`, which computes all four from helpers in the same file |

Ruled out as false positives, each with evidence (full detail in [the issue comment](https://github.com/JSONbored/metagraphed/issues/9710#issuecomment-5213466326)):

- `/api/v1/accounts`, `/api/v1/validators`, `/api/v1/subnets/movers`, `/api/v1/chain/transfer-pairs` — `sort` there is an enum of **named ranking modes**, not row field names (`/api/v1/accounts` rejects `order` outright). All rank correctly.
- `/api/v1/search`, `/api/v1/search-index` — `netuid`/`slug` are present, just not on the first page. A 100-row sample was not the collection.
- `/api/v1/coverage-depth`, `/api/v1/endpoint-pools`, `/api/v1/endpoints` — my probe was reading a sibling array. Spot-checked directly and all three sort correctly.

## The fix

Emit the fields, rather than withdraw the capability — every one is already computed or trivially derivable at the point the row is built, and `list_gaps`' own tool description already advertises `gap_count`.

Declared on the two `.strict()` row schemas as **optional**: both routes serve a baked artifact, and one published before this change carries none of the keys — a required field would reject a body that is otherwise exactly right.

## The gate

Two, both driven off `API_ROUTES` × `API_QUERY_COLLECTIONS` rather than a hand-kept list, so a collection added later is covered the day it is added:

- `validateAdvertisedSortFieldsExist()` in `scripts/validate.ts` (build-time, already registered in CI).
- A suite-level equivalent in `tests/artifacts.test.ts`, which additionally asserts it checked **more than 50** fields — a contract reshape that makes nothing match fails rather than going quietly green.

Verified the gate can fail: temporarily adding a bogus sort field produced

```
Validation failed with 1 issue(s):
- /api/v1/gaps: sort enum advertises "zzz_not_a_field", but no row in gaps.json
  carries that key — the sort would silently return the list unordered while
  meta echoes the field back
```

## Deliberately not in scope

`/api/v1/health` has the same defect on `name`, and its rows are assembled by the live prober into KV rather than by a build artifact, so the fix is a different subsystem and a genuine judgement call (thread `subnet_name` through the probe row, or drop the sort field). Split to #9715. Both gates carry an explicit exemption naming it, so the exemption comes out with the fix.

## Validation run

```
npm run build
npm run validate                  # 129 subnets, 3442 surfaces, 136 providers
npm run validate:contract-drift   # passed
npm run validate:schemas          # passed
npm run validate:openapi          # 200 routes + 24 feed + 107 network variants
npm run validate:api              # 200 Worker API routes
npm run lint && npm run format:check && npx tsc --noEmit
npx vitest run tests/artifacts.test.ts tests/endpoint-artifacts.test.ts \
  tests/gaps-mcp.test.ts tests/zod-schemas.test.ts tests/script-utils.test.ts
  # 440 passed
```

Confirmed the rebuilt artifacts carry the fields on **every** row: gaps 129/129 (7 distinct `gap_count` values), curation 129/129, rpc-endpoints 9/9.

Closes #9710
Refs #9715