### PR TITLE
feat(neon): mirror the three flat ledgers, completing the write side

### DIFF
--- a/src/ledger-neon-write.ts
+++ b/src/ledger-neon-write.ts
@@ -1,0 +1,130 @@
+// The three flat ledgers' Neon mirror (metagraphed-infra#336).
+//
+// `account_balances`, `hotkey_alpha` and `validator_nominator_counts` share one
+// module because they share one shape: a natural key, a handful of value
+// columns, and a `captured_at`. No prune, no derived siblings, no second table
+// computed from the same body. They are the simplest tables left on the list,
+// and giving each its own file would be three copies of the same twelve lines.
+//
+// ## Each has TWO writers, and both mirror
+//
+// #9728 was ONE unmirrored writer -- the neuron-daily backfill route -- leaving
+// `account_position_daily` 92 rows short in Neon while the row count looked
+// nearly right. Every table here writes from an inline sync branch AND from the
+// sync-batches queue consumer, so both call this. A mirror covering one of two
+// is a lie the moment traffic takes the other.
+//
+// ## No prune, and that is a property of the data rather than an omission
+//
+// Unlike `nominator_positions`, none of these is a latest-only ledger whose
+// absent rows must be deleted. An account that stops holding TAO keeps a row
+// with a zero balance; a hotkey that leaves a subnet keeps its last reading
+// with an ageing `captured_at`. The readers over them already treat staleness
+// as the signal, so a delete would remove information rather than correct it.
+//
+// The out-of-order guard still applies to all three: these lanes retry, and a
+// retried chunk arriving after a newer pass must be a no-op rather than a
+// silent regression -- both writes would otherwise succeed.
+
+import {
+  neonDualWriteEnabled,
+  recordNeonWriteVerdict,
+  writeRowsToNeon,
+  type NeonWriteResult,
+} from "./neon-write.ts";
+import { ACCOUNT_BALANCE_INSERT_COLUMNS } from "./account-balances-d1-write.ts";
+import { HOTKEY_ALPHA_INSERT_COLUMNS } from "./hotkey-alpha-d1-write.ts";
+import { VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS } from "./validator-nominator-summary.ts";
+import {
+  createPgSql,
+  type HyperdriveLike,
+  type WaitUntilLike,
+} from "./pg-sql.ts";
+import type { LaneHealthDb } from "./lane-health.ts";
+
+interface LedgerPlan {
+  table: string;
+  columns: readonly string[];
+  conflict: readonly string[];
+}
+
+/**
+ * One plan per lane, keyed by the name used in NEON_DUAL_WRITE_LANES.
+ *
+ * The conflict keys match each table's PRIMARY KEY in Neon, created 2026-08-07
+ * from D1's own DDL. An ON CONFLICT naming columns with no unique index behind
+ * them is a runtime error, not a slower query.
+ */
+export const LEDGER_MIRROR_PLANS: Readonly<Record<string, LedgerPlan>> = {
+  "account-balances": {
+    table: "account_balances",
+    columns: ACCOUNT_BALANCE_INSERT_COLUMNS,
+    conflict: ["ss58"],
+  },
+  "hotkey-alpha": {
+    table: "hotkey_alpha",
+    columns: HOTKEY_ALPHA_INSERT_COLUMNS,
+    conflict: ["hotkey", "netuid"],
+  },
+  "validator-nominator-counts": {
+    table: "validator_nominator_counts",
+    columns: VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS,
+    conflict: ["hotkey"],
+  },
+};
+
+export interface LedgerMirrorDeps {
+  sql?: { unsafe(text: string, values?: unknown[]): Promise<unknown> } | null;
+  laneHealthDb?: LaneHealthDb | null;
+  now?: () => number;
+}
+
+/**
+ * Mirror one ledger batch into Neon. Never throws.
+ *
+ * While dual-writing, D1 is the store every route reads, so a Neon failure
+ * costs a mirror and a lane verdict and nothing a caller can see.
+ */
+export async function mirrorLedgerToNeon(
+  env: Record<string, unknown> | null | undefined,
+  ctx: WaitUntilLike | null | undefined,
+  lane: string,
+  rows: Record<string, unknown>[],
+  deps: LedgerMirrorDeps = {},
+): Promise<{ attempted: boolean; result?: NeonWriteResult }> {
+  const plan = LEDGER_MIRROR_PLANS[lane];
+  // An unknown lane is a NO-OP rather than a throw, and deliberately so: the
+  // flag is a free-text list, and a typo there must not take down the D1 write
+  // this runs behind.
+  if (!plan || !neonDualWriteEnabled(env, lane)) return { attempted: false };
+
+  const hyperdrive = env?.HYPERDRIVE as HyperdriveLike | undefined;
+  const sql =
+    deps.sql ??
+    (hyperdrive?.connectionString && ctx ? createPgSql(hyperdrive, ctx) : null);
+  const laneDb =
+    deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as LaneHealthDb | undefined);
+  const now = deps.now ?? Date.now;
+
+  if (!sql) {
+    // Enabled but unbound is a misconfiguration, not silence.
+    await recordNeonWriteVerdict(
+      laneDb,
+      lane,
+      { ok: false, rows: 0, statements: 0, reason: "hyperdrive unbound" },
+      now(),
+    );
+    return { attempted: true };
+  }
+
+  const result = await writeRowsToNeon(
+    sql,
+    plan.table,
+    plan.columns,
+    rows,
+    plan.conflict,
+    `${plan.table}.captured_at < EXCLUDED.captured_at`,
+  );
+  await recordNeonWriteVerdict(laneDb, lane, result, now());
+  return { attempted: true, result };
+}

--- a/tests/ledger-neon-write.test.ts
+++ b/tests/ledger-neon-write.test.ts
@@ -1,0 +1,208 @@
+// The three flat ledgers' Neon mirror (src/ledger-neon-write.ts, infra#336).
+//
+// These tables are the simple case -- a natural key, a few values, a
+// captured_at, no prune -- so the tests are about the things that stay
+// dangerous when the write itself is easy: the conflict key matching a real
+// primary key, the out-of-order guard, and a typo'd lane name costing nothing.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  LEDGER_MIRROR_PLANS,
+  mirrorLedgerToNeon,
+} from "../src/ledger-neon-write.ts";
+
+const NOW = 1_785_800_000_000;
+
+function fakeSql(fail = false) {
+  const calls: { text: string; values: unknown[] }[] = [];
+  return {
+    calls,
+    async unsafe(text: string, values: unknown[] = []) {
+      calls.push({ text, values });
+      if (fail) throw new Error("relation does not exist");
+      return [];
+    },
+  };
+}
+
+function laneSpy() {
+  const rows: Record<string, unknown>[] = [];
+  return {
+    rows,
+    db: {
+      prepare(sql: string) {
+        return {
+          bind(...values: unknown[]) {
+            return {
+              async run() {
+                if (sql.startsWith("INSERT")) {
+                  rows.push({
+                    lane: values[0],
+                    verdict: values[1],
+                    detail: values[3],
+                  });
+                }
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+const ctx = { waitUntil() {} };
+
+describe("LEDGER_MIRROR_PLANS", () => {
+  test("conflict keys match each table's PRIMARY KEY in Neon", () => {
+    // Created 2026-08-07 from D1's own DDL:
+    //   account_balances            PRIMARY KEY (ss58)
+    //   hotkey_alpha                PRIMARY KEY (hotkey, netuid)
+    //   validator_nominator_counts  PRIMARY KEY (hotkey)
+    assert.deepEqual(LEDGER_MIRROR_PLANS["account-balances"].conflict, [
+      "ss58",
+    ]);
+    assert.deepEqual(LEDGER_MIRROR_PLANS["hotkey-alpha"].conflict, [
+      "hotkey",
+      "netuid",
+    ]);
+    assert.deepEqual(
+      LEDGER_MIRROR_PLANS["validator-nominator-counts"].conflict,
+      ["hotkey"],
+    );
+  });
+
+  test("every plan's conflict columns are a subset of its own columns", () => {
+    // A conflict naming a column the INSERT does not carry is a runtime error
+    // that only shows up under real traffic.
+    for (const [lane, plan] of Object.entries(LEDGER_MIRROR_PLANS)) {
+      for (const key of plan.conflict) {
+        assert.ok(
+          plan.columns.includes(key),
+          `${lane}: ${key} is not in its own column list`,
+        );
+      }
+    }
+  });
+});
+
+describe("mirrorLedgerToNeon", () => {
+  const rows = [{ ss58: "5A", free_tao: 1, reserved_tao: 0, captured_at: 9 }];
+
+  test("upserts on the plan's key, guarded against an out-of-order retry", async () => {
+    const sql = fakeSql();
+    const spy = laneSpy();
+    const out = await mirrorLedgerToNeon(
+      { NEON_DUAL_WRITE_LANES: "account-balances" },
+      ctx,
+      "account-balances",
+      rows,
+      { sql, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.equal(out.result?.ok, true);
+    assert.match(sql.calls[0].text, /INSERT INTO account_balances/);
+    assert.match(sql.calls[0].text, /ON CONFLICT \(ss58\) DO UPDATE/);
+    assert.match(
+      sql.calls[0].text,
+      /WHERE account_balances\.captured_at < EXCLUDED\.captured_at/,
+    );
+    assert.deepEqual(spy.rows, [
+      {
+        lane: "neon:account-balances",
+        verdict: "ok",
+        detail: "1 row(s) in 1 statement(s)",
+      },
+    ]);
+  });
+
+  test("a lane the flag does not name writes nothing", async () => {
+    const sql = fakeSql();
+    assert.deepEqual(
+      await mirrorLedgerToNeon(
+        { NEON_DUAL_WRITE_LANES: "hotkey-alpha" },
+        ctx,
+        "account-balances",
+        rows,
+        { sql },
+      ),
+      { attempted: false },
+    );
+    assert.equal(sql.calls.length, 0);
+  });
+
+  test("an UNKNOWN lane is a no-op, not a throw", async () => {
+    // The flag is a free-text list. A typo must not take down the D1 write this
+    // runs behind.
+    const sql = fakeSql();
+    assert.deepEqual(
+      await mirrorLedgerToNeon(
+        { NEON_DUAL_WRITE_LANES: "acount-balances" },
+        ctx,
+        "acount-balances",
+        rows,
+        { sql },
+      ),
+      { attempted: false },
+    );
+    assert.equal(sql.calls.length, 0);
+  });
+
+  test("a failing write is reported, never thrown", async () => {
+    const spy = laneSpy();
+    const out = await mirrorLedgerToNeon(
+      { NEON_DUAL_WRITE_LANES: "hotkey-alpha" },
+      ctx,
+      "hotkey-alpha",
+      [{ hotkey: "5H", netuid: 1, total_alpha: 2, captured_at: 9 }],
+      { sql: fakeSql(true), laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.equal(out.result?.ok, false);
+    assert.equal(spy.rows[0].verdict, "stale");
+  });
+
+  test("enabled with no binding records the misconfiguration", async () => {
+    const spy = laneSpy();
+    const out = await mirrorLedgerToNeon(
+      { NEON_DUAL_WRITE_LANES: "validator-nominator-counts" },
+      ctx,
+      "validator-nominator-counts",
+      [{ hotkey: "5H", nominator_count: 3, captured_at: 9 }],
+      { sql: null, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.deepEqual(out, { attempted: true });
+    assert.equal(spy.rows[0].lane, "neon:validator-nominator-counts");
+    assert.match(String(spy.rows[0].detail), /hyperdrive unbound/);
+  });
+
+  test("builds its own runner from the binding, and reports a dead origin", async () => {
+    const spy = laneSpy();
+    const out = await mirrorLedgerToNeon(
+      {
+        NEON_DUAL_WRITE_LANES: "account-balances",
+        HYPERDRIVE: { connectionString: "postgresql://u:p@127.0.0.1:1/none" },
+        METAGRAPH_HEALTH_DB: spy.db,
+      },
+      ctx,
+      "account-balances",
+      rows,
+    );
+    assert.equal(out.attempted, true);
+    assert.equal(out.result?.ok, false);
+  });
+
+  test("a bound Hyperdrive with no ctx declines rather than leaking", async () => {
+    const spy = laneSpy();
+    const out = await mirrorLedgerToNeon(
+      {
+        NEON_DUAL_WRITE_LANES: "account-balances",
+        HYPERDRIVE: { connectionString: "postgres://x" },
+      },
+      null,
+      "account-balances",
+      rows,
+      { laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.deepEqual(out, { attempted: true });
+    assert.match(String(spy.rows[0].detail), /hyperdrive unbound/);
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -371,6 +371,7 @@ import {
 } from "../src/neurons-d1-write.ts";
 import { mirrorNeuronSnapshotToNeon } from "../src/neurons-neon-write.ts";
 import { mirrorNominatorPositionsToNeon } from "../src/nominator-positions-neon-write.ts";
+import { mirrorLedgerToNeon } from "../src/ledger-neon-write.ts";
 import { neonReadEnabled } from "../src/neon-write.ts";
 import {
   writeAccountIdentityToD1,
@@ -1701,7 +1702,11 @@ function coerceNominatorCountSyncRow(row: Row) {
   return out;
 }
 
-async function handleValidatorNominatorCountsSync(request: Request, env: Env) {
+async function handleValidatorNominatorCountsSync(
+  request: Request,
+  env: Env,
+  ctx?: ExecutionContext,
+) {
   if (!env.VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET) {
     return writeJson(
       {
@@ -1822,6 +1827,16 @@ async function handleValidatorNominatorCountsSync(request: Request, env: Env) {
     await captureDataApiError(err, "validator-nominator-counts-sync-d1", env);
     return writeJson({ error: "d1 write failed" }, 502);
   }
+
+  // ONE OF THIS LANE'S TWO WRITERS. The sync-batches queue consumer is the
+  // other and mirrors too -- #9728 was a single unmirrored writer leaving a
+  // table short while the row count looked nearly right.
+  await mirrorLedgerToNeon(
+    env as unknown as Record<string, unknown>,
+    ctx,
+    "validator-nominator-counts",
+    rows,
+  );
 
   return writeJson({
     ok: true,
@@ -2106,7 +2121,11 @@ function coerceAccountBalanceSyncRow(row: Row) {
   return out;
 }
 
-async function handleAccountBalancesSync(request: Request, env: Env) {
+async function handleAccountBalancesSync(
+  request: Request,
+  env: Env,
+  ctx?: ExecutionContext,
+) {
   if (!env.ACCOUNT_BALANCES_SYNC_SECRET) {
     return writeJson(
       { error: "account-balances sync is not provisioned on this deployment" },
@@ -2277,6 +2296,16 @@ async function handleAccountBalancesSync(request: Request, env: Env) {
     return writeJson({ error: "d1 write failed" }, 502);
   }
 
+  // ONE OF THIS LANE'S TWO WRITERS. The sync-batches queue consumer is the
+  // other and mirrors too -- #9728 was a single unmirrored writer leaving a
+  // table short while the row count looked nearly right.
+  await mirrorLedgerToNeon(
+    env as unknown as Record<string, unknown>,
+    ctx,
+    "account-balances",
+    rows,
+  );
+
   return writeJson({
     ok: true,
     account_balances_written: rows.length,
@@ -2353,7 +2382,11 @@ function coerceHotkeyAlphaSyncRow(row: Row) {
   return out;
 }
 
-async function handleHotkeyAlphaSync(request: Request, env: Env) {
+async function handleHotkeyAlphaSync(
+  request: Request,
+  env: Env,
+  ctx?: ExecutionContext,
+) {
   if (!env.HOTKEY_ALPHA_SYNC_SECRET) {
     return writeJson(
       { error: "hotkey-alpha sync is not provisioned on this deployment" },
@@ -2525,6 +2558,16 @@ async function handleHotkeyAlphaSync(request: Request, env: Env) {
     await captureDataApiError(err, "hotkey-alpha-sync-d1", env);
     return writeJson({ error: "d1 write failed" }, 502);
   }
+
+  // ONE OF THIS LANE'S TWO WRITERS. The sync-batches queue consumer is the
+  // other and mirrors too -- #9728 was a single unmirrored writer leaving a
+  // table short while the row count looked nearly right.
+  await mirrorLedgerToNeon(
+    env as unknown as Record<string, unknown>,
+    ctx,
+    "hotkey-alpha",
+    rows,
+  );
 
   return writeJson({
     ok: true,
@@ -6785,7 +6828,7 @@ async function dispatchDataApiRequest(
       request.method === "POST" &&
       url.pathname === "/api/v1/internal/validator-nominator-counts-sync"
     ) {
-      return handleValidatorNominatorCountsSync(request, env);
+      return handleValidatorNominatorCountsSync(request, env, ctx);
     }
     if (
       request.method === "POST" &&
@@ -6797,13 +6840,13 @@ async function dispatchDataApiRequest(
       request.method === "POST" &&
       url.pathname === "/api/v1/internal/account-balances-sync"
     ) {
-      return handleAccountBalancesSync(request, env);
+      return handleAccountBalancesSync(request, env, ctx);
     }
     if (
       request.method === "POST" &&
       url.pathname === "/api/v1/internal/hotkey-alpha-sync"
     ) {
-      return handleHotkeyAlphaSync(request, env);
+      return handleHotkeyAlphaSync(request, env, ctx);
     }
     if (
       request.method === "POST" &&
@@ -7411,15 +7454,24 @@ export default {
       : {};
     const writers: SyncBatchWriters = env.METAGRAPH_HEALTH_DB
       ? {
-          "hotkey-alpha": (rows, pass) =>
-            writeHotkeyAlphaToD1(
+          "hotkey-alpha": async (rows, pass) => {
+            const result = await writeHotkeyAlphaToD1(
               env.METAGRAPH_HEALTH_DB as unknown as Parameters<
                 typeof writeHotkeyAlphaToD1
               >[0],
               rows,
               pass,
-            ),
-          // Recomputes the prune map from THIS message's rows, which is sound
+            );
+            // THE LANE'S OTHER WRITER, mirrored here as well as on the
+            // HTTP path.
+            await mirrorLedgerToNeon(
+              env as unknown as Record<string, unknown>,
+              ctx,
+              "hotkey-alpha",
+              rows,
+            );
+            return result;
+          }, // Recomputes the prune map from THIS message's rows, which is sound
           // only because the message asserted `key_complete` -- the
           // validator rejects it otherwise, so this writer never sees a chunk
           // that could prune rows it did not carry.
@@ -7441,15 +7493,24 @@ export default {
             );
             return result;
           },
-          "account-balances": (rows, pass) =>
-            writeAccountBalancesToD1(
+          "account-balances": async (rows, pass) => {
+            const result = await writeAccountBalancesToD1(
               env.METAGRAPH_HEALTH_DB as unknown as Parameters<
                 typeof writeAccountBalancesToD1
               >[0],
               rows,
               pass,
-            ),
-          // Redoes both derivations from THIS message's rows, which is sound
+            );
+            // THE LANE'S OTHER WRITER, mirrored here as well as on the
+            // HTTP path.
+            await mirrorLedgerToNeon(
+              env as unknown as Record<string, unknown>,
+              ctx,
+              "account-balances",
+              rows,
+            );
+            return result;
+          }, // Redoes both derivations from THIS message's rows, which is sound
           // only because the message asserted `key_complete` -- the validator
           // rejects a neurons message without it, so this writer never sees a
           // chunk whose prune map would delete rows it did not carry.
@@ -7460,13 +7521,23 @@ export default {
               >[0],
               neuronSnapshotWrite(rows, Date.now()),
             ),
-          "validator-nominator-counts": (rows) =>
-            writeValidatorNominatorCountsToD1(
+          "validator-nominator-counts": async (rows) => {
+            const result = await writeValidatorNominatorCountsToD1(
               env.METAGRAPH_HEALTH_DB as unknown as Parameters<
                 typeof writeValidatorNominatorCountsToD1
               >[0],
               rows,
-            ),
+            );
+            // THE LANE'S OTHER WRITER, mirrored here as well as on the
+            // HTTP path.
+            await mirrorLedgerToNeon(
+              env as unknown as Record<string, unknown>,
+              ctx,
+              "validator-nominator-counts",
+              rows,
+            );
+            return result;
+          },
         }
       : {};
     for (const message of batch.messages) {

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -124,7 +124,7 @@
     // same PRIMARY KEY (netuid, uid, snapshot_date) the mirror's ON CONFLICT
     // names. An ON CONFLICT with no unique index behind it is a runtime error,
     // not a slower query.
-    "NEON_DUAL_WRITE_LANES": "neurons,nominator-positions",
+    "NEON_DUAL_WRITE_LANES": "neurons,nominator-positions,account-balances,hotkey-alpha,validator-nominator-counts",
     "NEON_READ_LANES": "",
     "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",


### PR DESCRIPTION
Closes #9738. The last tables on metagraphed-infra#336's move list — and with them, **every table on that list now dual-writes.**

## One module, because they are one shape

A natural key, a handful of value columns, a `captured_at`. No prune, no derived siblings, no second table computed from the same body.

| lane | table | PRIMARY KEY |
| --- | --- | --- |
| `account-balances` | `account_balances` | `(ss58)` |
| `hotkey-alpha` | `hotkey_alpha` | `(hotkey, netuid)` |
| `validator-nominator-counts` | `validator_nominator_counts` | `(hotkey)` |

Conflict keys are checked against each table's **real** primary key, by a test that also asserts every conflict column appears in that plan's own column list — a conflict naming a column the `INSERT` does not carry is a runtime error that only shows up under real traffic.

## Each has two writers, and both mirror

#9728's lesson applied for the third time: every one of these writes from an inline sync branch **and** from the `sync-batches` queue consumer. **Six call sites for three tables.**

## No prune, and that is a property of the data

Unlike `nominator_positions`, none of these is a latest-only ledger whose absent rows must be deleted. An account that stops holding TAO keeps a row with a zero balance; a hotkey that leaves a subnet keeps its last reading with an ageing `captured_at`. The readers already treat staleness as the signal, so a delete would *remove* information rather than correct it.

The out-of-order guard still applies — these lanes retry, and a retried chunk arriving after a newer pass must be a no-op rather than a silent regression, since both writes would otherwise succeed.

## An unknown lane is a no-op, not a throw

`NEON_DUAL_WRITE_LANES` is a free-text list. A typo must not take down the D1 write the mirror runs behind.

## Verification

- **100% statements, branches, functions, lines** on the new module
- full suite: **712 files, 17,255 tests**, green
- **reads stay on D1** — `NEON_READ_LANES` untouched