### PR TITLE
feat(neon): watch each mirror against the table it mirrors

### DIFF
--- a/src/neon-mirror-watchdog.ts
+++ b/src/neon-mirror-watchdog.ts
@@ -1,0 +1,316 @@
+// The watchdog for a mirror lane that NEVER fires (#9770).
+//
+// #9698's alarm catches two fault classes: a lane reporting `stale`, and a lane
+// going SILENT after previously reporting. It cannot catch a third. Silence
+// detection learns each lane's cadence from a 7-day window and needs
+// LANE_ALARM_MIN_CADENCE_SAMPLES verdicts to learn it, so a lane with ZERO
+// samples has no cadence to be late against and is indistinguishable from a
+// lane that does not exist.
+//
+// Measured 2026-08-07, hours after the ledger mirrors deployed:
+//
+//     neon:account-balances            NO VERDICTS EVER
+//     neon:hotkey-alpha                NO VERDICTS EVER
+//     neon:validator-nominator-counts  NO VERDICTS EVER
+//     neon:nominator-positions         NO VERDICTS EVER
+//
+// That was benign -- those producers last wrote at 04:38-04:57, before the
+// mirrors deployed, and their staleness thresholds are 12h/30h/48h. But a
+// typo in NEON_DUAL_WRITE_LANES, a call site never reached, and a lane wired
+// but dead all look EXACTLY the same, and would keep looking the same
+// indefinitely. Same shape as #9704 (a read with no writer) and #9754 (a
+// decline nobody could tell from a failure): an absence that reads as health.
+//
+// ## The rule, which needs no cadence knowledge
+//
+// A MIRROR MUST BE NO OLDER THAN THE TABLE IT MIRRORS. The mirror runs in the
+// same request as the D1 write, so if a table's own `MAX(captured_at)` is newer
+// than the newest `neon:<lane>` verdict, that write happened and the mirror did
+// not follow it. This works identically for a 15-minute lane and a 48-hour one.
+//
+// ## But "never mirrored" is NOT the same fault, and must not be alarmed
+//
+// A lane with no verdict at all is indistinguishable from one whose producer
+// has not run since the mirror deployed. That was true of all four ledger lanes
+// above: their tables last wrote at 04:38-04:57 against a mirror deployed at
+// 08:05, so there had been nothing to mirror. Reporting them stale would be an
+// alarm firing on a system working correctly, and an alarm that cries wolf gets
+// muted -- which would cost more than the gap it was closing.
+//
+// Telling the two apart needs the mirror's DEPLOY time, which lane_health does
+// not know. So this reports demonstrable lag as `stale`, and never-mirrored as
+// a named fact in the same verdict's detail for a human to judge. That is one
+// query replacing the four-way manual comparison it came from.
+//
+// The table pairing is also why
+// the pairing is against the TABLE rather than against the D1 lane that writes
+// it: those lane names do not match one-for-one (`validator-nominator-counts`
+// is written by a lane called `validator-nominators`), and `nominator_positions`
+// has no writer-side lane at all -- only a staleness watchdog, which runs on
+// its own cron and would report health whether or not the producer ever ran.
+// Table freshness is the one signal every mirrored lane actually has.
+
+import { neonDualWriteLanes } from "./neon-write.ts";
+import { LEDGER_MIRROR_PLANS } from "./ledger-neon-write.ts";
+import { NEURON_MIRROR_PLANS } from "./neurons-neon-write.ts";
+import { NOMINATOR_POSITIONS_NEON_LANE } from "./nominator-positions-neon-write.ts";
+import {
+  loadLatestLaneHealth,
+  recordLaneVerdict,
+  type LaneHealthDb,
+} from "./lane-health.ts";
+
+/** This watchdog's own lane. */
+export const NEON_MIRROR_LAG_LANE = "neon-mirror-lag";
+
+/**
+ * How far a mirror may trail the table it mirrors before this reports.
+ *
+ * Generous on purpose. The mirror writes in the same request as the D1 write,
+ * so under any healthy condition the gap is milliseconds -- but a verdict write
+ * can fail independently (recordLaneVerdict swallows its own errors by design,
+ * because a watchdog whose alarm-recording broke its alarm would be worse than
+ * the bug). An hour separates "the mirror is not running" from "one verdict did
+ * not land", and only the first is worth an alarm.
+ */
+export const MIRROR_LAG_THRESHOLD_MS = 60 * 60 * 1000;
+
+/**
+ * Every mirrored lane and the D1 table whose freshness proves it ran.
+ *
+ * Built FROM the mirror plans rather than restated, so a lane cannot be added
+ * to a plan and left unwatched here -- the plans are the same constants the
+ * writers use, and a test asserts this covers every lane the flag can name.
+ *
+ * `neurons` maps to its own table only. The two tables handleNeuronsSync
+ * derives are mirrored under their own lane names and appear here in their own
+ * right, which is what lets a partial failure -- neurons landing while
+ * neuron_daily does not -- be seen as one lane lagging rather than as the whole
+ * sync being healthy.
+ */
+export const MIRROR_LANE_TABLES: Readonly<Record<string, string>> = {
+  ...Object.fromEntries(
+    Object.entries(LEDGER_MIRROR_PLANS).map(([lane, plan]) => [
+      lane,
+      plan.table,
+    ]),
+  ),
+  ...Object.fromEntries(
+    Object.entries(NEURON_MIRROR_PLANS).map(([lane, plan]) => [
+      lane,
+      plan.table,
+    ]),
+  ),
+  [NOMINATOR_POSITIONS_NEON_LANE]: "nominator_positions",
+};
+
+/** The minimal D1 surface this needs, so a test can hand it a fake. */
+export interface MirrorWatchdogDb {
+  prepare(sql: string): {
+    all(): Promise<{ results?: unknown[] } | null>;
+  };
+}
+
+export interface MirrorLag {
+  lane: string;
+  table: string;
+  /** The table's own newest write. */
+  tableAt: number;
+  /** The mirror lane's newest verdict, or null when it has NEVER reported. */
+  mirrorAt: number | null;
+  /** How far the mirror trails its table. Zero for a lane with no verdict --
+   * there is no gap to measure, which is the point of keeping the two apart. */
+  lagMs: number;
+}
+
+/**
+ * A table's newest write, per table, in one statement.
+ *
+ * One query rather than one per table: this runs on a cron beside five other
+ * lanes, and six round trips to answer "did anything move" is five more than
+ * the question needs.
+ */
+export function mirrorFreshnessSql(tables: readonly string[]): string {
+  return tables
+    .map(
+      (table) => `SELECT '${table}' AS t, MAX(captured_at) AS mx FROM ${table}`,
+    )
+    .join(" UNION ALL ");
+}
+
+export interface MirrorSurvey {
+  /** Mirrors that HAVE reported and have since fallen behind their table.
+   * Demonstrably a fault: the mirror ran, the table moved, the mirror did not
+   * follow. */
+  lagging: MirrorLag[];
+  /** Mirrors that have NEVER reported.
+   *
+   * Deliberately NOT reported as a fault, and this is the correction that
+   * matters. A never-mirrored lane looks identical to a lane whose producer
+   * simply has not run since the mirror deployed -- which was true of all four
+   * ledger lanes on 2026-08-07, whose tables last wrote at 04:38-04:57 against
+   * a mirror deployed at 08:05. Calling that stale would be an alarm firing on
+   * a system working correctly, and an alarm that cries wolf gets muted.
+   *
+   * Distinguishing the two needs the mirror's deploy time, which is not a thing
+   * lane_health knows. So this reports the fact and lets a human judge, which
+   * is exactly the manual step it replaces -- one query instead of four. */
+  neverMirrored: MirrorLag[];
+}
+
+/** Survey every watched mirror against the table it mirrors, worst first. */
+export function mirrorLags(
+  laneTables: Readonly<Record<string, string>>,
+  watched: ReadonlySet<string>,
+  tableFreshness: ReadonlyMap<string, number>,
+  mirrorVerdictAt: ReadonlyMap<string, number>,
+  thresholdMs: number,
+): MirrorSurvey {
+  const lagging: MirrorLag[] = [];
+  const neverMirrored: MirrorLag[] = [];
+  for (const [lane, table] of Object.entries(laneTables)) {
+    // Only lanes the deployment actually mirrors. A lane not named in
+    // NEON_DUAL_WRITE_LANES is SUPPOSED to have no verdicts, and reporting it
+    // would make this watchdog loud about the configuration working.
+    if (!watched.has(lane)) continue;
+    const tableAt = tableFreshness.get(table);
+    // A table nobody has written cannot prove anything about its mirror. Not a
+    // lag -- an absence of evidence, which is the distinction this whole file
+    // exists to keep.
+    if (tableAt == null) continue;
+    const mirrorAt = mirrorVerdictAt.get(`neon:${lane}`) ?? null;
+    if (mirrorAt == null) {
+      neverMirrored.push({ lane, table, tableAt, mirrorAt: null, lagMs: 0 });
+      continue;
+    }
+    const lagMs = tableAt - mirrorAt;
+    if (lagMs < thresholdMs) continue;
+    lagging.push({ lane, table, tableAt, mirrorAt, lagMs });
+  }
+  return {
+    lagging: lagging.sort((a, b) => b.lagMs - a.lagMs),
+    neverMirrored: neverMirrored.sort((a, b) => a.lane.localeCompare(b.lane)),
+  };
+}
+
+/** The survey as one line, for the verdict's detail column. */
+export function describeMirrorLags(survey: MirrorSurvey): string {
+  const parts: string[] = [];
+  if (survey.lagging.length > 0) {
+    parts.push(
+      survey.lagging
+        .map(
+          (lag) =>
+            `${lag.lane}: ${(lag.lagMs / 3_600_000).toFixed(1)}h behind ${lag.table}`,
+        )
+        .join("; "),
+    );
+  }
+  if (survey.neverMirrored.length > 0) {
+    // Named, not alarmed. A reader needs to know these exist to judge them.
+    parts.push(
+      `never mirrored (not alarmed): ${survey.neverMirrored
+        .map((lag) => lag.lane)
+        .join(", ")}`,
+    );
+  }
+  return parts.length === 0
+    ? "every mirror is current with its table"
+    : parts.join(" | ");
+}
+
+export interface MirrorWatchdogDeps {
+  db?: MirrorWatchdogDb | null;
+  laneHealthDb?: LaneHealthDb | null;
+  now?: () => number;
+  thresholdMs?: number;
+}
+
+export interface MirrorWatchdogOutcome {
+  attempted: boolean;
+  survey?: MirrorSurvey;
+  reason?: string;
+}
+
+/**
+ * Compare every mirrored lane against the table it mirrors. Never throws.
+ *
+ * `unknown` rather than `stale` when the tables cannot be read: this watchdog
+ * reports on OTHER lanes' evidence, and claiming they are behind because this
+ * query failed would put a fabricated verdict where triage reads one. The same
+ * distinction lane-health's own `staleLanes` makes.
+ */
+export async function runNeonMirrorWatchdog(
+  env: Record<string, unknown> | null | undefined,
+  deps: MirrorWatchdogDeps = {},
+): Promise<MirrorWatchdogOutcome> {
+  const watched = neonDualWriteLanes(env);
+  if (watched.size === 0) return { attempted: false };
+
+  const db =
+    deps.db ?? (env?.METAGRAPH_HEALTH_DB as MirrorWatchdogDb | undefined);
+  const laneDb =
+    deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as LaneHealthDb | undefined);
+  const now = deps.now ?? Date.now;
+  const thresholdMs = deps.thresholdMs ?? MIRROR_LAG_THRESHOLD_MS;
+
+  const tables = [
+    ...new Set(
+      Object.entries(MIRROR_LANE_TABLES)
+        .filter(([lane]) => watched.has(lane))
+        .map(([, table]) => table),
+    ),
+  ];
+  if (tables.length === 0) return { attempted: false };
+
+  let freshness: Map<string, number>;
+  try {
+    const result = await db?.prepare(mirrorFreshnessSql(tables)).all();
+    if (!result) throw new Error("no result");
+    freshness = new Map();
+    for (const raw of result.results ?? []) {
+      const row = raw as Record<string, unknown>;
+      // NULL CHECKED BEFORE Number(), because `Number(null)` is 0 and 0 passes
+      // Number.isFinite. `MAX(captured_at)` over an empty table returns NULL,
+      // and reading that as epoch 0 makes the table look like it was written
+      // in 1970 -- which this watchdog would then report as a mirror that
+      // never followed a write that never happened.
+      if (row.t == null || row.mx == null) continue;
+      const at = Number(row.mx);
+      if (Number.isFinite(at)) freshness.set(String(row.t), at);
+    }
+  } catch (error) {
+    await recordLaneVerdict(laneDb, {
+      lane: NEON_MIRROR_LAG_LANE,
+      verdict: "unknown",
+      age_ms: null,
+      detail: `table freshness unreadable: ${error instanceof Error ? error.message : String(error)}`,
+      checked_at: now(),
+    });
+    return { attempted: true, reason: "freshness unreadable" };
+  }
+
+  const latest = await loadLatestLaneHealth(laneDb);
+  const mirrorVerdictAt = new Map<string, number>();
+  for (const [lane, record] of Object.entries(latest)) {
+    if (lane.startsWith("neon:")) mirrorVerdictAt.set(lane, record.checked_at);
+  }
+
+  const survey = mirrorLags(
+    MIRROR_LANE_TABLES,
+    watched,
+    freshness,
+    mirrorVerdictAt,
+    thresholdMs,
+  );
+  // ONLY demonstrable lag is stale. never-mirrored rides along in the detail
+  // so it is visible without being alarmed on -- see this file's header.
+  await recordLaneVerdict(laneDb, {
+    lane: NEON_MIRROR_LAG_LANE,
+    verdict: survey.lagging.length === 0 ? "ok" : "stale",
+    age_ms: survey.lagging.length === 0 ? null : survey.lagging[0].lagMs,
+    detail: describeMirrorLags(survey),
+    checked_at: now(),
+  });
+  return { attempted: true, survey };
+}

--- a/tests/neon-mirror-watchdog.test.ts
+++ b/tests/neon-mirror-watchdog.test.ts
@@ -1,0 +1,479 @@
+// The watchdog for a mirror lane that never fires (src/neon-mirror-watchdog.ts).
+//
+// The property this file exists for is the one that makes a watchdog useful
+// rather than ignorable: it must separate a DEMONSTRABLE fault from an absence
+// it cannot interpret.
+//
+//   * a mirror that reported and then fell behind its table -> `stale`
+//   * a mirror that never reported at all -> NAMED, never alarmed, because it
+//     is indistinguishable from a producer that has not run since the mirror
+//     deployed. All four ledger lanes were in exactly that state on
+//     2026-08-07, and alarming them would have been an alarm on a working
+//     system.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  describeMirrorLags,
+  MIRROR_LAG_THRESHOLD_MS,
+  MIRROR_LANE_TABLES,
+  mirrorFreshnessSql,
+  mirrorLags,
+  NEON_MIRROR_LAG_LANE,
+  runNeonMirrorWatchdog,
+} from "../src/neon-mirror-watchdog.ts";
+import { neonDualWriteLanes } from "../src/neon-write.ts";
+
+const HOUR = 60 * 60 * 1000;
+const NOW = 1_785_800_000_000;
+
+function fakeDb(
+  rows: unknown[] | null,
+  laneRows: unknown[] = [],
+  opts: { noResultsKey?: boolean; throwNonError?: boolean } = {},
+) {
+  const calls: string[] = [];
+  return {
+    calls,
+    db: {
+      prepare(sql: string) {
+        calls.push(sql);
+        return {
+          async all() {
+            if (sql.startsWith("SELECT lane")) return { results: laneRows };
+            if (opts.throwNonError) throw "connection terminated";
+            if (rows === null) throw new Error("D1_ERROR: overloaded");
+            return opts.noResultsKey ? {} : { results: rows };
+          },
+          bind(...values: unknown[]) {
+            return {
+              async run() {
+                calls.push(`RUN ${sql} ${JSON.stringify(values.slice(0, 4))}`);
+              },
+              async all() {
+                return { results: [] };
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+describe("MIRROR_LANE_TABLES", () => {
+  test("covers every lane the deployed flag can name", () => {
+    // Built from the mirror plans rather than restated, so a lane added to a
+    // plan cannot be left unwatched here. This asserts the live config too:
+    // a lane named in NEON_DUAL_WRITE_LANES with no table pairing would be
+    // mirrored and unmonitored, which is the state this watchdog exists to end.
+    const deployed = neonDualWriteLanes({
+      NEON_DUAL_WRITE_LANES:
+        "neurons,nominator-positions,account-balances,hotkey-alpha,validator-nominator-counts",
+    });
+    for (const lane of deployed) {
+      assert.ok(
+        MIRROR_LANE_TABLES[lane],
+        `${lane} is mirrored but has no table to be checked against`,
+      );
+    }
+  });
+
+  test("pairs each lane with the table whose freshness proves it ran", () => {
+    assert.equal(MIRROR_LANE_TABLES["account-balances"], "account_balances");
+    assert.equal(MIRROR_LANE_TABLES["hotkey-alpha"], "hotkey_alpha");
+    assert.equal(
+      MIRROR_LANE_TABLES["validator-nominator-counts"],
+      "validator_nominator_counts",
+    );
+    // The one with NO writer-side lane at all, which is why this pairs against
+    // tables rather than against lane names.
+    assert.equal(
+      MIRROR_LANE_TABLES["nominator-positions"],
+      "nominator_positions",
+    );
+    assert.equal(MIRROR_LANE_TABLES.neuron_daily, "neuron_daily");
+  });
+});
+
+describe("mirrorFreshnessSql", () => {
+  test("asks every table in ONE statement", () => {
+    const sql = mirrorFreshnessSql(["a", "b"]);
+    assert.equal(
+      sql,
+      "SELECT 'a' AS t, MAX(captured_at) AS mx FROM a UNION ALL " +
+        "SELECT 'b' AS t, MAX(captured_at) AS mx FROM b",
+    );
+  });
+});
+
+describe("mirrorLags", () => {
+  const tables = { alpha: "t_alpha", beta: "t_beta" };
+  const watched = new Set(["alpha", "beta"]);
+
+  test("a mirror that reported and fell behind its table is LAGGING", () => {
+    const survey = mirrorLags(
+      tables,
+      watched,
+      new Map([["t_alpha", NOW]]),
+      new Map([["neon:alpha", NOW - 3 * HOUR]]),
+      HOUR,
+    );
+    assert.equal(survey.lagging.length, 1);
+    assert.equal(survey.lagging[0].lane, "alpha");
+    assert.equal(survey.lagging[0].lagMs, 3 * HOUR);
+    assert.deepEqual(survey.neverMirrored, []);
+  });
+
+  test("a mirror that NEVER reported is named, never alarmed", () => {
+    // The correction this file exists for. A never-mirrored lane is
+    // indistinguishable from a producer that has not run since the mirror
+    // deployed -- which was true of all four ledger lanes on 2026-08-07.
+    const survey = mirrorLags(
+      tables,
+      watched,
+      new Map([["t_alpha", NOW - 5 * HOUR]]),
+      new Map(),
+      HOUR,
+    );
+    assert.deepEqual(survey.lagging, [], "never-mirrored must NOT be a fault");
+    assert.equal(survey.neverMirrored.length, 1);
+    assert.equal(survey.neverMirrored[0].lane, "alpha");
+    assert.equal(survey.neverMirrored[0].mirrorAt, null);
+  });
+
+  test("a mirror current with its table is neither", () => {
+    const survey = mirrorLags(
+      tables,
+      watched,
+      new Map([["t_alpha", NOW]]),
+      new Map([["neon:alpha", NOW]]),
+      HOUR,
+    );
+    assert.deepEqual(survey, { lagging: [], neverMirrored: [] });
+  });
+
+  test("a mirror NEWER than its table is not a lag", () => {
+    // The mirror writes in the same request, and clocks are not exact. A
+    // negative gap is health, not a fault.
+    const survey = mirrorLags(
+      tables,
+      watched,
+      new Map([["t_alpha", NOW - HOUR]]),
+      new Map([["neon:alpha", NOW]]),
+      HOUR,
+    );
+    assert.deepEqual(survey.lagging, []);
+  });
+
+  test("a gap under the threshold is tolerated", () => {
+    const survey = mirrorLags(
+      tables,
+      watched,
+      new Map([["t_alpha", NOW]]),
+      new Map([["neon:alpha", NOW - HOUR + 1]]),
+      HOUR,
+    );
+    assert.deepEqual(survey.lagging, []);
+  });
+
+  test("a lane the flag does not name is ignored entirely", () => {
+    // Reporting it would make this watchdog loud about the configuration
+    // working as intended.
+    const survey = mirrorLags(
+      tables,
+      new Set(["alpha"]),
+      new Map([
+        ["t_alpha", NOW],
+        ["t_beta", NOW],
+      ]),
+      new Map(),
+      HOUR,
+    );
+    assert.deepEqual(
+      survey.neverMirrored.map((l) => l.lane),
+      ["alpha"],
+    );
+  });
+
+  test("a table nobody has written proves nothing about its mirror", () => {
+    // Absence of evidence, not evidence of a fault -- the same distinction
+    // lane-health's own `staleLanes` makes for an `unknown` verdict.
+    const survey = mirrorLags(tables, watched, new Map(), new Map(), HOUR);
+    assert.deepEqual(survey, { lagging: [], neverMirrored: [] });
+  });
+
+  test("lagging is sorted worst first, never-mirrored by name", () => {
+    const survey = mirrorLags(
+      { a: "t_a", b: "t_b", c: "t_c", d: "t_d" },
+      new Set(["a", "b", "c", "d"]),
+      new Map([
+        ["t_a", NOW],
+        ["t_b", NOW],
+        ["t_c", NOW],
+        ["t_d", NOW],
+      ]),
+      new Map([
+        ["neon:a", NOW - 2 * HOUR],
+        ["neon:b", NOW - 9 * HOUR],
+      ]),
+      HOUR,
+    );
+    assert.deepEqual(
+      survey.lagging.map((l) => l.lane),
+      ["b", "a"],
+    );
+    assert.deepEqual(
+      survey.neverMirrored.map((l) => l.lane),
+      ["c", "d"],
+    );
+  });
+});
+
+describe("describeMirrorLags", () => {
+  test("reports lag in hours and names the never-mirrored separately", () => {
+    assert.equal(
+      describeMirrorLags({ lagging: [], neverMirrored: [] }),
+      "every mirror is current with its table",
+    );
+    assert.equal(
+      describeMirrorLags({
+        lagging: [
+          {
+            lane: "hotkey-alpha",
+            table: "hotkey_alpha",
+            tableAt: NOW,
+            mirrorAt: NOW - 3 * HOUR,
+            lagMs: 3 * HOUR,
+          },
+        ],
+        neverMirrored: [
+          {
+            lane: "nominator-positions",
+            table: "nominator_positions",
+            tableAt: NOW,
+            mirrorAt: null,
+            lagMs: 0,
+          },
+        ],
+      }),
+      "hotkey-alpha: 3.0h behind hotkey_alpha | " +
+        "never mirrored (not alarmed): nominator-positions",
+    );
+  });
+});
+
+describe("runNeonMirrorWatchdog", () => {
+  test("does nothing until a lane is mirrored", async () => {
+    for (const env of [undefined, null, {}, { NEON_DUAL_WRITE_LANES: "" }]) {
+      assert.deepEqual(await runNeonMirrorWatchdog(env), { attempted: false });
+    }
+  });
+
+  test("a flag naming only unknown lanes has no table to ask about", async () => {
+    const spy = fakeDb([]);
+    assert.deepEqual(
+      await runNeonMirrorWatchdog(
+        { NEON_DUAL_WRITE_LANES: "not-a-lane" },
+        { db: spy.db, laneHealthDb: spy.db },
+      ),
+      { attempted: false },
+    );
+    assert.equal(spy.calls.length, 0);
+  });
+
+  test("records OK when every mirror is current", async () => {
+    const spy = fakeDb(
+      [{ t: "hotkey_alpha", mx: NOW }],
+      [
+        {
+          lane: "neon:hotkey-alpha",
+          verdict: "ok",
+          age_ms: null,
+          detail: "",
+          checked_at: NOW,
+        },
+      ],
+    );
+    const out = await runNeonMirrorWatchdog(
+      { NEON_DUAL_WRITE_LANES: "hotkey-alpha" },
+      { db: spy.db, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.deepEqual(out.survey, { lagging: [], neverMirrored: [] });
+    assert.ok(
+      spy.calls.some((c) => c.includes(`"${NEON_MIRROR_LAG_LANE}","ok"`)),
+      `expected an ok verdict, got: ${spy.calls.filter((c) => c.startsWith("RUN")).join(" / ")}`,
+    );
+  });
+
+  test("records STALE, with the worst lag as age_ms", async () => {
+    const spy = fakeDb(
+      [{ t: "hotkey_alpha", mx: NOW }],
+      [
+        {
+          lane: "neon:hotkey-alpha",
+          verdict: "ok",
+          age_ms: null,
+          detail: "",
+          checked_at: NOW - 4 * HOUR,
+        },
+      ],
+    );
+    const out = await runNeonMirrorWatchdog(
+      { NEON_DUAL_WRITE_LANES: "hotkey-alpha" },
+      { db: spy.db, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.equal(out.survey?.lagging.length, 1);
+    assert.ok(
+      spy.calls.some((c) => c.includes(`"${NEON_MIRROR_LAG_LANE}","stale"`)),
+    );
+  });
+
+  test("a never-mirrored lane does NOT make the verdict stale", async () => {
+    // The live 2026-08-07 case, and the whole reason this watchdog does not
+    // simply alarm on absence.
+    const spy = fakeDb([{ t: "hotkey_alpha", mx: NOW - 5 * HOUR }], []);
+    const out = await runNeonMirrorWatchdog(
+      { NEON_DUAL_WRITE_LANES: "hotkey-alpha" },
+      { db: spy.db, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.deepEqual(out.survey?.lagging, []);
+    assert.equal(out.survey?.neverMirrored.length, 1);
+    assert.ok(
+      spy.calls.some((c) => c.includes(`"${NEON_MIRROR_LAG_LANE}","ok"`)),
+      "a never-mirrored lane must not raise the verdict",
+    );
+    assert.ok(spy.calls.some((c) => c.includes("never mirrored")));
+  });
+
+  test("unreadable tables record UNKNOWN, never stale", async () => {
+    // This watchdog reports on OTHER lanes' evidence. Claiming they are behind
+    // because its own query failed would put a fabricated verdict where triage
+    // reads one.
+    const spy = fakeDb(null);
+    const out = await runNeonMirrorWatchdog(
+      { NEON_DUAL_WRITE_LANES: "hotkey-alpha" },
+      { db: spy.db, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.deepEqual(out, { attempted: true, reason: "freshness unreadable" });
+    assert.ok(
+      spy.calls.some((c) => c.includes(`"${NEON_MIRROR_LAG_LANE}","unknown"`)),
+    );
+  });
+
+  test("an unbound D1 is unknown too, not a silent pass", async () => {
+    const spy = fakeDb([]);
+    const out = await runNeonMirrorWatchdog(
+      { NEON_DUAL_WRITE_LANES: "hotkey-alpha" },
+      { db: null, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.equal(out.reason, "freshness unreadable");
+  });
+
+  test("rows with an unusable timestamp are dropped, not counted as zero", async () => {
+    // MAX(captured_at) over an empty table is NULL, and `Number(null)` is 0 --
+    // which passes Number.isFinite. Reading it as epoch 0 would report a
+    // mirror that never followed a write that never happened. (Caught by this
+    // test before the watchdog shipped.)
+    const spy = fakeDb([
+      { t: "hotkey_alpha", mx: null },
+      { t: null, mx: NOW },
+      { t: "hotkey_alpha", mx: "not-a-timestamp" },
+    ]);
+    const out = await runNeonMirrorWatchdog(
+      { NEON_DUAL_WRITE_LANES: "hotkey-alpha" },
+      { db: spy.db, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.deepEqual(out.survey, { lagging: [], neverMirrored: [] });
+  });
+
+  test("a response carrying no `results` key is an empty survey, not a crash", async () => {
+    const spy = fakeDb([], [], { noResultsKey: true });
+    const out = await runNeonMirrorWatchdog(
+      { NEON_DUAL_WRITE_LANES: "hotkey-alpha" },
+      { db: spy.db, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.deepEqual(out.survey, { lagging: [], neverMirrored: [] });
+  });
+
+  test("a rejection that is not an Error still reads in the verdict", async () => {
+    const spy = fakeDb([], [], { throwNonError: true });
+    await runNeonMirrorWatchdog(
+      { NEON_DUAL_WRITE_LANES: "hotkey-alpha" },
+      { db: spy.db, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.ok(spy.calls.some((c) => c.includes("connection terminated")));
+  });
+
+  test("non-mirror lanes in lane_health are ignored", async () => {
+    // lane_health holds every watchdog in the estate. Only `neon:` rows say
+    // anything about a mirror.
+    const spy = fakeDb(
+      [{ t: "hotkey_alpha", mx: NOW }],
+      [
+        {
+          lane: "metagraph",
+          verdict: "ok",
+          age_ms: null,
+          detail: "",
+          checked_at: NOW,
+        },
+        {
+          lane: "neon:hotkey-alpha",
+          verdict: "ok",
+          age_ms: null,
+          detail: "",
+          checked_at: NOW,
+        },
+      ],
+    );
+    const out = await runNeonMirrorWatchdog(
+      { NEON_DUAL_WRITE_LANES: "hotkey-alpha" },
+      { db: spy.db, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.deepEqual(out.survey, { lagging: [], neverMirrored: [] });
+  });
+
+  test("takes its D1 and clock off env, and its own threshold default", async () => {
+    const spy = fakeDb([{ t: "hotkey_alpha", mx: Date.now() }], []);
+    const out = await runNeonMirrorWatchdog({
+      NEON_DUAL_WRITE_LANES: "hotkey-alpha",
+      METAGRAPH_HEALTH_DB: spy.db,
+    });
+    assert.equal(out.attempted, true);
+    assert.ok(MIRROR_LAG_THRESHOLD_MS > 0);
+  });
+});
+
+describe("the deployed wiring", () => {
+  const wrangler = readFileSync("wrangler.data.jsonc", "utf8");
+
+  test("the cron the handler dispatches on is actually declared", async () => {
+    // A constant the trigger list does not carry is a watchdog that never runs
+    // -- which for THIS watchdog would be an unwatched watchdog, the exact
+    // recursion #9698 was built to end.
+    const { NEON_MIRROR_LAG_CRON } = await import("../workers/config.ts");
+    assert.ok(
+      wrangler.includes(`"${NEON_MIRROR_LAG_CRON}"`),
+      `wrangler.data.jsonc declares no "${NEON_MIRROR_LAG_CRON}" cron`,
+    );
+  });
+
+  test("every lane the deployed flag mirrors has a table pairing", () => {
+    // Against the REAL flag value, not a fixture: a lane mirrored in production
+    // with no pairing here would be written and unwatched.
+    const named = (
+      /"NEON_DUAL_WRITE_LANES":\s*"([^"]*)"/.exec(wrangler)?.[1] ?? ""
+    )
+      .split(",")
+      .map((lane) => lane.trim())
+      .filter(Boolean);
+    assert.ok(named.length > 0, "expected the flag to name some lanes");
+    for (const lane of named) {
+      assert.ok(
+        MIRROR_LANE_TABLES[lane],
+        `${lane} is mirrored in production but has no table to check it against`,
+      );
+    }
+  });
+});

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -330,6 +330,23 @@ export const TAO_USD_INDEX_CRON = "* * * * *";
 export const NEON_BACKFILL_CRON = "*/3 * * * *";
 
 /**
+ * The mirror-lag watchdog tick (metagraphed#9770).
+ *
+ * HOURLY, and deliberately far slower than the mirrors it watches. It reads
+ * `MAX(captured_at)` per mirrored table, which is a scan of each -- 364,935
+ * rows for `account_balances` alone -- so a 3-minute cadence would spend
+ * millions of D1 row reads an hour to re-learn a fact that changes at most
+ * every 15 minutes and, for the ledger lanes, every 12 to 48 HOURS.
+ *
+ * The threshold it enforces (MIRROR_LAG_THRESHOLD_MS) is an hour, so checking
+ * hourly cannot miss a fault it would otherwise report -- it can only report it
+ * one tick later.
+ *
+ * Minute 26 is free of every other lane on this Worker.
+ */
+export const NEON_MIRROR_LAG_CRON = "26 * * * *";
+
+/**
  * The webhook fan-out tick (metagraphed-infra#354).
  *
  * TWICE HOURLY on two free minutes. The cadence is a cost decision rather than a

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -45,7 +45,11 @@ import {
   rowFromBatch,
   type TaoUsdIndexRow,
 } from "../src/tao-usd-ingest.ts";
-import { NEON_BACKFILL_CRON, TAO_USD_INDEX_CRON } from "./config.ts";
+import {
+  NEON_BACKFILL_CRON,
+  NEON_MIRROR_LAG_CRON,
+  TAO_USD_INDEX_CRON,
+} from "./config.ts";
 import {
   buildConcentration,
   buildChainConcentration,
@@ -374,6 +378,7 @@ import { mirrorNominatorPositionsToNeon } from "../src/nominator-positions-neon-
 import { mirrorLedgerToNeon } from "../src/ledger-neon-write.ts";
 import { neonReadEnabled } from "../src/neon-write.ts";
 import { runNeonBackfill } from "../src/neon-backfill.ts";
+import { runNeonMirrorWatchdog } from "../src/neon-mirror-watchdog.ts";
 import {
   writeAccountIdentityToD1,
   writeSubnetHyperparamsToD1,
@@ -7311,6 +7316,11 @@ export default {
     env: Env,
     ctx: ExecutionContext,
   ) {
+    if (controller?.cron === NEON_MIRROR_LAG_CRON) {
+      // No ctx: this reads D1 only. It never touches Neon -- the whole point is
+      // to judge the mirrors from evidence they already left behind.
+      return runNeonMirrorWatchdog(env as unknown as Record<string, unknown>);
+    }
     if (controller?.cron === NEON_BACKFILL_CRON) {
       // `ctx` is threaded through rather than ignored: createPgSql needs a
       // waitUntil to hold the Hyperdrive connection open past the handler's

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -319,7 +319,7 @@
   // `controller.cron`, so the handler dispatches on the string rather than on
   // what minute it happens to be.
   "triggers": {
-    "crons": ["* * * * *", "*/3 * * * *"],
+    "crons": ["* * * * *", "*/3 * * * *", "26 * * * *"],
   },
 
   // HYPERDRIVE is gone with the box (2026-08-03): the Postgres it fronted was


### PR DESCRIPTION
Closes #9770

#9698's alarm catches two fault classes: a lane reporting `stale`, and a lane going **silent** after previously reporting. It cannot catch a third — **a lane that never reported at all.** Silence detection learns cadence from a 7-day window and needs three samples, so a lane with zero has no cadence to be late against.

Four mirror lanes are in that state right now:

```
neon:account-balances            NO VERDICTS EVER
neon:hotkey-alpha                NO VERDICTS EVER
neon:validator-nominator-counts  NO VERDICTS EVER
neon:nominator-positions         NO VERDICTS EVER
```

Benign — those producers last wrote at 04:38–04:57 against mirrors deployed at 08:05, and their staleness thresholds are 12h/30h/48h. But a typo in `NEON_DUAL_WRITE_LANES`, a call site never reached, and a lane wired but dead all look **exactly the same**, indefinitely. Same shape as #9704 and #9754: an absence that reads as health.

## The rule

**A mirror must be no older than the table it mirrors.** The mirror writes in the same request as the D1 write, so a table whose `MAX(captured_at)` is newer than its lane's newest verdict had a write the mirror did not follow. No cadence knowledge needed — identical for a 15-minute lane and a 48-hour one.

## Why it pairs against tables, not lanes

The lane names don't match one-for-one. `validator-nominator-counts` is written by a lane called `validator-nominators`, and **`nominator_positions` has no writer-side lane at all** — only a staleness watchdog, which runs on its own cron and reports health whether or not the producer ever ran. Table freshness is the one signal every mirrored lane actually has, and the lane→table map is built *from* the mirror plans so a lane can't be added to a plan and left unwatched.

## Never-mirrored is NAMED, not alarmed

This is the correction that makes it usable, and I got it wrong first. My initial version alarmed on absence — which would have fired on all four ledger lanes today, while the system was working correctly. An alarm that cries wolf gets muted, which costs more than the gap it closes.

Telling "never fired" from "no producer pass since deploy" needs the mirror's deploy time, which `lane_health` does not know. So demonstrable lag is `stale`; never-mirrored is named in the same verdict's detail for a human to judge. That's one query replacing the four-way manual comparison it came from.

Unreadable tables record `unknown`, never `stale` — this watchdog reports on *other* lanes' evidence, and claiming they're behind because its own query failed would put a fabricated verdict where triage reads one.

## Cadence

Hourly, not every three minutes. It scans `MAX(captured_at)` per mirrored table — 364,935 rows for `account_balances` alone — and the threshold it enforces is an hour, so a slower tick cannot miss a fault it would otherwise report, only report it one tick later.

## Verification

- **26 tests, 100% statements / branches / functions / lines**
- Full suite: **716 files, 17,391 tests, all passing**
- A test caught a real bug before this shipped: `Number(null)` is `0` and passes `Number.isFinite`, so `MAX(captured_at)` over an empty table read as epoch 0 — a mirror failing to follow a write that never happened.
- The wiring is pinned: the cron constant must appear in `wrangler.data.jsonc`, and **every lane the real deployed flag names must have a table pairing** — checked against the actual config string, not a fixture.