### PR TITLE
fix(search): point a pasted EVM address at the route that exists

### DIFF
--- a/src/identifier-resolver.ts
+++ b/src/identifier-resolver.ts
@@ -131,7 +131,10 @@ export function resolveIdentifier(query: unknown): ResolvedIdentifier[] {
       {
         kind: "evm-account",
         value: `0x${hex}`,
-        api_path: `/api/v1/evm/address-mapping/0x${hex}`,
+        // The route is `evm/address`, not `evm/address-mapping` --
+        // `AddressMapping.addressMapping` is the STORAGE item it reads, and the
+        // pallet name leaked into the path. The wrong one 404s.
+        api_path: `/api/v1/evm/address/0x${hex}`,
         ui_path: `/accounts?h160=0x${hex}`,
         exact: true,
       },

--- a/tests/identifier-resolver.test.ts
+++ b/tests/identifier-resolver.test.ts
@@ -14,6 +14,7 @@
 //      "you mistyped it".
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
+import { API_ROUTES } from "../src/contracts.ts";
 import {
   buildSearchResolve,
   resolveIdentifier,
@@ -181,13 +182,50 @@ describe("the resolver is safe on hostile input", () => {
     assert.deepEqual(kinds("\t74:12\n"), ["neuron"]);
   });
 
-  test("every result carries a usable api and ui path", () => {
-    for (const q of [ALICE, `0x${"a".repeat(64)}`, "7", "74:12"]) {
+  test("every api_path it hands out is a route that actually exists", () => {
+    // THE BUG THIS REPLACES A PREFIX CHECK WITH. The EVM branch emitted
+    // `/api/v1/evm/address-mapping/{h160}` -- the storage item's name, not the
+    // route's -- and the real path is `/api/v1/evm/address/{h160}`. It 404s.
+    // The old assertion only checked the `/api/v1/` prefix, and its query list
+    // never included an H160 at all, so the one kind that was wrong was also
+    // the one kind untested.
+    //
+    // Matching against API_ROUTES rather than a hand-kept list is the point: a
+    // future kind pointing at a route that does not exist fails here without
+    // anyone remembering to extend the fixture. This is a resolver that exists
+    // to stop sending people to 404s.
+    const declared = API_ROUTES.map(
+      (route) => new RegExp(`^${route.path.replace(/\{[^}]+\}/g, "[^/]+")}$`),
+    );
+    const seen = new Set<string>();
+    for (const q of [
+      ALICE,
+      `0x${"a".repeat(64)}`,
+      `0x${"b".repeat(40)}`, // the H160 the old fixture omitted
+      "7",
+      "5000000",
+      "74:12",
+    ]) {
       for (const hit of resolveIdentifier(q)) {
-        assert.match(hit.api_path, /^\/api\/v1\//, `${q}: ${hit.kind}`);
+        seen.add(hit.kind);
+        assert.equal(
+          declared.some((pattern) => pattern.test(hit.api_path)),
+          true,
+          `${hit.kind}: ${hit.api_path} matches no route in API_ROUTES`,
+        );
         assert.match(hit.ui_path, /^\//, `${q}: ${hit.kind}`);
       }
     }
+    // And the queries above really do exercise every kind, so "all paths are
+    // valid" is not vacuously true over a subset.
+    assert.deepEqual([...seen].sort(), [
+      "account",
+      "block",
+      "evm-account",
+      "extrinsic",
+      "neuron",
+      "subnet",
+    ]);
   });
 });
 


### PR DESCRIPTION
Closes metagraphed-infra#372.

`GET /api/v1/search/resolve?q=0x…40hex` answered `api_path: /api/v1/evm/address-mapping/{h160}`. That route does not exist. Verified against production:

| path | status |
|---|---|
| `/api/v1/evm/address-mapping/{h160}` | **404** |
| `/api/v1/evm/address/{h160}` | 200 |

`AddressMapping.addressMapping` is the *storage item* the route reads — the pallet name leaked into the path. `API_ROUTES`, `src/live-chain-routes.ts` and `openapi.json` all declare `/api/v1/evm/address/{h160}`, and nothing anywhere declares `address-mapping`.

This is exactly what the resolver exists to prevent. An H160 paste has one right answer, and it was handed a dead link with **`exact: true`** — the field a UI acts on to navigate rather than offer a choice.

## The assertion that should have caught it

```ts
assert.match(hit.api_path, /^\/api\/v1\//, `${q}: ${hit.kind}`);
```

A prefix check, over a fixture of `ALICE`, a 64-hex hash, `"7"` and `"74:12"` — **no H160**. The one kind that was wrong was also the one kind the assertion never reached.

It now matches every emitted `api_path` against `API_ROUTES` (templates expanded to regexes), so a future kind pointing at a route that does not exist fails without anyone remembering to extend a fixture. And because "all paths are valid" is trivially true over an empty set, the test also asserts the fixture reaches **all six kinds** — `account`, `block`, `evm-account`, `extrinsic`, `neuron`, `subnet`.

Verified it catches the bug: reverting `src/identifier-resolver.ts` alone fails with

```
AssertionError: evm-account: /api/v1/evm/address-mapping/0xbbbb… matches no route in API_ROUTES
```

## Not fixed here

The same branch's `ui_path` is `/accounts?h160=…`, and `h160` appears nowhere under `apps/ui/src` — `accounts.index.tsx` has no `validateSearch`, so the parameter is silently dropped and the user lands on the generic accounts index. That is a visual `apps/ui/` change requiring the screenshot contract, so it is metagraphed-infra#373 rather than part of this diff.

## Validation

```
npm run typecheck                                # clean
npm run lint                                     # clean
npx prettier --check                             # clean
npx vitest run tests/identifier-resolver.test.ts # 24 passed
```

No schema, contract or artifact change — the route path is a string the resolver emits, not a registration.

## Template Used

- Backend/code change
