### PR TITLE
feat(neon): mirror nominator_positions, from both writers, prune included

### DIFF
--- a/src/neon-write.ts
+++ b/src/neon-write.ts
@@ -203,6 +203,51 @@ export async function writeRowsToNeon(
 }
 
 /**
+ * Delete each key's rows older than that key's own cutoff.
+ *
+ * PER KEY, never batch-wide, and that is the whole contract. A full scan posts
+ * in several requests, so a "delete everything older than this batch" sweep
+ * would let one request delete rows another just wrote. The cutoff is therefore
+ * each key's OWN max captured_at, exactly as the D1 writer computes it.
+ *
+ * Runs AFTER the upsert and reports its own outcome: the worst a failure here
+ * can do is leave a stale row until the next tick, never delete one whose
+ * replacement was not written first.
+ */
+export async function pruneKeysInNeon(
+  sql: PgUnsafe | null | undefined,
+  table: string,
+  keyColumn: string,
+  cutoffs: ReadonlyMap<string, number>,
+): Promise<NeonWriteResult> {
+  if (!sql?.unsafe)
+    return { ok: false, rows: 0, statements: 0, reason: "unbound" };
+  if (cutoffs.size === 0) return { ok: true, rows: 0, statements: 0 };
+  // One statement for the whole map rather than one per key: a 24,000-coldkey
+  // pass would otherwise be 24,000 round trips through Hyperdrive. The pairs
+  // travel as two parallel arrays and are joined with UNNEST, which keeps the
+  // parameter count at two regardless of size.
+  const keys = [...cutoffs.keys()];
+  const values = keys.map((key) => cutoffs.get(key) as number);
+  try {
+    await sql.unsafe(
+      `DELETE FROM ${table} USING UNNEST($1::text[], $2::bigint[]) ` +
+        `AS cutoff(k, at) WHERE ${table}.${keyColumn} = cutoff.k ` +
+        `AND ${table}.captured_at < cutoff.at`,
+      [keys, values],
+    );
+  } catch (error) {
+    return {
+      ok: false,
+      rows: 0,
+      statements: 0,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+  return { ok: true, rows: cutoffs.size, statements: 1 };
+}
+
+/**
  * Record one Neon write's outcome as a lane verdict.
  *
  * THIS IS THE INVARIANT THE PILOT WAS MISSING. A store with no lane is

--- a/src/nominator-positions-neon-write.ts
+++ b/src/nominator-positions-neon-write.ts
@@ -1,0 +1,144 @@
+// The nominator-positions lane's Neon mirror (metagraphed-infra#336).
+//
+// TWO CALL SITES, BOTH MIRRORED, and that is the point rather than an
+// implementation detail. #9728 was one unmirrored writer -- the neuron-daily
+// backfill route -- leaving `account_position_daily` 92 rows short in Neon
+// while the row count looked nearly right. This lane also has two writers (the
+// sync handler and the queue consumer), so both call this or the mirror is a
+// lie the moment traffic takes the other path.
+//
+// ## The prune is what makes this lane different
+//
+// `nominator_positions` is a LATEST-ONLY ledger: a position that no longer
+// exists must be deleted, not left behind. A full Alpha scan is ~153,611 rows,
+// far past one request body, so the lane posts in several requests -- and a
+// batch-wide "delete everything older than this pass" sweep would let one
+// request delete the rows another just wrote.
+//
+// So the cutoff is PER COLDKEY, against that coldkey's own max captured_at,
+// exactly as writeNominatorPositionsToD1 computes it. It rests on the same
+// poster contract the D1 side does: one coldkey's positions are never split
+// across two requests.
+//
+// The prune runs AFTER the upsert, and its failure is reported separately. The
+// worst a failure can do in that order is leave a stale position until the next
+// tick -- never delete a position without having written its replacement first.
+
+import {
+  neonDualWriteEnabled,
+  pruneKeysInNeon,
+  recordNeonWriteVerdict,
+  writeRowsToNeon,
+  type NeonWriteResult,
+} from "./neon-write.ts";
+import { NOMINATOR_POSITION_INSERT_COLUMNS } from "./account-nominator-positions.ts";
+import {
+  createPgSql,
+  type HyperdriveLike,
+  type WaitUntilLike,
+} from "./pg-sql.ts";
+import type { LaneHealthDb } from "./lane-health.ts";
+
+/** The lane name this mirror answers to in NEON_DUAL_WRITE_LANES. */
+export const NOMINATOR_POSITIONS_NEON_LANE = "nominator-positions";
+
+/** Matches nominator_positions_pkey in Neon, created 2026-08-07. An ON CONFLICT
+ * naming columns with no unique index behind them is a runtime error. */
+export const NOMINATOR_POSITIONS_CONFLICT = [
+  "coldkey",
+  "hotkey",
+  "netuid",
+] as const;
+
+type Row = Record<string, unknown>;
+
+export interface NominatorPositionsMirrorOutcome {
+  attempted: boolean;
+  write?: NeonWriteResult;
+  prune?: NeonWriteResult;
+}
+
+export interface NominatorPositionsMirrorDeps {
+  sql?: { unsafe(text: string, values?: unknown[]): Promise<unknown> } | null;
+  laneHealthDb?: LaneHealthDb | null;
+  now?: () => number;
+}
+
+/**
+ * Mirror one nominator-positions batch into Neon. Never throws.
+ *
+ * Called from BOTH writers. While dual-writing, D1 is the store every route
+ * reads, so a Neon failure costs a mirror and a lane verdict and nothing else.
+ */
+export async function mirrorNominatorPositionsToNeon(
+  env: Record<string, unknown> | null | undefined,
+  ctx: WaitUntilLike | null | undefined,
+  input: { rows: Row[]; coldkeyMaxCapturedAt: ReadonlyMap<string, number> },
+  deps: NominatorPositionsMirrorDeps = {},
+): Promise<NominatorPositionsMirrorOutcome> {
+  if (!neonDualWriteEnabled(env, NOMINATOR_POSITIONS_NEON_LANE)) {
+    return { attempted: false };
+  }
+
+  const hyperdrive = env?.HYPERDRIVE as HyperdriveLike | undefined;
+  const sql =
+    deps.sql ??
+    (hyperdrive?.connectionString && ctx ? createPgSql(hyperdrive, ctx) : null);
+  const laneDb =
+    deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as LaneHealthDb | undefined);
+  const now = deps.now ?? Date.now;
+
+  if (!sql) {
+    // Enabled but unbound is a misconfiguration, not a quiet no-op.
+    const failure = {
+      ok: false,
+      rows: 0,
+      statements: 0,
+      reason: "hyperdrive unbound",
+    };
+    await recordNeonWriteVerdict(
+      laneDb,
+      NOMINATOR_POSITIONS_NEON_LANE,
+      failure,
+      now(),
+    );
+    return { attempted: true };
+  }
+
+  const write = await writeRowsToNeon(
+    sql,
+    "nominator_positions",
+    NOMINATOR_POSITION_INSERT_COLUMNS,
+    input.rows,
+    NOMINATOR_POSITIONS_CONFLICT,
+    // An older capture arriving after a newer one must be a no-op. This lane
+    // retries, so an out-of-order arrival is a real event.
+    "nominator_positions.captured_at < EXCLUDED.captured_at",
+  );
+  await recordNeonWriteVerdict(
+    laneDb,
+    NOMINATOR_POSITIONS_NEON_LANE,
+    write,
+    now(),
+  );
+
+  // THE PRUNE IS SKIPPED WHEN THE UPSERT FAILED, and that ordering is load
+  // bearing rather than tidy. Pruning against a batch whose rows did not land
+  // would delete live positions and leave nothing in their place; no retry
+  // undoes a delete.
+  if (!write.ok) return { attempted: true, write };
+
+  const prune = await pruneKeysInNeon(
+    sql,
+    "nominator_positions",
+    "coldkey",
+    input.coldkeyMaxCapturedAt,
+  );
+  await recordNeonWriteVerdict(
+    laneDb,
+    `${NOMINATOR_POSITIONS_NEON_LANE}-prune`,
+    prune,
+    now(),
+  );
+  return { attempted: true, write, prune };
+}

--- a/tests/nominator-positions-neon-write.test.ts
+++ b/tests/nominator-positions-neon-write.test.ts
@@ -1,0 +1,274 @@
+// The nominator-positions Neon mirror (src/nominator-positions-neon-write.ts).
+//
+// This lane's distinguishing hazard is the PRUNE. It is a latest-only ledger,
+// so a position that no longer exists must be deleted -- and a full scan posts
+// in several requests, so a batch-wide "delete everything older than this pass"
+// sweep would let one request delete rows another just wrote.
+//
+// The two properties that matter, both about not deleting live data:
+//
+//   * the cutoff is PER COLDKEY, against that coldkey's own max captured_at
+//   * the prune is SKIPPED ENTIRELY when the upsert failed -- pruning against
+//     rows that did not land deletes live positions and leaves nothing in
+//     their place, and no retry undoes a delete
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  mirrorNominatorPositionsToNeon,
+  NOMINATOR_POSITIONS_CONFLICT,
+  NOMINATOR_POSITIONS_NEON_LANE,
+} from "../src/nominator-positions-neon-write.ts";
+import { pruneKeysInNeon } from "../src/neon-write.ts";
+
+const NOW = 1_785_800_000_000;
+
+function fakeSql(failOn: "insert" | "delete" | null = null) {
+  const calls: { text: string; values: unknown[] }[] = [];
+  return {
+    calls,
+    async unsafe(text: string, values: unknown[] = []) {
+      calls.push({ text, values });
+      if (failOn === "insert" && text.startsWith("INSERT")) {
+        throw new Error("duplicate key");
+      }
+      if (failOn === "delete" && text.startsWith("DELETE")) {
+        throw new Error("deadlock detected");
+      }
+      return [];
+    },
+  };
+}
+
+function laneSpy() {
+  const rows: Record<string, unknown>[] = [];
+  return {
+    rows,
+    db: {
+      prepare(sql: string) {
+        return {
+          bind(...values: unknown[]) {
+            return {
+              async run() {
+                if (sql.startsWith("INSERT")) {
+                  rows.push({ lane: values[0], verdict: values[1] });
+                }
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+const ctx = { waitUntil() {} };
+const rows = [
+  {
+    coldkey: "5A",
+    hotkey: "5H",
+    netuid: 1,
+    share_fraction: 0.5,
+    captured_at: 9,
+  },
+];
+const cutoffs = new Map([["5A", 9]]);
+const on = { NEON_DUAL_WRITE_LANES: NOMINATOR_POSITIONS_NEON_LANE };
+
+describe("pruneKeysInNeon", () => {
+  test("deletes per key against that key's own cutoff, in ONE statement", () => {
+    // One statement for the whole map rather than one per key: a
+    // 24,000-coldkey pass would otherwise be 24,000 round trips.
+    const sql = fakeSql();
+    return pruneKeysInNeon(
+      sql,
+      "nominator_positions",
+      "coldkey",
+      new Map([
+        ["5A", 9],
+        ["5B", 11],
+      ]),
+    ).then((result) => {
+      assert.deepEqual(result, { ok: true, rows: 2, statements: 1 });
+      assert.equal(sql.calls.length, 1);
+      assert.match(
+        sql.calls[0].text,
+        /UNNEST\(\$1::text\[\], \$2::bigint\[\]\)/,
+      );
+      assert.match(sql.calls[0].text, /captured_at < cutoff\.at/);
+      // Keys and cutoffs travel as parallel arrays, so the pairing is
+      // positional -- a mismatch would prune one coldkey by another's clock.
+      assert.deepEqual(sql.calls[0].values, [
+        ["5A", "5B"],
+        [9, 11],
+      ]);
+    });
+  });
+
+  test("an empty map touches nothing", async () => {
+    const sql = fakeSql();
+    assert.deepEqual(await pruneKeysInNeon(sql, "t", "k", new Map()), {
+      ok: true,
+      rows: 0,
+      statements: 0,
+    });
+    assert.equal(sql.calls.length, 0);
+  });
+
+  test("an unbound runner and a failing delete are both reported", async () => {
+    assert.equal(
+      (await pruneKeysInNeon(null, "t", "k", cutoffs)).reason,
+      "unbound",
+    );
+    const failed = await pruneKeysInNeon(fakeSql("delete"), "t", "k", cutoffs);
+    assert.equal(failed.ok, false);
+    assert.match(String(failed.reason), /deadlock/);
+  });
+
+  test("a non-Error rejection still reads", async () => {
+    const sql = {
+      async unsafe() {
+        throw "connection terminated";
+      },
+    };
+    assert.equal(
+      (await pruneKeysInNeon(sql, "t", "k", cutoffs)).reason,
+      "connection terminated",
+    );
+  });
+});
+
+describe("mirrorNominatorPositionsToNeon", () => {
+  test("conflict key matches the table's primary key", () => {
+    assert.deepEqual(NOMINATOR_POSITIONS_CONFLICT, [
+      "coldkey",
+      "hotkey",
+      "netuid",
+    ]);
+  });
+
+  test("upserts then prunes, in that order, recording both", async () => {
+    const sql = fakeSql();
+    const spy = laneSpy();
+    const out = await mirrorNominatorPositionsToNeon(
+      on,
+      ctx,
+      { rows, coldkeyMaxCapturedAt: cutoffs },
+      { sql, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.equal(out.attempted, true);
+    assert.equal(out.write?.ok, true);
+    assert.equal(out.prune?.ok, true);
+    assert.ok(sql.calls[0].text.startsWith("INSERT"));
+    assert.ok(sql.calls[1].text.startsWith("DELETE"));
+    assert.deepEqual(
+      spy.rows.map((r) => r.lane),
+      ["neon:nominator-positions", "neon:nominator-positions-prune"],
+    );
+  });
+
+  test("carries the out-of-order guard, so a retry cannot regress a row", async () => {
+    const sql = fakeSql();
+    await mirrorNominatorPositionsToNeon(
+      on,
+      ctx,
+      { rows, coldkeyMaxCapturedAt: cutoffs },
+      { sql, laneHealthDb: laneSpy().db, now: () => NOW },
+    );
+    assert.match(
+      sql.calls[0].text,
+      /WHERE nominator_positions\.captured_at < EXCLUDED\.captured_at/,
+    );
+  });
+
+  test("SKIPS the prune entirely when the upsert failed", async () => {
+    // The property this file exists for. Pruning against rows that did not
+    // land deletes live positions and leaves nothing in their place, and no
+    // retry undoes a delete.
+    const sql = fakeSql("insert");
+    const spy = laneSpy();
+    const out = await mirrorNominatorPositionsToNeon(
+      on,
+      ctx,
+      { rows, coldkeyMaxCapturedAt: cutoffs },
+      { sql, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.equal(out.write?.ok, false);
+    assert.equal(out.prune, undefined);
+    assert.ok(
+      sql.calls.every((c) => !c.text.startsWith("DELETE")),
+      "no DELETE may be issued",
+    );
+    assert.deepEqual(
+      spy.rows.map((r) => r.verdict),
+      ["stale"],
+    );
+  });
+
+  test("a failed prune is reported without costing the upsert", async () => {
+    const spy = laneSpy();
+    const out = await mirrorNominatorPositionsToNeon(
+      on,
+      ctx,
+      { rows, coldkeyMaxCapturedAt: cutoffs },
+      { sql: fakeSql("delete"), laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.equal(out.write?.ok, true);
+    assert.equal(out.prune?.ok, false);
+    assert.deepEqual(
+      spy.rows.map((r) => r.verdict),
+      ["ok", "stale"],
+    );
+  });
+
+  test("does nothing unless the lane is named", async () => {
+    const sql = fakeSql();
+    for (const env of [
+      undefined,
+      null,
+      {},
+      { NEON_DUAL_WRITE_LANES: "neurons" },
+    ]) {
+      assert.deepEqual(
+        await mirrorNominatorPositionsToNeon(
+          env,
+          ctx,
+          { rows, coldkeyMaxCapturedAt: cutoffs },
+          { sql },
+        ),
+        { attempted: false },
+      );
+    }
+    assert.equal(sql.calls.length, 0);
+  });
+
+  test("enabled with no binding records the misconfiguration", async () => {
+    const spy = laneSpy();
+    const out = await mirrorNominatorPositionsToNeon(
+      on,
+      ctx,
+      { rows, coldkeyMaxCapturedAt: cutoffs },
+      { sql: null, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.deepEqual(out, { attempted: true });
+    assert.deepEqual(spy.rows, [
+      { lane: "neon:nominator-positions", verdict: "stale" },
+    ]);
+  });
+
+  test("builds its own runner from the binding, and reports a dead origin", async () => {
+    const spy = laneSpy();
+    const out = await mirrorNominatorPositionsToNeon(
+      {
+        ...on,
+        HYPERDRIVE: { connectionString: "postgresql://u:p@127.0.0.1:1/none" },
+        METAGRAPH_HEALTH_DB: spy.db,
+      },
+      ctx,
+      { rows, coldkeyMaxCapturedAt: cutoffs },
+    );
+    assert.equal(out.attempted, true);
+    assert.equal(out.write?.ok, false);
+    // And no prune followed the failed write.
+    assert.equal(out.prune, undefined);
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -364,6 +364,7 @@ import {
   writeNeuronSnapshotToD1,
 } from "../src/neurons-d1-write.ts";
 import { mirrorNeuronSnapshotToNeon } from "../src/neurons-neon-write.ts";
+import { mirrorNominatorPositionsToNeon } from "../src/nominator-positions-neon-write.ts";
 import { neonReadEnabled } from "../src/neon-write.ts";
 import {
   writeAccountIdentityToD1,
@@ -1876,7 +1877,11 @@ function coerceNominatorPositionSyncRow(row: Row) {
   return out;
 }
 
-async function handleNominatorPositionsSync(request: Request, env: Env) {
+async function handleNominatorPositionsSync(
+  request: Request,
+  env: Env,
+  ctx?: ExecutionContext,
+) {
   if (!env.NOMINATOR_POSITIONS_SYNC_SECRET) {
     return writeJson(
       {
@@ -2005,6 +2010,15 @@ async function handleNominatorPositionsSync(request: Request, env: Env) {
     await captureDataApiError(err, "nominator-positions-sync-d1", env);
     return writeJson({ error: "d1 write failed" }, 502);
   }
+
+  // ONE OF THIS LANE'S TWO WRITERS. The other is the queue consumer below, and
+  // it mirrors too -- #9728 was a single unmirrored writer leaving a table 92
+  // rows short while the count looked nearly right.
+  await mirrorNominatorPositionsToNeon(
+    env as unknown as Record<string, unknown>,
+    ctx,
+    { rows, coldkeyMaxCapturedAt: cutoffs },
+  );
 
   return writeJson({
     ok: true,
@@ -6743,7 +6757,7 @@ async function dispatchDataApiRequest(
       request.method === "POST" &&
       url.pathname === "/api/v1/internal/nominator-positions-sync"
     ) {
-      return handleNominatorPositionsSync(request, env);
+      return handleNominatorPositionsSync(request, env, ctx);
     }
     if (
       request.method === "POST" &&
@@ -7366,13 +7380,24 @@ export default {
           // only because the message asserted `key_complete` -- the
           // validator rejects it otherwise, so this writer never sees a chunk
           // that could prune rows it did not carry.
-          "nominator-positions": (rows) =>
-            writeNominatorPositionsToD1(
+          "nominator-positions": async (rows) => {
+            const cutoffs = coldkeyMaxCapturedAt(rows);
+            const result = await writeNominatorPositionsToD1(
               env.METAGRAPH_HEALTH_DB as unknown as Parameters<
                 typeof writeNominatorPositionsToD1
               >[0],
-              { rows, coldkeyMaxCapturedAt: coldkeyMaxCapturedAt(rows) },
-            ),
+              { rows, coldkeyMaxCapturedAt: cutoffs },
+            );
+            // THE LANE'S OTHER WRITER. Mirrored here as well as on the HTTP
+            // path: a mirror that covers one of two writers is a lie the
+            // moment traffic takes the other, which is exactly #9728.
+            await mirrorNominatorPositionsToNeon(
+              env as unknown as Record<string, unknown>,
+              ctx,
+              { rows, coldkeyMaxCapturedAt: cutoffs },
+            );
+            return result;
+          },
           "account-balances": (rows, pass) =>
             writeAccountBalancesToD1(
               env.METAGRAPH_HEALTH_DB as unknown as Parameters<

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -124,7 +124,7 @@
     // same PRIMARY KEY (netuid, uid, snapshot_date) the mirror's ON CONFLICT
     // names. An ON CONFLICT with no unique index behind it is a runtime error,
     // not a slower query.
-    "NEON_DUAL_WRITE_LANES": "neurons",
+    "NEON_DUAL_WRITE_LANES": "neurons,nominator-positions",
     "NEON_READ_LANES": "",
     "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",


### PR DESCRIPTION
Closes #9732. The next table on metagraphed-infra#336's list, and the first whose write is not a plain upsert.

## Two writers, both mirrored

#9728's lesson applied *before* the fact rather than after it. This lane writes from two places — `handleNominatorPositionsSync`'s inline branch, and the `sync-batches` queue consumer. **A mirror covering one of two is a lie the moment traffic takes the other.**

## The prune is the hazard

`nominator_positions` is a **latest-only ledger**: a position that no longer exists must be *deleted*, not left behind. A full Alpha scan is ~153,611 rows, far past one request body, so the lane posts in several requests — and a batch-wide *"delete everything older than this pass"* sweep would let one request delete the rows another just wrote.

The cutoff is therefore **per coldkey**, against that coldkey's own max `captured_at` — the same rule `writeNominatorPositionsToD1` applies, resting on the same poster contract (`pack_coldkey_chunks` never splits a coldkey).

Two ordering rules follow, both tested:

- the prune runs **after** the upsert, so the worst a failure can do is leave a stale position until the next tick
- the prune is **skipped entirely** when the upsert failed — pruning against rows that did not land deletes live positions and leaves nothing in their place, and **no retry undoes a delete**

## One statement, not one per key

`pruneKeysInNeon` joins the cutoff map with `UNNEST($1::text[], $2::bigint[])`, so a 24,000-coldkey pass is **one** round trip through Hyperdrive rather than 24,000. Keys and cutoffs travel as parallel arrays, so the pairing is positional — a mismatch would prune one coldkey by another's clock, which the test asserts against directly.

## Verification

- **100% statements, branches, functions, lines** on both Neon modules
- full suite: **709 files, 17,201 tests**, green
- Neon's `nominator_positions` created with `PRIMARY KEY (coldkey, hotkey, netuid)`, matching the mirror's `ON CONFLICT`
- **reads stay on D1** — `NEON_READ_LANES` untouched