### PR TITLE
feat(webhooks): give one subscriber one slot, so a hanging endpoint stops nine

### DIFF
--- a/src/webhook-queue.ts
+++ b/src/webhook-queue.ts
@@ -214,6 +214,82 @@ export function webhookDeliveryDisposition(
   return attempts >= maxAttempts ? "dead" : "retry";
 }
 
+/**
+ * How many subscribers the consumer delivers to at once.
+ *
+ * SIX, because that is Cloudflare's documented ceiling on connections
+ * *simultaneously waiting for response headers* per Worker invocation — and a
+ * hanging subscriber is precisely a connection waiting for headers, for the
+ * whole 8-second timeout. A seventh is queued rather than rejected, so a larger
+ * number would not error; it would just stop being the bound it claims to be.
+ */
+export const WEBHOOK_DELIVERY_CONCURRENCY = 6;
+
+/**
+ * How many HTTP attempts one QUEUE attempt is allowed.
+ *
+ * ONE. `deliverChangeEvent` defaults to three, with its own 500ms/1s backoff,
+ * and the consumer used to accept that default — so a single message could cost
+ * **8 queue attempts x 3 HTTP attempts = 24 POSTs** and hold a delivery slot for
+ * ~25 seconds. That is a second retry scheduler running inside the one
+ * metagraphed-infra#354 replaced, and it made two things untrue at once: the
+ * published promise of eight rounds, and the `attempts` the delivery record
+ * reports.
+ *
+ * THE COST IS LATENCY ON A BLIP, and it is the right trade. A momentary 5xx
+ * used to be retried 500ms later; it now waits for the queue's first backoff,
+ * five minutes. For a change feed that fires at most twice an hour, against a
+ * contract that promises at-least-once within twelve hours, five minutes is
+ * not a degradation — and in exchange one bad subscriber can no longer occupy a
+ * slot for 25 seconds while nine healthy ones wait.
+ */
+export const WEBHOOK_DELIVERY_HTTP_ATTEMPTS = 1;
+
+/**
+ * Split a batch so that one subscriber can never occupy more than one slot.
+ *
+ * THE FAIRNESS PRIMITIVE metagraphed-infra#354 asked for, and the argument for
+ * why the old one could go was only half right. `WEBHOOK_REDELIVERY_MAX_PER_SUBSCRIPTION`
+ * rationed a shared per-run sweep budget, and that budget genuinely does not
+ * exist any more. But the consumer then processed its batch **serially**, so a
+ * subscriber that hung took the other nine messages in that batch down with it
+ * — the starvation the cap existed to prevent, reintroduced by the loop rather
+ * than by the budget.
+ *
+ * So: groups run in parallel up to `WEBHOOK_DELIVERY_CONCURRENCY`, and each
+ * group runs serially. Two facts follow, and both are the point:
+ *
+ *   * **one subscriber = one slot.** Two messages for the same subscription
+ *     share a group, so a subscriber with a backlog cannot crowd out the rest
+ *     of the batch by having more of it.
+ *   * **per-subscriber order is preserved.** Deliveries to one endpoint stay in
+ *     the order they were enqueued, which parallelising the flat list would
+ *     have quietly given up.
+ *
+ * A message with no readable `subscription_id` gets its own group: it is acked
+ * without delivering anything, so grouping it with an unrelated subscriber
+ * would only make that subscriber wait.
+ */
+export function groupWebhookBatchBySubscription<T extends { body: unknown }>(
+  messages: readonly T[],
+): T[][] {
+  const groups = new Map<string, T[]>();
+  const ungrouped: T[][] = [];
+  for (const message of messages) {
+    const body = message?.body as { subscription_id?: unknown } | null;
+    const id = body?.subscription_id;
+    if (typeof id !== "string" || !id) {
+      ungrouped.push([message]);
+      continue;
+    }
+    const group = groups.get(id);
+    if (group) group.push(message);
+    else groups.set(id, [message]);
+  }
+  // Insertion order, so the batch's own ordering survives the grouping.
+  return [...groups.values(), ...ungrouped];
+}
+
 /** Where the last dispatched event id is remembered, so a cron that runs far
  * more often than a publish does not re-fan an event subscribers already got. */
 export const WEBHOOK_LAST_DISPATCHED_KEY = "webhooks:last-dispatched";

--- a/tests/webhook-queue.test.ts
+++ b/tests/webhook-queue.test.ts
@@ -14,6 +14,9 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   classifyWebhookBatch,
+  groupWebhookBatchBySubscription,
+  WEBHOOK_DELIVERY_CONCURRENCY,
+  WEBHOOK_DELIVERY_HTTP_ATTEMPTS,
   planWebhookFanOut,
   shouldDispatchChangeEvent,
   validWebhookDeliveryMessage,
@@ -284,5 +287,77 @@ describe("shouldDispatchChangeEvent", () => {
 
   test("an absent event id is never dispatched", () => {
     assert.equal(shouldDispatchChangeEvent(withChanges, "", null), false);
+  });
+});
+
+describe("groupWebhookBatchBySubscription (metagraphed-infra#354 fairness)", () => {
+  const m = (subscription_id: unknown, event_id = "e") => ({
+    body: { subscription_id, event_id, body: "{}" },
+  });
+
+  test("one subscriber's messages share ONE group, so it gets one slot", () => {
+    // The whole point. The consumer runs groups in parallel and each group
+    // serially, so a subscriber with four messages in a batch occupies one
+    // delivery slot rather than four -- which is the starvation the deleted
+    // per-subscription cap existed to prevent.
+    const groups = groupWebhookBatchBySubscription([
+      m("sub_a"),
+      m("sub_b"),
+      m("sub_a"),
+      m("sub_a"),
+    ]);
+    assert.equal(groups.length, 2);
+    assert.deepEqual(
+      groups.map((g) => g.length),
+      [3, 1],
+    );
+  });
+
+  test("preserves order within a subscriber and across the batch", () => {
+    // Per-subscriber order matters because a group runs serially -- deliveries
+    // to one endpoint keep the order they were enqueued in, which parallelising
+    // the flat list would have quietly given up.
+    const groups = groupWebhookBatchBySubscription([
+      m("sub_a", "e1"),
+      m("sub_b", "e2"),
+      m("sub_a", "e3"),
+    ]);
+    assert.deepEqual(
+      groups.map((g) => g.map((x) => x.body.event_id)),
+      [["e1", "e3"], ["e2"]],
+    );
+  });
+
+  test("a message with no readable subscription id gets its own group", () => {
+    // It is acked without delivering anything, so grouping it with a real
+    // subscriber would only make that subscriber wait behind a no-op.
+    const groups = groupWebhookBatchBySubscription([
+      m(undefined),
+      m("sub_a"),
+      m(""),
+      m(7),
+      { body: null },
+    ]);
+    assert.equal(groups.length, 5);
+    assert.equal(
+      groups.every((g) => g.length === 1),
+      true,
+    );
+  });
+
+  test("an empty batch is not an error", () => {
+    assert.deepEqual(groupWebhookBatchBySubscription([]), []);
+  });
+
+  test("the concurrency bound is the platform's, not a guess", () => {
+    // Six is Cloudflare's documented ceiling on connections SIMULTANEOUSLY
+    // WAITING FOR RESPONSE HEADERS per invocation, and a hanging subscriber is
+    // exactly that for its whole timeout. A seventh is queued rather than
+    // rejected, so a larger number would not error -- it would just stop being
+    // the bound it claims to be.
+    assert.equal(WEBHOOK_DELIVERY_CONCURRENCY, 6);
+    // And one HTTP attempt per queue attempt, so the eight rounds subscribers
+    // were promised are eight POSTs and not twenty-four.
+    assert.equal(WEBHOOK_DELIVERY_HTTP_ATTEMPTS, 1);
   });
 });

--- a/tests/webhooks-worker.test.ts
+++ b/tests/webhooks-worker.test.ts
@@ -1395,6 +1395,119 @@ describe("what the consumer writes is what the status surface reads", () => {
   });
 });
 
+describe("one subscriber cannot starve the batch (metagraphed-infra#354)", () => {
+  // THE BAR THIS CLOSES. #354 said the per-subscription fairness cap "is not a
+  // queue primitive -- one noisy subscriber must not starve the rest" and to
+  // establish how it is preserved BEFORE deleting it. It was deleted with an
+  // argument: the cap rationed a shared per-run sweep budget that no longer
+  // exists. That half was right. But the consumer then processed its batch in a
+  // serial `for` loop, so a subscriber that hung took the other nine messages
+  // with it -- the same starvation, reintroduced by the loop.
+  async function run(
+    kv: ReturnType<typeof makeKv>,
+    bodies: unknown[],
+    deliver: unknown,
+  ) {
+    const { handleWebhookQueue } = await import("../workers/api.ts");
+    const acts: string[] = [];
+    await handleWebhookQueue(
+      {
+        messages: bodies.map((body) => ({
+          body,
+          attempts: 1,
+          ack: () => acts.push("ack"),
+          retry: () => acts.push("retry"),
+        })),
+      } as never,
+      envWith(kv) as unknown as Env,
+      { waitUntil: (p: Promise<unknown>) => void p } as never,
+      deliver as never,
+    );
+    return acts;
+  }
+
+  const msg = (id: string, event = "e1") => ({
+    subscription_id: id,
+    event_id: event,
+    body: JSON.stringify({ type: "metagraph.publish" }),
+  });
+
+  test("a hanging subscriber does not hold up the others", async () => {
+    const kv = makeKv();
+    const slow = await seedSubscription(kv, "https://hooks.example.com/slow");
+    const fast = await seedSubscription(kv, "https://hooks.example.com/fast");
+    const finished: string[] = [];
+    let releaseSlow: () => void = () => {};
+    const slowHangs = new Promise<void>((resolve) => {
+      releaseSlow = resolve;
+    });
+
+    const run1 = run(
+      kv,
+      [msg(slow.id), msg(fast.id)],
+      async ({ subscription }: { subscription: Row }) => {
+        if (subscription.id === slow.id) await slowHangs;
+        finished.push(subscription.id as string);
+        return { status: "delivered", status_code: 200 };
+      },
+    );
+
+    // Let the microtask queue drain. Under the old serial loop the fast
+    // subscriber could not even START until the slow one returned.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    assert.deepEqual(
+      finished,
+      [fast.id],
+      "the healthy subscriber delivered while the other was still hanging",
+    );
+
+    releaseSlow();
+    await run1;
+    assert.deepEqual(finished.sort(), [fast.id, slow.id].sort());
+  });
+
+  test("one subscriber's messages stay serial, and in order", async () => {
+    // The other half of the primitive. A subscriber with a backlog occupies ONE
+    // slot rather than several, and its deliveries keep the order they were
+    // enqueued in -- parallelising the flat batch would have given that up.
+    const kv = makeKv();
+    const sub = await seedSubscription(kv, "https://hooks.example.com/a");
+    let inFlight = 0;
+    let peak = 0;
+    const order: string[] = [];
+
+    await run(
+      kv,
+      [msg(sub.id, "e1"), msg(sub.id, "e2"), msg(sub.id, "e3")],
+      async ({ event }: { event: Row }) => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        inFlight -= 1;
+        order.push(event.seq as string);
+        return { status: "delivered", status_code: 200 };
+      },
+    );
+
+    assert.equal(peak, 1, "one subscriber, one slot");
+    assert.equal(order.length, 3);
+  });
+
+  test("delivers with ONE http attempt, not the three deliverChangeEvent defaults to", async () => {
+    // Eight queue attempts x three HTTP attempts was 24 POSTs for one message,
+    // and a slot held for ~25 seconds. It also made the published promise of
+    // eight rounds and the delivery record's `attempts` both untrue.
+    const kv = makeKv();
+    const sub = await seedSubscription(kv, "https://hooks.example.com/a");
+    let seen: number | undefined;
+    await run(kv, [msg(sub.id)], async ({ maxAttempts }: Row) => {
+      seen = maxAttempts as number;
+      return { status: "delivered", status_code: 200 };
+    });
+    assert.equal(seen, 1);
+  });
+});
+
 describe("the webhook cron trigger (metagraphed-infra#354)", () => {
   // Delivery used to be a step inside the publish workflow, downstream of every
   // other step -- so when the live-API smoke check broke on 2026-08-02,

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -300,6 +300,7 @@ import {
   WEBHOOK_KV_PREFIX,
   resolveWebhookHostnamesWithDoh,
   generateSecret,
+  mapBounded,
   generateSubscriptionId,
   isValidSubscriptionId,
   publicSubscriptionView,
@@ -316,8 +317,11 @@ import {
 } from "../src/webhooks.ts";
 import {
   classifyWebhookBatch,
+  groupWebhookBatchBySubscription,
   planWebhookFanOut,
   shouldDispatchChangeEvent,
+  WEBHOOK_DELIVERY_CONCURRENCY,
+  WEBHOOK_DELIVERY_HTTP_ATTEMPTS,
   WEBHOOK_LAST_DISPATCHED_KEY,
   webhookDeliveryDisposition,
   webhookRetryDelaySeconds,
@@ -1854,12 +1858,29 @@ export async function handleWebhookQueue(
   deliver: typeof deliverChangeEvent = deliverChangeEvent,
 ): Promise<void> {
   const { valid, invalid } = classifyWebhookBatch(batch.messages);
+  const groups = groupWebhookBatchBySubscription(batch.messages);
   console.log(
     `webhook-deliveries: ${batch.messages.length} message(s), ` +
-      `${valid.length} valid, ${invalid} unparseable`,
+      `${valid.length} valid, ${invalid} unparseable, ` +
+      `${groups.length} subscriber group(s)`,
   );
 
-  for (const message of batch.messages) {
+  // ONE SLOT PER SUBSCRIBER, up to six at a time (metagraphed-infra#354). The
+  // batch used to be processed by a serial `for` loop, so one subscriber that
+  // hung took the other nine messages down with it -- the starvation the
+  // deleted per-subscription cap existed to prevent, reintroduced by the loop
+  // rather than by the budget it rationed.
+  //
+  // Groups run in parallel, and each group runs SERIALLY: a subscriber with a
+  // backlog cannot crowd out the batch by having more of it, and deliveries to
+  // one endpoint keep the order they were enqueued in.
+  await mapBounded(groups, WEBHOOK_DELIVERY_CONCURRENCY, async (group) => {
+    for (const message of group) await deliverOne(message);
+  });
+
+  async function deliverOne(
+    message: (typeof batch.messages)[number],
+  ): Promise<void> {
     const body = message.body as {
       subscription_id?: unknown;
       event_id?: unknown;
@@ -1878,7 +1899,7 @@ export async function handleWebhookQueue(
       typeof body.body !== "string"
     ) {
       message.ack();
-      continue;
+      return;
     }
 
     const subscription = (await env.METAGRAPH_CONTROL?.get(
@@ -1889,7 +1910,7 @@ export async function handleWebhookQueue(
     // takes effect on a delivery already in flight.
     if (!subscription) {
       message.ack();
-      continue;
+      return;
     }
 
     // PARSED BEFORE THE TRY, and a failure here ACKS. A body that is not JSON
@@ -1901,7 +1922,7 @@ export async function handleWebhookQueue(
       event = JSON.parse(body.body) as Record<string, unknown>;
     } catch {
       message.ack();
-      continue;
+      return;
     }
 
     let result: Record<string, unknown>;
@@ -1912,6 +1933,13 @@ export async function handleWebhookQueue(
         bodyText: body.body,
         fetchFn: fetch,
         now: () => new Date().toISOString(),
+        // ONE HTTP ATTEMPT PER QUEUE ATTEMPT. deliverChangeEvent defaults to
+        // three with its own backoff, and accepting that default meant one
+        // message could cost 24 POSTs and hold a slot for ~25 seconds -- a
+        // second retry scheduler inside the one the queue replaced, which made
+        // both the published eight-round promise and the delivery record's
+        // `attempts` untrue.
+        maxAttempts: WEBHOOK_DELIVERY_HTTP_ATTEMPTS,
         // Delivery-time DNS re-resolution is the SSRF guard, not an
         // optimisation: a hostname that resolved public at subscribe time can
         // point at a private address by the time a 12-hour-old retry fires.


### PR DESCRIPTION
Closes metagraphed-infra#380. This is the last unmet bar on metagraphed-infra#354.

That issue was explicit:

> **Care needed.** The per-subscription fairness cap is not a queue primitive — one noisy subscriber must not starve the rest. Establish how that is preserved BEFORE deleting it.

It was deleted with an argument rather than a replacement: `WEBHOOK_REDELIVERY_MAX_PER_SUBSCRIPTION` rationed a **shared per-run sweep budget**, and a queue has no such resource. **That half is right** and stays right.

## The half that was not

**The consumer processed its batch in a serial `for` loop** — up to 10 messages, at `max_concurrency: 4`, with messages for different subscriptions sharing a batch. One subscriber that hung blocked the other nine. The same starvation the cap existed to prevent, arriving through the loop instead of through the budget.

`max_concurrency: 4` does not help: it is what a slow subscriber *occupies*, not what protects against one.

## The fix, and why it is two properties rather than one

Messages are grouped by subscription; **groups run in parallel, each group runs serially.**

- **one subscriber = one slot** — a subscriber with four messages in a batch occupies one delivery slot, not four
- **per-subscriber order survives** — a naive `Promise.all` over the flat batch would have fixed the starvation and silently given this up

## Six is the platform's number, not a guess

Cloudflare documents six connections **simultaneously waiting for response headers** per Worker invocation, and a hanging subscriber is exactly that for its whole 8-second timeout. A seventh is *queued* rather than rejected — so a larger bound would not error, it would just stop being a bound.

## The second retry scheduler is gone too

`deliverChangeEvent` defaults to `maxAttempts: 3` with its own 500ms/1s backoff, and the consumer accepted that default. So one message could cost **8 queue attempts × 3 HTTP attempts = 24 POSTs** and hold a slot for ~25 seconds — a retry scheduler running inside the one #354 replaced, making two things untrue at once: the **eight rounds** subscribers were promised, and the `attempts` the delivery record reports.

One queue attempt is now one POST.

**The trade is latency on a blip**, and it is stated rather than hidden: a momentary 5xx used to be retried 500ms later and now waits five minutes for the queue's first backoff. Against a contract promising at-least-once within twelve hours, on a feed that fires at most twice an hour, that is not a degradation — and in exchange one bad subscriber can no longer hold a slot for 25 seconds while nine healthy ones wait.

Visible in the suite itself: `tests/webhooks-worker.test.ts` went from **1544 ms to 39 ms**, because the one test that waited on a real inner backoff no longer has one to wait for.

## Tests

Verified against the old shape — restoring the serial loop and dropping `maxAttempts` fails:

```
× a hanging subscriber does not hold up the others
    AssertionError: the healthy subscriber delivered while the other was still hanging
× delivers with ONE http attempt, not the three deliverChangeEvent defaults to
```

`one subscriber's messages stay serial, and in order` **passes on both** — deliberately. It is a preservation test, not a regression test: it guards the property a naive parallel fix would break, so it is expected to be green before and after.

## Validation

```
npm run typecheck    # clean
npm run lint         # clean
npx prettier --check # clean
npx vitest run tests/webhooks-worker.test.ts tests/webhook-queue.test.ts tests/webhooks.test.ts \
  tests/webhooks-core.test.ts tests/dead-letter.test.ts tests/alerter-hub.test.ts
# 302 passed
```

Patch coverage by intersecting the diff with a v8 report over both changed files: **0 uncovered statements, 0 uncovered branches, 0 uncovered functions** (109 changed lines).

## Template Used

- Backend/code change
