### PR TITLE
fix(queue): give neurons the completeness contract its chunking took away

### DIFF
--- a/migrations/d1/0030_neurons_passes.sql
+++ b/migrations/d1/0030_neurons_passes.sql
@@ -1,0 +1,56 @@
+-- Pass completeness for the metagraph snapshot (#9812).
+--
+-- WHY THIS LANE NEEDS ONE, and why it looked like it did not. The three lanes
+-- that already have a pass table (0020 account_balances, 0021 hotkey_alpha,
+-- 0029 the two nominator tables) are flat keyspace scans, and the argument for
+-- gating them was that a short load and a small one are indistinguishable.
+-- `neurons` was left out on the reasoning -- written down in
+-- src/sync-batch-queue.ts -- that "its producer NEVER chunks", so the whole
+-- snapshot arrives in one POST or none of it does.
+--
+-- THAT IS NO LONGER TRUE. metagraph.rs packs its snapshot into ~7+ requests
+-- grouped by netuid (its own test asserts `chunks.len() >= 7`), and the posting
+-- loop CONTINUES past a failed chunk before bailing at the end:
+--
+--     Ok(())  => posted += 1,
+--     Err(e)  => failures.push(...)
+--
+-- So the netuids in the chunks that succeeded are already written with
+-- captured_at advanced, while the rest keep an older stamp. The lane reports
+-- failure; the table does not.
+--
+-- NOT HYPOTHETICAL. The comment directly above that loop records it happening:
+-- "pass stopped there. The 108 subnets behind it kept a stamp that was by then
+-- 30 hours old."
+--
+-- MAX(captured_at) CANNOT SUBSTITUTE, and this is the specific trap: it
+-- reflects only the netuids that DID land, so a pass covering 21 of 129 subnets
+-- leaves a perfectly fresh-looking stamp behind it. That is the same shape as
+-- the 147,000-row account_balances incident this whole mechanism came from.
+--
+-- ROWS, NOT NETUIDS, and the reason is that the producer BUFFERS the whole
+-- snapshot before packing it. It therefore knows the exact row total in advance
+-- -- there is no estimate involved -- and an exact total detects a missing
+-- netuid just as surely as a netuid count would (30,110 expected against 29,854
+-- received never completes), while keeping all five pass tables one shape for
+-- one reader (src/pass-completeness.ts).
+--
+-- SAME COLUMNS AS 0020/0021/0029 deliberately, down to the names, because
+-- `latestCompletePass` and `passTallyStatement` interpolate the table name into
+-- otherwise identical SQL. Five tables with five shapes would be five readers.
+CREATE TABLE IF NOT EXISTS neurons_passes (
+  captured_at   INTEGER NOT NULL,
+  expected_rows INTEGER NOT NULL,
+  received_rows INTEGER NOT NULL DEFAULT 0,
+  -- Epoch-ms of the request that closed the gap. Set exactly once, never
+  -- cleared -- the at-least-once transport means received_rows can legitimately
+  -- exceed expected_rows on a retry, and the gate asks "did everything arrive",
+  -- not "how many times". Observed live on 2026-08-07: an account_balances pass
+  -- recorded 372,569 received against 364,819 expected and is correctly
+  -- COMPLETE.
+  completed_at  INTEGER,
+  PRIMARY KEY (captured_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_neurons_passes_completed
+  ON neurons_passes (completed_at DESC);

--- a/src/neurons-d1-write.ts
+++ b/src/neurons-d1-write.ts
@@ -12,6 +12,10 @@
 // prune. SQLite supports `excluded.` and a WHERE clause on DO UPDATE, so the
 // two paths agree line for line rather than merely in spirit.
 import { NEURON_INSERT_COLUMNS } from "./metagraph-neurons.ts";
+import {
+  passTallyStatement,
+  type PassTallyInput,
+} from "./pass-completeness.ts";
 
 /** Columns of `neuron_daily` = the neuron row plus its day and write stamp. */
 export const NEURON_DAILY_COLUMNS = [
@@ -333,6 +337,12 @@ export interface NeuronSnapshotWrite {
   positionRows: Row[];
   /** Per-netuid max captured_at -- NOT one batch-wide value. */
   netuidMaxCapturedAt: Map<number, number>;
+  /**
+   * This request's contribution to the pass tally (#9812), when the producer
+   * declared one. Optional because a producer that has not been updated must
+   * keep working -- absent means "no declaration", never "zero rows".
+   */
+  pass?: PassTallyInput | null;
 }
 
 // --- The three derivations, pure and shared ---------------------------------
@@ -469,7 +479,13 @@ export async function batchInSlices(
 
 export async function writeNeuronSnapshotToD1(
   db: D1Like,
-  { rows, dailyRows, positionRows, netuidMaxCapturedAt }: NeuronSnapshotWrite,
+  {
+    rows,
+    dailyRows,
+    positionRows,
+    netuidMaxCapturedAt,
+    pass,
+  }: NeuronSnapshotWrite,
 ): Promise<{ statements: number }> {
   const statements: D1PreparedStatement[] = [
     ...chunkStatements(
@@ -502,6 +518,12 @@ export async function writeNeuronSnapshotToD1(
         .bind(netuid, capturedAt),
     );
   }
+
+  // Batched WITH the rows it describes, so a tally cannot survive a failed row
+  // write and report a pass complete that never landed (#9812). Appended after
+  // the prunes for the same reason they are appended last -- ordering inside
+  // one batch is the only ordering there is.
+  if (pass) statements.push(passTallyStatement(db, "neurons", pass));
 
   if (statements.length) await batchInSlices(db, statements);
   return { statements: statements.length };

--- a/src/pass-completeness.ts
+++ b/src/pass-completeness.ts
@@ -54,6 +54,7 @@ const NONE: PassCompleteness = {
  * here gets a decline, not a query.
  */
 export const PASS_TABLES: Readonly<Record<string, string>> = {
+  neurons: "neurons_passes",
   "nominator-positions": "nominator_positions_passes",
   "validator-nominator-counts": "validator_nominator_counts_passes",
 };

--- a/src/sync-batch-queue.ts
+++ b/src/sync-batch-queue.ts
@@ -165,12 +165,22 @@ export const SYNC_BATCH_LANES = [
 export const PRUNING_LANES: readonly string[] = [
   "nominator-positions",
   // metagraphed-infra#357. It prunes per netuid, and it can assert
-  // key-completeness for a reason worth stating: its producer NEVER chunks.
-  // `metagraph.rs` bails -- "refusing to truncate a partial snapshot" -- if a
-  // pass exceeds its 50,000-row ceiling, and a pass is ~33,000 rows, so the
-  // whole snapshot arrives in one POST or none of it does. The packer then
-  // groups that POST by netuid, so every message really does carry every row
-  // for each netuid it names.
+  // key-completeness for a reason worth stating precisely: `pack_netuid_chunks`
+  // never SPLITS a netuid across two requests, so every message really does
+  // carry every row for each netuid it names.
+  //
+  // CORRECTED (#9812). This used to say the producer "NEVER chunks" -- that the
+  // whole snapshot arrives in one POST or none of it does. It packs ~7+
+  // requests per pass and has for some time; its own test asserts
+  // `chunks.len() >= 7`. The conclusion above survives because the guarantee
+  // that matters is per-NETUID, not per-pass -- but the old premise was false,
+  // and on a field whose failure mode is deleted rows, the next person to
+  // extend it would have been reasoning from something untrue.
+  //
+  // What chunking DID cost is separate and is why `neurons` now has a pass
+  // table: the posting loop continues past a failed chunk, so a partial pass
+  // leaves some netuids fresh and some stale, which key-completeness says
+  // nothing about.
   "neurons",
 ];
 

--- a/tests/data-api-neurons-d1.test.ts
+++ b/tests/data-api-neurons-d1.test.ts
@@ -52,6 +52,15 @@ const HYPERPARAMS_SCHEMA = fs.readFileSync(
   path.join(process.cwd(), "migrations/d1/0009_hyperparams_identity.sql"),
   "utf8",
 );
+// neurons_passes (#9812) -- the completeness contract this lane gained after
+// its producer started chunking. Loaded for the same reason as the tables
+// above: the real database carries it, and the write batches the tally
+// alongside the rows it describes, so a suite without it would exercise a
+// write path that cannot exist in production.
+const NEURONS_PASSES_SCHEMA = fs.readFileSync(
+  path.join(process.cwd(), "migrations/d1/0030_neurons_passes.sql"),
+  "utf8",
+);
 
 let db: InstanceType<typeof DatabaseSync>;
 
@@ -277,6 +286,7 @@ beforeEach(() => {
   db.exec(OBSERVATIONS_SCHEMA);
   db.exec(NOMINATOR_COUNTS_SCHEMA);
   db.exec(HYPERPARAMS_SCHEMA);
+  db.exec(NEURONS_PASSES_SCHEMA);
 });
 
 // netuid -> tempo(blocks), the row apy_estimate annualizes against. Values are
@@ -1852,9 +1862,78 @@ test("neurons-sync claims key-completeness on what it enqueues", async () => {
   );
   assert.equal(sent[0]!.key_complete, true);
   assert.equal(sent[0]!.lane, "neurons");
-  // No pass declaration: this lane has never had one, and inventing a total
-  // would mark an unproven load complete.
+  // This REQUEST declared none, so the message must not invent one -- a
+  // fabricated total would mark an unproven load complete. (The lane does have
+  // a pass contract now, #9812; the declaration is the producer's to make.)
   assert.equal("pass_total" in sent[0]!, false);
+});
+
+test("a declared pass_total rides the message and tallies to COMPLETE", async () => {
+  // The whole contract in one pass, split across two requests the way the
+  // producer actually chunks: the netuids that land are written immediately,
+  // so only the tally can say whether the REST of them ever arrived.
+  const passRow = (over: Record<string, unknown> = {}) =>
+    syncRow({ captured_at: 1_780_000_000_000, ...over });
+
+  const first = await call(
+    req("/api/v1/internal/neurons-sync", {
+      method: "POST",
+      headers: { "x-neurons-sync-token": SYNC_SECRET },
+      body: { rows: [passRow()], pass_total: 2 },
+    }),
+  );
+  assert.equal(first.status, 200);
+  let pass = db
+    .prepare(
+      "SELECT expected_rows, received_rows, completed_at FROM neurons_passes",
+    )
+    .all() as unknown as Row[];
+  assert.equal(pass.length, 1);
+  assert.equal(pass[0]!.expected_rows, 2);
+  assert.equal(pass[0]!.received_rows, 1);
+  assert.equal(
+    pass[0]!.completed_at,
+    null,
+    "one chunk of two is exactly the state that used to be invisible",
+  );
+
+  const second = await call(
+    req("/api/v1/internal/neurons-sync", {
+      method: "POST",
+      headers: { "x-neurons-sync-token": SYNC_SECRET },
+      body: { rows: [passRow({ netuid: 8, uid: 0 })], pass_total: 2 },
+    }),
+  );
+  assert.equal(second.status, 200);
+  pass = db
+    .prepare(
+      "SELECT expected_rows, received_rows, completed_at FROM neurons_passes",
+    )
+    .all() as unknown as Row[];
+  assert.equal(pass.length, 1, "one row per pass, keyed on its captured_at");
+  assert.equal(pass[0]!.received_rows, 2);
+  assert.ok(
+    pass[0]!.completed_at,
+    "the pass is complete once both chunks land",
+  );
+});
+
+test("a pass_total smaller than the rows sent is refused", async () => {
+  // The producer buffers before chunking, so a total under this request's own
+  // row count is a producer bug -- accepting it would complete a pass that
+  // never covered the network.
+  const res = await call(
+    req("/api/v1/internal/neurons-sync", {
+      method: "POST",
+      headers: { "x-neurons-sync-token": SYNC_SECRET },
+      body: { rows: [syncRow(), syncRow({ uid: 1 })], pass_total: 1 },
+    }),
+  );
+  assert.equal(res.status, 400);
+  assert.equal(
+    (db.prepare("SELECT COUNT(*) AS n FROM neurons_passes").get() as Row).n,
+    0,
+  );
 });
 
 test("neurons-sync 502s when the enqueue fails, so the producer retries", async () => {

--- a/tests/pass-completeness.test.ts
+++ b/tests/pass-completeness.test.ts
@@ -10,6 +10,7 @@
 //     migrations are applied by hand, so the window between deploying the code
 //     and applying 0029 must degrade, not 500
 import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 import {
   latestCompletePass,
@@ -195,8 +196,30 @@ describe("passTallyStatement", () => {
       assert.match(table, /_passes$/, lane);
     }
     assert.deepEqual(Object.keys(PASS_TABLES).sort(), [
+      "neurons",
       "nominator-positions",
       "validator-nominator-counts",
     ]);
+  });
+
+  test("every declared table is actually created by a migration", () => {
+    // The list above makes adding a lane a conscious act; this makes it a
+    // COMPLETE one. Migrations here are applied BY HAND, so a lane added to
+    // PASS_TABLES without its table does not fail at deploy -- it fails on
+    // every chunk, at runtime, and wedges the lane it was meant to protect.
+    //
+    // `latestCompletePass` declines on a missing table rather than throwing,
+    // which is right for a reader and is exactly why nothing else would notice.
+    const migrations = readdirSync("migrations/d1")
+      .filter((f) => f.endsWith(".sql"))
+      .map((f) => readFileSync(`migrations/d1/${f}`, "utf8"))
+      .join("\n");
+    for (const [lane, table] of Object.entries(PASS_TABLES)) {
+      assert.match(
+        migrations,
+        new RegExp(`CREATE TABLE IF NOT EXISTS ${table}\\b`),
+        `${lane} declares ${table}, which no migration creates`,
+      );
+    }
   });
 });

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -689,23 +689,56 @@ async function handleNeuronsSync(
   );
   const netuids = [...netuidMaxCapturedAt.keys()];
 
+  // THE PASS DECLARATION (#9812), and this lane's case is different from its
+  // four siblings'. Theirs is "a short load looks like a small one" over a flat
+  // keyspace. Here the producer packs the snapshot into ~7+ requests grouped by
+  // netuid and its posting loop CONTINUES past a failed chunk before bailing at
+  // the end -- so the netuids that landed are already written with captured_at
+  // advanced, while the rest keep an older stamp. The lane reports failure; the
+  // table does not.
+  //
+  // Recorded in metagraph.rs's own comment: "pass stopped there. The 108
+  // subnets behind it kept a stamp that was by then 30 hours old."
+  //
+  // MAX(captured_at) cannot see it, because it reflects only the netuids that
+  // DID land -- 21 of 129 subnets leaves a perfectly fresh-looking stamp.
+  //
+  // Optional, like every other lane's: a producer that has not been updated
+  // must keep working, and inventing a total would mark an unproven load
+  // complete -- the one lie this mechanism exists to prevent.
+  const neuronsDeclared = declaredPassTotal(
+    parsed,
+    NEURONS_SYNC_MAX_ROWS * 100,
+  );
+  if (neuronsDeclared.error) {
+    return writeJson({ error: neuronsDeclared.error }, 400);
+  }
+  const neuronsTally = passTallyFromRows(
+    rows,
+    neuronsDeclared.total,
+    Date.now(),
+  );
+  if (neuronsTally.error) {
+    return writeJson({ error: neuronsTally.error }, 400);
+  }
+  const pass = neuronsTally.pass ?? null;
+
   // Enqueue or write, never both -- see handleHotkeyAlphaSync's own note.
   //
   // THE PRUNE IS WHY THIS LANE WAITED (metagraphed-infra#357). Its write
   // DELETES rows for a netuid older than the newest captured_at it saw for that
   // netuid, so a message missing some of a netuid's rows would delete rows it
   // never carried. The packer groups by netuid and asserts `key_complete`
-  // because it made that true -- and it CAN, because this producer never
-  // chunks: metagraph.rs bails rather than truncate a partial snapshot, so the
-  // whole pass arrives in one POST or none of it does.
-  //
-  // No pass declaration: this lane has never had one, and inventing one would
-  // mark an unproven load complete.
+  // because it made that true -- and it still can, because pack_netuid_chunks
+  // never SPLITS a netuid across two chunks. (It does chunk, ~7+ requests per
+  // pass; the claim here used to be that it never chunked at all, which was the
+  // right conclusion from a premise that has not been true for some time.)
   if (syncLaneUsesQueue(env, "neurons")) {
     try {
       await enqueueSyncBatch(env.SYNC_BATCHES!, {
         lane: "neurons",
-        capturedAt: rows[0]!.captured_at as number,
+        capturedAt: pass?.capturedAt ?? (rows[0]!.captured_at as number),
+        ...(pass ? { passTotal: pass.expectedRows } : {}),
         rows,
       });
     } catch (err) {
@@ -744,7 +777,7 @@ async function handleNeuronsSync(
       env.METAGRAPH_HEALTH_DB as unknown as Parameters<
         typeof writeNeuronSnapshotToD1
       >[0],
-      { rows, dailyRows, positionRows, netuidMaxCapturedAt },
+      { rows, dailyRows, positionRows, netuidMaxCapturedAt, pass },
     ));
   } catch (err) {
     console.error("data-api neurons-sync D1 write failed:", err);
@@ -7830,12 +7863,12 @@ export default {
           // only because the message asserted `key_complete` -- the validator
           // rejects a neurons message without it, so this writer never sees a
           // chunk whose prune map would delete rows it did not carry.
-          neurons: (rows) =>
+          neurons: (rows, pass) =>
             writeNeuronSnapshotToD1(
               env.METAGRAPH_HEALTH_DB as unknown as Parameters<
                 typeof writeNeuronSnapshotToD1
               >[0],
-              neuronSnapshotWrite(rows, Date.now()),
+              { ...neuronSnapshotWrite(rows, Date.now()), pass },
             ),
           "validator-nominator-counts": async (rows, pass) => {
             const result = await writeValidatorNominatorCountsToD1(


### PR DESCRIPTION
`neurons` was the only lane on the sync queue with no completeness contract, and the reason it was left out has stopped being true.

## The premise that expired

`src/sync-batch-queue.ts` justifies letting `neurons` assert `key_complete` — the claim that authorises its destructive per-netuid prune — with:

> its producer **NEVER chunks**. `metagraph.rs` bails … so the whole snapshot arrives in one POST or none of it does.

It packs **~7+ requests per pass**, and has for some time. Its own test asserts `chunks.len() >= 7`.

The `key_complete` conclusion survives — `pack_netuid_chunks` never *splits* a netuid, so every message really does carry every row for each netuid it names, and the prune is per-netuid. But the premise was false, and on a field whose failure mode is deleted rows, the next person to extend that reasoning would have been building on something untrue. Corrected in both places it appears.

## What chunking actually cost

The posting loop **continues past a failed chunk** before bailing at the end:

```rust
Ok(())  => posted += 1,
Err(e)  => failures.push(...)
```

So the netuids that landed are already written with `captured_at` advanced, while the rest keep an older stamp. **The lane reports failure; the table does not.**

Not hypothetical — `metagraph.rs`'s own comment records it:

> pass stopped there. The 108 subnets behind it kept a stamp that was by then 30 hours old.

**`MAX(captured_at)` cannot see this**, and that is the specific trap: it reflects only the netuids that *did* land, so a pass covering 21 of 129 subnets leaves a perfectly fresh-looking stamp behind it. Exactly the shape of the 147,000-row `account_balances` incident that produced this mechanism.

It feeds `/subnets/{netuid}/metagraph`, `/validators`, `/accounts`, `/chain/idle-stake`, `/chain/concentration`, and the `neurons` half of every route in `NEON_READ_ROUTE_TABLES`. A subnet quietly serving a 30-hour-old metagraph reads as a quiet subnet, not a broken load.

## Rows, not netuids

The issue proposed declaring a **netuid** count, since the failure mode is whole netuids going missing. On reading the producer I went the other way, and the reason is worth stating: `metagraph.rs` **buffers the entire snapshot before packing it**, so `written` is exact rather than estimated. An exact row total detects a missing netuid just as surely (30,110 expected against 29,854 received never completes), and it keeps all five pass tables one shape for one reader — which is the property that made this change mechanical rather than novel.

## Sequencing

**Migration `0030` is already applied to production D1.** These are applied by hand, and the tally statement fails on every chunk against a missing table, so the table goes first:

```
account_balances_passes  hotkey_alpha_passes  neurons_passes
nominator_positions_passes  validator_nominator_counts_passes
```

Declare first, gate second — the order `account_balances` followed. **Gating the readers is deliberately not in this PR**; that belongs after a real pass has been observed landing complete.

## Tests

Mutation-checked rather than assumed. Removing the tally from `writeNeuronSnapshotToD1` makes the end-to-end test **FAIL**; restoring it passes:

```
× a declared pass_total rides the message and tallies to COMPLETE   (tally removed)
  Tests  79 passed (79)                                             (tally restored)
```

That test splits one pass across two requests the way the producer actually chunks, and asserts the middle state — `received 1/2, completed_at NULL` — because that is precisely the state that used to be invisible.

Two guards added on the way:

- `passTallyStatement`'s allowlist test now also asserts **every declared table is created by a migration**. These are applied by hand, so a lane added to `PASS_TABLES` without its table does not fail at deploy — it fails on every chunk at runtime and wedges the lane it was meant to protect, and `latestCompletePass` declines rather than throwing, which is right for a reader and exactly why nothing else would notice.
- The producer-side test asserts the declaration equals what the chunks actually deliver, and that one chunk is *less* than the whole pass — otherwise the gate proves nothing.

## Producer counterpart

Needs `JSONbored/metagraphed-infra` to declare `pass_total` on each chunk (branch `feat/neurons-pass-declaration`). Until that lands this is inert by design: no declaration means no tally, which is the same contract every other lane follows.

Closes #9812
