### PR TITLE
feat(queue): compress the message, so the largest lane can travel at all

### DIFF
--- a/src/sync-batch-compress.ts
+++ b/src/sync-batch-compress.ts
@@ -1,0 +1,158 @@
+// Compressing a sync-batches message, so the largest lane can travel at all
+// (metagraphed-infra#359, metagraphed#9759).
+//
+// WHY, MEASURED. `chain-detail`'s indivisible unit is ONE block: its four row
+// families are posted together precisely so a block and its extrinsics cannot
+// land separately, and `packMultiFamilyMessage` refuses to split them for that
+// reason. So the question was never "how many blocks per message" -- the batch
+// is already one block. It is whether one block fits.
+//
+// As raw JSON it does not. Built from the real rows of the busiest block
+// captured (#8790494 -- 35 extrinsics, 694 chain events, 515 account events,
+// 1,245 rows):
+//
+//   raw JSON     476.6 KiB     against a 128 KiB per-message cap -- 3.7x over
+//   gzip -9       40.5 KiB     11.8x, 87.5 KiB of headroom, ~3 blocks/message
+//
+// The payload is enormously repetitive -- the same ss58 addresses, pallet names
+// and event kinds hundreds of times over -- which is why the ratio is decisive
+// rather than marginal.
+//
+// AND IT IS THE LANE THE QUEUE MOST WANTS. `chain-detail` is the largest D1
+// writer here and the only continuous one: ~1,245 rows every 12 seconds is
+// ~9M rows/day, against `account-balances`' ~1.5M. metagraphed-infra#346's
+// argument for one queue was global backpressure -- "a lane left out is a lane
+// that can still overwhelm the database the others are being polite about" --
+// and this is that lane. The bulk lanes are bursty; this one never stops.
+//
+// ## What this deliberately does NOT do
+//
+// It does not compress the four lanes already on the queue. They fit, they are
+// running clean, and re-encoding a working transport to make it uniform is the
+// change this epic's own non-goals warn against. The DECODER accepts a
+// compressed body from any lane, so opting one in later is a producer-side
+// change with no consumer deploy -- but nothing is opted in today.
+
+/** The only algorithm here. `gzip` rather than `deflate-raw` because both ends
+ * are workerd and the header costs 18 bytes against a 40 KiB payload, which
+ * buys a self-describing stream for nothing that matters. */
+export const SYNC_BATCH_COMPRESSION = "gzip" as const;
+
+/**
+ * The first two bytes of a gzip stream (0x1f 0x8b).
+ *
+ * The consumer distinguishes a compressed message from a JSON one by SHAPE --
+ * `ArrayBuffer` versus object -- and this is the second check, not the first.
+ * A byte array that is not gzip is a message this consumer cannot read, and
+ * saying so by magic number produces a diagnosable error rather than a
+ * decompression stream failing somewhere inside.
+ */
+const GZIP_MAGIC = [0x1f, 0x8b] as const;
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const reader = stream.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    total += value.length;
+  }
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, at);
+    at += chunk.length;
+  }
+  return out;
+}
+
+/** True when a consumed body is compressed bytes rather than a JSON object. */
+export function isCompressedSyncBatchBody(
+  body: unknown,
+): body is ArrayBuffer | Uint8Array {
+  return body instanceof ArrayBuffer || body instanceof Uint8Array;
+}
+
+/**
+ * Compress a message, and refuse it if it STILL does not fit.
+ *
+ * THE BUDGET MEASURES THE COMPRESSED SIZE, which is the whole point: measuring
+ * the JSON would keep refusing messages that fit, and measuring nothing would
+ * reintroduce metagraphed-infra#360 -- a lane that stopped rather than degraded,
+ * because nothing measured a message before sending it.
+ *
+ * 11.8x is one block's ratio, not a guarantee. A block whose events happen to
+ * be less repetitive compresses worse, and the failure has to stay LOUD: the
+ * caller answers 502, the producer retries a chunk that was never accepted, and
+ * nothing is silently dropped. Degrading by splitting the families is the one
+ * thing this must never do.
+ */
+export async function compressSyncBatchMessage(
+  message: unknown,
+  maxBytes: number,
+): Promise<Uint8Array> {
+  const json = JSON.stringify(message);
+  const raw = new TextEncoder().encode(json);
+  // A one-chunk ReadableStream rather than a Blob: `Blob` is present in
+  // workerd but its `BlobPart` type is not in this project's lib set, and a
+  // stream is the shape CompressionStream wants anyway.
+  const packed = await drain(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(raw);
+        controller.close();
+      },
+    }).pipeThrough(new CompressionStream(SYNC_BATCH_COMPRESSION)),
+  );
+  if (packed.length > maxBytes) {
+    const lane = (message as { lane?: unknown })?.lane ?? "unknown";
+    throw new Error(
+      `sync-batches: ${String(lane)} message is ${packed.length} bytes ` +
+        `compressed (${raw.length} raw), over the ${maxBytes}-byte budget. ` +
+        `These families must land together, so the PRODUCER must post a ` +
+        `smaller batch -- splitting them here is the one degradation this ` +
+        `shape exists to prevent.`,
+    );
+  }
+  return packed;
+}
+
+/**
+ * Decompress and parse a message, or null if the bytes are not one.
+ *
+ * NULL RATHER THAN A THROW, because of what the caller does with each. The
+ * consumer acks an unparseable message rather than retrying it -- retrying
+ * something that can never parse burns the whole attempt budget and
+ * dead-letters anyway -- and that decision is easier to get right when "not a
+ * message" is a value instead of an exception to remember to catch.
+ */
+export async function decompressSyncBatchMessage(
+  body: unknown,
+): Promise<unknown> {
+  if (!isCompressedSyncBatchBody(body)) return null;
+  const bytes = body instanceof Uint8Array ? body : new Uint8Array(body);
+  if (
+    bytes.length < 2 ||
+    bytes[0] !== GZIP_MAGIC[0] ||
+    bytes[1] !== GZIP_MAGIC[1]
+  ) {
+    return null;
+  }
+  try {
+    const raw = await drain(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(bytes);
+          controller.close();
+        },
+      }).pipeThrough(new DecompressionStream(SYNC_BATCH_COMPRESSION)),
+    );
+    return JSON.parse(new TextDecoder().decode(raw)) as unknown;
+  } catch {
+    // Truncated bytes, a corrupted stream, or valid gzip that is not JSON. All
+    // three are "this will not parse on the fifth attempt either".
+    return null;
+  }
+}

--- a/src/sync-batch-queue.ts
+++ b/src/sync-batch-queue.ts
@@ -245,58 +245,6 @@ const ENVELOPE_HEADROOM = 2 * 1024;
  */
 export const MULTI_FAMILY_LANES: readonly string[] = ["chain-detail"];
 
-/**
- * Lanes refused this transport **as it is currently encoded**.
- *
- * MEASURED, not assumed (metagraphed-infra#359). `chain-detail`'s indivisible
- * unit is one block: its four families are posted together precisely so a block
- * and its extrinsics cannot land separately, and `packMultiFamilyMessage`
- * refuses to split them for that reason. So the question is never "how many
- * blocks per message" — it is whether ONE block fits.
- *
- * As raw JSON it does not. Built from the real rows of the busiest block
- * captured (#8790494 — 35 extrinsics, 694 chain events, 515 account events,
- * 1,245 rows):
- *
- *   raw JSON     476.6 KiB      against a 128 KiB per-message cap — 3.7x over
- *
- * No producer setting reaches that, because the batch is already one block.
- *
- * THE FIX IS COMPRESSION, AND IT IS NOT CLOSE. The payload is enormously
- * repetitive — the same ss58 addresses, pallet names and event kinds over and
- * over — and gzip gets **11.8x** on exactly these bytes:
- *
- *   gzip -9       40.5 KiB      87.5 KiB of headroom, ~3 blocks per message
- *
- * That is a real design change (`CompressionStream` at the route,
- * `DecompressionStream` at the consumer, a measured ceiling, and a loud failure
- * when a pathological block still overflows), which is why it is its own issue
- * rather than something smuggled in here.
- *
- * WHY THIS IS A GUARD AND NOT A COMMENT, in the meantime. Adding a lane to
- * SYNC_QUEUE_LANES is deliberately a one-word deploy-time change. Without this,
- * that one word turns every chain-detail tick into a 502 from an oversize
- * `send()` — and the producer advances its cursor only on a POST that
- * succeeded, so the lane does not degrade, it WEDGES, retrying the same
- * oversized batch forever. The cheapest possible mistake would take out the
- * highest-cadence lane, and chain-detail is also the largest D1 writer here:
- * ~1,245 rows every 12 seconds is ~9M rows/day, against account-balances'
- * ~1.5M. It is the lane the queue most wants, which is exactly why the
- * placeholder must fail closed.
- *
- * Everything else stays: the message shape, the packer and the consumer's
- * family writer are correct and tested, and compression drops in behind them
- * without touching any of it.
- */
-export const QUEUE_INELIGIBLE_LANES: Readonly<Record<string, string>> = {
-  "chain-detail":
-    "one block is 476.6 KiB of raw JSON (measured on #8790494) against a " +
-    "128 KiB per-message cap, and its four families cannot be split without " +
-    "losing the atomicity they travel together for. gzip takes the same bytes " +
-    "to 40.5 KiB, so this is a compression change rather than a permanent " +
-    "exclusion -- see metagraphed-infra#383",
-};
-
 /** The family names each multi-family lane may send. A name outside this list
  * is refused rather than written to a guessed table. */
 export const MULTI_FAMILY_LANE_ROW_FAMILIES: Readonly<
@@ -501,25 +449,21 @@ export function packSyncBatchMessages(input: {
  * and wrong. So an oversize chunk THROWS rather than degrading into the split
  * this shape exists to prevent.
  *
- * That is a real constraint, not a hypothetical: the producer batches 2 blocks
- * per POST at ~350-662 KiB, which is over the 128 KB cap. The producer has to
- * post smaller batches for this lane to move -- and a loud error at the
- * boundary is how that gets discovered, rather than a silently split write.
+ * IT DOES NOT MEASURE ITSELF ANY MORE. It used to check `JSON.stringify(...)`
+ * against the budget, and that was measuring the wrong thing once the message
+ * started travelling compressed: one chain-detail block is 476.6 KiB of JSON
+ * and 40.5 KiB on the wire, so a raw-bytes check refuses messages that fit.
+ * `compressSyncBatchMessage` owns the budget now, because it is the only place
+ * that knows the size the transport actually sees -- and it keeps the same
+ * loud-throw posture, for the same reason.
  */
 export function packMultiFamilyMessage(input: {
   lane: SyncBatchLane;
   capturedAt: number;
   passTotal?: number;
   families: Record<string, Record<string, unknown>[]>;
-  maxBytes?: number;
 }): SyncBatchMessage {
-  const {
-    lane,
-    capturedAt,
-    passTotal,
-    families,
-    maxBytes = SYNC_BATCH_MAX_BYTES,
-  } = input;
+  const { lane, capturedAt, passTotal, families } = input;
   const message: SyncBatchMessage = {
     lane,
     captured_at: capturedAt,
@@ -527,20 +471,8 @@ export function packMultiFamilyMessage(input: {
     families,
   } as SyncBatchMessage;
   // `rows` is absent by construction here; the validator refuses a message
-  // carrying both, so the type's required `rows` is deliberately not set.
+  // carrying both, so the type's optional `rows` is deliberately not set.
   delete (message as { rows?: unknown }).rows;
-
-  const bytes = JSON.stringify(message).length;
-  if (bytes > maxBytes) {
-    const counts = Object.entries(families)
-      .map(([name, rows]) => `${name}=${rows.length}`)
-      .join(", ");
-    throw new Error(
-      `sync-batches: ${lane} multi-family message is ${bytes} bytes (${counts}), ` +
-        `over the ${maxBytes}-byte budget; these families must land together, ` +
-        `so the PRODUCER must post a smaller batch rather than this splitting them`,
-    );
-  }
   return message;
 }
 
@@ -702,18 +634,12 @@ export function classifySyncBatch(
  *
  * Absent flag means the old path, so a deployment that has not opted in behaves
  * exactly as before -- the same posture every other switch here takes.
- *
- * ONE LANE OVERRIDES THE FLAG. A lane in QUEUE_INELIGIBLE_LANES does not fit
- * the transport at any producer setting, so naming it here is a mistake the
- * flag cannot express -- and an unexpressible mistake should be refused, not
- * obeyed. See that constant for the measurement.
  */
 export function syncLaneUsesQueue(
   env: { SYNC_BATCHES?: unknown; SYNC_QUEUE_LANES?: string },
   lane: SyncBatchLane,
 ): boolean {
   if (!env.SYNC_BATCHES) return false;
-  if (lane in QUEUE_INELIGIBLE_LANES) return false;
   const enabled = (env.SYNC_QUEUE_LANES ?? "")
     .split(",")
     .map((s) => s.trim())

--- a/src/sync-batch-queue.ts
+++ b/src/sync-batch-queue.ts
@@ -245,6 +245,58 @@ const ENVELOPE_HEADROOM = 2 * 1024;
  */
 export const MULTI_FAMILY_LANES: readonly string[] = ["chain-detail"];
 
+/**
+ * Lanes refused this transport **as it is currently encoded**.
+ *
+ * MEASURED, not assumed (metagraphed-infra#359). `chain-detail`'s indivisible
+ * unit is one block: its four families are posted together precisely so a block
+ * and its extrinsics cannot land separately, and `packMultiFamilyMessage`
+ * refuses to split them for that reason. So the question is never "how many
+ * blocks per message" — it is whether ONE block fits.
+ *
+ * As raw JSON it does not. Built from the real rows of the busiest block
+ * captured (#8790494 — 35 extrinsics, 694 chain events, 515 account events,
+ * 1,245 rows):
+ *
+ *   raw JSON     476.6 KiB      against a 128 KiB per-message cap — 3.7x over
+ *
+ * No producer setting reaches that, because the batch is already one block.
+ *
+ * THE FIX IS COMPRESSION, AND IT IS NOT CLOSE. The payload is enormously
+ * repetitive — the same ss58 addresses, pallet names and event kinds over and
+ * over — and gzip gets **11.8x** on exactly these bytes:
+ *
+ *   gzip -9       40.5 KiB      87.5 KiB of headroom, ~3 blocks per message
+ *
+ * That is a real design change (`CompressionStream` at the route,
+ * `DecompressionStream` at the consumer, a measured ceiling, and a loud failure
+ * when a pathological block still overflows), which is why it is its own issue
+ * rather than something smuggled in here.
+ *
+ * WHY THIS IS A GUARD AND NOT A COMMENT, in the meantime. Adding a lane to
+ * SYNC_QUEUE_LANES is deliberately a one-word deploy-time change. Without this,
+ * that one word turns every chain-detail tick into a 502 from an oversize
+ * `send()` — and the producer advances its cursor only on a POST that
+ * succeeded, so the lane does not degrade, it WEDGES, retrying the same
+ * oversized batch forever. The cheapest possible mistake would take out the
+ * highest-cadence lane, and chain-detail is also the largest D1 writer here:
+ * ~1,245 rows every 12 seconds is ~9M rows/day, against account-balances'
+ * ~1.5M. It is the lane the queue most wants, which is exactly why the
+ * placeholder must fail closed.
+ *
+ * Everything else stays: the message shape, the packer and the consumer's
+ * family writer are correct and tested, and compression drops in behind them
+ * without touching any of it.
+ */
+export const QUEUE_INELIGIBLE_LANES: Readonly<Record<string, string>> = {
+  "chain-detail":
+    "one block is 476.6 KiB of raw JSON (measured on #8790494) against a " +
+    "128 KiB per-message cap, and its four families cannot be split without " +
+    "losing the atomicity they travel together for. gzip takes the same bytes " +
+    "to 40.5 KiB, so this is a compression change rather than a permanent " +
+    "exclusion -- see metagraphed-infra#383",
+};
+
 /** The family names each multi-family lane may send. A name outside this list
  * is refused rather than written to a guessed table. */
 export const MULTI_FAMILY_LANE_ROW_FAMILIES: Readonly<
@@ -650,12 +702,18 @@ export function classifySyncBatch(
  *
  * Absent flag means the old path, so a deployment that has not opted in behaves
  * exactly as before -- the same posture every other switch here takes.
+ *
+ * ONE LANE OVERRIDES THE FLAG. A lane in QUEUE_INELIGIBLE_LANES does not fit
+ * the transport at any producer setting, so naming it here is a mistake the
+ * flag cannot express -- and an unexpressible mistake should be refused, not
+ * obeyed. See that constant for the measurement.
  */
 export function syncLaneUsesQueue(
   env: { SYNC_BATCHES?: unknown; SYNC_QUEUE_LANES?: string },
   lane: SyncBatchLane,
 ): boolean {
   if (!env.SYNC_BATCHES) return false;
+  if (lane in QUEUE_INELIGIBLE_LANES) return false;
   const enabled = (env.SYNC_QUEUE_LANES ?? "")
     .split(",")
     .map((s) => s.trim())

--- a/tests/data-api-sync-queue-consumer.test.ts
+++ b/tests/data-api-sync-queue-consumer.test.ts
@@ -217,6 +217,63 @@ describe("the sync queue consumer", () => {
     assert.equal(rows().length, 0);
   });
 
+  test("decompresses a compressed message before anything reads it", async () => {
+    // THE SILENT-LOSS PATH THIS CLOSES (metagraphed#9759). A compressed message
+    // arrives as BYTES, and validSyncBatchMessage calls bytes unparseable --
+    // which this consumer ACKS, on the reasoning that something which cannot
+    // parse now will not parse on the fifth attempt. For a compressed body that
+    // reasoning is wrong and the message is simply gone, so decompression has
+    // to happen above the validator, not inside the loop.
+    const { compressSyncBatchMessage } =
+      await import("../src/sync-batch-compress.ts");
+    const { SYNC_BATCH_MAX_BYTES } = await import("../src/sync-batch-queue.ts");
+    const packed = await compressSyncBatchMessage(
+      {
+        lane: "chain-detail",
+        captured_at: 1_780_000_000_000,
+        families: {
+          blockRows: [
+            {
+              block_number: 6_100_001,
+              block_hash: `0x${"ef".repeat(32)}`,
+              spec_version: 441,
+              extrinsic_count: 0,
+              chain_event_count: 0,
+              account_event_count: 0,
+              observed_at: 1_780_000_000_000,
+              synced_at: 1_780_000_000_000,
+            },
+          ],
+        },
+      },
+      SYNC_BATCH_MAX_BYTES,
+    );
+    const m = message(packed.buffer);
+    const neighbour = positionMessage();
+
+    await consume([m, neighbour]);
+
+    assert.deepEqual(m.calls, ["ack"]);
+    assert.deepEqual(neighbour.calls, ["ack"], "and its batch-mate is fine");
+    const blocks = db
+      .prepare("SELECT block_number FROM chain_detail_blocks")
+      .all() as Record<string, unknown>[];
+    assert.deepEqual(
+      blocks.map((row) => row.block_number),
+      [6_100_001],
+      "written, not acked into the void",
+    );
+  });
+
+  test("a compressed body that will not inflate is acked, not retried", async () => {
+    // Same rule the unparseable JSON path follows: truncated or corrupted bytes
+    // will not inflate on the fifth attempt either, so retrying only burns the
+    // budget and dead-letters anyway.
+    const m = message(new Uint8Array([0x1f, 0x8b, 0x00, 0x01]).buffer);
+    await consume([m]);
+    assert.deepEqual(m.calls, ["ack"]);
+  });
+
   test("a dead-letter batch is acked and NOT written (metagraphed-infra#363)", async () => {
     // sync-batches-dlq is bound to this same handler, so the branch on
     // batch.queue is the only thing standing between recording the loss and

--- a/tests/sync-batch-compress.test.ts
+++ b/tests/sync-batch-compress.test.ts
@@ -1,0 +1,197 @@
+// The compressed sync-batches wire format (metagraphed#9759).
+//
+// The property worth testing is not "gzip works". It is that the BUDGET now
+// measures the compressed size, that an incompressible payload still fails
+// LOUDLY rather than degrading into the split the multi-family shape exists to
+// prevent, and that a body which cannot be decompressed comes back as null --
+// because the consumer acks null and retries a throw, and getting that
+// backwards loses rows for the largest lane on the platform.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  compressSyncBatchMessage,
+  decompressSyncBatchMessage,
+  isCompressedSyncBatchBody,
+  SYNC_BATCH_COMPRESSION,
+} from "../src/sync-batch-compress.ts";
+import {
+  packMultiFamilyMessage,
+  SYNC_BATCH_MAX_BYTES,
+  validSyncBatchMessage,
+} from "../src/sync-batch-queue.ts";
+
+/** A chain-detail-shaped payload: repetitive, because the real one is. The same
+ * ss58 addresses, pallet names and event kinds appear hundreds of times, which
+ * is why the measured ratio on a real block is 11.8x rather than 2x. */
+function chainDetailFamilies(events: number) {
+  const HOTKEY = "5FyVinYphF6JS5FZHzhMQffxtgbz1WxwUEBAxTRo9nABwb5g";
+  const COLDKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+  return {
+    blockRows: [
+      { block_number: 8_790_494, block_hash: `0x${"ab".repeat(32)}` },
+    ],
+    extrinsicRows: Array.from({ length: 35 }, (_unused, i) => ({
+      block_number: 8_790_494,
+      extrinsic_index: i,
+      signer: COLDKEY,
+      call_module: "SubtensorModule",
+      call_function: "set_weights",
+    })),
+    chainEventRows: Array.from({ length: events }, (_unused, i) => ({
+      block_number: 8_790_494,
+      event_index: i,
+      pallet: "SubtensorModule",
+      method: "StakeAdded",
+      args: `["${HOTKEY}","${COLDKEY}",12345678901,7]`,
+    })),
+    accountEventRows: Array.from({ length: events }, (_unused, i) => ({
+      block_number: 8_790_494,
+      event_index: i,
+      event_kind: "StakeAdded",
+      hotkey: HOTKEY,
+      coldkey: COLDKEY,
+      netuid: 7,
+    })),
+  };
+}
+
+describe("compressSyncBatchMessage", () => {
+  test("a chain-detail block fits compressed, and does not fit raw", async () => {
+    // THE WHOLE REASON THIS EXISTS. Measured on the real rows of block
+    // #8790494: 476.6 KiB of JSON against a 128 KiB per-message cap, 40.5 KiB
+    // gzipped. This is the same shape at a size that reproduces the gap.
+    const message = packMultiFamilyMessage({
+      lane: "chain-detail",
+      capturedAt: 1_780_000_000_000,
+      families: chainDetailFamilies(694),
+    });
+    const raw = JSON.stringify(message).length;
+    assert.equal(
+      raw > SYNC_BATCH_MAX_BYTES,
+      true,
+      `raw ${raw} should exceed the budget`,
+    );
+    const packed = await compressSyncBatchMessage(
+      message,
+      SYNC_BATCH_MAX_BYTES,
+    );
+    assert.equal(packed.length < SYNC_BATCH_MAX_BYTES, true);
+    // Not a token improvement: this payload class compresses by an order of
+    // magnitude, which is what makes the change decisive rather than marginal.
+    assert.equal(raw / packed.length > 5, true, `ratio ${raw / packed.length}`);
+  });
+
+  test("round-trips to exactly the message that went in", async () => {
+    const message = packMultiFamilyMessage({
+      lane: "chain-detail",
+      capturedAt: 1_780_000_000_000,
+      families: chainDetailFamilies(40),
+    });
+    const back = await decompressSyncBatchMessage(
+      await compressSyncBatchMessage(message, SYNC_BATCH_MAX_BYTES),
+    );
+    assert.deepEqual(back, message);
+    // And it is still a message the consumer will accept -- compression is a
+    // wire encoding, not a schema change.
+    assert.equal(validSyncBatchMessage(back), true);
+  });
+
+  test("an INCOMPRESSIBLE payload still fails, and says both sizes", async () => {
+    // 11.8x is one block's ratio, not a guarantee. The failure has to stay
+    // loud: the route answers 502, the producer retries a chunk that was never
+    // accepted, and nothing is silently dropped. Random hex does not compress,
+    // so this is the case that proves the budget is still enforced.
+    const random = Array.from({ length: 200_000 }, () =>
+      Math.floor(Math.random() * 16).toString(16),
+    ).join("");
+    await assert.rejects(
+      compressSyncBatchMessage(
+        {
+          lane: "chain-detail",
+          captured_at: 1,
+          families: { blockRows: [{ random }] },
+        },
+        SYNC_BATCH_MAX_BYTES,
+      ),
+      (err: Error) => {
+        assert.match(err.message, /bytes compressed \(\d+ raw\)/);
+        // The producer is told what to do, since it is the only side that can.
+        assert.match(err.message, /PRODUCER must post a smaller batch/);
+        // And never the one degradation this shape exists to prevent.
+        assert.match(err.message, /splitting them here/);
+        return true;
+      },
+    );
+  });
+
+  test("names the lane, or says so when there isn't one", async () => {
+    // The error is read by whoever is looking at a 502 in the poller's log, so
+    // naming the lane is most of its value -- and a message that somehow has no
+    // lane must still produce a readable error rather than "undefined message".
+    const random = Array.from({ length: 200_000 }, () =>
+      Math.floor(Math.random() * 16).toString(16),
+    ).join("");
+    await assert.rejects(
+      compressSyncBatchMessage({ families: { blockRows: [{ random }] } }, 1024),
+      /sync-batches: unknown message is \d+ bytes/,
+    );
+  });
+
+  test("gzip, and self-describing", async () => {
+    assert.equal(SYNC_BATCH_COMPRESSION, "gzip");
+    const packed = await compressSyncBatchMessage({ lane: "x" }, 1024);
+    assert.equal(packed[0], 0x1f);
+    assert.equal(packed[1], 0x8b);
+  });
+});
+
+describe("decompressSyncBatchMessage", () => {
+  test("returns NULL rather than throwing on anything unreadable", async () => {
+    // Null, not a throw, because of what the consumer does with each: it ACKS
+    // an unparseable message (retrying something that can never parse burns the
+    // whole budget and dead-letters anyway) and RETRIES a throw. That decision
+    // is easier to keep right when "not a message" is a value.
+    for (const bad of [
+      new Uint8Array([1, 2, 3]), // not gzip
+      new Uint8Array([0x1f, 0x8b, 0x00]), // gzip magic, truncated stream
+      new Uint8Array(0), // empty
+    ]) {
+      assert.equal(await decompressSyncBatchMessage(bad), null);
+    }
+  });
+
+  test("gzip of something that is not JSON is null, not a crash", async () => {
+    const notJson = await compressSyncBatchMessage({ lane: "x" }, 1024);
+    // Corrupt the payload after the header so it inflates to garbage.
+    const corrupted = notJson.slice();
+    corrupted[corrupted.length - 5] ^= 0xff;
+    assert.equal(await decompressSyncBatchMessage(corrupted), null);
+  });
+
+  test("accepts an ArrayBuffer, which is what the runtime actually delivers", async () => {
+    // Queues hands `contentType: "bytes"` back as an ArrayBuffer, not a
+    // Uint8Array. Testing only the latter would leave the shape production
+    // uses uncovered -- and a view/buffer mix-up here reads every message as
+    // unparseable, which this consumer ACKS.
+    const message = { lane: "chain-detail", captured_at: 1, families: {} };
+    const packed = await compressSyncBatchMessage(
+      message,
+      SYNC_BATCH_MAX_BYTES,
+    );
+    assert.equal(isCompressedSyncBatchBody(packed.buffer), true);
+    assert.deepEqual(await decompressSyncBatchMessage(packed.buffer), message);
+  });
+
+  test("a JSON body is not mistaken for a compressed one", async () => {
+    // The four lanes already on the queue send objects, and they must keep
+    // taking the existing path untouched.
+    for (const body of [{ lane: "hotkey-alpha", rows: [] }, null, "text", 7]) {
+      assert.equal(
+        isCompressedSyncBatchBody(body),
+        false,
+        JSON.stringify(body),
+      );
+      assert.equal(await decompressSyncBatchMessage(body), null);
+    }
+  });
+});

--- a/tests/sync-batch-queue.test.ts
+++ b/tests/sync-batch-queue.test.ts
@@ -25,6 +25,7 @@ import {
   passTallyFor,
   PRUNING_LANE_KEYS,
   PRUNING_LANES,
+  QUEUE_INELIGIBLE_LANES,
   syncLaneUsesQueue,
   validSyncBatchMessage,
   writeSyncBatch,
@@ -179,6 +180,43 @@ describe("syncLaneUsesQueue", () => {
     const env = { ...bound, SYNC_QUEUE_LANES: " hotkey-alpha , neurons " };
     assert.equal(syncLaneUsesQueue(env, "hotkey-alpha"), true);
     assert.equal(syncLaneUsesQueue(env, "neurons"), true);
+  });
+
+  test("refuses a lane that cannot fit the transport, even when named", () => {
+    // THE ONE-WORD MISTAKE THIS CLOSES (metagraphed-infra#359). chain-detail's
+    // indivisible unit is one block -- its four families travel together so a
+    // block and its extrinsics cannot land apart -- and one block measures
+    // ~301 KiB against a 128 KiB cap. No producer setting reaches that.
+    //
+    // Without the guard, adding the word to SYNC_QUEUE_LANES turns every tick
+    // into a 502 from an oversize send(), and the producer advances its cursor
+    // only on a POST that succeeded -- so the lane does not degrade, it WEDGES,
+    // retrying the same oversized batch forever.
+    assert.equal(
+      syncLaneUsesQueue(
+        { ...bound, SYNC_QUEUE_LANES: "chain-detail,hotkey-alpha" },
+        "chain-detail",
+      ),
+      false,
+    );
+    // And it refuses only that lane -- a co-named healthy one still routes.
+    assert.equal(
+      syncLaneUsesQueue(
+        { ...bound, SYNC_QUEUE_LANES: "chain-detail,hotkey-alpha" },
+        "hotkey-alpha",
+      ),
+      true,
+    );
+  });
+
+  test("every ineligible lane carries a reason, and is a real lane", () => {
+    // The reason is what a future reader needs in order to decide whether the
+    // constraint still holds; an entry without one is a decision nobody can
+    // revisit. And a typo'd lane name would silently guard nothing.
+    for (const [lane, reason] of Object.entries(QUEUE_INELIGIBLE_LANES)) {
+      assert.equal(SYNC_BATCH_LANES.includes(lane as never), true, lane);
+      assert.equal(reason.length > 40, true, `${lane} needs a real reason`);
+    }
   });
 });
 

--- a/tests/sync-batch-queue.test.ts
+++ b/tests/sync-batch-queue.test.ts
@@ -21,11 +21,11 @@ import {
   syncBatchRows,
   QUEUE_MESSAGE_MAX_BYTES,
   SYNC_BATCH_LANES,
+  SYNC_BATCH_MAX_BYTES,
   SYNC_BATCH_MAX_ROWS,
   passTallyFor,
   PRUNING_LANE_KEYS,
   PRUNING_LANES,
-  QUEUE_INELIGIBLE_LANES,
   syncLaneUsesQueue,
   validSyncBatchMessage,
   writeSyncBatch,
@@ -180,43 +180,6 @@ describe("syncLaneUsesQueue", () => {
     const env = { ...bound, SYNC_QUEUE_LANES: " hotkey-alpha , neurons " };
     assert.equal(syncLaneUsesQueue(env, "hotkey-alpha"), true);
     assert.equal(syncLaneUsesQueue(env, "neurons"), true);
-  });
-
-  test("refuses a lane that cannot fit the transport, even when named", () => {
-    // THE ONE-WORD MISTAKE THIS CLOSES (metagraphed-infra#359). chain-detail's
-    // indivisible unit is one block -- its four families travel together so a
-    // block and its extrinsics cannot land apart -- and one block measures
-    // ~301 KiB against a 128 KiB cap. No producer setting reaches that.
-    //
-    // Without the guard, adding the word to SYNC_QUEUE_LANES turns every tick
-    // into a 502 from an oversize send(), and the producer advances its cursor
-    // only on a POST that succeeded -- so the lane does not degrade, it WEDGES,
-    // retrying the same oversized batch forever.
-    assert.equal(
-      syncLaneUsesQueue(
-        { ...bound, SYNC_QUEUE_LANES: "chain-detail,hotkey-alpha" },
-        "chain-detail",
-      ),
-      false,
-    );
-    // And it refuses only that lane -- a co-named healthy one still routes.
-    assert.equal(
-      syncLaneUsesQueue(
-        { ...bound, SYNC_QUEUE_LANES: "chain-detail,hotkey-alpha" },
-        "hotkey-alpha",
-      ),
-      true,
-    );
-  });
-
-  test("every ineligible lane carries a reason, and is a real lane", () => {
-    // The reason is what a future reader needs in order to decide whether the
-    // constraint still holds; an entry without one is a decision nobody can
-    // revisit. And a typo'd lane name would silently guard nothing.
-    for (const [lane, reason] of Object.entries(QUEUE_INELIGIBLE_LANES)) {
-      assert.equal(SYNC_BATCH_LANES.includes(lane as never), true, lane);
-      assert.equal(reason.length > 40, true, `${lane} needs a real reason`);
-    }
   });
 });
 
@@ -882,41 +845,32 @@ describe("multi-family messages (metagraphed-infra#359)", () => {
     }
   });
 
-  test("THROWS rather than splitting an oversize chunk", () => {
-    // The families must land together, so there is no correct way to split
-    // them here. The producer has to post a smaller batch -- and this error is
-    // how that gets discovered, instead of a silently split write.
-    assert.throws(
-      () =>
-        packMultiFamilyMessage({
-          lane: "chain-detail",
-          capturedAt: 1,
-          families: families(5_000),
-        }),
-      /must land together/,
-    );
-  });
-
-  test("the producer's CURRENT batch does not fit, and that is the finding", () => {
-    // chain-detail batches 2 blocks per POST at ~350-662 KiB (workers/data-api.ts
-    // header). The cap is 128 KB. So this lane cannot be cut over until the
-    // producer posts smaller batches -- asserting it here means the constraint
-    // is recorded in the code rather than rediscovered at cutover.
-    const bigBatch = {
-      blockRows: [{ number: 1, blob: "x".repeat(200_000) }],
-      extrinsicRows: [],
-      chainEventRows: [],
-      accountEventRows: [],
-    };
-    assert.throws(
-      () =>
-        packMultiFamilyMessage({
-          lane: "chain-detail",
-          capturedAt: 1,
-          families: bigBatch,
-        }),
-      /over the \d+-byte budget/,
-    );
+  test("does not measure itself -- the budget moved to the compressor", () => {
+    // It used to check JSON.stringify(...) against the budget, and that was
+    // measuring the wrong thing once the message started travelling
+    // compressed: one chain-detail block is 476.6 KiB of JSON and 40.5 KiB on
+    // the wire, so a raw-bytes check refuses messages that fit.
+    // compressSyncBatchMessage owns the budget now, because it is the only
+    // place that knows the size the transport actually sees.
+    const message = packMultiFamilyMessage({
+      lane: "chain-detail",
+      capturedAt: 1,
+      // Well over the byte budget, comfortably under the row ceiling -- which
+      // is the combination the old check made unsendable and the new one does
+      // not, because these bytes compress.
+      families: {
+        blockRows: [{ number: 1 }],
+        extrinsicRows: Array.from({ length: 900 }, (_unused, i) => ({
+          hash: `0x${"ab".repeat(32)}`,
+          signer: "5FyVinYphF6JS5FZHzhMQffxtgbz1WxwUEBAxTRo9nABwb5g",
+          index: i,
+        })),
+        chainEventRows: [{ kind: "x" }],
+        accountEventRows: [{ account: "5A" }],
+      },
+    });
+    assert.equal(JSON.stringify(message).length > SYNC_BATCH_MAX_BYTES, true);
+    assert.equal(validSyncBatchMessage(message), true);
   });
 
   test("writeSyncBatch routes a family message to the family writer", async () => {

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -429,9 +429,15 @@ import {
   isDeadLetterQueue,
 } from "../src/dead-letter.ts";
 import {
+  compressSyncBatchMessage,
+  decompressSyncBatchMessage,
+  isCompressedSyncBatchBody,
+} from "../src/sync-batch-compress.ts";
+import {
   classifySyncBatch,
   enqueueSyncBatch,
   packMultiFamilyMessage,
+  SYNC_BATCH_MAX_BYTES,
   type SyncBatchFamilyWriters,
   syncBatchRowCount,
   syncLaneUsesQueue,
@@ -850,19 +856,29 @@ async function handleChainDetailSync(request: Request, env: Env) {
   // together: a block whose drill-down shows no calls is readable and wrong.
   // packMultiFamilyMessage refuses to split them, so an oversize batch throws
   // here rather than silently becoming the split this shape exists to prevent.
+  //
+  // SENT COMPRESSED, because raw JSON does not fit and cannot be made to: one
+  // block measures 476.6 KiB against a 128 KiB cap, and the batch is already
+  // one block. gzip takes the same bytes to 40.5 KiB (metagraphed#9759). The
+  // budget is checked on the COMPRESSED size -- the only number the transport
+  // sees -- and still throws rather than degrading into a split.
   if (syncLaneUsesQueue(env, "chain-detail")) {
     try {
       await env.SYNC_BATCHES!.send(
-        packMultiFamilyMessage({
-          lane: "chain-detail",
-          capturedAt: Date.now(),
-          families: {
-            blockRows: batch.rows.blockRows,
-            extrinsicRows: batch.rows.extrinsicRows,
-            chainEventRows: batch.rows.chainEventRows,
-            accountEventRows: batch.rows.accountEventRows,
-          },
-        }),
+        await compressSyncBatchMessage(
+          packMultiFamilyMessage({
+            lane: "chain-detail",
+            capturedAt: Date.now(),
+            families: {
+              blockRows: batch.rows.blockRows,
+              extrinsicRows: batch.rows.extrinsicRows,
+              chainEventRows: batch.rows.chainEventRows,
+              accountEventRows: batch.rows.accountEventRows,
+            },
+          }),
+          SYNC_BATCH_MAX_BYTES,
+        ),
+        { contentType: "bytes" },
       );
     } catch (err) {
       console.error("data-api chain-detail enqueue failed:", err);
@@ -7399,7 +7415,23 @@ export default {
       await handleDeadLetterBatch(batch, env.METAGRAPH_HEALTH_DB);
       return;
     }
-    const { valid, invalid } = classifySyncBatch(batch.messages);
+    // DECOMPRESS BEFORE ANYTHING READS THE BODY (metagraphed#9759). A
+    // compressed message arrives as bytes, and `validSyncBatchMessage` would
+    // call those unparseable -- which the consumer ACKS. That is silent data
+    // loss for the largest lane on the platform, so it happens first, and a
+    // body that fails to decompress simply stays what it was and takes the
+    // existing unparseable path.
+    const decoded = await Promise.all(
+      batch.messages.map(async (message) =>
+        isCompressedSyncBatchBody(message.body)
+          ? {
+              message,
+              body: await decompressSyncBatchMessage(message.body),
+            }
+          : { message, body: message.body },
+      ),
+    );
+    const { valid, invalid } = classifySyncBatch(decoded);
     // syncBatchRowCount, not `m.rows.length`: a multi-family message carries
     // `families` and no `rows` at all, so the direct read threw a TypeError HERE
     // -- above the per-message try/catch below -- and failed the whole batch,
@@ -7521,23 +7553,19 @@ export default {
           },
         }
       : {};
-    for (const message of batch.messages) {
-      if (!validSyncBatchMessage(message.body)) {
+    for (const { message, body } of decoded) {
+      if (!validSyncBatchMessage(body)) {
         // Acked, not retried: a message that cannot parse will not parse on the
         // fifth attempt either, and burning the budget only delays the DLQ.
         message.ack();
         continue;
       }
       try {
-        await writeSyncBatch(message.body, writers, Date.now(), familyWriters);
+        await writeSyncBatch(body, writers, Date.now(), familyWriters);
         message.ack();
       } catch (err) {
         console.error("sync-batches: write failed:", err);
-        await captureDataApiError(
-          err,
-          `sync-batches/${message.body.lane}`,
-          env,
-        );
+        await captureDataApiError(err, `sync-batches/${body.lane}`, env);
         // Retried: a D1 write that failed under load is exactly what the queue's
         // backoff exists for, and this is the failure the one-second producer
         // sleep was standing in for.


### PR DESCRIPTION
Closes #9759. Removes the guard added in #9757, whose reason this fixes.

## The constraint, measured

`chain-detail`'s indivisible unit is **one block**. Its four families are posted together precisely so a block and its extrinsics cannot land separately, and `packMultiFamilyMessage` refuses to split them for that reason. So the question was never "how many blocks per message" — the batch is already one block. It is whether **one** block fits.

Built from the real rows of block #8790494 (35 extrinsics, 694 chain events, 515 account events — 1,245 rows):

| | |
|---|---|
| raw JSON | **476.6 KiB** — 3.7× over a 128 KiB cap |
| gzip -9 | **40.5 KiB** — 11.8×, 87.5 KiB headroom, ~3 blocks/message |

The payload is enormously repetitive — the same ss58 addresses, pallet names and event kinds hundreds of times over — which is why the ratio is decisive rather than marginal.

**And it is the lane the queue most wants.** `chain-detail` is the largest D1 writer here and the only continuous one: ~1,245 rows every 12 seconds is **~9M rows/day**, against `account-balances`' ~1.5M. metagraphed-infra#346's argument for one queue was global backpressure — "a lane left out is a lane that can still overwhelm the database the others are being polite about". The bulk lanes are bursty; this one never stops.

## The budget moved to where the size is known

`packMultiFamilyMessage` used to check `JSON.stringify(...)` against the budget. That is measuring the wrong thing once the wire is compressed — it refuses messages that fit. `compressSyncBatchMessage` owns it now, because it is the only place that knows the size the transport actually sees.

It keeps the loud throw and names **both** sizes, because **11.8× is one block's ratio, not a guarantee**. A block whose events happen to be less repetitive compresses worse, and the failure has to stay loud: the route answers 502, the producer retries a chunk that was never accepted, and nothing is silently dropped. There is a test with an incompressible payload proving the budget is still enforced.

## Decompression happens above the validator — this is the part that would have lost rows

A compressed message arrives as **bytes**. `validSyncBatchMessage` calls bytes unparseable, and this consumer **acks** unparseable, on the reasoning that something which cannot parse now will not parse on the fifth attempt. For a compressed body that reasoning is wrong and the message is simply **gone** — for the largest lane on the platform.

So decoding happens before anything reads a body, and a body that fails to inflate stays what it was and takes the existing unparseable path. Verified: reverting only the decode step fails `decompresses a compressed message before anything reads it`.

## Deliberately not done

The four lanes already on the queue are **not** compressed. They fit, they are running clean, and re-encoding a working transport for uniformity is what this epic's own non-goals warn against. The *decoder* accepts a compressed body from any lane, so opting one in later is a producer-side change with no consumer deploy — but nothing is opted in today.

## Validation

```
npm run typecheck    # clean
npm run lint         # clean
npx prettier --check # clean
npx vitest run tests/sync-batch-compress.test.ts tests/sync-batch-queue.test.ts \
  tests/data-api-sync-queue-consumer.test.ts tests/chain-detail-sync-route.test.ts \
  tests/data-api-{account-balances,neurons,nominator-positions}-d1.test.ts   # 202 passed
```

Patch coverage over `src/sync-batch-compress.ts` (whole new file), `src/sync-batch-queue.ts` and `workers/data-api.ts`: **0 uncovered statements, branches, or functions**.

`npm run validate` fails locally on `generated:53: per-subnet detail artifact is not reproducible from registry inputs` — **identically with this branch's changes stashed**, so it is stale local build output rather than this diff.

## Next

The lane still is not cut over. Adding `chain-detail` to `SYNC_QUEUE_LANES` is a separate deploy, after this lands and a real tick is observed — the same rule every other lane followed.

## Template Used

- Backend/code change
