### PR TITLE
fix(ui): pin the compatibility date, which was floating to today

### DIFF
--- a/apps/ui/wrangler.jsonc
+++ b/apps/ui/wrangler.jsonc
@@ -10,6 +10,25 @@
   // deploy` would create a NEW worker and never update the live `metagraphed-ui`
   // worker that holds the `metagraph.sh/*` route.
   "name": "metagraphed-ui",
+  // PINNED, and it has to be (#9725). Nitro's cloudflare-module preset supplies
+  // its own `compatibility_date` default when this file does not
+  // (nitro/dist/_presets.mjs:490), and that default is `"latest"` -- which
+  // resolves to THE DAY THE BUILD RUNS. So the generated
+  // dist/server/wrangler.json asked for today's date, every day, while the
+  // pinned wrangler (4.118.0) ships a workerd that supports dates only up to
+  // 2026-08-06. On 2026-08-07 the calendar passed the binary and every e2e run
+  // stopped booting -- "This Worker requires compatibility date 2026-08-07, but
+  // the newest date supported by this server binary is 2026-08-06" -- with
+  // nothing in the failing diff to explain it. Same class as #9689's expiring
+  // fixtures: a build whose output depends on the wall clock.
+  //
+  // BUMP THIS WITH THE WRANGLER VERSION, NOT ON ITS OWN. The date and the
+  // binary that has to support it are one decision; pinning makes it a reviewed
+  // value in a commit rather than a number that changes under every build.
+  //
+  // Nitro merges with defu(overrides, ctxConfig, userConfig, defaults) and defu
+  // gives earlier arguments priority, so this beats that default.
+  "compatibility_date": "2026-08-06",
   // #9004: the whole site was ALSO being served, in parallel, from the
   // account's leftover workers.dev subdomain --
   // https://metagraphed-ui.zeronode.workers.dev returned 200 for every route.


### PR DESCRIPTION
## Summary

The `ui` job's e2e step fails today on any PR that touches `apps/ui`:

```
[ERROR] service core:user:metagraphed-ui: This Worker requires compatibility
date "2026-08-07", but the newest date supported by this server binary is
"2026-08-06".
[e2e-server] wrangler exited 3x within 10000ms
Error: Process from config.webServer was not able to start. Exit code: 1
```

Nothing in the failing diff explains it, because nothing in the diff caused it.

## Cause

`apps/ui/wrangler.jsonc` never set `compatibility_date`, so Nitro's cloudflare-module preset supplied its own (`nitro/dist/_presets.mjs:490`):

```js
defaults.compatibility_date =
  nitro.options.compatibilityDate.cloudflare || nitro.options.compatibilityDate.default;
```

`compatibilityDate` defaults to `"latest"` — **the day the build runs**. So the generated `dist/server/wrangler.json` asked for today's date every day, while the pinned `wrangler` (4.118.0) ships a `workerd` supporting dates only up to 2026-08-06. On 2026-08-07 the calendar passed the binary.

Same class as #9689's expiring fixtures: a build whose output depends on the wall clock, failing on a morning with nothing in the diff to explain it.

## Why it stayed hidden

The `ui` job only runs when a PR touches `apps/ui`. #9722 merged cleanly today with that job **skipped**; #9719 touched `apps/ui` (one regenerated API-reference page) and hit it immediately. Not new today — newly *reachable* today, and it blocks every `apps/ui` PR until pinned.

## Verification

Nitro merges with `defu(overrides, ctxConfig, userConfig, defaults)`, and defu gives earlier arguments priority, so a value in `wrangler.jsonc` beats the default. Confirmed by rebuilding and booting, not by reading the merge order:

```
$ rm -rf dist/server && npm run build:worker
generated compatibility_date: 2026-08-06      # was today's date

$ npx wrangler dev --config dist/server/wrangler.json --port 8099
grep -c "compatibility date" → 0              # was 3 fatal errors in 10s
curl 127.0.0.1:8099 → HTTP 200
```

## Why pinned rather than raised

The date and the binary that has to support it are one decision. Pinning makes it a reviewed value that moves with the wrangler version in a single commit, instead of a number that changes silently under every build — which is what a compatibility date is for. The comment in the file says to bump the two together.

Closes #9725
