### PR TITLE
fix(neon): count the backfill's backlog in dates not reached, not rows written

### DIFF
--- a/src/neon-backfill.ts
+++ b/src/neon-backfill.ts
@@ -368,6 +368,16 @@ export interface BackfillTableOutcome {
   deficits: number;
   /** Rows still missing across all deficient dates, before any were copied. */
   missing: number;
+  /**
+   * Rows still missing over the dates this tick did NOT reach.
+   *
+   * NOT `missing - rowsCopied`, which is the wrong subtraction and goes
+   * negative in the ordinary case. The unit of work is a whole DATE, so
+   * copying a date 231 rows short writes all 30,278 of its rows -- the upsert
+   * makes the other 30,047 no-ops. Reporting "-30,047 rows still behind" is
+   * how that first showed up in production.
+   */
+  remaining: number;
   copied: DateCopyResult[];
   ok: boolean;
   reason?: string;
@@ -405,6 +415,7 @@ export async function reconcileTableToNeon(
     table,
     deficits: 0,
     missing: 0,
+    remaining: 0,
     copied: [] as DateCopyResult[],
   };
   if (!db?.prepare || !sql?.unsafe) {
@@ -430,6 +441,12 @@ export async function reconcileTableToNeon(
 
   const elapsed = deps.elapsed ?? (() => 0);
   const copied: DateCopyResult[] = [];
+  // Rows still owed, counted over the dates this tick did NOT reach. Each
+  // date's own deficit comes off as that date completes, so the figure never
+  // depends on how many rows were WRITTEN -- copying a whole date to close a
+  // 231-row gap writes 30,278 rows, and subtracting those would report a
+  // negative backlog.
+  let remaining = missing;
   for (const deficit of deficits.slice(0, MAX_DATES_PER_TICK)) {
     if (copied.length > 0 && elapsed() >= TICK_BUDGET_MS) break;
     const result = await copyDateToNeon(db, sql, plan, deficit.date);
@@ -439,13 +456,22 @@ export async function reconcileTableToNeon(
         table,
         deficits: deficits.length,
         missing,
+        remaining,
         copied,
         ok: false,
         reason: result.reason,
       };
     }
+    remaining -= deficit.d1 - deficit.neon;
   }
-  return { table, deficits: deficits.length, missing, copied, ok: true };
+  return {
+    table,
+    deficits: deficits.length,
+    missing,
+    remaining,
+    copied,
+    ok: true,
+  };
 }
 
 /** One line per table, for the lane verdict's detail column. */
@@ -457,10 +483,13 @@ export function describeOutcome(outcome: BackfillTableOutcome): string {
   }
   if (outcome.deficits === 0) return "in sync";
   const rows = outcome.copied.reduce((sum, c) => sum + c.rows, 0);
-  const remaining = outcome.deficits - outcome.copied.length;
+  const dates = outcome.deficits - outcome.copied.length;
+  // `remaining` counts the dates NOT reached, not `missing - rows`. Rows
+  // written and rows owed are different quantities: a date 231 rows short is
+  // closed by writing all 30,278 of its rows.
   return (
     `${rows} row(s) over ${outcome.copied.length} date(s); ` +
-    `${remaining} date(s) / ~${outcome.missing - rows} row(s) still behind`
+    `${dates} date(s) / ${outcome.remaining} row(s) still behind`
   );
 }
 
@@ -511,6 +540,7 @@ export async function runNeonBackfill(
         table: plan.table,
         deficits: 0,
         missing: 0,
+        remaining: 0,
         copied: [],
         ok: true,
         skipped: true,
@@ -526,6 +556,7 @@ export async function runNeonBackfill(
         table: plan.table,
         deficits: 0,
         missing: 0,
+        remaining: 0,
         copied: [],
         ok: false,
         reason: reason(error),

--- a/tests/neon-backfill.test.ts
+++ b/tests/neon-backfill.test.ts
@@ -549,6 +549,7 @@ describe("reconcileTableToNeon", () => {
       table: "neuron_daily",
       deficits: 0,
       missing: 0,
+      remaining: 0,
       copied: [],
       ok: false,
       reason: "unbound",
@@ -591,6 +592,7 @@ describe("reconcileTableToNeon", () => {
       table: "neuron_daily",
       deficits: 0,
       missing: 0,
+      remaining: 0,
       copied: [],
       ok: true,
     });
@@ -675,10 +677,43 @@ describe("reconcileTableToNeon", () => {
 });
 
 describe("describeOutcome", () => {
+  test("NEVER reports a negative backlog", () => {
+    // Caught in production on the first tick: `account_position_daily` was 231
+    // rows short, the unit of work is a whole DATE, so closing it wrote all
+    // 30,278 of that date's rows and `missing - written` read
+    // "~-30047 row(s) still behind".
+    //
+    // Rows written and rows owed are different quantities. `remaining` counts
+    // the deficit of the dates NOT reached, so it is bounded by `missing` and
+    // cannot go below zero however many rows a date turns out to hold.
+    const text = describeOutcome({
+      table: "account_position_daily",
+      deficits: 2,
+      missing: 231,
+      remaining: 0,
+      copied: [
+        {
+          ok: true,
+          rows: 30_278,
+          statements: 11,
+          pages: 16,
+          date: "2026-08-07",
+        },
+      ],
+      ok: true,
+    });
+    assert.doesNotMatch(text, /-\d/, `negative figure in: ${text}`);
+    assert.equal(
+      text,
+      "30278 row(s) over 1 date(s); 1 date(s) / 0 row(s) still behind",
+    );
+  });
+
   const base = {
     table: "neuron_daily",
     deficits: 0,
     missing: 0,
+    remaining: 0,
     copied: [],
     ok: true,
   };
@@ -694,11 +729,18 @@ describe("describeOutcome", () => {
         ...base,
         deficits: 26,
         missing: 816_803,
+        remaining: 786_694,
         copied: [
-          { ok: true, rows: 100, statements: 1, pages: 1, date: "2026-08-07" },
+          {
+            ok: true,
+            rows: 30_109,
+            statements: 13,
+            pages: 16,
+            date: "2026-08-07",
+          },
         ],
       }),
-      "100 row(s) over 1 date(s); 25 date(s) / ~816703 row(s) still behind",
+      "30109 row(s) over 1 date(s); 25 date(s) / 786694 row(s) still behind",
     );
     assert.equal(
       describeOutcome({


### PR DESCRIPTION
Closes #9762

Caught on the first production tick after #9752 deployed:

```
neon:backfill:account_position_daily  stale
  31091 row(s) over 1 date(s); 0 date(s) / ~-30949 row(s) still behind
```

`describeOutcome` derived the backlog as `missing - rowsWritten`. Those are different quantities. The unit of work is a whole **date**, so closing a 231-row deficit meant copying all 31,091 rows of that date — the out-of-order guard made the other ~30,860 no-ops. Subtracting rows *written* from rows *owed* goes negative in the ordinary case, not an exotic one.

`remaining` now counts the deficit of the dates the tick did **not** reach, decremented per date as each completes. Bounded by `missing`, so it cannot go below zero however many rows a date holds.

## The copy was always correct

`neuron_daily` converged at ~60,000 rows and 2 dates per tick while this printed what it printed, and Neon's row counts are right. Only the reporting was wrong — which is the part a human reads when #9698 escalates the lane, and the only per-tick record of whether the backfill is converging.

## Verification

- New test asserts the exact production case and that no `-` digit can appear in the string
- 52 tests, **100% statements / branches / functions / lines** on `src/neon-backfill.ts`
- `npm run typecheck` clean