### PR TITLE
fix(neon): make the SQL portable, declare what handlers actually read, and gate both

### DIFF
--- a/src/chain-turnover.ts
+++ b/src/chain-turnover.ts
@@ -311,7 +311,7 @@ export function buildChainTurnover(
 // Network-wide validator turnover, computed live: anchor the window to the newest STORED
 // snapshot (date() relative to MAX(snapshot_date)) so a lagging/restored store still compares
 // real boundary snapshots, read every subnet's validator rows at those two days (bounded by
-// validator_permit = 1; the date-first idx_neuron_daily_date_netuid_agg covers the boundary
+// validator_permit = TRUE; the date-first idx_neuron_daily_date_netuid_agg covers the boundary
 // scan), shape with buildChainTurnover. Cold/absent or single-snapshot D1 → comparable:false.
 export async function loadChainTurnover(
   d1: (
@@ -341,7 +341,7 @@ export async function loadChainTurnover(
   let rows: Array<Record<string, unknown>> = [];
   if (startDate != null && endDate != null && startDate !== endDate) {
     rows = await d1(
-      `SELECT ${CHAIN_TURNOVER_READ_COLUMNS} FROM neuron_daily WHERE validator_permit = 1 AND snapshot_date IN (?, ?)`,
+      `SELECT ${CHAIN_TURNOVER_READ_COLUMNS} FROM neuron_daily WHERE validator_permit = TRUE AND snapshot_date IN (?, ?)`,
       [startDate, endDate],
     );
   }

--- a/src/live-economics-refresh.ts
+++ b/src/live-economics-refresh.ts
@@ -273,7 +273,7 @@ export interface NeuronAggregate {
  */
 export const NEURON_AGGREGATE_QUERY =
   "SELECT netuid, COUNT(*) AS uid_count, " +
-  "SUM(CASE WHEN validator_permit = 1 THEN 1 ELSE 0 END) AS validator_count, " +
+  "SUM(CASE WHEN validator_permit THEN 1 ELSE 0 END) AS validator_count, " +
   "SUM(stake_tao) AS total_stake_alpha, MAX(stake_tao) AS max_stake_alpha " +
   "FROM neurons GROUP BY netuid";
 

--- a/src/metagraph-neurons.ts
+++ b/src/metagraph-neurons.ts
@@ -987,7 +987,7 @@ export async function loadSubnetMetagraph(
 ): Promise<Row> {
   const rows = await d1(
     `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ?${
-      validatorsOnly ? " AND validator_permit = 1" : ""
+      validatorsOnly ? " AND validator_permit = TRUE" : ""
     } ORDER BY uid`,
     [netuid],
   );
@@ -1002,7 +1002,7 @@ export async function loadSubnetValidators(
   // across snapshot-replaced captures (without it, SQLite returns tied rows in
   // arbitrary physical order). Mirrors loadSubnetMetagraph's ORDER BY uid.
   const rows = await d1(
-    `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? AND validator_permit = 1 ORDER BY stake_tao DESC, uid ASC`,
+    `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? AND validator_permit = TRUE ORDER BY stake_tao DESC, uid ASC`,
     [netuid],
   );
   return buildSubnetValidators(rows, netuid);
@@ -1054,7 +1054,7 @@ export async function loadGlobalValidators(
     d1(
       "SELECT netuid, uid, hotkey, coldkey, validator_trust, emission_tao, " +
         "stake_tao, block_number, captured_at FROM neurons " +
-        "WHERE validator_permit = 1 AND hotkey IS NOT NULL " +
+        "WHERE validator_permit = TRUE AND hotkey IS NOT NULL " +
         "ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC",
       [],
     ),
@@ -1253,7 +1253,7 @@ export async function loadValidatorDetail(
 ): Promise<Row> {
   const [rows, priceByNetuid, identityByColdkey] = await Promise.all([
     d1(
-      `SELECT ${NEURON_COLUMNS}, netuid FROM neurons WHERE hotkey = ? AND validator_permit = 1 ORDER BY netuid ASC, uid ASC`,
+      `SELECT ${NEURON_COLUMNS}, netuid FROM neurons WHERE hotkey = ? AND validator_permit = TRUE ORDER BY netuid ASC, uid ASC`,
       [hotkey],
     ),
     loadD1AlphaPricesByNetuid(d1),

--- a/src/movers.ts
+++ b/src/movers.ts
@@ -368,7 +368,7 @@ export async function loadSubnetMovers(
   if (startDate != null && endDate != null && startDate !== endDate) {
     const rows = await d1(
       "SELECT netuid, snapshot_date, COUNT(*) AS neuron_count, " +
-        "SUM(validator_permit) AS validator_count, " +
+        "SUM(CASE WHEN validator_permit THEN 1 ELSE 0 END) AS validator_count, " +
         "SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao " +
         "FROM neuron_daily WHERE snapshot_date IN (?, ?) GROUP BY netuid, snapshot_date",
       [startDate, endDate],

--- a/tests/accounts-list.test.ts
+++ b/tests/accounts-list.test.ts
@@ -428,7 +428,12 @@ describe("loadAccountsList", () => {
     };
     const data = await loadAccountsList(d1, { sort: "total_stake" });
     assert.match(captured!.sql, /FROM neurons/);
-    assert.doesNotMatch(captured!.sql, /validator_permit = 1/);
+    // Spelling-agnostic on purpose. This asserts the leaderboard covers EVERY
+    // registered hotkey, so it has to keep failing if a permit filter comes
+    // back -- and #9802 changed the portable spelling to `= TRUE`, which a
+    // `= 1` pattern would no longer see. A negative assertion pinned to one
+    // spelling stops testing anything the moment the other is used.
+    assert.doesNotMatch(captured!.sql, /validator_permit\s*=/i);
     assert.match(captured!.sql, /WHERE hotkey IS NOT NULL/);
     assert.deepEqual(captured!.params, []);
     assert.equal(data.account_count, 2);

--- a/tests/chain-turnover.test.ts
+++ b/tests/chain-turnover.test.ts
@@ -10,7 +10,7 @@ import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import type { Row } from "./row-type.ts";
 
-// One neuron_daily validator row (the loader scopes the read to validator_permit = 1).
+// One neuron_daily validator row (the loader scopes the read to validator_permit = TRUE).
 function vrow(
   snapshot_date: string,
   netuid: unknown,
@@ -311,7 +311,7 @@ describe("loadChainTurnover", () => {
     assert.equal(calls[0].params[0], "-30 days");
     assert.match(
       calls[1].sql,
-      /validator_permit = 1 AND snapshot_date IN \(\?, \?\)/,
+      /validator_permit = TRUE AND snapshot_date IN \(\?, \?\)/,
     );
     assert.deepEqual(calls[1].params, [START, END]);
     assert.equal(data.window, "30d");

--- a/tests/data-api-neurons-d1.test.ts
+++ b/tests/data-api-neurons-d1.test.ts
@@ -1214,7 +1214,7 @@ test("GET /api/v1/validators/:hotkey/history?netuid= scopes to one subnet (#9383
 });
 
 test("GET /api/v1/validators/:hotkey/history?netuid= reports a lost permit (#9383)", async () => {
-  // The unscoped query filters validator_permit = 1, which turns a lost permit
+  // The unscoped query filters validator_permit = TRUE, which turns a lost permit
   // into an absent day -- indistinguishable from a day the poller missed. Scoped,
   // the day is returned with the permit false.
   const day = dayAgo(1);

--- a/tests/metagraph-neurons.test.ts
+++ b/tests/metagraph-neurons.test.ts
@@ -1923,7 +1923,7 @@ describe("metagraph-neurons loaders", () => {
       },
       { sort: "avg_validator_trust", limit: 1 },
     );
-    assert.match(seenSql, /validator_permit = 1 AND hotkey IS NOT NULL/);
+    assert.match(seenSql, /validator_permit = TRUE AND hotkey IS NOT NULL/);
     assert.match(seenSql, /ORDER BY hotkey ASC/);
     assert.deepEqual(seenParams, []);
     assert.equal(data.validators.length, 1);
@@ -1982,7 +1982,7 @@ describe("metagraph-neurons loaders", () => {
         { netuid: 1, uid: 3, hotkey: "hk-a", coldkey: "ck-a", stake_tao: 20 },
       ];
     }, "hk-a");
-    assert.match(seenSql, /hotkey = \? AND validator_permit = 1/);
+    assert.match(seenSql, /hotkey = \? AND validator_permit = TRUE/);
     assert.match(seenSql, /ORDER BY netuid ASC, uid ASC/);
     assert.deepEqual(seenParams, ["hk-a"]);
     assert.equal(data.hotkey, "hk-a");
@@ -2000,7 +2000,7 @@ function neuronsD1(rows: Row[]) {
           return {
             all() {
               let r = rows;
-              if (sql.includes("validator_permit = 1")) {
+              if (sql.includes("validator_permit = TRUE")) {
                 r = r.filter((x: Row) => x.validator_permit === 1);
               }
               if (sql.includes("AND uid = ?")) {

--- a/tests/neon-read-routes.test.ts
+++ b/tests/neon-read-routes.test.ts
@@ -33,17 +33,152 @@ const MIRRORED = [
 
 const ALL = "account_position_daily,neurons,neuron_daily,nominator_positions";
 
-describe("NEON_READ_ROUTE_TABLES", () => {
-  test("every entry names only mirrored tables", () => {
-    for (const { pattern, tables } of NEON_READ_ROUTE_TABLES) {
-      assert.ok(tables.length > 0, `${pattern} declares no tables`);
-      for (const table of tables) {
-        assert.ok(
-          MIRRORED.includes(table),
-          `${pattern} names "${table}", which no mirror covers -- a route ` +
-            `gated on an unmirrored table would move to a store nothing writes`,
+/** Table names in a chunk of source, with CTE aliases excluded. */
+function tablesIn(source: string): string[] {
+  const body = source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1 ");
+  const ctes = new Set(
+    [...body.matchAll(/(?:WITH|,)\s+(\w+)\s+AS\s*\(/gi)].map((m) => m[1]!),
+  );
+  return [
+    ...new Set(
+      [
+        ...[...body.matchAll(/FROM\s+([a-z_][a-z0-9_]*)/g)].map((m) => m[1]!),
+        ...[...body.matchAll(/JOIN\s+([a-z_][a-z0-9_]*)/g)].map((m) => m[1]!),
+      ].filter((t) => !ctes.has(t)),
+    ),
+  ];
+}
+
+/**
+ * The tables a named loader reads, following the loaders IT calls.
+ *
+ * Bodies are found by brace matching rather than by a line heuristic, because
+ * the answer has to be a superset of the truth to be worth anything: a loader
+ * whose body is cut short reports fewer tables than it reads, which is the
+ * exact direction that produced #9811.
+ */
+const LOADER_SOURCES = [
+  "workers/data-api.ts",
+  "src/metagraph-neurons.ts",
+  "src/accounts-list.ts",
+  "src/account-portfolio.ts",
+  "src/concentration.ts",
+  "src/subnet-yield.ts",
+  "src/subnet-performance.ts",
+  "src/movers.ts",
+  "src/chain-turnover.ts",
+];
+
+let loaderBodies: Map<string, string> | null = null;
+function bodyOf(name: string): string | null {
+  if (loaderBodies == null) {
+    loaderBodies = new Map();
+    for (const file of LOADER_SOURCES) {
+      const src = readFileSync(file, "utf8");
+      for (const m of src.matchAll(/\bfunction\s+(\w+)\s*(?:<[^>]*>)?\s*\(/g)) {
+        const open = src.indexOf("{", m.index! + m[0].length);
+        if (open < 0) continue;
+        let depth = 0;
+        let end = open;
+        for (let i = open; i < src.length; i += 1) {
+          if (src[i] === "{") depth += 1;
+          else if (src[i] === "}") {
+            depth -= 1;
+            if (depth === 0) {
+              end = i;
+              break;
+            }
+          }
+        }
+        loaderBodies.set(
+          m[1]!,
+          (loaderBodies.get(m[1]!) ?? "") + src.slice(open, end + 1),
         );
       }
+    }
+  }
+  return loaderBodies.get(name) ?? null;
+}
+
+function loaderTables(name: string, seen = new Set<string>()): string[] {
+  if (seen.has(name)) return [];
+  seen.add(name);
+  const body = bodyOf(name);
+  if (body == null) return [];
+  const out = new Set(tablesIn(body));
+  for (const m of body.matchAll(/\b(load[A-Z]\w+)\s*\(/g)) {
+    for (const t of loaderTables(m[1]!, seen)) out.add(t);
+  }
+  return [...out];
+}
+
+/**
+ * The concrete path a route guard matches, literal or parameterised.
+ *
+ * Both forms have to resolve to a real path, because the map's patterns are
+ * regexes and the only way to ask "does the map cover this guard" is to run
+ * them against a string. `(\d+)` becomes a netuid and `([^/]+)` an ss58; the
+ * values are arbitrary, only the SHAPE has to survive.
+ *
+ * Returns null for a guard that is neither form, so a future third spelling
+ * shows up as a drop in `checked` rather than as silent success.
+ */
+function routePath(block: string): string | null {
+  const literal = /pathname === "([^"]+)"/.exec(block)?.[1];
+  if (literal) return literal;
+  const re = /pathname\.match\(\s*\/\^([^\n]*?)\$\//.exec(block)?.[1];
+  if (!re) return null;
+  return re
+    .replace(/\\\//g, "/")
+    .replace(/\((\?:)?\\d\+\)/g, "7")
+    .replace(/\((\?:)?\[\^\/\]\+\)/g, "5Abc")
+    .replace(/\\d\+/g, "7")
+    .replace(/\[\^\/\]\+/g, "5Abc")
+    .replace(/\\\./g, ".");
+}
+
+describe("NEON_READ_ROUTE_TABLES", () => {
+  test("every entry names at least one table", () => {
+    // This USED to assert that entries name ONLY mirrored tables, and that
+    // assertion was the bug rather than a guard. It forced every entry to
+    // under-declare: the handler for /api/v1/validators reads subnet_snapshots,
+    // account_identity and subnet_hyperparams through side loaders, none of
+    // which any mirror covers, so naming them was forbidden and the route was
+    // mapped as `["neurons"]` alone. Enabling `neurons` then moved a route
+    // whose other three tables do not exist on Neon.
+    //
+    // Naming an unmirrored table is now the POINT. neonServesRoute needs every
+    // listed table to be read-enabled, and "no mirror writes it" is enforced
+    // separately against the flag, so an unmirrored dependency blocks the move
+    // by construction instead of being invisible to the gate.
+    for (const { pattern, tables } of NEON_READ_ROUTE_TABLES) {
+      assert.ok(tables.length > 0, `${pattern} declares no tables`);
+    }
+  });
+
+  test("a route reading an unmirrored table can never be served from Neon", () => {
+    // The property the entries above are relied on for, asserted directly
+    // rather than inferred: with EVERY mirrored table read-enabled, the four
+    // routes with an unmirrored dependency still resolve to D1.
+    const everyMirroredTable = MIRRORED.join(",");
+    for (const path of [
+      "/api/v1/validators",
+      "/api/v1/accounts",
+      "/api/v1/accounts/5Abc/subnets",
+      "/api/v1/subnets/1/concentration/history",
+    ]) {
+      assert.equal(
+        neonServesRoute(
+          { NEON_READ_LANES: everyMirroredTable },
+          new URL(`https://api.metagraph.sh${path}`),
+        ),
+        false,
+        `${path} would be served from Neon, but it reads a table no mirror ` +
+          `covers -- that read comes back empty and the response degrades ` +
+          `with no error (#9811)`,
+      );
     }
   });
 
@@ -92,36 +227,65 @@ describe("NEON_READ_ROUTE_TABLES", () => {
     const problems: string[] = [];
 
     for (const block of blocks) {
+      // TRANSITIVE, and this is the part that was missing. The block's own SQL
+      // is only the tables the handler reads INLINE; several handlers get most
+      // of their data from side loaders in src/, and those run on the same
+      // runner. Resolving only the block is what let /api/v1/validators be
+      // mapped as `["neurons"]` while actually reading five tables.
       const tables = [
-        ...new Set(
-          [...block.matchAll(/FROM\s+(\w+)/g)]
-            .map((m) => m[1])
-            .filter((t) => MIRRORED.includes(t)),
-        ),
+        ...new Set([
+          ...tablesIn(block),
+          ...[...block.matchAll(/\b(load[A-Z]\w+)\s*\(/g)].flatMap((m) =>
+            loaderTables(m[1]!),
+          ),
+        ]),
       ].sort();
-      if (tables.length === 0) continue;
+      if (!tables.some((t) => MIRRORED.includes(t))) continue;
 
-      // The literal path this guard matches, when it is a literal.
-      const literal = /pathname === "([^"]+)"/.exec(block)?.[1];
-      if (!literal) continue;
+      // The path this guard matches, resolved to something concrete.
+      //
+      // PARAMETERISED ROUTES COUNT TOO. This used to read the literal form
+      // only and `continue` past everything else, which quietly exempted every
+      // `/subnets/{netuid}/...` and `/validators/{hotkey}` route from the one
+      // assertion that says "if you read a mirrored table, declare it". Those
+      // are not edge cases -- they are most of the neurons family, and a route
+      // missing from the map does not fail: it silently stays on D1 forever
+      // while the migration reports itself finished.
+      const path = routePath(block);
+      if (path == null) continue;
 
-      const entry = NEON_READ_ROUTE_TABLES.find((r) => r.pattern.test(literal));
+      const entry = NEON_READ_ROUTE_TABLES.find((r) => r.pattern.test(path));
       checked += 1;
       if (!entry) {
-        problems.push(`${literal} reads [${tables}] but has no entry`);
+        problems.push(`${path} reads [${tables}] but has no entry`);
         continue;
       }
-      const declared = [...entry.tables].sort();
-      if (JSON.stringify(declared) !== JSON.stringify(tables)) {
+      // SUBSET, not equality, and the direction is the whole point.
+      //
+      // A table this scan FINDS and the entry does not declare is #9768's bug
+      // exactly: the route reads it, the gate does not check it, so the read
+      // moves on another table's evidence. That must fail.
+      //
+      // The reverse -- declared but not found here -- is not a defect and must
+      // not fail. This scan reads the matcher block only, and several handlers
+      // delegate part of their work to a loader in src/, so the block is a
+      // LOWER BOUND on what the route touches. Over-declaring is also the
+      // conservative direction: it makes the gate demand more proof, never
+      // less. Asserting equality here would force the map to be narrowed to
+      // match a scanner's blind spot, which is how a gate ends up certifying
+      // less than it appears to.
+      const declared = new Set(entry.tables);
+      const undeclared = tables.filter((t) => !declared.has(t));
+      if (undeclared.length > 0) {
         problems.push(
-          `${literal} reads [${tables}] but declares [${declared}]`,
+          `${path} reads [${undeclared}] but declares [${[...declared].sort()}]`,
         );
       }
     }
 
     assert.ok(
-      checked >= 6,
-      `only ${checked} literal routes checked -- the block split stopped ` +
+      checked >= 12,
+      `only ${checked} routes checked -- the block split stopped ` +
         `working, so this test is passing on nothing`,
     );
     assert.deepEqual(problems, [], problems.join("\n"));

--- a/tests/neon-sql-portability.test.ts
+++ b/tests/neon-sql-portability.test.ts
@@ -1,0 +1,312 @@
+// No SQL that a Neon read flag can reach is allowed to be store-specific
+// (#9791).
+//
+// ## What this exists to have caught
+//
+// #9784 shipped a per-route map of which TABLES each route reads, and moved
+// fifteen routes onto Neon on the strength of it. Nothing checked whether the
+// QUERIES could run there. Two separate incompatibilities were waiting, and
+// each one cost a rollback:
+//
+//   #9792  `date(MAX(snapshot_date), '-30 days')` -- a SQLite FUNCTION that
+//          Postgres does not have.       /subnets/movers      5 rows -> 0
+//                                        /subnets/{n}/history 28 rows -> 0
+//   #9802  `validator_permit = 1` -- a TYPING mismatch. D1 stores the column
+//          INTEGER 0/1; Neon declares it BOOLEAN, because the mirror writes
+//          real JS booleans. Postgres rejects `boolean = integer`.
+//                                        /validators          5 rows -> 0
+//
+// NEITHER FAILURE THREW ANYTHING A CALLER COULD SEE. The first yielded a NULL
+// boundary so `>=` matched nothing; the second errored into a
+// `?? buildGlobalValidators([])` fallback. Both returned a schema-stable 200
+// with zero rows -- the one shape indistinguishable from "no data yet". Only a
+// row-count baseline caught them, twice, after they were already live.
+//
+// This file is the gate that has to hold before anything goes back in.
+//
+// ## Why a deny-list and not a parser
+//
+// A real SQL parser would be more precise and is the wrong trade here: the
+// query text is assembled from template literals with interpolations, so it is
+// not parseable without evaluating it. A deny-list is checkable on raw text,
+// cheap, and fails in the direction that matters -- a false positive costs a
+// rewrite, a false negative costs a silently empty route in production.
+//
+// ## Why it scans loader modules and not just the matcher
+//
+// The route that broke worst did not hold its own SQL. /validators is served
+// by loadGlobalValidators in src/metagraph-neurons.ts, reached through an
+// injected runner that createPgD1Runner can swap for a Postgres one. Scanning
+// only matchNeuronsD1Route would have declared #9802 impossible while it was
+// live. Anything a movable route can reach is in scope.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { NEON_READ_ROUTE_TABLES } from "../workers/data-api.ts";
+
+interface Rule {
+  pattern: RegExp;
+  what: string;
+  instead: string;
+}
+
+/**
+ * Constructs that are valid SQLite and NOT valid Postgres.
+ *
+ * Each entry names the Postgres equivalent, because the useful failure message
+ * is the one that says what to write instead.
+ */
+const SQLITE_ONLY: readonly Rule[] = [
+  {
+    pattern: /\bdate\s*\([^;]*?,\s*[`'"][-+]?\d/i,
+    what: "date(x, 'modifier') — SQLite date arithmetic",
+    instead:
+      "compute the boundary in TypeScript and bind it (see neuronDailyWindowBounds / src/iso-date-window.ts)",
+  },
+  {
+    pattern: /\bdatetime\s*\([^;]*?,\s*[`'"][-+]?\d/i,
+    what: "datetime(x, 'modifier')",
+    instead: "compute it in TypeScript and bind it",
+  },
+  {
+    pattern: /\bstrftime\s*\(/i,
+    what: "strftime()",
+    instead: "to_char(), or format it in TypeScript",
+  },
+  {
+    pattern: /\bjulianday\s*\(/i,
+    what: "julianday()",
+    instead: "date subtraction in TypeScript",
+  },
+  {
+    pattern: /\bunixepoch\s*\(/i,
+    what: "unixepoch()",
+    instead: "extract(epoch from …), or bind Date.now()",
+  },
+  {
+    pattern: /\bifnull\s*\(/i,
+    what: "IFNULL()",
+    instead: "COALESCE(), which both accept",
+  },
+  {
+    pattern: /\bgroup_concat\s*\(/i,
+    what: "GROUP_CONCAT()",
+    instead: "STRING_AGG()",
+  },
+  {
+    pattern: /\bjson_extract\s*\(/i,
+    what: "json_extract()",
+    instead: "-> / ->> operators",
+  },
+  {
+    pattern: /\bjson_each\s*\(/i,
+    what: "json_each()",
+    instead: "jsonb_array_elements()",
+  },
+  {
+    pattern: /\binstr\s*\(/i,
+    what: "INSTR()",
+    instead: "POSITION(… IN …) or STRPOS()",
+  },
+  { pattern: /\bLIMIT\s+-1\b/i, what: "LIMIT -1", instead: "omit the LIMIT" },
+  {
+    pattern: /\bAUTOINCREMENT\b/i,
+    what: "AUTOINCREMENT",
+    instead: "GENERATED … AS IDENTITY",
+  },
+];
+
+/**
+ * Columns D1 stores as INTEGER 0/1 and Neon declares BOOLEAN.
+ *
+ * This is NOT a dialect difference -- both stores would accept both spellings
+ * against a column of the matching type. It is a SCHEMA difference, and the
+ * authority for the list is the mirror itself: `NEON_BACKFILL_PLANS[*].booleans`
+ * in src/neon-backfill.ts names exactly the columns it converts with
+ * `Boolean(value)` on the way in, which is why Neon's side of them is BOOLEAN.
+ *
+ * Kept in sync by a test below rather than by hand.
+ */
+const BOOLEAN_COLUMNS = [
+  "validator_permit",
+  "active",
+  "is_immunity_period",
+] as const;
+
+/** Comparisons and aggregates that only work against ONE of the two schemas. */
+const BOOLEAN_MISUSE: readonly Rule[] = BOOLEAN_COLUMNS.flatMap((column) => [
+  {
+    // `col = 1` / `col = 0`: Postgres rejects `boolean = integer` outright.
+    pattern: new RegExp(`\\b${column}\\s*=\\s*[01]\\b`, "i"),
+    what: `${column} = 0/1 — Postgres has this column as BOOLEAN`,
+    instead: `${column} = TRUE / = FALSE, which SQLite also accepts (it aliases TRUE to 1)`,
+  },
+  {
+    // SUM over the raw column: Postgres has no SUM(boolean) at all.
+    pattern: new RegExp(`\\bSUM\\s*\\(\\s*${column}\\s*\\)`, "i"),
+    what: `SUM(${column}) — Postgres cannot sum a boolean`,
+    instead: `SUM(CASE WHEN ${column} THEN 1 ELSE 0 END), which is portable`,
+  },
+]);
+
+const ALL_RULES: readonly Rule[] = [...SQLITE_ONLY, ...BOOLEAN_MISUSE];
+
+/**
+ * Modules whose SQL a movable route can execute through an injected runner.
+ *
+ * These hold the loaders the analytics routes delegate to. `createPgD1Runner`
+ * makes them store-agnostic by construction -- which is exactly why their SQL
+ * has to be portable, and why #9802 lived here rather than in the matcher.
+ */
+const REACHABLE_LOADERS = [
+  "src/metagraph-neurons.ts",
+  "src/movers.ts",
+  "src/chain-turnover.ts",
+  "src/concentration.ts",
+  "src/subnet-yield.ts",
+  "src/subnet-performance.ts",
+  "src/live-economics-refresh.ts",
+];
+
+/**
+ * Comments removed.
+ *
+ * A comment DESCRIBING a banned construct is not a use of it -- and the
+ * comments here necessarily name them, because they explain why the code no
+ * longer uses them. Scanning raw text flagged /api/v1/chain/turnover for the
+ * note recording what it was ported away from.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1 ");
+}
+
+/** The matcher body, which is where the inline route SQL lives. */
+function matcherSource(): string {
+  const src = readFileSync("workers/data-api.ts", "utf8");
+  const start = src.indexOf("function matchNeuronsD1Route");
+  assert.ok(start > 0, "matchNeuronsD1Route not found");
+  const end = src.indexOf("\nfunction ", start + 10);
+  return src.slice(start, end > 0 ? end : undefined);
+}
+
+/** Per-route blocks, keyed by the literal path each guard matches. */
+function routeBlocks(): { path: string; block: string }[] {
+  const out: { path: string; block: string }[] = [];
+  for (const block of matcherSource()
+    .split(/\n {2}(?=if \()/)
+    .slice(1)) {
+    const literal = /pathname === "([^"]+)"/.exec(block)?.[1];
+    if (literal) out.push({ path: literal, block: stripComments(block) });
+  }
+  return out;
+}
+
+function violations(source: string, rules: readonly Rule[]): string[] {
+  return rules
+    .filter((r) => r.pattern.test(source))
+    .map((r) => `uses ${r.what} — use ${r.instead}`);
+}
+
+describe("Neon-movable SQL is portable", () => {
+  test("the block split still finds routes", () => {
+    // Without this, the per-route assertion below passes on an empty list --
+    // which is exactly how a scanning check stops checking.
+    const blocks = routeBlocks();
+    assert.ok(
+      blocks.length >= 6,
+      `only ${blocks.length} literal routes found in matchNeuronsD1Route; the ` +
+        `split broke and this suite is testing nothing`,
+    );
+  });
+
+  test("no route the read map may move contains store-specific SQL", () => {
+    // THE GATE. A route in NEON_READ_ROUTE_TABLES is one the flag can send to
+    // Postgres, so its SQL has to run there.
+    const problems: string[] = [];
+    for (const { path, block } of routeBlocks()) {
+      if (!NEON_READ_ROUTE_TABLES.some((r) => r.pattern.test(path))) continue;
+      for (const v of violations(block, ALL_RULES))
+        problems.push(`${path}: ${v}`);
+    }
+    assert.deepEqual(
+      problems,
+      [],
+      "these routes can be sent to Neon by NEON_READ_LANES but their SQL is " +
+        "store-specific. On Postgres they do not error visibly -- they return " +
+        `an EMPTY result at 200 OK (#9791):\n${problems.join("\n")}`,
+    );
+  });
+
+  test("the loaders a movable route reaches are portable too", () => {
+    // #9802 lived in src/metagraph-neurons.ts, not in the matcher. A gate that
+    // only read the matcher would have called that regression impossible while
+    // it was serving an empty leaderboard in production.
+    const problems: string[] = [];
+    for (const file of REACHABLE_LOADERS) {
+      const source = stripComments(readFileSync(file, "utf8"));
+      for (const v of violations(source, ALL_RULES))
+        problems.push(`${file}: ${v}`);
+    }
+    assert.deepEqual(problems, [], problems.join("\n"));
+  });
+});
+
+describe("the deny-list is honest", () => {
+  test("it matches the construct that caused #9792", () => {
+    // Proving the fixture can fail. A deny-list that matches nothing would
+    // pass this suite forever.
+    const offending =
+      "SELECT MIN(snapshot_date) FROM neuron_daily " +
+      "WHERE snapshot_date >= (SELECT date(MAX(snapshot_date), '-30 days') FROM neuron_daily)";
+    const hit = SQLITE_ONLY.find((r) => r.pattern.test(offending));
+    assert.ok(hit, "the date(x, modifier) rule no longer matches #9792's SQL");
+    assert.match(hit.what, /date\(/);
+  });
+
+  test("it matches both constructs that caused #9802", () => {
+    for (const offending of [
+      "SELECT netuid, uid FROM neurons WHERE validator_permit = 1 AND hotkey IS NOT NULL",
+      "SELECT netuid, SUM(validator_permit) AS validator_count FROM neuron_daily GROUP BY netuid",
+    ]) {
+      assert.ok(
+        BOOLEAN_MISUSE.some((r) => r.pattern.test(offending)),
+        `no boolean rule matches #9802's SQL: ${offending}`,
+      );
+    }
+  });
+
+  test("it does not flag the portable spellings", () => {
+    // A false positive costs a needless rewrite, so the rules have to be
+    // narrow: `date` as a COLUMN name, single-argument date(), `= TRUE`, and
+    // the CASE form all have to pass.
+    const portable =
+      "SELECT snapshot_date, MAX(captured_at), " +
+      "SUM(CASE WHEN validator_permit THEN 1 ELSE 0 END) AS validator_count " +
+      "FROM neuron_daily WHERE snapshot_date >= $1 AND validator_permit = TRUE " +
+      "AND COALESCE(stake_tao, 0) > 0 GROUP BY snapshot_date";
+    for (const { pattern, what } of ALL_RULES) {
+      assert.ok(!pattern.test(portable), `${what} matched portable SQL`);
+    }
+  });
+
+  test("BOOLEAN_COLUMNS is the set the mirror actually converts", () => {
+    // The authority is src/neon-backfill.ts: the columns it wraps in
+    // Boolean() are precisely the ones Neon declares BOOLEAN. If a plan gains
+    // one and this list does not, the new column is unguarded -- so derive the
+    // expectation from that file rather than trusting the copy above.
+    const source = readFileSync("src/neon-backfill.ts", "utf8");
+    const declared = new Set<string>();
+    for (const m of source.matchAll(/booleans:\s*\[([^\]]*)\]/g)) {
+      for (const q of m[1]!.matchAll(/["']([^"']+)["']/g)) declared.add(q[1]!);
+    }
+    assert.ok(declared.size > 0, "no `booleans:` plan entries found");
+    assert.deepEqual(
+      [...declared].sort(),
+      [...BOOLEAN_COLUMNS].sort(),
+      "NEON_BACKFILL_PLANS names a different set of boolean columns than this " +
+        "deny-list guards",
+    );
+  });
+});

--- a/tests/neon-sql-portability.test.ts
+++ b/tests/neon-sql-portability.test.ts
@@ -239,10 +239,38 @@ describe("Neon-movable SQL is portable", () => {
     );
   });
 
+  test("every tagged statement in the matcher is portable", () => {
+    // The same scan at STATEMENT granularity rather than block granularity.
+    // Block-level scanning reports the route; this reports the query, which is
+    // the difference between "something in /subnets/movers is wrong" and a
+    // line you can go fix. Both are kept because they fail on different
+    // things: a statement built by concatenation is invisible here and caught
+    // above, and a construct in a comment-adjacent block is caught here.
+    const statements = [...matcherSource().matchAll(/sql`([^`]*)`/g)].map(
+      (m) => m[1]!,
+    );
+    assert.ok(
+      statements.length >= 10,
+      `only ${statements.length} tagged statements found -- the extraction ` +
+        `stopped working, so this assertion is passing on nothing`,
+    );
+    const problems: string[] = [];
+    for (const statement of statements) {
+      for (const v of violations(statement, ALL_RULES)) {
+        problems.push(
+          `${v}\n    in: ${statement.replace(/\s+/g, " ").trim().slice(0, 120)}`,
+        );
+      }
+    }
+    assert.deepEqual(problems, [], `\n  ${problems.join("\n  ")}\n`);
+  });
+
   test("the loaders a movable route reaches are portable too", () => {
-    // #9802 lived in src/metagraph-neurons.ts, not in the matcher. A gate that
-    // only read the matcher would have called that regression impossible while
-    // it was serving an empty leaderboard in production.
+    // #9802 lived in src/metagraph-neurons.ts, not in the matcher, and it was
+    // built by string concatenation rather than a tagged template -- so BOTH
+    // of the scans above are blind to it. A gate that only read the matcher
+    // would have called that regression impossible while it was serving an
+    // empty leaderboard in production.
     const problems: string[] = [];
     for (const file of REACHABLE_LOADERS) {
       const source = stripComments(readFileSync(file, "utf8"));
@@ -250,6 +278,54 @@ describe("Neon-movable SQL is portable", () => {
         problems.push(`${file}: ${v}`);
     }
     assert.deepEqual(problems, [], problems.join("\n"));
+  });
+
+  test("the scan actually covers every route the read map may move", () => {
+    // The matcher scans ONE function. That is only sufficient while every
+    // route in NEON_READ_ROUTE_TABLES is dispatched from it -- and the map is
+    // the thing that grows as tables move off D1 (#9787 has 46 to go).
+    // Without this, adding a route whose handler lives elsewhere silently
+    // shrinks the scan's coverage to nothing in particular, and it would still
+    // report green.
+    //
+    // Compare on a CONCRETE PATH, not on regex source: the dispatcher spells
+    // the parameterised routes with capture groups (`(\d+)`) and the map
+    // without them, so the two sources never match textually even when they
+    // describe the same route.
+    const body = matcherSource();
+    const guards = [
+      // `if (url.pathname === "...")`
+      ...[...body.matchAll(/pathname === "([^"]+)"/g)].map(
+        (m) => (path: string) => path === m[1],
+      ),
+      // `url.pathname.match(/^\/api\/v1\/.../)`
+      ...[...body.matchAll(/pathname\.match\(\s*(\/\^[^\n]*?\$\/)/g)].map(
+        (m) => {
+          const re = new RegExp(m[1]!.slice(1, -1));
+          return (path: string) => re.test(path);
+        },
+      ),
+    ];
+    assert.ok(
+      guards.length >= 12,
+      `only ${guards.length} route guards extracted -- the extraction stopped ` +
+        `working, so this test is passing on nothing`,
+    );
+
+    const uncovered = NEON_READ_ROUTE_TABLES.filter(({ pattern }) => {
+      const path = pattern.source
+        .replace(/^\^|\$$/g, "")
+        .replace(/\\\//g, "/")
+        .replace(/\[\^\/\]\+/g, "5Abc")
+        .replace(/\\d\+/g, "7");
+      return !guards.some((matches) => matches(path));
+    });
+    assert.deepEqual(
+      uncovered.map((u) => u.pattern.source),
+      [],
+      "these read-map routes are not dispatched from the scanned function, so " +
+        "the portability scan does not see their SQL",
+    );
   });
 });
 

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -695,7 +695,7 @@ function dbWith({
                   }
                   // Validators ranking (stake_tao DESC).
                   if (
-                    /validator_permit = 1 ORDER BY stake_tao DESC/.test(sql)
+                    /validator_permit = TRUE ORDER BY stake_tao DESC/.test(sql)
                   ) {
                     const rows = neurons || [];
                     return { results: rows };

--- a/tests/validator-history.test.ts
+++ b/tests/validator-history.test.ts
@@ -286,7 +286,7 @@ describe("buildValidatorHistory — scoped to one subnet (#9383)", () => {
   });
 
   test("a lost permit is reported, not dropped", () => {
-    // The scoped query deliberately omits the `validator_permit = 1` filter: a day
+    // The scoped query deliberately omits the `validator_permit = TRUE` filter: a day
     // the permit was lost is the event an operator most needs, and filtering it
     // makes it indistinguishable from a day the poller missed.
     const point = (

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -5530,24 +5530,44 @@ async function handleAccountKeysRoute(request: Request, env: Env, url: URL) {
 //
 // The D1 twins of every neurons/neuron_daily/account_position_daily read the
 // deleted Postgres dispatcher served, matched whenever METAGRAPH_NEURONS_SOURCE
-// is off "postgres" (see neuronsServedFromD1's own header). Each twin mirrors
-// the Postgres route it replaced, param handling and column list alike; only
-// the dialect moved:
-//   - no ::casts (snapshot_date is already TEXT 'YYYY-MM-DD'; SQLite compares
-//     it lexicographically, which for ISO dates IS date order)
-//   - validator_permit = TRUE            -> = 1 (INTEGER 0/1 schema)
-//   - SUM(validator_permit::int)         -> SUM(validator_permit)
-//   - DISTINCT ON (k) ... ORDER BY k, d  -> ROW_NUMBER() OVER (PARTITION BY
-//     k ORDER BY d DESC) = 1, or a group-wise-MAX join (SQLite has no
-//     DISTINCT ON)
-//   - MAX(snapshot_date) - N::int        -> NEITHER. This one is no longer a
-//     translation at all (#9798): the SQLite rendering was
-//     `date(MAX(snapshot_date), '-N days')`, and translating a dialect function
-//     into another dialect function is exactly what broke when these routes
-//     moved to Neon -- Postgres has no `date(x, modifier)`, so the subquery
-//     yielded nothing and two routes served an empty 200 (#9792). The shift now
-//     happens in TypeScript and the boundary is BOUND; see
-//     neuronDailyWindowBounds. Nothing here should acquire a fourth rendering.
+// is off "postgres" (see neuronsServedFromD1's own header).
+//
+// THIS IS NO LONGER A TRANSLATION TABLE, and reading it as one is what broke
+// the cutover twice. It was written when these queries had exactly one store to
+// satisfy, so each row recorded how a Postgres idiom had been re-rendered for
+// SQLite. Then #9784 gave the same query text a second store to run against,
+// and every one-directional rendering below became a live hazard: the SQLite
+// side is now the ONLY side, executed verbatim against both dialects. A
+// rendering that is merely correct for D1 serves a wrong answer on Neon.
+//
+// So the surviving rule is ONE PORTABLE RENDERING, not two dialects kept in
+// sync. Each entry says what both stores accept and why the alternatives are
+// out -- and `tests/neon-sql-portability.test.ts` fails the build if a query on
+// a movable route reacquires one:
+//   - snapshot_date needs no ::cast -- it is TEXT 'YYYY-MM-DD' in both, and
+//     lexicographic comparison IS date order for ISO dates in both.
+//   - `validator_permit = TRUE`, never `= 1`. D1 stores the column INTEGER 0/1
+//     and Neon declares it BOOLEAN, because the mirror writes real JS booleans.
+//     Postgres rejects `boolean = integer` outright, so `= 1` made the query
+//     throw, the `?? buildGlobalValidators([])` fallback swallowed it, and
+//     /validators served an EMPTY leaderboard at 200 OK until #9802 rolled the
+//     flag back. `TRUE` is a keyword in both (SQLite aliases it to 1).
+//   - `SUM(CASE WHEN validator_permit THEN 1 ELSE 0 END)`, never
+//     `SUM(validator_permit)`. Postgres has no SUM over boolean at all; the
+//     CASE is portable because SQLite reads a nonzero integer as true and
+//     Postgres reads the boolean directly.
+//   - DISTINCT ON (k) ... ORDER BY k, d is Postgres-only -- use ROW_NUMBER()
+//     OVER (PARTITION BY k ORDER BY d DESC) = 1, or a group-wise-MAX join,
+//     which both dialects have.
+//   - A window boundary is computed in TypeScript and BOUND, never shifted in
+//     SQL (#9798). `date(MAX(snapshot_date), '-N days')` is SQLite's and
+//     Postgres has no equivalent, so the subquery yielded nothing and two
+//     routes served an empty 200 (#9792). See neuronDailyWindowBounds.
+//
+// The two regressions share one shape worth naming: neither raised an error a
+// caller could see. Both returned a schema-stable 200 with zero rows, which is
+// indistinguishable from "no data yet" -- so nothing but a row-count baseline
+// caught them.
 //
 // Cross-tier joins: subnet_snapshots has a live D1 home (migrations/d1/
 // 0002_observations.sql), so the alpha_price_tao joins/loads port for real.
@@ -5679,7 +5699,7 @@ async function loadAlphaPricesByNetuidD1(
 // chunking into a dozen round trips (what the lakehouse reader has to do,
 // having no join to reach for). Joining against `neurons` inside SQLite costs
 // ZERO bound parameters and one query, and keeps the filter exactly in step
-// with the leaderboard's own `validator_permit = 1 AND hotkey IS NOT NULL`.
+// with the leaderboard's own `validator_permit = TRUE AND hotkey IS NOT NULL`.
 //
 // Same degrade-to-empty-map contract as loadAlphaPricesByNetuidD1 above: on
 // any failure every nominator_count stays null, which is precisely the state
@@ -5716,7 +5736,7 @@ async function loadNominatorCountsD1(
              (SELECT MAX(captured_at) FROM validator_nominator_counts) AS scan_at
       FROM (
         SELECT DISTINCT hotkey FROM neurons
-        WHERE validator_permit = 1 AND hotkey IS NOT NULL
+        WHERE validator_permit = TRUE AND hotkey IS NOT NULL
       ) n
       LEFT JOIN validator_nominator_counts c ON c.hotkey = n.hotkey`;
     return fillConfirmedZeros(
@@ -5796,7 +5816,7 @@ async function loadRealizedStakeBaselinesD1(
             FROM neuron_daily nd
             LEFT JOIN subnet_snapshots s
               ON s.netuid = nd.netuid AND s.snapshot_date = nd.snapshot_date
-            WHERE nd.validator_permit = 1` +
+            WHERE nd.validator_permit = TRUE` +
           (hotkey ? " AND nd.hotkey = ?" : "") +
           ` AND nd.snapshot_date <= ? AND nd.snapshot_date >= ?
             GROUP BY nd.hotkey, nd.snapshot_date
@@ -6039,7 +6059,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
         url.searchParams.get("validator_permit") === "true";
       const rows = validatorsOnly
         ? await sql.unsafe(
-            `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? AND validator_permit = 1 ORDER BY uid`,
+            `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? AND validator_permit = TRUE ORDER BY uid`,
             [netuid],
           )
         : await sql.unsafe(
@@ -6120,7 +6140,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
     return async (sql) => {
       const netuid = Number(subnetValidators[1]);
       const rows = await sql.unsafe(
-        `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? AND validator_permit = 1 ORDER BY stake_tao DESC, uid ASC`,
+        `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? AND validator_permit = TRUE ORDER BY stake_tao DESC, uid ASC`,
         [netuid],
       );
       return json(
@@ -6145,7 +6165,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
       // well-defined and are returned alongside the totals. Two things change
       // besides the projection: alpha is reported natively (the TAO conversion is
       // kept too, so the point is comparable with the unscoped series), and the
-      // `validator_permit = 1` filter is dropped -- a day the permit was lost is
+      // `validator_permit = TRUE` filter is dropped -- a day the permit was lost is
       // the event an operator most needs to see, and filtering it away makes it
       // look identical to a day the poller missed.
       // Same normalisation the account-family routes use for their own netuid
@@ -6213,7 +6233,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
           FROM neuron_daily nd
           LEFT JOIN subnet_snapshots s
             ON s.netuid = nd.netuid AND s.snapshot_date = nd.snapshot_date
-          WHERE nd.hotkey = ${hotkey} AND nd.validator_permit = 1 AND nd.snapshot_date >= ${cutoff}
+          WHERE nd.hotkey = ${hotkey} AND nd.validator_permit = TRUE AND nd.snapshot_date >= ${cutoff}
           GROUP BY nd.snapshot_date ORDER BY nd.snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`
         : await sql`
           SELECT nd.snapshot_date AS snapshot_date, COUNT(DISTINCT nd.netuid) AS subnet_count,
@@ -6222,7 +6242,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
           FROM neuron_daily nd
           LEFT JOIN subnet_snapshots s
             ON s.netuid = nd.netuid AND s.snapshot_date = nd.snapshot_date
-          WHERE nd.hotkey = ${hotkey} AND nd.validator_permit = 1
+          WHERE nd.hotkey = ${hotkey} AND nd.validator_permit = TRUE
           GROUP BY nd.snapshot_date ORDER BY nd.snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`;
       return json(
         buildValidatorHistory(rows, hotkey, {
@@ -6263,7 +6283,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
       ] = await Promise.all([
         sql`
           SELECT netuid, uid, hotkey, coldkey, validator_trust, emission_tao, stake_tao, block_number, captured_at, take
-          FROM neurons WHERE validator_permit = 1 AND hotkey IS NOT NULL
+          FROM neurons WHERE validator_permit = TRUE AND hotkey IS NOT NULL
           ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC`,
         loadRealizedStakeBaselinesD1(sql, {}, env),
         loadAlphaPricesByNetuidD1(sql, env),
@@ -6302,7 +6322,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
         identityByColdkey,
       ] = await Promise.all([
         sql.unsafe(
-          `SELECT ${NEURON_COLUMNS}, netuid FROM neurons WHERE hotkey = ? AND validator_permit = 1 ORDER BY netuid ASC, uid ASC`,
+          `SELECT ${NEURON_COLUMNS}, netuid FROM neurons WHERE hotkey = ? AND validator_permit = TRUE ORDER BY netuid ASC, uid ASC`,
           [hotkey],
         ),
         loadRealizedStakeBaselinesD1(sql, { hotkey }, env),
@@ -6640,14 +6660,14 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
       const rows = cutoff
         ? await sql`
           SELECT snapshot_date, COUNT(*) AS neuron_count,
-            SUM(validator_permit) AS validator_count,
+            SUM(CASE WHEN validator_permit THEN 1 ELSE 0 END) AS validator_count,
             SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao
           FROM neuron_daily
           WHERE netuid = ${netuid} AND snapshot_date >= ${cutoff}
           GROUP BY snapshot_date ORDER BY snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`
         : await sql`
           SELECT snapshot_date, COUNT(*) AS neuron_count,
-            SUM(validator_permit) AS validator_count,
+            SUM(CASE WHEN validator_permit THEN 1 ELSE 0 END) AS validator_count,
             SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao
           FROM neuron_daily
           WHERE netuid = ${netuid}
@@ -6682,7 +6702,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
         rows = await sql`
           SELECT snapshot_date, netuid, hotkey, validator_permit
           FROM neuron_daily
-          WHERE validator_permit = 1 AND snapshot_date IN (${startDate}, ${endDate})`;
+          WHERE validator_permit = TRUE AND snapshot_date IN (${startDate}, ${endDate})`;
       }
       return json(
         buildChainTurnover(rows, {
@@ -6758,7 +6778,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
       if (startDate != null && endDate != null && startDate !== endDate) {
         const rows = await sql`
           SELECT netuid, snapshot_date, COUNT(*) AS neuron_count,
-            SUM(validator_permit) AS validator_count,
+            SUM(CASE WHEN validator_permit THEN 1 ELSE 0 END) AS validator_count,
             SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao
           FROM neuron_daily
           WHERE snapshot_date IN (${startDate}, ${endDate})

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -5903,6 +5903,36 @@ export const POSITION_HISTORY_NEON_LANE = "account_position_daily";
  * handler's own SQL in tests/neon-read-routes.test.ts -- a map that drifts from
  * the queries would gate on the wrong evidence, which is worse than no gate.
  */
+/**
+ * EVERY table the handler reads, mirrored or not -- including the ones reached
+ * through a side loader.
+ *
+ * This list used to name only MIRRORED tables, and that was the defect, not a
+ * simplification. The dispatcher picks ONE runner for the whole handler, so a
+ * route sent to Neon sends ALL of its queries there, side loaders included. A
+ * table that is not mirrored does not exist on that side; the read comes back
+ * empty and the response degrades silently.
+ *
+ * `/api/v1/validators` is the worked example, and it was mapped as
+ * `["neurons"]`. Its handler also calls loadAlphaPricesByNetuidD1
+ * (subnet_snapshots), loadIdentityByColdkeyMap (account_identity),
+ * loadSubnetTemposD1 (subnet_hyperparams) and loadNominatorCountsD1
+ * (validator_nominator_counts). Three of those five tables have no Neon copy
+ * at all and the fourth has a mirror that has never fired -- so enabling
+ * `neurons` moved a route whose data was 3/5 absent on the other side.
+ *
+ * Naming the unmirrored tables is what makes that safe WITHOUT a second
+ * mechanism: neonServesRoute requires every listed table to appear in
+ * NEON_READ_LANES, and a table nothing mirrors can never legitimately be
+ * listed there (tests/neon-read-routes.test.ts enforces that separately). So
+ * an unmirrored dependency blocks the move by construction, and the route
+ * un-blocks on its own the day that table gets a proven mirror.
+ *
+ * The lists are asserted against the handler's TRANSITIVE reads in
+ * tests/neon-read-routes.test.ts. Over-declaring is safe and under-declaring
+ * is the bug, so that test checks one direction: everything the code reads
+ * must be named here.
+ */
 export const NEON_READ_ROUTE_TABLES: readonly {
   pattern: RegExp;
   tables: readonly string[];
@@ -5924,11 +5954,20 @@ export const NEON_READ_ROUTE_TABLES: readonly {
     pattern: /^\/api\/v1\/subnets\/\d+\/yield\/history$/,
     tables: ["neuron_daily"],
   },
-  // Both: the live card comes from `neurons`, the series from `neuron_daily`.
   {
-    pattern: /^\/api\/v1\/subnets\/\d+\/concentration\/history$/,
-    tables: ["neurons", "neuron_daily"],
+    pattern: /^\/api\/v1\/subnets\/\d+\/concentration$/,
+    tables: ["neuron_daily"],
   },
+  {
+    pattern: /^\/api\/v1\/subnets\/\d+\/performance$/,
+    tables: ["neuron_daily"],
+  },
+  { pattern: /^\/api\/v1\/subnets\/\d+\/yield$/, tables: ["neuron_daily"] },
+  {
+    pattern: /^\/api\/v1\/subnets\/\d+\/neurons\/\d+$/,
+    tables: ["neuron_daily"],
+  },
+  // Both: the live card comes from `neurons`, the series from `neuron_daily`.
   {
     pattern: /^\/api\/v1\/subnets\/\d+\/performance\/history$/,
     tables: ["neurons", "neuron_daily"],
@@ -5942,8 +5981,6 @@ export const NEON_READ_ROUTE_TABLES: readonly {
     tables: ["neurons", "neuron_daily"],
   },
   // `neurons` only.
-  { pattern: /^\/api\/v1\/validators$/, tables: ["neurons"] },
-  { pattern: /^\/api\/v1\/accounts$/, tables: ["neurons"] },
   { pattern: /^\/api\/v1\/chain\/concentration$/, tables: ["neurons"] },
   {
     pattern: /^\/api\/v1\/chain\/concentration\/subnets$/,
@@ -5952,9 +5989,45 @@ export const NEON_READ_ROUTE_TABLES: readonly {
   { pattern: /^\/api\/v1\/chain\/performance$/, tables: ["neurons"] },
   { pattern: /^\/api\/v1\/chain\/idle-stake$/, tables: ["neurons"] },
   { pattern: /^\/api\/v1\/chain\/yield$/, tables: ["neurons"] },
+  { pattern: /^\/api\/v1\/subnets\/\d+\/validators$/, tables: ["neurons"] },
+  { pattern: /^\/api\/v1\/accounts\/[^/]+\/portfolio$/, tables: ["neurons"] },
   {
     pattern: /^\/api\/v1\/subnets\/\d+\/metagraph$/,
     tables: ["neurons"],
+  },
+  // BLOCKED until the unmirrored tables below get a proven Neon lane. These
+  // are not aspirational entries -- listing the real dependency is what keeps
+  // neonServesRoute returning false for them today (#9811).
+  {
+    // + loadAlphaPricesByNetuidD1.
+    pattern: /^\/api\/v1\/accounts$/,
+    tables: ["neurons", "subnet_snapshots"],
+  },
+  {
+    pattern: /^\/api\/v1\/accounts\/[^/]+\/subnets$/,
+    tables: ["neurons", "subnet_snapshots"],
+  },
+  {
+    // + prices, identities, tempos and nominator counts.
+    pattern: /^\/api\/v1\/validators$/,
+    tables: [
+      "neurons",
+      "subnet_snapshots",
+      "account_identity",
+      "subnet_hyperparams",
+      "validator_nominator_counts",
+    ],
+  },
+  {
+    pattern: /^\/api\/v1\/subnets\/\d+\/concentration\/history$/,
+    tables: [
+      "neurons",
+      "neuron_daily",
+      "subnet_snapshots",
+      "account_identity",
+      "subnet_hyperparams",
+      "validator_nominator_counts",
+    ],
   },
 ];
 

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -163,37 +163,30 @@
     // mirrors have never fired (12h/30h/48h producers), which #9772's watchdog
     // reports as never-mirrored-not-alarmed. Naming one would move a read onto
     // a store with no proven writer -- #9704 exactly.
-    // neuron_daily PULLED 2026-08-07 after #9784: two routes returned ZERO
-    // rows from Neon. The runners are interface-compatible; the SQL DIALECT is
-    // not. /api/v1/subnets/movers and /api/v1/subnets/{netuid}/history both
-    // anchor their window with SQLite's `date(MAX(snapshot_date), '-30 days')`,
-    // which Postgres has no equivalent for -- so the subquery yields nothing
-    // and the >= matches nothing. Measured against a pre-cutover baseline:
-    // movers 5 rows -> 0, subnet history 28 -> 0.
     //
-    // `neurons` and `account_position_daily` stay: every route on them returned
-    // the same row counts, and the only differences were values that move with
-    // the 15-minute producer.
+    // `neurons` and `neuron_daily` are RE-ADDED here after two rollbacks. Both
+    // were pulled on 2026-08-07 for the same underlying reason -- a query that
+    // is valid SQLite and invalid Postgres -- surfacing in two different ways:
     //
-    // Re-adding neuron_daily needs those two queries ported to portable SQL
-    // (an explicit date literal computed in TS, not in the database) -- see
-    // #9789.
-    // `neurons` PULLED 2026-08-07, immediately after neuron_daily (#9791).
-    // /api/v1/validators returned ZERO from Neon and fell back to an empty
-    // artifact -- 5 rows -> 0, measured across three deploys:
-    //   baseline (pre-cutover)  5 rows
-    //   f07234628 (pre-cutover) 5 rows
-    //   2df376f7e (post)        0 rows
+    //   #9792  neuron_daily. /subnets/movers and /subnets/{netuid}/history
+    //          anchored a window with `date(MAX(snapshot_date), '-30 days')`,
+    //          which Postgres does not have. movers 5 rows -> 0, history
+    //          28 -> 0.
+    //   #9802  neurons. /validators compared `validator_permit = 1` against a
+    //          column Neon declares BOOLEAN. 5 rows -> 0, measured across three
+    //          deploys (baseline 5, f07234628 5, 2df376f7e 0).
     //
-    // Same root cause class as #9791: a query that is valid SQLite and not
-    // valid Postgres fails, and this route falls back to an artifact rather
-    // than erroring -- so the failure is invisible from the response alone.
+    // Both are fixed at the source rather than worked around: the window
+    // boundary is computed in TypeScript and bound (#9807), and the boolean
+    // comparisons and aggregates now use spellings both stores accept. Neither
+    // failure was visible from a response -- each returned a schema-stable 200
+    // with zero rows -- so what makes this re-add different from the last two
+    // is not confidence, it is that both classes are now checked in CI by
+    // tests/neon-sql-portability.test.ts, which scans the movable routes AND
+    // the loader modules they reach and fails the build on either construct.
     //
-    // account_position_daily stays. Its one route was verified against a D1
-    // baseline across four deploys and is unchanged.
-    //
-    // NOTHING goes back into this flag until #9793's dialect scan runs in CI.
-    "NEON_READ_LANES": "account_position_daily",
+    // Rollback remains deleting the entry.
+    "NEON_READ_LANES": "account_position_daily,neurons,neuron_daily",
     // The two ACCUMULATING tables, and only those (src/neon-backfill.ts).
     //
     // The mirror above writes what each request carries, which finishes the job


### PR DESCRIPTION
Closes #9809. Refs #9814.

Three things had to be true before `neurons` and `neuron_daily` could go back into `NEON_READ_LANES`. Two of them were not, and I found the third while fixing the second.

## 1. Boolean columns were typed differently on each side (#9809)

D1 stores `validator_permit` / `active` / `is_immunity_period` as INTEGER `0`/`1`. Neon declares them **BOOLEAN**, because that is what the mirror writes (`shapeRowForNeon`).

| was | now |
|---|---|
| `validator_permit = 1` | `validator_permit = TRUE` |
| `SUM(validator_permit)` | `SUM(CASE WHEN validator_permit THEN 1 ELSE 0 END)` |

`TRUE` is a keyword in SQLite too, and SQLite reads a nonzero integer as true in `CASE WHEN` — so both new spellings are correct on **both** stores. One rendering, not a translation pair. 17 sites.

This is what emptied `/api/v1/validators`: Postgres rejects `boolean = integer`, the query threw, and `?? buildGlobalValidators([])` returned an **empty leaderboard at 200 OK**.

## 2. Nothing checked portability, so it regressed twice

`tests/neon-sql-portability.test.ts` fails the build on either class — the dialect functions from #9791 and the boolean typing above. What makes it worth more than the 17 edits:

- **It scans the loader modules, not just the matcher.** #9802 lived in `src/metagraph-neurons.ts`. A matcher-only scan would have called it impossible while it was live.
- **The boolean column list is derived from `NEON_BACKFILL_PLANS`**, with a test asserting the two agree — a table gaining a boolean column cannot leave the deny-list behind.
- **Every rule is proven to fire.** Reverting `src/metagraph-neurons.ts` to `main` fails the suite with the file, the construct, and the fix to write instead.

It also absorbs the two strengths of the scan #9807 added in parallel (statement-granularity extraction, dispatcher-derived coverage), so there is one place that answers "can this query run on both stores".

## 3. The map under-declared by design, and that is worse than either bug (#9814)

The dispatcher picks **one runner for the whole handler**, so a moved route sends *all* its queries to Neon — including its side loaders'. The map only ever held **inline** reads, and a test enforced that entries name *only mirrored tables*. Both halves guarantee under-declaration.

`/api/v1/validators` was mapped `["neurons"]`. It also reads `subnet_snapshots`, `account_identity`, `subnet_hyperparams` and `validator_nominator_counts` through loaders — **three of five tables have no Neon copy at all.** Enabling `neurons` would have moved it anyway, for the third time.

Full transitive audit of the handler call graph — **21 routes read a mirrored table**:

- **17 movable** (only proven mirrored tables)
- **4 blocked** by an unmirrored dependency: `/validators`, `/subnets/{n}/concentration/history`, `/accounts`, `/accounts/{ss58}/subnets`

Three of the four were already mapped and under-declared. Seven more routes read a mirrored table and had **no entry at all**, so they could never move regardless of the flag; they have one now.

Entries now declare the full set including unmirrored tables. `neonServesRoute` already requires every listed table to be read-enabled, and nothing may name an unmirrored table in `NEON_READ_LANES` — so the four block by construction and un-block on their own once those tables have a proven mirror. Mirroring them is #9814.

## Flag

`NEON_READ_LANES` → `account_position_daily,neurons,neuron_daily`.

Still not named: `nominator_positions`, `hotkey_alpha`, `account_balances`, `validator_nominator_counts` — mirrors that have never fired (12h/30h/48h producers), which #9772's watchdog reports as never-mirrored-not-alarmed. A test fails if one is named.

## Verification

- 620 tests across the affected suites, plus `typecheck`, `eslint`, `prettier` clean.
- Both new gates proven to fail on the real defect, not just to pass.
- The two `= 1` occurrences that are **TypeScript default parameters** are deliberately untouched — a blind regex hit exactly those on an earlier attempt.
- A negative assertion in `tests/accounts-list.test.ts` was pinned to `= 1`; it now matches either spelling, since as written it would have silently stopped testing anything.

**Correction to my own earlier claim:** I said the pre-cutover baseline was what caught both regressions and would catch the next. It compares full response hashes, so it reports normal producer churn as divergence — it fired on a deploy where the flags had not moved. I've rewritten it to compare row counts, payload shape, row identity, and non-zero scalar count, which are stable under churn and collapse when a query breaks. It now agrees with itself across runs, which it never did before.
