### PR TITLE
perf(neon): budget a backfill tick in rows, not dates

### DIFF
--- a/src/neon-backfill.ts
+++ b/src/neon-backfill.ts
@@ -87,10 +87,28 @@ type Row = Record<string, unknown>;
  * slice to hold while the Neon statements for it are built. */
 export const D1_PAGE_ROWS = 2_000;
 
-/** Hard ceiling on dates copied per tick, whatever the clock says. A cap the
- * budget cannot override keeps one tick's cost predictable when a date turns
- * out to be far smaller than the ~32,000 rows these tables average. */
-export const MAX_DATES_PER_TICK = 4;
+/** Hard ceiling on dates copied per tick, whatever the clock or the row budget
+ * says. This is a runaway guard, not the working limit -- TICK_ROW_BUDGET is.
+ *
+ * It used to be 4, chosen for `neuron_daily` where a date is ~32,000 rows, and
+ * the docstring said it was there for the case where "a date turns out to be
+ * far smaller". It did the opposite: capping on DATE COUNT makes a table with
+ * small dates crawl. `subnet_snapshots` is one row per subnet per day, so four
+ * dates is 516 rows -- against a 20-second budget -- and its 406-date backlog
+ * would have taken five hours at three minutes a tick. */
+export const MAX_DATES_PER_TICK = 64;
+
+/** The working per-tick limit, in ROWS.
+ *
+ * Rows are what a tick actually costs -- D1 reads, Neon statements, memory
+ * held while the page is in flight -- and dates are only a proxy that happens
+ * to hold for one table. Budgeting in rows makes a tick's cost the same across
+ * plans whose dates differ by two orders of magnitude.
+ *
+ * Checked BETWEEN dates, like the clock budget, because a date is the unit of
+ * work: stopping inside one would leave a deficit the next tick recomputes
+ * correctly but restarts. So a tick can overshoot by at most one date. */
+export const TICK_ROW_BUDGET = 40_000;
 
 /** Wall-clock budget, checked BETWEEN dates. Cron ticks here are 3 minutes
  * apart, so finishing well inside one leaves the next tick a clean start
@@ -823,10 +841,20 @@ export async function reconcileTableToNeon(
   // 231-row gap writes 30,278 rows, and subtracting those would report a
   // negative backlog.
   let remaining = missing;
+  let rowsThisTick = 0;
   for (const deficit of deficits.slice(0, MAX_DATES_PER_TICK)) {
-    if (copied.length > 0 && elapsed() >= TICK_BUDGET_MS) break;
+    // Both budgets guard the SECOND date onward, never the first: a tick that
+    // copied nothing would make no progress at all, and the backlog would sit
+    // there while the lane reported it forever.
+    if (
+      copied.length > 0 &&
+      (elapsed() >= TICK_BUDGET_MS || rowsThisTick >= TICK_ROW_BUDGET)
+    ) {
+      break;
+    }
     const result = await copyDateToNeon(db, sql, plan, deficit.date);
     copied.push(result);
+    rowsThisTick += result.rows;
     if (!result.ok) {
       return {
         table,

--- a/tests/neon-backfill.test.ts
+++ b/tests/neon-backfill.test.ts
@@ -18,6 +18,7 @@ import {
   D1_PAGE_ROWS,
   IDLE_RECHECK_MS,
   MAX_DATES_PER_TICK,
+  TICK_ROW_BUDGET,
   NEON_BACKFILL_PLANS,
   TICK_BUDGET_MS,
   WHOLE_TABLE_UNIT,
@@ -904,7 +905,35 @@ describe("reconcileTableToNeon", () => {
       elapsed: () => 0,
     });
     assert.equal(out.deficits, 6);
-    assert.equal(out.copied.length, MAX_DATES_PER_TICK);
+    // Six dates, all tiny, all copied: the DATE cap is a runaway guard now,
+    // not the working limit. Capping on date count is what made
+    // subnet_snapshots (129 rows a date) crawl at 516 rows a tick.
+    assert.equal(out.copied.length, 6);
+  });
+
+  test("stops on the ROW budget, which is the working limit", async () => {
+    // Rows are what a tick costs; dates are a proxy that only holds for one
+    // table. Each date here writes one short page of 1,999 rows, so the budget
+    // lands mid-run rather than at a date boundary chosen to suit it.
+    const dates = Array.from({ length: 30 }, (_, i) => ({
+      d: `2026-07-${String(i + 1).padStart(2, "0")}`,
+      n: 1,
+    }));
+    const page = Array.from({ length: 1999 }, (_, uid) => ({ netuid: 1, uid }));
+    const d1 = fakeDb([dates, ...dates.map(() => page)]);
+    const out = await reconcileTableToNeon(d1.db, fakeSql([]).sql, PLAN, {
+      elapsed: () => 0,
+    });
+    const expected = Math.ceil(TICK_ROW_BUDGET / 1999);
+    assert.equal(
+      out.copied.length,
+      expected,
+      "should stop at the first date that carries the tick past the budget",
+    );
+    assert.ok(
+      out.copied.length < MAX_DATES_PER_TICK,
+      "date cap not the binder",
+    );
   });
 
   test("stops on the budget BETWEEN dates, never inside one", async () => {


### PR DESCRIPTION
Closes #9834.

`MAX_DATES_PER_TICK = 4` was chosen for `neuron_daily` (~32,000 rows a date). Its docstring said the cap existed for when "a date turns out to be far smaller" — but capping on **date count** does the opposite.

Measured on the live lane just now: `subnet_snapshots` is **129 rows a date**, so four dates is **516 rows** against a 20-second budget. Its 406-date backlog would take **~5 hours** at one tick every three minutes.

## Change

| | before | after |
|---|---|---|
| working limit | 4 dates | `TICK_ROW_BUDGET` = 40,000 rows |
| date cap | 4 (binding) | 64 (runaway guard) |
| clock budget | 20s | unchanged |

Rows are what a tick actually costs — D1 reads, Neon statements, memory held while a page is in flight. Dates are a proxy that holds for exactly one table.

Both budgets are checked **between** dates, like the clock already was, because a date is the unit of work and stopping inside one leaves a deficit the next tick recomputes correctly but restarts. Neither guards the **first** date, or a tick could copy nothing and report the same backlog forever.

For `subnet_snapshots` that's 64 dates × 129 rows ≈ 8,256 rows a tick — the backlog clears in ~20 minutes instead of 5 hours. For `neuron_daily` it is *more* conservative than before (2 dates ≈ 64,000 rows, versus 4 ≈ 128,000).

## Verification

74 tests. The date-cap test now asserts all six small dates are copied rather than four, and a new test drives 30 dates of 1,999 rows each to prove the row budget — not the date cap — is what stops the tick.