### PR TITLE
fix(webhooks): report the delivery outcome the consumer actually writes

### DIFF
--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -802,8 +802,60 @@ export async function dispatchChangeEvent({
 // needs to see delivery outcomes, so the consumer writes a record and this
 // summarises it. Reporting, not control.
 
-// Roll a subscription's parked records into a compact health view for the public
-// GET. Pure — the caller injects the records it listed from the store.
+/**
+ * One delivery outcome, in the shape the summary below reads.
+ *
+ * THE WRITER AND THE READER LIVE TOGETHER NOW, and that is the point. #354's
+ * consumer wrote `{status, attempts, last_status, updated_at}` while this file
+ * kept reading `{state, round, reason, status_code, last_attempt_at}` — the old
+ * parked-record vocabulary. Not one field overlapped, so `dead_letter` was
+ * permanently 0, every record counted as pending (a fully delivered
+ * subscription reported `retrying`), and every `last_failure` field came back
+ * undefined. The tests missed it because they hand-seeded records instead of
+ * writing what the consumer writes.
+ *
+ * `state` is the DISPOSITION, not the HTTP outcome: `delivered` is terminal
+ * success, `pending` is scheduled for another attempt, `dead` is terminal
+ * failure. The summary counts on exactly those three.
+ */
+export function deliveryRecordFor({
+  subscriptionId,
+  eventId,
+  result,
+  disposition,
+  attempts,
+  nowIso,
+  nextAttemptAt = null,
+}: {
+  subscriptionId: string;
+  eventId: string;
+  result: Row | null | undefined;
+  disposition: "delivered" | "retry" | "dead";
+  attempts: number;
+  nowIso: string;
+  /** When the queue will try again, for a retried delivery. Null otherwise --
+   * a terminal record has no next attempt, and inventing one would read as a
+   * delivery still to come. */
+  nextAttemptAt?: string | null;
+}): Row {
+  return {
+    subscription_id: subscriptionId,
+    event_id: eventId,
+    state: disposition === "retry" ? "pending" : disposition,
+    // The queue's attempt counter, which is what replaced the hand-kept round.
+    round: attempts,
+    // Absent on a success, and deliberately not defaulted to "ok": `reason` is
+    // read as a failure cause, and a delivered record having one would be a lie
+    // that reads like a diagnosis.
+    reason: (result?.reason as string) ?? null,
+    status_code: (result?.status_code as number) ?? null,
+    last_attempt_at: nowIso,
+    next_attempt_at: disposition === "retry" ? nextAttemptAt : null,
+  };
+}
+
+// Roll a subscription's delivery records into a compact health view for the
+// public GET. Pure — the caller injects the records it listed from the store.
 export function summarizeDeliveryRecords(
   records: Row[] | null | undefined,
 ): Row {
@@ -815,10 +867,16 @@ export function summarizeDeliveryRecords(
   let latest: Row | null = null; // the failure with the most recent attempt (ISO sorts lexically)
   for (const record of list) {
     if (record.state === "dead") deadLetter += 1;
-    else pending += 1;
+    // A DELIVERED RECORD IS NEITHER. It used to fall into `pending` through the
+    // else, so a subscription whose every event landed reported `retrying` with
+    // a pending count equal to its recent history.
+    else if (record.state !== "delivered") pending += 1;
+    // `last_failure`, so a success does not become the reported failure just by
+    // being the most recent thing that happened.
     if (
-      !latest ||
-      (record.last_attempt_at as string) > (latest.last_attempt_at as string)
+      record.state !== "delivered" &&
+      (!latest ||
+        (record.last_attempt_at as string) > (latest.last_attempt_at as string))
     ) {
       latest = record;
     }

--- a/tests/webhooks-worker.test.ts
+++ b/tests/webhooks-worker.test.ts
@@ -1171,6 +1171,188 @@ describe("webhook queue consumer: the terminal and transient edges", () => {
   });
 });
 
+describe("what the consumer writes is what the status surface reads", () => {
+  // THE GAP THIS CLOSES. Every other test in this file hand-seeds delivery
+  // records, so the consumer's ACTUAL output was never read back by the reader
+  // that serves it -- and the two had drifted into disjoint vocabularies. The
+  // consumer wrote {status, attempts, last_status, updated_at}; the summariser
+  // read {state, round, reason, status_code, last_attempt_at}. Nothing
+  // overlapped, so `dead_letter` was permanently 0, a fully delivered
+  // subscription reported "retrying", and every last_failure field was
+  // undefined -- all while these tests were green.
+  //
+  // So this drives the real consumer and then the real GET. No seeding.
+  async function deliverThen(
+    kv: ReturnType<typeof makeKv>,
+    subscriptionId: string,
+    result: Row,
+    attempts = 1,
+  ) {
+    const { handleWebhookQueue } = await import("../workers/api.ts");
+    await handleWebhookQueue(
+      {
+        messages: [
+          {
+            body: {
+              subscription_id: subscriptionId,
+              event_id: "evt_1",
+              body: JSON.stringify({ type: "metagraph.publish" }),
+            },
+            attempts,
+            ack: () => {},
+            retry: () => {},
+          },
+        ],
+      } as never,
+      envWith(kv) as unknown as Env,
+      { waitUntil: (p: Promise<unknown>) => void p } as never,
+      (async () => result) as never,
+    );
+  }
+
+  const deliveryOf = async (kv: ReturnType<typeof makeKv>, id: string) =>
+    (
+      await (
+        await handleRequest(
+          req(`/api/v1/webhooks/subscriptions/${id}`),
+          envWith(kv) as unknown as Env,
+          {},
+        )
+      ).json()
+    ).data.delivery;
+
+  test("a delivered event reports ok, not retrying", async () => {
+    // The loudest symptom: a subscription whose every event landed reported
+    // `retrying`, with a pending count equal to its recent history, because a
+    // delivered record fell through to `pending` in the summariser's else.
+    const kv = makeKv();
+    const sub = await seedSubscription(kv, "https://hooks.example.com/a");
+    await deliverThen(kv, sub.id, { status: "delivered", status_code: 200 });
+
+    assert.deepEqual(await deliveryOf(kv, sub.id), {
+      status: "ok",
+      pending: 0,
+      dead_letter: 0,
+      last_failure: null,
+    });
+  });
+
+  test("a terminal failure reports dead_letter, with the reason it failed for", async () => {
+    // `dead_letter` could never be non-zero: the summariser tested
+    // `record.state === "dead"` against a record that carried no `state`.
+    const kv = makeKv();
+    const sub = await seedSubscription(kv, "https://hooks.example.com/a");
+    await deliverThen(kv, sub.id, {
+      status: "failed",
+      reason: "http-400",
+      status_code: 400,
+      retryable: false,
+    });
+
+    const delivery = await deliveryOf(kv, sub.id);
+    assert.equal(delivery.status, "dead_letter");
+    assert.equal(delivery.dead_letter, 1);
+    assert.equal(delivery.pending, 0);
+    assert.equal(delivery.last_failure.event_id, "evt_1");
+    assert.equal(delivery.last_failure.reason, "http-400");
+    assert.equal(delivery.last_failure.status_code, 400);
+    assert.equal(delivery.last_failure.state, "dead");
+    assert.equal(
+      delivery.last_failure.next_attempt_at,
+      null,
+      "a terminal record has no next attempt",
+    );
+  });
+
+  test("a retryable failure reports retrying, and when it will be retried", async () => {
+    const kv = makeKv();
+    const sub = await seedSubscription(kv, "https://hooks.example.com/a");
+    await deliverThen(
+      kv,
+      sub.id,
+      { status: "failed", reason: "timeout", retryable: true },
+      2,
+    );
+
+    const delivery = await deliveryOf(kv, sub.id);
+    assert.equal(delivery.status, "retrying");
+    assert.equal(delivery.pending, 1);
+    assert.equal(delivery.dead_letter, 0);
+    assert.equal(delivery.last_failure.reason, "timeout");
+    assert.equal(delivery.last_failure.attempts, 2, "the queue's own counter");
+    // 5 min doubling per attempt: the second attempt waits 10 minutes.
+    assert.equal(
+      Date.parse(delivery.last_failure.next_attempt_at) -
+        Date.parse(delivery.last_failure.last_attempt_at),
+      10 * 60 * 1000,
+    );
+  });
+
+  test("a delivered event does not become the reported last_failure", async () => {
+    // It is named last_FAILURE. Picking the most recent record of any kind made
+    // a success overwrite the failure a subscriber is trying to debug.
+    const kv = makeKv();
+    const sub = await seedSubscription(kv, "https://hooks.example.com/a");
+    await deliverThen(kv, sub.id, {
+      status: "failed",
+      reason: "http-500",
+      status_code: 500,
+      retryable: false,
+    });
+    // A later event, delivered. Written under its own key, so both records live.
+    kv.store.set(
+      `webhooks:delivery:${sub.id}:evt_2`,
+      JSON.stringify({
+        subscription_id: sub.id,
+        event_id: "evt_2",
+        state: "delivered",
+        round: 1,
+        reason: null,
+        status_code: 200,
+        last_attempt_at: "2099-01-01T00:00:00.000Z",
+        next_attempt_at: null,
+      }),
+    );
+
+    const delivery = await deliveryOf(kv, sub.id);
+    assert.equal(delivery.last_failure.event_id, "evt_1");
+    assert.equal(delivery.dead_letter, 1);
+    assert.equal(delivery.pending, 0, "the delivered one is neither");
+  });
+
+  test("a message with no event_id is acked, not recorded under undefined", async () => {
+    // The record key is (subscription, event); without an event id there is
+    // nothing to key on, and the delivery could never be reported even if it
+    // succeeded.
+    const kv = makeKv();
+    const sub = await seedSubscription(kv, "https://hooks.example.com/a");
+    const acts: string[] = [];
+    const { handleWebhookQueue } = await import("../workers/api.ts");
+    await handleWebhookQueue(
+      {
+        messages: [
+          {
+            body: {
+              subscription_id: sub.id,
+              body: JSON.stringify({ type: "metagraph.publish" }),
+            },
+            attempts: 1,
+            ack: () => acts.push("ack"),
+            retry: () => acts.push("retry"),
+          },
+        ],
+      } as never,
+      envWith(kv) as unknown as Env,
+      { waitUntil: (p: Promise<unknown>) => void p } as never,
+    );
+    assert.deepEqual(acts, ["ack"]);
+    assert.equal(
+      [...kv.store.keys()].some((key) => key.includes("undefined")),
+      false,
+    );
+  });
+});
+
 describe("the webhook cron trigger (metagraphed-infra#354)", () => {
   // Delivery used to be a step inside the publish workflow, downstream of every
   // other step -- so when the live-API smoke check broke on 2026-08-02,

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -287,6 +287,7 @@ import { handleFullnodeRpcProxyRequest } from "./request-handlers/fullnode-rpc-p
 import {
   buildChangeEvent,
   deliverChangeEvent,
+  deliveryRecordFor,
   deliveryStorageKey,
   deliveryStoragePrefix,
   eventMatchesFilters,
@@ -1854,9 +1855,13 @@ export async function handleWebhookQueue(
     // Unparseable is ACKED, not retried -- it will not parse on the eighth
     // attempt either, and the DLQ is more useful holding deliveries that might
     // still succeed. Same rule the sync-batches consumer follows.
+    // `event_id` is checked here too, not just by validWebhookDeliveryMessage:
+    // it keys the delivery record AND half the idempotency header, so a message
+    // without one cannot be reported on even if it delivers.
     if (
       !body ||
       typeof body.subscription_id !== "string" ||
+      typeof body.event_id !== "string" ||
       typeof body.body !== "string"
     ) {
       message.ack();
@@ -1922,26 +1927,35 @@ export async function handleWebhookQueue(
     // now), but the RECORD is not: this writes the outcome, it does not drive
     // anything. Best-effort, because a KV hiccup must not turn a delivered
     // event into a retried one.
+    //
+    // BUILT BY deliveryRecordFor, which sits next to the summariser that reads
+    // it. Spelling the record out here is what let the two drift apart into
+    // disjoint vocabularies while every test still passed.
+    const retryDelaySeconds = webhookRetryDelaySeconds(message.attempts);
+    const nowIso = new Date().toISOString();
     try {
       await env.METAGRAPH_CONTROL?.put?.(
         deliveryStorageKey(body.subscription_id, body.event_id),
-        JSON.stringify({
-          subscription_id: body.subscription_id,
-          event_id: body.event_id,
-          status: disposition === "retry" ? "parked" : disposition,
-          attempts: message.attempts,
-          last_status: (result?.status as string) ?? null,
-          updated_at: new Date().toISOString(),
-        }),
+        JSON.stringify(
+          deliveryRecordFor({
+            subscriptionId: body.subscription_id,
+            eventId: body.event_id,
+            result,
+            disposition,
+            attempts: message.attempts,
+            nowIso,
+            nextAttemptAt: new Date(
+              Date.parse(nowIso) + retryDelaySeconds * 1000,
+            ).toISOString(),
+          }),
+        ),
         { expirationTtl: WEBHOOK_DELIVERY_TTL_SECONDS },
       );
     } catch {
       /* status reporting must never change a delivery's disposition */
     }
     if (disposition === "retry") {
-      message.retry({
-        delaySeconds: webhookRetryDelaySeconds(message.attempts),
-      });
+      message.retry({ delaySeconds: retryDelaySeconds });
     } else {
       // Delivered, or terminal. A terminal failure acks so the platform routes
       // it to the dead-letter queue on the final attempt rather than spinning


### PR DESCRIPTION
Closes metagraphed-infra#371.

#9655/#9662 moved webhook delivery onto a queue and replaced the parked-record scheduler. The **record** was deliberately kept, because `GET /api/v1/webhooks/subscriptions/{id}` and the `get_webhook_subscription` MCP tool report delivery health from it. The new consumer wrote a new shape, and the summariser that reads it was never updated.

| consumer wrote | summariser read |
|---|---|
| `status`, `attempts`, `last_status`, `updated_at` | `state`, `round`, `reason`, `status_code`, `last_attempt_at`, `next_attempt_at` |

**No field overlapped except `event_id`.** So the delivery-health block was wrong in exactly the situation it exists for — a subscriber debugging a missed event:

- **`dead_letter` was permanently 0**, and `status` could never be `dead_letter`: the count tests `record.state === "dead"` on a record carrying no `state`.
- **A fully delivered subscription reported `retrying`** — every record fell through the `else` into `pending`, so `pending` equalled its recent history, successes included.
- **Every `last_failure` field came back `undefined`**, and an undefined `last_attempt_at` on every record meant the "most recent attempt" comparison never advanced past the first one listed.

## The fix

The record is built by **`deliveryRecordFor`, which lives next to `summarizeDeliveryRecords`**. Spelling the shape out at the call site is what let the two drift apart in the first place; putting the writer and the reader in one place is the structural half of this change, not a tidy-up.

Two semantics are corrected with it:

- **a delivered record is neither pending nor dead** — it used to reach `pending` through the else
- **`last_failure` is chosen among failures** — it is named `last_FAILURE`, and picking the most recent record of any kind let a later success displace the failure being debugged

`event_id` is now checked alongside `subscription_id` in the consumer's guard. It keys the delivery record and half the idempotency header, so a message without one could not be reported on even when it delivered — previously it would have written a record under a key containing `undefined`.

The published response shape is unchanged: `status`, `pending`, `dead_letter`, `last_failure{event_id, attempts, reason, status_code, state, last_attempt_at, next_attempt_at}`. This changes what fills it, not what it is.

## Why the tests were green

They hand-seeded the pre-#354 record shape into KV and read it back, so nothing asserted what the consumer *writes*. The five new tests drive the real consumer and then the real GET, with no seeding.

Verified they catch it: reverting `src/webhooks.ts` and `workers/api.ts` to `main` while keeping the tests fails **all five**.

## Validation

```
npm run typecheck        # clean
npm run lint             # clean
npx prettier --check     # clean on all three changed files
npx vitest run tests/webhooks-worker.test.ts tests/webhooks.test.ts \
  tests/webhooks-core.test.ts tests/webhook-queue.test.ts   # 243 passed
```

Patch coverage by intersecting the diff's changed lines with a v8 report over both changed source files: **0 uncovered statements, 0 uncovered branches** (88 changed lines).

One unrelated failure exists on `main` and is not from this diff: `tests/mcp-server.test.ts > POST /mcp tools/call resolves real artifacts from the local env` reads built artifacts and fails without a prior `npm run build`. Confirmed by stashing this branch's changes and re-running it on a clean tree.

## Not fixed here

The per-subscription fairness bar in metagraphed-infra#354 and the unread dead-letter queues are separate and still open; they are tracked on that issue rather than folded in.

## Template Used

- Backend/code change
