### PR TITLE
fix(mcp): a `fields` projection must still satisfy the tool's own schema

### DIFF
--- a/schemas-src/mcp-tools/curation-and-gaps.ts
+++ b/schemas-src/mcp-tools/curation-and-gaps.ts
@@ -19,6 +19,7 @@ import {
   netuidSchema,
   numericCursorSchema,
   orderSchema,
+  projectableRows,
   sortSchema,
 } from "./shared.ts";
 import { CurationArtifactSchema } from "../routes/curation-gaps.ts";
@@ -57,6 +58,7 @@ export type ListCurationInput = z.infer<typeof ListCurationInputSchema>;
 export const ListCurationOutputSchema = CurationArtifactSchema.pick({
   curation: true,
 }).extend({
+  curation: projectableRows(CurationArtifactSchema.shape.curation),
   ...McpListArtifactStamp,
   ...McpListPageFields,
 });
@@ -93,6 +95,7 @@ export type ListGapsInput = z.infer<typeof ListGapsInputSchema>;
 export const ListGapsOutputSchema = GapsArtifactSchema.pick({
   gaps: true,
 }).extend({
+  gaps: projectableRows(GapsArtifactSchema.shape.gaps),
   ...McpListArtifactStamp,
   ...McpListPageFields,
 });

--- a/schemas-src/mcp-tools/endpoint-pools-and-provider.ts
+++ b/schemas-src/mcp-tools/endpoint-pools-and-provider.ts
@@ -20,6 +20,7 @@ import {
   netuidSchema,
   numericCursorSchema,
   orderSchema,
+  projectableRows,
   providerSlugSchema,
   sortSchema,
 } from "./shared.ts";
@@ -93,6 +94,7 @@ export type ListEndpointPoolsInput = z.infer<
 export const ListEndpointPoolsOutputSchema = EndpointPoolsArtifactSchema.pick({
   pools: true,
 }).extend({
+  pools: projectableRows(EndpointPoolsArtifactSchema.shape.pools),
   ...McpListArtifactStamp,
   ...McpListPageFields,
 });
@@ -148,6 +150,7 @@ export const ListEndpointIncidentsOutputSchema =
     summary: true,
     incidents: true,
   }).extend({
+    incidents: projectableRows(EndpointIncidentsArtifactSchema.shape.incidents),
     ...McpListArtifactStamp,
     ...McpListPageFields,
   });
@@ -246,6 +249,7 @@ export const ListProviderEndpointsOutputSchema =
   ProviderEndpointsArtifactSchema.pick({
     endpoints: true,
   }).extend({
+    endpoints: projectableRows(ProviderEndpointsArtifactSchema.shape.endpoints),
     ...McpListArtifactStamp,
     // The handler echoes the requested slug rather than the route
     // artifact's `provider` block: the tool is asked for one provider by

--- a/schemas-src/mcp-tools/endpoints-catalog.ts
+++ b/schemas-src/mcp-tools/endpoints-catalog.ts
@@ -22,6 +22,7 @@ import {
   netuidSchema,
   numericCursorSchema,
   orderSchema,
+  projectableRows,
   providerSlugSchema,
   sortSchema,
 } from "./shared.ts";
@@ -119,7 +120,9 @@ export const ListEndpointsInputSchema = z
   .strict();
 export type ListEndpointsInput = z.infer<typeof ListEndpointsInputSchema>;
 
-export const ListEndpointsOutputSchema = EndpointsArtifactSchema;
+export const ListEndpointsOutputSchema = EndpointsArtifactSchema.extend({
+  endpoints: projectableRows(EndpointsArtifactSchema.shape.endpoints),
+});
 export type ListEndpointsOutput = z.infer<typeof ListEndpointsOutputSchema>;
 
 export const GetSubnetEndpointsInputSchema = z

--- a/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
+++ b/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
@@ -18,6 +18,7 @@ import {
   netuidSchema,
   numericCursorSchema,
   orderSchema,
+  projectableRows,
   querySchema,
   sortSchema,
 } from "./shared.ts";
@@ -88,6 +89,9 @@ export const ListEnrichmentEvidenceOutputSchema =
   ReviewEnrichmentEvidenceArtifactSchema.pick({
     entries: true,
   }).extend({
+    entries: projectableRows(
+      ReviewEnrichmentEvidenceArtifactSchema.shape.entries,
+    ),
     ...McpListArtifactStamp,
     ...McpListPageFields,
   });
@@ -136,6 +140,9 @@ export const ListReviewGapsOutputSchema =
   ReviewGapPrioritiesArtifactSchema.pick({
     priorities: true,
   }).extend({
+    priorities: projectableRows(
+      ReviewGapPrioritiesArtifactSchema.shape.priorities,
+    ),
     ...McpListArtifactStamp,
     ...McpListPageFields,
   });
@@ -250,6 +257,9 @@ export const ListReviewEnrichmentTargetsOutputSchema =
   ReviewEnrichmentTargetsArtifactSchema.pick({
     targets: true,
   }).extend({
+    targets: projectableRows(
+      ReviewEnrichmentTargetsArtifactSchema.shape.targets,
+    ),
     ...McpListArtifactStamp,
     ...McpListPageFields,
   });

--- a/schemas-src/mcp-tools/enrichment-queue-and-candidates.ts
+++ b/schemas-src/mcp-tools/enrichment-queue-and-candidates.ts
@@ -17,6 +17,7 @@ import {
   netuidSchema,
   numericCursorSchema,
   orderSchema,
+  projectableRows,
   querySchema,
   sortSchema,
 } from "./shared.ts";
@@ -136,6 +137,7 @@ export const ListEnrichmentQueueOutputSchema =
   ReviewEnrichmentQueueArtifactSchema.pick({
     queue: true,
   }).extend({
+    queue: projectableRows(ReviewEnrichmentQueueArtifactSchema.shape.queue),
     ...McpListArtifactStamp,
     ...McpListPageFields,
   });
@@ -206,6 +208,9 @@ export const ListAdapterCandidatesOutputSchema =
   ReviewAdapterCandidatesArtifactSchema.pick({
     candidates: true,
   }).extend({
+    candidates: projectableRows(
+      ReviewAdapterCandidatesArtifactSchema.shape.candidates,
+    ),
     ...McpListArtifactStamp,
     ...McpListPageFields,
   });

--- a/schemas-src/mcp-tools/get-emission-pipeline.ts
+++ b/schemas-src/mcp-tools/get-emission-pipeline.ts
@@ -12,10 +12,11 @@
 // now publishes.
 import { z } from "zod";
 import {
-  netuidSchema,
   fieldsSchema,
   limitSchema,
+  netuidSchema,
   orderSchema,
+  projectableRows,
   sortSchema,
 } from "./shared.ts";
 import { EMISSION_PIPELINE_SORT_FIELDS } from "../../src/emission-pipeline-surface.ts";
@@ -49,7 +50,10 @@ export type GetEmissionPipelineInput = z.infer<
   typeof GetEmissionPipelineInputSchema
 >;
 
-export const GetEmissionPipelineOutputSchema = EmissionPipelineArtifactSchema;
+export const GetEmissionPipelineOutputSchema =
+  EmissionPipelineArtifactSchema.extend({
+    subnets: projectableRows(EmissionPipelineArtifactSchema.shape.subnets),
+  });
 export type GetEmissionPipelineOutput = z.infer<
   typeof GetEmissionPipelineOutputSchema
 >;

--- a/schemas-src/mcp-tools/registry-catalogs-1.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-1.ts
@@ -23,6 +23,7 @@ import {
   netuidSchema,
   numericCursorSchema,
   orderSchema,
+  projectableRows,
   providerSlugSchema,
   sortSchema,
 } from "./shared.ts";
@@ -71,7 +72,9 @@ export const ListProvidersInputSchema = z
   .strict();
 export type ListProvidersInput = z.infer<typeof ListProvidersInputSchema>;
 
-export const ListProvidersOutputSchema = ProvidersArtifactSchema;
+export const ListProvidersOutputSchema = ProvidersArtifactSchema.extend({
+  providers: projectableRows(ProvidersArtifactSchema.shape.providers),
+});
 export type ListProvidersOutput = z.infer<typeof ListProvidersOutputSchema>;
 
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
@@ -104,7 +107,9 @@ export const ListSurfacesInputSchema = z
   .strict();
 export type ListSurfacesInput = z.infer<typeof ListSurfacesInputSchema>;
 
-export const ListSurfacesOutputSchema = SurfacesArtifactSchema;
+export const ListSurfacesOutputSchema = SurfacesArtifactSchema.extend({
+  surfaces: projectableRows(SurfacesArtifactSchema.shape.surfaces),
+});
 export type ListSurfacesOutput = z.infer<typeof ListSurfacesOutputSchema>;
 
 const CANDIDATE_STATES = CANDIDATE_STATE_VALUES;
@@ -150,5 +155,7 @@ export const ListCandidatesInputSchema = z
   .strict();
 export type ListCandidatesInput = z.infer<typeof ListCandidatesInputSchema>;
 
-export const ListCandidatesOutputSchema = CandidatesArtifactSchema;
+export const ListCandidatesOutputSchema = CandidatesArtifactSchema.extend({
+  candidates: projectableRows(CandidatesArtifactSchema.shape.candidates),
+});
 export type ListCandidatesOutput = z.infer<typeof ListCandidatesOutputSchema>;

--- a/schemas-src/mcp-tools/registry-catalogs-2.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-2.ts
@@ -26,6 +26,7 @@ import {
   netuidSchema,
   numericCursorSchema,
   orderSchema,
+  projectableRows,
   providerSlugSchema,
   querySchema,
   sortSchema,
@@ -61,7 +62,9 @@ export const ListEvidenceInputSchema = z
   .strict();
 export type ListEvidenceInput = z.infer<typeof ListEvidenceInputSchema>;
 
-export const ListEvidenceOutputSchema = EvidenceLedgerArtifactSchema;
+export const ListEvidenceOutputSchema = EvidenceLedgerArtifactSchema.extend({
+  claims: projectableRows(EvidenceLedgerArtifactSchema.shape.claims),
+});
 export type ListEvidenceOutput = z.infer<typeof ListEvidenceOutputSchema>;
 
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
@@ -165,7 +168,9 @@ export const ListRpcEndpointsInputSchema = z
   .strict();
 export type ListRpcEndpointsInput = z.infer<typeof ListRpcEndpointsInputSchema>;
 
-export const ListRpcEndpointsOutputSchema = RpcEndpointsArtifactSchema;
+export const ListRpcEndpointsOutputSchema = RpcEndpointsArtifactSchema.extend({
+  endpoints: projectableRows(RpcEndpointsArtifactSchema.shape.endpoints),
+});
 export type ListRpcEndpointsOutput = z.infer<
   typeof ListRpcEndpointsOutputSchema
 >;
@@ -231,6 +236,7 @@ export const ListRpcPoolsOutputSchema = RpcPoolsArtifactSchema.pick({
   source: true,
   pools: true,
 }).extend({
+  pools: projectableRows(RpcPoolsArtifactSchema.shape.pools),
   ...McpListArtifactStamp,
   // Added by the live overlay, so it is not on the route artifact.
   operational_observed_at: z.string().nullable(),
@@ -254,7 +260,10 @@ export type ListSourceSnapshotsInput = z.infer<
   typeof ListSourceSnapshotsInputSchema
 >;
 
-export const ListSourceSnapshotsOutputSchema = SourceSnapshotsArtifactSchema;
+export const ListSourceSnapshotsOutputSchema =
+  SourceSnapshotsArtifactSchema.extend({
+    sources: projectableRows(SourceSnapshotsArtifactSchema.shape.sources),
+  });
 export type ListSourceSnapshotsOutput = z.infer<
   typeof ListSourceSnapshotsOutputSchema
 >;
@@ -337,6 +346,9 @@ export const ListProfileCompletenessOutputSchema =
     summary: true,
     profiles: true,
   }).extend({
+    profiles: projectableRows(
+      ReviewProfileCompletenessArtifactSchema.shape.profiles,
+    ),
     ...McpListArtifactStamp,
     ...McpListPageFields,
   });

--- a/schemas-src/mcp-tools/registry-summary-gaps.ts
+++ b/schemas-src/mcp-tools/registry-summary-gaps.ts
@@ -17,6 +17,7 @@ import {
   netuidSchema,
   numericCursorSchema,
   orderSchema,
+  projectableRows,
   sortSchema,
 } from "./shared.ts";
 import { SubnetGapsArtifactSchema } from "../routes/review-gaps-profile.ts";
@@ -191,6 +192,7 @@ export const ListSubnetGapsOutputSchema = SubnetGapsArtifactSchema.pick({
   netuid: true,
   priorities: true,
 }).extend({
+  priorities: projectableRows(SubnetGapsArtifactSchema.shape.priorities),
   ...McpSubnetListArtifactStamp,
   ...McpListPageFields,
 });

--- a/schemas-src/mcp-tools/search-documents.ts
+++ b/schemas-src/mcp-tools/search-documents.ts
@@ -21,6 +21,7 @@ import {
   netuidSchema,
   numericCursorSchema,
   orderSchema,
+  projectableRows,
   querySchema,
   sortSchema,
 } from "./shared.ts";
@@ -50,6 +51,7 @@ export type ListSearchIndexInput = z.infer<typeof ListSearchIndexInputSchema>;
 export const ListSearchIndexOutputSchema = SearchIndexArtifactSchema.pick({
   documents: true,
 }).extend({
+  documents: projectableRows(SearchIndexArtifactSchema.shape.documents),
   ...McpListArtifactStamp,
   ...McpListPageFields,
 });

--- a/schemas-src/mcp-tools/shared.ts
+++ b/schemas-src/mcp-tools/shared.ts
@@ -510,3 +510,27 @@ export const McpListArtifactStamp = {
 export const McpSubnetListArtifactStamp = {
   generated_at: z.string().nullable(),
 };
+
+/**
+ * The row shape a tool publishes when it also advertises a `fields`
+ * projection (#9880).
+ *
+ * A tool with a `fields` parameter lets the CALLER decide which columns come
+ * back, so its published row cannot require any of them -- do that and the
+ * tool fails its own contract the moment someone uses the parameter it
+ * advertises. That is not hypothetical: 25 of the 32 tools that take `fields`
+ * were doing exactly this, because deriving their rows from the route schemas
+ * (#9796) replaced an open object, which a projected row trivially satisfied,
+ * with a strict one that it cannot.
+ *
+ * Takes the ARRAY off the route schema and returns the same array with every
+ * row field optional, so the derivation is still a derivation: the field NAMES
+ * and their types still come from the route, and a rename there is still a
+ * compile error here. Only the requiredness changes, and it changes because
+ * the caller controls it.
+ */
+export function projectableRows<Row extends z.ZodObject<z.ZodRawShape>>(
+  rows: z.ZodArray<Row>,
+) {
+  return z.array(rows.element.partial());
+}

--- a/schemas-src/mcp-tools/subnet-registry-lists.ts
+++ b/schemas-src/mcp-tools/subnet-registry-lists.ts
@@ -27,6 +27,7 @@ import {
   netuidSchema,
   numericCursorSchema,
   orderSchema,
+  projectableRows,
   providerSlugSchema,
   querySchema,
   sortSchema,
@@ -107,6 +108,9 @@ export const ListSubnetCandidatesOutputSchema =
     netuid: true,
     candidates: true,
   }).extend({
+    candidates: projectableRows(
+      SubnetCandidatesArtifactSchema.shape.candidates,
+    ),
     ...McpSubnetListArtifactStamp,
     ...McpListPageFields,
   });
@@ -156,6 +160,7 @@ export const ListSubnetEvidenceOutputSchema = SubnetEvidenceArtifactSchema.pick(
     claims: true,
   },
 ).extend({
+  claims: projectableRows(SubnetEvidenceArtifactSchema.shape.claims),
   ...McpSubnetListArtifactStamp,
   ...McpListPageFields,
 });

--- a/schemas-src/mcp-tools/subnet-scoped-lists.ts
+++ b/schemas-src/mcp-tools/subnet-scoped-lists.ts
@@ -26,6 +26,7 @@ import {
   netuidSchema,
   numericCursorSchema,
   orderSchema,
+  projectableRows,
   providerSlugSchema,
   sortSchema,
 } from "./shared.ts";
@@ -127,6 +128,7 @@ export const ListSubnetEndpointsOutputSchema =
     netuid: true,
     endpoints: true,
   }).extend({
+    endpoints: projectableRows(SubnetEndpointsArtifactSchema.shape.endpoints),
     ...McpSubnetListArtifactStamp,
     ...McpListPageFields,
   });

--- a/scripts/validate-mcp.ts
+++ b/scripts/validate-mcp.ts
@@ -2010,6 +2010,88 @@ for (const def of listToolDefinitions()) {
   await callOk(def.name, args);
 }
 
+// --- A `fields` projection must satisfy the tool's own schema (#9880) ------
+//
+// A tool that advertises `fields` lets the CALLER decide which columns come
+// back. Its published row therefore cannot REQUIRE any of them -- do that and
+// the tool fails its own contract the moment someone uses the parameter it
+// advertises.
+//
+// 25 of the 32 tools taking `fields` were doing exactly that, and the sweep
+// above could not see it: it calls each tool with the arguments its schema
+// gives EXAMPLES for, and `fields` has none (there is no single sensible
+// example -- the valid names differ per tool). So the projected path, the one
+// an agent uses precisely because the full row is too big, was never checked.
+//
+// This calls each one AGAIN with a projection, picking a field name off the
+// unprojected response so the argument is always valid for that tool.
+let projectionChecked = 0;
+const projectionUnexercised: string[] = [];
+for (const def of listToolDefinitions()) {
+  const properties = ((def.inputSchema as Row | undefined)?.properties ??
+    {}) as Row;
+  if (!properties.fields) continue;
+  if (RESPONSE_UNVALIDATED_REASONS.has(def.name)) continue;
+  const args: Row = {};
+  for (const key of ((def.inputSchema as Row)?.required ?? []) as string[]) {
+    const example = declaredExample(properties[key] as Row);
+    if (example.found) args[key] = example.value;
+  }
+  const plain = await call(def.name, args);
+  if (plain.isError) {
+    projectionUnexercised.push(def.name);
+    continue;
+  }
+  // The collection this tool returns, and one real field name off it. Derived
+  // rather than hardcoded: the valid `fields` values are per-tool, and a
+  // hardcoded list would be one more hand-maintained copy.
+  const rows = Object.values(plain).find(
+    (value) =>
+      Array.isArray(value) &&
+      value.length > 0 &&
+      typeof value[0] === "object" &&
+      value[0] !== null,
+  ) as Row[] | undefined;
+  const row = rows?.[0] ?? (plain.neuron as Row | undefined);
+  const field =
+    row && typeof row === "object" ? Object.keys(row)[0] : undefined;
+  if (!field) {
+    // The harness has no rows for this tool, so there is nothing to project.
+    // Counted rather than skipped silently: an unexercised check that reports
+    // success is the blindness #9795 was about.
+    projectionUnexercised.push(def.name);
+    continue;
+  }
+  const projected = await call(def.name, { ...args, fields: field });
+  if (projected.isError) {
+    projectionUnexercised.push(def.name);
+    continue;
+  }
+  const payload = projected.structuredContent;
+  if (!payload) {
+    projectionUnexercised.push(def.name);
+    continue;
+  }
+  projectionChecked++;
+  const validate = new Ajv2020({ strict: false }).compile(
+    def.outputSchema as Row,
+  );
+  assert.ok(
+    validate(payload),
+    `${def.name}: a response projected with the tool's OWN \`fields\` parameter ` +
+      `(fields: "${field}") must still satisfy its published outputSchema -- ` +
+      `${JSON.stringify(validate.errors?.slice(0, 4))}. A row schema that requires ` +
+      `a field the caller can project away is a contract the tool breaks by design.`,
+  );
+}
+console.log(
+  `MCP projection coverage: ${projectionChecked} of ${projectionChecked + projectionUnexercised.length} ` +
+    `\`fields\`-capable tools had their PROJECTED response validated` +
+    (projectionUnexercised.length > 0
+      ? ` (${projectionUnexercised.length} serve no rows in the hermetic harness, so their projected shape rests on the production sweep: ${projectionUnexercised.join(", ")})`
+      : ""),
+);
+
 // --- Response-shape coverage assertions (#9795) ----------------------------
 //
 // See the ledgers' definition above for why these exist. Both allowlists are


### PR DESCRIPTION
**A regression I introduced.** Reporting it in full rather than folding the fix
quietly into another change.

## What broke

A tool that advertises a `fields` projection lets the **caller** decide which
columns come back. Its published row therefore cannot **require** any of them.

Deriving the MCP output schemas from the route `ArtifactSchema`s (#9796, shipped
in #9855 and #9859) replaced open row objects — which a projected row trivially
satisfied — with strict ones that it cannot.

I swept all 32 `fields`-capable tools against production, calling each with a
field name taken off its own unprojected response:

> **25 of 32 fail their own published `outputSchema` under their own `fields`
> parameter.**

```
list_curation   fields="candidate_count"  FAILS: /curation/0 must have required property 'slug'
list_providers  fields="authority"        FAILS: /providers/0 must have required property 'name'
list_surfaces   fields="auth_required"    FAILS: /surfaces/0 must have required property 'kind'
…
```

Same defect class the whole epic exists to remove — a published contract the
code violates — except this time the epic caused it.

## Why the gate did not see it

`validate:mcp` sweeps every tool with the arguments its schema gives
**examples** for. `fields` has none, and correctly so: the valid names differ
per tool, so there is no single sensible example. The projected path — the one
an agent uses *precisely because* the full row is too big — was never called.

## The fix

`projectableRows()` takes the array off the route schema and returns it with
every row field optional:

```ts
export function projectableRows<Row extends z.ZodObject<z.ZodRawShape>>(
  rows: z.ZodArray<Row>,
) {
  return z.array(rows.element.partial());
}
```

The derivation stays a derivation — field **names** and **types** still come
from the route, and a rename there is still a compile error here. Only
requiredness changes, and it changes because the caller controls it.

Applied to all 25.

## The gate now calls the projected path

`validate:mcp` calls every `fields`-capable tool a **second** time with a
projection, picking the field name off the unprojected response so the argument
is always valid for that tool.

**And it reports the limit rather than hiding it.** Only 2 of 32 can be
exercised hermetically — the other 30 serve no rows there:

```
MCP projection coverage: 2 of 32 `fields`-capable tools had their PROJECTED
response validated (30 serve no rows in the hermetic harness, so their projected
shape rests on the production sweep: …)
```

An unexercised check that reports success is exactly the blindness #9795 was
about, so it says so instead. Closing it properly is #9801's production
conformance sweep — this is one more concrete thing that sweep would catch.

## Verification

Re-swept all 25 against production **after** the fix:

```
projected responses valid: 25   still failing: 0   unexercised: 0
```

- `npx tsc --noEmit` · `npx eslint .` · `npx prettier --check .` — clean
- `npm run build` — 7/7 steps passed
- `validate:mcp` · `validate:schema-opacity` · `validate:schema-vocabularies` ·
  `validate:contract-drift` · `validate:single-schema-source` · `validate:api` — all pass
- `npx vitest run` — **725 files, 17585 tests, 0 failures**

Closes #9882