### PR TITLE
fix(neon): give the hotkey-alpha mirror the filter D1 has had since #9558

### DIFF
--- a/src/ledger-neon-write.ts
+++ b/src/ledger-neon-write.ts
@@ -46,6 +46,11 @@ interface LedgerPlan {
   table: string;
   columns: readonly string[];
   conflict: readonly string[];
+  /** A SQL predicate rows must satisfy to be inserted, over the `src` alias
+   * buildPgUpsert gives the VALUES list. Present only where the D1 writer
+   * filters too -- a mirror that stores MORE than its source is a mirror in
+   * name only (#9832). */
+  filter?: string;
 }
 
 /**
@@ -65,6 +70,19 @@ export const LEDGER_MIRROR_PLANS: Readonly<Record<string, LedgerPlan>> = {
     table: "hotkey_alpha",
     columns: HOTKEY_ALPHA_INSERT_COLUMNS,
     conflict: ["hotkey", "netuid"],
+    // THE FILTER D1 HAS HAD SINCE #9558, finally on this side too.
+    //
+    // D1 stores only pools a `nominator_positions` row references, because
+    // `TotalHotkeyAlpha` has ~762,577 entries and the positions name ~17,900
+    // -- the other 43x is "written every pass, read by nothing" and saturated
+    // D1 outright. The mirror never had the predicate, so Neon accumulated
+    // 47,320 rows against D1's 17,867 (#9832).
+    //
+    // Postgres spelling of the same EXISTS the D1 writer passes to
+    // chunkStatements; `src` is the alias buildPgUpsert gives the VALUES list.
+    filter:
+      "EXISTS (SELECT 1 FROM nominator_positions np" +
+      " WHERE np.hotkey = src.hotkey AND np.netuid = src.netuid)",
   },
   "validator-nominator-counts": {
     table: "validator_nominator_counts",
@@ -124,6 +142,7 @@ export async function mirrorLedgerToNeon(
     rows,
     plan.conflict,
     `${plan.table}.captured_at < EXCLUDED.captured_at`,
+    plan.filter,
   );
   await recordNeonWriteVerdict(laneDb, lane, result, now());
   return { attempted: true, result };

--- a/src/neon-write.ts
+++ b/src/neon-write.ts
@@ -104,10 +104,25 @@ export function buildPgUpsert(
   conflict: readonly string[],
   rowCount: number,
   guard?: string,
+  filter?: string,
 ): string {
-  const head =
-    `INSERT INTO ${table} (${columns.join(", ")}) VALUES ` +
-    pgValuesClause(rowCount, columns.length);
+  // `filter` switches the row source from a bare VALUES list to a SELECT over
+  // it, so a predicate can reject rows before they are inserted. The D1 side
+  // has had this since #9558 -- `chunkStatements` takes the same argument --
+  // and its absence here is what let `hotkey_alpha` diverge: D1 stores only
+  // pools a nominator_position references, the mirror stored everything, and
+  // Neon ended up with ~29,000 rows D1 refuses on purpose (#9832).
+  //
+  // The alias is `src`, and the predicate refers to its columns by name.
+  const head = filter
+    ? `INSERT INTO ${table} (${columns.join(", ")}) SELECT ${columns
+        .map((c) => `src.${c}`)
+        .join(", ")} FROM (VALUES ${pgValuesClause(
+        rowCount,
+        columns.length,
+      )}) AS src (${columns.join(", ")}) WHERE ${filter}`
+    : `INSERT INTO ${table} (${columns.join(", ")}) VALUES ` +
+      pgValuesClause(rowCount, columns.length);
   if (conflict.length === 0) return head;
   const updates = columns
     .filter((column) => !conflict.includes(column))
@@ -173,6 +188,7 @@ export async function writeRowsToNeon(
   rows: readonly Record<string, unknown>[],
   conflict: readonly string[] = [],
   guard?: string,
+  filter?: string,
 ): Promise<NeonWriteResult> {
   if (!sql?.unsafe)
     return { ok: false, rows: 0, statements: 0, reason: "unbound" };
@@ -185,7 +201,14 @@ export async function writeRowsToNeon(
   let statements = 0;
   for (let i = 0; i < rows.length; i += perStatement) {
     const chunk = rows.slice(i, i + perStatement);
-    const text = buildPgUpsert(table, columns, conflict, chunk.length, guard);
+    const text = buildPgUpsert(
+      table,
+      columns,
+      conflict,
+      chunk.length,
+      guard,
+      filter,
+    );
     try {
       await sql.unsafe(text, pgFlatValues(chunk, columns));
     } catch (error) {

--- a/tests/ledger-neon-write.test.ts
+++ b/tests/ledger-neon-write.test.ts
@@ -206,3 +206,38 @@ describe("mirrorLedgerToNeon", () => {
     assert.match(String(spy.rows[0].detail), /hyperdrive unbound/);
   });
 });
+
+describe("the hotkey-alpha filter (#9832)", () => {
+  test("only hotkey-alpha carries a filter, and it matches D1's", () => {
+    // D1 filters this lane and only this lane (REFERENCED_BY_A_POSITION,
+    // #9558). A mirror that stores MORE than its source is a mirror in name
+    // only -- Neon held 47,320 rows against D1's 17,867 until this landed.
+    const filtered = Object.entries(LEDGER_MIRROR_PLANS).filter(
+      ([, p]) => p.filter,
+    );
+    assert.deepEqual(
+      filtered.map(([lane]) => lane),
+      ["hotkey-alpha"],
+    );
+    const [, plan] = filtered[0]!;
+    assert.match(plan.filter!, /EXISTS \(SELECT 1 FROM nominator_positions/);
+    // Both key columns, or the predicate would match on hotkey alone and let
+    // every netuid for a referenced hotkey through.
+    assert.match(plan.filter!, /np\.hotkey = src\.hotkey/);
+    assert.match(plan.filter!, /np\.netuid = src\.netuid/);
+  });
+
+  test("the predicate names only columns the plan actually sends", () => {
+    // `src` is the VALUES alias, so a predicate referring to a column outside
+    // the plan's list is a runtime error on every write.
+    const plan = LEDGER_MIRROR_PLANS["hotkey-alpha"]!;
+    for (const col of [...plan.filter!.matchAll(/src\.(\w+)/g)].map(
+      (m) => m[1]!,
+    )) {
+      assert.ok(
+        plan.columns.includes(col),
+        `filter reads src.${col}, which the plan does not send`,
+      );
+    }
+  });
+});

--- a/tests/neon-write.test.ts
+++ b/tests/neon-write.test.ts
@@ -169,6 +169,54 @@ describe("pgFlatValues", () => {
   });
 });
 
+describe("buildPgUpsert with a filter (#9832)", () => {
+  test("switches the row source to a SELECT so a predicate can reject rows", () => {
+    const text = buildPgUpsert(
+      "hotkey_alpha",
+      ["hotkey", "netuid", "total_alpha", "captured_at"],
+      ["hotkey", "netuid"],
+      2,
+      "hotkey_alpha.captured_at < EXCLUDED.captured_at",
+      "EXISTS (SELECT 1 FROM nominator_positions np WHERE np.hotkey = src.hotkey AND np.netuid = src.netuid)",
+    );
+    // The rows arrive as a VALUES list aliased `src`, and the predicate reads
+    // its columns by name -- the Postgres spelling of the EXISTS the D1 writer
+    // has passed to chunkStatements since #9558.
+    assert.match(
+      text,
+      /FROM \(VALUES .*\) AS src \(hotkey, netuid, total_alpha, captured_at\)/,
+    );
+    assert.match(text, /WHERE EXISTS \(SELECT 1 FROM nominator_positions/);
+    // The conflict clause and the out-of-order guard survive the switch.
+    assert.match(text, /ON CONFLICT \(hotkey, netuid\) DO UPDATE SET/);
+    assert.match(
+      text,
+      /WHERE hotkey_alpha\.captured_at < EXCLUDED\.captured_at/,
+    );
+  });
+
+  test("placeholder count is unchanged, so the caller's values still line up", () => {
+    const cols = ["a", "b"];
+    const plain = buildPgUpsert("t", cols, ["a"], 3);
+    const filtered = buildPgUpsert("t", cols, ["a"], 3, undefined, "src.b > 0");
+    const count = (s: string) => (s.match(/\$\d+/g) ?? []).length;
+    assert.equal(count(filtered), count(plain));
+    assert.equal(count(filtered), 6, "3 rows x 2 columns");
+  });
+
+  test("no filter leaves the statement exactly as it was", () => {
+    // Every other lane must be untouched by this: the filtered form is opt-in
+    // and only hotkey-alpha opts in.
+    const cols = ["a", "b"];
+    assert.equal(
+      buildPgUpsert("t", cols, ["a"], 2, "t.a < EXCLUDED.a", undefined),
+      buildPgUpsert("t", cols, ["a"], 2, "t.a < EXCLUDED.a"),
+    );
+    assert.match(buildPgUpsert("t", cols, ["a"], 2), /VALUES \(\$1, \$2\)/);
+    assert.doesNotMatch(buildPgUpsert("t", cols, ["a"], 2), /SELECT/);
+  });
+});
+
 describe("writeRowsToNeon", () => {
   test("writes one statement when the rows fit", async () => {
     const sql = fakeSql();


### PR DESCRIPTION
Closes #9832.

```
hotkey_alpha   D1 17,867   Neon 47,320
```

D1 stores only pools a `nominator_positions` row references — `TotalHotkeyAlpha` has ~762,577 entries, the positions name ~17,900, and the other 43× is *"written every pass, read by nothing"* and **saturated D1 outright**. That filter has been deliberate since #9558.

**The mirror never had the predicate.** So Neon accumulated the exact keyspace D1 exists to refuse.

## I read this backwards for most of a session

I concluded "D1 is silently lossy, 62% of rows missing, live correctness bug on four routes", wrote it into an issue and a status report, and retracted it twice. D1 was right the whole time.

What misled me: the pass ledger said `expected 47,264 / received 47,264 / COMPLETE`, and D1's `max(captured_at)` tracked the newest pass. Both are equally consistent with *"the write ran and lost rows"* and *"the write ran and filtered rows"* — a completeness ledger counts rows **received**, not rows **stored**.

The lesson is in the memory now: **read the write path before believing the row counts.** Two writers fed by one consumer call can differ on purpose.

## The change

`buildPgUpsert` takes an optional `filter` and switches the row source from a bare `VALUES` list to a `SELECT` over it, aliased `src`, so a predicate can reject rows before insert — the same shape `chunkStatements` has offered on the D1 side since #9558. The asymmetry was that only one writer used it.

**Opt-in.** Every other lane's statement is byte-identical, asserted by a test. Two more assert:

- the **placeholder count is unchanged**, so the caller's flat value list still lines up
- the predicate names **only columns the plan actually sends**, since `src` cannot see anything else

## After this deploys

Neon stops accumulating unreferenced pools. The ~29,000 already there are pre-existing and will need a one-off delete; the parity watchdog carries `hotkey_alpha` as an expected divergence until then, and that exemption should be removed once the two agree.