### PR TITLE
fix(neon): batch the parity sweep under D1's 5-term compound SELECT cap

### DIFF
--- a/src/neon-parity-watchdog.ts
+++ b/src/neon-parity-watchdog.ts
@@ -118,7 +118,48 @@ export interface TableParity {
   delta: number;
 }
 
-/** One `SELECT count` per table, unioned so the sweep is a single statement. */
+/**
+ * D1's compound-SELECT ceiling, MEASURED against production 2026-08-07.
+ *
+ * Upstream SQLite defaults `SQLITE_MAX_COMPOUND_SELECT` to 500. D1 builds it
+ * at FIVE. Probed directly against the production database: 3 and 5 terms
+ * answer, 6 and up fail with
+ *
+ *     D1_ERROR: too many terms in compound SELECT: SQLITE_ERROR
+ *
+ * This is not a tuning knob, it is the reason this lane never worked. It
+ * shipped in #9850 sweeping ten tables in one UNION ALL -- five past the
+ * limit -- so the D1 half of the comparison threw before it read a single row
+ * and the watchdog recorded `unknown: counts unreadable` every hour from the
+ * moment it deployed. A watchdog that cannot read its subject reports the
+ * truth about itself and nothing about what it watches, which is why this was
+ * only caught by looking at the lane rather than trusting that it was green.
+ *
+ * Batching here rather than at the call site because the ceiling grows more
+ * dangerous as PARITY_TABLES grows: every table added to the migration adds a
+ * term, and the failure is total (no counts at all) rather than partial.
+ */
+export const D1_MAX_COMPOUND_TERMS = 5;
+
+/**
+ * The sweep, split into statements no wider than D1 will parse.
+ *
+ * Postgres has no comparable limit, but both stores run the SAME batches so
+ * the two halves stay symmetric and one row-shape reader serves both.
+ */
+export function parityCountBatches(
+  tables: readonly string[],
+  perBatch: number = D1_MAX_COMPOUND_TERMS,
+): string[] {
+  const batches: string[] = [];
+  for (let i = 0; i < tables.length; i += perBatch) {
+    batches.push(parityCountSql(tables.slice(i, i + perBatch)));
+  }
+  return batches;
+}
+
+/** One `SELECT count` per table, unioned. Never call with more than
+ * D1_MAX_COMPOUND_TERMS tables -- use parityCountBatches. */
 export function parityCountSql(tables: readonly string[]): string {
   return tables
     .map((t) => `SELECT '${t}' AS t, COUNT(*) AS n FROM ${t}`)
@@ -216,17 +257,17 @@ export async function runNeonParityWatchdog(
   const now = deps.now ?? Date.now;
   if (!db?.prepare || !sql?.unsafe) return { attempted: false };
 
-  const statement = parityCountSql(PARITY_TABLES);
+  const batches = parityCountBatches(PARITY_TABLES);
   let d1Counts: Map<string, number>;
   let neonCounts: Map<string, number>;
   try {
     const [a, b] = await Promise.all([
-      db.prepare(statement).all(),
-      sql.unsafe(statement) as Promise<unknown>,
+      Promise.all(batches.map((s) => db.prepare(s).all())),
+      Promise.all(batches.map((s) => sql.unsafe(s) as Promise<unknown>)),
     ]);
-    if (!a) throw new Error("d1 returned nothing");
-    d1Counts = countsFrom(a.results ?? []);
-    neonCounts = countsFrom(Array.isArray(b) ? b : []);
+    if (a.some((r) => !r)) throw new Error("d1 returned nothing");
+    d1Counts = countsFrom(a.flatMap((r) => r?.results ?? []));
+    neonCounts = countsFrom(b.flatMap((r) => (Array.isArray(r) ? r : [])));
   } catch (error) {
     // `unknown`, not `stale`: a store that would not answer is not evidence of
     // a gap, and calling it one would put every table in the detail line.

--- a/tests/neon-parity-watchdog.test.ts
+++ b/tests/neon-parity-watchdog.test.ts
@@ -7,11 +7,13 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 import {
+  D1_MAX_COMPOUND_TERMS,
   NEON_PARITY_CRON,
   NEON_PARITY_LANE,
   PARITY_MIN_ROWS,
   PARITY_TABLES,
   describeParity,
+  parityCountBatches,
   parityCountSql,
   parityGaps,
   persistentGaps,
@@ -36,6 +38,19 @@ function fakeDb(rows: unknown[] | null, throwIt = false) {
             if (/lane_health/i.test(sql)) return { results: fakeDb.laneRows };
             if (throwIt && sql.startsWith("SELECT '"))
               throw new Error("D1_ERROR");
+            // THE FAKE ENFORCES D1'S REAL CEILING. Without this the double
+            // accepts any width, the suite agrees with whatever the code
+            // happens to build, and #9850 ships a lane that reports
+            // `unknown: counts unreadable` every hour for its whole life --
+            // which is exactly what happened. A test that only asserts the
+            // code's own assumption cannot see the store disagreeing with it.
+            if (sql.startsWith("SELECT '")) {
+              const terms = sql.split(/\bUNION ALL\b/).length;
+              if (terms > D1_MAX_COMPOUND_TERMS)
+                throw new Error(
+                  "D1_ERROR: too many terms in compound SELECT: SQLITE_ERROR",
+                );
+            }
             return rows === null ? null : { results: rows };
           },
           bind(...values: unknown[]) {
@@ -83,6 +98,49 @@ describe("parityCountSql", () => {
     // The point of `'x' AS t` over a per-table round trip: identical text on
     // both sides means a difference cannot come from asking different things.
     assert.ok(!/\?|\$\d/.test(parityCountSql([...PARITY_TABLES])));
+  });
+});
+
+describe("parityCountBatches", () => {
+  test("no batch is wider than D1 will parse", () => {
+    // The ceiling is 5, measured against production. Anything above it does
+    // not degrade -- it throws, and the sweep reads NOTHING.
+    for (const sql of parityCountBatches([...PARITY_TABLES])) {
+      assert.ok(
+        sql.split(/\bUNION ALL\b/).length <= D1_MAX_COMPOUND_TERMS,
+        `batch too wide: ${sql}`,
+      );
+    }
+  });
+
+  test("every table is counted exactly once", () => {
+    const named = parityCountBatches([...PARITY_TABLES])
+      .flatMap((sql) => [...sql.matchAll(/SELECT '(\w+)' AS t/g)])
+      .map((m) => m[1]);
+    assert.deepEqual(named.sort(), [...PARITY_TABLES].sort());
+  });
+
+  test("the live table list ACTUALLY needs splitting", () => {
+    // A negative assertion passes on nothing. If PARITY_TABLES ever shrank to
+    // five, the two tests above would hold on a single batch and stop proving
+    // that batching works at all -- so pin that the real config exercises it.
+    assert.ok(
+      PARITY_TABLES.length > D1_MAX_COMPOUND_TERMS,
+      "PARITY_TABLES no longer exceeds one batch; this suite stopped testing the split",
+    );
+    assert.ok(parityCountBatches([...PARITY_TABLES]).length > 1);
+  });
+
+  test("a table list that fits stays one statement", () => {
+    assert.equal(parityCountBatches(["a", "b"]).length, 1);
+  });
+
+  test("the width is overridable, and the remainder is not dropped", () => {
+    // 5 tables at 2 per batch is 3 batches, the last holding ONE -- the case
+    // an off-by-one in the loop bound loses silently.
+    const batches = parityCountBatches(["a", "b", "c", "d", "e"], 2);
+    assert.equal(batches.length, 3);
+    assert.equal(batches[2], parityCountSql(["e"]));
   });
 });
 


### PR DESCRIPTION
`neon-parity` has reported `unknown: counts unreadable` on every tick since #9850 deployed. D1 caps compound SELECT at **5 terms** (upstream SQLite defaults to 500); the sweep unioned all ten `PARITY_TABLES` into one statement, so the D1 half threw before reading a row.

Measured against production D1 — 3 and 5 terms answer, 6/8/10 throw `too many terms in compound SELECT`.

## What changed

- `parityCountBatches()` splits the sweep into statements of at most `D1_MAX_COMPOUND_TERMS`; the runner merges counts from all batches on both stores.
- **The test double now enforces the real ceiling.** It previously accepted any width, which is precisely why the suite passed on code the store rejects. With the fake fixed, the pre-fix sweep fails 7 tests.
- A test pins that `PARITY_TABLES` actually exceeds one batch, so the split stays exercised rather than passing vacuously if the list ever shrinks.

## Verification

```
36 passed  (with the fix)
 7 failed  (fake enforcing the cap, single-statement sweep restored)
```

Closes #9881