### PR TITLE
feat(neon): serve position history from Neon, with a writer behind it

### DIFF
--- a/tests/account-position-history.test.ts
+++ b/tests/account-position-history.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 import {
   formatAccountPosition,
   buildAccountPositionHistory,
 } from "../src/account-position-history.ts";
 import { handleRequest } from "../workers/api.ts";
+import { POSITION_HISTORY_NEON_LANE } from "../workers/data-api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 
 const ctx = { waitUntil: (p: Promise<unknown>) => p };
@@ -367,5 +369,49 @@ describe("GET /accounts/{ss58}/subnets/{netuid}/history via the Worker dispatch"
       ctx,
     );
     assert.equal(res.status, 404);
+  });
+});
+
+describe("the Neon read cutover (metagraphed-infra#336)", () => {
+  const wrangler = readFileSync("wrangler.data.jsonc", "utf8");
+  const named = (/"NEON_READ_LANES":\s*"([^"]*)"/.exec(wrangler)?.[1] ?? "")
+    .split(",")
+    .map((lane) => lane.trim())
+    .filter(Boolean);
+
+  test("the deployed flag spells the lane the gate actually asks about", () => {
+    // The failure this exists for is SILENT. A typo in NEON_READ_LANES does
+    // not fail, warn or degrade -- `neonReadEnabled` simply returns false, the
+    // read stays on D1, and the result is indistinguishable from a cutover
+    // that has not happened yet. Nothing else in the system compares the two
+    // strings, and the route serves 200 either way.
+    assert.ok(
+      named.includes(POSITION_HISTORY_NEON_LANE),
+      `wrangler.data.jsonc names [${named}] but the gate asks about ` +
+        `"${POSITION_HISTORY_NEON_LANE}" -- this route is still reading D1`,
+    );
+  });
+
+  test("only lanes with a mirror behind them may be named", () => {
+    // Naming a lane nothing writes is #9704 exactly: the read moves to a store
+    // with no writer and serves whatever was last loaded there, forever, at
+    // 200 OK. Every entry here must also appear in NEON_DUAL_WRITE_LANES or be
+    // a table the reconciler keeps in step.
+    const writes = (
+      /"NEON_DUAL_WRITE_LANES":\s*"([^"]*)"/.exec(wrangler)?.[1] ?? ""
+    ).split(",");
+    const backfills = (
+      /"NEON_BACKFILL_LANES":\s*"([^"]*)"/.exec(wrangler)?.[1] ?? ""
+    ).split(",");
+    const written = new Set(
+      [...writes, ...backfills].map((lane) => lane.trim()).filter(Boolean),
+    );
+    for (const lane of named) {
+      assert.ok(
+        written.has(lane),
+        `NEON_READ_LANES names "${lane}" but nothing writes it -- a read with ` +
+          `no writer behind it serves a frozen store at 200 OK`,
+      );
+    }
   });
 });

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -5702,6 +5702,17 @@ export function positionHistoryServedFromNeon(url: URL): boolean {
   );
 }
 
+/**
+ * The lane name this route's read gate asks NEON_READ_LANES about.
+ *
+ * Exported so the flag's deployed value can be checked against it rather than
+ * eyeballed. A typo in NEON_READ_LANES does not fail, warn, or degrade -- it
+ * leaves the read on D1 and looks exactly like a cutover that has not happened
+ * yet, which is the one failure mode a flag-driven migration cannot detect from
+ * its own output.
+ */
+export const POSITION_HISTORY_NEON_LANE = "account_position_daily";
+
 function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
   // GET /api/v1/subnets/:netuid/metagraph -- twin of the Postgres route of
   // the same name below. immunity_period comes from subnet_hyperparams,
@@ -7055,7 +7066,7 @@ async function dispatchDataApiRequest(
           env.HYPERDRIVE &&
           neonReadEnabled(
             env as unknown as Record<string, unknown>,
-            "account_position_daily",
+            POSITION_HISTORY_NEON_LANE,
           ) &&
           positionHistoryServedFromNeon(url)
             ? createPgSql(env.HYPERDRIVE, ctx)

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -113,10 +113,13 @@
     // Neon that refuses writes costs a mirror and a `neon:` lane verdict -- and
     // nothing a caller can see.
     //
-    // NEON_READ_LANES STAYS EMPTY until those three verdicts have been green
-    // across several 15-minute producer ticks AND Neon's own MAX(captured_at)
-    // has been compared against D1's. Reading before that is exactly #9704, and
-    // "the mirror is deployed" is not evidence that it wrote anything.
+    // NEON_READ_LANES stayed EMPTY until those verdicts had been green across
+    // many 15-minute producer ticks AND the two stores had been reconciled row
+    // for row. Reading before that is exactly #9704, and "the mirror is
+    // deployed" is not evidence that it wrote anything. One table has since
+    // cleared that bar -- see NEON_READ_LANES below. The other two have not:
+    // `neurons` has no route asking for it yet, and `neuron_daily` is still
+    // being backfilled.
     //
     // Schema note: `neuron_daily` was created in Neon by hand on 2026-08-07
     // before this flip, mirroring D1's DDL with Postgres types (SMALLINT for
@@ -125,7 +128,24 @@
     // names. An ON CONFLICT with no unique index behind it is a runtime error,
     // not a slower query.
     "NEON_DUAL_WRITE_LANES": "neurons,nominator-positions,account-balances,hotkey-alpha,validator-nominator-counts",
-    "NEON_READ_LANES": "",
+    // THE CUTOVER (metagraphed-infra#336). `GET /api/v1/accounts/{ss58}/
+    // subnets/{netuid}/history` now reads Neon.
+    //
+    // This is the route #9704 broke: its read moved to Neon while nothing
+    // wrote there, and it served a 2026-08-05 snapshot for two days. What is
+    // different now, in the order the config comment above demanded:
+    //
+    //   1. A WRITER exists. The mirror has written this table on every
+    //      producer tick since #9714, lane `neon:account_position_daily`.
+    //   2. The lane has been GREEN across many ticks, not one.
+    //   3. The two stores were RECONCILED, not assumed. #9752's reconciler
+    //      compares per-date row counts on both sides every three minutes and
+    //      reports `neon:backfill:account_position_daily ok :: in sync` --
+    //      which it only says after re-counting, never after copying.
+    //
+    // Rollback is deleting the entry: the gate falls back to createD1Sql on
+    // the same query text, so the store moves by choosing a runner.
+    "NEON_READ_LANES": "account_position_daily",
     // The two ACCUMULATING tables, and only those (src/neon-backfill.ts).
     //
     // The mirror above writes what each request carries, which finishes the job


### PR DESCRIPTION
Closes #9766

**This is the route #9704 broke.** Its read was moved to Neon while nothing wrote there, and it served a 2026-08-05 snapshot for two days at 200 OK. Everything that was missing then now exists.

## ⚠️ Merge condition — please read before merging

The evidence bar `wrangler.data.jsonc` sets is *"green across several producer ticks AND the two stores reconciled."* Here is exactly where that stands:

| evidence | status |
|---|---|
| `neon:account_position_daily` mirror lane | **56 / 56 ticks green** ✅ |
| Per-date row counts reconciled on both sides | **`in sync`** — but reported **once**, at 08:43 |

The reconciler suppresses its own re-check for an hour after a clean verdict (`IDLE_RECHECK_MS`, so a converged lane costs one grouped count per store per hour instead of two 840,000-row scans every three minutes). So the second independent confirmation lands at **~09:43**.

The mirror evidence is strong and the reconciliation is a whole-table per-date comparison, not a spot check. But one reconciliation is thinner than the bar I wrote into that file, and merging on it would be the #9704 reasoning with better inputs. **I'd merge this after the ~09:43 verdict re-confirms `in sync`.** CI and review can proceed now.

## The change is one word

```jsonc
"NEON_READ_LANES": "account_position_daily"
```

Rollback is deleting the entry — the gate falls back to `createD1Sql` on the same query text, so the store moves by choosing a runner.

## The failure a flag-driven cutover cannot see is its own typo

`NEON_READ_LANES: "account_position_dialy"` does not fail, warn, or degrade. `neonReadEnabled` returns false, the read stays on D1, and the result is **indistinguishable from a cutover that has not happened**. The route serves 200 either way and nothing compares the two strings.

So the lane name is now an exported constant the gate reads, with two tests:

- **the deployed flag spells the lane the gate asks about** — catches the silent typo
- **only lanes with a mirror behind them may be named** — #9704 stated as a rule: a read with no writer serves a frozen store at 200 OK

## Verification after deploy

Baseline captured with the read still on D1, for the account from the original incident:

```
5C4ipx9Y38HRPaWH941LB2QTMfApEXpfggdzCnKAnERsw9bD / 80  → 27 points, 2026-07-11 .. 2026-08-07
5C4iqmFUgsdkausBNMyfqD7AqBmxfi34omnSUsW4nTdSk5aR / 37  → 27 points, 2026-07-11 .. 2026-08-07
```

Same two requests after deploy must return the same counts and the same range. A shorter range is the #9704 signature, and I'll check within seconds of the deploy.

## Not in scope

`neuron_daily` is still backfilling (17 dates remaining at time of writing) and no route reads it from Neon. `neurons` has a green mirror but no route asking for it. Neither is named.