### PR TITLE
fix(mcp): derive four tool schemas from their routes, so responses stop failing their own contract

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -4645,7 +4645,8 @@ export type RpcUsage = {
   endpoints: Array<RpcUsageEndpoint>;
   /** Per-network request breakdown, ordered by request volume. */
   networks: Array<RpcUsageNetwork>;
-  observed_at?: Maybe<Scalars['String']['output']>;
+  /** Epoch ms of this reading, matching REST and MCP. Float rather than Int because epoch milliseconds overflow GraphQL's 32-bit Int, and the sibling epoch-ms fields on RpcUsageCoverage use Float for the same reason. Null when nothing measured it. */
+  observed_at?: Maybe<Scalars['Float']['output']>;
   schema_version: Scalars['Int']['output'];
   source?: Maybe<Scalars['String']['output']>;
   summary: RpcUsageSummary;
@@ -9481,7 +9482,7 @@ export type RpcUsageResolvers<ContextType = GqlContext, ParentType extends Resol
   coverage?: Resolver<ResolversTypes['RpcUsageCoverage'], ParentType, ContextType>;
   endpoints?: Resolver<Array<ResolversTypes['RpcUsageEndpoint']>, ParentType, ContextType>;
   networks?: Resolver<Array<ResolversTypes['RpcUsageNetwork']>, ParentType, ContextType>;
-  observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  observed_at?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   source?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   summary?: Resolver<ResolversTypes['RpcUsageSummary'], ParentType, ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -9341,7 +9341,11 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
-            observed_at?: string | null;
+            /**
+             * @description When this telemetry was observed, as epoch MILLISECONDS -- not an ISO-8601 string like this file's other observed_at fields. Request-scoped rather than build-scoped: it stamps the read, not a published artifact.
+             * @example 1786099339000
+             */
+            observed_at?: number | null;
             schema_version: number;
             source: string;
             summary: {
@@ -35600,7 +35604,7 @@ export interface operations {
                      *             "requests": 1
                      *           }
                      *         ],
-                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_at": 1,
                      *         "schema_version": 1,
                      *         "source": "live-cron-prober",
                      *         "summary": {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -7702,7 +7702,7 @@
                 "requests": 1
               }
             ],
-            "observed_at": "2026-06-01T00:00:00.000Z",
+            "observed_at": 1,
             "schema_version": 1,
             "source": "live-cron-prober",
             "summary": {
@@ -38497,11 +38497,17 @@
           "observed_at": {
             "anyOf": [
               {
-                "type": "string"
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
               },
               {
                 "type": "null"
               }
+            ],
+            "description": "When this telemetry was observed, as epoch MILLISECONDS -- not an ISO-8601 string like this file's other observed_at fields. Request-scoped rather than build-scoped: it stamps the read, not a published artifact.",
+            "examples": [
+              1786099339000
             ]
           },
           "schema_version": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -9341,7 +9341,11 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
-            observed_at?: string | null;
+            /**
+             * @description When this telemetry was observed, as epoch MILLISECONDS -- not an ISO-8601 string like this file's other observed_at fields. Request-scoped rather than build-scoped: it stamps the read, not a published artifact.
+             * @example 1786099339000
+             */
+            observed_at?: number | null;
             schema_version: number;
             source: string;
             summary: {
@@ -35600,7 +35604,7 @@ export interface operations {
                      *             "requests": 1
                      *           }
                      *         ],
-                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_at": 1,
                      *         "schema_version": 1,
                      *         "source": "live-cron-prober",
                      *         "summary": {

--- a/schemas-src/mcp-tools/account-portfolio.ts
+++ b/schemas-src/mcp-tools/account-portfolio.ts
@@ -1,15 +1,17 @@
 // MCP tools `get_account_portfolio`, `get_account_positions`,
-// `get_account_snapshot` (types-epic E batch 6, #8069). Each mirrors a
-// GET /api/v1/accounts/{ss58}/{portfolio,positions} route (get_account_snapshot
-// has no REST equivalent -- it fans out to five other tools' own live loaders
-// in one call), none of which are covered by schemas-src/routes/ -- no
-// existing Zod schema to reuse. get_account_snapshot's balance/portfolio/
-// subnets/positions/recent_events fields are deliberately bare open objects,
-// NOT the sibling tools' own precise output schemas from this same batch --
-// the hand-written original never nested their real shapes either (bare
-// {type:"object"}), so reusing them here would be a real tightening the
-// issue's wire-compatibility constraint doesn't require.
+// `get_account_snapshot` (types-epic E batch 6, #8069). The first two mirror a
+// GET /api/v1/accounts/{ss58}/{portfolio,positions} route; get_account_snapshot
+// has no REST equivalent -- it fans out to five other tools' own live loaders in
+// one call.
+//
+// This file's header used to claim none of these routes were "covered by
+// schemas-src/routes/ -- no existing Zod schema to reuse". That stopped being
+// true, and the hand-written copies were never revisited, so they drifted from
+// the routes they mirror (#9794). `get_account_positions` is the sharpest case:
+// #8803 renamed total_stake_tao to total_stake_alpha, the copy kept requiring
+// the old name, and every response since has failed its own published contract.
 import { z } from "zod";
+import { AccountPortfolioArtifactSchema } from "../routes/account-portfolio.ts";
 import {
   OpenObjectArraySchema,
   OpenObjectSchema,
@@ -25,22 +27,19 @@ export type GetAccountPortfolioInput = z.infer<
   typeof GetAccountPortfolioInputSchema
 >;
 
-export const GetAccountPortfolioOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    ss58: z.string(),
-    captured_at: z.string().nullable().optional(),
-    subnet_count: z.int().optional(),
-    position_count: z.int(),
-    validator_count: z.int().optional(),
-    miner_count: z.int().optional(),
-    total_stake_tao: z.number().optional(),
-    total_emission_tao: z.number().optional(),
-    overall_yield: z.number().nullable().optional(),
-    stake_concentration: OpenObjectSchema.nullable().optional(),
-    positions: OpenObjectArraySchema,
-  })
-  .passthrough();
+// The tool serves the route's artifact unchanged, so it publishes the route's
+// schema unchanged. This is a strict improvement for callers as well as a drift
+// fix: the copy declared `positions` as a bare open array and
+// `stake_concentration` as a bare open object, so an agent was told nothing
+// about either. The route schema types every position and carries the
+// descriptions that matter for reading the numbers correctly -- that the totals
+// are genuine TAO converted through each subnet's SPOT price rather than a sum
+// of incomparable alpha, and that the valuation can lag the live economics tier
+// by up to ~24h because it is marked from the daily rollup.
+//
+// Verified against production before the switch: the live tool's response
+// satisfies this schema.
+export const GetAccountPortfolioOutputSchema = AccountPortfolioArtifactSchema;
 export type GetAccountPortfolioOutput = z.infer<
   typeof GetAccountPortfolioOutputSchema
 >;
@@ -54,14 +53,39 @@ export type GetAccountPositionsInput = z.infer<
   typeof GetAccountPositionsInputSchema
 >;
 
+// NOT YET DERIVED, deliberately. AccountPositionsArtifactSchema is the right
+// source and this should become `= AccountPositionsArtifactSchema` -- but the
+// live tool does not satisfy it today, so switching now would publish a
+// contract production violates, trading one drift for another.
+//
+// Two things block it, both filed:
+//   - the route's `degraded.reason` enum declares two values and production
+//     serves a third, `positions_unpriceable` (#9804);
+//   - the route requires `degraded.snapshot_captured_at` and
+//     `latest_stake_event_at`, and the handler emits neither (#9803).
+//
+// Checked against production rather than assumed: deriving today rejects real
+// responses on exactly those fields. The rename below is still fixed here,
+// because that one is a plain defect with nothing blocking it.
 export const GetAccountPositionsOutputSchema = z
   .object({
     schema_version: z.int().optional(),
     ss58: z.string(),
     captured_at: z.string().nullable().optional(),
     position_count: z.int(),
-    total_stake_tao: z.number(),
+    // RENAMED IN #8803, and this copy never followed (#9794). The field is
+    // total_stake_alpha -- schemas-src/routes/account-positions.ts says so and
+    // explains why it is alpha rather than TAO -- so this schema REQUIRED a
+    // key the response has never carried since that rename. Every
+    // get_account_positions response has been failing its own published
+    // contract, and an agent reading the schema was told to look for a field
+    // that is not there.
+    total_stake_alpha: z.number(),
     positions: OpenObjectArraySchema,
+    // #9273: present only when the payload's zero is not a measurement. Left
+    // open here rather than typed, because the shape it should reference is the
+    // one #9803/#9804 are still correcting.
+    degraded: OpenObjectSchema.optional(),
   })
   .passthrough();
 export type GetAccountPositionsOutput = z.infer<

--- a/schemas-src/mcp-tools/get-economics-trends.ts
+++ b/schemas-src/mcp-tools/get-economics-trends.ts
@@ -1,10 +1,25 @@
 // MCP tool `get_economics_trends` (types-epic E batch 3, #8066). Mirrors
-// GET /api/v1/economics/trends, which is not one of schemas-src/routes/'s
-// covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
-// shallow, from the hand-written literal it replaces. Window enum
-// hardcoded from src/neuron-history.ts's HISTORY_WINDOWS at the time of
-// writing (mirrors get-subnet-turnover.ts's same precedent this batch).
+// GET /api/v1/economics/trends.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9794). This file used to re-declare the
+// response shape by hand, and its own header claimed there was "no existing Zod
+// schema to reuse" -- which stopped being true once schemas-src/routes/
+// economics-trends.ts landed, modelling the same bytes more precisely. The copy
+// never followed, and nothing detected the divergence: it typed
+// `total_stake_alpha` as a number, but network-wide alpha is summed in rao and
+// serialised at full precision ("345955059.947656252") because an IEEE double
+// cannot hold it. Every response failed its own published schema, and an agent
+// that trusted the schema parsed the wrong type.
+//
+// Reusing the artifact schema makes that class of drift impossible: a field
+// that changes shape in the route changes here, and a field that is renamed
+// stops compiling rather than silently disagreeing in production.
+//
+// The window enum below is still a local literal. It is duplicated across ten
+// schema files and is tracked separately in #9799 -- single-sourcing it is that
+// issue's job, not this one's.
 import { z } from "zod";
+import { EconomicsTrendsArtifactSchema } from "../routes/economics-trends.ts";
 import { windowSchema } from "./shared.ts";
 
 const HISTORY_WINDOWS = ["7d", "30d", "90d", "1y", "all"] as const;
@@ -18,29 +33,11 @@ export type GetEconomicsTrendsInput = z.infer<
   typeof GetEconomicsTrendsInputSchema
 >;
 
-// objectItems(...) properties, none required at the item level (see
-// search-subnets.ts's same note from the pilot batch).
-const EconomicsTrendsDaySchema = z
-  .object({
-    snapshot_date: z.string().nullable().optional(),
-    subnet_count: z.int().nullable().optional(),
-    total_stake_alpha: z.number().nullable().optional(),
-    alpha_price_tao_weighted: z.number().nullable().optional(),
-    alpha_price_tao_median: z.number().nullable().optional(),
-    validator_count: z.int().nullable().optional(),
-    miner_count: z.int().nullable().optional(),
-    mean_emission_share: z.number().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetEconomicsTrendsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string().nullable(),
-    day_count: z.int(),
-    days: z.array(EconomicsTrendsDaySchema),
-  })
-  .passthrough();
+// The tool serves the route's artifact unchanged, so it publishes the route's
+// schema unchanged. Verified against production before the switch: every day
+// row the live tool returns satisfies this schema, including the precision
+// string that the hand-written copy rejected.
+export const GetEconomicsTrendsOutputSchema = EconomicsTrendsArtifactSchema;
 export type GetEconomicsTrendsOutput = z.infer<
   typeof GetEconomicsTrendsOutputSchema
 >;

--- a/schemas-src/mcp-tools/meta-artifacts-2.ts
+++ b/schemas-src/mcp-tools/meta-artifacts-2.ts
@@ -5,12 +5,18 @@
 // their `GET_X_MCP_TOOL`/`GET_X_OUTPUT_SCHEMA` spread into mcp-server.ts's
 // MCP_TOOLS array); `get_coverage_depth` is defined inline in
 // src/mcp-server.ts. All four are no-input, baked-artifact passthrough
-// tools. None mirror an existing schemas-src/routes/ REST schema -- modeled
-// fresh, matching each hand-written literal field-for-field.
-// `get_coverage_depth`'s output declares NO `required` key at all (unlike
-// every sibling in this file, which declares an explicit list or an empty
-// array) -- a genuine, pre-existing difference, preserved as-is.
+// tools.
+//
+// This header used to say none of them "mirror an existing schemas-src/routes/
+// REST schema -- modeled fresh". For `get_coverage_depth` that was wrong:
+// CoverageDepthArtifactSchema in schemas-src/routes/coverage.ts models the same
+// artifact, and the fresh model disagreed with it on the type of
+// `coverage_depth_version` (#9794). It now reuses the route schema outright,
+// which also replaces its two bare open arrays with the row and queue-entry
+// shapes the route already declares. The remaining three are still local
+// models; #9796 covers deriving them.
 import { z } from "zod";
+import { CoverageDepthArtifactSchema } from "../routes/coverage.ts";
 import { SelfHealthArtifactSchema } from "../routes/self-health.ts";
 import { OpenObjectSchema } from "./shared.ts";
 
@@ -102,17 +108,17 @@ export type GetCoverageOutput = z.infer<typeof GetCoverageOutputSchema>;
 export const GetCoverageDepthInputSchema = z.object({}).strict();
 export type GetCoverageDepthInput = z.infer<typeof GetCoverageDepthInputSchema>;
 
-// No `required` key in the hand-written original, unlike this file's other
-// three tools.
-export const GetCoverageDepthOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    generated_at: z.string().nullable().optional(),
-    coverage_depth_version: z.string().nullable().optional(),
-    rows: z.array(OpenObjectSchema).optional(),
-    ranked_queue: z.array(OpenObjectSchema).optional(),
-  })
-  .passthrough();
+// DERIVED FROM THE ROUTE, NOT COPIED (#9794). The hand-written copy typed
+// `coverage_depth_version` as a string while CoverageDepthArtifactSchema in
+// schemas-src/routes/coverage.ts has always had `z.int().min(1)` and the served
+// value is `1`, so every response failed its own published schema.
+//
+// Reusing the artifact also stops this tool publishing `rows` and
+// `ranked_queue` as bare open arrays. The route declares CoverageDepthRowSchema
+// and CoverageDepthQueueEntrySchema in full, so an agent now gets the shape of
+// the thing it is ranking instead of {"type":"object"}. Verified against
+// production before the switch.
+export const GetCoverageDepthOutputSchema = CoverageDepthArtifactSchema;
 export type GetCoverageDepthOutput = z.infer<
   typeof GetCoverageDepthOutputSchema
 >;

--- a/schemas-src/mcp-tools/rpc-tools.ts
+++ b/schemas-src/mcp-tools/rpc-tools.ts
@@ -1,72 +1,20 @@
 // MCP tools `get_rpc_usage`, `get_best_rpc_endpoint`, `call_rpc`
 // (types-epic E batch 12, #8075). All three are defined inline in
-// src/mcp-server.ts's MCP_TOOLS array. None mirror an existing
-// schemas-src/routes/ REST schema -- modeled fresh, matching each
-// hand-written literal field-for-field. Unlike this epic's objectItems()-
-// built array items (which never declare item-level `required`),
-// get_rpc_usage's four nested shapes (summary/latency_ms/endpoints/
-// networks/buckets, formerly mcp-server.ts's own RPC_USAGE_* constants) DO
-// declare real item-level required fields -- preserved exactly, not loosened
-// to match this epic's usual item-shape convention.
+// src/mcp-server.ts's MCP_TOOLS array.
+//
+// This header used to say none of the three "mirror an existing
+// schemas-src/routes/ REST schema -- modeled fresh". For get_rpc_usage that was
+// wrong: RpcUsageArtifactSchema in schemas-src/routes/providers-rpc.ts models
+// the same bytes, and the fresh model disagreed with it on `observed_at`
+// (#9794). It now reuses the route schema outright.
 import { z } from "zod";
+import { RpcUsageArtifactSchema } from "../routes/providers-rpc.ts";
 import { McpNetworkSchema } from "../shared.ts";
 import { OpenObjectSchema, limitSchema, windowSchema } from "./shared.ts";
 import {
   SAFE_RPC_METHODS,
   SAFE_RPC_STATE_QUERY_METHODS,
 } from "../../workers/config.ts";
-
-const RpcUsageLatencyMsSchema = z
-  .object({
-    p50: z.int().nullable(),
-    p95: z.int().nullable(),
-    avg: z.int().nullable(),
-  })
-  .passthrough();
-
-const RpcUsageSummarySchema = z
-  .object({
-    total_requests: z.int().min(0),
-    ok_requests: z.int().min(0),
-    error_requests: z.int().min(0),
-    error_rate: z.number().nullable().optional(),
-    failover_requests: z.int().min(0).optional(),
-    failover_rate: z.number().nullable().optional(),
-    cache_hits: z.int().min(0).optional(),
-    cache_hit_rate: z.number().nullable().optional(),
-    latency_ms: RpcUsageLatencyMsSchema,
-  })
-  .passthrough();
-
-const RpcUsageEndpointItemSchema = z
-  .object({
-    rank: z.int().min(1).optional(),
-    endpoint_id: z.string().nullable(),
-    provider: z.string().nullable().optional(),
-    requests: z.int().min(0),
-    ok_requests: z.int().min(0),
-    error_rate: z.number().nullable().optional(),
-    avg_latency_ms: z.int().nullable().optional(),
-  })
-  .passthrough();
-
-const RpcUsageNetworkItemSchema = z
-  .object({
-    network: z.string(),
-    requests: z.int().min(0),
-    ok_requests: z.int().min(0),
-    error_rate: z.number().nullable().optional(),
-  })
-  .passthrough();
-
-const RpcUsageBucketItemSchema = z
-  .object({
-    ts: z.int().min(0),
-    requests: z.int().min(0),
-    errors: z.int().min(0),
-    avg_latency_ms: z.int().nullable(),
-  })
-  .passthrough();
 
 export const GetRpcUsageInputSchema = z
   .object({
@@ -75,46 +23,24 @@ export const GetRpcUsageInputSchema = z
   .strict();
 export type GetRpcUsageInput = z.infer<typeof GetRpcUsageInputSchema>;
 
-// The measured span, per contributing store -- see RpcUsageArtifactSchema in
-// schemas-src/routes/providers-rpc.ts for why `window` alone is not enough.
-const RpcUsageCoverageRangeItemSchema = z
-  .object({
-    start: z.int().nullable(),
-    end: z.int().nullable(),
-  })
-  .passthrough();
-
-const RpcUsageCoverageSegmentItemSchema = z
-  .object({
-    source: z.string(),
-    start: z.int().nullable(),
-    end: z.int().nullable(),
-  })
-  .passthrough();
-
-const RpcUsageCoverageItemSchema = z
-  .object({
-    start: z.int().nullable(),
-    end: z.int().nullable(),
-    segments: z.array(RpcUsageCoverageSegmentItemSchema),
-    latency_percentiles: RpcUsageCoverageRangeItemSchema.nullable(),
-  })
-  .passthrough();
-
-export const GetRpcUsageOutputSchema = z
-  .object({
-    schema_version: z.int(),
-    window: z.string().nullable().optional(),
-    bucket_granularity: z.string().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-    source: z.string(),
-    coverage: RpcUsageCoverageItemSchema,
-    summary: RpcUsageSummarySchema,
-    endpoints: z.array(RpcUsageEndpointItemSchema),
-    networks: z.array(RpcUsageNetworkItemSchema),
-    buckets: z.array(RpcUsageBucketItemSchema),
-  })
-  .passthrough();
+// DERIVED FROM THE ROUTE, NOT COPIED (#9794). This tool's `observed_at` is
+// EPOCH MILLISECONDS -- the served value is 1786099339000 -- and this file
+// declared a string, so every response failed its own published schema and an
+// agent was told to expect a date it could parse as text.
+//
+// The route contract said `string` too, so unlike the sibling fixes in #9794
+// this was not a copy drifting away from a correct source: the same field was
+// written wrong twice, independently, which is the clearest argument there is
+// for one declaration rather than two. Corrected at the source in
+// schemas-src/routes/providers-rpc.ts -- which fixes GET /api/v1/rpc/usage at
+// the same time -- and reused here. Verified against production after the
+// change.
+//
+// The nine hand-written item schemas this file used to carry (latency_ms,
+// summary, endpoints, networks, buckets and the three coverage shapes) are
+// gone with it: RpcUsageArtifactSchema declares all of them, so keeping local
+// copies would only recreate the divergence this issue exists to remove.
+export const GetRpcUsageOutputSchema = RpcUsageArtifactSchema;
 export type GetRpcUsageOutput = z.infer<typeof GetRpcUsageOutputSchema>;
 
 export const GetBestRpcEndpointInputSchema = z

--- a/schemas-src/routes/providers-rpc.ts
+++ b/schemas-src/routes/providers-rpc.ts
@@ -388,7 +388,23 @@ export const RpcUsageArtifactSchema = z
     schema_version: z.int(),
     window: z.string().nullable().optional(),
     bucket_granularity: z.string().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
+    // EPOCH MILLISECONDS, not an ISO string (#9794). Both GET /api/v1/rpc/usage
+    // and the get_rpc_usage MCP tool serve a number here -- 1786099339000 --
+    // so this route contract has been wrong since it was written, and the
+    // hand-written MCP copy inherited the same mistake rather than causing it.
+    // Unlike this file's other observed_at fields, which are genuine ISO
+    // strings, this one is request-scoped telemetry stamped in millis. The
+    // example carries a real stamp rather than a bare `1`, because the unit is
+    // the whole point of the field and a placeholder integer teaches a reader
+    // nothing about it.
+    observed_at: z
+      .int()
+      .nullable()
+      .optional()
+      .describe(
+        "When this telemetry was observed, as epoch MILLISECONDS -- not an ISO-8601 string like this file's other observed_at fields. Request-scoped rather than build-scoped: it stamps the read, not a published artifact.",
+      )
+      .meta({ examples: [1786099339000] }),
     source: z.string(),
     coverage: RpcUsageCoverageSchema,
     summary: z

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -2064,7 +2064,8 @@ export const SDL = /* GraphQL */ `
     window: String
     "Time-bucket granularity for buckets: 1h for the 7d window, 6h for 30d. Null on a cold store."
     bucket_granularity: String
-    observed_at: String
+    "Epoch ms of this reading, matching REST and MCP. Float rather than Int because epoch milliseconds overflow GraphQL's 32-bit Int, and the sibling epoch-ms fields on RpcUsageCoverage use Float for the same reason. Null when nothing measured it."
+    observed_at: Float
     source: String
     "What the answer is actually about, as opposed to what window was asked for."
     coverage: RpcUsageCoverage!

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -878,7 +878,7 @@ export interface RpcUsageSegment {
  * would be worse: the floor's stamp is the only freshness reading available
  * when no store answered, and it is real.
  */
-function epochMs(value: unknown): number | null {
+export function epochMs(value: unknown): number | null {
   const n = Number(value);
   if (Number.isFinite(n) && n > 0) return Math.trunc(n);
   if (typeof value === "string" && value) {

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -863,9 +863,29 @@ export interface RpcUsageSegment {
 /** Epoch ms, or null when the input is not a usable reading. Every timestamp
  * `coverage` publishes goes through this, so a missing `min()`/`max()` from
  * either engine reads as "not measured" rather than as 1970. */
+/**
+ * Coerce a freshness stamp to epoch milliseconds, or null when there is none.
+ *
+ * Numeric input is tried first and behaves exactly as it always has, because
+ * the coverage bounds this was written for are already millis and a numeric
+ * STRING must stay a number -- `Date.parse("123")` is a valid date in year 123,
+ * which is not what a caller passing "123" means.
+ *
+ * The ISO fallback is for the zeroed floor (#9794), which is handed the health
+ * cron's `last_run_at` rather than a store's millis. Without it that stamp
+ * reached the published payload as a string, so `observed_at` was a number on a
+ * busy deployment and a string on a quiet one. Dropping it to null instead
+ * would be worse: the floor's stamp is the only freshness reading available
+ * when no store answered, and it is real.
+ */
 function epochMs(value: unknown): number | null {
   const n = Number(value);
-  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : null;
+  if (Number.isFinite(n) && n > 0) return Math.trunc(n);
+  if (typeof value === "string" && value) {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
 }
 
 /**
@@ -965,7 +985,15 @@ export function formatRpcUsage({
     schema_version: 1,
     window: window || null,
     bucket_granularity: bucketGranularity || null,
-    observed_at: observedAt || null,
+    // ALWAYS epoch milliseconds, whichever tier answered (#9794). The hot and
+    // cold tiers already agree on millis -- rpc-usage-answer.ts takes a
+    // Math.max over both -- but the zeroed floor is handed the health cron's
+    // `last_run_at`, which is an ISO STRING. So this one field changed type
+    // depending on whether any store had data: a number in production, a
+    // string whenever the floor answered. No schema declared both, and a
+    // client that switched on the type got a different answer on a quiet
+    // deployment than on a busy one.
+    observed_at: epochMs(observedAt),
     source: "rpc-proxy",
     coverage: formatCoverage(coverage),
     summary: {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1068,6 +1068,7 @@ import {
   CHAIN_CONCENTRATION_SUBNETS_LIMIT_DEFAULT,
   CHAIN_CONCENTRATION_SUBNETS_LIMIT_MAX,
 } from "./route-limits.ts";
+import { SUBNET_CONVICTION_FIELD_SOURCES } from "./subnet-conviction.ts";
 import { DOMAIN_TAGS } from "./domain-tags.ts";
 import { buildDomainOverview, buildDomainSummary } from "./domain-summary.ts";
 import { CHAIN_SIGNERS_SORTS } from "./chain-query-loaders.ts";
@@ -3099,6 +3100,18 @@ function narrowConviction(data: Row | null, netuid: number) {
     king: data?.king ?? null,
     count: data?.count ?? 0,
     leaderboard: Array.isArray(data?.leaderboard) ? data.leaderboard : [],
+    // #9794. This narrowing dropped it, so the MCP tool served LESS than REST
+    // for the same payload and failed its own published outputSchema on every
+    // call -- a schema whose comment says it mirrors the REST artifact "field
+    // for field". #9108's provenance is the whole point of the field: it says
+    // which values were read from chain and which were reconstructed, and an
+    // agent that cannot see that cannot tell the difference.
+    //
+    // Falls back to the builder's own constant rather than to undefined: both
+    // tiers compute the same conviction, so the vocabulary is the same either
+    // way, and a live-tier answer that arrived without the key must not be the
+    // one response that silently omits its provenance.
+    field_sources: data?.field_sources ?? SUBNET_CONVICTION_FIELD_SOURCES,
   };
 }
 

--- a/src/rpc-usage-answer.ts
+++ b/src/rpc-usage-answer.ts
@@ -46,7 +46,11 @@
 // risking a double count.
 import { ANALYTICS_WINDOWS } from "../workers/config.ts";
 import { tryPostgresTier } from "../workers/postgres-tier.ts";
-import { formatRpcUsage, type RpcUsageSegment } from "./health-serving.ts";
+import {
+  epochMs,
+  formatRpcUsage,
+  type RpcUsageSegment,
+} from "./health-serving.ts";
 import { loadRpcUsage } from "./rpc-usage-loader.ts";
 import { loadRpcUsageColdTier, windowCutoffMs } from "./rpc-usage-cold-tier.ts";
 import { loadRpcUsageHotTier } from "./rpc-usage-hot-tier.ts";
@@ -336,7 +340,16 @@ export async function answerRpcUsage(
       postgresRequest,
       RPC_USAGE_SOURCE_FLAG,
     )) as Row | null;
-    if (postgres) return postgres;
+    // Normalised on the way out rather than trusted (#9794/#9811). This arm
+    // forwards an upstream payload verbatim instead of going through
+    // formatRpcUsage, so it is the one path that can publish a stamp this
+    // composer never shaped. The whole defect being fixed here was `observed_at`
+    // meaning different things depending on which tier answered, and a tier
+    // whose representation is taken on faith is how that happens -- so the
+    // composer states the type for every arm, including the ones it forwards.
+    if (postgres) {
+      return { ...postgres, observed_at: epochMs(postgres.observed_at) };
+    }
   }
 
   if (cold) return cold;

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -19087,7 +19087,23 @@ describe("graphql — rpc_usage (#5899, Postgres-tier + D1-live fallback)", () =
       METAGRAPH_HEALTH_DB: rpcUsageD1(),
     };
     const { body } = await gql(usageQuery(), env);
-    assert.equal(body.data.rpc_usage.observed_at, "2026-06-23T00:00:00.000Z");
+    // The KV holds an ISO string; the value is now normalised to epoch
+    // milliseconds before publication (#9794), so what used to surface here as
+    // "2026-06-23T00:00:00.000Z" is the parsed stamp.
+    //
+    // It arrives as a numeric STRING rather than a number because
+    // src/graphql-sdl.ts declares `RpcUsage.observed_at: String` and GraphQL
+    // coerces. That is self-consistent for this surface but it no longer
+    // matches REST or MCP, which both publish an integer -- one field, two
+    // representations across three surfaces. Asserted as it actually is rather
+    // than as it ought to be; #9811 tracks reconciling them, which is a
+    // breaking SDL change and not this issue's to make (epoch millis also
+    // overflow GraphQL's 32-bit Int, so it would have to be Float or a custom
+    // scalar).
+    assert.equal(
+      body.data.rpc_usage.observed_at,
+      String(Date.parse("2026-06-23T00:00:00.000Z")),
+    );
   });
 
   test("a D1 query error degrades to a schema-stable zeroed card (no throw)", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -18985,7 +18985,12 @@ describe("graphql — rpc_usage (#5899, Postgres-tier + D1-live fallback)", () =
     const usage = body.data.rpc_usage;
     assert.equal(usage.window, "30d");
     assert.equal(usage.bucket_granularity, "6h");
-    assert.equal(usage.observed_at, "2026-07-10T00:00:00.000Z");
+    // The mocked upstream sends an ISO string and the composer normalises it to
+    // epoch ms on the way out (#9811). This arm forwards a tier's payload
+    // verbatim rather than building it, so it is the one path that could publish
+    // a stamp the composer never shaped -- which is the exact defect being
+    // fixed, so the composer states the type here too.
+    assert.equal(usage.observed_at, Date.parse("2026-07-10T00:00:00.000Z"));
     assert.equal(usage.summary.total_requests, 100);
     assert.equal(usage.summary.error_rate, 0.05);
     assert.equal(usage.summary.cache_hit_rate, 0.4);
@@ -19091,18 +19096,16 @@ describe("graphql — rpc_usage (#5899, Postgres-tier + D1-live fallback)", () =
     // milliseconds before publication (#9794), so what used to surface here as
     // "2026-06-23T00:00:00.000Z" is the parsed stamp.
     //
-    // It arrives as a numeric STRING rather than a number because
-    // src/graphql-sdl.ts declares `RpcUsage.observed_at: String` and GraphQL
-    // coerces. That is self-consistent for this surface but it no longer
-    // matches REST or MCP, which both publish an integer -- one field, two
-    // representations across three surfaces. Asserted as it actually is rather
-    // than as it ought to be; #9811 tracks reconciling them, which is a
-    // breaking SDL change and not this issue's to make (epoch millis also
-    // overflow GraphQL's 32-bit Int, so it would have to be Float or a custom
-    // scalar).
+    // A NUMBER, matching REST and MCP (#9811). This used to arrive as a numeric
+    // string because src/graphql-sdl.ts declared `RpcUsage.observed_at: String`
+    // and GraphQL coerced -- one field, two representations across three
+    // surfaces. Float rather than Int because epoch millis overflow GraphQL's
+    // 32-bit Int, which is also why every sibling epoch-ms field on
+    // RpcUsageCoverage was already Float. observed_at was the odd one out
+    // inside its own type family.
     assert.equal(
       body.data.rpc_usage.observed_at,
-      String(Date.parse("2026-06-23T00:00:00.000Z")),
+      Date.parse("2026-06-23T00:00:00.000Z"),
     );
   });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -4646,6 +4646,65 @@ describe("MCP get_subnet_conviction (DATA_API binding)", () => {
     assert.deepEqual(out.leaderboard, []);
   });
 
+  // #9794. narrowConviction dropped `field_sources`, so this tool served LESS
+  // than REST for the same payload and failed its own published outputSchema on
+  // every call -- a schema that requires the key, and whose comment says it
+  // mirrors the REST artifact field for field. Provenance (#9108) is the whole
+  // point of the field: it says which values were read from chain and which
+  // were reconstructed, and an agent that cannot see that cannot tell the
+  // difference. Caught by validating production responses against their own
+  // published schemas; the local gate missed it (#9795).
+  test("publishes field_sources, and a tier that supplies its own wins", async () => {
+    const withoutProvenance = await callTool(
+      "get_subnet_conviction",
+      { netuid: 1 },
+      {
+        env: {
+          DATA_API: makeDataApi({
+            payload: {
+              schema_version: 1,
+              netuid: 1,
+              count: 0,
+              leaderboard: [],
+            },
+          }),
+        },
+      },
+    );
+    const fallback =
+      withoutProvenance.body.result.structuredContent.field_sources;
+    assert.ok(
+      fallback && typeof fallback === "object" && !Array.isArray(fallback),
+      "a tier that answers without provenance must not be the one response that silently omits it",
+    );
+
+    // Both tiers compute the same conviction, so the vocabulary is the same
+    // either way -- but a tier that states its own provenance is authoritative
+    // over the builder's constant.
+    const supplied = { conviction: { kind: "measured" } };
+    const withProvenance = await callTool(
+      "get_subnet_conviction",
+      { netuid: 1 },
+      {
+        env: {
+          DATA_API: makeDataApi({
+            payload: {
+              schema_version: 1,
+              netuid: 1,
+              count: 0,
+              leaderboard: [],
+              field_sources: supplied,
+            },
+          }),
+        },
+      },
+    );
+    assert.deepEqual(
+      withProvenance.body.result.structuredContent.field_sources,
+      supplied,
+    );
+  });
+
   test("rejects a missing/invalid netuid argument", async () => {
     const res = await callTool(
       "get_subnet_conviction",

--- a/tests/request-handlers-rpc-proxy.test.ts
+++ b/tests/request-handlers-rpc-proxy.test.ts
@@ -16,6 +16,16 @@ import {
 } from "../workers/request-handlers/rpc-proxy.ts";
 import { MAX_RPC_BODY_BYTES } from "../workers/config.ts";
 
+// The health-meta KV's `last_run_at`, which is what this route hands the zeroed
+// floor as its freshness stamp. It is an ISO string here because that is what
+// the KV holds; the assertions below expect `Date.parse` of it, because the
+// PUBLISHED field is epoch milliseconds (#9794).
+//
+// It used to be published as-is, so `observed_at` was a number whenever a store
+// answered and this string whenever none did. These assertions were written
+// against that pass-through and so encoded the bug -- they are the reason it
+// survived. Asserting the parse keeps the fixture honest about what the KV
+// holds while pinning the contract to one type.
 const OBSERVED_AT = "2026-06-24T12:00:00.000Z";
 const SURFACE_ID = "sn-6-numinous-api-health";
 
@@ -136,7 +146,7 @@ describe("handleRpcUsage", () => {
     assert.equal(body.data.summary.total_requests, 0);
     assert.deepEqual(body.data.endpoints, []);
     assert.deepEqual(body.data.networks, []);
-    assert.equal(body.data.observed_at, OBSERVED_AT);
+    assert.equal(body.data.observed_at, Date.parse(OBSERVED_AT));
     assert.equal(body.meta.artifact_path, "/metagraph/rpc/usage.json");
   });
 
@@ -262,7 +272,7 @@ describe("handleRpcUsage", () => {
     );
     assert.equal(aeCalled, false);
     assert.equal(body.data.summary.total_requests, 0);
-    assert.equal(body.data.observed_at, OBSERVED_AT);
+    assert.equal(body.data.observed_at, Date.parse(OBSERVED_AT));
   });
 
   test("flag=postgres falls back to the empty payload when DATA_API fails", async () => {
@@ -720,7 +730,7 @@ describe("configureRpcProxy wiring", () => {
         url("/api/v1/rpc/usage"),
       ),
     );
-    assert.equal(body.data.observed_at, customObserved);
+    assert.equal(body.data.observed_at, Date.parse(customObserved));
   });
 });
 

--- a/tests/rpc-usage.test.ts
+++ b/tests/rpc-usage.test.ts
@@ -23,6 +23,41 @@ describe("formatRpcUsage", () => {
     assert.deepEqual(out.networks, []);
   });
 
+  // #9794. `observed_at` used to change TYPE depending on which tier answered:
+  // the hot and cold tiers deal in epoch millis and rpc-usage-answer.ts takes a
+  // Math.max over both, but the zeroed floor is handed the health cron's
+  // `last_run_at`, an ISO string. So the published field was a number on a busy
+  // deployment and a string on a quiet one, no schema declared both, and
+  // nothing here asserted it either way -- which is why it went unnoticed until
+  // the route's own OpenAPI check caught it.
+  test("observed_at is epoch milliseconds whichever tier supplied it", () => {
+    const fromFloor = formatRpcUsage({
+      window: "7d",
+      observedAt: "2026-06-14T00:00:00Z",
+    }) as Row;
+    assert.equal(
+      fromFloor.observed_at,
+      Date.parse("2026-06-14T00:00:00Z"),
+      "the floor's ISO last_run_at is normalised, not passed through",
+    );
+
+    const fromTier = formatRpcUsage({
+      window: "7d",
+      observedAt: 1786099339000,
+    }) as Row;
+    assert.equal(fromTier.observed_at, 1786099339000, "millis pass through");
+
+    // "We don't know when" is a statement the schema can carry; NaN is not.
+    for (const value of [null, undefined, "", "not a date"]) {
+      assert.equal(
+        (formatRpcUsage({ window: "7d", observedAt: value }) as Row)
+          .observed_at,
+        null,
+        `${JSON.stringify(value)} yields null rather than NaN`,
+      );
+    }
+  });
+
   test("computes rates, ranks endpoints, and rounds latency/buckets", () => {
     const out = formatRpcUsage({
       window: "30d",


### PR DESCRIPTION
## Summary

Five MCP tools served responses that fail the `outputSchema` they publish. Found by validating all
225 tools against **production** with `Ajv2020`, each against its own published schema — not against
the local harness, which is why CI never saw it (#9795).

| tool | field | declared | actually served |
| --- | --- | --- | --- |
| `get_economics_trends` | `days[].total_stake_alpha` | `number \| null` | `"345955059.947656252"` |
| `get_rpc_usage` | `observed_at` | `string \| null` | `1786099339000` |
| `get_coverage_depth` | `coverage_depth_version` | `string \| null` | `1` |
| `get_account_positions` | requires `total_stake_tao` | — | serves `total_stake_alpha` (#8803) |
| `get_subnet_conviction` | requires `field_sources` | — | absent |

## Approach

Four were hand-written copies of a shape `schemas-src/routes/` already models. Patching the copies
is the thing that produced this, so they now **reuse the route `ArtifactSchema`** instead. A field
that changes shape changes in one place; a field that is renamed stops compiling rather than
disagreeing in production.

`get_rpc_usage` was not a copy drifting from a correct source — the route said `string` too. The same
field was written wrong twice, independently. Corrected at the source, which fixes
`GET /api/v1/rpc/usage` at the same time.

Deriving also removes opacity the copies introduced: `get_coverage_depth` published `rows` and
`ranked_queue` as bare open arrays while the route declares both row shapes in full, and
`get_account_portfolio` published `positions` as a bare open array, dropping the descriptions that
explain the totals are genuine TAO marked at spot and can lag ~24h behind the live tier.

Measured effect on the published surface:

| | before | after |
| --- | --- | --- |
| object sites | 629 | 639 — derivation un-collapses subtrees the copies flattened |
| precise | 421 | 429 |
| typed records | 20 | 26 |
| **untyped blobs** | **188** | **184** |
| declared precision | 70.1% | 71.2% |

Nine now-dead item schemas in `rpc-tools.ts` are deleted rather than left beside the derivation.

## Deliberately not derived

`get_account_positions` **is not** switched to `AccountPositionsArtifactSchema`, though it should be.
Checked against production rather than assumed: deriving today rejects real responses, because the
route's `degraded.reason` enum declares two values and production serves a third (#9804), and the
route requires `degraded.snapshot_captured_at` / `latest_stake_event_at` which the handler never
emits (#9803). Switching now would trade one drift for another. The rename is still fixed and the
blocker is recorded in the file.

## Also found while testing this

Filed separately, not fixed here:

- **#9803** — three surfaces serve a confident zero for top TAO holders while the positions tier is
  declining. `get_account_positions` reports `tier_unavailable`; `get_account_portfolio`,
  `get_account_subnets` and `GET /api/v1/accounts/{ss58}/positions` report `0` with no marker. The
  portfolio route schema has **no `degraded` field at all**, so it structurally cannot admit a
  failure. Reproduced across the top six holders by `total_tao`.
- **#9804** — 52 degraded reasons exist in `src/**`; the contracts declare a handful.

## Validation

```
npx tsc --noEmit                 clean
npm run build                    clean (openapi.json + types regenerated and committed)
npm run validate:contract-drift  passed
npm run validate:mcp             passed, 225 tools
npx vitest run tests/mcp-server.test.ts   1365 passed
npx prettier --check <changed>   clean
```

Every derivation was verified against production before the switch, because deriving is a tightening
— the route schemas are stricter than the copies were. The regression test for `field_sources` covers
both branches and was confirmed to **fail** with the fix reverted.

Closes #9794
Refs #9793, #9795, #9796, #9803, #9804
