### PR TITLE
feat(ui): verify the checksum in the search boxes, and recognise what they missed

### DIFF
--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -43,7 +43,7 @@ import {
 } from "lucide-react";
 import { askQuestion, searchQuery, semanticSearchQuery } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
-import { isValidSs58 } from "@/lib/metagraphed/accounts";
+import { isChecksumValidSs58, isValidH160, normalizeH160 } from "@/lib/metagraphed/accounts";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { resolveAddress } from "@/lib/metagraphed/resolve-address";
 import { isCompositeExtrinsicRef } from "@/lib/metagraphed/extrinsics";
@@ -269,7 +269,15 @@ const KIND_META: Record<string, { label: string; icon: typeof Layers; cls: strin
 // smaller AI-ranked complement, not a replacement.
 const SEMANTIC_LIMIT = 8;
 
-type Target = { to: string; params?: Record<string, string> } | { external: string };
+type Target =
+  | {
+      to: string;
+      params?: Record<string, string>;
+      /** Query string for a destination that is a search param rather than a
+       * path segment -- `?h160=` and `?uid=` (metagraphed-infra#373/#376). */
+      search?: Record<string, string | number>;
+    }
+  | { external: string };
 
 function targetToHref(target: Target): string {
   if ("external" in target) return target.external;
@@ -277,6 +285,16 @@ function targetToHref(target: Target): string {
   if (target.params) {
     for (const [k, v] of Object.entries(target.params))
       path = path.replace(`$${k}`, encodeURIComponent(v));
+  }
+  // Appended here, not only at navigate(): this href is also what "copy link"
+  // writes to the clipboard and what the open-in-new-tab path uses, so a search
+  // param left out here produces a link that silently loses the identifier --
+  // which is the bug metagraphed-infra#373 was.
+  if (target.search) {
+    const query = new URLSearchParams(
+      Object.entries(target.search).map(([k, v]) => [k, String(v)]),
+    ).toString();
+    if (query) path += `?${query}`;
   }
   return path;
 }
@@ -480,7 +498,9 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
       icon: typeof User;
       searchValue?: string;
     }> = [];
-    if (isValidSs58(q)) {
+    // CHECKSUM, not shape (metagraphed-infra#376) -- see nav-omnibox for the
+    // full argument. The two boxes had the same gap and now share the recogniser.
+    if (isChecksumValidSs58(q)) {
       targets.push({
         label: `Account ${resolveAddress(q, { keep: 8 }).display}`,
         hint: q,
@@ -488,6 +508,30 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
         searchValue: q,
         kind: "account",
         icon: User,
+      });
+    }
+    if (isValidH160(q)) {
+      targets.push({
+        label: `EVM ${q.slice(0, 10)}\u2026${q.slice(-6)}`,
+        hint: "find the account this EVM address maps to",
+        target: { to: "/accounts", search: { h160: normalizeH160(q) } },
+        searchValue: q,
+        kind: "account",
+        icon: User,
+      });
+    }
+    const neuronRef = /^(\d{1,4}):(\d{1,5})$/.exec(q);
+    if (neuronRef && Number(neuronRef[1]) <= 1024) {
+      targets.push({
+        label: `Subnet ${neuronRef[1]} \u00b7 uid ${neuronRef[2]}`,
+        hint: "jump to a neuron by netuid:uid",
+        target: {
+          to: "/subnets/$netuid",
+          params: { netuid: neuronRef[1]! },
+          search: { uid: Number(neuronRef[2]) },
+        },
+        kind: "subnet",
+        icon: Hash,
       });
     }
     if (/^(?:0|[1-9][0-9]{0,9})$/.test(q)) {
@@ -588,7 +632,11 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
       }
       trackAction("open:same-tab");
       onOpenChange(false);
-      router.navigate({ to: target.to, params: target.params as never });
+      router.navigate({
+        to: target.to,
+        params: target.params as never,
+        search: (target.search ?? {}) as never,
+      });
     },
     [router, onOpenChange, debounced],
   );

--- a/apps/ui/src/components/metagraphed/nav-omnibox.tsx
+++ b/apps/ui/src/components/metagraphed/nav-omnibox.tsx
@@ -20,7 +20,7 @@ import { classNames } from "@/lib/metagraphed/format";
 import { Kbd, safeExternalUrl } from "@jsonbored/ui-kit";
 import { Panel } from "@/components/metagraphed/primitives";
 import { loadRecent, pushRecent } from "@/lib/metagraphed/search-history";
-import { isValidSs58 } from "@/lib/metagraphed/accounts";
+import { isChecksumValidSs58, isValidH160, normalizeH160 } from "@/lib/metagraphed/accounts";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { resolveAddress } from "@/lib/metagraphed/resolve-address";
 import { isCompositeExtrinsicRef } from "@/lib/metagraphed/extrinsics";
@@ -118,6 +118,9 @@ type NavTarget =
       hint: string;
       to: string;
       params?: Record<string, string | number>;
+      /** Query string for targets whose destination is a search param rather
+       * than a path segment -- `?h160=` and `?uid=` (metagraphed-infra#373/#376). */
+      search?: Record<string, string | number>;
       icon: typeof User;
       badge: string;
     };
@@ -188,7 +191,13 @@ export function NavOmnibox({ onOpenPalette }: Props) {
     const q = debounced.trim();
     const targets: NavTarget[] = [];
 
-    if (isValidSs58(q)) {
+    // CHECKSUM, not shape (metagraphed-infra#376). A one-character typo in an
+    // ss58 is still 48 base58 characters, so the charset regex this used to
+    // call offered it -- and the user landed on an account page reading "no
+    // activity", which sounds like a fact about the address rather than "you
+    // mistyped it". /api/v1/search/resolve has always verified it; this box is
+    // where most people paste, and it did not.
+    if (isChecksumValidSs58(q)) {
       targets.push({
         kind: "nav",
         label: `Account ${resolveAddress(q, { keep: 8 }).display}`,
@@ -197,6 +206,36 @@ export function NavOmnibox({ onOpenPalette }: Props) {
         params: { ss58: q },
         icon: User,
         badge: "wallet",
+      });
+    }
+
+    // An EVM address is a chain identifier too, and this box did not know it.
+    // The page it lands on resolves the mapping (metagraphed-infra#373).
+    if (isValidH160(q)) {
+      targets.push({
+        kind: "nav",
+        label: `EVM ${q.slice(0, 10)}…${q.slice(-6)}`,
+        hint: "Find the account this EVM address maps to",
+        to: "/accounts",
+        search: { h160: normalizeH160(q) },
+        icon: User,
+        badge: "wallet",
+      });
+    }
+
+    // `74:12` -- the netuid:uid form the resolver recognises and this box did
+    // not, so pasting one fell through to keyword search.
+    const neuronRef = /^(\d{1,4}):(\d{1,5})$/.exec(q);
+    if (neuronRef && Number(neuronRef[1]) <= 1024) {
+      targets.push({
+        kind: "nav",
+        label: `Subnet ${neuronRef[1]} · uid ${neuronRef[2]}`,
+        hint: "Jump to a neuron by netuid:uid",
+        to: "/subnets/$netuid",
+        params: { netuid: neuronRef[1]! },
+        search: { uid: Number(neuronRef[2]) },
+        icon: Hash,
+        badge: "subnet",
       });
     }
 
@@ -307,7 +346,11 @@ export function NavOmnibox({ onOpenPalette }: Props) {
       return;
     }
     if (item.kind === "nav") {
-      navigate({ to: item.to as never, params: (item.params ?? {}) as never });
+      navigate({
+        to: item.to as never,
+        params: (item.params ?? {}) as never,
+        search: (item.search ?? {}) as never,
+      });
       return;
     }
     const href = hrefFor(item.hit);

--- a/apps/ui/src/lib/metagraphed/accounts.test.ts
+++ b/apps/ui/src/lib/metagraphed/accounts.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { isValidH160, isValidSs58, normalizeH160, ss58PathSegment } from "./accounts";
+import {
+  isChecksumValidSs58,
+  isValidH160,
+  isValidSs58,
+  normalizeH160,
+  ss58PathSegment,
+} from "./accounts";
 
 const VALID_SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
@@ -70,5 +76,40 @@ describe("isValidH160 / normalizeH160 (metagraphed-infra#373)", () => {
 
   it("lowercases, so a checksummed paste is one cache key and one URL", () => {
     expect(normalizeH160(`  0x1234567890ABCDEF1234567890abcdef12345678 `)).toBe(ADDRESS);
+  });
+});
+
+describe("isChecksumValidSs58 (metagraphed-infra#376)", () => {
+  // Alice, the address /api/v1/search/resolve's own tests use.
+  const ALICE = "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM";
+
+  it("accepts a real address", () => {
+    expect(isChecksumValidSs58(ALICE)).toBe(true);
+    expect(isChecksumValidSs58(`  ${ALICE}  `)).toBe(true);
+    expect(isChecksumValidSs58(VALID_SS58)).toBe(true);
+  });
+
+  it("REJECTS a one-character typo the shape check accepts", () => {
+    // The whole reason this exists. A mutated last character is still 48 base58
+    // characters, so isValidSs58 offers it -- and the user lands on an account
+    // page rendering "no activity", which reads as a fact about the address
+    // rather than as "you mistyped it".
+    const typo = `${ALICE.slice(0, -1)}X`;
+    expect(typo).toHaveLength(ALICE.length);
+    expect(isValidSs58(typo)).toBe(true);
+    expect(isChecksumValidSs58(typo)).toBe(false);
+  });
+
+  it("rejects prose, an EVM address, and non-strings", () => {
+    for (const bad of ["", "  ", "inference", "0x".padEnd(42, "a"), null, 7, {}]) {
+      expect(isChecksumValidSs58(bad)).toBe(false);
+    }
+  });
+
+  it("leaves the lenient check alone for its other callers", () => {
+    // isValidSs58 stays a shape check on purpose: its other 39 call sites
+    // format an address that already came from the chain, or build an extrinsic
+    // from one the wallet supplied. Neither can be a typo.
+    expect(isValidSs58(`${ALICE.slice(0, -1)}X`)).toBe(true);
   });
 });

--- a/apps/ui/src/lib/metagraphed/accounts.ts
+++ b/apps/ui/src/lib/metagraphed/accounts.ts
@@ -1,4 +1,5 @@
 // Helpers for the account explorer (hotkey / coldkey ss58 lookups).
+import { decodeSs58 } from "./ss58";
 
 // Substrate ss58 addresses are base58 (no 0 O I l) and ~47–48 chars; Bittensor
 // addresses start with 5. Keep this lenient — the backend validates definitively;
@@ -36,4 +37,31 @@ export function isValidH160(ref: string): boolean {
  * and one URL rather than two. */
 export function normalizeH160(ref: string): string {
   return ref.trim().toLowerCase();
+}
+
+/**
+ * True when an address is a real SS58 address, CHECKSUM INCLUDED
+ * (metagraphed-infra#376).
+ *
+ * `isValidSs58` above is a charset-and-length check, and it is the right shape
+ * for its other callers: they format an address that already came from the
+ * chain, or build an extrinsic from one the wallet supplied. Neither can be a
+ * typo, and paying for a blake2b there would be work with no question behind it.
+ *
+ * A SEARCH BOX IS DIFFERENT. A one-character mutation of an ss58 is still 48
+ * base58 characters, so the shape check happily offers it -- and the user lands
+ * on an account page rendering "no activity", which reads as a fact about the
+ * address rather than as "you mistyped it". `/api/v1/search/resolve` has always
+ * verified the checksum for exactly that reason; the omnibox and the command
+ * palette had their own recogniser and did not.
+ *
+ * No new dependency and no second implementation: `decodeSs58` from
+ * `@jsonbored/chain-summaries` already does the base58 decode, the blake2b, and
+ * the comparison, and it is already in this bundle.
+ */
+export function isChecksumValidSs58(address: unknown): boolean {
+  if (typeof address !== "string") return false;
+  const trimmed = address.trim();
+  if (!trimmed) return false;
+  return decodeSs58(trimmed)?.checksumValid === true;
 }


### PR DESCRIPTION
Closes #9758.

Follows #9750, whose `isValidH160` / `normalizeH160` helpers this uses. Rebased onto main now that it has landed.

## The gap

`SearchBox` — the only consumer of `/api/v1/search/resolve` — renders **only on `/agents`**. The two boxes people actually use, the navbar omnibox and the ⌘K command palette, each kept their own recogniser, and its account check is `isValidSs58`: a base58 charset-and-length regex.

**A one-character typo in an ss58 is still 48 base58 characters.** So both boxes offered it as an account link, and the user landed on an account page rendering "no activity" — which reads as a fact about the address rather than as "you mistyped it". `/api/v1/search/resolve` has verified the checksum since the day it shipped, for exactly that reason.

## The fix

`isChecksumValidSs58` uses **`decodeSs58` from `@jsonbored/chain-summaries`** — already in this bundle, already doing the base58 decode, the blake2b and the comparison. No new dependency, no second implementation of the algorithm.

**`isValidSs58` is deliberately left alone** for its other 39 call sites. They format an address that already came from the chain, or build an extrinsic from one the wallet supplied; neither can be a typo, and a blake2b there is work with no question behind it. There is a test asserting that distinction stays true rather than drifting into "tighten everything".

## Two shapes the boxes did not recognise

Both now offer what the resolver does and they did not:

- **an EVM address** → `/accounts?h160=…`, which #9750 turns into the account it maps to
- **`74:12`** → subnet 74, uid 12. It used to fall through to keyword search

The boxes keep their own extras — `sn 7`, `netuid 7`, the composite `123#4` extrinsic ref, partial `0x` hashes — which the resolver does not have. This adds to the recogniser rather than replacing it, and does it locally rather than by calling the endpoint, because an omnibox that renders as you type should not wait on a request to show its first suggestion.

## A trap the type change surfaced

Widening `Target`/`NavTarget` with a `search` field meant deciding where the query string gets appended. The palette's `targetToHref` feeds **"copy link" and open-in-new-tab**, not just navigation — so a query string added only at `navigate()` would produce a copied link that silently loses the identifier. Which is precisely the bug metagraphed-infra#373 was. It is appended in `targetToHref`, with a comment saying why.

## Validation

```
npm run build --workspace=packages/ui-kit   # required first, or tsc reports phantom errors
npm run build --workspace=packages/client
npm run typecheck --workspace=apps/ui       # clean
npm run lint --workspace=apps/ui            # 0 errors (9 pre-existing warnings, none in changed files)
npm run format:check --workspace=apps/ui    # clean
npm test --workspace=apps/ui                # 1860 passed
npm run build --workspace=apps/ui           # clean
```

I could not measure the initial-bundle gate locally — `npm run build` here emits nitro `.output/`, and the CI gate reads `dist/client` + the TanStack manifest. CI measures it. The change adds **no new dependency**; `@jsonbored/chain-summaries` is already imported by `ss58-inspector.tsx`, so the delta is whatever `decodeSs58` pulls into the shell chunk. Flagging it rather than claiming a number I did not take.

No screenshot table: maintainer PR. The visible change is two extra suggestion rows for inputs that previously produced none.

## Template Used

- Frontend PR

