### PR TITLE
feat(api): let callers of tao-usd and emission-pipeline ask for less

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -8692,6 +8692,8 @@ export interface components {
                     storage: string | null;
                 };
             };
+            matched_subnet_count?: number;
+            returned_subnet_count?: number;
             schema_version: number;
             subnets: {
                 alpha_in_emission: number | null;
@@ -16473,6 +16475,12 @@ export interface operations {
             query?: {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
+                sort?: "final_share" | "emission_share" | "weighted_share" | "gated_share" | "gate_delta" | "distance_to_bar" | "tao_in_emission" | "excess_tao" | "tao_total" | "liquidity_fraction" | "miner_burned" | "netuid";
+                order?: "asc" | "desc";
+                /** @description Maximum number of rows to return in one page (at most 512). Routes differ in how they handle a larger value: some reject it with 400 `invalid_query`, others clamp to the maximum and answer 200. Read the `limit` echoed in the response body rather than assuming the page is the size you asked for. */
+                limit?: number;
+                /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
+                fields?: string;
             };
             header?: never;
             path: {
@@ -16520,6 +16528,8 @@ export interface operations {
                      *             "storage": "example"
                      *           }
                      *         },
+                     *         "matched_subnet_count": 1,
+                     *         "returned_subnet_count": 1,
                      *         "schema_version": 1,
                      *         "subnets": [
                      *           {
@@ -35409,6 +35419,12 @@ export interface operations {
             query?: {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
+                sort?: "final_share" | "emission_share" | "weighted_share" | "gated_share" | "gate_delta" | "distance_to_bar" | "tao_in_emission" | "excess_tao" | "tao_total" | "liquidity_fraction" | "miner_burned" | "netuid";
+                order?: "asc" | "desc";
+                /** @description Maximum number of rows to return in one page (at most 512). Routes differ in how they handle a larger value: some reject it with 400 `invalid_query`, others clamp to the maximum and answer 200. Read the `limit` echoed in the response body rather than assuming the page is the size you asked for. */
+                limit?: number;
+                /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
+                fields?: string;
             };
             header?: never;
             path?: never;
@@ -35453,6 +35469,8 @@ export interface operations {
                      *             "storage": "example"
                      *           }
                      *         },
+                     *         "matched_subnet_count": 1,
+                     *         "returned_subnet_count": 1,
                      *         "schema_version": 1,
                      *         "subnets": [
                      *           {
@@ -43948,6 +43966,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `1h`, `24h`, `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "1h" | "24h" | "7d" | "30d";
+                include_points?: boolean;
             };
             header?: never;
             path?: never;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4541,6 +4541,50 @@
             "minimum": 0,
             "type": "integer"
           }
+        },
+        {
+          "name": "sort",
+          "schema": {
+            "enum": [
+              "final_share",
+              "emission_share",
+              "weighted_share",
+              "gated_share",
+              "gate_delta",
+              "distance_to_bar",
+              "tao_in_emission",
+              "excess_tao",
+              "tao_total",
+              "liquidity_fraction",
+              "miner_burned",
+              "netuid"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "order",
+          "schema": {
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "limit",
+          "schema": {
+            "maximum": 512,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "fields",
+          "schema": {
+            "type": "string"
+          }
         }
       ]
     },
@@ -8927,6 +8971,12 @@
               "30d"
             ],
             "type": "string"
+          }
+        },
+        {
+          "name": "include_points",
+          "schema": {
+            "type": "boolean"
           }
         }
       ]

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -4929,6 +4929,8 @@
                 "storage": "example"
               }
             },
+            "matched_subnet_count": 1,
+            "returned_subnet_count": 1,
             "schema_version": 1,
             "subnets": [
               {
@@ -28110,6 +28112,16 @@
               "type": "string"
             },
             "type": "object"
+          },
+          "matched_subnet_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "returned_subnet_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
           },
           "schema_version": {
             "maximum": 9007199254740991,
@@ -56706,6 +56718,60 @@
               "minimum": 0,
               "type": "integer"
             }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "final_share",
+                "emission_share",
+                "weighted_share",
+                "gated_share",
+                "gate_delta",
+                "distance_to_bar",
+                "tao_in_emission",
+                "excess_tao",
+                "tao_total",
+                "liquidity_fraction",
+                "miner_burned",
+                "netuid"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 512). Routes differ in how they handle a larger value: some reject it with 400 `invalid_query`, others clamp to the maximum and answer 200. Read the `limit` echoed in the response body rather than assuming the page is the size you asked for.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 512,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored.",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -78684,6 +78750,60 @@
               "minimum": 0,
               "type": "integer"
             }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "final_share",
+                "emission_share",
+                "weighted_share",
+                "gated_share",
+                "gate_delta",
+                "distance_to_bar",
+                "tao_in_emission",
+                "excess_tao",
+                "tao_total",
+                "liquidity_fraction",
+                "miner_burned",
+                "netuid"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 512). Routes differ in how they handle a larger value: some reject it with 400 `invalid_query`, others clamp to the maximum and answer 200. Read the `limit` echoed in the response body rather than assuming the page is the size you asked for.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 512,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored.",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -88761,6 +88881,14 @@
                 "30d"
               ],
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_points",
+            "required": false,
+            "schema": {
+              "type": "boolean"
             }
           }
         ],

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -8692,6 +8692,8 @@ export interface components {
                     storage: string | null;
                 };
             };
+            matched_subnet_count?: number;
+            returned_subnet_count?: number;
             schema_version: number;
             subnets: {
                 alpha_in_emission: number | null;
@@ -16473,6 +16475,12 @@ export interface operations {
             query?: {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
+                sort?: "final_share" | "emission_share" | "weighted_share" | "gated_share" | "gate_delta" | "distance_to_bar" | "tao_in_emission" | "excess_tao" | "tao_total" | "liquidity_fraction" | "miner_burned" | "netuid";
+                order?: "asc" | "desc";
+                /** @description Maximum number of rows to return in one page (at most 512). Routes differ in how they handle a larger value: some reject it with 400 `invalid_query`, others clamp to the maximum and answer 200. Read the `limit` echoed in the response body rather than assuming the page is the size you asked for. */
+                limit?: number;
+                /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
+                fields?: string;
             };
             header?: never;
             path: {
@@ -16520,6 +16528,8 @@ export interface operations {
                      *             "storage": "example"
                      *           }
                      *         },
+                     *         "matched_subnet_count": 1,
+                     *         "returned_subnet_count": 1,
                      *         "schema_version": 1,
                      *         "subnets": [
                      *           {
@@ -35409,6 +35419,12 @@ export interface operations {
             query?: {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
+                sort?: "final_share" | "emission_share" | "weighted_share" | "gated_share" | "gate_delta" | "distance_to_bar" | "tao_in_emission" | "excess_tao" | "tao_total" | "liquidity_fraction" | "miner_burned" | "netuid";
+                order?: "asc" | "desc";
+                /** @description Maximum number of rows to return in one page (at most 512). Routes differ in how they handle a larger value: some reject it with 400 `invalid_query`, others clamp to the maximum and answer 200. Read the `limit` echoed in the response body rather than assuming the page is the size you asked for. */
+                limit?: number;
+                /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
+                fields?: string;
             };
             header?: never;
             path?: never;
@@ -35453,6 +35469,8 @@ export interface operations {
                      *             "storage": "example"
                      *           }
                      *         },
+                     *         "matched_subnet_count": 1,
+                     *         "returned_subnet_count": 1,
                      *         "schema_version": 1,
                      *         "subnets": [
                      *           {
@@ -43948,6 +43966,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `1h`, `24h`, `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "1h" | "24h" | "7d" | "30d";
+                include_points?: boolean;
             };
             header?: never;
             path?: never;

--- a/schemas-src/mcp-tools/get-emission-pipeline.ts
+++ b/schemas-src/mcp-tools/get-emission-pipeline.ts
@@ -12,14 +12,38 @@
 // together and there is exactly one place to fix — which is the whole point of
 // not keeping a second copy here.
 import { z } from "zod";
-import { netuidSchema } from "./shared.ts";
+import {
+  netuidSchema,
+  fieldsSchema,
+  limitSchema,
+  orderSchema,
+  sortSchema,
+} from "./shared.ts";
 import { EMISSION_PIPELINE_BODY } from "../routes/emission-pipeline.ts";
+import { EMISSION_PIPELINE_SORT_FIELDS } from "../../src/emission-pipeline-surface.ts";
+import {
+  EMISSION_PIPELINE_LIMIT_MAX,
+  EMISSION_PIPELINE_MCP_LIMIT_DEFAULT,
+} from "../../src/route-limits.ts";
 
 export const GetEmissionPipelineInputSchema = z
   .object({
     // Narrows the per-subnet rows only; the aggregate and the identity checks
     // stay network-wide, matching ?netuid= on the REST route.
     netuid: netuidSchema().optional(),
+    // #9720. 129 subnets x 16 fields is ~56 KB, and `netuid` was the only
+    // filter -- it narrows to ONE subnet or leaves all of them, with nothing in
+    // between. NARROWING THE RESPONSE NEVER NARROWS THE MEASUREMENT: the
+    // aggregate and the four identity checks are computed over every subnet
+    // before any of this applies, so `verification` still covers the whole
+    // distribution.
+    sort: sortSchema(EMISSION_PIPELINE_SORT_FIELDS).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsSchema().optional(),
+    limit: limitSchema(
+      EMISSION_PIPELINE_LIMIT_MAX,
+      EMISSION_PIPELINE_MCP_LIMIT_DEFAULT,
+    ).optional(),
   })
   .strict();
 export type GetEmissionPipelineInput = z.infer<

--- a/schemas-src/mcp-tools/get-tao-usd.ts
+++ b/schemas-src/mcp-tools/get-tao-usd.ts
@@ -3,7 +3,27 @@ import { z } from "zod";
 import { windowSchema } from "./shared.ts";
 
 export const GetTaoUsdInputSchema = z
-  .object({ window: windowSchema(["1h", "24h", "7d", "30d"]).optional() })
+  .object({
+    window: windowSchema(["1h", "24h", "7d", "30d"]).optional(),
+    // #9720. The series is ~1,428 points and ~143 KB on the default window,
+    // while every summary a caller usually wants -- latest, change_usd,
+    // change_pct, point_count, priced_point_count, oldest_observed_at -- sits
+    // beside it as a top-level scalar. DEFAULTS TO FALSE HERE and to true on
+    // the REST route: a browser can stream 143 KB and a context window cannot,
+    // so the surface with the hard constraint carries the default (the same
+    // asymmetry #9701 established for list_candidates).
+    include_points: z
+      .boolean()
+      .optional()
+      .describe(
+        "Include the full per-point price series. Defaults to FALSE here — " +
+          "the summary above it (latest, change_usd, change_pct, the counts) " +
+          "is computed over the whole window either way, so omitting the " +
+          "points narrows the response without narrowing the measurement. " +
+          "Set true when you need the series itself.",
+      )
+      .meta({ default: false, examples: [false] }),
+  })
   .strict();
 export type GetTaoUsdInput = z.infer<typeof GetTaoUsdInputSchema>;
 
@@ -28,15 +48,21 @@ export const GetTaoUsdOutputSchema = z
     oldest_observed_at: z.string().nullable(),
     change_usd: z.number().nullable(),
     change_pct: z.number().nullable(),
-    points: z.array(
-      z
-        .object({
-          observed_at: z.string(),
-          block_number: z.int().nullable(),
-          usd_per_tao: z.number().nullable(),
-        })
-        .passthrough(),
-    ),
+    // Optional because `include_points: false` OMITS the key rather than
+    // sending an empty array (#9720): an empty array is indistinguishable from
+    // a window that priced nothing, and the counts above already say how many
+    // points exist.
+    points: z
+      .array(
+        z
+          .object({
+            observed_at: z.string(),
+            block_number: z.int().nullable(),
+            usd_per_tao: z.number().nullable(),
+          })
+          .passthrough(),
+      )
+      .optional(),
   })
   .passthrough();
 export type GetTaoUsdOutput = z.infer<typeof GetTaoUsdOutputSchema>;

--- a/schemas-src/routes/emission-pipeline.ts
+++ b/schemas-src/routes/emission-pipeline.ts
@@ -75,6 +75,17 @@ export const EMISSION_PIPELINE_BODY = {
   block_emission_tao: z.number().nullable(),
   block_emission_halvings: z.int().min(0).nullable(),
   subnets: z.array(SubnetEmissionDecompositionSchema),
+  // Present only when the caller narrowed the list with `limit`/`fields`
+  // (#9720), so today's body is byte-for-byte unchanged for everyone else.
+  // Published when they DO narrow it, because otherwise a 20-row page and a
+  // network that really has 20 subnets are the same response.
+  //
+  // The row schema above continues to describe the UNPROJECTED row: a `fields`
+  // projection returns a subset of these same keys, and this follows the
+  // convention /api/v1/economics already set rather than weakening the contract
+  // for every caller who does not project.
+  matched_subnet_count: z.int().min(0).optional(),
+  returned_subnet_count: z.int().min(0).optional(),
   aggregate: z
     .object({
       eligible_count: z.int().min(0),

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -31,7 +31,9 @@ import {
   EMISSION_CHANGES_LIMIT_MAX,
   CHAIN_CONCENTRATION_SUBNETS_LIMIT_DEFAULT,
   CHAIN_CONCENTRATION_SUBNETS_LIMIT_MAX,
+  EMISSION_PIPELINE_LIMIT_MAX,
 } from "./route-limits.ts";
+import { EMISSION_PIPELINE_SORT_FIELDS } from "./emission-pipeline-surface.ts";
 import {
   CONCENTRATION_LENSES,
   CONCENTRATION_RANKING_SORTS,
@@ -2523,7 +2525,20 @@ export const API_ROUTES = [
     "short",
     ["subnets", "analytics"],
     {
-      parameters: [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
+      parameters: [
+        { name: "netuid", schema: { type: "integer", minimum: 0 } },
+        { name: "sort", schema: enumSchema(EMISSION_PIPELINE_SORT_FIELDS) },
+        { name: "order", schema: enumSchema(["asc", "desc"]) },
+        {
+          name: "limit",
+          schema: {
+            type: "integer",
+            minimum: 1,
+            maximum: EMISSION_PIPELINE_LIMIT_MAX,
+          },
+        },
+        { name: "fields", schema: { type: "string" } },
+      ],
     },
     [],
   ),
@@ -3856,6 +3871,7 @@ export const API_ROUTES = [
         name: "window",
         schema: { type: "string", enum: ["1h", "24h", "7d", "30d"] },
       },
+      { name: "include_points", schema: { type: "boolean" } },
     ],
     [],
   ),

--- a/src/emission-pipeline-surface.ts
+++ b/src/emission-pipeline-surface.ts
@@ -18,6 +18,119 @@ import {
   type EmissionDecomposition,
 } from "./emission-decomposition.ts";
 import { resolveLiveEconomics } from "./health-serving.ts";
+import {
+  parseFieldsParam,
+  projectRows,
+  unknownAgainstRows,
+  type Row,
+} from "./field-projection.ts";
+
+/**
+ * The per-subnet columns this surface can rank by (#9720).
+ *
+ * `final_share` leads deliberately. #9707 established that it, not
+ * `emission_share`, is the number that answers "where is the emission" --
+ * `emission_share` is the v440 STAGE-1 PRICE SHARE, and 52 subnets carry a
+ * positive one while receiving nothing. A ranking that offered only the
+ * stage-1 share would reproduce, on a new parameter, the exact defect that
+ * issue fixed on the leaderboard.
+ */
+export const EMISSION_PIPELINE_SORT_FIELDS = [
+  "final_share",
+  "emission_share",
+  "weighted_share",
+  "gated_share",
+  "gate_delta",
+  "distance_to_bar",
+  "tao_in_emission",
+  "excess_tao",
+  "tao_total",
+  "liquidity_fraction",
+  "miner_burned",
+  "netuid",
+] as const;
+export type EmissionPipelineSortField =
+  (typeof EMISSION_PIPELINE_SORT_FIELDS)[number];
+
+export interface EmissionPipelineNarrowing {
+  sort?: EmissionPipelineSortField | null;
+  order?: "asc" | "desc" | null;
+  limit?: number | null;
+  /** Already-parsed field names, or null for the full row. */
+  fields?: string[] | null;
+}
+
+/**
+ * Parse `?sort/order/limit/fields` for this surface.
+ *
+ * One parser for all three surfaces, same reason the projection is shared: the
+ * REST route, the GraphQL field and the MCP tool must not disagree about which
+ * values are legal. `fields` is validated against the ROWS rather than a fixed
+ * list, reusing the shared projection helper, so a column added to the
+ * decomposition is projectable the day it appears.
+ */
+export function parseEmissionPipelineNarrowing(
+  params: URLSearchParams,
+  rows: Row[],
+  { limitMax }: { limitMax: number },
+):
+  | EmissionPipelineNarrowing
+  | { error: { parameter: string; message: string } } {
+  const sort = params.get("sort");
+  if (
+    sort != null &&
+    !EMISSION_PIPELINE_SORT_FIELDS.includes(sort as EmissionPipelineSortField)
+  ) {
+    return {
+      error: {
+        parameter: "sort",
+        message: `"${sort}" is not a supported sort. Supported: ${EMISSION_PIPELINE_SORT_FIELDS.join(", ")}.`,
+      },
+    };
+  }
+  const order = params.get("order");
+  if (order != null && order !== "asc" && order !== "desc") {
+    return {
+      error: {
+        parameter: "order",
+        message: `"${order}" is not a supported order. Supported: asc, desc.`,
+      },
+    };
+  }
+  const rawLimit = params.get("limit");
+  let limit: number | null = null;
+  if (rawLimit != null && rawLimit !== "") {
+    const parsed = Number(rawLimit);
+    // Rejected rather than clamped: a caller who asked for 5000 and silently
+    // received 129 has a truncated list they believe is complete.
+    if (
+      !/^\d+$/.test(rawLimit.trim()) ||
+      !Number.isInteger(parsed) ||
+      parsed < 1 ||
+      parsed > limitMax
+    ) {
+      return {
+        error: {
+          parameter: "limit",
+          message: `limit must be an integer between 1 and ${limitMax}.`,
+        },
+      };
+    }
+    limit = parsed;
+  }
+  const fields = parseFieldsParam(
+    params,
+    unknownAgainstRows(rows),
+    "emission pipeline subnets",
+  );
+  if (fields.error) return { error: fields.error };
+  return {
+    sort: sort as EmissionPipelineSortField | null,
+    order,
+    limit,
+    fields: fields.fields,
+  };
+}
 
 /**
  * Why a capture with no `chain_state` is served as an error rather than as a
@@ -53,6 +166,9 @@ export interface EmissionPipelineSurface extends EmissionDecomposition {
    */
   schema_version: 1;
   field_sources: typeof EMISSION_FIELD_SOURCES;
+  /** Present only when {@link narrowEmissionPipeline} actually narrowed. */
+  matched_subnet_count?: number;
+  returned_subnet_count?: number;
 }
 
 interface EconomicsBlob {
@@ -118,5 +234,70 @@ export function projectEmissionPipeline(
         ? decomposition.subnets
         : decomposition.subnets.filter((subnet) => subnet.netuid === netuid),
     field_sources: EMISSION_FIELD_SOURCES,
+  };
+}
+
+/**
+ * Apply `sort`/`order`/`limit`/`fields` to an already-projected surface (#9720).
+ *
+ * Separate from the projection above, and downstream of it, for two reasons.
+ * The `fields` allow-list is derived from the DECOMPOSED rows, so the rows have
+ * to exist before the parameter can be validated -- and taking the surface
+ * rather than the blob means the caller projects once, never twice, so there is
+ * no second null-return to handle that cannot happen.
+ *
+ * NARROWING THE RESPONSE NEVER NARROWS THE MEASUREMENT. `aggregate` and
+ * `verification` arrive already computed over EVERY subnet and are passed
+ * through untouched, so a caller asking for ten rows still receives
+ * verification covering the whole distribution. An identity evaluated over a
+ * ten-row slice is not a thing that can be verified -- the same reason the
+ * pre-existing `netuid` filter leaves the aggregate network-wide.
+ */
+export function narrowEmissionPipeline(
+  surface: EmissionPipelineSurface,
+  narrowing: EmissionPipelineNarrowing = {},
+): EmissionPipelineSurface {
+  const matched = surface.subnets.length;
+  let subnets = surface.subnets;
+
+  if (narrowing.sort) {
+    const key = narrowing.sort;
+    // Largest-first by default for every key here: each is a magnitude ("how
+    // much of the emission", "how much TAO"), so desc is what the question
+    // means in all twelve cases -- unlike the concentration ranking, whose
+    // measures point in opposite directions and need per-key defaults.
+    const factor = narrowing.order === "asc" ? 1 : -1;
+    subnets = [...subnets].sort((a, b) => {
+      const left = (a as unknown as Row)[key];
+      const right = (b as unknown as Row)[key];
+      // A row missing the sort column sinks in EITHER direction rather than
+      // riding a null to the top of an ascending list.
+      const leftMissing = left == null || !Number.isFinite(Number(left));
+      const rightMissing = right == null || !Number.isFinite(Number(right));
+      if (leftMissing !== rightMissing) return leftMissing ? 1 : -1;
+      if (!leftMissing && Number(left) !== Number(right)) {
+        return (Number(left) - Number(right)) * factor;
+      }
+      return a.netuid - b.netuid;
+    });
+  }
+
+  const limited =
+    narrowing.limit != null ? subnets.slice(0, narrowing.limit) : subnets;
+  const narrowed = narrowing.limit != null || narrowing.fields != null;
+
+  return {
+    ...surface,
+    subnets: projectRows(
+      limited as unknown as Row[],
+      narrowing.fields,
+    ) as unknown as typeof surface.subnets,
+    // Published only when the list was actually narrowed, so today's body is
+    // byte-for-byte unchanged for every caller who does not narrow it -- and
+    // when they do, a 20-row page and a network that really has 20 subnets stop
+    // being the same response.
+    ...(narrowed
+      ? { matched_subnet_count: matched, returned_subnet_count: limited.length }
+      : {}),
   };
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1150,6 +1150,8 @@ import {
 import {
   EMISSION_PIPELINE_UNAVAILABLE_CODE,
   EMISSION_PIPELINE_UNAVAILABLE_MESSAGE,
+  narrowEmissionPipeline,
+  parseEmissionPipelineNarrowing,
   projectEmissionPipeline,
   resolveEmissionPipelineEconomics,
 } from "./emission-pipeline-surface.ts";
@@ -1491,6 +1493,11 @@ import {
   PIPELINE_HISTORY_WINDOWS,
 } from "./emission-pipeline-history.ts";
 import { DEFAULT_PIPELINE_HISTORY_WINDOW } from "./route-limits.ts";
+import {
+  EMISSION_PIPELINE_LIMIT_MAX,
+  EMISSION_PIPELINE_MCP_LIMIT_DEFAULT,
+} from "./route-limits.ts";
+import type { Row as FieldProjectionRow } from "./field-projection.ts";
 import {
   buildEmissionChanges,
   loadEmissionChanges,
@@ -5354,14 +5361,46 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         readArtifact: () =>
           loadOptionalArtifact(ctx, "/metagraph/economics.json"),
       });
-      const data = projectEmissionPipeline(economics, args?.netuid ?? null);
-      if (!data) {
+      const netuid = args?.netuid ?? null;
+      const surface = projectEmissionPipeline(economics, netuid);
+      if (!surface) {
         throw toolError(
           EMISSION_PIPELINE_UNAVAILABLE_CODE,
           EMISSION_PIPELINE_UNAVAILABLE_MESSAGE,
         );
       }
-      return data;
+      // #9720. The published inputSchema does not run at dispatch, so the tool
+      // guards with the ROUTE's parser rather than a second hand-written check
+      // -- the same reuse that keeps the two from disagreeing about which sort
+      // keys and field names are legal. `fields` is validated against the
+      // DECOMPOSED rows, which is why the projection runs first.
+      const params = new URLSearchParams();
+      for (const key of ["sort", "order", "fields"] as const) {
+        const value = (args as Row | null | undefined)?.[key];
+        if (value != null) params.set(key, String(value));
+      }
+      // The DEFAULT lives here and not on the REST route: a browser can stream
+      // 56 KB and a context window cannot. An explicit `netuid` already narrows
+      // to one subnet, so a default page on top of it would be noise.
+      const limit = (args as Row | null | undefined)?.limit;
+      params.set(
+        "limit",
+        String(
+          limit ??
+            (netuid === null
+              ? EMISSION_PIPELINE_MCP_LIMIT_DEFAULT
+              : EMISSION_PIPELINE_LIMIT_MAX),
+        ),
+      );
+      const narrowing = parseEmissionPipelineNarrowing(
+        params,
+        surface.subnets as unknown as FieldProjectionRow[],
+        { limitMax: EMISSION_PIPELINE_LIMIT_MAX },
+      );
+      if ("error" in narrowing) {
+        throw toolError("invalid_params", narrowing.error.message);
+      }
+      return narrowEmissionPipeline(surface, narrowing);
     },
   },
   {
@@ -8190,7 +8229,13 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         >[0],
         { windowHours: TAO_USD_WINDOWS[label] },
       );
-      return buildTaoUsdSeries(rows, { window: label });
+      // Defaults to FALSE here and to true on REST -- see the schema. The
+      // summary is computed over the whole window either way, so this narrows
+      // the response without narrowing the measurement.
+      return buildTaoUsdSeries(rows, {
+        window: label,
+        includePoints: args?.include_points === true,
+      });
     },
   },
   {

--- a/src/route-limits.ts
+++ b/src/route-limits.ts
@@ -214,3 +214,17 @@ export const CANDIDATES_LIMIT_MAX = 1000;
  */
 export const CHAIN_CONCENTRATION_SUBNETS_LIMIT_DEFAULT = 20;
 export const CHAIN_CONCENTRATION_SUBNETS_LIMIT_MAX = 512;
+
+/**
+ * `/api/v1/chain/emission-pipeline` -- the v440 decomposition per subnet (#9720).
+ *
+ * A CEILING with no default: the collection is one row per subnet (~129 today)
+ * and the REST route has always served all of them, so imposing a default here
+ * would truncate every existing caller's body without their asking. The MCP
+ * tool carries the narrowing default instead -- a browser can stream 56 KB and
+ * a context window cannot, the same asymmetry CANDIDATES_LIMIT_DEFAULT is
+ * argued on. The max sits above the subnet count so "the whole pipeline" stays
+ * one request.
+ */
+export const EMISSION_PIPELINE_LIMIT_MAX = 512;
+export const EMISSION_PIPELINE_MCP_LIMIT_DEFAULT = 20;

--- a/src/tao-usd-series.ts
+++ b/src/tao-usd-series.ts
@@ -108,7 +108,10 @@ export async function loadTaoUsdSeries(
  */
 export function buildTaoUsdSeries(
   rows: Row[] | null | undefined,
-  { window }: { window?: unknown } = {},
+  {
+    window,
+    includePoints = true,
+  }: { window?: unknown; includePoints?: boolean } = {},
 ): Row {
   const points = (Array.isArray(rows) ? rows : [])
     .map((r) => ({
@@ -155,7 +158,13 @@ export function buildTaoUsdSeries(
       changeUsd === null || oldest === null || oldest === 0
         ? null
         : round(changeUsd / oldest),
-    points,
+    // OMITTED, not emptied, when the caller opts out (#9720). An empty array
+    // would be indistinguishable from a window that priced nothing, and the
+    // counts above already say how many points exist -- so absence is the only
+    // honest way to say "you asked not to be sent these". Every summary field
+    // above is computed over the FULL series either way: narrowing the response
+    // must not narrow the measurement.
+    ...(includePoints ? { points } : {}),
   };
 }
 

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -2097,6 +2097,62 @@ describe("emission-pipeline route", () => {
     assert.equal(body.error.code, "emission_pipeline_unavailable");
   });
 
+  test("narrows with sort/order/limit/fields, and reports what it narrowed (#9720)", async () => {
+    const env = envWithEconomics({
+      chain_state: CHAIN_STATE,
+      subnets: SUBNETS,
+    } as Row);
+    const base = "https://api.metagraph.sh/api/v1/chain/emission-pipeline";
+
+    // Unnarrowed: today's body, and no count fields at all.
+    const plain = await getJson(base, env);
+    assert.equal(plain.body.data.subnets.length, 2);
+    assert.equal("matched_subnet_count" in plain.body.data, false);
+
+    // final_share, not emission_share -- #9707's distinction, now sortable.
+    const ranked = await getJson(`${base}?sort=final_share`, env);
+    assert.ok(
+      ranked.body.data.subnets[0].final_share >=
+        ranked.body.data.subnets[1].final_share,
+    );
+
+    const paged = await getJson(`${base}?sort=final_share&limit=1`, env);
+    assert.equal(paged.body.data.subnets.length, 1);
+    assert.equal(paged.body.data.matched_subnet_count, 2);
+    assert.equal(paged.body.data.returned_subnet_count, 1);
+    // A one-row page must not silently redefine the network split, exactly as
+    // the ?netuid filter above does not.
+    assert.equal(paged.body.data.aggregate.eligible_count, 2);
+    assert.deepEqual(
+      paged.body.data.verification,
+      plain.body.data.verification,
+    );
+
+    const projected = await getJson(`${base}?fields=netuid,final_share`, env);
+    for (const row of projected.body.data.subnets) {
+      assert.deepEqual(Object.keys(row).sort(), ["final_share", "netuid"]);
+    }
+  });
+
+  test("rejects a bad sort, order, limit or field rather than ignoring it (#9720)", async () => {
+    const env = envWithEconomics({
+      chain_state: CHAIN_STATE,
+      subnets: SUBNETS,
+    } as Row);
+    const base = "https://api.metagraph.sh/api/v1/chain/emission-pipeline";
+    for (const qs of [
+      "sort=whatever",
+      "order=sideways",
+      "limit=0",
+      "limit=99999",
+      "limit=abc",
+      "fields=netuid,not_a_column",
+    ]) {
+      const { status } = await getJson(`${base}?${qs}`, env);
+      assert.equal(status, 400, `${qs} should have been rejected`);
+    }
+  });
+
   test("rejects an unsupported or malformed query param", async () => {
     const env = envWithEconomics({
       chain_state: CHAIN_STATE,

--- a/tests/emission-pipeline-surface.test.ts
+++ b/tests/emission-pipeline-surface.test.ts
@@ -12,6 +12,9 @@ import { describe, test } from "vitest";
 import {
   EMISSION_PIPELINE_UNAVAILABLE_CODE,
   EMISSION_PIPELINE_UNAVAILABLE_MESSAGE,
+  EMISSION_PIPELINE_SORT_FIELDS,
+  narrowEmissionPipeline,
+  parseEmissionPipelineNarrowing,
   projectEmissionPipeline,
   resolveEmissionPipelineEconomics,
 } from "../src/emission-pipeline-surface.ts";
@@ -104,6 +107,226 @@ describe("emission-pipeline surface — projectEmissionPipeline", () => {
     assert.equal(projectEmissionPipeline(null), null);
     assert.equal(projectEmissionPipeline(undefined), null);
     assert.equal(projectEmissionPipeline({ subnets: SUBNETS }), null);
+  });
+});
+
+describe("emission-pipeline surface — narrowing (#9720)", () => {
+  const surface = () => projectEmissionPipeline(ECONOMICS)!;
+
+  test("an empty narrowing leaves the body byte-for-byte unchanged", () => {
+    // The whole back-compat claim in one assertion: every caller who does not
+    // narrow must receive exactly what they received before this shipped,
+    // including the ABSENCE of the two count fields.
+    const before = surface();
+    const after = narrowEmissionPipeline(before, {});
+    assert.deepEqual(after, before);
+    assert.equal("matched_subnet_count" in after, false);
+    assert.equal("returned_subnet_count" in after, false);
+  });
+
+  test("sorts by final_share largest-first, and order flips it", () => {
+    // final_share, not emission_share: #9707 established that the stage-1 price
+    // share is not the number that answers "where is the emission", and subnet
+    // 2 here is exactly that case -- a positive emission_share gated to zero.
+    const [first] = narrowEmissionPipeline(surface(), {
+      sort: "final_share",
+    }).subnets;
+    assert.equal(first.netuid, 1);
+    assert.ok((first.final_share as number) > 0);
+
+    const asc = narrowEmissionPipeline(surface(), {
+      sort: "final_share",
+      order: "asc",
+    }).subnets;
+    assert.equal(asc[0].netuid, 2);
+    assert.equal(asc[0].final_share, 0);
+
+    // The stage-1 share orders the other way round, which is the whole reason
+    // both are offered.
+    const byStage1 = narrowEmissionPipeline(surface(), {
+      sort: "emission_share",
+    }).subnets;
+    assert.equal(byStage1[0].netuid, 2);
+  });
+
+  test("limit pages without hiding how many matched", () => {
+    const narrowed = narrowEmissionPipeline(surface(), { limit: 1 });
+    assert.equal(narrowed.subnets.length, 1);
+    assert.equal(narrowed.matched_subnet_count, 2);
+    assert.equal(narrowed.returned_subnet_count, 1);
+  });
+
+  test("fields projects the row and nothing else", () => {
+    const narrowed = narrowEmissionPipeline(surface(), {
+      fields: ["netuid", "final_share"],
+    });
+    for (const row of narrowed.subnets) {
+      assert.deepEqual(Object.keys(row).sort(), ["final_share", "netuid"]);
+    }
+    assert.equal(narrowed.matched_subnet_count, 2);
+  });
+
+  test("NARROWING THE RESPONSE NEVER NARROWS THE MEASUREMENT", () => {
+    // The one that matters. A caller asking for one row must still receive an
+    // aggregate and a verification computed over EVERY subnet -- an identity
+    // evaluated on a one-row slice is not a thing that can be verified, and
+    // silently rescoping it would turn a narrowed response into an unsound one.
+    const full = surface();
+    const narrowed = narrowEmissionPipeline(full, {
+      limit: 1,
+      fields: ["netuid"],
+      sort: "final_share",
+    });
+    assert.deepEqual(narrowed.aggregate, full.aggregate);
+    assert.deepEqual(narrowed.verification, full.verification);
+    assert.deepEqual(narrowed.chain_state, full.chain_state);
+    assert.deepEqual(narrowed.field_sources, full.field_sources);
+    // Spelled out rather than left to deepEqual: the aggregate counts BOTH
+    // subnets while exactly one row is served, which is the property under
+    // test. Rescoping the aggregate to the page would make these read 1 and 0.
+    assert.equal(narrowed.subnets.length, 1);
+    assert.equal(narrowed.aggregate.eligible_count, 2);
+    assert.equal(narrowed.aggregate.disabled_count, 1);
+    assert.equal(narrowed.aggregate.total_final_share, 1);
+    assert.equal(
+      narrowed.verification.checks.length,
+      full.verification.checks.length,
+    );
+  });
+
+  test("a row missing the sort column sinks in EITHER direction", () => {
+    // `liquidity_fraction` is null on netuid 2 (tao_total is 0) and a real
+    // number on netuid 1 -- a genuine mixed column, so this cannot pass
+    // vacuously the way a fixture with no nulls in it would.
+    const full = surface();
+    assert.equal(
+      (full.subnets.find((row) => row.netuid === 2) as unknown as Row)
+        .liquidity_fraction,
+      null,
+      "fixture no longer produces a null sort value; the test would prove nothing",
+    );
+
+    for (const order of ["asc", "desc"] as const) {
+      const rows = narrowEmissionPipeline(full, {
+        sort: "liquidity_fraction",
+        order,
+      }).subnets;
+      assert.equal(
+        rows[rows.length - 1].netuid,
+        2,
+        `a null sort value floated on order=${order}`,
+      );
+      assert.equal(rows[0].netuid, 1);
+    }
+
+    // Nulls interleaved with values, so the comparator meets a missing value
+    // as its LEFT operand as well as its right -- two rows only ever exercise
+    // one of the two arms.
+    const zeroTao = { tao_in_emission_tao: "0", excess_tao: "0" };
+    const interleaved = projectEmissionPipeline({
+      ...ECONOMICS,
+      subnets: [
+        { ...SUBNETS[0], netuid: 1, ...zeroTao },
+        { ...SUBNETS[0], netuid: 2 },
+        { ...SUBNETS[0], netuid: 3, ...zeroTao },
+        { ...SUBNETS[0], netuid: 4 },
+      ],
+    })!;
+    for (const order of ["asc", "desc"] as const) {
+      const rows = narrowEmissionPipeline(interleaved, {
+        sort: "liquidity_fraction",
+        order,
+      }).subnets;
+      const measured = rows.filter(
+        (row) => (row as unknown as Row).liquidity_fraction != null,
+      );
+      const missing = rows.filter(
+        (row) => (row as unknown as Row).liquidity_fraction == null,
+      );
+      assert.equal(measured.length, 2);
+      assert.equal(missing.length, 2);
+      assert.deepEqual(
+        rows.slice(-2).map((row) => row.netuid),
+        missing.map((row) => row.netuid),
+        `nulls did not sink to the end on order=${order}`,
+      );
+    }
+  });
+
+  test("equal sort values break on netuid, so the order is total", () => {
+    const tied = projectEmissionPipeline({
+      ...ECONOMICS,
+      subnets: [
+        { ...SUBNETS[0], netuid: 5 },
+        { ...SUBNETS[0], netuid: 3 },
+        { ...SUBNETS[0], netuid: 4 },
+      ],
+    })!;
+    for (const order of ["asc", "desc"] as const) {
+      assert.deepEqual(
+        narrowEmissionPipeline(tied, {
+          sort: "emission_share",
+          order,
+        }).subnets.map((row) => row.netuid),
+        [3, 4, 5],
+        `tie-break was not netuid-ascending on order=${order}`,
+      );
+    }
+  });
+});
+
+describe("emission-pipeline surface — parseEmissionPipelineNarrowing (#9720)", () => {
+  const rows = () =>
+    projectEmissionPipeline(ECONOMICS)!.subnets as unknown as Row[];
+  const parse = (qs: string) =>
+    parseEmissionPipelineNarrowing(new URLSearchParams(qs), rows(), {
+      limitMax: 512,
+    });
+
+  test("an empty query narrows nothing", () => {
+    assert.deepEqual(parse(""), {
+      sort: null,
+      order: null,
+      limit: null,
+      fields: null,
+    });
+  });
+
+  test("accepts every published sort field", () => {
+    for (const sort of EMISSION_PIPELINE_SORT_FIELDS) {
+      assert.equal((parse(`sort=${sort}`) as Row).sort, sort);
+    }
+  });
+
+  test("names the offending parameter and lists what is valid", () => {
+    const sort = parse("sort=whatever") as { error: Row };
+    assert.equal(sort.error.parameter, "sort");
+    assert.match(sort.error.message as string, /final_share/);
+
+    const order = parse("order=sideways") as { error: Row };
+    assert.equal(order.error.parameter, "order");
+
+    const fields = parse("fields=netuid,not_a_column") as { error: Row };
+    assert.equal(fields.error.parameter, "fields");
+    assert.match(fields.error.message as string, /not_a_column/);
+    assert.match(fields.error.message as string, /emission pipeline subnets/);
+  });
+
+  test("an out-of-range limit is REJECTED, never clamped", () => {
+    for (const bad of ["0", "-1", "513", "1.5", "abc"]) {
+      const result = parse(`limit=${encodeURIComponent(bad)}`) as {
+        error: Row;
+      };
+      assert.ok("error" in result, `limit=${bad} should have been rejected`);
+      assert.equal(result.error.parameter, "limit");
+    }
+    assert.equal((parse("limit=1") as Row).limit, 1);
+    assert.equal((parse("limit=512") as Row).limit, 512);
+  });
+
+  test("a valid fields list comes back parsed and de-duplicated", () => {
+    const parsed = parse("fields=netuid,final_share,netuid") as Row;
+    assert.deepEqual(parsed.fields, ["netuid", "final_share"]);
   });
 });
 
@@ -334,9 +557,26 @@ describe("emission-pipeline surface — tri-surface parity", () => {
     const env = graphqlEnv(ECONOMICS as Row);
     const rows = (await gql(GQL_ROWS_QUERY, env)).data.emission_pipeline;
     const rollup = (await gql(GQL_ROLLUP_QUERY, env)).data.emission_pipeline;
-    const mcp = (await callTool({}, ECONOMICS as Row)).structuredContent;
+    // The MCP tool applies a narrowing DEFAULT the other two surfaces do not
+    // (#9720: a browser can stream 56 KB and a context window cannot), so
+    // parity is asserted on the decomposition rather than on the page. Passing
+    // an explicit limit above the subnet count removes the only difference.
+    const mcp = (await callTool({ limit: 512 }, ECONOMICS as Row))
+      .structuredContent;
 
-    assert.deepEqual(mcp, shared);
+    assert.deepEqual(mcp.subnets, shared.subnets);
+    assert.deepEqual(mcp.aggregate, shared.aggregate);
+    assert.deepEqual(mcp.verification, shared.verification);
+    assert.deepEqual(mcp.chain_state, shared.chain_state);
+    assert.deepEqual(mcp.field_sources, shared.field_sources);
+    assert.equal(mcp.block_emission_tao, shared.block_emission_tao);
+
+    // And the default really does narrow, so the asymmetry above is a
+    // deliberate difference rather than a test written around a bug.
+    const defaulted = (await callTool({}, ECONOMICS as Row)).structuredContent;
+    assert.equal(defaulted.returned_subnet_count, shared.subnets.length);
+    assert.equal(defaulted.matched_subnet_count, shared.subnets.length);
+    assert.deepEqual(defaulted.aggregate, shared.aggregate);
     // GraphQL is selection-shaped, so compare the fields each query selected
     // rather than the whole object.
     assert.deepEqual(rows.subnets, shared.subnets);

--- a/tests/tao-usd-series.test.ts
+++ b/tests/tao-usd-series.test.ts
@@ -446,6 +446,52 @@ describe("buildTaoUsdSeries", () => {
   });
 });
 
+describe("buildTaoUsdSeries — include_points (#9720)", () => {
+  // `observed_at` is epoch ms on the wire, newest first -- the shape
+  // loadTaoUsdSeries returns.
+  const BASE = Date.parse("2026-08-07T00:00:00.000Z");
+  const rows = [
+    { observed_at: BASE + 120_000, block_number: 3, usd_per_tao: 200 },
+    { observed_at: BASE + 60_000, block_number: 2, usd_per_tao: null },
+    { observed_at: BASE, block_number: 1, usd_per_tao: 100 },
+  ];
+
+  test("the series rides along by default", () => {
+    const card = buildTaoUsdSeries(rows, { window: "24h" });
+    assert.equal(Array.isArray(card.points), true);
+    assert.equal((card.points as Row[]).length, 3);
+  });
+
+  test("include_points false OMITS the key, never empties it", () => {
+    // An empty array is indistinguishable from a window that priced nothing.
+    // Absence is the only shape that says "you asked not to be sent these".
+    const card = buildTaoUsdSeries(rows, {
+      window: "24h",
+      includePoints: false,
+    });
+    assert.equal("points" in card, false);
+  });
+
+  test("NARROWING THE RESPONSE NEVER NARROWS THE MEASUREMENT", () => {
+    // Every summary must be computed over the FULL window either way -- the
+    // whole value of the toggle is that dropping the series costs nothing.
+    const withPoints = buildTaoUsdSeries(rows, { window: "24h" });
+    const without = buildTaoUsdSeries(rows, {
+      window: "24h",
+      includePoints: false,
+    });
+    const { points: _dropped, ...summary } = withPoints as Row;
+    assert.deepEqual(without, summary);
+    // Spelled out, because these are the numbers a caller keeps.
+    assert.equal(without.point_count, 3);
+    assert.equal(without.priced_point_count, 2);
+    assert.equal(without.change_usd, 100);
+    assert.equal(without.change_pct, 1);
+    assert.equal((without.latest as Row).usd_per_tao, 200);
+    assert.equal(without.oldest_observed_at, new Date(BASE).toISOString());
+  });
+});
+
 describe("GET /api/v1/network/tao-usd", () => {
   const get = (p: string, e?: Env) =>
     handleRequest(
@@ -479,6 +525,41 @@ describe("GET /api/v1/network/tao-usd", () => {
     const data = await body(await get("/api/v1/network/tao-usd?window=1h"));
     assert.equal(data.point_count, 0);
     assert.equal(data.latest, null);
+  });
+
+  test("REST keeps sending the points unless asked not to (#9720)", async () => {
+    // The REST default is deliberately UNCHANGED: a browser can stream the
+    // series and every existing caller expects it.
+    reading(0, 196.17);
+    reading(60_000, 196.2, 99);
+    const kept = await body(await get("/api/v1/network/tao-usd"));
+    assert.equal((kept.points as Row[]).length, 2);
+
+    const dropped = await body(
+      await get("/api/v1/network/tao-usd?include_points=false"),
+    );
+    assert.equal("points" in dropped, false);
+    // The summary survives intact, which is the point.
+    assert.equal(dropped.point_count, 2);
+    assert.equal((dropped.latest as Row).usd_per_tao, 196.17);
+
+    const explicit = await body(
+      await get("/api/v1/network/tao-usd?include_points=true"),
+    );
+    assert.equal((explicit.points as Row[]).length, 2);
+  });
+
+  test("include_points is STRICT — a near-miss is a 400, not a silent true", async () => {
+    // `raw === "true"` would read every one of these as false or as true by
+    // accident, and a toggle whose job is "send me less" that silently ignores
+    // its own value is the defect this route is being changed to fix.
+    for (const value of ["FALSE", "0", "1", "no", "yes", "True"]) {
+      assert.equal(
+        (await get(`/api/v1/network/tao-usd?include_points=${value}`)).status,
+        400,
+        `include_points=${value} should have been rejected`,
+      );
+    }
   });
 
   test("the exact-path match does not swallow a neighbouring path", async () => {
@@ -537,6 +618,11 @@ describe("tao_usd over GraphQL and MCP", () => {
     )) as Row;
     assert.equal(card.window, DEFAULT_TAO_USD_WINDOW);
     assert.equal((card.latest as Row).usd_per_tao, 196.17);
+    // #9720: the MCP tool defaults include_points to FALSE while REST defaults
+    // it to true. A browser can stream 143 KB and a context window cannot, so
+    // the surface with the hard constraint carries the default.
+    assert.equal("points" in card, false);
+    assert.equal(card.point_count, 1);
     // A model must not substitute 0 for an unpriceable block.
     assert.match(tool.description, /never as a zero price/);
   });

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -35,9 +35,13 @@ import { loadEconomicsTrends } from "../../src/economics-trends.ts";
 import {
   EMISSION_PIPELINE_UNAVAILABLE_CODE,
   EMISSION_PIPELINE_UNAVAILABLE_MESSAGE,
+  narrowEmissionPipeline,
+  parseEmissionPipelineNarrowing,
   projectEmissionPipeline,
   resolveEmissionPipelineEconomics,
 } from "../../src/emission-pipeline-surface.ts";
+import { EMISSION_PIPELINE_LIMIT_MAX } from "../../src/route-limits.ts";
+import type { Row as FieldProjectionRow } from "../../src/field-projection.ts";
 import { economicsCurrentKvReader } from "./analytics.ts";
 import {
   COMPARE_DIMENSIONS,
@@ -1171,7 +1175,13 @@ export async function handleEmissionPipeline(
   env: Env,
   url: URL,
 ): Promise<Response> {
-  const validationError = validateQueryParams(url, ["netuid"]);
+  const validationError = validateQueryParams(url, [
+    "netuid",
+    "sort",
+    "order",
+    "limit",
+    "fields",
+  ]);
   if (validationError) return analyticsQueryError(validationError);
   const netuidResult = parseNonNegativeIntParam(
     url.searchParams.get("netuid"),
@@ -1189,14 +1199,30 @@ export async function handleEmissionPipeline(
     },
   });
 
-  const data = projectEmissionPipeline(economics, netuidResult.value);
-  if (!data) {
+  // #9720: 129 subnets x 16 fields is ~56 KB, and ?netuid was the only filter
+  // -- it narrows to ONE subnet or leaves all of them. `fields` is validated
+  // against the DECOMPOSED rows, so parse it after the projection has produced
+  // them, then re-project with the narrowing applied. Two passes over 129 rows
+  // is not worth a bespoke path.
+  const surface = projectEmissionPipeline(economics, netuidResult.value);
+  if (!surface) {
     return errorResponse(
       EMISSION_PIPELINE_UNAVAILABLE_CODE,
       EMISSION_PIPELINE_UNAVAILABLE_MESSAGE,
       503,
     );
   }
+  // #9720: 129 subnets x 16 fields is ~56 KB, and ?netuid was the only filter
+  // -- it narrows to ONE subnet or leaves all of them. `fields` is validated
+  // against the DECOMPOSED rows, which is why this runs after the projection
+  // rather than before it.
+  const narrowing = parseEmissionPipelineNarrowing(
+    url.searchParams,
+    surface.subnets as unknown as FieldProjectionRow[],
+    { limitMax: EMISSION_PIPELINE_LIMIT_MAX },
+  );
+  if ("error" in narrowing) return analyticsQueryError(narrowing.error);
+  const data = narrowEmissionPipeline(surface, narrowing);
 
   return await envelopeResponse(
     request,

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -823,6 +823,34 @@ function parseBoundedIntParam(
   return { value };
 }
 
+/**
+ * A strict boolean query parameter (#9720).
+ *
+ * STRICT on purpose. The `raw === "true"` idiom used elsewhere in this file is
+ * fine for a tri-state flag where absent means "both", but wrong for a toggle
+ * whose whole job is "send me less": `include_points=FALSE` or `=0` would read
+ * as true and quietly return the 143 KB body the caller asked to avoid -- a
+ * parameter accepted and ignored, which is the failure mode this route is being
+ * changed to fix, not to reproduce.
+ */
+function parseBooleanParam(
+  url: URL,
+  parameter: string,
+  def: boolean,
+): { value: boolean } | { error: QueryError } {
+  const raw = url.searchParams.get(parameter);
+  if (raw == null || raw === "") return { value: def };
+  if (raw !== "true" && raw !== "false") {
+    return {
+      error: {
+        parameter,
+        message: `${parameter} must be true or false.`,
+      },
+    };
+  }
+  return { value: raw === "true" };
+}
+
 // --- Per-UID metagraph (#1304/#1305) --- D1 fully eliminated (2026-07-17);
 // neurons' D1 write path was retired in #4772/#4909 (see handleSubnetMetagraph
 // below), so this now serves a schema-stable literal rather than a live
@@ -6178,8 +6206,19 @@ export async function handleSubnetHolders(
 // A null price is a stated outcome (`price_basis: insufficient_pools`), not a
 // gap -- see src/tao-usd-series.ts for why this must never coalesce it.
 export async function handleTaoUsd(request: Request, env: Env, url: URL) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateQueryParams(url, [
+    "window",
+    "include_points",
+  ]);
   if (validationError) return analyticsQueryError(validationError);
+  // #9720. The series is 1,428 points and ~143 KB on the default window, while
+  // every summary a caller usually wants -- latest, change_usd, change_pct, the
+  // two counts -- is a top-level scalar beside it. REST keeps sending the
+  // points unless asked not to; the MCP tool asks not to by default, because a
+  // browser can stream 143 KB and a context window cannot (the same asymmetry
+  // #9701 established for list_candidates).
+  const includePoints = parseBooleanParam(url, "include_points", true);
+  if ("error" in includePoints) return analyticsQueryError(includePoints.error);
   const label = url.searchParams.get("window") ?? DEFAULT_TAO_USD_WINDOW;
   const windowHours = TAO_USD_WINDOWS[label];
   if (windowHours === undefined) {
@@ -6196,7 +6235,10 @@ export async function handleTaoUsd(request: Request, env: Env, url: URL) {
   );
   // A cold or unwritten table yields an EMPTY series with a null `latest`, not
   // a 404: "we have not priced this window" is a real state.
-  const data = buildTaoUsdSeries(rows, { window: label });
+  const data = buildTaoUsdSeries(rows, {
+    window: label,
+    includePoints: includePoints.value,
+  });
   return envelopeResponse(
     request,
     { data, meta: { contract_version: contractVersion(env) } },


### PR DESCRIPTION
## Summary

Both tools returned their full body or nothing. Measured on production:

| Tool | Bytes | Shape |
|---|---|---|
| `get_tao_usd` | **143,126** | 1,428 series `points`; every summary a caller usually wants (`latest`, `change_usd`, `change_pct`, `point_count`, `priced_point_count`, `oldest_observed_at`) already sits beside them as a top-level scalar |
| `get_emission_pipeline` | **56,280** | 129 subnets × 16 fields, with `?netuid` the only filter — it narrows to ONE subnet or leaves all 129 |

An agent asking "what is TAO worth right now" paid ~36K tokens for a number already at the top of the body.

`/api/v1/economics` already had the shape both were missing (`fields`, `limit`, `sort`, `order`), so this applies an established pattern rather than inventing one.

## tao-usd — `include_points`

The key is **omitted, not emptied**, when false: an empty array is indistinguishable from a window that priced nothing, and `point_count`/`priced_point_count` already say how many exist.

The parse is **strict**. `include_points=FALSE`, `=0`, `=yes` are all 400s, not a silent `true`. The `raw === "true"` idiom used elsewhere in that file is fine for a tri-state flag where absent means "both", but a toggle whose whole job is "send me less" that ignores its own value is precisely the defect this change exists to fix.

## emission-pipeline — `sort` / `order` / `limit` / `fields`

`final_share` leads the sort enum deliberately. #9707 established that it, not `emission_share`, answers "where is the emission" — 52 subnets carry a positive stage-1 price share while receiving nothing. A ranking offering only `emission_share` would reproduce that bug on a new parameter.

## Narrowing the response never narrows the measurement

The property worth reviewing. Both surfaces compute their summary over the **full** set before any narrowing applies, so a caller asking for ten rows still receives an `aggregate` and a `verification` covering the whole distribution — an identity evaluated over a ten-row slice is not a thing that can be verified. Asserted directly on both surfaces rather than left to review, including that a one-row page still reports `eligible_count: 2`.

## Structure

Narrowing is a **separate pure function downstream of** the projection, not a third parameter on it:

- the `fields` allow-list is derived from the *decomposed* rows, so the rows must exist before the parameter can be validated;
- taking the surface rather than the blob means the caller projects **once**, so there is no second null-return to handle that cannot happen (and therefore no unreachable branch to annotate away);
- `projectEmissionPipeline`'s signature is unchanged and its three existing callers are untouched.

## Defaults live on the MCP tool, not on REST

A browser can stream 143 KB and a context window cannot, so the surface with the hard constraint carries the default — the same asymmetry #9701 established for `list_candidates`. Every existing REST caller receives byte-for-byte what it received before, **including the absence of the two new count fields**, which is asserted.

The MCP tool guards with the route's own parser rather than a second hand-written check: the published `inputSchema` does not run at dispatch (#8942's settled decision), and two guards is how a tool and its route come to disagree about which values are legal.

The tri-surface parity test caught this honestly — the MCP default makes its body differ from REST's, so parity is now asserted on the *decomposition* with an explicit `limit`, plus a separate assertion that the default really does narrow. Parity of the data, not of the page.

## Validation run

```
npm run build                     # 7/7 steps
npm run validate                  # 129 subnets, 3442 surfaces
npm run validate:api              # 200 Worker API routes
npm run validate:contract-drift   # passed
npm run validate:openapi          # 200 routes + 24 feed + 107 network variants
node scripts/validate-docs.ts     # passed
npx tsx scripts/validate-mcp.ts   # 224 tools
npm run lint && npm run format:check && npx tsc --noEmit
```

Coverage of both changed modules measured by lcov line/branch intersection: `emission-pipeline-surface.ts` **fully covered**, `tao-usd-series.ts` fully covered except one pre-existing branch this PR does not touch.

One test in this PR was rewritten after coverage exposed it as vacuous — the null-sink case had an `if (holes > 0)` guard and the fixture produced no nulls, so it asserted nothing. It now pins a genuinely mixed column and asserts the fixture still produces the null it depends on.

Closes #9720
