### PR TITLE
feat(neon): serve the four side tables from Neon

### DIFF
--- a/tests/neon-read-routes.test.ts
+++ b/tests/neon-read-routes.test.ts
@@ -580,19 +580,30 @@ describe("the deployed flag", () => {
     }
   });
 
-  test("does NOT name a table whose mirror has never fired", () => {
-    // Measured 2026-08-07 and reported by #9772's watchdog: these four have no
-    // `neon:` verdict at all, because their producers run on 12h/30h/48h
-    // cadences. Naming one moves a read onto an unproven store.
+  test("does NOT name a table the two stores still disagree about", () => {
+    // Was "whose mirror has never fired", listing four tables whose producers
+    // run on 12h/30h/48h cadences. Two have since been PROVEN by measurement
+    // rather than by waiting, and the reason they are off this list is the
+    // reason the list exists -- so it is now about parity, not about cadence:
+    //
+    //   validator_nominator_counts  112,250 == 112,250 after #9845's lane
+    //                               closed a deficit the mirror could not
+    //                               reach (14 rows the producer stopped
+    //                               emitting)
+    //   nominator_positions         still 13,402 short; #9853's lane is
+    //                               deployed and converging
+    //   hotkey_alpha                D1 and Neon are SUPPOSED to differ here
+    //                               until the mirror applies #9558's filter
+    //                               (#9832) -- not a lag, a design mismatch
+    //   account_balances            no reconciler lane and no route needs it
     for (const unproven of [
       "nominator_positions",
       "hotkey_alpha",
       "account_balances",
-      "validator_nominator_counts",
     ]) {
       assert.ok(
         !named.includes(unproven),
-        `${unproven}'s mirror has never fired -- see #9770/#9772`,
+        `${unproven} is not at parity with D1 -- see #9832/#9852`,
       );
     }
   });

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -190,7 +190,7 @@
     // the loader modules they reach and fails the build on either construct.
     //
     // Rollback remains deleting the entry.
-    "NEON_READ_LANES": "account_position_daily,neurons,neuron_daily",
+    "NEON_READ_LANES": "account_position_daily,neurons,neuron_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts",
     // The two ACCUMULATING tables, and only those (src/neon-backfill.ts).
     //
     // The mirror above writes what each request carries, which finishes the job


### PR DESCRIPTION
Closes #9814.

All four verified at **exact parity** against D1 immediately before pushing:

```
subnet_snapshots            50,891 == 50,891
subnet_hyperparams             129 ==    129
account_identity               498 ==    498
validator_nominator_counts 112,250 == 112,250
```

## Unblocks the six routes pinned to D1 since #9826

`/accounts` · `/accounts/{ss58}/subnets` · `/accounts/{ss58}/portfolio` · `/validators/{hotkey}/history` · `/validators` · `/subnets/{n}/concentration/history`

Each was blocked because its handler reads one of these tables through a **side loader**, and the dispatcher gives a handler one runner for every query it makes (#9814). Naming the real dependency is what kept them on D1; satisfying it is what releases them.

## How the four got here

Two arrived by migration (#9829 created them; #9820's whole-table partition filled them). Two arrived by **reconciler lanes that the mirror could not substitute for**:

- `validator_nominator_counts` sat at a stable −14 because those hotkeys were written before the mirror existed and the producer no longer emits them. #9845 closed it.
- `nominator_positions` sat at −13,402 for the same reason, three orders of magnitude larger. #9853 closed it to 11 rows of live churn.

Both confirmed the rule I had encoded backwards: *latest-only describes what the producer writes, not what the table retains.*

## The unproven-table test is reframed

It listed tables whose **mirror had never fired** — a cadence question. Two came off that list not because their mirrors fired but because a reconciler closed a gap the mirror structurally could not reach. So it now asserts **parity**, and the three remaining entries are there for three different reasons: one converging, one divergent *by design* until #9832 gives the mirror #9558's filter, one with no reconciler and no route asking for it.

A list whose entries share a name but not a reason stops meaning anything.

## Verification plan

A 25-route structural baseline was captured on D1 minutes ago. I'll diff it within minutes of deploy — **row counts, payload shape, row identity and non-zero scalar counts**, never a payload hash. That last distinction matters: the hash version reported normal producer churn as divergence and fired on a deploy where no flag had moved.