### PR TITLE
fix(ci): unred main — five failures, none visible to the PR that caused them

### DIFF
--- a/src/table-freshness-watchdog.ts
+++ b/src/table-freshness-watchdog.ts
@@ -183,6 +183,18 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
   // test doing its job: a new table arrived and was unwatched until named.
   // Pass ledgers are written with their parent table, so they share its
   // cadence.
+  // 0030, added while this map already existed -- the coverage test caught it
+  // the same way it caught 0029's pair. `neurons` is the 15-minute producer,
+  // so its pass ledger is the freshest of the four, but the threshold stays at
+  // the family's 36h: a pass table records COMPLETED passes, and a producer
+  // that stops mid-pass leaves the last completed one behind. Tightening this
+  // would alarm on the producer's cadence rather than on its failure.
+  neurons_passes: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 36 * HOUR,
+    reason: "written with neurons",
+  },
   nominator_positions_passes: {
     column: "captured_at",
     kind: "ms",

--- a/tests/changelog-mcp.test.ts
+++ b/tests/changelog-mcp.test.ts
@@ -16,11 +16,30 @@ import { mockEnv, type Row } from "./row-type.ts";
 type ReadArtifact = (env: Env, path: string) => Promise<StorageReadResult>;
 
 const SAMPLE_CHANGELOG = {
+  // Required by GET_CHANGELOG_OUTPUT_SCHEMA and present on the real artifact
+  // (GET /api/v1/changelog returns it alongside source/summary/artifacts).
+  // The fixture predated the field and stopped validating when the schema
+  // caught up with what the endpoint had been serving all along.
+  schema_version: 1,
+  contract_version: "2026-07-03.2",
+  generated_at: "2026-08-07T10:09:17.651Z",
   source: "generated-artifact-diff",
+  // The full summary the schema requires, matching GET /api/v1/changelog.
+  // The fixture carried only the three artifact_* counts.
   summary: {
     artifact_added_count: 1,
     artifact_modified_count: 2,
     artifact_removed_count: 0,
+    netuid_added_count: 0,
+    netuid_removed_count: 0,
+    netuid_renamed_count: 0,
+    coverage_delta: {
+      candidate_count: { before: 2171, after: 2174, delta: 3 },
+      curated_overlay_count: { before: 129, after: 129, delta: 0 },
+      native_only_count: { before: 0, after: 0, delta: 0 },
+      provider_count: null,
+      surface_count: { before: 3493, after: 3493, delta: 0 },
+    },
   },
   artifacts: { added: [], modified: [], removed: [] },
   subnets: { added: [], removed: [], renamed: [] },

--- a/tests/neon-migrate.test.ts
+++ b/tests/neon-migrate.test.ts
@@ -23,10 +23,7 @@ describe("pendingMigrations", () => {
 
   test("skips what is already applied", () => {
     assert.deepEqual(
-      pendingMigrations(
-        ["0001_a.sql", "0002_b.sql"],
-        new Set(["0001_a.sql"]),
-      ),
+      pendingMigrations(["0001_a.sql", "0002_b.sql"], new Set(["0001_a.sql"])),
       ["0002_b.sql"],
     );
   });

--- a/tests/zod-schemas.test.ts
+++ b/tests/zod-schemas.test.ts
@@ -3001,6 +3001,98 @@ describe("batch 10 (#8064) route artifact schemas parse real builder output", ()
       { path: "openapi.json", size_bytes: 1_900_000 },
     ];
     const budgets = evaluateArtifactBudgets(sizes);
+    // A REAL coverage object, trimmed to the fields CoverageArtifactSchema
+    // requires and captured from GET /api/v1/coverage on 2026-08-07. #9827
+    // widened this field from a loose object to the full artifact schema, and
+    // the old two-key stub stopped validating -- which turned main red rather
+    // than failing in that PR, because the fixture lived in a different file.
+    const coverage = {
+      schema_version: 1,
+      contract_version: "2026-07-03.2",
+      generated_at: "2026-08-07T10:09:17.651Z",
+      application_subnet_count: 128,
+      candidate_count: 2174,
+      candidate_subnet_count: 129,
+      chain_subnet_count: 129,
+      completeness: {
+        average_score: 81,
+        dimension_coverage: {
+          community: {
+            pct: 72,
+            present: 93,
+          },
+          "data-artifact": {
+            pct: 92,
+            present: 119,
+          },
+          docs: {
+            pct: 100,
+            present: 129,
+          },
+          openapi: {
+            pct: 50,
+            present: 65,
+          },
+          "source-repo": {
+            pct: 95,
+            present: 123,
+          },
+          sse: {
+            pct: 4,
+            present: 5,
+          },
+          "subnet-api": {
+            pct: 94,
+            present: 121,
+          },
+          website: {
+            pct: 95,
+            present: 122,
+          },
+        },
+        fully_complete_count: 4,
+        fully_complete_pct: 3,
+        median_score: 78,
+        methodology:
+          "Per-subnet completeness_score (0-100) weighs curated public identity and operational interface coverage. Full per-subnet scores and gaps live at /metagraph/review/profile-completeness.json; the sortable leaderboard is /api/v1/profiles?sort=completeness_score&order=asc.",
+        score_distribution: {
+          "100": 3,
+          "0-24": 0,
+          "25-49": 4,
+          "50-74": 25,
+          "75-99": 97,
+        },
+        scored_subnet_count: 129,
+      },
+      curated_overlay_count: 129,
+      curation_level_counts: {
+        "adapter-backed": 2,
+        "maintainer-reviewed": 127,
+      },
+      manifested_count: 0,
+      native_only_count: 0,
+      native_only_with_candidates: 0,
+      native_only_without_candidates: 0,
+      native_snapshot_captured_at: "2026-08-07T10:10:10Z",
+      network: "finney",
+      probed_count: 129,
+      probed_surface_count: 1859,
+      root_subnet_count: 1,
+      source: {
+        candidates: "registry/candidates",
+        native: {
+          identity_storage: "SubtensorModule.SubnetIdentitiesV3",
+          kind: "bittensor-sdk",
+          method:
+            "SubtensorApi.metagraphs.get_all_metagraphs_info(all_mechanisms=True)",
+          package: "bittensor",
+          rpc_family: "subnetInfo",
+          version: "10.4.0",
+        },
+        overlays: "registry/subnets",
+      },
+      surface_count: 3493,
+    };
     const data = {
       schema_version: 1,
       contract_version: CONTRACT_10,
@@ -3021,7 +3113,7 @@ describe("batch 10 (#8064) route artifact schemas parse real builder output", ()
       artifact_budget_summary: summarizeArtifactBudgets(budgets),
       artifact_budgets: budgets.filter((b) => b.status !== "ok"),
       candidate_count: 300,
-      coverage: { candidate_count: 300, surface_count: 900 },
+      coverage,
       endpoint_count: 3101,
       profile_count: 129,
       provider_count: 136,

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -701,7 +701,7 @@ async function handleNeuronsSync(
   // subnets behind it kept a stamp that was by then 30 hours old."
   //
   // MAX(captured_at) cannot see it, because it reflects only the netuids that
-  // DID land -- 21 of 129 subnets leaves a perfectly fresh-looking stamp.
+  // DID land -- 21 of 129 netuids leaves a perfectly fresh-looking stamp.
   //
   // Optional, like every other lane's: a producer that has not been updated
   // must keep working, and inventing a total would mark an unproven load


### PR DESCRIPTION
Closes #9837, closes #9839.

`main` was red on **five independent things**. Every open PR inherited all of them.

| failure | cause |
|---|---|
| `format:check` | `tests/neon-migrate.test.ts` unformatted — my miss in #9829 |
| `BuildSummaryArtifactSchema` | #9827 widened `coverage` to the full artifact; fixture was a two-key stub |
| `SAMPLE_CHANGELOG` | fixture predated `schema_version`, `contract_version`, `generated_at` and most of `summary` |
| `root-is-not-a-subnet` | #9816 wrote "21 of 129 **subnets**" into `data-api.ts` — 129 is the netuid count, and that prose is what the test forbids |

## The pattern

In every case the assertion and the thing it asserts about live in **different files**, so a PR-scoped diff couldn't see the break. #9827 changed a schema in `schemas-src/`; its fixture is in `tests/`. #9816 edited a comment in `workers/`; the rule lives in `tests/root-is-not-a-subnet.test.ts`. Each was green on its own PR and red on merge.

## Fixtures checked against reality, not loosened

The tempting repair — relax the schema until the fixture passes — would have been wrong three times. I checked the live endpoints first:

- `GET /api/v1/coverage` returns **every** field `CoverageArtifactSchema` requires
- `GET /api/v1/changelog` returns `schema_version`, `contract_version`, `generated_at` and the full `summary` including `coverage_delta`

So the schemas were right and the fixtures had drifted from what the API has been serving all along. Fixtures updated from live data.

## Verification

`typecheck`, `eslint .` and `prettier --check .` clean repo-wide; all four previously-failing test files pass locally.