### PR TITLE
feat(api): type the health summary, and find where the untyped ones actually live

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -8107,7 +8107,13 @@ export interface components {
         HealthLatestArtifact: components["schemas"]["ArtifactBase"] & ({
             /** Format: date-time */
             observed_at: string | null;
+            /** @description Network-wide health rollup for this observation (#9800). Was a bare open object, so the headline health figures were undeclared. `status_counts` is keyed by health verdict, so a new verdict adds a key rather than changing the contract -- a typed record, not opacity. */
             summary: {
+                status_counts?: {
+                    [key: string]: number;
+                };
+                surface_count?: number;
+            } & {
                 [key: string]: unknown;
             };
             surfaces: components["schemas"]["HealthSurface"][];

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -32206,6 +32206,20 @@
               },
               "summary": {
                 "additionalProperties": true,
+                "description": "Network-wide health rollup for this observation (#9800). Was a bare open object, so the headline health figures were undeclared. `status_counts` is keyed by health verdict, so a new verdict adds a key rather than changing the contract -- a typed record, not opacity.",
+                "properties": {
+                  "status_counts": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "surface_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
                 "type": "object"
               },
               "surfaces": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -8107,7 +8107,13 @@ export interface components {
         HealthLatestArtifact: components["schemas"]["ArtifactBase"] & ({
             /** Format: date-time */
             observed_at: string | null;
+            /** @description Network-wide health rollup for this observation (#9800). Was a bare open object, so the headline health figures were undeclared. `status_counts` is keyed by health verdict, so a new verdict adds a key rather than changing the contract -- a typed record, not opacity. */
             summary: {
+                status_counts?: {
+                    [key: string]: number;
+                };
+                surface_count?: number;
+            } & {
                 [key: string]: unknown;
             };
             surfaces: components["schemas"]["HealthSurface"][];

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -169,6 +169,20 @@
               },
               "summary": {
                 "additionalProperties": true,
+                "description": "Network-wide health rollup for this observation (#9800). Was a bare open object, so the headline health figures were undeclared. `status_counts` is keyed by health verdict, so a new verdict adds a key rather than changing the contract -- a typed record, not opacity.",
+                "properties": {
+                  "status_counts": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "surface_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
                 "type": "object"
               },
               "surfaces": {

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -20,6 +20,20 @@
               },
               "summary": {
                 "type": "object",
+                "description": "Network-wide health rollup for this observation (#9800). Was a bare open object, so the headline health figures were undeclared. `status_counts` is keyed by health verdict, so a new verdict adds a key rather than changing the contract -- a typed record, not opacity.",
+                "properties": {
+                  "surface_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "status_counts": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  }
+                },
                 "additionalProperties": true
               },
               "surfaces": {


### PR DESCRIPTION
## Summary

Continues #9800. `HealthLatestArtifact.summary` was a bare open object — the network-wide health
rollup, undeclared — so a caller reading the contract learned nothing about the headline figures.

It now declares `surface_count` and `status_counts`, the latter as a typed **record** because its
keys are the health verdict vocabulary: a new verdict adds a key rather than changing the contract.

## How it was found matters more than the fix

This component is **not in `schemas-src/`**. It lives in `schemas/components/`, a set of hand-written
JSON Schema files that `scripts/bundle-schemas.ts` merges into `schemas/api-components.schema.json`,
over which `scripts/openapi-components.ts` then overlays the Zod-owned components — *"overlaid last
so they win if a stale hand-edited key with the same name ever reappears"*.

So there are **two contract sources**, and 27 components still come from the hand-written side.

Editing the bundle directly does nothing: the build regenerates it from the parts, **silently**. That
is exactly what happened on the first attempt here — the change simply was not there afterwards, with
no error. The fix has to go in the part file.

Filed as **#9830**, because migrating 27 components is its own change with its own blast radius. The
overlay comment already describes the migration path the repo intends: a component moved to Zod wins
automatically, so it can be done incrementally, in any order, with no coordination.

## Result

Route contract untyped object sites: **17 → 16**.

## Validation

```
npx tsc --noEmit                 clean
npm run build                    clean (bundle + openapi + types regenerated and committed)
npm run validate:contract-drift  passed
npm run validate:api             passed, 201 routes
```

`validate:api` validates the live Worker response against the generated OpenAPI schema, and
`/api/v1/health` is one of the 201 — so the new shape is confirmed against a real response by the
gate itself, not by a separate probe.

Refs #9793, #9800, #9830
