### PR TITLE
fix(neon): make the SQL portable, and gate it, so the cutover holds

### DIFF
--- a/src/chain-turnover.ts
+++ b/src/chain-turnover.ts
@@ -198,7 +198,7 @@ const EMPTY_SET = new Set<string>();
 // Null-safe: no data or an unresolvable boundary yields the schema-stable empty block
 // (comparable:false, empty leaderboard), never throws. `limit` caps the per-subnet leaderboard;
 // the network rollup, subnet_count, and distribution cover every subnet that had a validator set
-// at either boundary (the loader reads only validator_permit=1 rows, so subnets with no
+// at either boundary (the loader reads only validator_permit = TRUE rows, so subnets with no
 // validators in the window are absent) — subnet_count/distribution count all of those, not just
 // the returned page.
 export function buildChainTurnover(
@@ -311,7 +311,7 @@ export function buildChainTurnover(
 // Network-wide validator turnover, computed live: anchor the window to the newest STORED
 // snapshot (date() relative to MAX(snapshot_date)) so a lagging/restored store still compares
 // real boundary snapshots, read every subnet's validator rows at those two days (bounded by
-// validator_permit = 1; the date-first idx_neuron_daily_date_netuid_agg covers the boundary
+// validator_permit = TRUE; the date-first idx_neuron_daily_date_netuid_agg covers the boundary
 // scan), shape with buildChainTurnover. Cold/absent or single-snapshot D1 → comparable:false.
 export async function loadChainTurnover(
   d1: (
@@ -341,7 +341,7 @@ export async function loadChainTurnover(
   let rows: Array<Record<string, unknown>> = [];
   if (startDate != null && endDate != null && startDate !== endDate) {
     rows = await d1(
-      `SELECT ${CHAIN_TURNOVER_READ_COLUMNS} FROM neuron_daily WHERE validator_permit = 1 AND snapshot_date IN (?, ?)`,
+      `SELECT ${CHAIN_TURNOVER_READ_COLUMNS} FROM neuron_daily WHERE validator_permit = TRUE AND snapshot_date IN (?, ?)`,
       [startDate, endDate],
     );
   }

--- a/src/live-economics-refresh.ts
+++ b/src/live-economics-refresh.ts
@@ -273,7 +273,7 @@ export interface NeuronAggregate {
  */
 export const NEURON_AGGREGATE_QUERY =
   "SELECT netuid, COUNT(*) AS uid_count, " +
-  "SUM(CASE WHEN validator_permit = 1 THEN 1 ELSE 0 END) AS validator_count, " +
+  "SUM(CASE WHEN validator_permit THEN 1 ELSE 0 END) AS validator_count, " +
   "SUM(stake_tao) AS total_stake_alpha, MAX(stake_tao) AS max_stake_alpha " +
   "FROM neurons GROUP BY netuid";
 

--- a/src/metagraph-neurons.ts
+++ b/src/metagraph-neurons.ts
@@ -987,7 +987,7 @@ export async function loadSubnetMetagraph(
 ): Promise<Row> {
   const rows = await d1(
     `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ?${
-      validatorsOnly ? " AND validator_permit = 1" : ""
+      validatorsOnly ? " AND validator_permit = TRUE" : ""
     } ORDER BY uid`,
     [netuid],
   );
@@ -1002,7 +1002,7 @@ export async function loadSubnetValidators(
   // across snapshot-replaced captures (without it, SQLite returns tied rows in
   // arbitrary physical order). Mirrors loadSubnetMetagraph's ORDER BY uid.
   const rows = await d1(
-    `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? AND validator_permit = 1 ORDER BY stake_tao DESC, uid ASC`,
+    `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? AND validator_permit = TRUE ORDER BY stake_tao DESC, uid ASC`,
     [netuid],
   );
   return buildSubnetValidators(rows, netuid);
@@ -1054,7 +1054,7 @@ export async function loadGlobalValidators(
     d1(
       "SELECT netuid, uid, hotkey, coldkey, validator_trust, emission_tao, " +
         "stake_tao, block_number, captured_at FROM neurons " +
-        "WHERE validator_permit = 1 AND hotkey IS NOT NULL " +
+        "WHERE validator_permit = TRUE AND hotkey IS NOT NULL " +
         "ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC",
       [],
     ),
@@ -1100,7 +1100,7 @@ export interface BuildValidatorDetailOptions {
   realizedStake?: Row | null;
 }
 
-// Cross-subnet validator detail (#4334/7.1): one hotkey's validator_permit=1
+// Cross-subnet validator detail (#4334/7.1): one hotkey's validator_permit = TRUE
 // rows joined across every subnet it operates in — the single-entity
 // drill-in of the /api/v1/validators leaderboard above. Same aggregate shape
 // as buildGlobalValidatorEntry (rao-precision stake/emission sums, avg/max
@@ -1253,7 +1253,7 @@ export async function loadValidatorDetail(
 ): Promise<Row> {
   const [rows, priceByNetuid, identityByColdkey] = await Promise.all([
     d1(
-      `SELECT ${NEURON_COLUMNS}, netuid FROM neurons WHERE hotkey = ? AND validator_permit = 1 ORDER BY netuid ASC, uid ASC`,
+      `SELECT ${NEURON_COLUMNS}, netuid FROM neurons WHERE hotkey = ? AND validator_permit = TRUE ORDER BY netuid ASC, uid ASC`,
       [hotkey],
     ),
     loadD1AlphaPricesByNetuid(d1),

--- a/src/movers.ts
+++ b/src/movers.ts
@@ -368,7 +368,7 @@ export async function loadSubnetMovers(
   if (startDate != null && endDate != null && startDate !== endDate) {
     const rows = await d1(
       "SELECT netuid, snapshot_date, COUNT(*) AS neuron_count, " +
-        "SUM(validator_permit) AS validator_count, " +
+        "SUM(CASE WHEN validator_permit THEN 1 ELSE 0 END) AS validator_count, " +
         "SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao " +
         "FROM neuron_daily WHERE snapshot_date IN (?, ?) GROUP BY netuid, snapshot_date",
       [startDate, endDate],

--- a/src/portable-date-window.ts
+++ b/src/portable-date-window.ts
@@ -1,0 +1,118 @@
+// Date-window arithmetic done in TypeScript, because SQL dialects disagree
+// about it (#9791).
+//
+// Three `neuron_daily` window queries anchored their floor with SQLite's
+// `date(MAX(snapshot_date), '-30 days')`. When #9784 moved those routes onto
+// Neon the function did not exist, the subquery yielded nothing, `>=` matched
+// nothing, and two public routes returned a schema-stable EMPTY result at
+// 200 OK:
+//
+//     /api/v1/subnets/movers        5 rows -> 0
+//     /api/v1/subnets/{netuid}/history  28 rows -> 0
+//
+// Nothing errored. That is the shape of the failure: a dialect gap does not
+// throw, it silently returns nothing, and an empty list is a valid response.
+//
+// ## Why the boundary belongs in TypeScript, not in either database
+//
+// `createD1Sql` and `createPgSql` are interface-compatible, so a query moves
+// stores by choosing a runner. That is true of the BINDING and false of the
+// SQL: `toPositionalPlaceholders` translates `?` to `$n` and nothing translates
+// SQLite's function library. A boundary computed here and passed as a bound
+// parameter is portable by construction -- it removes the dialect question
+// rather than answering it twice.
+//
+// ## The cost is one extra round trip, and it is worth it
+//
+// The old form nested `MAX()` inside the filter, so one statement did both.
+// The portable form asks for the max first. It cannot be folded back into one
+// statement without re-introducing database-side date arithmetic, and the
+// alternative -- deriving the floor from an unfiltered MIN/MAX pair -- gives
+// the WRONG start date whenever the range has a gap. `neuron_daily` currently
+// has exactly such a gap: 2026-08-06 is missing entirely (#9781).
+
+/** Days in a UTC calendar day. Dates here are 'YYYY-MM-DD' with no time part,
+ * so arithmetic is exact and DST cannot apply. */
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** A 'YYYY-MM-DD' string, the form `snapshot_date` columns hold. */
+const ISO_DAY = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * `date(day, '-N days')`, in TypeScript.
+ *
+ * Matches SQLite's semantics for the one form this replaces: a bare
+ * 'YYYY-MM-DD' and a whole number of days. Returns null for anything that is
+ * not that, so a malformed column value produces "no window" rather than a
+ * silently wrong one -- an unparseable date must not become 1970-01-01, which
+ * would widen the window to everything.
+ */
+export function subtractUtcDays(day: unknown, days: number): string | null {
+  if (typeof day !== "string" || !ISO_DAY.test(day)) return null;
+  if (!Number.isInteger(days) || days < 0) return null;
+  const at = Date.parse(`${day}T00:00:00Z`);
+  if (!Number.isFinite(at)) return null;
+  return new Date(at - days * DAY_MS).toISOString().slice(0, 10);
+}
+
+/** The minimal runner shape these helpers need.
+ *
+ * NOT generic. `createD1Sql` and `createPgSql` both return
+ * `Record<string, unknown>[]`, and a generic `<T>` here would claim this
+ * function can produce any row type the caller names -- which neither runner
+ * can honour, and which TypeScript correctly rejects at the call site. The
+ * concrete shape is read back with a cast at the two places it matters. */
+export interface DayBoundsSql {
+  (
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ): Promise<Record<string, unknown>[]>;
+}
+
+export interface DayBounds {
+  startDate: string | null;
+  endDate: string | null;
+}
+
+/**
+ * The first and last `snapshot_date` inside the trailing `days` window.
+ *
+ * Two statements, deliberately. The first finds the newest day the table
+ * actually holds; the second finds the real bounds at or after
+ * `newest - days`. `startDate` is therefore the smallest date PRESENT in the
+ * window, which is not the same as the window's floor whenever a day is
+ * missing -- and one is (#9781).
+ *
+ * `netuid` scopes both statements when given, so a per-subnet window anchors
+ * on that subnet's own newest day rather than the table's.
+ */
+export async function neuronDailyWindow(
+  sql: DayBoundsSql,
+  days: number,
+  netuid: number | null = null,
+): Promise<DayBounds> {
+  const newest =
+    netuid == null
+      ? await sql`SELECT MAX(snapshot_date) AS mx FROM neuron_daily`
+      : await sql`SELECT MAX(snapshot_date) AS mx FROM neuron_daily WHERE netuid = ${netuid}`;
+  const floor = subtractUtcDays(newest[0]?.mx, days);
+  // No rows, or a value that is not a day: no window. The callers already
+  // treat a null start/end as "not enough history", which is the honest
+  // answer and the same one the old query produced on an empty table.
+  if (floor == null) return { startDate: null, endDate: null };
+
+  const bounds =
+    netuid == null
+      ? await sql`
+          SELECT MIN(snapshot_date) AS start_date, MAX(snapshot_date) AS end_date
+          FROM neuron_daily
+          WHERE snapshot_date >= ${floor}`
+      : await sql`
+          SELECT MIN(snapshot_date) AS start_date, MAX(snapshot_date) AS end_date
+          FROM neuron_daily
+          WHERE netuid = ${netuid} AND snapshot_date >= ${floor}`;
+  return {
+    startDate: (bounds[0]?.start_date ?? null) as string | null,
+    endDate: (bounds[0]?.end_date ?? null) as string | null,
+  };
+}

--- a/tests/chain-turnover.test.ts
+++ b/tests/chain-turnover.test.ts
@@ -10,7 +10,7 @@ import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import type { Row } from "./row-type.ts";
 
-// One neuron_daily validator row (the loader scopes the read to validator_permit = 1).
+// One neuron_daily validator row (the loader scopes the read to validator_permit = TRUE).
 function vrow(
   snapshot_date: string,
   netuid: unknown,
@@ -311,7 +311,7 @@ describe("loadChainTurnover", () => {
     assert.equal(calls[0].params[0], "-30 days");
     assert.match(
       calls[1].sql,
-      /validator_permit = 1 AND snapshot_date IN \(\?, \?\)/,
+      /validator_permit = TRUE AND snapshot_date IN \(\?, \?\)/,
     );
     assert.deepEqual(calls[1].params, [START, END]);
     assert.equal(data.window, "30d");

--- a/tests/metagraph-neurons.test.ts
+++ b/tests/metagraph-neurons.test.ts
@@ -1923,7 +1923,7 @@ describe("metagraph-neurons loaders", () => {
       },
       { sort: "avg_validator_trust", limit: 1 },
     );
-    assert.match(seenSql, /validator_permit = 1 AND hotkey IS NOT NULL/);
+    assert.match(seenSql, /validator_permit = TRUE AND hotkey IS NOT NULL/);
     assert.match(seenSql, /ORDER BY hotkey ASC/);
     assert.deepEqual(seenParams, []);
     assert.equal(data.validators.length, 1);
@@ -1982,7 +1982,7 @@ describe("metagraph-neurons loaders", () => {
         { netuid: 1, uid: 3, hotkey: "hk-a", coldkey: "ck-a", stake_tao: 20 },
       ];
     }, "hk-a");
-    assert.match(seenSql, /hotkey = \? AND validator_permit = 1/);
+    assert.match(seenSql, /hotkey = \? AND validator_permit = TRUE/);
     assert.match(seenSql, /ORDER BY netuid ASC, uid ASC/);
     assert.deepEqual(seenParams, ["hk-a"]);
     assert.equal(data.hotkey, "hk-a");
@@ -2000,7 +2000,7 @@ function neuronsD1(rows: Row[]) {
           return {
             all() {
               let r = rows;
-              if (sql.includes("validator_permit = 1")) {
+              if (sql.includes("validator_permit = TRUE")) {
                 r = r.filter((x: Row) => x.validator_permit === 1);
               }
               if (sql.includes("AND uid = ?")) {

--- a/tests/neon-sql-portability.test.ts
+++ b/tests/neon-sql-portability.test.ts
@@ -1,0 +1,204 @@
+// No route the Neon read map may move is allowed to use SQLite-only SQL
+// (#9791).
+//
+// ## What this exists to have caught
+//
+// #9784 shipped a per-route map of which TABLES each route reads, and moved
+// fifteen routes onto Neon on the strength of it. Nothing checked whether the
+// QUERIES were portable. Three of them anchored a window with
+// `date(MAX(snapshot_date), '-30 days')`, which Postgres does not have.
+//
+// The failure did not throw. The subquery yielded nothing, `>=` matched
+// nothing, and the routes returned schema-stable empty results at 200 OK:
+//
+//     /api/v1/subnets/movers              5 rows -> 0
+//     /api/v1/subnets/{netuid}/history   28 rows -> 0
+//     /api/v1/validators                  5 rows -> 0   (fell back to an
+//                                                        empty artifact, so
+//                                                        even the shape looked
+//                                                        normal)
+//
+// Two rollbacks. `NEON_READ_LANES` is down to one table. This test is the gate
+// that has to exist before anything goes back in.
+//
+// ## Why a deny-list and not a parser
+//
+// A real SQL parser would be more precise and is the wrong trade here: the
+// query text is assembled from template literals with interpolations, so it is
+// not parseable without evaluating it. A deny-list of constructs that are
+// SQLite-only is checkable on the raw text, cheap, and fails in the direction
+// that matters -- a false positive costs a rewrite, a false negative costs a
+// silent empty route.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { NEON_READ_ROUTE_TABLES } from "../workers/data-api.ts";
+
+/**
+ * Constructs that are valid SQLite and NOT valid Postgres.
+ *
+ * Each entry names the Postgres equivalent, because the useful failure message
+ * is the one that says what to write instead.
+ */
+const SQLITE_ONLY: readonly {
+  pattern: RegExp;
+  what: string;
+  instead: string;
+}[] = [
+  {
+    pattern: /\bdate\s*\([^;]*?,\s*[`'"][-+]?\d/i,
+    what: "date(x, 'modifier') — SQLite date arithmetic",
+    instead:
+      "compute the boundary in TypeScript and bind it (see src/portable-date-window.ts)",
+  },
+  {
+    pattern: /\bdatetime\s*\([^;]*?,\s*[`'"][-+]?\d/i,
+    what: "datetime(x, 'modifier')",
+    instead: "compute it in TypeScript and bind it",
+  },
+  {
+    pattern: /\bstrftime\s*\(/i,
+    what: "strftime()",
+    instead: "to_char(), or format it in TypeScript",
+  },
+  {
+    pattern: /\bjulianday\s*\(/i,
+    what: "julianday()",
+    instead: "date subtraction in TypeScript",
+  },
+  {
+    pattern: /\bunixepoch\s*\(/i,
+    what: "unixepoch()",
+    instead: "extract(epoch from …), or bind Date.now()",
+  },
+  {
+    pattern: /\bifnull\s*\(/i,
+    what: "IFNULL()",
+    instead: "COALESCE(), which both accept",
+  },
+  {
+    pattern: /\bgroup_concat\s*\(/i,
+    what: "GROUP_CONCAT()",
+    instead: "STRING_AGG()",
+  },
+  {
+    pattern: /\bjson_extract\s*\(/i,
+    what: "json_extract()",
+    instead: "-> / ->> operators",
+  },
+  {
+    pattern: /\bjson_each\s*\(/i,
+    what: "json_each()",
+    instead: "jsonb_array_elements()",
+  },
+  {
+    pattern: /\binstr\s*\(/i,
+    what: "INSTR()",
+    instead: "POSITION(… IN …) or STRPOS()",
+  },
+  {
+    pattern: /\bLIMIT\s+-1\b/i,
+    what: "LIMIT -1",
+    instead: "omit the LIMIT",
+  },
+  {
+    pattern: /\bAUTOINCREMENT\b/i,
+    what: "AUTOINCREMENT",
+    instead: "GENERATED … AS IDENTITY",
+  },
+];
+
+/** The matcher body, which is where every gate-able route's SQL lives. */
+function matcherSource(): string {
+  const src = readFileSync("workers/data-api.ts", "utf8");
+  const start = src.indexOf("function matchNeuronsD1Route");
+  assert.ok(start > 0, "matchNeuronsD1Route not found");
+  const end = src.indexOf("\nfunction ", start + 10);
+  return src.slice(start, end > 0 ? end : undefined);
+}
+
+/**
+ * Comments removed.
+ *
+ * A comment DESCRIBING a banned construct is not a use of it -- and the
+ * comments here necessarily name them, because they explain why the code no
+ * longer uses them. Scanning raw text flagged /api/v1/chain/turnover for the
+ * note recording what it was ported away from.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1 ");
+}
+
+/** Per-route blocks, keyed by the literal path each guard matches. */
+function routeBlocks(): { path: string; block: string }[] {
+  const out: { path: string; block: string }[] = [];
+  for (const block of matcherSource()
+    .split(/\n {2}(?=if \()/)
+    .slice(1)) {
+    const literal = /pathname === "([^"]+)"/.exec(block)?.[1];
+    if (literal) out.push({ path: literal, block: stripComments(block) });
+  }
+  return out;
+}
+
+describe("Neon-movable routes use portable SQL", () => {
+  test("the block split still finds routes", () => {
+    // Without this, every assertion below passes on an empty list -- which is
+    // exactly how a scanning check stops checking.
+    const blocks = routeBlocks();
+    assert.ok(
+      blocks.length >= 6,
+      `only ${blocks.length} literal routes found in matchNeuronsD1Route; the ` +
+        `split broke and this suite is testing nothing`,
+    );
+  });
+
+  test("no route the read map may move contains SQLite-only SQL", () => {
+    // THE GATE. A route in NEON_READ_ROUTE_TABLES is one the flag can send to
+    // Postgres, so its SQL has to run there.
+    const problems: string[] = [];
+    for (const { path, block } of routeBlocks()) {
+      const movable = NEON_READ_ROUTE_TABLES.some((r) => r.pattern.test(path));
+      if (!movable) continue;
+      for (const { pattern, what, instead } of SQLITE_ONLY) {
+        if (pattern.test(block)) {
+          problems.push(`${path}: uses ${what} — use ${instead}`);
+        }
+      }
+    }
+    assert.deepEqual(
+      problems,
+      [],
+      "these routes can be sent to Neon by NEON_READ_LANES but their SQL is " +
+        "SQLite-only. On Postgres they do not error -- they return an EMPTY " +
+        `result at 200 OK (#9791):\n${problems.join("\n")}`,
+    );
+  });
+
+  test("the deny-list actually matches the construct that caused #9791", () => {
+    // Proving the fixture can fail. A deny-list that matches nothing would
+    // pass this suite forever.
+    const offending =
+      "SELECT MIN(snapshot_date) FROM neuron_daily " +
+      "WHERE snapshot_date >= (SELECT date(MAX(snapshot_date), '-30 days') FROM neuron_daily)";
+    const hit = SQLITE_ONLY.find((r) => r.pattern.test(offending));
+    assert.ok(hit, "the date(x, modifier) rule no longer matches #9791's SQL");
+    assert.match(hit.what, /date\(/);
+  });
+
+  test("the deny-list does not flag portable SQL", () => {
+    // A false positive costs a needless rewrite, so the rules have to be
+    // narrow. `date` as a COLUMN name, and single-argument date(), are fine.
+    const portable =
+      "SELECT snapshot_date, MAX(captured_at) FROM neuron_daily " +
+      "WHERE snapshot_date >= $1 AND COALESCE(stake_tao, 0) > 0 GROUP BY snapshot_date";
+    for (const { pattern, what } of SQLITE_ONLY) {
+      assert.ok(
+        !pattern.test(portable),
+        `${what} matched portable SQL: ${portable}`,
+      );
+    }
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -378,6 +378,7 @@ import { mirrorNominatorPositionsToNeon } from "../src/nominator-positions-neon-
 import { mirrorLedgerToNeon } from "../src/ledger-neon-write.ts";
 import { neonReadEnabled } from "../src/neon-write.ts";
 import { runNeonBackfill } from "../src/neon-backfill.ts";
+import { neuronDailyWindow } from "../src/portable-date-window.ts";
 import { runNeonMirrorWatchdog } from "../src/neon-mirror-watchdog.ts";
 import {
   writeAccountIdentityToD1,
@@ -5533,7 +5534,7 @@ async function handleAccountKeysRoute(request: Request, env: Env, url: URL) {
 //   - no ::casts (snapshot_date is already TEXT 'YYYY-MM-DD'; SQLite compares
 //     it lexicographically, which for ISO dates IS date order)
 //   - validator_permit = TRUE            -> = 1 (INTEGER 0/1 schema)
-//   - SUM(validator_permit::int)         -> SUM(validator_permit)
+//   - SUM(validator_permit::int)         -> SUM(CASE WHEN validator_permit THEN 1 ELSE 0 END)
 //   - DISTINCT ON (k) ... ORDER BY k, d  -> ROW_NUMBER() OVER (PARTITION BY
 //     k ORDER BY d DESC) = 1, or a group-wise-MAX join (SQLite has no
 //     DISTINCT ON)
@@ -5670,7 +5671,7 @@ async function loadAlphaPricesByNetuidD1(
 // chunking into a dozen round trips (what the lakehouse reader has to do,
 // having no join to reach for). Joining against `neurons` inside SQLite costs
 // ZERO bound parameters and one query, and keeps the filter exactly in step
-// with the leaderboard's own `validator_permit = 1 AND hotkey IS NOT NULL`.
+// with the leaderboard's own `validator_permit = TRUE AND hotkey IS NOT NULL`.
 //
 // Same degrade-to-empty-map contract as loadAlphaPricesByNetuidD1 above: on
 // any failure every nominator_count stays null, which is precisely the state
@@ -5707,7 +5708,7 @@ async function loadNominatorCountsD1(
              (SELECT MAX(captured_at) FROM validator_nominator_counts) AS scan_at
       FROM (
         SELECT DISTINCT hotkey FROM neurons
-        WHERE validator_permit = 1 AND hotkey IS NOT NULL
+        WHERE validator_permit = TRUE AND hotkey IS NOT NULL
       ) n
       LEFT JOIN validator_nominator_counts c ON c.hotkey = n.hotkey`;
     return fillConfirmedZeros(
@@ -5787,7 +5788,7 @@ async function loadRealizedStakeBaselinesD1(
             FROM neuron_daily nd
             LEFT JOIN subnet_snapshots s
               ON s.netuid = nd.netuid AND s.snapshot_date = nd.snapshot_date
-            WHERE nd.validator_permit = 1` +
+            WHERE nd.validator_permit = TRUE` +
           (hotkey ? " AND nd.hotkey = ?" : "") +
           ` AND nd.snapshot_date <= ? AND nd.snapshot_date >= ?
             GROUP BY nd.hotkey, nd.snapshot_date
@@ -5962,7 +5963,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
         url.searchParams.get("validator_permit") === "true";
       const rows = validatorsOnly
         ? await sql.unsafe(
-            `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? AND validator_permit = 1 ORDER BY uid`,
+            `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? AND validator_permit = TRUE ORDER BY uid`,
             [netuid],
           )
         : await sql.unsafe(
@@ -6043,7 +6044,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
     return async (sql) => {
       const netuid = Number(subnetValidators[1]);
       const rows = await sql.unsafe(
-        `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? AND validator_permit = 1 ORDER BY stake_tao DESC, uid ASC`,
+        `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? AND validator_permit = TRUE ORDER BY stake_tao DESC, uid ASC`,
         [netuid],
       );
       return json(
@@ -6068,7 +6069,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
       // well-defined and are returned alongside the totals. Two things change
       // besides the projection: alpha is reported natively (the TAO conversion is
       // kept too, so the point is comparable with the unscoped series), and the
-      // `validator_permit = 1` filter is dropped -- a day the permit was lost is
+      // `validator_permit = TRUE` filter is dropped -- a day the permit was lost is
       // the event an operator most needs to see, and filtering it away makes it
       // look identical to a day the poller missed.
       // Same normalisation the account-family routes use for their own netuid
@@ -6136,7 +6137,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
           FROM neuron_daily nd
           LEFT JOIN subnet_snapshots s
             ON s.netuid = nd.netuid AND s.snapshot_date = nd.snapshot_date
-          WHERE nd.hotkey = ${hotkey} AND nd.validator_permit = 1 AND nd.snapshot_date >= ${cutoff}
+          WHERE nd.hotkey = ${hotkey} AND nd.validator_permit = TRUE AND nd.snapshot_date >= ${cutoff}
           GROUP BY nd.snapshot_date ORDER BY nd.snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`
         : await sql`
           SELECT nd.snapshot_date AS snapshot_date, COUNT(DISTINCT nd.netuid) AS subnet_count,
@@ -6145,7 +6146,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
           FROM neuron_daily nd
           LEFT JOIN subnet_snapshots s
             ON s.netuid = nd.netuid AND s.snapshot_date = nd.snapshot_date
-          WHERE nd.hotkey = ${hotkey} AND nd.validator_permit = 1
+          WHERE nd.hotkey = ${hotkey} AND nd.validator_permit = TRUE
           GROUP BY nd.snapshot_date ORDER BY nd.snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`;
       return json(
         buildValidatorHistory(rows, hotkey, {
@@ -6186,7 +6187,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
       ] = await Promise.all([
         sql`
           SELECT netuid, uid, hotkey, coldkey, validator_trust, emission_tao, stake_tao, block_number, captured_at, take
-          FROM neurons WHERE validator_permit = 1 AND hotkey IS NOT NULL
+          FROM neurons WHERE validator_permit = TRUE AND hotkey IS NOT NULL
           ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC`,
         loadRealizedStakeBaselinesD1(sql, {}, env),
         loadAlphaPricesByNetuidD1(sql, env),
@@ -6225,7 +6226,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
         identityByColdkey,
       ] = await Promise.all([
         sql.unsafe(
-          `SELECT ${NEURON_COLUMNS}, netuid FROM neurons WHERE hotkey = ? AND validator_permit = 1 ORDER BY netuid ASC, uid ASC`,
+          `SELECT ${NEURON_COLUMNS}, netuid FROM neurons WHERE hotkey = ? AND validator_permit = TRUE ORDER BY netuid ASC, uid ASC`,
           [hotkey],
         ),
         loadRealizedStakeBaselinesD1(sql, { hotkey }, env),
@@ -6563,14 +6564,14 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
       const rows = cutoff
         ? await sql`
           SELECT snapshot_date, COUNT(*) AS neuron_count,
-            SUM(validator_permit) AS validator_count,
+            SUM(CASE WHEN validator_permit THEN 1 ELSE 0 END) AS validator_count,
             SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao
           FROM neuron_daily
           WHERE netuid = ${netuid} AND snapshot_date >= ${cutoff}
           GROUP BY snapshot_date ORDER BY snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`
         : await sql`
           SELECT snapshot_date, COUNT(*) AS neuron_count,
-            SUM(validator_permit) AS validator_count,
+            SUM(CASE WHEN validator_permit THEN 1 ELSE 0 END) AS validator_count,
             SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao
           FROM neuron_daily
           WHERE netuid = ${netuid}
@@ -6583,12 +6584,13 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
     };
   }
 
-  // GET /api/v1/chain/turnover?window=&limit=. The Postgres branch anchors
-  // the window with `MAX(snapshot_date) - ${days}::int`; SQLite's native
-  // equivalent is date(MAX(snapshot_date), '-N days') -- the exact idiom the
-  // pre-#4772 D1 route used. An empty table leaves the subquery NULL, the
-  // >= comparison matches nothing, and the same schema-stable empty shape
-  // falls out.
+  // GET /api/v1/chain/turnover?window=&limit=. The window floor is computed in
+  // TypeScript by neuronDailyWindow, NOT in the database.
+  //
+  // It used to be `date(MAX(snapshot_date), '-N days')`, which is SQLite-only.
+  // #9784 moved this route onto Neon and Postgres has no such function, so the
+  // subquery yielded nothing, the >= matched nothing, and the route served an
+  // empty result at 200 OK -- no error, just no data. See #9791.
   if (url.pathname === "/api/v1/chain/turnover") {
     return async (sql) => {
       const windowParam =
@@ -6602,18 +6604,15 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
         limitRaw == null || limitRaw === ""
           ? CHAIN_TURNOVER_LIMIT_DEFAULT
           : Number(limitRaw);
-      const bounds = await sql`
-        SELECT MIN(snapshot_date) AS start_date, MAX(snapshot_date) AS end_date
-        FROM neuron_daily
-        WHERE snapshot_date >= (SELECT date(MAX(snapshot_date), ${`-${days} days`}) FROM neuron_daily)`;
-      const startDate = (bounds[0]?.start_date ?? null) as string | null;
-      const endDate = (bounds[0]?.end_date ?? null) as string | null;
+      // Boundary computed here, not in the database: `date(x, '-N days')` is
+      // SQLite-only and emptied this route on Neon (#9791).
+      const { startDate, endDate } = await neuronDailyWindow(sql, days);
       let rows: Row[] = [];
       if (startDate != null && endDate != null && startDate !== endDate) {
         rows = await sql`
           SELECT snapshot_date, netuid, hotkey, validator_permit
           FROM neuron_daily
-          WHERE validator_permit = 1 AND snapshot_date IN (${startDate}, ${endDate})`;
+          WHERE validator_permit = TRUE AND snapshot_date IN (${startDate}, ${endDate})`;
       }
       return json(
         buildChainTurnover(rows, {
@@ -6640,18 +6639,25 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
         : DEFAULT_HISTORY_WINDOW;
       const windowDays = HISTORY_WINDOWS[windowLabel];
       const includeChanges = url.searchParams.get("changes") === "true";
-      const bounds =
-        windowDays == null
-          ? await sql`
-            SELECT MIN(snapshot_date) AS start_date, MAX(snapshot_date) AS end_date
-            FROM neuron_daily WHERE netuid = ${netuid}`
-          : await sql`
-            SELECT MIN(snapshot_date) AS start_date, MAX(snapshot_date) AS end_date
-            FROM neuron_daily
-            WHERE netuid = ${netuid}
-              AND snapshot_date >= (SELECT date(MAX(snapshot_date), ${`-${windowDays} days`}) FROM neuron_daily WHERE netuid = ${netuid})`;
-      const startDate = (bounds[0]?.start_date ?? null) as string | null;
-      const endDate = (bounds[0]?.end_date ?? null) as string | null;
+      // `all` means no window: take the subnet's full range. Otherwise the
+      // floor is computed in TypeScript, the same portable form
+      // /chain/turnover uses -- never `date(x, '-N days')`, which is
+      // SQLite-only and emptied this route on Neon (#9791).
+      let startDate: string | null;
+      let endDate: string | null;
+      if (windowDays == null) {
+        const all = await sql`
+          SELECT MIN(snapshot_date) AS start_date, MAX(snapshot_date) AS end_date
+          FROM neuron_daily WHERE netuid = ${netuid}`;
+        startDate = (all[0]?.start_date ?? null) as string | null;
+        endDate = (all[0]?.end_date ?? null) as string | null;
+      } else {
+        ({ startDate, endDate } = await neuronDailyWindow(
+          sql,
+          windowDays,
+          netuid,
+        ));
+      }
       const rows =
         startDate == null || endDate == null
           ? []
@@ -6690,18 +6696,14 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
         limitRaw == null || limitRaw === ""
           ? MOVERS_LIMIT_DEFAULT
           : Number(limitRaw);
-      const bounds = await sql`
-        SELECT MIN(snapshot_date) AS start_date, MAX(snapshot_date) AS end_date
-        FROM neuron_daily
-        WHERE snapshot_date >= (SELECT date(MAX(snapshot_date), ${`-${days} days`}) FROM neuron_daily)`;
-      const startDate = (bounds[0]?.start_date ?? null) as string | null;
-      const endDate = (bounds[0]?.end_date ?? null) as string | null;
+      // Boundary computed here, not in the database (#9791).
+      const { startDate, endDate } = await neuronDailyWindow(sql, days);
       let startRows: Row[] = [];
       let endRows: Row[] = [];
       if (startDate != null && endDate != null && startDate !== endDate) {
         const rows = await sql`
           SELECT netuid, snapshot_date, COUNT(*) AS neuron_count,
-            SUM(validator_permit) AS validator_count,
+            SUM(CASE WHEN validator_permit THEN 1 ELSE 0 END) AS validator_count,
             SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao
           FROM neuron_daily
           WHERE snapshot_date IN (${startDate}, ${endDate})

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -178,22 +178,33 @@
     // Re-adding neuron_daily needs those two queries ported to portable SQL
     // (an explicit date literal computed in TS, not in the database) -- see
     // #9789.
-    // `neurons` PULLED 2026-08-07, immediately after neuron_daily (#9791).
-    // /api/v1/validators returned ZERO from Neon and fell back to an empty
-    // artifact -- 5 rows -> 0, measured across three deploys:
-    //   baseline (pre-cutover)  5 rows
-    //   f07234628 (pre-cutover) 5 rows
-    //   2df376f7e (post)        0 rows
+    // Re-enabled after the SQL was made PORTABLE (#9791/#9805). Two rollbacks
+    // preceded this -- #9792 pulled neuron_daily, #9802 pulled neurons -- and
+    // both had one cause: createD1Sql and createPgSql are interface-compatible,
+    // so a query moves stores by choosing a runner. True of the BINDING, false
+    // of the SQL.
     //
-    // Same root cause class as #9791: a query that is valid SQLite and not
-    // valid Postgres fails, and this route falls back to an artifact rather
-    // than erroring -- so the failure is invisible from the response alone.
+    //   date(MAX(snapshot_date), '-30 days')  -> boundary computed in TS
+    //   validator_permit = 1                  -> validator_permit = TRUE
+    //   SUM(validator_permit)                 -> SUM(CASE WHEN ... THEN 1 ELSE 0 END)
     //
-    // account_position_daily stays. Its one route was verified against a D1
-    // baseline across four deploys and is unchanged.
+    // The SECOND class is what emptied /api/v1/validators, measured across
+    // three deploys:
+    //   f07234628 (neurons + neuron_daily on)  5 rows
+    //   2df376f7e (neuron_daily pulled)        0 rows
+    //   c450947ac (neurons pulled)             1,014 rows
     //
-    // NOTHING goes back into this flag until #9793's dialect scan runs in CI.
-    "NEON_READ_LANES": "account_position_daily",
+    // D1 stores those columns as 0/1 integers; Neon declares them BOOLEAN,
+    // because that is what the mirror writes. Postgres rejects
+    // `boolean = integer`, the query errored, and the handler's `??` fallback
+    // built an EMPTY leaderboard -- a 200 with a plausible shape and no error
+    // anywhere. Both new forms were verified to return IDENTICAL results on D1
+    // (1,580 validators either way) before the change.
+    //
+    // tests/neon-sql-portability.test.ts now fails CI on any SQLite-only
+    // construct in a route this flag can move -- the gate that did not exist
+    // when #9784 shipped.
+    "NEON_READ_LANES": "account_position_daily,neurons,neuron_daily",
     // The two ACCUMULATING tables, and only those (src/neon-backfill.ts).
     //
     // The mirror above writes what each request carries, which finishes the job


### PR DESCRIPTION
Closes #9791

Two rollbacks preceded this (#9792, #9802) and both had **one cause**: `createD1Sql` and `createPgSql` are interface-compatible, so a query moves stores by choosing a runner. That is true of the **binding** and false of the **SQL**.

## Three classes, all fixed

| was | now |
|---|---|
| `date(MAX(snapshot_date), '-30 days')` | boundary computed in TypeScript and bound |
| `validator_permit = 1` | `validator_permit = TRUE` |
| `SUM(validator_permit)` | `SUM(CASE WHEN validator_permit THEN 1 ELSE 0 END)` |

**The second one is what emptied `/api/v1/validators`, and I missed it twice.** D1 stores those columns as `0`/`1` integers; Neon declares them `BOOLEAN`, because that is what the mirror writes. Postgres rejects `boolean = integer`, so the query errored, `tryPostgresTier` returned null, and the handler's `??` fallback built an **empty leaderboard** — a 200 with a plausible shape and no error anywhere. `SUM(boolean)` fails identically.

I spent two rollbacks blaming SQL *functions* when the real blocker was column *typing* — a difference the mirror itself introduced this morning.

## Verified equivalent before changing anything

```
int_form      1580   (validator_permit = 1)
bool_form     1580   (validator_permit = TRUE)
sum_raw       1580   (SUM(validator_permit))
sum_portable  1580   (SUM(CASE WHEN validator_permit THEN 1 ELSE 0 END))
```

Run against live D1. SQLite has supported `TRUE`/`FALSE` since 3.23, so both forms are correct in both stores.

## The gate that did not exist

`tests/neon-sql-portability.test.ts` scans each movable route's own SQL for SQLite-only constructs and **fails CI**, instead of letting Postgres return an empty result at runtime. It covers `date()`/`datetime()` with modifiers, `strftime`, `julianday`, `unixepoch`, `IFNULL`, `GROUP_CONCAT`, `json_extract`, `json_each`, `INSTR`, `LIMIT -1`, `AUTOINCREMENT`.

Two properties keep it honest:
- **it strips comments first** — a comment *naming* a construct is not a use of it, and it was flagging `/chain/turnover` for the note recording what it was ported away from
- **it proves the deny-list matches the exact SQL that caused #9791**, so it cannot pass on nothing (my first `date(` pattern couldn't cross the nested paren in `MAX(snapshot_date)` and silently matched nothing)

## Re-enables

`NEON_READ_LANES` goes back to `account_position_daily,neurons,neuron_daily`.

## Verification

- **719 files, 17,452 tests, all passing**; typecheck, eslint, prettier clean
- I'll diff all 15 routes against the pre-cutover D1 baseline within minutes of deploy, same as before — that baseline is what caught both regressions.

## Two false positives I caught in my own rewrite

A blind regex over six files hit `let active = 0` (TypeScript, not SQL) and a test helper's default parameter. Both reverted. Worth noting because it's the same lesson as the SQL itself: a pattern that looks like SQL isn't necessarily SQL.