### PR TITLE
fix(neon): pull neuron_daily out of the read flag, it empties two routes

### DIFF
--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -163,7 +163,22 @@
     // mirrors have never fired (12h/30h/48h producers), which #9772's watchdog
     // reports as never-mirrored-not-alarmed. Naming one would move a read onto
     // a store with no proven writer -- #9704 exactly.
-    "NEON_READ_LANES": "account_position_daily,neurons,neuron_daily",
+    // neuron_daily PULLED 2026-08-07 after #9784: two routes returned ZERO
+    // rows from Neon. The runners are interface-compatible; the SQL DIALECT is
+    // not. /api/v1/subnets/movers and /api/v1/subnets/{netuid}/history both
+    // anchor their window with SQLite's `date(MAX(snapshot_date), '-30 days')`,
+    // which Postgres has no equivalent for -- so the subquery yields nothing
+    // and the >= matches nothing. Measured against a pre-cutover baseline:
+    // movers 5 rows -> 0, subnet history 28 -> 0.
+    //
+    // `neurons` and `account_position_daily` stay: every route on them returned
+    // the same row counts, and the only differences were values that move with
+    // the 15-minute producer.
+    //
+    // Re-adding neuron_daily needs those two queries ported to portable SQL
+    // (an explicit date literal computed in TS, not in the database) -- see
+    // #9789.
+    "NEON_READ_LANES": "account_position_daily,neurons",
     // The two ACCUMULATING tables, and only those (src/neon-backfill.ts).
     //
     // The mirror above writes what each request carries, which finishes the job


### PR DESCRIPTION
Closes #9791

**Rollback.** #9784 moved the `neuron_daily` analytics routes onto Neon; two of them return **zero rows**.

Measured against a baseline captured before the cutover:

| route | before (D1) | after (Neon) |
|---|---:|---:|
| `/api/v1/subnets/1/history` | 28 rows | **0** |
| `/api/v1/subnets/movers?window=30d` | 5 rows | **0** |

## Cause

```sql
WHERE snapshot_date >= (SELECT date(MAX(snapshot_date), '-30 days') FROM neuron_daily)
```

`date(x, '-30 days')` is SQLite. Postgres has no equivalent — the subquery yields nothing, `>=` matches nothing, and the route returns a schema-stable empty result. A 200 with no rows, which is precisely the shape that does not read as a failure.

## The assumption that was wrong

The runners are interface-compatible, and the code says the store moves "by choosing a runner, not by rewriting a query". That is true of the **binding** and false of the **SQL**. `toPositionalPlaceholders` handles `?` → `$n`; nothing handles SQLite's function library.

## What stays

`neurons` and `account_position_daily` remain on Neon. Every route on them returned identical row counts; the only differences were values that move with the 15-minute producer (e.g. `/chain/idle-stake` 129 rows both sides, `/validators` 5 both sides).

## Follow-up in #9791

1. Port the two queries to compute their window boundary in TypeScript and bind it — portable by construction.
2. Add a CI scan for SQLite-only constructs (`date()`/`strftime()` with modifiers, `IFNULL`, `GROUP_CONCAT`, `json_extract`, …) across every route `NEON_READ_ROUTE_TABLES` may move. The map already extracts per-route SQL for its table assertion, so the scan is nearly free — and it would have failed #9784 at CI rather than in production.

## What worked

The pre-cutover content baseline caught this within minutes of the deploy, and rollback is one word. Both should be standard for every remaining cutover in #9787.