### PR TITLE
fix(mcp): say which epoch incentive and dividends actually come from

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -7313,7 +7313,8 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       "Captured from the chain on a schedule; empty when no snapshot exists yet. " +
       "PASS `fields` UNLESS YOU GENUINELY NEED EVERY COLUMN: the full response is " +
       '256 rows x 17 fields (~95 KB, ~24k tokens on subnet 1). `fields: ["uid", ' +
-      "\"hotkey\"]` answers 'is this hotkey registered, and at which UID' in ~18 KB.",
+      "\"hotkey\"]` answers 'is this hotkey registered, and at which UID' in ~18 KB. " +
+      "EPOCH PROVENANCE (#9871): `incentive`, `dividends`, `emission_tao`, `consensus`, `trust` and `rank` are derived from the weights validators set in the LAST COMPLETED tempo -- not from live activity, and not from the epoch currently open. `captured_at`/`block_number` say when WE sampled the chain, which is a different thing. Comparing these against an in-progress epoch from an off-chain source (a subnet's own API, a dashboard) will disagree, and the disagreement is expected rather than a defect. Read `tempo` from get_subnet_hyperparams to find the epoch length. ",
     inputSchema: z.toJSONSchema(GetSubnetMetagraphInputSchema, {
       target: "draft-2020-12",
     }),
@@ -7730,7 +7731,8 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       "Fetch a single neuron in one subnet by its UID: hot and cold keys, stake, " +
       "rank, trust, consensus, incentive, dividends, emission, validator " +
       "permit, immunity, and axon. Returns neuron: null when that UID is not " +
-      "in the latest snapshot. Narrow the row with `fields`.",
+      "in the latest snapshot. Narrow the row with `fields`. " +
+      "EPOCH PROVENANCE (#9871): `incentive`, `dividends`, `emission_tao`, `consensus`, `trust` and `rank` are derived from the weights validators set in the LAST COMPLETED tempo -- not from live activity, and not from the epoch currently open. `captured_at`/`block_number` say when WE sampled the chain, which is a different thing. Comparing these against an in-progress epoch from an off-chain source (a subnet's own API, a dashboard) will disagree, and the disagreement is expected rather than a defect. Read `tempo` from get_subnet_hyperparams to find the epoch length. ",
     inputSchema: z.toJSONSchema(GetNeuronInputSchema, {
       target: "draft-2020-12",
     }),

--- a/tests/mcp-epoch-provenance.test.ts
+++ b/tests/mcp-epoch-provenance.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { MCP_TOOLS } from "../src/mcp-server.ts";
+
+// #9871: an external consumer cross-validated our SN53 chain data against the
+// subnet's own signed provider API. Every figure they could independently check
+// was exact -- per-hotkey `incentive` matched engy's finalized
+// `weight_u16 / 65535` to 5 decimal places across 12 miners. Then they compared
+// it against the subnet's OPEN epoch, saw a ~3x disagreement, and were "one
+// step away from reporting your data as broken".
+//
+// It was not broken. `incentive` and its siblings derive from the weights set
+// in the LAST COMPLETED tempo; `captured_at`/`block_number` say when WE sampled
+// the chain, which is a different thing, and nothing on the payload said so.
+//
+// The warning is the fix that prevents the wrong conclusion, so it is the thing
+// worth pinning: a description is easy to shorten later by someone who does not
+// know what it was load-bearing for.
+const WEIGHT_DERIVED_TOOLS = ["get_neuron", "get_subnet_metagraph"];
+
+describe("weight-derived fields declare which epoch they came from (#9871)", () => {
+  for (const name of WEIGHT_DERIVED_TOOLS) {
+    test(`${name} warns that these values are last-tempo, not live`, () => {
+      const tool = MCP_TOOLS.find((entry) => entry.name === name);
+      assert.ok(tool, `${name} must be a registered tool`);
+      const description = String(tool.description ?? "");
+      // The claim itself, not the exact wording -- what must survive is that a
+      // reader is told the values lag by a tempo and that comparing them to an
+      // in-progress epoch is expected to disagree.
+      assert.match(
+        description,
+        /LAST COMPLETED tempo/,
+        `${name} must say the values come from the last completed tempo`,
+      );
+      assert.match(
+        description,
+        /in-progress epoch/i,
+        `${name} must warn against comparing with an in-progress epoch`,
+      );
+      // captured_at is the trap: it looks like provenance and is not.
+      assert.match(
+        description,
+        /captured_at/,
+        `${name} must say what captured_at actually means, since that is the field a reader reaches for`,
+      );
+    });
+  }
+});


### PR DESCRIPTION
## An external consumer nearly filed our data as broken

An agent standing up an SN53 (engy) miner cross-validated our chain data against
the subnet's own **signed provider API**. Everything they could independently
check was exact:

- per-hotkey `incentive` matched engy's finalized `weight_u16 / 65535` to **five
  decimal places** across twelve miners
- `validator_count` matched the permit-holding set exactly
- `incentive` and `dividends` both normalised to 1.0 (dividends to 0.999893)

Then they compared it against the subnet's **open** epoch:

> engy's top miner by current-epoch weight had ~3x the chain incentive I
> expected, and the chain's top-incentive neuron was not in the current epoch's
> top 8 at all. **I was one step away from reporting your data as broken.**

It was not broken. Re-running against the finalized epoch produced exact
agreement on all twelve samples.

## The actual defect

`incentive`, `dividends`, `emission_tao`, `consensus`, `trust` and `rank` derive
from the weights validators set in the **last completed tempo**.

We publish `captured_at` and `block_number` — which say when *we* sampled the
chain. That is a different thing, and the gap was invisible. Worse: `captured_at`
is precisely the field a reader reaches for to answer "as of when", so it
answers a question they were not asking, convincingly.

Verified on `main` before writing this — the payload carries no epoch
provenance at all:

```
GET /api/v1/subnets/53/neurons/0
  neuron: uid, hotkey, coldkey, active, validator_permit, rank, trust,
          validator_trust, consensus, incentive, dividends, emission_tao,
          stake_tao, registered_at_block, is_immunity_period, axon, take
```

## What this ships

The description warning on `get_neuron` and `get_subnet_metagraph`, which the
reporter named as the minimum acceptable answer — and which is the part that
actually prevents the wrong conclusion. It points at `tempo` for the epoch
length.

The reporter also singled out this exact convention as what stopped them
misreporting elsewhere:

> `emission_share` flagged as "STAGE-1 PRICE SHARE, NOT the share of TAO a
> subnet receives" stopped me misreporting subnet economics.

So the pattern already exists here. It was simply missing on the one field that
bites.

## What this deliberately does not ship

**A computed epoch boundary.** Bittensor's boundary is not `block % tempo`, and
a confidently wrong block number is worse than none — the same reasoning as the
degraded markers in #9273.

**A real `weights_set_at_block`.** The chain's per-neuron `last_update` is not
in our schema or in D1 today, so it needs a capture change. Sized in #9871.

## Test

Pins the **claim**, not the wording — that a reader is told the values are
last-tempo, that comparing against an in-progress epoch is expected to disagree,
and what `captured_at` actually means. A description is easy to shorten later by
someone who does not know what it was load-bearing for.

- `npx vitest run tests/mcp-epoch-provenance.test.ts tests/mcp-server.test.ts` — 1367 pass
- `validate:mcp` — passes, 225 tools
- `npx tsc --noEmit` · `npx eslint .` · `npx prettier --check .` — clean

Refs #9871