### PR TITLE
fix(queue): refuse chain-detail the transport it measurably does not fit

### DIFF
--- a/src/sync-batch-queue.ts
+++ b/src/sync-batch-queue.ts
@@ -245,6 +245,58 @@ const ENVELOPE_HEADROOM = 2 * 1024;
  */
 export const MULTI_FAMILY_LANES: readonly string[] = ["chain-detail"];
 
+/**
+ * Lanes refused this transport **as it is currently encoded**.
+ *
+ * MEASURED, not assumed (metagraphed-infra#359). `chain-detail`'s indivisible
+ * unit is one block: its four families are posted together precisely so a block
+ * and its extrinsics cannot land separately, and `packMultiFamilyMessage`
+ * refuses to split them for that reason. So the question is never "how many
+ * blocks per message" — it is whether ONE block fits.
+ *
+ * As raw JSON it does not. Built from the real rows of the busiest block
+ * captured (#8790494 — 35 extrinsics, 694 chain events, 515 account events,
+ * 1,245 rows):
+ *
+ *   raw JSON     476.6 KiB      against a 128 KiB per-message cap — 3.7x over
+ *
+ * No producer setting reaches that, because the batch is already one block.
+ *
+ * THE FIX IS COMPRESSION, AND IT IS NOT CLOSE. The payload is enormously
+ * repetitive — the same ss58 addresses, pallet names and event kinds over and
+ * over — and gzip gets **11.8x** on exactly these bytes:
+ *
+ *   gzip -9       40.5 KiB      87.5 KiB of headroom, ~3 blocks per message
+ *
+ * That is a real design change (`CompressionStream` at the route,
+ * `DecompressionStream` at the consumer, a measured ceiling, and a loud failure
+ * when a pathological block still overflows), which is why it is its own issue
+ * rather than something smuggled in here.
+ *
+ * WHY THIS IS A GUARD AND NOT A COMMENT, in the meantime. Adding a lane to
+ * SYNC_QUEUE_LANES is deliberately a one-word deploy-time change. Without this,
+ * that one word turns every chain-detail tick into a 502 from an oversize
+ * `send()` — and the producer advances its cursor only on a POST that
+ * succeeded, so the lane does not degrade, it WEDGES, retrying the same
+ * oversized batch forever. The cheapest possible mistake would take out the
+ * highest-cadence lane, and chain-detail is also the largest D1 writer here:
+ * ~1,245 rows every 12 seconds is ~9M rows/day, against account-balances'
+ * ~1.5M. It is the lane the queue most wants, which is exactly why the
+ * placeholder must fail closed.
+ *
+ * Everything else stays: the message shape, the packer and the consumer's
+ * family writer are correct and tested, and compression drops in behind them
+ * without touching any of it.
+ */
+export const QUEUE_INELIGIBLE_LANES: Readonly<Record<string, string>> = {
+  "chain-detail":
+    "one block is 476.6 KiB of raw JSON (measured on #8790494) against a " +
+    "128 KiB per-message cap, and its four families cannot be split without " +
+    "losing the atomicity they travel together for. gzip takes the same bytes " +
+    "to 40.5 KiB, so this is a compression change rather than a permanent " +
+    "exclusion -- see metagraphed-infra#383",
+};
+
 /** The family names each multi-family lane may send. A name outside this list
  * is refused rather than written to a guessed table. */
 export const MULTI_FAMILY_LANE_ROW_FAMILIES: Readonly<
@@ -650,12 +702,18 @@ export function classifySyncBatch(
  *
  * Absent flag means the old path, so a deployment that has not opted in behaves
  * exactly as before -- the same posture every other switch here takes.
+ *
+ * ONE LANE OVERRIDES THE FLAG. A lane in QUEUE_INELIGIBLE_LANES does not fit
+ * the transport at any producer setting, so naming it here is a mistake the
+ * flag cannot express -- and an unexpressible mistake should be refused, not
+ * obeyed. See that constant for the measurement.
  */
 export function syncLaneUsesQueue(
   env: { SYNC_BATCHES?: unknown; SYNC_QUEUE_LANES?: string },
   lane: SyncBatchLane,
 ): boolean {
   if (!env.SYNC_BATCHES) return false;
+  if (lane in QUEUE_INELIGIBLE_LANES) return false;
   const enabled = (env.SYNC_QUEUE_LANES ?? "")
     .split(",")
     .map((s) => s.trim())

--- a/tests/sync-batch-queue.test.ts
+++ b/tests/sync-batch-queue.test.ts
@@ -25,6 +25,7 @@ import {
   passTallyFor,
   PRUNING_LANE_KEYS,
   PRUNING_LANES,
+  QUEUE_INELIGIBLE_LANES,
   syncLaneUsesQueue,
   validSyncBatchMessage,
   writeSyncBatch,
@@ -179,6 +180,43 @@ describe("syncLaneUsesQueue", () => {
     const env = { ...bound, SYNC_QUEUE_LANES: " hotkey-alpha , neurons " };
     assert.equal(syncLaneUsesQueue(env, "hotkey-alpha"), true);
     assert.equal(syncLaneUsesQueue(env, "neurons"), true);
+  });
+
+  test("refuses a lane that cannot fit the transport, even when named", () => {
+    // THE ONE-WORD MISTAKE THIS CLOSES (metagraphed-infra#359). chain-detail's
+    // indivisible unit is one block -- its four families travel together so a
+    // block and its extrinsics cannot land apart -- and one block measures
+    // ~301 KiB against a 128 KiB cap. No producer setting reaches that.
+    //
+    // Without the guard, adding the word to SYNC_QUEUE_LANES turns every tick
+    // into a 502 from an oversize send(), and the producer advances its cursor
+    // only on a POST that succeeded -- so the lane does not degrade, it WEDGES,
+    // retrying the same oversized batch forever.
+    assert.equal(
+      syncLaneUsesQueue(
+        { ...bound, SYNC_QUEUE_LANES: "chain-detail,hotkey-alpha" },
+        "chain-detail",
+      ),
+      false,
+    );
+    // And it refuses only that lane -- a co-named healthy one still routes.
+    assert.equal(
+      syncLaneUsesQueue(
+        { ...bound, SYNC_QUEUE_LANES: "chain-detail,hotkey-alpha" },
+        "hotkey-alpha",
+      ),
+      true,
+    );
+  });
+
+  test("every ineligible lane carries a reason, and is a real lane", () => {
+    // The reason is what a future reader needs in order to decide whether the
+    // constraint still holds; an entry without one is a decision nobody can
+    // revisit. And a typo'd lane name would silently guard nothing.
+    for (const [lane, reason] of Object.entries(QUEUE_INELIGIBLE_LANES)) {
+      assert.equal(SYNC_BATCH_LANES.includes(lane as never), true, lane);
+      assert.equal(reason.length > 40, true, `${lane} needs a real reason`);
+    }
   });
 });
 


### PR DESCRIPTION
Closes metagraphed-infra#359. Follow-up: metagraphed-infra#383.

Adding a lane to `SYNC_QUEUE_LANES` is deliberately a **one-word deploy-time change**. For `chain-detail` that one word would take out the highest-cadence lane on the platform, and nothing in the code said so.

## The measurement

`chain-detail`'s indivisible unit is **one block**. Its four families are posted together precisely so a block and its extrinsics cannot land separately, and `packMultiFamilyMessage` refuses to split them for that reason. So the question was never "how many blocks per message" — the batch is already one block. It is whether **one** block fits.

Built from the real rows of the busiest block captured, #8790494 (35 extrinsics, 694 chain events, 515 account events — 1,245 rows):

| | |
|---|---|
| raw JSON | **476.6 KiB** |
| queue per-message cap | 128 KiB |
| | **3.7× over** |

The producer's own doc comment estimated "350–662 KiB per two blocks" — right about the order, low on the per-block figure.

## Why a guard rather than a comment

The failure mode is not degradation. Every tick would 502 on an oversize `send()`, and **the producer advances its cursor only on a POST that succeeded** — so the lane does not fall behind gracefully, it **wedges**, retrying the same oversized batch forever. That is the cheapest possible mistake causing the most expensive possible outcome, and `chain-detail` is also the largest D1 writer here: ~1,245 rows every 12 seconds is **~9M rows/day**, against `account-balances`' ~1.5M.

`syncLaneUsesQueue` now refuses a lane in `QUEUE_INELIGIBLE_LANES` regardless of the flag. A co-named healthy lane still routes — there is a test for both directions.

## This is not "the lane cannot move"

The payload is enormously repetitive — the same ss58 addresses, pallet names and event kinds, hundreds of times over. gzip on those exact bytes:

| | |
|---|---|
| gzip -9 | **40.5 KiB** |
| ratio | **11.8×** |
| headroom under the cap | 87.5 KiB |
| blocks per message | ~3 |

So the answer is a wire-encoding change, and it is decisive rather than marginal. It needs `CompressionStream` at the route, `DecompressionStream` at the consumer, the byte budget measuring the **compressed** size, and a loud failure for a block that still overflows — a real design with its own failure modes, which is why it is metagraphed-infra#383 and not smuggled in here.

The constant carries the measurement and the ratio, so the next person to look does not have to re-derive either.

## Nothing else changes

The multi-family message shape, `packMultiFamilyMessage`, and the consumer's family writer are correct, tested, and untouched. Compression drops in behind them.

## Validation

```
npm run typecheck    # clean
npm run lint         # clean
npx prettier --check # clean
npx vitest run tests/sync-batch-queue.test.ts tests/data-api-sync-queue-consumer.test.ts \
  tests/chain-detail-sync-route.test.ts   # 81 passed
```

Verified the guard test catches its own removal: deleting the `QUEUE_INELIGIBLE_LANES` line from `syncLaneUsesQueue` fails `refuses a lane that cannot fit the transport, even when named`.

Patch coverage by intersecting the diff with a v8 report: **0 uncovered statements, 0 uncovered branches** (58 changed lines).

## Template Used

- Backend/code change
