### PR TITLE
fix: turn main green — four Validate failures, two of them mine

### DIFF
--- a/migrations/d1/0030_neurons_passes.sql
+++ b/migrations/d1/0030_neurons_passes.sql
@@ -24,7 +24,7 @@
 -- 30 hours old."
 --
 -- MAX(captured_at) CANNOT SUBSTITUTE, and this is the specific trap: it
--- reflects only the netuids that DID land, so a pass covering 21 of 129 subnets
+-- reflects only the netuids that DID land, so a pass covering 21 of 129 netuids
 -- leaves a perfectly fresh-looking stamp behind it. That is the same shape as
 -- the 147,000-row account_balances incident this whole mechanism came from.
 --

--- a/src/table-freshness-watchdog.ts
+++ b/src/table-freshness-watchdog.ts
@@ -123,6 +123,15 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
     maxAgeMs: 2 * HOUR,
     reason: "metagraph sync every 15 min",
   },
+  // Added by 0030, the same way 0029's pair was: the coverage test caught it
+  // unwatched. Written in the same batch as `neurons` -- deliberately, so a
+  // tally cannot outlive the rows it describes -- so it shares that cadence.
+  neurons_passes: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 2 * HOUR,
+    reason: "written with neurons",
+  },
   neuron_daily: {
     column: "captured_at",
     kind: "ms",

--- a/tests/changelog-mcp.test.ts
+++ b/tests/changelog-mcp.test.ts
@@ -16,11 +16,31 @@ import { mockEnv, type Row } from "./row-type.ts";
 type ReadArtifact = (env: Env, path: string) => Promise<StorageReadResult>;
 
 const SAMPLE_CHANGELOG = {
+  // schema_version + generated_at are REQUIRED since #9796 derived
+  // GetChangelogOutputSchema from ChangelogArtifactSchema instead of copying it.
+  // Both are present on the real artifact -- verified against GET /api/v1/changelog
+  // -- so the fixture was the stale side, not the schema.
+  schema_version: 1,
+  generated_at: "2026-08-07T10:09:17.651Z",
   source: "generated-artifact-diff",
   summary: {
     artifact_added_count: 1,
     artifact_modified_count: 2,
     artifact_removed_count: 0,
+    // The real summary carries a coverage_delta and the netuid counts; the
+    // derived schema requires them. `provider_count: null` is deliberate --
+    // the live artifact reports null for a metric it could not diff, and a
+    // fixture that only ever shows the populated shape would not exercise it.
+    coverage_delta: {
+      candidate_count: { after: 2174, before: 2171, delta: 3 },
+      curated_overlay_count: { after: 129, before: 129, delta: 0 },
+      native_only_count: { after: 0, before: 0, delta: 0 },
+      provider_count: null,
+      surface_count: { after: 3493, before: 3493, delta: 0 },
+    },
+    netuid_added_count: 0,
+    netuid_removed_count: 0,
+    netuid_renamed_count: 31,
   },
   artifacts: { added: [], modified: [], removed: [] },
   subnets: { added: [], removed: [], renamed: [] },

--- a/tests/neon-migrate.test.ts
+++ b/tests/neon-migrate.test.ts
@@ -23,10 +23,7 @@ describe("pendingMigrations", () => {
 
   test("skips what is already applied", () => {
     assert.deepEqual(
-      pendingMigrations(
-        ["0001_a.sql", "0002_b.sql"],
-        new Set(["0001_a.sql"]),
-      ),
+      pendingMigrations(["0001_a.sql", "0002_b.sql"], new Set(["0001_a.sql"])),
       ["0002_b.sql"],
     );
   });

--- a/tests/zod-schemas.test.ts
+++ b/tests/zod-schemas.test.ts
@@ -3021,7 +3021,63 @@ describe("batch 10 (#8064) route artifact schemas parse real builder output", ()
       artifact_budget_summary: summarizeArtifactBudgets(budgets),
       artifact_budgets: budgets.filter((b) => b.status !== "ok"),
       candidate_count: 300,
-      coverage: { candidate_count: 300, surface_count: 900 },
+      // A FULL CoverageArtifact, because meta-contracts.ts now types this field
+      // as CoverageArtifactSchema rather than an open record -- the build summary
+      // embeds the whole coverage card. Taken from the live artifact rather than
+      // invented, which is what "real builder output" in this test's name means.
+      coverage: {
+        application_subnet_count: 128,
+        candidate_count: 2174,
+        candidate_subnet_count: 129,
+        chain_subnet_count: 129,
+        completeness: {
+          average_score: 81,
+          fully_complete_count: 4,
+          fully_complete_pct: 3,
+          median_score: 78,
+          methodology:
+            "Per-subnet completeness_score (0-100) weighs curated public identity and operational interface coverage. Full per-subnet scores and gaps live at /metagraph/review/profile-completeness.json; the sortable leaderboard is /api/v1/profiles?sort=completeness_score&order=asc.",
+          score_distribution: {
+            "0-24": 0,
+            "100": 3,
+            "25-49": 4,
+            "50-74": 25,
+            "75-99": 97,
+          },
+          scored_subnet_count: 129,
+        },
+        contract_version: "2026-07-03.2",
+        curated_overlay_count: 129,
+        curation_level_counts: {
+          "adapter-backed": 2,
+          "maintainer-reviewed": 127,
+        },
+        generated_at: "2026-08-07T10:09:18.055Z",
+        manifested_count: 0,
+        native_only_count: 0,
+        native_only_with_candidates: 0,
+        native_only_without_candidates: 0,
+        native_snapshot_captured_at: "2026-08-07T10:10:10Z",
+        network: "finney",
+        probed_count: 129,
+        probed_surface_count: 1859,
+        root_subnet_count: 1,
+        schema_version: 1,
+        source: {
+          candidates: "registry/candidates",
+          native: {
+            identity_storage: "SubtensorModule.SubnetIdentitiesV3",
+            kind: "bittensor-sdk",
+            method:
+              "SubtensorApi.metagraphs.get_all_metagraphs_info(all_mechanisms=True)",
+            package: "bittensor",
+            rpc_family: "subnetInfo",
+            version: "10.4.0",
+          },
+          overlays: "registry/subnets",
+        },
+        surface_count: 3493,
+      },
       endpoint_count: 3101,
       profile_count: 129,
       provider_count: 136,

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -701,7 +701,7 @@ async function handleNeuronsSync(
   // subnets behind it kept a stamp that was by then 30 hours old."
   //
   // MAX(captured_at) cannot see it, because it reflects only the netuids that
-  // DID land -- 21 of 129 subnets leaves a perfectly fresh-looking stamp.
+  // DID land -- 21 of 129 netuids leaves a perfectly fresh-looking stamp.
   //
   // Optional, like every other lane's: a producer that has not been updated
   // must keep working, and inventing a total would mark an unproven load


### PR DESCRIPTION
`main` has been red since at least `20dcf1e4f` with **four** `Validate` failures. Two were mine, two were not, and **no branch cut from main can prove itself green until all four land** — which is why this is one PR rather than three.

| failure | cause |
|---|---|
| `root-is-not-a-subnet` › no source file claims "129 subnets" | **mine (#9816)** |
| `table-freshness-watchdog` › every table in migrations/d1 is classified | **mine (#9816)** |
| `changelog-mcp` › SAMPLE_CHANGELOG validates against GET_CHANGELOG_OUTPUT_SCHEMA | stale fixture |
| `zod-schemas` › build-summary: BuildSummaryArtifactSchema.parse(...) | stale fixture |
| `tests/neon-migrate.test.ts` not prettier-formatted | same as #9838 |

## Mine

**"21 of 129 subnets"** in a comment. 129 is the *netuid* count — root is not a subnet, which is exactly what that test enforces. Fixed in `workers/data-api.ts` and in the `0030` migration header, which repeats the sentence.

**`neurons_passes` unclassified.** `0030` added it and nothing named it in `TABLE_FRESHNESS`. The map's own comment, three entries above where the new one goes, records `0029`'s pair arriving the same way — *"a new table arrived and was unwatched until named."* I read that while writing `0029`'s entries and still missed `0030`'s. It gets `neurons`' 2h threshold because the tally is written in the **same batch** as the rows it describes.

## Not mine — and the schemas are right, the fixtures were stale

Both verified against the live artifacts rather than assumed:

**`changelog-mcp`.** #9796 derived `GetChangelogOutputSchema` from `ChangelogArtifactSchema` instead of copying it, making `schema_version`, `generated_at` and `summary.coverage_delta` required. `GET /api/v1/changelog` carries all three today. `provider_count: null` is kept deliberately — the live artifact reports null for a metric it could not diff, and a fixture that only shows the populated shape never exercises that arm.

**`zod-schemas`.** `meta-contracts.ts` now types build-summary's `coverage` as `CoverageArtifactSchema` rather than an open record, because the build summary embeds the whole coverage card. The fixture was a two-field stub. Replaced with the real card from `GET /api/v1/build` — which is what *"real builder output"* in that test's name is supposed to mean.

**`neon-migrate`.** Prettier only, no behaviour change. Same fix as #9838, included because `format:check` runs in the same job as the tests above, so neither PR could go green without the other. **#9838 can be closed as redundant.**

## A note on how I found these

I misdiagnosed the changelog failure twice before getting it right. First I imported `SAMPLE_CHANGELOG` from `src/` — it is defined in the test file — and validated `undefined`, which reported a meaningless root-level `must be object`. The assertion itself is `assert.ok(validate(...))`, which reports *false* and nothing else; extracting `validate.errors` is what turned it into a one-line answer both times.

Worth flagging separately: an `assert.ok(validate(x))` that discards `validate.errors` makes every future failure of these schema tests cost the same detour.

## Validation

```
vitest changelog-mcp zod-schemas table-freshness-watchdog root-is-not-a-subnet   # 365 passed
npm run typecheck     # clean
npm run lint          # clean
npm run format:check  # clean
```

Refs #9837