### PR TITLE
feat(mcp): compose the two snapshot tools from the five routes each already calls

### DIFF
--- a/schemas-src/mcp-tools/account-portfolio.ts
+++ b/schemas-src/mcp-tools/account-portfolio.ts
@@ -14,7 +14,10 @@
 import { z } from "zod";
 import { AccountPortfolioArtifactSchema } from "../routes/account-portfolio.ts";
 import { AccountPositionsArtifactSchema } from "../routes/account-positions.ts";
-import { OpenObjectSchema, ss58Schema } from "./shared.ts";
+import { AccountBalanceArtifactSchema } from "../routes/account-balance.ts";
+import { AccountEventsArtifactSchema } from "../routes/account-events-feed.ts";
+import { AccountSubnetsArtifactSchema } from "../routes/account-summary.ts";
+import { ss58Schema } from "./shared.ts";
 
 export const GetAccountPortfolioInputSchema = z
   .object({
@@ -93,14 +96,26 @@ export type GetAccountSnapshotInput = z.infer<
   typeof GetAccountSnapshotInputSchema
 >;
 
+// COMPOSED FROM THE FIVE ROUTES IT CALLS (#9797). Five bare
+// `{"type":"object"}` sites stood here, on the tool whose entire purpose is
+// those five views. There is no SINGLE route to derive from, but there are
+// five, and the handler calls them by path -- /balance (a live RPC read,
+// mirroring get_account_balance's handler exactly), /portfolio, /subnets,
+// /positions and /events, each falling back to that route's own builder. The
+// answer was never a fresh model; it was a composition nobody had written
+// down.
+//
+// Verified against production before the switch, slice by slice: the live
+// tool's five sections each validate against the route artifact schema they
+// now publish.
 export const GetAccountSnapshotOutputSchema = z
   .object({
     ss58: z.string(),
-    balance: OpenObjectSchema,
-    portfolio: OpenObjectSchema,
-    subnets: OpenObjectSchema,
-    positions: OpenObjectSchema,
-    recent_events: OpenObjectSchema,
+    balance: AccountBalanceArtifactSchema,
+    portfolio: AccountPortfolioArtifactSchema,
+    subnets: AccountSubnetsArtifactSchema,
+    positions: AccountPositionsArtifactSchema,
+    recent_events: AccountEventsArtifactSchema,
   })
   .passthrough();
 export type GetAccountSnapshotOutput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-snapshot.ts
+++ b/schemas-src/mcp-tools/get-subnet-snapshot.ts
@@ -1,10 +1,26 @@
-// MCP tool `get_subnet_snapshot` (types-epic E batch 2, #8065). Fans out to
-// 5 live views (hyperparameters, concentration, performance, top_validators,
-// recent_events) with its own compound handler -- no single REST route or
-// schemas-src schema to reuse. Modeled fresh, shallow, from the hand-written
-// literal it replaces.
+// MCP tool `get_subnet_snapshot`. Fans out to 5 of a subnet's live views in
+// one round trip: hyperparameters, concentration, performance, top_validators
+// and recent_events.
+//
+// COMPOSED FROM THE FIVE ROUTES IT CALLS (#9797). This file's header used to
+// say there was "no single REST route or schemas-src schema to reuse", and
+// modelled the result "fresh, shallow" -- five bare `{"type":"object"}` sites,
+// on the tool whose entire purpose is those five views. There is no SINGLE
+// route to derive from, but there are five, and the handler calls them by
+// path: /hyperparameters, /concentration, /performance, /validators and
+// /events, each falling back to that route's own builder. So the answer was
+// never a fresh model; it was a composition nobody had written down.
+//
+// Verified against production before the switch, slice by slice: the live
+// tool's five sections each validate against the route artifact schema they
+// now publish.
 import { z } from "zod";
-import { OpenObjectSchema, netuidSchema } from "./shared.ts";
+import { netuidSchema } from "./shared.ts";
+import { SubnetConcentrationArtifactSchema } from "../routes/subnet-concentration.ts";
+import { SubnetEventsArtifactSchema } from "../routes/subnet-events.ts";
+import { SubnetHyperparametersArtifactSchema } from "../routes/subnet-hyperparameters.ts";
+import { SubnetValidatorsArtifactSchema } from "../routes/subnet-metagraph.ts";
+import { SubnetPerformanceArtifactSchema } from "../routes/subnet-performance.ts";
 
 export const GetSubnetSnapshotInputSchema = z
   .object({
@@ -35,11 +51,14 @@ export type GetSubnetSnapshotInput = z.infer<
 export const GetSubnetSnapshotOutputSchema = z
   .object({
     netuid: netuidSchema(),
-    hyperparameters: OpenObjectSchema,
-    concentration: OpenObjectSchema,
-    performance: OpenObjectSchema,
-    top_validators: OpenObjectSchema,
-    recent_events: OpenObjectSchema,
+    hyperparameters: SubnetHyperparametersArtifactSchema,
+    concentration: SubnetConcentrationArtifactSchema,
+    performance: SubnetPerformanceArtifactSchema,
+    // The validators artifact re-sliced to `top_validators_limit`, so
+    // `validator_count` counts the returned page rather than the subnet --
+    // the handler recomputes it after the slice.
+    top_validators: SubnetValidatorsArtifactSchema,
+    recent_events: SubnetEventsArtifactSchema,
   })
   .passthrough();
 export type GetSubnetSnapshotOutput = z.infer<

--- a/scripts/validate-schema-opacity.ts
+++ b/scripts/validate-schema-opacity.ts
@@ -51,6 +51,16 @@ const DELIBERATELY_GENERIC =
 const CALLER_DEFINED_EXTENSION =
   "an extension block whose content each adapter defines for itself";
 
+/** Caller-supplied, echoed back. The server does not define the shape because
+ * the caller does. */
+const CALLER_SUPPLIED =
+  "supplied by the caller and echoed back; the server does not define its shape";
+
+/** Whatever the node or the query returned. A GraphQL result is shaped by the
+ * query the caller wrote; an RPC error body is shaped by the node. */
+const CALLER_SHAPED_RESULT =
+  "shaped by the caller's own query or by the upstream node, not by us";
+
 /** Standing debt, not a decision. Every one of these is an MCP tool schema
  * that has not been derived from its route yet (#9796/#9797). They are listed
  * so a NEW opaque site still fails this gate -- the list may only shrink. */
@@ -83,28 +93,18 @@ const ROUTE_OPEN_SITES: Record<string, string> = {
  * this gate -- the list may only shrink, and it is the honest count of what
  * #9797 has left to do. */
 const MCP_NOT_YET_TYPED: string[] = [
-  "call_rpc.error",
   "compare_validators.validators[]",
-  "decode_evm_call.args",
   "find_subnet_for_task.results[]",
   "get_account.activity",
   "get_account_counterparties.relationship",
-  "get_account_snapshot.balance",
-  "get_account_snapshot.portfolio",
-  "get_account_snapshot.positions",
-  "get_account_snapshot.recent_events",
-  "get_account_snapshot.subnets",
-  "get_adapter.extensions",
   "get_adapter.snapshot",
   "get_agent_catalog.subnets[]",
-  "get_api_schema.document",
   "get_block.block",
   "get_domain_summary.domains[]",
   "get_domain_summary.emission_concentration",
   "get_economics.subnets[]",
   "get_economics.summary",
   "get_extrinsic.extrinsic",
-  "get_governance_config_changes.extrinsics[].call_args",
   "get_health_history.summary",
   "get_health_history.surfaces[]",
   "get_neuron.neuron",
@@ -114,36 +114,42 @@ const MCP_NOT_YET_TYPED: string[] = [
   "get_subnet_gaps.priorities[]",
   "get_subnet_health.summary",
   "get_subnet_metagraph.neurons[]",
-  "get_subnet_snapshot.concentration",
-  "get_subnet_snapshot.hyperparameters",
-  "get_subnet_snapshot.performance",
-  "get_subnet_snapshot.recent_events",
-  "get_subnet_snapshot.top_validators",
   "get_subnet_trajectory.deltas",
   "get_subnet_trajectory.points[]",
-  "get_sudo.extrinsics[].call_args",
-  "get_webhook_subscription.filters",
   "how_do_i_call.services[]",
-  "list_block_extrinsics.extrinsics[].call_args",
-  "list_chain_events.events[].args",
   "list_enrichment_targets.filters",
   "list_enrichment_targets.targets[].dimensions",
   "list_enrichment_targets.targets[].top_gaps[]",
-  "list_extrinsics.extrinsics[].call_args",
   "list_profiles.profiles[]",
   "list_search.documents[]",
   "list_subnet_apis.services[]",
   "list_subnet_health.surfaces[]",
   "list_subnet_validators.validators[]",
   "list_surface_credentials.credentials[]",
-  "query_graphql.data",
-  "query_graphql.errors[]",
-  "run_saved_query.params",
 ];
 
-const MCP_OPEN_SITES: Record<string, string> = Object.fromEntries(
-  MCP_NOT_YET_TYPED.map((site) => [site, NOT_YET_TYPED]),
-);
+/** MCP sites that are open on purpose, same three categories as the REST list
+ * above. Kept separate from the debt below so the two never blur. */
+const MCP_REASONED_OPEN_SITES: Record<string, string> = {
+  "call_rpc.error": CALLER_SHAPED_RESULT,
+  "decode_evm_call.args": DECODED_CHAIN_PAYLOAD,
+  "get_adapter.extensions": CALLER_DEFINED_EXTENSION,
+  "get_api_schema.document": EMBEDDED_THIRD_PARTY_DOCUMENT,
+  "get_governance_config_changes.extrinsics[].call_args": DECODED_CHAIN_PAYLOAD,
+  "get_sudo.extrinsics[].call_args": DECODED_CHAIN_PAYLOAD,
+  "get_webhook_subscription.filters": CALLER_SUPPLIED,
+  "list_block_extrinsics.extrinsics[].call_args": DECODED_CHAIN_PAYLOAD,
+  "list_chain_events.events[].args": DECODED_CHAIN_PAYLOAD,
+  "list_extrinsics.extrinsics[].call_args": DECODED_CHAIN_PAYLOAD,
+  "query_graphql.data": CALLER_SHAPED_RESULT,
+  "query_graphql.errors[]": CALLER_SHAPED_RESULT,
+  "run_saved_query.params": CALLER_SUPPLIED,
+};
+
+const MCP_OPEN_SITES: Record<string, string> = {
+  ...Object.fromEntries(MCP_NOT_YET_TYPED.map((site) => [site, NOT_YET_TYPED])),
+  ...MCP_REASONED_OPEN_SITES,
+};
 
 // ---- the walk --------------------------------------------------------------
 


### PR DESCRIPTION
## The ten worst-placed open objects

`get_subnet_snapshot` and `get_account_snapshot` fan out to five live views
each, and published **all ten as bare `{"type":"object"}`** — ten of the 56
sites on the opacity debt list, and the ten worst-placed, because those five
sections *are* the tool's entire output.

`get-subnet-snapshot.ts` said why, in its own header:

> Fans out to 5 live views … with its own compound handler — **no single REST
> route or schemas-src schema to reuse**. Modeled fresh, shallow.

The first half is true and the conclusion does not follow. There is no *single*
route — there are five, and the handler calls them by path:

| slice | route the handler calls | fallback builder |
|---|---|---|
| `hyperparameters` | `/api/v1/subnets/{netuid}/hyperparameters` | `buildSubnetHyperparams` |
| `concentration` | `/api/v1/subnets/{netuid}/concentration` | `buildConcentration` |
| `performance` | `/api/v1/subnets/{netuid}/performance` | `buildSubnetPerformance` |
| `top_validators` | `/api/v1/subnets/{netuid}/validators` | `buildSubnetValidators` |
| `recent_events` | `/api/v1/subnets/{netuid}/events` | `buildSubnetEvents` |

and for the account tool `/balance` (a live RPC read mirroring
`get_account_balance`'s handler exactly), `/portfolio`, `/subnets`,
`/positions`, `/events`.

**The answer was never a fresh model. It was a composition nobody had written
down.**

## Verified before switching, because composing is a tightening

Both tools called live against production, each slice validated with `Ajv2020`
against the route artifact component it would inherit:

```
### get_subnet_snapshot            ### get_account_snapshot
  hyperparameters   OK               balance         OK
  concentration     OK               portfolio       OK
  performance       OK               subnets         OK
  top_validators    OK               positions       OK
  recent_events     OK               recent_events   OK
```

10/10.

## Thirteen sites move out of debt and into reasons

The first pass generated `NOT_YET_TYPED` mechanically, so genuinely-arbitrary
sites landed in the debt list rather than the reasoned one. Corrected:

| sites | reason |
|---|---|
| 6 | decoded chain `call_args` / event `args` — shaped per pallet+call, re-shaped by every runtime upgrade |
| 3 | a caller's own GraphQL result, and the node's error body |
| 2 | caller-supplied `params` / webhook `filters` |
| 1 | an embedded third-party OpenAPI document |
| 1 | the adapter-defined extension block |

Those were never debt. **Open MCP object sites 56 → 46, of which 33 remain
standing debt against #9797** — and the gate now separates a decision from an
IOU, which it could not do before.

## Validation

- `npx tsc --noEmit` · `npx eslint .` · `npx prettier --check .` — clean
- `npm run build` — 7/7 steps passed
- `validate:mcp` (225 tools) · `validate:schema-opacity` ·
  `validate:schema-vocabularies` · `validate:contract-drift` ·
  `validate:single-schema-source` · `validate:api` · `validate:openapi` ·
  `validate:schemas` — all pass
- `npx vitest run` — **724 files, 17578 tests, 0 failures**

The gate caught its own staleness on the way through: after the composition
landed it failed with *"10 allowlist entries no longer match an open site —
delete them"*, naming exactly the ten.

Closes #9876