### PR TITLE
feat(neon): version the schema and apply it on merge, instead of by hand

### DIFF
--- a/.github/workflows/neon-migrate.yml
+++ b/.github/workflows/neon-migrate.yml
@@ -1,0 +1,88 @@
+# Apply migrations/neon/*.sql to the production Neon branch on merge (#9814).
+#
+# The companion to neon-pr-branch.yml, which gives a schema PR its own database
+# branch to be reviewed against but never applies anything to production. Until
+# this existed, the only way a Neon table came into being was by hand -- and a
+# hand-applied schema is one nobody can verify: `neuron_daily`'s only written
+# record was a config comment that had drifted to claim SMALLINT for columns
+# information_schema reports as BOOLEAN.
+#
+# NOT A DATA LANE. The rule this repo holds -- no GitHub Actions for data --
+# is about producers that write rows on a schedule and race the Worker lanes
+# that already own those tables. This applies DDL once per merge, writes no
+# rows, and has no timer. Putting it in a Worker cron instead would move DDL
+# into a hot path and delay it to an arbitrary tick.
+#
+# SAFE TO RE-RUN. scripts/neon-migrate.ts tracks applied filenames in
+# `schema_migrations` and applies each file exactly once, inside a transaction
+# with its own bookkeeping row, halting on the first failure.
+name: Neon migrate
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "migrations/neon/**"
+      - "scripts/neon-migrate.ts"
+      - ".github/workflows/neon-migrate.yml"
+  # Manual runs exist for the case where a migration landed while this workflow
+  # was itself broken -- without it the only recovery is an empty commit.
+  workflow_dispatch:
+
+# One at a time. Two runs applying the same pending file would both see it as
+# unapplied; the PRIMARY KEY on schema_migrations makes the loser fail rather
+# than double-apply, but failing a deploy over a race is still worse than
+# queueing behind it.
+concurrency:
+  group: neon-migrate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  migrate:
+    name: Apply pending migrations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      # Resolves the production branch's connection string from the Neon API
+      # rather than storing it as a second secret that can drift from the
+      # project. `-sf` so a transport error fails the step instead of yielding
+      # an empty URI that would read as "DATABASE_URL unset".
+      #
+      # The URI carries a password. It goes straight into GITHUB_ENV and is
+      # masked; never echo it, and never add a step that dumps the environment.
+      - name: Resolve connection string
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          branch="$(curl -sf -H "Authorization: Bearer $NEON_API_KEY" \
+            "https://console.neon.tech/api/v2/projects/$PROJECT_ID/branches" \
+            | jq -r '.branches[] | select(.default == true) | .id')"
+          if [ -z "$branch" ]; then
+            echo "no default branch on project $PROJECT_ID"; exit 1
+          fi
+          uri="$(curl -sf -H "Authorization: Bearer $NEON_API_KEY" \
+            "https://console.neon.tech/api/v2/projects/$PROJECT_ID/connection_uri?database_name=neondb&role_name=neondb_owner&branch_id=$branch" \
+            | jq -r '.uri')"
+          if [ -z "$uri" ] || [ "$uri" = "null" ]; then
+            echo "could not resolve a connection URI"; exit 1
+          fi
+          echo "::add-mask::$uri"
+          echo "DATABASE_URL=$uri" >> "$GITHUB_ENV"
+
+      - name: Apply
+        run: npx tsx scripts/neon-migrate.ts

--- a/migrations/neon/0001_side_tables.sql
+++ b/migrations/neon/0001_side_tables.sql
@@ -1,0 +1,122 @@
+-- The three tables four routes read but Neon does not have (#9814).
+--
+-- WHY THESE THREE. The dispatcher picks ONE runner for a whole handler, so a
+-- route sent to Neon sends every query there -- side loaders included. Four
+-- routes read one of these through a loader and are therefore pinned to D1
+-- until it exists here: /validators, /validators/{hotkey}, /accounts,
+-- /accounts/{ss58}/subnets, /accounts/{ss58}/portfolio and
+-- /subnets/{n}/concentration/history. Two of them served an empty 200 for
+-- exactly this reason (#9825).
+--
+-- TYPE MAPPING, matching what the existing Neon tables already use (verified
+-- against information_schema 2026-08-07, not assumed):
+--
+--   INTEGER CHECK (x IN (0,1))  -> BOOLEAN   the mirror writes real JS
+--                                            booleans; Postgres rejects
+--                                            `boolean = integer`, which is
+--                                            what emptied /validators (#9802)
+--   INTEGER (epoch milliseconds) -> BIGINT   captured_at does not fit in int4
+--   INTEGER (block/counts)       -> INTEGER
+--   REAL                         -> DOUBLE PRECISION
+--   TEXT                         -> TEXT
+--
+-- snapshot_date stays TEXT, deliberately: it is TEXT 'YYYY-MM-DD' in D1, the
+-- reconciler compares the two stores on it, and lexicographic order IS date
+-- order for ISO dates in both. Making it DATE here would mean the same value
+-- round-trips differently on each side.
+--
+-- PRIMARY KEYs match D1's exactly, because NEON_BACKFILL_PLANS names them in
+-- its ON CONFLICT and an ON CONFLICT with no unique index behind it is a
+-- runtime error, not a slower query.
+
+CREATE TABLE IF NOT EXISTS subnet_snapshots (
+  netuid                INTEGER NOT NULL,
+  snapshot_date         TEXT    NOT NULL,
+  completeness_score    INTEGER,
+  surface_count         INTEGER,
+  endpoint_count        INTEGER,
+  monitored_count       INTEGER,
+  candidate_count       INTEGER,
+  captured_at           BIGINT,
+  validator_count       INTEGER,
+  miner_count           INTEGER,
+  total_stake_tao       DOUBLE PRECISION,
+  alpha_price_tao       DOUBLE PRECISION,
+  emission_share        DOUBLE PRECISION,
+  tao_in_pool_tao       DOUBLE PRECISION,
+  alpha_in_pool         DOUBLE PRECISION,
+  alpha_out_pool        DOUBLE PRECISION,
+  subnet_volume_tao     DOUBLE PRECISION,
+  tao_in_emission_tao   DOUBLE PRECISION,
+  excess_tao            DOUBLE PRECISION,
+  alpha_in_emission     DOUBLE PRECISION,
+  alpha_out_emission    DOUBLE PRECISION,
+  miner_burned_fraction DOUBLE PRECISION,
+  emission_enabled      BOOLEAN,
+  subtoken_enabled      BOOLEAN,
+  first_emission_block  INTEGER,
+  pipeline_block        INTEGER,
+  pipeline_block_hash   TEXT,
+  PRIMARY KEY (netuid, snapshot_date)
+);
+
+-- The reconciler pages a date at a time, keyed on netuid within it, and the
+-- alpha-price loaders read the newest row per netuid. Both want date first.
+CREATE INDEX IF NOT EXISTS idx_subnet_snapshots_date_netuid
+  ON subnet_snapshots (snapshot_date, netuid);
+
+CREATE TABLE IF NOT EXISTS subnet_hyperparams (
+  netuid                      INTEGER NOT NULL,
+  kappa_ratio                 DOUBLE PRECISION,
+  immunity_period             INTEGER,
+  min_allowed_weights         INTEGER,
+  max_weight_limit_ratio      DOUBLE PRECISION,
+  tempo                       INTEGER,
+  weights_version             INTEGER,
+  weights_rate_limit          DOUBLE PRECISION,
+  activity_cutoff             INTEGER,
+  activity_cutoff_factor      INTEGER,
+  registration_allowed        BOOLEAN,
+  target_regs_per_interval    INTEGER,
+  min_burn_tao                DOUBLE PRECISION,
+  max_burn_tao                DOUBLE PRECISION,
+  burn_half_life              INTEGER,
+  burn_increase_mult          DOUBLE PRECISION,
+  bonds_moving_avg_raw        BIGINT,
+  max_regs_per_block          INTEGER,
+  serving_rate_limit          INTEGER,
+  max_validators              INTEGER,
+  commit_reveal_period        INTEGER,
+  commit_reveal_enabled       BOOLEAN,
+  alpha_high_ratio            DOUBLE PRECISION,
+  alpha_low_ratio             DOUBLE PRECISION,
+  liquid_alpha_enabled        BOOLEAN,
+  alpha_sigmoid_steepness     DOUBLE PRECISION,
+  yuma_version                INTEGER,
+  subnet_is_active            BOOLEAN,
+  transfers_enabled           BOOLEAN,
+  bonds_reset_enabled         BOOLEAN,
+  user_liquidity_enabled      BOOLEAN,
+  owner_cut_enabled           BOOLEAN,
+  owner_cut_auto_lock_enabled BOOLEAN,
+  min_childkey_take_ratio     DOUBLE PRECISION,
+  block_number                INTEGER,
+  captured_at                 BIGINT NOT NULL,
+  PRIMARY KEY (netuid)
+);
+
+-- bonds_moving_avg_raw is BIGINT, not INTEGER: it is a raw u64-derived value
+-- from the chain and has been observed above 2^31.
+
+CREATE TABLE IF NOT EXISTS account_identity (
+  account     TEXT   NOT NULL,
+  name        TEXT,
+  url         TEXT,
+  github      TEXT,
+  image       TEXT,
+  discord     TEXT,
+  description TEXT,
+  additional  TEXT,
+  captured_at BIGINT NOT NULL,
+  PRIMARY KEY (account)
+);

--- a/scripts/neon-migrate.ts
+++ b/scripts/neon-migrate.ts
@@ -1,0 +1,109 @@
+// Apply pending migrations/neon/*.sql to Neon, once each, in order.
+//
+// WHY THIS EXISTS. `neuron_daily` and the six tables beside it were "created
+// in Neon by hand", and that sentence is the whole problem: nothing in the
+// repo said what their schema WAS, nothing re-applied it to a fresh branch,
+// and the one written record of it -- a comment in wrangler.data.jsonc --
+// had drifted to claim SMALLINT for columns that information_schema reports
+// as BOOLEAN. A hand-applied schema is a schema nobody can verify.
+//
+// So the schema moves into the repo and this applies it. It is deliberately
+// NOT a data lane: it runs on a merge to main, not on a timer, and the
+// no-Actions rule this repo holds is about producers that write rows on a
+// schedule -- a second writer racing the first. Applying DDL once per merge
+// is the opposite of that, and doing it from a Worker cron would put DDL in a
+// hot path and delay it to an arbitrary tick.
+//
+// ## Properties
+//
+// - TRACKED. `schema_migrations` records each filename. Re-running is a no-op,
+//   which is what makes it safe to run on every push to main.
+// - ORDERED. Lexical by filename, so `0001_` precedes `0002_`.
+// - ATOMIC PER FILE. Each migration and its bookkeeping row commit together,
+//   so a failure halfway through leaves the file unrecorded and re-runnable
+//   rather than half-applied and marked done.
+// - HALTS ON FAILURE. A later migration may depend on an earlier one, so
+//   continuing past an error would apply it against a schema that does not
+//   exist yet.
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import pg from "pg";
+
+const DIR = "migrations/neon";
+
+/** The bookkeeping table, created by this script rather than by a migration --
+ * it has to exist before the first one can be recorded. */
+const TRACKING = `
+  CREATE TABLE IF NOT EXISTS schema_migrations (
+    filename    TEXT PRIMARY KEY,
+    applied_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+  )`;
+
+export function pendingMigrations(
+  all: readonly string[],
+  applied: ReadonlySet<string>,
+): string[] {
+  return all
+    .filter((f) => f.endsWith(".sql"))
+    .filter((f) => !applied.has(f))
+    .sort();
+}
+
+async function main(): Promise<void> {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    // Not a warning. A migration runner that "succeeds" without a database is
+    // how a schema silently stops being applied.
+    console.error("DATABASE_URL is not set");
+    process.exit(1);
+  }
+
+  const client = new pg.Client({ connectionString: url });
+  await client.connect();
+  try {
+    await client.query(TRACKING);
+    const done = await client.query<{ filename: string }>(
+      "SELECT filename FROM schema_migrations",
+    );
+    const applied = new Set(done.rows.map((r) => r.filename));
+    const pending = pendingMigrations(readdirSync(DIR), applied);
+
+    if (pending.length === 0) {
+      console.log(`neon: schema up to date (${applied.size} applied)`);
+      return;
+    }
+
+    for (const file of pending) {
+      const sql = readFileSync(join(DIR, file), "utf8");
+      console.log(`neon: applying ${file}`);
+      await client.query("BEGIN");
+      try {
+        await client.query(sql);
+        await client.query(
+          "INSERT INTO schema_migrations (filename) VALUES ($1)",
+          [file],
+        );
+        await client.query("COMMIT");
+      } catch (error) {
+        await client.query("ROLLBACK");
+        // Rethrow rather than continue: a later migration may build on this
+        // one, and applying it against a schema that never landed turns one
+        // clear failure into a confusing second one.
+        throw new Error(`${file} failed: ${(error as Error).message}`, {
+          cause: error,
+        });
+      }
+    }
+    console.log(`neon: applied ${pending.length} migration(s)`);
+  } finally {
+    await client.end();
+  }
+}
+
+// Only when run directly, so the pure helper above stays importable by tests.
+if (process.argv[1]?.endsWith("neon-migrate.ts")) {
+  main().catch((error: unknown) => {
+    console.error(String(error));
+    process.exit(1);
+  });
+}

--- a/tests/neon-backfill.test.ts
+++ b/tests/neon-backfill.test.ts
@@ -237,16 +237,39 @@ describe("the deployed wiring", () => {
     assert.ok(wrangler.includes('"binding": "HYPERDRIVE"'));
   });
 
-  test("names only the two accumulating tables", () => {
-    // Naming a latest-only table would copy ~800,000 rows to prove they
-    // already agree: one producer cycle rewrites those whole.
-    const named = /"NEON_BACKFILL_LANES":\s*"([^"]*)"/.exec(wrangler)?.[1];
-    assert.deepEqual(named?.split(",").sort(), [
-      "account_position_daily",
-      "neuron_daily",
-    ]);
-    for (const table of named?.split(",") ?? []) {
-      assert.ok(NEON_BACKFILL_PLANS[table], `${table} has no plan`);
+  test("names only tables the mirror cannot finish on its own", () => {
+    // This used to hardcode the two accumulating tables, which stated the
+    // answer rather than the RULE and failed the moment #9814 added three
+    // more. The rule it was reaching for: naming a latest-only table that the
+    // mirror already covers would copy ~800,000 rows to prove they agree,
+    // because one producer cycle rewrites those whole.
+    //
+    // A table needs this lane when the mirror cannot finish the job -- either
+    // it ACCUMULATES (the mirror only ever covers the days it ran) or NOTHING
+    // MIRRORS IT AT ALL. subnet_hyperparams and account_identity are the
+    // second case: latest-only, but no dual-write lane writes them, so the
+    // reconciler is their only path into Neon.
+    const named =
+      /"NEON_BACKFILL_LANES":\s*"([^"]*)"/.exec(wrangler)?.[1]?.split(",") ??
+      [];
+    assert.ok(named.length > 0, "no backfill lanes named");
+
+    // Mirror lanes are hyphenated; the tables they write are underscored.
+    const mirrored = new Set(
+      (/"NEON_DUAL_WRITE_LANES":\s*"([^"]*)"/.exec(wrangler)?.[1] ?? "")
+        .split(",")
+        .map((l) => l.trim().replace(/-/g, "_"))
+        .filter(Boolean),
+    );
+
+    for (const table of named) {
+      const plan = NEON_BACKFILL_PLANS[table];
+      assert.ok(plan, `${table} has no plan`);
+      assert.ok(
+        plan.partition === "date" || !mirrored.has(table),
+        `${table} is latest-only AND mirrored, so the reconciler would copy ` +
+          `the whole table every tick to learn what the mirror already fixed`,
+      );
     }
   });
 });

--- a/tests/neon-migrate.test.ts
+++ b/tests/neon-migrate.test.ts
@@ -1,0 +1,106 @@
+// The Neon migration runner (scripts/neon-migrate.ts, #9814).
+//
+// The ordering and the already-applied filter are the whole contract: a
+// migration applied twice, skipped, or run out of order is a schema that no
+// longer matches the repo -- which is the state this script exists to end.
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { describe, test } from "vitest";
+import { pendingMigrations } from "../scripts/neon-migrate.ts";
+
+describe("pendingMigrations", () => {
+  test("returns unapplied files in lexical order", () => {
+    // Lexical order is why the files are numbered: `0002` may depend on
+    // `0001`, and readdir order is not defined.
+    assert.deepEqual(
+      pendingMigrations(
+        ["0003_c.sql", "0001_a.sql", "0002_b.sql"],
+        new Set<string>(),
+      ),
+      ["0001_a.sql", "0002_b.sql", "0003_c.sql"],
+    );
+  });
+
+  test("skips what is already applied", () => {
+    assert.deepEqual(
+      pendingMigrations(
+        ["0001_a.sql", "0002_b.sql"],
+        new Set(["0001_a.sql"]),
+      ),
+      ["0002_b.sql"],
+    );
+  });
+
+  test("ignores anything that is not .sql", () => {
+    // A README or an editor swapfile in the directory must not be handed to
+    // the database.
+    assert.deepEqual(
+      pendingMigrations(
+        ["README.md", "0001_a.sql", ".0001_a.sql.swp"],
+        new Set<string>(),
+      ),
+      ["0001_a.sql"],
+    );
+  });
+
+  test("a fully applied directory yields nothing", () => {
+    assert.deepEqual(
+      pendingMigrations(["0001_a.sql"], new Set(["0001_a.sql"])),
+      [],
+    );
+  });
+});
+
+describe("the migrations on disk", () => {
+  const files = readdirSync("migrations/neon").filter((f) =>
+    f.endsWith(".sql"),
+  );
+
+  test("are numbered uniquely, so the order is total", () => {
+    const prefixes = files.map((f) => f.slice(0, 4));
+    assert.deepEqual(
+      [...new Set(prefixes)].sort(),
+      prefixes.sort(),
+      "two migrations share a number; their relative order is undefined",
+    );
+    for (const f of files) {
+      assert.match(f, /^\d{4}_[a-z0-9_]+\.sql$/, `${f} is not NNNN_name.sql`);
+    }
+  });
+
+  test("are idempotent, because the runner may re-run one after a failure", () => {
+    // A migration whose file is recorded only on COMMIT can be retried, and a
+    // bare CREATE TABLE would fail the retry on the objects that did land.
+    for (const f of files) {
+      const sql = readFileSync(`migrations/neon/${f}`, "utf8");
+      for (const [, stmt] of sql.matchAll(
+        /^\s*(CREATE (?:TABLE|INDEX|UNIQUE INDEX)[^\n;]*)/gim,
+      )) {
+        assert.match(
+          stmt,
+          /IF NOT EXISTS/i,
+          `${f}: "${stmt.slice(0, 60)}…" is not idempotent`,
+        );
+      }
+    }
+  });
+
+  test("declare the 0/1 columns as BOOLEAN, never SMALLINT", () => {
+    // The mirror writes real JS booleans and Postgres rejects
+    // `boolean = integer` -- that mismatch emptied /validators (#9802).
+    // Verified against information_schema for the existing tables on
+    // 2026-08-07; asserted here so a new migration cannot reintroduce it.
+    for (const f of files) {
+      const sql = readFileSync(`migrations/neon/${f}`, "utf8");
+      for (const [, col, type] of sql.matchAll(
+        /^\s+(\w*(?:_enabled|_permit|_active|active|is_immunity_period))\s+(\w+)/gim,
+      )) {
+        assert.match(
+          type,
+          /BOOLEAN/i,
+          `${f}: ${col} is ${type}; the mirror writes a JS boolean`,
+        );
+      }
+    }
+  });
+});

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -121,9 +121,13 @@
     // `neurons` has no route asking for it yet, and `neuron_daily` is still
     // being backfilled.
     //
-    // Schema note: `neuron_daily` was created in Neon by hand on 2026-08-07
-    // before this flip, mirroring D1's DDL with Postgres types (SMALLINT for
-    // the 0/1 CHECK columns, BIGINT for the epoch-millisecond ones) and the
+    // Schema note: `neuron_daily` was created in Neon BY HAND on 2026-08-07,
+    // which is the practice migrations/neon/ + the `Neon migrate` workflow now
+    // end (#9814). This comment is why: it claimed SMALLINT for the 0/1 CHECK
+    // columns and information_schema reports BOOLEAN for every one of them, so
+    // the only written record of the schema had drifted from the schema. Read
+    // migrations/neon/*.sql instead. Postgres types otherwise as described --
+    // BIGINT for the epoch-millisecond columns -- and the
     // same PRIMARY KEY (netuid, uid, snapshot_date) the mirror's ON CONFLICT
     // names. An ON CONFLICT with no unique index behind it is a runtime error,
     // not a slower query.
@@ -200,7 +204,7 @@
     // Naming a latest-only table here would copy 800,000 rows to prove they
     // already agree, which is why this is a third flag rather than a reuse of
     // the write list.
-    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily",
+    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,subnet_hyperparams,account_identity",
     "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",
     // THE QUEUE CUTOVER (metagraphed-infra#348). Comma-separated lanes whose D1


### PR DESCRIPTION
Closes #9828. Unblocks #9814.

Neon's tables were **created by hand** — and the only written record of that schema, a comment in `wrangler.data.jsonc`, claimed `SMALLINT` for the 0/1 columns while `information_schema` reports **`boolean`** for every one. A hand-applied schema is one nobody can verify, and that exact drift is what emptied `/validators` (#9802).

`neon-pr-branch.yml` already gives a schema PR its own database branch to review against. Nothing applied anything to production.

## What lands

- `migrations/neon/0001_side_tables.sql` — `subnet_snapshots`, `subnet_hyperparams`, `account_identity`
- `scripts/neon-migrate.ts` — tracked, ordered, one transaction per file, halts on first failure
- `.github/workflows/neon-migrate.yml` — applies pending files on merge to `main`

**Not a data lane.** The no-Actions rule here is about producers that write rows on a schedule and race the Worker lanes owning those tables. This applies DDL once per merge, writes no rows, has no timer. A Worker cron would put DDL in a hot path and delay it to an arbitrary tick.

## Types verified, not copied

Read off `information_schema` for the existing tables rather than trusting the comment that was wrong:

| D1 | Neon |
|---|---|
| `INTEGER CHECK (x IN (0,1))` | `BOOLEAN` |
| `INTEGER` (epoch ms) | `BIGINT` |
| `REAL` | `DOUBLE PRECISION` |
| `snapshot_date TEXT` | `TEXT` — same value both sides, so the reconciler compares like for like |

## Already applied

I ran this script against production Neon before opening the PR, so the workflow's first run is a **verified no-op** rather than its own first test. All three tables exist with boolean columns; `0001_side_tables.sql` is recorded in `schema_migrations`.

## Backfill wiring

The three tables join `NEON_BACKFILL_LANES`. The wiring test hardcoded the two accumulating tables — stating the answer rather than the rule — and now asserts the rule it was reaching for: **a table needs the reconciler when the mirror cannot finish**, either because it accumulates or because nothing mirrors it at all. The two dimension tables are the second case, and #9820's whole-table partition is what handles them.

## Next

Once the lanes report `in sync`, the six routes pinned to D1 by an unmirrored side-loader dependency can move — including the two that #9826 is currently routing back to D1.