### PR TITLE
fix(prober): bound how long one surface can hold a worker slot

### DIFF
--- a/src/health-probe-core.ts
+++ b/src/health-probe-core.ts
@@ -977,6 +977,75 @@ export async function mapLimit<T, R>(
   return results;
 }
 
+/**
+ * The longest a single surface's probe can legitimately take, plus slack
+ * (metagraphed#9769).
+ *
+ * DERIVED, NOT GUESSED, because a flat ceiling is either too low for the
+ * slowest legitimate surface or too high to bound anything. Each kind's
+ * worst case is knowable from its own configuration:
+ *
+ *   HTTP surfaces      one request                 -> timeout_ms
+ *   subtensor RPC/WSS  SUBTENSOR_PROBE_CALLS.length
+ *                      requests, issued SEQUENTIALLY, each with a fresh
+ *                      timeout                     -> timeout_ms x 5
+ *
+ * That second row is the one worth stating out loud: `probeSubtensorHttp`
+ * loops the five probe calls and short-circuits only on a transport error, so
+ * an endpoint that ACCEPTS connections and then stalls costs five full
+ * timeouts, not one. At the 12s default that is a minute in a single slot of
+ * eight, on a sweep of 615 surfaces driven by a 15-minute cron.
+ *
+ * The slack is generous on purpose. This is not a tighter timeout -- each
+ * request keeps its own abort -- it is a backstop for a probe that has stopped
+ * being subject to any timeout at all, so it should only ever fire on
+ * something genuinely stuck.
+ */
+export const PROBE_SLOT_SLACK_MS = 5_000;
+
+export function probeSlotDeadlineMs(surface: ProbeSurface): number {
+  const isRpc = ["subtensor-rpc", "subtensor-wss"].includes(surface.kind);
+  const timeoutMs = surface.probe?.timeout_ms || (isRpc ? 12_000 : 8_000);
+  const sequentialCalls = isRpc ? SUBTENSOR_PROBE_CALLS.length : 1;
+  return timeoutMs * sequentialCalls + PROBE_SLOT_SLACK_MS;
+}
+
+/**
+ * Resolve `work`, or a fallback once `deadlineMs` has passed.
+ *
+ * THE SLOT IS THE RESOURCE, not the request. Every probe already aborts its own
+ * fetch; what nothing bounded was how long the surface may hold one of the
+ * eight worker slots, and a slot held is a slot the other 614 surfaces queue
+ * behind. So this does not cancel the work -- it stops WAITING for it.
+ *
+ * The abandoned promise is left to settle on its own and its result discarded.
+ * That is deliberate: it has its own abort and will finish or fail shortly, and
+ * a rejection from an abandoned probe must not become an unhandled rejection,
+ * which is why the catch is attached rather than the promise merely dropped.
+ */
+export async function withProbeDeadline<T>(
+  work: Promise<T>,
+  deadlineMs: number,
+  onDeadline: () => T,
+  scheduler: typeof setTimeout = setTimeout,
+): Promise<T> {
+  work.catch(() => undefined);
+  // Assigned before the race, not merely probably assigned: `new Promise`'s
+  // executor runs SYNCHRONOUSLY, so this is set by the time the line below
+  // reads it. A `timer !== undefined` guard in the finally would be a branch no
+  // test can reach, which is how a file starts collecting coverage pragmas
+  // instead of reasons.
+  let timer!: ReturnType<typeof setTimeout>;
+  const expiry = new Promise<T>((resolve) => {
+    timer = scheduler(() => resolve(onDeadline()), deadlineMs);
+  });
+  try {
+    return await Promise.race([work, expiry]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // --- Top-level: probe one surface → common probe-derived row ------------------
 // Returns the fields both callers share. It does NOT compute `last_ok` or
 // `uptime_sample_ratio` (history/store-derived): the Node build computes those

--- a/src/health-prober.ts
+++ b/src/health-prober.ts
@@ -23,7 +23,9 @@ import {
   normalizeProbeStatus,
   okLatencyMs,
   probeSurface as coreProbeSurface,
+  probeSlotDeadlineMs,
   rollupSubnetStatus,
+  withProbeDeadline,
   type ProbeSurface,
 } from "./health-probe-core.ts";
 import { ipv6EmbeddedIpv4 } from "./ip-safety.ts";
@@ -478,6 +480,9 @@ interface RunHealthProberOverrides {
   safetyFetch?: typeof fetch;
   connect?: ReturnType<typeof workerWebSocketConnector>;
   concurrency?: number;
+  /** The per-surface slot deadline, injected so a test can prove a stuck probe
+   * releases its slot without waiting the real ceiling (metagraphed#9769). */
+  probeDeadlineMs?: (surface: ProbeSurface) => number;
 }
 
 // Run one full probe sweep and persist results. Returns a small summary object.
@@ -491,6 +496,7 @@ export async function runHealthProber(
   const loadSurfaces =
     overrides.loadSurfaces || (() => loadOperationalSurfaces(env));
   const probe = overrides.probeSurface || coreProbeSurface;
+  const slotDeadlineMs = overrides.probeDeadlineMs || probeSlotDeadlineMs;
   const probeOptions =
     overrides.probeOptions ||
     ({
@@ -546,7 +552,27 @@ export async function runHealthProber(
     };
     let base: Row;
     try {
-      base = await probe(input, probeOptions);
+      // BOUNDED BY THE SLOT, not just by the request (metagraphed#9769). Every
+      // probe aborts its own fetch, but nothing bounded how long one surface may
+      // hold one of the eight worker slots -- and a subtensor endpoint that
+      // accepts connections and then stalls costs FIVE sequential timeouts, a
+      // minute in a slot, on a 615-surface sweep driven by a 15-minute cron.
+      //
+      // A timed-out probe is `failed`, exactly like a thrown one: it did not
+      // answer. Recording it as anything softer would let a permanently stuck
+      // endpoint read as healthy-but-slow forever.
+      const deadlineMs = slotDeadlineMs(input);
+      base = await withProbeDeadline(
+        probe(input, probeOptions),
+        deadlineMs,
+        () => ({
+          status: "failed",
+          classification: "unsupported",
+          latency_ms: null,
+          status_code: null,
+          error: `probe exceeded its ${deadlineMs}ms slot deadline`,
+        }),
+      );
     } catch (error) {
       base = {
         status: "failed",

--- a/tests/health-probe-core.test.ts
+++ b/tests/health-probe-core.test.ts
@@ -22,6 +22,10 @@ import {
   type HttpProbeResult,
   type ProbeSurface,
   type RpcProbeResult,
+  probeSlotDeadlineMs,
+  PROBE_SLOT_SLACK_MS,
+  SUBTENSOR_PROBE_CALLS,
+  withProbeDeadline,
 } from "../src/health-probe-core.ts";
 import type { Row } from "./row-type.ts";
 
@@ -1852,5 +1856,125 @@ describe("probeSurface field-default branches", () => {
     );
     assert.equal(row.content_type, null);
     assert.equal(row.redirect_target, null);
+  });
+});
+
+describe("probeSlotDeadlineMs (metagraphed#9769)", () => {
+  const surface = (kind: string, timeout_ms?: number) =>
+    ({
+      id: "s",
+      kind,
+      url: "https://example.com",
+      probe: {
+        method: "GET",
+        expect: "any",
+        ...(timeout_ms ? { timeout_ms } : {}),
+      },
+    }) as never;
+
+  test("an HTTP surface gets one request's worth, plus slack", () => {
+    assert.equal(
+      probeSlotDeadlineMs(surface("subnet-api")),
+      8_000 + PROBE_SLOT_SLACK_MS,
+    );
+    assert.equal(
+      probeSlotDeadlineMs(surface("subnet-api", 10_000)),
+      10_000 + PROBE_SLOT_SLACK_MS,
+    );
+  });
+
+  test("an RPC surface gets FIVE, because its calls are sequential", () => {
+    // THE CASE THIS EXISTS FOR. probeSubtensorHttp loops SUBTENSOR_PROBE_CALLS
+    // and short-circuits only on a transport error, so an endpoint that accepts
+    // connections and then stalls costs five full timeouts -- a minute in one
+    // of eight slots at the 12s default. A ceiling derived from one request
+    // would fire on a legitimately slow node; this one only fires on a stuck.
+    assert.equal(SUBTENSOR_PROBE_CALLS.length, 5);
+    for (const kind of ["subtensor-rpc", "subtensor-wss"]) {
+      assert.equal(
+        probeSlotDeadlineMs(surface(kind)),
+        12_000 * 5 + PROBE_SLOT_SLACK_MS,
+        kind,
+      );
+    }
+  });
+
+  test("derives from the surface's OWN timeout, not a constant", () => {
+    // A flat ceiling is either too low for the slowest legitimate surface or
+    // too high to bound anything. The seed carries 25s timeouts on four
+    // surfaces; those must not be cut short.
+    assert.equal(
+      probeSlotDeadlineMs(surface("subtensor-rpc", 25_000)),
+      25_000 * 5 + PROBE_SLOT_SLACK_MS,
+    );
+  });
+
+  test("survives a surface with no probe block at all", () => {
+    assert.equal(
+      probeSlotDeadlineMs({ id: "s", kind: "docs", url: "u" } as never),
+      8_000 + PROBE_SLOT_SLACK_MS,
+    );
+  });
+});
+
+describe("withProbeDeadline (metagraphed#9769)", () => {
+  test("returns the work when it finishes in time", async () => {
+    assert.equal(
+      await withProbeDeadline(Promise.resolve("done"), 50, () => "late"),
+      "done",
+    );
+  });
+
+  test("stops WAITING once the deadline passes", async () => {
+    // It does not cancel the probe -- every probe already aborts its own fetch.
+    // What it releases is the worker SLOT, which is the resource 614 other
+    // surfaces are queued behind.
+    const never = new Promise<string>(() => {});
+    assert.equal(await withProbeDeadline(never, 1, () => "late"), "late");
+  });
+
+  test("an abandoned probe's rejection does not escape", async () => {
+    // A dropped promise that rejects later becomes an unhandled rejection, which
+    // in a Worker is an error event on a run that otherwise succeeded. The catch
+    // is attached deliberately rather than the promise merely dropped.
+    let reject: (e: Error) => void = () => {};
+    const doomed = new Promise<string>((_resolve, r) => {
+      reject = r;
+    });
+    const result = await withProbeDeadline(doomed, 1, () => "late");
+    assert.equal(result, "late");
+    reject(new Error("the probe failed after we stopped waiting"));
+    // Settle a microtask later; an unhandled rejection would surface here.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  });
+
+  test("clears its timer, so a fast probe leaves nothing pending", async () => {
+    // A Worker invocation that finishes with a live timer can be held open by
+    // it. The timer is cleared in a finally, and this asserts the scheduler
+    // handle is the one that gets cleared.
+    let cleared = false;
+    const scheduler = ((fn: () => void, ms: number) => {
+      const handle = setTimeout(fn, ms);
+      return {
+        handle,
+        [Symbol.toPrimitive]: () => 0,
+      } as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+    const original = globalThis.clearTimeout;
+    globalThis.clearTimeout = ((h: never) => {
+      cleared = true;
+      original(h as never);
+    }) as typeof clearTimeout;
+    try {
+      await withProbeDeadline(
+        Promise.resolve("fast"),
+        10_000,
+        () => "late",
+        scheduler,
+      );
+    } finally {
+      globalThis.clearTimeout = original;
+    }
+    assert.equal(cleared, true);
   });
 });

--- a/tests/health-prober.test.ts
+++ b/tests/health-prober.test.ts
@@ -378,6 +378,47 @@ const probeImpl = async (input: Row) =>
         status_code: 404,
       };
 
+describe("a stuck surface releases its slot (metagraphed#9769)", () => {
+  test("a probe that never resolves does not stall the sweep", async () => {
+    // THE DEFECT. mapLimit runs eight workers over 615 surfaces; every probe
+    // aborts its own fetch, but nothing bounded how long ONE surface may hold a
+    // worker slot -- and a subtensor endpoint that accepts connections and then
+    // stalls costs five sequential timeouts, a minute in a slot, on a
+    // 15-minute cron. Here the probe never settles at all, which is the same
+    // failure with the clock removed.
+    const { env } = makeProberEnv({ priorStatus: [] });
+    const kv = makeKv();
+    const result = await runHealthProber(env, FAKE_CTX, {
+      now: () => 50000,
+      kv,
+      loadSurfaces: async () => SURFACES,
+      // The RPC surface hangs forever; the HTTP one answers immediately.
+      probeSurface: (async (input: Row) =>
+        input.kind === "subtensor-rpc"
+          ? new Promise(() => {})
+          : {
+              status: "ok",
+              classification: "live",
+              latency_ms: 10,
+              status_code: 200,
+            }) as never,
+      probeOptions: {},
+      // The real deadline is derived per surface (12s x 5 + slack for RPC);
+      // overridden here so the test does not wait a minute to prove a minute is
+      // too long.
+      probeDeadlineMs: () => 5,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.probed, 2, "the sweep completed rather than hanging");
+    // And the stuck one is recorded as FAILED, not quietly omitted or left
+    // looking healthy -- it did not answer, which is what failed means.
+    const counts = result.counts as Record<string, number>;
+    assert.equal(counts.ok, 1);
+    assert.equal(counts.failed, 1);
+  });
+});
+
 describe("runHealthProber", () => {
   test("posts the probed batch to Postgres + writes the three KV snapshots with correct shapes", async () => {
     const { env, posted } = makeProberEnv({


### PR DESCRIPTION
Closes #9769. Split out of metagraphed-infra#363, which proposed moving the prober onto a queue — see that issue for why the premise behind the proposal was half wrong.

## The defect

`mapLimit` runs **eight** workers over **615** surfaces on a `*/15` cron. Every probe aborts its own fetch, but **nothing bounded how long one surface may hold a slot** — and a slot held is a slot the other 614 queue behind.

**The worst case is not `timeout_ms`.** `probeSubtensorHttp` loops the five `SUBTENSOR_PROBE_CALLS` **sequentially**, each with a fresh `AbortController`, short-circuiting only on a transport error. So an endpoint that *accepts connections and then stalls* costs **five full timeouts** — a minute in one of eight slots, at the 12s default.

The only existing protection is `PROBE_WALLTIME_WARN_MS`: a `console.warn` **8 minutes after** the sweep has already overrun. It does not abort, shed, or shard.

## The deadline is derived, not guessed

```
HTTP surfaces      one request                        -> timeout_ms + slack
subtensor RPC/WSS  SUBTENSOR_PROBE_CALLS.length, sequential -> timeout_ms x 5 + slack
```

A flat ceiling would be either too low for the four seed surfaces configured at 25 s, or too high to bound anything. Deriving it from the surface's own configuration means it can only fire on something genuinely stuck — it is a backstop for a probe that has stopped being subject to any timeout at all, not a tighter timeout.

## Three details worth stating

- **It does not cancel the probe — it stops waiting for it.** The slot is the resource; the request already has its own abort.
- **The abandoned promise gets a `catch` attached**, deliberately rather than merely dropped: a rejection from a probe nobody is waiting for would otherwise become an unhandled rejection on a run that succeeded.
- **A timed-out probe is `failed`**, exactly like a thrown one — it did not answer. Anything softer would let a permanently stuck endpoint read as healthy-but-slow forever.

## Verified against the defect

The sweep test does not merely fail without the fix — it **hangs**:

```
× a probe that never resolves does not stall the sweep   8005ms
  Error: Test timed out in 8000ms.
```

which is the defect stated as a test. The deadline is injectable so that test proves it in 5 ms rather than waiting the real 65 s ceiling.

## Deliberately NOT done

Rebuilding the prober on a queue, as metagraphed-infra#363 suggested. That issue's own caveat applies to itself — *"availability of a service is not evidence it helps"* — and a queue fragments a sweep that currently produces one coherent snapshot, to fix something a deadline fixes. It also premised on replacing hand-rolled retry, and the prober **has no retry at all**: a case-insensitive grep for `retry|retries|attempt` across both files returns zero matches.

## Validation

```
npm run typecheck    # clean
npm run lint         # clean
npx prettier --check # clean
npx vitest run tests/health-prober.test.ts tests/health-probe-core.test.ts   # 221 passed
```

Patch coverage over both changed files: **0 uncovered statements, 0 uncovered branches**. One guard was *removed* rather than annotated to get there — `timer !== undefined` in the `finally` is unreachable, because `new Promise`'s executor runs synchronously, and the comment now says so.

## Template Used

- Backend/code change
