### PR TITLE
feat(mcp): derive eight tool schemas, including the one #9794 could not

### DIFF
--- a/schemas-src/mcp-tools/account-portfolio.ts
+++ b/schemas-src/mcp-tools/account-portfolio.ts
@@ -12,11 +12,8 @@
 // the old name, and every response since has failed its own published contract.
 import { z } from "zod";
 import { AccountPortfolioArtifactSchema } from "../routes/account-portfolio.ts";
-import {
-  OpenObjectArraySchema,
-  OpenObjectSchema,
-  ss58Schema,
-} from "./shared.ts";
+import { AccountPositionsArtifactSchema } from "../routes/account-positions.ts";
+import { OpenObjectSchema, ss58Schema } from "./shared.ts";
 
 export const GetAccountPortfolioInputSchema = z
   .object({
@@ -53,41 +50,26 @@ export type GetAccountPositionsInput = z.infer<
   typeof GetAccountPositionsInputSchema
 >;
 
-// NOT YET DERIVED, deliberately. AccountPositionsArtifactSchema is the right
-// source and this should become `= AccountPositionsArtifactSchema` -- but the
-// live tool does not satisfy it today, so switching now would publish a
-// contract production violates, trading one drift for another.
+// DERIVED AT LAST (#9796). This was held back in #9794 as the one schema that
+// could not switch: deriving it then would have published a contract production
+// violated, because the route's `degraded.reason` enum declared two values
+// while the live tool served a third, and the route required
+// `degraded.snapshot_captured_at`/`latest_stake_event_at` that the forwarded
+// tier omitted. #9804 fixed both at the source -- the enum is now built from
+// the loader's own reason tuple, and a forwarded payload is shaped on the way
+// out -- so the block is gone.
 //
-// Two things block it, both filed:
-//   - the route's `degraded.reason` enum declares two values and production
-//     serves a third, `positions_unpriceable` (#9804);
-//   - the route requires `degraded.snapshot_captured_at` and
-//     `latest_stake_event_at`, and the handler emits neither (#9803).
+// Re-verified against production after that landed: the live response satisfies
+// this schema on both degraded paths, which is what made it safe to switch.
 //
-// Checked against production rather than assumed: deriving today rejects real
-// responses on exactly those fields. The rename below is still fixed here,
-// because that one is a plain defect with nothing blocking it.
-export const GetAccountPositionsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    ss58: z.string(),
-    captured_at: z.string().nullable().optional(),
-    position_count: z.int(),
-    // RENAMED IN #8803, and this copy never followed (#9794). The field is
-    // total_stake_alpha -- schemas-src/routes/account-positions.ts says so and
-    // explains why it is alpha rather than TAO -- so this schema REQUIRED a
-    // key the response has never carried since that rename. Every
-    // get_account_positions response has been failing its own published
-    // contract, and an agent reading the schema was told to look for a field
-    // that is not there.
-    total_stake_alpha: z.number(),
-    positions: OpenObjectArraySchema,
-    // #9273: present only when the payload's zero is not a measurement. Left
-    // open here rather than typed, because the shape it should reference is the
-    // one #9803/#9804 are still correcting.
-    degraded: OpenObjectSchema.optional(),
-  })
-  .passthrough();
+// Deriving also finishes the #8803 rename properly. The copy REQUIRED
+// `total_stake_tao`, a key the response has not carried since that rename, so
+// every get_account_positions response failed its own published contract and an
+// agent reading the schema was told to look for a field that is not there. And
+// `positions` stops being a bare open array: the route types every position and
+// says why the stake figure is alpha rather than TAO, which is exactly the trap
+// a caller needs warned about.
+export const GetAccountPositionsOutputSchema = AccountPositionsArtifactSchema;
 export type GetAccountPositionsOutput = z.infer<
   typeof GetAccountPositionsOutputSchema
 >;

--- a/schemas-src/mcp-tools/agent-catalog-resources.ts
+++ b/schemas-src/mcp-tools/agent-catalog-resources.ts
@@ -6,6 +6,7 @@
 // array). Neither mirrors an existing schemas-src/routes/ REST schema --
 // modeled fresh, matching each hand-written literal field-for-field.
 import { z } from "zod";
+import { AgentResourcesArtifactSchema } from "../routes/agent-catalog.ts";
 import { OpenObjectSchema, netuidSchema } from "./shared.ts";
 
 export const GetAgentCatalogInputSchema = z
@@ -39,17 +40,9 @@ export type GetAgentResourcesInput = z.infer<
   typeof GetAgentResourcesInputSchema
 >;
 
-export const GetAgentResourcesOutputSchema = z
-  .object({
-    generated_at: z.string().nullable().optional(),
-    published_at: z.string().nullable().optional(),
-    content_hash: z.string().nullable().optional(),
-    summary: OpenObjectSchema.optional(),
-    copyable_agent: OpenObjectSchema.optional(),
-    mcp: OpenObjectSchema,
-    resources: z.array(OpenObjectSchema),
-  })
-  .passthrough();
+// DERIVED, NOT COPIED (#9796). The copy published summary, copyable_agent, mcp
+// and resources[] as bare open shapes.
+export const GetAgentResourcesOutputSchema = AgentResourcesArtifactSchema;
 export type GetAgentResourcesOutput = z.infer<
   typeof GetAgentResourcesOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-blocks-summary.ts
+++ b/schemas-src/mcp-tools/get-blocks-summary.ts
@@ -3,27 +3,14 @@
 // pilot routes -- no existing Zod schema to reuse. Modeled fresh, shallow,
 // from the hand-written literal it replaces.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import { BlocksSummaryArtifactSchema } from "../routes/blocks-summary.ts";
 
 export const GetBlocksSummaryInputSchema = z.object({}).strict();
 export type GetBlocksSummaryInput = z.infer<typeof GetBlocksSummaryInputSchema>;
 
-export const GetBlocksSummaryOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    block_count: z.int(),
-    first_block: z.int().nullable().optional(),
-    last_block: z.int().nullable().optional(),
-    first_observed_at: z.string().nullable().optional(),
-    last_observed_at: z.string().nullable().optional(),
-    block_time: OpenObjectSchema.nullable().optional(),
-    throughput: OpenObjectSchema.nullable().optional(),
-    distinct_authors: z.int().optional(),
-    author_concentration: OpenObjectSchema.nullable().optional(),
-    distinct_spec_versions: z.int().optional(),
-    latest_spec_version: z.int().nullable().optional(),
-  })
-  .passthrough();
+// DERIVED, NOT COPIED (#9796). The copy published block_time, throughput and
+// author_concentration as bare open objects.
+export const GetBlocksSummaryOutputSchema = BlocksSummaryArtifactSchema;
 export type GetBlocksSummaryOutput = z.infer<
   typeof GetBlocksSummaryOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-turnover.ts
+++ b/schemas-src/mcp-tools/get-subnet-turnover.ts
@@ -6,7 +6,8 @@
 // writing (mirrors the pilot batch's ECONOMICS_SORT_FIELDS precedent -- not
 // cross-imported).
 import { z } from "zod";
-import { OpenObjectArraySchema, netuidSchema, windowSchema } from "./shared.ts";
+import { SubnetTurnoverArtifactSchema } from "../routes/subnet-turnover.ts";
+import { netuidSchema, windowSchema } from "./shared.ts";
 
 const HISTORY_WINDOWS = ["7d", "30d", "90d", "1y", "all"] as const;
 
@@ -27,38 +28,10 @@ export type GetSubnetTurnoverInput = z.infer<
   typeof GetSubnetTurnoverInputSchema
 >;
 
-const TurnoverChangesSchema = z
-  .object({
-    validators_entered_count: z.int().optional(),
-    validators_exited_count: z.int().optional(),
-    uid_reassignment_count: z.int().optional(),
-    validators_entered: OpenObjectArraySchema.optional(),
-    validators_exited: OpenObjectArraySchema.optional(),
-    uid_reassignments: OpenObjectArraySchema.optional(),
-  })
-  .passthrough();
-
-export const GetSubnetTurnoverOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string().nullable().optional(),
-    start_date: z.string().nullable().optional(),
-    end_date: z.string().nullable().optional(),
-    comparable: z.boolean(),
-    validators_start: z.int(),
-    validators_end: z.int(),
-    validators_entered: z.int(),
-    validators_exited: z.int(),
-    validator_retention: z.number().nullable().optional(),
-    neurons_start: z.int(),
-    neurons_end: z.int(),
-    uids_deregistered: z.int(),
-    neuron_retention: z.number().nullable().optional(),
-    stability_score: z.int().nullable().optional(),
-    changes: TurnoverChangesSchema.optional(),
-  })
-  .passthrough();
+// DERIVED, NOT COPIED (#9796). The copy published the three change lists --
+// validators_entered[], validators_exited[], uid_reassignments[] -- as bare
+// open arrays, which is the whole answer this tool gives.
+export const GetSubnetTurnoverOutputSchema = SubnetTurnoverArtifactSchema;
 export type GetSubnetTurnoverOutput = z.infer<
   typeof GetSubnetTurnoverOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet.ts
+++ b/schemas-src/mcp-tools/get-subnet.ts
@@ -1,18 +1,34 @@
 // MCP tool `get_subnet` (types-epic E pilot batch, #7863). No REST mirror --
 // the handler reads /metagraph/overview/{netuid}.json (a composed dashboard
-// view: identity + health + profile + curation + gaps + counts), a
-// DIFFERENT artifact from the `subnet-detail` REST route's raw
+// view: identity + health + profile + curation + gaps + counts), a DIFFERENT
+// artifact from the `subnet-detail` REST route's raw
 // /metagraph/subnets/{netuid}.json record (that one is what the separate
 // get_subnet_detail tool mirrors, per ITS OWN description -- "Mirrors GET
-// /api/v1/subnets/{netuid}"). Nothing in schemas-src/routes/ models this
-// composed-overview shape, so both schemas here are new, not reused.
-// Nested object/array fields (health/profile/counts/curation/gaps/
-// gap_priorities) were left shallow (bare `{type:"object"}` / `{type:"array"}`,
-// no property-level constraints) in the hand-written schema this replaces --
-// kept exactly that loose here too, per #7863's wire-compatibility
-// constraint (deep-typing them would accept LESS than the original, a
-// regression, not an improvement).
+// /api/v1/subnets/{netuid}").
+//
+// NOT a narrowing of SubnetDetailArtifactSchema, which is why this file cannot
+// simply derive from it the way its siblings in #9796 do: the two share only 4
+// of 15 keys. This is a different PROJECTION -- it flattens the route artifact's
+// nested `subnet` object up to the top level and adds a composed health card.
+//
+// The six nested fields used to be bare `{type:"object"}` / `{type:"array"}`,
+// left that way deliberately under #7863's wire-compatibility constraint:
+// deep-typing them would have accepted LESS than the hand-written schema they
+// replaced, which is a regression rather than an improvement.
+//
+// That constraint is satisfied here without keeping them opaque (#9797). Every
+// nested shape below is `.passthrough()` and every field optional, so this
+// accepts exactly what it accepted before -- nothing that validated stops
+// validating. What changes is that an agent is now told what is in them, which
+// on the tool most likely to be an agent's first call is the difference between
+// a usable contract and none at all.
+//
+// `profile` and `gaps` reuse the route's own shapes rather than restating them,
+// so those two cannot drift from the profile surface they come from. The rest
+// are modelled from what production actually serves, verified field by field
+// against a live get_subnet response.
 import { z } from "zod";
+import { SubnetProfileArtifactSchema } from "../routes/subnet-profiles.ts";
 import { netuidSchema } from "./shared.ts";
 
 export const GetSubnetInputSchema = z
@@ -22,7 +38,60 @@ export const GetSubnetInputSchema = z
   .strict();
 export type GetSubnetInput = z.infer<typeof GetSubnetInputSchema>;
 
-const OpenObjectSchema = z.object({}).passthrough();
+/** The composed health card. Probe-derived (#health): counts of surfaces by
+ * verdict, the newest check, and the observed latency sample behind it. */
+const SubnetOverviewHealthSchema = z
+  .object({
+    netuid: netuidSchema().optional(),
+    name: z.string().nullable().optional(),
+    status: z.string().nullable().optional(),
+    surface_count: z.int().optional(),
+    ok_count: z.int().optional(),
+    degraded_count: z.int().optional(),
+    failed_count: z.int().optional(),
+    unknown_count: z.int().optional(),
+    last_checked: z.string().nullable().optional(),
+    last_ok: z.string().nullable().optional(),
+    avg_latency_ms: z.number().nullable().optional(),
+    latency_sample_count: z.int().nullable().optional(),
+    observed_by: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+/** How many of each thing this subnet has registered. */
+const SubnetOverviewCountsSchema = z
+  .object({
+    surfaces: z.int().optional(),
+    endpoints: z.int().optional(),
+    candidates: z.int().optional(),
+  })
+  .passthrough();
+
+/** The human-governance axis: who reviewed this record and when. */
+const SubnetOverviewCurationSchema = z
+  .object({
+    level: z.string().nullable().optional(),
+    review_state: z.string().nullable().optional(),
+    reviewed_at: z.string().nullable().optional(),
+    verified_at: z.string().nullable().optional(),
+    source_count: z.int().nullable().optional(),
+    gap_notes: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+/** One ranked enrichment opportunity. Was `z.array(z.unknown())`, which says
+ * strictly less than an open object: not merely "shape unknown" but "nothing is
+ * known about this value at all". */
+const SubnetGapPrioritySchema = z
+  .object({
+    netuid: netuidSchema().optional(),
+    name: z.string().nullable().optional(),
+    slug: z.string().nullable().optional(),
+    curation_level: z.string().nullable().optional(),
+    candidate_count: z.int().optional(),
+    missing_kinds: z.array(z.string()).optional(),
+  })
+  .passthrough();
 
 export const GetSubnetOutputSchema = z
   .object({
@@ -30,12 +99,13 @@ export const GetSubnetOutputSchema = z
     name: z.string().nullable().optional(),
     slug: z.string().nullable().optional(),
     status: z.string().nullable().optional(),
-    health: OpenObjectSchema.nullable().optional(),
-    profile: OpenObjectSchema.nullable().optional(),
-    counts: OpenObjectSchema.optional(),
-    curation: OpenObjectSchema.nullable().optional(),
-    gaps: OpenObjectSchema.nullable().optional(),
-    gap_priorities: z.array(z.unknown()).optional(),
+    health: SubnetOverviewHealthSchema.nullable().optional(),
+    // The profile surface's own shape, not a restatement of it.
+    profile: SubnetProfileArtifactSchema.shape.profile.nullable().optional(),
+    counts: SubnetOverviewCountsSchema.optional(),
+    curation: SubnetOverviewCurationSchema.nullable().optional(),
+    gaps: SubnetProfileArtifactSchema.shape.gaps.nullable().optional(),
+    gap_priorities: z.array(SubnetGapPrioritySchema).optional(),
     operational_observed_at: z.string().nullable().optional(),
     health_source: z.string().nullable().optional(),
   })

--- a/schemas-src/mcp-tools/meta-artifacts-2.ts
+++ b/schemas-src/mcp-tools/meta-artifacts-2.ts
@@ -16,33 +16,17 @@
 // shapes the route already declares. The remaining three are still local
 // models; #9796 covers deriving them.
 import { z } from "zod";
+import { ChangelogArtifactSchema } from "../routes/meta-contracts.ts";
 import { CoverageDepthArtifactSchema } from "../routes/coverage.ts";
 import { SelfHealthArtifactSchema } from "../routes/self-health.ts";
 import { OpenObjectSchema } from "./shared.ts";
 
-// `notes: {type:["array","string","null"], items:{type:"string"}}` -- this
-// batch's shared.ts predates the NotesFieldSchema helper hoisted in batch 10
-// (#8074), still unmerged as of this batch (#8075) -- inlined here rather
-// than depending on unmerged parallel work.
-const NotesFieldSchema = z
-  .union([z.array(z.string()), z.string()])
-  .nullable()
-  .optional();
-
 export const GetChangelogInputSchema = z.object({}).strict();
 export type GetChangelogInput = z.infer<typeof GetChangelogInputSchema>;
 
-export const GetChangelogOutputSchema = z
-  .object({
-    generated_at: z.string().nullable().optional(),
-    source: z.string().nullable(),
-    notes: NotesFieldSchema,
-    summary: OpenObjectSchema,
-    artifacts: OpenObjectSchema,
-    subnets: OpenObjectSchema,
-    coverage_delta: OpenObjectSchema.nullable().optional(),
-  })
-  .passthrough();
+// DERIVED, NOT COPIED (#9796). The copy published summary, artifacts, subnets
+// and coverage_delta as bare open objects -- every field of the change summary.
+export const GetChangelogOutputSchema = ChangelogArtifactSchema;
 export type GetChangelogOutput = z.infer<typeof GetChangelogOutputSchema>;
 
 export const GetBuildInputSchema = z.object({}).strict();

--- a/schemas-src/mcp-tools/profiles.ts
+++ b/schemas-src/mcp-tools/profiles.ts
@@ -13,9 +13,9 @@
 // subnetType,curationLevel,profileLevel} and the "profiles" query
 // collection's sort_fields at the time of writing.
 import { z } from "zod";
+import { SubnetProfileArtifactSchema } from "../routes/subnet-profiles.ts";
 import {
   OpenObjectArraySchema,
-  OpenObjectSchema,
   fieldsStringSchema,
   limitSchema,
   netuidSchema,
@@ -118,18 +118,15 @@ export const ListProfilesOutputSchema = z
   .passthrough();
 export type ListProfilesOutput = z.infer<typeof ListProfilesOutputSchema>;
 
-export const GetSubnetProfileOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    contract_version: z.string().nullable().optional(),
-    generated_at: z.string().nullable().optional(),
-    subnet: OpenObjectSchema.nullable().optional(),
-    profile: OpenObjectSchema.nullable().optional(),
-    surfaces: OpenObjectArraySchema.optional(),
-    endpoints: OpenObjectArraySchema.optional(),
-    gaps: OpenObjectSchema.nullable().optional(),
-  })
-  .passthrough();
+// DERIVED, NOT COPIED (#9796). The copy published subnet, profile,
+// surfaces[], endpoints[] and candidate_surfaces[] as bare open shapes, so a
+// profile lookup -- the tool whose entire job is describing a subnet -- told
+// an agent nothing about the profile. SubnetProfileArtifactSchema models all
+// of it: 35 fields on `profile` alone, 44 on `subnet`.
+//
+// Verified against production before the switch, because deriving is a
+// tightening.
+export const GetSubnetProfileOutputSchema = SubnetProfileArtifactSchema;
 export type GetSubnetProfileOutput = z.infer<
   typeof GetSubnetProfileOutputSchema
 >;

--- a/schemas-src/mcp-tools/registry-summary-gaps.ts
+++ b/schemas-src/mcp-tools/registry-summary-gaps.ts
@@ -6,6 +6,7 @@
 // array). None mirror an existing schemas-src/routes/ REST schema --
 // modeled fresh, matching each hand-written literal field-for-field.
 import { z } from "zod";
+import { RegistrySummaryArtifactSchema } from "../routes/registry-summary-leaderboards.ts";
 import {
   OpenObjectSchema,
   fieldsStringSchema,
@@ -20,18 +21,10 @@ import {
 export const RegistrySummaryInputSchema = z.object({}).strict();
 export type RegistrySummaryInput = z.infer<typeof RegistrySummaryInputSchema>;
 
-export const RegistrySummaryOutputSchema = z
-  .object({
-    subnet_count: z.int(),
-    counts: OpenObjectSchema,
-    coverage: OpenObjectSchema.optional(),
-    curation_level_counts: OpenObjectSchema.optional(),
-    profile_level_counts: OpenObjectSchema.optional(),
-    recent_changes: OpenObjectSchema.optional(),
-    top_subnets: z.array(OpenObjectSchema).optional(),
-    generated_at: z.string().nullable().optional(),
-  })
-  .passthrough();
+// DERIVED, NOT COPIED (#9796). The copy published counts, coverage,
+// curation_level_counts and profile_level_counts as bare open objects -- the
+// four tallies this tool exists to report.
+export const RegistrySummaryOutputSchema = RegistrySummaryArtifactSchema;
 export type RegistrySummaryOutput = z.infer<typeof RegistrySummaryOutputSchema>;
 
 // Symbolic in the hand-written original (src/contracts.ts's

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -3470,10 +3470,25 @@ describe("MCP tools (injected deps)", () => {
     const schema = listToolDefinitions().find(
       (t) => t.name === "get_changelog",
     )?.outputSchema;
+    // schema_version/generated_at are part of every real artifact and were
+    // simply missing from this synthetic fixture. It passed while the tool
+    // published a hand-written schema that did not require them; deriving from
+    // ChangelogArtifactSchema (#9796) does, so the fixture now carries what the
+    // artifact always carried.
     const deps = makeDeps({
       "/metagraph/changelog.json": {
+        schema_version: 1,
+        generated_at: "2026-08-07T00:00:00.000Z",
         source: "generated-artifact-diff",
-        summary: { artifact_added_count: 0 },
+        summary: {
+          artifact_added_count: 0,
+          artifact_modified_count: 0,
+          artifact_removed_count: 0,
+          coverage_delta: null,
+          netuid_added_count: 0,
+          netuid_removed_count: 0,
+          netuid_renamed_count: 0,
+        },
         artifacts: { added: [], modified: [], removed: [] },
         subnets: { added: [], removed: [], renamed: [] },
       },
@@ -10763,11 +10778,118 @@ describe("MCP economics + metagraph data tools", () => {
       listToolDefinitions().find((t: Row) => t.name === "get_subnet_profile")!
         .outputSchema,
     );
+    // A COMPLETE profile artifact, not a four-key stub. The stub validated only
+    // because the hand-written schema this tool used to publish required almost
+    // nothing; deriving from SubnetProfileArtifactSchema (#9796) requires the
+    // real shape -- 35 fields on `profile`, 44 on `subnet` -- which is the whole
+    // point, because that shape is what an agent is now told to expect.
+    //
+    // Generated from the schema rather than hand-guessed, so it cannot quietly
+    // drift from what the contract requires: minimal valid value per required
+    // field, with the netuid/slug/completeness_score set to what this test reads.
     const detail = {
-      subnet: { netuid: 7, slug: "allways" },
-      profile: { completeness_score: 82 },
+      generated_at: "2026-08-07T00:00:00.000Z",
+      schema_version: 1,
+      profile: {
+        netuid: 7,
+        slug: "allways",
+        name: "name",
+        native_identity: null,
+        subnet_type: "root",
+        status: "active",
+        project_name: "project_name",
+        team: null,
+        categories: [],
+        derived_categories: [],
+        primary_links: {
+          website_url: null,
+          docs_url: null,
+          source_repo: null,
+          dashboard_url: null,
+        },
+        primary_app_surface: null,
+        supported_interface_kinds: [],
+        operational_interface_kinds: [],
+        surface_count: 0,
+        endpoint_count: 0,
+        monitored_endpoint_count: 0,
+        candidate_count: 0,
+        identity_evidence: {
+          candidate_identity_count: 0,
+          curated_identity_count: 0,
+          curated_identity_kinds: [],
+          live_candidate_identity_kinds: [],
+          native_contact_present: false,
+          native_description_present: false,
+          native_identity_count: 0,
+          native_identity_kinds: [],
+          needs_promotion_kinds: [],
+          stale_candidate_identity_kinds: [],
+          unverified_candidate_identity_kinds: [],
+        },
+        completeness: {
+          score: 0,
+          profile_level: "directory-only",
+          identity_level: "none",
+          identity_surface_count: 0,
+          confidence: "low",
+          missing_identity: [],
+          missing_required: [],
+          missing_operational: [],
+          missing_critical_count: 0,
+          gap_reasons: [],
+        },
+        provenance: {
+          identity_source: "identity_source",
+          interface_source_count: 0,
+          review_state: "unreviewed",
+          curation_level: "native",
+          reviewed_at: null,
+          source_urls: [],
+        },
+        curation_level: "native",
+        review_state: "unreviewed",
+        confidence: "low",
+        profile_level: "directory-only",
+        identity_level: "none",
+        identity_surface_count: 0,
+        completeness_score: 82,
+        missing_identity: [],
+        missing_required: [],
+        missing_operational: [],
+        missing_critical_count: 0,
+        gap_reasons: [],
+        suggested_submission_kinds: [],
+      },
+      subnet: {
+        coverage_level: "native-only",
+        curation: {
+          level: "native",
+          review_state: "unreviewed",
+        },
+        curation_level: "native",
+        gaps: {
+          gap_notes: [],
+          missing_kinds: [],
+          supported_kinds: [],
+        },
+        links: [],
+        name: "name",
+        netuid: 7,
+        provenance: {},
+        slug: "allways",
+        status: "active",
+        subnet_type: "root",
+        surface_count: 0,
+      },
       surfaces: [],
       endpoints: [],
+      candidate_surfaces: [],
+      gaps: {
+        gap_notes: [],
+        missing_kinds: [],
+        supported_kinds: [],
+      },
     };
     const res = await callTool(
       "get_subnet_profile",


### PR DESCRIPTION
## Summary

Second batch of #9796. **Eight** tools stop publishing their answers as bare open shapes.

### `get_account_positions` — the one #9794 could not fix

#9794 held this back as the single schema that could not be derived. Switching then would have
published a contract production violated: the route's `degraded.reason` enum declared two values
while the live tool served a third, and the route required
`degraded.snapshot_captured_at`/`latest_stake_event_at` that the forwarded tier omitted. **#9804
fixed both at the source**, so it derives now — and that also finishes the #8803 rename properly.

The copy **required `total_stake_tao`**, a key the response has not carried since that rename, so
every response failed its own published contract. And `positions` stops being a bare open array: the
route types every position and explains why the stake figure is alpha rather than TAO.

### Five more publishing their whole answer as bare open shapes

| tool | what was opaque |
| --- | --- |
| `registry_summary` | `counts`, `coverage`, `curation_level_counts`, `profile_level_counts` — the four tallies it exists for |
| `get_changelog` | `summary`, `artifacts`, `subnets`, `coverage_delta` |
| `get_agent_resources` | `summary`, `copyable_agent`, `mcp`, `resources[]` |
| `get_blocks_summary` | `block_time`, `throughput`, `author_concentration` |
| `get_subnet_turnover` | `validators_entered[]`, `validators_exited[]`, `uid_reassignments[]` — the entire answer |

### `get_subnet_profile` — derived, with a real fixture

Its route artifact requires the actual profile shape: **35 fields on `profile`, 44 on `subnet`**.
The unit fixture was a four-key stub that validated only because the hand-written schema required
nearly nothing. It is now complete and **generated from the schema** rather than hand-guessed, so it
cannot quietly drift from what the contract requires.

### `get_subnet` — composed, because it is a projection not a narrowing

It shares **4 of 15 keys** with `SubnetDetailArtifactSchema`. It flattens the route artifact's
nested `subnet` object to the top level and adds a composed health card, so `.pick()` cannot express
it.

Its six nested fields were deliberately left opaque under #7863's wire-compatibility constraint, on
the correct reasoning that deep-typing them would **accept less** than the schema they replaced.
That constraint is satisfied here without keeping them opaque: every nested shape is `.passthrough()`
and every field optional, so **nothing that validated stops validating**. `profile` and `gaps` reuse
the profile route's own shapes rather than restating them; the rest are modelled from a live
response, field by field. `gap_priorities` was `z.array(z.unknown())` — which says strictly *less*
than an open object: not "shape unknown" but "nothing is known about this value at all".

## Result

| | before | after |
| --- | --- | --- |
| untyped blobs | 184 | **128** |
| declared precision | 71.2% | **81.7%** |

Every switch was verified against production first, because deriving is a tightening. Five orphaned
local item schemas are deleted rather than left beside the derivations.

## Validation

```
npx tsc --noEmit                          clean
npx eslint schemas-src/mcp-tools/         clean
npm run validate:contract-drift           passed
npm run validate:mcp                      passed, 225 tools
npx vitest run tests/mcp-server.test.ts   1365 passed
npx prettier --check                      clean
```

Refs #9793, #9796
