### PR TITLE
feat(mcp): let a multi-subnet sweep opt out of the repeated economics summary

### DIFF
--- a/schemas-src/mcp-tools/get-subnet-economics.ts
+++ b/schemas-src/mcp-tools/get-subnet-economics.ts
@@ -9,6 +9,23 @@ import { OpenObjectSchema, netuidSchema } from "./shared.ts";
 export const GetSubnetEconomicsInputSchema = z
   .object({
     netuid: netuidSchema(),
+    // #9874: the summary block is network-wide, so a per-subnet sweep receives
+    // the identical object once per subnet. Defaulted to `true` rather than to
+    // the reporter's suggested `false`: dropping a field every existing caller
+    // currently receives is a breaking change, and this parameter is worth
+    // having on its own before that is worth arguing about.
+    include_summary: z
+      .boolean()
+      .optional()
+      .describe(
+        "Include the network-wide `summary` block (default `true`). PASS " +
+          "`false` WHEN SWEEPING MORE THAN ONE SUBNET: the block is identical " +
+          "on every call, so 129 subnets means receiving the same aggregate " +
+          "129 times — about 19% of the response, measured on 2026-08-07. " +
+          "With `false` the key is `null` rather than absent, so a caller " +
+          "reading it does not have to branch on presence.",
+      )
+      .meta({ examples: [false] }),
   })
   .strict();
 export type GetSubnetEconomicsInput = z.infer<

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -2938,7 +2938,11 @@ function mcpAccountIdentityHistoryRequest(
 
 // One subnet's economics: live KV tier (KV-primary), else the committed R2
 // snapshot — the precedence /api/v1/economics uses. A missing row → economics:null.
-async function loadSubnetEconomics(ctx: McpCtx, netuid: number) {
+async function loadSubnetEconomics(
+  ctx: McpCtx,
+  netuid: number,
+  { includeSummary = true }: { includeSummary?: boolean } = {},
+) {
   const live = await resolveLiveEconomics({
     readHealthKv: ctx.readHealthKv,
     env: ctx.env,
@@ -2950,7 +2954,12 @@ async function loadSubnetEconomics(ctx: McpCtx, netuid: number) {
     netuid,
     source: live?.source || "r2-fallback",
     captured_at: blob?.captured_at ?? null,
-    summary: blob?.summary ?? null,
+    // #9874: null rather than omitted when the caller opted out. `summary` is
+    // already nullable (no economics blob yields null), so a caller reading it
+    // branches on the same value it always did -- an omitted key would make
+    // "you asked me not to" indistinguishable from "there is no blob" only by
+    // remembering which argument you sent.
+    summary: includeSummary ? (blob?.summary ?? null) : null,
     economics:
       withSpotPrice(
         blob?.subnets?.find((row: Row) => row?.netuid === netuid),
@@ -4917,7 +4926,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       "subnet receives — spec 440 separates them by MinerBurned reweighting, " +
       "the Hill emission gate, the SubnetEmissionEnabled filter, the alpha " +
       "injection cap, and the liquidity balancer. Do not present it as TAO " +
-      "earned or emitted. get_network_parameters carries the gate parameters.",
+      "earned or emitted. get_network_parameters carries the gate parameters. " +
+      "SWEEPING SEVERAL SUBNETS? Pass `include_summary: false` — the `summary` " +
+      "block is network-wide and identical on every call, so it is about 19% " +
+      "of each response repeated once per subnet.",
     inputSchema: z.toJSONSchema(GetSubnetEconomicsInputSchema, {
       target: "draft-2020-12",
     }),
@@ -4926,7 +4938,12 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       ctx: McpCtx,
     ) {
       const netuid = requireNetuid(args);
-      return loadSubnetEconomics(ctx, netuid);
+      return loadSubnetEconomics(ctx, netuid, {
+        // Absent means include, matching the published default -- optionalBoolean
+        // defaults an absent flag to false, which is the wrong way round here.
+        includeSummary:
+          optionalNullableBoolean(args, "include_summary") ?? true,
+      });
     },
   },
   {

--- a/tests/mcp-economics-summary-optout.test.ts
+++ b/tests/mcp-economics-summary-optout.test.ts
@@ -1,0 +1,149 @@
+// `include_summary` on get_subnet_economics (#9874).
+//
+// The block is network-wide, so a caller sweeping 129 subnets receives the
+// identical object 129 times -- ~19% of each response, measured against
+// production on 2026-08-07 (1,658 bytes total, 315 of them summary).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleMcpRequest, listToolDefinitions } from "../src/mcp-server.ts";
+import type { Row } from "./row-type.ts";
+
+// The economics blob this tool reads, with the network-wide `summary` the
+// parameter under test drops. Served through the same readArtifact dep the
+// production loader calls, so the opt-out is exercised on the real path.
+const ECONOMICS = {
+  captured_at: "2026-08-07T15:00:00.000Z",
+  summary: {
+    subnet_count: 129,
+    with_economics_count: 129,
+    total_stake_alpha: 12345.6,
+    total_validators: 8100,
+    total_miners: 21000,
+    registration_open_count: 111,
+  },
+  subnets: [
+    {
+      netuid: 1,
+      validator_count: 64,
+      miner_count: 192,
+      registration_open: true,
+      alpha_price: 0.0325,
+      emission_share: 0.041,
+    },
+  ],
+};
+
+function deps(artifacts: Row = { "/metagraph/economics.json": ECONOMICS }) {
+  return {
+    readArtifact(_env: unknown, path: string) {
+      return Promise.resolve(
+        Object.hasOwn(artifacts, path)
+          ? {
+              ok: true,
+              data: artifacts[path],
+              source: "test",
+              storage_tier: "git",
+            }
+          : {
+              ok: false,
+              status: 404,
+              code: "artifact_not_found",
+              message: path,
+            },
+      );
+    },
+    readHealthKv() {
+      return Promise.resolve(null);
+    },
+  };
+}
+
+async function callTool(args: Row, artifacts?: Row) {
+  const res = await handleMcpRequest(
+    new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "get_subnet_economics", arguments: args },
+      }),
+    }),
+    {} as never,
+    deps(artifacts) as never,
+  );
+  const body = (await res.json()) as Row;
+  return {
+    data: (body.result as Row)?.structuredContent as Row,
+    text: String(
+      (((body.result as Row)?.content ?? []) as Row[])[0]?.text ?? "",
+    ),
+  };
+}
+
+describe("get_subnet_economics include_summary (#9874)", () => {
+  test("omitted keeps the summary, so no existing caller changes", async () => {
+    const { data } = await callTool({ netuid: 1 });
+    assert.ok(Object.hasOwn(data, "summary"));
+    assert.equal(data.netuid, 1);
+    // Every sibling field is asserted BY NAME, not by comparing two calls to
+    // each other: writing this change I dropped `captured_at` from the
+    // loader, and a same-vs-same comparison passes happily when a field is
+    // missing from both sides.
+    assert.equal(data.captured_at, "2026-08-07T15:00:00.000Z");
+    assert.equal(data.source, "r2-fallback");
+    assert.equal((data.economics as Row).emission_share, 0.041);
+  });
+
+  test("true is the same as omitted", async () => {
+    const [omitted, explicit] = await Promise.all([
+      callTool({ netuid: 1 }),
+      callTool({ netuid: 1, include_summary: true }),
+    ]);
+    assert.deepEqual(omitted.data, explicit.data);
+  });
+
+  test("false nulls the summary and leaves everything else alone", async () => {
+    const [withSummary, without] = await Promise.all([
+      callTool({ netuid: 1 }),
+      callTool({ netuid: 1, include_summary: false }),
+    ]);
+    assert.equal(without.data.summary, null);
+    // The opt-out drops the summary and NOTHING else.
+    assert.equal(without.data.captured_at, "2026-08-07T15:00:00.000Z");
+    assert.equal((without.data.economics as Row).emission_share, 0.041);
+    // Null rather than absent: a caller reading `summary` gets the same value
+    // the no-blob case already produced, instead of having to branch on
+    // whether the key exists.
+    assert.equal(Object.hasOwn(without.data, "summary"), true);
+    assert.deepEqual(
+      { ...without.data, summary: undefined },
+      { ...withSummary.data, summary: undefined },
+    );
+  });
+
+  test("a non-boolean is rejected rather than coerced", async () => {
+    // "false" the string is the mistake worth catching: coercing it would
+    // silently include the block the caller asked to drop.
+    const { text } = await callTool({ netuid: 1, include_summary: "false" });
+    assert.match(text, /invalid_params/);
+  });
+
+  test("the parameter is published with an example a sweep would copy", async () => {
+    const def = listToolDefinitions().find(
+      (tool) => (tool as Row).name === "get_subnet_economics",
+    ) as Row;
+    const input = def.inputSchema as Row;
+    const param = (input.properties as Row).include_summary as Row;
+    assert.equal(param.type, "boolean");
+    // The example is `false`, because `true` is the default and an example
+    // showing the default teaches nothing.
+    assert.deepEqual(param.examples, [false]);
+    assert.equal(
+      (input.required as string[]).includes("include_summary"),
+      false,
+    );
+    assert.match(String(def.description), /include_summary/);
+  });
+});


### PR DESCRIPTION
## Summary

`get_subnet_economics` embeds a **network-wide** `summary` block on every call, so an agent walking the registry receives the identical aggregate once per subnet. The external report that raised #9871–#9873 called this *"pure repetition across a multi-subnet sweep"* — the only item on their list they classified as pure waste.

Measured against production on 2026-08-07:

| | bytes |
|---|---:|
| one `get_subnet_economics` response | 1,658 |
| of which `summary` | 315 (**19%**) |
| a 129-subnet sweep today | 213,882 |
| the same sweep with `include_summary: false` | 173,562 (**−19%**) |

## Two deliberate choices

**Defaults to `true`, not to the reporter's suggested `false`.** Dropping a field every existing caller currently receives is a breaking change, and the parameter is worth having before that is worth arguing about. The tool description says plainly that a sweep should pass `false`, and the published example is `false` — an example showing the default teaches nothing. Revisiting the default belongs with usage data, separately.

**Opting out sets `summary` to `null` rather than omitting the key.** `summary` is already nullable (a missing economics blob yields `null`), so a caller reads the same value it always did — instead of "you asked me not to" being distinguishable from "there is no blob" only by remembering which argument was sent.

## One thing worth flagging

Writing this I dropped `captured_at` from `loadSubnetEconomics` while restructuring its return. The **existing** suite caught it, not my new tests — which compared the two calls to each other, and a same-vs-same comparison passes happily when a field is missing from both sides. The new tests now assert every sibling field **by name**, with that reason written next to them.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean.
- `npm run validate:mcp`, `validate:contract-drift` — pass.
- 5 new tests; 1,373 pass across the affected suites.
- Patch coverage by diff∩coverage intersection: **1/1 changed executable line in `src/**`**, no uncovered branches.

Closes #9874