### PR TITLE
fix(neon): give validator_nominator_counts a reconciler lane

### DIFF
--- a/src/neon-backfill.ts
+++ b/src/neon-backfill.ts
@@ -225,6 +225,13 @@ const SUBNET_HYPERPARAMS_COLUMNS = [
   "captured_at",
 ] as const;
 
+/** validator_nominator_counts. */
+const VALIDATOR_NOMINATOR_COUNTS_COLUMNS = [
+  "hotkey",
+  "nominator_count",
+  "captured_at",
+] as const;
+
 /** account_identity. */
 const ACCOUNT_IDENTITY_COLUMNS = [
   "account",
@@ -296,6 +303,25 @@ export const NEON_BACKFILL_PLANS: Readonly<Record<string, BackfillPlan>> = {
       "owner_cut_enabled",
       "owner_cut_auto_lock_enabled",
     ],
+  },
+  // Latest-only AND mirrored, which by the rule below would need no lane --
+  // except measurement says otherwise. D1 held 112,250 rows and Neon 112,236
+  // on 2026-08-07, and the gap did not move across repeated checks. It is not
+  // churn: it is 14 hotkeys D1 wrote BEFORE the mirror lane existed and has
+  // not rewritten since, so no producer cycle will ever carry them.
+  //
+  // That is the hole in "a mirror covers a latest-only table": it does, but
+  // only for rows the producer still emits. A validator that stopped having
+  // nominators keeps its D1 row forever (upsert-only, no prune) and never
+  // reaches Neon. /validators reads this table, so 14 wrong rows is 14 wrong
+  // nominator counts on a leaderboard.
+  validator_nominator_counts: {
+    table: "validator_nominator_counts",
+    columns: VALIDATOR_NOMINATOR_COUNTS_COLUMNS,
+    conflict: ["hotkey"],
+    keyset: ["hotkey"],
+    partition: "whole",
+    booleans: [],
   },
   account_identity: {
     table: "account_identity",

--- a/tests/neon-backfill.test.ts
+++ b/tests/neon-backfill.test.ts
@@ -265,10 +265,23 @@ describe("the deployed wiring", () => {
     for (const table of named) {
       const plan = NEON_BACKFILL_PLANS[table];
       assert.ok(plan, `${table} has no plan`);
+      // A mirrored latest-only table normally needs no lane -- but "the
+      // mirror covers it" only holds for rows the producer still EMITS. A row
+      // written to D1 before the mirror existed, and never rewritten since,
+      // reaches Neon by no other path. validator_nominator_counts is the
+      // measured case: a 14-row deficit that did not move across repeated
+      // checks on 2026-08-07.
+      //
+      // So this is an allowlist with evidence rather than a derived rule,
+      // because the derived rule was wrong.
+      const provenStuck = new Set(["validator_nominator_counts"]);
       assert.ok(
-        plan.partition === "date" || !mirrored.has(table),
+        plan.partition === "date" ||
+          !mirrored.has(table) ||
+          provenStuck.has(table),
         `${table} is latest-only AND mirrored, so the reconciler would copy ` +
-          `the whole table every tick to learn what the mirror already fixed`,
+          `the whole table every tick to learn what the mirror already fixed` +
+          ` -- add it to provenStuck with a measurement if that is wrong`,
       );
     }
   });

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -204,7 +204,7 @@
     // Naming a latest-only table here would copy 800,000 rows to prove they
     // already agree, which is why this is a third flag rather than a reuse of
     // the write list.
-    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,subnet_hyperparams,account_identity",
+    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts",
     "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",
     // THE QUEUE CUTOVER (metagraphed-infra#348). Comma-separated lanes whose D1


### PR DESCRIPTION
Closes #9844.

Measured twice, minutes apart:

```
D1    112,250
Neon  112,236     deficit 14, unchanged
```

**A deficit that does not move is not churn.** Those 14 hotkeys were written to D1 *before the mirror lane existed* and have not been rewritten since — so no producer cycle will ever carry them.

## The rule I encoded in #9829 was wrong

It said a latest-only mirrored table needs no reconciler, because one cycle rewrites it whole. That holds only for rows the producer still **emits**. This table and `hotkey_alpha` are both upsert-only with no prune, so a validator that stops having nominators keeps its D1 row forever and never reaches Neon.

*Latest-only describes what the producer writes, not what the table retains.*

## Why it blocks the cutover

`/api/v1/validators` reads this through `loadNominatorCountsD1`. Fourteen missing rows is fourteen wrong nominator counts on a leaderboard — small, silent, and exactly what a row-count check waves through when the two numbers happen to agree.

## Change

Whole-table plan (#9820's partition), named in `NEON_BACKFILL_LANES`. The comparison is `(COUNT(*), MAX(captured_at))` — two trivial reads — and it copies only on disagreement.

The wiring test asserted the derived rule; since the rule is wrong, it becomes an **allowlist that requires a measurement to join**, with this one's evidence in the comment.