### PR TITLE
fix(neon): convert ? to $n in createPgSql.unsafe, six routes served empty

### DIFF
--- a/src/pg-sql.ts
+++ b/src/pg-sql.ts
@@ -93,7 +93,24 @@ export function createPgSql(
   };
   const sql = ((strings: TemplateStringsArray, ...values: unknown[]) =>
     run(pgStatementText(strings), values)) as PgSql;
-  sql.unsafe = (text: string, values: unknown[] = []) => run(text, values);
+  // `?` -> `$n`, exactly as createPgD1Runner does it, and for the same reason
+  // -- this is the escape hatch route handlers reach for when the statement is
+  // assembled from a column-list constant, and they write SQLite's `?` because
+  // D1 is what they were written against.
+  //
+  // WITHOUT THIS, SIX ROUTES SERVED EMPTY (#9821). Postgres does not recognise
+  // `?` as a placeholder, so `WHERE netuid = ? AND snapshot_date >= ?` never
+  // matched and /subnets/{n}/performance/history went 28 rows -> 0, along with
+  // /subnets/{n}/validators, /subnets/{n}/performance, /subnets/{n}/neurons/
+  // {uid}, that route's /history, and /validators/{hotkey}/history.
+  //
+  // The conversion existed and was wired into createPgD1Runner ONLY, so the
+  // tagged-template path and the injected-runner path were both safe and the
+  // third path -- this one -- was not. A statement that already uses `$n` and
+  // no `?` passes through unchanged, so applying it here is not a behaviour
+  // change for any caller that was already correct.
+  sql.unsafe = (text: string, values: unknown[] = []) =>
+    run(toPositionalPlaceholders(text), values);
   return sql;
 }
 

--- a/tests/pg-sql.test.ts
+++ b/tests/pg-sql.test.ts
@@ -100,6 +100,63 @@ describe("createPgSql", () => {
     assert.deepEqual(calls[0]!.values, ["5A", 64]);
   });
 
+  test("unsafe() rewrites `?` placeholders, like the D1 runner does", async () => {
+    // THE BUG THIS PINS (#9821). `unsafe` is the escape hatch route handlers
+    // use when the statement is built from a column-list constant, and they
+    // write SQLite's `?` because D1 is what they were written against. This
+    // path was the only one of the three that did not convert, so six routes
+    // served an EMPTY 200 the moment the read flag moved them: Postgres does
+    // not recognise `?`, so nothing matched.
+    const { client, calls } = fakeClient([{ n: 1 }]);
+    const { ctx } = ctxSpy();
+    const sql = createPgSql(
+      { connectionString: "postgres://x" },
+      ctx,
+      () => client as never,
+    );
+    const rows = await sql.unsafe(
+      "SELECT a, b FROM neuron_daily WHERE netuid = ? AND snapshot_date >= ? ORDER BY snapshot_date DESC LIMIT ?",
+      [1, "2026-07-08", 500],
+    );
+    assert.deepEqual(rows, [{ n: 1 }]);
+    assert.equal(
+      calls[0]!.text,
+      "SELECT a, b FROM neuron_daily WHERE netuid = $1 AND snapshot_date >= $2 ORDER BY snapshot_date DESC LIMIT $3",
+    );
+    assert.deepEqual(calls[0]!.values, [1, "2026-07-08", 500]);
+  });
+
+  test("unsafe() leaves an already-numbered statement alone", async () => {
+    // Applying the conversion here must not be a behaviour change for callers
+    // that were already correct -- otherwise fixing the broken path would
+    // break the working one.
+    const { client, calls } = fakeClient([]);
+    const { ctx } = ctxSpy();
+    const sql = createPgSql(
+      { connectionString: "postgres://x" },
+      ctx,
+      () => client as never,
+    );
+    const text = "SELECT n FROM t WHERE a = $1 AND b = $2";
+    await sql.unsafe(text, ["x", "y"]);
+    assert.equal(calls[0]!.text, text);
+  });
+
+  test("unsafe() does not renumber a `?` inside a string literal", async () => {
+    // The conversion is shared with createPgD1Runner and already handles this;
+    // asserting it through THIS path too, because a caller reaching for
+    // `unsafe` is the one most likely to embed a literal.
+    const { client, calls } = fakeClient([]);
+    const { ctx } = ctxSpy();
+    const sql = createPgSql(
+      { connectionString: "postgres://x" },
+      ctx,
+      () => client as never,
+    );
+    await sql.unsafe("SELECT '? ok' AS q FROM t WHERE a = ?", ["v"]);
+    assert.equal(calls[0]!.text, "SELECT '? ok' AS q FROM t WHERE a = $1");
+  });
+
   test("returns the connection via waitUntil, not on the response path", async () => {
     // Hyperdrive holds the real pool; this handle must go back to it. Awaiting
     // the teardown would add its latency to every read, and leaking it would


### PR DESCRIPTION
Closes #9821

`/api/v1/subnets/1/performance/history` went **28 rows → 0** when #9810 deployed. Five more went with it, all serving a schema-stable `200 OK` with an empty payload.

## One line, three paths

There are three ways a handler reaches Postgres. Only two converted `?` to `$n`:

| path | conversion |
|---|---|
| tagged template | `pgStatementText` ✅ |
| injected `D1Runner` | `createPgD1Runner` ✅ |
| **`sql.unsafe`** | **none** ❌ |

`unsafe` is the escape hatch handlers use when the statement is built from a column-list constant (`SELECT \${PERFORMANCE_HISTORY_READ_COLUMNS} FROM …`) — so the path most likely to carry `?` was the one that didn't convert.

## Affected, all confirmed live at rows=0

`/subnets/{n}/performance/history`, `/subnets/{n}/performance`, `/subnets/{n}/validators`, `/subnets/{n}/neurons/{uid}`, `/subnets/{n}/neurons/{uid}/history`, `/validators/{hotkey}/history`

## Why both gates missed it

A **third class**, after #9792 (dialect functions) and #9802 (column typing). `tests/neon-sql-portability.test.ts` scans for SQLite-only *constructs* — and `?` isn't one. It is correct SQL on two of three paths and wrong only on the third, so no construct deny-list could find it.

My route baseline missed it too: of the six, only one was in the 15-route list. I'm extending that list.

## Verification

- 21 tests in `tests/pg-sql.test.ts`, 228 across the Neon suites.
- Three new assertions: `?` is rewritten; an already-`$n` statement is **unchanged** (so fixing the broken path can't break the working one); a `?` inside a string literal isn't renumbered.
- `neon-write`'s bulk INSERTs build `$n` directly and are unaffected — covered by the passthrough test.

**Fixing forward rather than rolling back**, per the migration goal. The flag stays as-is; this makes it correct.