### PR TITLE
fix(neon): pull neurons out of the read flag too, /validators serves empty

### DIFF
--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -178,7 +178,22 @@
     // Re-adding neuron_daily needs those two queries ported to portable SQL
     // (an explicit date literal computed in TS, not in the database) -- see
     // #9789.
-    "NEON_READ_LANES": "account_position_daily,neurons",
+    // `neurons` PULLED 2026-08-07, immediately after neuron_daily (#9791).
+    // /api/v1/validators returned ZERO from Neon and fell back to an empty
+    // artifact -- 5 rows -> 0, measured across three deploys:
+    //   baseline (pre-cutover)  5 rows
+    //   f07234628 (pre-cutover) 5 rows
+    //   2df376f7e (post)        0 rows
+    //
+    // Same root cause class as #9791: a query that is valid SQLite and not
+    // valid Postgres fails, and this route falls back to an artifact rather
+    // than erroring -- so the failure is invisible from the response alone.
+    //
+    // account_position_daily stays. Its one route was verified against a D1
+    // baseline across four deploys and is unchanged.
+    //
+    // NOTHING goes back into this flag until #9793's dialect scan runs in CI.
+    "NEON_READ_LANES": "account_position_daily",
     // The two ACCUMULATING tables, and only those (src/neon-backfill.ts).
     //
     // The mirror above writes what each request carries, which finishes the job


### PR DESCRIPTION
Refs #9791

**Second rollback.** `/api/v1/validators` returns zero validators from Neon.

| deploy | `/api/v1/validators?limit=5` |
|---|---:|
| baseline (pre-cutover) | 5 rows |
| `f07234628` (pre-cutover) | 5 rows |
| `2df376f7e` (post-#9784) | **0 rows** |

Rolling `neuron_daily` back in #9792 was not enough — `/validators` reads `neurons` alone, which stayed enabled.

## Worse to detect than #9791

When this route's D1/Neon query fails it **falls back to `/metagraph/validators.json`**, and that artifact is itself empty:

```json
{"validator_count": null, "captured_at": null, "block_number": null, "validators": []}
```

So the response is a 200 with a plausible shape, no error, no degraded header. The failure is invisible from the response alone. Only a pre-cutover content baseline showed it — and it took three deploys of comparison to attribute it correctly, because the first post-merge probe ran before #9784 had actually deployed.

## What stays

`account_position_daily` only. Its one route was verified against a D1 baseline across four deploys and is unchanged.

## The rule this establishes

**Nothing goes back into `NEON_READ_LANES` until CI rejects SQLite-only SQL on any route the read map may move.** #9784 shipped a per-route *table* map and no check that the *queries* were portable — the map said which routes may move, nothing said which routes can. That gap cost two rollbacks.

Follow-up work already in progress on #9791: the three `date(MAX(snapshot_date), '-N days')` sites ported to compute their window in TypeScript, plus the dialect scan.