### PR TITLE
fix(ui): regenerate the subnet catalog, which went stale on main

### DIFF
--- a/apps/ui/content/docs/catalog.mdx
+++ b/apps/ui/content/docs/catalog.mdx
@@ -5,7 +5,7 @@ description: 128 curated subnets, generated from the registry overlays in regist
 
 **128 curated subnets** — 117 with a site, 46 with docs, 117 with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](https://metagraph.sh)**; per-subnet JSON at `https://api.metagraph.sh/api/v1/subnets/{netuid}`. Root (SN0) is base-layer chain infrastructure, listed separately below, not counted as a subnet.
 
-**Focus areas:** `compute` 9 · `data` 7 · `defi` 7 · `inference` 5 · `language-models` 4 · `prediction-markets` 4 · `computer-vision` 3 · `finance` 3 · `dashboard` 2 · `data-artifact` 2 · `decentralized-training` 2 · `depin` 2
+**Focus areas:** `compute` 9 · `data` 7 · `defi` 6 · `inference` 6 · `language-models` 4 · `prediction-markets` 4 · `computer-vision` 3 · `finance` 3 · `dashboard` 2 · `data-artifact` 2 · `decentralized-training` 2 · `depin` 2
 
 - **[root](https://metagraph.sh/subnets/0)** `SN0` — `chain-rpc` · [site](https://bittensor.com) · [docs](https://docs.learnbittensor.org/concepts/bittensor-networks) · [repo](https://github.com/opentensor/subtensor)
 - **[Apex](https://metagraph.sh/subnets/1)** `SN1` · [site](https://apex.macrocosmos.ai/) · [docs](https://docs.macrocosmos.ai/subnets/subnet-1-apex) · [repo](https://github.com/macrocosm-os/apex)
@@ -60,7 +60,7 @@ description: 128 curated subnets, generated from the registry overlays in regist
 - **[Synth](https://metagraph.sh/subnets/50)** `SN50` — `finance` · [site](https://synthdata.co/) · [repo](https://github.com/synthdataco/synth-subnet)
 - **[lium.io](https://metagraph.sh/subnets/51)** `SN51` — `compute` · [site](https://lium.io/) · [repo](https://github.com/Datura-ai/lium-io)
 - **[Dojo](https://metagraph.sh/subnets/52)** `SN52` — `tensorplex` · [site](https://www.tensorplex.ai/) · [docs](https://docs.tensorplex.ai/tensorplex-docs/tensorplex-dojo-bittensor-subnet/subnet-mechanism) · [repo](https://github.com/tensorplex-labs/dojo)
-- **[EfficientFrontier](https://metagraph.sh/subnets/53)** `SN53` — `defi` `financial-trading` `trading-strategies` · [site](https://www.signalplus.com/) · [repo](https://github.com/oxylok/53-EfficientFrontier)
+- **[engy](https://metagraph.sh/subnets/53)** `SN53` — `inference` `llm-serving` `verified-compute` · [site](https://engy.ai/) · [repo](https://github.com/hanlinai/engy)
 - **[Yanez MIID](https://metagraph.sh/subnets/54)** `SN54` — `compliance` `synthetic-data` · [site](https://www.yanez.ai/) · [repo](https://github.com/yanez-compliance/MIID-subnet)
 - **[NIOME](https://metagraph.sh/subnets/55)** `SN55` — `genomics` `synthetic-data` · [site](https://niome.genomes.io/) · [repo](https://github.com/genomesio/subnet-niome)
 - **[Gradients](https://metagraph.sh/subnets/56)** `SN56` — `ai-training` `operational-interface` · [site](https://www.gradients.io/) · [docs](https://api.gradients.io/docs) · [repo](https://github.com/gradients-ai/G.O.D)


### PR DESCRIPTION
Closes #9760.

`apps/ui/content/docs/catalog.mdx` is generated from the registry overlays by `apps/ui/scripts/generate-catalog-docs.ts`, and the `ui` job regenerates it and fails on any diff. A registry change landed without the regeneration, so **main is stale and every UI PR inherits the failure** — #9755 hit it first.

```diff
- **[EfficientFrontier](…/subnets/53)** `SN53` — `defi` `financial-trading` `trading-strategies`
+ **[engy](…/subnets/53)** `SN53` — `inference` `llm-serving` `verified-compute`
```

plus the focus-area tally that derives from it (`defi` 7 → 6, `inference` 5 → 6).

#9749 refreshed the **README's** catalog block but not this one. They come from different scripts over the same registry, and only one of the two is guarded by a check that fails the build — so the README stayed current and this did not.

## Contents

The output of `node scripts/generate-catalog-docs.ts` run from `apps/ui`, and nothing else. Two lines.

```
Wrote content/docs/catalog.mdx: 128 curated subnets.
```

## Worth a follow-up rather than a fix here

This is the third time a generated artifact has gone stale on main and red-lined unrelated branches. The failure is well-shaped — it names the file and the exact command — but it lands on whoever opens the next PR rather than on the change that caused it. Whether the registry-publish lane should regenerate this the way it already regenerates the README's block is noted on the issue.

## Template Used

- Docs-only change

