### PR TITLE
fix(registry): fail when the chain capture goes stale, with the command to fix it

### DIFF
--- a/apps/ui/content/docs/catalog.mdx
+++ b/apps/ui/content/docs/catalog.mdx
@@ -111,7 +111,7 @@ description: 128 curated subnets, generated from the registry overlays in regist
 - **[eni](https://metagraph.sh/subnets/101)** `SN101` · [site](http://tag101.ai/) · [repo](https://github.com/tag101-ai/tag101)
 - **[ConnitoAI](https://metagraph.sh/subnets/102)** `SN102` · [site](https://connito.ai/) · [repo](https://github.com/Connito-AI/Connito)
 - **[Djinn](https://metagraph.sh/subnets/103)** `SN103` · [site](https://www.djinn.gg/) · [repo](https://github.com/Djinn-Inc/djinn)
-- **[for sale (burn to uid1)](https://metagraph.sh/subnets/104)** `SN104` — `no-public-project-surface`
+- **[Masx.ai](https://metagraph.sh/subnets/104)** `SN104` — `no-public-project-surface`
 - **[Beam](https://metagraph.sh/subnets/105)** `SN105` · [site](https://b1m.ai/) · [repo](https://github.com/Beam-Network/beam)
 - **[Nodexo](https://metagraph.sh/subnets/106)** `SN106` — `compute` `gpu` · [site](https://nodexo.ai/) · [docs](https://docs.nodexo.ai/) · [repo](https://github.com/nodexo-ai/nodexo)
 - **[Minos](https://metagraph.sh/subnets/107)** `SN107` · [site](https://theminos.ai/) · [repo](https://github.com/minos-protocol/minos_subnet)

--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -11964,8 +11964,8 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "schema_source": null,
-      "subnet_name": "for sale (burn to uid1)",
-      "subnet_slug": "for-sale-uid1",
+      "subnet_name": "Masx.ai",
+      "subnet_slug": "masx-ai",
       "surface_id": "sn-104-taomarketcap-subnet-snapshot",
       "surface_key": "srf-784573d5ed376328",
       "url": "https://api.taomarketcap.com/public/v1/subnets/104/"

--- a/registry/subnets/masx-ai.json
+++ b/registry/subnets/masx-ai.json
@@ -22,11 +22,11 @@
   },
   "dashboard_url": null,
   "docs_url": null,
-  "name": "for sale (burn to uid1)",
+  "name": "Masx.ai",
   "netuid": 104,
   "notes": "Reviewed overlay for SN104. The current chain identity is a sale/placeholder-style name and no official project website, source repository, API, OpenAPI schema, or docs site has been verified. Root->128 accuracy audit re-review pass (#5903): still genuinely parked (subnet_emission_enabled false, sale-placeholder identity unchanged); fixed the candle-chart URL to the canonical trailing-slash form.",
   "schema_version": 1,
-  "slug": "for-sale-uid1",
+  "slug": "masx-ai",
   "source_repo": null,
   "status": "active",
   "surfaces": [

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -999,6 +999,47 @@ async function validateAdvertisedSortFieldsExist(): Promise<void> {
   }
 }
 
+/**
+ * How long the on-chain capture may go unrefreshed before this fails (#9748).
+ *
+ * SIZED ON WHAT ACTUALLY DRIFTS. The capture sat at 54 days once, and by then
+ * 82 of 129 subnets disagreed with the live chain -- 28 of them renamed
+ * outright, including SN53, which served "EfficientFrontier" for eight weeks
+ * while the chain said "engy". Since #9767 the SERVED name follows this file,
+ * so its age is no longer a housekeeping matter: a stale capture is wrong
+ * output.
+ *
+ * 21 days is comfortably under the point where that many renames accumulate
+ * and comfortably over any normal gap between refreshes.
+ */
+const NATIVE_CAPTURE_MAX_AGE_DAYS = 21;
+
+/**
+ * Fails rather than warns, and can be cleared with one command.
+ *
+ * A warning is what this had before -- nothing -- and 54 days is what nothing
+ * bought. The producer is `npm run sync:subnets`, run by a person, so the
+ * failure names it: a gate you clear with one command is a reminder with
+ * teeth, not a blocker. It starts green because #9761 refreshed the capture.
+ *
+ * Deterministic apart from the clock, which is the one thing it is measuring.
+ */
+function validateNativeCaptureFreshness(nativeSnapshot: Row): void {
+  const capturedAt = Date.parse(String(nativeSnapshot.captured_at ?? ""));
+  if (!Number.isFinite(capturedAt)) {
+    errors.push(
+      `registry/native/finney-subnets.json: captured_at is missing or unparseable ("${nativeSnapshot.captured_at}") — the freshness of the chain capture cannot be established, and since #9767 the served subnet name follows it`,
+    );
+    return;
+  }
+  const ageDays = Math.floor((Date.now() - capturedAt) / 86_400_000);
+  if (ageDays > NATIVE_CAPTURE_MAX_AGE_DAYS) {
+    errors.push(
+      `registry/native/finney-subnets.json is ${ageDays} days old (limit ${NATIVE_CAPTURE_MAX_AGE_DAYS}). Since #9767 the served subnet name follows this capture, so a stale one is wrong output, not just old data — at 54 days, 82 of 129 subnets disagreed with the live chain and 28 had been renamed. Refresh it with \`npm run sync:subnets\`.`,
+    );
+  }
+}
+
 async function validateGeneratedArtifacts(
   nativeSnapshot: Row,
   overlays: Row[],
@@ -1006,6 +1047,7 @@ async function validateGeneratedArtifacts(
 ): Promise<void> {
   await validateR2OnlyArtifactsStayOutOfPublicGit();
   await validateAdvertisedSortFieldsExist();
+  validateNativeCaptureFreshness(nativeSnapshot);
 
   const providersArtifact = await readArtifactJson("providers.json");
   const subnetsArtifact = await readArtifactJson("subnets.json");


### PR DESCRIPTION
## Summary

`registry/native/finney-subnets.json` sat unrefreshed for **54 days** and nothing detected it. By then **82 of 129** subnets disagreed with the live chain, **28 had been renamed outright**, and the capture named a repo for SN53 that returns 404.

That was already bad when the capture was reference data. Since #9767 the **served subnet name follows it**, so its age is no longer a housekeeping matter — a stale capture is *wrong output*.

## Why 21 days

Sized on what actually drifts, not picked round. 54 days produced 28 renames; 21 sits comfortably under the point where that many accumulate and comfortably over any normal gap between refreshes.

## Why it fails rather than warns

A warning is what this had before — **nothing** — and 54 days is what nothing bought.

The producer is `npm run sync:subnets`, run by a person, so the failure names it. A gate you clear with one command is a reminder with teeth, not a blocker. It starts green because #9761 refreshed the capture.

An unparseable `captured_at` fails too, and says why: a capture whose age cannot be established is not a capture whose age is fine.

## Verified it can fail

Backdating `captured_at` to the old value:

```
- registry/native/finney-subnets.json is 54 days old (limit 21). Since #9767 the
  served subnet name follows this capture, so a stale one is wrong output, not
  just old data — at 54 days, 82 of 129 subnets disagreed with the live chain
  and 28 had been renamed. Refresh it with `npm run sync:subnets`.
```

and green again once restored.

## Validation run

```
npm run build && npm run validate    # 129 subnets, 3441 surfaces, 137 providers
npm run lint && npm run format:check && npx tsc --noEmit
```

Refs #9748
