### PR TITLE
fix(neon): give nominator_positions a reconciler lane

### DIFF
--- a/src/neon-backfill.ts
+++ b/src/neon-backfill.ts
@@ -243,6 +243,15 @@ const SUBNET_HYPERPARAMS_COLUMNS = [
   "captured_at",
 ] as const;
 
+/** nominator_positions. */
+const NOMINATOR_POSITIONS_COLUMNS = [
+  "coldkey",
+  "hotkey",
+  "netuid",
+  "share_fraction",
+  "captured_at",
+] as const;
+
 /** validator_nominator_counts. */
 const VALIDATOR_NOMINATOR_COUNTS_COLUMNS = [
   "hotkey",
@@ -333,6 +342,24 @@ export const NEON_BACKFILL_PLANS: Readonly<Record<string, BackfillPlan>> = {
   // nominators keeps its D1 row forever (upsert-only, no prune) and never
   // reaches Neon. /validators reads this table, so 14 wrong rows is 14 wrong
   // nominator counts on a leaderboard.
+  // Same shape as validator_nominator_counts below, and the same evidence.
+  // Measured 2026-08-07: D1 123,522 rows, Neon 110,120 -- Neon short 13,402.
+  //
+  // Checked the write path before believing the numbers this time (#9832 was
+  // a lesson): the consumer hands BOTH writers the identical
+  // `{ rows, coldkeyMaxCapturedAt }`, so they share a prune contract, and
+  // chunkStatements applies no filter for this table. There is no asymmetry to
+  // explain the gap, which leaves the ordinary one -- rows written to D1
+  // before the mirror lane existed, for coldkeys the producer no longer emits.
+  // The mirror carries ~485 rows a pass; it will never reach them.
+  nominator_positions: {
+    table: "nominator_positions",
+    columns: NOMINATOR_POSITIONS_COLUMNS,
+    conflict: ["coldkey", "hotkey", "netuid"],
+    keyset: ["coldkey", "hotkey", "netuid"],
+    partition: "whole",
+    booleans: [],
+  },
   validator_nominator_counts: {
     table: "validator_nominator_counts",
     columns: VALIDATOR_NOMINATOR_COUNTS_COLUMNS,

--- a/tests/neon-backfill.test.ts
+++ b/tests/neon-backfill.test.ts
@@ -275,7 +275,10 @@ describe("the deployed wiring", () => {
       //
       // So this is an allowlist with evidence rather than a derived rule,
       // because the derived rule was wrong.
-      const provenStuck = new Set(["validator_nominator_counts"]);
+      const provenStuck = new Set([
+        "validator_nominator_counts",
+        "nominator_positions",
+      ]);
       assert.ok(
         plan.partition === "date" ||
           !mirrored.has(table) ||

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -204,7 +204,7 @@
     // Naming a latest-only table here would copy 800,000 rows to prove they
     // already agree, which is why this is a third flag rather than a reuse of
     // the write list.
-    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts",
+    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,nominator_positions",
     "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",
     // THE QUEUE CUTOVER (metagraphed-infra#348). Comma-separated lanes whose D1


### PR DESCRIPTION
Closes #9852.

```
nominator_positions   D1 123,522   Neon 110,120   short 13,402, stable
```

## I read the write path first this time

#9832 was a lesson in not trusting a row-count difference before checking what each writer is *supposed* to store — I got `hotkey_alpha` backwards twice by skipping that. For this table:

- The consumer hands **both** writers the identical `{ rows, coldkeyMaxCapturedAt: cutoffs }`, so they share a prune contract.
- `chunkStatements` is called with **no filter** — unlike `hotkey_alpha`, whose D1 side filters to referenced pools while its mirror doesn't.

No asymmetry to explain the gap. That leaves the ordinary explanation: rows written to D1 **before the mirror lane existed**, for coldkeys the producer no longer emits. The mirror carries ~485 rows a pass (`neon:nominator-positions ok — 485 row(s) in 1 statement(s)`); it will never reach them.

Same mechanism as #9844's 14 rows, three orders of magnitude larger.

## Why it matters

`nominator_positions` gates `top-holders-holdings`, `subnet-holders`, `chain-holders` and `validator-nominator-positions` — none can move to Neon while the stores disagree by 13,402 rows.

Whole-table plan (#9820's partition) keyed on `(coldkey, hotkey, netuid)`. 74 tests pass; `typecheck` and `eslint` clean.