### PR TITLE
fix(ci): make main green — a format failure was hiding four more

### DIFF
--- a/src/table-freshness-watchdog.ts
+++ b/src/table-freshness-watchdog.ts
@@ -123,6 +123,14 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
     maxAgeMs: 2 * HOUR,
     reason: "metagraph sync every 15 min",
   },
+  // Added by 0030 after this map was written -- the same coverage test that
+  // caught 0029's two tables caught this one, which is what it is for.
+  neurons_passes: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: 2 * HOUR,
+    reason: "written with neurons",
+  },
   neuron_daily: {
     column: "captured_at",
     kind: "ms",

--- a/tests/changelog-mcp.test.ts
+++ b/tests/changelog-mcp.test.ts
@@ -15,12 +15,37 @@ import { mockEnv, type Row } from "./row-type.ts";
 
 type ReadArtifact = (env: Env, path: string) => Promise<StorageReadResult>;
 
+// Shaped from a real GET /api/v1/changelog response (2026-08-07), with the
+// three diff lists left empty so the fixture stays readable.
+//
+// #9823 derived get_changelog's outputSchema from ChangelogArtifactSchema
+// rather than restating it. The fixture that stood here predated that and was
+// a partial: it omitted the artifact wrapper (`schema_version`,
+// `generated_at`) and four `summary` keys that production has always served.
+// It satisfied the open object the copy used to publish, and nothing else, so
+// it stopped validating the moment the schema became the real one. A partial
+// fixture cannot exercise a full schema.
 const SAMPLE_CHANGELOG = {
+  schema_version: 1,
+  contract_version: "2026-07-03.2",
+  generated_at: "2026-08-07T10:09:17.651Z",
   source: "generated-artifact-diff",
   summary: {
     artifact_added_count: 1,
     artifact_modified_count: 2,
     artifact_removed_count: 0,
+    coverage_delta: {
+      candidate_count: { before: 2171, after: 2174, delta: 3 },
+      curated_overlay_count: { before: 129, after: 129, delta: 0 },
+      native_only_count: { before: 0, after: 0, delta: 0 },
+      // Null is the real, served value when a side of the diff has no count
+      // to compare -- not a placeholder.
+      provider_count: null,
+      surface_count: { before: 3493, after: 3493, delta: 0 },
+    },
+    netuid_added_count: 0,
+    netuid_removed_count: 0,
+    netuid_renamed_count: 31,
   },
   artifacts: { added: [], modified: [], removed: [] },
   subnets: { added: [], removed: [], renamed: [] },

--- a/tests/neon-migrate.test.ts
+++ b/tests/neon-migrate.test.ts
@@ -23,10 +23,7 @@ describe("pendingMigrations", () => {
 
   test("skips what is already applied", () => {
     assert.deepEqual(
-      pendingMigrations(
-        ["0001_a.sql", "0002_b.sql"],
-        new Set(["0001_a.sql"]),
-      ),
+      pendingMigrations(["0001_a.sql", "0002_b.sql"], new Set(["0001_a.sql"])),
       ["0002_b.sql"],
     );
   });

--- a/tests/zod-schemas.test.ts
+++ b/tests/zod-schemas.test.ts
@@ -3021,7 +3021,117 @@ describe("batch 10 (#8064) route artifact schemas parse real builder output", ()
       artifact_budget_summary: summarizeArtifactBudgets(budgets),
       artifact_budgets: budgets.filter((b) => b.status !== "ok"),
       candidate_count: 300,
-      coverage: { candidate_count: 300, surface_count: 900 },
+      // A REAL captured /api/v1/coverage response (2026-08-07), not a stub.
+      // #9827 made this field the CoverageArtifact rather than an open
+      // object; the two-key stub that stood here satisfied the open object
+      // and nothing else, so the test started failing the moment the field
+      // was typed. A partial fixture cannot exercise a full schema.
+      coverage: {
+        application_subnet_count: 128,
+        candidate_count: 2174,
+        candidate_subnet_count: 129,
+        chain_subnet_count: 129,
+        completeness: {
+          average_score: 81,
+          dimension_coverage: {
+            community: {
+              pct: 72,
+              present: 93,
+            },
+            "data-artifact": {
+              pct: 92,
+              present: 119,
+            },
+            docs: {
+              pct: 100,
+              present: 129,
+            },
+            openapi: {
+              pct: 50,
+              present: 65,
+            },
+            "source-repo": {
+              pct: 95,
+              present: 123,
+            },
+            sse: {
+              pct: 4,
+              present: 5,
+            },
+            "subnet-api": {
+              pct: 94,
+              present: 121,
+            },
+            website: {
+              pct: 95,
+              present: 122,
+            },
+          },
+          fully_complete_count: 4,
+          fully_complete_pct: 3,
+          median_score: 78,
+          methodology:
+            "Per-subnet completeness_score (0-100) weighs curated public identity and operational interface coverage. Full per-subnet scores and gaps live at /metagraph/review/profile-completeness.json; the sortable leaderboard is /api/v1/profiles?sort=completeness_score&order=asc.",
+          score_distribution: {
+            "100": 3,
+            "0-24": 0,
+            "25-49": 4,
+            "50-74": 25,
+            "75-99": 97,
+          },
+          scored_subnet_count: 129,
+        },
+        contract_version: "2026-07-03.2",
+        curated_overlay_count: 129,
+        curation_level_counts: {
+          "adapter-backed": 2,
+          "maintainer-reviewed": 127,
+        },
+        domain_coverage: {
+          agents: 13,
+          compute: 9,
+          data: 9,
+          finance: 9,
+          inference: 16,
+          media: 4,
+          prediction: 7,
+          privacy: 2,
+          robotics: 3,
+          science: 5,
+          search: 2,
+          security: 4,
+          storage: 1,
+        },
+        first_party_subnet_count: 116,
+        generated_at: "2026-08-07T10:09:17.651Z",
+        manifested_count: 0,
+        native_only_count: 0,
+        native_only_with_candidates: 0,
+        native_only_without_candidates: 0,
+        native_snapshot_captured_at: "2026-08-07T10:10:10Z",
+        network: "finney",
+        official_surface_count: 444,
+        probed_count: 129,
+        probed_surface_count: 1859,
+        registry_observed_surface_count: 785,
+        root_subnet_count: 1,
+        schema_version: 1,
+        source: {
+          candidates: "registry/candidates",
+          native: {
+            identity_storage: "SubtensorModule.SubnetIdentitiesV3",
+            kind: "bittensor-sdk",
+            method:
+              "SubtensorApi.metagraphs.get_all_metagraphs_info(all_mechanisms=True)",
+            package: "bittensor",
+            rpc_family: "subnetInfo",
+            version: "10.4.0",
+          },
+          overlays: "registry/subnets",
+        },
+        subnets_without_official_surface: 13,
+        surface_count: 3493,
+      },
       endpoint_count: 3101,
       profile_count: 129,
       provider_count: 136,

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -701,7 +701,7 @@ async function handleNeuronsSync(
   // subnets behind it kept a stamp that was by then 30 hours old."
   //
   // MAX(captured_at) cannot see it, because it reflects only the netuids that
-  // DID land -- 21 of 129 subnets leaves a perfectly fresh-looking stamp.
+  // DID land -- 21 of 129 netuids leaves a perfectly fresh-looking stamp.
   //
   // Optional, like every other lane's: a producer that has not been updated
   // must keep working, and inventing a total would mark an unproven load


### PR DESCRIPTION
## Summary

`Validate` has been red on `main` since 370c7ceb. The `test` job dies at its
first step, `npm run format:check`, so the vitest run beneath it has not
executed since — and four further failures accumulated behind that wall unseen.
Three PRs merged with `test: FAILURE` in that window (#9823, #9827, #9831),
because the check rollup was read as "the checks that reported success" rather
than every check.

| # | failure | fix |
| --- | --- | --- |
| 1 | `prettier --check` rejects `tests/neon-migrate.test.ts` | formatted |
| 2 | `zod-schemas` — `BuildSummaryArtifactSchema.parse(...)` fails | real captured `coverage` artifact replaces a two-key stub |
| 3 | `changelog-mcp` — `SAMPLE_CHANGELOG` fails its own `outputSchema` | real captured shape replaces a partial |
| 4 | `root-is-not-a-subnet` — `workers/data-api.ts` says "129 subnets" | "129 netuids" — 129 is the netuid count, root included |
| 5 | `table-freshness-watchdog` — `neurons_passes` unclassified | classified `written with neurons`, like its four sibling pass tables |

## The shape shared by (2) and (3)

Both are **a partial fixture against a schema that stopped being partial.**

#9827 typed `BuildSummaryArtifact.coverage` as the real `CoverageArtifact`
instead of an open object; #9823 derived `get_changelog`'s `outputSchema` from
`ChangelogArtifactSchema` instead of restating it. Each fixture had only ever
satisfied the open object — a two-key stub for the first, an artifact with no
`schema_version`/`generated_at` and four missing `summary` keys for the second
— so both failed the moment their contract became specific.

Neither is a defect in the schema. Production serves every field the fixtures
were missing, verified against `GET /api/v1/coverage` and
`GET /api/v1/changelog`. So the fix is not to loosen the schema: it is to make
each fixture a **real captured response**, which is the convention the rest of
this file already follows ("fixture is a real captured production response").
A partial fixture cannot exercise a full schema, and one that passes only
because the schema is vague is not testing anything.

(4) and (5) are each a coverage test working exactly as designed — both were
written to fail when a new table or a new subnet count reaches the tree
unclassified, and both did, on the same PR (#9812).

## Validation

- `npx prettier --check .` — clean
- `npx eslint .` — clean
- `npx vitest run` — **723 files, 17545 tests, 0 failures** (was 3 files / 3
  failures, plus the format wall above it)

Closes #9842