### PR TITLE
fix(ui): take a pasted EVM address to the account it maps to

### DIFF
--- a/apps/ui/src/lib/metagraphed/accounts.test.ts
+++ b/apps/ui/src/lib/metagraphed/accounts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isValidSs58, ss58PathSegment } from "./accounts";
+import { isValidH160, isValidSs58, normalizeH160, ss58PathSegment } from "./accounts";
 
 const VALID_SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
@@ -33,5 +33,42 @@ describe("ss58PathSegment", () => {
 
   it("throws before encoding invalid ss58 refs", () => {
     expect(() => ss58PathSegment("not-an-address")).toThrow("Invalid ss58 address");
+  });
+});
+
+describe("isValidH160 / normalizeH160 (metagraphed-infra#373)", () => {
+  const ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
+
+  it("accepts a well-formed EVM address in either case", () => {
+    expect(isValidH160(ADDRESS)).toBe(true);
+    expect(isValidH160(ADDRESS.toUpperCase().replace("0X", "0x"))).toBe(true);
+    expect(isValidH160(`  ${ADDRESS}  `)).toBe(true);
+  });
+
+  it("requires the 0x, matching /api/v1/search/resolve", () => {
+    // Forty bare hex characters are far more likely to be something pasted by
+    // accident than an EVM address. The two recognisers disagreeing about that
+    // is how a paste resolves one way in the search box and another on the page
+    // it lands on.
+    expect(isValidH160(ADDRESS.slice(2))).toBe(false);
+  });
+
+  it("rejects the wrong length and non-hex", () => {
+    expect(isValidH160(`${ADDRESS}0`)).toBe(false);
+    expect(isValidH160(ADDRESS.slice(0, -1))).toBe(false);
+    expect(isValidH160(`0x${"g".repeat(40)}`)).toBe(false);
+    // A 32-byte hash is not an account address, and offering it as one would
+    // send a block-hash paste to a lookup that can only fail.
+    expect(isValidH160(`0x${"a".repeat(64)}`)).toBe(false);
+  });
+
+  it("does not mistake an ss58 for an EVM address, or the reverse", () => {
+    const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+    expect(isValidH160(SS58)).toBe(false);
+    expect(isValidSs58(ADDRESS)).toBe(false);
+  });
+
+  it("lowercases, so a checksummed paste is one cache key and one URL", () => {
+    expect(normalizeH160(`  0x1234567890ABCDEF1234567890abcdef12345678 `)).toBe(ADDRESS);
   });
 });

--- a/apps/ui/src/lib/metagraphed/accounts.ts
+++ b/apps/ui/src/lib/metagraphed/accounts.ts
@@ -18,3 +18,22 @@ export function ss58PathSegment(ref: string): string {
   }
   return encodeURIComponent(trimmed);
 }
+
+/** An Ethereum-style address: 0x + 20 bytes of hex.
+ *
+ * Deliberately requires the `0x`, matching `/api/v1/search/resolve` -- 40 bare
+ * hex characters are far more likely to be something pasted by accident than an
+ * EVM address, and the two recognisers disagreeing about that is how a paste
+ * resolves one way in the search box and another on the page it lands on. */
+const H160 = /^0x[0-9a-fA-F]{40}$/;
+
+/** True when a ref is a well-formed EVM (H160) address. */
+export function isValidH160(ref: string): boolean {
+  return H160.test(ref.trim());
+}
+
+/** Lowercased, so a checksummed paste and an all-lower one are one cache key
+ * and one URL rather than two. */
+export function normalizeH160(ref: string): string {
+  return ref.trim().toLowerCase();
+}

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -184,6 +184,7 @@ import type {
   RpcEndpointsSummary,
   RpcUsage,
   SchemaInfo,
+  EvmAddressMappingResponse,
   SearchResolveResponse,
   SemanticSearchResponse,
   Subnet,
@@ -9035,6 +9036,30 @@ export const searchResolveQuery = (q: string) =>
         signal,
       }),
     enabled: q.trim().length > 0,
+    staleTime: Infinity,
+  });
+
+/**
+ * The ss58 an EVM address maps to (metagraphed-infra#373).
+ *
+ * WHY THE UI DOES THE LOOKUP. `/api/v1/search/resolve` recognises an H160 from
+ * its shape alone and points here, deliberately without resolving it: the
+ * resolver is lookup-free so that every OTHER identifier shape stays an instant
+ * answer. Turning the mapping into a destination is a second request, and this
+ * is where it belongs.
+ *
+ * `staleTime: Infinity` because an EVM->ss58 mapping is set once on-chain and
+ * does not change.
+ */
+export const evmAddressMappingQuery = (h160: string) =>
+  queryOptions({
+    queryKey: k("evm-address", h160),
+    queryFn: ({ signal }) =>
+      apiFetch<EvmAddressMappingResponse>(
+        `/api/v1/evm/address/${encodeURIComponent(h160.trim())}`,
+        { signal },
+      ),
+    enabled: h160.trim().length > 0,
     staleTime: Infinity,
   });
 

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -3993,6 +3993,15 @@ export interface SearchResolveResponse {
   unambiguous: boolean;
 }
 
+/** The ss58 an EVM (H160) address maps to on-chain, from
+ * `AddressMapping.addressMapping`. `ss58` is null when the address has never
+ * been mapped -- a real answer, not a missing one. */
+export interface EvmAddressMappingResponse {
+  h160: string;
+  ss58: string | null;
+  queried_at: string | null;
+}
+
 export interface SemanticSearchResponse {
   query: string;
   count: number;

--- a/apps/ui/src/routes/-accounts-index-page.tsx
+++ b/apps/ui/src/routes/-accounts-index-page.tsx
@@ -1,6 +1,6 @@
-import { Link, useNavigate } from "@tanstack/react-router";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 import { Search, Wallet } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
@@ -15,20 +15,35 @@ import { WalletConnectButton } from "@/components/metagraphed/wallet-connect";
 import { useWallet } from "@/hooks/use-wallet";
 import { AddressDisplay } from "@/components/metagraphed/address-display";
 import { taoCompact } from "@/components/metagraphed/neuron-format";
-import { isValidSs58 } from "@/lib/metagraphed/accounts";
+import { isValidH160, isValidSs58, normalizeH160 } from "@/lib/metagraphed/accounts";
 import { formatNumber } from "@/lib/metagraphed/format";
-import { accountsListQuery, chainSignersQuery } from "@/lib/metagraphed/queries";
+import {
+  accountsListQuery,
+  chainSignersQuery,
+  evmAddressMappingQuery,
+} from "@/lib/metagraphed/queries";
 
 export function AccountsPage() {
   const navigate = useNavigate();
   const [value, setValue] = useState("");
   const trimmed = value.trim();
-  const valid = isValidSs58(trimmed);
+  // An H160 is a valid thing to paste here too, and rejecting it as "not a
+  // valid ss58" would be wrong twice over -- the resolver already told the user
+  // this address has a destination.
+  const isH160 = isValidH160(trimmed);
+  const valid = isValidSs58(trimmed) || isH160;
   const touched = trimmed.length > 0;
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!valid) return;
+    if (isH160) {
+      // Through the same ?h160= path a resolver link takes, so there is ONE
+      // implementation of "an EVM address becomes an account" rather than two
+      // that can disagree.
+      navigate({ to: "/accounts", search: { h160: normalizeH160(trimmed) } });
+      return;
+    }
     navigate({ to: "/accounts/$ss58", params: { ss58: trimmed } });
   };
 
@@ -45,9 +60,10 @@ export function AccountsPage() {
           </ActionBar>
         }
       />
+      <EvmAddressRedirect />
       <form onSubmit={submit} className="mx-auto w-full max-w-2xl">
         <label htmlFor="ss58" className="mb-2 block mg-type-caption text-ink-muted">
-          Account address (ss58)
+          Account address (ss58 or EVM)
         </label>
         <div className="flex flex-col gap-2 sm:flex-row">
           <div className="relative flex-1">
@@ -75,8 +91,8 @@ export function AccountsPage() {
         </div>
         <p className="mt-2 mg-type-data text-ink-muted">
           {touched && !valid
-            ? "That doesn't look like a valid ss58 address."
-            : "Paste a hotkey or coldkey ss58 address to view its activity."}
+            ? "That doesn't look like a valid ss58 or EVM address."
+            : "Paste a hotkey or coldkey ss58 address — or an EVM (0x) address — to view its activity."}
         </p>
       </form>
 
@@ -225,6 +241,58 @@ function AccountsLeaderboard({
           Validator directory →
         </Link>
       </div>
+    </Panel>
+  );
+}
+
+/**
+ * Turn a `?h160=` into the account it maps to (metagraphed-infra#373).
+ *
+ * `/api/v1/search/resolve` answers a pasted EVM address with
+ * `ui_path: /accounts?h160=0x…` and `exact: true`. Nothing read that parameter,
+ * so the one identifier the resolver is CERTAIN about landed on a generic index
+ * with the address dropped — the worst outcome of the six shapes it recognises,
+ * because it is the one where the user was promised a specific answer.
+ *
+ * THREE OUTCOMES, and the two that are not a redirect both say something true:
+ *
+ *   * mapped     -> replace into /accounts/{ss58}. `replace`, not push, so Back
+ *                   returns to wherever the link was clicked rather than
+ *                   bouncing through this page again.
+ *   * unmapped   -> "no account" is a REAL answer from the chain, not an error.
+ *                   `AddressMapping.addressMapping` simply has no entry, which
+ *                   is the normal state for an address that has never been used
+ *                   on this chain.
+ *   * unreadable -> say so, and leave the lookup form usable underneath.
+ */
+function EvmAddressRedirect() {
+  const navigate = useNavigate();
+  const { h160 } = useSearch({ from: "/accounts/" });
+  const address = h160 && isValidH160(h160) ? normalizeH160(h160) : "";
+  const mapping = useQuery({ ...evmAddressMappingQuery(address), retry: 0 });
+  const ss58 = mapping.data?.data.ss58 ?? null;
+
+  useEffect(() => {
+    if (!ss58) return;
+    navigate({ to: "/accounts/$ss58", params: { ss58 }, replace: true });
+  }, [ss58, navigate]);
+
+  if (!h160) return null;
+  return (
+    <Panel className="mx-auto mb-6 w-full max-w-2xl">
+      <p className="mg-type-caption text-ink-muted">EVM address</p>
+      <p className="mt-1 break-all font-mono text-sm text-ink-strong">{h160}</p>
+      <p className="mt-2 mg-type-data text-ink-muted">
+        {!address
+          ? "That is not a well-formed EVM address (expected 0x followed by 40 hex characters)."
+          : mapping.isPending
+            ? "Looking up the account this address maps to…"
+            : mapping.isError
+              ? "Could not read the EVM address mapping just now."
+              : ss58
+                ? "Found it — taking you there."
+                : "This EVM address is not mapped to a Bittensor account on-chain."}
+      </p>
     </Panel>
   );
 }

--- a/apps/ui/src/routes/accounts.index.tsx
+++ b/apps/ui/src/routes/accounts.index.tsx
@@ -2,6 +2,26 @@ import { createFileRoute } from "@tanstack/react-router";
 import { AccountsPage } from "./-accounts-index-page";
 
 export const Route = createFileRoute("/accounts/")({
+  /**
+   * `?h160=` — where a pasted EVM address lands (metagraphed-infra#373).
+   *
+   * `/api/v1/search/resolve` has always answered an H160 with
+   * `ui_path: /accounts?h160=0x…`, and this route had no `validateSearch` at
+   * all, so the parameter was parsed by nothing and dropped: the one identifier
+   * the resolver marks `exact: true` sent the user to a generic account index
+   * with their address silently discarded.
+   *
+   * Kept out of the resolver on purpose. Turning an H160 into an account is a
+   * LOOKUP, and the resolver is lookup-free so that every other shape stays an
+   * instant, offline answer — so the second request belongs here, on the page
+   * that needs it.
+   */
+  // The return type is `{ h160?: string }` and not `{ h160: string | undefined }`
+  // deliberately: TanStack treats a validated route's `search` as REQUIRED
+  // unless `{}` is assignable to it, and the second spelling makes every
+  // existing `redirect({ to: "/accounts" })` a type error.
+  validateSearch: (search: Record<string, unknown>): { h160?: string } =>
+    typeof search.h160 === "string" ? { h160: search.h160 } : {},
   head: () => ({
     meta: [
       { title: "Accounts — Metagraphed" },


### PR DESCRIPTION
Closes metagraphed-infra#373.

`GET /api/v1/search/resolve` has always answered a pasted EVM address with:

```json
{"kind":"evm-account","ui_path":"/accounts?h160=0x1234…","exact":true}
```

and `apps/ui/src/routes/accounts.index.tsx` had **no `validateSearch` at all** — `h160` appears nowhere under `apps/ui/src`. So the parameter was parsed by nothing and dropped, and the **one identifier the resolver marks `exact: true`** landed on a generic account index with the address silently discarded.

That is the worst outcome of the six shapes the resolver recognises, because it is the one where the user was promised a specific answer.

## The lookup stays out of the resolver

Turning an H160 into an account is a **chain read** — `AddressMapping.addressMapping`, served by `/api/v1/evm/address/{h160}`. The resolver is deliberately lookup-free so every other shape stays an instant, offline answer; adding a round trip there would cost `74:12` and a block hash their speed to serve this one case. So the second request belongs on the page that needs it.

## Three outcomes, and the two that aren't a redirect both say something true

| | |
|---|---|
| **mapped** | `replace` into `/accounts/{ss58}` — *replace*, not push, so Back returns to wherever the link was clicked rather than bouncing through this page again |
| **unmapped** | "not mapped to a Bittensor account" is a **real answer from the chain**, not an error. It is the normal state for an address never used here |
| **unreadable** | says so, with the lookup form still usable underneath |

## The form accepts an EVM address too

…and routes it through the **same `?h160=` path** a resolver link takes, so there is one implementation of "an EVM address becomes an account" rather than two that can disagree. The label and helper text now say ss58 *or* EVM, and an H160 no longer reads as "that doesn't look like a valid ss58 address" — which was wrong twice over, since the resolver had just told the user it had a destination.

## Two details worth calling out

**`isValidH160` requires the `0x`**, matching `src/identifier-resolver.ts` exactly. Forty bare hex characters are more likely to be something pasted by accident than an address, and the two recognisers disagreeing about that is how a paste resolves one way in the search box and another on the page it lands on. There is a test for that specific disagreement, and for a 64-hex hash not being offered as an account.

**`validateSearch` returns `{ h160?: string }`, not `{ h160: string | undefined }`.** TanStack treats a validated route's `search` as *required* unless `{}` is assignable to it — the second spelling makes every existing `redirect({ to: "/accounts" })` a type error, and `portfolio.tsx` and `tools.ss58.tsx` both do exactly that.

## Validation

```
npm run build --workspace=packages/ui-kit   # required first, or tsc reports phantom errors
npm run build --workspace=packages/client
npm run typecheck --workspace=apps/ui       # clean
npm run lint --workspace=apps/ui            # 0 errors (9 pre-existing warnings, none in changed files)
npm run format:check --workspace=apps/ui    # clean
npm test --workspace=apps/ui                # 1851 passed
npm run build --workspace=apps/ui           # clean
```

No screenshot table: this is a maintainer PR. The visible change is a small status panel above the lookup form that appears only when `?h160=` is present, plus two label/helper strings.

## Not in this PR

metagraphed-infra#376 — the site-wide command palette still uses its own checksum-less heuristics instead of the resolver, so this destination is reachable from the `/agents` search box and from a pasted URL, but not yet from the omnibox.

## Template Used

- Frontend PR
