### PR TITLE
feat(api): type twelve untyped object sites in the route contract

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5417,6 +5417,19 @@ export interface components {
                 [key: string]: unknown;
             })[];
             blocker_summary?: {
+                by_code?: {
+                    [key: string]: number;
+                };
+                by_level?: {
+                    [key: string]: number;
+                };
+                by_severity?: {
+                    [key: string]: number;
+                };
+                by_status?: {
+                    [key: string]: number;
+                };
+            } & {
                 [key: string]: unknown;
             };
             callable_service_count?: number;
@@ -5861,14 +5874,17 @@ export interface components {
             }[];
             artifact_count: number;
             artifact_size_bytes: number;
-            artifacts?: {
+            artifacts?: ({
+                path: string;
+                sha256?: string | null;
+                size_bytes?: number;
+                storage_tier?: string | null;
+            } & {
                 [key: string]: unknown;
-            }[];
+            })[];
             candidate_count?: number;
             contract_version?: string;
-            coverage?: {
-                [key: string]: unknown;
-            };
+            coverage?: components["schemas"]["CoverageArtifact"];
             endpoint_count?: number;
             full_artifact_count?: number;
             full_artifact_size_bytes?: number;
@@ -7005,9 +7021,16 @@ export interface components {
             schema_version: 1;
             source: {
                 candidates: string;
-                native: string | {
+                native: string | ({
+                    identity_storage?: string | null;
+                    kind?: string | null;
+                    method?: string | null;
+                    package?: string | null;
+                    rpc_family?: string | null;
+                    version?: string | null;
+                } & {
                     [key: string]: unknown;
-                };
+                });
                 overlays: string;
             };
             surface_count: number;
@@ -8188,6 +8211,11 @@ export interface components {
             contract_version?: string;
             generated_at?: string | null;
             global: {
+                status_counts?: {
+                    [key: string]: number;
+                };
+                surface_count?: number;
+            } & {
                 [key: string]: unknown;
             };
             health_source?: string;
@@ -8732,14 +8760,45 @@ export interface components {
             } & {
                 [key: string]: unknown;
             };
-            coverage?: {
+            coverage?: ({
+                average_score?: number;
+                dimension_coverage?: {
+                    [key: string]: {
+                        [key: string]: unknown;
+                    };
+                };
+                fully_complete_count?: number;
+                fully_complete_pct?: number;
+                median_score?: number;
+                methodology?: string;
+                score_distribution?: {
+                    [key: string]: number;
+                };
+                scored_subnet_count?: number;
+            } & {
                 [key: string]: unknown;
-            } | null;
+            }) | null;
             curation_level_counts?: components["schemas"]["CountMap"];
             generated_at: string;
             notes?: string | string[];
             profile_level_counts?: components["schemas"]["CountMap"];
             recent_changes?: {
+                artifacts?: {
+                    added?: number;
+                    modified?: number;
+                    removed?: number;
+                } & {
+                    [key: string]: unknown;
+                };
+                generated_at?: string | null;
+                subnets?: {
+                    added?: number;
+                    removed?: number;
+                    renamed?: number;
+                } & {
+                    [key: string]: unknown;
+                };
+            } & {
                 [key: string]: unknown;
             };
             /** @constant */
@@ -9437,6 +9496,37 @@ export interface components {
                 previous_hash?: string | null;
                 schema_url: string | null;
                 snapshot?: {
+                    auth_detail?: ({
+                        location?: string | null;
+                        name?: string | null;
+                        scheme?: string | null;
+                        value_format?: string | null;
+                    } & {
+                        [key: string]: unknown;
+                    }) | null;
+                    auth_required?: boolean;
+                    auth_schemes?: string[];
+                    component_schema_count?: number;
+                    contract_version?: string | null;
+                    drift_status?: string | null;
+                    generated_at?: string | null;
+                    hash?: string | null;
+                    netuid?: number | null;
+                    observed_at?: string | null;
+                    openapi_version?: string | null;
+                    path_count?: number;
+                    previous_hash?: string | null;
+                    schema_url?: string | null;
+                    schema_version?: number;
+                    server_count?: number;
+                    subnet_name?: string | null;
+                    subnet_slug?: string | null;
+                    surface_id?: string | null;
+                    surface_url?: string | null;
+                    tag_count?: number;
+                    title?: string | null;
+                    version?: string | null;
+                } & {
                     [key: string]: unknown;
                 };
                 /** @enum {string} */
@@ -9934,9 +10024,13 @@ export interface components {
             github_unreachable?: boolean;
             /** @enum {string} */
             lifecycle?: "active" | "deprecated" | "parked" | "pending";
-            links: {
+            links: ({
+                label: string;
+                source_url?: string | null;
+                url: string;
+            } & {
                 [key: string]: unknown;
-            }[];
+            })[];
             logo_url?: string | null;
             mechanism_count?: number;
             name: string;
@@ -9951,6 +10045,23 @@ export interface components {
             previously_known_as?: string[];
             probed_surface_count?: number;
             provenance: {
+                existence?: {
+                    authority?: string | null;
+                    captured_at?: string | null;
+                    method?: string | null;
+                    network?: string | null;
+                    source_kind?: string | null;
+                } & {
+                    [key: string]: unknown;
+                };
+                identity?: {
+                    display_name_source?: string | null;
+                    native_name_quality?: string | null;
+                } & {
+                    [key: string]: unknown;
+                };
+                interface_metadata?: string | null;
+            } & {
                 [key: string]: unknown;
             };
             registered_at_block?: number;
@@ -17024,7 +17135,10 @@ export interface operations {
                      *           "github_unreachable": false,
                      *           "lifecycle": "active",
                      *           "links": [
-                     *             {}
+                     *             {
+                     *               "label": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
                      *           ],
                      *           "logo_url": "https://api.metagraph.sh/example",
                      *           "mechanism_count": 1,
@@ -21147,7 +21261,10 @@ export interface operations {
                      *           }
                      *         ],
                      *         "blocker_summary": {
-                     *           "example": null
+                     *           "by_code": {},
+                     *           "by_level": {},
+                     *           "by_severity": {},
+                     *           "by_status": {}
                      *         },
                      *         "callable_service_count": 1,
                      *         "contract_version": "2026-06-29.1",
@@ -22420,12 +22537,39 @@ export interface operations {
                      *         "artifact_count": 1,
                      *         "artifact_size_bytes": 1,
                      *         "artifacts": [
-                     *           {}
+                     *           {
+                     *             "path": "example"
+                     *           }
                      *         ],
                      *         "candidate_count": 1,
                      *         "contract_version": "2026-06-29.1",
                      *         "coverage": {
-                     *           "example": null
+                     *           "application_subnet_count": 1,
+                     *           "candidate_count": 1,
+                     *           "candidate_subnet_count": 1,
+                     *           "chain_subnet_count": 1,
+                     *           "completeness": {},
+                     *           "contract_version": "2026-06-29.1",
+                     *           "curated_overlay_count": 1,
+                     *           "curation_level_counts": {},
+                     *           "generated_at": "2026-06-01T00:00:00.000Z",
+                     *           "manifested_count": 1,
+                     *           "native_only_count": 1,
+                     *           "native_only_with_candidates": 1,
+                     *           "native_only_without_candidates": 1,
+                     *           "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
+                     *           "network": "finney",
+                     *           "notes": "Example description.",
+                     *           "probed_count": 1,
+                     *           "probed_surface_count": 1,
+                     *           "root_subnet_count": 1,
+                     *           "schema_version": 1,
+                     *           "source": {
+                     *             "candidates": "example",
+                     *             "native": "example",
+                     *             "overlays": "example"
+                     *           },
+                     *           "surface_count": 1
                      *         },
                      *         "endpoint_count": 1,
                      *         "full_artifact_count": 1,
@@ -31766,7 +31910,8 @@ export interface operations {
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "global": {
-                     *           "example": null
+                     *           "status_counts": {},
+                     *           "surface_count": 1
                      *         },
                      *         "health_source": "probe-derived",
                      *         "operational_observed_at": "2026-06-01T00:00:00.000Z",
@@ -33992,7 +34137,14 @@ export interface operations {
                      *           "surfaces": 1
                      *         },
                      *         "coverage": {
-                     *           "example": null
+                     *           "average_score": 100,
+                     *           "dimension_coverage": {},
+                     *           "fully_complete_count": 1,
+                     *           "fully_complete_pct": 1,
+                     *           "median_score": 100,
+                     *           "methodology": "GET",
+                     *           "score_distribution": {},
+                     *           "scored_subnet_count": 1
                      *         },
                      *         "curation_level_counts": {
                      *           "example": 1
@@ -34003,7 +34155,9 @@ export interface operations {
                      *           "example": 1
                      *         },
                      *         "recent_changes": {
-                     *           "example": null
+                     *           "artifacts": {},
+                     *           "generated_at": "2026-06-01T00:00:00.000Z",
+                     *           "subnets": {}
                      *         },
                      *         "schema_version": 1,
                      *         "subnet_count": 1,
@@ -37184,7 +37338,10 @@ export interface operations {
                      *           "github_unreachable": false,
                      *           "lifecycle": "active",
                      *           "links": [
-                     *             {}
+                     *             {
+                     *               "label": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
                      *           ],
                      *           "logo_url": "https://api.metagraph.sh/example",
                      *           "mechanism_count": 1,
@@ -42263,7 +42420,10 @@ export interface operations {
                      *           "github_unreachable": false,
                      *           "lifecycle": "active",
                      *           "links": [
-                     *             {}
+                     *             {
+                     *               "label": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
                      *           ],
                      *           "logo_url": "https://api.metagraph.sh/example",
                      *           "mechanism_count": 1,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -1395,7 +1395,10 @@
               }
             ],
             "blocker_summary": {
-              "example": null
+              "by_code": {},
+              "by_level": {},
+              "by_severity": {},
+              "by_status": {}
             },
             "callable_service_count": 1,
             "contract_version": "2026-06-29.1",
@@ -2019,12 +2022,39 @@
             "artifact_count": 1,
             "artifact_size_bytes": 1,
             "artifacts": [
-              {}
+              {
+                "path": "example"
+              }
             ],
             "candidate_count": 1,
             "contract_version": "2026-06-29.1",
             "coverage": {
-              "example": null
+              "application_subnet_count": 1,
+              "candidate_count": 1,
+              "candidate_subnet_count": 1,
+              "chain_subnet_count": 1,
+              "completeness": {},
+              "contract_version": "2026-06-29.1",
+              "curated_overlay_count": 1,
+              "curation_level_counts": {},
+              "generated_at": "2026-06-01T00:00:00.000Z",
+              "manifested_count": 1,
+              "native_only_count": 1,
+              "native_only_with_candidates": 1,
+              "native_only_without_candidates": 1,
+              "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
+              "network": "finney",
+              "notes": "Example description.",
+              "probed_count": 1,
+              "probed_surface_count": 1,
+              "root_subnet_count": 1,
+              "schema_version": 1,
+              "source": {
+                "candidates": "example",
+                "native": "example",
+                "overlays": "example"
+              },
+              "surface_count": 1
             },
             "endpoint_count": 1,
             "full_artifact_count": 1,
@@ -6083,7 +6113,8 @@
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
             "global": {
-              "example": null
+              "status_counts": {},
+              "surface_count": 1
             },
             "health_source": "probe-derived",
             "operational_observed_at": "2026-06-01T00:00:00.000Z",
@@ -6896,7 +6927,14 @@
               "surfaces": 1
             },
             "coverage": {
-              "example": null
+              "average_score": 100,
+              "dimension_coverage": {},
+              "fully_complete_count": 1,
+              "fully_complete_pct": 1,
+              "median_score": 100,
+              "methodology": "GET",
+              "score_distribution": {},
+              "scored_subnet_count": 1
             },
             "curation_level_counts": {
               "example": 1
@@ -6907,7 +6945,9 @@
               "example": 1
             },
             "recent_changes": {
-              "example": null
+              "artifacts": {},
+              "generated_at": "2026-06-01T00:00:00.000Z",
+              "subnets": {}
             },
             "schema_version": 1,
             "subnet_count": 1,
@@ -8835,7 +8875,10 @@
               "github_unreachable": false,
               "lifecycle": "active",
               "links": [
-                {}
+                {
+                  "label": "example",
+                  "url": "https://api.metagraph.sh/example"
+                }
               ],
               "logo_url": "https://api.metagraph.sh/example",
               "mechanism_count": 1,
@@ -10537,7 +10580,10 @@
               "github_unreachable": false,
               "lifecycle": "active",
               "links": [
-                {}
+                {
+                  "label": "example",
+                  "url": "https://api.metagraph.sh/example"
+                }
               ],
               "logo_url": "https://api.metagraph.sh/example",
               "mechanism_count": 1,
@@ -16434,8 +16480,51 @@
           },
           "blocker_summary": {
             "additionalProperties": {},
-            "propertyNames": {
-              "type": "string"
+            "properties": {
+              "by_code": {
+                "additionalProperties": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "by_level": {
+                "additionalProperties": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "by_severity": {
+                "additionalProperties": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "by_status": {
+                "additionalProperties": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "type": "string"
+                },
+                "type": "object"
+              }
             },
             "type": "object"
           },
@@ -18842,9 +18931,39 @@
           "artifacts": {
             "items": {
               "additionalProperties": {},
-              "propertyNames": {
-                "type": "string"
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "sha256": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "size_bytes": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "storage_tier": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
               },
+              "required": [
+                "path"
+              ],
               "type": "object"
             },
             "type": "array"
@@ -18858,11 +18977,7 @@
             "type": "string"
           },
           "coverage": {
-            "additionalProperties": {},
-            "propertyNames": {
-              "type": "string"
-            },
-            "type": "object"
+            "$ref": "#/components/schemas/CoverageArtifact"
           },
           "endpoint_count": {
             "maximum": 9007199254740991,
@@ -25867,7 +25982,68 @@
                   },
                   {
                     "additionalProperties": {},
-                    "properties": {},
+                    "properties": {
+                      "identity_storage": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "kind": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "method": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "package": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "rpc_family": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "version": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
                     "type": "object"
                   }
                 ]
@@ -32640,8 +32816,23 @@
           },
           "global": {
             "additionalProperties": {},
-            "propertyNames": {
-              "type": "string"
+            "properties": {
+              "status_counts": {
+                "additionalProperties": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "surface_count": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              }
             },
             "type": "object"
           },
@@ -35474,7 +35665,58 @@
             "anyOf": [
               {
                 "additionalProperties": {},
-                "properties": {},
+                "properties": {
+                  "average_score": {
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "dimension_coverage": {
+                    "additionalProperties": {
+                      "additionalProperties": {},
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "fully_complete_count": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "fully_complete_pct": {
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "median_score": {
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "methodology": {
+                    "type": "string"
+                  },
+                  "score_distribution": {
+                    "additionalProperties": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "scored_subnet_count": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
                 "type": "object"
               },
               {
@@ -35506,7 +35748,60 @@
           },
           "recent_changes": {
             "additionalProperties": {},
-            "properties": {},
+            "properties": {
+              "artifacts": {
+                "additionalProperties": {},
+                "properties": {
+                  "added": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "modified": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "removed": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "generated_at": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "subnets": {
+                "additionalProperties": {},
+                "properties": {
+                  "added": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "removed": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "renamed": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              }
+            },
             "type": "object"
           },
           "schema_version": {
@@ -39017,8 +39312,246 @@
                 },
                 "snapshot": {
                   "additionalProperties": {},
-                  "propertyNames": {
-                    "type": "string"
+                  "properties": {
+                    "auth_detail": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": {},
+                          "properties": {
+                            "location": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "name": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "scheme": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "value_format": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "auth_required": {
+                      "type": "boolean"
+                    },
+                    "auth_schemes": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "component_schema_count": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "contract_version": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "drift_status": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "generated_at": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "hash": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "netuid": {
+                      "anyOf": [
+                        {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "observed_at": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "openapi_version": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "path_count": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "previous_hash": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "schema_url": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "schema_version": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    "server_count": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "subnet_name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "subnet_slug": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "surface_id": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "surface_url": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "tag_count": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "title": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "version": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
                   },
                   "type": "object"
                 },
@@ -41796,7 +42329,28 @@
           "links": {
             "items": {
               "additionalProperties": {},
-              "properties": {},
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "source_url": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "label",
+                "url"
+              ],
               "type": "object"
             },
             "type": "array"
@@ -41891,7 +42445,100 @@
           },
           "provenance": {
             "additionalProperties": {},
-            "properties": {},
+            "properties": {
+              "existence": {
+                "additionalProperties": {},
+                "properties": {
+                  "authority": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "captured_at": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "method": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "network": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "source_kind": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "identity": {
+                "additionalProperties": {},
+                "properties": {
+                  "display_name_source": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "native_name_quality": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "interface_metadata": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
             "type": "object"
           },
           "registered_at_block": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5417,6 +5417,19 @@ export interface components {
                 [key: string]: unknown;
             })[];
             blocker_summary?: {
+                by_code?: {
+                    [key: string]: number;
+                };
+                by_level?: {
+                    [key: string]: number;
+                };
+                by_severity?: {
+                    [key: string]: number;
+                };
+                by_status?: {
+                    [key: string]: number;
+                };
+            } & {
                 [key: string]: unknown;
             };
             callable_service_count?: number;
@@ -5861,14 +5874,17 @@ export interface components {
             }[];
             artifact_count: number;
             artifact_size_bytes: number;
-            artifacts?: {
+            artifacts?: ({
+                path: string;
+                sha256?: string | null;
+                size_bytes?: number;
+                storage_tier?: string | null;
+            } & {
                 [key: string]: unknown;
-            }[];
+            })[];
             candidate_count?: number;
             contract_version?: string;
-            coverage?: {
-                [key: string]: unknown;
-            };
+            coverage?: components["schemas"]["CoverageArtifact"];
             endpoint_count?: number;
             full_artifact_count?: number;
             full_artifact_size_bytes?: number;
@@ -7005,9 +7021,16 @@ export interface components {
             schema_version: 1;
             source: {
                 candidates: string;
-                native: string | {
+                native: string | ({
+                    identity_storage?: string | null;
+                    kind?: string | null;
+                    method?: string | null;
+                    package?: string | null;
+                    rpc_family?: string | null;
+                    version?: string | null;
+                } & {
                     [key: string]: unknown;
-                };
+                });
                 overlays: string;
             };
             surface_count: number;
@@ -8188,6 +8211,11 @@ export interface components {
             contract_version?: string;
             generated_at?: string | null;
             global: {
+                status_counts?: {
+                    [key: string]: number;
+                };
+                surface_count?: number;
+            } & {
                 [key: string]: unknown;
             };
             health_source?: string;
@@ -8732,14 +8760,45 @@ export interface components {
             } & {
                 [key: string]: unknown;
             };
-            coverage?: {
+            coverage?: ({
+                average_score?: number;
+                dimension_coverage?: {
+                    [key: string]: {
+                        [key: string]: unknown;
+                    };
+                };
+                fully_complete_count?: number;
+                fully_complete_pct?: number;
+                median_score?: number;
+                methodology?: string;
+                score_distribution?: {
+                    [key: string]: number;
+                };
+                scored_subnet_count?: number;
+            } & {
                 [key: string]: unknown;
-            } | null;
+            }) | null;
             curation_level_counts?: components["schemas"]["CountMap"];
             generated_at: string;
             notes?: string | string[];
             profile_level_counts?: components["schemas"]["CountMap"];
             recent_changes?: {
+                artifacts?: {
+                    added?: number;
+                    modified?: number;
+                    removed?: number;
+                } & {
+                    [key: string]: unknown;
+                };
+                generated_at?: string | null;
+                subnets?: {
+                    added?: number;
+                    removed?: number;
+                    renamed?: number;
+                } & {
+                    [key: string]: unknown;
+                };
+            } & {
                 [key: string]: unknown;
             };
             /** @constant */
@@ -9437,6 +9496,37 @@ export interface components {
                 previous_hash?: string | null;
                 schema_url: string | null;
                 snapshot?: {
+                    auth_detail?: ({
+                        location?: string | null;
+                        name?: string | null;
+                        scheme?: string | null;
+                        value_format?: string | null;
+                    } & {
+                        [key: string]: unknown;
+                    }) | null;
+                    auth_required?: boolean;
+                    auth_schemes?: string[];
+                    component_schema_count?: number;
+                    contract_version?: string | null;
+                    drift_status?: string | null;
+                    generated_at?: string | null;
+                    hash?: string | null;
+                    netuid?: number | null;
+                    observed_at?: string | null;
+                    openapi_version?: string | null;
+                    path_count?: number;
+                    previous_hash?: string | null;
+                    schema_url?: string | null;
+                    schema_version?: number;
+                    server_count?: number;
+                    subnet_name?: string | null;
+                    subnet_slug?: string | null;
+                    surface_id?: string | null;
+                    surface_url?: string | null;
+                    tag_count?: number;
+                    title?: string | null;
+                    version?: string | null;
+                } & {
                     [key: string]: unknown;
                 };
                 /** @enum {string} */
@@ -9934,9 +10024,13 @@ export interface components {
             github_unreachable?: boolean;
             /** @enum {string} */
             lifecycle?: "active" | "deprecated" | "parked" | "pending";
-            links: {
+            links: ({
+                label: string;
+                source_url?: string | null;
+                url: string;
+            } & {
                 [key: string]: unknown;
-            }[];
+            })[];
             logo_url?: string | null;
             mechanism_count?: number;
             name: string;
@@ -9951,6 +10045,23 @@ export interface components {
             previously_known_as?: string[];
             probed_surface_count?: number;
             provenance: {
+                existence?: {
+                    authority?: string | null;
+                    captured_at?: string | null;
+                    method?: string | null;
+                    network?: string | null;
+                    source_kind?: string | null;
+                } & {
+                    [key: string]: unknown;
+                };
+                identity?: {
+                    display_name_source?: string | null;
+                    native_name_quality?: string | null;
+                } & {
+                    [key: string]: unknown;
+                };
+                interface_metadata?: string | null;
+            } & {
                 [key: string]: unknown;
             };
             registered_at_block?: number;
@@ -17024,7 +17135,10 @@ export interface operations {
                      *           "github_unreachable": false,
                      *           "lifecycle": "active",
                      *           "links": [
-                     *             {}
+                     *             {
+                     *               "label": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
                      *           ],
                      *           "logo_url": "https://api.metagraph.sh/example",
                      *           "mechanism_count": 1,
@@ -21147,7 +21261,10 @@ export interface operations {
                      *           }
                      *         ],
                      *         "blocker_summary": {
-                     *           "example": null
+                     *           "by_code": {},
+                     *           "by_level": {},
+                     *           "by_severity": {},
+                     *           "by_status": {}
                      *         },
                      *         "callable_service_count": 1,
                      *         "contract_version": "2026-06-29.1",
@@ -22420,12 +22537,39 @@ export interface operations {
                      *         "artifact_count": 1,
                      *         "artifact_size_bytes": 1,
                      *         "artifacts": [
-                     *           {}
+                     *           {
+                     *             "path": "example"
+                     *           }
                      *         ],
                      *         "candidate_count": 1,
                      *         "contract_version": "2026-06-29.1",
                      *         "coverage": {
-                     *           "example": null
+                     *           "application_subnet_count": 1,
+                     *           "candidate_count": 1,
+                     *           "candidate_subnet_count": 1,
+                     *           "chain_subnet_count": 1,
+                     *           "completeness": {},
+                     *           "contract_version": "2026-06-29.1",
+                     *           "curated_overlay_count": 1,
+                     *           "curation_level_counts": {},
+                     *           "generated_at": "2026-06-01T00:00:00.000Z",
+                     *           "manifested_count": 1,
+                     *           "native_only_count": 1,
+                     *           "native_only_with_candidates": 1,
+                     *           "native_only_without_candidates": 1,
+                     *           "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
+                     *           "network": "finney",
+                     *           "notes": "Example description.",
+                     *           "probed_count": 1,
+                     *           "probed_surface_count": 1,
+                     *           "root_subnet_count": 1,
+                     *           "schema_version": 1,
+                     *           "source": {
+                     *             "candidates": "example",
+                     *             "native": "example",
+                     *             "overlays": "example"
+                     *           },
+                     *           "surface_count": 1
                      *         },
                      *         "endpoint_count": 1,
                      *         "full_artifact_count": 1,
@@ -31766,7 +31910,8 @@ export interface operations {
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "global": {
-                     *           "example": null
+                     *           "status_counts": {},
+                     *           "surface_count": 1
                      *         },
                      *         "health_source": "probe-derived",
                      *         "operational_observed_at": "2026-06-01T00:00:00.000Z",
@@ -33992,7 +34137,14 @@ export interface operations {
                      *           "surfaces": 1
                      *         },
                      *         "coverage": {
-                     *           "example": null
+                     *           "average_score": 100,
+                     *           "dimension_coverage": {},
+                     *           "fully_complete_count": 1,
+                     *           "fully_complete_pct": 1,
+                     *           "median_score": 100,
+                     *           "methodology": "GET",
+                     *           "score_distribution": {},
+                     *           "scored_subnet_count": 1
                      *         },
                      *         "curation_level_counts": {
                      *           "example": 1
@@ -34003,7 +34155,9 @@ export interface operations {
                      *           "example": 1
                      *         },
                      *         "recent_changes": {
-                     *           "example": null
+                     *           "artifacts": {},
+                     *           "generated_at": "2026-06-01T00:00:00.000Z",
+                     *           "subnets": {}
                      *         },
                      *         "schema_version": 1,
                      *         "subnet_count": 1,
@@ -37184,7 +37338,10 @@ export interface operations {
                      *           "github_unreachable": false,
                      *           "lifecycle": "active",
                      *           "links": [
-                     *             {}
+                     *             {
+                     *               "label": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
                      *           ],
                      *           "logo_url": "https://api.metagraph.sh/example",
                      *           "mechanism_count": 1,
@@ -42263,7 +42420,10 @@ export interface operations {
                      *           "github_unreachable": false,
                      *           "lifecycle": "active",
                      *           "links": [
-                     *             {}
+                     *             {
+                     *               "label": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
                      *           ],
                      *           "logo_url": "https://api.metagraph.sh/example",
                      *           "mechanism_count": 1,

--- a/schemas-src/routes/agent-catalog.ts
+++ b/schemas-src/routes/agent-catalog.ts
@@ -123,7 +123,19 @@ export const AgentCatalogArtifactSchema = ArtifactBaseSchema.extend({
   subnet_count: z.int().min(0),
   blocked_subnet_count: z.int().min(0).optional(),
   callable_service_count: z.int().min(0).optional(),
-  blocker_summary: z.record(z.string(), z.unknown()).optional(),
+  // #9800. Was `z.record(z.string(), z.unknown())`. Each member is a genuine
+  // dynamic-key tally -- the keys are the blocker vocabulary itself -- so these
+  // are typed RECORDS rather than fixed property lists: a new blocker code adds
+  // a key without changing the contract, which is the point.
+  blocker_summary: z
+    .object({
+      by_code: z.record(z.string(), z.int().min(0)).optional(),
+      by_level: z.record(z.string(), z.int().min(0)).optional(),
+      by_severity: z.record(z.string(), z.int().min(0)).optional(),
+      by_status: z.record(z.string(), z.int().min(0)).optional(),
+    })
+    .passthrough()
+    .optional(),
   subnets: z.array(AgentCatalogSubnetEntrySchema),
   blocked_subnets: z.array(AgentCatalogBlockedSubnetEntrySchema).optional(),
 });

--- a/schemas-src/routes/coverage.ts
+++ b/schemas-src/routes/coverage.ts
@@ -12,7 +12,7 @@ import {
 } from "../envelope.ts";
 import { BittensorNetworkSchema } from "../shared.ts";
 
-const CoverageCompletenessSchema = z
+export const CoverageCompletenessSchema = z
   .object({
     scored_subnet_count: z.int().min(0).optional(),
     average_score: z.int().min(0).max(100).optional(),
@@ -31,7 +31,23 @@ const CoverageCompletenessSchema = z
 const CoverageSourceSchema = z
   .object({
     candidates: z.string(),
-    native: z.union([z.string(), z.object({}).passthrough()]),
+    // #9800. The object arm was bare. It describes HOW the native identity was
+    // read -- which package, which RPC family, which storage item -- which is the
+    // provenance a caller needs to judge the figure. The string arm is the older
+    // shorthand form and is kept for wire compatibility.
+    native: z.union([
+      z.string(),
+      z
+        .object({
+          identity_storage: z.string().nullable().optional(),
+          kind: z.string().nullable().optional(),
+          method: z.string().nullable().optional(),
+          package: z.string().nullable().optional(),
+          rpc_family: z.string().nullable().optional(),
+          version: z.string().nullable().optional(),
+        })
+        .passthrough(),
+    ]),
     overlays: z.string(),
   })
   .strict();

--- a/schemas-src/routes/health.ts
+++ b/schemas-src/routes/health.ts
@@ -38,7 +38,16 @@ export const HealthSummaryArtifactSchema = z
     // surface_count -- src/contracts.ts documents this as an open shape
     // (additionalProperties: true), matching the incident by_kind pattern
     // the issue calls out.
-    global: z.record(z.string(), z.unknown()),
+    // #9800. Was `z.record(z.string(), z.unknown())` -- a record whose value
+    // schema is `unknown`, which declares no more than a bare open object. This
+    // is the network-wide health rollup; `status_counts` is a typed record
+    // because its keys ARE the verdict vocabulary.
+    global: z
+      .object({
+        surface_count: z.int().min(0).optional(),
+        status_counts: z.record(z.string(), z.int().min(0)).optional(),
+      })
+      .passthrough(),
     health_source: z.string().optional(),
     operational_observed_at: z.string().nullable().optional(),
     schema_version: z.int(),

--- a/schemas-src/routes/meta-contracts.ts
+++ b/schemas-src/routes/meta-contracts.ts
@@ -20,6 +20,7 @@
 // the hand-edited schema was stale from before diffSubnets() gained name/slug.
 // Modeled here against the real (object) shape.
 import { z } from "zod";
+import { CoverageArtifactSchema } from "./coverage.ts";
 import { API_ROUTE_METHODS } from "../../src/contracts.ts";
 import { ArtifactBaseSchema, CacheProfileSchema } from "../envelope.ts";
 
@@ -229,7 +230,22 @@ export const BuildSummaryArtifactSchema = ArtifactBaseSchema.extend({
   full_artifact_size_bytes: z.int().min(0).optional(),
   storage_tier_counts: z.record(z.string(), z.int().min(0)).optional(),
   storage_tier_size_bytes: z.record(z.string(), z.int().min(0)).optional(),
-  artifacts: z.array(z.record(z.string(), z.unknown())).optional(),
+  // #9800. Was `z.record(z.string(), z.unknown())` -- a record whose value
+  // schema is `unknown`, which declares no more than a bare open object does.
+  // These are the published artifact inventory rows; each carries its path,
+  // digest, size and storage tier.
+  artifacts: z
+    .array(
+      z
+        .object({
+          path: z.string(),
+          sha256: z.string().nullable().optional(),
+          size_bytes: z.int().min(0).optional(),
+          storage_tier: z.string().nullable().optional(),
+        })
+        .passthrough(),
+    )
+    .optional(),
   artifact_budget_summary: z
     .object({
       fail_count: z.int().min(0),
@@ -240,7 +256,10 @@ export const BuildSummaryArtifactSchema = ArtifactBaseSchema.extend({
     .optional(),
   artifact_budgets: z.array(ArtifactSizeBudgetSchema).optional(),
   candidate_count: z.int().min(0).optional(),
-  coverage: z.record(z.string(), z.unknown()).optional(),
+  // The coverage artifact itself, reused rather than restated (#9800). Was
+  // `z.record(z.string(), z.unknown())`, so the build summary embedded the whole
+  // coverage card and declared nothing about it.
+  coverage: CoverageArtifactSchema.optional(),
   endpoint_count: z.int().min(0).optional(),
   profile_count: z.int().min(0).optional(),
   provider_count: z.int().min(0).optional(),

--- a/schemas-src/routes/registry-summary-leaderboards.ts
+++ b/schemas-src/routes/registry-summary-leaderboards.ts
@@ -17,10 +17,14 @@ import {
   CountMapSchema,
   successEnvelopeSchema,
 } from "../envelope.ts";
+import { CoverageCompletenessSchema } from "./coverage.ts";
 
 export const RegistrySummaryArtifactSchema = ArtifactBaseSchema.extend({
   subnet_count: z.int().min(0),
-  coverage: z.object({}).passthrough().nullable().optional(),
+  // The completeness block from GET /api/v1/coverage, not a restatement of it
+  // (#9800). This was a bare open object, so the headline coverage figure the
+  // registry summary exists to report told a reader nothing about its own shape.
+  coverage: CoverageCompletenessSchema.nullable().optional(),
   counts: z
     .object({
       surfaces: z.int().min(0),
@@ -43,7 +47,30 @@ export const RegistrySummaryArtifactSchema = ArtifactBaseSchema.extend({
       })
       .passthrough(),
   ),
-  recent_changes: z.object({}).passthrough().optional(),
+  // #9800. Was a bare open object; this is the publish-time diff summary, and
+  // the counts inside it are the whole point of the field.
+  recent_changes: z
+    .object({
+      generated_at: z.string().nullable().optional(),
+      artifacts: z
+        .object({
+          added: z.int().min(0).optional(),
+          modified: z.int().min(0).optional(),
+          removed: z.int().min(0).optional(),
+        })
+        .passthrough()
+        .optional(),
+      subnets: z
+        .object({
+          added: z.int().min(0).optional(),
+          removed: z.int().min(0).optional(),
+          renamed: z.int().min(0).optional(),
+        })
+        .passthrough()
+        .optional(),
+    })
+    .passthrough()
+    .optional(),
 }).passthrough();
 export type RegistrySummaryArtifact = z.infer<
   typeof RegistrySummaryArtifactSchema

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -408,7 +408,17 @@ export const SubnetDetailSchema = z
     lifecycle: z.enum(["active", "deprecated", "parked", "pending"]).optional(),
     // Genuinely open shape in the source contract (additionalProperties:
     // true, no fixed properties) -- see this file's header.
-    links: z.array(z.object({}).passthrough()),
+    // #9800. Was an array of bare open objects, so the curated link list --
+    // website, docs, repo -- said nothing about what a link is.
+    links: z.array(
+      z
+        .object({
+          label: z.string(),
+          url: z.string(),
+          source_url: z.string().nullable().optional(),
+        })
+        .passthrough(),
+    ),
     logo_url: z.url().nullable().optional(),
     mechanism_count: z.int().min(0).optional(),
     name: z.string(),
@@ -422,7 +432,31 @@ export const SubnetDetailSchema = z
     previously_known_as: z.array(z.string()).optional(),
     probed_surface_count: z.int().min(0).optional(),
     // Same open-shape carve-out as `links` above.
-    provenance: z.object({}).passthrough(),
+    // #9800. Was a bare open object. This is the record's own audit trail --
+    // where each claim came from and how it was established -- so leaving it
+    // undeclared removed exactly the information a caller weighs the record by.
+    provenance: z
+      .object({
+        existence: z
+          .object({
+            authority: z.string().nullable().optional(),
+            captured_at: z.string().nullable().optional(),
+            method: z.string().nullable().optional(),
+            network: z.string().nullable().optional(),
+            source_kind: z.string().nullable().optional(),
+          })
+          .passthrough()
+          .optional(),
+        identity: z
+          .object({
+            display_name_source: z.string().nullable().optional(),
+            native_name_quality: z.string().nullable().optional(),
+          })
+          .passthrough()
+          .optional(),
+        interface_metadata: z.string().nullable().optional(),
+      })
+      .passthrough(),
     registered_at_block: z.int().min(0).optional(),
     slug: z.string(),
     social: z

--- a/schemas-src/routes/subnet-profiles.ts
+++ b/schemas-src/routes/subnet-profiles.ts
@@ -73,7 +73,53 @@ const SchemaIndexEntrySchema = z
     path: z.string().nullable().optional(),
     previous_hash: z.string().nullable().optional(),
     schema_url: z.url().nullable(),
-    snapshot: z.record(z.string(), z.unknown()).optional(),
+    // #9800. Was `z.record(z.string(), z.unknown())` -- a record whose value
+    // schema is `unknown`, which declares no more than a bare open object does.
+    // This is the captured OpenAPI snapshot's own metadata: what was fetched,
+    // when, from where, and whether it has drifted since. Verified field by
+    // field against a live list_schemas response.
+    snapshot: z
+      .object({
+        surface_id: z.string().nullable().optional(),
+        surface_url: z.string().nullable().optional(),
+        schema_url: z.string().nullable().optional(),
+        netuid: z.int().min(0).nullable().optional(),
+        subnet_name: z.string().nullable().optional(),
+        subnet_slug: z.string().nullable().optional(),
+        title: z.string().nullable().optional(),
+        version: z.string().nullable().optional(),
+        openapi_version: z.string().nullable().optional(),
+        path_count: z.int().min(0).optional(),
+        component_schema_count: z.int().min(0).optional(),
+        server_count: z.int().min(0).optional(),
+        tag_count: z.int().min(0).optional(),
+        auth_required: z.boolean().optional(),
+        // An OBJECT, not a string -- 30 of 65 rows carry one and 29 are null,
+        // so a single-row sample reads as "always null" (#9800). It describes
+        // HOW the surface authenticates: which scheme, in which header, and the
+        // shape of the value. `value_format` is a placeholder like `<api-key>`,
+        // never a credential.
+        auth_detail: z
+          .object({
+            scheme: z.string().nullable().optional(),
+            location: z.string().nullable().optional(),
+            name: z.string().nullable().optional(),
+            value_format: z.string().nullable().optional(),
+          })
+          .passthrough()
+          .nullable()
+          .optional(),
+        auth_schemes: z.array(z.string()).optional(),
+        hash: z.string().nullable().optional(),
+        previous_hash: z.string().nullable().optional(),
+        drift_status: z.string().nullable().optional(),
+        observed_at: z.string().nullable().optional(),
+        generated_at: z.string().nullable().optional(),
+        contract_version: z.string().nullable().optional(),
+        schema_version: z.int().optional(),
+      })
+      .passthrough()
+      .optional(),
     status: z.enum([
       "captured",
       "error",


### PR DESCRIPTION
## Summary

First half of #9800. The REST contract is the source #9796 derives every MCP schema from, so
anything left imprecise here propagates to every tool that inherits it.

Twelve object sites typed, each **verified against a live response** rather than assumed:

| artifact | site | now |
| --- | --- | --- |
| registry summary | `coverage` | the coverage route's own completeness shape, **reused** rather than restated |
| registry summary | `recent_changes` | the publish-time diff counts |
| build summary | `artifacts[]` | `path` / `sha256` / `size_bytes` / `storage_tier` |
| build summary | `coverage` | `CoverageArtifactSchema` itself, reused |
| subnet detail | `subnet.links[]` | `label` / `url` / `source_url` |
| subnet detail | `subnet.provenance` | the record's audit trail — where each claim came from and how it was established |
| network health | `global` | `surface_count` + a `status_counts` record |
| agent catalog | `blocker_summary` | four tallies, as typed **records** |
| coverage | `source.native` | how the native identity was read |
| schema index | `schemas[].snapshot` | the captured OpenAPI snapshot's metadata, 23 fields |

Four of these were `z.record(z.string(), z.unknown())` rather than a bare open object — a record
whose *value schema is `unknown`*, which declares nothing more than `{}` while looking like it
declares something.

`blocker_summary`'s members are typed **records** on purpose: their keys are the blocker vocabulary
itself, so a new code adds a key without changing the contract. That is the legitimate dynamic-key
case from #9793, not opacity.

## A sampling error worth recording

`schemas[].snapshot.auth_detail` reads as *"always null"* from the first row. It is an **object on
30 of 65 rows** — scheme, header location, name, and a `<api-key>` value placeholder. Typing it from
one sample would have published a contract that rejects half the real rows.

It was caught only because the change was validated against **every** row before shipping, which is
the same discipline that caught the original five drifts.

## Result

| | before | after |
| --- | --- | --- |
| route untyped sites | 29 | **17** |
| declared precision | 96.9% | **98.2%** |

## What remains in #9800

**12 are genuinely arbitrary** and belong on the allowlist rather than being typed — an embedded
third-party OpenAPI document (`info`, `paths`, `components`, `servers[]`, `x-metagraphed`), extrinsic
`call_args` (×3), event `args` (×2), an embedded JSON Schema, and a recorded third-party response
body. Declaring shapes for those would be a lie, not precision.

**5 could not be typed from evidence yet** — `AdapterArtifact/snapshot`,
`AgentCatalogSubnetArtifact/services[]/auth`, `HealthLatestArtifact/summary`, and the two
verification `summary` sites. Their routes returned error envelopes when probed, so there is no live
sample to model from, and after the `auth_detail` near-miss above I am not typing them from a guess.
They need a working sample first.

Both groups are tracked in #9800, and the allowlist validator that makes the arbitrary ones a
reviewed choice rather than a silent default is #9797's.

## Validation

```
npx tsc --noEmit                     clean
npm run build                        clean (openapi + types regenerated and committed)
npm run validate:contract-drift      passed
npm run validate:api                 passed, 201 routes
npx vitest run mcp-server + graphql  2445 passed
npx prettier --check schemas-src/    clean
```

Refs #9793, #9800
