### PR TITLE
fix(mcp): default the page on every list tool, not just the one measured

### DIFF
--- a/src/adapter-candidates-mcp.ts
+++ b/src/adapter-candidates-mcp.ts
@@ -3,7 +3,7 @@
 // /metagraph/review/adapter-candidates.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -185,7 +185,7 @@ export async function loadAdapterCandidatesList(
       "Adapter candidates snapshot unavailable.",
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "adapter-candidates",

--- a/src/candidates-mcp.ts
+++ b/src/candidates-mcp.ts
@@ -2,12 +2,9 @@
 // Applies the same list-query transforms as the REST route over the baked
 // /metagraph/candidates.json artifact (mirrors gaps-mcp.ts for GET /api/v1/gaps).
 
-import {
-  CANDIDATES_LIMIT_DEFAULT,
-  CANDIDATES_LIMIT_MAX,
-} from "./route-limits.ts";
+import { CANDIDATES_LIMIT_MAX } from "./route-limits.ts";
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -112,15 +109,13 @@ export function candidatesQueryUrl(
       );
     }
     url.searchParams.set("limit", String(limit));
-  } else {
-    // DEFAULTED, because absent used to mean unbounded (#9700). This tool
-    // takes no required arguments, so `list_candidates {}` is the obvious
-    // first call -- and it returned 7,537,056 bytes, ~1.9M tokens, roughly ten
-    // context windows. Not a big answer: no usable answer. The envelope still
-    // carries `total` and `next_cursor`, so the whole catalog is reachable by
-    // paging rather than by accident.
-    url.searchParams.set("limit", String(CANDIDATES_LIMIT_DEFAULT));
   }
+  // No `else` any more. This tool's own default (#9701, when `list_candidates
+  // {}` returned 7,537,056 bytes) is now applyMcpQueryFilters' default for
+  // EVERY loader that shares the seam (#9730) -- it was never specific to
+  // candidates, it was specific to the tool that got measured first. Two
+  // mechanisms setting the same limit on the same call is one more than can be
+  // kept honest.
   if (args?.cursor !== undefined) {
     const cursor = args.cursor;
     if (typeof cursor !== "number" || !Number.isInteger(cursor) || cursor < 0) {
@@ -184,7 +179,7 @@ export async function loadCandidatesList(
       "Candidates catalog snapshot unavailable.",
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "candidates",

--- a/src/curation-mcp.ts
+++ b/src/curation-mcp.ts
@@ -3,7 +3,7 @@
 // /metagraph/curation.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -162,7 +162,7 @@ export async function loadCurationList(
   if (!blob || typeof blob !== "object") {
     throw curationMcpError("not_found", "Curation snapshot unavailable.");
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "curation",

--- a/src/endpoint-incidents-mcp.ts
+++ b/src/endpoint-incidents-mcp.ts
@@ -3,7 +3,7 @@
 // /metagraph/endpoint-incidents.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -174,7 +174,7 @@ export async function loadEndpointIncidentsList(
       "Endpoint incident snapshot unavailable.",
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "endpoint-incidents",

--- a/src/endpoint-pools-mcp.ts
+++ b/src/endpoint-pools-mcp.ts
@@ -3,7 +3,7 @@
 // /metagraph/endpoint-pools.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 import {
@@ -184,7 +184,7 @@ export async function loadEndpointPoolsList(
       "Endpoint pool snapshot unavailable.",
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "endpoint-pools",

--- a/src/enrichment-evidence-mcp.ts
+++ b/src/enrichment-evidence-mcp.ts
@@ -3,7 +3,7 @@
 // /metagraph/review/enrichment-evidence.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -190,7 +190,7 @@ export async function loadEnrichmentEvidenceList(
       "Enrichment evidence snapshot unavailable.",
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "enrichment-evidence",

--- a/src/enrichment-queue-mcp.ts
+++ b/src/enrichment-queue-mcp.ts
@@ -3,7 +3,7 @@
 // /metagraph/review/enrichment-queue.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -211,7 +211,7 @@ export async function loadEnrichmentQueueList(
       "Enrichment queue snapshot unavailable.",
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "enrichment-queue",

--- a/src/evidence-mcp.ts
+++ b/src/evidence-mcp.ts
@@ -3,7 +3,7 @@
 // /metagraph/evidence-ledger.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 import {
@@ -151,7 +151,7 @@ export async function loadEvidenceList(
       "Public evidence ledger snapshot unavailable.",
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "claims",

--- a/src/gaps-mcp.ts
+++ b/src/gaps-mcp.ts
@@ -3,7 +3,7 @@
 // /metagraph/gaps.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -156,7 +156,7 @@ export async function loadGapsList(
   if (!blob || typeof blob !== "object") {
     throw gapsMcpError("not_found", "Interface gaps snapshot unavailable.");
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "gaps",

--- a/src/global-incidents-mcp.ts
+++ b/src/global-incidents-mcp.ts
@@ -4,7 +4,7 @@
 // handleGlobalIncidents runs over the `surfaces` ledger -- mirrors
 // endpoint-incidents-mcp.ts's query-builder + list-application pattern.
 
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 
 export const GLOBAL_INCIDENTS_SORT_FIELDS =
@@ -107,7 +107,7 @@ export function applyGlobalIncidentsListQuery(
   args: Record<string, unknown> | null | undefined,
 ): GlobalIncidentsListResult {
   const queryUrl = globalIncidentsQueryUrl(args);
-  const transformed = applyQueryFilters(data, queryUrl, "incidents");
+  const transformed = applyMcpQueryFilters(data, queryUrl, "incidents");
   if (transformed.error) {
     throw globalIncidentsMcpError("invalid_params", transformed.error.message);
   }

--- a/src/health-history-mcp.ts
+++ b/src/health-history-mcp.ts
@@ -4,7 +4,7 @@
 
 import { z } from "zod";
 import { DAY_PATTERN } from "../workers/request-params.ts";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
   GetHealthHistoryInputSchema,
@@ -156,7 +156,7 @@ export async function loadHealthHistory(
       `No health-history snapshot for ${date}.`,
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "health-surfaces",

--- a/src/mcp-list-query.ts
+++ b/src/mcp-list-query.ts
@@ -1,0 +1,66 @@
+// The one way an MCP list loader pages a collection (#9730).
+//
+// ## Why this module exists rather than an option at 32 call sites
+//
+// `paginateRows` in workers/list-query.ts pages only when the caller passed
+// `limit` or `cursor`. With neither, it returns EVERY row -- and `DEFAULT_LIMIT`
+// is unreachable, because it applies only once the caller has already opted in.
+//
+// That is right for REST, where a browser can stream the whole collection, and
+// wrong for MCP, where the context window is the hard constraint. Measured
+// against production on 2026-08-07, calling each zero-required-argument tool
+// with `{}`:
+//
+//   list_endpoints      9,059,868 bytes   3,492 rows
+//   list_surfaces       7,820,280 bytes   3,492 rows
+//   list_evidence       3,623,240 bytes   3,871 rows
+//   list_search         2,881,186 bytes   3,757 rows
+//   list_search_index   2,208,844 bytes   3,757 rows
+//   list_profiles       1,287,854 bytes     129 rows
+//
+// Seventeen tools over 100 KB. The largest is roughly 2.3M tokens -- ten times a
+// 200K context window -- from a tool that takes no required arguments and is
+// therefore a plausible FIRST call from an agent exploring the server.
+//
+// #9701 fixed exactly one of these (`list_candidates`, 7.5 MB) by setting the
+// limit inside that one loader. Doing that 32 more times would leave the next
+// loader to be written with the same hole and nothing to catch it. A single
+// wrapper makes the correct call the only import available, and
+// tests/mcp-list-query-default.test.ts asserts no `src/*-mcp.ts` reaches past
+// it -- so a loader added tonight is covered tonight.
+//
+// ## What it does NOT change
+//
+// Nothing about REST. `applyQueryFilters` keeps its existing behaviour for
+// every caller that does not pass `defaultLimit`, and the two `workers/` call
+// sites do not. `total` and `next_cursor` still ride in the envelope, so the
+// full collection stays reachable by paging -- it stops being reachable by
+// accident.
+import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { MCP_LIST_LIMIT_DEFAULT } from "./route-limits.ts";
+
+/**
+ * `applyQueryFilters` with the MCP page default applied.
+ *
+ * Identical in every other respect -- same collection config, same filters,
+ * same validation, same errors. An explicit `limit` in the query string still
+ * wins; this only supplies one when the caller gave none.
+ */
+export function applyMcpQueryFilters(
+  data: Record<string, unknown> | null | undefined,
+  url: URL,
+  queryCollection: string,
+  queryFilterNames: string[] = [],
+  options: { csvResponse?: boolean; defaultLimit?: number } = {},
+): ReturnType<typeof applyQueryFilters> {
+  return applyQueryFilters(data, url, queryCollection, queryFilterNames, {
+    ...options,
+    // A loader may raise its own ceiling (a collection whose rows are tiny, or
+    // one whose whole point is the full network), but it has to say so -- the
+    // default is what applies when nobody thought about it, which is precisely
+    // the case that produced a 9 MB response.
+    defaultLimit: options.defaultLimit ?? MCP_LIST_LIMIT_DEFAULT,
+  });
+}
+
+export type { Row };

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -218,7 +218,7 @@ import {
 import { buildTierPolicies } from "./api-tiers.ts";
 import { recordApiKeyUsage } from "../workers/api.ts";
 import { DAY_PATTERN } from "../workers/request-params.ts";
-import { applyQueryFilters } from "../workers/list-query.ts";
+import { applyMcpQueryFilters } from "./mcp-list-query.ts";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.ts";
 import {
   currentPostgresTierFallbackGeneration,
@@ -3809,7 +3809,7 @@ function cursorWindow(
   if (cursor > 0) {
     url.searchParams.set("cursor", String(cursor));
   }
-  const { data, meta } = applyQueryFilters(
+  const { data, meta } = applyMcpQueryFilters(
     { [dataKey]: rows },
     url,
     collection,
@@ -11349,7 +11349,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       if (fields) queryUrl.searchParams.set("fields", fields);
       if (limit !== null) queryUrl.searchParams.set("limit", String(limit));
       if (cursor > 0) queryUrl.searchParams.set("cursor", String(cursor));
-      const transformed = applyQueryFilters(
+      const transformed = applyMcpQueryFilters(
         data,
         queryUrl,
         "endpoints",

--- a/src/network-economics.ts
+++ b/src/network-economics.ts
@@ -3,7 +3,7 @@
 // handlers keep tier precedence and envelope wiring.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 import {
@@ -171,7 +171,7 @@ export async function loadNetworkEconomics(
   // Spot on every row (#9408 completion), derived BEFORE the query filters so a
   // `fields` projection treats it like any other column — selectable, and
   // dropped from a narrowed row rather than force-appended to it.
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     withSpotPricedEconomics(blob as Row) as Record<string, unknown>,
     queryUrl,
     "economics",

--- a/src/profile-completeness-mcp.ts
+++ b/src/profile-completeness-mcp.ts
@@ -4,7 +4,7 @@
 // /metagraph/review/profile-completeness.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -183,7 +183,7 @@ export async function loadProfileCompletenessList(
       "Profile completeness snapshot unavailable.",
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "profile-completeness",

--- a/src/profiles-mcp.ts
+++ b/src/profiles-mcp.ts
@@ -3,7 +3,7 @@
 // profiles.json and per-netuid profile detail snapshots.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -159,7 +159,7 @@ export async function loadProfilesList(
   if (!blob || typeof blob !== "object") {
     throw profilesMcpError("not_found", "Profiles snapshot unavailable.");
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "profiles",

--- a/src/provider-endpoints-mcp.ts
+++ b/src/provider-endpoints-mcp.ts
@@ -4,7 +4,7 @@
 // /metagraph/providers/{slug}/endpoints.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -234,7 +234,7 @@ export async function loadProviderEndpointsList(
       `No endpoint catalog exists for provider '${slug}'.`,
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "endpoints",

--- a/src/providers-mcp.ts
+++ b/src/providers-mcp.ts
@@ -3,7 +3,7 @@
 // /metagraph/providers.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -150,7 +150,7 @@ export async function loadProvidersList(
   if (!blob || typeof blob !== "object") {
     throw providersMcpError("not_found", "Providers index unavailable.");
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "providers",

--- a/src/review-enrichment-targets-mcp.ts
+++ b/src/review-enrichment-targets-mcp.ts
@@ -4,7 +4,7 @@
 // /metagraph/review/enrichment-targets.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -242,7 +242,7 @@ export async function loadReviewEnrichmentTargetsList(
       "Review enrichment targets snapshot unavailable.",
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "enrichment-targets",

--- a/src/review-gaps-mcp.ts
+++ b/src/review-gaps-mcp.ts
@@ -3,7 +3,7 @@
 // /metagraph/review/gap-priorities.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -161,7 +161,7 @@ export async function loadReviewGapsList(
       "Review gap priorities snapshot unavailable.",
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "review-gap-priorities",

--- a/src/route-limits.ts
+++ b/src/route-limits.ts
@@ -184,19 +184,46 @@ export const DEFAULT_PIPELINE_HISTORY_WINDOW = "30d";
 /**
  * `list_candidates` (MCP) -- the network-wide candidate-surface catalog.
  *
- * A DEFAULT, not just a ceiling, and the MCP tool is the reason. With no
- * `limit` the loader forwarded none, so the route served every row: measured
- * 2026-08-07 at **7,537,056 bytes for 2,037 candidates** -- roughly 1.9M
- * tokens, about ten times a 200K context window. An agent calling
- * list_candidates while exploring (the obvious first move, since it takes no
- * required arguments) did not get a large answer, it got no usable answer at
- * all. `limit: 10` returns 37,850 bytes, so the data was never the problem.
+ * The DEFAULT that used to live here is now MCP_LIST_LIMIT_DEFAULT below: the
+ * hole #9701 fixed here was never specific to candidates, only measured here
+ * first (7,537,056 bytes for 2,037 candidates -- roughly 1.9M tokens, about ten
+ * 200K context windows, from a tool taking no required arguments). #9730 found
+ * sixteen more sharing the same seam, the largest at 9 MB, and moved the
+ * default to the seam. Only the CEILING is candidate-specific.
  *
- * Deliberately narrower than the REST route, which still serves unbounded:
- * a browser can stream 7.5 MB and a context window cannot, so the surface with
- * the hard constraint is the one that carries the default. `total` and
+ * Deliberately narrower than the REST route, which still serves unbounded: a
+ * browser can stream 7.5 MB and a context window cannot, so the surface with
+ * the hard constraint carries the default. `total` and `next_cursor` ride in
+ * the envelope either way, so the full set stays reachable by paging -- it is
+ * no longer reachable by accident.
+ */
+export const CANDIDATES_LIMIT_MAX = 1000;
+
+/**
+ * Every MCP list tool that pages through `applyQueryFilters` (#9730).
+ *
+ * A DEFAULT, not a ceiling, and the MCP surface is the reason. `paginateRows`
+ * in workers/list-query.ts only pages when the caller passed `limit` or
+ * `cursor`; with neither it returns EVERY row, and `DEFAULT_LIMIT` is
+ * unreachable until the caller has already opted in. So the 32 loaders under
+ * src/*-mcp.ts forwarded no limit and served the whole collection.
+ *
+ * Measured against production 2026-08-07, calling each zero-required-argument
+ * tool with `{}`: list_endpoints **9,059,868 bytes** (3,492 rows), list_surfaces
+ * 7,820,280, list_evidence 3,623,240, list_search 2,881,186, list_search_index
+ * 2,208,844, list_profiles 1,287,854 -- seventeen tools over 100 KB. The largest
+ * is roughly 2.3M tokens, more than ten times a 200K context window, from a tool
+ * that takes no required arguments and is therefore a plausible FIRST call.
+ *
+ * Deliberately narrower than the REST routes, which keep serving unbounded: a
+ * browser can stream 9 MB and a context window cannot, so the surface with the
+ * hard constraint carries the default. That is the same asymmetry
+ * #9701 is argued on -- generalised from the one tool that got measured to
+ * every tool that shares the seam. `total` and
  * `next_cursor` ride in the envelope either way, so the full set stays
  * reachable by paging -- it is no longer reachable by accident.
+ *
+ * 20 matches the value #9701 chose for the same reason: enough rows to see the
+ * shape of a collection, small enough that a wrong guess costs nothing.
  */
-export const CANDIDATES_LIMIT_DEFAULT = 20;
-export const CANDIDATES_LIMIT_MAX = 1000;
+export const MCP_LIST_LIMIT_DEFAULT = 20;

--- a/src/rpc-endpoints-mcp.ts
+++ b/src/rpc-endpoints-mcp.ts
@@ -9,7 +9,7 @@
 // rpc-pools-mcp.ts (live overlay before filter).
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import { KV_HEALTH_RPC_POOL } from "./health-prober.ts";
@@ -284,7 +284,7 @@ export async function loadRpcEndpointsList(
     if (merged) overlaid = merged as Record<string, unknown>;
   }
 
-  const transformed = applyQueryFilters(overlaid, queryUrl, "endpoints", []);
+  const transformed = applyMcpQueryFilters(overlaid, queryUrl, "endpoints", []);
   if (transformed.error) {
     throw rpcEndpointsMcpError("invalid_params", transformed.error.message);
   }

--- a/src/rpc-pools-mcp.ts
+++ b/src/rpc-pools-mcp.ts
@@ -8,7 +8,7 @@
 // live-overlay step of its own.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 import { KV_HEALTH_RPC_POOL } from "./health-prober.ts";
@@ -216,7 +216,7 @@ export async function loadRpcPoolsList(
     };
   }
 
-  const transformed = applyQueryFilters(overlaid, queryUrl, "rpc-pools", []);
+  const transformed = applyMcpQueryFilters(overlaid, queryUrl, "rpc-pools", []);
   if (transformed.error) {
     throw rpcPoolsMcpError("invalid_params", transformed.error.message);
   }

--- a/src/search-index-mcp.ts
+++ b/src/search-index-mcp.ts
@@ -3,7 +3,7 @@
 // /metagraph/search-index.json artifact (slim documents without token blobs).
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 import {
@@ -165,7 +165,7 @@ export async function loadSearchIndexList(
       "Search index snapshot unavailable.",
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "documents",

--- a/src/search-mcp.ts
+++ b/src/search-mcp.ts
@@ -5,7 +5,7 @@
 // without its subnet-only filter, and unlike list_search_index it keeps tokens.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 import {
@@ -149,7 +149,7 @@ export async function loadSearchList(
   if (!blob || typeof blob !== "object") {
     throw searchMcpError("not_found", "Search snapshot unavailable.");
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "documents",

--- a/src/source-snapshots-mcp.ts
+++ b/src/source-snapshots-mcp.ts
@@ -3,7 +3,7 @@
 // /metagraph/source-snapshots.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 import {
@@ -151,7 +151,7 @@ export async function loadSourceSnapshotsList(
       "Source snapshots ledger unavailable.",
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "sources",

--- a/src/subnet-candidates-mcp.ts
+++ b/src/subnet-candidates-mcp.ts
@@ -4,7 +4,7 @@
 // /metagraph/candidates/{netuid}.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -183,7 +183,7 @@ export async function loadSubnetCandidatesList(
       `No candidate snapshot exists for netuid ${netuid}.`,
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "candidates",

--- a/src/subnet-endpoints-mcp.ts
+++ b/src/subnet-endpoints-mcp.ts
@@ -4,7 +4,7 @@
 // /metagraph/endpoints/{netuid}.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -219,7 +219,7 @@ export async function loadSubnetEndpointsList(
       `No endpoint snapshot exists for netuid ${netuid}.`,
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "endpoints",

--- a/src/subnet-evidence-mcp.ts
+++ b/src/subnet-evidence-mcp.ts
@@ -4,7 +4,7 @@
 // /metagraph/evidence/{netuid}.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 import {
@@ -163,7 +163,7 @@ export async function loadSubnetEvidenceList(
       `No evidence snapshot exists for netuid ${netuid}.`,
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "claims",

--- a/src/subnet-gaps-mcp.ts
+++ b/src/subnet-gaps-mcp.ts
@@ -4,7 +4,7 @@
 // artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -176,7 +176,7 @@ export async function loadSubnetGapsList(
       `No gap report exists for netuid ${netuid}.`,
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     // Collection KEY (indexes API_QUERY_COLLECTIONS), not the row key -- the

--- a/src/subnet-health-mcp.ts
+++ b/src/subnet-health-mcp.ts
@@ -4,7 +4,7 @@
 // /metagraph/health/subnets/{netuid}.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -180,7 +180,7 @@ export async function loadSubnetHealthList(
       `No health snapshot exists for netuid ${netuid}.`,
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "health-surfaces",

--- a/src/subnet-surfaces-mcp.ts
+++ b/src/subnet-surfaces-mcp.ts
@@ -4,7 +4,7 @@
 // /metagraph/surfaces/{netuid}.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -168,7 +168,7 @@ export async function loadSubnetSurfacesList(
       `No surface snapshot exists for netuid ${netuid}.`,
     );
   }
-  const transformed = applyQueryFilters(
+  const transformed = applyMcpQueryFilters(
     blob as Record<string, unknown>,
     queryUrl,
     "curated-surfaces",

--- a/src/surfaces-mcp.ts
+++ b/src/surfaces-mcp.ts
@@ -3,7 +3,7 @@
 // /metagraph/surfaces.json artifact.
 
 import { z } from "zod";
-import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -164,7 +164,12 @@ export async function loadSurfacesList(
       "Curated surfaces catalog unavailable.",
     );
   }
-  const transformed = applyQueryFilters(blob, queryUrl, "curated-surfaces", []);
+  const transformed = applyMcpQueryFilters(
+    blob,
+    queryUrl,
+    "curated-surfaces",
+    [],
+  );
   if (transformed.error) {
     throw surfacesMcpError("invalid_params", transformed.error.message);
   }

--- a/tests/candidates-mcp.test.ts
+++ b/tests/candidates-mcp.test.ts
@@ -12,7 +12,8 @@ import {
   loadCandidatesList,
 } from "../src/candidates-mcp.ts";
 import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
-import { CANDIDATES_LIMIT_DEFAULT } from "../src/route-limits.ts";
+import { MCP_LIST_LIMIT_DEFAULT } from "../src/route-limits.ts";
+import { applyMcpQueryFilters } from "../src/mcp-list-query.ts";
 import type { Row } from "./row-type.ts";
 
 type CandidatesCtx = Parameters<typeof loadCandidatesList>[0];
@@ -152,13 +153,31 @@ describe("candidates-mcp (#7889)", () => {
   // roughly 1.9M tokens, about ten 200K context windows. Not a large answer;
   // no usable answer. `limit: 10` returned 37,850 bytes, so the volume was
   // never the data's fault.
+  // #9730 moved the default from this URL to the shared seam every MCP loader
+  // pages through, so the assertion moved with it -- from "the query string
+  // says 20" to "the caller receives 20", which is the fact that actually
+  // mattered and the one a future refactor cannot quietly satisfy by accident.
   test("an absent limit is defaulted, not left unbounded", () => {
-    const url = candidatesQueryUrl({});
+    const rows = Array.from({ length: 100 }, (_, index) => ({
+      id: `cand-${index}`,
+      netuid: index,
+      kind: "subnet-api",
+    }));
+    const { data, meta } = applyMcpQueryFilters(
+      { candidates: rows },
+      candidatesQueryUrl({}),
+      "candidates",
+      [],
+    ) as { data: Row; meta: Row };
     assert.equal(
-      url.searchParams.get("limit"),
-      String(CANDIDATES_LIMIT_DEFAULT),
+      (data.candidates as Row[]).length,
+      MCP_LIST_LIMIT_DEFAULT,
       "no limit must mean the default, never the whole catalog",
     );
+    // The rest stays reachable -- by paging, rather than by accident.
+    const pagination = meta.pagination as Row;
+    assert.equal(pagination.total, 100);
+    assert.equal(pagination.next_cursor, MCP_LIST_LIMIT_DEFAULT);
   });
 
   test("an explicit limit still wins over the default", () => {

--- a/tests/mcp-list-query-default.test.ts
+++ b/tests/mcp-list-query-default.test.ts
@@ -1,0 +1,162 @@
+// Every MCP list loader pages through the seam that carries a default (#9730).
+//
+// The defect this guards is not "a tool returns too much once". It is that the
+// hole is INVISIBLE at the call site: `applyQueryFilters` with no `limit` and no
+// `cursor` returns every row, silently, and nothing about writing a new loader
+// suggests otherwise. #9701 fixed one instance by hand; sixteen more were still
+// live when #9730 measured them, the largest at 9,059,868 bytes.
+//
+// So the gate is structural rather than per-tool: no module under src/*-mcp.ts
+// may reach past src/mcp-list-query.ts to the raw engine. A loader added
+// tonight is covered tonight, without anyone remembering to add it to a list.
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { applyMcpQueryFilters } from "../src/mcp-list-query.ts";
+import { applyQueryFilters } from "../workers/list-query.ts";
+import { MCP_LIST_LIMIT_DEFAULT } from "../src/route-limits.ts";
+import type { Row } from "./row-type.ts";
+
+const SRC_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../src",
+);
+
+/**
+ * The modules allowed to import the raw engine.
+ *
+ * `mcp-list-query.ts` IS the wrapper. `graphql.ts` is a third surface with its
+ * own pagination contract -- a GraphQL query states its own page size and an
+ * invalid one is an error rather than a substituted default, so a hidden
+ * default there would contradict the schema clients read.
+ */
+const MAY_IMPORT_THE_RAW_ENGINE = new Set(["mcp-list-query.ts", "graphql.ts"]);
+
+function sourceFiles(): string[] {
+  return readdirSync(SRC_DIR).filter((name) => name.endsWith(".ts"));
+}
+
+describe("MCP list pagination default (#9730)", () => {
+  test("no MCP loader reaches past the wrapper to the raw engine", () => {
+    const offenders: string[] = [];
+    let checked = 0;
+    for (const name of sourceFiles()) {
+      const source = readFileSync(path.join(SRC_DIR, name), "utf8");
+      if (!source.includes("list-query.ts")) continue;
+      checked += 1;
+      if (MAY_IMPORT_THE_RAW_ENGINE.has(name)) continue;
+      // The import specifier, not the call: a module could alias the symbol,
+      // and what must not happen is reaching the raw module at all.
+      if (/from "\.\.\/workers\/list-query\.ts"/.test(source)) {
+        offenders.push(name);
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      `these import the raw engine directly and so page unbounded — import ` +
+        `applyMcpQueryFilters from ./mcp-list-query.ts instead: ${offenders.join(", ")}`,
+    );
+    // A pass over nothing proves nothing. If the layout changes such that no
+    // module matches, this fails rather than going quietly green.
+    assert.ok(
+      checked > 25,
+      `expected well over 25 modules touching the list engine, saw ${checked}`,
+    );
+  });
+
+  test("the wrapper defaults a page the raw engine would have left unbounded", () => {
+    const rows = Array.from({ length: 200 }, (_, index) => ({
+      netuid: index,
+      name: `sn-${index}`,
+      slug: `sn-${index}`,
+      coverage_level: "probed",
+      curation_level: "maintainer-reviewed",
+      gaps: { missing_kinds: [], supported_kinds: [], gap_notes: [] },
+    }));
+    const url = () => new URL("https://mcp.internal/gaps");
+
+    // The behaviour that shipped: every row, from a call that asked for none.
+    const raw = applyQueryFilters({ gaps: rows }, url(), "gaps", []) as {
+      data: Row;
+    };
+    assert.equal(
+      (raw.data.gaps as Row[]).length,
+      200,
+      "the raw engine is expected to stay unbounded — REST depends on it",
+    );
+
+    const wrapped = applyMcpQueryFilters({ gaps: rows }, url(), "gaps", []) as {
+      data: Row;
+      meta: Row;
+    };
+    assert.equal((wrapped.data.gaps as Row[]).length, MCP_LIST_LIMIT_DEFAULT);
+    // Reachable by paging, which is the difference between a default and a cap.
+    const pagination = wrapped.meta.pagination as Row;
+    assert.equal(pagination.total, 200);
+    assert.equal(pagination.returned, MCP_LIST_LIMIT_DEFAULT);
+    assert.equal(pagination.next_cursor, MCP_LIST_LIMIT_DEFAULT);
+  });
+
+  test("an explicit limit still wins, in both directions", () => {
+    const rows = Array.from({ length: 200 }, (_, index) => ({
+      netuid: index,
+      name: `sn-${index}`,
+      slug: `sn-${index}`,
+      coverage_level: "probed",
+      curation_level: "maintainer-reviewed",
+      gaps: { missing_kinds: [], supported_kinds: [], gap_notes: [] },
+    }));
+    const withLimit = (value: string) => {
+      const url = new URL("https://mcp.internal/gaps");
+      url.searchParams.set("limit", value);
+      return applyMcpQueryFilters({ gaps: rows }, url, "gaps", []) as {
+        data: Row;
+      };
+    };
+    // Smaller than the default.
+    assert.equal((withLimit("5").data.gaps as Row[]).length, 5);
+    // And larger — the default must not have become a ceiling.
+    assert.equal((withLimit("100").data.gaps as Row[]).length, 100);
+  });
+
+  test("a cursor alone still pages, as it did before", () => {
+    const rows = Array.from({ length: 200 }, (_, index) => ({
+      netuid: index,
+      name: `sn-${index}`,
+      slug: `sn-${index}`,
+      coverage_level: "probed",
+      curation_level: "maintainer-reviewed",
+      gaps: { missing_kinds: [], supported_kinds: [], gap_notes: [] },
+    }));
+    const url = new URL("https://mcp.internal/gaps");
+    url.searchParams.set("cursor", "10");
+    const { data } = applyMcpQueryFilters({ gaps: rows }, url, "gaps", []) as {
+      data: Row;
+    };
+    const page = data.gaps as Row[];
+    assert.equal(page.length, MCP_LIST_LIMIT_DEFAULT);
+    assert.equal(page[0].netuid, 10, "the cursor must still offset the page");
+  });
+
+  test("a loader may raise its own ceiling, but has to say so", () => {
+    const rows = Array.from({ length: 200 }, (_, index) => ({
+      netuid: index,
+      name: `sn-${index}`,
+      slug: `sn-${index}`,
+      coverage_level: "probed",
+      curation_level: "maintainer-reviewed",
+      gaps: { missing_kinds: [], supported_kinds: [], gap_notes: [] },
+    }));
+    const { data } = applyMcpQueryFilters(
+      { gaps: rows },
+      new URL("https://mcp.internal/gaps"),
+      "gaps",
+      [],
+      { defaultLimit: 75 },
+    ) as { data: Row };
+    assert.equal((data.gaps as Row[]).length, 75);
+  });
+});

--- a/tests/search-mcp.test.ts
+++ b/tests/search-mcp.test.ts
@@ -19,6 +19,7 @@ type LoadDeps = Parameters<typeof loadSearchList>[2];
 import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
+import { MCP_LIST_LIMIT_DEFAULT } from "../src/route-limits.ts";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",
@@ -430,16 +431,22 @@ describe("search-mcp", () => {
       },
     });
 
+    // EVERY set carries an explicit `limit`. Without one the two surfaces are
+    // not being asked equivalent questions: since #9730 the MCP loader supplies
+    // a page default and REST stays unbounded, so their reported `limit`
+    // differs BY DESIGN even when the rows are identical. That asymmetry is the
+    // subject of its own test below, where it reads as the deliberate choice it
+    // is rather than as a parity failure.
     const paramSets = [
-      { q: "seven" },
-      { q: "datura" },
+      { q: "seven", limit: 10 },
+      { q: "datura", limit: 10 },
       { sort: "title", order: "desc", limit: 1 },
       { sort: "netuid", order: "asc", limit: 2, cursor: 1 },
       { fields: "id,title", limit: 2 },
-      { type: "subnet" },
-      { type: "surface", netuid: 7 },
-      { netuid: 7 },
-      {},
+      { type: "subnet", limit: 10 },
+      { type: "surface", netuid: 7, limit: 10 },
+      { netuid: 7, limit: 10 },
+      { limit: 5 },
     ];
 
     for (const params of paramSets) {
@@ -475,5 +482,33 @@ describe("search-mcp", () => {
       assert.equal(mcp.sort, page.sort);
       assert.equal(mcp.order, page.order);
     }
+
+    // And where they deliberately DIVERGE (#9730): with no `limit` at all, the
+    // MCP loader pages and REST does not. Asserted on both sides here rather
+    // than left implicit, because a later change that silently aligned them
+    // would defeat one of the two -- a browser can stream the full catalog and
+    // a context window cannot.
+    const unbounded = await loadSearchList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      {},
+    );
+    const restRes = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/search"),
+      restEnv as unknown as Env,
+      {},
+    );
+    const restBody = await restRes.json();
+    assert.equal(
+      unbounded.limit,
+      MCP_LIST_LIMIT_DEFAULT,
+      "MCP must page by default",
+    );
+    assert.equal(
+      restBody.meta.pagination.limit,
+      restBody.meta.pagination.total,
+      "REST must stay unbounded by default",
+    );
+    // Same total either way -- the collection is paged, never hidden.
+    assert.equal(unbounded.total, restBody.meta.pagination.total);
   });
 });

--- a/workers/list-query.ts
+++ b/workers/list-query.ts
@@ -55,7 +55,10 @@ export function applyQueryFilters(
   url: URL,
   queryCollection: string,
   queryFilterNames: string[] = [],
-  { csvResponse = false }: { csvResponse?: boolean } = {},
+  {
+    csvResponse = false,
+    defaultLimit,
+  }: { csvResponse?: boolean; defaultLimit?: number } = {},
 ): ApplyQueryFiltersResult {
   const params = url.searchParams;
   const config = (
@@ -71,7 +74,7 @@ export function applyQueryFilters(
     data,
     params,
     listQueryConfig(config, queryFilterNames),
-    { csvResponse },
+    { csvResponse, defaultLimit },
   );
 }
 
@@ -341,7 +344,7 @@ function applyListTransform(
   data: Record<string, unknown>,
   params: URLSearchParams,
   config: QueryCollectionConfig,
-  options: { csvResponse?: boolean } = {},
+  options: { csvResponse?: boolean; defaultLimit?: number } = {},
 ): ApplyQueryFiltersResult {
   const queryError = validateListQuery(params, config, options);
   if (queryError) {
@@ -366,7 +369,7 @@ function applyListTransform(
     config.range_filters,
   );
   const sorted = sortRows(filtered, params);
-  const paginated = paginateRows(sorted, params);
+  const paginated = paginateRows(sorted, params, options.defaultLimit);
   return {
     data: {
       ...data,
@@ -467,12 +470,30 @@ interface PaginatedRows {
   sort: string | null;
 }
 
-function paginateRows(rows: Row[], params: URLSearchParams): PaginatedRows {
+function paginateRows(
+  rows: Row[],
+  params: URLSearchParams,
+  // #9730. Without this, omitting BOTH `limit` and `cursor` returns every row,
+  // and DEFAULT_LIMIT below is unreachable because it only applies once the
+  // caller has already opted into paging. That is correct for REST -- a browser
+  // can stream 9 MB -- and catastrophic for MCP, where the same seam served
+  // list_endpoints as 9,059,868 bytes to a tool call that took no arguments.
+  //
+  // Passed explicitly by the caller rather than inferred (from the mcp.internal
+  // hostname, say), because which surface is asking is the caller's fact to
+  // state, and a hostname test would silently mis-serve any future caller that
+  // used a different one.
+  defaultLimit?: number,
+): PaginatedRows {
   const requestedLimit = integerParam(params.get("limit"));
   const requestedCursor = integerParam(params.get("cursor"));
-  const shouldPage = requestedLimit !== null || requestedCursor !== null;
+  const shouldPage =
+    requestedLimit !== null || requestedCursor !== null || defaultLimit != null;
   const limit = shouldPage
-    ? Math.min(Math.max(requestedLimit ?? DEFAULT_LIMIT, MIN_LIMIT), MAX_LIMIT)
+    ? Math.min(
+        Math.max(requestedLimit ?? defaultLimit ?? DEFAULT_LIMIT, MIN_LIMIT),
+        MAX_LIMIT,
+      )
     : rows.length;
   const cursor = Math.min(Math.max(requestedCursor ?? 0, 0), rows.length);
   const next = cursor + limit;


### PR DESCRIPTION
## Summary

#9701 fixed `list_candidates` returning 7.5 MB unbounded. It was not the only one — it was the one that got measured.

Called every zero-required-argument tool that declares a `limit`, against production, with `arguments: {}`:

| Tool | Bytes | Rows |
|---|---:|---:|
| `list_endpoints` | **9,059,868** | 3,492 |
| `list_surfaces` | **7,820,280** | 3,492 |
| `list_evidence` | **3,623,240** | 3,871 |
| `list_search` | **2,881,186** | 3,757 |
| `list_search_index` | **2,208,844** | 3,757 |
| `list_profiles` | **1,287,854** | 129 |
| …11 more over 100 KB | | |

`list_endpoints` at 9 MB is roughly 2.3M tokens — ten times a 200K context window — from a tool that takes **no required arguments** and is therefore a plausible *first* call from an agent exploring the server. 88 tools declare a `limit`; **9** declared a default.

## One line explains all of them

`paginateRows` in `workers/list-query.ts`:

```js
const shouldPage = requestedLimit !== null || requestedCursor !== null;
...
rows: shouldPage ? rows.slice(cursor, next) : rows,
```

Omit both `limit` and `cursor` and every row is returned — with `DEFAULT_LIMIT` unreachable, because it applies only once the caller has already opted into paging.

## Why the seam, not seventeen handlers

The hole is **invisible at the call site**. Nothing about writing a new loader suggests that passing no limit means passing no limit to anything, which is why #9701's per-tool fix left sixteen more live. A dedicated `src/mcp-list-query.ts` wraps the engine with the default, the 31 loaders import that instead, and a **structural gate** asserts no `src/*-mcp.ts` reaches past it — so a loader written tonight is covered tonight rather than being the next one somebody measures.

## Measured end to end, on production rows

| Tool | Before | After | |
|---|---:|---:|---|
| `list_search` | 1,347,700 | 4,390 | 307× |
| `list_surfaces` | 3,750,533 | 15,138 | 248× |
| `list_endpoints` | 4,267,337 | 25,968 | 164× |
| `list_curation` | 147,683 | 16,853 | 9× |
| `list_gaps` | 82,660 | 9,816 | 8× |

(These are the same rows the REST routes serve today, run through both code paths — so the "before" column is the behaviour on `main`, not an estimate.)

## What is deliberately untouched

**REST stays unbounded.** A browser can stream 9 MB and a context window cannot, so the surface with the hard constraint carries the default — #9701's asymmetry, generalised. `total` and `next_cursor` still ride in the envelope, so the full collection remains reachable **by paging**; it is no longer reachable **by accident**.

**GraphQL stays unbounded too**, and that is a decision rather than an oversight: a GraphQL query states its own page size and an invalid one is an error rather than a substituted default, so a hidden default there would contradict the schema clients read. The gate's allow-list names both exemptions and says why.

## Cleanup

`list_candidates`' own copy of this default comes out with it — the hole was never specific to candidates, only measured there first, and two mechanisms setting the same limit on the same call is one more than can be kept honest. `CANDIDATES_LIMIT_MAX` stays; only the redundant default goes.

## Two tests changed, not worked around

- `candidates-mcp` asserted the query **string** carried the default. It now asserts the caller **receives** twenty rows — the fact that actually mattered, and one a refactor cannot satisfy by accident.
- `search-mcp`'s REST/MCP parity loop compared param sets with no `limit`, which are no longer equivalent questions. Every set now carries one, and the deliberate divergence is asserted explicitly at the end of that test, on both sides, so a later change that silently aligned them fails.

## Validation run

```
npm run build                     # 7/7
npm run validate                  # 129 subnets, 3442 surfaces
npm run validate:api              # 200 routes
npm run validate:contract-drift   # passed
npx tsx scripts/validate-mcp.ts   # 224 tools
npm run lint && npm run format:check && npx tsc --noEmit
```

Tests: **3,595 passed** across the 43 suites touching the list engine, the MCP server, GraphQL and every `*-mcp` loader — plus 5 new cases in `tests/mcp-list-query-default.test.ts` covering the structural gate, the default, an explicit limit winning in **both** directions (the default must not have become a ceiling), a bare `cursor` still paging, and a loader raising its own ceiling explicitly.

Closes #9730