### PR TITLE
feat(neon): reconcile the two accumulating daily tables, D1 to Neon

### DIFF
--- a/migrations/d1/0028_daily_tables_date_keyset.sql
+++ b/migrations/d1/0028_daily_tables_date_keyset.sql
@@ -1,0 +1,42 @@
+-- Date-leading keyset indexes on the two accumulating daily tables (infra#336).
+--
+-- The D1 -> Neon reconciler (src/neon-backfill.ts) walks one snapshot_date at a
+-- time, paging on that table's primary key minus the date:
+--
+--     WHERE snapshot_date = ? AND (netuid > ? OR (netuid = ? AND uid > ?))
+--     ORDER BY netuid, uid LIMIT ?
+--
+-- Both halves of that -- the seek and the ordering -- have to come from one
+-- index, or the query degrades in a way that scales with the whole table rather
+-- than with one day of it.
+--
+-- ## account_position_daily had NO date-leading index at all
+--
+-- PRIMARY KEY (account, netuid, snapshot_date) and
+-- idx_account_position_daily_account_date (account, snapshot_date) both lead
+-- with `account`, so `WHERE snapshot_date = ?` is not a prefix of either and
+-- falls back to a full scan -- 834,081 rows measured 2026-08-07, per page. The
+-- reconciler reads ~167 pages per date, so without this index one date costs
+-- ~139M rows read. With it, one date costs one date.
+--
+-- ## neuron_daily's existing index stops one column short
+--
+-- idx_neuron_daily_date_netuid (snapshot_date, netuid) seeks the date and
+-- orders by netuid, but not by `uid` within a netuid -- so SQLite either sorts
+-- each page or walks the PRIMARY KEY across every date to get the order for
+-- free. Adding `uid` as a third column removes that choice.
+--
+-- The narrower index is then DROPPED rather than kept: (snapshot_date, netuid)
+-- is a strict prefix of (snapshot_date, netuid, uid), so every lookup it served
+-- the wider one serves identically. Keeping both would cost a second index
+-- write on all ~32,000 rows this table gains each day, in exchange for nothing.
+--
+-- Purely additive to the schema otherwise: no column, constraint or table
+-- changes, so the reads that exist today keep working through the migration.
+CREATE INDEX IF NOT EXISTS idx_neuron_daily_date_netuid_uid
+  ON neuron_daily (snapshot_date, netuid, uid);
+
+DROP INDEX IF EXISTS idx_neuron_daily_date_netuid;
+
+CREATE INDEX IF NOT EXISTS idx_account_position_daily_date_account
+  ON account_position_daily (snapshot_date, account, netuid);

--- a/src/neon-backfill.ts
+++ b/src/neon-backfill.ts
@@ -1,0 +1,550 @@
+// The D1 -> Neon reconciler for the two ACCUMULATING daily tables (infra#336).
+//
+// ## Why the mirror alone does not finish the job
+//
+// #9712/#9729/#9733/#9739 mirror every write into Neon, which is enough for the
+// five LATEST-ONLY tables: `neurons`, `nominator_positions` and the three flat
+// ledgers are fully rewritten each producer cycle, so one cycle after the
+// mirror turns on the two stores agree. Measured, `neurons` matched D1 exactly
+// on the first pass -- 129 netuids, 30,109 rows, identical SUM(uid).
+//
+// `neuron_daily` and `account_position_daily` accumulate by date and are never
+// rewritten, so a mirror can only ever cover the days it was running for.
+// Measured 2026-08-07 with the mirror healthy and current:
+//
+//     neuron_daily            D1 846,912   NEON  30,109   (today, and nothing else)
+//     account_position_daily  D1 834,081   NEON 833,849
+//
+// ## Why this is a reconciler and not a script
+//
+// A script closes that gap once. It does not close it the next time a mirror
+// write fails mid-chunk, a lane is turned off and back on, or a deploy lands
+// between two halves of a producer cycle. And until this file existed nothing
+// in the system compared the two stores AT ALL -- which is the blind spot that
+// let a frozen Neon serve `GET /api/v1/accounts/{ss58}/subnets/{netuid}/history`
+// for two days without a single failing check (#9705).
+//
+// So the deficit is recomputed from both sides every tick. When there is
+// nothing missing this is a no-op costing one grouped count per store, and it
+// stays wired afterwards as the consistency check the pilot never had.
+//
+// ## The deficit IS the cursor
+//
+// There is no stored progress and no state table. Each tick asks both stores
+// for their per-date row counts and copies the newest date where Neon has fewer
+// rows than D1. An interrupted tick, a redeploy mid-copy, and two ticks
+// overlapping all resolve to the same place, because the only state is the data
+// itself. That is also why the unit of work is a WHOLE DATE: stopping halfway
+// through one would leave a deficit the next tick recomputes correctly but
+// restarts, so the budget is checked between dates rather than inside one.
+//
+// ## Newest date first
+//
+// Both tables are read as "the last N days", so copying backwards from today
+// makes the served window correct progressively rather than all at once at the
+// end. If this never finishes, what it did finish is the part anything asks
+// for.
+
+import {
+  neonBackfillLanes,
+  writeRowsToNeon,
+  type NeonWriteResult,
+  type PgUnsafe,
+} from "./neon-write.ts";
+import {
+  ACCOUNT_POSITION_DAILY_COLUMNS,
+  NEURON_DAILY_COLUMNS,
+} from "./neurons-d1-write.ts";
+import {
+  createPgSql,
+  type HyperdriveLike,
+  type WaitUntilLike,
+} from "./pg-sql.ts";
+import {
+  loadLatestLaneHealth,
+  recordLaneVerdict,
+  type LaneHealthDb,
+} from "./lane-health.ts";
+
+type Row = Record<string, unknown>;
+
+/** Rows read from D1 per page. Two thousand rows of the wider table is roughly
+ * a megabyte of JSON, which is a comfortable D1 response and a comfortable
+ * slice to hold while the Neon statements for it are built. */
+export const D1_PAGE_ROWS = 2_000;
+
+/** Hard ceiling on dates copied per tick, whatever the clock says. A cap the
+ * budget cannot override keeps one tick's cost predictable when a date turns
+ * out to be far smaller than the ~32,000 rows these tables average. */
+export const MAX_DATES_PER_TICK = 4;
+
+/** Wall-clock budget, checked BETWEEN dates. Cron ticks here are 3 minutes
+ * apart, so finishing well inside one leaves the next tick a clean start
+ * rather than an overlap. */
+export const TICK_BUDGET_MS = 20_000;
+
+/** How long a clean verdict suppresses the next comparison.
+ *
+ * The comparison is two grouped counts over ~840,000 rows each. During the
+ * backfill that cost is worth paying every tick; once the stores agree it is
+ * ~600M D1 rows read a month to re-learn the same thing. So a lane that just
+ * reported no deficit skips the comparison until this much time has passed,
+ * which turns a 3-minute reconciler into an hourly one exactly when it becomes
+ * a watchdog rather than a copier. */
+export const IDLE_RECHECK_MS = 60 * 60 * 1000;
+
+/** The minimal D1 surface this needs, so a test can hand it a fake. */
+export interface BackfillDb {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      all(): Promise<{ results?: unknown[] } | null>;
+    };
+    all(): Promise<{ results?: unknown[] } | null>;
+  };
+}
+
+export interface BackfillPlan {
+  table: string;
+  columns: readonly string[];
+  /** Neon's primary key. Matches D1's, which is why one row shape serves both. */
+  conflict: readonly string[];
+  /** The primary key MINUS snapshot_date, in key order: the columns a page
+   * within one date resumes from. */
+  keyset: readonly string[];
+  /** Columns D1 stores as 0/1 and Neon declares BOOLEAN.
+   *
+   * NOT a stylistic difference -- it is the one shape mismatch between the two
+   * stores, and it has already caused an outage in this lane. The rows the
+   * live mirror sends carry real JS booleans (the bit conversion lives in
+   * SQLite's implicit binding, not in the shared row shaping), so Neon's
+   * columns are BOOLEAN and its writes succeed. Rows read BACK out of D1 are
+   * integers, so this path -- and only this path -- has to convert them. */
+  booleans: readonly string[];
+}
+
+/**
+ * One plan per table, keyed by the name used in NEON_BACKFILL_LANES.
+ *
+ * The conflict keys are D1's declared PRIMARY KEYs, read off sqlite_master
+ * 2026-08-07 rather than assumed, and they match Neon's. An ON CONFLICT naming
+ * columns with no unique index behind them is a runtime error, not a slower
+ * query.
+ */
+export const NEON_BACKFILL_PLANS: Readonly<Record<string, BackfillPlan>> = {
+  neuron_daily: {
+    table: "neuron_daily",
+    columns: NEURON_DAILY_COLUMNS,
+    conflict: ["netuid", "uid", "snapshot_date"],
+    keyset: ["netuid", "uid"],
+    booleans: ["active", "validator_permit", "is_immunity_period"],
+  },
+  account_position_daily: {
+    table: "account_position_daily",
+    columns: ACCOUNT_POSITION_DAILY_COLUMNS,
+    conflict: ["account", "netuid", "snapshot_date"],
+    keyset: ["account", "netuid"],
+    booleans: ["active", "validator_permit"],
+  },
+};
+
+/**
+ * The guard every backfill write carries.
+ *
+ * Without it this path can REGRESS live data. Today's rows are rewritten by
+ * the producer all day, so a page read from D1 at 12:00 and written to Neon at
+ * 12:01 would overwrite whatever the mirror wrote at 12:00:30. With it, an
+ * older `captured_at` is a no-op and the newer row stands.
+ */
+export function backfillGuard(table: string): string {
+  return `${table}.captured_at < EXCLUDED.captured_at`;
+}
+
+/**
+ * The keyset predicate for resuming a page, as SQL plus its bind values.
+ *
+ * Expanded rather than written as a row-value comparison -- `(a, b) > (?, ?)`
+ * is valid SQLite but the expanded form is what the (snapshot_date, a, b)
+ * index seeks on unambiguously, and this query's whole cost model depends on
+ * that index being used.
+ */
+export function keysetPredicate(
+  keyset: readonly string[],
+  cursor: readonly unknown[],
+): { sql: string; values: unknown[] } {
+  const terms: string[] = [];
+  const values: unknown[] = [];
+  for (let i = 0; i < keyset.length; i += 1) {
+    const equals = keyset.slice(0, i).map((column) => `${column} = ?`);
+    terms.push([...equals, `${keyset[i]} > ?`].join(" AND "));
+    values.push(...cursor.slice(0, i), cursor[i]);
+  }
+  return { sql: `(${terms.map((term) => `(${term})`).join(" OR ")})`, values };
+}
+
+/** Per-date row counts from D1, as a map of snapshot_date to count. */
+export async function d1DateCounts(
+  db: BackfillDb | null | undefined,
+  table: string,
+): Promise<Map<string, number> | null> {
+  try {
+    const result = await db
+      ?.prepare(
+        `SELECT snapshot_date AS d, COUNT(*) AS n FROM ${table} GROUP BY snapshot_date`,
+      )
+      .all();
+    if (!result) return null;
+    return countMap(result.results ?? [], "d", "n");
+  } catch {
+    // Null, never an empty map: "D1 did not answer" and "D1 has no rows" would
+    // otherwise both read as a deficit of everything Neon holds, and the second
+    // one is the shape of a catastrophic mistaken copy.
+    return null;
+  }
+}
+
+/** Per-date row counts from Neon, in the same shape. */
+export async function neonDateCounts(
+  sql: PgUnsafe | null | undefined,
+  table: string,
+): Promise<Map<string, number> | null> {
+  if (!sql?.unsafe) return null;
+  try {
+    const rows = (await sql.unsafe(
+      `SELECT snapshot_date::text AS d, COUNT(*) AS n FROM ${table} GROUP BY snapshot_date`,
+    )) as unknown[];
+    return countMap(Array.isArray(rows) ? rows : [], "d", "n");
+  } catch {
+    return null;
+  }
+}
+
+function countMap(
+  rows: readonly unknown[],
+  dateKey: string,
+  countKey: string,
+): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const raw of rows) {
+    const row = raw as Row;
+    const date = row?.[dateKey];
+    if (date == null) continue;
+    const n = Number(row[countKey]);
+    out.set(String(date), Number.isFinite(n) ? n : 0);
+  }
+  return out;
+}
+
+export interface DateDeficit {
+  date: string;
+  d1: number;
+  neon: number;
+}
+
+/**
+ * Dates where Neon holds fewer rows than D1, NEWEST FIRST.
+ *
+ * Strictly `neon < d1`. A date where Neon holds MORE is not reported and not
+ * acted on: this path only ever adds rows, and a surplus in Neon is a question
+ * about deletes that copying cannot answer and must not paper over.
+ */
+export function dateDeficits(
+  d1Counts: ReadonlyMap<string, number>,
+  neonCounts: ReadonlyMap<string, number>,
+): DateDeficit[] {
+  const out: DateDeficit[] = [];
+  for (const [date, d1] of d1Counts) {
+    const neon = neonCounts.get(date) ?? 0;
+    if (neon < d1) out.push({ date, d1, neon });
+  }
+  // ISO dates sort lexicographically, so `localeCompare` reversed is the whole
+  // ordering -- and the keys came from a Map, so there are no ties to break.
+  return out.sort((a, b) => b.date.localeCompare(a.date));
+}
+
+/** D1's integers where Neon declares BOOLEAN, and nothing else touched. */
+export function shapeRowForNeon(row: Row, booleans: readonly string[]): Row {
+  const out: Row = { ...row };
+  for (const column of booleans) {
+    const value = out[column];
+    if (value != null) out[column] = Boolean(value);
+  }
+  return out;
+}
+
+/** One page of a date's rows from D1, in keyset order. */
+export async function readDatePage(
+  db: BackfillDb,
+  plan: BackfillPlan,
+  date: string,
+  cursor: readonly unknown[] | null,
+  limit: number,
+): Promise<Row[]> {
+  const keyset = cursor ? keysetPredicate(plan.keyset, cursor) : null;
+  const sql =
+    `SELECT ${plan.columns.join(", ")} FROM ${plan.table} ` +
+    `WHERE snapshot_date = ?${keyset ? ` AND ${keyset.sql}` : ""} ` +
+    `ORDER BY ${plan.keyset.join(", ")} LIMIT ?`;
+  const result = await db
+    .prepare(sql)
+    .bind(date, ...(keyset?.values ?? []), limit)
+    .all();
+  return (result?.results ?? []) as Row[];
+}
+
+export interface DateCopyResult extends NeonWriteResult {
+  date: string;
+  pages: number;
+}
+
+/**
+ * Copy one date, page by page, until D1 returns a short page.
+ *
+ * Stops at the first failed write rather than continuing to the next page, for
+ * the same reason `writeRowsToNeon` stops at the first failed chunk: continuing
+ * past a failure produces a row count that looks nearly complete over a table
+ * that is not.
+ */
+export async function copyDateToNeon(
+  db: BackfillDb,
+  sql: PgUnsafe,
+  plan: BackfillPlan,
+  date: string,
+  pageRows: number = D1_PAGE_ROWS,
+): Promise<DateCopyResult> {
+  let cursor: unknown[] | null = null;
+  let rows = 0;
+  let statements = 0;
+  let pages = 0;
+  for (;;) {
+    let page: Row[];
+    try {
+      page = await readDatePage(db, plan, date, cursor, pageRows);
+    } catch (error) {
+      return {
+        ok: false,
+        rows,
+        statements,
+        pages,
+        date,
+        reason: reason(error),
+      };
+    }
+    if (page.length === 0) return { ok: true, rows, statements, pages, date };
+    pages += 1;
+    const result = await writeRowsToNeon(
+      sql,
+      plan.table,
+      plan.columns,
+      page.map((row) => shapeRowForNeon(row, plan.booleans)),
+      plan.conflict,
+      backfillGuard(plan.table),
+    );
+    rows += result.rows;
+    statements += result.statements;
+    if (!result.ok) {
+      return {
+        ok: false,
+        rows,
+        statements,
+        pages,
+        date,
+        reason: result.reason,
+      };
+    }
+    if (page.length < pageRows)
+      return { ok: true, rows, statements, pages, date };
+    const last = page[page.length - 1];
+    cursor = plan.keyset.map((column) => last[column]);
+  }
+}
+
+function reason(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export interface BackfillTableOutcome {
+  table: string;
+  /** Deficient dates found this tick, before any were copied. */
+  deficits: number;
+  /** Rows still missing across all deficient dates, before any were copied. */
+  missing: number;
+  copied: DateCopyResult[];
+  ok: boolean;
+  reason?: string;
+  /** True when the comparison was skipped because a clean verdict is recent. */
+  skipped?: boolean;
+}
+
+export interface BackfillDeps {
+  sql?: PgUnsafe | null;
+  db?: BackfillDb | null;
+  laneHealthDb?: LaneHealthDb | null;
+  now?: () => number;
+  /** Injectable so a test can drive the budget without waiting on a clock. */
+  elapsed?: () => number;
+}
+
+/**
+ * Reconcile one table. Never throws.
+ *
+ * The verdict is `stale` whenever a deficit remains after this tick, including
+ * the tick that found one and copied it successfully -- because "there is still
+ * a gap" is the thing a reader of `lane_health` needs to know, and a verdict of
+ * `ok` on a tick that copied 4 of 26 missing dates would report progress as
+ * completion. #9698's alarm escalates a lane that stays stale, which during a
+ * backfill is exactly the signal that it has stopped converging.
+ */
+export async function reconcileTableToNeon(
+  db: BackfillDb | null | undefined,
+  sql: PgUnsafe | null | undefined,
+  plan: BackfillPlan,
+  deps: BackfillDeps = {},
+): Promise<BackfillTableOutcome> {
+  const table = plan.table;
+  const base = {
+    table,
+    deficits: 0,
+    missing: 0,
+    copied: [] as DateCopyResult[],
+  };
+  if (!db?.prepare || !sql?.unsafe) {
+    return { ...base, ok: false, reason: "unbound" };
+  }
+  const [d1Counts, neonCounts] = await Promise.all([
+    d1DateCounts(db, table),
+    neonDateCounts(sql, table),
+  ]);
+  if (!d1Counts || !neonCounts) {
+    // A store that would not answer is NOT a deficit of everything the other
+    // holds. Refusing to act on a half-read comparison is the whole reason
+    // both counters return null rather than an empty map.
+    return {
+      ...base,
+      ok: false,
+      reason: `count failed: ${!d1Counts ? "d1" : "neon"}`,
+    };
+  }
+  const deficits = dateDeficits(d1Counts, neonCounts);
+  const missing = deficits.reduce((sum, d) => sum + (d.d1 - d.neon), 0);
+  if (deficits.length === 0) return { ...base, ok: true };
+
+  const elapsed = deps.elapsed ?? (() => 0);
+  const copied: DateCopyResult[] = [];
+  for (const deficit of deficits.slice(0, MAX_DATES_PER_TICK)) {
+    if (copied.length > 0 && elapsed() >= TICK_BUDGET_MS) break;
+    const result = await copyDateToNeon(db, sql, plan, deficit.date);
+    copied.push(result);
+    if (!result.ok) {
+      return {
+        table,
+        deficits: deficits.length,
+        missing,
+        copied,
+        ok: false,
+        reason: result.reason,
+      };
+    }
+  }
+  return { table, deficits: deficits.length, missing, copied, ok: true };
+}
+
+/** One line per table, for the lane verdict's detail column. */
+export function describeOutcome(outcome: BackfillTableOutcome): string {
+  if (outcome.skipped) return "no deficit at last check";
+  if (!outcome.ok) {
+    const rows = outcome.copied.reduce((sum, c) => sum + c.rows, 0);
+    return `${rows} row(s) copied before failure: ${outcome.reason ?? "unknown"}`;
+  }
+  if (outcome.deficits === 0) return "in sync";
+  const rows = outcome.copied.reduce((sum, c) => sum + c.rows, 0);
+  const remaining = outcome.deficits - outcome.copied.length;
+  return (
+    `${rows} row(s) over ${outcome.copied.length} date(s); ` +
+    `${remaining} date(s) / ~${outcome.missing - rows} row(s) still behind`
+  );
+}
+
+export interface BackfillOutcome {
+  attempted: boolean;
+  tables: BackfillTableOutcome[];
+}
+
+/**
+ * Run the reconciler for every table named in NEON_BACKFILL_LANES.
+ *
+ * Never throws: this is a cron lane behind no request, and a fault here must
+ * cost a verdict rather than a tick.
+ */
+export async function runNeonBackfill(
+  env: Record<string, unknown> | null | undefined,
+  ctx: WaitUntilLike | null | undefined,
+  deps: BackfillDeps = {},
+): Promise<BackfillOutcome> {
+  const lanes = neonBackfillLanes(env);
+  if (lanes.size === 0) return { attempted: false, tables: [] };
+
+  const hyperdrive = env?.HYPERDRIVE as HyperdriveLike | undefined;
+  const sql =
+    deps.sql ??
+    (hyperdrive?.connectionString && ctx ? createPgSql(hyperdrive, ctx) : null);
+  const db = deps.db ?? (env?.METAGRAPH_HEALTH_DB as BackfillDb | undefined);
+  const laneDb =
+    deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as LaneHealthDb | undefined);
+  const now = deps.now ?? Date.now;
+  const startedAt = now();
+  const elapsed = deps.elapsed ?? (() => now() - startedAt);
+
+  const latest = await loadLatestLaneHealth(laneDb);
+  const tables: BackfillTableOutcome[] = [];
+  for (const lane of lanes) {
+    const plan = NEON_BACKFILL_PLANS[lane];
+    // An unknown lane is a no-op rather than a throw: the flag is a free-text
+    // list and a typo must not take down the tick for the lanes spelled right.
+    if (!plan) continue;
+
+    const previous = latest[`neon:backfill:${lane}`];
+    if (
+      previous?.verdict === "ok" &&
+      now() - previous.checked_at < IDLE_RECHECK_MS
+    ) {
+      tables.push({
+        table: plan.table,
+        deficits: 0,
+        missing: 0,
+        copied: [],
+        ok: true,
+        skipped: true,
+      });
+      continue;
+    }
+
+    let outcome: BackfillTableOutcome;
+    try {
+      outcome = await reconcileTableToNeon(db, sql, plan, { elapsed });
+    } catch (error) {
+      outcome = {
+        table: plan.table,
+        deficits: 0,
+        missing: 0,
+        copied: [],
+        ok: false,
+        reason: reason(error),
+      };
+    }
+    tables.push(outcome);
+    // `ok` ONLY when the comparison itself found nothing missing -- never on
+    // the tick that copied the last date. A copy reports what it wrote, not
+    // what is now true, so the tick after the final one re-counts both stores
+    // and is what actually declares them equal. That is one extra tick and it
+    // is the difference between "we sent the rows" and "they are there".
+    const settled = outcome.ok && outcome.deficits === 0;
+    await recordLaneVerdict(laneDb, {
+      lane: `neon:backfill:${lane}`,
+      verdict: settled ? "ok" : "stale",
+      age_ms: null,
+      detail: describeOutcome(outcome),
+      checked_at: now(),
+    });
+  }
+  return { attempted: true, tables };
+}

--- a/src/neon-write.ts
+++ b/src/neon-write.ts
@@ -289,7 +289,13 @@ export async function recordNeonWriteVerdict(
 export function neonDualWriteLanes(
   env: Record<string, unknown> | null | undefined,
 ): Set<string> {
-  const raw = env?.NEON_DUAL_WRITE_LANES;
+  return parseLaneList(env?.NEON_DUAL_WRITE_LANES);
+}
+
+/** A comma list, empty on anything that is not one. Shared by all three Neon
+ * flags so "unset", "empty string" and "trailing comma" cannot mean different
+ * things depending on which stage of the cutover is reading them. */
+function parseLaneList(raw: unknown): Set<string> {
   if (typeof raw !== "string" || raw.trim() === "") return new Set();
   return new Set(
     raw
@@ -315,14 +321,24 @@ export function neonDualWriteLanes(
 export function neonReadLanes(
   env: Record<string, unknown> | null | undefined,
 ): Set<string> {
-  const raw = env?.NEON_READ_LANES;
-  if (typeof raw !== "string" || raw.trim() === "") return new Set();
-  return new Set(
-    raw
-      .split(",")
-      .map((lane) => lane.trim())
-      .filter((lane) => lane.length > 0),
-  );
+  return parseLaneList(env?.NEON_READ_LANES);
+}
+
+/**
+ * Which tables the D1 -> Neon reconciler covers (src/neon-backfill.ts).
+ *
+ * A THIRD flag rather than a reuse of the write list, because it answers a
+ * third question. Mirroring a lane says new writes reach Neon; reconciling one
+ * says everything written BEFORE the mirror does too. The five latest-only
+ * tables need only the first -- one producer cycle rewrites them whole -- so
+ * naming them here would copy 800,000 rows to prove they already match.
+ *
+ * Names TABLES, not lanes, because that is what a deficit is measured over.
+ */
+export function neonBackfillLanes(
+  env: Record<string, unknown> | null | undefined,
+): Set<string> {
+  return parseLaneList(env?.NEON_BACKFILL_LANES);
 }
 
 /** Whether `lane`'s reads should be served from Neon on this deployment. */

--- a/tests/neon-backfill.test.ts
+++ b/tests/neon-backfill.test.ts
@@ -1,0 +1,961 @@
+// The D1 -> Neon reconciler (src/neon-backfill.ts, infra#336).
+//
+// This lane copies rows between two stores on a cron with nobody watching, so
+// the tests are about the ways that goes wrong quietly:
+//
+//   * a store that will not answer must NOT read as "the other store has
+//     everything and this one has nothing", which is the shape of a
+//     catastrophic mistaken copy
+//   * D1's 0/1 must arrive as Neon's BOOLEAN -- the one shape difference
+//     between the stores, and one that has already broken this lane once
+//   * the write must carry the out-of-order guard, because today's rows are
+//     being rewritten by the producer WHILE this pages through them
+//   * a tick that copies 4 of 26 missing dates must not report `ok`
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  backfillGuard,
+  copyDateToNeon,
+  d1DateCounts,
+  dateDeficits,
+  describeOutcome,
+  D1_PAGE_ROWS,
+  IDLE_RECHECK_MS,
+  keysetPredicate,
+  MAX_DATES_PER_TICK,
+  NEON_BACKFILL_PLANS,
+  neonDateCounts,
+  readDatePage,
+  reconcileTableToNeon,
+  runNeonBackfill,
+  shapeRowForNeon,
+  TICK_BUDGET_MS,
+} from "../src/neon-backfill.ts";
+import { neonBackfillLanes } from "../src/neon-write.ts";
+
+const NOW = 1_785_800_000_000;
+const PLAN = NEON_BACKFILL_PLANS.neuron_daily;
+
+/** A D1 stand-in that answers each query from a scripted queue and records
+ * every statement it was asked to run. */
+function fakeDb(pages: unknown[][] = [], throwOn: string | null = null) {
+  const calls: { sql: string; values: unknown[] }[] = [];
+  const written: Record<string, unknown>[] = [];
+  const queue = [...pages];
+  const answer = (sql: string, values: unknown[]) => {
+    calls.push({ sql, values });
+    if (throwOn && sql.includes(throwOn))
+      throw new Error("D1_ERROR: overloaded");
+    // A scripted `null` page stands for a D1 response with no `results` key at
+    // all, which is a different thing from an empty result set.
+    const next = queue.length > 0 ? queue.shift() : [];
+    return next === null ? {} : { results: next as unknown[] };
+  };
+  return {
+    calls,
+    written,
+    db: {
+      prepare(sql: string) {
+        return {
+          async all() {
+            return answer(sql, []);
+          },
+          bind(...values: unknown[]) {
+            return {
+              async all() {
+                return answer(sql, values);
+              },
+              async run() {
+                calls.push({ sql, values });
+                if (sql.startsWith("INSERT")) {
+                  written.push({
+                    lane: values[0],
+                    verdict: values[1],
+                    detail: values[3],
+                  });
+                }
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+function fakeSql(rows: unknown[] = [], fail: string | null = null) {
+  const calls: { text: string; values: unknown[] }[] = [];
+  return {
+    calls,
+    sql: {
+      async unsafe(text: string, values: unknown[] = []) {
+        calls.push({ text, values });
+        if (fail && text.includes(fail)) throw new Error("relation missing");
+        return text.startsWith("SELECT") ? rows : [];
+      },
+    },
+  };
+}
+
+function laneSpy() {
+  const written: Record<string, unknown>[] = [];
+  return {
+    written,
+    db: {
+      prepare(sql: string) {
+        return {
+          async all() {
+            return { results: laneSpy.rows };
+          },
+          bind(...values: unknown[]) {
+            return {
+              async run() {
+                if (sql.startsWith("INSERT")) {
+                  written.push({
+                    lane: values[0],
+                    verdict: values[1],
+                    detail: values[3],
+                  });
+                }
+              },
+              async all() {
+                return { results: [] };
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+// Rows loadLatestLaneHealth sees; set per-test, read by the fake above.
+laneSpy.rows = [] as Record<string, unknown>[];
+
+const ctx = { waitUntil() {} };
+
+describe("NEON_BACKFILL_PLANS", () => {
+  test("every plan's conflict, keyset and boolean columns are its own columns", () => {
+    for (const [name, plan] of Object.entries(NEON_BACKFILL_PLANS)) {
+      for (const column of [...plan.conflict, ...plan.booleans]) {
+        assert.ok(
+          plan.columns.includes(column),
+          `${name}: ${column} is not in its own column list`,
+        );
+      }
+      // The keyset is the primary key MINUS snapshot_date, in key order. If it
+      // ever drifted from that, a page would resume from the wrong place and
+      // skip rows silently -- the deficit would shrink and never reach zero.
+      assert.deepEqual(
+        [...plan.keyset, "snapshot_date"].sort(),
+        [...plan.conflict].sort(),
+        `${name}: keyset + snapshot_date must equal the primary key`,
+      );
+    }
+  });
+
+  test("conflict keys match the primary keys D1 declares", () => {
+    // Read off sqlite_master 2026-08-07, and identical in Neon.
+    assert.deepEqual(NEON_BACKFILL_PLANS.neuron_daily.conflict, [
+      "netuid",
+      "uid",
+      "snapshot_date",
+    ]);
+    assert.deepEqual(NEON_BACKFILL_PLANS.account_position_daily.conflict, [
+      "account",
+      "netuid",
+      "snapshot_date",
+    ]);
+  });
+
+  test("guards every write against a concurrent producer pass", () => {
+    assert.equal(
+      backfillGuard("neuron_daily"),
+      "neuron_daily.captured_at < EXCLUDED.captured_at",
+    );
+  });
+});
+
+describe("the deployed wiring", () => {
+  const wrangler = readFileSync("wrangler.data.jsonc", "utf8");
+
+  test("the cron the handler dispatches on is actually declared", async () => {
+    // A constant the trigger list does not carry is a lane that never fires,
+    // and nothing else in CI compares the two.
+    const { NEON_BACKFILL_CRON } = await import("../workers/config.ts");
+    assert.ok(
+      wrangler.includes(`"${NEON_BACKFILL_CRON}"`),
+      `wrangler.data.jsonc declares no "${NEON_BACKFILL_CRON}" cron, so the reconciler never runs`,
+    );
+  });
+
+  test("runs on the Worker that holds BOTH bindings", () => {
+    // D1 in and Hyperdrive out. Anywhere else this would be a copy over HTTP.
+    assert.ok(wrangler.includes('"binding": "METAGRAPH_HEALTH_DB"'));
+    assert.ok(wrangler.includes('"binding": "HYPERDRIVE"'));
+  });
+
+  test("names only the two accumulating tables", () => {
+    // Naming a latest-only table would copy ~800,000 rows to prove they
+    // already agree: one producer cycle rewrites those whole.
+    const named = /"NEON_BACKFILL_LANES":\s*"([^"]*)"/.exec(wrangler)?.[1];
+    assert.deepEqual(named?.split(",").sort(), [
+      "account_position_daily",
+      "neuron_daily",
+    ]);
+    for (const table of named?.split(",") ?? []) {
+      assert.ok(NEON_BACKFILL_PLANS[table], `${table} has no plan`);
+    }
+  });
+});
+
+describe("neonBackfillLanes", () => {
+  test("is its own flag, defaulting to empty", () => {
+    assert.deepEqual([...neonBackfillLanes(undefined)], []);
+    assert.deepEqual([...neonBackfillLanes({})], []);
+    assert.deepEqual([...neonBackfillLanes({ NEON_BACKFILL_LANES: "  " })], []);
+    assert.deepEqual([...neonBackfillLanes({ NEON_BACKFILL_LANES: 7 })], []);
+    assert.deepEqual(
+      [...neonBackfillLanes({ NEON_BACKFILL_LANES: "a, b ,,c" })],
+      ["a", "b", "c"],
+    );
+    // Naming a lane for the mirror must not enrol it in an 800,000-row copy.
+    assert.deepEqual(
+      [...neonBackfillLanes({ NEON_DUAL_WRITE_LANES: "neurons" })],
+      [],
+    );
+  });
+});
+
+describe("keysetPredicate", () => {
+  test("expands to one OR term per key column, with positional values", () => {
+    assert.deepEqual(keysetPredicate(["netuid", "uid"], [12, 500]), {
+      sql: "((netuid > ?) OR (netuid = ? AND uid > ?))",
+      values: [12, 12, 500],
+    });
+  });
+
+  test("a single-column keyset is a plain comparison", () => {
+    assert.deepEqual(keysetPredicate(["account"], ["5A"]), {
+      sql: "((account > ?))",
+      values: ["5A"],
+    });
+  });
+});
+
+describe("dateDeficits", () => {
+  const d1 = new Map([
+    ["2026-08-05", 100],
+    ["2026-08-06", 100],
+    ["2026-08-07", 100],
+    ["2026-08-04", 100],
+  ]);
+
+  test("reports only where Neon has fewer rows, newest date first", () => {
+    const neon = new Map([
+      ["2026-08-05", 100],
+      ["2026-08-06", 40],
+      ["2026-08-07", 0],
+    ]);
+    assert.deepEqual(dateDeficits(d1, neon), [
+      { date: "2026-08-07", d1: 100, neon: 0 },
+      { date: "2026-08-06", d1: 100, neon: 40 },
+      { date: "2026-08-04", d1: 100, neon: 0 },
+    ]);
+  });
+
+  test("a date where Neon holds MORE is not reported", () => {
+    // This path only ever adds rows. A surplus is a question about deletes,
+    // and copying cannot answer it -- reporting it would put the lane
+    // permanently stale over something it can never fix.
+    assert.deepEqual(
+      dateDeficits(
+        new Map([["2026-08-07", 10]]),
+        new Map([["2026-08-07", 99]]),
+      ),
+      [],
+    );
+  });
+
+  test("equal counts are not a deficit", () => {
+    assert.deepEqual(
+      dateDeficits(
+        new Map([["2026-08-07", 10]]),
+        new Map([["2026-08-07", 10]]),
+      ),
+      [],
+    );
+  });
+});
+
+describe("shapeRowForNeon", () => {
+  test("D1's 0/1 become real booleans, and nothing else changes", () => {
+    // The one shape difference between the stores. Rows the live mirror sends
+    // carry JS booleans, so Neon's columns are BOOLEAN; rows read back out of
+    // D1 are integers, so only this path has to convert.
+    assert.deepEqual(
+      shapeRowForNeon(
+        { active: 1, validator_permit: 0, rank: 0.5, hotkey: "5H" },
+        ["active", "validator_permit"],
+      ),
+      { active: true, validator_permit: false, rank: 0.5, hotkey: "5H" },
+    );
+  });
+
+  test("null stays null rather than becoming false", () => {
+    // `active IS NULL` and `active = false` are different facts about a neuron,
+    // and Boolean(null) would quietly merge them.
+    assert.deepEqual(shapeRowForNeon({ active: null }, ["active"]), {
+      active: null,
+    });
+  });
+
+  test("a column the row does not carry is left absent", () => {
+    assert.deepEqual(shapeRowForNeon({ uid: 3 }, ["active"]), { uid: 3 });
+  });
+
+  test("does not mutate its input", () => {
+    const row = { active: 1 };
+    shapeRowForNeon(row, ["active"]);
+    assert.equal(row.active, 1);
+  });
+});
+
+describe("d1DateCounts / neonDateCounts", () => {
+  test("group by snapshot_date on each side", async () => {
+    const d1 = fakeDb([[{ d: "2026-08-07", n: 30109 }]]);
+    assert.deepEqual(
+      [...((await d1DateCounts(d1.db, "neuron_daily")) ?? [])],
+      [["2026-08-07", 30109]],
+    );
+    assert.match(d1.calls[0].sql, /GROUP BY snapshot_date/);
+
+    const neon = fakeSql([{ d: "2026-08-07", n: "30109" }]);
+    assert.deepEqual(
+      [...((await neonDateCounts(neon.sql, "neuron_daily")) ?? [])],
+      // Postgres returns COUNT(*) as a string; the map holds numbers either way.
+      [["2026-08-07", 30109]],
+    );
+    assert.match(neon.calls[0].text, /snapshot_date::text/);
+  });
+
+  test("a store that will not answer returns NULL, never an empty map", async () => {
+    // The distinction this lane's safety rests on. An empty map would read as
+    // "this store holds nothing", and against a healthy other side that is a
+    // deficit of every row in the table.
+    assert.equal(await d1DateCounts(null, "neuron_daily"), null);
+    assert.equal(
+      await d1DateCounts(fakeDb([], "GROUP BY").db, "neuron_daily"),
+      null,
+    );
+    assert.equal(await neonDateCounts(null, "neuron_daily"), null);
+    assert.equal(await neonDateCounts({}, "neuron_daily"), null);
+    assert.equal(
+      await neonDateCounts(fakeSql([], "GROUP BY").sql, "neuron_daily"),
+      null,
+    );
+  });
+
+  test("rows with no date, a bad count, or a non-array response are tolerated", async () => {
+    const d1 = fakeDb([
+      [
+        { d: null, n: 5 },
+        { d: "2026-08-07", n: "x" },
+      ],
+    ]);
+    assert.deepEqual(
+      [...((await d1DateCounts(d1.db, "neuron_daily")) ?? [])],
+      [["2026-08-07", 0]],
+    );
+    const notRows = {
+      async unsafe() {
+        return null;
+      },
+    };
+    assert.deepEqual([...((await neonDateCounts(notRows, "t")) ?? [])], []);
+  });
+
+  test("a D1 response carrying no `results` key is an empty count, not a crash", async () => {
+    const d1 = fakeDb([null as unknown as unknown[]]);
+    assert.deepEqual(
+      [...((await d1DateCounts(d1.db, "neuron_daily")) ?? [])],
+      [],
+    );
+  });
+});
+
+describe("readDatePage", () => {
+  test("the first page has no keyset predicate", async () => {
+    const d1 = fakeDb([[{ netuid: 1 }]]);
+    await readDatePage(d1.db, PLAN, "2026-08-07", null, 500);
+    assert.match(
+      d1.calls[0].sql,
+      /WHERE snapshot_date = \? ORDER BY netuid, uid LIMIT \?/,
+    );
+    assert.deepEqual(d1.calls[0].values, ["2026-08-07", 500]);
+  });
+
+  test("a resumed page seeks past the cursor, in keyset order", async () => {
+    const d1 = fakeDb([[]]);
+    await readDatePage(d1.db, PLAN, "2026-08-07", [12, 500], 500);
+    assert.match(
+      d1.calls[0].sql,
+      /WHERE snapshot_date = \? AND \(\(netuid > \?\) OR \(netuid = \? AND uid > \?\)\)/,
+    );
+    assert.deepEqual(d1.calls[0].values, ["2026-08-07", 12, 12, 500, 500]);
+  });
+
+  test("selects exactly the plan's columns, so the write can bind positionally", async () => {
+    const d1 = fakeDb([[]]);
+    await readDatePage(d1.db, PLAN, "2026-08-07", null, 1);
+    assert.ok(
+      d1.calls[0].sql.startsWith(
+        `SELECT ${PLAN.columns.join(", ")} FROM neuron_daily `,
+      ),
+    );
+  });
+
+  test("a response carrying no `results` key reads as the end of the date", async () => {
+    const d1 = fakeDb([null as unknown as unknown[]]);
+    assert.deepEqual(
+      await readDatePage(d1.db, PLAN, "2026-08-07", null, 1),
+      [],
+    );
+  });
+});
+
+describe("copyDateToNeon", () => {
+  const row = (netuid: number, uid: number) => ({
+    netuid,
+    uid,
+    active: 1,
+    validator_permit: 0,
+    is_immunity_period: 1,
+    captured_at: 9,
+    snapshot_date: "2026-08-07",
+  });
+
+  test("pages until D1 returns a short page, resuming from the last key", async () => {
+    const d1 = fakeDb([[row(1, 1), row(1, 2)], [row(2, 9)]]);
+    const neon = fakeSql();
+    const out = await copyDateToNeon(d1.db, neon.sql, PLAN, "2026-08-07", 2);
+    assert.deepEqual(
+      { ok: out.ok, rows: out.rows, pages: out.pages, date: out.date },
+      { ok: true, rows: 3, pages: 2, date: "2026-08-07" },
+    );
+    // The second read resumes from (1, 2) -- the last row of the first page.
+    assert.deepEqual(d1.calls[1].values, ["2026-08-07", 1, 1, 2, 2]);
+  });
+
+  test("an empty first page finishes without writing", async () => {
+    const d1 = fakeDb([[]]);
+    const neon = fakeSql();
+    const out = await copyDateToNeon(d1.db, neon.sql, PLAN, "2026-08-07", 2);
+    assert.deepEqual(
+      { ok: out.ok, rows: out.rows, pages: out.pages },
+      {
+        ok: true,
+        rows: 0,
+        pages: 0,
+      },
+    );
+    assert.equal(neon.calls.length, 0);
+  });
+
+  test("carries the out-of-order guard and converts the boolean columns", async () => {
+    // Both properties in one assertion because they protect the same write:
+    // the guard stops this path regressing a row the producer just refreshed,
+    // and the conversion is what lets the row be inserted at all.
+    const d1 = fakeDb([[row(1, 1)]]);
+    const neon = fakeSql();
+    await copyDateToNeon(d1.db, neon.sql, PLAN, "2026-08-07", 5);
+    assert.match(
+      neon.calls[0].text,
+      /WHERE neuron_daily\.captured_at < EXCLUDED\.captured_at/,
+    );
+    assert.match(
+      neon.calls[0].text,
+      /ON CONFLICT \(netuid, uid, snapshot_date\)/,
+    );
+    const active = PLAN.columns.indexOf("active");
+    const permit = PLAN.columns.indexOf("validator_permit");
+    assert.equal(neon.calls[0].values[active], true);
+    assert.equal(neon.calls[0].values[permit], false);
+  });
+
+  test("stops at the first failed write rather than paging on", async () => {
+    const d1 = fakeDb([[row(1, 1)], [row(2, 1)]]);
+    const neon = fakeSql([], "INSERT");
+    const out = await copyDateToNeon(d1.db, neon.sql, PLAN, "2026-08-07", 1);
+    assert.equal(out.ok, false);
+    assert.match(String(out.reason), /relation missing/);
+    assert.equal(out.pages, 1);
+    assert.equal(d1.calls.length, 1, "no second page may be read");
+  });
+
+  test("a failed D1 read is reported, not thrown", async () => {
+    const out = await copyDateToNeon(
+      fakeDb([], "SELECT").db,
+      fakeSql().sql,
+      PLAN,
+      "2026-08-07",
+      5,
+    );
+    assert.equal(out.ok, false);
+    assert.match(String(out.reason), /overloaded/);
+  });
+
+  test("a rejection that is not an Error still reads", async () => {
+    const thrower = {
+      prepare() {
+        return {
+          bind() {
+            return {
+              async all(): Promise<never> {
+                throw "connection terminated";
+              },
+            };
+          },
+          async all() {
+            return { results: [] };
+          },
+        };
+      },
+    };
+    const out = await copyDateToNeon(
+      thrower,
+      fakeSql().sql,
+      PLAN,
+      "2026-08-07",
+      5,
+    );
+    assert.equal(out.reason, "connection terminated");
+  });
+
+  test("defaults to the module's page size", async () => {
+    const d1 = fakeDb([[]]);
+    await copyDateToNeon(d1.db, fakeSql().sql, PLAN, "2026-08-07");
+    assert.equal(d1.calls[0].values.at(-1), D1_PAGE_ROWS);
+  });
+});
+
+describe("reconcileTableToNeon", () => {
+  const counts = (n: number) => [{ d: "2026-08-07", n }];
+
+  test("an unbound store is reported, and nothing is read", async () => {
+    assert.deepEqual(await reconcileTableToNeon(null, fakeSql().sql, PLAN), {
+      table: "neuron_daily",
+      deficits: 0,
+      missing: 0,
+      copied: [],
+      ok: false,
+      reason: "unbound",
+    });
+    assert.equal(
+      (await reconcileTableToNeon(fakeDb().db, null, PLAN)).reason,
+      "unbound",
+    );
+  });
+
+  test("a half-read comparison copies NOTHING", async () => {
+    // The property that keeps a transient Neon fault from being read as "Neon
+    // is empty" and triggering an 846,912-row copy.
+    const d1 = fakeDb([counts(100)]);
+    const out = await reconcileTableToNeon(
+      d1.db,
+      fakeSql([], "GROUP BY").sql,
+      PLAN,
+    );
+    assert.equal(out.ok, false);
+    assert.equal(out.reason, "count failed: neon");
+    assert.equal(d1.calls.length, 1, "only the count may be read");
+
+    const failedD1 = await reconcileTableToNeon(
+      fakeDb([], "GROUP BY").db,
+      fakeSql(counts(100)).sql,
+      PLAN,
+    );
+    assert.equal(failedD1.reason, "count failed: d1");
+  });
+
+  test("stores that agree are a no-op", async () => {
+    const d1 = fakeDb([counts(100)]);
+    const out = await reconcileTableToNeon(
+      d1.db,
+      fakeSql(counts(100)).sql,
+      PLAN,
+    );
+    assert.deepEqual(out, {
+      table: "neuron_daily",
+      deficits: 0,
+      missing: 0,
+      copied: [],
+      ok: true,
+    });
+    assert.equal(d1.calls.length, 1);
+  });
+
+  test("copies the deficient dates and reports how much was missing", async () => {
+    const d1 = fakeDb([
+      [
+        { d: "2026-08-06", n: 2 },
+        { d: "2026-08-07", n: 1 },
+      ],
+      [{ netuid: 1, uid: 1, captured_at: 9 }],
+      [{ netuid: 1, uid: 2, captured_at: 9 }],
+    ]);
+    const out = await reconcileTableToNeon(
+      d1.db,
+      fakeSql([{ d: "2026-08-06", n: 0 }]).sql,
+      PLAN,
+    );
+    assert.equal(out.ok, true);
+    assert.equal(out.deficits, 2);
+    assert.equal(out.missing, 3);
+    // Newest first: 08-07 before 08-06.
+    assert.deepEqual(
+      out.copied.map((c) => c.date),
+      ["2026-08-07", "2026-08-06"],
+    );
+  });
+
+  test("caps the dates per tick even when the clock says there is room", async () => {
+    const dates = ["01", "02", "03", "04", "05", "06"].map((d) => ({
+      d: `2026-08-${d}`,
+      n: 1,
+    }));
+    const d1 = fakeDb([dates, ...dates.map(() => [] as unknown[])]);
+    const out = await reconcileTableToNeon(d1.db, fakeSql([]).sql, PLAN, {
+      elapsed: () => 0,
+    });
+    assert.equal(out.deficits, 6);
+    assert.equal(out.copied.length, MAX_DATES_PER_TICK);
+  });
+
+  test("stops on the budget BETWEEN dates, never inside one", async () => {
+    // A date copied halfway would leave a deficit the next tick recomputes
+    // correctly but restarts, so the unit of work is a whole date.
+    const dates = [1, 2, 3].map((i) => ({ d: `2026-08-0${i}`, n: 1 }));
+    const d1 = fakeDb([dates, [], [], []]);
+    const out = await reconcileTableToNeon(d1.db, fakeSql([]).sql, PLAN, {
+      elapsed: () => TICK_BUDGET_MS,
+    });
+    assert.equal(
+      out.copied.length,
+      1,
+      "the first date always runs to completion",
+    );
+  });
+
+  test("a failed copy stops the tick and reports the reason", async () => {
+    const d1 = fakeDb([
+      [
+        { d: "2026-08-07", n: 1 },
+        { d: "2026-08-06", n: 1 },
+      ],
+      [{ netuid: 1, uid: 1, captured_at: 9 }],
+    ]);
+    const out = await reconcileTableToNeon(
+      d1.db,
+      fakeSql([], "INSERT").sql,
+      PLAN,
+    );
+    assert.equal(out.ok, false);
+    assert.match(String(out.reason), /relation missing/);
+    assert.equal(out.copied.length, 1);
+  });
+
+  test("defaults its budget clock rather than requiring one", async () => {
+    const d1 = fakeDb([[{ d: "2026-08-07", n: 1 }], []]);
+    const out = await reconcileTableToNeon(d1.db, fakeSql([]).sql, PLAN);
+    assert.equal(out.ok, true);
+  });
+});
+
+describe("describeOutcome", () => {
+  const base = {
+    table: "neuron_daily",
+    deficits: 0,
+    missing: 0,
+    copied: [],
+    ok: true,
+  };
+
+  test("names the state a reader of lane_health needs", () => {
+    assert.equal(
+      describeOutcome({ ...base, skipped: true }),
+      "no deficit at last check",
+    );
+    assert.equal(describeOutcome(base), "in sync");
+    assert.equal(
+      describeOutcome({
+        ...base,
+        deficits: 26,
+        missing: 816_803,
+        copied: [
+          { ok: true, rows: 100, statements: 1, pages: 1, date: "2026-08-07" },
+        ],
+      }),
+      "100 row(s) over 1 date(s); 25 date(s) / ~816703 row(s) still behind",
+    );
+    assert.equal(
+      describeOutcome({
+        ...base,
+        ok: false,
+        deficits: 2,
+        copied: [
+          { ok: false, rows: 40, statements: 1, pages: 1, date: "2026-08-07" },
+        ],
+      }),
+      "40 row(s) copied before failure: unknown",
+    );
+    assert.match(
+      describeOutcome({ ...base, ok: false, reason: "deadlock" }),
+      /0 row\(s\) copied before failure: deadlock/,
+    );
+  });
+});
+
+describe("runNeonBackfill", () => {
+  const on = { NEON_BACKFILL_LANES: "neuron_daily" };
+
+  test("does nothing until a table is named", async () => {
+    const d1 = fakeDb();
+    for (const env of [undefined, null, {}, { NEON_BACKFILL_LANES: "" }]) {
+      assert.deepEqual(await runNeonBackfill(env, ctx, { db: d1.db }), {
+        attempted: false,
+        tables: [],
+      });
+    }
+    assert.equal(d1.calls.length, 0);
+  });
+
+  test("an UNKNOWN table is a no-op, not a throw", async () => {
+    // The flag is a free-text list, and a typo must not take down the tick for
+    // the tables spelled right.
+    laneSpy.rows = [];
+    const spy = laneSpy();
+    const out = await runNeonBackfill(
+      { NEON_BACKFILL_LANES: "neuron_dialy" },
+      ctx,
+      {
+        db: fakeDb().db,
+        sql: fakeSql().sql,
+        laneHealthDb: spy.db,
+        now: () => NOW,
+      },
+    );
+    assert.deepEqual(out, { attempted: true, tables: [] });
+    assert.equal(spy.written.length, 0);
+  });
+
+  test("reports STALE while any deficit remains, even on a successful copy", async () => {
+    // A tick that copied 4 of 26 missing dates has not finished, and a verdict
+    // of `ok` there would report progress as completion -- which is precisely
+    // what #9698's alarm reads to decide whether this lane is converging.
+    laneSpy.rows = [];
+    const spy = laneSpy();
+    const d1 = fakeDb([[{ d: "2026-08-07", n: 1 }], []]);
+    await runNeonBackfill(on, ctx, {
+      db: d1.db,
+      sql: fakeSql([]).sql,
+      laneHealthDb: spy.db,
+      now: () => NOW,
+    });
+    assert.equal(spy.written[0].lane, "neon:backfill:neuron_daily");
+    assert.equal(spy.written[0].verdict, "stale");
+  });
+
+  test("reports OK only when the comparison itself finds nothing missing", async () => {
+    laneSpy.rows = [];
+    const spy = laneSpy();
+    const d1 = fakeDb([[{ d: "2026-08-07", n: 5 }]]);
+    await runNeonBackfill(on, ctx, {
+      db: d1.db,
+      sql: fakeSql([{ d: "2026-08-07", n: 5 }]).sql,
+      laneHealthDb: spy.db,
+      now: () => NOW,
+    });
+    assert.equal(spy.written[0].verdict, "ok");
+    assert.equal(spy.written[0].detail, "in sync");
+  });
+
+  test("skips the comparison for an hour after a clean verdict", async () => {
+    // Two grouped counts over ~840,000 rows each is worth paying every three
+    // minutes while copying and worth paying hourly once it is a watchdog.
+    laneSpy.rows = [
+      {
+        lane: "neon:backfill:neuron_daily",
+        verdict: "ok",
+        age_ms: null,
+        detail: "in sync",
+        checked_at: NOW - 60_000,
+      },
+    ];
+    const spy = laneSpy();
+    const d1 = fakeDb();
+    const out = await runNeonBackfill(on, ctx, {
+      db: d1.db,
+      sql: fakeSql().sql,
+      laneHealthDb: spy.db,
+      now: () => NOW,
+    });
+    assert.equal(out.tables[0].skipped, true);
+    assert.equal(d1.calls.length, 0, "no count may be run while suppressed");
+    assert.equal(spy.written.length, 0, "and no verdict is rewritten");
+  });
+
+  test("a STALE verdict is never suppressed, however recent", async () => {
+    // Suppressing on a known-bad state is how a lane goes quiet while broken.
+    laneSpy.rows = [
+      {
+        lane: "neon:backfill:neuron_daily",
+        verdict: "stale",
+        age_ms: null,
+        detail: "behind",
+        checked_at: NOW - 1_000,
+      },
+    ];
+    const spy = laneSpy();
+    const d1 = fakeDb([[{ d: "2026-08-07", n: 1 }]]);
+    const out = await runNeonBackfill(on, ctx, {
+      db: d1.db,
+      sql: fakeSql([{ d: "2026-08-07", n: 1 }]).sql,
+      laneHealthDb: spy.db,
+      now: () => NOW,
+    });
+    assert.equal(out.tables[0].skipped, undefined);
+    assert.ok(d1.calls.length > 0);
+  });
+
+  test("an EXPIRED clean verdict re-compares", async () => {
+    laneSpy.rows = [
+      {
+        lane: "neon:backfill:neuron_daily",
+        verdict: "ok",
+        age_ms: null,
+        detail: "in sync",
+        checked_at: NOW - IDLE_RECHECK_MS - 1,
+      },
+    ];
+    const spy = laneSpy();
+    const d1 = fakeDb([[{ d: "2026-08-07", n: 1 }]]);
+    await runNeonBackfill(on, ctx, {
+      db: d1.db,
+      sql: fakeSql([{ d: "2026-08-07", n: 1 }]).sql,
+      laneHealthDb: spy.db,
+      now: () => NOW,
+    });
+    assert.equal(spy.written[0].verdict, "ok");
+  });
+
+  test("one table's fault costs a verdict, never the other table's turn", async () => {
+    // Everything inside reconcileTableToNeon guards its own store access, so
+    // the outer catch exists for what those guards do not cover -- here, an
+    // injected clock. What it protects is the LOOP: two tables share this
+    // tick, and the first one faulting must not leave the second unmeasured.
+    laneSpy.rows = [];
+    const spy = laneSpy();
+    let ticks = 0;
+    const out = await runNeonBackfill(
+      { NEON_BACKFILL_LANES: "neuron_daily,account_position_daily" },
+      ctx,
+      {
+        db: fakeDb([
+          [
+            { d: "2026-08-07", n: 1 },
+            { d: "2026-08-06", n: 1 },
+          ],
+          [],
+          [{ d: "2026-08-07", n: 1 }],
+        ]).db,
+        sql: fakeSql([]).sql,
+        laneHealthDb: spy.db,
+        now: () => NOW,
+        elapsed: () => {
+          ticks += 1;
+          if (ticks === 1) throw new Error("clock unavailable");
+          return 0;
+        },
+      },
+    );
+    assert.equal(out.attempted, true);
+    assert.equal(out.tables[0].ok, false);
+    assert.deepEqual(
+      spy.written.map((r) => [r.lane, r.verdict]),
+      [
+        ["neon:backfill:neuron_daily", "stale"],
+        ["neon:backfill:account_position_daily", "stale"],
+      ],
+    );
+    assert.match(String(spy.written[0].detail), /clock unavailable/);
+  });
+
+  test("enabled with no Hyperdrive records the misconfiguration", async () => {
+    laneSpy.rows = [];
+    const spy = laneSpy();
+    const out = await runNeonBackfill(on, null, {
+      db: fakeDb().db,
+      laneHealthDb: spy.db,
+      now: () => NOW,
+    });
+    assert.equal(out.tables[0].reason, "unbound");
+    assert.equal(spy.written[0].verdict, "stale");
+  });
+
+  test("times its own budget from the start of the tick when none is injected", async () => {
+    // The default budget clock is a closure over the tick's start, so a tick
+    // that copies several dates measures itself against when IT began rather
+    // than against each date.
+    laneSpy.rows = [];
+    const spy = laneSpy();
+    const out = await runNeonBackfill(on, ctx, {
+      db: fakeDb([
+        [
+          { d: "2026-08-07", n: 1 },
+          { d: "2026-08-06", n: 1 },
+        ],
+        [],
+        [],
+      ]).db,
+      sql: fakeSql([]).sql,
+      laneHealthDb: spy.db,
+    });
+    assert.equal(out.tables[0].ok, true);
+    assert.equal(out.tables[0].copied.length, 2);
+  });
+
+  test("takes its D1, its lane record and its clock off env, with no deps at all", async () => {
+    // The Worker calls this with `(env, ctx)` and nothing else, so every `??`
+    // in the wiring has to resolve from the environment -- including the fact
+    // that METAGRAPH_HEALTH_DB is BOTH the store being reconciled and the
+    // store the verdict is written to, because in production they are one
+    // binding over one database.
+    //
+    // Hyperdrive points at a closed port, so this also covers the real
+    // createPgSql path and a dead origin reading as a failed comparison rather
+    // than an empty Neon.
+    const combined = fakeDb([
+      [], // loadLatestLaneHealth: no prior verdict
+      [{ d: "2026-08-07", n: 30_109 }], // d1DateCounts
+    ]);
+    const out = await runNeonBackfill(
+      {
+        ...on,
+        HYPERDRIVE: { connectionString: "postgresql://u:p@127.0.0.1:1/none" },
+        METAGRAPH_HEALTH_DB: combined.db,
+      },
+      ctx,
+    );
+    assert.equal(out.attempted, true);
+    assert.equal(out.tables[0].ok, false);
+    assert.match(String(out.tables[0].reason), /count failed: neon/);
+    assert.deepEqual(combined.written, [
+      {
+        lane: "neon:backfill:neuron_daily",
+        verdict: "stale",
+        detail: "0 row(s) copied before failure: count failed: neon",
+      },
+    ]);
+  });
+});

--- a/tests/neon-backfill.test.ts
+++ b/tests/neon-backfill.test.ts
@@ -349,7 +349,9 @@ describe("d1DateCounts / neonDateCounts", () => {
       null,
     );
     assert.equal(await neonDateCounts(null, "neuron_daily"), null);
-    assert.equal(await neonDateCounts({}, "neuron_daily"), null);
+    // A runner object with no `unsafe` on it -- what createPgSql returns when
+    // the binding is present but the connection never opened.
+    assert.equal(await neonDateCounts({} as never, "neuron_daily"), null);
     assert.equal(
       await neonDateCounts(fakeSql([], "GROUP BY").sql, "neuron_daily"),
       null,

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -301,11 +301,33 @@ export const FRESHNESS_WATCHDOG_STATE_KEY = "watchdog:freshness:signature";
 // #8600: TAO/USD index tick. Every minute, which is ADR 0025 decision 5's
 // cadence and also Cloudflare's finest cron granularity -- the 300s staleness
 // threshold in the same decision assumes it, giving a reading four ticks of
-// headroom before it is served as stale. This is the only cron on the data-api
-// Worker; it lives there rather than on the api Worker because that is where
-// the Hyperdrive binding is, and a cross-Worker hop for a write the same
-// Worker could do is the shape #4832 spent a PR removing.
+// headroom before it is served as stale. It lives on the data-api Worker
+// rather than the api Worker because that is where the Hyperdrive binding is,
+// and a cross-Worker hop for a write the same Worker could do is the shape
+// #4832 spent a PR removing.
 export const TAO_USD_INDEX_CRON = "* * * * *";
+
+/**
+ * The D1 -> Neon reconciler tick (metagraphed-infra#336).
+ *
+ * On the data-api Worker for the same reason as the line above -- it is the
+ * only Worker holding BOTH the D1 binding the rows come from and the Hyperdrive
+ * binding they go to, so anywhere else this would be a copy over HTTP.
+ *
+ * EVERY THREE MINUTES, which is a backfill cadence rather than a watchdog one.
+ * The first run has ~817,000 rows of `neuron_daily` history to move at up to
+ * four dates a tick, and at this cadence that converges in well under an hour;
+ * an hourly cron would take a day. It does not stay expensive once it lands:
+ * the lane skips its comparison entirely for an hour after a clean verdict
+ * (IDLE_RECHECK_MS), so the steady state is one grouped count per store per
+ * hour and every tick in between is a single read of `lane_health`.
+ *
+ * Distinct from TAO_USD_INDEX_CRON's `* * * * *` rather than folded into it:
+ * two expressions deliver two events with two `controller.cron` values, which
+ * is what lets the handler dispatch without a minute-of-the-hour test that
+ * would drift the moment either cadence changed.
+ */
+export const NEON_BACKFILL_CRON = "*/3 * * * *";
 
 /**
  * The webhook fan-out tick (metagraphed-infra#354).

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -45,7 +45,7 @@ import {
   rowFromBatch,
   type TaoUsdIndexRow,
 } from "../src/tao-usd-ingest.ts";
-import { TAO_USD_INDEX_CRON } from "./config.ts";
+import { NEON_BACKFILL_CRON, TAO_USD_INDEX_CRON } from "./config.ts";
 import {
   buildConcentration,
   buildChainConcentration,
@@ -373,6 +373,7 @@ import { mirrorNeuronSnapshotToNeon } from "../src/neurons-neon-write.ts";
 import { mirrorNominatorPositionsToNeon } from "../src/nominator-positions-neon-write.ts";
 import { mirrorLedgerToNeon } from "../src/ledger-neon-write.ts";
 import { neonReadEnabled } from "../src/neon-write.ts";
+import { runNeonBackfill } from "../src/neon-backfill.ts";
 import {
   writeAccountIdentityToD1,
   writeSubnetHyperparamsToD1,
@@ -7307,8 +7308,14 @@ export default {
   async scheduled(
     controller: ScheduledController,
     env: Env,
-    _ctx: ExecutionContext,
+    ctx: ExecutionContext,
   ) {
+    if (controller?.cron === NEON_BACKFILL_CRON) {
+      // `ctx` is threaded through rather than ignored: createPgSql needs a
+      // waitUntil to hold the Hyperdrive connection open past the handler's
+      // return, and without it the reconciler declines instead of copying.
+      return runNeonBackfill(env as unknown as Record<string, unknown>, ctx);
+    }
     if (controller?.cron !== TAO_USD_INDEX_CRON) {
       return { ok: false, skipped: true, reason: "unknown cron" };
     }

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -126,6 +126,20 @@
     // not a slower query.
     "NEON_DUAL_WRITE_LANES": "neurons,nominator-positions,account-balances,hotkey-alpha,validator-nominator-counts",
     "NEON_READ_LANES": "",
+    // The two ACCUMULATING tables, and only those (src/neon-backfill.ts).
+    //
+    // The mirror above writes what each request carries, which finishes the job
+    // for the five LATEST-ONLY tables -- one producer cycle rewrites `neurons`,
+    // `nominator_positions` and the three flat ledgers whole, and `neurons`
+    // duly matched D1 exactly on its first pass. These two accumulate by date
+    // and are never rewritten, so the mirror covers only the days it was
+    // running for. Measured 2026-08-07: `neuron_daily` D1 846,912 / Neon
+    // 30,109; `account_position_daily` D1 834,081 / Neon 833,849.
+    //
+    // Naming a latest-only table here would copy 800,000 rows to prove they
+    // already agree, which is why this is a third flag rather than a reuse of
+    // the write list.
+    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily",
     "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",
     // THE QUEUE CUTOVER (metagraphed-infra#348). Comma-separated lanes whose D1
@@ -278,8 +292,14 @@
   // No committed default either: unset, the tick is a recorded no-op rather
   // than a silent fallback to somebody's public node. See
   // workers/env-extra.d.ts for why that is a choice and not an oversight.
+  // "* * * * *" = TAO_USD_INDEX_CRON; "*/3 * * * *" = NEON_BACKFILL_CRON, the
+  // D1 -> Neon reconciler (workers/config.ts documents both cadences). The
+  // second is a SUBSET of the first by the clock and still a separate entry:
+  // Cloudflare delivers one event per matching expression with its own
+  // `controller.cron`, so the handler dispatches on the string rather than on
+  // what minute it happens to be.
   "triggers": {
-    "crons": ["* * * * *"],
+    "crons": ["* * * * *", "*/3 * * * *"],
   },
 
   // HYPERDRIVE is gone with the box (2026-08-03): the Postgres it fronted was
@@ -401,6 +421,7 @@
   // different answers:
   //
   //   NEON_DUAL_WRITE_LANES  which lanes MIRROR into Neon after their D1 write
+  //   NEON_BACKFILL_LANES    which tables are RECONCILED D1 -> Neon on a cron
   //   NEON_READ_LANES        which lanes are SERVED from Neon
   //
   // Both empty at this commit, so rebinding moves nothing. The order is fixed:


### PR DESCRIPTION
Closes #9751

The write side of the Neon consolidation is done — seven tables, thirteen call sites. This is the part the mirror structurally cannot do.

## What the mirror finishes and what it does not

A mirror writes what each request carries. Five of the seven tables are fully rewritten every producer cycle, so one cycle after the mirror turned on they agree — `neurons` matched D1 exactly on its first pass, 129 netuids, 30,109 rows, identical `SUM(uid)`. The two **daily** tables accumulate by date and are never rewritten, so the mirror covers only the days it ran for:

| table | D1 | Neon | missing |
|---|---:|---:|---:|
| `neurons` | 30,109 | 30,109 | 0 |
| `account_position_daily` | 834,081 | 833,849 | 232 |
| `neuron_daily` | 846,912 | 30,109 | 816,803 |

## Why a reconciler rather than a script

A script closes that once. It does not close it the next time a mirror write fails mid-chunk, a lane is toggled, or a deploy lands between two halves of a producer cycle. And nothing in the estate compared the two stores **at all** — which is the blind spot that let a frozen Neon serve `GET /api/v1/accounts/{ss58}/subnets/{netuid}/history` for two days without a failing check (#9705). So this stays wired after it converges, as the consistency check that did not exist.

## The deficit is the cursor

No state table, no stored progress. Each tick asks both stores for per-date row counts and copies the newest date where Neon is short. An interrupted tick, a redeploy mid-copy, and two overlapping ticks all resolve to the same place, because the only state is the data itself. The unit of work is a whole date for the same reason — the budget is checked *between* dates, never inside one.

## The three things the copy has to get right

- **A store that will not answer returns `null`, never an empty map.** An empty map reads as "this store holds nothing", and against a healthy other side that is a deficit of every row in the table. A transient Neon fault must not trigger an 846,912-row copy.
- **The write carries `captured_at < EXCLUDED.captured_at`.** Today's rows are being rewritten by the producer *while* this pages through them, so without the guard a page read at 12:00 and written at 12:01 would overwrite what the mirror wrote at 12:00:30.
- **D1's `0`/`1` becomes Neon's `BOOLEAN`.** The one shape difference between the stores, and one that has already broken this lane — the rows the live mirror sends carry real JS booleans, so Neon's columns are `BOOLEAN`; rows read back out of D1 are integers.

## Reporting

`ok` only when the comparison itself finds nothing missing — never on the tick that copied the last date. A copy reports what it sent, not what is there, so the tick *after* the final one is what declares the stores equal. While a deficit remains the verdict is `stale`, which is what #9698's alarm reads to decide whether this lane is still converging.

Once clean, the lane suppresses its own comparison for an hour, so the steady state is one grouped count per store per hour rather than two 840,000-row scans every three minutes.

## Migration 0028

`account_position_daily` had **no** date-leading index — `WHERE snapshot_date = ?` was a full scan per page, ~139M rows read for a single date. `neuron_daily`'s existing `(snapshot_date, netuid)` stopped one column short of the `ORDER BY`, and is dropped as a strict prefix of the new `(snapshot_date, netuid, uid)`.

**Applied by hand before merge**, per this repo's D1 convention.

## Not in this PR

`NEON_READ_LANES` stays empty. This is the work that has to finish before it can change.

## Verification

- 51 tests, **100% statements / branches / functions / lines** on `src/neon-backfill.ts`
- `npm run build` clean, no contract drift
- The wiring is pinned by test: the cron constant the handler dispatches on must appear in `wrangler.data.jsonc`'s trigger list, both bindings must be on this Worker, and every table named in the flag must have a plan