### PR TITLE
feat(registry): flag surfaces whose URL names a moving target

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7912,6 +7912,7 @@ export interface components {
         Gaps: {
             gap_notes: string[];
             missing_kinds: components["schemas"]["SurfaceKind"][];
+            moving_target_surfaces?: string[];
             supported_kinds: components["schemas"]["SurfaceKind"][];
         };
         GapsArtifact: {
@@ -16956,6 +16957,9 @@ export interface operations {
                      *           ],
                      *           "missing_kinds": [
                      *             "archive"
+                     *           ],
+                     *           "moving_target_surfaces": [
+                     *             "example"
                      *           ],
                      *           "supported_kinds": [
                      *             "archive"
@@ -37114,6 +37118,9 @@ export interface operations {
                      *           "missing_kinds": [
                      *             "archive"
                      *           ],
+                     *           "moving_target_surfaces": [
+                     *             "example"
+                     *           ],
                      *           "supported_kinds": [
                      *             "archive"
                      *           ]
@@ -41289,6 +41296,9 @@ export interface operations {
                      *           "missing_kinds": [
                      *             "archive"
                      *           ],
+                     *           "moving_target_surfaces": [
+                     *             "example"
+                     *           ],
                      *           "supported_kinds": [
                      *             "archive"
                      *           ]
@@ -42024,6 +42034,9 @@ export interface operations {
                      *           ],
                      *           "missing_kinds": [
                      *             "archive"
+                     *           ],
+                     *           "moving_target_surfaces": [
+                     *             "example"
                      *           ],
                      *           "supported_kinds": [
                      *             "archive"

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -8773,6 +8773,9 @@
               "missing_kinds": [
                 "archive"
               ],
+              "moving_target_surfaces": [
+                "example"
+              ],
               "supported_kinds": [
                 "archive"
               ]
@@ -9858,6 +9861,9 @@
               "missing_kinds": [
                 "archive"
               ],
+              "moving_target_surfaces": [
+                "example"
+              ],
               "supported_kinds": [
                 "archive"
               ]
@@ -10306,6 +10312,9 @@
               ],
               "missing_kinds": [
                 "archive"
+              ],
+              "moving_target_surfaces": [
+                "example"
               ],
               "supported_kinds": [
                 "archive"
@@ -31098,6 +31107,12 @@
           "missing_kinds": {
             "items": {
               "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          },
+          "moving_target_surfaces": {
+            "items": {
+              "type": "string"
             },
             "type": "array"
           },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7912,6 +7912,7 @@ export interface components {
         Gaps: {
             gap_notes: string[];
             missing_kinds: components["schemas"]["SurfaceKind"][];
+            moving_target_surfaces?: string[];
             supported_kinds: components["schemas"]["SurfaceKind"][];
         };
         GapsArtifact: {
@@ -16956,6 +16957,9 @@ export interface operations {
                      *           ],
                      *           "missing_kinds": [
                      *             "archive"
+                     *           ],
+                     *           "moving_target_surfaces": [
+                     *             "example"
                      *           ],
                      *           "supported_kinds": [
                      *             "archive"
@@ -37114,6 +37118,9 @@ export interface operations {
                      *           "missing_kinds": [
                      *             "archive"
                      *           ],
+                     *           "moving_target_surfaces": [
+                     *             "example"
+                     *           ],
                      *           "supported_kinds": [
                      *             "archive"
                      *           ]
@@ -41289,6 +41296,9 @@ export interface operations {
                      *           "missing_kinds": [
                      *             "archive"
                      *           ],
+                     *           "moving_target_surfaces": [
+                     *             "example"
+                     *           ],
                      *           "supported_kinds": [
                      *             "archive"
                      *           ]
@@ -42024,6 +42034,9 @@ export interface operations {
                      *           ],
                      *           "missing_kinds": [
                      *             "archive"
+                     *           ],
+                     *           "moving_target_surfaces": [
+                     *             "example"
                      *           ],
                      *           "supported_kinds": [
                      *             "archive"

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -321,6 +321,13 @@ export const GapsSchema = z
   .object({
     gap_notes: z.array(z.string()),
     missing_kinds: z.array(SurfaceKindSchema),
+    // #9746: ids of tracked surfaces whose URL names a MOVING TARGET
+    // (a /latest or /current terminal), so the operator may publish a
+    // parameterized sibling beside them that this registry does not track.
+    // A lead to resolve against the operator's own documentation -- never a
+    // claim that such a sibling exists. Optional so a body published before
+    // this shipped still validates.
+    moving_target_surfaces: z.array(z.string()).optional(),
     supported_kinds: z.array(SurfaceKindSchema),
   })
   .strict();

--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -45,6 +45,7 @@ import {
   nativeContactHandle,
   nativeContactUrl,
   nativeDisplayName,
+  buildSubnetGaps,
   nativeNameQuality,
   netuidForEvidenceClaim,
   normalizePublicHttpUrl,
@@ -2938,7 +2939,7 @@ function mergeSubnet(
       cleanDescription(overlay?.description) ||
       null,
     docs_url: overlay?.docs_url || null,
-    gaps: buildGaps(overlay?.surfaces || [], overlay),
+    gaps: buildSubnetGaps(overlay?.surfaces || [], overlay),
     mechanism_count: nativeSubnet.mechanism_count,
     name: displayName,
     native_name: nativeName,
@@ -3034,38 +3035,6 @@ function mergeSubnet(
     // display-only — never feeds completeness (the #343 flywheel gate).
     // metagraphed otherwise keeps only the contact_present boolean.
     contact: subnetContact(overlay?.contact),
-  };
-}
-
-function buildGaps(surfaces: Row[], overlay: Row | null | undefined): Row {
-  const kinds = new Set(surfaces.map((surface) => surface.kind));
-  if (overlay?.docs_url) {
-    kinds.add("docs");
-  }
-  if (overlay?.source_repo) {
-    kinds.add("source-repo");
-  }
-  if (overlay?.website_url) {
-    kinds.add("website");
-  }
-  if (overlay?.dashboard_url) {
-    kinds.add("dashboard");
-  }
-  const expectedKinds = [
-    "docs",
-    "source-repo",
-    "website",
-    "dashboard",
-    "openapi",
-    "subnet-api",
-    "sse",
-    "data-artifact",
-  ];
-  const missingKinds = expectedKinds.filter((kind) => !kinds.has(kind));
-  return {
-    missing_kinds: missingKinds,
-    supported_kinds: [...kinds].sort(),
-    gap_notes: overlay?.curation?.gap_notes || [],
   };
 }
 

--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -2792,6 +2792,47 @@ export function extractAuth(spec: Row): Row {
   };
 }
 
+/**
+ * The per-subnet gaps block: which public interface kinds are missing, which
+ * are supported, and which tracked surfaces name a moving target.
+ *
+ * ONE implementation, because there were two. scripts/build-artifacts.ts and
+ * scripts/validate.ts each carried a byte-for-byte copy, and the
+ * reproducibility check compares one against the other -- so adding a field to
+ * the build alone turned every subnet into "per-subnet detail artifact is not
+ * reproducible from registry inputs". Two copies of a derivation that exists to
+ * be compared against itself is a bug generator, not a safety net.
+ */
+export function buildSubnetGaps(
+  surfaces: Row[],
+  overlay: (Row & { curation?: Row }) | null | undefined,
+): Row {
+  const kinds = new Set(surfaces.map((surface) => surface.kind));
+  if (overlay?.docs_url) kinds.add("docs");
+  if (overlay?.source_repo) kinds.add("source-repo");
+  if (overlay?.website_url) kinds.add("website");
+  if (overlay?.dashboard_url) kinds.add("dashboard");
+  const expectedKinds = [
+    "docs",
+    "source-repo",
+    "website",
+    "dashboard",
+    "openapi",
+    "subnet-api",
+    "sse",
+    "data-artifact",
+  ];
+  return {
+    missing_kinds: expectedKinds.filter((kind) => !kinds.has(kind)),
+    supported_kinds: [...kinds].sort(),
+    // #9746: surfaces whose URL names a moving target, so the operator may
+    // publish a parameterized sibling beside them that this registry does not
+    // track. A lead to check against their own docs, never a claim one exists.
+    moving_target_surfaces: movingTargetSurfaceIds(surfaces),
+    gap_notes: (overlay?.curation as Row | undefined)?.gap_notes || [],
+  };
+}
+
 // Declared lifecycle, derived from canonical on-chain identity names (teams set
 // subnet_name exactly to "deprecated"/"Parked"/"Pending" when a subnet is no
 // longer a live product), distinct from `status` (chain-registration state,
@@ -2889,12 +2930,15 @@ export function staleOperationalKinds({
 // scripts/lib/formatting.ts (#510 maintainability decomposition). Re-exported
 // here verbatim so every existing importer of scripts/lib.ts keeps its import
 // path unchanged — pure code-motion with byte-identical artifact output.
+import { movingTargetSurfaceIds } from "./lib/formatting.ts";
+
 export {
   slugify,
   formatLlmMarkdownText,
   classifyNativeName,
   nativeNameQuality,
   nativeDisplayName,
+  movingTargetSurfaceIds,
   sanitizeChainText,
   stripUrls,
   cleanDescription,

--- a/scripts/lib/formatting.ts
+++ b/scripts/lib/formatting.ts
@@ -95,6 +95,68 @@ export function classifyNativeName(
   return { raw_name: raw, quality: "chain" };
 }
 
+/**
+ * Surfaces whose URL names a MOVING TARGET, so a parameterized sibling may
+ * exist that the registry does not track (#9746).
+ *
+ * Found while fixing SN53 (#9737): its first-party API exposes both
+ * `/api/subnet/v1/epoch/latest` and `/api/subnet/v1/epoch/{index}`. The second
+ * is strictly more capable -- same shape, any finalized epoch -- and a capture
+ * that records only the first cannot see it, because nothing about `/latest`
+ * announces that `/{index}` exists.
+ *
+ * Measured across the registry: 26 callable surfaces on 13 subnets end in one
+ * of these terminals, including `api.blockmachine.io/epochs/current` and
+ * `chain.joinbase.ai/v1/weights/latest` -- the same shape as SN53's, on
+ * subnets nobody has looked at.
+ *
+ * THIS ASSERTS NOTHING ABOUT A SIBLING'S EXISTENCE. It reports that a tracked
+ * surface answers "what is happening now" and that "what happened then" may be
+ * published beside it. Resolving that means reading the OPERATOR'S OWN
+ * documentation, which is how SN53's was found -- probing guessed paths would
+ * be unsolicited traffic against a third party, and a 200 on a guessed URL is
+ * not evidence that the operator publishes it as a surface, which is the
+ * standard every other entry in this registry is held to.
+ *
+ * Deliberately anchored to the END of the path: a `/latest/` in the middle of a
+ * URL is a directory name, not a point-in-time view.
+ */
+const MOVING_TARGET_TERMINAL = /\/(?:latest|current|newest|head)\/?$/i;
+
+/**
+ * CALLABLE kinds only. A `/latest` on a dashboard or a website is a page a
+ * human opens, not an API capability with an indexed sibling -- flagging one
+ * would send an enricher to read documentation that does not exist. Measured:
+ * restricting to these drops the one `dashboard` false positive and keeps all
+ * 24 `subnet-api` and 3 `data-artifact` hits.
+ */
+const MOVING_TARGET_KINDS = new Set([
+  "subnet-api",
+  "openapi",
+  "sse",
+  "data-artifact",
+]);
+
+export function movingTargetSurfaceIds(surfaces: Row[] | undefined): string[] {
+  return (Array.isArray(surfaces) ? surfaces : [])
+    .filter((surface) => {
+      if (!MOVING_TARGET_KINDS.has(String(surface?.kind))) return false;
+      const url = typeof surface?.url === "string" ? surface.url : "";
+      if (!url) return false;
+      // The path only -- a query string may legitimately carry "latest" as a
+      // value without the surface being a point-in-time view.
+      let pathname: string;
+      try {
+        pathname = new URL(url).pathname;
+      } catch {
+        return false;
+      }
+      return MOVING_TARGET_TERMINAL.test(pathname);
+    })
+    .map((surface) => String(surface.id))
+    .sort();
+}
+
 export function nativeNameQuality(subnet: Row | undefined): string {
   const rawName =
     typeof subnet?.raw_name === "string" ? subnet.raw_name : subnet?.name;

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -17,6 +17,7 @@ import {
   isValidUrl,
   normalizePublicHttpUrl,
   nativeDisplayName,
+  buildSubnetGaps,
   nativeNameQuality,
   listJsonFiles,
   listJsonFilesRecursive,
@@ -722,40 +723,6 @@ function validateReviewDecision(
   );
 }
 
-function buildGeneratedArtifactGaps(
-  surfaces: Row[],
-  overlay: Row | undefined,
-): Row {
-  const kinds = new Set(surfaces.map((surface) => surface.kind));
-  if (overlay?.docs_url) {
-    kinds.add("docs");
-  }
-  if (overlay?.source_repo) {
-    kinds.add("source-repo");
-  }
-  if (overlay?.website_url) {
-    kinds.add("website");
-  }
-  if (overlay?.dashboard_url) {
-    kinds.add("dashboard");
-  }
-  const expectedKinds = [
-    "docs",
-    "source-repo",
-    "website",
-    "dashboard",
-    "openapi",
-    "subnet-api",
-    "sse",
-    "data-artifact",
-  ];
-  return {
-    missing_kinds: expectedKinds.filter((kind) => !kinds.has(kind)),
-    supported_kinds: [...kinds].sort(),
-    gap_notes: overlay?.curation?.gap_notes || [],
-  };
-}
-
 function buildExpectedGeneratedSubnet(
   nativeSnapshot: Row,
   overlay: Row | undefined,
@@ -813,7 +780,7 @@ function buildExpectedGeneratedSubnet(
       cleanDescription(overlay?.description) ||
       null,
     docs_url: overlay?.docs_url || null,
-    gaps: buildGeneratedArtifactGaps(overlay?.surfaces || [], overlay),
+    gaps: buildSubnetGaps(overlay?.surfaces || [], overlay),
     mechanism_count: nativeSubnet.mechanism_count,
     name: displayName,
     native_name: nativeName,

--- a/tests/formatting.test.ts
+++ b/tests/formatting.test.ts
@@ -6,6 +6,7 @@ import {
   classifyNativeName,
   nativeNameQuality,
   sanitizeChainText,
+  movingTargetSurfaceIds,
   nativeDisplayName,
   stripUrls,
   cleanDescription,
@@ -105,6 +106,87 @@ describe("stripUrls — a typo'd scheme is still a URL (#9748)", () => {
     assert.equal(stripUrls("visit https://example.com/a?b=c ok"), "visit ok");
     // No false positive on ordinary text that merely contains the letters.
     assert.equal(stripUrls("https is a protocol"), "https is a protocol");
+  });
+});
+
+describe("movingTargetSurfaceIds — a /latest may have a sibling (#9746)", () => {
+  const surface = (id: string, url: string, kind = "subnet-api") => ({
+    id,
+    url,
+    kind,
+  });
+
+  test("flags a callable surface whose PATH ends in a moving-target terminal", () => {
+    // The SN53 shape: /epoch/latest is tracked, /epoch/{index} is not, and
+    // nothing about the first announces the second.
+    assert.deepEqual(
+      movingTargetSurfaceIds([
+        surface("a", "https://provider.engy.ai/api/subnet/v1/epoch/latest"),
+        surface(
+          "b",
+          "https://api.blockmachine.io/epochs/current",
+          "data-artifact",
+        ),
+        surface("c", "https://api.affine.io/api/v1/rank/current"),
+      ]),
+      ["a", "b", "c"],
+    );
+    // Trailing slash, and the other two terminals.
+    assert.deepEqual(
+      movingTargetSurfaceIds([
+        surface("d", "https://x.test/v1/newest/"),
+        surface("e", "https://x.test/v1/head"),
+      ]),
+      ["d", "e"],
+    );
+  });
+
+  test("ignores a terminal that is not at the END of the path", () => {
+    // A /latest/ in the middle is a directory name, not a point-in-time view.
+    assert.deepEqual(
+      movingTargetSurfaceIds([
+        surface("mid", "https://x.test/latest/reports/2026"),
+        surface("word", "https://x.test/v1/latest-releases"),
+      ]),
+      [],
+    );
+  });
+
+  test("ignores a query string that merely says latest", () => {
+    // ?window=latest is a parameter value; the surface is not a moving target.
+    assert.deepEqual(
+      movingTargetSurfaceIds([
+        surface("q", "https://x.test/v1/epochs?window=latest"),
+      ]),
+      [],
+    );
+  });
+
+  test("ignores NON-callable kinds", () => {
+    // A /latest on a dashboard or a website is a page a human opens, not an
+    // API capability with an indexed sibling -- flagging one would send an
+    // enricher to read documentation that does not exist.
+    assert.deepEqual(
+      movingTargetSurfaceIds([
+        surface("dash", "https://x.test/app/latest", "dashboard"),
+        surface("site", "https://x.test/latest", "website"),
+        surface("repo", "https://github.com/o/r/latest", "source-repo"),
+      ]),
+      [],
+    );
+  });
+
+  test("survives junk without throwing", () => {
+    assert.deepEqual(movingTargetSurfaceIds(undefined), []);
+    assert.deepEqual(movingTargetSurfaceIds([]), []);
+    assert.deepEqual(
+      movingTargetSurfaceIds([
+        surface("nourl", ""),
+        surface("bad", "not a url at all/latest"),
+        { id: "nokind", url: "https://x.test/v1/latest" } as never,
+      ]),
+      [],
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Found while fixing SN53 (#9737): its first-party API exposes both `/api/subnet/v1/epoch/latest` **and** `/api/subnet/v1/epoch/{index}`. The second is strictly more capable — same shape, any finalized epoch — and a capture that records only the first cannot see it, because nothing about `/latest` announces that `/{index}` exists.

**It generalises.** 27 callable surfaces across 14 subnets end in a `latest`/`current`/`newest`/`head` terminal, including `api.blockmachine.io/epochs/current` and `chain.joinbase.ai/v1/weights/latest` — the same shape as SN53's, on subnets nobody has looked at.

The gaps block now carries `moving_target_surfaces`, so it's queryable through `list_gaps` the day it lands rather than being a note somebody reads.

## It asserts nothing about a sibling's existence

It reports that a tracked surface answers *"what is happening now"*, and that *"what happened then"* may be published beside it. Resolving that means reading the **operator's own documentation** — which is how SN53's was found.

Probing guessed paths would be unsolicited traffic against a third party, and a 200 on a guessed URL is not evidence that the operator *publishes* it as a surface, which is the standard every other entry in this registry is held to.

## Precision, measured rather than assumed

- **Anchored to the end of the path** — a `/latest/` in the middle is a directory name, and `/latest-releases` is a word.
- **Path only** — `?window=latest` is a parameter value, not a moving target.
- **Callable kinds only.** A `/latest` on a dashboard or website is a page a human opens, not an API with an indexed sibling; flagging one would send an enricher to read documentation that doesn't exist. Restricting to `subnet-api`/`openapi`/`sse`/`data-artifact` drops the one `dashboard` false positive and keeps all **24 subnet-api** and **3 data-artifact** hits.

Each of those is a test, including one that the helper survives junk (empty URL, unparseable URL, missing kind) without throwing.

## It also collapses buildGaps to one implementation

`scripts/build-artifacts.ts` and `scripts/validate.ts` each carried a **byte-for-byte copy**, and the reproducibility check compares one against the other — so adding this field to the build alone reported as `per-subnet detail artifact is not reproducible from registry inputs` on **every subnet**, rather than as the divergence it was.

That is the **third** time today a duplicated derivation produced a failure that named the wrong thing (after `subnetDisplayName` in #9767 and this). Two copies of a function that exists to be compared against itself is a bug generator, not a safety net.

## Validation run

```
npm run build                     # 7/7
npm run validate                  # 129 subnets, 3441 surfaces, 137 providers
npm run validate:api              # 201 routes
npm run validate:contract-drift   # passed
node scripts/validate-docs.ts     # passed
npm run lint && npm run format:check && npx tsc --noEmit
```

638 tests across formatting, the artifact gate, the gaps loader, the schemas and the lib helpers.

Closes #9746
