### PR TITLE
fix(neon): split the read-map blocks at the guard, and correct all eight entries

### DIFF
--- a/tests/neon-read-routes.test.ts
+++ b/tests/neon-read-routes.test.ts
@@ -221,8 +221,29 @@ describe("NEON_READ_ROUTE_TABLES", () => {
     const end = src.indexOf("\nfunction ", start + 10);
     const body = src.slice(start, end > 0 ? end : undefined);
 
-    // One block per `if (...) { return async (sql) => ... }` route guard.
-    const blocks = body.split(/\n {2}(?=if \()/).slice(1);
+    // One block per route, split at each mention of `url.pathname`.
+    //
+    // NOT at `\n  if (`, which is what this did first and which silently
+    // MISATTRIBUTED SQL TO THE WRONG ROUTE. A parameterised guard is two
+    // statements:
+    //
+    //     const validatorHistoryMatch = url.pathname.match(/…/);
+    //     if (validatorHistoryMatch) { … }
+    //
+    // so splitting before the `if` puts the path expression at the END of the
+    // PREVIOUS route's block. Every parameterised route was then compared
+    // against its neighbour's SQL, and `/validators/{hotkey}/history` passed
+    // while joining a table it does not declare -- which is how it reached
+    // production reading subnet_snapshots from a store that has no such table.
+    //
+    // Splitting at `url.pathname` puts the path expression FIRST in its own
+    // block, both spellings alike, with the handler that follows it.
+    const marks = [...body.matchAll(/url\.pathname(?: ===|\.match)/g)].map(
+      (m) => m.index!,
+    );
+    const blocks = marks.map((start, i) =>
+      body.slice(start, marks[i + 1] ?? body.length),
+    );
     let checked = 0;
     const problems: string[] = [];
 

--- a/tests/pg-sql.test.ts
+++ b/tests/pg-sql.test.ts
@@ -10,6 +10,7 @@
 // So the assertions are about the built TEXT and the value order, not merely
 // that a query ran.
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 import {
   createPgD1Runner,
@@ -308,6 +309,83 @@ describe("toPositionalPlaceholders", () => {
       Array.from({ length: 11 }, (_, i) => `$${i + 1}`),
     );
     assert.equal(out.includes("?"), false);
+  });
+});
+
+describe("every dispatch path to Postgres converts placeholders", () => {
+  // THE GATE FOR #9821'S CLASS, and it exists because neither of the other two
+  // gates could have caught it.
+  //
+  // tests/neon-sql-portability.test.ts scans query TEXT for constructs that
+  // are SQLite-only. `?` is not one of those: it is correct SQL on two of the
+  // three paths into Postgres and wrong only on the third. The defect was
+  // never in a query -- it was in HOW A STATEMENT IS DISPATCHED, and
+  // createPgSql.unsafe was the one path that passed its text straight through.
+  // Six routes served an empty 200 until #9822.
+  //
+  // So this asserts the property per PATH rather than per query, and the
+  // coverage check below is the load-bearing half: a fourth factory added
+  // without conversion fails here instead of in production.
+  const bad = "SELECT a FROM t WHERE x = ? AND y = ?";
+  const good = "SELECT a FROM t WHERE x = $1 AND y = $2";
+
+  /** One invoker per factory, because their public shapes differ. */
+  const PATHS: Record<
+    string,
+    (h: { connectionString: string }, c: never, f: () => never) => Promise<void>
+  > = {
+    createPgSql: async (h, c, f) => {
+      await createPgSql(h, c, f).unsafe(bad, [1, 2]);
+    },
+    createPgD1Runner: async (h, c, f) => {
+      await createPgD1Runner(h, c, f)(bad, [1, 2]);
+    },
+  };
+
+  for (const [name, invoke] of Object.entries(PATHS)) {
+    test(`${name} rewrites ? to $n`, async () => {
+      const { client, calls } = fakeClient([]);
+      const { ctx } = ctxSpy();
+      await invoke(
+        { connectionString: "postgres://x" },
+        ctx as never,
+        (() => client) as never,
+      );
+      assert.equal(
+        calls[0]!.text,
+        good,
+        `${name} sent \`?\` to Postgres, which does not recognise it -- the ` +
+          `query matches nothing and the route serves an empty 200 (#9821)`,
+      );
+    });
+  }
+
+  test("every factory in src/pg-sql.ts is covered above", () => {
+    // The half that keeps this honest. Without it, adding a third way to reach
+    // Postgres leaves the new path unasserted while this suite still reports
+    // green -- which is exactly how `unsafe` went unchecked for as long as it
+    // did.
+    const src = readFileSync("src/pg-sql.ts", "utf8");
+    const factories = [...src.matchAll(/export function (createPg\w+)/g)].map(
+      (m) => m[1]!,
+    );
+    assert.ok(factories.length > 0, "no createPg* factories found");
+    assert.deepEqual(
+      factories.sort(),
+      Object.keys(PATHS).sort(),
+      "a factory that dispatches to Postgres is not exercised by the " +
+        "placeholder assertions above -- add an invoker for it",
+    );
+  });
+
+  test("the tagged-template path numbers its own placeholders", () => {
+    // The third path, asserted where it actually happens: the template form
+    // never sees a `?` at all, because pgStatementText builds `$n` from the
+    // interpolation count.
+    assert.equal(
+      pgStatementText(["SELECT a FROM t WHERE x = ", " AND y = ", ""]),
+      good,
+    );
   });
 });
 

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -5972,50 +5972,35 @@ export const NEON_READ_ROUTE_TABLES: readonly {
   pattern: RegExp;
   tables: readonly string[];
 }[] = [
-  // Reads `neurons` for the account's current UIDs, then the dated positions.
-  {
-    pattern: /^\/api\/v1\/accounts\/[^/]+\/subnets\/\d+\/history$/,
-    tables: ["neurons", "account_position_daily"],
-  },
-  // neuron_daily only -- the day-over-day aggregates.
+  // neuron_daily only.
   { pattern: /^\/api\/v1\/subnets\/movers$/, tables: ["neuron_daily"] },
   { pattern: /^\/api\/v1\/chain\/turnover$/, tables: ["neuron_daily"] },
-  {
-    pattern: /^\/api\/v1\/subnets\/\d+\/turnover$/,
-    tables: ["neuron_daily"],
-  },
+  { pattern: /^\/api\/v1\/subnets\/\d+\/turnover$/, tables: ["neuron_daily"] },
   { pattern: /^\/api\/v1\/subnets\/\d+\/history$/, tables: ["neuron_daily"] },
   {
     pattern: /^\/api\/v1\/subnets\/\d+\/yield\/history$/,
     tables: ["neuron_daily"],
   },
   {
-    pattern: /^\/api\/v1\/subnets\/\d+\/concentration$/,
-    tables: ["neuron_daily"],
-  },
-  {
-    pattern: /^\/api\/v1\/subnets\/\d+\/performance$/,
-    tables: ["neuron_daily"],
-  },
-  { pattern: /^\/api\/v1\/subnets\/\d+\/yield$/, tables: ["neuron_daily"] },
-  {
-    pattern: /^\/api\/v1\/subnets\/\d+\/neurons\/\d+$/,
-    tables: ["neuron_daily"],
-  },
-  // Both: the live card comes from `neurons`, the series from `neuron_daily`.
-  {
     pattern: /^\/api\/v1\/subnets\/\d+\/performance\/history$/,
-    tables: ["neurons", "neuron_daily"],
+    tables: ["neuron_daily"],
   },
   {
     pattern: /^\/api\/v1\/subnets\/\d+\/neurons\/\d+\/history$/,
-    tables: ["neurons", "neuron_daily"],
+    tables: ["neuron_daily"],
   },
-  {
-    pattern: /^\/api\/v1\/validators\/[^/]+\/history$/,
-    tables: ["neurons", "neuron_daily"],
-  },
-  // `neurons` only.
+  // `neurons` only. Several of these declared `neuron_daily` until the map
+  // test's block split was corrected (#9825): a parameterised guard is two
+  // statements, so splitting before the `if` attributed each route's SQL to
+  // its NEIGHBOUR. Gating on the wrong table is what that test exists to stop,
+  // and it was doing the opposite.
+  { pattern: /^\/api\/v1\/subnets\/\d+\/metagraph$/, tables: ["neurons"] },
+  { pattern: /^\/api\/v1\/subnets\/\d+\/neurons\/\d+$/, tables: ["neurons"] },
+  { pattern: /^\/api\/v1\/subnets\/\d+\/validators$/, tables: ["neurons"] },
+  { pattern: /^\/api\/v1\/subnets\/\d+\/concentration$/, tables: ["neurons"] },
+  { pattern: /^\/api\/v1\/subnets\/\d+\/performance$/, tables: ["neurons"] },
+  { pattern: /^\/api\/v1\/subnets\/\d+\/yield$/, tables: ["neurons"] },
+  { pattern: /^\/api\/v1\/subnets\/\d+\/idle-stake$/, tables: ["neurons"] },
   { pattern: /^\/api\/v1\/chain\/concentration$/, tables: ["neurons"] },
   {
     pattern: /^\/api\/v1\/chain\/concentration\/subnets$/,
@@ -6024,17 +6009,30 @@ export const NEON_READ_ROUTE_TABLES: readonly {
   { pattern: /^\/api\/v1\/chain\/performance$/, tables: ["neurons"] },
   { pattern: /^\/api\/v1\/chain\/idle-stake$/, tables: ["neurons"] },
   { pattern: /^\/api\/v1\/chain\/yield$/, tables: ["neurons"] },
-  { pattern: /^\/api\/v1\/subnets\/\d+\/validators$/, tables: ["neurons"] },
-  { pattern: /^\/api\/v1\/accounts\/[^/]+\/portfolio$/, tables: ["neurons"] },
+  // Reads `neurons` for the account's current UIDs, then the dated positions.
   {
-    pattern: /^\/api\/v1\/subnets\/\d+\/metagraph$/,
-    tables: ["neurons"],
+    pattern: /^\/api\/v1\/accounts\/[^/]+\/subnets\/\d+\/history$/,
+    tables: ["neurons", "account_position_daily"],
   },
-  // BLOCKED until the unmirrored tables below get a proven Neon lane. These
-  // are not aspirational entries -- listing the real dependency is what keeps
-  // neonServesRoute returning false for them today (#9811).
+  // BLOCKED until their unmirrored tables have a proven Neon lane (#9814).
+  // Listing the real dependency is what keeps neonServesRoute returning false
+  // for them, and what will un-block them automatically once the mirror exists.
+  //
+  // The first two are LIVE REGRESSIONS this corrects (#9825). Both were
+  // declared without `subnet_snapshots` and both moved to Neon when #9810
+  // enabled `neurons`/`neuron_daily`; the join found no such table and each
+  // served an empty 200.
   {
     // + loadAlphaPricesByNetuidD1.
+    pattern: /^\/api\/v1\/accounts\/[^/]+\/portfolio$/,
+    tables: ["neurons", "subnet_snapshots"],
+  },
+  {
+    // Joins subnet_snapshots directly for the alpha -> TAO conversion.
+    pattern: /^\/api\/v1\/validators\/[^/]+\/history$/,
+    tables: ["neuron_daily", "subnet_snapshots"],
+  },
+  {
     pattern: /^\/api\/v1\/accounts$/,
     tables: ["neurons", "subnet_snapshots"],
   },
@@ -6049,6 +6047,15 @@ export const NEON_READ_ROUTE_TABLES: readonly {
       "neurons",
       "subnet_snapshots",
       "account_identity",
+      "subnet_hyperparams",
+      "validator_nominator_counts",
+    ],
+  },
+  {
+    pattern: /^\/api\/v1\/validators\/[^/]+$/,
+    tables: [
+      "neurons",
+      "subnet_snapshots",
       "subnet_hyperparams",
       "validator_nominator_counts",
     ],


### PR DESCRIPTION
Closes #9825, closes #9824.

## The map test was matching the wrong route's SQL

It split `matchNeuronsD1Route` at `\n  if (` — but a parameterised guard is **two statements**:

```ts
const validatorHistoryMatch = url.pathname.match(/…/);
if (validatorHistoryMatch) { … }
```

So the path expression landed at the **end of the previous route's block**, and every parameterised route was checked against its **neighbour's SQL**. The test that exists to stop a route being gated on the wrong table was doing exactly that itself.

Split at each `url.pathname` mention instead — the path is then first in its own block for both spellings.

## Two live regressions it hid

Both moved to Neon when #9810 enabled `neurons`/`neuron_daily`, both join `subnet_snapshots` which has no Neon copy, both served an empty 200:

| route | declared | actually reads |
|---|---|---|
| `/validators/{hotkey}/history` | `neurons, neuron_daily` | `neuron_daily`, **`subnet_snapshots`** |
| `/accounts/{ss58}/portfolio` | `neurons` | `neurons`, **`subnet_snapshots`** |

Confirmed live: `point_count: 0` for an active validator, scoped and unscoped.

## Four gated on a table their query never touches

`/subnets/{n}/neurons/{uid}`, `/concentration`, `/performance`, `/yield` all declared `neuron_daily` and all read `neurons`. They work today only because both tables happen to be enabled.

## Two with no entry at all

`/validators/{hotkey}` and `/subnets/{n}/idle-stake`.

## Plus the dispatch-path gate (#9824)

#9821 was a class neither existing gate could catch: `?` is *correct* SQL on two of the three paths into Postgres and wrong only on the third, so it's a property of the **dispatch**, not of any query. This asserts each factory in `src/pg-sql.ts` converts, and a coverage check fails if a new factory is added without an invoker — verified by deleting an entry.

## On the migration goal

The two `subnet_snapshots` routes fall back to D1 **for now**. That is the blocking mechanism working, not a workaround — they un-block themselves the day #9814 gives that table a proven mirror. #9820 already shipped the reconciler plans for it; what's left is the Neon DDL.