### PR TITLE
fix(neon): remove the dialect from the window boundary, and scan for the next one

### DIFF
--- a/src/iso-date-window.ts
+++ b/src/iso-date-window.ts
@@ -1,0 +1,56 @@
+// Window boundaries that do not depend on the store's SQL dialect (#9798).
+//
+// WHY THIS EXISTS. Three neuron_daily routes anchored their window on
+// `date(MAX(snapshot_date), '-N days')`. That function is SQLite's; Postgres
+// has no equivalent, so on Neon the subquery yielded nothing, `>=` matched
+// nothing, and the routes returned a schema-stable 200 with ZERO rows --
+// `/subnets/{netuid}/history` went 28 -> 0 and `/subnets/movers` 5 -> 0 (#9792).
+// Not an error. The one shape that reads as "no data yet".
+//
+// The neurons family moves store by choosing a runner, and the runners really
+// are interface-compatible -- `toPositionalPlaceholders` handles `?` -> `$n`.
+// What is NOT compatible is the function library, and nothing was checking it.
+//
+// THE FIX IS TO REMOVE THE DIALECT FROM THE QUESTION rather than to translate
+// it. The anchor is `MAX(snapshot_date)` shifted by N days: reading a max is
+// portable, binding a date literal is portable, and the shift is arithmetic
+// that belongs in TypeScript. Once it happens here there is no date function
+// left in the SQL for two dialects to disagree about.
+//
+// NOT `windowCutoffDate`, which the history routes use and which shifts from
+// `Date.now()`. That difference is deliberate and load-bearing: these three
+// anchor on the newest row the table actually HAS, so a producer that has
+// fallen a day behind still yields a full window instead of a short one.
+
+/** Milliseconds in a day. Snapshot dates are whole days, so this never straddles a DST change. */
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** `YYYY-MM-DD`, the stored shape of every `snapshot_date` in the neurons family. */
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Shift an ISO `YYYY-MM-DD` date by a whole number of days.
+ *
+ * Returns null rather than throwing or producing `"Invalid Date"` for anything
+ * that is not a date, because the input is a value READ BACK FROM THE STORE:
+ * an empty table yields SQL NULL, which arrives here as null/undefined. A
+ * caller that gets null must treat the window as unbounded or empty on its own
+ * terms -- exactly what the `date(...)` subquery's NULL used to do -- rather
+ * than binding the string "Invalid Date" into a query.
+ *
+ * Parsed as UTC (the `Z`) so the result never depends on where the Worker ran.
+ * Without it, `new Date("2026-08-07")` is UTC but `new Date(y, m, d)` is local,
+ * and a boundary computed in one and compared against the other slips a day
+ * for half the world.
+ */
+export function shiftIsoDate(date: unknown, days: number): string | null {
+  if (typeof date !== "string" || !ISO_DATE.test(date)) return null;
+  const ms = Date.parse(`${date}T00:00:00Z`);
+  // NOT unreachable: the regex counts digits, not calendars, so "2026-13-01"
+  // and "2026-01-32" reach here and Date.parse returns NaN for both. (It does
+  // NOT reject every impossible date -- "2026-02-31" silently rolls over to
+  // March 3rd, which is why this guard is a backstop and not the validator.)
+  if (!Number.isFinite(ms)) return null;
+  if (!Number.isFinite(days)) return null;
+  return new Date(ms + Math.trunc(days) * DAY_MS).toISOString().slice(0, 10);
+}

--- a/tests/data-api-neurons-d1.test.ts
+++ b/tests/data-api-neurons-d1.test.ts
@@ -1302,6 +1302,73 @@ test("GET /api/v1/chain/turnover compares the window's boundary snapshots", asyn
   assert.equal(network.validators_exited, 1);
 });
 
+// THE WINDOW BOUNDARY ITSELF, which nothing asserted until #9798. Every test
+// above seeds rows entirely INSIDE the window, so they pass unchanged even if
+// the boundary is dropped altogether -- verified by mutation: replacing the
+// computed cutoff with `null` left all 75 tests green. That is the shape of gap
+// that let #9784 ship: the SQL said `date(MAX(snapshot_date), '-N days')`,
+// Postgres has no such function, the subquery yielded nothing, and two routes
+// served an empty 200 in production with a full suite behind them.
+//
+// So these seed a row OUTSIDE the window and require it to be excluded. Both
+// neuronDailyWindowBounds shapes are covered: chain-wide, and per-netuid.
+test("GET /api/v1/chain/turnover excludes snapshots older than the window", async () => {
+  const ancient = dayAgo(60);
+  const start = dayAgo(5);
+  const end = dayAgo(1);
+  for (const snapshot_date of [ancient, start, end]) {
+    insertDaily({
+      netuid: 7,
+      uid: 0,
+      hotkey: "5A",
+      validator_permit: 1,
+      snapshot_date,
+    });
+  }
+  const res = await call(req("/api/v1/chain/turnover?window=7d"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  // The 60-day-old row is the oldest in the table, so an unbounded MIN would
+  // return it -- which is exactly what a dropped boundary produces.
+  assert.equal(
+    body.start_date,
+    start,
+    "the window's start must be the oldest row INSIDE it, not the table's oldest",
+  );
+  assert.equal(body.end_date, end);
+});
+
+test("GET /api/v1/subnets/:netuid/history excludes snapshots older than the window", async () => {
+  const ancient = dayAgo(60);
+  const start = dayAgo(5);
+  for (const snapshot_date of [ancient, start, dayAgo(1)]) {
+    insertDaily({
+      netuid: 7,
+      uid: 0,
+      hotkey: "5A",
+      validator_permit: 1,
+      snapshot_date,
+    });
+  }
+  // A netuid the window must not reach across: its own bounds are computed
+  // per-netuid, so a row here must not become subnet 7's start date.
+  insertDaily({
+    netuid: 9,
+    uid: 0,
+    hotkey: "5Z",
+    validator_permit: 1,
+    snapshot_date: dayAgo(90),
+  });
+  const res = await call(req("/api/v1/subnets/7/turnover?window=7d"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(
+    body.start_date,
+    start,
+    "the per-netuid window must exclude both the old row and the other netuid",
+  );
+});
+
 test("GET /api/v1/chain/turnover on an empty store serves the schema-stable empty shape", async () => {
   const res = await call(req("/api/v1/chain/turnover"));
   assert.equal(res.status, 200);

--- a/tests/iso-date-window.test.ts
+++ b/tests/iso-date-window.test.ts
@@ -1,0 +1,73 @@
+// The window boundary that replaced a dialect function (#9798).
+//
+// This exists because `date(MAX(snapshot_date), '-30 days')` -- SQLite's, with
+// no Postgres equivalent -- silently emptied `/subnets/{netuid}/history` and
+// `/subnets/movers` the moment #9784 moved them to Neon: the subquery yielded
+// nothing, `>=` matched nothing, and both served a schema-stable 200 with zero
+// rows. Doing the shift here is what removes the dialect from the question, so
+// the arithmetic is worth pinning on its own.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { shiftIsoDate } from "../src/iso-date-window.ts";
+
+describe("shiftIsoDate", () => {
+  test("shifts backwards, which is the only direction the routes use", () => {
+    assert.equal(shiftIsoDate("2026-08-07", -30), "2026-07-08");
+    assert.equal(shiftIsoDate("2026-08-07", -1), "2026-08-06");
+    assert.equal(shiftIsoDate("2026-08-07", -7), "2026-07-31");
+  });
+
+  test("crosses month, year and leap-day boundaries", () => {
+    // The arithmetic is on epoch ms, so these are not special cases in the
+    // implementation -- they are the cases a hand-rolled y/m/d subtraction
+    // would get wrong, which is why it is not hand-rolled.
+    assert.equal(shiftIsoDate("2026-03-01", -1), "2026-02-28");
+    assert.equal(shiftIsoDate("2024-03-01", -1), "2024-02-29", "leap year");
+    assert.equal(shiftIsoDate("2026-01-01", -1), "2025-12-31");
+    assert.equal(shiftIsoDate("2026-01-15", -365), "2025-01-15");
+  });
+
+  test("a zero or forward shift is arithmetic, not a special case", () => {
+    assert.equal(shiftIsoDate("2026-08-07", 0), "2026-08-07");
+    assert.equal(shiftIsoDate("2026-08-07", 30), "2026-09-06");
+  });
+
+  test("truncates a fractional day rather than emitting a time", () => {
+    // A window constant should always be whole days, but the output is BOUND
+    // INTO SQL and compared against 'YYYY-MM-DD' -- so a value carrying hours
+    // would silently match nothing, which is the failure mode this whole
+    // module exists to end.
+    assert.equal(shiftIsoDate("2026-08-07", -1.9), "2026-08-06");
+    assert.equal(shiftIsoDate("2026-08-07", 1.9), "2026-08-08");
+  });
+
+  test("returns null for a value that is not an ISO date", () => {
+    // These arrive FROM THE STORE. An empty table yields SQL NULL, and the
+    // caller must see the same "no window" signal the NULL subquery produced
+    // rather than bind the string "Invalid Date" into a query.
+    assert.equal(shiftIsoDate(null, -30), null);
+    assert.equal(shiftIsoDate(undefined, -30), null);
+    assert.equal(shiftIsoDate("", -30), null);
+    assert.equal(shiftIsoDate(20260807, -30), null, "a number is not a date");
+    assert.equal(shiftIsoDate("2026-08-07T00:00:00Z", -30), null, "not bare");
+    assert.equal(shiftIsoDate("07/08/2026", -30), null);
+    assert.equal(shiftIsoDate("2026-8-7", -30), null, "unpadded");
+  });
+
+  test("returns null for a well-SHAPED date the calendar rejects", () => {
+    // The regex counts digits, not calendars, so this branch is genuinely
+    // reachable -- verified against Date.parse rather than assumed.
+    assert.equal(shiftIsoDate("2026-13-01", -1), null, "month 13");
+    assert.equal(shiftIsoDate("2026-01-32", -1), null, "day 32");
+    assert.equal(shiftIsoDate("2026-00-10", -1), null, "month 0");
+    // And the one Date.parse does NOT reject, pinned so the comment in the
+    // module stays honest: it rolls over rather than failing.
+    assert.equal(shiftIsoDate("2026-02-31", 0), "2026-03-03");
+  });
+
+  test("returns null when the shift itself is not a number", () => {
+    assert.equal(shiftIsoDate("2026-08-07", Number.NaN), null);
+    assert.equal(shiftIsoDate("2026-08-07", Number.POSITIVE_INFINITY), null);
+    assert.equal(shiftIsoDate("2026-08-07", Number.NEGATIVE_INFINITY), null);
+  });
+});

--- a/tests/neon-read-routes.test.ts
+++ b/tests/neon-read-routes.test.ts
@@ -127,6 +127,156 @@ describe("NEON_READ_ROUTE_TABLES", () => {
     assert.deepEqual(problems, [], problems.join("\n"));
   });
 
+  // THE DIALECT SCAN (#9798). The map's table assertion above answers "is this
+  // route's data in Neon". It cannot answer "will this route's SQL RUN on
+  // Neon", and that is the question #9784 got wrong: the runners are
+  // interface-compatible -- toPositionalPlaceholders rewrites `?` to `$n` --
+  // but the FUNCTION LIBRARY is not, and nothing checked it.
+  //
+  // The cost of missing it is what makes this worth a test rather than a
+  // review habit. `date(x, '-30 days')` does not raise on Postgres; the
+  // subquery yields nothing, `>=` matches nothing, and the route serves a
+  // schema-stable 200 with zero rows. `/subnets/{netuid}/history` went 28 -> 0
+  // and `/subnets/movers` 5 -> 0, and only a pre-cutover content baseline
+  // caught it. There are 46 tables left to move in #9787; the next one should
+  // fail here instead.
+  test("no route that may move to Neon uses SQLite-only SQL", () => {
+    // Each pattern is anchored to a call, so a bare mention in prose cannot
+    // trip it. `date(`/`strftime(` are listed with their opening paren for the
+    // same reason -- `snapshot_date` must not match `date(`.
+    const SQLITE_ONLY: readonly { pattern: RegExp; why: string }[] = [
+      {
+        // The one that actually shipped. Postgres spells it
+        // `max(snapshot_date)::date - N`, and neither spelling belongs in the
+        // SQL at all -- bind the boundary (neuronDailyWindowBounds).
+        pattern: /\b(?:date|datetime|julianday)\s*\(/i,
+        why: "SQLite date functions; Postgres has no date(x, modifier) -- compute the boundary in TypeScript and bind it",
+      },
+      {
+        pattern: /\bstrftime\s*\(/i,
+        why: "SQLite strftime; Postgres uses to_char/date_trunc",
+      },
+      {
+        pattern: /\bifnull\s*\(/i,
+        why: "SQLite IFNULL; both dialects have COALESCE",
+      },
+      {
+        pattern: /\bgroup_concat\s*\(/i,
+        why: "SQLite GROUP_CONCAT; Postgres uses string_agg",
+      },
+      {
+        pattern: /\bjson_extract\s*\(/i,
+        why: "SQLite json_extract; Postgres uses -> / ->>",
+      },
+      {
+        pattern: /\binstr\s*\(/i,
+        why: "SQLite INSTR; Postgres uses position()/strpos()",
+      },
+      {
+        pattern: /\bautoincrement\b/i,
+        why: "SQLite AUTOINCREMENT",
+      },
+    ];
+
+    const src = readFileSync("workers/data-api.ts", "utf8");
+    const start = src.indexOf("function matchNeuronsD1Route");
+    assert.ok(start > 0, "matchNeuronsD1Route not found");
+    const end = src.indexOf("\nfunction ", start + 10);
+    const body = src.slice(start, end > 0 ? end : undefined);
+
+    // Only the SQL, not the comments around it: this file explains the bug in
+    // prose directly above the fix, and a scan that cannot tell those apart
+    // would have to be weakened until it stopped working.
+    const statements = [...body.matchAll(/sql`([^`]*)`/g)].map((m) => m[1]);
+    assert.ok(
+      statements.length >= 10,
+      `only ${statements.length} tagged statements found -- the extraction ` +
+        `stopped working, so this test is passing on nothing`,
+    );
+
+    const problems: string[] = [];
+    for (const statement of statements) {
+      for (const { pattern, why } of SQLITE_ONLY) {
+        if (pattern.test(statement)) {
+          problems.push(
+            `${why}\n    in: ${statement.replace(/\s+/g, " ").trim().slice(0, 120)}`,
+          );
+        }
+      }
+    }
+    assert.deepEqual(problems, [], `\n  ${problems.join("\n  ")}\n`);
+  });
+
+  test("the scan actually covers every route the read map may move", () => {
+    // The scan reads ONE function. That is only sufficient while every route in
+    // NEON_READ_ROUTE_TABLES is dispatched from it -- and the map is the thing
+    // that grows as tables move off D1. Without this, adding a route whose
+    // handler lives elsewhere silently shrinks the scan's coverage to nothing
+    // in particular, and it would still report green.
+    const src = readFileSync("workers/data-api.ts", "utf8");
+    const start = src.indexOf("function matchNeuronsD1Route");
+    const end = src.indexOf("\nfunction ", start + 10);
+    const body = src.slice(start, end > 0 ? end : undefined);
+
+    // Compare on a CONCRETE PATH, not on regex source: the dispatcher spells
+    // the parameterised routes with capture groups (`(\d+)`) and the map
+    // without them, so the two sources never match textually even when they
+    // describe the same route.
+    const guards = [
+      // `if (url.pathname === "...")`
+      ...[...body.matchAll(/pathname === "([^"]+)"/g)].map(
+        (m) => (path: string) => path === m[1],
+      ),
+      // `url.pathname.match(/^\/api\/v1\/.../)`
+      ...[...body.matchAll(/pathname\.match\(\s*(\/\^[^\n]*?\$\/)/g)].map(
+        (m) => {
+          const re = new RegExp(m[1]!.slice(1, -1));
+          return (path: string) => re.test(path);
+        },
+      ),
+    ];
+    assert.ok(
+      guards.length >= 12,
+      `only ${guards.length} route guards extracted -- the extraction stopped ` +
+        `working, so this test is passing on nothing`,
+    );
+
+    const uncovered = NEON_READ_ROUTE_TABLES.filter(({ pattern }) => {
+      const path = pattern.source
+        .replace(/^\^|\$$/g, "")
+        .replace(/\\\//g, "/")
+        .replace(/\[\^\/\]\+/g, "5Abc")
+        .replace(/\\d\+/g, "7");
+      return !guards.some((matches) => matches(path));
+    });
+    assert.deepEqual(
+      uncovered.map((u) => u.pattern.source),
+      [],
+      "these read-map routes are not dispatched from the scanned function, so " +
+        "the dialect scan does not see their SQL",
+    );
+  });
+
+  test("the dialect scan would catch the construct that actually shipped", () => {
+    // A negative assertion passes on nothing unless the fixture could fail, and
+    // this one guards a regex list -- the failure mode is a pattern that
+    // matches nothing at all, which looks identical to a clean codebase.
+    const shipped =
+      "SELECT MIN(snapshot_date) FROM neuron_daily WHERE snapshot_date >= " +
+      "(SELECT date(MAX(snapshot_date), '-30 days') FROM neuron_daily)";
+    assert.ok(
+      /\b(?:date|datetime|julianday)\s*\(/i.test(shipped),
+      "the scan no longer matches the exact SQL that emptied two routes",
+    );
+    // And it must not fire on the column name it is spelled to avoid.
+    assert.ok(
+      !/\b(?:date|datetime|julianday)\s*\(/i.test(
+        "SELECT snapshot_date FROM neuron_daily WHERE netuid = ?",
+      ),
+      "the scan matches a plain snapshot_date column, which would make it noise",
+    );
+  });
+
   test("the position-history route declares BOTH tables it reads", () => {
     // The specific bug this map corrects. #9768 gated it on
     // account_position_daily alone.

--- a/tests/neuron-daily-window-bounds.test.ts
+++ b/tests/neuron-daily-window-bounds.test.ts
@@ -1,0 +1,145 @@
+// The four query shapes of neuronDailyWindowBounds (#9798).
+//
+// tests/data-api-neurons-d1.test.ts drives the two shapes today's routes reach,
+// end to end against real SQLite. This file covers all four, because the other
+// two are unreachable only by accident of the current window maps --
+// CHAIN_TURNOVER_WINDOWS and MOVERS_WINDOWS are `Record<string, number>` so a
+// chain-wide call cannot carry a null window, while HISTORY_WINDOWS's
+// `all: null` makes the per-netuid one. Add `all` to either map and the
+// untested shape ships.
+//
+// It also pins the thing that actually matters after #9792: THE SQL CONTAINS NO
+// DIALECT FUNCTION. `date(MAX(snapshot_date), '-30 days')` is SQLite's, Postgres
+// has none, and its absence is why these routes can move store at all -- so the
+// statements themselves are asserted, not just their results.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { neuronDailyWindowBounds } from "../workers/data-api.ts";
+
+type Call = { text: string; values: unknown[] };
+
+/**
+ * A tagged-template `sql` that records what it was asked, and answers from a
+ * queue. Deliberately does not parse SQL -- the assertions here are about the
+ * statement TEXT and the bound values, which is exactly what a real database
+ * cannot tell you (it would happily run either dialect's own spelling).
+ */
+function fakeSql(responses: Record<string, unknown>[][]) {
+  const calls: Call[] = [];
+  const queue = [...responses];
+  const sql = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    calls.push({ text: strings.join("?").replace(/\s+/g, " ").trim(), values });
+    return Promise.resolve(queue.shift() ?? []);
+  };
+  sql.unsafe = () => Promise.resolve([]);
+  return { sql: sql as never, calls };
+}
+
+describe("neuronDailyWindowBounds", () => {
+  test("chain-wide, windowed: binds the shifted max and names no date function", async () => {
+    const { sql, calls } = fakeSql([
+      [{ end_date: "2026-08-07" }],
+      [{ start_date: "2026-07-09" }],
+    ]);
+    const bounds = await neuronDailyWindowBounds(sql, 30);
+    assert.deepEqual(bounds, {
+      startDate: "2026-07-09",
+      endDate: "2026-08-07",
+    });
+    assert.equal(calls.length, 2);
+    // The boundary is a BOUND VALUE, computed here: 2026-08-07 minus 30 days.
+    assert.deepEqual(calls[1]!.values, ["2026-07-08"]);
+    assert.match(calls[1]!.text, /snapshot_date >= \?/);
+  });
+
+  test("per-netuid, windowed: scopes BOTH statements to the netuid", async () => {
+    const { sql, calls } = fakeSql([
+      [{ end_date: "2026-08-07" }],
+      [{ start_date: "2026-08-01" }],
+    ]);
+    const bounds = await neuronDailyWindowBounds(sql, 7, 7);
+    assert.equal(bounds.startDate, "2026-08-01");
+    // The max must be the NETUID's max, not the table's -- a chain-wide max
+    // would shift the window off a subnet that stopped reporting days ago.
+    assert.match(calls[0]!.text, /WHERE netuid = \?/);
+    assert.deepEqual(calls[0]!.values, [7]);
+    assert.deepEqual(calls[1]!.values, [7, "2026-07-31"]);
+  });
+
+  test("a null window binds no boundary at all", async () => {
+    // `all` in HISTORY_WINDOWS. There is nothing to shift, so the start is the
+    // slice's own minimum and no cutoff is bound -- binding null here would
+    // match nothing, which is the #9792 failure wearing a different hat.
+    const perNetuid = fakeSql([
+      [{ end_date: "2026-08-07" }],
+      [{ start_date: "2025-01-01" }],
+    ]);
+    await neuronDailyWindowBounds(perNetuid.sql, null, 7);
+    assert.deepEqual(perNetuid.calls[1]!.values, [7]);
+    assert.doesNotMatch(perNetuid.calls[1]!.text, /snapshot_date >= /);
+
+    const chainWide = fakeSql([
+      [{ end_date: "2026-08-07" }],
+      [{ start_date: "2024-06-01" }],
+    ]);
+    const bounds = await neuronDailyWindowBounds(chainWide.sql, null);
+    assert.deepEqual(bounds, {
+      startDate: "2024-06-01",
+      endDate: "2026-08-07",
+    });
+    assert.deepEqual(chainWide.calls[1]!.values, []);
+  });
+
+  test("an empty table returns nulls and never issues the second query", async () => {
+    // Both halves matter: nulls are the signal every caller already branches
+    // on, and skipping the second read is what stops an empty store costing
+    // two round trips per request.
+    const { sql, calls } = fakeSql([[{ end_date: null }]]);
+    assert.deepEqual(await neuronDailyWindowBounds(sql, 30), {
+      startDate: null,
+      endDate: null,
+    });
+    assert.equal(calls.length, 1);
+
+    const noRow = fakeSql([[]]);
+    assert.deepEqual(await neuronDailyWindowBounds(noRow.sql, 30), {
+      startDate: null,
+      endDate: null,
+    });
+    assert.equal(noRow.calls.length, 1);
+  });
+
+  test("a store that returns no row for the MIN degrades to a null start", async () => {
+    // Not reachable through D1 or Postgres, both of which always return a row
+    // for a bare aggregate -- which is precisely why it is asserted here rather
+    // than left to a runner that happens to behave.
+    const { sql } = fakeSql([[{ end_date: "2026-08-07" }], []]);
+    assert.deepEqual(await neuronDailyWindowBounds(sql, 30), {
+      startDate: null,
+      endDate: "2026-08-07",
+    });
+  });
+
+  test("no statement it issues contains a dialect-specific date function", async () => {
+    // The regression guard. Every shape, every statement.
+    for (const [days, netuid] of [
+      [30, null],
+      [7, 7],
+      [null, 7],
+      [null, null],
+    ] as const) {
+      const { sql, calls } = fakeSql([
+        [{ end_date: "2026-08-07" }],
+        [{ start_date: "2026-07-09" }],
+      ]);
+      await neuronDailyWindowBounds(sql, days, netuid);
+      for (const { text } of calls) {
+        assert.doesNotMatch(
+          text,
+          /\b(?:date|datetime|julianday|strftime)\s*\(/i,
+          `dialect function in: ${text}`,
+        );
+      }
+    }
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -330,6 +330,9 @@ function windowCutoffDate(
     .slice(0, 10);
 }
 
+// #9798: window boundaries computed here rather than in SQL, so no dialect
+// function survives into a query two stores have to agree about.
+import { shiftIsoDate } from "../src/iso-date-window.ts";
 import { isPublicWebhookUrl, timingSafeEqual } from "../src/webhooks.ts";
 // #8385: shape-check push key material at intake (see that module).
 import { isValidPushKeyMaterial } from "../src/web-push.ts";
@@ -5537,8 +5540,14 @@ async function handleAccountKeysRoute(request: Request, env: Env, url: URL) {
 //   - DISTINCT ON (k) ... ORDER BY k, d  -> ROW_NUMBER() OVER (PARTITION BY
 //     k ORDER BY d DESC) = 1, or a group-wise-MAX join (SQLite has no
 //     DISTINCT ON)
-//   - MAX(snapshot_date) - N::int        -> date(MAX(snapshot_date),
-//     '-N days')
+//   - MAX(snapshot_date) - N::int        -> NEITHER. This one is no longer a
+//     translation at all (#9798): the SQLite rendering was
+//     `date(MAX(snapshot_date), '-N days')`, and translating a dialect function
+//     into another dialect function is exactly what broke when these routes
+//     moved to Neon -- Postgres has no `date(x, modifier)`, so the subquery
+//     yielded nothing and two routes served an empty 200 (#9792). The shift now
+//     happens in TypeScript and the boundary is BOUND; see
+//     neuronDailyWindowBounds. Nothing here should acquire a fourth rendering.
 //
 // Cross-tier joins: subnet_snapshots has a live D1 home (migrations/d1/
 // 0002_observations.sql), so the alpha_price_tao joins/loads port for real.
@@ -5945,6 +5954,74 @@ export function neonServesRoute(
   );
   if (!entry) return false;
   return entry.tables.every((table) => neonReadEnabled(env, table));
+}
+
+/**
+ * The `[start, end]` snapshot dates of an N-day window over `neuron_daily`,
+ * anchored on the newest row the table HAS rather than on the clock.
+ *
+ * WHY IT IS TWO QUERIES AND NOT ONE (#9798). This used to be a single statement
+ * whose WHERE clause read `snapshot_date >= (SELECT date(MAX(snapshot_date),
+ * '-N days') FROM neuron_daily)`. `date(x, '-N days')` is SQLite's; Postgres
+ * has no such function, so the moment #9784 moved these routes to Neon the
+ * subquery yielded nothing, `>=` matched nothing, and `/subnets/{netuid}/
+ * history` and `/subnets/movers` each served a schema-stable 200 with ZERO rows
+ * until #9792 rolled the flag back.
+ *
+ * Splitting it removes the dialect from the question rather than translating
+ * it: reading a MAX is portable, `shiftIsoDate` is arithmetic, and binding a
+ * date literal is portable. There is no date function left for two dialects to
+ * disagree about, which is why this cannot regress the way the last one did.
+ *
+ * The extra round trip buys that outright. Both statements are single-row
+ * aggregate reads against the table's own index, on a path that already issues
+ * a second, far heavier query for the rows themselves.
+ *
+ * ANCHORED ON THE DATA, deliberately -- see iso-date-window.ts. Shifting from
+ * `Date.now()` (what windowCutoffDate does for the history routes) would return
+ * a SHORT window whenever the producer has fallen a day behind, which is the
+ * failure this whole family is being watched for.
+ *
+ * Returns nulls when the table (or the netuid's slice of it) is empty, which is
+ * exactly what the NULL subquery used to produce -- every caller already
+ * branches on that.
+ *
+ * EXPORTED FOR ASSERTION, the same reason positionHistoryServedFromNeon is:
+ * only two of its four query shapes are reachable from today's routes
+ * (`CHAIN_TURNOVER_WINDOWS`/`MOVERS_WINDOWS` are `Record<string, number>`, so a
+ * chain-wide call can never carry a null window, while HISTORY_WINDOWS's
+ * `all: null` makes the per-netuid one). Leaving the other two untested because
+ * no current caller reaches them is how a window function ends up wrong the
+ * first time a route needs it -- and annotating them out of coverage would say
+ * the same thing more quietly.
+ */
+export async function neuronDailyWindowBounds(
+  sql: D1Sql,
+  days: number | null,
+  netuid: number | null = null,
+): Promise<{ startDate: string | null; endDate: string | null }> {
+  const maxRows =
+    netuid == null
+      ? await sql`SELECT MAX(snapshot_date) AS end_date FROM neuron_daily`
+      : await sql`SELECT MAX(snapshot_date) AS end_date FROM neuron_daily WHERE netuid = ${netuid}`;
+  const endDate = (maxRows[0]?.end_date ?? null) as string | null;
+  if (endDate == null) return { startDate: null, endDate: null };
+
+  // A null window means "everything", so there is no cutoff to bind and the
+  // start is the table's own minimum.
+  const cutoff = days == null ? null : shiftIsoDate(endDate, -days);
+  const minRows =
+    netuid == null
+      ? cutoff == null
+        ? await sql`SELECT MIN(snapshot_date) AS start_date FROM neuron_daily`
+        : await sql`SELECT MIN(snapshot_date) AS start_date FROM neuron_daily WHERE snapshot_date >= ${cutoff}`
+      : cutoff == null
+        ? await sql`SELECT MIN(snapshot_date) AS start_date FROM neuron_daily WHERE netuid = ${netuid}`
+        : await sql`SELECT MIN(snapshot_date) AS start_date FROM neuron_daily WHERE netuid = ${netuid} AND snapshot_date >= ${cutoff}`;
+  return {
+    startDate: (minRows[0]?.start_date ?? null) as string | null,
+    endDate,
+  };
 }
 
 function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
@@ -6583,12 +6660,9 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
     };
   }
 
-  // GET /api/v1/chain/turnover?window=&limit=. The Postgres branch anchors
-  // the window with `MAX(snapshot_date) - ${days}::int`; SQLite's native
-  // equivalent is date(MAX(snapshot_date), '-N days') -- the exact idiom the
-  // pre-#4772 D1 route used. An empty table leaves the subquery NULL, the
-  // >= comparison matches nothing, and the same schema-stable empty shape
-  // falls out.
+  // GET /api/v1/chain/turnover?window=&limit=. The window is anchored on the
+  // newest row the table HAS, not on the clock -- see neuronDailyWindowBounds,
+  // which also explains why the shift no longer happens in SQL.
   if (url.pathname === "/api/v1/chain/turnover") {
     return async (sql) => {
       const windowParam =
@@ -6602,12 +6676,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
         limitRaw == null || limitRaw === ""
           ? CHAIN_TURNOVER_LIMIT_DEFAULT
           : Number(limitRaw);
-      const bounds = await sql`
-        SELECT MIN(snapshot_date) AS start_date, MAX(snapshot_date) AS end_date
-        FROM neuron_daily
-        WHERE snapshot_date >= (SELECT date(MAX(snapshot_date), ${`-${days} days`}) FROM neuron_daily)`;
-      const startDate = (bounds[0]?.start_date ?? null) as string | null;
-      const endDate = (bounds[0]?.end_date ?? null) as string | null;
+      const { startDate, endDate } = await neuronDailyWindowBounds(sql, days);
       let rows: Row[] = [];
       if (startDate != null && endDate != null && startDate !== endDate) {
         rows = await sql`
@@ -6640,18 +6709,11 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
         : DEFAULT_HISTORY_WINDOW;
       const windowDays = HISTORY_WINDOWS[windowLabel];
       const includeChanges = url.searchParams.get("changes") === "true";
-      const bounds =
-        windowDays == null
-          ? await sql`
-            SELECT MIN(snapshot_date) AS start_date, MAX(snapshot_date) AS end_date
-            FROM neuron_daily WHERE netuid = ${netuid}`
-          : await sql`
-            SELECT MIN(snapshot_date) AS start_date, MAX(snapshot_date) AS end_date
-            FROM neuron_daily
-            WHERE netuid = ${netuid}
-              AND snapshot_date >= (SELECT date(MAX(snapshot_date), ${`-${windowDays} days`}) FROM neuron_daily WHERE netuid = ${netuid})`;
-      const startDate = (bounds[0]?.start_date ?? null) as string | null;
-      const endDate = (bounds[0]?.end_date ?? null) as string | null;
+      const { startDate, endDate } = await neuronDailyWindowBounds(
+        sql,
+        windowDays,
+        netuid,
+      );
       const rows =
         startDate == null || endDate == null
           ? []
@@ -6690,12 +6752,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
         limitRaw == null || limitRaw === ""
           ? MOVERS_LIMIT_DEFAULT
           : Number(limitRaw);
-      const bounds = await sql`
-        SELECT MIN(snapshot_date) AS start_date, MAX(snapshot_date) AS end_date
-        FROM neuron_daily
-        WHERE snapshot_date >= (SELECT date(MAX(snapshot_date), ${`-${days} days`}) FROM neuron_daily)`;
-      const startDate = (bounds[0]?.start_date ?? null) as string | null;
-      const endDate = (bounds[0]?.end_date ?? null) as string | null;
+      const { startDate, endDate } = await neuronDailyWindowBounds(sql, days);
       let startRows: Row[] = [];
       let endRows: Row[] = [];
       if (startDate != null && endDate != null && startDate !== endDate) {


### PR DESCRIPTION
Both Neon read rollbacks — #9792 (`neuron_daily`) and #9802 (`neurons`) — name the same prerequisite. #9802 states it as a rule:

> **Nothing goes back into `NEON_READ_LANES` until CI rejects SQLite-only SQL on any route the read map may move.**

This is that check, plus the three ported queries. It is the gate on the rest of the migration, not a cleanup after it.

## The follow-ups went untracked

#9792 listed both items in #9791 — and carried `Closes #9791`, so the issue closed on the rollback. Neither had landed. The SQLite idiom is still in **three** routes (not two), and nothing in CI would catch a fourth.

| line | route | emptied by #9784? |
|---|---|---|
| `workers/data-api.ts` | `GET /api/v1/chain/turnover` | not measured |
| `workers/data-api.ts` | `GET /api/v1/subnets/{netuid}/turnover` | **yes** — 28 → 0 |
| `workers/data-api.ts` | `GET /api/v1/subnets/movers` | **yes** — 5 → 0 |

`/chain/turnover` reads the same table through the same idiom and would have emptied identically. It simply was not in the measured baseline — worth saying plainly, because "two routes broke" is what the rollback observed, not what was wrong.

## The port removes the dialect rather than translating it

`date(x, '-30 days')` is SQLite's. Postgres has none, so the subquery yielded nothing, `>=` matched nothing, and the routes served a **schema-stable 200 with zero rows** — not an error, the one shape that reads as "no data yet".

The anchor is `MAX(snapshot_date)` shifted by N days. Reading a max is portable and binding a date literal is portable, so the shift moves into TypeScript (`src/iso-date-window.ts`) and **no date function survives into the SQL**. Translating one dialect function into another is exactly what broke; there is now nothing left to translate.

Anchored on the data, not the clock — deliberately, and unlike `windowCutoffDate`. Shifting from `Date.now()` returns a short window whenever the producer has fallen a day behind, which is the failure this family is being watched for.

Two statements instead of one. Both are single-row aggregate reads against the table's own index, on a path that already issues a far heavier second query for the rows.

## The scan is the durable half

Porting three queries fixes today's three. The scan is what fails the *next* one at CI instead of in production, and with everything in D1 moving to Neon that is the part that keeps paying.

It reuses the per-route SQL extraction the map's own test already does, and it has **two** anti-vacuous guards, because a scan that quietly stops looking is worse than no scan:

- it asserts it found ≥10 tagged statements before judging them;
- a second test asserts **every route in `NEON_READ_ROUTE_TABLES` is dispatched from the function being scanned** — otherwise adding a route whose handler lives elsewhere silently shrinks coverage to nothing and still reports green. (That test genuinely fails when the matching is wrong: my first attempt compared regex sources and flagged 9 parameterised routes, because the dispatcher spells them with capture groups and the map does not.)

Scanned today: 26 statements, covering all 13 read-map routes including `/validators` — the one #9802 caught.

## The window boundary had no coverage at all

Every existing `neuron_daily` route test seeded rows entirely **inside** the window, so replacing the computed cutoff with `null` left **all 75 tests green**. Verified by mutation. That is the gap that let #9784 ship with a full suite behind it.

Added tests seed a row *outside* the window and require it to be excluded — mutation-checked in both directions:

```
× GET /api/v1/chain/turnover excludes snapshots older than the window          (cutoff removed)
× GET /api/v1/subnets/:netuid/history excludes snapshots older than the window (cutoff removed)
  Tests  77 passed (77)                                                         (cutoff restored)
```

The dialect scan was mutation-checked the same way: restoring the old `date(MAX(...), '-N days')` SQL makes it **fail**.

`neuronDailyWindowBounds` is exported for assertion, the same reason `positionHistoryServedFromNeon` is: only two of its four query shapes are reachable from today's routes, because `CHAIN_TURNOVER_WINDOWS`/`MOVERS_WINDOWS` are `Record<string, number>` while `HISTORY_WINDOWS` has `all: null`. Leaving the other two untested is how a window function is wrong the first time a route needs it — and a coverage annotation would say the same thing more quietly.

## Validation

Patch coverage measured by intersecting the diff's changed lines with a v8 report, not read off a file percentage:

```
src/iso-date-window.ts    statements 10/10 = 100%   branches  5/5  = 100%
workers/data-api.ts       statements 10/10 = 100%   branches 16/16 = 100%
```

```
npm run typecheck              # clean
npm run lint                   # clean
npm run format:check           # clean
npm run validate:contract-drift # passed
npm run scan:public-safety      # passed
vitest (5 suites)              # 103 passed
```

Closes #9798
