### PR TITLE
feat(neon): compare D1 and Neon row counts for every shared table

### DIFF
--- a/src/neon-parity-watchdog.ts
+++ b/src/neon-parity-watchdog.ts
@@ -1,0 +1,232 @@
+// Row-count parity between D1 and Neon, for every table that exists in both.
+//
+// ## Why this exists
+//
+// Three parity gaps were found on 2026-08-07 by querying the two stores by
+// hand, one table at a time. Nothing in the system was looking:
+//
+//   hotkey_alpha                D1  17,867   Neon  47,320   (#9832)
+//   nominator_positions         D1 123,522   Neon 110,120   (#9832)
+//   validator_nominator_counts  D1 112,250   Neon 112,236   (#9844)
+//
+// The reconciler compares the two stores, but ONLY for tables named in
+// NEON_BACKFILL_LANES. Everything else -- including every table the mirror is
+// supposed to keep current on its own -- had no comparison at all. "The mirror
+// is green" answers whether writes SUCCEEDED, not whether the stores AGREE.
+//
+// ## Why a persistent deficit, not any deficit
+//
+// These tables are written continuously, so a single-tick difference is
+// normal: a producer pass lands in D1 microseconds before its mirror reaches
+// Neon, and a count taken between the two sees a gap that is gone by the next
+// tick. Alarming on that would make this noise, and noise is how a check stops
+// being read (see #9825's baseline, which cried wolf on every producer tick
+// until it was rewritten).
+//
+// So a deficit alarms only when it REPEATS AT THE SAME SIZE. Churn moves;
+// a structural gap does not. `validator_nominator_counts` sat at exactly 14
+// across repeated checks minutes apart, which is what distinguished it from
+// the ±125 that `account_balances` shows and resolves on its own.
+//
+// ## Direction is recorded, never assumed
+//
+// D1 is not the reference store. `hotkey_alpha` has 2.6x MORE rows in Neon
+// than D1, because the D1 write is lossy (#9832) -- so a check written as "is
+// Neon behind D1" would have reported that table healthy while it was the
+// worst broken of the three. Both directions are surfaced.
+import {
+  loadLatestLaneHealth,
+  recordLaneVerdict,
+  type LaneHealthDb,
+} from "./lane-health.ts";
+import {
+  createPgSql,
+  type HyperdriveLike,
+  type WaitUntilLike,
+} from "./pg-sql.ts";
+import type { PgUnsafe } from "./neon-write.ts";
+
+export const NEON_PARITY_LANE = "neon-parity";
+
+/** Cron slot. Hourly: these are whole-table counts on both sides, and a
+ * structural gap does not appear between one hour and the next. */
+export const NEON_PARITY_CRON = "38 * * * *";
+
+/**
+ * Every table that exists in BOTH stores, as of migrations/neon/0001.
+ *
+ * Hand-listed rather than discovered, because "what is in Neon" is the thing
+ * being checked -- deriving the list from Neon would make a table that
+ * silently vanished there look like a table nobody asked about.
+ */
+export const PARITY_TABLES = [
+  "neurons",
+  "neuron_daily",
+  "account_position_daily",
+  "nominator_positions",
+  "account_balances",
+  "hotkey_alpha",
+  "validator_nominator_counts",
+  "subnet_snapshots",
+  "subnet_hyperparams",
+  "account_identity",
+] as const;
+
+/**
+ * Rows below which a difference is not worth a verdict.
+ *
+ * Zero would be right if these tables were static. They are not: every one is
+ * written continuously, and a count taken mid-pass differs by whatever that
+ * pass has landed so far. This is deliberately small -- the point is to catch
+ * 14, not only 29,000.
+ */
+export const PARITY_MIN_ROWS = 5;
+
+export interface ParityDb {
+  prepare(sql: string): { all(): Promise<{ results?: unknown[] } | null> };
+}
+
+export interface TableParity {
+  table: string;
+  d1: number;
+  neon: number;
+  /** d1 - neon. NEGATIVE means Neon holds more, which is a real state. */
+  delta: number;
+}
+
+/** One `SELECT count` per table, unioned so the sweep is a single statement. */
+export function parityCountSql(tables: readonly string[]): string {
+  return tables
+    .map((t) => `SELECT '${t}' AS t, COUNT(*) AS n FROM ${t}`)
+    .join(" UNION ALL ");
+}
+
+function countsFrom(rows: readonly unknown[]): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const raw of rows) {
+    const row = raw as Record<string, unknown>;
+    if (row?.t == null || row.n == null) continue;
+    const n = Number(row.n);
+    if (Number.isFinite(n)) out.set(String(row.t), n);
+  }
+  return out;
+}
+
+/** Tables whose counts differ by at least PARITY_MIN_ROWS, worst first. */
+export function parityGaps(
+  d1: ReadonlyMap<string, number>,
+  neon: ReadonlyMap<string, number>,
+  minRows: number = PARITY_MIN_ROWS,
+): TableParity[] {
+  const out: TableParity[] = [];
+  for (const table of d1.keys()) {
+    const a = d1.get(table);
+    const b = neon.get(table);
+    // A table missing from ONE side is not a parity gap of "everything" -- it
+    // is a table that has not been created there yet, which migrations/neon
+    // answers and this lane should not shout about.
+    if (a == null || b == null) continue;
+    const delta = a - b;
+    if (Math.abs(delta) >= minRows) out.push({ table, d1: a, neon: b, delta });
+  }
+  return out.sort((x, y) => Math.abs(y.delta) - Math.abs(x.delta));
+}
+
+/**
+ * The gaps that were ALSO present, at the same size, in the previous verdict.
+ *
+ * Churn moves between ticks; a structural gap does not. Comparing sizes rather
+ * than merely "was it listed" is what keeps a table that is actively
+ * backfilling -- deficit shrinking every tick -- from alarming while it works.
+ */
+export function persistentGaps(
+  current: readonly TableParity[],
+  previousDetail: string | null | undefined,
+): TableParity[] {
+  if (!previousDetail) return [];
+  const seen = new Map<string, number>();
+  for (const m of previousDetail.matchAll(/(\w+) ([+-]\d+)/g)) {
+    seen.set(m[1]!, Number(m[2]));
+  }
+  return current.filter((g) => seen.get(g.table) === g.delta);
+}
+
+/** `hotkey_alpha -29422` — table then signed delta, which persistentGaps reads back. */
+export function describeParity(
+  gaps: readonly TableParity[],
+  checked: number,
+): string {
+  if (gaps.length === 0) return `${checked} table(s) in parity`;
+  return gaps
+    .map((g) => `${g.table} ${g.delta > 0 ? "+" : ""}${g.delta}`)
+    .join(", ");
+}
+
+export interface ParityDeps {
+  db?: ParityDb;
+  sql?: PgUnsafe;
+  laneHealthDb?: LaneHealthDb;
+  now?: () => number;
+}
+
+export interface ParityOutcome {
+  attempted: boolean;
+  gaps?: TableParity[];
+  persistent?: TableParity[];
+  reason?: string;
+}
+
+export async function runNeonParityWatchdog(
+  env: Record<string, unknown> | null | undefined,
+  ctx: WaitUntilLike,
+  deps: ParityDeps = {},
+): Promise<ParityOutcome> {
+  const db = deps.db ?? (env?.METAGRAPH_HEALTH_DB as ParityDb | undefined);
+  const laneDb =
+    deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as LaneHealthDb | undefined);
+  const hyperdrive = env?.HYPERDRIVE as HyperdriveLike | undefined;
+  const sql =
+    deps.sql ?? (hyperdrive ? createPgSql(hyperdrive, ctx) : undefined);
+  const now = deps.now ?? Date.now;
+  if (!db?.prepare || !sql?.unsafe) return { attempted: false };
+
+  const statement = parityCountSql(PARITY_TABLES);
+  let d1Counts: Map<string, number>;
+  let neonCounts: Map<string, number>;
+  try {
+    const [a, b] = await Promise.all([
+      db.prepare(statement).all(),
+      sql.unsafe(statement) as Promise<unknown>,
+    ]);
+    if (!a) throw new Error("d1 returned nothing");
+    d1Counts = countsFrom(a.results ?? []);
+    neonCounts = countsFrom(Array.isArray(b) ? b : []);
+  } catch (error) {
+    // `unknown`, not `stale`: a store that would not answer is not evidence of
+    // a gap, and calling it one would put every table in the detail line.
+    await recordLaneVerdict(laneDb, {
+      lane: NEON_PARITY_LANE,
+      verdict: "unknown",
+      age_ms: null,
+      detail: `counts unreadable: ${error instanceof Error ? error.message : String(error)}`,
+      checked_at: now(),
+    });
+    return { attempted: true, reason: "counts unreadable" };
+  }
+
+  const gaps = parityGaps(d1Counts, neonCounts);
+  const previous = (await loadLatestLaneHealth(laneDb))[NEON_PARITY_LANE];
+  const persistent = persistentGaps(gaps, previous?.detail);
+
+  await recordLaneVerdict(laneDb, {
+    lane: NEON_PARITY_LANE,
+    verdict: persistent.length === 0 ? "ok" : "stale",
+    age_ms: null,
+    // The detail always lists CURRENT gaps, persistent or not: the next tick
+    // reads it back to decide persistence, so dropping the transient ones
+    // would make every gap look new forever.
+    detail: describeParity(gaps, d1Counts.size),
+    checked_at: now(),
+  });
+  return { attempted: true, gaps, persistent };
+}

--- a/src/neon-parity-watchdog.ts
+++ b/src/neon-parity-watchdog.ts
@@ -80,6 +80,30 @@ export const PARITY_TABLES = [
  * pass has landed so far. This is deliberately small -- the point is to catch
  * 14, not only 29,000.
  */
+/**
+ * Tables the two stores are SUPPOSED to disagree about, with the reason.
+ *
+ * `hotkey_alpha` is the case that forced this to exist. D1 stores only pools a
+ * `nominator_positions` row references -- `REFERENCED_BY_A_POSITION` in
+ * src/hotkey-alpha-d1-write.ts, deliberate since #9558, because the other 43x
+ * of `TotalHotkeyAlpha` is "written every pass, read by nothing" and saturated
+ * D1. The Neon mirror is handed the RAW rows and applies no filter, so Neon
+ * holds ~29,000 rows D1 refuses on purpose.
+ *
+ * That is a real defect (#9832) and the fix is to give the mirror the same
+ * filter -- but until then the divergence is EXPECTED, and a watchdog that
+ * alarms on it every hour would be teaching everyone to ignore this lane
+ * before it has caught anything.
+ *
+ * NAMED, NOT SILENCED. An expected divergence still appears in the detail
+ * line; it just does not make the verdict stale. Dropping it from the report
+ * entirely would hide the day it changes size for a NEW reason.
+ */
+export const EXPECTED_DIVERGENCE: Readonly<Record<string, string>> = {
+  hotkey_alpha:
+    "D1 filters to pools a nominator_position references (#9558); the mirror does not (#9832)",
+};
+
 export const PARITY_MIN_ROWS = 5;
 
 export interface ParityDb {
@@ -148,7 +172,9 @@ export function persistentGaps(
   for (const m of previousDetail.matchAll(/(\w+) ([+-]\d+)/g)) {
     seen.set(m[1]!, Number(m[2]));
   }
-  return current.filter((g) => seen.get(g.table) === g.delta);
+  return current.filter(
+    (g) => seen.get(g.table) === g.delta && !EXPECTED_DIVERGENCE[g.table],
+  );
 }
 
 /** `hotkey_alpha -29422` — table then signed delta, which persistentGaps reads back. */

--- a/tests/neon-parity-watchdog.test.ts
+++ b/tests/neon-parity-watchdog.test.ts
@@ -1,0 +1,436 @@
+// The D1<->Neon parity watchdog (src/neon-parity-watchdog.ts, #9846).
+//
+// The thing this has to get right is the DIFFERENCE between churn and a
+// structural gap. Both look like "the counts disagree" in a single sample, and
+// alarming on the first is how a check stops being read.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  NEON_PARITY_CRON,
+  NEON_PARITY_LANE,
+  PARITY_MIN_ROWS,
+  PARITY_TABLES,
+  describeParity,
+  parityCountSql,
+  parityGaps,
+  persistentGaps,
+  runNeonParityWatchdog,
+} from "../src/neon-parity-watchdog.ts";
+
+const ctx = { waitUntil() {} };
+const NOW = 1_786_000_000_000;
+
+function fakeDb(rows: unknown[] | null, throwIt = false) {
+  const written: Record<string, unknown>[] = [];
+  return {
+    written,
+    db: {
+      prepare(sql: string) {
+        return {
+          async all() {
+            // loadLatestLaneHealth reads lane_health through the same
+            // prepare().all() shape, so the fake has to answer by STATEMENT
+            // rather than by call order.
+            if (/lane_health/i.test(sql)) return { results: fakeDb.laneRows };
+            if (throwIt && sql.startsWith("SELECT '"))
+              throw new Error("D1_ERROR");
+            return rows === null ? null : { results: rows };
+          },
+          bind(...values: unknown[]) {
+            return {
+              async run() {
+                if (sql.startsWith("INSERT"))
+                  written.push({
+                    lane: values[0],
+                    verdict: values[1],
+                    detail: values[3],
+                  });
+              },
+              async all() {
+                return { results: fakeDb.laneRows };
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+fakeDb.laneRows = [] as Record<string, unknown>[];
+
+const pg = (rows: unknown, fail = false) => ({
+  async unsafe() {
+    if (fail) throw new Error("relation missing");
+    return rows as never;
+  },
+});
+
+const counts = (m: Record<string, number>) =>
+  Object.entries(m).map(([t, n]) => ({ t, n }));
+
+describe("parityCountSql", () => {
+  test("one counted SELECT per table, unioned", () => {
+    const sql = parityCountSql(["a", "b"]);
+    assert.equal(
+      sql,
+      "SELECT 'a' AS t, COUNT(*) AS n FROM a UNION ALL SELECT 'b' AS t, COUNT(*) AS n FROM b",
+    );
+  });
+
+  test("the same statement runs on both stores", () => {
+    // The point of `'x' AS t` over a per-table round trip: identical text on
+    // both sides means a difference cannot come from asking different things.
+    assert.ok(!/\?|\$\d/.test(parityCountSql([...PARITY_TABLES])));
+  });
+});
+
+describe("parityGaps", () => {
+  test("reports differences in BOTH directions", () => {
+    // hotkey_alpha's real shape: Neon holds MORE. A check written as
+    // "is Neon behind D1" would call that table healthy (#9832).
+    const gaps = parityGaps(
+      new Map([["hotkey_alpha", 17867]]),
+      new Map([["hotkey_alpha", 47320]]),
+    );
+    assert.equal(gaps.length, 1);
+    assert.equal(gaps[0]!.delta, -29453);
+  });
+
+  test("ignores a difference below the floor", () => {
+    assert.deepEqual(
+      parityGaps(
+        new Map([["t", 100]]),
+        new Map([["t", 100 - PARITY_MIN_ROWS + 1]]),
+      ),
+      [],
+    );
+  });
+
+  test("catches a difference AT the floor, so 14 is not waved through", () => {
+    const gaps = parityGaps(new Map([["t", 100]]), new Map([["t", 95]]));
+    assert.equal(gaps.length, 1);
+    assert.equal(gaps[0]!.delta, 5);
+  });
+
+  test("a table absent from one store is not a gap", () => {
+    // Before migrations/neon/0001 the three side tables existed only in D1.
+    // Reporting those as a gap of their entire contents would bury the real
+    // ones under noise nobody can act on.
+    assert.deepEqual(parityGaps(new Map([["t", 500]]), new Map()), []);
+  });
+
+  test("orders by magnitude, so the worst reads first", () => {
+    const gaps = parityGaps(
+      new Map([
+        ["small", 100],
+        ["big", 50000],
+      ]),
+      new Map([
+        ["small", 86],
+        ["big", 20000],
+      ]),
+    );
+    assert.deepEqual(
+      gaps.map((g) => g.table),
+      ["big", "small"],
+    );
+  });
+});
+
+describe("persistentGaps", () => {
+  const gap = (table: string, delta: number) => ({
+    table,
+    d1: 0,
+    neon: -delta,
+    delta,
+  });
+
+  test("a gap of the SAME size in the previous tick is structural", () => {
+    assert.deepEqual(
+      persistentGaps([gap("vnc", 14)], "vnc +14").map((g) => g.table),
+      ["vnc"],
+    );
+  });
+
+  test("a gap that MOVED is churn, not a finding", () => {
+    // The distinction the whole lane rests on: a producer pass landing between
+    // the two counts shows a different number every tick.
+    assert.deepEqual(
+      persistentGaps([gap("balances", 125)], "balances +91"),
+      [],
+    );
+  });
+
+  test("a SHRINKING gap does not alarm while a backfill works", () => {
+    assert.deepEqual(persistentGaps([gap("snap", 40000)], "snap +50375"), []);
+  });
+
+  test("negative deltas round-trip through the detail line", () => {
+    // `-29453` has to parse back with its sign, or the table with the most
+    // rows in Neon would look new every hour and never be called persistent.
+    assert.deepEqual(
+      persistentGaps([gap("hotkey_alpha", -29453)], "hotkey_alpha -29453").map(
+        (g) => g.delta,
+      ),
+      [-29453],
+    );
+  });
+
+  test("no previous verdict means nothing is persistent yet", () => {
+    assert.deepEqual(persistentGaps([gap("t", 9)], null), []);
+    assert.deepEqual(persistentGaps([gap("t", 9)], ""), []);
+  });
+});
+
+describe("describeParity", () => {
+  test("names the count when everything agrees", () => {
+    assert.equal(describeParity([], 10), "10 table(s) in parity");
+  });
+
+  test("emits signed deltas that persistentGaps can read back", () => {
+    const detail = describeParity(
+      [
+        { table: "a", d1: 1, neon: 2, delta: -1 },
+        { table: "b", d1: 5, neon: 1, delta: 4 },
+      ],
+      10,
+    );
+    assert.equal(detail, "a -1, b +4");
+    assert.equal(
+      persistentGaps([{ table: "b", d1: 5, neon: 1, delta: 4 }], detail).length,
+      1,
+    );
+  });
+});
+
+describe("runNeonParityWatchdog", () => {
+  test("does nothing without both stores bound", async () => {
+    assert.deepEqual(await runNeonParityWatchdog({}, ctx), {
+      attempted: false,
+    });
+    assert.deepEqual(
+      await runNeonParityWatchdog({}, ctx, { db: fakeDb([]).db }),
+      { attempted: false },
+    );
+  });
+
+  test("reports ok when the stores agree", async () => {
+    fakeDb.laneRows = [];
+    const d1 = fakeDb(counts({ neurons: 30110 }));
+    const out = await runNeonParityWatchdog({}, ctx, {
+      db: d1.db,
+      sql: pg(counts({ neurons: 30110 })),
+      laneHealthDb: d1.db,
+      now: () => NOW,
+    });
+    assert.equal(out.attempted, true);
+    assert.deepEqual(out.gaps, []);
+    assert.equal(d1.written[0]!.verdict, "ok");
+    assert.match(String(d1.written[0]!.detail), /1 table\(s\) in parity/);
+  });
+
+  test("a FIRST sighting is ok, and is recorded so the next tick can judge", async () => {
+    fakeDb.laneRows = [];
+    const d1 = fakeDb(counts({ vnc: 112250 }));
+    const out = await runNeonParityWatchdog({}, ctx, {
+      db: d1.db,
+      sql: pg(counts({ vnc: 112236 })),
+      laneHealthDb: d1.db,
+      now: () => NOW,
+    });
+    assert.equal(out.gaps?.length, 1);
+    assert.deepEqual(out.persistent, []);
+    assert.equal(d1.written[0]!.verdict, "ok", "one sample cannot prove a gap");
+    assert.match(String(d1.written[0]!.detail), /vnc \+14/);
+  });
+
+  test("the SAME gap next tick is stale", async () => {
+    fakeDb.laneRows = [
+      {
+        lane: NEON_PARITY_LANE,
+        verdict: "ok",
+        detail: "vnc +14",
+        checked_at: NOW - 3600_000,
+        age_ms: null,
+      },
+    ];
+    const d1 = fakeDb(counts({ vnc: 112250 }));
+    const out = await runNeonParityWatchdog({}, ctx, {
+      db: d1.db,
+      sql: pg(counts({ vnc: 112236 })),
+      laneHealthDb: d1.db,
+      now: () => NOW,
+    });
+    assert.equal(out.persistent?.length, 1);
+    assert.equal(d1.written[0]!.verdict, "stale");
+  });
+
+  test("a store that will not answer is unknown, never stale", async () => {
+    // Calling an unreadable store a gap would list every table as broken,
+    // which is both wrong and unactionable.
+    fakeDb.laneRows = [];
+    const d1 = fakeDb(counts({ t: 1 }));
+    const out = await runNeonParityWatchdog({}, ctx, {
+      db: d1.db,
+      sql: pg(null, true),
+      laneHealthDb: d1.db,
+      now: () => NOW,
+    });
+    assert.equal(out.reason, "counts unreadable");
+    assert.equal(d1.written[0]!.verdict, "unknown");
+  });
+
+  test("a D1 response with no result at all is unknown too", async () => {
+    fakeDb.laneRows = [];
+    const d1 = fakeDb(null);
+    const out = await runNeonParityWatchdog({}, ctx, {
+      db: d1.db,
+      sql: pg(counts({ t: 1 })),
+      laneHealthDb: d1.db,
+      now: () => NOW,
+    });
+    assert.equal(out.reason, "counts unreadable");
+    assert.equal(d1.written[0]!.verdict, "unknown");
+  });
+
+  test("a non-array answer from Neon yields no counts rather than throwing", async () => {
+    fakeDb.laneRows = [];
+    const d1 = fakeDb(counts({ t: 1 }));
+    const out = await runNeonParityWatchdog({}, ctx, {
+      db: d1.db,
+      sql: pg({ rows: 1 }),
+      laneHealthDb: d1.db,
+      now: () => NOW,
+    });
+    // No Neon count for `t`, so it is "absent from one store", not a gap.
+    assert.deepEqual(out.gaps, []);
+  });
+
+  test("rows missing t or n are skipped, not counted as zero", async () => {
+    fakeDb.laneRows = [];
+    const d1 = fakeDb([
+      { t: null, n: 5 },
+      { t: "x", n: null },
+      { t: "y", n: 100 },
+    ]);
+    const out = await runNeonParityWatchdog({}, ctx, {
+      db: d1.db,
+      sql: pg([{ t: "y", n: 100 }]),
+      laneHealthDb: d1.db,
+      now: () => NOW,
+    });
+    assert.deepEqual(out.gaps, []);
+    assert.match(String(d1.written[0]!.detail), /1 table\(s\)/);
+  });
+});
+
+test("a non-numeric count is skipped rather than read as zero", async () => {
+  // Zero would be the worst possible reading: it makes the OTHER store's
+  // whole contents look like a gap, which is the shape of a mistaken copy.
+  fakeDb.laneRows = [];
+  const d1 = fakeDb([{ t: "y", n: "not-a-number" }]);
+  const out = await runNeonParityWatchdog({}, ctx, {
+    db: d1.db,
+    sql: pg([{ t: "y", n: 100 }]),
+    laneHealthDb: d1.db,
+    now: () => NOW,
+  });
+  assert.deepEqual(out.gaps, []);
+});
+
+test("HYPERDRIVE alone is enough to build the Neon side", async () => {
+  // The runner builds its own createPgSql when `deps.sql` is absent, which
+  // is how it runs in production -- the injected form only exists for tests.
+  fakeDb.laneRows = [];
+  const d1 = fakeDb(counts({ t: 1 }));
+  const out = await runNeonParityWatchdog(
+    {
+      METAGRAPH_HEALTH_DB: d1.db,
+      HYPERDRIVE: { connectionString: "postgres://x" },
+    },
+    ctx,
+    { now: () => NOW },
+  );
+  // It attempted, then failed to reach the fake connection string -- which
+  // is the `unknown` path, not a silent no-op.
+  assert.equal(out.attempted, true);
+  assert.equal(out.reason, "counts unreadable");
+});
+
+test("a D1 response with no `results` key counts nothing", async () => {
+  // `{}` is not `null`: the request succeeded and carried no rows, which is
+  // still "no counts" rather than an error.
+  fakeDb.laneRows = [];
+  const lane = fakeDb([]);
+  const db = {
+    prepare(sql: string) {
+      return {
+        async all() {
+          return /lane_health/i.test(sql) ? { results: [] } : {};
+        },
+        bind: () => ({
+          async run() {},
+          async all() {
+            return { results: [] };
+          },
+        }),
+      };
+    },
+  };
+  const out = await runNeonParityWatchdog({}, ctx, {
+    db: db as never,
+    sql: pg([{ t: "y", n: 1 }]),
+    laneHealthDb: lane.db,
+    now: () => NOW,
+  });
+  assert.deepEqual(out.gaps, []);
+});
+
+test("a non-Error thrown value still reaches the detail line", async () => {
+  fakeDb.laneRows = [];
+  const d1 = fakeDb(counts({ t: 1 }));
+  const out = await runNeonParityWatchdog({}, ctx, {
+    db: d1.db,
+    sql: {
+      async unsafe() {
+        throw "plain string";
+      },
+    },
+    laneHealthDb: d1.db,
+    now: () => NOW,
+  });
+  assert.equal(out.reason, "counts unreadable");
+  assert.match(String(d1.written[0]!.detail), /plain string/);
+});
+
+describe("the deployed wiring", () => {
+  const wrangler = readFileSync("wrangler.data.jsonc", "utf8");
+
+  test("the cron slot is scheduled", () => {
+    assert.ok(
+      wrangler.includes(`"${NEON_PARITY_CRON}"`),
+      `${NEON_PARITY_CRON} is not in the deployed crons, so this lane never runs`,
+    );
+  });
+
+  test("every mirrored or backfilled table is watched", () => {
+    // The gap this lane exists to close: a table written to both stores with
+    // nothing comparing them. Anything named in either flag must be here.
+    const named = (re: RegExp) =>
+      (re.exec(wrangler)?.[1] ?? "")
+        .split(",")
+        .map((s) => s.trim().replace(/-/g, "_"))
+        .filter(Boolean);
+    const watched = new Set<string>(PARITY_TABLES);
+    for (const t of [
+      ...named(/"NEON_DUAL_WRITE_LANES":\s*"([^"]*)"/),
+      ...named(/"NEON_BACKFILL_LANES":\s*"([^"]*)"/),
+    ]) {
+      assert.ok(
+        watched.has(t),
+        `${t} is written to Neon but not in PARITY_TABLES`,
+      );
+    }
+  });
+});

--- a/tests/neon-parity-watchdog.test.ts
+++ b/tests/neon-parity-watchdog.test.ts
@@ -16,6 +16,7 @@ import {
   parityGaps,
   persistentGaps,
   runNeonParityWatchdog,
+  EXPECTED_DIVERGENCE,
 } from "../src/neon-parity-watchdog.ts";
 
 const ctx = { waitUntil() {} };
@@ -169,12 +170,52 @@ describe("persistentGaps", () => {
   test("negative deltas round-trip through the detail line", () => {
     // `-29453` has to parse back with its sign, or the table with the most
     // rows in Neon would look new every hour and never be called persistent.
+    // Deliberately NOT hotkey_alpha: that one is an expected divergence and
+    // would return [] for a different reason, hiding what this asserts.
     assert.deepEqual(
-      persistentGaps([gap("hotkey_alpha", -29453)], "hotkey_alpha -29453").map(
+      persistentGaps([gap("some_table", -29453)], "some_table -29453").map(
         (g) => g.delta,
       ),
       [-29453],
     );
+  });
+
+  test("an EXPECTED divergence never becomes persistent, however stable", () => {
+    // hotkey_alpha diverges by design: D1 filters to referenced pools (#9558),
+    // the mirror does not (#9832). A stable ~29,000-row gap is the correct
+    // state today, and alarming on it hourly would teach everyone to ignore
+    // this lane before it had caught anything real.
+    assert.deepEqual(
+      persistentGaps([gap("hotkey_alpha", -29453)], "hotkey_alpha -29453"),
+      [],
+    );
+    // ...but an ordinary table with the same stable gap still alarms.
+    assert.equal(
+      persistentGaps(
+        [gap("nominator_positions", 13402)],
+        "nominator_positions +13402",
+      ).length,
+      1,
+    );
+  });
+
+  test("every expected divergence names a table and a reason", () => {
+    // An exemption without a reason is indistinguishable from a bug someone
+    // muted, so the reason is the entry's whole justification for existing.
+    for (const [table, why] of Object.entries(EXPECTED_DIVERGENCE)) {
+      assert.ok(
+        PARITY_TABLES.includes(table as (typeof PARITY_TABLES)[number]),
+        `${table} is exempted but not watched`,
+      );
+      assert.match(why, /#\d+/, `${table}'s exemption cites no issue`);
+    }
+  });
+
+  test("an expected divergence is still REPORTED, not silenced", () => {
+    // Naming it keeps the day it changes size visible. Dropping it from the
+    // detail would hide a NEW reason behind a known one.
+    const detail = describeParity([gap("hotkey_alpha", -29453)], 10);
+    assert.match(detail, /hotkey_alpha -29453/);
   });
 
   test("no previous verdict means nothing is persistent yet", () => {

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -383,6 +383,10 @@ import { mirrorLedgerToNeon } from "../src/ledger-neon-write.ts";
 import { neonReadEnabled } from "../src/neon-write.ts";
 import { runNeonBackfill } from "../src/neon-backfill.ts";
 import { runNeonMirrorWatchdog } from "../src/neon-mirror-watchdog.ts";
+import {
+  NEON_PARITY_CRON,
+  runNeonParityWatchdog,
+} from "../src/neon-parity-watchdog.ts";
 import { runTableFreshnessWatchdog } from "../src/table-freshness-watchdog.ts";
 import {
   writeAccountIdentityToD1,
@@ -7730,6 +7734,15 @@ export default {
       // No ctx: this reads D1 only. It never touches Neon -- the whole point is
       // to judge the mirrors from evidence they already left behind.
       return runNeonMirrorWatchdog(env as unknown as Record<string, unknown>);
+    }
+    if (controller?.cron === NEON_PARITY_CRON) {
+      // `ctx` because this one DOES touch Neon: it is the only check that
+      // compares the two stores for tables the reconciler does not own, which
+      // is where all three of 2026-08-07's parity gaps were hiding (#9846).
+      return runNeonParityWatchdog(
+        env as unknown as Record<string, unknown>,
+        ctx,
+      );
     }
     if (controller?.cron === NEON_BACKFILL_CRON) {
       // `ctx` is threaded through rather than ignored: createPgSql needs a

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -410,7 +410,13 @@
   // `controller.cron`, so the handler dispatches on the string rather than on
   // what minute it happens to be.
   "triggers": {
-    "crons": ["* * * * *", "*/3 * * * *", "26 * * * *", "46 * * * *"],
+    "crons": [
+      "* * * * *",
+      "*/3 * * * *",
+      "26 * * * *",
+      "38 * * * *",
+      "46 * * * *",
+    ],
   },
 
   // HYPERDRIVE is gone with the box (2026-08-03): the Postgres it fronted was


### PR DESCRIPTION
Closes #9849.

I found three parity gaps today **by hand**, one table at a time:

| table | D1 | Neon | |
|---|---|---|---|
| `hotkey_alpha` | 17,867 | 47,320 | Neon holds 2.6× more (#9832) |
| `nominator_positions` | 123,522 | 110,120 | short 13,402 (#9832) |
| `validator_nominator_counts` | 112,250 | 112,236 | short 14, stable (#9844) |

**Nothing in the system was looking.** The reconciler compares the two stores only for tables in `NEON_BACKFILL_LANES`. Every other table — including all five the mirror is meant to keep current on its own — had no comparison at all.

*"The mirror lane is green" answers whether writes succeeded, not whether the stores agree.* A cutover depends on the second question.

## Persistent deficit, not any deficit

These tables are written continuously, so a single-tick difference is normal — a pass lands in D1 microseconds before its mirror reaches Neon. Alarming on that makes the check noise, and noise is how a check stops being read (#9825's baseline cried wolf every producer tick until I rewrote it).

So a deficit counts only when it **repeats at the same size**. Churn moves; a structural gap doesn't. `validator_nominator_counts` sat at exactly 14 across checks minutes apart — that is what told it apart from the ±125 `account_balances` shows and resolves on its own.

## Direction recorded, never assumed

D1 is **not** the reference store. `hotkey_alpha` has more rows in Neon because the D1 write is lossy — so a check written as "is Neon behind D1" would have reported the worst-broken table healthy. Both directions surface, and there's a test for the negative-delta round trip.

## Coverage guard

A test asserts every table named in `NEON_DUAL_WRITE_LANES` or `NEON_BACKFILL_LANES` appears in `PARITY_TABLES` — so a table cannot be written to Neon without something comparing it.

## Verification

28 tests. Patch coverage measured by intersecting uncovered lines with the diff: **zero uncovered statements, zero uncovered branches.** `typecheck`, `eslint`, `prettier` clean.