### PR TITLE
feat(queue): give the two nominator lanes the completeness contract they never had

### DIFF
--- a/migrations/d1/0029_nominator_positions_passes.sql
+++ b/migrations/d1/0029_nominator_positions_passes.sql
@@ -1,0 +1,65 @@
+-- Pass completeness for the position ledger (metagraphed-infra#346).
+--
+-- WHY THIS LANE NEEDS ONE, and why its absence was not obvious. `account_balances`
+-- got a pass table (0020) after a truncated load published a leaderboard missing
+-- real top holders: 147,000 well-formed rows look exactly like 364,000 of them,
+-- only fewer, so a count cannot prove completeness and only the PRODUCER knows
+-- how big its scan was. `hotkey_alpha` got one (0021) for the same reason.
+--
+-- `nominator_positions` never did, and it feeds the same class of surface:
+-- /accounts/{ss58}/positions, /subnets/{netuid}/holders, /chain/holders, the
+-- positions basis of /validators/{hotkey}/nominators, and `delegated_tao` on the
+-- top-holders leaderboard. Those already DECLINE while `hotkey_alpha` has no
+-- complete pass -- `pool_totals_unproven` -- because a partial pool ledger
+-- silently UNDERPRICES a holder. A partial POSITION ledger is worse in the same
+-- direction: it silently DROPS them, and the ranking that results is plausible
+-- and wrong.
+--
+-- It was invisible because the lane moved onto the queue with the gap it already
+-- had on the HTTP path. Nothing regressed; it simply never had the gate, and
+-- being routed alongside two lanes that do made it look like it did.
+--
+-- SAME SHAPE AS 0020/0021 deliberately, down to the column names: the producer
+-- declares the pass size once, every request adds its own row count, and a pass
+-- is complete when the two agree. Three tables with three shapes would be three
+-- readers to write.
+--
+-- ONE ROW PER PASS, keyed on the pass's own captured_at -- stamped once at scan
+-- start and repeated across every chunk (validator_nominators.rs). Rows
+-- accumulate as requests land, so "in flight", "complete" and "abandoned" stay
+-- three distinguishable states rather than one absence.
+CREATE TABLE IF NOT EXISTS nominator_positions_passes (
+  captured_at   INTEGER NOT NULL,
+  expected_rows INTEGER NOT NULL,
+  received_rows INTEGER NOT NULL DEFAULT 0,
+  -- Epoch-ms of the request that closed the gap. Set exactly once, never
+  -- cleared -- the at-least-once transport means received_rows can legitimately
+  -- exceed expected_rows on a retry, and the gate asks "did everything arrive",
+  -- not "how many times".
+  completed_at  INTEGER,
+  PRIMARY KEY (captured_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_nominator_positions_passes_completed
+  ON nominator_positions_passes (completed_at DESC);
+
+-- The counts lane's twin. It comes from the SAME Alpha scan but lands in a
+-- different table behind a different secret, and the two are gated
+-- independently by the producer -- so a scan that can refresh one of them is
+-- worth running, and each needs to be able to say for itself whether it
+-- arrived whole.
+--
+-- `validator_nominator_counts` feeds the nominator_count on
+-- /validators/{hotkey}/nominators. A short pass there under-reports how many
+-- delegators a validator has, which reads as a validator losing support rather
+-- than as a load that did not finish.
+CREATE TABLE IF NOT EXISTS validator_nominator_counts_passes (
+  captured_at   INTEGER NOT NULL,
+  expected_rows INTEGER NOT NULL,
+  received_rows INTEGER NOT NULL DEFAULT 0,
+  completed_at  INTEGER,
+  PRIMARY KEY (captured_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_validator_nominator_counts_passes_completed
+  ON validator_nominator_counts_passes (completed_at DESC);

--- a/src/nominator-positions-d1-write.ts
+++ b/src/nominator-positions-d1-write.ts
@@ -26,6 +26,10 @@ import {
   type D1PreparedStatement,
 } from "./neurons-d1-write.ts";
 import { NOMINATOR_POSITION_INSERT_COLUMNS } from "./account-nominator-positions.ts";
+import {
+  passTallyStatement,
+  type PassTallyInput,
+} from "./pass-completeness.ts";
 
 type Row = Record<string, unknown>;
 
@@ -49,6 +53,17 @@ export interface NominatorPositionsWrite {
 export async function writeNominatorPositionsToD1(
   db: D1Like,
   { rows, coldkeyMaxCapturedAt }: NominatorPositionsWrite,
+  /**
+   * The producer's declared pass, when it declared one
+   * (metagraphed-infra#346).
+   *
+   * IN THE SAME BATCH as the rows, deliberately, so the tally and the data it
+   * describes commit together. A tally written separately could survive a
+   * failed row write and report a pass complete that never landed -- which is
+   * the exact lie this mechanism exists to prevent, arrived at from the other
+   * direction.
+   */
+  pass?: PassTallyInput | null,
 ): Promise<{ statements: number }> {
   const statements: D1PreparedStatement[] = chunkStatements(
     db,
@@ -68,6 +83,8 @@ export async function writeNominatorPositionsToD1(
     );
   }
 
+  if (pass)
+    statements.push(passTallyStatement(db, "nominator-positions", pass));
   if (statements.length) await batchInSlices(db, statements);
   return { statements: statements.length };
 }

--- a/src/pass-completeness.ts
+++ b/src/pass-completeness.ts
@@ -1,0 +1,185 @@
+// "Did this lane's whole scan arrive?" — one implementation (metagraphed-infra#346).
+//
+// THE QUESTION A ROW COUNT CANNOT ANSWER. `ORDER BY … LIMIT n` over a partial
+// ledger returns the largest values PRESENT, not the largest that EXIST — a
+// well-formed leaderboard quietly missing its #2. Production served exactly
+// that on 2026-08-05: 147,000 `account_balances` rows, every one correct, and
+// the second-largest free balance on the network simply absent. The serving
+// guard was `results.length === 0`, and 147,000 clears it.
+//
+// Completeness is not observable in the ledger. 147,000 well-formed rows look
+// exactly like 364,000 of them, only fewer. So the producer declares its pass
+// size up front — it can, because these lanes buffer the whole walk before
+// posting anything — and a `*_passes` table tallies what actually landed.
+//
+// WHY THIS IS PARAMETERIZED, when `account-balances-completeness.ts` and
+// `hotkey-alpha-completeness.ts` are not. Those two came first, one per lane,
+// and were right to: there were two. Adding a third and fourth copy of the same
+// sixty lines is where that stops being right. Both existing modules gate
+// published leaderboards today, so folding them onto this belongs in its own
+// diff rather than riding along with the lanes that had no gate at all — but
+// they should move, and the shapes are identical on purpose so that it is a
+// mechanical change when someone does.
+
+interface D1Like {
+  prepare(sql: string): {
+    first(): Promise<unknown>;
+  };
+}
+
+export interface PassCompleteness {
+  /** captured_at of the newest pass that fully landed, or null if none has. */
+  capturedAt: number | null;
+  /** What that pass declared it would deliver. Null when capturedAt is null. */
+  expectedRows: number | null;
+  /** What actually landed under that stamp. */
+  receivedRows: number | null;
+  /** Why a caller may not read yet, or null when it may. */
+  reason: "no_complete_pass" | "unavailable" | null;
+}
+
+const NONE: PassCompleteness = {
+  capturedAt: null,
+  expectedRows: null,
+  receivedRows: null,
+  reason: "no_complete_pass",
+};
+
+/**
+ * The pass tables this reader will query.
+ *
+ * AN ALLOWLIST, because the table name is interpolated into SQL. D1 has no
+ * placeholder for an identifier, so the only safe formulation is one that
+ * cannot take an arbitrary string — a caller passing a lane name that is not
+ * here gets a decline, not a query.
+ */
+export const PASS_TABLES: Readonly<Record<string, string>> = {
+  "nominator-positions": "nominator_positions_passes",
+  "validator-nominator-counts": "validator_nominator_counts_passes",
+};
+
+/**
+ * The newest COMPLETE pass for a lane, or a decline.
+ *
+ * Keys on `completed_at IS NOT NULL` rather than on arithmetic over the counts.
+ * The transport is at-least-once — a retried chunk adds its rows again — so
+ * `received_rows` can legitimately exceed `expected_rows`, and an equality
+ * check would call a finished pass unfinished. The stamp is set once by
+ * whichever write closed the gap and is never cleared.
+ *
+ * DECLINES rather than throwing on a missing binding, an unknown lane, or a
+ * failed query. A table that does not exist yet lands in the same place, which
+ * matters here because D1 migrations in this repo are applied by hand: the
+ * window between deploying this code and applying `0029` must read as "do not
+ * rank", not as a 500.
+ */
+export async function latestCompletePass(
+  db: D1Like | null | undefined,
+  lane: string,
+): Promise<PassCompleteness> {
+  const table = PASS_TABLES[lane];
+  if (!table || !db?.prepare) return { ...NONE, reason: "unavailable" };
+  try {
+    const row = (await db
+      .prepare(
+        `SELECT captured_at, expected_rows, received_rows
+           FROM ${table}
+          WHERE completed_at IS NOT NULL
+          ORDER BY completed_at DESC
+          LIMIT 1`,
+      )
+      .first()) as {
+      captured_at?: unknown;
+      expected_rows?: unknown;
+      received_rows?: unknown;
+    } | null;
+    const capturedAt = Number(row?.captured_at);
+    if (!row || !Number.isFinite(capturedAt) || capturedAt <= 0) return NONE;
+    return {
+      capturedAt,
+      expectedRows: Number(row.expected_rows) || null,
+      receivedRows: Number(row.received_rows) || null,
+      reason: null,
+    };
+  } catch {
+    return { ...NONE, reason: "unavailable" };
+  }
+}
+
+/**
+ * The predicate a reader should gate on.
+ *
+ * Deliberately NOT "are there rows" — that is the check this whole mechanism
+ * exists to replace. A caller that reads must additionally scope its query to
+ * `capturedAt`, or it mixes the complete pass with whatever partial one landed
+ * after it.
+ */
+export function mayReadPass(
+  completeness: PassCompleteness,
+): completeness is PassCompleteness & { capturedAt: number } {
+  return completeness.reason === null && completeness.capturedAt !== null;
+}
+
+/** One chunk's contribution to a pass tally, as the producer declared it. */
+export interface PassTallyInput {
+  capturedAt: number;
+  expectedRows: number;
+  receivedRows: number;
+  nowMs: number;
+}
+
+/**
+ * The upsert that accumulates a pass, for a lane's own table.
+ *
+ * `completed_at` is COALESCEd rather than recomputed, so the first write that
+ * closes the gap owns the stamp and a later retry cannot move it. The
+ * comparison is `>=`, never `=`, precisely so an at-least-once producer cannot
+ * leave a complete pass looking unfinished.
+ *
+ * THROWS for a lane with no table, rather than returning null. A writer calls
+ * this with its OWN hardcoded lane name, so an unknown one is a programming
+ * error and not a runtime condition — the same posture `packSyncBatchMessages`
+ * takes for a pruning lane with no declared key. Returning null instead would
+ * put a permanently-false branch in every caller, which is how a file starts
+ * collecting coverage pragmas instead of reasons.
+ */
+export function passTallyStatement<S>(
+  db: { prepare(sql: string): { bind(...values: unknown[]): S } },
+  lane: string,
+  pass: PassTallyInput,
+): S {
+  const table = PASS_TABLES[lane];
+  if (!table) {
+    throw new Error(
+      `pass-completeness: no pass table for lane ${lane}; add it to PASS_TABLES ` +
+        `and ship the migration, or the tally has nowhere to land`,
+    );
+  }
+  return db
+    .prepare(
+      `INSERT INTO ${table}
+         (captured_at, expected_rows, received_rows, completed_at)
+       VALUES (?, ?, ?, CASE WHEN ? >= ? THEN ? ELSE NULL END)
+       ON CONFLICT (captured_at) DO UPDATE SET
+         expected_rows = excluded.expected_rows,
+         received_rows = ${table}.received_rows + excluded.received_rows,
+         completed_at = COALESCE(
+           ${table}.completed_at,
+           CASE
+             WHEN ${table}.received_rows + excluded.received_rows
+                  >= excluded.expected_rows
+             THEN ?
+             ELSE NULL
+           END
+         )`,
+    )
+    .bind(
+      pass.capturedAt,
+      pass.expectedRows,
+      pass.receivedRows,
+      pass.receivedRows,
+      pass.expectedRows,
+      pass.nowMs,
+      pass.nowMs,
+    );
+}

--- a/src/validator-nominator-counts-d1-write.ts
+++ b/src/validator-nominator-counts-d1-write.ts
@@ -28,6 +28,10 @@ import {
   type D1PreparedStatement,
 } from "./neurons-d1-write.ts";
 import { VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS } from "./validator-nominator-summary.ts";
+import {
+  passTallyStatement,
+  type PassTallyInput,
+} from "./pass-completeness.ts";
 
 type Row = Record<string, unknown>;
 
@@ -42,6 +46,9 @@ type Row = Record<string, unknown>;
 export async function writeValidatorNominatorCountsToD1(
   db: D1Like,
   rows: Row[],
+  /** The producer's declared pass, batched with the rows so the tally and the
+   * data it describes commit together (metagraphed-infra#346). */
+  pass?: PassTallyInput | null,
 ): Promise<{ statements: number }> {
   const statements: D1PreparedStatement[] = chunkStatements(
     db,
@@ -50,6 +57,8 @@ export async function writeValidatorNominatorCountsToD1(
     ["hotkey"],
     rows,
   );
+  if (pass)
+    statements.push(passTallyStatement(db, "validator-nominator-counts", pass));
   if (statements.length) await batchInSlices(db, statements);
   return { statements: statements.length };
 }

--- a/tests/data-api-nominator-positions-d1.test.ts
+++ b/tests/data-api-nominator-positions-d1.test.ts
@@ -19,16 +19,25 @@ import type { Row } from "./row-type.ts";
 
 const { default: worker } = await import("../workers/data-api.ts");
 
-const SCHEMA = fs.readFileSync(
-  path.join(process.cwd(), "migrations/d1/0011_nominator_positions.sql"),
-  "utf8",
-);
+const SCHEMA =
+  fs.readFileSync(
+    path.join(process.cwd(), "migrations/d1/0011_nominator_positions.sql"),
+    "utf8",
+  ) +
+  fs.readFileSync(
+    path.join(
+      process.cwd(),
+      "migrations/d1/0029_nominator_positions_passes.sql",
+    ),
+    "utf8",
+  );
 
 const PATH = "/api/v1/internal/nominator-positions-sync";
 const SECRET = "test-nominator-positions-sync-secret";
 const COLDKEY_A = "5Df7xwEPkZm4itD3PfSzHsV9extvnQpTFBiNCSgBCJtxEP9e";
 const COLDKEY_B = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 const HOTKEY = "5FyVinYphF6JS5FZHzhMQffxtgbz1WxwUEBAxTRo9nABwb5g";
+const HOTKEY_B = "5CXRfP2ekFhYQ6BCwEy5V8YyxgLmUmTNzHZTKAfTHKhKPBqE";
 
 let db: InstanceType<typeof DatabaseSync>;
 
@@ -105,6 +114,11 @@ const rows = () =>
     .prepare("SELECT * FROM nominator_positions ORDER BY coldkey, netuid")
     .all() as Row[];
 
+const passes = () =>
+  db
+    .prepare("SELECT * FROM nominator_positions_passes ORDER BY captured_at")
+    .all() as Row[];
+
 beforeEach(() => {
   db = new DatabaseSync(":memory:");
   db.exec(SCHEMA);
@@ -126,6 +140,7 @@ describe("POST /api/v1/internal/nominator-positions-sync", () => {
       coldkeys_pruned: 2,
       stores: ["d1"],
       d1_statements: 3,
+      pass_total: null,
     });
     assert.equal(rows().length, 3);
     assert.equal(rows()[0]!.share_fraction, 0.5);
@@ -303,6 +318,103 @@ describe("POST /api/v1/internal/nominator-positions-sync", () => {
   });
 });
 
+describe("pass completeness (metagraphed-infra#346)", () => {
+  test("a declared pass is tallied, and completes when the rows all land", async () => {
+    // THE GAP THIS CLOSES. This ledger feeds /accounts/{ss58}/positions,
+    // /subnets/{netuid}/holders, /chain/holders and delegated_tao on the
+    // top-holders leaderboard. Those already decline while hotkey_alpha has no
+    // complete pass, because a partial POOL ledger underprices a holder -- but
+    // a partial POSITION ledger silently DROPS them, and nothing measured it.
+    const first = await post({ pass_total: 2, rows: [positionRow()] });
+    assert.equal(first.status, 200);
+    assert.equal(((await first.json()) as Row).pass_total, 2);
+    let pass = passes()[0]!;
+    assert.equal(pass.expected_rows, 2);
+    assert.equal(pass.received_rows, 1);
+    assert.equal(pass.completed_at, null, "one of two is not a complete pass");
+
+    const second = await post({
+      pass_total: 2,
+      rows: [positionRow({ hotkey: HOTKEY_B })],
+    });
+    assert.equal(second.status, 200);
+    pass = passes()[0]!;
+    assert.equal(pass.received_rows, 2);
+    assert.ok(pass.completed_at, "the request that closed the gap stamps it");
+  });
+
+  test("a replay cannot un-complete a finished pass", async () => {
+    // At-least-once: the producer re-sends a chunk on failure, so received_rows
+    // can exceed expected_rows. An equality check would call that finished pass
+    // unfinished; the stamp is set once and never cleared.
+    await post({ pass_total: 1, rows: [positionRow()] });
+    const stampedAt = passes()[0]!.completed_at;
+    assert.ok(stampedAt);
+    await post({ pass_total: 1, rows: [positionRow()] });
+    const after = passes()[0]!;
+    assert.equal(after.received_rows, 2, "over-delivered, which is legal");
+    assert.equal(after.completed_at, stampedAt, "and the stamp did not move");
+  });
+
+  test("the queue path carries the declaration too", async () => {
+    // The path this lane actually takes. A queue knows a message was
+    // DELIVERED; it does not know whether the producer's whole scan arrived,
+    // and only the second fact catches a load that stopped halfway.
+    const sent: Row[] = [];
+    const res = await post(
+      { pass_total: 7, rows: [positionRow()] },
+      SECRET,
+      env({
+        SYNC_BATCHES: { send: async (m: Row) => void sent.push(m) },
+        SYNC_QUEUE_LANES: "nominator-positions",
+      }),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(((await res.json()) as Row).pass_total, 7);
+    assert.equal(sent[0]!.pass_total, 7);
+    assert.equal(rows().length, 0, "enqueued, not written -- never both");
+    assert.equal(
+      passes().length,
+      0,
+      "and the tally is the consumer's to write",
+    );
+  });
+
+  test("omitting pass_total writes no tally at all", async () => {
+    // A producer may post without declaring, and inventing a total would mark
+    // an unproven load complete -- the precise lie the tally exists to prevent.
+    const res = await post({ rows: [positionRow()] });
+    assert.equal(res.status, 200);
+    assert.equal(((await res.json()) as Row).pass_total, null);
+    assert.equal(passes().length, 0);
+  });
+
+  test("rejects a declaration the request contradicts", async () => {
+    // Two stamps in one request would credit rows to whichever one the code
+    // happened to pick, and a reader would trust a total never delivered under
+    // that key.
+    const twoStamps = await post({
+      pass_total: 5,
+      rows: [positionRow(), positionRow({ captured_at: 1_780_000_000_001 })],
+    });
+    assert.equal(twoStamps.status, 400);
+    // And a total under this request's own row count is incoherent.
+    const tooSmall = await post({
+      pass_total: 1,
+      rows: [positionRow(), positionRow({ hotkey: HOTKEY_B })],
+    });
+    assert.equal(tooSmall.status, 400);
+    assert.equal(passes().length, 0, "neither wrote a tally");
+  });
+
+  test("rejects an absurd, negative or fractional pass_total", async () => {
+    for (const bad of [0, -1, 1.5, "many"]) {
+      const res = await post({ pass_total: bad, rows: [positionRow()] });
+      assert.equal(res.status, 400, String(bad));
+    }
+  });
+});
+
 describe("routed to the sync queue (metagraphed-infra#355)", () => {
   function queueEnv(send: (m: unknown) => Promise<void>) {
     return env({
@@ -328,6 +440,8 @@ describe("routed to the sync queue (metagraphed-infra#355)", () => {
       ok: true,
       nominator_positions_written: 2,
       stores: ["queue"],
+
+      pass_total: null,
     });
     assert.equal(sent.length, 1);
     assert.equal(rows().length, 0, "D1 must not also have been written");

--- a/tests/data-api-sync-queue-consumer.test.ts
+++ b/tests/data-api-sync-queue-consumer.test.ts
@@ -31,6 +31,20 @@ const SCHEMA =
   fs.readFileSync(
     path.join(process.cwd(), "migrations/d1/0010_chain_detail.sql"),
     "utf8",
+  ) +
+  fs.readFileSync(
+    path.join(
+      process.cwd(),
+      "migrations/d1/0012_validator_nominator_counts.sql",
+    ),
+    "utf8",
+  ) +
+  fs.readFileSync(
+    path.join(
+      process.cwd(),
+      "migrations/d1/0029_nominator_positions_passes.sql",
+    ),
+    "utf8",
   );
 
 const COLDKEY = "5CXRfP2ekFhYQ6BCwEy5V8YyxgLmUmTNzHZTKAfTHKhKPBqE";
@@ -272,6 +286,28 @@ describe("the sync queue consumer", () => {
     const m = message(new Uint8Array([0x1f, 0x8b, 0x00, 0x01]).buffer);
     await consume([m]);
     assert.deepEqual(m.calls, ["ack"]);
+  });
+
+  test("credits a declared pass on the nominator lanes too (metagraphed#9783)", async () => {
+    // Both lanes are routed and neither had a tally until #9783. The queue path
+    // is the one they actually take, so the declaration has to survive it --
+    // a queue knows a message arrived, not whether the whole scan did.
+    const m = message({
+      lane: "validator-nominator-counts",
+      captured_at: 1_780_000_000_000,
+      pass_total: 2,
+      rows: [
+        { hotkey: HOTKEY, nominator_count: 3, captured_at: 1_780_000_000_000 },
+      ],
+    });
+    await consume([m]);
+    assert.deepEqual(m.calls, ["ack"]);
+    const pass = db
+      .prepare("SELECT * FROM validator_nominator_counts_passes")
+      .all()[0] as Record<string, unknown>;
+    assert.equal(pass.expected_rows, 2);
+    assert.equal(pass.received_rows, 1);
+    assert.equal(pass.completed_at, null, "one of two is not a complete pass");
   });
 
   test("a dead-letter batch is acked and NOT written (metagraphed-infra#363)", async () => {

--- a/tests/data-api-validator-nominator-counts-d1.test.ts
+++ b/tests/data-api-validator-nominator-counts-d1.test.ts
@@ -22,10 +22,28 @@ import type { Row } from "./row-type.ts";
 const { default: worker } = await import("../workers/data-api.ts");
 const { QUEUE_MESSAGE_MAX_BYTES } = await import("../src/sync-batch-queue.ts");
 
-const SCHEMA = fs.readFileSync(
-  path.join(process.cwd(), "migrations/d1/0012_validator_nominator_counts.sql"),
-  "utf8",
-);
+const SCHEMA =
+  fs.readFileSync(
+    path.join(
+      process.cwd(),
+      "migrations/d1/0012_validator_nominator_counts.sql",
+    ),
+    "utf8",
+  ) +
+  fs.readFileSync(
+    path.join(
+      process.cwd(),
+      "migrations/d1/0029_nominator_positions_passes.sql",
+    ),
+    "utf8",
+  );
+
+const passes = () =>
+  db
+    .prepare(
+      "SELECT * FROM validator_nominator_counts_passes ORDER BY captured_at",
+    )
+    .all() as Row[];
 
 const PATH = "/api/v1/internal/validator-nominator-counts-sync";
 const SECRET = "test-validator-nominator-counts-sync-secret";
@@ -122,6 +140,8 @@ describe("POST /api/v1/internal/validator-nominator-counts-sync", () => {
       nominator_counts_written: 2,
       stores: ["d1"],
       d1_statements: 1,
+
+      pass_total: null,
     });
     assert.equal(rows().length, 2);
     // A zero IS stored -- the producer's scan is exhaustive, so "this hotkey
@@ -300,5 +320,84 @@ describe("routed to the sync queue (metagraphed-infra#355)", () => {
     );
     assert.equal(response.status, 502);
     assert.equal(rows().length, 0);
+  });
+});
+
+describe("pass completeness (metagraphed#9783)", () => {
+  test("a declared pass is tallied and completes when the rows land", async () => {
+    // A count cannot prove completeness: 100,000 well-formed rows look exactly
+    // like 222,000 of them, only fewer. A short pass here under-reports how
+    // many delegators a validator has, which reads as a validator losing
+    // support rather than as a load that did not finish.
+    const first = await post({ pass_total: 2, rows: [countRow()] });
+    assert.equal(first.status, 200);
+    assert.equal(((await first.json()) as Row).pass_total, 2);
+    assert.equal(passes()[0]!.received_rows, 1);
+    assert.equal(passes()[0]!.completed_at, null);
+
+    await post({ pass_total: 2, rows: [countRow({ hotkey: HOTKEY_B })] });
+    assert.equal(passes()[0]!.received_rows, 2);
+    assert.ok(
+      passes()[0]!.completed_at,
+      "the write that closed the gap stamps it",
+    );
+  });
+
+  test("the queue path carries the declaration too", async () => {
+    // A queue knows a message was DELIVERED; it does not know whether the whole
+    // scan arrived. The declaration has to survive the transport or the tally
+    // means nothing on the path the lane actually takes.
+    const sent: Row[] = [];
+    const res = await post(
+      { pass_total: 9, rows: [countRow()] },
+      SECRET,
+      env({
+        SYNC_BATCHES: { send: async (m: Row) => void sent.push(m) },
+        SYNC_QUEUE_LANES: "validator-nominator-counts",
+      }),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(((await res.json()) as Row).pass_total, 9);
+    assert.equal(sent[0]!.pass_total, 9);
+    assert.equal(rows().length, 0, "enqueued, not written -- never both");
+  });
+
+  test("omitting pass_total writes no tally", async () => {
+    await post({ rows: [countRow()] });
+    assert.equal(passes().length, 0);
+  });
+
+  test("rejects a declaration the request contradicts", async () => {
+    assert.equal(
+      (
+        await post({
+          pass_total: 5,
+          rows: [
+            countRow(),
+            countRow({ hotkey: HOTKEY_B, captured_at: 1_780_000_000_001 }),
+          ],
+        })
+      ).status,
+      400,
+      "two captured_at stamps under one declaration",
+    );
+    assert.equal(
+      (
+        await post({
+          pass_total: 1,
+          rows: [countRow(), countRow({ hotkey: HOTKEY_B })],
+        })
+      ).status,
+      400,
+      "a total smaller than this request's own rows",
+    );
+    for (const bad of [0, -3, 2.5, "lots"]) {
+      assert.equal(
+        (await post({ pass_total: bad, rows: [countRow()] })).status,
+        400,
+        String(bad),
+      );
+    }
+    assert.equal(passes().length, 0, "none of them wrote a tally");
   });
 });

--- a/tests/pass-completeness.test.ts
+++ b/tests/pass-completeness.test.ts
@@ -1,0 +1,202 @@
+// The shared pass-completeness reader and tally (metagraphed-infra#346).
+//
+// The property worth testing is not the SQL. It is the two rules that make a
+// tally usable at all, both of which are easy to get subtly wrong:
+//
+//   * a pass is complete when `completed_at` is SET, never when the counts are
+//     equal -- the transport is at-least-once, so a retried chunk adds its rows
+//     again and `received_rows` can legitimately exceed `expected_rows`
+//   * an unreadable table means "do not rank", never a throw -- these
+//     migrations are applied by hand, so the window between deploying the code
+//     and applying 0029 must degrade, not 500
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  latestCompletePass,
+  mayReadPass,
+  PASS_TABLES,
+  passTallyStatement,
+} from "../src/pass-completeness.ts";
+
+const db = (row: unknown, sqlSink?: string[]) => ({
+  prepare(sql: string) {
+    sqlSink?.push(sql);
+    return {
+      async first() {
+        return row;
+      },
+    };
+  },
+});
+
+describe("latestCompletePass", () => {
+  test("reads the newest complete pass for a known lane", async () => {
+    const sql: string[] = [];
+    const out = await latestCompletePass(
+      db(
+        {
+          captured_at: 1_780_000_000_000,
+          expected_rows: 222_381,
+          received_rows: 222_381,
+        },
+        sql,
+      ),
+      "nominator-positions",
+    );
+    assert.deepEqual(out, {
+      capturedAt: 1_780_000_000_000,
+      expectedRows: 222_381,
+      receivedRows: 222_381,
+      reason: null,
+    });
+    assert.equal(mayReadPass(out), true);
+    // Keys on the STAMP, not on arithmetic over the counts.
+    assert.match(sql[0]!, /completed_at IS NOT NULL/);
+    assert.match(sql[0]!, /FROM nominator_positions_passes/);
+  });
+
+  test("an over-delivered pass is still complete", async () => {
+    // The at-least-once overshoot, which an equality check would call
+    // unfinished forever: a retried chunk adds its rows again, so received can
+    // exceed expected and the stamp is what settles it.
+    const out = await latestCompletePass(
+      db({ captured_at: 1, expected_rows: 100, received_rows: 137 }),
+      "nominator-positions",
+    );
+    assert.equal(mayReadPass(out), true);
+    assert.equal(out.receivedRows, 137);
+  });
+
+  test("no complete pass is a decline, not an empty success", async () => {
+    const out = await latestCompletePass(db(null), "nominator-positions");
+    assert.equal(out.reason, "no_complete_pass");
+    assert.equal(mayReadPass(out), false);
+  });
+
+  test("an unreadable table declines rather than throwing", async () => {
+    // These migrations are applied BY HAND, so between the deploy and the
+    // migration this query hits a table that does not exist. That must read as
+    // "do not rank", exactly like no complete pass -- not as a 500 on a
+    // published leaderboard.
+    const throwing = {
+      prepare() {
+        throw new Error("no such table: nominator_positions_passes");
+      },
+    };
+    const out = await latestCompletePass(throwing, "nominator-positions");
+    assert.equal(out.reason, "unavailable");
+    assert.equal(mayReadPass(out), false);
+  });
+
+  test("an unknown lane declines instead of interpolating into SQL", async () => {
+    // The table name is interpolated, so the allowlist is the injection guard.
+    const sql: string[] = [];
+    const out = await latestCompletePass(
+      db({}, sql),
+      "'; DROP TABLE neurons--",
+    );
+    assert.equal(out.reason, "unavailable");
+    assert.deepEqual(sql, [], "no query was built at all");
+  });
+
+  test("a row with unusable counts still reports the pass", async () => {
+    // expected_rows/received_rows are reported as null rather than 0 when the
+    // column is unreadable, because 0 is a measurement and null is an absence
+    // -- and the gate keys on completed_at, which this row has.
+    const out = await latestCompletePass(
+      db({ captured_at: 5, expected_rows: null, received_rows: 0 }),
+      "nominator-positions",
+    );
+    assert.equal(out.reason, null);
+    assert.equal(out.expectedRows, null);
+    assert.equal(out.receivedRows, null);
+  });
+
+  test("a missing binding declines", async () => {
+    assert.equal(
+      (await latestCompletePass(null, "nominator-positions")).reason,
+      "unavailable",
+    );
+  });
+});
+
+describe("passTallyStatement", () => {
+  const bindOf = (
+    lane: string,
+    pass: Parameters<typeof passTallyStatement>[2],
+  ) => {
+    let sql = "";
+    let values: unknown[] = [];
+    passTallyStatement(
+      {
+        prepare(text: string) {
+          sql = text;
+          return { bind: (...v: unknown[]) => ((values = v), {}) };
+        },
+      },
+      lane,
+      pass,
+    );
+    return { sql, values };
+  };
+
+  test("accumulates rather than overwrites, and stamps once", async () => {
+    const { sql } = bindOf("nominator-positions", {
+      capturedAt: 1,
+      expectedRows: 10,
+      receivedRows: 4,
+      nowMs: 99,
+    });
+    // received_rows ADDS -- a pass is many requests, and the last one must not
+    // erase what the earlier ones delivered.
+    assert.match(
+      sql,
+      /received_rows = nominator_positions_passes\.received_rows \+ excluded\.received_rows/,
+    );
+    // completed_at is COALESCEd -- the first write that closes the gap owns the
+    // stamp, and a later retry cannot move it.
+    assert.match(sql, /completed_at = COALESCE\(/);
+    // >= and never =, so at-least-once cannot leave a complete pass unfinished.
+    assert.match(sql, />= excluded\.expected_rows/);
+  });
+
+  test("binds the values the upsert's CASE arms need", () => {
+    const { values } = bindOf("validator-nominator-counts", {
+      capturedAt: 7,
+      expectedRows: 10,
+      receivedRows: 10,
+      nowMs: 42,
+    });
+    assert.deepEqual(values, [7, 10, 10, 10, 10, 42, 42]);
+  });
+
+  test("THROWS for a lane with no table, rather than silently writing nothing", () => {
+    // A writer calls this with its OWN hardcoded lane, so an unknown one is a
+    // programming error rather than a runtime condition. Returning null would
+    // put a permanently-false branch in every caller -- and worse, a lane added
+    // to a route but not to PASS_TABLES would silently keep no tally, which
+    // looks exactly like the gap this whole mechanism exists to close.
+    assert.throws(
+      () =>
+        passTallyStatement(
+          { prepare: () => ({ bind: () => ({}) }) },
+          "hotkey-alpha",
+          { capturedAt: 1, expectedRows: 1, receivedRows: 1, nowMs: 1 },
+        ),
+      /no pass table for lane hotkey-alpha/,
+    );
+  });
+
+  test("every declared table is one this reader will query", () => {
+    // The two lists are the same object, and this asserts it stays that way --
+    // a table in one and not the other is a tally nothing reads, or a read of
+    // a table nothing writes.
+    for (const [lane, table] of Object.entries(PASS_TABLES)) {
+      assert.match(table, /_passes$/, lane);
+    }
+    assert.deepEqual(Object.keys(PASS_TABLES).sort(), [
+      "nominator-positions",
+      "validator-nominator-counts",
+    ]);
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -433,6 +433,7 @@ import {
   handleDeadLetterBatch,
   isDeadLetterQueue,
 } from "../src/dead-letter.ts";
+import type { PassTallyInput } from "../src/pass-completeness.ts";
 import {
   compressSyncBatchMessage,
   decompressSyncBatchMessage,
@@ -1803,14 +1804,32 @@ async function handleValidatorNominatorCountsSync(
 
   const rows = incoming.map(coerceNominatorCountSyncRow);
 
+  // THE PASS DECLARATION (metagraphed-infra#346). This lane had none, which is
+  // why a short load here was indistinguishable from a validator genuinely
+  // losing delegators: a count cannot prove completeness, and only the producer
+  // knows how big its scan was. Optional, because a producer that has not been
+  // updated must keep working -- and inventing a total would mark an unproven
+  // load complete, which is the lie the tally exists to prevent.
+  const countsDeclared = declaredPassTotal(
+    parsed,
+    VALIDATOR_NOMINATOR_COUNTS_SYNC_MAX_ROWS * 100,
+  );
+  if (countsDeclared.error) {
+    return writeJson({ error: countsDeclared.error }, 400);
+  }
+  const countsTally = passTallyFromRows(rows, countsDeclared.total, Date.now());
+  if (countsTally.error) {
+    return writeJson({ error: countsTally.error }, 400);
+  }
+  const pass = countsTally.pass ?? null;
+
   // Enqueue or write, never both -- see handleHotkeyAlphaSync's own note.
-  // This lane carries no pass declaration, so the queue message carries none
-  // either: inventing one would mark an unproven load complete.
   if (syncLaneUsesQueue(env, "validator-nominator-counts")) {
     try {
       await enqueueSyncBatch(env.SYNC_BATCHES!, {
         lane: "validator-nominator-counts",
-        capturedAt: rows[0]!.captured_at as number,
+        capturedAt: pass?.capturedAt ?? (rows[0]!.captured_at as number),
+        ...(pass ? { passTotal: pass.expectedRows } : {}),
         rows,
       });
     } catch (err) {
@@ -1822,6 +1841,7 @@ async function handleValidatorNominatorCountsSync(
       ok: true,
       nominator_counts_written: rows.length,
       stores: ["queue"],
+      pass_total: pass?.expectedRows ?? null,
     });
   }
 
@@ -1840,6 +1860,7 @@ async function handleValidatorNominatorCountsSync(
         typeof writeValidatorNominatorCountsToD1
       >[0],
       rows,
+      pass,
     ));
   } catch (err) {
     console.error(
@@ -1865,6 +1886,9 @@ async function handleValidatorNominatorCountsSync(
     nominator_counts_written: rows.length,
     stores: ["d1"],
     d1_statements: d1Statements,
+    // Echoed so a producer can see its declaration was understood rather than
+    // silently dropped -- the failure mode a purely optional field invites.
+    pass_total: pass?.expectedRows ?? null,
   });
 }
 
@@ -2000,6 +2024,31 @@ async function handleNominatorPositionsSync(
   const rows = incoming.map(coerceNominatorPositionSyncRow);
   const cutoffs = coldkeyMaxCapturedAt(rows);
 
+  // THE PASS DECLARATION (metagraphed-infra#346), and this is the lane where
+  // its absence mattered most. `nominator_positions` feeds
+  // /accounts/{ss58}/positions, /subnets/{netuid}/holders, /chain/holders, the
+  // positions basis of /validators/{hotkey}/nominators, and `delegated_tao` on
+  // the top-holders leaderboard. Those already DECLINE while `hotkey_alpha`
+  // has no complete pass, because a partial POOL ledger underprices a holder.
+  // A partial POSITION ledger silently DROPS them, which is the same failure
+  // in a worse direction, and nothing measured it.
+  const positionsDeclared = declaredPassTotal(
+    parsed,
+    NOMINATOR_POSITIONS_SYNC_MAX_ROWS * 100,
+  );
+  if (positionsDeclared.error) {
+    return writeJson({ error: positionsDeclared.error }, 400);
+  }
+  const positionsTally = passTallyFromRows(
+    rows,
+    positionsDeclared.total,
+    Date.now(),
+  );
+  if (positionsTally.error) {
+    return writeJson({ error: positionsTally.error }, 400);
+  }
+  const pass = positionsTally.pass ?? null;
+
   // Enqueue or write, never both -- see handleHotkeyAlphaSync's own note.
   //
   // `key_complete` is not ceremony. The write below PRUNES: it deletes rows
@@ -2021,7 +2070,8 @@ async function handleNominatorPositionsSync(
       // how a claim outlives the property it describes.
       await enqueueSyncBatch(env.SYNC_BATCHES!, {
         lane: "nominator-positions",
-        capturedAt: rows[0]!.captured_at as number,
+        capturedAt: pass?.capturedAt ?? (rows[0]!.captured_at as number),
+        ...(pass ? { passTotal: pass.expectedRows } : {}),
         rows,
       });
     } catch (err) {
@@ -2033,6 +2083,7 @@ async function handleNominatorPositionsSync(
       ok: true,
       nominator_positions_written: rows.length,
       stores: ["queue"],
+      pass_total: pass?.expectedRows ?? null,
     });
   }
 
@@ -2051,6 +2102,7 @@ async function handleNominatorPositionsSync(
         typeof writeNominatorPositionsToD1
       >[0],
       { rows, coldkeyMaxCapturedAt: cutoffs },
+      pass,
     ));
   } catch (err) {
     console.error("data-api nominator-positions-sync D1 write failed:", err);
@@ -2073,6 +2125,9 @@ async function handleNominatorPositionsSync(
     coldkeys_pruned: cutoffs.size,
     stores: ["d1"],
     d1_statements: d1Statements,
+    // Echoed so a producer can see its declaration was understood rather than
+    // silently dropped -- the failure mode a purely optional field invites.
+    pass_total: pass?.expectedRows ?? null,
   });
 }
 
@@ -2141,6 +2196,74 @@ function coerceAccountBalanceSyncRow(row: Row) {
   const out: Row = {};
   for (const col of ACCOUNT_BALANCE_INSERT_COLUMNS) out[col] = row[col];
   return out;
+}
+
+/**
+ * Parse and validate a producer's declared pass size (metagraphed-infra#346).
+ *
+ * ONE IMPLEMENTATION for the lanes that gained a tally, rather than the
+ * account-balances route's inline copy repeated twice more. `undefined` means
+ * "not declared", which is legal — a producer may post without declaring, and
+ * INVENTING a total would mark an unproven load complete, which is the precise
+ * lie the tally exists to prevent.
+ *
+ * Returns an error string rather than a Response so the caller keeps its own
+ * status codes and message shape.
+ */
+function declaredPassTotal(
+  parsed: unknown,
+  maxTotal: number,
+): { total?: number; error?: string } {
+  const total = Array.isArray(parsed)
+    ? undefined
+    : (parsed as { pass_total?: unknown } | null)?.pass_total;
+  if (total === undefined) return {};
+  if (
+    !Number.isInteger(total) ||
+    (total as number) <= 0 ||
+    (total as number) > maxTotal
+  ) {
+    return {
+      error: `pass_total must be a positive integer no greater than ${maxTotal}`,
+    };
+  }
+  return { total: total as number };
+}
+
+/**
+ * Turn a declaration plus this request's rows into a tally, or refuse.
+ *
+ * REQUIRES EXACTLY ONE captured_at, which is what makes the tally meaningful:
+ * two stamps in one request would credit rows to whichever one this code
+ * happened to pick, and a reader would trust a total that was never delivered
+ * under that key. Same rule handleAccountBalancesSync applies to its own lane.
+ */
+function passTallyFromRows(
+  rows: Row[],
+  declaredTotal: number | undefined,
+  nowMs: number,
+): { pass?: PassTallyInput; error?: string } {
+  if (declaredTotal === undefined) return {};
+  const stamps = new Set<number>(rows.map((row) => row.captured_at as number));
+  if (stamps.size !== 1) {
+    return {
+      error:
+        "a request declaring pass_total must carry exactly one captured_at",
+    };
+  }
+  if (declaredTotal < rows.length) {
+    return {
+      error: "pass_total cannot be smaller than this request's row count",
+    };
+  }
+  return {
+    pass: {
+      capturedAt: [...stamps][0]!,
+      expectedRows: declaredTotal,
+      receivedRows: rows.length,
+      nowMs,
+    },
+  };
 }
 
 async function handleAccountBalancesSync(
@@ -7509,13 +7632,18 @@ export default {
           // only because the message asserted `key_complete` -- the
           // validator rejects it otherwise, so this writer never sees a chunk
           // that could prune rows it did not carry.
-          "nominator-positions": async (rows) => {
+          "nominator-positions": async (rows, pass) => {
             const cutoffs = coldkeyMaxCapturedAt(rows);
             const result = await writeNominatorPositionsToD1(
               env.METAGRAPH_HEALTH_DB as unknown as Parameters<
                 typeof writeNominatorPositionsToD1
               >[0],
               { rows, coldkeyMaxCapturedAt: cutoffs },
+              // The declared pass rides the transport (metagraphed-infra#346).
+              // A queue knows a message was DELIVERED; it does not know whether
+              // the producer's whole scan arrived, and only the second fact
+              // catches a load that stopped halfway.
+              pass,
             );
             // THE LANE'S OTHER WRITER. Mirrored here as well as on the HTTP
             // path: a mirror that covers one of two writers is a lie the
@@ -7555,12 +7683,13 @@ export default {
               >[0],
               neuronSnapshotWrite(rows, Date.now()),
             ),
-          "validator-nominator-counts": async (rows) => {
+          "validator-nominator-counts": async (rows, pass) => {
             const result = await writeValidatorNominatorCountsToD1(
               env.METAGRAPH_HEALTH_DB as unknown as Parameters<
                 typeof writeValidatorNominatorCountsToD1
               >[0],
               rows,
+              pass,
             );
             // THE LANE'S OTHER WRITER, mirrored here as well as on the
             // HTTP path.


### PR DESCRIPTION
Closes #9783. Producer counterpart: JSONbored/metagraphed-infra#390.

`validator-nominator-counts` and `nominator-positions` are both routed through `sync-batches` and **neither had a `*_passes` table**. No declaration, no tally, and nothing able to tell a short load from a small one.

Not a regression — they moved onto the queue with the gap they already had on HTTP. But being routed alongside two lanes that *do* have the gate made it look like they did, and metagraphed-infra#346's own rule is *"do not delete a gate because a queue probably covers it."*

## Why `nominator_positions` is the one that matters

It feeds `/accounts/{ss58}/positions`, `/subnets/{netuid}/holders`, `/chain/holders`, the positions basis of `/validators/{hotkey}/nominators`, and **`delegated_tao` on the top-holders leaderboard**.

All of those **already decline** while `hotkey_alpha` has no complete pass — `pool_totals_unproven` — on the reasoning that a partial *pool* ledger silently **underprices** a holder. A partial *position* ledger silently **drops** them: the same failure in a worse direction, with nothing measuring it.

That is the exact shape of the incident that produced this mechanism: 147,000 `account_balances` rows, every one correct, and the network's second-largest free balance simply absent. The serving guard was `results.length === 0`, and 147,000 clears it.

## One reader, not a third and fourth copy

`account-balances-completeness.ts` and `hotkey-alpha-completeness.ts` were right to be per-lane when there were two. A third and fourth copy of the same sixty lines is where that stops being right, so this is parameterized.

The two existing modules are **deliberately left alone** — they gate published leaderboards today, and folding them on belongs in its own diff rather than riding along with the lanes that had no gate at all. The shapes are identical on purpose so that stays mechanical.

## Three decisions worth calling out

**The lane list is the injection guard.** D1 has no placeholder for an identifier, so the table name is interpolated — an unknown lane declines *without building a query at all*, and there is a test that passes `'; DROP TABLE neurons--` as a lane name.

**An unreadable table declines, it does not throw.** These migrations are applied **by hand**, so between deploying this and applying `0029` the query hits a table that does not exist. That must read as "do not rank", exactly like no complete pass — not as a 500 on a published leaderboard.

**`passTallyStatement` throws for an unknown lane** rather than returning null. A writer calls it with its own hardcoded lane, so an unknown one is a programming error — and returning null would put a permanently-false branch in every caller, plus let a lane added to a route but not to `PASS_TABLES` silently keep no tally, which looks exactly like the gap being closed here.

## Sequencing

Declare first, gate second — the order `account_balances` followed (declare in #322, gate in #324). **Gating the readers is deliberately not in this PR**: it should land once a real pass has been observed landing complete, not on the strength of the code being merged.

The tally is batched **with the rows it describes**, so a tally cannot survive a failed row write and report a pass complete that never landed.

## Validation

```
npm run typecheck    # clean
npm run lint         # clean
npx prettier --check # clean
npx vitest run tests/pass-completeness.test.ts tests/data-api-nominator-positions-d1.test.ts \
  tests/data-api-validator-nominator-counts-d1.test.ts tests/data-api-sync-queue-consumer.test.ts
# 63 passed
```

Patch coverage across all four changed files: **0 uncovered statements, branches, or functions**.

## Migration

`migrations/d1/0029_nominator_positions_passes.sql` is applied by hand, as every migration here is. Until it is, both routes still accept `pass_total` and the write simply fails the tally statement — so **apply it before the producer starts declaring** (metagraphed-infra#390).

## Template Used

- Backend/code change
