### PR TITLE
feat(mcp): look a neuron up by hotkey, and select metagraph rows before columns

### DIFF
--- a/schemas-src/mcp-tools/get-subnet-metagraph.ts
+++ b/schemas-src/mcp-tools/get-subnet-metagraph.ts
@@ -4,8 +4,11 @@
 // reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
 import { z } from "zod";
 import {
+  NEURON_SORT_FIELD_NAMES,
+  NEURON_SORT_NULLS_LAST_NOTE,
   NeuronFieldsInputSchema,
   OpenObjectArraySchema,
+  accountKeySchema,
   netuidSchema,
 } from "./shared.ts";
 
@@ -19,6 +22,76 @@ export const GetSubnetMetagraphInputSchema = z
         "Restrict to neurons that hold (`true`) or lack (`false`) a validator permit.",
       )
       .meta({ examples: [true] }),
+    // --- row selection (#9872) ---------------------------------------------
+    //
+    // The row count is the dominant cost of this tool, not the column count:
+    // a three-field projection of subnet 53 still came back at ~24k tokens
+    // because a hotkey is 48 characters and there are 256 of them. `fields`
+    // is a column fix for a row problem, so these five parameters cut rows.
+    hotkeys: z
+      .array(accountKeySchema("hotkey"))
+      .min(1)
+      .optional()
+      .describe(
+        "Return only the neurons holding these hotkeys. This is the lookup " +
+          "to use when you know a hotkey and want its row: every off-chain " +
+          "system (a subnet's own API, a dashboard, wallet tooling) " +
+          "identifies a miner by hotkey, while `uid` is an internal slot " +
+          "number that is REUSED after deregistration. A hotkey that is not " +
+          "registered on this subnet is simply absent from the result — that " +
+          "is the answer to 'is it registered', not an error.",
+      )
+      .meta({
+        examples: [["5CzcUxRe7rFbtGjw4DGfoJZTFqPnMwUFMTiMFURxCWmwBhqK"]],
+      }),
+    active: z
+      .boolean()
+      .optional()
+      .describe(
+        "Restrict to neurons the chain marks active (`true`) or inactive (`false`).",
+      )
+      .meta({ examples: [true] }),
+    min_incentive: z
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        "Drop neurons whose `incentive` is below this floor (inclusive, so " +
+          "`min_incentive: 0` keeps the whole zero-incentive population — " +
+          "which on most subnets is the majority). Rows with a null " +
+          "`incentive` never pass a floor. For 'only the neurons actually " +
+          "earning', either pass a small positive floor, or use `sort_by: " +
+          '"incentive"` with a `limit`, which needs no threshold at all.',
+      )
+      .meta({ examples: [0.001] }),
+    sort_by: z
+      .enum(NEURON_SORT_FIELD_NAMES)
+      .optional()
+      .describe(
+        `Order the rows by one numeric field. ${NEURON_SORT_NULLS_LAST_NOTE} ` +
+          "Omit to keep the snapshot's own UID order.",
+      )
+      .meta({ examples: ["incentive"] }),
+    order: z
+      .enum(["asc", "desc"])
+      .optional()
+      .describe(
+        "Sort direction for `sort_by`; defaults to `desc`, because the " +
+          "question a sort usually answers here is 'who is at the top'. " +
+          "Ignored when `sort_by` is omitted.",
+      )
+      .meta({ examples: ["desc"] }),
+    limit: z
+      .int()
+      .min(1)
+      .optional()
+      .describe(
+        "Return at most this many neurons, applied AFTER any filter and " +
+          "sort. There is deliberately no default: omitting it returns the " +
+          "whole snapshot, exactly as this tool always has. Pair it with " +
+          "`sort_by` — a limit on unsorted rows just truncates by UID.",
+      )
+      .meta({ examples: [12] }),
     // #9082: narrow each returned row to these fields. Omit for the full
     // row. Valid names are NeuronSchema's own, so this enum cannot drift
     // from what the route can project.
@@ -33,7 +106,27 @@ export const GetSubnetMetagraphOutputSchema = z
   .object({
     schema_version: z.int().optional(),
     netuid: netuidSchema(),
-    neuron_count: z.int(),
+    neuron_count: z
+      .int()
+      .describe(
+        "How many neurons are in `neurons` — the count AFTER any filter, " +
+          "sort or limit, so it always equals `neurons.length`. When that is " +
+          "fewer than the snapshot holds, `total_neuron_count` says how many " +
+          "there were.",
+      ),
+    // Emitted only when a selection parameter actually removed rows (#9872).
+    // Without it a filtered call answers `neuron_count: 12` for a 256-neuron
+    // subnet, which reads as a measurement of the subnet rather than of the
+    // response -- the same confident-zero failure #9307 is about.
+    total_neuron_count: z
+      .int()
+      .optional()
+      .describe(
+        "How many neurons the snapshot holds before `hotkeys`/`active`/" +
+          "`min_incentive`/`limit` were applied. Present only when one of " +
+          "them removed rows; its absence means `neuron_count` is the whole " +
+          "snapshot.",
+      ),
     captured_at: z.string().nullable().optional(),
     block_number: z.int().nullable().optional(),
     neurons: OpenObjectArraySchema,

--- a/schemas-src/mcp-tools/neurons.ts
+++ b/schemas-src/mcp-tools/neurons.ts
@@ -17,22 +17,51 @@ import { z } from "zod";
 import {
   NeuronFieldsInputSchema,
   OpenObjectSchema,
+  accountKeySchema,
   netuidSchema,
   uidSchema,
   windowSchema,
 } from "./shared.ts";
 import { NeuronHistoryArtifactSchema } from "../routes/subnet-metagraph.ts";
 
+// EXACTLY ONE of `uid` / `hotkey` identifies the neuron (#9872), and that is
+// PUBLISHED rather than only described.
+//
+// `oneOf` of two `required` branches is exactly-one, not at-least-one: passing
+// both matches both branches, and matching two branches fails `oneOf`. It
+// reaches the wire through `.meta()`, which z.toJSONSchema merges into the
+// emitted schema -- `.refine()` would not, because a refinement has no JSON
+// Schema form and Zod emits the base object regardless.
+//
+// The handler still enforces it (this server validates arguments in the
+// handler by design, #8942). The published constraint is what an agent READS
+// before calling; the handler is what makes the reading true.
 export const GetNeuronInputSchema = z
   .object({
     netuid: netuidSchema(),
-    uid: uidSchema(),
+    uid: uidSchema()
+      .optional()
+      .describe(
+        "The neuron's UID — its slot number within this subnet. Give this " +
+          "OR `hotkey`, not both. A UID is REUSED after a deregistration, so " +
+          "it identifies a slot rather than an operator; if what you have is " +
+          "a key from a subnet API, a dashboard or a wallet, pass `hotkey`.",
+      ),
+    hotkey: accountKeySchema("hotkey")
+      .optional()
+      .describe(
+        "The neuron's SS58 hotkey — the stable way to name an operator, and " +
+          "the identifier every off-chain system uses. Give this OR `uid`, " +
+          "not both. Returns `neuron: null` when the hotkey holds no UID on " +
+          "this subnet, which is the answer to 'is it still registered'.",
+      ),
     // #9082: narrow each returned row to these fields. Omit for the full
     // row. Valid names are NeuronSchema's own, so this enum cannot drift
     // from what the route can project.
     fields: NeuronFieldsInputSchema.meta({ examples: ["netuid,name,slug"] }),
   })
-  .strict();
+  .strict()
+  .meta({ oneOf: [{ required: ["uid"] }, { required: ["hotkey"] }] });
 export type GetNeuronInput = z.infer<typeof GetNeuronInputSchema>;
 
 export const GetNeuronOutputSchema = z

--- a/schemas-src/mcp-tools/shared.ts
+++ b/schemas-src/mcp-tools/shared.ts
@@ -455,6 +455,56 @@ export const NeuronFieldsInputSchema = z
   )
   .optional();
 
+// --- sorting the Neuron row (#9872) -----------------------------------------
+//
+// Derived from NeuronSchema the same way NEURON_FIELD_NAMES above is, and for
+// the same reason: a numeric field added to the contract becomes sortable the
+// day it lands, with no second list to remember. The predicate is "what is
+// this field's type once optional/nullable are peeled off" -- `incentive` is
+// declared `z.number().nullable().optional()`, so a bare `.def.type` check
+// would see "optional" and conclude nothing is sortable.
+//
+// Every numeric field qualifies, including the ones where most rows are null
+// (`rank` is assigned only to non-zero-incentive neurons; the immunity fields
+// exist only inside the immunity window). Excluding them would be a judgment
+// call baked into a list, which is the thing this derivation exists to avoid
+// -- and the null-ordering rule below makes them behave predictably anyway.
+function neuronFieldBaseType(schema: unknown): string {
+  let cur = schema as {
+    _zod?: { def?: { type?: string; innerType?: unknown } };
+  };
+  // optional/nullable/default nest at most a few deep in practice; the bound
+  // makes a malformed schema return "" rather than spin.
+  for (let depth = 0; depth < 8; depth += 1) {
+    const type = cur?._zod?.def?.type;
+    if (type === "optional" || type === "nullable" || type === "default") {
+      cur = cur._zod!.def!.innerType as typeof cur;
+      continue;
+    }
+    return type ?? "";
+  }
+  return "";
+}
+
+/** Every numeric field of the published Neuron contract, in declaration order. */
+export const NEURON_SORT_FIELD_NAMES = Object.entries(NeuronSchema.shape)
+  .filter(([, schema]) => neuronFieldBaseType(schema) === "number")
+  .map(([name]) => name) as [string, ...string[]];
+
+/**
+ * `null` sorts LAST in both directions, deliberately.
+ *
+ * A null here means "this neuron has no value for that field" -- unranked,
+ * outside its immunity window, no Delegates entry -- not "the lowest value".
+ * Ordering ascending would otherwise put the entire unranked population ahead
+ * of rank 1, which reads as a leaderboard and is the opposite of the truth.
+ */
+export const NEURON_SORT_NULLS_LAST_NOTE =
+  "Rows whose sort field is null are returned LAST in both directions — a " +
+  "null means the neuron has no value for that field (unranked, outside " +
+  "immunity, no delegate take), never a low one. Ties break by `uid` " +
+  "ascending, so the order is stable across calls.";
+
 // ---------------------------------------------------------------------------
 // The paginated-list projection (#9796).
 //

--- a/scripts/validate-mcp.ts
+++ b/scripts/validate-mcp.ts
@@ -1929,6 +1929,44 @@ function declaredExample(schema: Row | undefined): {
   return { found: false };
 }
 
+// Which arguments must be supplied to call this tool at all.
+//
+// `required` alone is not the whole answer once a tool publishes a choice
+// (#9872): `get_neuron` takes EITHER `uid` OR `hotkey`, so neither can appear
+// in `required` -- and a sweep that reads only `required` would call it with
+// no identifier at all and be told so, which looks exactly like a broken
+// contract. Taking the first `oneOf`/`anyOf` branch's own `required` picks one
+// side of the choice, which is what a caller does too.
+//
+// Only a branch that constrains PRESENCE is followed. `get_feed` publishes a
+// value-conditional one -- `kind: "subnet"` requires `netuid`, the other kinds
+// forbid it -- and adopting its first branch's `required` produced
+// `{kind: "registry", netuid: 64}`, which the server rightly rejects. Resolving
+// that needs the condition, not just the requirement, so a branch carrying
+// `properties`/`not`/`if` is left alone and the tool is swept from `required`
+// as before.
+//
+// Derived from the published schema rather than from a table of tools that
+// have a choice: a tool that grows one is swept correctly the day it lands,
+// and this cannot fall out of date because there is nothing to update.
+function requiredArgumentNames(inputSchema: Row | undefined): string[] {
+  const base = ((inputSchema?.required ?? []) as string[]).slice();
+  for (const key of ["oneOf", "anyOf"]) {
+    const branches = inputSchema?.[key];
+    if (!Array.isArray(branches) || branches.length === 0) continue;
+    const presenceOnly = branches.filter((branch) => {
+      const keys = Object.keys((branch ?? {}) as Row);
+      return keys.length === 1 && keys[0] === "required";
+    });
+    if (presenceOnly.length !== branches.length) break;
+    for (const name of ((presenceOnly[0] as Row)?.required ?? []) as string[]) {
+      if (!base.includes(name)) base.push(name);
+    }
+    break;
+  }
+  return base;
+}
+
 // --- Declared slug examples must name something that exists (#9860) --------
 //
 // A `slug` example is copied verbatim by the first agent that reads the tool,
@@ -1973,7 +2011,7 @@ for (const def of listToolDefinitions()) {
   if (RESPONSE_UNVALIDATED_REASONS.has(def.name)) continue;
   const inputSchema = def.inputSchema as Row | undefined;
   const properties = (inputSchema?.properties ?? {}) as Row;
-  const required = (inputSchema?.required ?? []) as string[];
+  const required = requiredArgumentNames(inputSchema);
   const args: Row = {};
   const undocumented: string[] = [];
   for (const key of required) {
@@ -2033,7 +2071,7 @@ for (const def of listToolDefinitions()) {
   if (!properties.fields) continue;
   if (RESPONSE_UNVALIDATED_REASONS.has(def.name)) continue;
   const args: Row = {};
-  for (const key of ((def.inputSchema as Row)?.required ?? []) as string[]) {
+  for (const key of requiredArgumentNames(def.inputSchema as Row | undefined)) {
     const example = declaredExample(properties[key] as Row);
     if (example.found) args[key] = example.value;
   }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -579,7 +579,10 @@ import {
   GetSubnetMetagraphInputSchema,
   GetSubnetMetagraphOutputSchema,
 } from "../schemas-src/mcp-tools/get-subnet-metagraph.ts";
-import { NEURON_FIELD_NAMES } from "../schemas-src/mcp-tools/shared.ts";
+import {
+  NEURON_FIELD_NAMES,
+  NEURON_SORT_FIELD_NAMES,
+} from "../schemas-src/mcp-tools/shared.ts";
 import {
   GetSubnetHistoryInputSchema,
   GetSubnetHistoryOutputSchema,
@@ -1257,6 +1260,7 @@ import {
   buildNeuronDetail,
   buildSubnetMetagraph,
   projectNeuronPayload,
+  selectNeuronRows,
   buildSubnetValidators,
   buildGlobalValidators,
   NO_ALPHA_PRICES,
@@ -2372,6 +2376,10 @@ const MCP_NETWORK_VALUES = McpNetworkSchema.options;
 // dispatch (#8942) -- tests/mcp-schema-enforcement.test.ts holds every tool to
 // actually rejecting what its schema forbids, and this is that rejection.
 const NEURON_FIELD_VALUES = NEURON_FIELD_NAMES as readonly string[];
+// The sortable subset, same single source and same reason (#9872): the enum
+// get_subnet_metagraph publishes and the values its handler accepts are one
+// list, derived from NeuronSchema's numeric fields.
+const NEURON_SORT_FIELD_VALUES = NEURON_SORT_FIELD_NAMES as readonly string[];
 
 /**
  * An optional array-of-enum argument: null when absent, a validated list
@@ -3774,6 +3782,43 @@ function requireSs58(args: Row) {
     );
   }
   return value;
+}
+
+// The optional forms of requireHotkey, for the two neuron tools that take a
+// hotkey as an ALTERNATIVE to a UID rather than as the subject (#9872). Each
+// element is pattern-checked, so a caller who passes a coldkey-looking typo
+// or a name gets `invalid_params` naming the bad element rather than an empty
+// result they would read as "not registered".
+function optionalHotkey(args: Row, key: string): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string" || !SS58_ADDRESS_PATTERN.test(value)) {
+    throw toolError(
+      "invalid_params",
+      `Argument \`${key}\` must be a valid SS58 hotkey (base58, 47-48 chars).`,
+    );
+  }
+  return value;
+}
+
+function optionalHotkeyArray(args: Row, key: string): string[] | null {
+  const value = args?.[key];
+  if (value === undefined || value === null) return null;
+  if (!Array.isArray(value) || value.length === 0) {
+    throw toolError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty array of SS58 hotkeys.`,
+    );
+  }
+  for (const entry of value) {
+    if (typeof entry !== "string" || !SS58_ADDRESS_PATTERN.test(entry)) {
+      throw toolError(
+        "invalid_params",
+        `Argument \`${key}\` contains an entry that is not a valid SS58 hotkey (base58, 47-48 chars).`,
+      );
+    }
+  }
+  return value as string[];
 }
 
 // A validator identity is the same SS58 shape as an account, just a different
@@ -7311,9 +7356,18 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       "emission, validator permit, immunity, and axon, ordered by UID. Set " +
       "validator_permit to true to return only permit-holding validators. " +
       "Captured from the chain on a schedule; empty when no snapshot exists yet. " +
-      "PASS `fields` UNLESS YOU GENUINELY NEED EVERY COLUMN: the full response is " +
-      '256 rows x 17 fields (~95 KB, ~24k tokens on subnet 1). `fields: ["uid", ' +
-      "\"hotkey\"]` answers 'is this hotkey registered, and at which UID' in ~18 KB. " +
+      "SELECT ROWS BEFORE COLUMNS: the full response is 256 rows x 17 fields " +
+      "(~95 KB, ~24k tokens on subnet 1), and the ROW count dominates it — a " +
+      "three-field projection of a 256-neuron subnet is still ~24k tokens, " +
+      "because a hotkey is 48 characters. `hotkeys: [...]` returns just those " +
+      "neurons and is the right way to ask 'what is this hotkey's incentive' " +
+      "or 'is it still registered'; `sort_by` + `order` + `limit` answers " +
+      "'top N by incentive/stake/dividends' without a full dump; `active` and " +
+      "`min_incentive` drop the rows you were going to discard anyway. " +
+      "`neuron_count` is always the number returned, and `total_neuron_count` " +
+      "appears alongside it whenever a selection removed rows, so a narrowed " +
+      "count is never mistaken for the subnet's size. THEN narrow the columns " +
+      "with `fields`. " +
       "EPOCH PROVENANCE (#9871): `incentive`, `dividends`, `emission_tao`, `consensus`, `trust` and `rank` are derived from the weights validators set in the LAST COMPLETED tempo -- not from live activity, and not from the epoch currently open. `captured_at`/`block_number` say when WE sampled the chain, which is a different thing. Comparing these against an in-progress epoch from an off-chain source (a subnet's own API, a dashboard) will disagree, and the disagreement is expected rather than a defect. Read `tempo` from get_subnet_hyperparams to find the epoch length. ",
     inputSchema: z.toJSONSchema(GetSubnetMetagraphInputSchema, {
       target: "draft-2020-12",
@@ -7333,14 +7387,33 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // #9082: rejected before the tier read, so an unsupported field costs a
       // tool error rather than a full 256-row fetch the caller never sees.
       const fields = optionalEnumArray(args, "fields", NEURON_FIELD_VALUES);
+      // #9872: same argument -- every one of these is validated before the
+      // fetch, so a bad `sort_by` costs an error rather than a 95 KB response
+      // the caller then discovers they cannot use.
+      const selection = {
+        hotkeys: optionalHotkeyArray(args, "hotkeys"),
+        active: optionalNullableBoolean(args, "active"),
+        minIncentive: optionalNonNegativeNumber(args, "min_incentive"),
+        sortBy: optionalEnum(args, "sort_by", NEURON_SORT_FIELD_VALUES),
+        order: optionalEnum(args, "order", ["asc", "desc"] as const),
+        limit: optionalPositiveInt(args, "limit"),
+      };
+      // PROJECTED LAST, for the reason list_subnet_validators states: the
+      // selection filters and sorts on `hotkey`/`active`/`incentive` and on
+      // whichever field `sort_by` names, so narrowing the rows first would
+      // make the result depend on whether the caller happened to ask for the
+      // columns being filtered on.
       return projectNeuronPayload(
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/metagraph`, {
-            validator_permit: validatorPermit ? "true" : undefined,
-          }),
-          "METAGRAPH_NEURONS_SOURCE",
-        )) ?? buildSubnetMetagraph([], netuid),
+        selectNeuronRows(
+          (await tryPostgresTier(
+            ctx.env,
+            mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/metagraph`, {
+              validator_permit: validatorPermit ? "true" : undefined,
+            }),
+            "METAGRAPH_NEURONS_SOURCE",
+          )) ?? buildSubnetMetagraph([], netuid),
+          selection,
+        ),
         fields,
       );
     },
@@ -7726,12 +7799,19 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
   },
   {
     name: "get_neuron",
-    title: "Get one neuron by UID",
+    title: "Get one neuron by UID or hotkey",
     description:
-      "Fetch a single neuron in one subnet by its UID: hot and cold keys, stake, " +
-      "rank, trust, consensus, incentive, dividends, emission, validator " +
-      "permit, immunity, and axon. Returns neuron: null when that UID is not " +
-      "in the latest snapshot. Narrow the row with `fields`. " +
+      "Fetch a single neuron in one subnet, named by EITHER its `uid` (slot " +
+      "number) OR its `hotkey` (SS58) — give one, not both. Returns hot and " +
+      "cold keys, stake, rank, trust, consensus, incentive, dividends, " +
+      "emission, validator permit, immunity, and axon. PREFER `hotkey` when " +
+      "you have one: a UID is an internal slot that is REUSED after a " +
+      "deregistration, so it can silently come to mean a different operator, " +
+      "while every off-chain system (a subnet's own API, a dashboard, wallet " +
+      "tooling) identifies a miner by hotkey. Returns neuron: null when that " +
+      "UID or hotkey is not in the latest snapshot — for a hotkey that is the " +
+      "answer to 'is it still registered', not an error. Narrow the row with " +
+      "`fields`. " +
       "EPOCH PROVENANCE (#9871): `incentive`, `dividends`, `emission_tao`, `consensus`, `trust` and `rank` are derived from the weights validators set in the LAST COMPLETED tempo -- not from live activity, and not from the epoch currently open. `captured_at`/`block_number` say when WE sampled the chain, which is a different thing. Comparing these against an in-progress epoch from an off-chain source (a subnet's own API, a dashboard) will disagree, and the disagreement is expected rather than a defect. Read `tempo` from get_subnet_hyperparams to find the epoch length. ",
     inputSchema: z.toJSONSchema(GetNeuronInputSchema, {
       target: "draft-2020-12",
@@ -7743,8 +7823,53 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // (#4772) -- buildNeuronDetail(null, ...) below never sees it. It IS
       // still forwarded in the synthetic path below, mirroring REST's
       // handleNeuron.
-      const uid = requireNonNegativeInt(args, "uid");
+      const uid = optionalNonNegativeInt(args, "uid");
+      const hotkey = optionalHotkey(args, "hotkey");
+      // #9872: exactly one identifier. Enforced here rather than in the
+      // schema because this server validates arguments in the handler by
+      // design (#8942) -- and because both failures need to say which pair
+      // they are about, not merely that the object did not match.
+      if (uid === null && hotkey === null) {
+        throw toolError(
+          "invalid_params",
+          "Name the neuron with either `uid` (its slot number on this subnet) or `hotkey` (its SS58 key). A UID is reused after a deregistration, so `hotkey` is the stable one.",
+        );
+      }
+      if (uid !== null && hotkey !== null) {
+        throw toolError(
+          "invalid_params",
+          "Give `uid` or `hotkey`, not both — they can name different neurons, and there is no rule for which should win.",
+        );
+      }
       const fields = optionalEnumArray(args, "fields", NEURON_FIELD_VALUES);
+      // The hotkey path reads the whole snapshot and picks the row out of it.
+      // The neurons tier addresses a neuron by (netuid, uid) only, so there is
+      // no per-hotkey read to issue -- but the caller still receives one row
+      // instead of every row, which is the cost this closes (#9872). If the
+      // tier ever grows a hotkey address, this is the only place that changes.
+      if (hotkey !== null) {
+        const snapshot =
+          (await tryPostgresTier(
+            ctx.env,
+            mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/metagraph`),
+            "METAGRAPH_NEURONS_SOURCE",
+          )) ?? buildSubnetMetagraph([], netuid);
+        const rows = Array.isArray(snapshot.neurons)
+          ? (snapshot.neurons as Row[])
+          : [];
+        const match = rows.find((row) => row.hotkey === hotkey) ?? null;
+        return projectNeuronPayload(
+          {
+            schema_version: snapshot.schema_version ?? 1,
+            netuid,
+            captured_at: snapshot.captured_at ?? null,
+            block_number: snapshot.block_number ?? null,
+            // null is a real answer: the hotkey holds no UID on this subnet.
+            neuron: match,
+          },
+          fields,
+        );
+      }
       return projectNeuronPayload(
         (await tryPostgresTier(
           ctx.env,

--- a/src/metagraph-neurons.ts
+++ b/src/metagraph-neurons.ts
@@ -90,6 +90,119 @@ export function projectNeuronPayload<T extends Row>(
   return projected as T;
 }
 
+// --- row selection over a metagraph payload (#9872) -------------------------
+//
+// Lives here for the same reason the `fields=` projection above does: the row
+// shape is shared, so the logic that narrows it should be too rather than
+// growing a copy at each call site.
+//
+// Applied AFTER the snapshot is fetched, not pushed into the tier query. That
+// is not a shortcut -- the cost this closes is the RESPONSE, not the read. An
+// agent asking "what incentive does hotkey X have" was paying ~24k tokens to
+// receive 256 rows it then filtered itself; the fetch was never the part it
+// could see. `list_subnet_validators`'s `limit`/`min_stake_tao` already work
+// this way, with the same trade-off written down at its handler.
+
+export interface NeuronSelection {
+  hotkeys?: string[] | null;
+  active?: boolean | null;
+  minIncentive?: number | null;
+  sortBy?: string | null;
+  order?: "asc" | "desc" | null;
+  limit?: number | null;
+}
+
+/** True when a selection would do anything at all. */
+function selectsAnything(selection: NeuronSelection): boolean {
+  return (
+    (selection.hotkeys?.length ?? 0) > 0 ||
+    selection.active != null ||
+    selection.minIncentive != null ||
+    selection.limit != null
+  );
+}
+
+// A null/absent sort value orders LAST in both directions -- see
+// NEURON_SORT_NULLS_LAST_NOTE for why "unranked" must not read as "rank
+// worst". Non-numeric values (a D1 numeric string that escaped coercion)
+// take the same branch: unorderable is unorderable.
+function sortValue(row: Row, field: string): number | null {
+  const raw = row[field];
+  return typeof raw === "number" && Number.isFinite(raw) ? raw : null;
+}
+
+function compareNeurons(a: Row, b: Row, field: string, desc: boolean): number {
+  const left = sortValue(a, field);
+  const right = sortValue(b, field);
+  if (left === null || right === null) {
+    if (left === right) return uidTiebreak(a, b);
+    return left === null ? 1 : -1;
+  }
+  if (left !== right) return desc ? right - left : left - right;
+  return uidTiebreak(a, b);
+}
+
+// Stable, and stable on the field a caller can actually see: relying on
+// Array#sort's stability would tie the published order to the snapshot's
+// arrival order, which is not a promise this tool makes.
+function uidTiebreak(a: Row, b: Row): number {
+  const left = typeof a.uid === "number" ? a.uid : Number.MAX_SAFE_INTEGER;
+  const right = typeof b.uid === "number" ? b.uid : Number.MAX_SAFE_INTEGER;
+  return left - right;
+}
+
+/**
+ * Filter, sort and cap a metagraph payload's `neurons`.
+ *
+ * Returns the payload untouched when the selection is empty, so an unfiltered
+ * call stays byte-identical -- including the absence of `total_neuron_count`,
+ * whose whole job is to mark a response that is NOT the whole snapshot.
+ */
+export function selectNeuronRows<T extends Row>(
+  data: T,
+  selection: NeuronSelection,
+): T {
+  const rows = Array.isArray(data?.neurons) ? (data.neurons as Row[]) : null;
+  if (!rows) return data;
+  const sortBy = selection.sortBy ?? null;
+  if (!selectsAnything(selection) && !sortBy) return data;
+
+  const wanted = selection.hotkeys?.length ? new Set(selection.hotkeys) : null;
+  let selected = rows.filter((row) => {
+    if (wanted && !(typeof row.hotkey === "string" && wanted.has(row.hotkey))) {
+      return false;
+    }
+    if (selection.active != null && row.active !== selection.active) {
+      return false;
+    }
+    if (selection.minIncentive != null) {
+      // A null incentive never clears a floor -- "no value" is not "below
+      // the bar", and admitting it would make min_incentive:0 a no-op that
+      // silently kept rows the caller was filtering for.
+      if (typeof row.incentive !== "number") return false;
+      if (row.incentive < selection.minIncentive) return false;
+    }
+    return true;
+  });
+
+  if (sortBy) {
+    const desc = (selection.order ?? "desc") === "desc";
+    selected = [...selected].sort((a, b) => compareNeurons(a, b, sortBy, desc));
+  }
+  if (selection.limit != null) selected = selected.slice(0, selection.limit);
+
+  const narrowed = selected.length !== rows.length;
+  return {
+    ...data,
+    neuron_count: selected.length,
+    // Only when rows were actually removed: on an unnarrowed response the
+    // field would be a duplicate of neuron_count, and its presence is the
+    // signal that neuron_count is not the subnet's size.
+    ...(narrowed ? { total_neuron_count: rows.length } : {}),
+    neurons: selected,
+  } as T;
+}
+
 // The columns the handlers SELECT for a neuron row.
 export const NEURON_COLUMNS =
   "uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, " +

--- a/tests/mcp-neuron-hotkey-lookup.test.ts
+++ b/tests/mcp-neuron-hotkey-lookup.test.ts
@@ -1,0 +1,324 @@
+// get_neuron by hotkey, and get_subnet_metagraph row selection (#9872).
+//
+// Driven through the real MCP dispatch rather than by calling handlers
+// directly, because half of what is under test IS the dispatch path: the
+// arguments a caller sends arrive as raw JSON, and the "exactly one of
+// uid/hotkey" rule is enforced in the handler by design (#8942).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleMcpRequest, listToolDefinitions } from "../src/mcp-server.ts";
+import { createLocalArtifactEnv } from "../scripts/lib.ts";
+import type { Row } from "./row-type.ts";
+
+const HOTKEY_A = "5GP7c3fFazW9GXK8Up3qgu2DJBk8inu4aK9TZy3RuoSWVCMi";
+const HOTKEY_B = "5CzcUxRe7rFbtGjw4DGfoJZTFqPnMwUFMTiMFURxCWmwBhqK";
+const HOTKEY_ABSENT = "5DkwfxC9mZTTCsRUt6nrnwQEWVQ4xnWDkGDMDkFHqTfxNZTP";
+
+function snapshotRows(): Row[] {
+  return [
+    { uid: 0, hotkey: HOTKEY_A, active: true, incentive: 0, stake_tao: 5 },
+    { uid: 1, hotkey: HOTKEY_B, active: true, incentive: 0.5, stake_tao: 1 },
+    { uid: 2, hotkey: null, active: false, incentive: 0.9, stake_tao: 3 },
+  ];
+}
+
+// The neurons tier answering /metagraph and /neurons/{uid}, the two paths
+// these tools reach through tryPostgresTier.
+function neuronsTierEnv() {
+  return {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_NEURONS_SOURCE: "postgres",
+    DATA_API: {
+      async fetch(input: Request | string) {
+        const url = new URL(typeof input === "string" ? input : input.url);
+        const neuronMatch = url.pathname.match(/\/neurons\/(\d+)$/);
+        if (neuronMatch) {
+          const uid = Number(neuronMatch[1]);
+          return Response.json({
+            schema_version: 1,
+            netuid: 53,
+            captured_at: "2026-08-07T16:18:31.183Z",
+            block_number: 8793568,
+            neuron: snapshotRows().find((row) => row.uid === uid) ?? null,
+          });
+        }
+        return Response.json({
+          schema_version: 1,
+          netuid: 53,
+          neuron_count: 3,
+          captured_at: "2026-08-07T16:18:31.183Z",
+          block_number: 8793568,
+          neurons: snapshotRows(),
+        });
+      },
+    },
+  };
+}
+
+async function callTool(name: string, args: Row, env = neuronsTierEnv()) {
+  const res = await handleMcpRequest(
+    new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name, arguments: args },
+      }),
+    }),
+    env as never,
+    { waitUntil() {}, passThroughOnException() {} } as never,
+  );
+  return (await res.json()) as Row;
+}
+
+function structured(body: Row): Row {
+  return (body.result as Row)?.structuredContent as Row;
+}
+
+function errorText(body: Row): string {
+  const content = ((body.result as Row)?.content ?? []) as Row[];
+  return String(content[0]?.text ?? "");
+}
+
+describe("get_neuron accepts a hotkey (#9872)", () => {
+  test("a hotkey returns that neuron, with the snapshot's own stamp", async () => {
+    const body = await callTool("get_neuron", { netuid: 53, hotkey: HOTKEY_B });
+    const data = structured(body);
+    assert.equal((data.neuron as Row).uid, 1);
+    assert.equal((data.neuron as Row).hotkey, HOTKEY_B);
+    assert.equal(data.netuid, 53);
+    // captured_at/block_number must come from the snapshot, not be invented:
+    // an agent comparing this against an off-chain source needs to know when
+    // WE sampled (#9871).
+    assert.equal(data.captured_at, "2026-08-07T16:18:31.183Z");
+    assert.equal(data.block_number, 8793568);
+  });
+
+  test("a hotkey that holds no UID here answers neuron: null, not an error", async () => {
+    const body = await callTool("get_neuron", {
+      netuid: 53,
+      hotkey: HOTKEY_ABSENT,
+    });
+    assert.equal(body.error, undefined);
+    assert.equal(structured(body).neuron, null);
+  });
+
+  test("uid still works and is unchanged", async () => {
+    const body = await callTool("get_neuron", { netuid: 53, uid: 0 });
+    assert.equal((structured(body).neuron as Row).hotkey, HOTKEY_A);
+  });
+
+  test("neither identifier is rejected, naming both options", async () => {
+    const body = await callTool("get_neuron", { netuid: 53 });
+    const text = errorText(body);
+    assert.match(text, /invalid_params/);
+    assert.match(text, /uid/);
+    assert.match(text, /hotkey/);
+  });
+
+  test("both identifiers are rejected rather than one silently winning", async () => {
+    const body = await callTool("get_neuron", {
+      netuid: 53,
+      uid: 0,
+      hotkey: HOTKEY_B,
+    });
+    assert.match(errorText(body), /invalid_params/);
+  });
+
+  test("a malformed hotkey is invalid_params, not an empty result", async () => {
+    // The distinction matters: an empty result reads as "not registered",
+    // which is a wrong answer to a typo.
+    const body = await callTool("get_neuron", {
+      netuid: 53,
+      hotkey: "not-an-ss58",
+    });
+    assert.match(errorText(body), /invalid_params/);
+  });
+
+  test("`fields` still projects the row it returns", async () => {
+    const body = await callTool("get_neuron", {
+      netuid: 53,
+      hotkey: HOTKEY_B,
+      fields: ["uid", "incentive"],
+    });
+    assert.deepEqual(Object.keys(structured(body).neuron as Row).sort(), [
+      "incentive",
+      "uid",
+    ]);
+  });
+
+  test("a cold tier answers neuron: null with a null stamp, never a stale one", async () => {
+    // No METAGRAPH_NEURONS_SOURCE, so tryPostgresTier declines and the empty
+    // snapshot builder answers. The stamp must come back null rather than
+    // being invented: "we have no snapshot" and "the snapshot says no" are
+    // different answers and a caller has to be able to tell them apart.
+    const body = await callTool(
+      "get_neuron",
+      { netuid: 53, hotkey: HOTKEY_B },
+      createLocalArtifactEnv() as never,
+    );
+    const data = structured(body);
+    assert.equal(data.neuron, null);
+    assert.equal(data.captured_at, null);
+    assert.equal(data.block_number, null);
+  });
+
+  test("a tier payload missing neurons/stamp degrades instead of throwing", async () => {
+    // The tier is a separate service; a shape it has never returned is still
+    // a shape this handler can be handed. It must not throw a 500 at an agent
+    // for it.
+    const env = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        async fetch() {
+          return Response.json({});
+        },
+      },
+    };
+    const data = structured(
+      await callTool(
+        "get_neuron",
+        { netuid: 53, hotkey: HOTKEY_B },
+        env as never,
+      ),
+    );
+    assert.equal(data.neuron, null);
+    assert.equal(data.schema_version, 1);
+    assert.equal(data.captured_at, null);
+    assert.equal(data.block_number, null);
+  });
+
+  test("the published schema states the choice, so a client can enforce it", async () => {
+    const def = listToolDefinitions().find(
+      (tool) => (tool as Row).name === "get_neuron",
+    ) as Row;
+    const input = def.inputSchema as Row;
+    // Not merely described in prose: `oneOf` of two `required` branches is
+    // exactly-one, because passing both matches both and matching two fails.
+    assert.deepEqual(input.oneOf, [
+      { required: ["uid"] },
+      { required: ["hotkey"] },
+    ]);
+    assert.deepEqual(input.required, ["netuid"]);
+  });
+});
+
+describe("get_subnet_metagraph row selection (#9872)", () => {
+  test("hotkeys narrows to those rows and reports the pre-filter total", async () => {
+    const data = structured(
+      await callTool("get_subnet_metagraph", {
+        netuid: 53,
+        hotkeys: [HOTKEY_B],
+      }),
+    );
+    assert.equal((data.neurons as Row[]).length, 1);
+    assert.equal(data.neuron_count, 1);
+    assert.equal(data.total_neuron_count, 3);
+  });
+
+  test("an unfiltered call is unchanged, including no total_neuron_count", async () => {
+    const data = structured(
+      await callTool("get_subnet_metagraph", { netuid: 53 }),
+    );
+    assert.equal(data.neuron_count, 3);
+    assert.equal(Object.hasOwn(data, "total_neuron_count"), false);
+  });
+
+  test("sort_by + limit answers a leaderboard question", async () => {
+    const data = structured(
+      await callTool("get_subnet_metagraph", {
+        netuid: 53,
+        sort_by: "incentive",
+        limit: 2,
+      }),
+    );
+    assert.deepEqual(
+      (data.neurons as Row[]).map((row) => row.uid),
+      [2, 1],
+    );
+  });
+
+  test("a sort_by that is not a numeric field is rejected", async () => {
+    // `hotkey` is a real Neuron field, so this proves the SORT vocabulary is
+    // enforced separately from the projection vocabulary rather than both
+    // falling back to NeuronSchema's full key set.
+    const body = await callTool("get_subnet_metagraph", {
+      netuid: 53,
+      sort_by: "hotkey",
+    });
+    assert.match(errorText(body), /invalid_params/);
+  });
+
+  test("a bad hotkey in the array is rejected before the fetch", async () => {
+    const body = await callTool("get_subnet_metagraph", {
+      netuid: 53,
+      hotkeys: [HOTKEY_B, "nope"],
+    });
+    assert.match(errorText(body), /invalid_params/);
+  });
+
+  test("an empty hotkeys array is rejected rather than treated as no filter", async () => {
+    const body = await callTool("get_subnet_metagraph", {
+      netuid: 53,
+      hotkeys: [],
+    });
+    assert.match(errorText(body), /invalid_params/);
+  });
+
+  test("active:false selects the inactive rows, not 'no filter'", async () => {
+    const data = structured(
+      await callTool("get_subnet_metagraph", { netuid: 53, active: false }),
+    );
+    assert.deepEqual(
+      (data.neurons as Row[]).map((row) => row.uid),
+      [2],
+    );
+  });
+
+  test("min_incentive drops the rows below the floor", async () => {
+    const data = structured(
+      await callTool("get_subnet_metagraph", {
+        netuid: 53,
+        min_incentive: 0.5,
+      }),
+    );
+    assert.deepEqual(
+      (data.neurons as Row[]).map((row) => row.uid),
+      [1, 2],
+    );
+    assert.equal(data.total_neuron_count, 3);
+  });
+
+  test("a negative min_incentive is rejected", async () => {
+    const body = await callTool("get_subnet_metagraph", {
+      netuid: 53,
+      min_incentive: -1,
+    });
+    assert.match(errorText(body), /invalid_params/);
+  });
+
+  test("limit:0 is rejected — an explicit cap of nothing is a mistake, not a request", async () => {
+    const body = await callTool("get_subnet_metagraph", {
+      netuid: 53,
+      limit: 0,
+    });
+    assert.match(errorText(body), /invalid_params/);
+  });
+
+  test("selection runs before projection, so a filter does not need its column asked for", async () => {
+    // min_incentive filters on `incentive` while the caller asks only for
+    // `uid`: if projection ran first the filter would see no incentive at all
+    // and drop every row.
+    const data = structured(
+      await callTool("get_subnet_metagraph", {
+        netuid: 53,
+        min_incentive: 0.5,
+        fields: ["uid"],
+      }),
+    );
+    assert.deepEqual(data.neurons, [{ uid: 1 }, { uid: 2 }]);
+  });
+});

--- a/tests/metagraph-neuron-selection.test.ts
+++ b/tests/metagraph-neuron-selection.test.ts
@@ -1,0 +1,257 @@
+// Row selection over a metagraph snapshot (#9872).
+//
+// The reporter's case, in numbers measured against subnet 53's real snapshot
+// on 2026-08-07 (256 neurons, 98,081 bytes): a single-hotkey lookup is 517
+// bytes, `sort_by: incentive` + `limit: 12` is 4,972. The tests below pin the
+// SEMANTICS that make those numbers correct rather than the numbers, which
+// move with the chain.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { selectNeuronRows } from "../src/metagraph-neurons.ts";
+import { NEURON_SORT_FIELD_NAMES } from "../schemas-src/mcp-tools/shared.ts";
+import { NeuronSchema } from "../schemas-src/routes/subnet-metagraph.ts";
+import type { Row } from "./row-type.ts";
+
+// Five neurons covering every branch the selector has: a zero incentive, a
+// null one, a duplicate value (to force the uid tiebreak), and an inactive row.
+function snapshot(): Row {
+  return {
+    schema_version: 1,
+    netuid: 53,
+    neuron_count: 5,
+    captured_at: "2026-08-07T16:18:31.183Z",
+    block_number: 8793568,
+    neurons: [
+      { uid: 0, hotkey: "hk-a", active: true, incentive: 0, stake_tao: 5 },
+      { uid: 1, hotkey: "hk-b", active: true, incentive: 0.5, stake_tao: 1 },
+      { uid: 2, hotkey: "hk-c", active: false, incentive: 0.9, stake_tao: 3 },
+      { uid: 3, hotkey: "hk-d", active: true, incentive: null, stake_tao: 9 },
+      { uid: 4, hotkey: "hk-e", active: true, incentive: 0.5, stake_tao: 2 },
+    ],
+  };
+}
+
+const uids = (data: Row) => (data.neurons as Row[]).map((n) => n.uid);
+
+describe("selectNeuronRows (#9872)", () => {
+  test("an empty selection returns the very same object", () => {
+    const data = snapshot();
+    // Identity, not deep equality: the unfiltered response must stay
+    // byte-identical for every existing caller, and a fresh object that
+    // merely looks the same would still have gained total_neuron_count.
+    assert.equal(selectNeuronRows(data, {}), data);
+    assert.equal(
+      Object.hasOwn(selectNeuronRows(data, {}), "total_neuron_count"),
+      false,
+    );
+  });
+
+  test("hotkeys returns only those rows, and an unregistered one is absent rather than an error", () => {
+    const picked = selectNeuronRows(snapshot(), {
+      hotkeys: ["hk-c", "hk-not-registered"],
+    });
+    assert.deepEqual(uids(picked), [2]);
+    assert.equal(picked.neuron_count, 1);
+    // The whole point of the pair: 1 of 5, not a bare 1 that reads as the
+    // size of the subnet.
+    assert.equal(picked.total_neuron_count, 5);
+  });
+
+  test("active distinguishes false from absent", () => {
+    assert.deepEqual(
+      uids(selectNeuronRows(snapshot(), { active: true })),
+      [0, 1, 3, 4],
+    );
+    assert.deepEqual(
+      uids(selectNeuronRows(snapshot(), { active: false })),
+      [2],
+    );
+    // Absent must not narrow to the false rows -- the tri-state bug this
+    // helper's optionalNullableBoolean exists to prevent.
+    assert.deepEqual(uids(selectNeuronRows(snapshot(), {})), [0, 1, 2, 3, 4]);
+  });
+
+  test("a floor is inclusive, and a null incentive never clears it", () => {
+    // min_incentive: 0 keeps the zero population (uid 0) -- documented, and
+    // the reason the tool description points at sort_by+limit instead for
+    // "only the neurons actually earning".
+    assert.deepEqual(
+      uids(selectNeuronRows(snapshot(), { minIncentive: 0 })),
+      [0, 1, 2, 4],
+    );
+    assert.deepEqual(
+      uids(selectNeuronRows(snapshot(), { minIncentive: 0.5 })),
+      [1, 2, 4],
+    );
+    assert.deepEqual(
+      uids(selectNeuronRows(snapshot(), { minIncentive: 1 })),
+      [],
+    );
+  });
+
+  test("null sorts last in BOTH directions, and ties break by uid", () => {
+    // uid 3 is the null; it trails in each direction rather than leading the
+    // ascending one, which is the difference between "unranked" and "worst".
+    assert.deepEqual(
+      uids(selectNeuronRows(snapshot(), { sortBy: "incentive" })),
+      [2, 1, 4, 0, 3],
+    );
+    assert.deepEqual(
+      uids(selectNeuronRows(snapshot(), { sortBy: "incentive", order: "asc" })),
+      [0, 1, 4, 2, 3],
+    );
+    // uid 1 and uid 4 both sit at 0.5 and keep uid order in both directions.
+    assert.deepEqual(
+      uids(selectNeuronRows(snapshot(), { sortBy: "incentive" })).slice(1, 3),
+      [1, 4],
+    );
+  });
+
+  test("sort defaults to descending, because a sort here asks who is on top", () => {
+    assert.deepEqual(
+      uids(selectNeuronRows(snapshot(), { sortBy: "stake_tao" })),
+      uids(
+        selectNeuronRows(snapshot(), { sortBy: "stake_tao", order: "desc" }),
+      ),
+    );
+    assert.deepEqual(
+      uids(selectNeuronRows(snapshot(), { sortBy: "stake_tao" })),
+      [3, 0, 2, 4, 1],
+    );
+  });
+
+  test("limit applies after the filter and the sort", () => {
+    const top = selectNeuronRows(snapshot(), {
+      active: true,
+      sortBy: "incentive",
+      limit: 2,
+    });
+    // uid 2 has the highest incentive but is inactive, so the filter drops it
+    // BEFORE the sort picks a top two -- a limit applied first would have
+    // returned it.
+    assert.deepEqual(uids(top), [1, 4]);
+    assert.equal(top.neuron_count, 2);
+    assert.equal(top.total_neuron_count, 5);
+  });
+
+  test("a sort alone reports no total_neuron_count, because it removed nothing", () => {
+    const sorted = selectNeuronRows(snapshot(), { sortBy: "incentive" });
+    assert.equal(sorted.neuron_count, 5);
+    assert.equal(Object.hasOwn(sorted, "total_neuron_count"), false);
+    // A limit that is larger than the snapshot is also not a narrowing.
+    const generous = selectNeuronRows(snapshot(), { limit: 500 });
+    assert.equal(Object.hasOwn(generous, "total_neuron_count"), false);
+  });
+
+  test("neuron_count always equals neurons.length", () => {
+    for (const selection of [
+      {},
+      { hotkeys: ["hk-a"] },
+      { active: true },
+      { minIncentive: 0.5 },
+      { sortBy: "stake_tao", limit: 3 },
+      { hotkeys: ["hk-nobody"] },
+    ]) {
+      const result = selectNeuronRows(snapshot(), selection);
+      assert.equal(result.neuron_count, (result.neurons as Row[]).length);
+    }
+  });
+
+  test("a non-finite sort value is treated as null, not as a number", () => {
+    // NaN/Infinity compare false against everything, so letting one through
+    // would make the whole order depend on where it happened to sit. It takes
+    // the same last-place branch a null does.
+    const rows = [
+      { uid: 0, stake_tao: 2 },
+      { uid: 1, stake_tao: Number.NaN },
+      { uid: 2, stake_tao: Number.POSITIVE_INFINITY },
+      { uid: 3, stake_tao: 7 },
+    ];
+    assert.deepEqual(
+      uids(selectNeuronRows({ neurons: rows }, { sortBy: "stake_tao" })),
+      [3, 0, 1, 2],
+    );
+  });
+
+  test("rows with no uid still order deterministically", () => {
+    // The tiebreak reads `uid`; a row without one must not make the sort
+    // depend on arrival order. Two of them tie with each other and trail the
+    // rows that have one.
+    const rows = [
+      { hotkey: "hk-x", stake_tao: 1 },
+      { uid: 5, stake_tao: 1 },
+      { hotkey: "hk-y", stake_tao: 1 },
+    ];
+    const sorted = selectNeuronRows({ neurons: rows }, { sortBy: "stake_tao" });
+    assert.deepEqual(
+      (sorted.neurons as Row[]).map((row) => row.uid ?? row.hotkey),
+      [5, "hk-x", "hk-y"],
+    );
+  });
+
+  test("a payload with no neurons array is passed through untouched", () => {
+    // buildNeuronDetail's single-row shape goes through the same handler path
+    // on the hotkey branch; it must not acquire a neurons array here.
+    const detail = { schema_version: 1, netuid: 53, neuron: null };
+    assert.equal(selectNeuronRows(detail, { limit: 1 }), detail);
+  });
+});
+
+describe("NEURON_SORT_FIELD_NAMES (#9872)", () => {
+  test("is every numeric field of NeuronSchema, and only those", () => {
+    // Asserted against the schema rather than against a copied list: the
+    // point of deriving it is that a numeric field added to the contract
+    // becomes sortable with no list to update, and a test carrying its own
+    // copy would defeat that on the first addition.
+    const numericByName = Object.entries(NeuronSchema.shape).filter(
+      ([, schema]) => {
+        let cur = schema as {
+          _zod?: { def?: { type?: string; innerType?: unknown } };
+        };
+        for (let depth = 0; depth < 8; depth += 1) {
+          const type = cur?._zod?.def?.type;
+          if (
+            type === "optional" ||
+            type === "nullable" ||
+            type === "default"
+          ) {
+            cur = cur._zod!.def!.innerType as typeof cur;
+            continue;
+          }
+          return type === "number";
+        }
+        return false;
+      },
+    );
+    assert.deepEqual(
+      [...NEURON_SORT_FIELD_NAMES].sort(),
+      numericByName.map(([name]) => name).sort(),
+    );
+    // A negative assertion passes on an empty set, so prove the set is real
+    // and that a known string field really is excluded (#9689).
+    assert.ok(NEURON_SORT_FIELD_NAMES.length >= 10);
+    assert.equal(NEURON_SORT_FIELD_NAMES.includes("hotkey"), false);
+    assert.equal(NEURON_SORT_FIELD_NAMES.includes("incentive"), true);
+  });
+
+  test("every sortable name actually sorts", () => {
+    // Guards the case where the derivation drifts from the comparator -- a
+    // published enum value that silently no-ops is the defect #9750 fixed on
+    // list_gaps, and this is the same shape.
+    for (const field of NEURON_SORT_FIELD_NAMES) {
+      // When `field` IS "uid" the two keys collapse into one, so the rows
+      // carry the sort values as their uids -- hence the second expectation.
+      const rows = [
+        { uid: 0, [field]: 1 },
+        { uid: 1, [field]: 3 },
+        { uid: 2, [field]: 2 },
+      ];
+      const sorted = selectNeuronRows({ neurons: rows }, { sortBy: field });
+      assert.deepEqual(
+        uids(sorted),
+        field === "uid" ? [3, 2, 1] : [1, 2, 0],
+        `sort_by: ${field} did not order the rows`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

An external agent operating an SN53 miner reported that answering **"what incentive does hotkey `5Cz196…GdNS` have"** cost a **~24k-token response**: `get_neuron` took only `(netuid, uid)`, so the only way in from a hotkey was to pull all 256 metagraph rows and filter client-side.

`fields` could not fix it. **The row count dominates this payload, not the column count** — a three-field projection of subnet 53 still measured ~24k tokens, because a hotkey is 48 characters and there are 256 of them. Projection is a column fix for a row problem.

## What changed

**`get_neuron` takes EITHER `uid` OR `hotkey`.** The choice is *published*, not just described — `oneOf` of two `required` branches is exactly-one, since passing both matches both branches and matching two fails `oneOf`. A hotkey holding no UID answers `neuron: null`, which is the answer to "is it still registered", not an error.

**`get_subnet_metagraph` gains five row-selecting parameters** — `hotkeys`, `active`, `min_incentive`, `sort_by`/`order`, `limit` — applied in that order and always **before** `fields`, so a filter never depends on whether the caller happened to project the column being filtered on.

Measured against subnet 53's real snapshot on 2026-08-07 (256 neurons, 98,081 bytes):

| call | bytes | change |
|---|---:|---:|
| full response (today) | 98,081 | — |
| `hotkeys: ["5Cz…"]` | 517 | **−99%** |
| `sort_by: incentive`, `limit: 12` | 4,972 | **−95%** |
| `min_incentive` above 0 (103 of 256 earning) | 41,221 | −58% |

**A narrowed response carries `total_neuron_count`.** Without it a filtered call answers `neuron_count: 12` for a 256-neuron subnet, which reads as a measurement of the *subnet* rather than of the *response* — the confident-zero failure #9307 is about. It appears only when a selection actually removed rows, so an unfiltered response stays byte-identical.

**The sortable vocabulary is derived from `NeuronSchema`'s numeric fields**, not listed — same reason `NEURON_FIELD_NAMES` is, so a numeric field added to the contract becomes sortable the day it lands. **Nulls order LAST in both directions**: `rank` is null for the whole zero-incentive population, and ordering ascending would otherwise put every unranked neuron ahead of rank 1.

## A gate blind spot this exposed

`validate:mcp` builds each tool's arguments from `required`, so a tool publishing a *choice* would be called with no identifier at all and its own correct rejection would read as a broken contract. It now follows a **presence-only** `oneOf`/`anyOf` branch — and deliberately **not** a value-conditional one: `get_feed` publishes "`kind: "subnet"` requires `netuid`", and adopting that branch produced `{kind: "registry", netuid: 64}`, which the server rightly refuses.

## Verification

- **Production, before shipping**: subnet 53's live 256-neuron snapshot pulled and run through the selector — `active` and `incentive` arrive as real booleans/numbers on the tier path, and today's split is 103 earning / 153 at exactly zero / 0 null.
- **Every new response shape validated against its own published `outputSchema`** with Ajv2020 — 9 cases including each `fields`-projected one, which is the regression class of #9884.
- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean.
- `npm run validate:mcp`, `validate:contract-drift`, `validate:schemas`, `validate:schema-opacity`, `validate:single-schema-source`, `validate:schema-vocabularies` — pass.
- 35 new tests; 1,800 pass across the affected suites.
- **Patch coverage measured by diff∩coverage intersection: 59/59 changed executable lines in `src/**`, zero uncovered branches.**

Closes #9872