### PR TITLE
fix(api): the degraded contract and the code disagreed twice, in opposite directions

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5104,10 +5104,10 @@ export interface components {
                 /** @description The newest StakeAdded/StakeRemoved this account has on chain, when that is what contradicts the zero. */
                 latest_stake_event_at: string | null;
                 /**
-                 * @description `tier_unavailable`: every tier declined, so this zero is a read failure. `snapshot_predates_stake_activity`: the position ledger answered zero, but this account has an on-chain StakeAdded/StakeRemoved NEWER than the ledger's own snapshot -- it was demonstrably staking after the ledger was captured, so `positions: 0` is a claim the ledger is not entitled to make.
+                 * @description `tier_unavailable`: every tier declined, so this zero is a read failure. `snapshot_predates_stake_activity`: the position ledger answered zero, but this account has an on-chain StakeAdded/StakeRemoved NEWER than the ledger's own snapshot -- it was demonstrably staking after the ledger was captured, so `positions: 0` is a claim the ledger is not entitled to make. `positions_unpriceable`: the ledger HAS rows for this account, but one or more could not be priced against the live neurons table -- they are excluded from `positions` and from `total_stake_alpha` rather than reported with a fabricated zero, so the total understates the real holding.
                  * @enum {string}
                  */
-                reason: "tier_unavailable" | "snapshot_predates_stake_activity";
+                reason: "tier_unavailable" | "snapshot_predates_stake_activity" | "positions_unpriceable";
                 /** @description The LEDGER's own capture stamp, not this account's -- present even when the account has no rows in it, which is the case this field exists for. */
                 snapshot_captured_at: string | null;
             };

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -14537,10 +14537,11 @@
                 "description": "The newest StakeAdded/StakeRemoved this account has on chain, when that is what contradicts the zero."
               },
               "reason": {
-                "description": "`tier_unavailable`: every tier declined, so this zero is a read failure. `snapshot_predates_stake_activity`: the position ledger answered zero, but this account has an on-chain StakeAdded/StakeRemoved NEWER than the ledger's own snapshot -- it was demonstrably staking after the ledger was captured, so `positions: 0` is a claim the ledger is not entitled to make.",
+                "description": "`tier_unavailable`: every tier declined, so this zero is a read failure. `snapshot_predates_stake_activity`: the position ledger answered zero, but this account has an on-chain StakeAdded/StakeRemoved NEWER than the ledger's own snapshot -- it was demonstrably staking after the ledger was captured, so `positions: 0` is a claim the ledger is not entitled to make. `positions_unpriceable`: the ledger HAS rows for this account, but one or more could not be priced against the live neurons table -- they are excluded from `positions` and from `total_stake_alpha` rather than reported with a fabricated zero, so the total understates the real holding.",
                 "enum": [
                   "tier_unavailable",
-                  "snapshot_predates_stake_activity"
+                  "snapshot_predates_stake_activity",
+                  "positions_unpriceable"
                 ],
                 "type": "string"
               },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5104,10 +5104,10 @@ export interface components {
                 /** @description The newest StakeAdded/StakeRemoved this account has on chain, when that is what contradicts the zero. */
                 latest_stake_event_at: string | null;
                 /**
-                 * @description `tier_unavailable`: every tier declined, so this zero is a read failure. `snapshot_predates_stake_activity`: the position ledger answered zero, but this account has an on-chain StakeAdded/StakeRemoved NEWER than the ledger's own snapshot -- it was demonstrably staking after the ledger was captured, so `positions: 0` is a claim the ledger is not entitled to make.
+                 * @description `tier_unavailable`: every tier declined, so this zero is a read failure. `snapshot_predates_stake_activity`: the position ledger answered zero, but this account has an on-chain StakeAdded/StakeRemoved NEWER than the ledger's own snapshot -- it was demonstrably staking after the ledger was captured, so `positions: 0` is a claim the ledger is not entitled to make. `positions_unpriceable`: the ledger HAS rows for this account, but one or more could not be priced against the live neurons table -- they are excluded from `positions` and from `total_stake_alpha` rather than reported with a fabricated zero, so the total understates the real holding.
                  * @enum {string}
                  */
-                reason: "tier_unavailable" | "snapshot_predates_stake_activity";
+                reason: "tier_unavailable" | "snapshot_predates_stake_activity" | "positions_unpriceable";
                 /** @description The LEDGER's own capture stamp, not this account's -- present even when the account has no rows in it, which is the case this field exists for. */
                 snapshot_captured_at: string | null;
             };

--- a/schemas-src/routes/account-positions.ts
+++ b/schemas-src/routes/account-positions.ts
@@ -26,6 +26,7 @@
 // Bucket (c): captured_at fields drop format:date-time in favor of plain
 // z.string().nullable(), matching this epic's established convention.
 import { z } from "zod";
+import { POSITIONS_DEGRADED_REASONS } from "../../src/account-nominator-positions.ts";
 import { successEnvelopeSchema } from "../envelope.ts";
 
 const NominatorPositionSchema = z
@@ -48,10 +49,15 @@ const NominatorPositionSchema = z
 // permanently-null field trains callers not to look.
 const AccountPositionsDegradedSchema = z
   .object({
+    // Built from the loader's own tuple, not re-typed here (#9804). This enum
+    // used to list two of the three reasons the code can emit, so production
+    // served `positions_unpriceable` against a contract that called it
+    // impossible -- a strict client rejected a valid response, and a client
+    // switching on the enum fell through silently.
     reason: z
-      .enum(["tier_unavailable", "snapshot_predates_stake_activity"])
+      .enum(POSITIONS_DEGRADED_REASONS)
       .describe(
-        "`tier_unavailable`: every tier declined, so this zero is a read failure. `snapshot_predates_stake_activity`: the position ledger answered zero, but this account has an on-chain StakeAdded/StakeRemoved NEWER than the ledger's own snapshot -- it was demonstrably staking after the ledger was captured, so `positions: 0` is a claim the ledger is not entitled to make.",
+        "`tier_unavailable`: every tier declined, so this zero is a read failure. `snapshot_predates_stake_activity`: the position ledger answered zero, but this account has an on-chain StakeAdded/StakeRemoved NEWER than the ledger's own snapshot -- it was demonstrably staking after the ledger was captured, so `positions: 0` is a claim the ledger is not entitled to make. `positions_unpriceable`: the ledger HAS rows for this account, but one or more could not be priced against the live neurons table -- they are excluded from `positions` and from `total_stake_alpha` rather than reported with a fabricated zero, so the total understates the real holding.",
       ),
     snapshot_captured_at: z
       .string()

--- a/src/account-nominator-positions.ts
+++ b/src/account-nominator-positions.ts
@@ -132,6 +132,27 @@ export const POSITIONS_DEGRADED_SNAPSHOT_PREDATES_ACTIVITY =
  */
 export const POSITIONS_DEGRADED_UNPRICEABLE = "positions_unpriceable";
 
+/**
+ * Every reason this surface can publish, as the tuple the schema enum is built
+ * from.
+ *
+ * The enum used to be re-typed by hand in schemas-src/routes/account-positions.ts
+ * and listed two of these three, so production served `positions_unpriceable`
+ * against a contract that said it was impossible (#9804). A client validating
+ * strictly rejected a valid response; a client switching on the enum fell
+ * through silently -- on the one field whose entire job is telling a caller not
+ * to trust the number beside it.
+ *
+ * Declared here, next to the constants, so a reason cannot exist in code
+ * without appearing in the published contract. Adding one below and forgetting
+ * the schema is no longer possible; there is only one list.
+ */
+export const POSITIONS_DEGRADED_REASONS = [
+  POSITIONS_DEGRADED_TIER_UNAVAILABLE,
+  POSITIONS_DEGRADED_SNAPSHOT_PREDATES_ACTIVITY,
+  POSITIONS_DEGRADED_UNPRICEABLE,
+] as const;
+
 export interface AccountPositionsDegraded {
   reason: string;
   /** The LEDGER's own capture stamp, not this account's -- present even when
@@ -266,6 +287,39 @@ export function distinctHotkeys(
  * defect this route shares with #9260/#9263, and it is worse here because the
  * payload carries a confident TOTAL rather than merely an empty list.
  */
+/**
+ * Give a forwarded tier's payload the `degraded` shape this route's contract
+ * declares.
+ *
+ * The Postgres arm forwards an upstream response verbatim instead of building
+ * it here, so it is the one path that can publish a `degraded` block this file
+ * never shaped -- and production does exactly that, serving a bare
+ * `{"reason":"tier_unavailable"}` while the schema declares
+ * `snapshot_captured_at` and `latest_stake_event_at` required (nullable, but
+ * required). Every locally-built decline already carries all three.
+ *
+ * Null is the honest value for a stamp an upstream did not send: "we don't know
+ * when" is a statement the schema can carry, and a missing key is not. Anything
+ * the upstream DID send is preserved -- this fills gaps, it does not overwrite.
+ *
+ * Same reasoning as the rpc-usage composer refusing to trust a forwarded tier's
+ * `observed_at` (#9794): a tier whose representation is taken on faith is how a
+ * field ends up meaning different things on different paths.
+ */
+export function shapeForwardedPositions<T>(payload: T): T {
+  const row = payload as Record<string, unknown> | null;
+  const degraded = row?.degraded as Record<string, unknown> | undefined;
+  if (!degraded || typeof degraded !== "object") return payload;
+  return {
+    ...row,
+    degraded: {
+      snapshot_captured_at: null,
+      latest_stake_event_at: null,
+      ...degraded,
+    },
+  } as T;
+}
+
 export function unavailableAccountPositions(
   ss58: string,
 ): AccountPositionsResult {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1338,7 +1338,10 @@ import {
   DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW,
 } from "./subnet-deregistrations.ts";
 import { buildAccountPortfolio } from "./account-portfolio.ts";
-import { unavailableAccountPositions } from "./account-nominator-positions.ts";
+import {
+  shapeForwardedPositions,
+  unavailableAccountPositions,
+} from "./account-nominator-positions.ts";
 import {
   buildNeuronHistory,
   buildSubnetHistory,
@@ -9153,15 +9156,19 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       ctx: McpCtx,
     ) {
       const ss58 = requireSs58(args);
-      return (
+      // Shaped on the way out because the first arm forwards an upstream
+      // payload verbatim (#9804). Every locally-built decline already carries
+      // the full `degraded` block, so this is a no-op for them -- it exists for
+      // the one arm this file does not build.
+      return shapeForwardedPositions(
         (await tryPostgresTier(
           ctx.env,
           mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/positions`),
           "METAGRAPH_NEURONS_SOURCE",
         )) ??
-        (await loadAccountPositionsD1(ctx.env, ss58)) ??
-        (await loadAccountPositionsColdTier(ctx.env, ss58)) ??
-        unavailableAccountPositions(ss58)
+          (await loadAccountPositionsD1(ctx.env, ss58)) ??
+          (await loadAccountPositionsColdTier(ctx.env, ss58)) ??
+          unavailableAccountPositions(ss58),
       );
     },
   },
@@ -9237,12 +9244,16 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             ctx.env,
             mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/positions`),
             "METAGRAPH_NEURONS_SOURCE",
-          ).then(
-            async (data) =>
+          ).then(async (data) =>
+            // Same shaping as the single-facet tool above, for the same reason:
+            // this arm can forward a payload this file never built (#9804), and
+            // the compound card must not disagree with the tool it mirrors.
+            shapeForwardedPositions(
               data ??
-              (await loadAccountPositionsD1(ctx.env, ss58)) ??
-              (await loadAccountPositionsColdTier(ctx.env, ss58)) ??
-              unavailableAccountPositions(ss58),
+                (await loadAccountPositionsD1(ctx.env, ss58)) ??
+                (await loadAccountPositionsColdTier(ctx.env, ss58)) ??
+                unavailableAccountPositions(ss58),
+            ),
           ),
           tryPostgresTier(
             ctx.env,

--- a/tests/account-nominator-positions.test.ts
+++ b/tests/account-nominator-positions.test.ts
@@ -3,11 +3,14 @@ import assert from "node:assert/strict";
 
 import {
   NOMINATOR_POSITION_INSERT_COLUMNS,
+  POSITIONS_DEGRADED_REASONS,
   POSITIONS_DEGRADED_SNAPSHOT_PREDATES_ACTIVITY,
+  POSITIONS_DEGRADED_TIER_UNAVAILABLE,
   POSITIONS_DEGRADED_UNPRICEABLE,
   annotatePositionsSnapshot,
   buildAccountPositions,
   distinctHotkeys,
+  shapeForwardedPositions,
   stakeByHotkeyNetuid,
 } from "../src/account-nominator-positions.ts";
 import { handleRequest } from "../workers/api.ts";
@@ -542,5 +545,68 @@ describe("NOMINATOR_POSITION_INSERT_COLUMNS", () => {
       "share_fraction",
       "captured_at",
     ]);
+  });
+});
+
+// #9804. The published contract and the code disagreed twice, in opposite
+// directions, on the one field whose entire job is telling a caller not to
+// trust the number beside it.
+describe("degraded is exactly what the contract declares (#9804)", () => {
+  test("every reason the code can emit is a member of the published enum", () => {
+    // The enum used to be re-typed by hand in the route schema and listed two
+    // of the three constants, so production served `positions_unpriceable`
+    // against a contract calling it impossible: a strict client rejected a
+    // valid response, and a client switching on the enum fell through silently.
+    // Building the enum from this tuple is the fix; this test is what stops a
+    // fourth constant being added without joining it.
+    for (const reason of [
+      POSITIONS_DEGRADED_TIER_UNAVAILABLE,
+      POSITIONS_DEGRADED_SNAPSHOT_PREDATES_ACTIVITY,
+      POSITIONS_DEGRADED_UNPRICEABLE,
+    ]) {
+      assert.ok(
+        (POSITIONS_DEGRADED_REASONS as readonly string[]).includes(reason),
+        `${reason} is emitted by this module but absent from POSITIONS_DEGRADED_REASONS, so the published enum does not declare it`,
+      );
+    }
+  });
+
+  test("a forwarded tier's bare degraded block is given the declared shape", () => {
+    // The Postgres arm forwards an upstream payload verbatim, and production
+    // serves `{"reason":"tier_unavailable"}` from it -- while the schema
+    // declares snapshot_captured_at and latest_stake_event_at required
+    // (nullable, but required). Null is the honest value for a stamp the
+    // upstream did not send; a missing key is not.
+    const shaped = shapeForwardedPositions({
+      ss58: SS58,
+      position_count: 0,
+      degraded: { reason: POSITIONS_DEGRADED_TIER_UNAVAILABLE },
+    }) as unknown as Record<string, Record<string, unknown>>;
+    assert.deepEqual(shaped.degraded, {
+      snapshot_captured_at: null,
+      latest_stake_event_at: null,
+      reason: POSITIONS_DEGRADED_TIER_UNAVAILABLE,
+    });
+  });
+
+  test("it fills gaps without overwriting what the upstream did send", () => {
+    const shaped = shapeForwardedPositions({
+      degraded: {
+        reason: POSITIONS_DEGRADED_SNAPSHOT_PREDATES_ACTIVITY,
+        snapshot_captured_at: "2026-08-01T00:00:00.000Z",
+      },
+    }) as Record<string, Record<string, unknown>>;
+    assert.equal(
+      shaped.degraded.snapshot_captured_at,
+      "2026-08-01T00:00:00.000Z",
+    );
+    assert.equal(shaped.degraded.latest_stake_event_at, null);
+  });
+
+  test("a payload with no degraded block is returned untouched", () => {
+    // A measured answer must not grow a `degraded` key it never had -- that
+    // would be the mirror-image defect, a healthy read wearing a decline.
+    const measured = { ss58: SS58, position_count: 3 };
+    assert.equal(shapeForwardedPositions(measured), measured);
   });
 });


### PR DESCRIPTION
## Summary

`get_account_positions` publishes `degraded` to say a zero is a **read failure rather than a
measurement**. Its schema and its code disagreed about that field on both sides at once — the worst
place for a contract to be wrong, because this is the field whose entire job is telling a caller not
to trust the number beside it.

### The enum declared two reasons; the code emits three

Production serves `positions_unpriceable` — a coldkey whose ledger rows exist but cannot be priced
against the live `neurons` table. The schema said that was impossible. A client validating strictly
**rejected a valid response**; a client switching on the enum fell through silently on the one case
it most needed to handle.

The enum is now built from `POSITIONS_DEGRADED_REASONS`, exported next to the constants that define
it, so a reason cannot exist in code without appearing in the published contract — there is only one
list.

The Ajv sweep in #9794 missed this because it probed one account and got `tier_unavailable`. The
undeclared value only appears for accounts whose positions cannot be priced.

### The schema requires two fields the forwarded tier omits

`snapshot_captured_at` and `latest_stake_event_at` are declared required (nullable, but required),
and production serves a bare `{"reason":"tier_unavailable"}`. Every decline this module builds
carries all three — the bare one comes from the Postgres arm, which forwards an upstream payload
verbatim rather than building it here.

That payload is now shaped on the way out, the same way the rpc-usage composer stopped trusting a
forwarded tier's `observed_at` in #9794. Null is the honest value for a stamp an upstream did not
send; a missing key is not. Anything the upstream **did** send is preserved, and a payload with no
`degraded` block is returned untouched — a measured answer must not grow a decline it never had.

Both call sites are covered, including `get_account_snapshot`'s, so the compound card and the
single-facet tool cannot disagree about what a coldkey holds.

## Verification

Against production, before and after:

| account | before | after |
| --- | --- | --- |
| `5E2LP6EnZ54m...` (`positions_unpriceable`) | **rejected** by its own schema | validates |
| `5GsbTgfvgCH4...` (`tier_unavailable`) | missing both required fields | shaped at the boundary |

The forwarded-shape test was confirmed to **fail** with the fix reverted.

```
npx tsc --noEmit                 clean
npm run build                    clean (openapi + types regenerated and committed)
npm run validate:contract-drift  passed
npm run validate:api             passed, 201 routes
npm run validate:mcp             passed, 225 tools
npx vitest run <3 suites>        2480 passed
```

## Note on #9803

I filed #9803 claiming three surfaces served a confident zero. **That was my error** and it is now
closed with a correction: I probed `get_account_portfolio` and `get_account_subnets` with
*coldkeys*, and both read `neurons` keyed by **hotkey**, so `0` was the correct answer. Re-probed
with a real validator hotkey, both return 119 positions/subnets and are healthy. What survived that
investigation is exactly what this PR fixes.

Closes #9804
Refs #9793, #9796
