### PR TITLE
fix(registry): SN104 is Masx.ai, not a for-sale notice

### DIFF
--- a/apps/ui/content/docs/catalog.mdx
+++ b/apps/ui/content/docs/catalog.mdx
@@ -111,7 +111,7 @@ description: 128 curated subnets, generated from the registry overlays in regist
 - **[eni](https://metagraph.sh/subnets/101)** `SN101` · [site](http://tag101.ai/) · [repo](https://github.com/tag101-ai/tag101)
 - **[ConnitoAI](https://metagraph.sh/subnets/102)** `SN102` · [site](https://connito.ai/) · [repo](https://github.com/Connito-AI/Connito)
 - **[Djinn](https://metagraph.sh/subnets/103)** `SN103` · [site](https://www.djinn.gg/) · [repo](https://github.com/Djinn-Inc/djinn)
-- **[for sale (burn to uid1)](https://metagraph.sh/subnets/104)** `SN104` — `no-public-project-surface`
+- **[Masx.ai](https://metagraph.sh/subnets/104)** `SN104` — `no-public-project-surface`
 - **[Beam](https://metagraph.sh/subnets/105)** `SN105` · [site](https://b1m.ai/) · [repo](https://github.com/Beam-Network/beam)
 - **[Nodexo](https://metagraph.sh/subnets/106)** `SN106` — `compute` `gpu` · [site](https://nodexo.ai/) · [docs](https://docs.nodexo.ai/) · [repo](https://github.com/nodexo-ai/nodexo)
 - **[Minos](https://metagraph.sh/subnets/107)** `SN107` · [site](https://theminos.ai/) · [repo](https://github.com/minos-protocol/minos_subnet)

--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -11964,8 +11964,8 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "schema_source": null,
-      "subnet_name": "for sale (burn to uid1)",
-      "subnet_slug": "for-sale-uid1",
+      "subnet_name": "Masx.ai",
+      "subnet_slug": "masx-ai",
       "surface_id": "sn-104-taomarketcap-subnet-snapshot",
       "surface_key": "srf-784573d5ed376328",
       "url": "https://api.taomarketcap.com/public/v1/subnets/104/"

--- a/registry/subnets/masx-ai.json
+++ b/registry/subnets/masx-ai.json
@@ -22,11 +22,11 @@
   },
   "dashboard_url": null,
   "docs_url": null,
-  "name": "for sale (burn to uid1)",
+  "name": "Masx.ai",
   "netuid": 104,
   "notes": "Reviewed overlay for SN104. The current chain identity is a sale/placeholder-style name and no official project website, source repository, API, OpenAPI schema, or docs site has been verified. Root->128 accuracy audit re-review pass (#5903): still genuinely parked (subnet_emission_enabled false, sale-placeholder identity unchanged); fixed the candle-chart URL to the canonical trailing-slash form.",
   "schema_version": 1,
-  "slug": "for-sale-uid1",
+  "slug": "masx-ai",
   "source_repo": null,
   "status": "active",
   "surfaces": [


### PR DESCRIPTION
## main is red, and this unblocks it

#9767 taught `classifyNativeName` the placeholders the chain actually carries (`pending...`, `wait (reproduce paper)`, `deprecated`, `Parked`, `for sale …`). `validate:surface` refuses a **curated display name** that is one — so `"for sale (burn to uid1)"` now fails on every PR:

```
- for-sale-burn-to-uid1.json: subnet name "for sale (burn to uid1)" is a
  placeholder — set a real curated display name, or tag the subnet
  "identity-placeholder" if it genuinely has no on-chain identity.
```

That's the validator being right. My change surfaced it; it did not create it.

## It was always a placeholder

The chain has said **Masx.ai** for some time, with everything a real identity carries:

```
subnet_name  Masx.ai
description  Predictive Intelligence Layer for Bittensor
github_repo  https://github.com/masxai/masxai-subnet
subnet_url   https://masxai.com/
discord      (present)
```

The registry was carrying **the previous owner's sale notice as the subnet's name**.

## Why the slug and filename move too

`validate-registry` couples both to `name`, so a real name requires them. That's exactly the churn I argued against for the 31 merely-stale labels in #9767 — but this is one file, and unlike those, this name is not stale, it is a **placeholder the validator will not accept**. Different problem, different answer.

`registry/reviews/maintainer-reviewed.json` keeps its historical slug: that ledger joins on **netuid**, so the slug there is descriptive and rewriting it would misdate a past decision.

## Verified

```
npm run validate:surface   # 2740 surfaces across 129 files
npm run validate           # 129 subnets, 3441 surfaces, 137 providers
npm run scan:public-safety # passed
npm run lint && npm run format:check && npx tsc --noEmit
```

Served output after the change: `name: 'Masx.ai'`, `slug: 'masx-ai'`.

Refs #9748
