### PR TITLE
feat(search): route the embedding through AI Gateway, and turn it on

### DIFF
--- a/scripts/private-boundary-patterns.ts
+++ b/scripts/private-boundary-patterns.ts
@@ -26,6 +26,18 @@ export const contentPatterns: { name: string; regex: RegExp }[] = [
       /\b(?:private prompt|private rubric|private score|private threshold|corpus weight|accepted rejected example|accepted\/rejected example)\b/i,
   },
   {
+    // WHAT THIS PROTECTS, stated because a later reader will otherwise read it
+    // as "no AI plumbing may be named in public" and either widen it wrongly or
+    // work around it. It guards the PRIVATE SUBMISSION GATE's provider routing:
+    // which gateway and which model the private reviewer runs through.
+    //
+    // It does NOT cover this repo's own public AI layer, whose model ids are
+    // already published in src/ai-search.ts and wrangler.jsonc on purpose
+    // (`@cf/qwen/qwen3-embedding-0.6b`, `@cf/meta/llama-4-scout-17b-16e-instruct`)
+    // and whose binding is `AI`. metagraphed-infra#362 added
+    // `METAGRAPH_AI_GATEWAY` for that public path; the namespace prefix means
+    // the word-boundary here does not match it, and the test file asserts BOTH
+    // directions so that stays a decision rather than a coincidence.
     name: "provider-specific private model route",
     regex: /\b(?:AI_GATEWAY|WORKERS_AI|@cf\/openai\/|gpt-oss-)\b/i,
   },

--- a/src/ai-search.ts
+++ b/src/ai-search.ts
@@ -33,6 +33,49 @@ export const ASK_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
 // https://developers.cloudflare.com/workers-ai/models/llama-4-scout-17b-16e-instruct/
 // (checked 2026-07-24) -- update alongside ASK_MODEL if the model ever changes.
 const ASK_PROVIDER = "cloudflare_workers_ai";
+
+/**
+ * How long a gatewayed embedding stays cached, in seconds.
+ *
+ * ONE HOUR, and it is a cache of the MODEL CALL, not of the search result. The
+ * same query string always produces the same vector from a fixed model, so this
+ * cannot go stale in the way a response cache can: what changes between two
+ * searches for "speech to text" is the Vectorize index, and that is queried
+ * fresh every time regardless. Ranking is untouched.
+ */
+export const AI_GATEWAY_CACHE_TTL_SECONDS = 60 * 60;
+
+/**
+ * The Workers AI gateway options, when one is configured.
+ *
+ * OFF UNLESS NAMED. A blank var means no gateway argument at all, so a
+ * deployment that has not opted in behaves exactly as before -- and the
+ * rollback is deleting one word, the same shape SYNC_QUEUE_LANES uses.
+ *
+ * The shipped value is `default`, which Cloudflare CREATES on the first
+ * authenticated request naming it. That is why this could be turned on in the
+ * same change that added it, rather than waiting on a gateway somebody has to
+ * provision by hand first.
+ *
+ * WHAT IT BUYS, precisely: `/api/v1/search/semantic` embeds EVERY request, so
+ * two users searching the same phrase pay for two model calls and a hot query
+ * pays on every hit (metagraphed-infra#362). A gateway caches the embedding and
+ * adds per-model analytics and cost visibility, without touching ranking.
+ *
+ * NOT the same thing as the response's `cache-control: no-store`. That header
+ * is about the SEARCH RESULT, which depends on the live index; this caches the
+ * vector the query is turned into. They are independent, and only the second is
+ * safe to cache.
+ */
+export function aiGatewayOptions(
+  env: { METAGRAPH_AI_GATEWAY?: string },
+  cacheTtlSeconds: number = AI_GATEWAY_CACHE_TTL_SECONDS,
+): { gateway: { id: string; cacheTtl: number } } | null {
+  const id = env.METAGRAPH_AI_GATEWAY?.trim();
+  if (!id) return null;
+  return { gateway: { id, cacheTtl: cacheTtlSeconds } };
+}
+
 const ASK_TRACE_NAME = "ask";
 // #8965: distinct trace names so the three AI entry points are separable in
 // PostHog. semantic_search embeds but never completes; embedding_sync is the
@@ -343,11 +386,18 @@ export async function runEmbeddingSync(
   // bills per call, so `inputCount` (the batch size) is what makes the daily
   // cron's cost comparable to a single query-time embedding.
   const syncTraceId = crypto.randomUUID();
+  const gateway = aiGatewayOptions(env);
   for (const batch of chunk(pending, EMBED_BATCH_SIZE)) {
     const batchStartedAt = Date.now();
-    const response = await env.AI.run(EMBED_MODEL, {
-      text: batch.map((entry) => embeddingText(entry.doc)),
-    }).catch(async (error: unknown) => {
+    const response = await env.AI.run(
+      EMBED_MODEL,
+      { text: batch.map((entry) => embeddingText(entry.doc)) },
+      // Gatewayed too, though this lane's hit rate is near zero -- a daily sync
+      // re-embeds only documents whose content hash CHANGED. It is here for the
+      // per-model cost analytics, which is the half of metagraphed-infra#362's
+      // ask that applies to a cron rather than to a repeated query.
+      ...(gateway ? [gateway] : []),
+    ).catch(async (error: unknown) => {
       await recordAiEmbeddingEvent(env, {
         provider: ASK_PROVIDER,
         model: EMBED_MODEL,
@@ -444,12 +494,17 @@ async function embedQuery(
       { distinctId: telemetry.distinctId },
     );
 
-  const response = await env.AI.run(EMBED_MODEL, { text: [text] }).catch(
-    async (error: unknown) => {
-      await record(true, error);
-      throw error;
-    },
-  );
+  // THE ONE THAT REPEATS. Two users searching the same phrase used to pay for
+  // two identical model calls, and a hot query paid on every hit.
+  const gateway = aiGatewayOptions(env);
+  const response = await env.AI.run(
+    EMBED_MODEL,
+    { text: [text] },
+    ...(gateway ? [gateway] : []),
+  ).catch(async (error: unknown) => {
+    await record(true, error);
+    throw error;
+  });
   const vector = response?.data?.[0];
   if (!Array.isArray(vector)) {
     const error = new Error("embedding model returned no vector");

--- a/tests/ai-search.test.ts
+++ b/tests/ai-search.test.ts
@@ -16,6 +16,8 @@ import {
   semanticSearch,
   askQuestion,
   SEMANTIC_MAX_QUERY_LENGTH,
+  aiGatewayOptions,
+  AI_GATEWAY_CACHE_TTL_SECONDS,
 } from "../src/ai-search.ts";
 import { handleRequest, handleScheduled } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
@@ -54,8 +56,8 @@ function stubAi() {
   const calls: Row[] = [];
   return {
     calls,
-    run(model: string, input: Row) {
-      calls.push({ model, input });
+    run(model: string, input: Row, options?: Row) {
+      calls.push({ model, input, options });
       if (model === EMBED_MODEL) {
         const n = Array.isArray(input.text) ? input.text.length : 1;
         return Promise.resolve({
@@ -76,8 +78,8 @@ function embedAiWith(dataFor: AnyFn) {
   const calls: Row[] = [];
   return {
     calls,
-    run(model: string, input: Row) {
-      calls.push({ model, input });
+    run(model: string, input: Row, options?: Row) {
+      calls.push({ model, input, options });
       if (model === EMBED_MODEL) {
         return Promise.resolve({ data: dataFor(input.text) });
       }
@@ -1742,5 +1744,139 @@ describe("embedding-sync cron", () => {
     )) as Row;
     assert.equal(result.ok, true);
     assert.ok(result.total >= 0);
+  });
+});
+
+describe("AI Gateway on the embedding path (metagraphed-infra#362)", () => {
+  test("no var, no gateway argument -- the direct call is unchanged", () => {
+    // A deployment that has not opted in must behave exactly as before, and a
+    // blank string must read as absent rather than as a gateway named "".
+    for (const env of [
+      {},
+      { METAGRAPH_AI_GATEWAY: "" },
+      { METAGRAPH_AI_GATEWAY: "   " },
+    ]) {
+      assert.equal(aiGatewayOptions(env), null, JSON.stringify(env));
+    }
+  });
+
+  test("a named gateway carries the cache TTL, because caching is the point", () => {
+    assert.deepEqual(aiGatewayOptions({ METAGRAPH_AI_GATEWAY: "default" }), {
+      gateway: { id: "default", cacheTtl: AI_GATEWAY_CACHE_TTL_SECONDS },
+    });
+    // Trimmed, so a stray space in a dashboard-set var is not a different
+    // gateway id that silently fails every AI call.
+    assert.deepEqual(aiGatewayOptions({ METAGRAPH_AI_GATEWAY: " default " }), {
+      gateway: { id: "default", cacheTtl: AI_GATEWAY_CACHE_TTL_SECONDS },
+    });
+  });
+
+  test("the query-time embed actually passes it to AI.run", async () => {
+    // The whole value of #362 step 3 is on THIS call: /api/v1/search/semantic
+    // embeds every request, so two users searching the same phrase used to pay
+    // for two identical model calls.
+    const ai = stubAi();
+    await semanticSearch(
+      mockEnv({
+        AI: ai,
+        VECTORIZE: stubVectorize(),
+        METAGRAPH_ENABLE_AI: "true",
+        METAGRAPH_AI_GATEWAY: "default",
+      }),
+      "speech to text",
+    );
+    const embed = ai.calls.find((c) => c.model === EMBED_MODEL);
+    assert.deepEqual((embed?.options as Row)?.gateway, {
+      id: "default",
+      cacheTtl: AI_GATEWAY_CACHE_TTL_SECONDS,
+    });
+  });
+
+  test("the daily embedding sync is gatewayed too", async () => {
+    // Its cache hit rate is near zero -- the sync re-embeds only documents
+    // whose content hash CHANGED -- so this is here for the per-model cost
+    // analytics, which is the half of #362's ask that applies to a cron.
+    const ai = stubAi();
+    const searchDocs = {
+      ok: true,
+      data: {
+        documents: [
+          {
+            id: "subnet:1",
+            type: "subnet",
+            netuid: 1,
+            title: "One",
+            tokens: ["a"],
+          },
+        ],
+      },
+    };
+    await runEmbeddingSync(
+      mockEnv({
+        AI: ai,
+        VECTORIZE: stubVectorize(),
+        METAGRAPH_AI_GATEWAY: "default",
+      }),
+      {
+        readArtifact: (() =>
+          Promise.resolve(searchDocs)) as unknown as ReadArtifact,
+      },
+    );
+    const embed = ai.calls.find((c) => c.model === EMBED_MODEL);
+    assert.deepEqual((embed?.options as Row)?.gateway, {
+      id: "default",
+      cacheTtl: AI_GATEWAY_CACHE_TTL_SECONDS,
+    });
+  });
+
+  test("a failed sync embed is reported before it propagates", async () => {
+    // The error path of the batch embed, which had no coverage of its own: it
+    // records the failure as an $ai_embedding event and then rethrows, so the
+    // run fails visibly rather than reporting a successful sync that embedded
+    // nothing. Reshaping this call for the gateway argument is what surfaced
+    // that it was never exercised.
+    const searchDocs = {
+      ok: true,
+      data: {
+        documents: [
+          {
+            id: "subnet:1",
+            type: "subnet",
+            netuid: 1,
+            title: "One",
+            tokens: ["a"],
+          },
+        ],
+      },
+    };
+    await assert.rejects(
+      runEmbeddingSync(
+        mockEnv({
+          AI: { run: () => Promise.reject(new Error("model unavailable")) },
+          VECTORIZE: stubVectorize(),
+        }),
+        {
+          readArtifact: (() =>
+            Promise.resolve(searchDocs)) as unknown as ReadArtifact,
+        },
+      ),
+      /model unavailable/,
+    );
+  });
+
+  test("and passes NOTHING when no gateway is configured", async () => {
+    // Not `{ gateway: undefined }` -- an options object the runtime has to
+    // interpret is a different call from no options at all.
+    const ai = stubAi();
+    await semanticSearch(
+      mockEnv({
+        AI: ai,
+        VECTORIZE: stubVectorize(),
+        METAGRAPH_ENABLE_AI: "true",
+      }),
+      "speech to text",
+    );
+    const embed = ai.calls.find((c) => c.model === EMBED_MODEL);
+    assert.equal(embed?.options, undefined);
   });
 });

--- a/tests/private-boundary-patterns.test.ts
+++ b/tests/private-boundary-patterns.test.ts
@@ -115,6 +115,25 @@ describe("contentPatterns — provider-specific private model route", () => {
       assert.equal(regex.test(`route: ${token}`), false, token);
     }
   });
+
+  test("this repo's OWN public AI gateway var is deliberately not a violation", () => {
+    // BOTH DIRECTIONS, so the carve-out is a decision rather than a coincidence
+    // of where a \b happens to fall. The pattern guards the PRIVATE submission
+    // gate's provider routing. metagraphed-infra#362 routes the PUBLIC semantic
+    // search path through a gateway, and that path's model ids are already
+    // published on purpose -- so `METAGRAPH_AI_GATEWAY` must pass...
+    assert.equal(
+      regex.test('"METAGRAPH_AI_GATEWAY": "default"'),
+      false,
+      "the public AI layer's own gateway var",
+    );
+    // ...while a bare AI_GATEWAY must still fail, or the pattern has been
+    // widened into uselessness by the change that made room for the var above.
+    assert.ok(
+      regex.test('"AI_GATEWAY": "private-reviewer"'),
+      "a bare AI_GATEWAY is still a leak",
+    );
+  });
 });
 
 describe("pathPatterns — private submission-gate implementation path", () => {

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -115,6 +115,13 @@ interface Env {
   POLLER_LANE_HEALTH_SYNC_SECRET?: string;
   /** The sync-batches producer binding (metagraphed-infra#346). Absent means
    * every lane writes D1 inline, exactly as before. */
+  /** The AI Gateway the Workers AI embedding calls route through
+   * (metagraphed-infra#362). Declared here as well as in wrangler.jsonc's
+   * `vars`, the same way SYNC_QUEUE_LANES is: regenerating the whole
+   * worker-configuration.d.ts to pick it up drags in an unrelated
+   * literal-typing change from a newer wrangler, which breaks four existing
+   * tier-flag comparisons. */
+  METAGRAPH_AI_GATEWAY?: string;
   SYNC_BATCHES?: Queue<unknown>;
   /** Comma-separated lanes routed through the queue. One place decides, and it
    * is deploy-time so a cutover and its rollback are both a setting rather than

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -68,6 +68,32 @@
     // AI/VECTORIZE bindings are present, the routes serve live; otherwise they
     // return 503 ai_unavailable. Flip to "false" to instantly disable.
     "METAGRAPH_ENABLE_AI": "true",
+    // AI Gateway in front of the Workers AI embedding calls
+    // (metagraphed-infra#362 step 3). ON.
+    //
+    // "default" IS A REAL ID, not a placeholder: Cloudflare creates the
+    // account's default gateway on the first authenticated request that names
+    // it. That is what makes this shippable as one var rather than a var plus a
+    // dashboard step plus an API token with AI Gateway Edit -- which the
+    // wrangler OAuth scopes do not carry, so a provisioned-first approach would
+    // have meant leaving this off until somebody clicked something.
+    //
+    // WHAT IT BUYS. /api/v1/search/semantic embeds EVERY request, so two users
+    // searching the same phrase paid for two identical model calls and a hot
+    // query paid on every hit. The gateway caches the embedding for an hour and
+    // adds per-model request/latency/cost analytics, which is the only
+    // gateway-side view of AI spend this account has had.
+    //
+    // RANKING IS UNTOUCHED, and the distinction is worth being precise about:
+    // what is cached is the VECTOR a query turns into -- deterministic for a
+    // fixed model -- not the search result. The Vectorize index is still queried
+    // fresh on every request, which is exactly why the response keeps
+    // `cache-control: no-store` and why that header is not a contradiction.
+    //
+    // EMPTY TURNS IT OFF. src/ai-search.ts's aiGatewayOptions returns null on a
+    // blank value and both `AI.run` calls go direct, so the rollback is one
+    // word, like SYNC_QUEUE_LANES.
+    "METAGRAPH_AI_GATEWAY": "default",
     // Raw chain capture (#9111): ON. Opt-in by construction so a deploy can
     // never start capturing before migrations/d1/0006_raw_capture.sql exists
     // -- that table holds the watermark the whole no-gap guarantee rests on.


### PR DESCRIPTION
Closes metagraphed-infra#381 — step 3 of metagraphed-infra#362. Steps 1 and 2 are already live.

## What it costs today

`GET /api/v1/search/semantic` answers `cache-control: no-store` and calls `env.AI.run(EMBED_MODEL, { text: [q] })` on **every** request, ungatewayed, with nothing cached in front of it. Two users searching the same phrase pay for two identical model calls; a hot query pays on every hit. The only KV in `src/ai-search.ts` is the embedding *manifest* — a content hash for the sync cron's delta detection, not a query cache.

There is also **no gateway-side view of AI spend at all**. `recordAiEmbeddingEvent` reports to PostHog, which is our own accounting, not Cloudflare's.

## It ships ON, not behind an empty flag

`gateway: { id: "default" }` names the account's default gateway, which **Cloudflare creates on the first authenticated request**. So this needed no pre-provisioned gateway, no dashboard step, and no API token carrying `AI Gateway - Edit` — which the local wrangler OAuth scopes do not have (`ai:write` covers model inference; the AI Gateway management API returns 403).

The alternative was shipping the plumbing behind `""` and waiting for someone to click something, which is how a feature stays permanently one step from done. Blank still means **no gateway argument at all**, so rollback is deleting one word — the same shape `SYNC_QUEUE_LANES` uses.

## Ranking is untouched, and `no-store` is not a contradiction

What the gateway caches is the **vector a query turns into** — deterministic for a fixed model. The Vectorize index is still queried fresh on every request. That is exactly why the response keeps `cache-control: no-store` while the model call becomes cacheable: they are different things, and only one of them is safe to cache.

## The CI gate that blocked this is not weakened

`validate:private-boundary` bans a literal `AI_GATEWAY`. That pattern is named "provider-specific private model route" and guards **the private submission gate's** provider routing — not this repo's public AI layer, whose model ids (`@cf/qwen/qwen3-embedding-0.6b`, `@cf/meta/llama-4-scout-17b-16e-instruct`) are published on purpose and whose binding is `AI`.

So the pattern is unchanged. What changed is that it now **says what it protects**, and a test asserts both directions:

```ts
assert.equal(regex.test('"METAGRAPH_AI_GATEWAY": "default"'), false);  // the public var passes
assert.ok(regex.test('"AI_GATEWAY": "private-reviewer"'));             // a bare one still fails
```

Without that second assertion, a later widening could make the first one pass vacuously.

## Also

- **The daily sync is gatewayed too**, and the comment says why it is worth it despite a near-zero hit rate: the sync re-embeds only documents whose content hash *changed*, so that half is for the per-model cost analytics rather than the cache.
- **Reshaping that call surfaced an untested error path.** The batch embed's `.catch` records the failure as an `$ai_embedding` event and rethrows — so a bad run fails visibly instead of reporting a successful sync that embedded nothing. It had no coverage; it does now.
- `METAGRAPH_AI_GATEWAY` is declared in `workers/env-extra.d.ts` rather than by regenerating `worker-configuration.d.ts`, the same way `SYNC_QUEUE_LANES` is. Regenerating drags in an unrelated literal-typing change from a newer wrangler that breaks four existing tier-flag comparisons; that is its own PR, not this one's collateral.

## Validation

```
npm run typecheck               # clean
npm run lint                    # clean
npx prettier --check            # clean
npm run validate:private-boundary  # Private-boundary validation passed
npx vitest run tests/ai-search.test.ts tests/private-boundary-patterns.test.ts
# 118 passed
```

Verified the test catches a missing option: reverting only the query-time `AI.run` call to its ungatewayed form fails `the query-time embed actually passes it to AI.run`.

Patch coverage by intersecting the diff with a v8 report over `src/ai-search.ts`: **0 uncovered statements, branches, or functions** (64 changed lines).

## Template Used

- Backend/code change
