### PR TITLE
docs(migration): 0030 says netuids, not subnets

### DIFF
--- a/migrations/d1/0030_neurons_passes.sql
+++ b/migrations/d1/0030_neurons_passes.sql
@@ -24,7 +24,7 @@
 -- 30 hours old."
 --
 -- MAX(captured_at) CANNOT SUBSTITUTE, and this is the specific trap: it
--- reflects only the netuids that DID land, so a pass covering 21 of 129 subnets
+-- reflects only the netuids that DID land, so a pass covering 21 of 129 netuids
 -- leaves a perfectly fresh-looking stamp behind it. That is the same shape as
 -- the 147,000-row account_balances incident this whole mechanism came from.
 --


### PR DESCRIPTION
The last of the `"129 subnets"` claims I introduced in #9816.

#9843 fixed the one in `workers/data-api.ts` — the file `root-is-not-a-subnet` actually scans. This one is in the `0030` migration header, which repeats the **identical sentence** and is not in that test's file list.

129 is the netuid count. Root is not a subnet, which is the entire point of #8638, so the claim is wrong wherever it appears — and a migration header is read as documentation for as long as the table exists.

**Not a CI failure.** Fixed because it is the same error the test exists to prevent, sitting in a file the test happens not to look at.

## Worth noting for #9846's neighbourhood

`root-is-not-a-subnet` scans a hardcoded list of five files:

```ts
for (const file of [
  "../src/mcp-server.ts",
  "../src/economics-trends.ts",
  "../workers/data-api.ts",
  "../apps/ui/src/lib/metagraphed/agent-prompt.ts",
  "../apps/ui/src/components/metagraphed/agent-live-card.tsx",
]) {
```

That list is why this survived: I wrote the same sentence into two files and only one of them was watched. A repo-wide scan for `/\b129\s+subnets\b/i` — excluding the places where the phrase is legitimately about the count itself — would have caught both at once, and would keep catching them in files nobody thought to add.

Not proposing that change here; flagging it because the narrow list is the reason a second copy shipped.

## Validation

Comment-only, no SQL change. `migrations/d1/0030_neurons_passes.sql` is already applied to production; this touches nothing executable.