### PR TITLE
feat(watchdog): sweep EVERY table for freshness, not just the ones with a lane

### DIFF
--- a/src/table-freshness-watchdog.ts
+++ b/src/table-freshness-watchdog.ts
@@ -1,0 +1,558 @@
+// One watchdog over EVERY table, because per-lane watchdogs only cover the
+// lanes somebody remembered (#9786).
+//
+// Every staleness watchdog in this repo is hand-written for one table:
+// `neurons-staleness`, `chain-detail-staleness`, `account-balances-staleness`,
+// and so on. Each knows one table, one threshold, one cron. The consequence is
+// structural, not accidental -- a table nobody wrote a watchdog for is watched
+// by nothing, forever, and adding a table adds no coverage until someone
+// remembers to add a watchdog too.
+//
+// On 2026-08-07 a one-query sweep of all 46 tables found FOUR frozen for five
+// days -- `subnets`, `surfaces`, `providers`, `surface_history`, the whole
+// registry cluster, whose only writer was a retired GitHub Actions lane
+// (#9779). Nothing reported it. It was found by hand.
+//
+// ## `null` is the point
+//
+// A table whose staleness is meaningless -- `api_keys` grows only when someone
+// signs up, `d1_migrations` only on a migration -- is declared with
+// `maxAgeMs: null` and a reason. That is deliberately not the same as being
+// absent from the list: absent means nobody has thought about it, and the test
+// beside this file fails on absent. Every table must be CLASSIFIED, and "this
+// one cannot be stale" is a classification.
+//
+// ## What this does NOT replace
+//
+// The per-lane watchdogs check SEMANTICS -- row counts, netuid coverage, pass
+// completeness. This checks only "did anything arrive". Both matter, and the
+// difference is exactly the `MAX(captured_at)` blind spot that let the
+// metagraph look recovered while 108 of 129 netuids were still missing: a
+// fresh timestamp on a partial table passes here and fails there.
+
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+
+/** This watchdog's own lane. */
+export const TABLE_FRESHNESS_LANE = "table-freshness";
+
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+
+export interface FreshnessExpectation {
+  /** The column carrying "when did a row last arrive". */
+  column: string;
+  /** `ms` = epoch milliseconds; `date` = a 'YYYY-MM-DD' text column. */
+  kind: "ms" | "date";
+  /** How old the newest row may be. `null` = staleness is meaningless here. */
+  maxAgeMs: number | null;
+  /** Why that number, or why null. Read by whoever gets the alarm. */
+  reason: string;
+  /** An open issue explaining a table that is ALREADY breaching, so the alarm
+   * points somewhere instead of merely being loud. */
+  knownIssue?: string;
+}
+
+/**
+ * Every table in migrations/d1, and what its freshness means.
+ *
+ * Thresholds are set from MEASURED cadence (2026-08-07 sweep) with headroom,
+ * not from what the producer claims. A threshold under one producer interval
+ * alarms forever; one at ten times it never alarms at all.
+ */
+export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
+  // --- live capture: minutes old in steady state -------------------------
+  chain_detail_blocks: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 2 * HOUR,
+    reason: "firehose poller, continuous",
+  },
+  chain_detail_extrinsics: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 2 * HOUR,
+    reason: "firehose poller, continuous",
+  },
+  chain_detail_chain_events: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 2 * HOUR,
+    reason: "firehose poller, continuous",
+  },
+  chain_detail_account_events: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 2 * HOUR,
+    reason: "firehose poller, continuous",
+  },
+  blocks_head: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 2 * HOUR,
+    reason: "head tracker",
+  },
+  raw_capture_state: {
+    column: "updated_at",
+    kind: "ms",
+    maxAgeMs: 2 * HOUR,
+    reason: "RAW_CAPTURE_CRON every 5 min",
+  },
+  raw_capture_state_v2: {
+    column: "updated_at",
+    kind: "ms",
+    maxAgeMs: null,
+    reason: "successor table, not yet cut over",
+  },
+  tao_usd_index: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 2 * HOUR,
+    reason: "TAO_USD_INDEX_CRON every minute",
+  },
+  lane_health: {
+    column: "checked_at",
+    kind: "ms",
+    maxAgeMs: 2 * HOUR,
+    reason: "every watchdog writes here; silence means they all stopped",
+  },
+
+  // --- the metagraph family: 15-minute producer --------------------------
+  neurons: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 2 * HOUR,
+    reason: "metagraph sync every 15 min",
+  },
+  neuron_daily: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 2 * HOUR,
+    reason: "derived from the same sync",
+  },
+  account_position_daily: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 2 * HOUR,
+    reason: "derived from the same sync",
+  },
+  subnet_snapshots: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 4 * HOUR,
+    reason: "health prober",
+  },
+  subnet_hyperparams: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 12 * HOUR,
+    reason: "hyperparams sync",
+  },
+  account_identity: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 12 * HOUR,
+    reason: "identity sync",
+  },
+
+  // --- slow ledgers: 12h/30h/48h producers, measured 4.9-5.2h old ---------
+  account_balances: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 24 * HOUR,
+    reason: "12h producer; matches ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS x2",
+  },
+  account_balances_passes: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 24 * HOUR,
+    reason: "written with account_balances",
+  },
+  hotkey_alpha: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 60 * HOUR,
+    reason: "48h producer; HOTKEY_ALPHA_STALENESS_THRESHOLD_MS is 48h",
+  },
+  hotkey_alpha_passes: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 60 * HOUR,
+    reason: "written with hotkey_alpha",
+  },
+  // Added by 0029 while this map was being written -- which is the coverage
+  // test doing its job: a new table arrived and was unwatched until named.
+  // Pass ledgers are written with their parent table, so they share its
+  // cadence.
+  nominator_positions_passes: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 36 * HOUR,
+    reason: "written with nominator_positions",
+  },
+  validator_nominator_counts_passes: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 36 * HOUR,
+    reason: "written with validator_nominator_counts",
+  },
+  nominator_positions: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 36 * HOUR,
+    reason: "30h producer",
+  },
+  validator_nominator_counts: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 36 * HOUR,
+    reason: "written with nominator_positions",
+  },
+
+  // --- probe/rollup lanes -------------------------------------------------
+  surface_checks: {
+    column: "checked_at",
+    kind: "ms",
+    maxAgeMs: 4 * HOUR,
+    reason: "surface prober",
+  },
+  surface_status: {
+    column: "checked_at",
+    kind: "ms",
+    maxAgeMs: 4 * HOUR,
+    reason: "written with surface_checks",
+  },
+  surface_uptime_daily: {
+    column: "day",
+    kind: "date",
+    maxAgeMs: 48 * HOUR,
+    reason: "daily rollup",
+  },
+  surface_failure_daily: {
+    column: "day",
+    kind: "date",
+    maxAgeMs: 48 * HOUR,
+    reason: "daily rollup",
+  },
+  api_usage_rollup: {
+    column: "day",
+    kind: "date",
+    maxAgeMs: 48 * HOUR,
+    reason: "daily rollup",
+  },
+  chain_concentration_daily: {
+    column: "day",
+    kind: "date",
+    maxAgeMs: 72 * HOUR,
+    reason: "daily rollup, and it can only cover days neuron_daily has (#9781)",
+  },
+  subnet_burn_history: {
+    column: "observed_at",
+    kind: "ms",
+    maxAgeMs: 4 * HOUR,
+    reason: "SUBNET_BURN_CAPTURE_CRON, 4x hourly",
+  },
+  emission_gate_param_history: {
+    column: "observed_at",
+    kind: "ms",
+    maxAgeMs: 6 * HOUR,
+    reason: "EMISSION_GATE_SAMPLE_CRON, 6x hourly",
+  },
+
+  // --- change-logs: they append only when something CHANGES ---------------
+  account_identity_history: {
+    column: "observed_at",
+    kind: "ms",
+    maxAgeMs: null,
+    reason: "append-on-change; quiet means nobody renamed",
+  },
+  subnet_hyperparams_history: {
+    column: "observed_at",
+    kind: "ms",
+    maxAgeMs: null,
+    reason: "append-on-change",
+  },
+  subnet_emission_enabled_history: {
+    column: "observed_at",
+    kind: "ms",
+    maxAgeMs: null,
+    reason: "append-on-change",
+  },
+
+  // --- the registry cluster: CURRENTLY BROKEN, and alarmed on purpose -----
+  // Not exempted. #9779 is a real outage -- the only writer was a retired
+  // GitHub Actions lane -- and suppressing it here to keep the lane green
+  // would be the exact thing a watchdog must never do.
+  subnets: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 48 * HOUR,
+    reason: "registry sync on merge",
+    knownIssue: "#9779",
+  },
+  surfaces: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 48 * HOUR,
+    reason: "registry sync on merge",
+    knownIssue: "#9779",
+  },
+  providers: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 48 * HOUR,
+    reason: "registry sync on merge",
+    knownIssue: "#9779",
+  },
+  surface_history: {
+    column: "recorded_at",
+    kind: "ms",
+    maxAgeMs: null,
+    reason: "append-on-change, but its writer is dead",
+    knownIssue: "#9779",
+  },
+
+  // --- user state and control: change only when a human acts --------------
+  api_keys: {
+    column: "created_at",
+    kind: "ms",
+    maxAgeMs: null,
+    reason: "signup-driven",
+  },
+  api_key_usage_daily: {
+    column: "day",
+    kind: "date",
+    maxAgeMs: null,
+    reason: "only rows when a key is used",
+  },
+  api_key_blocks: {
+    column: "",
+    kind: "ms",
+    maxAgeMs: null,
+    reason: "no timestamp column",
+  },
+  api_quota_daily: {
+    column: "day",
+    kind: "date",
+    maxAgeMs: null,
+    reason: "only rows when a key is used",
+  },
+  rpc_accounts: {
+    column: "created_at",
+    kind: "ms",
+    maxAgeMs: null,
+    reason: "signup-driven",
+  },
+  github_accounts: {
+    column: "created_at",
+    kind: "ms",
+    maxAgeMs: null,
+    reason: "signup-driven",
+  },
+  chain_alert_triggers: {
+    column: "created_at",
+    kind: "ms",
+    maxAgeMs: null,
+    reason: "user-created; empty until ALERT_TRIGGER_CREATE_TOKEN is set",
+  },
+  chain_alert_deliveries: {
+    column: "",
+    kind: "ms",
+    maxAgeMs: null,
+    reason: "no timestamp column",
+  },
+  watch_push_subscriptions: {
+    column: "",
+    kind: "ms",
+    maxAgeMs: null,
+    reason: "no timestamp column",
+  },
+  emission_flow_watch: {
+    column: "updated_at",
+    kind: "ms",
+    maxAgeMs: null,
+    reason: "a watch list, edited by hand",
+  },
+};
+
+/** The minimal D1 surface this needs, so a test can hand it a fake. */
+export interface FreshnessDb {
+  prepare(sql: string): { all(): Promise<{ results?: unknown[] } | null> };
+}
+
+/**
+ * Tables asked about in one statement.
+ *
+ * D1 rejects a compound SELECT past roughly five terms
+ * (`too many terms in compound SELECT`), so the sweep is batched rather than
+ * issued as one 40-way UNION. Four keeps a margin under that.
+ */
+export const FRESHNESS_BATCH = 4;
+
+/** The tables this sweep actually queries: those with a column to read. */
+export function freshnessTables(): string[] {
+  return Object.entries(TABLE_FRESHNESS)
+    .filter(([, e]) => e.column !== "")
+    .map(([table]) => table)
+    .sort();
+}
+
+/** One batch's query. `date` columns are compared as text, which sorts. */
+export function freshnessSql(
+  tables: readonly string[],
+  spec: Readonly<Record<string, FreshnessExpectation>> = TABLE_FRESHNESS,
+): string {
+  return tables
+    .map((t) => `SELECT '${t}' AS t, MAX(${spec[t].column}) AS mx FROM ${t}`)
+    .join(" UNION ALL ");
+}
+
+export interface StaleTable {
+  table: string;
+  ageMs: number;
+  maxAgeMs: number;
+  reason: string;
+  knownIssue?: string;
+}
+
+/** Which tables are older than their own expectation, worst first. */
+export function staleTables(
+  newest: ReadonlyMap<string, number>,
+  nowMs: number,
+  spec: Readonly<Record<string, FreshnessExpectation>> = TABLE_FRESHNESS,
+): StaleTable[] {
+  const out: StaleTable[] = [];
+  for (const [table, e] of Object.entries(spec)) {
+    if (e.maxAgeMs == null) continue;
+    const at = newest.get(table);
+    // A table that returned no timestamp is EMPTY, not stale. An empty table
+    // has no arrival to be late -- reporting it would make every
+    // not-yet-populated table permanently loud.
+    if (at == null) continue;
+    const ageMs = nowMs - at;
+    if (ageMs <= e.maxAgeMs) continue;
+    out.push({
+      table,
+      ageMs,
+      maxAgeMs: e.maxAgeMs,
+      reason: e.reason,
+      knownIssue: e.knownIssue,
+    });
+  }
+  return out.sort((a, b) => b.ageMs - a.ageMs);
+}
+
+/** One line for the verdict's detail column. */
+export function describeStaleTables(stale: readonly StaleTable[]): string {
+  if (stale.length === 0) return "every table is within its expected age";
+  return stale
+    .map((s) => {
+      const h = (s.ageMs / HOUR).toFixed(1);
+      const cap = (s.maxAgeMs / HOUR).toFixed(0);
+      return `${s.table} ${h}h > ${cap}h${s.knownIssue ? ` (known: ${s.knownIssue})` : ""}`;
+    })
+    .join("; ");
+}
+
+/** Parse a batch's rows into table -> epoch ms. */
+export function parseFreshnessRows(
+  rows: readonly unknown[],
+  spec: Readonly<Record<string, FreshnessExpectation>> = TABLE_FRESHNESS,
+): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const raw of rows) {
+    const row = raw as Record<string, unknown>;
+    // NULL CHECKED BEFORE Number(): `Number(null)` is 0 and 0 passes
+    // Number.isFinite, so MAX() over an empty table would read as 1970 and
+    // report every empty table as decades stale.
+    if (row?.t == null || row?.mx == null) continue;
+    const table = String(row.t);
+    const expectation = spec[table];
+    if (!expectation) continue;
+    const at =
+      expectation.kind === "date"
+        ? Date.parse(`${String(row.mx)}T00:00:00Z`)
+        : Number(row.mx);
+    if (Number.isFinite(at)) out.set(table, at);
+  }
+  return out;
+}
+
+export interface FreshnessDeps {
+  db?: FreshnessDb | null;
+  laneHealthDb?: LaneHealthDb | null;
+  now?: () => number;
+  spec?: Readonly<Record<string, FreshnessExpectation>>;
+}
+
+export interface FreshnessOutcome {
+  attempted: boolean;
+  stale?: StaleTable[];
+  checked?: number;
+  reason?: string;
+}
+
+/**
+ * Sweep every declared table. Never throws.
+ *
+ * A batch that fails does NOT fail the sweep: the other batches still carry
+ * real information, and one unreadable table should not hide thirty healthy
+ * ones. But if EVERY batch fails the verdict is `unknown` rather than `ok`,
+ * because "nothing was measured" and "nothing is stale" must not look alike.
+ */
+export async function runTableFreshnessWatchdog(
+  env: Record<string, unknown> | null | undefined,
+  deps: FreshnessDeps = {},
+): Promise<FreshnessOutcome> {
+  const db = deps.db ?? (env?.METAGRAPH_HEALTH_DB as FreshnessDb | undefined);
+  const laneDb =
+    deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as LaneHealthDb | undefined);
+  const now = deps.now ?? Date.now;
+  const spec = deps.spec ?? TABLE_FRESHNESS;
+  const tables = Object.entries(spec)
+    .filter(([, e]) => e.column !== "")
+    .map(([t]) => t)
+    .sort();
+
+  const newest = new Map<string, number>();
+  let batches = 0;
+  let failed = 0;
+  for (let i = 0; i < tables.length; i += FRESHNESS_BATCH) {
+    const batch = tables.slice(i, i + FRESHNESS_BATCH);
+    batches += 1;
+    try {
+      const result = await db?.prepare(freshnessSql(batch, spec)).all();
+      if (!result) throw new Error("no result");
+      for (const [table, at] of parseFreshnessRows(
+        result.results ?? [],
+        spec,
+      )) {
+        newest.set(table, at);
+      }
+    } catch {
+      failed += 1;
+    }
+  }
+
+  if (batches > 0 && failed === batches) {
+    await recordLaneVerdict(laneDb, {
+      lane: TABLE_FRESHNESS_LANE,
+      verdict: "unknown",
+      age_ms: null,
+      detail: "no table could be read",
+      checked_at: now(),
+    });
+    return { attempted: true, reason: "all batches failed" };
+  }
+
+  const stale = staleTables(newest, now(), spec);
+  await recordLaneVerdict(laneDb, {
+    lane: TABLE_FRESHNESS_LANE,
+    verdict: stale.length === 0 ? "ok" : "stale",
+    age_ms: stale.length === 0 ? null : stale[0].ageMs,
+    detail:
+      describeStaleTables(stale) +
+      (failed > 0 ? ` | ${failed} of ${batches} batches unreadable` : ""),
+    checked_at: now(),
+  });
+  return { attempted: true, stale, checked: newest.size };
+}

--- a/tests/table-freshness-watchdog.test.ts
+++ b/tests/table-freshness-watchdog.test.ts
@@ -1,0 +1,460 @@
+// The all-tables freshness sweep (src/table-freshness-watchdog.ts, #9786).
+//
+// The test that gives this file its value is the COVERAGE one: every table in
+// migrations/d1 must be classified, so a new table cannot arrive unwatched.
+// That is the whole failure this watchdog exists to end -- four tables were
+// frozen for five days because no per-lane watchdog covered them, and none
+// ever would have.
+//
+// `maxAgeMs: null` is a classification, not an exemption: it says "staleness
+// is meaningless here" and has to be written down. Absent from the list means
+// nobody thought about it, and that fails.
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { describe, test } from "vitest";
+import {
+  describeStaleTables,
+  FRESHNESS_BATCH,
+  freshnessSql,
+  freshnessTables,
+  parseFreshnessRows,
+  runTableFreshnessWatchdog,
+  staleTables,
+  TABLE_FRESHNESS,
+  TABLE_FRESHNESS_LANE,
+  type FreshnessExpectation,
+} from "../src/table-freshness-watchdog.ts";
+
+const HOUR = 60 * 60 * 1000;
+const NOW = 1_785_800_000_000;
+
+function fakeDb(byTable: Record<string, unknown>, failOn: string[] = []) {
+  const calls: string[] = [];
+  const written: Record<string, unknown>[] = [];
+  return {
+    calls,
+    written,
+    db: {
+      prepare(sql: string) {
+        calls.push(sql);
+        return {
+          async all() {
+            if (failOn.some((f) => sql.includes(f))) {
+              throw new Error("D1_ERROR: overloaded");
+            }
+            const names = [...sql.matchAll(/SELECT '(\w+)' AS t/g)].map(
+              (m) => m[1],
+            );
+            return {
+              results: names.map((t) => ({ t, mx: byTable[t] ?? null })),
+            };
+          },
+          bind(...values: unknown[]) {
+            return {
+              async run() {
+                if (sql.startsWith("INSERT")) {
+                  written.push({
+                    lane: values[0],
+                    verdict: values[1],
+                    age: values[2],
+                    detail: values[3],
+                  });
+                }
+              },
+              async all() {
+                return { results: [] };
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+describe("TABLE_FRESHNESS coverage", () => {
+  test("every table in migrations/d1 is classified", () => {
+    // THE LOAD-BEARING TEST. A table absent from the map is one nobody has
+    // decided the freshness meaning of, and it would be swept by nothing --
+    // exactly how the registry cluster went five days unnoticed (#9779).
+    const dir = path.join(process.cwd(), "migrations/d1");
+    const declared = new Set<string>();
+    for (const file of readdirSync(dir).filter((f) => f.endsWith(".sql"))) {
+      const sql = readFileSync(path.join(dir, file), "utf8");
+      for (const m of sql.matchAll(
+        /CREATE TABLE\s+(?:IF NOT EXISTS\s+)?(\w+)/gi,
+      )) {
+        declared.add(m[1]);
+      }
+    }
+    assert.ok(
+      declared.size >= 40,
+      `only ${declared.size} tables parsed out of migrations/d1 -- the parse ` +
+        `broke, so this test is passing on nothing`,
+    );
+    const missing = [...declared].filter((t) => !TABLE_FRESHNESS[t]).sort();
+    assert.deepEqual(
+      missing,
+      [],
+      "these tables have no freshness classification. Add them to " +
+        "TABLE_FRESHNESS -- `maxAgeMs: null` with a reason is a valid answer, " +
+        `being absent is not:\n${missing.join("\n")}`,
+    );
+  });
+
+  test("the map names no table that does not exist", () => {
+    // A stale entry would be swept forever against a dropped table, which
+    // fails every batch it lands in and hides the tables beside it.
+    const dir = path.join(process.cwd(), "migrations/d1");
+    const declared = new Set<string>();
+    for (const file of readdirSync(dir).filter((f) => f.endsWith(".sql"))) {
+      for (const m of readFileSync(path.join(dir, file), "utf8").matchAll(
+        /CREATE TABLE\s+(?:IF NOT EXISTS\s+)?(\w+)/gi,
+      )) {
+        declared.add(m[1]);
+      }
+    }
+    for (const table of Object.keys(TABLE_FRESHNESS)) {
+      assert.ok(
+        declared.has(table),
+        `${table} is classified but never created`,
+      );
+    }
+  });
+
+  test("every entry gives a reason, and a threshold or an explicit null", () => {
+    for (const [table, e] of Object.entries(TABLE_FRESHNESS)) {
+      assert.ok(e.reason.length > 8, `${table} has no real reason`);
+      assert.ok(
+        e.maxAgeMs === null || e.maxAgeMs > 0,
+        `${table}'s maxAgeMs must be a positive number or null`,
+      );
+      if (e.column === "") {
+        assert.equal(
+          e.maxAgeMs,
+          null,
+          `${table} has no timestamp column, so it cannot have a threshold`,
+        );
+      }
+    }
+  });
+
+  test("the registry cluster is NOT exempted", () => {
+    // #9779 is a live outage. Classifying these `null` to keep the lane green
+    // is precisely what a watchdog must never do -- quiet only when healthy.
+    for (const table of ["subnets", "surfaces", "providers"]) {
+      const e = TABLE_FRESHNESS[table];
+      assert.ok(e.maxAgeMs !== null, `${table} must stay alarmed`);
+      assert.equal(e.knownIssue, "#9779", `${table} should point at its issue`);
+    }
+  });
+});
+
+describe("freshnessSql", () => {
+  test("asks a batch in one statement", () => {
+    assert.equal(
+      freshnessSql(["neurons", "lane_health"]),
+      "SELECT 'neurons' AS t, MAX(captured_at) AS mx FROM neurons UNION ALL " +
+        "SELECT 'lane_health' AS t, MAX(checked_at) AS mx FROM lane_health",
+    );
+  });
+
+  test("batches stay under D1's compound-SELECT term limit", () => {
+    // D1 rejects a compound SELECT past roughly five terms.
+    assert.ok(FRESHNESS_BATCH <= 4, "batch size must keep a margin under 5");
+  });
+
+  test("only tables with a column are swept", () => {
+    const swept = freshnessTables();
+    assert.ok(!swept.includes("api_key_blocks"), "no timestamp column");
+    assert.ok(swept.includes("neurons"));
+  });
+});
+
+describe("staleTables", () => {
+  const spec: Record<string, FreshnessExpectation> = {
+    fast: {
+      column: "captured_at",
+      kind: "ms",
+      maxAgeMs: HOUR,
+      reason: "hourly",
+    },
+    slow: {
+      column: "captured_at",
+      kind: "ms",
+      maxAgeMs: 48 * HOUR,
+      reason: "daily",
+    },
+    never: {
+      column: "created_at",
+      kind: "ms",
+      maxAgeMs: null,
+      reason: "signup",
+    },
+  };
+
+  test("reports only tables past their OWN threshold, worst first", () => {
+    const out = staleTables(
+      new Map([
+        ["fast", NOW - 5 * HOUR],
+        ["slow", NOW - 5 * HOUR],
+        ["never", NOW - 900 * HOUR],
+      ]),
+      NOW,
+      spec,
+    );
+    assert.deepEqual(
+      out.map((s) => s.table),
+      ["fast"],
+    );
+    assert.equal(out[0].maxAgeMs, HOUR);
+  });
+
+  test("a null threshold is never stale, however old", () => {
+    assert.deepEqual(staleTables(new Map([["never", 0]]), NOW, spec), []);
+  });
+
+  test("an EMPTY table is not stale", () => {
+    // No arrival means nothing is late. Reporting it would make every
+    // not-yet-populated table permanently loud.
+    assert.deepEqual(staleTables(new Map(), NOW, spec), []);
+  });
+
+  test("exactly at the threshold is not stale", () => {
+    assert.deepEqual(
+      staleTables(new Map([["fast", NOW - HOUR]]), NOW, spec),
+      [],
+    );
+  });
+});
+
+describe("parseFreshnessRows", () => {
+  const spec: Record<string, FreshnessExpectation> = {
+    ms: { column: "captured_at", kind: "ms", maxAgeMs: HOUR, reason: "x" },
+    dated: { column: "day", kind: "date", maxAgeMs: HOUR, reason: "x" },
+  };
+
+  test("reads epoch-ms and date columns alike", () => {
+    const out = parseFreshnessRows(
+      [
+        { t: "ms", mx: NOW },
+        { t: "dated", mx: "2026-08-07" },
+      ],
+      spec,
+    );
+    assert.equal(out.get("ms"), NOW);
+    assert.equal(out.get("dated"), Date.parse("2026-08-07T00:00:00Z"));
+  });
+
+  test("a NULL max is dropped, not read as 1970", () => {
+    // `Number(null)` is 0 and passes Number.isFinite. Reading MAX() over an
+    // empty table as epoch 0 would report it as decades stale.
+    assert.equal(parseFreshnessRows([{ t: "ms", mx: null }], spec).size, 0);
+    assert.equal(parseFreshnessRows([{ t: null, mx: NOW }], spec).size, 0);
+    assert.equal(parseFreshnessRows([{ t: "ms", mx: "nope" }], spec).size, 0);
+  });
+
+  test("a table the spec does not know is ignored", () => {
+    assert.equal(
+      parseFreshnessRows([{ t: "surprise", mx: NOW }], spec).size,
+      0,
+    );
+  });
+});
+
+describe("describeStaleTables", () => {
+  test("names the age, the cap, and any known issue", () => {
+    assert.equal(
+      describeStaleTables([]),
+      "every table is within its expected age",
+    );
+    assert.equal(
+      describeStaleTables([
+        {
+          table: "surfaces",
+          ageMs: 126 * HOUR,
+          maxAgeMs: 48 * HOUR,
+          reason: "x",
+          knownIssue: "#9779",
+        },
+        { table: "neurons", ageMs: 3 * HOUR, maxAgeMs: 2 * HOUR, reason: "y" },
+      ]),
+      "surfaces 126.0h > 48h (known: #9779); neurons 3.0h > 2h",
+    );
+  });
+});
+
+describe("runTableFreshnessWatchdog", () => {
+  const spec: Record<string, FreshnessExpectation> = {
+    a: { column: "captured_at", kind: "ms", maxAgeMs: HOUR, reason: "hourly" },
+    b: { column: "captured_at", kind: "ms", maxAgeMs: HOUR, reason: "hourly" },
+    c: { column: "captured_at", kind: "ms", maxAgeMs: HOUR, reason: "hourly" },
+    d: { column: "captured_at", kind: "ms", maxAgeMs: HOUR, reason: "hourly" },
+    e: { column: "captured_at", kind: "ms", maxAgeMs: HOUR, reason: "hourly" },
+    skip: { column: "", kind: "ms", maxAgeMs: null, reason: "no column" },
+  };
+  const fresh = { a: NOW, b: NOW, c: NOW, d: NOW, e: NOW };
+
+  test("records OK when every table is within its age", async () => {
+    const spy = fakeDb(fresh);
+    const out = await runTableFreshnessWatchdog(null, {
+      db: spy.db,
+      laneHealthDb: spy.db,
+      now: () => NOW,
+      spec,
+    });
+    assert.deepEqual(out.stale, []);
+    assert.equal(out.checked, 5);
+    assert.equal(spy.written[0].lane, TABLE_FRESHNESS_LANE);
+    assert.equal(spy.written[0].verdict, "ok");
+  });
+
+  test("batches rather than issuing one huge compound SELECT", async () => {
+    const spy = fakeDb(fresh);
+    await runTableFreshnessWatchdog(null, {
+      db: spy.db,
+      laneHealthDb: spy.db,
+      now: () => NOW,
+      spec,
+    });
+    const selects = spy.calls.filter((c) => c.startsWith("SELECT"));
+    assert.equal(selects.length, 2, "5 tables at batch size 4 = 2 batches");
+    for (const s of selects) {
+      assert.ok(
+        (s.match(/UNION ALL/g) ?? []).length < 4,
+        `batch has too many terms: ${s}`,
+      );
+    }
+    // The column-less table is never queried.
+    assert.ok(!selects.some((s) => s.includes("'skip'")));
+  });
+
+  test("records STALE with the worst age", async () => {
+    const spy = fakeDb({ ...fresh, a: NOW - 9 * HOUR, b: NOW - 3 * HOUR });
+    const out = await runTableFreshnessWatchdog(null, {
+      db: spy.db,
+      laneHealthDb: spy.db,
+      now: () => NOW,
+      spec,
+    });
+    assert.deepEqual(
+      out.stale?.map((s) => s.table),
+      ["a", "b"],
+    );
+    assert.equal(spy.written[0].verdict, "stale");
+    assert.equal(spy.written[0].age, 9 * HOUR);
+  });
+
+  test("ONE failed batch does not hide the healthy tables beside it", async () => {
+    // The other batches still carry real information.
+    const spy = fakeDb({ ...fresh, e: NOW - 9 * HOUR }, ["'a'"]);
+    const out = await runTableFreshnessWatchdog(null, {
+      db: spy.db,
+      laneHealthDb: spy.db,
+      now: () => NOW,
+      spec,
+    });
+    assert.deepEqual(
+      out.stale?.map((s) => s.table),
+      ["e"],
+    );
+    assert.match(String(spy.written[0].detail), /1 of 2 batches unreadable/);
+  });
+
+  test("EVERY batch failing is unknown, never ok", async () => {
+    // "nothing was measured" and "nothing is stale" must not look alike.
+    const spy = fakeDb(fresh, ["SELECT"]);
+    const out = await runTableFreshnessWatchdog(null, {
+      db: spy.db,
+      laneHealthDb: spy.db,
+      now: () => NOW,
+      spec,
+    });
+    assert.equal(out.reason, "all batches failed");
+    assert.equal(spy.written[0].verdict, "unknown");
+  });
+
+  test("an unbound D1 is unknown too", async () => {
+    const spy = fakeDb({});
+    const out = await runTableFreshnessWatchdog(null, {
+      db: null,
+      laneHealthDb: spy.db,
+      now: () => NOW,
+      spec,
+    });
+    assert.equal(out.reason, "all batches failed");
+    assert.equal(spy.written[0].verdict, "unknown");
+  });
+
+  test("a batch response with no `results` key contributes nothing, not a crash", async () => {
+    // D1 can answer without the key at all; `?? []` must absorb it rather than
+    // letting a TypeError take out the batch.
+    const noKey = {
+      prepare(sql: string) {
+        return {
+          async all() {
+            return sql.startsWith("SELECT") ? {} : { results: [] };
+          },
+          bind() {
+            return {
+              async run() {},
+              async all() {
+                return { results: [] };
+              },
+            };
+          },
+        };
+      },
+    };
+    const out = await runTableFreshnessWatchdog(null, {
+      db: noKey,
+      laneHealthDb: noKey,
+      now: () => NOW,
+      spec,
+    });
+    assert.equal(out.checked, 0);
+    assert.deepEqual(out.stale, []);
+  });
+
+  test("takes its D1 and clock off env with no deps", async () => {
+    const spy = fakeDb({});
+    const out = await runTableFreshnessWatchdog({
+      METAGRAPH_HEALTH_DB: spy.db,
+    });
+    assert.equal(out.attempted, true);
+  });
+});
+
+describe("the deployed wiring", () => {
+  const wrangler = readFileSync("wrangler.data.jsonc", "utf8");
+
+  test("the cron the handler dispatches on is declared", async () => {
+    const { TABLE_FRESHNESS_CRON } = await import("../workers/config.ts");
+    assert.ok(
+      wrangler.includes(`"${TABLE_FRESHNESS_CRON}"`),
+      `wrangler.data.jsonc declares no "${TABLE_FRESHNESS_CRON}" cron, so the sweep never runs`,
+    );
+  });
+
+  test("the cadence is faster than the tightest threshold it enforces", async () => {
+    // A sweep slower than what it checks would report a breach late enough to
+    // be useless. Hourly against a two-hour floor leaves one tick of margin.
+    const { TABLE_FRESHNESS_CRON } = await import("../workers/config.ts");
+    assert.match(
+      TABLE_FRESHNESS_CRON,
+      /^\d+ \* \* \* \*$/,
+      "expected an hourly cron",
+    );
+    const tightest = Math.min(
+      ...Object.values(TABLE_FRESHNESS)
+        .map((e) => e.maxAgeMs)
+        .filter((v): v is number => v != null),
+    );
+    assert.ok(
+      tightest >= 2 * HOUR,
+      `tightest threshold is ${tightest / HOUR}h but the sweep runs hourly -- ` +
+        `anything under 2h would alarm on its own sampling gap`,
+    );
+  });
+});

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -347,6 +347,19 @@ export const NEON_BACKFILL_CRON = "*/3 * * * *";
 export const NEON_MIRROR_LAG_CRON = "26 * * * *";
 
 /**
+ * The all-tables freshness sweep (metagraphed#9786).
+ *
+ * HOURLY. It reads `MAX(<timestamp>)` from every declared table, so a fast
+ * cadence would spend millions of D1 row reads re-learning facts that change
+ * at most every few minutes and, for most tables, every few hours. The
+ * tightest threshold it enforces is two hours, so an hourly tick cannot miss a
+ * breach -- only report it one tick later.
+ *
+ * Minute 46 is free of every other lane on this Worker.
+ */
+export const TABLE_FRESHNESS_CRON = "46 * * * *";
+
+/**
  * The webhook fan-out tick (metagraphed-infra#354).
  *
  * TWICE HOURLY on two free minutes. The cadence is a cost decision rather than a

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -48,6 +48,7 @@ import {
 import {
   NEON_BACKFILL_CRON,
   NEON_MIRROR_LAG_CRON,
+  TABLE_FRESHNESS_CRON,
   TAO_USD_INDEX_CRON,
 } from "./config.ts";
 import {
@@ -379,6 +380,7 @@ import { mirrorLedgerToNeon } from "../src/ledger-neon-write.ts";
 import { neonReadEnabled } from "../src/neon-write.ts";
 import { runNeonBackfill } from "../src/neon-backfill.ts";
 import { runNeonMirrorWatchdog } from "../src/neon-mirror-watchdog.ts";
+import { runTableFreshnessWatchdog } from "../src/table-freshness-watchdog.ts";
 import {
   writeAccountIdentityToD1,
   writeSubnetHyperparamsToD1,
@@ -7528,6 +7530,12 @@ export default {
     env: Env,
     ctx: ExecutionContext,
   ) {
+    if (controller?.cron === TABLE_FRESHNESS_CRON) {
+      // D1 only. It reads MAX(<timestamp>) per table and writes one verdict.
+      return runTableFreshnessWatchdog(
+        env as unknown as Record<string, unknown>,
+      );
+    }
     if (controller?.cron === NEON_MIRROR_LAG_CRON) {
       // No ctx: this reads D1 only. It never touches Neon -- the whole point is
       // to judge the mirrors from evidence they already left behind.

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -413,7 +413,7 @@
   // `controller.cron`, so the handler dispatches on the string rather than on
   // what minute it happens to be.
   "triggers": {
-    "crons": ["* * * * *", "*/3 * * * *", "26 * * * *"],
+    "crons": ["* * * * *", "*/3 * * * *", "26 * * * *", "46 * * * *"],
   },
 
   // HYPERDRIVE is gone with the box (2026-08-03): the Postgres it fronted was


### PR DESCRIPTION
Closes #9786

Every staleness watchdog in this repo is hand-written for one table — `neurons-staleness`, `chain-detail-staleness`, `account-balances-staleness`. The consequence is structural, not accidental: **a table nobody wrote a watchdog for is watched by nothing, forever**, and adding a table adds no coverage until someone remembers.

A one-query sweep of all 46 tables found **four frozen for five days** — `subnets`, `surfaces`, `providers`, `surface_history`, the whole registry cluster, whose only writer was a retired GitHub Actions lane (#9779). Nothing reported it. I found it by hand.

## `null` is the point

```ts
neurons:      { column: "captured_at", maxAgeMs: 2 * HOUR,  reason: "metagraph sync every 15 min" }
api_keys:     { column: "created_at",  maxAgeMs: null,      reason: "signup-driven" }
```

`maxAgeMs: null` is a **classification**, not an exemption — "staleness is meaningless here", written down with a reason. Absent from the list means nobody thought about it, and the coverage test fails on absent.

**That test earned itself within the hour**: migration 0029 landed `nominator_positions_passes` and `validator_nominator_counts_passes` while I was writing this, and the suite failed until they were classified.

## The registry cluster is NOT exempted

#9779 is a live outage. Classifying those four `null` to keep the lane green is precisely what a watchdog must never do. They carry a real threshold plus a `knownIssue`, so the verdict reads `surfaces 126.0h > 48h (known: #9779)` — pointed, not merely loud. A test pins that they stay alarmed.

## What it does not replace

The per-lane watchdogs check **semantics** — row counts, netuid coverage, pass completeness. This checks only *"did anything arrive"*. Both matter: a fresh timestamp on a partial table passes here and fails there, which is exactly the `MAX(captured_at)` blind spot that let the metagraph look recovered while 108 of 129 netuids were still missing.

## Design notes

- **Batched at 4** — D1 rejects a compound SELECT past ~5 terms, and a 40-way UNION would fail as one unit.
- **One failed batch does not hide the healthy tables beside it**; but if *every* batch fails the verdict is `unknown`, never `ok` — "nothing was measured" and "nothing is stale" must not look alike.
- **An empty table is not stale.** No arrival means nothing is late.
- **NULL checked before `Number()`** — `Number(null)` is `0` and passes `Number.isFinite`, so `MAX()` over an empty table would read as 1970 and report every empty table as decades stale.
- **Hourly**, with a test asserting the tightest threshold is ≥2h so the sweep can't alarm on its own sampling gap.

## Verification

25 tests, **100% statements / branches / functions / lines**. Full suite: 719 files, 17,473 tests, all passing.