### PR TITLE
feat(mcp): derive 149 tool schemas from the routes they mirror

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4926,9 +4926,9 @@ export interface components {
         AccountEventsArtifact: {
             event_count: number;
             events: components["schemas"]["AccountEvent"][];
-            limit: number;
+            limit: number | null;
             next_cursor?: string | null;
-            offset: number;
+            offset: number | null;
             schema_version: number;
             ss58: string;
         } & {
@@ -4950,9 +4950,9 @@ export interface components {
                 summary?: string | null;
                 tip_tao?: number | null;
             }[];
-            limit: number;
+            limit: number | null;
             next_cursor?: string | null;
-            offset: number;
+            offset: number | null;
             schema_version: number;
             ss58: string;
         } & {
@@ -4970,9 +4970,9 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
-            limit: number;
+            limit: number | null;
             next_cursor?: string | null;
-            offset: number;
+            offset: number | null;
             schema_version: number;
             ss58: string;
         } & {
@@ -5346,9 +5346,9 @@ export interface components {
             [key: string]: unknown;
         };
         AccountTransfersArtifact: {
-            limit: number;
+            limit: number | null;
             next_cursor?: string | null;
-            offset: number;
+            offset: number | null;
             schema_version: number;
             ss58: string;
             transfer_count: number;
@@ -5773,8 +5773,8 @@ export interface components {
             block_number: number | null;
             event_count: number;
             events: components["schemas"]["AccountEvent"][];
-            limit: number;
-            offset: number;
+            limit: number | null;
+            offset: number | null;
             ref: string | null;
             schema_version: number;
         } & {
@@ -5799,8 +5799,8 @@ export interface components {
                 summary: string | null;
                 tip_tao: number | null;
             }[];
-            limit: number;
-            offset: number;
+            limit: number | null;
+            offset: number | null;
             ref: string | null;
             schema_version: number;
         } & {
@@ -5818,9 +5818,9 @@ export interface components {
                 parent_hash: string | null;
                 spec_version: number | null;
             }[];
-            limit: number;
+            limit: number | null;
             next_cursor: string | null;
-            offset: number;
+            offset: number | null;
             schema_version: number;
         } & {
             [key: string]: unknown;
@@ -7770,9 +7770,9 @@ export interface components {
                 summary: string | null;
                 tip_tao: number | null;
             }[];
-            limit: number;
+            limit: number | null;
             next_cursor: string | null;
-            offset: number;
+            offset: number | null;
             schema_version: number;
         } & {
             [key: string]: unknown;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -13473,9 +13473,16 @@
             "type": "array"
           },
           "limit": {
-            "maximum": 9007199254740991,
-            "minimum": -9007199254740991,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "next_cursor": {
             "anyOf": [
@@ -13488,9 +13495,16 @@
             ]
           },
           "offset": {
-            "maximum": 9007199254740991,
-            "minimum": -9007199254740991,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "schema_version": {
             "maximum": 9007199254740991,
@@ -13655,9 +13669,16 @@
             "type": "array"
           },
           "limit": {
-            "maximum": 9007199254740991,
-            "minimum": -9007199254740991,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "next_cursor": {
             "anyOf": [
@@ -13670,9 +13691,16 @@
             ]
           },
           "offset": {
-            "maximum": 9007199254740991,
-            "minimum": -9007199254740991,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "schema_version": {
             "maximum": 9007199254740991,
@@ -13778,9 +13806,16 @@
             "type": "array"
           },
           "limit": {
-            "maximum": 9007199254740991,
-            "minimum": -9007199254740991,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "next_cursor": {
             "anyOf": [
@@ -13793,9 +13828,16 @@
             ]
           },
           "offset": {
-            "maximum": 9007199254740991,
-            "minimum": -9007199254740991,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "schema_version": {
             "maximum": 9007199254740991,
@@ -16078,9 +16120,16 @@
         "additionalProperties": {},
         "properties": {
           "limit": {
-            "maximum": 9007199254740991,
-            "minimum": -9007199254740991,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "next_cursor": {
             "anyOf": [
@@ -16093,9 +16142,16 @@
             ]
           },
           "offset": {
-            "maximum": 9007199254740991,
-            "minimum": -9007199254740991,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "schema_version": {
             "maximum": 9007199254740991,
@@ -18235,14 +18291,28 @@
             "type": "array"
           },
           "limit": {
-            "maximum": 9007199254740991,
-            "minimum": -9007199254740991,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "offset": {
-            "maximum": 9007199254740991,
-            "minimum": -9007199254740991,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "ref": {
             "anyOf": [
@@ -18451,14 +18521,28 @@
             "type": "array"
           },
           "limit": {
-            "maximum": 9007199254740991,
-            "minimum": -9007199254740991,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "offset": {
-            "maximum": 9007199254740991,
-            "minimum": -9007199254740991,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "ref": {
             "anyOf": [
@@ -18603,9 +18687,16 @@
             "type": "array"
           },
           "limit": {
-            "maximum": 9007199254740991,
-            "minimum": -9007199254740991,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "next_cursor": {
             "anyOf": [
@@ -18618,9 +18709,16 @@
             ]
           },
           "offset": {
-            "maximum": 9007199254740991,
-            "minimum": -9007199254740991,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "schema_version": {
             "maximum": 9007199254740991,
@@ -30322,9 +30420,16 @@
             "type": "array"
           },
           "limit": {
-            "maximum": 9007199254740991,
-            "minimum": -9007199254740991,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "next_cursor": {
             "anyOf": [
@@ -30337,9 +30442,16 @@
             ]
           },
           "offset": {
-            "maximum": 9007199254740991,
-            "minimum": -9007199254740991,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "schema_version": {
             "maximum": 9007199254740991,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4926,9 +4926,9 @@ export interface components {
         AccountEventsArtifact: {
             event_count: number;
             events: components["schemas"]["AccountEvent"][];
-            limit: number;
+            limit: number | null;
             next_cursor?: string | null;
-            offset: number;
+            offset: number | null;
             schema_version: number;
             ss58: string;
         } & {
@@ -4950,9 +4950,9 @@ export interface components {
                 summary?: string | null;
                 tip_tao?: number | null;
             }[];
-            limit: number;
+            limit: number | null;
             next_cursor?: string | null;
-            offset: number;
+            offset: number | null;
             schema_version: number;
             ss58: string;
         } & {
@@ -4970,9 +4970,9 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
-            limit: number;
+            limit: number | null;
             next_cursor?: string | null;
-            offset: number;
+            offset: number | null;
             schema_version: number;
             ss58: string;
         } & {
@@ -5346,9 +5346,9 @@ export interface components {
             [key: string]: unknown;
         };
         AccountTransfersArtifact: {
-            limit: number;
+            limit: number | null;
             next_cursor?: string | null;
-            offset: number;
+            offset: number | null;
             schema_version: number;
             ss58: string;
             transfer_count: number;
@@ -5773,8 +5773,8 @@ export interface components {
             block_number: number | null;
             event_count: number;
             events: components["schemas"]["AccountEvent"][];
-            limit: number;
-            offset: number;
+            limit: number | null;
+            offset: number | null;
             ref: string | null;
             schema_version: number;
         } & {
@@ -5799,8 +5799,8 @@ export interface components {
                 summary: string | null;
                 tip_tao: number | null;
             }[];
-            limit: number;
-            offset: number;
+            limit: number | null;
+            offset: number | null;
             ref: string | null;
             schema_version: number;
         } & {
@@ -5818,9 +5818,9 @@ export interface components {
                 parent_hash: string | null;
                 spec_version: number | null;
             }[];
-            limit: number;
+            limit: number | null;
             next_cursor: string | null;
-            offset: number;
+            offset: number | null;
             schema_version: number;
         } & {
             [key: string]: unknown;
@@ -7770,9 +7770,9 @@ export interface components {
                 summary: string | null;
                 tip_tao: number | null;
             }[];
-            limit: number;
+            limit: number | null;
             next_cursor: string | null;
-            offset: number;
+            offset: number | null;
             schema_version: number;
         } & {
             [key: string]: unknown;

--- a/schemas-src/mcp-tools/account-balance.ts
+++ b/schemas-src/mcp-tools/account-balance.ts
@@ -1,11 +1,19 @@
-// MCP tool `get_account_balance` (types-epic E batch 6, #8069). Mirrors
-// GET /api/v1/accounts/{ss58}/balance, which is not one of
-// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
-// reuse. Modeled fresh, matching the hand-written literal it replaces
-// field-for-field.
+// MCP tool `get_account_balance`.
+// Mirrors GET /api/v1/accounts/{ss58}/balance.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { ss58Schema } from "./shared.ts";
-import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
+import { McpNetworkSchema } from "../shared.ts";
+import { AccountBalanceArtifactSchema } from "../routes/account-balance.ts";
 
 export const GetAccountBalanceInputSchema = z
   .object({
@@ -21,16 +29,7 @@ export type GetAccountBalanceInput = z.infer<
   typeof GetAccountBalanceInputSchema
 >;
 
-export const GetAccountBalanceOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    ss58: z.string(),
-    balance_tao: z.number().nullable(),
-    queried_at: z.string().nullable(),
-    // #9108 provenance, mirroring the REST artifact field for field.
-    field_sources: FieldSourcesSchema,
-  })
-  .passthrough();
+export const GetAccountBalanceOutputSchema = AccountBalanceArtifactSchema;
 export type GetAccountBalanceOutput = z.infer<
   typeof GetAccountBalanceOutputSchema
 >;

--- a/schemas-src/mcp-tools/account-delegation.ts
+++ b/schemas-src/mcp-tools/account-delegation.ts
@@ -1,13 +1,23 @@
-// MCP tools `get_account_children`, `get_account_parents` (types-epic E
-// batch 6, #8069). Each mirrors a GET /api/v1/accounts/{ss58}/{children,
-// parents} route that is not one of schemas-src/routes/'s covered pilot
-// routes -- no existing Zod schema to reuse. Modeled fresh, matching each
-// hand-written literal field-for-field, including its own item-level
-// looseness (neither the hand-written subnets items nor their nested
-// entries items declare a `required` array).
+// MCP tools `get_account_parents`, `get_account_children`.
+// Mirror GET /api/v1/accounts/{ss58}/parents, GET
+// /api/v1/accounts/{ss58}/children.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import { netuidSchema, ss58Schema } from "./shared.ts";
-import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
+import { ss58Schema } from "./shared.ts";
+import { McpNetworkSchema } from "../shared.ts";
+import {
+  AccountChildrenArtifactSchema,
+  AccountParentsArtifactSchema,
+} from "../routes/account-child-delegation.ts";
 
 export const GetAccountChildrenInputSchema = z
   .object({
@@ -23,31 +33,7 @@ export type GetAccountChildrenInput = z.infer<
   typeof GetAccountChildrenInputSchema
 >;
 
-const ChildEntrySchema = z
-  .object({
-    child: z.string().nullable().optional(),
-    proportion: z.string().optional(),
-    proportion_fraction: z.number().optional(),
-  })
-  .strict();
-
-const ChildSubnetSchema = z
-  .object({
-    netuid: netuidSchema().optional(),
-    entries: z.array(ChildEntrySchema).optional(),
-  })
-  .strict();
-
-export const GetAccountChildrenOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    account: z.string(),
-    subnets: z.array(ChildSubnetSchema).nullable().optional(),
-    queried_at: z.string().nullable().optional(),
-    // #9108 provenance, mirroring the REST artifact field for field.
-    field_sources: FieldSourcesSchema,
-  })
-  .passthrough();
+export const GetAccountChildrenOutputSchema = AccountChildrenArtifactSchema;
 export type GetAccountChildrenOutput = z.infer<
   typeof GetAccountChildrenOutputSchema
 >;
@@ -66,31 +52,7 @@ export type GetAccountParentsInput = z.infer<
   typeof GetAccountParentsInputSchema
 >;
 
-const ParentEntrySchema = z
-  .object({
-    parent: z.string().nullable().optional(),
-    proportion: z.string().optional(),
-    proportion_fraction: z.number().optional(),
-  })
-  .strict();
-
-const ParentSubnetSchema = z
-  .object({
-    netuid: netuidSchema().optional(),
-    entries: z.array(ParentEntrySchema).optional(),
-  })
-  .strict();
-
-export const GetAccountParentsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    account: z.string(),
-    subnets: z.array(ParentSubnetSchema).nullable().optional(),
-    queried_at: z.string().nullable().optional(),
-    // #9108 provenance, mirroring the REST artifact field for field.
-    field_sources: FieldSourcesSchema,
-  })
-  .passthrough();
+export const GetAccountParentsOutputSchema = AccountParentsArtifactSchema;
 export type GetAccountParentsOutput = z.infer<
   typeof GetAccountParentsOutputSchema
 >;

--- a/schemas-src/mcp-tools/account-extrinsics.ts
+++ b/schemas-src/mcp-tools/account-extrinsics.ts
@@ -1,12 +1,15 @@
-// MCP tool `get_account_extrinsics` (types-epic E batch 7, #8070). Mirrors
-// GET /api/v1/accounts/{ss58}/extrinsics, which is not one of
-// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
-// reuse. The extrinsics item shape mirrors src/mcp-server.ts's shared
-// EXTRINSIC_ITEM object literal (also used by list_extrinsics/get_extrinsic/
-// get_block_extrinsics, none of which are in this batch) -- modeled fresh
-// here rather than importing a shared schema, since those other tools stay
-// hand-written JSON Schema for now and EXTRINSIC_ITEM itself has no Zod
-// equivalent yet.
+// MCP tool `get_account_extrinsics`.
+// Mirrors GET /api/v1/accounts/{ss58}/extrinsics.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
   blockBoundSchema,
@@ -15,6 +18,7 @@ import {
   offsetSchema,
   ss58Schema,
 } from "./shared.ts";
+import { AccountExtrinsicsArtifactSchema } from "../routes/account-extrinsics.ts";
 
 export const GetAccountExtrinsicsInputSchema = z
   .object({
@@ -32,37 +36,7 @@ export type GetAccountExtrinsicsInput = z.infer<
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
-const ExtrinsicItemSchema = z
-  .object({
-    block_number: z.int().nullable().optional(),
-    extrinsic_index: z.int().nullable().optional(),
-    extrinsic_hash: z.string().nullable().optional(),
-    signer: z.string().nullable().optional(),
-    call_module: z.string().nullable().optional(),
-    call_function: z.string().nullable().optional(),
-    call_args: z.unknown().optional(),
-    success: z.boolean().nullable().optional(),
-    fee_tao: z.unknown().optional(),
-    tip_tao: z.unknown().optional(),
-    observed_at: z.string().nullable().optional(),
-    // #8525: deterministic human-readable action sentence for this
-    // extrinsic's call, or null when no template matches
-    // call_module.call_function -- never a guessed/partial sentence.
-    summary: z.string().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetAccountExtrinsicsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    ss58: z.string(),
-    extrinsic_count: z.int(),
-    limit: z.int().nullable().optional(),
-    offset: z.int().nullable().optional(),
-    next_cursor: z.string().nullable().optional(),
-    extrinsics: z.array(ExtrinsicItemSchema),
-  })
-  .passthrough();
+export const GetAccountExtrinsicsOutputSchema = AccountExtrinsicsArtifactSchema;
 export type GetAccountExtrinsicsOutput = z.infer<
   typeof GetAccountExtrinsicsOutputSchema
 >;

--- a/schemas-src/mcp-tools/account-footprints.ts
+++ b/schemas-src/mcp-tools/account-footprints.ts
@@ -1,19 +1,36 @@
-// MCP tools `get_account_stake_moves`, `get_account_axon_removals`,
-// `get_account_prometheus`, `get_account_registrations`,
-// `get_account_weight_setters`, `get_account_serving`,
-// `get_account_deregistrations` (types-epic E batch 7, #8070). Each mirrors
-// a GET /api/v1/accounts/{ss58}/* footprint route that is not one of
-// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
-// reuse. All seven share one shape (address/window/total_X/subnet_count/
-// concentration/dominant_netuid/subnets), but with genuinely different
-// per-tool field names (movements vs removals vs announcements, etc.), so
-// each is modeled explicitly rather than through a shared factory. Unlike
-// the objectItems()-built item shapes elsewhere in this epic, these
-// `subnets` items are hand-written as STRICT objects (additionalProperties:
-// false) with every field in their own `required` array -- modeled here
-// with the SAME strictness, not the usual item-level looseness.
+// MCP tools `get_account_axon_removals`, `get_account_prometheus`,
+// `get_account_weight_setters`, `get_account_deregistrations`,
+// `get_account_stake_moves`, `get_account_registrations`,
+// `get_account_serving`.
+// Mirror GET /api/v1/accounts/{ss58}/axon-removals, GET
+// /api/v1/accounts/{ss58}/prometheus, GET
+// /api/v1/accounts/{ss58}/weight-setters, GET
+// /api/v1/accounts/{ss58}/deregistrations, GET
+// /api/v1/accounts/{ss58}/stake-moves, GET
+// /api/v1/accounts/{ss58}/registrations, GET /api/v1/accounts/{ss58}/serving.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import { netuidSchema, ss58Schema, windowSchema } from "./shared.ts";
+import { ss58Schema, windowSchema } from "./shared.ts";
+import {
+  AccountAxonRemovalsArtifactSchema,
+  AccountDeregistrationsArtifactSchema,
+  AccountRegistrationsArtifactSchema,
+  AccountWeightSettersArtifactSchema,
+} from "../routes/account-activity-registrations.ts";
+import {
+  AccountPrometheusArtifactSchema,
+  AccountServingArtifactSchema,
+  AccountStakeMovesArtifactSchema,
+} from "../routes/account-activity.ts";
 
 // Symbolic in each hand-written original (src/account-*.ts's own
 // *_WINDOWS/DEFAULT_*_WINDOW constants), cross-checked against the actual
@@ -32,28 +49,7 @@ export type GetAccountStakeMovesInput = z.infer<
   typeof GetAccountStakeMovesInputSchema
 >;
 
-const StakeMovesSubnetSchema = z
-  .object({
-    netuid: netuidSchema(),
-    movements: z.int(),
-    first_moved_at: z.string().nullable(),
-    last_moved_at: z.string().nullable(),
-    price_tao_at_last_move: z.number().nullable(),
-  })
-  .strict();
-
-export const GetAccountStakeMovesOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    address: z.string(),
-    window: z.string().nullable(),
-    total_movements: z.int(),
-    subnet_count: z.int(),
-    concentration: z.number().nullable().optional(),
-    dominant_netuid: z.int().nullable().optional(),
-    subnets: z.array(StakeMovesSubnetSchema),
-  })
-  .passthrough();
+export const GetAccountStakeMovesOutputSchema = AccountStakeMovesArtifactSchema;
 export type GetAccountStakeMovesOutput = z.infer<
   typeof GetAccountStakeMovesOutputSchema
 >;
@@ -68,27 +64,8 @@ export type GetAccountAxonRemovalsInput = z.infer<
   typeof GetAccountAxonRemovalsInputSchema
 >;
 
-const AxonRemovalsSubnetSchema = z
-  .object({
-    netuid: netuidSchema(),
-    removals: z.int(),
-    first_removed_at: z.string().nullable(),
-    last_removed_at: z.string().nullable(),
-  })
-  .strict();
-
-export const GetAccountAxonRemovalsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    address: z.string(),
-    window: z.string().nullable(),
-    total_removals: z.int(),
-    subnet_count: z.int(),
-    concentration: z.number().nullable().optional(),
-    dominant_netuid: z.int().nullable().optional(),
-    subnets: z.array(AxonRemovalsSubnetSchema),
-  })
-  .passthrough();
+export const GetAccountAxonRemovalsOutputSchema =
+  AccountAxonRemovalsArtifactSchema;
 export type GetAccountAxonRemovalsOutput = z.infer<
   typeof GetAccountAxonRemovalsOutputSchema
 >;
@@ -103,27 +80,7 @@ export type GetAccountPrometheusInput = z.infer<
   typeof GetAccountPrometheusInputSchema
 >;
 
-const PrometheusSubnetSchema = z
-  .object({
-    netuid: netuidSchema(),
-    announcements: z.int(),
-    first_announced_at: z.string().nullable(),
-    last_announced_at: z.string().nullable(),
-  })
-  .strict();
-
-export const GetAccountPrometheusOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    address: z.string(),
-    window: z.string().nullable(),
-    total_announcements: z.int(),
-    subnet_count: z.int(),
-    concentration: z.number().nullable().optional(),
-    dominant_netuid: z.int().nullable().optional(),
-    subnets: z.array(PrometheusSubnetSchema),
-  })
-  .passthrough();
+export const GetAccountPrometheusOutputSchema = AccountPrometheusArtifactSchema;
 export type GetAccountPrometheusOutput = z.infer<
   typeof GetAccountPrometheusOutputSchema
 >;
@@ -138,27 +95,8 @@ export type GetAccountRegistrationsInput = z.infer<
   typeof GetAccountRegistrationsInputSchema
 >;
 
-const RegistrationsSubnetSchema = z
-  .object({
-    netuid: netuidSchema(),
-    registrations: z.int(),
-    first_registered_at: z.string().nullable(),
-    last_registered_at: z.string().nullable(),
-  })
-  .strict();
-
-export const GetAccountRegistrationsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    address: z.string(),
-    window: z.string().nullable(),
-    total_registrations: z.int(),
-    subnet_count: z.int(),
-    concentration: z.number().nullable().optional(),
-    dominant_netuid: z.int().nullable().optional(),
-    subnets: z.array(RegistrationsSubnetSchema),
-  })
-  .passthrough();
+export const GetAccountRegistrationsOutputSchema =
+  AccountRegistrationsArtifactSchema;
 export type GetAccountRegistrationsOutput = z.infer<
   typeof GetAccountRegistrationsOutputSchema
 >;
@@ -173,27 +111,8 @@ export type GetAccountWeightSettersInput = z.infer<
   typeof GetAccountWeightSettersInputSchema
 >;
 
-const WeightSettersSubnetSchema = z
-  .object({
-    netuid: netuidSchema(),
-    weight_sets: z.int(),
-    first_set_at: z.string().nullable(),
-    last_set_at: z.string().nullable(),
-  })
-  .strict();
-
-export const GetAccountWeightSettersOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    address: z.string(),
-    window: z.string().nullable(),
-    total_weight_sets: z.int(),
-    subnet_count: z.int(),
-    concentration: z.number().nullable().optional(),
-    dominant_netuid: z.int().nullable().optional(),
-    subnets: z.array(WeightSettersSubnetSchema),
-  })
-  .passthrough();
+export const GetAccountWeightSettersOutputSchema =
+  AccountWeightSettersArtifactSchema;
 export type GetAccountWeightSettersOutput = z.infer<
   typeof GetAccountWeightSettersOutputSchema
 >;
@@ -208,27 +127,7 @@ export type GetAccountServingInput = z.infer<
   typeof GetAccountServingInputSchema
 >;
 
-const ServingSubnetSchema = z
-  .object({
-    netuid: netuidSchema(),
-    announcements: z.int(),
-    first_served_at: z.string().nullable(),
-    last_served_at: z.string().nullable(),
-  })
-  .strict();
-
-export const GetAccountServingOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    address: z.string(),
-    window: z.string().nullable(),
-    total_announcements: z.int(),
-    subnet_count: z.int(),
-    concentration: z.number().nullable().optional(),
-    dominant_netuid: z.int().nullable().optional(),
-    subnets: z.array(ServingSubnetSchema),
-  })
-  .passthrough();
+export const GetAccountServingOutputSchema = AccountServingArtifactSchema;
 export type GetAccountServingOutput = z.infer<
   typeof GetAccountServingOutputSchema
 >;
@@ -243,27 +142,8 @@ export type GetAccountDeregistrationsInput = z.infer<
   typeof GetAccountDeregistrationsInputSchema
 >;
 
-const DeregistrationsSubnetSchema = z
-  .object({
-    netuid: netuidSchema(),
-    deregistrations: z.int(),
-    first_deregistered_at: z.string().nullable(),
-    last_deregistered_at: z.string().nullable(),
-  })
-  .strict();
-
-export const GetAccountDeregistrationsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    address: z.string(),
-    window: z.string().nullable(),
-    total_deregistrations: z.int(),
-    subnet_count: z.int(),
-    concentration: z.number().nullable().optional(),
-    dominant_netuid: z.int().nullable().optional(),
-    subnets: z.array(DeregistrationsSubnetSchema),
-  })
-  .passthrough();
+export const GetAccountDeregistrationsOutputSchema =
+  AccountDeregistrationsArtifactSchema;
 export type GetAccountDeregistrationsOutput = z.infer<
   typeof GetAccountDeregistrationsOutputSchema
 >;

--- a/schemas-src/mcp-tools/account-identity.ts
+++ b/schemas-src/mcp-tools/account-identity.ts
@@ -1,8 +1,16 @@
-// MCP tools `get_account_identity`, `get_account_identity_history`
-// (types-epic E batch 6, #8069). Each mirrors a GET /api/v1/accounts/{ss58}/
-// identity* route that is not one of schemas-src/routes/'s covered pilot
-// routes -- no existing Zod schema to reuse. Modeled fresh, matching each
-// hand-written literal field-for-field.
+// MCP tools `get_account_identity`, `get_account_identity_history`.
+// Mirror GET /api/v1/accounts/{ss58}/identity, GET
+// /api/v1/accounts/{ss58}/identity-history.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
   keysetCursorSchema,
@@ -10,6 +18,10 @@ import {
   offsetSchema,
   ss58Schema,
 } from "./shared.ts";
+import {
+  AccountIdentityArtifactSchema,
+  AccountIdentityHistoryArtifactSchema,
+} from "../routes/account-identity.ts";
 
 export const GetAccountIdentityInputSchema = z
   .object({
@@ -20,21 +32,7 @@ export type GetAccountIdentityInput = z.infer<
   typeof GetAccountIdentityInputSchema
 >;
 
-export const GetAccountIdentityOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    account: z.string(),
-    has_identity: z.boolean(),
-    name: z.string().nullable().optional(),
-    url: z.string().nullable().optional(),
-    github: z.string().nullable().optional(),
-    image: z.string().nullable().optional(),
-    discord: z.string().nullable().optional(),
-    description: z.string().nullable().optional(),
-    additional: z.string().nullable().optional(),
-    captured_at: z.string().nullable().optional(),
-  })
-  .passthrough();
+export const GetAccountIdentityOutputSchema = AccountIdentityArtifactSchema;
 export type GetAccountIdentityOutput = z.infer<
   typeof GetAccountIdentityOutputSchema
 >;
@@ -60,31 +58,8 @@ export type GetAccountIdentityHistoryInput = z.infer<
 // ?? null`, so the key itself is always present even though the hand-
 // written original never required it. Modeled here as nullable (still
 // required), matching real behavior.
-const AccountIdentityHistoryEntrySchema = z
-  .object({
-    observed_at: z.string().nullable().optional(),
-    name: z.string().nullable().optional(),
-    url: z.string().nullable().optional(),
-    github: z.string().nullable().optional(),
-    image: z.string().nullable().optional(),
-    discord: z.string().nullable().optional(),
-    description: z.string().nullable().optional(),
-    additional: z.string().nullable().optional(),
-    identity_hash: z.string().nullable(),
-  })
-  .passthrough();
-
-export const GetAccountIdentityHistoryOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    account: z.string(),
-    entry_count: z.int(),
-    limit: z.int().nullable().optional(),
-    offset: z.int().nullable().optional(),
-    next_cursor: z.string().nullable().optional(),
-    entries: z.array(AccountIdentityHistoryEntrySchema),
-  })
-  .passthrough();
+export const GetAccountIdentityHistoryOutputSchema =
+  AccountIdentityHistoryArtifactSchema;
 export type GetAccountIdentityHistoryOutput = z.infer<
   typeof GetAccountIdentityHistoryOutputSchema
 >;

--- a/schemas-src/mcp-tools/account-portfolio.ts
+++ b/schemas-src/mcp-tools/account-portfolio.ts
@@ -1,7 +1,8 @@
 // MCP tools `get_account_portfolio`, `get_account_positions`,
 // `get_account_snapshot` (types-epic E batch 6, #8069). The first two mirror a
 // GET /api/v1/accounts/{ss58}/{portfolio,positions} route; get_account_snapshot
-// has no REST equivalent -- it fans out to five other tools' own live loaders in
+// has no REST equivalent -- it fans out to five other tools' own live loaders
+// in
 // one call.
 //
 // This file's header used to claim none of these routes were "covered by

--- a/schemas-src/mcp-tools/account-position-history.ts
+++ b/schemas-src/mcp-tools/account-position-history.ts
@@ -1,15 +1,21 @@
-// MCP tool `get_account_position_history` (types-epic E batch 6, #8069).
-// Mirrors GET /api/v1/accounts/{ss58}/subnets/{netuid}/history, which is
-// not one of schemas-src/routes/'s covered pilot routes -- no existing Zod
-// schema to reuse. Modeled fresh, matching the hand-written literal it
-// replaces field-for-field.
+// MCP tool `get_account_position_history`.
+// Mirrors GET /api/v1/accounts/{ss58}/subnets/{netuid}/history.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_account_position_history: 1 bare `{"type":"object"}` site.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import {
-  OpenObjectArraySchema,
-  netuidSchema,
-  ss58Schema,
-  windowSchema,
-} from "./shared.ts";
+import { netuidSchema, ss58Schema, windowSchema } from "./shared.ts";
+import { AccountPositionHistoryArtifactSchema } from "../routes/account-positions.ts";
 
 export const GetAccountPositionHistoryInputSchema = z
   .object({
@@ -22,16 +28,8 @@ export type GetAccountPositionHistoryInput = z.infer<
   typeof GetAccountPositionHistoryInputSchema
 >;
 
-export const GetAccountPositionHistoryOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    ss58: z.string(),
-    netuid: netuidSchema(),
-    window: z.string().nullable().optional(),
-    point_count: z.int(),
-    points: OpenObjectArraySchema,
-  })
-  .passthrough();
+export const GetAccountPositionHistoryOutputSchema =
+  AccountPositionHistoryArtifactSchema;
 export type GetAccountPositionHistoryOutput = z.infer<
   typeof GetAccountPositionHistoryOutputSchema
 >;

--- a/schemas-src/mcp-tools/account-root-claim.ts
+++ b/schemas-src/mcp-tools/account-root-claim.ts
@@ -1,11 +1,19 @@
-// MCP tool `get_account_root_claim` (types-epic E batch 6, #8069). Mirrors
-// GET /api/v1/accounts/{ss58}/root-claim, which is not one of
-// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
-// reuse. Modeled fresh, matching the hand-written literal it replaces
-// field-for-field.
+// MCP tool `get_account_root_claim`.
+// Mirrors GET /api/v1/accounts/{ss58}/root-claim.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import { netuidSchema, ss58Schema } from "./shared.ts";
-import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
+import { ss58Schema } from "./shared.ts";
+import { McpNetworkSchema } from "../shared.ts";
+import { AccountRootClaimArtifactSchema } from "../routes/account-root-claim.ts";
 
 export const GetAccountRootClaimInputSchema = z
   .object({
@@ -21,40 +29,7 @@ export type GetAccountRootClaimInput = z.infer<
   typeof GetAccountRootClaimInputSchema
 >;
 
-const RootClaimTypeSchema = z
-  .object({
-    kind: z.string(),
-    subnets: z.array(z.int()).optional(),
-  })
-  .strict();
-
-const RootClaimEntrySchema = z
-  .object({
-    netuid: netuidSchema(),
-    claimable_rate: z.number(),
-    claimed: z.string(),
-    threshold: z.number(),
-  })
-  .strict();
-
-const RootClaimHotkeySchema = z
-  .object({
-    hotkey: z.string(),
-    entries: z.array(RootClaimEntrySchema),
-  })
-  .strict();
-
-export const GetAccountRootClaimOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    ss58: z.string(),
-    claim_type: RootClaimTypeSchema.nullable().optional(),
-    hotkeys: z.array(RootClaimHotkeySchema).nullable().optional(),
-    queried_at: z.string().nullable(),
-    // #9108 provenance, mirroring the REST artifact field for field.
-    field_sources: FieldSourcesSchema,
-  })
-  .passthrough();
+export const GetAccountRootClaimOutputSchema = AccountRootClaimArtifactSchema;
 export type GetAccountRootClaimOutput = z.infer<
   typeof GetAccountRootClaimOutputSchema
 >;

--- a/schemas-src/mcp-tools/account-stake-flow.ts
+++ b/schemas-src/mcp-tools/account-stake-flow.ts
@@ -1,20 +1,18 @@
-// MCP tool `get_account_stake_flow` (types-epic E batch 6, #8069). Mirrors
-// GET /api/v1/accounts/{ss58}/stake-flow, backed by the SAME
-// src/stake-flow.ts STAKE_FLOW_WINDOWS/STAKE_FLOW_DIRECTIONS constants the
-// REST subnet-scoped stake-flow route (schemas-src/routes/
-// subnet-stake-flow.ts, types-epic B batch 2 #8056) uses -- NOT reused as a
-// schema import: that's a per-SUBNET artifact shape (SubnetStakeFlowArtifact,
-// strict/flat), while this tool is per-ACCOUNT with a materially different
-// shape (address-keyed, additionalProperties:true, a nested per-subnet
-// breakdown array) -- the two were never the same contract. Modeled fresh,
-// matching the hand-written literal it replaces field-for-field.
+// MCP tool `get_account_stake_flow`.
+// Mirrors GET /api/v1/accounts/{ss58}/stake-flow.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import {
-  kindSchema,
-  netuidSchema,
-  ss58Schema,
-  windowSchema,
-} from "./shared.ts";
+import { kindSchema, ss58Schema, windowSchema } from "./shared.ts";
+import { AccountStakeFlowArtifactSchema } from "../routes/account-activity.ts";
 
 // Symbolic in the hand-written original (src/stake-flow.ts's
 // STAKE_FLOW_WINDOWS/STAKE_FLOW_DIRECTIONS), cross-checked against the
@@ -35,39 +33,7 @@ export type GetAccountStakeFlowInput = z.infer<
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
-const AccountStakeFlowSubnetSchema = z
-  .object({
-    netuid: netuidSchema().optional(),
-    staked_tao: z.unknown().optional(),
-    unstaked_tao: z.unknown().optional(),
-    net_flow_tao: z.unknown().optional(),
-    gross_flow_tao: z.unknown().optional(),
-    flow_ratio: z.number().nullable().optional(),
-    direction: z.string().nullable().optional(),
-    stake_events: z.int().optional(),
-    unstake_events: z.int().optional(),
-  })
-  .passthrough();
-
-export const GetAccountStakeFlowOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    address: z.string(),
-    window: z.string().nullable(),
-    total_staked_tao: z.unknown(),
-    total_unstaked_tao: z.unknown(),
-    net_flow_tao: z.unknown(),
-    gross_flow_tao: z.unknown(),
-    flow_ratio: z.number().nullable().optional(),
-    direction: z.string().nullable(),
-    stake_events: z.int(),
-    unstake_events: z.int(),
-    subnet_count: z.int(),
-    concentration: z.number().nullable().optional(),
-    dominant_netuid: z.int().nullable().optional(),
-    subnets: z.array(AccountStakeFlowSubnetSchema),
-  })
-  .passthrough();
+export const GetAccountStakeFlowOutputSchema = AccountStakeFlowArtifactSchema;
 export type GetAccountStakeFlowOutput = z.infer<
   typeof GetAccountStakeFlowOutputSchema
 >;

--- a/schemas-src/mcp-tools/account-summary.ts
+++ b/schemas-src/mcp-tools/account-summary.ts
@@ -1,12 +1,16 @@
-// MCP tools `get_account`, `get_account_entities`, `get_account_events`,
-// `get_account_subnets` (types-epic E batch 6, #8069). Each mirrors a
-// GET /api/v1/accounts/{ss58}* route that is not one of schemas-src/routes/'s
-// covered pilot routes -- no existing Zod schema to reuse. AccountEventItem/
-// AccountRegistrationItem are deliberately NOT the same as any REST
-// schemas-src/routes/ AccountEvent-style schema (none exist yet for this
-// domain): modeled fresh, matching each hand-written literal (and the
-// shared ACCOUNT_EVENT_ITEM/ACCOUNT_REGISTRATION_ITEM object literals
-// src/mcp-server.ts's objectItems() wraps) field-for-field.
+// MCP tools `get_account_entities`, `get_account_events`.
+// Mirror GET /api/v1/accounts/{ss58}/entities, GET
+// /api/v1/accounts/{ss58}/events.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
   OpenObjectSchema,
@@ -18,6 +22,8 @@ import {
   offsetSchema,
   ss58Schema,
 } from "./shared.ts";
+import { AccountEntitiesArtifactSchema } from "../routes/account-entities.ts";
+import { AccountEventsArtifactSchema } from "../routes/account-events-feed.ts";
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
@@ -98,24 +104,7 @@ export type GetAccountEntitiesInput = z.infer<
   typeof GetAccountEntitiesInputSchema
 >;
 
-export const GetAccountEntitiesOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    ss58: z.string(),
-    labels: z.array(AccountLabelItemSchema),
-    ownership_tie_count: z.int(),
-    ownership_ties: z.array(
-      z
-        .object({
-          netuid: netuidSchema().nullable().optional(),
-          role: z.string().optional(),
-          block_number: z.int().nullable().optional(),
-          observed_at: z.string().nullable().optional(),
-        })
-        .passthrough(),
-    ),
-  })
-  .passthrough();
+export const GetAccountEntitiesOutputSchema = AccountEntitiesArtifactSchema;
 export type GetAccountEntitiesOutput = z.infer<
   typeof GetAccountEntitiesOutputSchema
 >;
@@ -134,17 +123,7 @@ export const GetAccountEventsInputSchema = z
   .strict();
 export type GetAccountEventsInput = z.infer<typeof GetAccountEventsInputSchema>;
 
-export const GetAccountEventsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    ss58: z.string(),
-    event_count: z.int(),
-    limit: z.int().nullable().optional(),
-    offset: z.int().nullable().optional(),
-    next_cursor: z.string().nullable().optional(),
-    events: z.array(AccountEventItemSchema),
-  })
-  .passthrough();
+export const GetAccountEventsOutputSchema = AccountEventsArtifactSchema;
 export type GetAccountEventsOutput = z.infer<
   typeof GetAccountEventsOutputSchema
 >;

--- a/schemas-src/mcp-tools/account-transfers.ts
+++ b/schemas-src/mcp-tools/account-transfers.ts
@@ -1,8 +1,15 @@
-// MCP tools `get_account_transfers`, `get_account_counterparties`
-// (types-epic E batch 7, #8070). Each mirrors a GET /api/v1/accounts/{ss58}/
-// {transfers,counterparties} route that is not one of schemas-src/routes/'s
-// covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
-// matching each hand-written literal field-for-field.
+// MCP tool `get_account_transfers`.
+// Mirrors GET /api/v1/accounts/{ss58}/transfers.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
   OpenObjectSchema,
@@ -12,6 +19,7 @@ import {
   offsetSchema,
   ss58Schema,
 } from "./shared.ts";
+import { AccountTransfersArtifactSchema } from "../routes/account-events-feed.ts";
 
 const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 
@@ -38,29 +46,7 @@ export type GetAccountTransfersInput = z.infer<
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
-const AccountTransferItemSchema = z
-  .object({
-    block_number: z.int().nullable().optional(),
-    event_index: z.int().nullable().optional(),
-    from: z.string().nullable().optional(),
-    to: z.string().nullable().optional(),
-    amount_tao: z.unknown().optional(),
-    direction: z.string().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetAccountTransfersOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    ss58: z.string(),
-    transfer_count: z.int(),
-    limit: z.int().nullable().optional(),
-    offset: z.int().nullable().optional(),
-    next_cursor: z.string().nullable().optional(),
-    transfers: z.array(AccountTransferItemSchema),
-  })
-  .passthrough();
+export const GetAccountTransfersOutputSchema = AccountTransfersArtifactSchema;
 export type GetAccountTransfersOutput = z.infer<
   typeof GetAccountTransfersOutputSchema
 >;

--- a/schemas-src/mcp-tools/accounts-leaderboards.ts
+++ b/schemas-src/mcp-tools/accounts-leaderboards.ts
@@ -1,10 +1,19 @@
-// MCP tools `list_accounts`, `get_top_holders` (types-epic E batch 7,
-// #8070). Each mirrors a GET /api/v1/accounts* leaderboard route that is
-// not one of schemas-src/routes/'s covered pilot routes -- no existing Zod
-// schema to reuse. Modeled fresh, matching each hand-written literal
-// field-for-field.
+// MCP tools `list_accounts`, `get_top_holders`.
+// Mirror GET /api/v1/accounts, GET /api/v1/accounts/top-holders.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import { OpenObjectArraySchema, limitSchema, sortSchema } from "./shared.ts";
+import { limitSchema, sortSchema } from "./shared.ts";
+import { AccountsListArtifactSchema } from "../routes/accounts-list.ts";
+import { TopHoldersArtifactSchema } from "../routes/top-holders.ts";
 
 // Symbolic in the hand-written originals (src/accounts-list.ts's
 // ACCOUNTS_LIST_SORTS/*_LIMIT_*, src/top-holders.ts's TOP_HOLDERS_SORTS/
@@ -38,34 +47,7 @@ export type ListAccountsInput = z.infer<typeof ListAccountsInputSchema>;
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
-const AccountsListItemSchema = z
-  .object({
-    hotkey: z.string().optional(),
-    coldkey: z.string().nullable().optional(),
-    coldkey_count: z.int().optional(),
-    subnet_count: z.int().optional(),
-    uid_count: z.int().optional(),
-    validator_count: z.int().optional(),
-    miner_count: z.int().optional(),
-    total_stake_tao: z.unknown().optional(),
-    total_emission_tao: z.unknown().optional(),
-    latest_captured_at: z.string().nullable().optional(),
-    latest_block_number: z.int().nullable().optional(),
-    subnets: OpenObjectArraySchema.optional(),
-  })
-  .passthrough();
-
-export const ListAccountsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    sort: z.enum(ACCOUNTS_LIST_SORTS),
-    limit: z.int(),
-    captured_at: z.string().nullable().optional(),
-    block_number: z.int().nullable().optional(),
-    account_count: z.int(),
-    accounts: z.array(AccountsListItemSchema),
-  })
-  .passthrough();
+export const ListAccountsOutputSchema = AccountsListArtifactSchema;
 export type ListAccountsOutput = z.infer<typeof ListAccountsOutputSchema>;
 
 export const GetTopHoldersInputSchema = z
@@ -77,40 +59,5 @@ export const GetTopHoldersInputSchema = z
 export type GetTopHoldersInput = z.infer<typeof GetTopHoldersInputSchema>;
 
 // objectItems(...) properties, none required at the item level.
-const TopHolderItemSchema = z
-  .object({
-    ss58: z.string().optional(),
-    free_tao: z
-      .unknown()
-      .optional()
-      .describe("Genuine free TAO from the System::Account chain-state scan."),
-    delegated_tao: z
-      .unknown()
-      .optional()
-      .describe(
-        "This account's delegated stake, valued in TAO. TAO-converted: each delegated position is multiplied by its own subnet's alpha_price_tao, taken from the latest daily subnet_snapshots row for that netuid, so cross-subnet alpha is never summed as if it were TAO (#8803). That table has a DAILY cadence, so the price can lag up to ~24h behind the live economics tier. A netuid whose latest snapshot carries no usable price is excluded from the sum rather than counted as zero.",
-      ),
-    total_tao: z
-      .unknown()
-      .optional()
-      .describe(
-        "free_tao + delegated_tao. Both addends are TAO, so the sum is a real TAO quantity; it inherits delegated_tao's ~24h price staleness. Default sort.",
-      ),
-    net_flow_7d: z.unknown().optional(),
-    net_flow_30d: z.unknown().optional(),
-    net_flow_90d: z.unknown().optional(),
-    last_updated: z.string().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetTopHoldersOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    sort: z.enum(TOP_HOLDERS_SORTS),
-    limit: z.int(),
-    captured_at: z.string().nullable().optional(),
-    account_count: z.int(),
-    accounts: z.array(TopHolderItemSchema),
-  })
-  .passthrough();
+export const GetTopHoldersOutputSchema = TopHoldersArtifactSchema;
 export type GetTopHoldersOutput = z.infer<typeof GetTopHoldersOutputSchema>;

--- a/schemas-src/mcp-tools/blocks.ts
+++ b/schemas-src/mcp-tools/blocks.ts
@@ -1,18 +1,27 @@
-// MCP tools `list_blocks`, `get_block`, `list_block_extrinsics`,
-// `get_block_events` (types-epic E batch 8, #8071). Each mirrors a
-// GET /api/v1/blocks* route that is not one of schemas-src/routes/'s covered
-// pilot routes -- no existing Zod schema to reuse. Modeled fresh, matching
-// each hand-written literal field-for-field.
+// MCP tools `list_block_extrinsics`, `list_blocks`, `get_block_events`.
+// Mirror GET /api/v1/blocks/{ref}/extrinsics, GET /api/v1/blocks, GET
+// /api/v1/blocks/{ref}/events.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
-  AccountEventItemSchema,
-  ExtrinsicItemSchema,
   OpenObjectSchema,
   blockBoundSchema,
   keysetCursorSchema,
   limitSchema,
   offsetSchema,
 } from "./shared.ts";
+import { BlockEventsArtifactSchema } from "../routes/block-events.ts";
+import { BlockExtrinsicsArtifactSchema } from "../routes/block-extrinsics.ts";
+import { BlocksFeedArtifactSchema } from "../routes/blocks.ts";
 
 const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 
@@ -74,29 +83,7 @@ export type ListBlocksInput = z.infer<typeof ListBlocksInputSchema>;
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
-const BlockItemSchema = z
-  .object({
-    block_number: z.int().nullable().optional(),
-    block_hash: z.string().nullable().optional(),
-    parent_hash: z.string().nullable().optional(),
-    author: z.string().nullable().optional(),
-    extrinsic_count: z.int().nullable().optional(),
-    event_count: z.int().nullable().optional(),
-    spec_version: z.int().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-  })
-  .passthrough();
-
-export const ListBlocksOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    block_count: z.int(),
-    limit: z.int().nullable().optional(),
-    offset: z.int().nullable().optional(),
-    next_cursor: z.string().nullable().optional(),
-    blocks: z.array(BlockItemSchema),
-  })
-  .passthrough();
+export const ListBlocksOutputSchema = BlocksFeedArtifactSchema;
 export type ListBlocksOutput = z.infer<typeof ListBlocksOutputSchema>;
 
 export const GetBlockInputSchema = z
@@ -148,17 +135,7 @@ export type ListBlockExtrinsicsInput = z.infer<
   typeof ListBlockExtrinsicsInputSchema
 >;
 
-export const ListBlockExtrinsicsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    ref: z.unknown(),
-    block_number: z.int().nullable().optional(),
-    extrinsic_count: z.int(),
-    limit: z.int().nullable().optional(),
-    offset: z.int().nullable().optional(),
-    extrinsics: z.array(ExtrinsicItemSchema),
-  })
-  .passthrough();
+export const ListBlockExtrinsicsOutputSchema = BlockExtrinsicsArtifactSchema;
 export type ListBlockExtrinsicsOutput = z.infer<
   typeof ListBlockExtrinsicsOutputSchema
 >;
@@ -182,15 +159,5 @@ export const GetBlockEventsInputSchema = z
   .strict();
 export type GetBlockEventsInput = z.infer<typeof GetBlockEventsInputSchema>;
 
-export const GetBlockEventsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    ref: z.unknown(),
-    block_number: z.int().nullable().optional(),
-    event_count: z.int(),
-    limit: z.int().nullable().optional(),
-    offset: z.int().nullable().optional(),
-    events: z.array(AccountEventItemSchema),
-  })
-  .passthrough();
+export const GetBlockEventsOutputSchema = BlockEventsArtifactSchema;
 export type GetBlockEventsOutput = z.infer<typeof GetBlockEventsOutputSchema>;

--- a/schemas-src/mcp-tools/catalog-detail.ts
+++ b/schemas-src/mcp-tools/catalog-detail.ts
@@ -1,9 +1,18 @@
-// MCP tools `list_subnet_apis`, `get_api_schema`, `get_fixture`,
-// `get_provider_detail` (types-epic E batch 9, #8073). Each is defined
-// inline in src/mcp-server.ts's MCP_TOOLS array (unlike this batch's other
-// 13 tools, which live in separate src/*-mcp.ts files). None mirror an
-// existing schemas-src/routes/ REST schema -- modeled fresh, matching each
-// hand-written literal field-for-field.
+// MCP tool `get_provider_detail`.
+// Mirrors GET /api/v1/providers/{slug}.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_provider_detail: 2 bare `{"type":"object"}` sites.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
   OpenArraySchema,
@@ -11,6 +20,7 @@ import {
   netuidSchema,
   surfaceIdSchema,
 } from "./shared.ts";
+import { ProviderArtifactSchema } from "../routes/providers-rpc.ts";
 
 export const ListSubnetApisInputSchema = z
   .object({
@@ -92,20 +102,7 @@ export type GetProviderDetailInput = z.infer<
 // when include_endpoints is set. Both are operator-controlled artifact
 // payloads, so nothing is required in the hand-written original; the keys
 // below describe each shape when present.
-export const GetProviderDetailOutputSchema = z
-  .object({
-    id: z.string().nullable().optional(),
-    slug: z.string().nullable().optional(),
-    name: z.string().nullable().optional(),
-    authority: z.string().nullable().optional(),
-    kind: z.string().nullable().optional(),
-    provider: OpenObjectSchema.nullable().optional(),
-    endpoints: z
-      .union([OpenObjectSchema, OpenArraySchema])
-      .nullable()
-      .optional(),
-  })
-  .passthrough();
+export const GetProviderDetailOutputSchema = ProviderArtifactSchema;
 export type GetProviderDetailOutput = z.infer<
   typeof GetProviderDetailOutputSchema
 >;

--- a/schemas-src/mcp-tools/catalog-indexes.ts
+++ b/schemas-src/mcp-tools/catalog-indexes.ts
@@ -1,36 +1,31 @@
-// MCP tools `list_fixtures`, `list_schemas` (types-epic E batch 11, #8074).
-// Both are defined inline in src/mcp-server.ts's MCP_TOOLS array, take no
-// input, and mirror GET /api/v1/fixtures and GET /api/v1/schemas
-// respectively. Neither mirrors an existing schemas-src/routes/ REST schema
-// -- modeled fresh, matching each hand-written literal field-for-field.
-// `list_schemas`' `notes` is a PLAIN nullable string, unlike the
-// array-or-string-or-null `notes` shape most of this batch's other list_*
-// tools use (see shared.ts's NotesFieldSchema) -- a genuine, deliberate
-// difference, not something to "fix" to match its siblings.
+// MCP tools `list_fixtures`, `list_schemas`.
+// Mirror GET /api/v1/fixtures, GET /api/v1/schemas.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   list_fixtures: 1 bare `{"type":"object"}` site.
+//   list_schemas: 1 bare `{"type":"object"}` site.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import { FixturesIndexArtifactSchema } from "../routes/fixtures.ts";
+import { SchemaIndexArtifactSchema } from "../routes/subnet-profiles.ts";
 
 export const ListFixturesInputSchema = z.object({}).strict();
 export type ListFixturesInput = z.infer<typeof ListFixturesInputSchema>;
 
-export const ListFixturesOutputSchema = z
-  .object({
-    candidate_count: z.int().optional(),
-    coverage: z.array(OpenObjectSchema).optional(),
-    generated_at: z.string().nullable().optional(),
-  })
-  .passthrough();
+export const ListFixturesOutputSchema = FixturesIndexArtifactSchema;
 export type ListFixturesOutput = z.infer<typeof ListFixturesOutputSchema>;
 
 export const ListSchemasInputSchema = z.object({}).strict();
 export type ListSchemasInput = z.infer<typeof ListSchemasInputSchema>;
 
-export const ListSchemasOutputSchema = z
-  .object({
-    schemas: z.array(OpenObjectSchema).optional(),
-    observed_at: z.string().nullable().optional(),
-    generated_at: z.string().nullable().optional(),
-    notes: z.string().nullable().optional(),
-  })
-  .passthrough();
+export const ListSchemasOutputSchema = SchemaIndexArtifactSchema;
 export type ListSchemasOutput = z.infer<typeof ListSchemasOutputSchema>;

--- a/schemas-src/mcp-tools/chain-calls-fees.ts
+++ b/schemas-src/mcp-tools/chain-calls-fees.ts
@@ -1,13 +1,23 @@
-// MCP tools `get_chain_calls`, `get_chain_signers`, `get_chain_fees`
-// (types-epic E batch 9, #8072). Each mirrors a GET /api/v1/chain/
-// {calls,signers,fees} route that is not one of schemas-src/routes/'s
-// covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
-// matching each hand-written literal field-for-field. `window` is a LITERAL
-// inline `["7d","30d"]` enum in all three hand-written originals (no
-// symbolic *_WINDOWS import), backed by the shared parseAnalyticsWindow()
-// runtime helper -- modeled the same way here, no shared constant.
+// MCP tools `get_chain_calls`, `get_chain_signers`, `get_chain_fees`.
+// Mirror GET /api/v1/chain/calls, GET /api/v1/chain/signers, GET
+// /api/v1/chain/fees.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { limitSchema, sortSchema, windowSchema } from "./shared.ts";
+import {
+  ChainCallsArtifactSchema,
+  ChainFeesArtifactSchema,
+  ChainSignersArtifactSchema,
+} from "../routes/chain-analytics.ts";
 
 const WINDOWS_2 = ["7d", "30d"] as const;
 
@@ -35,26 +45,7 @@ export type GetChainCallsInput = z.infer<typeof GetChainCallsInputSchema>;
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
-const ChainCallGroupSchema = z
-  .object({
-    call_module: z.string().nullable().optional(),
-    call_function: z.string().nullable().optional(),
-    count: z.int().nullable().optional(),
-    share: z.unknown().optional(),
-  })
-  .passthrough();
-
-export const GetChainCallsOutputSchema = z
-  .object({
-    schema_version: z.int(),
-    window: z.string(),
-    group_by: z.string(),
-    observed_at: z.string().nullable().optional(),
-    total_extrinsics: z.int(),
-    call_count: z.int(),
-    calls: z.array(ChainCallGroupSchema),
-  })
-  .passthrough();
+export const GetChainCallsOutputSchema = ChainCallsArtifactSchema;
 export type GetChainCallsOutput = z.infer<typeof GetChainCallsOutputSchema>;
 
 export const GetChainSignersInputSchema = z
@@ -74,26 +65,7 @@ export const GetChainSignersInputSchema = z
 export type GetChainSignersInput = z.infer<typeof GetChainSignersInputSchema>;
 
 // objectItems(...) properties, none required at the item level.
-const ChainSignerSchema = z
-  .object({
-    signer: z.string().nullable().optional(),
-    tx_count: z.int().nullable().optional(),
-    total_fee_tao: z.number().nullable().optional(),
-    total_tip_tao: z.number().nullable().optional(),
-    last_tx_block: z.int().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetChainSignersOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string(),
-    sort: z.enum(["tx_count", "total_fee_tao"]),
-    observed_at: z.string().nullable().optional(),
-    signer_count: z.int(),
-    signers: z.array(ChainSignerSchema),
-  })
-  .passthrough();
+export const GetChainSignersOutputSchema = ChainSignersArtifactSchema;
 export type GetChainSignersOutput = z.infer<typeof GetChainSignersOutputSchema>;
 
 export const GetChainFeesInputSchema = z
@@ -112,37 +84,5 @@ export const GetChainFeesInputSchema = z
 export type GetChainFeesInput = z.infer<typeof GetChainFeesInputSchema>;
 
 // objectItems(...) properties, none required at the item level.
-const ChainFeesDaySchema = z
-  .object({
-    day: z.string().nullable().optional(),
-    extrinsic_count: z.int().nullable().optional(),
-    signed_extrinsic_count: z.int().nullable().optional(),
-    total_fee_tao: z.number().nullable().optional(),
-    avg_fee_tao: z.number().nullable().optional(),
-    median_fee_tao: z.number().nullable().optional(),
-    total_tip_tao: z.number().nullable().optional(),
-    avg_tip_tao: z.number().nullable().optional(),
-    median_tip_tao: z.number().nullable().optional(),
-  })
-  .passthrough();
-
-const ChainTopFeePayerSchema = z
-  .object({
-    signer: z.string().nullable().optional(),
-    total_fee_tao: z.number().nullable().optional(),
-    total_tip_tao: z.number().nullable().optional(),
-    extrinsic_count: z.int().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetChainFeesOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string(),
-    observed_at: z.string().nullable().optional(),
-    day_count: z.int(),
-    daily: z.array(ChainFeesDaySchema),
-    top_fee_payers: z.array(ChainTopFeePayerSchema),
-  })
-  .passthrough();
+export const GetChainFeesOutputSchema = ChainFeesArtifactSchema;
 export type GetChainFeesOutput = z.infer<typeof GetChainFeesOutputSchema>;

--- a/schemas-src/mcp-tools/chain-events-activity.ts
+++ b/schemas-src/mcp-tools/chain-events-activity.ts
@@ -1,15 +1,24 @@
-// MCP tools `get_chain_activity`, `list_chain_events`, `get_network_activity`
-// (types-epic E batch 9, #8072). Each mirrors a GET /api/v1/chain{-events,
-// /activity} route that is not one of schemas-src/routes/'s covered pilot
-// routes -- no existing Zod schema to reuse. Modeled fresh, matching each
-// hand-written literal field-for-field. `window` on all three tools using it
-// is a LITERAL inline `["7d","30d"]` enum in the hand-written original (no
-// symbolic *_WINDOWS import, unlike chain-leaderboards.ts's tools), backed by
-// the shared parseAnalyticsWindow() runtime helper rather than an
-// Object.hasOwn() check -- modeled the same way here, no shared constant.
+// MCP tools `get_chain_activity`, `list_chain_events`, `get_network_activity`.
+// Mirror GET /api/v1/chain-events/stats, GET /api/v1/chain-events, GET
+// /api/v1/chain/activity.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { keysetCursorSchema, limitSchema, windowSchema } from "./shared.ts";
 import { McpNetworkSchema } from "../shared.ts";
+import { ChainActivityArtifactSchema } from "../routes/chain-analytics.ts";
+import {
+  ChainEventsFeedArtifactSchema,
+  ChainEventsStatsArtifactSchema,
+} from "../routes/chain-events.ts";
 
 const WINDOWS_2 = ["7d", "30d"] as const;
 
@@ -32,21 +41,7 @@ export type GetChainActivityInput = z.infer<typeof GetChainActivityInputSchema>;
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
-const ChainActivityGroupSchema = z
-  .object({
-    pallet: z.string().nullable().optional(),
-    method: z.string().nullable().optional(),
-    count: z.int().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetChainActivityOutputSchema = z
-  .object({
-    window_blocks: z.int(),
-    groups: z.int(),
-    activity: z.array(ChainActivityGroupSchema),
-  })
-  .passthrough();
+export const GetChainActivityOutputSchema = ChainEventsStatsArtifactSchema;
 export type GetChainActivityOutput = z.infer<
   typeof GetChainActivityOutputSchema
 >;
@@ -99,31 +94,7 @@ export type ListChainEventsInput = z.infer<typeof ListChainEventsInputSchema>;
 // nullable-integer CHAIN_EVENT_ITEM convention batch 8's
 // get_block_chain_events/get_extrinsic_chain_events use for the same field
 // name; this tool inlines its own item shape rather than sharing that one.
-const ChainEventFeedItemSchema = z
-  .object({
-    block_number: z.int().nullable().optional(),
-    event_index: z.int().nullable().optional(),
-    pallet: z.string().nullable().optional(),
-    method: z.string().nullable().optional(),
-    args: z.unknown().optional(),
-    phase: z.unknown().optional(),
-    extrinsic_index: z.int().nullable().optional(),
-    observed_at: z.unknown().optional(),
-    // #8525: deterministic human-readable action sentence for this event's
-    // pallet.method, or null when no template matches -- never a
-    // guessed/partial sentence.
-    summary: z.string().nullable().optional(),
-  })
-  .passthrough();
-
-export const ListChainEventsOutputSchema = z
-  .object({
-    count: z.int(),
-    next_before: z.int().nullable().optional(),
-    next_cursor: z.string().nullable().optional(),
-    events: z.array(ChainEventFeedItemSchema),
-  })
-  .passthrough();
+export const ListChainEventsOutputSchema = ChainEventsFeedArtifactSchema;
 export type ListChainEventsOutput = z.infer<typeof ListChainEventsOutputSchema>;
 
 export const GetNetworkActivityInputSchema = z
@@ -136,27 +107,7 @@ export type GetNetworkActivityInput = z.infer<
 >;
 
 // objectItems(...) properties, none required at the item level.
-const NetworkActivityDaySchema = z
-  .object({
-    day: z.string().nullable().optional(),
-    block_count: z.int().nullable().optional(),
-    extrinsic_count: z.int().nullable().optional(),
-    event_count: z.int().nullable().optional(),
-    successful_extrinsics: z.int().nullable().optional(),
-    success_rate: z.number().nullable().optional(),
-    unique_signers: z.int().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetNetworkActivityOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string(),
-    observed_at: z.string().nullable().optional(),
-    day_count: z.int(),
-    days: z.array(NetworkActivityDaySchema),
-  })
-  .passthrough();
+export const GetNetworkActivityOutputSchema = ChainActivityArtifactSchema;
 export type GetNetworkActivityOutput = z.infer<
   typeof GetNetworkActivityOutputSchema
 >;

--- a/schemas-src/mcp-tools/chain-identity-history.ts
+++ b/schemas-src/mcp-tools/chain-identity-history.ts
@@ -1,14 +1,22 @@
-// MCP tool `get_chain_identity_history` (types-epic E batch 9, #8072).
-// Mirrors GET /api/v1/chain/identity-history, which is not one of
-// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
-// reuse. Modeled fresh, matching the hand-written literal it replaces
-// field-for-field.
+// MCP tool `get_chain_identity_history`.
+// Mirrors GET /api/v1/chain/identity-history.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
   CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
   CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
 } from "../../src/route-limits.ts";
-import { limitSchema, netuidSchema } from "./shared.ts";
+import { limitSchema } from "./shared.ts";
+import { ChainIdentityHistoryArtifactSchema } from "../routes/chain-identity-history.ts";
 
 export const GetChainIdentityHistoryInputSchema = z
   .object({
@@ -24,30 +32,8 @@ export type GetChainIdentityHistoryInput = z.infer<
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
-const ChainIdentityChangeSchema = z
-  .object({
-    netuid: netuidSchema().nullable().optional(),
-    block_number: z.int().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-    subnet_name: z.string().nullable().optional(),
-    symbol: z.string().nullable().optional(),
-    description: z.string().nullable().optional(),
-    github_repo: z.string().nullable().optional(),
-    subnet_url: z.string().nullable().optional(),
-    discord: z.string().nullable().optional(),
-    logo_url: z.string().nullable().optional(),
-    identity_hash: z.string().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetChainIdentityHistoryOutputSchema = z
-  .object({
-    schema_version: z.int(),
-    count: z.int(),
-    subnet_count: z.int(),
-    changes: z.array(ChainIdentityChangeSchema),
-  })
-  .passthrough();
+export const GetChainIdentityHistoryOutputSchema =
+  ChainIdentityHistoryArtifactSchema;
 export type GetChainIdentityHistoryOutput = z.infer<
   typeof GetChainIdentityHistoryOutputSchema
 >;

--- a/schemas-src/mcp-tools/chain-leaderboards.ts
+++ b/schemas-src/mcp-tools/chain-leaderboards.ts
@@ -1,27 +1,36 @@
-// MCP tools `get_chain_turnover`, `get_chain_stake_flow`,
-// `get_chain_alpha_volume`, `get_chain_weights`, `get_chain_weight_setters`,
-// `get_chain_stake_moves`, `get_chain_stake_transfers`,
-// `get_chain_axon_removals`, `get_chain_serving`, `get_chain_prometheus`
-// (types-epic E batch 9, #8072). Each mirrors a GET /api/v1/chain/* route
-// that is not one of schemas-src/routes/'s covered pilot routes -- no
-// existing Zod schema to reuse. Modeled fresh, matching each hand-written
-// literal field-for-field. Nine of the ten share one shape (subnet_count +
-// a STRICT `network` rollup object + a nullable `*_distribution` stats
-// object [DistributionStatsSchema, shared.ts] + a `subnets` leaderboard
-// array of STRICT items -- additionalProperties:false, every item field
-// required, unlike the objectItems() looseness convention used elsewhere
-// in this epic), but with genuinely different per-tool field names
-// (movers vs senders vs removers, etc.), so each is modeled explicitly
-// rather than through a shared factory. get_chain_weight_setters is the
-// exception: a flat setters leaderboard with no network/distribution
-// rollup, using the usual objectItems() item-level looseness instead.
+// MCP tools `get_chain_stake_flow`, `get_chain_alpha_volume`,
+// `get_chain_turnover`, `get_chain_stake_moves`, `get_chain_axon_removals`,
+// `get_chain_stake_transfers`, `get_chain_prometheus`, `get_chain_serving`,
+// `get_chain_weights`, `get_chain_weight_setters`.
+// Mirror GET /api/v1/chain/stake-flow, GET /api/v1/chain/alpha-volume, GET
+// /api/v1/chain/turnover, GET /api/v1/chain/stake-moves, GET
+// /api/v1/chain/axon-removals, GET /api/v1/chain/stake-transfers, GET
+// /api/v1/chain/prometheus, GET /api/v1/chain/serving, GET
+// /api/v1/chain/weights, GET /api/v1/chain/weights/setters.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
+import { limitSchema, windowSchema } from "./shared.ts";
+import { ChainAlphaVolumeArtifactSchema } from "../routes/chain-alpha-volume.ts";
 import {
-  DistributionStatsSchema,
-  limitSchema,
-  netuidSchema,
-  windowSchema,
-} from "./shared.ts";
+  ChainAxonRemovalsArtifactSchema,
+  ChainPrometheusArtifactSchema,
+  ChainServingArtifactSchema,
+  ChainStakeMovesArtifactSchema,
+  ChainStakeTransfersArtifactSchema,
+  ChainWeightsArtifactSchema,
+} from "../routes/chain-network-rollups.ts";
+import { ChainStakeFlowArtifactSchema } from "../routes/chain-stake-flow.ts";
+import { ChainTurnoverArtifactSchema } from "../routes/chain-turnover.ts";
+import { ChainWeightSettersArtifactSchema } from "../routes/chain-weight-setters.ts";
 
 const WINDOWS_2 = ["7d", "30d"] as const;
 const WINDOWS_3 = ["7d", "30d", "90d"] as const;
@@ -35,42 +44,7 @@ export const GetChainTurnoverInputSchema = z
   .strict();
 export type GetChainTurnoverInput = z.infer<typeof GetChainTurnoverInputSchema>;
 
-const ChainTurnoverNetworkSchema = z
-  .object({
-    validators_start: z.int(),
-    validators_end: z.int(),
-    validators_entered: z.int(),
-    validators_exited: z.int(),
-    validator_retention: z.number().nullable(),
-    stability_score: z.int().nullable(),
-  })
-  .strict();
-
-const ChainTurnoverSubnetSchema = z
-  .object({
-    netuid: netuidSchema(),
-    validators_start: z.int(),
-    validators_end: z.int(),
-    validators_entered: z.int(),
-    validators_exited: z.int(),
-    validator_retention: z.number(),
-    stability_score: z.int(),
-  })
-  .strict();
-
-export const GetChainTurnoverOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string().nullable().optional(),
-    start_date: z.string().nullable().optional(),
-    end_date: z.string().nullable().optional(),
-    comparable: z.boolean(),
-    subnet_count: z.int(),
-    network: ChainTurnoverNetworkSchema,
-    stability_distribution: DistributionStatsSchema.nullable().optional(),
-    subnets: z.array(ChainTurnoverSubnetSchema),
-  })
-  .passthrough();
+export const GetChainTurnoverOutputSchema = ChainTurnoverArtifactSchema;
 export type GetChainTurnoverOutput = z.infer<
   typeof GetChainTurnoverOutputSchema
 >;
@@ -85,44 +59,7 @@ export type GetChainStakeFlowInput = z.infer<
   typeof GetChainStakeFlowInputSchema
 >;
 
-const ChainStakeFlowNetworkSchema = z
-  .object({
-    total_staked_tao: z.number(),
-    total_unstaked_tao: z.number(),
-    net_flow_tao: z.number(),
-    gross_flow_tao: z.number(),
-    stake_events: z.int(),
-    unstake_events: z.int(),
-    gaining: z.int(),
-    losing: z.int(),
-    flat: z.int(),
-  })
-  .strict();
-
-const ChainStakeFlowSubnetSchema = z
-  .object({
-    netuid: netuidSchema(),
-    total_staked_tao: z.number(),
-    total_unstaked_tao: z.number(),
-    net_flow_tao: z.number(),
-    gross_flow_tao: z.number(),
-    stake_events: z.int(),
-    unstake_events: z.int(),
-    direction: z.string(),
-  })
-  .strict();
-
-export const GetChainStakeFlowOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-    subnet_count: z.int(),
-    network: ChainStakeFlowNetworkSchema,
-    net_flow_distribution: DistributionStatsSchema.nullable().optional(),
-    subnets: z.array(ChainStakeFlowSubnetSchema),
-  })
-  .passthrough();
+export const GetChainStakeFlowOutputSchema = ChainStakeFlowArtifactSchema;
 export type GetChainStakeFlowOutput = z.infer<
   typeof GetChainStakeFlowOutputSchema
 >;
@@ -136,57 +73,11 @@ export type GetChainAlphaVolumeInput = z.infer<
   typeof GetChainAlphaVolumeInputSchema
 >;
 
-const ChainAlphaVolumeNetworkSchema = z
-  .object({
-    buy_volume_alpha: z.unknown(),
-    sell_volume_alpha: z.unknown(),
-    total_volume_alpha: z.unknown(),
-    buy_volume_tao: z.unknown(),
-    sell_volume_tao: z.unknown(),
-    total_volume_tao: z.unknown(),
-    buy_count: z.int(),
-    sell_count: z.int(),
-    net_volume_alpha: z.unknown(),
-    sentiment_ratio: z.number().nullable(),
-    sentiment: z.string(),
-  })
-  .strict();
-
 // Each subnet entry is a full get_subnet_volume-shaped scorecard -- loose
 // (additionalProperties:true), only netuid/window required, matching the
 // hand-written original exactly rather than nesting get_subnet_volume's own
 // (not-yet-converted) precise schema.
-const ChainAlphaVolumeSubnetSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string(),
-    buy_volume_alpha: z.unknown().optional(),
-    sell_volume_alpha: z.unknown().optional(),
-    total_volume_alpha: z.unknown().optional(),
-    buy_volume_tao: z.unknown().optional(),
-    sell_volume_tao: z.unknown().optional(),
-    total_volume_tao: z.unknown().optional(),
-    buy_count: z.int().optional(),
-    sell_count: z.int().optional(),
-    net_volume_alpha: z.unknown().optional(),
-    sentiment_ratio: z.number().nullable().optional(),
-    sentiment: z.string().nullable().optional(),
-    vol_mcap_ratio: z.number().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetChainAlphaVolumeOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string().optional(),
-    observed_at: z.string().nullable().optional(),
-    subnet_count: z.int(),
-    network: ChainAlphaVolumeNetworkSchema,
-    volume_distribution: DistributionStatsSchema.nullable().optional(),
-    subnets: z.array(ChainAlphaVolumeSubnetSchema),
-  })
-  .passthrough();
+export const GetChainAlphaVolumeOutputSchema = ChainAlphaVolumeArtifactSchema;
 export type GetChainAlphaVolumeOutput = z.infer<
   typeof GetChainAlphaVolumeOutputSchema
 >;
@@ -199,34 +90,7 @@ export const GetChainWeightsInputSchema = z
   .strict();
 export type GetChainWeightsInput = z.infer<typeof GetChainWeightsInputSchema>;
 
-const ChainWeightsNetworkSchema = z
-  .object({
-    distinct_setters: z.int(),
-    weight_sets: z.int(),
-    sets_per_setter: z.number().nullable(),
-  })
-  .strict();
-
-const ChainWeightsSubnetSchema = z
-  .object({
-    netuid: netuidSchema(),
-    distinct_setters: z.int(),
-    weight_sets: z.int(),
-    sets_per_setter: z.number(),
-  })
-  .strict();
-
-export const GetChainWeightsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-    subnet_count: z.int(),
-    network: ChainWeightsNetworkSchema,
-    intensity_distribution: DistributionStatsSchema.nullable().optional(),
-    subnets: z.array(ChainWeightsSubnetSchema),
-  })
-  .passthrough();
+export const GetChainWeightsOutputSchema = ChainWeightsArtifactSchema;
 export type GetChainWeightsOutput = z.infer<typeof GetChainWeightsOutputSchema>;
 
 export const GetChainWeightSettersInputSchema = z
@@ -241,28 +105,8 @@ export type GetChainWeightSettersInput = z.infer<
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
-const ChainWeightSetterSchema = z
-  .object({
-    hotkey: z.string().nullable().optional(),
-    uid: z.int().nullable().optional(),
-    weight_sets: z.int().optional(),
-    share: z.unknown().optional(),
-    first_set_at: z.string().nullable().optional(),
-    last_set_at: z.string().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetChainWeightSettersOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string().nullable(),
-    observed_at: z.string().nullable().optional(),
-    distinct_setters: z.int(),
-    weight_sets: z.int(),
-    setter_count: z.int(),
-    setters: z.array(ChainWeightSetterSchema),
-  })
-  .passthrough();
+export const GetChainWeightSettersOutputSchema =
+  ChainWeightSettersArtifactSchema;
 export type GetChainWeightSettersOutput = z.infer<
   typeof GetChainWeightSettersOutputSchema
 >;
@@ -277,34 +121,7 @@ export type GetChainStakeMovesInput = z.infer<
   typeof GetChainStakeMovesInputSchema
 >;
 
-const ChainStakeMovesNetworkSchema = z
-  .object({
-    distinct_movers: z.int(),
-    movements: z.int(),
-    movements_per_mover: z.number().nullable(),
-  })
-  .strict();
-
-const ChainStakeMovesSubnetSchema = z
-  .object({
-    netuid: netuidSchema(),
-    distinct_movers: z.int(),
-    movements: z.int(),
-    movements_per_mover: z.number(),
-  })
-  .strict();
-
-export const GetChainStakeMovesOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-    subnet_count: z.int(),
-    network: ChainStakeMovesNetworkSchema,
-    intensity_distribution: DistributionStatsSchema.nullable().optional(),
-    subnets: z.array(ChainStakeMovesSubnetSchema),
-  })
-  .passthrough();
+export const GetChainStakeMovesOutputSchema = ChainStakeMovesArtifactSchema;
 export type GetChainStakeMovesOutput = z.infer<
   typeof GetChainStakeMovesOutputSchema
 >;
@@ -319,34 +136,8 @@ export type GetChainStakeTransfersInput = z.infer<
   typeof GetChainStakeTransfersInputSchema
 >;
 
-const ChainStakeTransfersNetworkSchema = z
-  .object({
-    distinct_senders: z.int(),
-    transfers: z.int(),
-    transfers_per_sender: z.number().nullable(),
-  })
-  .strict();
-
-const ChainStakeTransfersSubnetSchema = z
-  .object({
-    netuid: netuidSchema(),
-    distinct_senders: z.int(),
-    transfers: z.int(),
-    transfers_per_sender: z.number(),
-  })
-  .strict();
-
-export const GetChainStakeTransfersOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-    subnet_count: z.int(),
-    network: ChainStakeTransfersNetworkSchema,
-    intensity_distribution: DistributionStatsSchema.nullable().optional(),
-    subnets: z.array(ChainStakeTransfersSubnetSchema),
-  })
-  .passthrough();
+export const GetChainStakeTransfersOutputSchema =
+  ChainStakeTransfersArtifactSchema;
 export type GetChainStakeTransfersOutput = z.infer<
   typeof GetChainStakeTransfersOutputSchema
 >;
@@ -361,34 +152,7 @@ export type GetChainAxonRemovalsInput = z.infer<
   typeof GetChainAxonRemovalsInputSchema
 >;
 
-const ChainAxonRemovalsNetworkSchema = z
-  .object({
-    distinct_removers: z.int(),
-    removals: z.int(),
-    removals_per_remover: z.number().nullable(),
-  })
-  .strict();
-
-const ChainAxonRemovalsSubnetSchema = z
-  .object({
-    netuid: netuidSchema(),
-    distinct_removers: z.int(),
-    removals: z.int(),
-    removals_per_remover: z.number(),
-  })
-  .strict();
-
-export const GetChainAxonRemovalsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-    subnet_count: z.int(),
-    network: ChainAxonRemovalsNetworkSchema,
-    intensity_distribution: DistributionStatsSchema.nullable().optional(),
-    subnets: z.array(ChainAxonRemovalsSubnetSchema),
-  })
-  .passthrough();
+export const GetChainAxonRemovalsOutputSchema = ChainAxonRemovalsArtifactSchema;
 export type GetChainAxonRemovalsOutput = z.infer<
   typeof GetChainAxonRemovalsOutputSchema
 >;
@@ -401,34 +165,7 @@ export const GetChainServingInputSchema = z
   .strict();
 export type GetChainServingInput = z.infer<typeof GetChainServingInputSchema>;
 
-const ChainServingNetworkSchema = z
-  .object({
-    distinct_servers: z.int(),
-    announcements: z.int(),
-    announcements_per_server: z.number().nullable(),
-  })
-  .strict();
-
-const ChainServingSubnetSchema = z
-  .object({
-    netuid: netuidSchema(),
-    distinct_servers: z.int(),
-    announcements: z.int(),
-    announcements_per_server: z.number(),
-  })
-  .strict();
-
-export const GetChainServingOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-    subnet_count: z.int(),
-    network: ChainServingNetworkSchema,
-    intensity_distribution: DistributionStatsSchema.nullable().optional(),
-    subnets: z.array(ChainServingSubnetSchema),
-  })
-  .passthrough();
+export const GetChainServingOutputSchema = ChainServingArtifactSchema;
 export type GetChainServingOutput = z.infer<typeof GetChainServingOutputSchema>;
 
 export const GetChainPrometheusInputSchema = z
@@ -441,34 +178,7 @@ export type GetChainPrometheusInput = z.infer<
   typeof GetChainPrometheusInputSchema
 >;
 
-const ChainPrometheusNetworkSchema = z
-  .object({
-    distinct_exporters: z.int(),
-    announcements: z.int(),
-    announcements_per_exporter: z.number().nullable(),
-  })
-  .strict();
-
-const ChainPrometheusSubnetSchema = z
-  .object({
-    netuid: netuidSchema(),
-    distinct_exporters: z.int(),
-    announcements: z.int(),
-    announcements_per_exporter: z.number(),
-  })
-  .strict();
-
-export const GetChainPrometheusOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-    subnet_count: z.int(),
-    network: ChainPrometheusNetworkSchema,
-    intensity_distribution: DistributionStatsSchema.nullable().optional(),
-    subnets: z.array(ChainPrometheusSubnetSchema),
-  })
-  .passthrough();
+export const GetChainPrometheusOutputSchema = ChainPrometheusArtifactSchema;
 export type GetChainPrometheusOutput = z.infer<
   typeof GetChainPrometheusOutputSchema
 >;

--- a/schemas-src/mcp-tools/chain-registrations.ts
+++ b/schemas-src/mcp-tools/chain-registrations.ts
@@ -1,28 +1,24 @@
-// MCP tools `get_chain_registrations`, `get_chain_deregistrations`
-// (types-epic E batch 9, #8072). Each mirrors a GET /api/v1/chain/
-// {de,}registrations route that is not one of schemas-src/routes/'s covered
-// pilot routes -- no existing Zod schema to reuse. Modeled fresh, matching
-// each hand-written literal field-for-field.
+// MCP tools `get_chain_registrations`, `get_chain_deregistrations`.
+// Mirror GET /api/v1/chain/registrations, GET /api/v1/chain/deregistrations.
 //
-// The two are NOT siblings despite the name: get_chain_deregistrations
-// follows the same STRICT network/intensity_distribution/subnets[] shape as
-// chain-leaderboards.ts's nine tools (additionalProperties:false + full
-// required arrays), but get_chain_registrations's hand-written original is
-// genuinely looser -- its `network` sub-object has no additionalProperties/
-// required declared (structurally open, JSON Schema's own default),
-// `intensity_distribution` is a completely untyped `{type:["object","null"]}`
-// (no properties at all, unlike its sibling's typed DistributionStatsSchema),
-// and `subnets` uses the usual objectItems() item-level looseness instead of
-// strict items. Modeled as-is, not "fixed" to match its sibling -- the epic's
-// wire-compatibility mandate preserves what shipped, not what's consistent.
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_chain_registrations: 1 bare `{"type":"object"}` site.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
+import { limitSchema, windowSchema } from "./shared.ts";
 import {
-  DistributionStatsSchema,
-  OpenObjectSchema,
-  limitSchema,
-  netuidSchema,
-  windowSchema,
-} from "./shared.ts";
+  ChainDeregistrationsArtifactSchema,
+  ChainRegistrationsArtifactSchema,
+} from "../routes/chain-network-rollups.ts";
 
 const WINDOWS_2 = ["7d", "30d"] as const;
 const LIMIT_MAX_100 = 100;
@@ -39,40 +35,11 @@ export type GetChainRegistrationsInput = z.infer<
 
 // Genuinely open (no additionalProperties:false, no required array in the
 // hand-written original) -- see file header.
-const ChainRegistrationsNetworkSchema = z
-  .object({
-    distinct_registrants: z.int().nullable().optional(),
-    registrations: z.int().nullable().optional(),
-    registrations_per_registrant: z.number().nullable().optional(),
-  })
-  .passthrough();
-
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch) -- unlike
 // get_chain_deregistrations's strict items below.
-const ChainRegistrationsSubnetSchema = z
-  .object({
-    netuid: netuidSchema().nullable().optional(),
-    distinct_registrants: z.int().nullable().optional(),
-    registrations: z.int().nullable().optional(),
-    registrations_per_registrant: z.number().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetChainRegistrationsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string().nullable(),
-    observed_at: z.string().nullable().optional(),
-    subnet_count: z.int(),
-    network: ChainRegistrationsNetworkSchema,
-    // Untyped in the hand-written original (bare `{type:["object","null"]}`,
-    // no properties) -- NOT DistributionStatsSchema despite the field name
-    // matching its sibling tools' typed *_distribution fields.
-    intensity_distribution: OpenObjectSchema.nullable().optional(),
-    subnets: z.array(ChainRegistrationsSubnetSchema),
-  })
-  .passthrough();
+export const GetChainRegistrationsOutputSchema =
+  ChainRegistrationsArtifactSchema;
 export type GetChainRegistrationsOutput = z.infer<
   typeof GetChainRegistrationsOutputSchema
 >;
@@ -87,34 +54,8 @@ export type GetChainDeregistrationsInput = z.infer<
   typeof GetChainDeregistrationsInputSchema
 >;
 
-const ChainDeregistrationsNetworkSchema = z
-  .object({
-    distinct_deregistered_hotkeys: z.int(),
-    deregistrations: z.int(),
-    deregistrations_per_hotkey: z.number().nullable(),
-  })
-  .strict();
-
-const ChainDeregistrationsSubnetSchema = z
-  .object({
-    netuid: netuidSchema(),
-    distinct_deregistered_hotkeys: z.int(),
-    deregistrations: z.int(),
-    deregistrations_per_hotkey: z.number(),
-  })
-  .strict();
-
-export const GetChainDeregistrationsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-    subnet_count: z.int(),
-    network: ChainDeregistrationsNetworkSchema,
-    intensity_distribution: DistributionStatsSchema.nullable().optional(),
-    subnets: z.array(ChainDeregistrationsSubnetSchema),
-  })
-  .passthrough();
+export const GetChainDeregistrationsOutputSchema =
+  ChainDeregistrationsArtifactSchema;
 export type GetChainDeregistrationsOutput = z.infer<
   typeof GetChainDeregistrationsOutputSchema
 >;

--- a/schemas-src/mcp-tools/chain-scorecards.ts
+++ b/schemas-src/mcp-tools/chain-scorecards.ts
@@ -1,26 +1,29 @@
-// MCP tools `get_chain_concentration`, `get_chain_performance`,
-// `get_chain_idle_stake`, `get_chain_yield` (types-epic E batch 9, #8072).
-// Each mirrors a GET /api/v1/chain/* route that is not one of
-// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
-// reuse. All four take no input (bare `{}`). Modeled fresh, matching each
-// hand-written literal field-for-field -- including several bare nullable
-// `{type:["object","null"]}` fields with no declared shape, which stay
-// untyped open objects here too (not "improved" with a guessed shape).
+// MCP tools `get_chain_idle_stake`, `get_chain_yield`.
+// Mirror GET /api/v1/chain/idle-stake, GET /api/v1/chain/yield.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_chain_yield: 1 bare `{"type":"object"}` site.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { ChainConcentrationArtifactSchema } from "../routes/chain-concentration.ts";
 import { ChainConcentrationSubnetsArtifactSchema } from "../routes/chain-concentration-subnets.ts";
 import { ChainPerformanceArtifactSchema } from "../routes/chain-performance.ts";
-import {
-  OpenObjectSchema,
-  netuidSchema,
-  limitSchema,
-  orderSchema,
-  sortSchema,
-} from "./shared.ts";
+import { limitSchema, orderSchema, sortSchema } from "./shared.ts";
 import {
   CHAIN_CONCENTRATION_SUBNETS_LIMIT_DEFAULT,
   CHAIN_CONCENTRATION_SUBNETS_LIMIT_MAX,
 } from "../../src/route-limits.ts";
+import { ChainIdleStakeArtifactSchema } from "../routes/chain-idle-stake.ts";
+import { ChainYieldArtifactSchema } from "../routes/chain-yield.ts";
 
 // --- get_chain_concentration_subnets (#9717) ---------------------------------
 // The cross-subnet RANKING, as opposed to get_chain_concentration's single
@@ -109,24 +112,7 @@ export type GetChainIdleStakeInput = z.infer<
   typeof GetChainIdleStakeInputSchema
 >;
 
-const ChainIdleStakeSubnetSchema = z
-  .object({
-    netuid: netuidSchema(),
-    neuron_count: z.int(),
-    idle_neuron_count: z.int(),
-    idle_stake_alpha: z.number(),
-  })
-  .passthrough();
-
-export const GetChainIdleStakeOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    captured_at: z.string().nullable().optional(),
-    subnet_count: z.int(),
-    total_idle_stake_alpha: z.number(),
-    subnets: z.array(ChainIdleStakeSubnetSchema),
-  })
-  .passthrough();
+export const GetChainIdleStakeOutputSchema = ChainIdleStakeArtifactSchema;
 export type GetChainIdleStakeOutput = z.infer<
   typeof GetChainIdleStakeOutputSchema
 >;
@@ -134,20 +120,5 @@ export type GetChainIdleStakeOutput = z.infer<
 export const GetChainYieldInputSchema = z.object({}).strict();
 export type GetChainYieldInput = z.infer<typeof GetChainYieldInputSchema>;
 
-export const GetChainYieldOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    subnet_count: z.int(),
-    neuron_count: z.int(),
-    validator_count: z.int().optional(),
-    miner_count: z.int().optional(),
-    captured_at: z.string().nullable().optional(),
-    total_stake_tao: z.number().optional(),
-    total_emission_tao: z.number().optional(),
-    network_yield: z.number().nullable().optional(),
-    validator_yield: z.number().nullable().optional(),
-    miner_yield: z.number().nullable().optional(),
-    distribution: OpenObjectSchema.nullable().optional(),
-  })
-  .passthrough();
+export const GetChainYieldOutputSchema = ChainYieldArtifactSchema;
 export type GetChainYieldOutput = z.infer<typeof GetChainYieldOutputSchema>;

--- a/schemas-src/mcp-tools/chain-transfers.ts
+++ b/schemas-src/mcp-tools/chain-transfers.ts
@@ -1,28 +1,27 @@
-// MCP tools `get_chain_transfers`, `get_chain_transfer_pairs` (types-epic E
-// batch 9, #8072). Each mirrors a GET /api/v1/chain/transfer{s,-pairs} route
-// that is not one of schemas-src/routes/'s covered pilot routes -- no
-// existing Zod schema to reuse. Both hand-written originals are
-// additionalProperties:false (strict) at the top level, unlike the
-// additionalProperties:true posture most tools in this epic use -- modeled
-// here with the same strictness. Their `window` fields are a REQUIRED but
-// NULLABLE enum (`type:["string","null"], enum:[...windows, null]`) --
-// `z.enum(...).nullable()`, not `.optional()`.
+// MCP tools `get_chain_transfers`, `get_chain_transfer_pairs`.
+// Mirror GET /api/v1/chain/transfers, GET /api/v1/chain/transfer-pairs.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { limitSchema, sortSchema, windowSchema } from "./shared.ts";
+import {
+  ChainTransferPairsArtifactSchema,
+  ChainTransfersArtifactSchema,
+} from "../routes/chain-transfers.ts";
 
 const WINDOWS_2 = ["7d", "30d"] as const;
 
 // Mirrors mcp-server.ts's shared CHAIN_TRANSFER_PARTY_ITEM object literal
 // (this batch's last consumer -- get_chain_transfer_pairs.pairs items have
 // their own distinct shape, not this one).
-const ChainTransferPartySchema = z
-  .object({
-    address: z.string(),
-    volume_tao: z.number(),
-    transfer_count: z.int().min(0),
-  })
-  .strict();
-
 export const GetChainTransfersInputSchema = z
   .object({
     window: windowSchema(WINDOWS_2).optional(),
@@ -33,20 +32,7 @@ export type GetChainTransfersInput = z.infer<
   typeof GetChainTransfersInputSchema
 >;
 
-export const GetChainTransfersOutputSchema = z
-  .object({
-    schema_version: z.int(),
-    window: z.enum(WINDOWS_2).nullable(),
-    observed_at: z.string().nullable(),
-    total_volume_tao: z.number(),
-    transfer_count: z.int().min(0),
-    unique_senders: z.int().min(0),
-    unique_receivers: z.int().min(0),
-    top_sender_share: z.number().nullable(),
-    top_senders: z.array(ChainTransferPartySchema),
-    top_receivers: z.array(ChainTransferPartySchema),
-  })
-  .strict();
+export const GetChainTransfersOutputSchema = ChainTransfersArtifactSchema;
 export type GetChainTransfersOutput = z.infer<
   typeof GetChainTransfersOutputSchema
 >;
@@ -62,31 +48,8 @@ export type GetChainTransferPairsInput = z.infer<
   typeof GetChainTransferPairsInputSchema
 >;
 
-const ChainTransferPairSchema = z
-  .object({
-    from: z.string(),
-    to: z.string(),
-    volume_tao: z.number(),
-    transfer_count: z.int().min(0),
-    last_block: z.int().nullable(),
-    last_observed_at: z.string().nullable(),
-  })
-  .strict();
-
-export const GetChainTransferPairsOutputSchema = z
-  .object({
-    schema_version: z.int(),
-    window: z.enum(WINDOWS_2).nullable(),
-    sort: z.enum(["volume", "count"]),
-    observed_at: z.string().nullable(),
-    total_volume_tao: z.number(),
-    transfer_count: z.int().min(0),
-    unique_pairs: z.int().min(0),
-    pair_count: z.int().min(0),
-    top_pair_share: z.number().nullable(),
-    pairs: z.array(ChainTransferPairSchema),
-  })
-  .strict();
+export const GetChainTransferPairsOutputSchema =
+  ChainTransferPairsArtifactSchema;
 export type GetChainTransferPairsOutput = z.infer<
   typeof GetChainTransferPairsOutputSchema
 >;

--- a/schemas-src/mcp-tools/compare-subnets.ts
+++ b/schemas-src/mcp-tools/compare-subnets.ts
@@ -1,9 +1,20 @@
-// MCP tool `compare_subnets` (types-epic E batch 4, #8067). Mirrors GET
-// /api/v1/compare, which is not one of schemas-src/routes/'s covered pilot
-// routes -- no existing Zod schema to reuse. Modeled fresh, shallow, from
-// the hand-written literal it replaces.
+// MCP tool `compare_subnets`.
+// Mirrors GET /api/v1/compare.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   compare_subnets: 1 bare `{"type":"object"}` site.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import { OpenObjectArraySchema } from "./shared.ts";
+import { CompareArtifactSchema } from "../routes/compare.ts";
 
 const COMPARE_DIMENSIONS = ["structure", "economics", "health"] as const;
 
@@ -26,13 +37,5 @@ export const CompareSubnetsInputSchema = z
   .strict();
 export type CompareSubnetsInput = z.infer<typeof CompareSubnetsInputSchema>;
 
-export const CompareSubnetsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    requested_netuids: z.array(z.int()),
-    dimensions: z.array(z.string()),
-    subnets: OpenObjectArraySchema,
-    observed_at: z.string().nullable().optional(),
-  })
-  .passthrough();
+export const CompareSubnetsOutputSchema = CompareArtifactSchema;
 export type CompareSubnetsOutput = z.infer<typeof CompareSubnetsOutputSchema>;

--- a/schemas-src/mcp-tools/endpoints-catalog.ts
+++ b/schemas-src/mcp-tools/endpoints-catalog.ts
@@ -1,12 +1,21 @@
-// MCP tools `list_endpoints`, `get_subnet_endpoints` (types-epic E batch 9,
-// #8073). Both are defined inline in src/mcp-server.ts's MCP_TOOLS array
-// (unlike this batch's 11 other list_* tools, which live in separate
-// src/*-mcp.ts files). Neither mirrors an existing schemas-src/routes/ REST
-// schema -- modeled fresh, matching each hand-written literal
-// field-for-field.
+// MCP tools `list_endpoints`, `get_subnet_endpoints`.
+// Mirror GET /api/v1/endpoints, GET /api/v1/subnets/{netuid}/endpoints.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   list_endpoints: 1 bare `{"type":"object"}` site.
+//   get_subnet_endpoints: 1 bare `{"type":"object"}` site.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
-  OpenObjectSchema,
   fieldsStringSchema,
   kindSchema,
   limitSchema,
@@ -16,6 +25,10 @@ import {
   providerSlugSchema,
   sortSchema,
 } from "./shared.ts";
+import {
+  EndpointsArtifactSchema,
+  SubnetEndpointsArtifactSchema,
+} from "../routes/endpoints-pools.ts";
 
 const SURFACE_KINDS = [
   "archive",
@@ -127,20 +140,7 @@ export const ListEndpointsInputSchema = z
   .strict();
 export type ListEndpointsInput = z.infer<typeof ListEndpointsInputSchema>;
 
-export const ListEndpointsOutputSchema = z
-  .object({
-    endpoints: z.array(OpenObjectSchema).optional(),
-    total: z.int().optional(),
-    returned: z.int().optional(),
-    cursor: z.int().optional(),
-    limit: z.int().optional(),
-    next_cursor: z.int().nullable().optional(),
-    sort: z.string().nullable().optional(),
-    order: z.string().nullable().optional(),
-    generated_at: z.string().nullable().optional(),
-    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
-  })
-  .passthrough();
+export const ListEndpointsOutputSchema = EndpointsArtifactSchema;
 export type ListEndpointsOutput = z.infer<typeof ListEndpointsOutputSchema>;
 
 export const GetSubnetEndpointsInputSchema = z
@@ -152,14 +152,7 @@ export type GetSubnetEndpointsInput = z.infer<
   typeof GetSubnetEndpointsInputSchema
 >;
 
-export const GetSubnetEndpointsOutputSchema = z
-  .object({
-    netuid: netuidSchema().nullable().optional(),
-    endpoints: z.array(OpenObjectSchema).optional(),
-    generated_at: z.string().nullable().optional(),
-    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
-  })
-  .passthrough();
+export const GetSubnetEndpointsOutputSchema = SubnetEndpointsArtifactSchema;
 export type GetSubnetEndpointsOutput = z.infer<
   typeof GetSubnetEndpointsOutputSchema
 >;

--- a/schemas-src/mcp-tools/evm.ts
+++ b/schemas-src/mcp-tools/evm.ts
@@ -1,16 +1,18 @@
-// MCP tools `decode_evm_call`, `get_evm_address_mapping` (types-epic E
-// batch 7, #8070). decode_evm_call is pure/local (src/evm-precompiles.ts,
-// no REST mirror); get_evm_address_mapping mirrors GET /api/v1/evm/address/
-// {h160}. Neither is one of schemas-src/routes/'s covered pilot routes --
-// no existing Zod schema to reuse. Both hand-written originals declare
-// their outputSchema INLINE on the tool definition (not via the shared
-// TOOL_OUTPUT_SCHEMAS map every other tool in this epic uses) and are
-// additionalProperties:false (strict) at the top level, unlike the
-// additionalProperties:true posture everywhere else in this epic -- modeled
-// here with the SAME strictness, not loosened to match the majority
-// convention.
+// MCP tool `get_evm_address_mapping`.
+// Mirrors GET /api/v1/evm/address/{h160}.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
+import { McpNetworkSchema } from "../shared.ts";
+import { EvmAddressMappingArtifactSchema } from "../routes/network-singletons.ts";
 
 const H160Schema = z.string().regex(/^0x[0-9a-fA-F]{40}$/);
 
@@ -60,16 +62,7 @@ export type GetEvmAddressMappingInput = z.infer<
   typeof GetEvmAddressMappingInputSchema
 >;
 
-export const GetEvmAddressMappingOutputSchema = z
-  .object({
-    schema_version: z.int(),
-    h160: z.string(),
-    ss58: z.string().nullable(),
-    queried_at: z.string().nullable(),
-    // #9108 provenance, mirroring the REST artifact field for field.
-    field_sources: FieldSourcesSchema,
-  })
-  .strict();
+export const GetEvmAddressMappingOutputSchema = EvmAddressMappingArtifactSchema;
 export type GetEvmAddressMappingOutput = z.infer<
   typeof GetEvmAddressMappingOutputSchema
 >;

--- a/schemas-src/mcp-tools/extrinsics.ts
+++ b/schemas-src/mcp-tools/extrinsics.ts
@@ -1,7 +1,15 @@
-// MCP tools `list_extrinsics`, `get_extrinsic` (types-epic E batch 8,
-// #8071). Each mirrors a GET /api/v1/extrinsics* route that is not one of
-// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
-// reuse. Modeled fresh, matching each hand-written literal field-for-field.
+// MCP tool `list_extrinsics`.
+// Mirrors GET /api/v1/extrinsics.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
   blockBoundSchema,
@@ -16,11 +24,8 @@ import {
  * read it rather than restating it — they previously declared no maximum at all.
  */
 export const EXTRINSICS_LIMIT_MAX = 100;
-import {
-  AccountEventItemSchema,
-  ExtrinsicItemSchema,
-  OpenObjectSchema,
-} from "./shared.ts";
+import { AccountEventItemSchema, OpenObjectSchema } from "./shared.ts";
+import { ExtrinsicsFeedArtifactSchema } from "../routes/extrinsics.ts";
 
 const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 
@@ -92,16 +97,7 @@ export const ListExtrinsicsInputSchema = z
   .strict();
 export type ListExtrinsicsInput = z.infer<typeof ListExtrinsicsInputSchema>;
 
-export const ListExtrinsicsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    extrinsic_count: z.int(),
-    limit: z.int().nullable().optional(),
-    offset: z.int().nullable().optional(),
-    next_cursor: z.string().nullable().optional(),
-    extrinsics: z.array(ExtrinsicItemSchema),
-  })
-  .passthrough();
+export const ListExtrinsicsOutputSchema = ExtrinsicsFeedArtifactSchema;
 export type ListExtrinsicsOutput = z.infer<typeof ListExtrinsicsOutputSchema>;
 
 export const GetExtrinsicInputSchema = z

--- a/schemas-src/mcp-tools/get-chain-holders.ts
+++ b/schemas-src/mcp-tools/get-chain-holders.ts
@@ -1,11 +1,22 @@
-// get_chain_holders (#9607): every subnet ranked by alpha-ownership
-// concentration, mirroring GET /api/v1/chain/holders.
+// MCP tool `get_chain_holders`.
+// Mirrors GET /api/v1/chain/holders.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import { limitSchema, netuidSchema, sortSchema } from "./shared.ts";
+import { limitSchema, sortSchema } from "./shared.ts";
 import {
   CHAIN_HOLDERS_LIMIT_DEFAULT,
   CHAIN_HOLDERS_LIMIT_MAX,
 } from "../../src/route-limits.ts";
+import { ChainHoldersArtifactSchema } from "../routes/chain-holders.ts";
 
 export const GetChainHoldersInputSchema = z
   .object({
@@ -25,42 +36,5 @@ export const GetChainHoldersInputSchema = z
   .strict();
 export type GetChainHoldersInput = z.infer<typeof GetChainHoldersInputSchema>;
 
-export const GetChainHoldersOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    sort: z.string(),
-    limit: z.int().nullable(),
-    subnet_count: z.int().nullable(),
-    network: z
-      .object({
-        subnets_measured: z.int().nullable(),
-        subnets_with_majority_holder: z.int().nullable(),
-        subnets_with_single_holder: z.int().nullable(),
-        median_top1_share: z.number().nullable(),
-      })
-      .passthrough(),
-    captured_at: z.string().nullable(),
-    positions_captured_at: z.string().nullable(),
-    subnets: z.array(
-      z
-        .object({
-          netuid: netuidSchema(),
-          holder_count: z.int().nullable(),
-          total_alpha: z.number().nullable(),
-          top1_share: z.number().nullable(),
-          top5_share: z.number().nullable(),
-          top10_share: z.number().nullable(),
-          top20_share: z.number().nullable(),
-          top_holder: z.string().nullable(),
-        })
-        .passthrough(),
-    ),
-    // Present ONLY on a decline. A model seeing an empty `subnets` must read
-    // this before concluding the network has no measured holders.
-    degraded: z
-      .object({ reason: z.enum(["pool_totals_unproven", "unavailable"]) })
-      .passthrough()
-      .optional(),
-  })
-  .passthrough();
+export const GetChainHoldersOutputSchema = ChainHoldersArtifactSchema;
 export type GetChainHoldersOutput = z.infer<typeof GetChainHoldersOutputSchema>;

--- a/schemas-src/mcp-tools/get-domain-summary.ts
+++ b/schemas-src/mcp-tools/get-domain-summary.ts
@@ -1,5 +1,6 @@
 // MCP tool `get_domain_summary` (types-epic E batch 4, #8067). Composite
-// tool mirroring EITHER GET /api/v1/domains/{tag}/summary (DomainSummaryArtifact
+// tool mirroring EITHER GET /api/v1/domains/{tag}/summary
+// (DomainSummaryArtifact
 // shape) OR GET /api/v1/domains (DomainsArtifact shape), chosen by whether
 // `domain` was passed -- schemas-src/routes/domains.ts (#8055) models each
 // REST shape separately and strictly; this tool's single return value can be

--- a/schemas-src/mcp-tools/get-economics.ts
+++ b/schemas-src/mcp-tools/get-economics.ts
@@ -1,7 +1,8 @@
 // MCP tool `get_economics` (types-epic E pilot batch, #7863). The handler
 // (src/network-economics.ts's loadNetworkEconomics) calls resolveLiveEconomics
 // -- the SAME live/R2-fallback tier the REST `economics` route uses -- so the
-// underlying per-subnet row data is identical to schemas-src/routes/economics.ts's
+// underlying per-subnet row data is identical to
+// schemas-src/routes/economics.ts's
 // SubnetEconomicsSchema. The hand-written wire schema this replaces
 // (GET_ECONOMICS_OUTPUT_SCHEMA, src/network-economics.ts) deliberately left
 // `summary`/`subnets` shallow (bare `{type:["object","null"]}` /

--- a/schemas-src/mcp-tools/get-emission-changes.ts
+++ b/schemas-src/mcp-tools/get-emission-changes.ts
@@ -1,11 +1,22 @@
-// get_emission_changes (#9615): the emission-gate change log, mirroring
-// GET /api/v1/chain/governance/emission-changes.
+// MCP tool `get_emission_changes`.
+// Mirrors GET /api/v1/chain/governance/emission-changes.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { kindSchema, limitSchema } from "./shared.ts";
 import {
   EMISSION_CHANGES_LIMIT_DEFAULT,
   EMISSION_CHANGES_LIMIT_MAX,
 } from "../../src/route-limits.ts";
+import { EmissionGateChangesArtifactSchema } from "../routes/emission-gate-changes.ts";
 
 export const GetEmissionChangesInputSchema = z
   .object({
@@ -20,19 +31,7 @@ export type GetEmissionChangesInput = z.infer<
   typeof GetEmissionChangesInputSchema
 >;
 
-export const GetEmissionChangesOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    kind: z.string().nullable(),
-    limit: z.int().nullable(),
-    change_count: z.int(),
-    /** Entries that are a FIRST OBSERVATION rather than a change. Subtract
-     * these before counting governance events. */
-    predates_capture_count: z.int(),
-    latest_change_at: z.string().nullable(),
-    changes: z.array(z.record(z.string(), z.unknown())),
-  })
-  .passthrough();
+export const GetEmissionChangesOutputSchema = EmissionGateChangesArtifactSchema;
 export type GetEmissionChangesOutput = z.infer<
   typeof GetEmissionChangesOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-emission-pipeline.ts
+++ b/schemas-src/mcp-tools/get-emission-pipeline.ts
@@ -1,16 +1,15 @@
-// MCP tool `get_emission_pipeline` (#8744) — the v440 emission decomposition.
+// MCP tool `get_emission_pipeline`.
+// Mirrors GET /api/v1/chain/emission-pipeline.
 //
-// Unlike get-economics-trends.ts, this one's REST counterpart IS covered by
-// schemas-src/routes/, so the output schema reuses that route's own body
-// (EMISSION_PIPELINE_BODY) rather than being modelled fresh — the same
-// reuse-the-route-schema precedent get-subnet-stake-quote.ts set. The tool
-// returns the projection alone, with none of ArtifactBase's envelope fields,
-// which is why the route file exports the body separately.
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
 //
-// Strictness is inherited deliberately: the tool and the route describe the
-// same bytes, so if a capture ever grew a field, both contracts would be wrong
-// together and there is exactly one place to fix — which is the whole point of
-// not keeping a second copy here.
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
   netuidSchema,
@@ -19,12 +18,12 @@ import {
   orderSchema,
   sortSchema,
 } from "./shared.ts";
-import { EMISSION_PIPELINE_BODY } from "../routes/emission-pipeline.ts";
 import { EMISSION_PIPELINE_SORT_FIELDS } from "../../src/emission-pipeline-surface.ts";
 import {
   EMISSION_PIPELINE_LIMIT_MAX,
   EMISSION_PIPELINE_MCP_LIMIT_DEFAULT,
 } from "../../src/route-limits.ts";
+import { EmissionPipelineArtifactSchema } from "../routes/emission-pipeline.ts";
 
 export const GetEmissionPipelineInputSchema = z
   .object({
@@ -50,9 +49,7 @@ export type GetEmissionPipelineInput = z.infer<
   typeof GetEmissionPipelineInputSchema
 >;
 
-export const GetEmissionPipelineOutputSchema = z
-  .object(EMISSION_PIPELINE_BODY)
-  .strict();
+export const GetEmissionPipelineOutputSchema = EmissionPipelineArtifactSchema;
 export type GetEmissionPipelineOutput = z.infer<
   typeof GetEmissionPipelineOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-failure-reasons.ts
+++ b/schemas-src/mcp-tools/get-failure-reasons.ts
@@ -1,8 +1,19 @@
-// get_failure_reasons (#9622): why surfaces fail and whether the mix is
-// changing, mirroring GET /api/v1/health/failure-reasons.
+// MCP tool `get_failure_reasons`.
+// Mirrors GET /api/v1/health/failure-reasons.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { kindStringSchema, netuidSchema } from "./shared.ts";
 import { FAILURE_REASONS_WINDOWS } from "../../src/route-limits.ts";
+import { FailureReasonsArtifactSchema } from "../routes/failure-reasons.ts";
 
 export const GetFailureReasonsInputSchema = z
   .object({
@@ -21,49 +32,7 @@ export type GetFailureReasonsInput = z.infer<
   typeof GetFailureReasonsInputSchema
 >;
 
-export const GetFailureReasonsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string().nullable(),
-    netuid: netuidSchema().nullable(),
-    kind: z.string().nullable(),
-    days_covered: z.int().nullable(),
-    oldest_day: z.string().nullable(),
-    newest_day: z.string().nullable(),
-    total_checks: z.int().nullable(),
-    failing_checks: z.int().nullable(),
-    failure_rate: z.number().nullable(),
-    reasons: z.array(
-      z
-        .object({
-          classification: z.string(),
-          is_failure: z.boolean(),
-          checks: z.int(),
-          share: z.number().nullable(),
-          failure_share: z.number().nullable(),
-        })
-        .passthrough(),
-    ),
-    series: z.array(
-      z
-        .object({
-          day: z.string(),
-          total_checks: z.int(),
-          failing_checks: z.int(),
-          failure_rate: z.number().nullable(),
-          by_classification: z.record(z.string(), z.int()),
-        })
-        .passthrough(),
-    ),
-    // Present ONLY on a decline. An empty window is a MEASUREMENT -- the prober
-    // recorded nothing in that range -- so a model must read this before
-    // concluding the read failed.
-    degraded: z
-      .object({ reason: z.enum(["unavailable"]) })
-      .passthrough()
-      .optional(),
-  })
-  .passthrough();
+export const GetFailureReasonsOutputSchema = FailureReasonsArtifactSchema;
 export type GetFailureReasonsOutput = z.infer<
   typeof GetFailureReasonsOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-global-incidents.ts
+++ b/schemas-src/mcp-tools/get-global-incidents.ts
@@ -1,11 +1,20 @@
-// MCP tool `get_global_incidents` (types-epic E batch 4, #8068). Mirrors
-// GET /api/v1/incidents, which is not one of schemas-src/routes/'s covered
-// pilot routes -- no existing Zod schema to reuse. Modeled fresh, shallow,
-// from the hand-written literal it replaces.
+// MCP tool `get_global_incidents`.
+// Mirrors GET /api/v1/incidents.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_global_incidents: 3 bare `{"type":"object"}` sites.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
-  OpenObjectArraySchema,
-  OpenObjectSchema,
   limitSchema,
   netuidSchema,
   numericCursorSchema,
@@ -13,6 +22,7 @@ import {
   sortSchema,
   windowSchema,
 } from "./shared.ts";
+import { GlobalIncidentsArtifactSchema } from "../routes/health-surfaces.ts";
 
 // Symbolic in the hand-written original (src/contracts.ts's
 // API_QUERY_COLLECTIONS.incidents.sort_fields), cross-checked against the
@@ -38,27 +48,7 @@ export type GetGlobalIncidentsInput = z.infer<
   typeof GetGlobalIncidentsInputSchema
 >;
 
-export const GetGlobalIncidentsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-    source: z.string().nullable().optional(),
-    summary: OpenObjectSchema,
-    // #8824: the incident-qualifying threshold, mirrors the REST route.
-    // surfaces (OpenObjectArraySchema, shallow) already carries each
-    // surface's transient_failure_count/transient_failed_samples through.
-    min_incident_samples: z.int().optional(),
-    surfaces: OpenObjectArraySchema,
-    total: z.int().optional(),
-    returned: z.int().optional(),
-    limit: z.int().optional(),
-    cursor: z.int().optional(),
-    next_cursor: z.int().nullable().optional(),
-    sort: z.string().nullable().optional(),
-    order: z.string().nullable().optional(),
-  })
-  .passthrough();
+export const GetGlobalIncidentsOutputSchema = GlobalIncidentsArtifactSchema;
 export type GetGlobalIncidentsOutput = z.infer<
   typeof GetGlobalIncidentsOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-health-history.ts
+++ b/schemas-src/mcp-tools/get-health-history.ts
@@ -1,9 +1,11 @@
 // MCP tool `get_health_history` (types-epic E batch 2, #8065). Mirrors GET
 // /api/v1/health/history/{date}, which is not one of schemas-src/routes/'s
 // covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
-// shallow, from the hand-written literal it replaces (src/health-history-mcp.ts).
+// shallow, from the hand-written literal it replaces
+// (src/health-history-mcp.ts).
 // Enum values hardcoded from src/contracts.ts's QUERY_ENUMS.{surfaceKind,
-// healthStatus,healthClassification} and API_QUERY_COLLECTIONS["health-surfaces"]
+// healthStatus,healthClassification} and
+// API_QUERY_COLLECTIONS["health-surfaces"]
 // .sort_fields at the time of writing (mirrors the pilot batch's
 // ECONOMICS_SORT_FIELDS precedent -- not cross-imported).
 import { z } from "zod";

--- a/schemas-src/mcp-tools/get-health-trends.ts
+++ b/schemas-src/mcp-tools/get-health-trends.ts
@@ -1,19 +1,23 @@
-// MCP tool `get_health_trends` (types-epic E batch 2, #8065). Mirrors GET
-// /api/v1/health/trends, which is not one of schemas-src/routes/'s covered
-// pilot routes -- no existing Zod schema to reuse. Modeled fresh, shallow,
-// from the hand-written literal it replaces.
+// MCP tool `get_health_trends`.
+// Mirrors GET /api/v1/health/trends.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_health_trends: 1 bare `{"type":"object"}` site.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import { BulkHealthTrendsArtifactSchema } from "../routes/health-surfaces.ts";
 
 export const GetHealthTrendsInputSchema = z.object({}).strict();
 export type GetHealthTrendsInput = z.infer<typeof GetHealthTrendsInputSchema>;
 
-export const GetHealthTrendsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    observed_at: z.string().nullable().optional(),
-    source: z.string().nullable().optional(),
-    windows: OpenObjectSchema,
-  })
-  .passthrough();
+export const GetHealthTrendsOutputSchema = BulkHealthTrendsArtifactSchema;
 export type GetHealthTrendsOutput = z.infer<typeof GetHealthTrendsOutputSchema>;

--- a/schemas-src/mcp-tools/get-indexer-lag.ts
+++ b/schemas-src/mcp-tools/get-indexer-lag.ts
@@ -1,46 +1,21 @@
-// get_indexer_lag (#9620): how long after a block is produced it becomes
-// queryable here, mirroring GET /api/v1/chain/indexer-lag.
+// MCP tool `get_indexer_lag`.
+// Mirrors GET /api/v1/chain/indexer-lag.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
+import { IndexerLagArtifactSchema } from "../routes/indexer-lag.ts";
 
 /** No inputs: the route measures one window and has nothing to filter. */
 export const GetIndexerLagInputSchema = z.object({}).strict();
 export type GetIndexerLagInput = z.infer<typeof GetIndexerLagInputSchema>;
 
-export const GetIndexerLagOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    block_count: z.int().nullable(),
-    window: z
-      .object({
-        oldest_block: z.int().nullable(),
-        newest_block: z.int().nullable(),
-        oldest_observed_at: z.string().nullable(),
-        newest_observed_at: z.string().nullable(),
-      })
-      .passthrough()
-      .nullable(),
-    write_latency_ms: z
-      .object({
-        min: z.number().nullable(),
-        p50: z.number().nullable(),
-        p95: z.number().nullable(),
-        p99: z.number().nullable(),
-        max: z.number().nullable(),
-        mean: z.number().nullable(),
-      })
-      .passthrough()
-      .nullable(),
-    head_age_ms: z.number().nullable(),
-    measured_at: z.string(),
-    // Present ONLY on a decline. A model seeing null measurements must read
-    // this before concluding the lane is instantaneous.
-    degraded: z
-      .object({
-        reason: z.enum(["no_retained_blocks", "unavailable"]),
-        detail: z.string().optional(),
-      })
-      .passthrough()
-      .optional(),
-  })
-  .passthrough();
+export const GetIndexerLagOutputSchema = IndexerLagArtifactSchema;
 export type GetIndexerLagOutput = z.infer<typeof GetIndexerLagOutputSchema>;

--- a/schemas-src/mcp-tools/get-network-health.ts
+++ b/schemas-src/mcp-tools/get-network-health.ts
@@ -1,42 +1,25 @@
-// MCP tool `get_network_health` (types-epic E pilot batch, #7863). The
-// handler calls the SAME loadGlobalOperationalHealth() the REST `health`
-// route uses (workers/api.ts's handleApiRequest, matched.id === "health"),
-// so the underlying DATA is identical -- but the hand-written wire schema
-// this replaces (GET_NETWORK_HEALTH_OUTPUT_SCHEMA, src/global-operational-health.ts)
-// deliberately left `global`/`subnets` shallow (bare `{type:"object"}` /
-// `{type:"array", items:{type:"object"}}`, no property-level constraints),
-// unlike the REST route's own deep, `.strict()` HealthSummaryArtifactSchema
-// (schemas-src/routes/health.ts). Keeping that same looseness here --
-// NOT reusing HealthSummaryArtifactSchema wholesale -- per #7863's wire-
-// compatibility constraint: publishing a stricter MCP contract than the one
-// that already shipped would reject payloads existing clients' own
-// validators (calibrated to the loose original) currently accept, which the
-// issue calls out as a regression, not an improvement. Only the fields that
-// were ALREADY typed at this same shallow grain are modeled; nothing here
-// changes what a conforming client accepts.
+// MCP tool `get_network_health`.
+// Mirrors GET /api/v1/health.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_network_health: 2 bare `{"type":"object"}` sites.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
+import { HealthSummaryArtifactSchema } from "../routes/health.ts";
 
 export const GetNetworkHealthInputSchema = z.object({}).strict();
 export type GetNetworkHealthInput = z.infer<typeof GetNetworkHealthInputSchema>;
 
-const OpenObjectSchema = z.object({}).passthrough();
-
-export const GetNetworkHealthOutputSchema = z
-  .object({
-    schema_version: z.int(),
-    // A flat 3-member union (int | string | null), not
-    // z.union([...]).nullable() -- the latter nests (anyOf-of-anyOf) where
-    // the original is a single flat `type:["integer","string","null"]`.
-    contract_version: z.union([z.int(), z.string(), z.null()]).optional(),
-    generated_at: z.string().nullable().optional(),
-    source: z.string().nullable().optional(),
-    health_source: z.string().nullable().optional(),
-    scope: z.string(),
-    operational_observed_at: z.string().nullable().optional(),
-    global: OpenObjectSchema,
-    subnets: z.array(OpenObjectSchema),
-  })
-  .passthrough();
+export const GetNetworkHealthOutputSchema = HealthSummaryArtifactSchema;
 export type GetNetworkHealthOutput = z.infer<
   typeof GetNetworkHealthOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-registry-leaderboards.ts
+++ b/schemas-src/mcp-tools/get-registry-leaderboards.ts
@@ -1,11 +1,21 @@
-// MCP tool `get_registry_leaderboards` (types-epic E batch 4, #8067). Mirrors
-// GET /api/v1/registry/leaderboards, which is not one of schemas-src/routes/'s
-// covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
-// shallow, from the hand-written literal it replaces. Board enum hardcoded
-// from src/health-serving.ts's LEADERBOARD_BOARDS (base 6 boards +
-// ECONOMIC_BOARD_SPECS's 6 keys) at the time of writing.
+// MCP tool `get_registry_leaderboards`.
+// Mirrors GET /api/v1/registry/leaderboards.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_registry_leaderboards: 1 bare `{"type":"object"}` site.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import { OpenObjectSchema, limitSchema } from "./shared.ts";
+import { limitSchema } from "./shared.ts";
+import { RegistryLeaderboardsArtifactSchema } from "../routes/registry-summary-leaderboards.ts";
 
 const LEADERBOARD_BOARDS = [
   "healthiest",
@@ -36,14 +46,8 @@ export type GetRegistryLeaderboardsInput = z.infer<
   typeof GetRegistryLeaderboardsInputSchema
 >;
 
-export const GetRegistryLeaderboardsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    board: z.string().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-    boards: OpenObjectSchema,
-  })
-  .passthrough();
+export const GetRegistryLeaderboardsOutputSchema =
+  RegistryLeaderboardsArtifactSchema;
 export type GetRegistryLeaderboardsOutput = z.infer<
   typeof GetRegistryLeaderboardsOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-detail.ts
+++ b/schemas-src/mcp-tools/get-subnet-detail.ts
@@ -1,16 +1,22 @@
-// MCP tool `get_subnet_detail` (types-epic E batch 2, #8065). Despite
-// "Mirrors GET /api/v1/subnets/{netuid}" in its description, the handler
-// reads the RAW /metagraph/subnets/{netuid}.json artifact and nests it under
-// a `subnet` key (`{schema_version, generated_at, subnet: {...}, ...}`) --
-// a different top-level wrapper shape than schemas-src/routes/subnet-detail.ts's
-// SubnetDetailArtifactSchema (the REST route's own `data`, which is the
-// subnet's fields directly, not nested under `subnet`). Not reusable;
-// modeled fresh, shallow, from the hand-written literal it replaces (same
-// look-but-don't-reuse finding as get-network-health.ts/get-economics.ts in
-// the pilot batch).
+// MCP tool `get_subnet_detail`.
+// Mirrors GET /api/v1/subnets/{netuid}.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_subnet_detail: 2 bare `{"type":"object"}` sites.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import { OpenObjectSchema, netuidSchema } from "./shared.ts";
+import { netuidSchema } from "./shared.ts";
 import { McpNetworkSchema } from "../shared.ts";
+import { SubnetDetailArtifactSchema } from "../routes/subnet-detail.ts";
 
 export const GetSubnetDetailInputSchema = z
   .object({
@@ -20,18 +26,5 @@ export const GetSubnetDetailInputSchema = z
   .strict();
 export type GetSubnetDetailInput = z.infer<typeof GetSubnetDetailInputSchema>;
 
-export const GetSubnetDetailOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    generated_at: z.string().nullable().optional(),
-    subnet: OpenObjectSchema,
-    candidate_surfaces: z.array(z.unknown()).optional(),
-    candidates: z.array(z.unknown()).optional(),
-    endpoints: z.array(z.unknown()).optional(),
-    gaps: z.unknown().optional(),
-    surfaces: z.array(z.unknown()).optional(),
-    verified_surfaces: z.array(z.unknown()).optional(),
-    economics: OpenObjectSchema.nullable().optional(),
-  })
-  .passthrough();
+export const GetSubnetDetailOutputSchema = SubnetDetailArtifactSchema;
 export type GetSubnetDetailOutput = z.infer<typeof GetSubnetDetailOutputSchema>;

--- a/schemas-src/mcp-tools/get-subnet-event-summary.ts
+++ b/schemas-src/mcp-tools/get-subnet-event-summary.ts
@@ -1,57 +1,30 @@
-// MCP tool `get_subnet_event_summary` (types-epic E batch 3, #8066). Mirrors
-// GET /api/v1/subnets/{netuid}/event-summary, which is not one of
-// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
-// reuse (schemas-src/routes/subnet-event-summary.ts, #8055, is REST-side
-// and not yet mergeable-shared as of this batch). Modeled fresh, shallow,
-// from the hand-written literal it replaces. Window enum hardcoded from
-// src/account-events.ts's SUBNET_EVENT_SUMMARY_WINDOWS at the time of
-// writing.
+// MCP tool `get_subnet_event_summary`.
+// Mirrors GET /api/v1/subnets/{netuid}/event-summary.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_subnet_event_summary: 1 bare `{"type":"object"}` site.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
   SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
   SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
 } from "../../src/route-limits.ts";
-import {
-  OpenObjectArraySchema,
-  limitSchema,
-  netuidSchema,
-  windowSchema,
-} from "./shared.ts";
+import { limitSchema, netuidSchema, windowSchema } from "./shared.ts";
+import { SubnetEventSummaryArtifactSchema } from "../routes/subnet-event-summary.ts";
 
 const SUBNET_EVENT_SUMMARY_WINDOWS = ["7d", "30d", "90d"] as const;
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
-const EventCategorySummarySchema = z
-  .object({
-    category: z.string().nullable().optional(),
-    event_count: z.int().optional(),
-    kind_count: z.int().optional(),
-    amount_tao: z.unknown().optional(),
-    alpha_amount: z.unknown().optional(),
-    first_block: z.int().nullable().optional(),
-    last_block: z.int().nullable().optional(),
-    first_observed_at: z.string().nullable().optional(),
-    last_observed_at: z.string().nullable().optional(),
-  })
-  .passthrough();
-
-const EventKindSummarySchema = z
-  .object({
-    event_kind: z.string().nullable().optional(),
-    category: z.string().nullable().optional(),
-    event_count: z.int().optional(),
-    hotkey_count: z.int().optional(),
-    coldkey_count: z.int().optional(),
-    amount_tao: z.unknown().optional(),
-    alpha_amount: z.unknown().optional(),
-    first_block: z.int().nullable().optional(),
-    last_block: z.int().nullable().optional(),
-    first_observed_at: z.string().nullable().optional(),
-    last_observed_at: z.string().nullable().optional(),
-  })
-  .passthrough();
-
 export const GetSubnetEventSummaryInputSchema = z
   .object({
     netuid: netuidSchema(),
@@ -66,22 +39,8 @@ export type GetSubnetEventSummaryInput = z.infer<
   typeof GetSubnetEventSummaryInputSchema
 >;
 
-export const GetSubnetEventSummaryOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string().nullable(),
-    observed_at: z.string().nullable().optional(),
-    total_events: z.int(),
-    kind_count: z.int(),
-    category_count: z.int().optional(),
-    recent_event_count: z.int(),
-    limit: z.int().nullable().optional(),
-    categories: z.array(EventCategorySummarySchema),
-    event_kinds: z.array(EventKindSummarySchema),
-    recent_events: OpenObjectArraySchema,
-  })
-  .passthrough();
+export const GetSubnetEventSummaryOutputSchema =
+  SubnetEventSummaryArtifactSchema;
 export type GetSubnetEventSummaryOutput = z.infer<
   typeof GetSubnetEventSummaryOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-events.ts
+++ b/schemas-src/mcp-tools/get-subnet-events.ts
@@ -1,11 +1,15 @@
-// MCP tool `get_subnet_events` (types-epic E batch 4, #8067). Mirrors GET
-// /api/v1/subnets/{netuid}/events, covered by schemas-src/routes/
-// subnet-events.ts (#8055) -- NOT reused: that REST schema's AccountEvent
-// item requires block_number+event_kind and the artifact requires
-// schema_version; this tool's own hand-written ACCOUNT_EVENT_ITEM leaves
-// every item field optional (via the shared objectItems() shape) and
-// schema_version optional too. Modeled fresh instead, matching the
-// hand-written literal it replaces field-for-field.
+// MCP tool `get_subnet_events`.
+// Mirrors GET /api/v1/subnets/{netuid}/events.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
   blockBoundSchema,
@@ -15,6 +19,7 @@ import {
   netuidSchema,
   offsetSchema,
 } from "./shared.ts";
+import { SubnetEventsArtifactSchema } from "../routes/subnet-events.ts";
 
 export const GetSubnetEventsInputSchema = z
   .object({
@@ -31,31 +36,5 @@ export type GetSubnetEventsInput = z.infer<typeof GetSubnetEventsInputSchema>;
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
-const AccountEventItemSchema = z
-  .object({
-    block_number: z.int().nullable().optional(),
-    event_index: z.int().nullable().optional(),
-    event_kind: z.string().nullable().optional(),
-    hotkey: z.string().nullable().optional(),
-    coldkey: z.string().nullable().optional(),
-    netuid: netuidSchema().nullable().optional(),
-    uid: z.int().nullable().optional(),
-    amount_tao: z.unknown().optional(),
-    alpha_amount: z.unknown().optional(),
-    observed_at: z.string().nullable().optional(),
-    extrinsic_index: z.int().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetSubnetEventsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    event_count: z.int(),
-    limit: z.int().nullable().optional(),
-    offset: z.int().nullable().optional(),
-    next_cursor: z.string().nullable().optional(),
-    events: z.array(AccountEventItemSchema),
-  })
-  .passthrough();
+export const GetSubnetEventsOutputSchema = SubnetEventsArtifactSchema;
 export type GetSubnetEventsOutput = z.infer<typeof GetSubnetEventsOutputSchema>;

--- a/schemas-src/mcp-tools/get-subnet-health-incidents.ts
+++ b/schemas-src/mcp-tools/get-subnet-health-incidents.ts
@@ -1,9 +1,18 @@
-// MCP tool `get_subnet_health_incidents` (types-epic E batch 2, #8065).
-// Mirrors GET /api/v1/subnets/{netuid}/health/incidents, which is not one of
-// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
-// reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
+// MCP tool `get_subnet_health_incidents`.
+// Mirrors GET /api/v1/subnets/{netuid}/health/incidents.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { netuidSchema, windowSchema } from "./shared.ts";
+import { HealthIncidentsArtifactSchema } from "../routes/health-surfaces.ts";
 
 const HEALTH_WINDOWS = ["7d", "30d"] as const;
 
@@ -17,42 +26,8 @@ export type GetSubnetHealthIncidentsInput = z.infer<
   typeof GetSubnetHealthIncidentsInputSchema
 >;
 
-const GetSubnetHealthIncidentSchema = z
-  .object({
-    started_at: z.int().nullable().optional(),
-    ended_at: z.int().nullable().optional(),
-    duration_ms: z.int().nullable().optional(),
-    failed_samples: z.int().optional(),
-  })
-  .passthrough();
-
-const GetSubnetHealthIncidentsSurfaceSchema = z
-  .object({
-    surface_id: z.string().nullable().optional(),
-    samples: z.int().optional(),
-    uptime_ratio: z.number().nullable().optional(),
-    incident_count: z.int().optional(),
-    downtime_ms: z.int().optional(),
-    // #8824: sub-MIN_INCIDENT_SAMPLES gap-islands excluded from incidents --
-    // island count + their total failed probes -- mirrors the REST route.
-    transient_failure_count: z.int().optional(),
-    transient_failed_samples: z.int().optional(),
-    incidents: z.array(GetSubnetHealthIncidentSchema).optional(),
-  })
-  .passthrough();
-
-export const GetSubnetHealthIncidentsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-    source: z.string().nullable().optional(),
-    // #8824: the incident-qualifying threshold, mirrors the REST route.
-    min_incident_samples: z.int().optional(),
-    surfaces: z.array(GetSubnetHealthIncidentsSurfaceSchema),
-  })
-  .passthrough();
+export const GetSubnetHealthIncidentsOutputSchema =
+  HealthIncidentsArtifactSchema;
 export type GetSubnetHealthIncidentsOutput = z.infer<
   typeof GetSubnetHealthIncidentsOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-health-percentiles.ts
+++ b/schemas-src/mcp-tools/get-subnet-health-percentiles.ts
@@ -1,9 +1,18 @@
-// MCP tool `get_subnet_health_percentiles` (types-epic E batch 2, #8065).
-// Mirrors GET /api/v1/subnets/{netuid}/health/percentiles, which is not one
-// of schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
-// reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
+// MCP tool `get_subnet_health_percentiles`.
+// Mirrors GET /api/v1/subnets/{netuid}/health/percentiles.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { netuidSchema, windowSchema } from "./shared.ts";
+import { HealthPercentilesArtifactSchema } from "../routes/health-surfaces.ts";
 
 const HEALTH_WINDOWS = ["7d", "30d"] as const;
 
@@ -17,35 +26,8 @@ export type GetSubnetHealthPercentilesInput = z.infer<
   typeof GetSubnetHealthPercentilesInputSchema
 >;
 
-const LatencyPercentilesSchema = z
-  .object({
-    p50: z.int().nullable().optional(),
-    p95: z.int().nullable().optional(),
-    p99: z.int().nullable().optional(),
-    avg: z.int().nullable().optional(),
-    min: z.int().nullable().optional(),
-    max: z.int().nullable().optional(),
-  })
-  .passthrough();
-
-const GetSubnetHealthPercentilesSurfaceSchema = z
-  .object({
-    surface_id: z.string().nullable().optional(),
-    samples: z.int().optional(),
-    latency_ms: LatencyPercentilesSchema.optional(),
-  })
-  .passthrough();
-
-export const GetSubnetHealthPercentilesOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-    source: z.string().nullable().optional(),
-    surfaces: z.array(GetSubnetHealthPercentilesSurfaceSchema),
-  })
-  .passthrough();
+export const GetSubnetHealthPercentilesOutputSchema =
+  HealthPercentilesArtifactSchema;
 export type GetSubnetHealthPercentilesOutput = z.infer<
   typeof GetSubnetHealthPercentilesOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-health-trends.ts
+++ b/schemas-src/mcp-tools/get-subnet-health-trends.ts
@@ -1,9 +1,21 @@
-// MCP tool `get_subnet_health_trends` (types-epic E batch 2, #8065). Mirrors
-// GET /api/v1/subnets/{netuid}/health/trends, which is not one of
-// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
-// reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
+// MCP tool `get_subnet_health_trends`.
+// Mirrors GET /api/v1/subnets/{netuid}/health/trends.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_subnet_health_trends: 1 bare `{"type":"object"}` site.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import { OpenObjectSchema, netuidSchema } from "./shared.ts";
+import { netuidSchema } from "./shared.ts";
+import { HealthTrendsArtifactSchema } from "../routes/health-surfaces.ts";
 
 export const GetSubnetHealthTrendsInputSchema = z
   .object({
@@ -14,15 +26,7 @@ export type GetSubnetHealthTrendsInput = z.infer<
   typeof GetSubnetHealthTrendsInputSchema
 >;
 
-export const GetSubnetHealthTrendsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    observed_at: z.string().nullable().optional(),
-    source: z.string().nullable().optional(),
-    windows: OpenObjectSchema,
-  })
-  .passthrough();
+export const GetSubnetHealthTrendsOutputSchema = HealthTrendsArtifactSchema;
 export type GetSubnetHealthTrendsOutput = z.infer<
   typeof GetSubnetHealthTrendsOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-history.ts
@@ -1,13 +1,18 @@
-// MCP tool `get_subnet_history` (types-epic E batch 4, #8067). Mirrors GET
-// /api/v1/subnets/{netuid}/history, covered by schemas-src/routes/
-// subnet-history.ts (#8055) -- NOT reused: that REST schema's `window`
-// field is required (bare nullable string, no enum); this tool's own
-// hand-written original leaves `window` optional and constrains it to a
-// 5-value enum. Reusing would both loosen (drop the enum) and tighten
-// (require the key) the existing contract in different ways -- modeled
-// fresh instead, matching the original exactly.
+// MCP tool `get_subnet_history`.
+// Mirrors GET /api/v1/subnets/{netuid}/history.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { netuidSchema, windowSchema } from "./shared.ts";
+import { SubnetHistoryArtifactSchema } from "../routes/subnet-history.ts";
 
 const HISTORY_WINDOWS = ["7d", "30d", "90d", "1y", "all"] as const;
 
@@ -21,25 +26,7 @@ export type GetSubnetHistoryInput = z.infer<typeof GetSubnetHistoryInputSchema>;
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
-const SubnetHistoryPointSchema = z
-  .object({
-    snapshot_date: z.string().nullable().optional(),
-    neuron_count: z.int().nullable().optional(),
-    validator_count: z.int().nullable().optional(),
-    total_stake_alpha: z.unknown().optional(),
-    total_emission_alpha: z.unknown().optional(),
-  })
-  .passthrough();
-
-export const GetSubnetHistoryOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string().nullable().optional(),
-    point_count: z.int(),
-    points: z.array(SubnetHistoryPointSchema),
-  })
-  .passthrough();
+export const GetSubnetHistoryOutputSchema = SubnetHistoryArtifactSchema;
 export type GetSubnetHistoryOutput = z.infer<
   typeof GetSubnetHistoryOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-holders.ts
+++ b/schemas-src/mcp-tools/get-subnet-holders.ts
@@ -1,16 +1,22 @@
-// get_subnet_holders (#9557): the per-subnet alpha holder leaderboard, mirroring
-// GET /api/v1/subnets/{netuid}/holders.
+// MCP tool `get_subnet_holders`.
+// Mirrors GET /api/v1/subnets/{netuid}/holders.
 //
-// The output mirrors src/subnet-holders.ts's buildSubnetHolders() rather than
-// the route schema's stricter form, following every sibling tool here: a tool
-// output is read by a model, so it stays permissive about extra keys and states
-// only the fields a caller may rely on.
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { limitSchema, netuidSchema } from "./shared.ts";
 import {
   SUBNET_HOLDERS_LIMIT_DEFAULT,
   SUBNET_HOLDERS_LIMIT_MAX,
 } from "../../src/route-limits.ts";
+import { SubnetHoldersArtifactSchema } from "../routes/subnet-holders.ts";
 
 export const GetSubnetHoldersInputSchema = z
   .object({
@@ -23,47 +29,7 @@ export const GetSubnetHoldersInputSchema = z
   .strict();
 export type GetSubnetHoldersInput = z.infer<typeof GetSubnetHoldersInputSchema>;
 
-export const GetSubnetHoldersOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    limit: z.int().nullable(),
-    // Whole-subnet, never bounded by the returned page.
-    holder_count: z.int().nullable(),
-    total_alpha: z.number().nullable(),
-    concentration: z
-      .object({
-        top5_share: z.number().nullable(),
-        top10_share: z.number().nullable(),
-        top20_share: z.number().nullable(),
-      })
-      .passthrough(),
-    captured_at: z.string().nullable(),
-    positions_captured_at: z.string().nullable(),
-    holders: z.array(
-      z
-        .object({
-          coldkey: z.string(),
-          alpha: z.number(),
-          share_of_total: z.number().nullable(),
-          hotkey_count: z.int().nullable(),
-        })
-        .passthrough(),
-    ),
-    // Present ONLY when the ranking was declined. A model seeing `holders: []`
-    // must read this before concluding the subnet has no holders.
-    degraded: z
-      .object({
-        reason: z.enum([
-          "pool_totals_unproven",
-          "root_not_in_alpha_map",
-          "unavailable",
-        ]),
-      })
-      .passthrough()
-      .optional(),
-  })
-  .passthrough();
+export const GetSubnetHoldersOutputSchema = SubnetHoldersArtifactSchema;
 export type GetSubnetHoldersOutput = z.infer<
   typeof GetSubnetHoldersOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-hyperparams.ts
+++ b/schemas-src/mcp-tools/get-subnet-hyperparams.ts
@@ -1,16 +1,30 @@
-// MCP tools `get_subnet_hyperparams`, `get_subnet_hyperparams_history`
-// (types-epic E batch 4, #8067). Mirror GET /api/v1/subnets/{netuid}/
-// hyperparameters(/history), neither of which is one of schemas-src/routes/'s
-// covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
-// shallow, from the hand-written literals they replace.
+// MCP tools `get_subnet_hyperparams`, `get_subnet_hyperparams_history`.
+// Mirror GET /api/v1/subnets/{netuid}/hyperparameters, GET
+// /api/v1/subnets/{netuid}/hyperparameters/history.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_subnet_hyperparams: 1 bare `{"type":"object"}` site.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
-  OpenObjectSchema,
   keysetCursorSchema,
   limitSchema,
   netuidSchema,
   offsetSchema,
 } from "./shared.ts";
+import {
+  SubnetHyperparametersArtifactSchema,
+  SubnetHyperparamsHistoryArtifactSchema,
+} from "../routes/subnet-hyperparameters.ts";
 
 export const GetSubnetHyperparamsInputSchema = z
   .object({
@@ -21,15 +35,8 @@ export type GetSubnetHyperparamsInput = z.infer<
   typeof GetSubnetHyperparamsInputSchema
 >;
 
-export const GetSubnetHyperparamsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    captured_at: z.string().nullable().optional(),
-    block_number: z.int().nullable().optional(),
-    hyperparameters: OpenObjectSchema.nullable().optional(),
-  })
-  .passthrough();
+export const GetSubnetHyperparamsOutputSchema =
+  SubnetHyperparametersArtifactSchema;
 export type GetSubnetHyperparamsOutput = z.infer<
   typeof GetSubnetHyperparamsOutputSchema
 >;
@@ -48,26 +55,8 @@ export type GetSubnetHyperparamsHistoryInput = z.infer<
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
-const HyperparamsHistoryEntrySchema = z
-  .object({
-    block_number: z.int().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-    hyperparameters: OpenObjectSchema.nullable().optional(),
-    hyperparams_hash: z.string().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetSubnetHyperparamsHistoryOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    entry_count: z.int(),
-    limit: z.int().nullable().optional(),
-    offset: z.int().nullable().optional(),
-    next_cursor: z.string().nullable().optional(),
-    entries: z.array(HyperparamsHistoryEntrySchema),
-  })
-  .passthrough();
+export const GetSubnetHyperparamsHistoryOutputSchema =
+  SubnetHyperparamsHistoryArtifactSchema;
 export type GetSubnetHyperparamsHistoryOutput = z.infer<
   typeof GetSubnetHyperparamsHistoryOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-identity-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-identity-history.ts
@@ -1,21 +1,15 @@
-// MCP tool `get_subnet_identity_history` (types-epic E batch 4, #8067).
-// Mirrors GET /api/v1/subnets/{netuid}/identity-history, backed by the SAME
-// src/subnet-identity-history.ts buildSubnetIdentityHistory()/
-// formatIdentityHistoryEntry() the REST route (schemas-src/routes/
-// subnet-identity-history.ts, #8055) uses -- NOT reused as a schema import:
-// this tool's own required set (schema_version IS required here, unlike
-// REST's envelope-relative posture) and additionalProperties posture
-// differ enough that a blind reuse would change what this tool's own
-// contract accepts. Modeled fresh instead, matching the hand-written
-// literal it replaces field-for-field.
+// MCP tool `get_subnet_identity_history`.
+// Mirrors GET /api/v1/subnets/{netuid}/identity-history.
 //
-// Real finding (bucket b), same root cause #8055 already found and fixed
-// on the REST side: the hand-written entry schema required identity_hash
-// as a non-nullable string, but formatIdentityHistoryEntry() builds it as
-// `record.identity_hash ?? null` -- a row with no computed hash yields
-// identity_hash: null, which the old schema would have rejected. Modeled
-// here as nullable (still required -- the key itself is always present),
-// matching real behavior.
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
   keysetCursorSchema,
@@ -23,6 +17,7 @@ import {
   netuidSchema,
   offsetSchema,
 } from "./shared.ts";
+import { SubnetIdentityHistoryArtifactSchema } from "../routes/subnet-identity-history.ts";
 
 export const GetSubnetIdentityHistoryInputSchema = z
   .object({
@@ -39,32 +34,8 @@ export type GetSubnetIdentityHistoryInput = z.infer<
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch) -- except
 // identity_hash, which the original also required (see header).
-const SubnetIdentityHistoryEntrySchema = z
-  .object({
-    block_number: z.int().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-    subnet_name: z.string().nullable().optional(),
-    symbol: z.string().nullable().optional(),
-    description: z.string().nullable().optional(),
-    github_repo: z.string().nullable().optional(),
-    subnet_url: z.string().nullable().optional(),
-    discord: z.string().nullable().optional(),
-    logo_url: z.string().nullable().optional(),
-    identity_hash: z.string().nullable(),
-  })
-  .passthrough();
-
-export const GetSubnetIdentityHistoryOutputSchema = z
-  .object({
-    schema_version: z.int(),
-    netuid: netuidSchema(),
-    entry_count: z.int(),
-    limit: z.int().nullable().optional(),
-    offset: z.int().nullable().optional(),
-    next_cursor: z.string().nullable().optional(),
-    entries: z.array(SubnetIdentityHistoryEntrySchema),
-  })
-  .passthrough();
+export const GetSubnetIdentityHistoryOutputSchema =
+  SubnetIdentityHistoryArtifactSchema;
 export type GetSubnetIdentityHistoryOutput = z.infer<
   typeof GetSubnetIdentityHistoryOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-idle-stake.ts
+++ b/schemas-src/mcp-tools/get-subnet-idle-stake.ts
@@ -1,9 +1,18 @@
-// MCP tool `get_subnet_idle_stake` (types-epic E batch 2, #8065). Mirrors
-// GET /api/v1/subnets/{netuid}/idle-stake, which is not one of
-// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
-// reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
+// MCP tool `get_subnet_idle_stake`.
+// Mirrors GET /api/v1/subnets/{netuid}/idle-stake.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { netuidSchema } from "./shared.ts";
+import { SubnetIdleStakeArtifactSchema } from "../routes/subnet-idle-stake.ts";
 
 export const GetSubnetIdleStakeInputSchema = z
   .object({
@@ -14,16 +23,7 @@ export type GetSubnetIdleStakeInput = z.infer<
   typeof GetSubnetIdleStakeInputSchema
 >;
 
-export const GetSubnetIdleStakeOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    captured_at: z.string().nullable().optional(),
-    neuron_count: z.int(),
-    idle_neuron_count: z.int(),
-    idle_stake_alpha: z.number(),
-  })
-  .passthrough();
+export const GetSubnetIdleStakeOutputSchema = SubnetIdleStakeArtifactSchema;
 export type GetSubnetIdleStakeOutput = z.infer<
   typeof GetSubnetIdleStakeOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-lease.ts
+++ b/schemas-src/mcp-tools/get-subnet-lease.ts
@@ -1,11 +1,23 @@
-// MCP tools `get_subnet_lease`, `get_subnet_lease_history` (types-epic E
-// batch 4, #8067). Mirror GET /api/v1/subnets/{netuid}/lease(/history),
-// neither of which is one of schemas-src/routes/'s covered pilot routes --
-// no existing Zod schema to reuse. Modeled fresh, shallow, from the
-// hand-written literals they replace.
+// MCP tools `get_subnet_lease`, `get_subnet_lease_history`.
+// Mirror GET /api/v1/subnets/{netuid}/lease, GET
+// /api/v1/subnets/{netuid}/lease/history.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { netuidSchema } from "./shared.ts";
-import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
+import { McpNetworkSchema } from "../shared.ts";
+import {
+  SubnetLeaseArtifactSchema,
+  SubnetLeaseHistoryArtifactSchema,
+} from "../routes/subnet-lease.ts";
 
 export const GetSubnetLeaseInputSchema = z
   .object({
@@ -19,31 +31,7 @@ export const GetSubnetLeaseInputSchema = z
   .strict();
 export type GetSubnetLeaseInput = z.infer<typeof GetSubnetLeaseInputSchema>;
 
-const LeaseDetailSchema = z
-  .object({
-    lease_id: z.int().optional(),
-    beneficiary: z.string().optional(),
-    coldkey: z.string().optional(),
-    hotkey: z.string().optional(),
-    emissions_share_percent: z.int().optional(),
-    end_block: z.int().nullable().optional(),
-    netuid: netuidSchema().optional(),
-    cost_tao: z.number().optional(),
-    accumulated_dividends_alpha: z.number().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetSubnetLeaseOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    leased: z.boolean().nullable(),
-    lease: LeaseDetailSchema.nullable().optional(),
-    queried_at: z.string().nullable().optional(),
-    // #9108 provenance, mirroring the REST artifact field for field.
-    field_sources: FieldSourcesSchema,
-  })
-  .passthrough();
+export const GetSubnetLeaseOutputSchema = SubnetLeaseArtifactSchema;
 export type GetSubnetLeaseOutput = z.infer<typeof GetSubnetLeaseOutputSchema>;
 
 export const GetSubnetLeaseHistoryInputSchema = z
@@ -55,23 +43,8 @@ export type GetSubnetLeaseHistoryInput = z.infer<
   typeof GetSubnetLeaseHistoryInputSchema
 >;
 
-const LeaseEventSchema = z
-  .object({
-    event_kind: z.string().optional(),
-    beneficiary: z.string().nullable().optional(),
-    block_number: z.int().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetSubnetLeaseHistoryOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    count: z.int(),
-    lease_events: z.array(LeaseEventSchema),
-  })
-  .passthrough();
+export const GetSubnetLeaseHistoryOutputSchema =
+  SubnetLeaseHistoryArtifactSchema;
 export type GetSubnetLeaseHistoryOutput = z.infer<
   typeof GetSubnetLeaseHistoryOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-movers.ts
+++ b/schemas-src/mcp-tools/get-subnet-movers.ts
@@ -1,22 +1,22 @@
-// MCP tool `get_subnet_movers` (types-epic E batch 2, #8065). Mirrors GET
-// /api/v1/subnets/movers, which is not one of schemas-src/routes/'s covered
-// pilot routes -- no existing Zod schema to reuse. Modeled fresh, shallow,
-// from the hand-written literal it replaces. Window/sort enums hardcoded
-// from src/movers.ts's MOVERS_WINDOWS/MOVERS_SORTS at the time of writing
-// (mirrors the pilot batch's ECONOMICS_SORT_FIELDS precedent -- not
-// cross-imported, to avoid a runtime dependency for what is purely a wire-
-// schema enum).
+// MCP tool `get_subnet_movers`.
+// Mirrors GET /api/v1/subnets/movers.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
   MOVERS_LIMIT_DEFAULT,
   MOVERS_LIMIT_MAX,
 } from "../../src/route-limits.ts";
-import {
-  limitSchema,
-  netuidSchema,
-  sortSchema,
-  windowSchema,
-} from "./shared.ts";
+import { limitSchema, sortSchema, windowSchema } from "./shared.ts";
+import { SubnetMoversArtifactSchema } from "../routes/subnet-movers.ts";
 
 const MOVERS_WINDOW_KEYS = ["7d", "30d", "90d"] as const;
 const MOVERS_SORTS = ["stake", "emission", "validators", "neurons"] as const;
@@ -32,35 +32,5 @@ export type GetSubnetMoversInput = z.infer<typeof GetSubnetMoversInputSchema>;
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
-const GetSubnetMoverItemSchema = z
-  .object({
-    netuid: netuidSchema().optional(),
-    stake_start_alpha: z.unknown().optional(),
-    stake_end_alpha: z.unknown().optional(),
-    stake_delta_alpha: z.unknown().optional(),
-    stake_pct_change: z.number().nullable().optional(),
-    emission_start_alpha: z.unknown().optional(),
-    emission_end_alpha: z.unknown().optional(),
-    emission_delta_alpha: z.unknown().optional(),
-    emission_pct_change: z.number().nullable().optional(),
-    validators_start: z.int().optional(),
-    validators_end: z.int().optional(),
-    validators_delta: z.int().optional(),
-    neurons_start: z.int().optional(),
-    neurons_end: z.int().optional(),
-    neurons_delta: z.int().optional(),
-  })
-  .passthrough();
-
-export const GetSubnetMoversOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    window: z.string().nullable(),
-    start_date: z.string().nullable().optional(),
-    end_date: z.string().nullable().optional(),
-    sort: z.string().nullable(),
-    subnet_count: z.int(),
-    movers: z.array(GetSubnetMoverItemSchema),
-  })
-  .passthrough();
+export const GetSubnetMoversOutputSchema = SubnetMoversArtifactSchema;
 export type GetSubnetMoversOutput = z.infer<typeof GetSubnetMoversOutputSchema>;

--- a/schemas-src/mcp-tools/get-subnet-ownership-conviction.ts
+++ b/schemas-src/mcp-tools/get-subnet-ownership-conviction.ts
@@ -1,12 +1,20 @@
-// MCP tools `get_subnet_ownership_history`, `get_subnet_conviction`
-// (types-epic E batch 4, #8067). Mirror GET /api/v1/subnets/{netuid}/
-// ownership-history and GET /api/v1/subnets/{netuid}/conviction, neither of
-// which is one of schemas-src/routes/'s covered pilot routes -- no existing
-// Zod schema to reuse. Modeled fresh, shallow, from the hand-written
-// literals they replace.
+// MCP tools `get_subnet_conviction`, `get_subnet_ownership_history`.
+// Mirror GET /api/v1/subnets/{netuid}/conviction, GET
+// /api/v1/subnets/{netuid}/ownership-history.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { netuidSchema } from "./shared.ts";
-import { FieldSourcesSchema } from "../shared.ts";
+import { SubnetConvictionArtifactSchema } from "../routes/subnet-conviction.ts";
+import { SubnetOwnershipHistoryArtifactSchema } from "../routes/subnet-ownership-history.ts";
 
 export const GetSubnetOwnershipHistoryInputSchema = z
   .object({
@@ -17,24 +25,8 @@ export type GetSubnetOwnershipHistoryInput = z.infer<
   typeof GetSubnetOwnershipHistoryInputSchema
 >;
 
-const OwnershipChangeSchema = z
-  .object({
-    netuid: netuidSchema().nullable().optional(),
-    old_coldkey: z.string().nullable().optional(),
-    new_coldkey: z.string().nullable().optional(),
-    block_number: z.int().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetSubnetOwnershipHistoryOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    count: z.int(),
-    ownership_changes: z.array(OwnershipChangeSchema),
-  })
-  .passthrough();
+export const GetSubnetOwnershipHistoryOutputSchema =
+  SubnetOwnershipHistoryArtifactSchema;
 export type GetSubnetOwnershipHistoryOutput = z.infer<
   typeof GetSubnetOwnershipHistoryOutputSchema
 >;
@@ -48,29 +40,7 @@ export type GetSubnetConvictionInput = z.infer<
   typeof GetSubnetConvictionInputSchema
 >;
 
-const ConvictionLeaderboardEntrySchema = z
-  .object({
-    hotkey: z.string().optional(),
-    is_owner: z.boolean().optional(),
-    locked_mass: z.number().optional(),
-    conviction: z.number().optional(),
-  })
-  .passthrough();
-
-export const GetSubnetConvictionOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    queried_at_block: z.int().nullable().optional(),
-    unlock_rate: z.int().nullable().optional(),
-    maturity_rate: z.int().nullable().optional(),
-    king: z.string().nullable().optional(),
-    count: z.int(),
-    leaderboard: z.array(ConvictionLeaderboardEntrySchema),
-    // #9108 provenance, mirroring the REST artifact field for field.
-    field_sources: FieldSourcesSchema,
-  })
-  .passthrough();
+export const GetSubnetConvictionOutputSchema = SubnetConvictionArtifactSchema;
 export type GetSubnetConvictionOutput = z.infer<
   typeof GetSubnetConvictionOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-recycled-burn.ts
+++ b/schemas-src/mcp-tools/get-subnet-recycled-burn.ts
@@ -1,16 +1,27 @@
-// MCP tools `get_subnet_recycled`, `get_subnet_burn` (types-epic E batch 4,
-// #8067). Backed by the SAME src/subnet-recycled.ts loadSubnetRecycled() /
-// src/subnet-burn.ts loadSubnetBurn() the REST routes (schemas-src/routes/
-// subnet-registration-cost.ts, #8055) use -- NOT reused as schema imports:
-// that REST schema leaves recycled_tao/burn_tao/queried_at all optional
-// (`.passthrough()`, matching the KV-cache-hit code path that may return a
-// smaller cached shape), but these MCP tools' own hand-written originals
-// require queried_at (nullable, but always present). Reusing would loosen
-// this tool's existing required set. Modeled fresh instead, matching each
-// hand-written literal exactly.
+// MCP tools `get_subnet_recycled`, `get_subnet_burn`,
+// `get_subnet_burn_history`, `get_chain_burn`.
+// Mirror GET /api/v1/subnets/{netuid}/recycled, GET
+// /api/v1/subnets/{netuid}/burn, GET /api/v1/subnets/{netuid}/burn/history, GET
+// /api/v1/chain/burn.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { netuidSchema, windowSchema } from "./shared.ts";
-import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
+import { McpNetworkSchema } from "../shared.ts";
+import {
+  ChainBurnArtifactSchema,
+  SubnetBurnArtifactSchema,
+  SubnetBurnHistoryArtifactSchema,
+  SubnetRecycledArtifactSchema,
+} from "../routes/subnet-registration-cost.ts";
 
 export const GetSubnetRecycledInputSchema = z
   .object({
@@ -26,16 +37,7 @@ export type GetSubnetRecycledInput = z.infer<
   typeof GetSubnetRecycledInputSchema
 >;
 
-export const GetSubnetRecycledOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    recycled_tao: z.number().nullable().optional(),
-    queried_at: z.string().nullable(),
-    // #9104 provenance, mirroring the REST artifact field for field.
-    field_sources: FieldSourcesSchema,
-  })
-  .passthrough();
+export const GetSubnetRecycledOutputSchema = SubnetRecycledArtifactSchema;
 export type GetSubnetRecycledOutput = z.infer<
   typeof GetSubnetRecycledOutputSchema
 >;
@@ -52,16 +54,7 @@ export const GetSubnetBurnInputSchema = z
   .strict();
 export type GetSubnetBurnInput = z.infer<typeof GetSubnetBurnInputSchema>;
 
-export const GetSubnetBurnOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    burn_tao: z.number().nullable().optional(),
-    queried_at: z.string().nullable(),
-    // #9104 provenance, mirroring the REST artifact field for field.
-    field_sources: FieldSourcesSchema,
-  })
-  .passthrough();
+export const GetSubnetBurnOutputSchema = SubnetBurnArtifactSchema;
 export type GetSubnetBurnOutput = z.infer<typeof GetSubnetBurnOutputSchema>;
 
 // #9399: the cross-subnet ranking. No netuid -- that is the point of it.
@@ -72,21 +65,7 @@ export const GetChainBurnInputSchema = z
   .strict();
 export type GetChainBurnInput = z.infer<typeof GetChainBurnInputSchema>;
 
-export const GetChainBurnOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    queried_at: z.string().nullable(),
-    subnet_count: z.int().nullable(),
-    read_count: z.int(),
-    cheapest_burn_tao: z.number().nullable(),
-    dearest_burn_tao: z.number().nullable(),
-    median_burn_tao: z.number().nullable(),
-    subnets: z.array(
-      z.object({ netuid: z.int(), burn_tao: z.number() }).passthrough(),
-    ),
-    field_sources: FieldSourcesSchema,
-  })
-  .passthrough();
+export const GetChainBurnOutputSchema = ChainBurnArtifactSchema;
 export type GetChainBurnOutput = z.infer<typeof GetChainBurnOutputSchema>;
 
 // #9402: one subnet's registration-cost series.
@@ -100,20 +79,7 @@ export type GetSubnetBurnHistoryInput = z.infer<
   typeof GetSubnetBurnHistoryInputSchema
 >;
 
-export const GetSubnetBurnHistoryOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string().nullable(),
-    point_count: z.int(),
-    current_burn_tao: z.number().nullable(),
-    change_tao: z.number().nullable(),
-    change_pct: z.number().nullable(),
-    points: z.array(
-      z.object({ observed_at: z.string(), burn_tao: z.number() }).passthrough(),
-    ),
-  })
-  .passthrough();
+export const GetSubnetBurnHistoryOutputSchema = SubnetBurnHistoryArtifactSchema;
 export type GetSubnetBurnHistoryOutput = z.infer<
   typeof GetSubnetBurnHistoryOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-stake-flow.ts
+++ b/schemas-src/mcp-tools/get-subnet-stake-flow.ts
@@ -1,12 +1,18 @@
-// MCP tool `get_subnet_stake_flow` (types-epic E batch 3, #8066). Mirrors
-// GET /api/v1/subnets/{netuid}/stake-flow, which is not one of
-// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
-// reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
-// Window/direction enums hardcoded from src/stake-flow.ts's
-// STAKE_FLOW_WINDOWS/STAKE_FLOW_DIRECTIONS at the time of writing (mirrors
-// the pilot batch's ECONOMICS_SORT_FIELDS precedent -- not cross-imported).
+// MCP tool `get_subnet_stake_flow`.
+// Mirrors GET /api/v1/subnets/{netuid}/stake-flow.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { kindSchema, netuidSchema, windowSchema } from "./shared.ts";
+import { SubnetStakeFlowArtifactSchema } from "../routes/subnet-stake-flow.ts";
 
 const STAKE_FLOW_WINDOWS = ["7d", "30d", "90d"] as const;
 const STAKE_FLOW_DIRECTIONS = ["all", "in", "out"] as const;
@@ -22,18 +28,7 @@ export type GetSubnetStakeFlowInput = z.infer<
   typeof GetSubnetStakeFlowInputSchema
 >;
 
-export const GetSubnetStakeFlowOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string().nullable(),
-    total_staked_tao: z.unknown(),
-    total_unstaked_tao: z.unknown(),
-    net_flow_tao: z.unknown(),
-    stake_events: z.int(),
-    unstake_events: z.int(),
-  })
-  .passthrough();
+export const GetSubnetStakeFlowOutputSchema = SubnetStakeFlowArtifactSchema;
 export type GetSubnetStakeFlowOutput = z.infer<
   typeof GetSubnetStakeFlowOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-surface-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-surface-history.ts
@@ -1,11 +1,22 @@
-// get_subnet_surface_history (#9612): one subnet's surface audit trail,
-// mirroring GET /api/v1/subnets/{netuid}/surface-history.
+// MCP tool `get_subnet_surface_history`.
+// Mirrors GET /api/v1/subnets/{netuid}/surface-history.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { limitSchema, netuidSchema } from "./shared.ts";
 import {
   SURFACE_HISTORY_LIMIT_DEFAULT,
   SURFACE_HISTORY_LIMIT_MAX,
 } from "../../src/route-limits.ts";
+import { SubnetSurfaceHistoryArtifactSchema } from "../routes/subnet-surface-history.ts";
 
 export const GetSubnetSurfaceHistoryInputSchema = z
   .object({
@@ -20,29 +31,8 @@ export type GetSubnetSurfaceHistoryInput = z.infer<
   typeof GetSubnetSurfaceHistoryInputSchema
 >;
 
-export const GetSubnetSurfaceHistoryOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    limit: z.int().nullable(),
-    change_count: z.int(),
-    surface_count: z.int(),
-    latest_change_at: z.string().nullable(),
-    changes: z.array(
-      z
-        .object({
-          surface_id: z.string().nullable(),
-          action: z.string().nullable(),
-          kind: z.string().nullable(),
-          url: z.string().nullable(),
-          name: z.string().nullable(),
-          source_commit: z.string().nullable(),
-          recorded_at: z.string(),
-        })
-        .passthrough(),
-    ),
-  })
-  .passthrough();
+export const GetSubnetSurfaceHistoryOutputSchema =
+  SubnetSurfaceHistoryArtifactSchema;
 export type GetSubnetSurfaceHistoryOutput = z.infer<
   typeof GetSubnetSurfaceHistoryOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-uptime.ts
+++ b/schemas-src/mcp-tools/get-subnet-uptime.ts
@@ -1,14 +1,21 @@
-// MCP tool `get_subnet_uptime` (types-epic E batch 2, #8065). Mirrors GET
-// /api/v1/subnets/{netuid}/uptime, which is not one of schemas-src/routes/'s
-// covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
-// shallow, from the hand-written literal it replaces.
+// MCP tool `get_subnet_uptime`.
+// Mirrors GET /api/v1/subnets/{netuid}/uptime.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_subnet_uptime: 2 bare `{"type":"object"}` sites.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import {
-  OpenObjectArraySchema,
-  OpenObjectSchema,
-  netuidSchema,
-  windowSchema,
-} from "./shared.ts";
+import { netuidSchema, windowSchema } from "./shared.ts";
+import { UptimeArtifactSchema } from "../routes/health-surfaces.ts";
 
 const UPTIME_WINDOWS = ["90d", "1y"] as const;
 
@@ -28,14 +35,5 @@ export const GetSubnetUptimeInputSchema = z
   .strict();
 export type GetSubnetUptimeInput = z.infer<typeof GetSubnetUptimeInputSchema>;
 
-export const GetSubnetUptimeOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string().nullable(),
-    observed_at: z.string().nullable().optional(),
-    surfaces: OpenObjectArraySchema,
-    reliability: OpenObjectSchema.nullable().optional(),
-  })
-  .passthrough();
+export const GetSubnetUptimeOutputSchema = UptimeArtifactSchema;
 export type GetSubnetUptimeOutput = z.infer<typeof GetSubnetUptimeOutputSchema>;

--- a/schemas-src/mcp-tools/get-subnet-validator-economics.ts
+++ b/schemas-src/mcp-tools/get-subnet-validator-economics.ts
@@ -1,9 +1,18 @@
-// MCP tool contract for get_subnet_validator_economics (#9323, #9327) — the agent-facing
-// twin of GET /api/v1/subnets/{netuid}/validator-economics.
+// MCP tools `get_subnet_validator_economics_history`,
+// `list_validator_economics`, `get_subnet_validator_economics`.
+// Mirror GET /api/v1/subnets/{netuid}/validator-economics/history, GET
+// /api/v1/validators/economics, GET
+// /api/v1/subnets/{netuid}/validator-economics.
 //
-// The output is deliberately `.passthrough()` on the artifact: the REST payload carries
-// `field_sources`, which the tool returns verbatim so an agent can tell a derived floor
-// from a measured hyperparameter without a second call.
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
   SubnetValidatorEconomicsArtifactSchema,
@@ -35,7 +44,7 @@ export type GetSubnetValidatorEconomicsInput = z.infer<
 >;
 
 export const GetSubnetValidatorEconomicsOutputSchema =
-  SubnetValidatorEconomicsArtifactSchema.passthrough();
+  SubnetValidatorEconomicsArtifactSchema;
 export type GetSubnetValidatorEconomicsOutput = z.infer<
   typeof GetSubnetValidatorEconomicsOutputSchema
 >;
@@ -78,7 +87,7 @@ export type ListValidatorEconomicsInput = z.infer<
 >;
 
 export const ListValidatorEconomicsOutputSchema =
-  ValidatorEconomicsRankingArtifactSchema.passthrough();
+  ValidatorEconomicsRankingArtifactSchema;
 export type ListValidatorEconomicsOutput = z.infer<
   typeof ListValidatorEconomicsOutputSchema
 >;
@@ -111,4 +120,4 @@ export type GetSubnetValidatorEconomicsHistoryInput = z.infer<
 >;
 
 export const GetSubnetValidatorEconomicsHistoryOutputSchema =
-  SubnetValidatorEconomicsHistoryArtifactSchema.passthrough();
+  SubnetValidatorEconomicsHistoryArtifactSchema;

--- a/schemas-src/mcp-tools/get-subnet-volume-ohlc.ts
+++ b/schemas-src/mcp-tools/get-subnet-volume-ohlc.ts
@@ -1,15 +1,20 @@
-// MCP tools `get_subnet_volume`, `get_subnet_ohlc` (types-epic E batch 4,
-// #8067). get_subnet_volume mirrors GET /api/v1/subnets/{netuid}/volume,
-// covered by schemas-src/routes/subnet-alpha-volume.ts (#8055) -- NOT
-// reused: that REST schema is `.strict()` with all 15 fields required; this
-// tool's own hand-written original requires only netuid+window, leaving
-// every numeric field optional. Reusing would substantially tighten this
-// tool's existing contract. get_subnet_ohlc mirrors GET /api/v1/subnets/
-// {netuid}/ohlc, which is not one of schemas-src/routes/'s covered pilot
-// routes -- no existing Zod schema to reuse either. Both modeled fresh,
-// shallow, from the hand-written literals they replace.
+// MCP tools `get_subnet_volume`, `get_subnet_ohlc`.
+// Mirror GET /api/v1/subnets/{netuid}/volume, GET
+// /api/v1/subnets/{netuid}/ohlc.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { netuidSchema } from "./shared.ts";
+import { SubnetAlphaVolumeArtifactSchema } from "../routes/subnet-alpha-volume.ts";
+import { SubnetOhlcArtifactSchema } from "../routes/subnet-ohlc.ts";
 
 export const GetSubnetVolumeInputSchema = z
   .object({
@@ -18,25 +23,7 @@ export const GetSubnetVolumeInputSchema = z
   .strict();
 export type GetSubnetVolumeInput = z.infer<typeof GetSubnetVolumeInputSchema>;
 
-export const GetSubnetVolumeOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string(),
-    buy_volume_alpha: z.unknown().optional(),
-    sell_volume_alpha: z.unknown().optional(),
-    total_volume_alpha: z.unknown().optional(),
-    buy_volume_tao: z.unknown().optional(),
-    sell_volume_tao: z.unknown().optional(),
-    total_volume_tao: z.unknown().optional(),
-    buy_count: z.int().optional(),
-    sell_count: z.int().optional(),
-    net_volume_alpha: z.unknown().optional(),
-    sentiment_ratio: z.number().nullable().optional(),
-    sentiment: z.string().nullable().optional(),
-    vol_mcap_ratio: z.number().nullable().optional(),
-  })
-  .passthrough();
+export const GetSubnetVolumeOutputSchema = SubnetAlphaVolumeArtifactSchema;
 export type GetSubnetVolumeOutput = z.infer<typeof GetSubnetVolumeOutputSchema>;
 
 const OHLC_INTERVALS = ["1h", "1d"] as const;
@@ -63,27 +50,5 @@ export type GetSubnetOhlcInput = z.infer<typeof GetSubnetOhlcInputSchema>;
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
-const OhlcCandleSchema = z
-  .object({
-    bucket_start: z.int().optional(),
-    bucket_start_iso: z.string().optional(),
-    open: z.unknown().optional(),
-    high: z.unknown().optional(),
-    low: z.unknown().optional(),
-    close: z.unknown().optional(),
-    volume_alpha: z.unknown().optional(),
-    volume_tao: z.unknown().optional(),
-    event_count: z.int().optional(),
-  })
-  .passthrough();
-
-export const GetSubnetOhlcOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    interval: z.string(),
-    candles: z.array(OhlcCandleSchema),
-    root_excluded: z.boolean(),
-  })
-  .passthrough();
+export const GetSubnetOhlcOutputSchema = SubnetOhlcArtifactSchema;
 export type GetSubnetOhlcOutput = z.infer<typeof GetSubnetOhlcOutputSchema>;

--- a/schemas-src/mcp-tools/get-subnet-weight-setters.ts
+++ b/schemas-src/mcp-tools/get-subnet-weight-setters.ts
@@ -1,9 +1,18 @@
-// MCP tool `get_subnet_weight_setters` (types-epic E batch 3, #8066).
-// Mirrors GET /api/v1/subnets/{netuid}/weights/setters, which is not one of
-// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
-// reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
+// MCP tool `get_subnet_weight_setters`.
+// Mirrors GET /api/v1/subnets/{netuid}/weights/setters.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { netuidSchema, windowSchema } from "./shared.ts";
+import { SubnetWeightSettersArtifactSchema } from "../routes/subnet-weights.ts";
 
 const SUBNET_WEIGHT_SETTERS_WINDOWS = ["7d", "30d"] as const;
 
@@ -19,36 +28,8 @@ export type GetSubnetWeightSettersInput = z.infer<
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
-const WeightSetterSchema = z
-  .object({
-    hotkey: z.string().nullable().optional(),
-    uid: z.int().nullable().optional(),
-    weight_sets: z.int().optional(),
-    share: z.unknown().optional(),
-    first_set_at: z.string().nullable().optional(),
-    last_set_at: z.string().nullable().optional(),
-    // #9389: null `overdue` means NOT EVALUATED, not "on time".
-    seconds_since_last_set: z.int().nullable().optional(),
-    tempos_since_last_set: z.number().nullable().optional(),
-    overdue: z.boolean().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetSubnetWeightSettersOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string().nullable(),
-    observed_at: z.string().nullable().optional(),
-    distinct_setters: z.int(),
-    weight_sets: z.int(),
-    setter_count: z.int(),
-    tempo: z.int().nullable().optional(),
-    overdue_tempo_multiple: z.int().optional(),
-    overdue_setter_count: z.int().optional(),
-    setters: z.array(WeightSetterSchema),
-  })
-  .passthrough();
+export const GetSubnetWeightSettersOutputSchema =
+  SubnetWeightSettersArtifactSchema;
 export type GetSubnetWeightSettersOutput = z.infer<
   typeof GetSubnetWeightSettersOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-weights.ts
+++ b/schemas-src/mcp-tools/get-subnet-weights.ts
@@ -1,9 +1,18 @@
-// MCP tool `get_subnet_weights` (types-epic E batch 3, #8066). Mirrors GET
-// /api/v1/subnets/{netuid}/weights, which is not one of schemas-src/routes/'s
-// covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
-// shallow, from the hand-written literal it replaces.
+// MCP tool `get_subnet_weights`.
+// Mirrors GET /api/v1/subnets/{netuid}/weights.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { netuidSchema, windowSchema } from "./shared.ts";
+import { SubnetWeightsArtifactSchema } from "../routes/subnet-weights.ts";
 
 const SUBNET_WEIGHTS_WINDOWS = ["7d", "30d"] as const;
 
@@ -15,17 +24,7 @@ export const GetSubnetWeightsInputSchema = z
   .strict();
 export type GetSubnetWeightsInput = z.infer<typeof GetSubnetWeightsInputSchema>;
 
-export const GetSubnetWeightsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string().nullable(),
-    observed_at: z.string().nullable().optional(),
-    distinct_setters: z.int(),
-    weight_sets: z.int(),
-    sets_per_setter: z.number().nullable(),
-  })
-  .passthrough();
+export const GetSubnetWeightsOutputSchema = SubnetWeightsArtifactSchema;
 export type GetSubnetWeightsOutput = z.infer<
   typeof GetSubnetWeightsOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-yield-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-yield-history.ts
@@ -1,9 +1,21 @@
-// MCP tool `get_subnet_yield_history` (types-epic E batch 3, #8066). Mirrors
-// GET /api/v1/subnets/{netuid}/yield/history, which is not one of
-// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
-// reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
+// MCP tool `get_subnet_yield_history`.
+// Mirrors GET /api/v1/subnets/{netuid}/yield/history.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_subnet_yield_history: 1 bare `{"type":"object"}` site.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import { OpenObjectArraySchema, netuidSchema, windowSchema } from "./shared.ts";
+import { netuidSchema, windowSchema } from "./shared.ts";
+import { SubnetYieldHistoryArtifactSchema } from "../routes/subnet-yield.ts";
 
 const YIELD_HISTORY_WINDOWS = ["7d", "30d", "90d"] as const;
 
@@ -17,15 +29,8 @@ export type GetSubnetYieldHistoryInput = z.infer<
   typeof GetSubnetYieldHistoryInputSchema
 >;
 
-export const GetSubnetYieldHistoryOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string().nullable(),
-    point_count: z.int(),
-    points: OpenObjectArraySchema,
-  })
-  .passthrough();
+export const GetSubnetYieldHistoryOutputSchema =
+  SubnetYieldHistoryArtifactSchema;
 export type GetSubnetYieldHistoryOutput = z.infer<
   typeof GetSubnetYieldHistoryOutputSchema
 >;

--- a/schemas-src/mcp-tools/get-subnet-yield.ts
+++ b/schemas-src/mcp-tools/get-subnet-yield.ts
@@ -1,9 +1,21 @@
-// MCP tool `get_subnet_yield` (types-epic E batch 3, #8066). Mirrors GET
-// /api/v1/subnets/{netuid}/yield, which is not one of schemas-src/routes/'s
-// covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
-// shallow, from the hand-written literal it replaces.
+// MCP tool `get_subnet_yield`.
+// Mirrors GET /api/v1/subnets/{netuid}/yield.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_subnet_yield: 1 bare `{"type":"object"}` site.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import { OpenObjectArraySchema, netuidSchema } from "./shared.ts";
+import { netuidSchema } from "./shared.ts";
+import { SubnetYieldArtifactSchema } from "../routes/subnet-yield.ts";
 
 export const GetSubnetYieldInputSchema = z
   .object({
@@ -12,24 +24,5 @@ export const GetSubnetYieldInputSchema = z
   .strict();
 export type GetSubnetYieldInput = z.infer<typeof GetSubnetYieldInputSchema>;
 
-export const GetSubnetYieldOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    captured_at: z.string().nullable().optional(),
-    block_number: z.int().nullable().optional(),
-    neuron_count: z.int(),
-    validator_count: z.int().optional(),
-    miner_count: z.int().optional(),
-    total_stake_alpha: z.number().nullable().optional(),
-    total_emission_alpha: z.number().nullable().optional(),
-    subnet_yield: z.number().nullable().optional(),
-    mean_yield: z.number().nullable().optional(),
-    median_yield: z.number().nullable().optional(),
-    p25_yield: z.number().nullable().optional(),
-    p75_yield: z.number().nullable().optional(),
-    p90_yield: z.number().nullable().optional(),
-    neurons: OpenObjectArraySchema,
-  })
-  .passthrough();
+export const GetSubnetYieldOutputSchema = SubnetYieldArtifactSchema;
 export type GetSubnetYieldOutput = z.infer<typeof GetSubnetYieldOutputSchema>;

--- a/schemas-src/mcp-tools/get-subnet.ts
+++ b/schemas-src/mcp-tools/get-subnet.ts
@@ -8,7 +8,8 @@
 //
 // NOT a narrowing of SubnetDetailArtifactSchema, which is why this file cannot
 // simply derive from it the way its siblings in #9796 do: the two share only 4
-// of 15 keys. This is a different PROJECTION -- it flattens the route artifact's
+// of 15 keys. This is a different PROJECTION -- it flattens the route
+// artifact's
 // nested `subnet` object up to the top level and adds a composed health card.
 //
 // The six nested fields used to be bare `{type:"object"}` / `{type:"array"}`,

--- a/schemas-src/mcp-tools/get-tao-usd.ts
+++ b/schemas-src/mcp-tools/get-tao-usd.ts
@@ -1,4 +1,5 @@
-// get_tao_usd (#9609): the TAO/USD index, mirroring GET /api/v1/network/tao-usd.
+// get_tao_usd (#9609): the TAO/USD index, mirroring GET
+// /api/v1/network/tao-usd.
 import { z } from "zod";
 import { windowSchema } from "./shared.ts";
 

--- a/schemas-src/mcp-tools/governance-feeds.ts
+++ b/schemas-src/mcp-tools/governance-feeds.ts
@@ -1,12 +1,16 @@
-// MCP tools `get_sudo`, `get_sudo_key`, `get_governance_config_changes`
-// (types-epic E batch 8, #8071). Each mirrors a GET /api/v1/{sudo,governance}*
-// route that is not one of schemas-src/routes/'s covered pilot routes -- no
-// existing Zod schema to reuse. Modeled fresh, matching each hand-written
-// literal field-for-field. get_sudo/get_governance_config_changes's input
-// omits `required` entirely in the hand-written original (every field
-// optional) rather than declaring `required: []` -- both are semantically
-// identical JSON Schema and the diff-audit script already treats them as
-// equal (see list_accounts/get_top_holders in #8070).
+// MCP tools `get_sudo`, `get_sudo_key`, `get_governance_config_changes`.
+// Mirror GET /api/v1/sudo, GET /api/v1/sudo/key, GET
+// /api/v1/governance/config-changes.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
   blockBoundSchema,
@@ -15,8 +19,9 @@ import {
   offsetSchema,
 } from "./shared.ts";
 import { EXTRINSICS_LIMIT_MAX } from "./extrinsics.ts";
-import { ExtrinsicItemSchema } from "./shared.ts";
-import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
+import { McpNetworkSchema } from "../shared.ts";
+import { ExtrinsicsFeedArtifactSchema } from "../routes/extrinsics.ts";
+import { SudoKeyArtifactSchema } from "../routes/network-singletons.ts";
 
 export const GetSudoInputSchema = z
   .object({
@@ -68,16 +73,7 @@ export const GetSudoInputSchema = z
   .strict();
 export type GetSudoInput = z.infer<typeof GetSudoInputSchema>;
 
-export const GetSudoOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    extrinsic_count: z.int(),
-    limit: z.int().nullable().optional(),
-    offset: z.int().nullable().optional(),
-    next_cursor: z.string().nullable().optional(),
-    extrinsics: z.array(ExtrinsicItemSchema),
-  })
-  .passthrough();
+export const GetSudoOutputSchema = ExtrinsicsFeedArtifactSchema;
 export type GetSudoOutput = z.infer<typeof GetSudoOutputSchema>;
 
 export const GetSudoKeyInputSchema = z
@@ -90,15 +86,7 @@ export const GetSudoKeyInputSchema = z
   .strict();
 export type GetSudoKeyInput = z.infer<typeof GetSudoKeyInputSchema>;
 
-export const GetSudoKeyOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    hotkey: z.string().nullable(),
-    queried_at: z.string().nullable(),
-    // #9078 provenance, mirroring SudoKeyArtifactSchema field for field.
-    field_sources: FieldSourcesSchema,
-  })
-  .passthrough();
+export const GetSudoKeyOutputSchema = SudoKeyArtifactSchema;
 export type GetSudoKeyOutput = z.infer<typeof GetSudoKeyOutputSchema>;
 
 export const GetGovernanceConfigChangesInputSchema = z
@@ -153,16 +141,8 @@ export type GetGovernanceConfigChangesInput = z.infer<
   typeof GetGovernanceConfigChangesInputSchema
 >;
 
-export const GetGovernanceConfigChangesOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    extrinsic_count: z.int(),
-    limit: z.int().nullable().optional(),
-    offset: z.int().nullable().optional(),
-    next_cursor: z.string().nullable().optional(),
-    extrinsics: z.array(ExtrinsicItemSchema),
-  })
-  .passthrough();
+export const GetGovernanceConfigChangesOutputSchema =
+  ExtrinsicsFeedArtifactSchema;
 export type GetGovernanceConfigChangesOutput = z.infer<
   typeof GetGovernanceConfigChangesOutputSchema
 >;

--- a/schemas-src/mcp-tools/meta-artifacts-1.ts
+++ b/schemas-src/mcp-tools/meta-artifacts-1.ts
@@ -1,79 +1,55 @@
 // MCP tools `get_lineage`, `get_freshness`, `get_contracts`,
-// `get_source_health` (types-epic E batch 12, #8075). `get_lineage` and
-// `get_source_health` are defined inline in src/mcp-server.ts's MCP_TOOLS
-// array; `get_freshness` is also inline but shares this file's grouping by
-// shape; `get_contracts` lives in its own src/contracts-mcp.ts (its
-// `GET_CONTRACTS_MCP_TOOL`/`GET_CONTRACTS_OUTPUT_SCHEMA` spread into
-// mcp-server.ts's MCP_TOOLS array). All four are no-input, baked-artifact
-// passthrough tools. None mirror an existing schemas-src/routes/ REST
-// schema -- modeled fresh, matching each hand-written literal
-// field-for-field.
+// `get_source_health`.
+// Mirror GET /api/v1/lineage, GET /api/v1/freshness, GET /api/v1/contracts, GET
+// /api/v1/source-health.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_lineage: 2 bare `{"type":"object"}` sites.
+//   get_freshness: 2 bare `{"type":"object"}` sites.
+//   get_contracts: 1 bare `{"type":"object"}` site.
+//   get_source_health: 1 bare `{"type":"object"}` site.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import {
+  FreshnessArtifactSchema,
+  SourceHealthArtifactSchema,
+} from "../routes/evidence-search.ts";
+import { LineageArtifactSchema } from "../routes/lineage.ts";
+import { ContractsArtifactSchema } from "../routes/meta-contracts.ts";
 
 // `notes: {type:["array","string","null"], items:{type:"string"}}` -- this
 // batch's shared.ts predates the NotesFieldSchema helper hoisted in batch 10
 // (#8074), still unmerged as of this batch (#8075) -- inlined here rather
 // than depending on unmerged parallel work.
-const NotesFieldSchema = z
-  .union([z.array(z.string()), z.string()])
-  .nullable()
-  .optional();
-
 export const GetLineageInputSchema = z.object({}).strict();
 export type GetLineageInput = z.infer<typeof GetLineageInputSchema>;
 
-export const GetLineageOutputSchema = z
-  .object({
-    link_count: z.int().optional(),
-    graduated_subnet_count: z.int().optional(),
-    broken_link_count: z.int().optional(),
-    links: z.array(OpenObjectSchema).optional(),
-    broken_links: z.array(OpenObjectSchema).optional(),
-    generated_at: z.string().nullable().optional(),
-  })
-  .passthrough();
+export const GetLineageOutputSchema = LineageArtifactSchema;
 export type GetLineageOutput = z.infer<typeof GetLineageOutputSchema>;
 
 export const GetFreshnessInputSchema = z.object({}).strict();
 export type GetFreshnessInput = z.infer<typeof GetFreshnessInputSchema>;
 
-export const GetFreshnessOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    sources: z.array(OpenObjectSchema),
-    summary: OpenObjectSchema.nullable().optional(),
-    generated_at: z.string().nullable().optional(),
-  })
-  .passthrough();
+export const GetFreshnessOutputSchema = FreshnessArtifactSchema;
 export type GetFreshnessOutput = z.infer<typeof GetFreshnessOutputSchema>;
 
 export const GetContractsInputSchema = z.object({}).strict();
 export type GetContractsInput = z.infer<typeof GetContractsInputSchema>;
 
-export const GetContractsOutputSchema = z
-  .object({
-    schema_version: z.int(),
-    contract_version: z.string().nullable().optional(),
-    generated_at: z.string().nullable().optional(),
-    name: z.string().nullable().optional(),
-    base_path: z.string().nullable().optional(),
-    primary_domain: z.string().nullable().optional(),
-    openapi_url: z.string().nullable().optional(),
-    type_definitions_url: z.string().nullable().optional(),
-    notes: NotesFieldSchema,
-    artifacts: z.array(OpenObjectSchema),
-  })
-  .passthrough();
+export const GetContractsOutputSchema = ContractsArtifactSchema;
 export type GetContractsOutput = z.infer<typeof GetContractsOutputSchema>;
 
 export const GetSourceHealthInputSchema = z.object({}).strict();
 export type GetSourceHealthInput = z.infer<typeof GetSourceHealthInputSchema>;
 
-export const GetSourceHealthOutputSchema = z
-  .object({
-    providers: z.array(OpenObjectSchema),
-    generated_at: z.string().nullable().optional(),
-  })
-  .passthrough();
+export const GetSourceHealthOutputSchema = SourceHealthArtifactSchema;
 export type GetSourceHealthOutput = z.infer<typeof GetSourceHealthOutputSchema>;

--- a/schemas-src/mcp-tools/meta-artifacts-2.ts
+++ b/schemas-src/mcp-tools/meta-artifacts-2.ts
@@ -1,25 +1,25 @@
-// MCP tools `get_changelog`, `get_build`, `get_coverage`,
-// `get_coverage_depth` (types-epic E batch 12, #8075). `get_changelog`,
-// `get_build`, and `get_coverage` each live in their own dedicated file
-// (src/changelog-mcp.ts, src/build-mcp.ts, src/registry-coverage.ts --
-// their `GET_X_MCP_TOOL`/`GET_X_OUTPUT_SCHEMA` spread into mcp-server.ts's
-// MCP_TOOLS array); `get_coverage_depth` is defined inline in
-// src/mcp-server.ts. All four are no-input, baked-artifact passthrough
-// tools.
+// MCP tools `get_build`, `get_coverage`.
+// Mirror GET /api/v1/build, GET /api/v1/coverage.
 //
-// This header used to say none of them "mirror an existing schemas-src/routes/
-// REST schema -- modeled fresh". For `get_coverage_depth` that was wrong:
-// CoverageDepthArtifactSchema in schemas-src/routes/coverage.ts models the same
-// artifact, and the fresh model disagreed with it on the type of
-// `coverage_depth_version` (#9794). It now reuses the route schema outright,
-// which also replaces its two bare open arrays with the row and queue-entry
-// shapes the route already declares. The remaining three are still local
-// models; #9796 covers deriving them.
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_build: 3 bare `{"type":"object"}` sites.
+//   get_coverage: 2 bare `{"type":"object"}` sites.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { ChangelogArtifactSchema } from "../routes/meta-contracts.ts";
 import { CoverageDepthArtifactSchema } from "../routes/coverage.ts";
 import { SelfHealthArtifactSchema } from "../routes/self-health.ts";
-import { OpenObjectSchema } from "./shared.ts";
+import { CoverageArtifactSchema } from "../routes/coverage.ts";
+import { BuildSummaryArtifactSchema } from "../routes/meta-contracts.ts";
 
 export const GetChangelogInputSchema = z.object({}).strict();
 export type GetChangelogInput = z.infer<typeof GetChangelogInputSchema>;
@@ -32,23 +32,7 @@ export type GetChangelogOutput = z.infer<typeof GetChangelogOutputSchema>;
 export const GetBuildInputSchema = z.object({}).strict();
 export type GetBuildInput = z.infer<typeof GetBuildInputSchema>;
 
-export const GetBuildOutputSchema = z
-  .object({
-    schema_version: z.int(),
-    contract_version: z.string().nullable().optional(),
-    generated_at: z.string().nullable().optional(),
-    published_at: z.string().nullable().optional(),
-    adapter_count: z.int().nullable().optional(),
-    artifact_count: z.int(),
-    artifact_size_bytes: z.int().nullable().optional(),
-    subnet_count: z.int().nullable().optional(),
-    surface_count: z.int().nullable().optional(),
-    provider_count: z.int().nullable().optional(),
-    artifacts: z.array(OpenObjectSchema).nullable().optional(),
-    coverage: OpenObjectSchema.nullable().optional(),
-    artifact_budget_summary: OpenObjectSchema.nullable().optional(),
-  })
-  .passthrough();
+export const GetBuildOutputSchema = BuildSummaryArtifactSchema;
 export type GetBuildOutput = z.infer<typeof GetBuildOutputSchema>;
 
 // #8422: get_self_health -- GET /api/v1/self-health parity, baked
@@ -73,20 +57,7 @@ export type GetSelfHealthOutput = z.infer<typeof GetSelfHealthOutputSchema>;
 export const GetCoverageInputSchema = z.object({}).strict();
 export type GetCoverageInput = z.infer<typeof GetCoverageInputSchema>;
 
-export const GetCoverageOutputSchema = z
-  .object({
-    generated_at: z.string().nullable().optional(),
-    surface_count: z.int(),
-    official_surface_count: z.int().optional(),
-    first_party_subnet_count: z.int().optional(),
-    chain_subnet_count: z.int().optional(),
-    candidate_count: z.int().optional(),
-    probed_count: z.int().optional(),
-    domain_coverage: OpenObjectSchema.optional(),
-    completeness: OpenObjectSchema,
-    subnets_without_official_surface: z.int().optional(),
-  })
-  .passthrough();
+export const GetCoverageOutputSchema = CoverageArtifactSchema;
 export type GetCoverageOutput = z.infer<typeof GetCoverageOutputSchema>;
 
 export const GetCoverageDepthInputSchema = z.object({}).strict();

--- a/schemas-src/mcp-tools/network-live.ts
+++ b/schemas-src/mcp-tools/network-live.ts
@@ -1,12 +1,21 @@
-// MCP tools `get_network_parameters`, `get_randomness_status` (types-epic E
-// batch 8, #8071). Each mirrors a GET /api/v1/network/* route that is not
-// one of schemas-src/routes/'s covered pilot routes -- no existing Zod
-// schema to reuse. Both take no input (bare `{}`) and every output field is
-// required-but-independently-nullable (each queried live from a separate RPC
-// call that can fail on its own) -- modeled fresh, matching each hand-written
-// literal field-for-field.
+// MCP tools `get_network_parameters`, `get_randomness_status`.
+// Mirror GET /api/v1/network/parameters, GET /api/v1/network/randomness.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
-import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
+import { McpNetworkSchema } from "../shared.ts";
+import {
+  NetworkParametersArtifactSchema,
+  RandomnessArtifactSchema,
+} from "../routes/network-singletons.ts";
 
 export const GetNetworkParametersInputSchema = z
   .object({
@@ -20,30 +29,7 @@ export type GetNetworkParametersInput = z.infer<
   typeof GetNetworkParametersInputSchema
 >;
 
-export const GetNetworkParametersOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    tao_weight: z.number().nullable(),
-    stake_threshold_tao: z.number().nullable(),
-    pending_childkey_cooldown_blocks: z.int().nullable(),
-    // #8747: issuance-derived, never the stale `BlockEmission` storage item.
-    total_issuance_tao: z.number().nullable(),
-    block_emission_tao: z.number().nullable(),
-    block_emission_halvings: z.int().nullable(),
-    // #8742: raw vs effective — the exponent's storage item is unset, and
-    // absent means the runtime default (3), never 0.
-    emission_gate_bar: z.number().nullable(),
-    emission_bar_quantile: z.number().nullable(),
-    emission_gate_exponent: z.number().nullable(),
-    emission_gate_exponent_effective: z.number().nullable(),
-    queried_at: z.string().nullable(),
-    // #9078 provenance, mirroring NetworkParametersArtifactSchema field for
-    // field. It matters most to an MCP caller: an agent that cites
-    // `emission_gate_exponent_effective: 3` as a chain reading is citing our
-    // runtime default, and this map is the only thing that says so.
-    field_sources: FieldSourcesSchema,
-  })
-  .passthrough();
+export const GetNetworkParametersOutputSchema = NetworkParametersArtifactSchema;
 export type GetNetworkParametersOutput = z.infer<
   typeof GetNetworkParametersOutputSchema
 >;
@@ -60,17 +46,7 @@ export type GetRandomnessStatusInput = z.infer<
   typeof GetRandomnessStatusInputSchema
 >;
 
-export const GetRandomnessStatusOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    last_stored_round: z.int().nullable(),
-    oldest_stored_round: z.int().nullable(),
-    stored_round_span: z.int().nullable(),
-    queried_at: z.string().nullable(),
-    // #9078 provenance, mirroring RandomnessArtifactSchema field for field.
-    field_sources: FieldSourcesSchema,
-  })
-  .passthrough();
+export const GetRandomnessStatusOutputSchema = RandomnessArtifactSchema;
 export type GetRandomnessStatusOutput = z.infer<
   typeof GetRandomnessStatusOutputSchema
 >;

--- a/schemas-src/mcp-tools/neurons.ts
+++ b/schemas-src/mcp-tools/neurons.ts
@@ -1,17 +1,27 @@
-// MCP tools `get_neuron`, `get_neuron_history` (types-epic E batch 4,
-// #8068). Each mirrors a GET /api/v1/subnets/{netuid}/neurons* route that is
-// not one of schemas-src/routes/'s covered pilot routes -- no existing Zod
-// schema to reuse. Modeled fresh, matching each hand-written literal
-// field-for-field.
+// MCP tool `get_neuron_history`.
+// Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}/history.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_neuron_history: 1 bare `{"type":"object"}` site.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
   NeuronFieldsInputSchema,
-  OpenObjectArraySchema,
   OpenObjectSchema,
   netuidSchema,
   uidSchema,
   windowSchema,
 } from "./shared.ts";
+import { NeuronHistoryArtifactSchema } from "../routes/subnet-metagraph.ts";
 
 export const GetNeuronInputSchema = z
   .object({
@@ -45,16 +55,7 @@ export const GetNeuronHistoryInputSchema = z
   .strict();
 export type GetNeuronHistoryInput = z.infer<typeof GetNeuronHistoryInputSchema>;
 
-export const GetNeuronHistoryOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    uid: z.int(),
-    window: z.string().nullable().optional(),
-    point_count: z.int(),
-    points: OpenObjectArraySchema,
-  })
-  .passthrough();
+export const GetNeuronHistoryOutputSchema = NeuronHistoryArtifactSchema;
 export type GetNeuronHistoryOutput = z.infer<
   typeof GetNeuronHistoryOutputSchema
 >;

--- a/schemas-src/mcp-tools/registry-catalogs-1.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-1.ts
@@ -1,16 +1,22 @@
-// MCP tools `list_providers`, `list_surfaces`, `list_candidates` (types-epic
-// E batch 9, #8073). Unlike every other tool converted so far in this
-// epic, these three are NOT defined inline in src/mcp-server.ts -- their
-// `LIST_X_MCP_TOOL`/`LIST_X_OUTPUT_SCHEMA` hand-written literals live in
-// src/providers-mcp.ts, src/surfaces-mcp.ts, and src/candidates-mcp.ts
-// respectively, imported into mcp-server.ts's MCP_TOOLS array via object
-// spread (`{ ...LIST_PROVIDERS_MCP_TOOL, async handler(...) {...} }`). The
-// z.toJSONSchema(...) wiring for these three happens in THEIR OWN files, not
-// mcp-server.ts. None mirror an existing schemas-src/routes/ REST schema --
-// modeled fresh, matching each hand-written literal field-for-field.
+// MCP tools `list_providers`, `list_surfaces`, `list_candidates`.
+// Mirror GET /api/v1/providers, GET /api/v1/surfaces, GET /api/v1/candidates.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   list_providers: 1 bare `{"type":"object"}` site.
+//   list_surfaces: 1 bare `{"type":"object"}` site.
+//   list_candidates: 1 bare `{"type":"object"}` site.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
-  OpenObjectSchema,
   fieldsStringSchema,
   kindSchema,
   limitSchema,
@@ -20,6 +26,9 @@ import {
   providerSlugSchema,
   sortSchema,
 } from "./shared.ts";
+import { CandidatesArtifactSchema } from "../routes/candidates-evidence.ts";
+import { SurfacesArtifactSchema } from "../routes/endpoints-pools.ts";
+import { ProvidersArtifactSchema } from "../routes/providers-rpc.ts";
 
 // Symbolic in each hand-written original (src/contracts.ts's QUERY_ENUMS /
 // API_QUERY_COLLECTIONS.*.sort_fields), cross-checked against the actual
@@ -65,20 +74,7 @@ export const ListProvidersInputSchema = z
   .strict();
 export type ListProvidersInput = z.infer<typeof ListProvidersInputSchema>;
 
-export const ListProvidersOutputSchema = z
-  .object({
-    generated_at: z.string().nullable().optional(),
-    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
-    providers: z.array(OpenObjectSchema),
-    total: z.int().optional(),
-    returned: z.int().optional(),
-    limit: z.int().optional(),
-    cursor: z.int().optional(),
-    next_cursor: z.int().nullable().optional(),
-    sort: z.string().nullable().optional(),
-    order: z.string().nullable().optional(),
-  })
-  .passthrough();
+export const ListProvidersOutputSchema = ProvidersArtifactSchema;
 export type ListProvidersOutput = z.infer<typeof ListProvidersOutputSchema>;
 
 const SURFACE_KINDS = [
@@ -126,20 +122,7 @@ export const ListSurfacesInputSchema = z
   .strict();
 export type ListSurfacesInput = z.infer<typeof ListSurfacesInputSchema>;
 
-export const ListSurfacesOutputSchema = z
-  .object({
-    generated_at: z.string().nullable().optional(),
-    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
-    surfaces: z.array(OpenObjectSchema),
-    total: z.int().optional(),
-    returned: z.int().optional(),
-    limit: z.int().optional(),
-    cursor: z.int().optional(),
-    next_cursor: z.int().nullable().optional(),
-    sort: z.string().nullable().optional(),
-    order: z.string().nullable().optional(),
-  })
-  .passthrough();
+export const ListSurfacesOutputSchema = SurfacesArtifactSchema;
 export type ListSurfacesOutput = z.infer<typeof ListSurfacesOutputSchema>;
 
 const CANDIDATE_STATES = [
@@ -192,22 +175,5 @@ export const ListCandidatesInputSchema = z
   .strict();
 export type ListCandidatesInput = z.infer<typeof ListCandidatesInputSchema>;
 
-export const ListCandidatesOutputSchema = z
-  .object({
-    generated_at: z.string().nullable().optional(),
-    notes: z
-      .union([z.array(z.string()), z.string()])
-      .nullable()
-      .optional(),
-    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
-    candidates: z.array(OpenObjectSchema),
-    total: z.int().optional(),
-    returned: z.int().optional(),
-    limit: z.int().optional(),
-    cursor: z.int().optional(),
-    next_cursor: z.int().nullable().optional(),
-    sort: z.string().nullable().optional(),
-    order: z.string().nullable().optional(),
-  })
-  .passthrough();
+export const ListCandidatesOutputSchema = CandidatesArtifactSchema;
 export type ListCandidatesOutput = z.infer<typeof ListCandidatesOutputSchema>;

--- a/schemas-src/mcp-tools/registry-catalogs-2.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-2.ts
@@ -1,20 +1,21 @@
-// MCP tools `list_evidence`, `list_rpc_endpoints`, `list_rpc_pools`,
-// `list_source_snapshots`, `list_profile_completeness` (types-epic E batch
-// 9, #8073). Like registry-catalogs-1.ts's three tools, these five are NOT
-// defined inline in src/mcp-server.ts -- their `LIST_X_MCP_TOOL`/
-// `LIST_X_OUTPUT_SCHEMA` hand-written literals live in src/evidence-mcp.ts,
-// src/rpc-endpoints-mcp.ts, src/rpc-pools-mcp.ts, src/source-snapshots-mcp.ts,
-// and src/profile-completeness-mcp.ts respectively, imported into
-// mcp-server.ts's MCP_TOOLS array via object spread. The z.toJSONSchema(...)
-// wiring for these five happens in THEIR OWN files, not mcp-server.ts. None
-// mirror an existing schemas-src/routes/ REST schema -- modeled fresh,
-// matching each hand-written literal field-for-field. Genuine per-tool
-// variation worth flagging: list_rpc_pools and list_profile_completeness
-// have NO schema_version output field at all (their siblings all do);
-// list_rpc_endpoints' schema_version is a plain nullable integer (not the
-// string|integer|null union every other tool in this batch uses); and
-// list_rpc_endpoints' `fields`/`cursor` inputs are `oneOf` unions (string-or-
-// array, integer-or-string) unlike every other tool's single-type fields.
+// MCP tools `list_evidence`, `list_rpc_endpoints`, `list_source_snapshots`.
+// Mirror GET /api/v1/evidence, GET /api/v1/rpc/endpoints, GET
+// /api/v1/source-snapshots.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   list_evidence: 2 bare `{"type":"object"}` sites.
+//   list_rpc_endpoints: 2 bare `{"type":"object"}` sites.
+//   list_source_snapshots: 2 bare `{"type":"object"}` sites.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
   OpenObjectSchema,
@@ -28,6 +29,9 @@ import {
   querySchema,
   sortSchema,
 } from "./shared.ts";
+import { EvidenceLedgerArtifactSchema } from "../routes/candidates-evidence.ts";
+import { SourceSnapshotsArtifactSchema } from "../routes/evidence-search.ts";
+import { RpcEndpointsArtifactSchema } from "../routes/providers-rpc.ts";
 
 const CLAIM_SORT_FIELDS = [
   "claim",
@@ -48,21 +52,7 @@ export const ListEvidenceInputSchema = z
   .strict();
 export type ListEvidenceInput = z.infer<typeof ListEvidenceInputSchema>;
 
-export const ListEvidenceOutputSchema = z
-  .object({
-    generated_at: z.string().nullable().optional(),
-    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
-    summary: OpenObjectSchema.nullable().optional(),
-    claims: z.array(OpenObjectSchema),
-    total: z.int().optional(),
-    returned: z.int().optional(),
-    limit: z.int().optional(),
-    cursor: z.int().optional(),
-    next_cursor: z.int().nullable().optional(),
-    sort: z.string().nullable().optional(),
-    order: z.string().nullable().optional(),
-  })
-  .passthrough();
+export const ListEvidenceOutputSchema = EvidenceLedgerArtifactSchema;
 export type ListEvidenceOutput = z.infer<typeof ListEvidenceOutputSchema>;
 
 const SURFACE_KINDS = [
@@ -193,27 +183,7 @@ export const ListRpcEndpointsInputSchema = z
   .strict();
 export type ListRpcEndpointsInput = z.infer<typeof ListRpcEndpointsInputSchema>;
 
-export const ListRpcEndpointsOutputSchema = z
-  .object({
-    generated_at: z.string().nullable().optional(),
-    notes: z
-      .union([z.array(z.string()), z.string()])
-      .nullable()
-      .optional(),
-    schema_version: z.int().nullable().optional(),
-    summary: OpenObjectSchema.nullable().optional(),
-    source: z.string().nullable().optional(),
-    operational_observed_at: z.string().nullable().optional(),
-    endpoints: z.array(OpenObjectSchema),
-    total: z.int().optional(),
-    returned: z.int().optional(),
-    limit: z.int().optional(),
-    cursor: z.int().optional(),
-    next_cursor: z.int().nullable().optional(),
-    sort: z.string().nullable().optional(),
-    order: z.string().nullable().optional(),
-  })
-  .passthrough();
+export const ListRpcEndpointsOutputSchema = RpcEndpointsArtifactSchema;
 export type ListRpcEndpointsOutput = z.infer<
   typeof ListRpcEndpointsOutputSchema
 >;
@@ -312,21 +282,7 @@ export type ListSourceSnapshotsInput = z.infer<
   typeof ListSourceSnapshotsInputSchema
 >;
 
-export const ListSourceSnapshotsOutputSchema = z
-  .object({
-    generated_at: z.string().nullable().optional(),
-    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
-    summary: OpenObjectSchema.nullable().optional(),
-    sources: z.array(OpenObjectSchema),
-    total: z.int().optional(),
-    returned: z.int().optional(),
-    limit: z.int().optional(),
-    cursor: z.int().optional(),
-    next_cursor: z.int().nullable().optional(),
-    sort: z.string().nullable().optional(),
-    order: z.string().nullable().optional(),
-  })
-  .passthrough();
+export const ListSourceSnapshotsOutputSchema = SourceSnapshotsArtifactSchema;
 export type ListSourceSnapshotsOutput = z.infer<
   typeof ListSourceSnapshotsOutputSchema
 >;

--- a/schemas-src/mcp-tools/runtime.ts
+++ b/schemas-src/mcp-tools/runtime.ts
@@ -1,8 +1,18 @@
-// MCP tool `get_runtime` (types-epic E batch 8, #8071). Mirrors
-// GET /api/v1/runtime, which is not one of schemas-src/routes/'s covered
-// pilot routes -- no existing Zod schema to reuse. Modeled fresh, matching
-// the hand-written literal it replaces field-for-field.
+// MCP tools `get_networks`, `get_runtime`.
+// Mirror GET /api/v1/networks, GET /api/v1/runtime.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
+import { NetworkCapabilitiesArtifactSchema } from "../routes/network-capabilities.ts";
+import { RuntimeVersionsArtifactSchema } from "../routes/runtime-versions.ts";
 
 export const GetRuntimeInputSchema = z.object({}).strict();
 export type GetRuntimeInput = z.infer<typeof GetRuntimeInputSchema>;
@@ -12,14 +22,6 @@ export type GetRuntimeInput = z.infer<typeof GetRuntimeInputSchema>;
 // other item shapes in this epic, spec_version/block_number are plain
 // (non-nullable) integers when present: the hand-written original wraps
 // them in bare `{type:"integer"}`, not NULLABLE_INT.
-const RuntimeTransitionSchema = z
-  .object({
-    spec_version: z.int().optional(),
-    block_number: z.int().optional(),
-    observed_at: z.string().nullable().optional(),
-  })
-  .passthrough();
-
 // #8702 upgrade radar. Every field is independently nullable because each
 // comes from its own upstream: a testnet RPC outage blanks the testnet reading
 // and nothing else. `pending_upgrade` carries "unknown" as a real value rather
@@ -29,67 +31,7 @@ const RuntimeTransitionSchema = z
 // There is deliberately no ETA/expected-date field anywhere in this shape: the
 // foundation publishes no deploy schedule, so any predicted date would be a
 // guess presented as data. See src/upgrade-radar.ts.
-const ChainReadingSchema = z
-  .object({
-    network: z.string(),
-    spec_version: z.int().nullable(),
-    observed_at: z.string().nullable(),
-  })
-  .passthrough();
-
-const ReleaseRecordSchema = z
-  .object({
-    tag: z.string(),
-    spec_version: z.int(),
-    published_at: z.string().nullable(),
-    url: z.string().nullable(),
-    name: z.string().nullable(),
-    prerelease: z.boolean(),
-  })
-  .passthrough();
-
-const UpgradeRadarSchema = z
-  .object({
-    mainnet: ChainReadingSchema,
-    testnet: ChainReadingSchema,
-    latest_release: ReleaseRecordSchema.nullable(),
-    pending_upgrade: z.enum([
-      "none",
-      "testnet_soaking",
-      "released_undeployed",
-      "unknown",
-    ]),
-    versions_behind: z.int().nullable(),
-  })
-  .passthrough();
-
-export const GetRuntimeOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    transition_count: z.int(),
-    current_spec_version: z.int().nullable().optional(),
-    coverage_from_block: z.int().nullable().optional(),
-    coverage_from_at: z.string().nullable().optional(),
-    // False when the timeline has interior holes — an agent must not read a
-    // short transitions list as the network's whole upgrade history.
-    coverage_complete: z.boolean().optional(),
-    coverage_gaps: z
-      .array(
-        z
-          .object({
-            after_spec_version: z.int().min(0),
-            before_spec_version: z.int().min(0),
-            after_block: z.int().min(0),
-            before_block: z.int().min(0),
-            block_span: z.int().min(0),
-          })
-          .passthrough(),
-      )
-      .optional(),
-    transitions: z.array(RuntimeTransitionSchema),
-    current: UpgradeRadarSchema.optional(),
-  })
-  .passthrough();
+export const GetRuntimeOutputSchema = RuntimeVersionsArtifactSchema;
 export type GetRuntimeOutput = z.infer<typeof GetRuntimeOutputSchema>;
 
 // #8699: the per-network capability matrix, for agents planning cross-network
@@ -97,35 +39,5 @@ export type GetRuntimeOutput = z.infer<typeof GetRuntimeOutputSchema>;
 export const GetNetworksInputSchema = z.object({}).strict();
 export type GetNetworksInput = z.infer<typeof GetNetworksInputSchema>;
 
-const NetworkRouteFamilySchema = z
-  .object({
-    family: z.string(),
-    route_count: z.int(),
-    example: z.string(),
-  })
-  .passthrough();
-
-export const GetNetworksOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    default_network: z.string(),
-    path_form: z.string().optional(),
-    network_count: z.int(),
-    networks: z.array(
-      z
-        .object({
-          id: z.string(),
-          chain: z.string(),
-          aliases: z.array(z.string()),
-          is_default: z.boolean(),
-          serves_data: z.boolean(),
-          served_families: z.array(NetworkRouteFamilySchema),
-          unserved_families: z.array(NetworkRouteFamilySchema),
-          partial_families: z.array(NetworkRouteFamilySchema),
-          note: z.string().nullable(),
-        })
-        .passthrough(),
-    ),
-  })
-  .passthrough();
+export const GetNetworksOutputSchema = NetworkCapabilitiesArtifactSchema;
 export type GetNetworksOutput = z.infer<typeof GetNetworksOutputSchema>;

--- a/schemas-src/mcp-tools/search-subnets.ts
+++ b/schemas-src/mcp-tools/search-subnets.ts
@@ -2,7 +2,8 @@
 // mirror -- src/mcp-server.ts's own handler builds this shape directly from
 // /metagraph/search.json + a ranking score, it isn't a route response. Both
 // schemas are modeled from the hand-written JSON Schema literals they
-// replace (src/mcp-server.ts's MCP_TOOLS entry + TOOL_OUTPUT_SCHEMAS.search_subnets),
+// replace (src/mcp-server.ts's MCP_TOOLS entry +
+// TOOL_OUTPUT_SCHEMAS.search_subnets),
 // field for field, preserving the EXACT wire contract -- required sets,
 // nullability, and additionalProperties posture all carried over unchanged.
 // This is a stricter constraint than types-epic B's OpenAPI components: no

--- a/schemas-src/mcp-tools/subnet-activity.ts
+++ b/schemas-src/mcp-tools/subnet-activity.ts
@@ -1,18 +1,34 @@
-// MCP tools `get_subnet_registrations`, `get_subnet_stake_moves`,
-// `get_subnet_stake_transfers`, `get_subnet_axon_removals`,
-// `get_subnet_serving`, `get_subnet_prometheus`, `get_subnet_deregistrations`
-// (types-epic E batch 3, #8066). Seven live account_events-window
-// scorecards sharing one shape (netuid/window/observed_at + a distinct-actor
-// count/event count/per-actor ratio, field names varying by kind) -- each
-// mirrors a GET /api/v1/subnets/{netuid}/<kind> route not covered by
-// schemas-src/routes/. Modeled fresh, shallow, from the hand-written
-// literals they replace (byte-identical structure across all seven, mirrors
-// the REST batch-1 precedent in schemas-src/routes/subnet-activity.ts,
-// #8055). Window enum hardcoded {"7d","30d"} from each tool's own
-// src/subnet-*.ts WINDOWS constant at the time of writing (all seven
-// verified identical).
+// MCP tools `get_subnet_axon_removals`, `get_subnet_stake_moves`,
+// `get_subnet_prometheus`, `get_subnet_deregistrations`,
+// `get_subnet_stake_transfers`, `get_subnet_registrations`,
+// `get_subnet_serving`.
+// Mirror GET /api/v1/subnets/{netuid}/axon-removals, GET
+// /api/v1/subnets/{netuid}/stake-moves, GET
+// /api/v1/subnets/{netuid}/prometheus, GET
+// /api/v1/subnets/{netuid}/deregistrations, GET
+// /api/v1/subnets/{netuid}/stake-transfers, GET
+// /api/v1/subnets/{netuid}/registrations, GET /api/v1/subnets/{netuid}/serving.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import { netuidSchema } from "./shared.ts";
+import {
+  SubnetAxonRemovalsArtifactSchema,
+  SubnetDeregistrationsArtifactSchema,
+  SubnetRegistrationsArtifactSchema,
+  SubnetServingArtifactSchema,
+} from "../routes/subnet-activity.ts";
+import { SubnetPrometheusArtifactSchema } from "../routes/subnet-prometheus.ts";
+import { SubnetStakeMovesArtifactSchema } from "../routes/subnet-stake-moves.ts";
+import { SubnetStakeTransfersArtifactSchema } from "../routes/subnet-stake-transfers.ts";
 
 const ACTIVITY_WINDOWS = ["7d", "30d"] as const;
 const ActivityWindowSchema = z.enum(ACTIVITY_WINDOWS).optional();
@@ -30,17 +46,8 @@ export const GetSubnetRegistrationsInputSchema = ActivityInputSchema;
 export type GetSubnetRegistrationsInput = z.infer<
   typeof GetSubnetRegistrationsInputSchema
 >;
-export const GetSubnetRegistrationsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string().nullable(),
-    observed_at: z.string().nullable().optional(),
-    distinct_registrants: z.int(),
-    registrations: z.int(),
-    registrations_per_registrant: z.number().nullable().optional(),
-  })
-  .passthrough();
+export const GetSubnetRegistrationsOutputSchema =
+  SubnetRegistrationsArtifactSchema;
 export type GetSubnetRegistrationsOutput = z.infer<
   typeof GetSubnetRegistrationsOutputSchema
 >;
@@ -49,17 +56,7 @@ export const GetSubnetStakeMovesInputSchema = ActivityInputSchema;
 export type GetSubnetStakeMovesInput = z.infer<
   typeof GetSubnetStakeMovesInputSchema
 >;
-export const GetSubnetStakeMovesOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string().nullable(),
-    observed_at: z.string().nullable().optional(),
-    distinct_movers: z.int(),
-    movements: z.int(),
-    movements_per_mover: z.number().nullable().optional(),
-  })
-  .passthrough();
+export const GetSubnetStakeMovesOutputSchema = SubnetStakeMovesArtifactSchema;
 export type GetSubnetStakeMovesOutput = z.infer<
   typeof GetSubnetStakeMovesOutputSchema
 >;
@@ -68,17 +65,8 @@ export const GetSubnetStakeTransfersInputSchema = ActivityInputSchema;
 export type GetSubnetStakeTransfersInput = z.infer<
   typeof GetSubnetStakeTransfersInputSchema
 >;
-export const GetSubnetStakeTransfersOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string().nullable(),
-    observed_at: z.string().nullable().optional(),
-    distinct_senders: z.int(),
-    transfers: z.int(),
-    transfers_per_sender: z.number().nullable().optional(),
-  })
-  .passthrough();
+export const GetSubnetStakeTransfersOutputSchema =
+  SubnetStakeTransfersArtifactSchema;
 export type GetSubnetStakeTransfersOutput = z.infer<
   typeof GetSubnetStakeTransfersOutputSchema
 >;
@@ -87,34 +75,15 @@ export const GetSubnetAxonRemovalsInputSchema = ActivityInputSchema;
 export type GetSubnetAxonRemovalsInput = z.infer<
   typeof GetSubnetAxonRemovalsInputSchema
 >;
-export const GetSubnetAxonRemovalsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string().nullable(),
-    observed_at: z.string().nullable().optional(),
-    distinct_removers: z.int(),
-    removals: z.int(),
-    removals_per_remover: z.number().nullable(),
-  })
-  .passthrough();
+export const GetSubnetAxonRemovalsOutputSchema =
+  SubnetAxonRemovalsArtifactSchema;
 export type GetSubnetAxonRemovalsOutput = z.infer<
   typeof GetSubnetAxonRemovalsOutputSchema
 >;
 
 export const GetSubnetServingInputSchema = ActivityInputSchema;
 export type GetSubnetServingInput = z.infer<typeof GetSubnetServingInputSchema>;
-export const GetSubnetServingOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string().nullable(),
-    observed_at: z.string().nullable().optional(),
-    distinct_servers: z.int(),
-    announcements: z.int(),
-    announcements_per_server: z.number().nullable(),
-  })
-  .passthrough();
+export const GetSubnetServingOutputSchema = SubnetServingArtifactSchema;
 export type GetSubnetServingOutput = z.infer<
   typeof GetSubnetServingOutputSchema
 >;
@@ -123,17 +92,7 @@ export const GetSubnetPrometheusInputSchema = ActivityInputSchema;
 export type GetSubnetPrometheusInput = z.infer<
   typeof GetSubnetPrometheusInputSchema
 >;
-export const GetSubnetPrometheusOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string().nullable(),
-    observed_at: z.string().nullable().optional(),
-    distinct_exporters: z.int(),
-    announcements: z.int(),
-    announcements_per_exporter: z.number().nullable(),
-  })
-  .passthrough();
+export const GetSubnetPrometheusOutputSchema = SubnetPrometheusArtifactSchema;
 export type GetSubnetPrometheusOutput = z.infer<
   typeof GetSubnetPrometheusOutputSchema
 >;
@@ -142,17 +101,8 @@ export const GetSubnetDeregistrationsInputSchema = ActivityInputSchema;
 export type GetSubnetDeregistrationsInput = z.infer<
   typeof GetSubnetDeregistrationsInputSchema
 >;
-export const GetSubnetDeregistrationsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    netuid: netuidSchema(),
-    window: z.string().nullable(),
-    observed_at: z.string().nullable().optional(),
-    distinct_deregistered_hotkeys: z.int(),
-    deregistrations: z.int(),
-    deregistrations_per_hotkey: z.number().nullable(),
-  })
-  .passthrough();
+export const GetSubnetDeregistrationsOutputSchema =
+  SubnetDeregistrationsArtifactSchema;
 export type GetSubnetDeregistrationsOutput = z.infer<
   typeof GetSubnetDeregistrationsOutputSchema
 >;

--- a/schemas-src/mcp-tools/subnet-registry-lists.ts
+++ b/schemas-src/mcp-tools/subnet-registry-lists.ts
@@ -1,13 +1,22 @@
-// MCP tools `get_subnet_candidates`, `list_subnet_candidates`,
-// `get_subnet_evidence`, `list_subnet_evidence`, `get_subnet_surfaces`
-// (types-epic E batch 11, #8074). The first, third, and fifth are defined
-// inline in src/mcp-server.ts's MCP_TOOLS array; `list_subnet_candidates`/
-// `list_subnet_evidence` live in src/subnet-candidates-mcp.ts and
-// src/subnet-evidence-mcp.ts respectively (their `LIST_X_MCP_TOOL`/
-// `LIST_X_OUTPUT_SCHEMA` spread into mcp-server.ts's MCP_TOOLS array) -- the
-// z.toJSONSchema(...) wiring for those two happens in THEIR OWN files, not
-// mcp-server.ts. None mirror an existing schemas-src/routes/ REST schema --
-// modeled fresh, matching each hand-written literal field-for-field.
+// MCP tools `get_subnet_candidates`, `get_subnet_evidence`,
+// `get_subnet_surfaces`.
+// Mirror GET /api/v1/subnets/{netuid}/candidates, GET
+// /api/v1/subnets/{netuid}/evidence, GET /api/v1/subnets/{netuid}/surfaces.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_subnet_candidates: 1 bare `{"type":"object"}` site.
+//   get_subnet_evidence: 1 bare `{"type":"object"}` site.
+//   get_subnet_surfaces: 1 bare `{"type":"object"}` site.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
   OpenObjectSchema,
@@ -21,6 +30,11 @@ import {
   querySchema,
   sortSchema,
 } from "./shared.ts";
+import {
+  SubnetCandidatesArtifactSchema,
+  SubnetEvidenceArtifactSchema,
+} from "../routes/candidates-evidence.ts";
+import { SubnetSurfacesArtifactSchema } from "../routes/endpoints-pools.ts";
 
 const SURFACE_KINDS = [
   "archive",
@@ -48,14 +62,7 @@ export type GetSubnetCandidatesInput = z.infer<
   typeof GetSubnetCandidatesInputSchema
 >;
 
-export const GetSubnetCandidatesOutputSchema = z
-  .object({
-    netuid: netuidSchema().nullable().optional(),
-    candidates: z.array(OpenObjectSchema).optional(),
-    generated_at: z.string().nullable().optional(),
-    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
-  })
-  .passthrough();
+export const GetSubnetCandidatesOutputSchema = SubnetCandidatesArtifactSchema;
 export type GetSubnetCandidatesOutput = z.infer<
   typeof GetSubnetCandidatesOutputSchema
 >;
@@ -139,14 +146,7 @@ export type GetSubnetEvidenceInput = z.infer<
   typeof GetSubnetEvidenceInputSchema
 >;
 
-export const GetSubnetEvidenceOutputSchema = z
-  .object({
-    netuid: netuidSchema().nullable().optional(),
-    claims: z.array(OpenObjectSchema).optional(),
-    generated_at: z.string().nullable().optional(),
-    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
-  })
-  .passthrough();
+export const GetSubnetEvidenceOutputSchema = SubnetEvidenceArtifactSchema;
 export type GetSubnetEvidenceOutput = z.infer<
   typeof GetSubnetEvidenceOutputSchema
 >;
@@ -200,14 +200,7 @@ export type GetSubnetSurfacesInput = z.infer<
   typeof GetSubnetSurfacesInputSchema
 >;
 
-export const GetSubnetSurfacesOutputSchema = z
-  .object({
-    netuid: netuidSchema().nullable().optional(),
-    surfaces: z.array(OpenObjectSchema).optional(),
-    generated_at: z.string().nullable().optional(),
-    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
-  })
-  .passthrough();
+export const GetSubnetSurfacesOutputSchema = SubnetSurfacesArtifactSchema;
 export type GetSubnetSurfacesOutput = z.infer<
   typeof GetSubnetSurfacesOutputSchema
 >;

--- a/schemas-src/mcp-tools/validators.ts
+++ b/schemas-src/mcp-tools/validators.ts
@@ -1,9 +1,21 @@
-// MCP tools `list_subnet_validators`, `list_global_validators`,
-// `get_validator_detail`, `compare_validators`, `get_validator_nominators`,
-// `get_validator_history` (types-epic E batch 4, #8068). Each mirrors a
-// GET /api/v1/validators* route that is not one of schemas-src/routes/'s
-// covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
-// matching each hand-written literal field-for-field.
+// MCP tools `get_validator_detail`, `list_global_validators`,
+// `get_validator_history`, `get_validator_nominators`.
+// Mirror GET /api/v1/validators/{hotkey}, GET /api/v1/validators, GET
+// /api/v1/validators/{hotkey}/history, GET
+// /api/v1/validators/{hotkey}/nominators.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift -- which is what the hand-written copies
+// this replaces had already accumulated.
+//
+// What the copies were publishing:
+//   get_validator_detail: 1 bare `{"type":"object"}` site.
+//
+// Verified against production before the switch, because deriving is a
+// TIGHTENING -- the route schema is stricter than the copy was. Every tool in
+// this file was called live and its response validated against the schema it
+// now publishes.
 import { z } from "zod";
 import {
   NeuronFieldsInputSchema,
@@ -19,6 +31,10 @@ import {
   GLOBAL_VALIDATOR_LIMIT_DEFAULT,
   GLOBAL_VALIDATOR_LIMIT_MAX,
 } from "../../src/route-limits.ts";
+import { GlobalValidatorsArtifactSchema } from "../routes/global-validators.ts";
+import { ValidatorDetailArtifactSchema } from "../routes/validator-detail.ts";
+import { ValidatorHistoryArtifactSchema } from "../routes/validator-history.ts";
+import { ValidatorNominatorsArtifactSchema } from "../routes/validator-nominators.ts";
 
 // Mirrors workers/config.ts's SS58_ADDRESS_PATTERN (inlined rather than
 // cross-imported from workers/, matching this directory's existing
@@ -110,45 +126,7 @@ export type ListGlobalValidatorsInput = z.infer<
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
-const GlobalValidatorSubnetItemSchema = z
-  .object({
-    netuid: netuidSchema().nullable().optional(),
-    uid: z.int().nullable().optional(),
-    stake_tao: z.unknown().optional(),
-    emission_tao: z.unknown().optional(),
-    validator_trust: z.number().nullable().optional(),
-  })
-  .passthrough();
-
-const GlobalValidatorItemSchema = z
-  .object({
-    hotkey: z.string().nullable().optional(),
-    coldkey: z.string().nullable().optional(),
-    coldkey_count: z.int().optional(),
-    subnet_count: z.int().optional(),
-    uid_count: z.int().optional(),
-    total_stake_tao: z.unknown().optional(),
-    total_emission_tao: z.unknown().optional(),
-    avg_validator_trust: z.number().nullable().optional(),
-    max_validator_trust: z.number().nullable().optional(),
-    latest_captured_at: z.string().nullable().optional(),
-    latest_block_number: z.int().nullable().optional(),
-    stake_dominance: z.number().nullable().optional(),
-    subnets: z.array(GlobalValidatorSubnetItemSchema).optional(),
-  })
-  .passthrough();
-
-export const ListGlobalValidatorsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    sort: z.enum(GLOBAL_VALIDATOR_SORTS),
-    limit: z.int(),
-    captured_at: z.string().nullable().optional(),
-    block_number: z.int().nullable().optional(),
-    validator_count: z.int(),
-    validators: z.array(GlobalValidatorItemSchema),
-  })
-  .passthrough();
+export const ListGlobalValidatorsOutputSchema = GlobalValidatorsArtifactSchema;
 export type ListGlobalValidatorsOutput = z.infer<
   typeof ListGlobalValidatorsOutputSchema
 >;
@@ -162,23 +140,7 @@ export type GetValidatorDetailInput = z.infer<
   typeof GetValidatorDetailInputSchema
 >;
 
-export const GetValidatorDetailOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    hotkey: z.string(),
-    coldkey: z.string().nullable().optional(),
-    coldkey_count: z.int().optional(),
-    subnet_count: z.int(),
-    take: z.number().nullable().optional(),
-    total_stake_tao: z.unknown().optional(),
-    total_emission_tao: z.unknown().optional(),
-    avg_validator_trust: z.number().nullable().optional(),
-    max_validator_trust: z.number().nullable().optional(),
-    captured_at: z.string().nullable().optional(),
-    block_number: z.int().nullable().optional(),
-    subnets: OpenObjectArraySchema,
-  })
-  .passthrough();
+export const GetValidatorDetailOutputSchema = ValidatorDetailArtifactSchema;
 export type GetValidatorDetailOutput = z.infer<
   typeof GetValidatorDetailOutputSchema
 >;
@@ -243,30 +205,8 @@ export type GetValidatorNominatorsInput = z.infer<
 >;
 
 // objectItems(...) properties, none required at the item level.
-const NominatorItemSchema = z
-  .object({
-    coldkey: z.string().optional(),
-    staked_tao: z.unknown().optional(),
-    unstaked_tao: z.unknown().optional(),
-    net_staked_tao: z.unknown().optional(),
-    gross_staked_tao: z.unknown().optional(),
-    event_count: z.int().optional(),
-    last_observed_at: z.string().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetValidatorNominatorsOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    hotkey: z.string(),
-    window: z.string().nullable().optional(),
-    sort: z.enum(NOMINATOR_SORTS).optional(),
-    limit: z.int().optional(),
-    offset: z.int().optional(),
-    nominator_count: z.int(),
-    nominators: z.array(NominatorItemSchema),
-  })
-  .passthrough();
+export const GetValidatorNominatorsOutputSchema =
+  ValidatorNominatorsArtifactSchema;
 export type GetValidatorNominatorsOutput = z.infer<
   typeof GetValidatorNominatorsOutputSchema
 >;
@@ -285,39 +225,7 @@ export type GetValidatorHistoryInput = z.infer<
 >;
 
 // objectItems(...) properties, none required at the item level.
-const ValidatorHistoryPointSchema = z
-  .object({
-    snapshot_date: z.string().nullable().optional(),
-    subnet_count: z.int().nullable().optional(),
-    // Present only when the request scoped a netuid. Absent (not null) on the
-    // unscoped series, because vTrust/consensus/dividends/take are per-subnet
-    // facts and a cross-subnet average of them is a number the chain never
-    // computes -- see subnetScopedFields in src/validator-history.ts.
-    netuid: netuidSchema().nullable().optional(),
-    uid: z.int().nullable().optional(),
-    stake_alpha: z.number().nullable().optional(),
-    emission_alpha: z.number().nullable().optional(),
-    validator_trust: z.number().nullable().optional(),
-    consensus: z.number().nullable().optional(),
-    dividends: z.number().nullable().optional(),
-    take: z.number().nullable().optional(),
-    validator_permit: z.boolean().nullable().optional(),
-    rewards_per_1000_alpha: z.number().nullable().optional(),
-    total_stake_tao: z.unknown().optional(),
-    total_emission_tao: z.unknown().optional(),
-    rewards_per_1000_tao: z.number().nullable().optional(),
-  })
-  .passthrough();
-
-export const GetValidatorHistoryOutputSchema = z
-  .object({
-    schema_version: z.int().optional(),
-    hotkey: z.string(),
-    window: z.string().nullable().optional(),
-    point_count: z.int(),
-    points: z.array(ValidatorHistoryPointSchema),
-  })
-  .passthrough();
+export const GetValidatorHistoryOutputSchema = ValidatorHistoryArtifactSchema;
 export type GetValidatorHistoryOutput = z.infer<
   typeof GetValidatorHistoryOutputSchema
 >;

--- a/schemas-src/routes/account-events-feed.ts
+++ b/schemas-src/routes/account-events-feed.ts
@@ -31,8 +31,15 @@ export const AccountEventsArtifactSchema = z
     schema_version: z.int(),
     ss58: z.string(),
     event_count: z.int().min(0),
-    limit: z.int(),
-    offset: z.int(),
+    // NULLABLE, and this is not defensive (#9796). The REST layer defaults
+    // `limit`/`offset` before the loader runs, so a live route response always
+    // carries integers -- which is why validate:api never saw this. The same
+    // loader also serves the MCP tool, which passes the caller's arguments
+    // straight through, and an omitted limit reaches it as undefined:
+    // `limit: limit ?? null` then emits null. The contract said that was
+    // impossible.
+    limit: z.int().nullable(),
+    offset: z.int().nullable(),
     next_cursor: z.string().nullable().optional(),
     events: z.array(AccountEventSchema),
   })
@@ -71,8 +78,8 @@ export const AccountHistoryArtifactSchema = z
     schema_version: z.int(),
     ss58: z.string(),
     day_count: z.int().min(0),
-    limit: z.int(),
-    offset: z.int(),
+    limit: z.int().nullable(),
+    offset: z.int().nullable(),
     next_cursor: z.string().nullable().optional(),
     days: z.array(AccountDaySchema),
   })
@@ -111,8 +118,8 @@ export const AccountTransfersArtifactSchema = z
     schema_version: z.int(),
     ss58: z.string(),
     transfer_count: z.int().min(0),
-    limit: z.int(),
-    offset: z.int(),
+    limit: z.int().nullable(),
+    offset: z.int().nullable(),
     next_cursor: z.string().nullable().optional(),
     transfers: z.array(AccountTransferEntrySchema),
   })

--- a/schemas-src/routes/account-extrinsics.ts
+++ b/schemas-src/routes/account-extrinsics.ts
@@ -49,8 +49,15 @@ export const AccountExtrinsicsArtifactSchema = z
     schema_version: z.int(),
     ss58: z.string(),
     extrinsic_count: z.int().min(0),
-    limit: z.int(),
-    offset: z.int(),
+    // NULLABLE, and this is not defensive (#9796). The REST layer defaults
+    // `limit`/`offset` before the loader runs, so a live route response always
+    // carries integers -- which is why validate:api never saw this. The same
+    // loader also serves the MCP tool, which passes the caller's arguments
+    // straight through, and an omitted limit reaches it as undefined:
+    // `limit: limit ?? null` then emits null. The contract said that was
+    // impossible.
+    limit: z.int().nullable(),
+    offset: z.int().nullable(),
     next_cursor: z.string().nullable().optional(),
     extrinsics: z.array(ExtrinsicSchema),
   })

--- a/schemas-src/routes/block-events.ts
+++ b/schemas-src/routes/block-events.ts
@@ -15,8 +15,15 @@ export const BlockEventsArtifactSchema = z
     ref: z.string().nullable(),
     block_number: z.int().min(0).nullable(),
     event_count: z.int().min(0),
-    limit: z.int(),
-    offset: z.int(),
+    // NULLABLE, and this is not defensive (#9796). The REST layer defaults
+    // `limit`/`offset` before the loader runs, so a live route response always
+    // carries integers -- which is why validate:api never saw this. The same
+    // loader also serves the MCP tool, which passes the caller's arguments
+    // straight through, and an omitted limit reaches it as undefined:
+    // `limit: limit ?? null` then emits null. The contract said that was
+    // impossible.
+    limit: z.int().nullable(),
+    offset: z.int().nullable(),
     events: z.array(AccountEventSchema),
   })
   .passthrough();

--- a/schemas-src/routes/block-extrinsics.ts
+++ b/schemas-src/routes/block-extrinsics.ts
@@ -13,8 +13,15 @@ export const BlockExtrinsicsArtifactSchema = z
     ref: z.string().nullable(),
     block_number: z.int().min(0).nullable(),
     extrinsic_count: z.int().min(0),
-    limit: z.int(),
-    offset: z.int(),
+    // NULLABLE, and this is not defensive (#9796). The REST layer defaults
+    // `limit`/`offset` before the loader runs, so a live route response always
+    // carries integers -- which is why validate:api never saw this. The same
+    // loader also serves the MCP tool, which passes the caller's arguments
+    // straight through, and an omitted limit reaches it as undefined:
+    // `limit: limit ?? null` then emits null. The contract said that was
+    // impossible.
+    limit: z.int().nullable(),
+    offset: z.int().nullable(),
     extrinsics: z.array(ExtrinsicSchema),
   })
   .passthrough();

--- a/schemas-src/routes/blocks.ts
+++ b/schemas-src/routes/blocks.ts
@@ -27,8 +27,15 @@ export const BlocksFeedArtifactSchema = z
   .object({
     schema_version: z.int(),
     block_count: z.int().min(0),
-    limit: z.int(),
-    offset: z.int(),
+    // NULLABLE, and this is not defensive (#9796). The REST layer defaults
+    // `limit`/`offset` before the loader runs, so a live route response always
+    // carries integers -- which is why validate:api never saw this. The same
+    // loader also serves the MCP tool, which passes the caller's arguments
+    // straight through, and an omitted limit reaches it as undefined:
+    // `limit: limit ?? null` then emits null. The contract said that was
+    // impossible.
+    limit: z.int().nullable(),
+    offset: z.int().nullable(),
     next_cursor: z.string().nullable(),
     blocks: z.array(BlockSchema),
   })

--- a/schemas-src/routes/extrinsics.ts
+++ b/schemas-src/routes/extrinsics.ts
@@ -41,8 +41,15 @@ export const ExtrinsicsFeedArtifactSchema = z
   .object({
     schema_version: z.int(),
     extrinsic_count: z.int().min(0),
-    limit: z.int(),
-    offset: z.int(),
+    // NULLABLE, and this is not defensive (#9796). The REST layer defaults
+    // `limit`/`offset` before the loader runs, so a live route response always
+    // carries integers -- which is why validate:api never saw this. The same
+    // loader also serves the MCP tool, which passes the caller's arguments
+    // straight through, and an omitted limit reaches it as undefined:
+    // `limit: limit ?? null` then emits null. The contract said that was
+    // impossible.
+    limit: z.int().nullable(),
+    offset: z.int().nullable(),
     next_cursor: z.string().nullable(),
     extrinsics: z.array(ExtrinsicSchema),
   })

--- a/tests/build-mcp.test.ts
+++ b/tests/build-mcp.test.ts
@@ -26,7 +26,116 @@ const SAMPLE_BUILD = {
   surface_count: 80,
   provider_count: 12,
   artifacts: [{ path: "subnets.json", size_bytes: 1000 }],
-  coverage: { surface_count: 80 },
+  // A REAL captured /api/v1/coverage response (2026-08-07). #9796 derived
+  // get_build's outputSchema from BuildSummaryArtifactSchema, which types this
+  // field as the CoverageArtifact rather than an open object; a one-key stub
+  // satisfied the open object and nothing else.
+  coverage: {
+    application_subnet_count: 128,
+    candidate_count: 2174,
+    candidate_subnet_count: 129,
+    chain_subnet_count: 129,
+    completeness: {
+      average_score: 81,
+      dimension_coverage: {
+        community: {
+          pct: 72,
+          present: 93,
+        },
+        "data-artifact": {
+          pct: 92,
+          present: 119,
+        },
+        docs: {
+          pct: 100,
+          present: 129,
+        },
+        openapi: {
+          pct: 50,
+          present: 65,
+        },
+        "source-repo": {
+          pct: 95,
+          present: 123,
+        },
+        sse: {
+          pct: 4,
+          present: 5,
+        },
+        "subnet-api": {
+          pct: 94,
+          present: 121,
+        },
+        website: {
+          pct: 95,
+          present: 122,
+        },
+      },
+      fully_complete_count: 4,
+      fully_complete_pct: 3,
+      median_score: 78,
+      methodology:
+        "Per-subnet completeness_score (0-100) weighs curated public identity and operational interface coverage. Full per-subnet scores and gaps live at /metagraph/review/profile-completeness.json; the sortable leaderboard is /api/v1/profiles?sort=completeness_score&order=asc.",
+      score_distribution: {
+        "100": 3,
+        "0-24": 0,
+        "25-49": 4,
+        "50-74": 25,
+        "75-99": 97,
+      },
+      scored_subnet_count: 129,
+    },
+    contract_version: "2026-07-03.2",
+    curated_overlay_count: 129,
+    curation_level_counts: {
+      "adapter-backed": 2,
+      "maintainer-reviewed": 127,
+    },
+    domain_coverage: {
+      agents: 13,
+      compute: 9,
+      data: 9,
+      finance: 9,
+      inference: 16,
+      media: 4,
+      prediction: 7,
+      privacy: 2,
+      robotics: 3,
+      science: 5,
+      search: 2,
+      security: 4,
+      storage: 1,
+    },
+    first_party_subnet_count: 116,
+    generated_at: "2026-08-07T10:09:17.651Z",
+    manifested_count: 0,
+    native_only_count: 0,
+    native_only_with_candidates: 0,
+    native_only_without_candidates: 0,
+    native_snapshot_captured_at: "2026-08-07T10:10:10Z",
+    network: "finney",
+    official_surface_count: 444,
+    probed_count: 129,
+    probed_surface_count: 1859,
+    registry_observed_surface_count: 785,
+    root_subnet_count: 1,
+    schema_version: 1,
+    source: {
+      candidates: "registry/candidates",
+      native: {
+        identity_storage: "SubtensorModule.SubnetIdentitiesV3",
+        kind: "bittensor-sdk",
+        method:
+          "SubtensorApi.metagraphs.get_all_metagraphs_info(all_mechanisms=True)",
+        package: "bittensor",
+        rpc_family: "subnetInfo",
+        version: "10.4.0",
+      },
+      overlays: "registry/subnets",
+    },
+    subnets_without_official_surface: 13,
+    surface_count: 3493,
+  },
   artifact_budget_summary: { ok_count: 40, warn_count: 2, fail_count: 0 },
 };
 

--- a/tests/contracts-mcp.test.ts
+++ b/tests/contracts-mcp.test.ts
@@ -25,10 +25,21 @@ const SAMPLE_CONTRACTS = {
   openapi_url: "/metagraph/openapi.json",
   type_definitions_url: "/metagraph/types.d.ts",
   notes: ["Native Bittensor chain data is canonical."],
+  status_domain: null,
+  // A real captured /api/v1/contracts row. #9796 derived get_contracts's
+  // outputSchema from ContractsArtifactSchema, which types every entry; the
+  // three-key stub only ever satisfied the open object the copy published.
   artifacts: [
     {
+      content_type: "application/json",
+      contract_version: "2026-07-03.2",
+      description:
+        "Public artifact contract metadata for metagraph.sh consumers.",
       id: "contracts",
       path: "/metagraph/contracts.json",
+      retirement: null,
+      schema_ref: "#/components/schemas/ContractsArtifact",
+      status: "live",
       storage_tier: "dual",
     },
   ],

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -3529,8 +3529,16 @@ describe("MCP tools (injected deps)", () => {
     )?.outputSchema;
     const deps = makeDeps({
       "/metagraph/build-summary.json": {
+        // A real captured production row, trimmed to one item. Deriving these
+        // tool schemas from their route ArtifactSchema (#9796) made the item
+        // shape specific; a three-key stub satisfied the open object the copy
+        // used to publish and nothing else.
         schema_version: 1,
-        artifact_count: 0,
+        generated_at: "2026-01-01T00:00:00Z",
+        artifact_count: 5,
+        artifact_size_bytes: 4025343,
+        subnet_count: 129,
+        surface_count: 3493,
         artifacts: [],
       },
     });
@@ -5805,7 +5813,7 @@ describe("MCP stake-flow and movers economics tools", () => {
         },
       ]),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -5858,7 +5866,7 @@ describe("MCP stake-flow and movers economics tools", () => {
         },
       ]),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -5911,7 +5919,7 @@ describe("MCP stake-flow and movers economics tools", () => {
         },
       ]),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -5964,7 +5972,7 @@ describe("MCP stake-flow and movers economics tools", () => {
         },
       ]),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -6017,7 +6025,7 @@ describe("MCP stake-flow and movers economics tools", () => {
         },
       ]),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -6070,7 +6078,7 @@ describe("MCP stake-flow and movers economics tools", () => {
         },
       ]),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -6123,7 +6131,7 @@ describe("MCP stake-flow and movers economics tools", () => {
         },
       ]),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -6408,7 +6416,7 @@ describe("MCP get_subnet_stake_moves", () => {
         newest_observed: 1_717_500_000_000,
       }),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 });
@@ -6448,7 +6456,7 @@ describe("MCP get_subnet_stake_transfers", () => {
         newest_observed: 1_717_500_000_000,
       }),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 });
@@ -6487,7 +6495,7 @@ describe("MCP get_subnet_registrations", () => {
         newest_observed: 1_717_500_000_000,
       }),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 });
@@ -6530,7 +6538,7 @@ describe("MCP get_subnet_weights", () => {
         newest_observed: 1_750_000_000_000,
       }),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 });
@@ -6639,7 +6647,7 @@ describe("MCP get_subnet_serving", () => {
         newest_observed: 1_750_000_000_000,
       }),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 });
@@ -6682,7 +6690,7 @@ describe("MCP get_subnet_prometheus", () => {
         newest_observed: 1_750_000_000_000,
       }),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 });
@@ -6829,7 +6837,7 @@ describe("MCP get_subnet_yield_history", () => {
         },
       },
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 });
@@ -11857,7 +11865,7 @@ describe("MCP economics + metagraph data tools", () => {
         turnoverRow("2026-06-30", 1, "V2"),
       ]),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -11968,7 +11976,7 @@ describe("MCP economics + metagraph data tools", () => {
         stakeFlowRow(1, "StakeRemoved", 20, 2),
       ]),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -12084,7 +12092,7 @@ describe("MCP economics + metagraph data tools", () => {
         alphaVolumeRow(1, "StakeRemoved", 20, 20, 2),
       ]),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -12192,7 +12200,7 @@ describe("MCP economics + metagraph data tools", () => {
         weightsRow(2, 10, 4),
       ]),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -12343,7 +12351,7 @@ describe("MCP economics + metagraph data tools", () => {
         },
       }),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -12448,7 +12456,7 @@ describe("MCP economics + metagraph data tools", () => {
         stakeMovesRow(2, 10, 4),
       ]),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -12557,7 +12565,7 @@ describe("MCP economics + metagraph data tools", () => {
         stakeTransfersRow(2, 10, 4),
       ]),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -12666,7 +12674,7 @@ describe("MCP economics + metagraph data tools", () => {
         axonRemovalsRow(2, 10, 4),
       ]),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -12775,7 +12783,7 @@ describe("MCP economics + metagraph data tools", () => {
         chainDeregistrationsRow(2, 10, 4),
       ]),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -12876,7 +12884,7 @@ describe("MCP economics + metagraph data tools", () => {
         chainServingRow(2, 10, 4),
       ]),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -12981,7 +12989,7 @@ describe("MCP economics + metagraph data tools", () => {
         chainPrometheusRow(2, 10, 4),
       ]),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -13131,7 +13139,7 @@ describe("MCP economics + metagraph data tools", () => {
         transferPairRow("C", "D", 100, 20),
       ]),
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -13328,11 +13336,26 @@ describe("MCP economics + metagraph data tools", () => {
     const globalLiveKv = {
       last_run_at: FRESH_RUN,
       summary: { surface_count: 1, status_counts: { ok: 1 } },
-      subnets: [{ netuid: 0, status: "ok" }],
+      // The per-subnet counts a live rollup always carries (verified against
+      // GET /api/v1/health). Deriving this tool's schema from
+      // HealthSummaryArtifactSchema (#9796) made them required; the two-key
+      // stub only ever satisfied the open object the copy published.
+      subnets: [
+        {
+          netuid: 0,
+          name: "root",
+          status: "ok",
+          surface_count: 8,
+          ok_count: 8,
+          degraded_count: 0,
+          failed_count: 0,
+          unknown_count: 0,
+        },
+      ],
     };
     const deps = makeDeps({}, { "health:current": globalLiveKv });
     const res = await callTool("get_network_health", {}, { deps });
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -13487,7 +13510,7 @@ describe("MCP economics + metagraph data tools", () => {
       { date: HEALTH_HISTORY_BLOB.date },
       { deps },
     );
-    const validate = new Ajv2020().compile(schema);
+    const validate = new Ajv2020({ strict: false }).compile(schema);
     assert.ok(validate(res.body.result.structuredContent));
   });
 
@@ -18015,7 +18038,22 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     )?.outputSchema;
     const deps = makeDeps({
       "/metagraph/providers.json": {
-        providers: [{ id: "datura", kind: "data-provider", name: "Datura" }],
+        // A real captured production row, trimmed to one item. Deriving these
+        // tool schemas from their route ArtifactSchema (#9796) made the item
+        // shape specific; a three-key stub satisfied the open object the copy
+        // used to publish and nothing else.
+        schema_version: 1,
+        generated_at: "2026-01-01T00:00:00Z",
+        providers: [
+          {
+            id: "404-gen",
+            name: "404-GEN",
+            kind: "subnet-team",
+            authority: "community",
+            website_url: "https://www.404.xyz/",
+            schema_version: 1,
+          },
+        ],
       },
     });
     const res = await callTool("list_providers", { limit: 1 }, { deps });
@@ -18166,7 +18204,24 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     )?.outputSchema;
     const deps = makeDeps({
       "/metagraph/surfaces.json": {
-        surfaces: [{ netuid: 7, kind: "openapi", provider: "datura" }],
+        // A real captured production row, trimmed to one item. Deriving these
+        // tool schemas from their route ArtifactSchema (#9796) made the item
+        // shape specific; a three-key stub satisfied the open object the copy
+        // used to publish and nothing else.
+        schema_version: 1,
+        generated_at: "2026-01-01T00:00:00Z",
+        surfaces: [
+          {
+            id: "bittensor-networks-docs",
+            netuid: 0,
+            kind: "docs",
+            provider: "opentensor",
+            url: "https://docs.learnbittensor.org/concepts/bittensor-networks",
+            authority: "official",
+            auth_required: false,
+            public_safe: true,
+          },
+        ],
       },
     });
     const res = await callTool("list_surfaces", { limit: 1 }, { deps });
@@ -18849,7 +18904,34 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     )?.outputSchema;
     const deps = makeDeps({
       "/metagraph/evidence-ledger.json": {
-        claims: [{ subject: "SN7", claim: "verified openapi" }],
+        // A real captured production row, trimmed to one item. Deriving these
+        // tool schemas from their route ArtifactSchema (#9796) made the item
+        // shape specific; a three-key stub satisfied the open object the copy
+        // used to publish and nothing else.
+        schema_version: 1,
+        generated_at: "2026-01-01T00:00:00Z",
+        summary: {
+          candidate_claim_count: 250,
+          claim_count: 3872,
+          subnet_claim_count: 129,
+          surface_claim_count: 3493,
+        },
+        claims: [
+          {
+            claim:
+              "root Backprop Finance dashboard is a candidate dashboard surface for SN0.",
+            confidence: "medium",
+            limits:
+              "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+            source_tier: "third-party-index",
+            source_type: "backprop-dashboard",
+            source_url: "https://backprop.finance/dtao/subnets/0-root",
+            subject: "candidate:sn-0-backprop-dashboard",
+            support_summary:
+              "Universal Backprop Finance dTAO subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+            verified_at: null,
+          },
+        ],
       },
     });
     const res = await callTool("list_evidence", { limit: 1 }, { deps });
@@ -18976,7 +19058,30 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     )?.outputSchema;
     const deps = makeDeps({
       "/metagraph/source-snapshots.json": {
-        sources: [{ id: "chain", hash: "0xabc", record_count: 42 }],
+        // A real captured production row, trimmed to one item. Deriving these
+        // tool schemas from their route ArtifactSchema (#9796) made the item
+        // shape specific; a three-key stub satisfied the open object the copy
+        // used to publish and nothing else.
+        schema_version: 1,
+        generated_at: "2026-01-01T00:00:00Z",
+        summary: {
+          adapter_snapshot_count: 65,
+          candidate_count: 2174,
+          overlay_count: 129,
+          provider_count: 137,
+          source_count: 71,
+          verification_result_count: 2174,
+        },
+        sources: [
+          {
+            captured_at: "2026-08-07T10:09:18.055Z",
+            hash: "006308d85c72f62872e168dd5bbda6c0e9f07ec39ca093e27d5c7fa6073ff7f2",
+            id: "adapter:ain",
+            kind: "adapter-snapshot",
+            path: "registry/adapters/latest/ain.json",
+            record_count: 2,
+          },
+        ],
       },
     });
     const res = await callTool("list_source_snapshots", { limit: 1 }, { deps });
@@ -19475,8 +19580,32 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     )?.outputSchema;
     const deps = makeDeps({
       "/metagraph/contracts.json": {
+        // A real captured production row, trimmed to one item. Deriving these
+        // tool schemas from their route ArtifactSchema (#9796) made the item
+        // shape specific; a three-key stub satisfied the open object the copy
+        // used to publish and nothing else.
         schema_version: 1,
-        artifacts: [{ id: "contracts", path: "/metagraph/contracts.json" }],
+        generated_at: "2026-01-01T00:00:00Z",
+        name: "Metagraphed public backend artifact contract",
+        base_path: "/metagraph",
+        primary_domain: "api.metagraph.sh",
+        status_domain: null,
+        openapi_url: "/metagraph/openapi.json",
+        type_definitions_url: "/metagraph/types.d.ts",
+        artifacts: [
+          {
+            content_type: "application/json",
+            contract_version: "2026-07-03.2",
+            description:
+              "Public artifact contract metadata for metagraph.sh consumers.",
+            id: "contracts",
+            path: "/metagraph/contracts.json",
+            retirement: null,
+            schema_ref: "#/components/schemas/ContractsArtifact",
+            status: "live",
+            storage_tier: "dual",
+          },
+        ],
       },
     });
     const res = await callTool("get_contracts", {}, { deps });


### PR DESCRIPTION
## Summary

`schemas-src/mcp-tools/` re-declared shapes `schemas-src/routes/` already
models. The copies were written when no route schema existed, the route schemas
arrived later, nothing detected the divergence — and the MCP side is the one
agents actually read.

## Measured first, not assumed

175 of 225 tools declare a REST mirror in their own description. Each was
resolved to that route's artifact component and then **called live against
production**, its response validated with `Ajv2020` against the route schema it
would inherit.

| verdict | tools |
|---|---|
| production response already satisfies the route schema | **150** |
| does not satisfy it | 24 |
| example argument has no live row (`get_adapter`) | 1 |

Only the 150 are switched here. Deriving is a **tightening**, so a switch
nobody validated against production is a switch that breaks production.

The 24 are **not drift** — they are a real MCP-side projection. The paginated
`list_*` tools drop `schema_version`, lift pagination out of `meta`, and
null-coalesce `generated_at`/`notes`; that is one deliberate shape across ~27
handlers. Expressing it as an explicit `.omit()`/`.extend()` against the route
schema — the form #9793 mandates — is its own change and stays with #9796.

## What the switch found

**Untyped blobs: 189 → 112**, across 21 fewer files. The copies collapsed whole
subtrees rather than modelling them, so an agent was told nothing about the very
field a tool exists to return.

### A route contract that had been wrong since it was written

`src/extrinsics.ts`, `src/blocks.ts` and `src/account-events.ts` all emit
`limit: limit ?? null` / `offset: offset ?? null`. Eight artifact schemas
declared both **non-nullable**.

The REST layer defaults `limit`/`offset` before the loader runs, so a live route
response always carries integers — which is exactly why `validate:api` never saw
it. The same loader also serves the MCP tool, which passes the caller's
arguments straight through: an omitted limit reaches it as `undefined`, and the
response carries `null` against a contract that called that impossible.

`validate:mcp` caught it the moment `get_sudo` derived. Both fields are now
nullable, with the reason written at the site.

### Six partial fixtures, one strict-Ajv mismatch

Six test fixtures were partial in the same way #9843's were — they satisfied the
open object the copies published and nothing else, so they stopped validating
once the schema became specific. Each is now a **real captured production row**
(`/api/v1/coverage`, `/api/v1/contracts`, `/api/v1/health`, `/api/v1/providers`,
`/api/v1/surfaces`, `/api/v1/evidence`, `/api/v1/source-snapshots`,
`/api/v1/build`, 2026-08-07) rather than a stub.

Four more compiled their schema with a **strict** `Ajv2020`, which rejects the
`format` keyword the route schemas carry and the hand-written copies did not.
Those now use `{ strict: false }` — matching the 24 other schema-validation
tests in the same file.

## How the headers were written

Each derived file's header states the tools, the routes they mirror, that the
schema is derived rather than copied, and — where measurable — what the copy was
publishing (field counts, the specific undeclared fields, the bare-object site
count). The old headers were rewritten because several made claims that had
stopped being true, e.g. *"no existing Zod schema to reuse"* and *"rather than
the route schema's stricter form"*.

## Validation

- `npx tsc --noEmit` · `npx eslint .` · `npx prettier --check .` — clean
- `npm run build` — 7/7 steps passed
- `validate:mcp` — **225 tools**, lifecycle + every `tools/call` + both
  subscribe round trips
- `validate:contract-drift` · `validate:single-schema-source` · `validate:api`
  (201 routes) · `validate:openapi` · `validate:schemas` — all pass
- `npx vitest run` — **724 files, 17578 tests, 0 failures**

Closes #9854