### PR TITLE
chore(webhooks): delete the fan-out nothing calls, and the sweep the comments still describe

### DIFF
--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -12,8 +12,10 @@ import { ipv6EmbeddedIpv4 } from "./ip-safety.ts";
 type Row = Record<string, unknown>;
 
 export const WEBHOOK_KV_PREFIX = "webhooks:sub:";
-// Per-(subscription, event) delivery state for at-least-once redelivery: a failed
-// transient delivery is parked here, retried on later runs, then dead-lettered.
+// Per-(subscription, event) delivery OUTCOME, for the public status surface.
+// It used to be delivery STATE -- a failed delivery was parked here and a later
+// run swept it -- but the queue schedules retries now (metagraphed-infra#354),
+// so nothing reads these to decide what to do. They are reporting only.
 export const WEBHOOK_DELIVERY_PREFIX = "webhooks:delivery:";
 export const WEBHOOK_SIGNATURE_HEADER = "x-metagraph-signature";
 export const WEBHOOK_TIMESTAMP_HEADER = "x-metagraph-timestamp";
@@ -50,7 +52,7 @@ export function subscriptionStorageKey(id: unknown): string {
   return `${WEBHOOK_KV_PREFIX}${id}`;
 }
 
-// All of a subscription's parked deliveries share this prefix, so its delivery
+// All of a subscription's delivery records share this prefix, so its delivery
 // health lists in one scan.
 export function deliveryStoragePrefix(subscriptionId: unknown): string {
   return `${WEBHOOK_DELIVERY_PREFIX}${subscriptionId}:`;
@@ -227,8 +229,9 @@ export async function resolveWebhookHostnamesWithDoh(
 //   "resolve-error" — the DNS resolver threw (e.g. a transient EAI_AGAIN / SERVFAIL
 //                     blip): a RETRYABLE condition, NOT a terminal reject
 // Splitting the transient resolver failure out from a genuine "unsafe" verdict is
-// what lets deliverChangeEvent park + retry it instead of silently dropping an
-// owed at-least-once delivery when DNS momentarily fails during a sweep.
+// what lets a DNS blip come back as `retryable: true` -- so the queue reschedules
+// it -- instead of a terminal "skipped" that dead-letters an owed delivery to a
+// healthy endpoint.
 function isUnsafeWebhookDnsError(error: unknown): boolean {
   const err = error as { code?: unknown; message?: unknown } | null | undefined;
   return (
@@ -505,8 +508,9 @@ export async function webhookEventId(bodyText: unknown): Promise<string> {
 }
 
 // Idempotency key scoped to one subscriber and one event, derived from the
-// subscription id and the exact event body. Every retry within a run and every
-// redelivery on a later run carries the same key, so subscribers can dedupe.
+// subscription id and the exact event body. Every attempt carries the same key --
+// the inner HTTP retries and all eight queue attempts alike -- so subscribers can
+// dedupe.
 export async function webhookIdempotencyKey(
   subscriptionId: unknown,
   bodyText: unknown,
@@ -630,12 +634,12 @@ export async function deliverChangeEvent({
   };
   const identity = { event_id: eventId, idempotency_key: idempotencyKey };
 
-  // Resolve + classify the URL AFTER identity is computed, so a transient resolver
-  // failure can be parked (it needs an event_id) and retried instead of dropped.
-  // A statically-unsafe URL, or one that resolves to a private address, is a
-  // terminal "skipped"; a resolver THROW (a DNS blip) is a retryable "failed" —
-  // returning "skipped" there would delete the parked record on the redelivery
-  // sweep and silently lose an owed at-least-once delivery to a healthy endpoint.
+  // Resolve + classify the URL AFTER identity is computed, so the result carries
+  // an event_id whichever way it goes. A statically-unsafe URL, or one that
+  // resolves to a private address, is a terminal "skipped"; a resolver THROW (a
+  // DNS blip) is a retryable "failed" — returning "skipped" there would
+  // dead-letter an owed at-least-once delivery to a healthy endpoint on the
+  // strength of one bad lookup.
   const urlStatus = await resolvedWebhookUrlStatus(
     subscription.url,
     resolveHostnames,
@@ -724,9 +728,11 @@ export async function deliverChangeEvent({
 }
 
 // Bounded-concurrency map: drains `items` through at most `concurrency` in-flight
-// `fn` calls. Shared by the fresh fan-out and the redelivery sweep -- exported
-// (#4984 Part 3 adversarial-review fix) so workers/alerter-hub.ts's own
-// delivery fan-out can reuse it rather than duplicating this logic.
+// `fn` calls. Its two webhook callers -- the fresh fan-out and the redelivery
+// sweep -- are both gone (metagraphed-infra#354), and it survives for
+// workers/alerter-hub.ts, which was given it in #4984 rather than duplicating it.
+// It lives here rather than moving because that is a file move for one caller,
+// and the next fan-out that needs a bound will look here first.
 export async function mapBounded<T, R>(
   items: T[] | null | undefined,
   concurrency: number,
@@ -736,8 +742,8 @@ export async function mapBounded<T, R>(
   // Place each result at its INPUT index, not in completion order — workers
   // resolve concurrently (and the per-item work does real async I/O: crypto
   // signing + fetch), so a push-on-complete would return results in a
-  // nondeterministic order. Order-preserving output is what every caller relies
-  // on (the redelivery sweep's per-subscription budget + redelivered sequence).
+  // nondeterministic order. The alerter's fan-out zips these back against its
+  // input list, so the order is load-bearing there.
   const results: R[] = new Array(list.length);
   let cursor = 0;
   const worker = async () => {
@@ -753,44 +759,6 @@ export async function mapBounded<T, R>(
   );
   await Promise.all(workers);
   return results;
-}
-
-// Bounded fan-out over many subscriptions. Concurrency-capped; never rejects —
-// each subscription resolves to a result record (delivered/failed/filtered/
-// skipped) so one bad endpoint can't sink the batch.
-export async function dispatchChangeEvent({
-  subscriptions,
-  event,
-  bodyText,
-  fetchFn,
-  now,
-  timeoutMs,
-  maxAttempts,
-  resolveHostnames,
-  concurrency = 8,
-}: {
-  subscriptions: Row[] | null | undefined;
-  event: Row;
-  bodyText?: string;
-  fetchFn: typeof fetch;
-  now?: () => string;
-  timeoutMs?: number;
-  maxAttempts?: number;
-  resolveHostnames?: (host: string) => Promise<string[]>;
-  concurrency?: number;
-}): Promise<Row[]> {
-  return mapBounded(subscriptions, concurrency, (subscription) =>
-    deliverChangeEvent({
-      subscription,
-      event,
-      bodyText,
-      fetchFn,
-      now,
-      timeoutMs,
-      maxAttempts,
-      resolveHostnames,
-    }),
-  );
 }
 
 // The scheduler that used to live here -- `nextDeliveryRecord`, folding a

--- a/tests/webhooks-core.test.ts
+++ b/tests/webhooks-core.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from "vitest";
 import {
   buildChangeEvent,
   deliverChangeEvent,
-  dispatchChangeEvent,
+  mapBounded,
   eventMatchesFilters,
   isPublicWebhookAddress,
   isPublicWebhookUrl,
@@ -603,10 +603,9 @@ describe("deliverChangeEvent", () => {
 
   test("returns a retryable failure (not a drop) when the resolver throws", async () => {
     // A transient DNS failure (resolver throws, e.g. EAI_AGAIN) must NOT be a
-    // terminal "skipped" — that would delete the parked record on the redelivery
-    // sweep and silently lose an owed at-least-once delivery to a healthy
-    // endpoint. It is a retryable "failed", carrying its event_id so it can be
-    // parked and retried.
+    // terminal "skipped" — that would dead-letter an owed at-least-once
+    // delivery to a healthy endpoint on the strength of one bad lookup. It is a
+    // retryable "failed", carrying its event_id so the queue can reschedule it.
     const out = await deliverChangeEvent({
       subscription: base,
       event,
@@ -618,7 +617,10 @@ describe("deliverChangeEvent", () => {
     assert.equal(out.status, "failed");
     assert.equal(out.reason, "resolve-error");
     assert.equal(out.retryable, true);
-    assert.ok(out.event_id, "carries identity so it can be parked + retried");
+    assert.ok(
+      out.event_id,
+      "carries identity, so the retry is the same delivery",
+    );
   });
 
   test("delivers on a 2xx with the current timestamp from now()", async () => {
@@ -744,53 +746,47 @@ describe("deliverChangeEvent", () => {
   });
 });
 
-// --- dispatchChangeEvent -----------------------------------------------------
-describe("dispatchChangeEvent", () => {
-  const event = buildChangeEvent({
-    changelog: { subnets: { added: [{ netuid: 7 }] } },
-  }) as Row;
-
-  test("fans out over many subscriptions, one result each", async () => {
-    const subs = Array.from({ length: 5 }, (_, i) => ({
-      id: `sub-${i}`,
-      url: "https://hooks.example.com/mg",
-      secret: "a-sixteen-char!!",
-    }));
-    const results = await dispatchChangeEvent({
-      subscriptions: subs,
-      event,
-      concurrency: 2,
-      fetchFn: async () => new Response("", { status: 200 }),
+// --- mapBounded ---------------------------------------------------------------
+// It USED to be tested only through `dispatchChangeEvent`, the fan-out that
+// wrapped it. That wrapper is gone (metagraphed-infra#354 -- the queue fans out
+// now), and deleting it would have taken this helper's whole test suite with it
+// while `workers/alerter-hub.ts` kept depending on it. So its guarantees are
+// asserted directly, by its own name.
+describe("mapBounded", () => {
+  test("never exceeds the concurrency it was given", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const results = await mapBounded([1, 2, 3, 4, 5, 6, 7], 3, async (n) => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      inFlight -= 1;
+      return n * 2;
     });
-    assert.equal(results.length, 5);
-    assert.ok(results.every((r) => r.status === "delivered"));
+    assert.equal(peak, 3, "the bound is the point");
+    assert.deepEqual(results, [2, 4, 6, 8, 10, 12, 14]);
   });
 
-  test("empty subscription list → empty results (no throw)", async () => {
-    const results = await dispatchChangeEvent({
-      subscriptions: [],
-      event,
-      fetchFn: async () => new Response("", { status: 200 }),
+  test("returns results in INPUT order, not completion order", async () => {
+    // The alerter's fan-out zips these back against its input list, so an
+    // order-of-completion result array would attribute every outcome to the
+    // wrong trigger. Slowest item first, so completion order is reversed.
+    const results = await mapBounded([30, 20, 10], 3, async (ms) => {
+      await new Promise((resolve) => setTimeout(resolve, ms));
+      return ms;
     });
-    assert.deepEqual(results, []);
+    assert.deepEqual(results, [30, 20, 10]);
   });
 
-  test("a bad endpoint cannot sink the batch", async () => {
-    const results = await dispatchChangeEvent({
-      subscriptions: [
-        {
-          id: "ok",
-          url: "https://hooks.example.com/mg",
-          secret: "a-sixteen-char!!",
-        },
-        { id: "bad", url: "http://example.com/x", secret: "a-sixteen-char!!" },
-      ],
-      event,
-      fetchFn: async () => new Response("", { status: 200 }),
-    });
-    assert.equal(results.length, 2);
-    const byId = Object.fromEntries(results.map((r) => [r.id, r.status]));
-    assert.equal(byId.ok, "delivered");
-    assert.equal(byId.bad, "skipped");
+  test("an empty or absent list is not an error", async () => {
+    for (const input of [[], null, undefined]) {
+      assert.deepEqual(await mapBounded(input, 4, async () => 1), []);
+    }
+  });
+
+  test("a concurrency below one still makes progress", async () => {
+    // Math.max(1, …) exists because a caller computing a bound from a count can
+    // reach zero, and zero workers would hang forever rather than fail.
+    assert.deepEqual(await mapBounded([1, 2], 0, async (n) => n), [1, 2]);
   });
 });

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -3,7 +3,6 @@ import { describe, test } from "vitest";
 import {
   buildChangeEvent,
   deliverChangeEvent,
-  dispatchChangeEvent,
   eventMatchesFilters,
   generateSecret,
   generateSubscriptionId,
@@ -399,44 +398,5 @@ describe("deliverChangeEvent", () => {
     assert.equal(res.status, "failed");
     assert.equal(res.attempts, 3);
     assert.equal(res.reason, "http-502");
-  });
-});
-
-describe("dispatchChangeEvent", () => {
-  test("returns one result per subscription and respects filters/safety", async () => {
-    const event = { change_kinds: ["subnets"], affected_netuids: [7, 9] };
-    const subs = [
-      {
-        id: "a",
-        url: "https://a.example.com/h",
-        secret: "secret-value-aaaaaa",
-        filters: { netuids: [7] },
-      },
-      {
-        id: "b",
-        url: "https://b.example.com/h",
-        secret: "secret-value-bbbbbb",
-        filters: { netuids: [100] },
-      },
-      {
-        id: "c",
-        url: "https://10.0.0.1/h",
-        secret: "secret-value-cccccc",
-        filters: {},
-      },
-    ];
-    const fetchFn = async () => new Response("", { status: 200 });
-    const results = await dispatchChangeEvent({
-      subscriptions: subs,
-      event,
-      fetchFn,
-      now: () => "t",
-      concurrency: 2,
-    });
-    const byId = Object.fromEntries(results.map((r) => [r.id, r.status]));
-    assert.equal(byId.a, "delivered");
-    assert.equal(byId.b, "filtered");
-    assert.equal(byId.c, "skipped");
-    assert.equal(results.length, 3);
   });
 });

--- a/workers/alerter-hub.ts
+++ b/workers/alerter-hub.ts
@@ -90,8 +90,10 @@ const ALERT_TRIGGER_REFRESH_TIMEOUT_MS = 4000;
 // the SAME trigger, not how many different triggers fire on one event) --
 // an unbounded Promise.all could open one outbound fetch per match,
 // exhausting this Durable Object invocation's concurrent-subrequest budget
-// under a large, broad-condition trigger set. Matches src/webhooks.ts's
-// own dispatchChangeEvent concurrency default.
+// under a large, broad-condition trigger set. The number came from
+// src/webhooks.ts's own fan-out default, which has since been deleted along
+// with that fan-out (metagraphed-infra#354) -- so this is now the only place it
+// is stated, rather than a copy of a live constant.
 const ALERT_DELIVERY_CONCURRENCY = 8;
 
 // AlerterHub.evaluate() is awaited by ChainFirehoseHub.broadcast() (see that


### PR DESCRIPTION
Closes metagraphed-infra#379. Clears the residue from metagraphed-infra#354, so that issue's remaining work is only the fairness question.

## Dead product code with live tests

`dispatchChangeEvent` — the bounded fan-out that delivered one event to many subscriptions — has **no caller in `src/`, `workers/` or `scripts/`**. The queue fans out now: `planWebhookFanOut` builds one message per matching subscription and the consumer delivers them.

It was still covered by two full `describe` blocks. Live tests over dead product code is worse than no tests: they make the file look exercised, and they keep passing while what they describe is unreachable.

## `mapBounded` stays, and now has a reason to be trusted

`workers/alerter-hub.ts` uses it for its own delivery fan-out, and it was exported for that purpose in #4984 rather than duplicated. But it was tested **only through `dispatchChangeEvent`** — so deleting the wrapper naively would have taken the helper's entire suite with it while a live caller kept depending on it.

It now has its own, asserting what the deleted tests only implied:

- **the concurrency bound** — measured by peak in-flight, not inferred
- **input-order results** — the alerter zips these back against its input list, so completion-order output would attribute every outcome to the wrong trigger. Slowest item first, so completion order is genuinely reversed
- **an empty or absent list**
- **a zero bound** — which is why the `Math.max(1, …)` is there, and had never been asserted. Zero workers would hang forever rather than fail

## Comments describing a system that no longer exists

Seven places narrated parking and the redelivery sweep as current behaviour: the delivery-record prefix ("a failed transient delivery is parked here, retried on later runs"), `deliveryStoragePrefix`, `isUnsafeWebhookDnsError`, the `urlStatus` block in `deliverChangeEvent`, `webhookIdempotencyKey`, `mapBounded` itself, and `workers/alerter-hub.ts`'s "matches src/webhooks.ts's own `dispatchChangeEvent` concurrency default" — a copy of a constant this PR deletes.

Each argued for the right behaviour, so none was harmful alone. Together they read as though #354 never happened, which is how the next reader concludes the parked-record path is still live. Each is rewritten to say the same thing about the mechanism that actually runs.

## No behaviour change

Nothing in `src/`, `workers/` or `scripts/` called the deleted function, and the surviving `mapBounded` is byte-identical.

## Validation

```
npm run typecheck    # clean
npm run lint         # clean
npx prettier --check # clean
npx vitest run tests/webhooks.test.ts tests/webhooks-core.test.ts \
  tests/webhooks-worker.test.ts tests/webhook-queue.test.ts tests/alerter-hub.test.ts
# 282 passed
```

Patch coverage by intersecting the diff with a v8 report over `src/webhooks.ts`: **0 uncovered statements, 0 uncovered branches**. `workers/alerter-hub.ts`'s four changed lines are comment-only.

## Template Used

- Backend/code change
