### PR TITLE
feat(queue): read both dead-letter queues, so a lost message reaches somebody

### DIFF
--- a/src/dead-letter.ts
+++ b/src/dead-letter.ts
@@ -1,0 +1,125 @@
+// The dead-letter queues, finally read (metagraphed-infra#354/#363).
+//
+// Both queues declared a `dead_letter_queue` and nothing consumed either one.
+// A message that exhausts its retries lands there, sits for the queue's
+// retention, and disappears — so the one class of failure the migration to
+// queues was supposed to make VISIBLE was the one class nothing could see.
+// #363 put it plainly: a dead-letter nobody looks at is a second log.
+//
+// WHAT A READER CAN AND CANNOT DO HERE. It cannot fix anything. A message
+// reaches a DLQ having already failed its full budget — five attempts for
+// `sync-batches`, eight for `webhook-deliveries` — so re-attempting it here
+// would be a ninth attempt wearing a different hat. What it CAN do is turn a
+// silent loss into a durable, alarmed record, which is the same trade
+// src/lane-health.ts makes and for the same reason: a notification answers
+// "was anyone paged", a row answers "was anything lost overnight".
+//
+// IT DOES NOT RECOVER, AND THE ALARM SHOULD NOT EITHER. Every other lane in
+// `lane_health` goes stale and then goes `ok` again when its producer catches
+// up, and src/lane-alarm.ts closes the issue on that recovery. A dead letter
+// has no equivalent: the message is gone, and nothing later un-loses it. So
+// this writes `stale` and never writes `ok`, an alarm opens after the usual
+// one-hour floor, and it closes when a HUMAN has dealt with it. An alarm that
+// cleared itself here would be asserting a recovery that cannot happen.
+//
+// The lane does age out on its own: lane-alarm stops re-raising a lane whose
+// newest verdict is older than seven days, treating it as residue rather than
+// an outage. So a one-off dead letter produces one issue, not a permanent one.
+
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+
+/** The two dead-letter queues, and the lane each reports under.
+ *
+ * Named for the QUEUE rather than for the producer, because that is what
+ * `batch.queue` carries and a mapping keyed on anything else would need a
+ * second place to stay correct. */
+export const DEAD_LETTER_LANES: Readonly<Record<string, string>> = {
+  "sync-batches-dlq": "sync-batches-dlq",
+  "webhook-deliveries-dlq": "webhook-deliveries-dlq",
+};
+
+/** Whether a delivered batch came from a dead-letter queue.
+ *
+ * THE FIRST THING EITHER HANDLER MUST ASK. Both Workers bind their DLQ to the
+ * same `queue()` export as the live queue, so without this check a dead letter
+ * would be handed to the normal path and RE-PROCESSED — writing rows that
+ * already failed, or re-POSTing a delivery a subscriber has already refused
+ * eight times. The branch is not a nicety; it is what makes binding the DLQ to
+ * the same handler safe at all. */
+export function isDeadLetterQueue(name: unknown): boolean {
+  return typeof name === "string" && name in DEAD_LETTER_LANES;
+}
+
+/**
+ * One line describing what landed, for the log and the lane verdict.
+ *
+ * SUMMARISED, NOT DUMPED. A dead-lettered `sync-batches` message can carry
+ * 5,000 rows and a `webhook-deliveries` one carries a whole event body; neither
+ * belongs in a log line or a `lane_health.detail` column. What is worth keeping
+ * is the shape — how many, from which lanes or subscriptions — because that is
+ * what tells a reader whether one producer broke or the database did.
+ *
+ * Pure, so the summary is testable without a queue.
+ */
+export function summarizeDeadLetterBatch(
+  queueName: string,
+  messages: readonly { readonly body: unknown }[],
+): string {
+  const keys = new Set<string>();
+  for (const message of messages) {
+    const body = message?.body as Record<string, unknown> | null;
+    if (!body || typeof body !== "object") {
+      keys.add("unparseable");
+      continue;
+    }
+    // `lane` for sync-batches, `subscription_id` for webhook-deliveries. One
+    // reader for both queues means reading whichever identity the message has,
+    // rather than two near-identical modules that drift.
+    const key = body.lane ?? body.subscription_id;
+    keys.add(typeof key === "string" && key ? key : "unidentified");
+  }
+  const named = [...keys].sort().join(",");
+  return `${messages.length} dead-lettered message(s) on ${queueName} (${named})`;
+}
+
+/**
+ * Ack a dead-letter batch and leave a record somebody will be shown.
+ *
+ * ACKS UNCONDITIONALLY, including when the record cannot be written. The
+ * message is already lost; refusing to ack would only cycle it through this
+ * handler's own retry budget and then through a second-order dead-letter that
+ * does not exist. Reporting must never be able to make the loss worse.
+ */
+export async function handleDeadLetterBatch(
+  batch: {
+    readonly queue: string;
+    readonly messages: readonly {
+      readonly body: unknown;
+      ack: () => void;
+    }[];
+  },
+  db: LaneHealthDb | undefined,
+  nowMs: number = Date.now(),
+): Promise<string> {
+  const detail = summarizeDeadLetterBatch(batch.queue, batch.messages);
+  console.error(`dead-letter: ${detail}`);
+  for (const message of batch.messages) message.ack();
+  const lane = DEAD_LETTER_LANES[batch.queue];
+  if (lane && db) {
+    // NOT WRAPPED IN A CATCH, and the acks above are why it does not need one:
+    // recordLaneVerdict swallows every D1 error and returns false rather than
+    // rejecting, and the messages are already acked by the time it runs. A
+    // `.catch` here would be a branch no test can reach, which is how a file
+    // starts collecting coverage pragmas instead of reasons.
+    await recordLaneVerdict(db, {
+      lane,
+      verdict: "stale",
+      // Not an age: nothing here is behind, something here is gone. A number
+      // would be read as lag by every consumer of this table.
+      age_ms: null,
+      detail,
+      checked_at: nowMs,
+    });
+  }
+  return detail;
+}

--- a/tests/data-api-sync-queue-consumer.test.ts
+++ b/tests/data-api-sync-queue-consumer.test.ts
@@ -217,6 +217,36 @@ describe("the sync queue consumer", () => {
     assert.equal(rows().length, 0);
   });
 
+  test("a dead-letter batch is acked and NOT written (metagraphed-infra#363)", async () => {
+    // sync-batches-dlq is bound to this same handler, so the branch on
+    // batch.queue is the only thing standing between recording the loss and
+    // attempting -- for the sixth time -- the write that caused it. A message
+    // reaches the DLQ having already failed five times; re-running the writer
+    // here would be that same failure with a different label.
+    const m = positionMessage();
+    await worker.queue!(
+      { queue: "sync-batches-dlq", messages: [m] } as never,
+      { METAGRAPH_HEALTH_DB: d1() } as never,
+      { waitUntil: () => {} } as never,
+    );
+    assert.deepEqual(m.calls, ["ack"]);
+    assert.equal(rows().length, 0, "recorded, not re-written");
+  });
+
+  test("a live batch is still written, so the branch cannot swallow one", async () => {
+    // The mirror of the test above, and the more dangerous direction: a branch
+    // that matched the LIVE queue name would ack every real message without
+    // writing it, silently discarding the lane.
+    const m = positionMessage();
+    await worker.queue!(
+      { queue: "sync-batches", messages: [m] } as never,
+      { METAGRAPH_HEALTH_DB: d1() } as never,
+      { waitUntil: () => {} } as never,
+    );
+    assert.deepEqual(m.calls, ["ack"]);
+    assert.equal(rows().length, 1);
+  });
+
   test("writes a multi-family message, and does not fail its batch-mates", async () => {
     // THE REGRESSION (metagraphed-infra#359). The handler's opening log line
     // summed `m.rows.length` over every valid message. A chain-detail message

--- a/tests/dead-letter.test.ts
+++ b/tests/dead-letter.test.ts
@@ -1,0 +1,205 @@
+// Reading the dead-letter queues (metagraphed-infra#354/#363).
+//
+// The property worth testing here is not the summary string. It is that a
+// dead-lettered message is ACKED AND NEVER RE-PROCESSED — both DLQs are bound
+// to the same `queue()` export as their live queue, so the branch that tells
+// them apart is the only thing standing between "record the loss" and "attempt
+// the failing write a sixth time".
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  DEAD_LETTER_LANES,
+  handleDeadLetterBatch,
+  isDeadLetterQueue,
+  summarizeDeadLetterBatch,
+} from "../src/dead-letter.ts";
+
+function message(body: unknown) {
+  const calls: string[] = [];
+  return { body, calls, ack: () => calls.push("ack") };
+}
+
+/** A LaneHealthDb that records what was bound, so the verdict is inspectable.
+ * `inserts` filters out recordLaneVerdict's own retention DELETE, which runs on
+ * the same connection and is not what these tests are about. */
+function db() {
+  const statements: { sql: string; values: unknown[] }[] = [];
+  return {
+    statements,
+    get inserts() {
+      return statements
+        .filter((s) => s.sql.startsWith("INSERT INTO lane_health"))
+        .map((s) => s.values);
+    },
+    prepare(sql: string) {
+      return {
+        bind(...values: unknown[]) {
+          return {
+            async run() {
+              statements.push({ sql, values });
+              return {};
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe("isDeadLetterQueue", () => {
+  test("recognises both dead-letter queues and nothing else", () => {
+    assert.equal(isDeadLetterQueue("sync-batches-dlq"), true);
+    assert.equal(isDeadLetterQueue("webhook-deliveries-dlq"), true);
+    // THE FAILURE THAT MATTERS. A live queue name matching here would route a
+    // real batch to the reader, which acks without writing -- silently
+    // discarding every row on the queue.
+    assert.equal(isDeadLetterQueue("sync-batches"), false);
+    assert.equal(isDeadLetterQueue("webhook-deliveries"), false);
+  });
+
+  test("is safe on the shapes a runtime could hand it", () => {
+    for (const bad of [undefined, null, 7, {}, [], ""]) {
+      assert.equal(isDeadLetterQueue(bad), false, String(bad));
+    }
+  });
+
+  test("every declared lane is recognised, so the two lists cannot drift", () => {
+    for (const queue of Object.keys(DEAD_LETTER_LANES)) {
+      assert.equal(isDeadLetterQueue(queue), true, queue);
+    }
+  });
+});
+
+describe("summarizeDeadLetterBatch", () => {
+  test("names the lanes a sync-batches dead letter came from", () => {
+    assert.equal(
+      summarizeDeadLetterBatch("sync-batches-dlq", [
+        message({ lane: "account-balances", rows: [] }),
+        message({ lane: "hotkey-alpha", rows: [] }),
+        message({ lane: "account-balances", rows: [] }),
+      ]),
+      "3 dead-lettered message(s) on sync-batches-dlq (account-balances,hotkey-alpha)",
+    );
+  });
+
+  test("names the subscriptions a webhook dead letter came from", () => {
+    // One reader for both queues, so it reads whichever identity the message
+    // has rather than two near-identical modules that drift apart.
+    assert.equal(
+      summarizeDeadLetterBatch("webhook-deliveries-dlq", [
+        message({ subscription_id: "sub_a", event_id: "evt", body: "{}" }),
+      ]),
+      "1 dead-lettered message(s) on webhook-deliveries-dlq (sub_a)",
+    );
+  });
+
+  test("does not dump the payload", () => {
+    // A sync message can carry 5,000 rows and a webhook message a whole event
+    // body. Neither belongs in a log line or a lane_health.detail column.
+    const detail = summarizeDeadLetterBatch("sync-batches-dlq", [
+      message({
+        lane: "account-balances",
+        rows: Array.from({ length: 5000 }, (_, i) => ({ ss58: `5${i}` })),
+      }),
+    ]);
+    assert.equal(detail.includes("ss58"), false);
+    assert.equal(detail.length < 120, true, detail);
+  });
+
+  test("reports an unreadable message rather than throwing on it", () => {
+    // A message reaching a DLQ is one whose processing already failed; assuming
+    // it parses is exactly the assumption that put it here.
+    assert.equal(
+      summarizeDeadLetterBatch("sync-batches-dlq", [
+        message(null),
+        message("not an object"),
+        message({ no: "identity" }),
+      ]),
+      "3 dead-lettered message(s) on sync-batches-dlq (unidentified,unparseable)",
+    );
+  });
+});
+
+describe("handleDeadLetterBatch", () => {
+  const batch = (queue: string, messages: ReturnType<typeof message>[]) => ({
+    queue,
+    messages,
+  });
+
+  test("acks every message and records one stale verdict for the batch", async () => {
+    const store = db();
+    const a = message({ lane: "account-balances", rows: [] });
+    const b = message({ lane: "hotkey-alpha", rows: [] });
+
+    await handleDeadLetterBatch(
+      batch("sync-batches-dlq", [a, b]),
+      store,
+      1_780_000_000_000,
+    );
+
+    assert.deepEqual(a.calls, ["ack"]);
+    assert.deepEqual(b.calls, ["ack"]);
+    assert.equal(
+      store.inserts.length,
+      1,
+      "one verdict per batch, not per message",
+    );
+    const [lane, verdict, ageMs, detail, checkedAt] = store.inserts[0]!;
+    assert.equal(lane, "sync-batches-dlq");
+    assert.equal(verdict, "stale");
+    // NOT a number. Nothing here is behind; something here is gone, and any
+    // value would be read as lag by every consumer of this table.
+    assert.equal(ageMs, null);
+    assert.equal(
+      detail,
+      "2 dead-lettered message(s) on sync-batches-dlq (account-balances,hotkey-alpha)",
+    );
+    assert.equal(checkedAt, 1_780_000_000_000);
+  });
+
+  test("acks even when the record cannot be written", async () => {
+    // The message is already lost. Refusing to ack would cycle it through this
+    // handler's own budget and change nothing -- reporting must never be able
+    // to make the loss worse.
+    const m = message({ lane: "account-balances", rows: [] });
+    await handleDeadLetterBatch(batch("sync-batches-dlq", [m]), {
+      prepare() {
+        throw new Error("D1 DB is overloaded");
+      },
+    } as never);
+    assert.deepEqual(m.calls, ["ack"]);
+  });
+
+  test("acks with no database bound at all", async () => {
+    const m = message({ subscription_id: "sub_a" });
+    await handleDeadLetterBatch(
+      batch("webhook-deliveries-dlq", [m]),
+      undefined,
+    );
+    assert.deepEqual(m.calls, ["ack"]);
+  });
+
+  test("records under the queue's own lane, so the two DLQs alarm separately", async () => {
+    const store = db();
+    await handleDeadLetterBatch(
+      batch("webhook-deliveries-dlq", [message({ subscription_id: "sub_a" })]),
+      store,
+      1,
+    );
+    assert.equal(store.inserts[0]![0], "webhook-deliveries-dlq");
+  });
+
+  test("an empty dead-letter batch writes a verdict rather than nothing", async () => {
+    // Queues can deliver an empty batch on a timeout boundary. Recording it is
+    // harmless and keeps the lane's cadence honest for lane-alarm, which
+    // measures silence against a lane's OWN observed interval.
+    const store = db();
+    const detail = await handleDeadLetterBatch(
+      batch("sync-batches-dlq", []),
+      store,
+      1,
+    );
+    assert.equal(detail, "0 dead-lettered message(s) on sync-batches-dlq ()");
+    assert.equal(store.inserts.length, 1);
+  });
+});

--- a/tests/webhooks-worker.test.ts
+++ b/tests/webhooks-worker.test.ts
@@ -1157,6 +1157,48 @@ describe("webhook queue consumer: the terminal and transient edges", () => {
     assert.deepEqual(acts, ["ack"], "no verdict is terminal, not a retry loop");
   });
 
+  test("a dead-letter batch is acked and NOT delivered (metagraphed-infra#363)", async () => {
+    // webhook-deliveries-dlq is bound to this same handler. Without the branch
+    // on batch.queue, an event a subscriber has already refused eight times
+    // would be POSTed at them a ninth -- the DLQ turned back into the retry
+    // loop it exists to end.
+    // `worker.queue` takes no injectable deliverer, so the observable proof is
+    // the DELIVERY RECORD: the live path writes one for every outcome, and the
+    // dead-letter path writes none. Asserting on a stubbed fetch would prove
+    // nothing here -- deliverChangeEvent closes over the global.
+    const { default: worker } = await import("../workers/api.ts");
+    const kv = makeKv();
+    const sub = await seedSubscription(kv, "https://hooks.example.com/a");
+    const acts: string[] = [];
+    await worker.queue!(
+      {
+        queue: "webhook-deliveries-dlq",
+        messages: [
+          {
+            body: {
+              subscription_id: sub.id,
+              event_id: "evt_1",
+              body: JSON.stringify({ type: "metagraph.publish" }),
+            },
+            attempts: 8,
+            ack: () => acts.push("ack"),
+            retry: () => acts.push("retry"),
+          },
+        ],
+      } as never,
+      envWith(kv) as unknown as Env,
+      { waitUntil: (p: Promise<unknown>) => void p } as never,
+    );
+    assert.deepEqual(acts, ["ack"]);
+    assert.deepEqual(
+      [...kv.store.keys()].filter((key) =>
+        key.startsWith(`webhooks:delivery:${sub.id}`),
+      ),
+      [],
+      "recorded as a dead letter, not run through delivery again",
+    );
+  });
+
   test("a body that is not JSON is acked, because it never will be", async () => {
     // Retrying it would spend the whole eight-attempt budget to dead-letter in
     // 12 hours what is already known to be undeliverable.

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -47,6 +47,10 @@ import {
   type LaneVerdict,
 } from "../src/lane-health.ts";
 import {
+  handleDeadLetterBatch,
+  isDeadLetterQueue,
+} from "../src/dead-letter.ts";
+import {
   applyQueryFilters,
   canonicalListSearch,
   paginationLinkHeader,
@@ -1602,6 +1606,14 @@ export default {
     env: Env,
     ctx: ExecutionContext,
   ): Promise<void> {
+    // THE DEAD-LETTER BRANCH COMES FIRST (metagraphed-infra#354/#363). The DLQ
+    // is bound to this same handler, so without it a delivery that a subscriber
+    // has already refused eight times would be POSTed at them a ninth. Acked
+    // and recorded, never re-delivered.
+    if (isDeadLetterQueue(batch.queue)) {
+      await handleDeadLetterBatch(batch, env.METAGRAPH_HEALTH_DB);
+      return;
+    }
     return handleWebhookQueue(batch, env, ctx);
   },
 };

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -416,6 +416,10 @@ import { MCP_TIERED_RATE_LIMIT } from "../src/mcp-server.ts";
 import { createPgSql } from "../src/pg-sql.ts";
 import { recordLaneVerdict } from "../src/lane-health.ts";
 import {
+  handleDeadLetterBatch,
+  isDeadLetterQueue,
+} from "../src/dead-letter.ts";
+import {
   classifySyncBatch,
   enqueueSyncBatch,
   packMultiFamilyMessage,
@@ -7291,6 +7295,15 @@ export default {
     env: Env,
     ctx: ExecutionContext,
   ): Promise<void> {
+    // THE DEAD-LETTER BRANCH COMES FIRST (metagraphed-infra#354/#363). The DLQ
+    // is bound to this same handler, so without it a message that already
+    // failed five attempts would be handed to the writer again -- a sixth
+    // attempt wearing a different hat, writing rows whose write is what killed
+    // them. `handleDeadLetterBatch` acks and records; it never retries.
+    if (isDeadLetterQueue(batch.queue)) {
+      await handleDeadLetterBatch(batch, env.METAGRAPH_HEALTH_DB);
+      return;
+    }
     const { valid, invalid } = classifySyncBatch(batch.messages);
     // syncBatchRowCount, not `m.rows.length`: a multi-family message carries
     // `families` and no `rows` at all, so the direct read threw a TypeError HERE

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -327,6 +327,31 @@
         "max_concurrency": 2,
         "dead_letter_queue": "sync-batches-dlq",
       },
+      // THE DEAD LETTER, finally read (metagraphed-infra#354/#363). It was
+      // declared above from the first deploy and consumed by nothing, so the
+      // one failure the migration to a queue was meant to make visible -- a
+      // chunk that exhausted every retry -- expired silently on the queue's
+      // own retention.
+      //
+      // SAME WORKER, and the handler branches on `batch.queue` BEFORE anything
+      // else. Without that branch this binding would hand a five-times-failed
+      // message back to the writer, which is a sixth attempt at the write that
+      // killed it.
+      //
+      // "max_retries": 0 because there is nothing to retry: the reader acks and
+      // records, and a failure to record must not put the message back. No
+      // dead_letter_queue of its own for the same reason -- a DLQ for the DLQ
+      // is a second place nobody looks.
+      {
+        "queue": "sync-batches-dlq",
+        // Bigger batch and a longer timeout than the live queue: this path is
+        // not latency-sensitive, and a burst of dead letters is exactly when
+        // reading them one small batch at a time is least useful.
+        "max_batch_size": 100,
+        "max_batch_timeout": 30,
+        "max_retries": 0,
+        "max_concurrency": 1,
+      },
     ],
   },
   "d1_databases": [

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -733,6 +733,25 @@
         "max_concurrency": 4,
         "dead_letter_queue": "webhook-deliveries-dlq",
       },
+      // THE DEAD LETTER, finally read (metagraphed-infra#354/#363). #354's bar
+      // was that "the DLQ holds what parking used to" -- but a parked record
+      // was READABLE by the subscriber through GET
+      // /api/v1/webhooks/subscriptions/{id}, and a dead-lettered message was
+      // readable by nobody. This is the half that was missing.
+      //
+      // SAME WORKER, and the handler branches on `batch.queue` BEFORE
+      // delivering. Without that branch this binding would POST an event at a
+      // subscriber who has already refused it eight times.
+      //
+      // "max_retries": 0 -- see the sync-batches-dlq consumer in
+      // wrangler.data.jsonc for the full argument; it is the same one.
+      {
+        "queue": "webhook-deliveries-dlq",
+        "max_batch_size": 100,
+        "max_batch_timeout": 30,
+        "max_retries": 0,
+        "max_concurrency": 1,
+      },
     ],
   },
   "durable_objects": {


### PR DESCRIPTION
Closes metagraphed-infra#377. Clears metagraphed-infra#363's cheapest "worth doing" item and the unfinished half of metagraphed-infra#354's bar (b).

`sync-batches-dlq` and `webhook-deliveries-dlq` each appeared in **exactly one line of config and nowhere else in the repo**. No consumer, no reader, no watchdog. A message that exhausted its budget — five attempts for a sync chunk, eight for a delivery — landed there, sat for the queue's retention, and disappeared.

So the one class of failure the migration to queues was supposed to make *visible* was the one class nothing could see. For webhooks it is also a regression against what parking gave: a parked record was **readable by the subscriber** through `GET /api/v1/webhooks/subscriptions/{id}`; a dead-lettered message was readable by nobody.

## The branch is the load-bearing part

Both DLQs bind to their existing Worker, so a dead letter arrives at the **same `queue()` export** as the live queue. Both handlers now branch on `batch.queue` before anything else, and that branch is what makes sharing the handler safe at all:

- without it, `sync-batches` hands a five-times-failed message back to the writer — a sixth attempt at the write that killed it
- without it, `webhook-deliveries` POSTs an event at a subscriber who has already refused it eight times

**The mirror failure is quieter and worse**: a branch matching the *live* queue name would ack every real message without writing it, silently discarding the lane. Both directions are tested in both Workers, and each test fails when the branch is disabled — verified by flipping `if (isDeadLetterQueue(...))` to `if (false && ...)`:

```
× a dead-letter batch is acked and NOT written (metagraphed-infra#363)
× a dead-letter batch is acked and NOT delivered (metagraphed-infra#363)
   AssertionError: recorded as a dead letter, not run through delivery again
```

The webhook one initially **passed** against the broken code — `worker.queue` takes no injectable deliverer, so a stubbed fetch proved nothing (`deliverChangeEvent` closes over the global). It now asserts on the **delivery record**: the live path writes one for every outcome, the dead-letter path writes none.

## What the reader does

Acks unconditionally, then records **one `stale` verdict per batch** in `lane_health`, summarised by lane (`sync-batches`) or subscription (`webhook-deliveries`) — one reader for both queues, reading whichever identity the message carries, rather than two near-identical modules that drift.

- **Acks even when the record cannot be written.** The message is already lost; refusing to ack would cycle it through this handler's own budget and change nothing. Reporting must never be able to make the loss worse.
- **Summarises, never dumps.** A sync message can carry 5,000 rows and a webhook message a whole event body. Neither belongs in a log line or a `lane_health.detail` column; there is a test asserting the payload does not appear.
- **`age_ms: null`**, deliberately. Nothing here is behind — something here is gone — and a number would be read as lag by every consumer of that table.

## It never writes `ok`, and that is the design

Every other lane goes stale then `ok` when its producer catches up, and `src/lane-alarm.ts` closes the issue on that recovery. **A dead letter has no equivalent**: the message is gone and nothing later un-loses it. So the alarm opens after lane-alarm's usual one-hour floor and closes when a human has dealt with it. An alarm that cleared itself here would be asserting a recovery that cannot happen.

A one-off does not become permanent noise: lane-alarm already stops re-raising a lane whose newest verdict is over seven days old, treating it as residue rather than an outage.

## Config

`max_retries: 0` on both consumers — there is nothing to retry, and a failure to *record* must not put the message back. No `dead_letter_queue` of their own, for the same reason: a DLQ for the DLQ is a second place nobody looks. Batch 100 / timeout 30s, since this path is not latency-sensitive and a burst of dead letters is exactly when reading them ten at a time is least useful.

## Validation

```
npm run typecheck    # clean
npm run lint         # clean
npm run build        # clean; no derived artifact changed
npm run validate     # 129 subnets, 3442 surfaces, 136 providers
npx prettier --check # clean on all 8 changed files
npx vitest run tests/dead-letter.test.ts tests/webhooks*.test.ts tests/webhook-queue.test.ts \
  tests/data-api-sync-queue-consumer.test.ts tests/sync-batch-queue.test.ts tests/lane-health.test.ts
# 283 passed
```

Patch coverage by intersecting the diff with a v8 report over `src/dead-letter.ts`, `workers/api.ts` and `workers/data-api.ts`: **0 uncovered statements, 0 uncovered branches, 0 uncovered functions**.

One thing dropped for that reason rather than annotated: the record call carried a `.catch(() => undefined)` that no test could reach, because `recordLaneVerdict` swallows every D1 error and returns `false` rather than rejecting, and the acks already happened. The comment now says so instead.

## Template Used

- Backend/code change
