### PR TITLE
fix(health): name each subnet in the rollup, so sort=name stops lying

### DIFF
--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -939,8 +939,14 @@ async function validateR2OnlyArtifactsStayOutOfPublicGit(): Promise<void> {
 // (`gap_count`), curation (`curation_level`, reachable only at `curation.level`),
 // rpc-endpoints (`layer`/`publication_state`/`pool_eligible`/`score`, emitted by
 // the sibling resource artifact but not this one), and health-subnets (`name`,
-// tracked separately: those rows are written by the live prober cron, not by a
-// build artifact, so the fix does not live here -- #9715).
+// fixed at the producer in #9715: the prober received subnet_name on its input
+// surface and dropped it before the per-netuid rollup).
+//
+// WHAT THIS CANNOT SEE. It reads BUILT artifacts, so a collection served from
+// KV or computed live is skipped -- /api/v1/health and /api/v1/incidents today.
+// tests/artifacts.test.ts asserts that skipped set is exactly those two, so a
+// route falling out of coverage fails rather than going quiet; both were
+// verified against live responses.
 //
 // Driven off the contract rather than a hand-kept list, so a collection added
 // later is covered the day it is added.

--- a/src/health-prober.ts
+++ b/src/health-prober.ts
@@ -425,6 +425,14 @@ export async function loadOperationalSurfaces(env: Env): Promise<Row[]> {
   return [];
 }
 
+/** `{ name }` when any surface in the group carries one, `{}` otherwise. */
+function nameOf(rows: Row[]): Row {
+  const named = rows.find(
+    (row) => typeof row.subnet_name === "string" && row.subnet_name,
+  );
+  return named ? { name: named.subnet_name as string } : {};
+}
+
 function summarizeGroup(rows: Row[]): Row {
   const counts = emptyStatusCounts();
   let lastChecked = 0;
@@ -574,6 +582,13 @@ export async function runHealthProber(
       // #1005: stable key re-keyed onto D1 history; null for pre-#1005 artifacts.
       surface_key: surface.surface_key ?? null,
       netuid: surface.netuid,
+      // #9715: carried through so the per-netuid rollup below can name the
+      // subnet. It was already on the ProbeSurface input (see subnet_name
+      // above) and dropped here, which left /api/v1/health advertising
+      // `sort=name` over rows that had no name -- sortRows does a flat
+      // row[key] lookup, so every row sank and the list came back untouched
+      // while meta.pagination.sort echoed the field back.
+      subnet_name: surface.subnet_name ?? null,
       kind: surface.kind,
       provider: surface.provider || null,
       url: surface.url,
@@ -700,7 +715,19 @@ async function persistToKv(
     byNetuid.set(row.netuid, group);
   }
   const subnets = [...byNetuid.entries()]
-    .map(([netuid, rows]) => ({ netuid, ...summarizeGroup(rows) }))
+    .map(([netuid, rows]) => ({
+      netuid,
+      // Every surface in a group belongs to the same subnet, so any row that
+      // carries the name answers for the group; the find rather than [0] is
+      // because a surface may have been registered without one.
+      //
+      // OMITTED rather than null when nothing carries it: the contract has
+      // always declared `name: z.string().optional()` on this row, so the
+      // shape it promises is "a string or absent", and a null would fail the
+      // .strict() schema that has been describing this payload all along.
+      ...nameOf(rows),
+      ...summarizeGroup(rows),
+    }))
     .sort((a, b) => (a.netuid as number) - (b.netuid as number));
 
   const current: Row = {

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -2448,14 +2448,34 @@ test("Worker API serves public artifact envelopes", async () => {
 //
 // Driven off the contract, not a hand-kept list, so a collection added later is
 // covered on the day it is added rather than the day someone remembers to.
-const SORT_FIELDS_WITHOUT_A_BUILT_ROW: Record<string, string[]> = {
-  // Written by the health prober into KV, not by this build. See #9715.
-  "/api/v1/health": ["name"],
-};
+/**
+ * Routes whose collection this build produces no artifact for, so the
+ * assertion below cannot reach them.
+ *
+ * DECLARED, because the version that shipped in #9716 carried a per-field
+ * exemption for /api/v1/health that was DEAD CODE: the loop skips a route
+ * whose artifact is absent long before it consults any exemption, and
+ * /metagraph/health/summary.json is written by the prober cron, never by the
+ * build. So the gate was quietly silent about that whole route while appearing
+ * to make a considered exception for one of its fields.
+ *
+ * Naming the skipped routes and asserting the set is EXACTLY this makes the
+ * silence visible: a route that starts being built gets checked from that
+ * moment, and one whose artifact stops being produced fails here instead of
+ * dropping out of coverage without a word. Both entries were verified against
+ * live responses before being listed -- /api/v1/incidents carries all four of
+ * its sort fields, and /api/v1/health's `name` is fixed at the producer
+ * (#9715) rather than exempted here.
+ */
+const ROUTES_THIS_BUILD_HAS_NO_ARTIFACT_FOR = [
+  "/api/v1/health",
+  "/api/v1/incidents",
+];
 
 test("every advertised sort field exists on the rows that route serves", () => {
   const collections = API_QUERY_COLLECTIONS as Record<string, Row>;
   let checked = 0;
+  const skipped: string[] = [];
 
   for (const apiRoute of API_ROUTES as Row[]) {
     const collectionName = apiRoute.query_collection as string | null;
@@ -2470,7 +2490,10 @@ test("every advertised sort field exists on the rows that route serves", () => {
     const collection = collections[collectionName];
     const sortFields = (collection?.sort_fields as string[]) || [];
     if (sortFields.length === 0) continue;
-    if (!existsSync(artifactFilePath(relative))) continue;
+    if (!existsSync(artifactFilePath(relative))) {
+      skipped.push(apiRoute.path as string);
+      continue;
+    }
 
     const rows = readArtifact(relative)[collection.data_key as string];
     if (!Array.isArray(rows) || rows.length === 0) continue;
@@ -2482,11 +2505,7 @@ test("every advertised sort field exists on the rows that route serves", () => {
       }
     }
 
-    const exempt = new Set(
-      SORT_FIELDS_WITHOUT_A_BUILT_ROW[apiRoute.path as string] || [],
-    );
     for (const field of sortFields) {
-      if (exempt.has(field)) continue;
       checked += 1;
       assert.ok(
         present.has(field),
@@ -2502,6 +2521,16 @@ test("every advertised sort field exists on the rows that route serves", () => {
   assert.ok(
     checked > 50,
     `expected to check well over 50 advertised sort fields, checked ${checked}`,
+  );
+
+  // And the silence is declared. A route that gains a built artifact should be
+  // checked from that moment; one that loses it should fail here rather than
+  // slipping out of coverage unremarked.
+  assert.deepEqual(
+    [...new Set(skipped)].sort(),
+    [...ROUTES_THIS_BUILD_HAS_NO_ARTIFACT_FOR].sort(),
+    "the set of routes this gate cannot reach has changed — verify the new " +
+      "one's sorts against a live response, then update the list",
   );
 });
 

--- a/tests/health-prober.test.ts
+++ b/tests/health-prober.test.ts
@@ -1749,6 +1749,63 @@ describe("persistToKv via runHealthProber", () => {
     assert.equal(posted.length, 1);
   });
 
+  test("names each subnet in the rollup, so sort=name is not inert (#9715)", async () => {
+    // /api/v1/health advertises `sort=name` and workers/list-query.ts resolves
+    // a sort with a flat row[key] lookup, sinking rows whose value is absent.
+    // With no `name` on these rows EVERY row sank, the list came back in its
+    // original order, and meta.pagination.sort echoed "name" back -- a ranking
+    // that announced itself and never happened. The prober had the name all
+    // along: it arrives on the ProbeSurface input and was dropped one step
+    // later, before the per-netuid grouping.
+    const kv = makeKv();
+    await runHealthProber(
+      mockEnv(),
+      FAKE_CTX,
+      proberOverrides({
+        now: () => 5000,
+        db: makeDb(),
+        kv,
+        loadSurfaces: async () => SURFACES,
+        probeSurface: probeImpl,
+        probeOptions: {},
+      }),
+    );
+    const current = kv.json(KV_HEALTH_CURRENT);
+    const byNetuid = new Map<number, Row>(
+      current.subnets.map((s: Row) => [s.netuid as number, s]),
+    );
+    assert.equal(byNetuid.get(0)?.name, "root");
+    assert.equal(byNetuid.get(7)?.name, "Acme");
+    // Every rollup row carries one, which is the property the sort needs.
+    for (const subnet of current.subnets as Row[]) {
+      assert.equal(typeof subnet.name, "string", `netuid ${subnet.netuid}`);
+    }
+  });
+
+  test("omits `name` rather than nulling it when no surface carries one", async () => {
+    // The contract has always declared `name: z.string().optional()` on this
+    // row, so the shape it promises is "a string or absent". A null would fail
+    // the .strict() schema that has been describing this payload all along.
+    const kv = makeKv();
+    await runHealthProber(
+      mockEnv(),
+      FAKE_CTX,
+      proberOverrides({
+        now: () => 5000,
+        db: makeDb(),
+        kv,
+        loadSurfaces: async () =>
+          SURFACES.map(({ subnet_name: _dropped, ...rest }) => rest),
+        probeSurface: probeImpl,
+        probeOptions: {},
+      }),
+    );
+    const current = kv.json(KV_HEALTH_CURRENT);
+    for (const subnet of current.subnets as Row[]) {
+      assert.equal("name" in subnet, false, `netuid ${subnet.netuid}`);
+    }
+  });
+
   test("builds the rpc-pool snapshot from RPC-kind rows incl. eligible_count", async () => {
     // Two RPC-kind surfaces: one ok (eligible), one failed (ineligible), plus a
     // non-RPC api surface that must be excluded from the pool.


### PR DESCRIPTION
## Summary

`/api/v1/health` advertises `sort=name`. Its rows carry `netuid` and nothing else:

```
avg_latency_ms, degraded_count, failed_count, last_checked, last_ok,
latency_sample_count, netuid, ok_count, status, surface_count, unknown_count
```

`sortRows` resolves a sort with a flat `row[key]` lookup and sinks rows whose value is absent, so **every** row sank, the list came back in its original order, and `meta.pagination.sort` echoed `"name"` back. A ranking that announced itself and never happened. Split out of #9710 as #9715.

## The prober had the name all along

`ProbeSurface` receives `subnet_name` (`src/health-prober.ts:533`) and the probed row dropped it one step later, before the per-netuid grouping that builds the rollup. Carrying it through is the whole fix — the serving path is untouched.

**Fixed at the producer rather than by joining the registry at serve time.** `loadGlobalOperationalHealth` takes only `env` + `readHealthKv`, so a serve-time join would add an artifact read to a short-cached route on every request, to recover a value that was already in hand when the row was written. This costs ~2.6 KB in one KV value per 15-minute cron.

## It never satisfied its own schema

`HealthSubnetSummarySchema` has always declared `name: z.string().optional()`. So this was not a contract gap — it was a producer that never wrote a field its published contract already promised.

That also settles the null question: `optional()` means *"a string or absent"*, so the name is **omitted**, not nulled, when no surface carries one. A null would fail the `.strict()` schema that has been describing this payload all along. Both behaviours are tested.

## It also removes dead code this gate shipped with

#9716 added `SORT_FIELDS_WITHOUT_A_BUILT_ROW` exempting `/api/v1/health`'s `name`. That exemption was **never reachable**: the loop skips a route whose artifact is absent long before consulting any exemption, and `/metagraph/health/summary.json` is written by the prober cron, never by the build. So the gate was silent about that whole route while appearing to make a considered exception for one of its fields — worse than saying nothing, because it implied coverage that did not exist.

Replaced with the honest thing. The skipped set is now **declared** and asserted to be exactly:

```
/api/v1/health      (11 sorts)
/api/v1/incidents   ( 4 sorts)
```

— the two routes this build produces no artifact for, out of 34 with a sort enum (24 checked, 8 templated). A route that gains a built artifact is checked from that moment; one that loses it fails here rather than dropping out of coverage unremarked.

Verified the new assertion can fail — removing one entry produces:

```
AssertionError: the set of routes this gate cannot reach has changed
  [ '/api/v1/health', + '/api/v1/incidents' ]
```

`/api/v1/incidents` was checked against a live response before being listed rather than assumed: its rows carry all four of `downtime_ms`, `incident_count`, `netuid`, `surface_id`.

## Validation run

```
npm run build && npm run validate    # 129 subnets, 3442 surfaces
npm run lint && npm run format:check && npx tsc --noEmit
```

Tests: 456 across the artifact gate, the prober, the schemas and the health loader — including two new producer cases (the name reaches every rollup row; it is omitted rather than nulled when absent).

Closes #9715
