### PR TITLE
feat(neon): gate reads on EVERY table a route touches, and move the analytics family

### DIFF
--- a/tests/neon-read-routes.test.ts
+++ b/tests/neon-read-routes.test.ts
@@ -1,0 +1,264 @@
+// Which routes may be served from Neon (workers/data-api.ts, infra#336).
+//
+// The gate picks ONE runner and the handler uses it for every query it makes,
+// so a route touching two mirrored tables cannot half-move. That is the
+// property this file exists to hold, and it is a correction to how #9768
+// shipped: the position-history gate checked only `account_position_daily`
+// while its handler also read `neurons`, so naming one table silently moved
+// both. It was safe -- `neurons` mirrors every producer tick and matched D1 on
+// a content checksum -- but safe by luck is not what a gate is for.
+//
+// The map is also asserted against the handlers' OWN SQL. A map that drifts
+// from the queries would gate on the wrong evidence, which is worse than no
+// gate: it would report a table as proven while reading one that is not.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  NEON_READ_ROUTE_TABLES,
+  neonServesRoute,
+  POSITION_HISTORY_NEON_LANE,
+} from "../workers/data-api.ts";
+
+/** Tables the mirror covers. A route reading one of these is gate-relevant. */
+const MIRRORED = [
+  "neurons",
+  "neuron_daily",
+  "account_position_daily",
+  "nominator_positions",
+  "account_balances",
+  "hotkey_alpha",
+  "validator_nominator_counts",
+];
+
+const ALL = "account_position_daily,neurons,neuron_daily,nominator_positions";
+
+describe("NEON_READ_ROUTE_TABLES", () => {
+  test("every entry names only mirrored tables", () => {
+    for (const { pattern, tables } of NEON_READ_ROUTE_TABLES) {
+      assert.ok(tables.length > 0, `${pattern} declares no tables`);
+      for (const table of tables) {
+        assert.ok(
+          MIRRORED.includes(table),
+          `${pattern} names "${table}", which no mirror covers -- a route ` +
+            `gated on an unmirrored table would move to a store nothing writes`,
+        );
+      }
+    }
+  });
+
+  test("no two entries match the same path", () => {
+    // `find` takes the first match, so an overlapping pair would make the
+    // second entry dead and its table list silently unenforced.
+    const samples = [
+      "/api/v1/subnets/movers",
+      "/api/v1/chain/turnover",
+      "/api/v1/subnets/1/turnover",
+      "/api/v1/subnets/1/history",
+      "/api/v1/validators",
+      "/api/v1/accounts",
+      "/api/v1/chain/concentration",
+      "/api/v1/chain/concentration/subnets",
+      "/api/v1/subnets/1/metagraph",
+    ];
+    for (const path of samples) {
+      const hits = NEON_READ_ROUTE_TABLES.filter((r) => r.pattern.test(path));
+      assert.equal(
+        hits.length,
+        1,
+        `${path} matches ${hits.length} entries; expected exactly one`,
+      );
+    }
+  });
+
+  test("each route's declared tables are the ones its handler queries", () => {
+    // THE LOAD-BEARING TEST, and it must be PER ROUTE. Checking only that each
+    // table appears somewhere in the map would pass a mapping that gates
+    // /subnets/movers on `neurons` when it actually reads `neuron_daily` --
+    // gating on the wrong evidence, which is worse than no gate.
+    //
+    // So: split the matcher into its per-route blocks, resolve each block to a
+    // concrete path, and compare the mirrored tables its SQL names against
+    // what NEON_READ_ROUTE_TABLES declares for that path.
+    const src = readFileSync("workers/data-api.ts", "utf8");
+    const start = src.indexOf("function matchNeuronsD1Route");
+    assert.ok(start > 0, "matchNeuronsD1Route not found");
+    const end = src.indexOf("\nfunction ", start + 10);
+    const body = src.slice(start, end > 0 ? end : undefined);
+
+    // One block per `if (...) { return async (sql) => ... }` route guard.
+    const blocks = body.split(/\n {2}(?=if \()/).slice(1);
+    let checked = 0;
+    const problems: string[] = [];
+
+    for (const block of blocks) {
+      const tables = [
+        ...new Set(
+          [...block.matchAll(/FROM\s+(\w+)/g)]
+            .map((m) => m[1])
+            .filter((t) => MIRRORED.includes(t)),
+        ),
+      ].sort();
+      if (tables.length === 0) continue;
+
+      // The literal path this guard matches, when it is a literal.
+      const literal = /pathname === "([^"]+)"/.exec(block)?.[1];
+      if (!literal) continue;
+
+      const entry = NEON_READ_ROUTE_TABLES.find((r) => r.pattern.test(literal));
+      checked += 1;
+      if (!entry) {
+        problems.push(`${literal} reads [${tables}] but has no entry`);
+        continue;
+      }
+      const declared = [...entry.tables].sort();
+      if (JSON.stringify(declared) !== JSON.stringify(tables)) {
+        problems.push(
+          `${literal} reads [${tables}] but declares [${declared}]`,
+        );
+      }
+    }
+
+    assert.ok(
+      checked >= 6,
+      `only ${checked} literal routes checked -- the block split stopped ` +
+        `working, so this test is passing on nothing`,
+    );
+    assert.deepEqual(problems, [], problems.join("\n"));
+  });
+
+  test("the position-history route declares BOTH tables it reads", () => {
+    // The specific bug this map corrects. #9768 gated it on
+    // account_position_daily alone.
+    const entry = NEON_READ_ROUTE_TABLES.find((r) =>
+      r.pattern.test("/api/v1/accounts/5Abc/subnets/80/history"),
+    );
+    assert.ok(entry, "position history has no entry");
+    assert.deepEqual([...entry.tables].sort(), [
+      "account_position_daily",
+      "neurons",
+    ]);
+    assert.ok(entry.tables.includes(POSITION_HISTORY_NEON_LANE));
+  });
+});
+
+describe("neonServesRoute", () => {
+  const url = (p: string) => new URL(`https://api.metagraph.sh${p}`);
+
+  test("serves only when EVERY table the route reads is enabled", () => {
+    const path = "/api/v1/accounts/5Abc/subnets/80/history";
+    // Both -> served.
+    assert.equal(
+      neonServesRoute(
+        { NEON_READ_LANES: "neurons,account_position_daily" },
+        url(path),
+      ),
+      true,
+    );
+    // Either one alone -> NOT served. This is #9768's gap, closed.
+    assert.equal(
+      neonServesRoute({ NEON_READ_LANES: "account_position_daily" }, url(path)),
+      false,
+    );
+    assert.equal(
+      neonServesRoute({ NEON_READ_LANES: "neurons" }, url(path)),
+      false,
+    );
+  });
+
+  test("a single-table route needs only its own table", () => {
+    assert.equal(
+      neonServesRoute(
+        { NEON_READ_LANES: "neuron_daily" },
+        url("/api/v1/subnets/movers"),
+      ),
+      true,
+    );
+    assert.equal(
+      neonServesRoute(
+        { NEON_READ_LANES: "neurons" },
+        url("/api/v1/subnets/movers"),
+      ),
+      false,
+    );
+  });
+
+  test("an UNMAPPED route is never served from Neon", () => {
+    // The safe default: a route nobody has enumerated the tables of must not
+    // ride in on another route's evidence.
+    assert.equal(
+      neonServesRoute({ NEON_READ_LANES: ALL }, url("/api/v1/blocks")),
+      false,
+    );
+    assert.equal(
+      neonServesRoute(
+        { NEON_READ_LANES: ALL },
+        url("/api/v1/subnets/1/holders"),
+      ),
+      false,
+    );
+  });
+
+  test("an empty or absent flag serves nothing", () => {
+    for (const env of [undefined, null, {}, { NEON_READ_LANES: "" }]) {
+      assert.equal(neonServesRoute(env, url("/api/v1/subnets/movers")), false);
+    }
+  });
+});
+
+describe("the deployed flag", () => {
+  const wrangler = readFileSync("wrangler.data.jsonc", "utf8");
+  const named = (/"NEON_READ_LANES":\s*"([^"]*)"/.exec(wrangler)?.[1] ?? "")
+    .split(",")
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+  test("names only tables something writes", () => {
+    // #9704 as a rule: a read with no writer behind it serves a frozen store
+    // at 200 OK.
+    const writes = (
+      /"NEON_DUAL_WRITE_LANES":\s*"([^"]*)"/.exec(wrangler)?.[1] ?? ""
+    ).split(",");
+    const backfills = (
+      /"NEON_BACKFILL_LANES":\s*"([^"]*)"/.exec(wrangler)?.[1] ?? ""
+    ).split(",");
+    const written = new Set(
+      [...writes, ...backfills].map((l) => l.trim()).filter(Boolean),
+    );
+    for (const lane of named) {
+      assert.ok(
+        written.has(lane),
+        `NEON_READ_LANES names "${lane}" but nothing writes it`,
+      );
+    }
+  });
+
+  test("names only tables the route map knows about", () => {
+    // A lane enabled for reading that no route declares is dead config -- it
+    // reads as a cutover that happened when none did.
+    const declared = new Set(NEON_READ_ROUTE_TABLES.flatMap((r) => r.tables));
+    for (const lane of named) {
+      assert.ok(
+        declared.has(lane),
+        `NEON_READ_LANES names "${lane}" but no route declares it`,
+      );
+    }
+  });
+
+  test("does NOT name a table whose mirror has never fired", () => {
+    // Measured 2026-08-07 and reported by #9772's watchdog: these four have no
+    // `neon:` verdict at all, because their producers run on 12h/30h/48h
+    // cadences. Naming one moves a read onto an unproven store.
+    for (const unproven of [
+      "nominator_positions",
+      "hotkey_alpha",
+      "account_balances",
+      "validator_nominator_counts",
+    ]) {
+      assert.ok(
+        !named.includes(unproven),
+        `${unproven}'s mirror has never fired -- see #9770/#9772`,
+      );
+    }
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -5734,6 +5734,96 @@ export function positionHistoryServedFromNeon(url: URL): boolean {
  */
 export const POSITION_HISTORY_NEON_LANE = "account_position_daily";
 
+/**
+ * Every mirrored table each neurons-family route reads.
+ *
+ * ALL OF THEM MUST BE READ-ENABLED FOR THE ROUTE TO MOVE, and that is a
+ * correction to how #9768 shipped. The handler picks ONE runner and uses it for
+ * every query it makes, so a route touching two tables cannot half-move. The
+ * position-history gate checked only `account_position_daily` -- but its
+ * handler also reads `neurons`, so naming one table silently moved both. It
+ * happened to be safe (`neurons` mirrors on every producer tick and matched D1
+ * on a content checksum), but "happened to be safe" is not the property a gate
+ * is for.
+ *
+ * Ordered longest-prefix-last so the first match wins on the specific route
+ * rather than a broader one. Each entry's table list is asserted against the
+ * handler's own SQL in tests/neon-read-routes.test.ts -- a map that drifts from
+ * the queries would gate on the wrong evidence, which is worse than no gate.
+ */
+export const NEON_READ_ROUTE_TABLES: readonly {
+  pattern: RegExp;
+  tables: readonly string[];
+}[] = [
+  // Reads `neurons` for the account's current UIDs, then the dated positions.
+  {
+    pattern: /^\/api\/v1\/accounts\/[^/]+\/subnets\/\d+\/history$/,
+    tables: ["neurons", "account_position_daily"],
+  },
+  // neuron_daily only -- the day-over-day aggregates.
+  { pattern: /^\/api\/v1\/subnets\/movers$/, tables: ["neuron_daily"] },
+  { pattern: /^\/api\/v1\/chain\/turnover$/, tables: ["neuron_daily"] },
+  {
+    pattern: /^\/api\/v1\/subnets\/\d+\/turnover$/,
+    tables: ["neuron_daily"],
+  },
+  { pattern: /^\/api\/v1\/subnets\/\d+\/history$/, tables: ["neuron_daily"] },
+  {
+    pattern: /^\/api\/v1\/subnets\/\d+\/yield\/history$/,
+    tables: ["neuron_daily"],
+  },
+  // Both: the live card comes from `neurons`, the series from `neuron_daily`.
+  {
+    pattern: /^\/api\/v1\/subnets\/\d+\/concentration\/history$/,
+    tables: ["neurons", "neuron_daily"],
+  },
+  {
+    pattern: /^\/api\/v1\/subnets\/\d+\/performance\/history$/,
+    tables: ["neurons", "neuron_daily"],
+  },
+  {
+    pattern: /^\/api\/v1\/subnets\/\d+\/neurons\/\d+\/history$/,
+    tables: ["neurons", "neuron_daily"],
+  },
+  {
+    pattern: /^\/api\/v1\/validators\/[^/]+\/history$/,
+    tables: ["neurons", "neuron_daily"],
+  },
+  // `neurons` only.
+  { pattern: /^\/api\/v1\/validators$/, tables: ["neurons"] },
+  { pattern: /^\/api\/v1\/accounts$/, tables: ["neurons"] },
+  { pattern: /^\/api\/v1\/chain\/concentration$/, tables: ["neurons"] },
+  {
+    pattern: /^\/api\/v1\/chain\/concentration\/subnets$/,
+    tables: ["neurons"],
+  },
+  { pattern: /^\/api\/v1\/chain\/performance$/, tables: ["neurons"] },
+  { pattern: /^\/api\/v1\/chain\/idle-stake$/, tables: ["neurons"] },
+  { pattern: /^\/api\/v1\/chain\/yield$/, tables: ["neurons"] },
+  {
+    pattern: /^\/api\/v1\/subnets\/\d+\/metagraph$/,
+    tables: ["neurons"],
+  },
+];
+
+/**
+ * Whether THIS request may be served from Neon.
+ *
+ * False unless every table the route reads is named in NEON_READ_LANES. A route
+ * with no entry is never served from Neon, which is the safe default: an
+ * unmapped route is one whose tables nobody has enumerated.
+ */
+export function neonServesRoute(
+  env: Record<string, unknown> | null | undefined,
+  url: URL,
+): boolean {
+  const entry = NEON_READ_ROUTE_TABLES.find((r) =>
+    r.pattern.test(url.pathname),
+  );
+  if (!entry) return false;
+  return entry.tables.every((table) => neonReadEnabled(env, table));
+}
+
 function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
   // GET /api/v1/subnets/:netuid/metagraph -- twin of the Postgres route of
   // the same name below. immunity_period comes from subnet_hyperparams,
@@ -7083,13 +7173,12 @@ async function dispatchDataApiRequest(
         // questions. NEON_READ_LANES answers the second one, defaults to empty,
         // and must not name a lane until that lane's `neon:` verdict has been
         // green across several producer ticks.
+        // Every table this route reads must be read-enabled, not just one --
+        // the handler uses ONE runner for all its queries, so a route touching
+        // two tables cannot half-move. See NEON_READ_ROUTE_TABLES.
         const store =
           env.HYPERDRIVE &&
-          neonReadEnabled(
-            env as unknown as Record<string, unknown>,
-            POSITION_HISTORY_NEON_LANE,
-          ) &&
-          positionHistoryServedFromNeon(url)
+          neonServesRoute(env as unknown as Record<string, unknown>, url)
             ? createPgSql(env.HYPERDRIVE, ctx)
             : createD1Sql(env.METAGRAPH_HEALTH_DB);
         try {

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -145,7 +145,25 @@
     //
     // Rollback is deleting the entry: the gate falls back to createD1Sql on
     // the same query text, so the store moves by choosing a runner.
-    "NEON_READ_LANES": "account_position_daily",
+    // Three tables, each proven before it was named:
+    //   account_position_daily  reconciled `in sync` (#9752), route verified
+    //                           against its D1 baseline across four deploys
+    //   neurons                 mirror green every producer tick since #9714,
+    //                           content-checksum identical to D1
+    //   neuron_daily            816,803 rows backfilled and reconciled
+    //                           `in sync` 2026-08-07 09:19
+    //
+    // `neurons` is named EXPLICITLY rather than ridden in on another lane's
+    // flag. Before this, the position-history gate checked only
+    // account_position_daily while its handler also read `neurons` -- safe by
+    // luck, not by gate. NEON_READ_ROUTE_TABLES now requires every table a
+    // route reads.
+    //
+    // NOT here: nominator_positions, hotkey_alpha, account_balances. Their
+    // mirrors have never fired (12h/30h/48h producers), which #9772's watchdog
+    // reports as never-mirrored-not-alarmed. Naming one would move a read onto
+    // a store with no proven writer -- #9704 exactly.
+    "NEON_READ_LANES": "account_position_daily,neurons,neuron_daily",
     // The two ACCUMULATING tables, and only those (src/neon-backfill.ts).
     //
     // The mirror above writes what each request carries, which finishes the job


### PR DESCRIPTION
Closes #9773

## The bug in what I shipped this morning

#9768 gated the position-history read on `account_position_daily`. **Its handler also reads `neurons`.**

The gate picks one runner and the handler uses it for every query it makes, so a route touching two tables cannot half-move — naming one table silently moved both. It happened to be safe (`neurons` mirrors on every producer tick and is checksum-identical to D1), but safe by luck is not the property a gate is for.

## The fix

`NEON_READ_ROUTE_TABLES` maps each route to **every** mirrored table it reads, and `neonServesRoute` requires all of them to be read-enabled. An unmapped route is never served from Neon — the safe default: a route whose tables nobody has enumerated must not ride in on another route's evidence.

```ts
{ pattern: /\/accounts\/[^/]+\/subnets\/\d+\/history$/, tables: ["neurons", "account_position_daily"] },
{ pattern: /\/subnets\/movers$/,                        tables: ["neuron_daily"] },
{ pattern: /\/chain\/idle-stake$/,                      tables: ["neurons"] },
…
```

## The map is asserted per route against the handlers' own SQL

Checking only that each table appears *somewhere* in the map would pass a mapping that gates `/subnets/movers` on `neurons` when it actually reads `neuron_daily` — gating on the wrong evidence, which is worse than no gate at all.

So the test splits `matchNeuronsD1Route` into its per-route blocks and compares each block's `FROM <mirrored table>` against what that route declares. **I verified it fails on exactly that mutation before trusting it:**

```
× each route's declared tables are the ones its handler queries
  AssertionError: /api/v1/subnets/movers reads [neuron_daily] but declares [neurons]
```

It also asserts ≥6 literal routes were checked, so a broken block-split fails loudly instead of passing on nothing.

## What moves, and the evidence for each

`NEON_READ_LANES` gains `neurons` and `neuron_daily`:

| table | evidence |
|---|---|
| `account_position_daily` | reconciled `in sync`; route verified against its D1 baseline across four deploys |
| `neurons` | mirror green every producer tick since #9714; content-checksum identical to D1 |
| `neuron_daily` | 816,803 rows backfilled, reconciled `in sync` 2026-08-07 09:19 |

**Staying out:** `nominator_positions`, `hotkey_alpha`, `account_balances`. Their mirrors have **never fired** — #9772's watchdog reports them as never-mirrored-not-alarmed, because their producers run on 12h/30h/48h cadences. A test pins them out of the read flag by name.

Rollback is deleting a lane from the flag.

## Verification

- 11 new tests; the six Neon/routing suites pass (169 tests)
- `npm run typecheck` clean, eslint clean
- **Baselines captured on D1 before the change** for all 15 affected routes (content hash + row count, volatile fields stripped). I'll diff them against Neon immediately after deploy and roll back on any mismatch.

## One thing CI should adjudicate

Five `validate-surface-*` test files fail in my local worktree at this base, on `registry/subnets/for-sale-burn-to-uid1.json` (SN104's on-chain identity is literally `"for sale (burn to uid1)"`, which trips the placeholder-name rule). My diff touches no registry file and no validator, the files are byte-identical to `origin/main`, and CI passed these on three PRs today from the same base — so this is a local/CI divergence rather than a regression here. Filing it separately; flagging it so the CI result on this PR is read as the authority.