### PR TITLE
fix(mcp): get_adapter advertised a slug with no adapter, and the gate could not see it

### DIFF
--- a/schemas-src/mcp-tools/get-adapter.ts
+++ b/schemas-src/mcp-tools/get-adapter.ts
@@ -20,10 +20,14 @@ export const GetAdapterInputSchema = z
     slug: z
       .string()
       .regex(/^[a-z0-9-]+$/)
+      // `gittensor` rather than `chutes` (#9860): there is no `chutes` adapter,
+      // so the tool's own advertised example answered `not_found`. An example
+      // is the first thing an agent copies, and one that does not work is worse
+      // than none -- it teaches the wrong slug AND wastes the call.
       .describe(
-        "The registry slug — lowercase, hyphenated (`chutes`), not the display name. Slugs are stable across renames.",
+        "The registry slug — lowercase, hyphenated (`gittensor`), not the display name. Slugs are stable across renames. Only subnets with a captured adapter snapshot have one; `list_subnets` is the way to find which.",
       )
-      .meta({ examples: ["chutes"] }),
+      .meta({ examples: ["gittensor"] }),
   })
   .strict();
 export type GetAdapterInput = z.infer<typeof GetAdapterInputSchema>;

--- a/scripts/validate-mcp.ts
+++ b/scripts/validate-mcp.ts
@@ -6,7 +6,8 @@
 // MCP endpoint is not artifact-backed and must not enter the
 // `checks.length === API_ROUTES.length` invariant.
 import assert from "node:assert/strict";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
 import { Ajv2020 } from "ajv/dist/2020.js";
 import { handleRequest } from "../workers/api.ts";
 import { PRIMARY_DOMAIN, REPOSITORY_URL } from "../src/contracts.ts";
@@ -42,6 +43,7 @@ import {
   artifactFilePath,
   createLocalArtifactEnv,
   latestArtifactDate,
+  repoRoot,
 } from "./lib.ts";
 
 // MCP tool call results are dynamic JSON-RPC payloads, read only for
@@ -1925,6 +1927,45 @@ function declaredExample(schema: Row | undefined): {
     }
   }
   return { found: false };
+}
+
+// --- Declared slug examples must name something that exists (#9860) --------
+//
+// A `slug` example is copied verbatim by the first agent that reads the tool,
+// so one naming a subnet/provider/adapter the registry does not have is not a
+// cosmetic error -- it teaches the wrong identifier AND wastes the call.
+// `get_adapter` advertised `chutes`, which has no adapter snapshot, and the
+// sweep below never caught it: that assertion only fires on `invalid_params`,
+// and this failure wears `not_found` instead.
+//
+// Checked against the COMMITTED registry rather than against a live response,
+// so it holds in any environment and cannot be masked by a cold tier.
+const SLUG_REGISTRIES: Record<string, string> = {
+  get_adapter: "registry/adapters/latest",
+  get_provider_detail: "registry/providers",
+  list_provider_endpoints: "registry/providers",
+};
+for (const [toolName, directory] of Object.entries(SLUG_REGISTRIES)) {
+  const def = listToolDefinitions().find((entry) => entry.name === toolName);
+  if (!def) continue;
+  const slug = ((def.inputSchema as Row)?.properties as Row)?.slug as
+    Row | undefined;
+  const examples = (slug?.examples ?? []) as unknown[];
+  if (examples.length === 0) continue;
+  const available = new Set(
+    readdirSync(path.join(repoRoot, directory))
+      .filter((entry) => entry.endsWith(".json"))
+      .map((entry) => entry.replace(/\.json$/, "")),
+  );
+  const missing = examples.filter(
+    (example) => typeof example === "string" && !available.has(example),
+  );
+  assert.deepEqual(
+    missing,
+    [],
+    `${toolName}: slug example(s) ${missing.join(", ")} name nothing in ${directory}/, so an agent ` +
+      `copying the tool's own example gets not_found. Available: ${[...available].sort().slice(0, 8).join(", ")}…`,
+  );
 }
 
 for (const def of listToolDefinitions()) {


### PR DESCRIPTION
## The defect

`get_adapter`'s `slug` parameter declared `examples: ["chutes"]`, and its
description used the same value. **There is no `chutes` adapter** —
`registry/adapters/latest/` holds `allways`, `gittensor`, `gradients`,
`numinous` and the `sn-*` set. An agent copying the tool's own example gets:

```
not_found: No adapter snapshot exists for slug 'chutes'
```

Found by the production sweep in #9855, where `get_adapter` was the single tool
whose example-derived call could not be answered.

## Why the gate missed it

`validate-mcp` already asserts that a tool must not reject the arguments its own
schema advertises — *"an example is the first thing an agent copies"*. That
assertion matches `ARGUMENT_REJECTED` (`invalid_params` /
`invalid_graphql_query`), and this failure wears **`not_found`** instead.

So the fix is not to quietly correct one string. Every declared `slug` example is
now checked against the **committed registry directory** it names:

| tool | directory |
|---|---|
| `get_adapter` | `registry/adapters/latest` |
| `get_provider_detail` | `registry/providers` |
| `list_provider_endpoints` | `registry/providers` |

Checked against the tree rather than a live response, so it holds in any
environment and a cold tier cannot mask it.

**Verified it fails.** Restoring `chutes`:

```
get_adapter: slug example(s) chutes name nothing in registry/adapters/latest/,
so an agent copying the tool's own example gets not_found.
Available: allways, gittensor, gradients, numinous, sn-110, sn-22, sn-46, sn-49…
```

The description now also says which subnets have a slug at all, since "only
subnets with a captured adapter snapshot have one" is the thing that made
`chutes` look plausible.

## Validation

- `npx tsc --noEmit` · `npx eslint .` · `npx prettier --check .` — clean
- `validate:mcp` — passes, 225 tools
- `tests/mcp-server.test.ts` — 1365 tests pass

Closes #9860