### PR TITLE
feat(neon): reconcile the five low-churn history tables

### DIFF
--- a/src/neon-backfill.ts
+++ b/src/neon-backfill.ts
@@ -314,6 +314,105 @@ const ACCOUNT_IDENTITY_COLUMNS = [
  * added for #9814 do nothing until both their Neon tables exist and the flag
  * lists them.
  */
+/**
+ * The five LOW-CHURN history tables (#9895), read off pragma_table_info
+ * 2026-08-07. 895 rows between them.
+ *
+ * `subnet_burn_history` and `tao_usd_index` are deliberately NOT here despite
+ * sharing the schema family. They are high-churn -- 12,255 and 1,440 rows a
+ * DAY respectively, measured -- and a `whole` plan recopies the entire table
+ * whenever the signature moves. For subnet_burn_history that is 36,894 rows
+ * rewritten every hour to add ~510. Those two need a live mirror so the
+ * reconciler idles, and get plans once they have one.
+ *
+ * `id` IS ABSENT FROM ALL FOUR AUTOINCREMENT TABLES, deliberately. Neon
+ * declares it GENERATED ALWAYS and assigns its own, because a mirror cannot
+ * preserve a value D1 hands out at insert time. That costs nothing: the
+ * natural key is unique in every one of them (531/531, 137/137, 123/123,
+ * 77/77 measured), so D1's own `(account, observed_at DESC, id DESC)` ordering
+ * never reaches the id tiebreaker.
+ */
+const ACCOUNT_IDENTITY_HISTORY_COLUMNS = [
+  "account",
+  "observed_at",
+  "name",
+  "url",
+  "github",
+  "image",
+  "discord",
+  "description",
+  "additional",
+  "identity_hash",
+] as const;
+
+const SUBNET_HYPERPARAMS_HISTORY_COLUMNS = [
+  "netuid",
+  "block_number",
+  "observed_at",
+  "kappa_ratio",
+  "immunity_period",
+  "min_allowed_weights",
+  "max_weight_limit_ratio",
+  "tempo",
+  "weights_version",
+  "weights_rate_limit",
+  "activity_cutoff",
+  "activity_cutoff_factor",
+  "registration_allowed",
+  "target_regs_per_interval",
+  "min_burn_tao",
+  "max_burn_tao",
+  "burn_half_life",
+  "burn_increase_mult",
+  "bonds_moving_avg_raw",
+  "max_regs_per_block",
+  "serving_rate_limit",
+  "max_validators",
+  "commit_reveal_period",
+  "commit_reveal_enabled",
+  "alpha_high_ratio",
+  "alpha_low_ratio",
+  "liquid_alpha_enabled",
+  "alpha_sigmoid_steepness",
+  "yuma_version",
+  "subnet_is_active",
+  "transfers_enabled",
+  "bonds_reset_enabled",
+  "user_liquidity_enabled",
+  "owner_cut_enabled",
+  "owner_cut_auto_lock_enabled",
+  "min_childkey_take_ratio",
+  "hyperparams_hash",
+] as const;
+
+const EMISSION_GATE_PARAM_HISTORY_COLUMNS = [
+  "param",
+  "value",
+  "previous_value",
+  "source",
+  "block_number",
+  "observed_at",
+  "predates_capture",
+] as const;
+
+const SUBNET_EMISSION_ENABLED_HISTORY_COLUMNS = [
+  "netuid",
+  "enabled",
+  "previous_enabled",
+  "block_number",
+  "observed_at",
+  "predates_capture",
+] as const;
+
+const CHAIN_CONCENTRATION_DAILY_COLUMNS = [
+  "day",
+  "neuron_count",
+  "card",
+  "source_captured_at",
+  "computed_at",
+  "builder_version",
+] as const;
+
 export const NEON_BACKFILL_PLANS: Readonly<Record<string, BackfillPlan>> = {
   neuron_daily: {
     table: "neuron_daily",
@@ -405,6 +504,68 @@ export const NEON_BACKFILL_PLANS: Readonly<Record<string, BackfillPlan>> = {
     keyset: ["account"],
     partition: "whole",
     booleans: [],
+  },
+  // The five low-churn history tables (#9895). Four are APPEND-ONLY -- a row,
+  // once written, is never rewritten -- so `freshness: null` and the signature
+  // degrades to COUNT, which is complete for them.
+  account_identity_history: {
+    table: "account_identity_history",
+    columns: ACCOUNT_IDENTITY_HISTORY_COLUMNS,
+    conflict: ["account", "observed_at"],
+    keyset: ["account", "observed_at"],
+    partition: "whole",
+    booleans: [],
+    freshness: null,
+  },
+  subnet_hyperparams_history: {
+    table: "subnet_hyperparams_history",
+    columns: SUBNET_HYPERPARAMS_HISTORY_COLUMNS,
+    conflict: ["netuid", "observed_at"],
+    keyset: ["netuid", "observed_at"],
+    partition: "whole",
+    booleans: [
+      "registration_allowed",
+      "commit_reveal_enabled",
+      "liquid_alpha_enabled",
+      "subnet_is_active",
+      "transfers_enabled",
+      "bonds_reset_enabled",
+      "user_liquidity_enabled",
+      "owner_cut_enabled",
+      "owner_cut_auto_lock_enabled",
+    ],
+    freshness: null,
+  },
+  emission_gate_param_history: {
+    table: "emission_gate_param_history",
+    columns: EMISSION_GATE_PARAM_HISTORY_COLUMNS,
+    conflict: ["param", "observed_at"],
+    keyset: ["param", "observed_at"],
+    partition: "whole",
+    booleans: ["predates_capture"],
+    freshness: null,
+  },
+  subnet_emission_enabled_history: {
+    table: "subnet_emission_enabled_history",
+    columns: SUBNET_EMISSION_ENABLED_HISTORY_COLUMNS,
+    conflict: ["netuid", "observed_at"],
+    keyset: ["netuid", "observed_at"],
+    partition: "whole",
+    booleans: ["enabled", "previous_enabled", "predates_capture"],
+    freshness: null,
+  },
+  // The ONE exception in the family: keyed on `day`, and today's row is
+  // RECOMPUTED as the day fills in. COUNT alone would let the two stores hold
+  // 27 rows each and disagree about today's card indefinitely, so this one
+  // compares on computed_at.
+  chain_concentration_daily: {
+    table: "chain_concentration_daily",
+    columns: CHAIN_CONCENTRATION_DAILY_COLUMNS,
+    conflict: ["day"],
+    keyset: ["day"],
+    partition: "whole",
+    booleans: [],
+    freshness: "computed_at",
   },
 };
 

--- a/src/neon-parity-watchdog.ts
+++ b/src/neon-parity-watchdog.ts
@@ -70,6 +70,14 @@ export const PARITY_TABLES = [
   "subnet_snapshots",
   "subnet_hyperparams",
   "account_identity",
+  // The five low-churn history tables (#9895). Adding them takes the list past
+  // ten, which is why the sweep had to be batched first (#9881): D1 parses at
+  // most five UNION ALL terms and fails the WHOLE statement above that.
+  "account_identity_history",
+  "subnet_hyperparams_history",
+  "emission_gate_param_history",
+  "subnet_emission_enabled_history",
+  "chain_concentration_daily",
 ] as const;
 
 /**

--- a/tests/neon-backfill.test.ts
+++ b/tests/neon-backfill.test.ts
@@ -207,12 +207,46 @@ describe("NEON_BACKFILL_PLANS", () => {
     // an updated-in-place row is drift with no count difference, and nothing
     // else would catch it. So the exemption is named per plan rather than
     // inherited by default.
-    const APPEND_ONLY: readonly string[] = [];
+    // Each of these was checked against production before being listed: a
+    // row, once written, is never rewritten. The AUTOINCREMENT four are
+    // append-only by construction (a new observation is a new row, never an
+    // edit of an old one), which is also why their natural keys are unique.
+    //
+    // chain_concentration_daily is NOT here on purpose -- today's row is
+    // recomputed as the day fills in, so it declares freshness "computed_at"
+    // and never reaches this check.
+    const APPEND_ONLY: readonly string[] = [
+      "account_identity_history",
+      "subnet_hyperparams_history",
+      "emission_gate_param_history",
+      "subnet_emission_enabled_history",
+    ];
     for (const [name, plan] of Object.entries(NEON_BACKFILL_PLANS)) {
       if (freshnessColumn(plan) !== null) continue;
       assert.ok(
         APPEND_ONLY.includes(name),
         `${name} has no freshness column; add it to APPEND_ONLY with the reason its rows are never rewritten`,
+      );
+    }
+  });
+
+  test("the AUTOINCREMENT histories conflict on the NATURAL key, not id", () => {
+    // Neon assigns its own id (GENERATED ALWAYS), so an id conflict target
+    // would never match and every reconcile would insert duplicates. The
+    // natural key is what identifies the row in BOTH stores -- measured unique
+    // in all four: 531/531, 137/137, 123/123, 77/77.
+    const byNaturalKey: Record<string, string[]> = {
+      account_identity_history: ["account", "observed_at"],
+      subnet_hyperparams_history: ["netuid", "observed_at"],
+      emission_gate_param_history: ["param", "observed_at"],
+      subnet_emission_enabled_history: ["netuid", "observed_at"],
+    };
+    for (const [name, key] of Object.entries(byNaturalKey)) {
+      const plan = NEON_BACKFILL_PLANS[name];
+      assert.deepEqual([...plan.conflict], key, `${name} conflict`);
+      assert.ok(
+        !plan.columns.includes("id"),
+        `${name} must not carry id: Neon declares it GENERATED ALWAYS and refuses an explicit value`,
       );
     }
   });

--- a/tests/neon-sql-portability.test.ts
+++ b/tests/neon-sql-portability.test.ts
@@ -146,6 +146,18 @@ const BOOLEAN_COLUMNS = [
   "user_liquidity_enabled",
   "owner_cut_enabled",
   "owner_cut_auto_lock_enabled",
+  // #9895's history plans. `enabled` and `previous_enabled` are
+  // subnet_emission_enabled_history's, and `predates_capture` is shared by it
+  // and emission_gate_param_history.
+  //
+  // `enabled` is the one genuinely generic name in this list. It is still
+  // correct to guard: the rules only run over SQL that can reach Neon (the
+  // movable routes, their tagged templates and their loaders), and within that
+  // set `enabled` belongs to a BOOLEAN column. A D1-only query elsewhere is
+  // never scanned.
+  "enabled",
+  "previous_enabled",
+  "predates_capture",
 ] as const;
 
 /** Comparisons and aggregates that only work against ONE of the two schemas. */

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -204,7 +204,7 @@
     // Naming a latest-only table here would copy 800,000 rows to prove they
     // already agree, which is why this is a third flag rather than a reuse of
     // the write list.
-    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,nominator_positions",
+    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily",
     "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",
     // THE QUEUE CUTOVER (metagraphed-infra#348). Comma-separated lanes whose D1


### PR DESCRIPTION
Closes #9901. #9896 created the tables; nothing populated them.

| table | rows | conflict key | freshness |
|---|---:|---|---|
| `account_identity_history` | 531 | `(account, observed_at)` | `null` |
| `subnet_hyperparams_history` | 137 | `(netuid, observed_at)` | `null` |
| `emission_gate_param_history` | 123 | `(param, observed_at)` | `null` |
| `subnet_emission_enabled_history` | 77 | `(netuid, observed_at)` | `null` |
| `chain_concentration_daily` | 27 | `(day)` | `computed_at` |

895 rows total, so a `whole` partition is genuinely cheap.

## Two tables from the same migration are excluded, on measurement

`subnet_burn_history` and `tao_usd_index` take **12,255** and **1,440 rows a day**. A `whole` plan recopies the whole table whenever the signature moves — for `subnet_burn_history` that is 36,894 rows rewritten hourly to add ~510, on a table three days old and heading for ~1.1M. They need a live mirror so the reconciler idles. A plan without one would be wasteful by construction.

## `chain_concentration_daily` is not append-only

Keyed on `day`; today's row is recomputed as the day fills in. `COUNT` alone would let both stores hold 27 rows and disagree about today's card indefinitely — so `freshness: "computed_at"`, while the other four take the `null` exemption #9886 added.

## The AUTOINCREMENT four conflict on the NATURAL key

Neon declares `id GENERATED ALWAYS`, so an `id` conflict target would never match and every reconcile would insert duplicates rather than settle. Natural keys measured unique in all four — 531/531, 137/137, 123/123, 77/77. A test pins the conflict target **and** that no plan carries `id`.

## Two guards did their job during this change

- `PARITY_TABLES` goes 10 → 15, which only parses because #9883 batched the sweep under D1's five-term cap first.
- The portability gate **failed on this diff** until `enabled`, `previous_enabled` and `predates_capture` joined `BOOLEAN_COLUMNS` — it derives that set from the plans precisely so a new boolean column cannot arrive unguarded.

242 tests pass across the 9 affected suites.
