### PR TITLE
fix(telemetry): gate $exception storms fleet-wide and stop billing expected conditions as errors

### DIFF
--- a/apps/ui/wrangler.jsonc
+++ b/apps/ui/wrangler.jsonc
@@ -56,6 +56,16 @@
   // file -- it never reads this config either way (it writes its own trusted
   // wrangler.preview.json and uses `wrangler versions upload`).
   "workers_dev": false,
+  // Bring this config in line with the four backend ones (#9900), which have
+  // carried both of these since #9435. Without them, an exception thrown in
+  // the SSR Worker arrives in PostHog with a minified, unmapped stack and no
+  // way to say which deploy produced it -- so a regression cannot be tied to
+  // the release that introduced it. `upload_source_maps` covers the SERVER
+  // bundle; the CLIENT bundle's maps are uploaded separately by
+  // @posthog/rollup-plugin in vite.config.ts, which is why this file
+  // previously looked already-covered and was not.
+  "upload_source_maps": true,
+  "version_metadata": { "binding": "CF_VERSION_METADATA" },
   // Run the SSR Worker in the Cloudflare PoP nearest the data it talks to
   // (api.metagraph.sh), not nearest the visitor — lowers SSR fetch latency.
   "placement": { "mode": "smart" },

--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -1362,6 +1362,19 @@ export async function runProjectionLane(
       await record(env, {
         error: new Error(`projection lane ${label}: compute declined`),
         route: `projection:${label}`,
+        // An EXPECTED condition, not a fault (#9900). `compute()` returning
+        // null is this lane's own documented "I have nothing better than what
+        // is already published" answer -- handled two lines below by
+        // returning reason: "compute_declined" and leaving the previous
+        // artifact in place. Reporting the same handled outcome a second time
+        // as an $exception cost ~25K events/month against a 100K free tier,
+        // per lane per network, and drowned real faults in the inbox.
+        //
+        // Still recorded, and still queryable by this exact route label -- a
+        // lane that goes permanently dark must remain visible. It is now a
+        // counted usage_event rather than an error.
+        expected: true,
+        errorCode: "compute_declined",
       });
       return {
         name: label,

--- a/src/r2-sql.ts
+++ b/src/r2-sql.ts
@@ -315,6 +315,35 @@ function failureClassification(
 const RATE_LIMITED_CODE = "rate_limited";
 
 /**
+ * The failure codes that are CAPACITY, not correctness (#9900).
+ *
+ * Each of these means the engine (or this module's own breaker) declined to
+ * answer right now -- an account-level rate limit, a query that ran past its
+ * ceiling, a call the breaker never sent. None of them indicates a defect in
+ * this code, and between them they were ~49.5K events/month against a 100K
+ * error-tracking free tier, measured 2026-08-03..04.
+ *
+ * They are still recorded, with identical attribution, as `usage_event`s
+ * (`expected: true`) -- see ExceptionEvent.expected. An r2-sql rate-limit
+ * storm remains just as visible; it stops being billed as an error.
+ *
+ * DELIBERATELY NOT LISTED: `http_422`. A scan-budget or malformed-query
+ * rejection means a query in THIS repo needs fixing, which is precisely what
+ * the error inbox is for -- and at ~7K/month it is affordable. Capacity and
+ * correctness are different facts, and only one of them is somebody's bug.
+ */
+const EXPECTED_FAILURE_CODES: ReadonlySet<string> = new Set([
+  "timeout",
+  "http_429",
+  RATE_LIMITED_CODE,
+]);
+
+/** Whether a classified r2-sql failure is an expected capacity condition. */
+export function isExpectedR2SqlFailure(errorCode: string): boolean {
+  return EXPECTED_FAILURE_CODES.has(errorCode);
+}
+
+/**
  * Run one read-only query and return its rows, or null on ANY failure.
  *
  * `sql` is built by the caller from validated, non-caller-controlled pieces —
@@ -439,6 +468,11 @@ export async function r2SqlQuery(
       errorCode,
       queryKind,
       queryShape: r2SqlQueryShape(sql),
+      // Capacity conditions (timeout, 429, breaker) are recorded as counted
+      // usage events instead of exceptions -- same route, same error_code,
+      // same query attribution, different product. See
+      // EXPECTED_FAILURE_CODES for why 422 is pointedly absent.
+      expected: isExpectedR2SqlFailure(errorCode),
     });
     return null;
   } finally {

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -346,6 +346,24 @@ export interface UsageEvent {
   // NEVER a caller-derived value or free-form error message. Only meaningful
   // when `ok` is false; omitted (not just falsy) for a successful call.
   errorCode?: string;
+  /**
+   * #9900: marks a failure this system EXPECTS and already handles -- an R2
+   * SQL 429 or timeout, a projection lane declining to compute. Set only by
+   * `recordExceptionEvent`'s expected-condition path; it is what lets a query
+   * separate "we are being rate-limited" from "a route broke", both of which
+   * are `ok: false`.
+   */
+  expected?: boolean;
+  /**
+   * #9900: query attribution carried over from `ExceptionEvent` when an
+   * expected query-engine failure is recorded here instead of as an
+   * exception. Same meaning as the fields of the same name on
+   * `ExceptionEvent` -- without them, moving r2-sql's 429s and timeouts off
+   * the error product would have silently discarded the per-query
+   * attribution #9459 added.
+   */
+  queryKind?: string;
+  queryShape?: string;
 }
 
 /** Public capture endpoint, appended to the resolved PostHog host. */
@@ -359,6 +377,11 @@ export interface RecordUsageEventDeps {
   /** Injectable [0,1) source for the sampling gate (tests) -- keeps a
    * sampled deployment's behavior deterministic under assertion. */
   random?: () => number;
+  /** Injectable cross-isolate storm gate (#9900). Same reason
+   * `admitExceptionCapture` is exported: "was it held by the FLEET-wide
+   * gate" is otherwise indistinguishable from "was it held locally" or
+   * "was it a no-op", and the distinction is the entire point of the fix. */
+  admitShared?: typeof admitExceptionCaptureShared;
 }
 
 // #8963: best-effort client identity from the User-Agent, for the tool calls
@@ -450,6 +473,17 @@ export function usageEventProperties(
 
   const authTier = sanitizeLabel(event.authTier);
   if (authTier !== undefined) properties.auth_tier = authTier;
+
+  // #9900 dimensions. Same omitted-not-defaulted contract as everything
+  // above: an ordinary usage event's payload is byte-for-byte unchanged, so
+  // every pre-existing query keeps working.
+  if (event.expected === true) properties.expected = true;
+
+  const queryKind = sanitizeLabel(event.queryKind);
+  if (queryKind !== undefined) properties.query_kind = queryKind;
+
+  const queryShape = sanitizeLabel(event.queryShape);
+  if (queryShape !== undefined) properties.query_shape = queryShape;
 
   return properties;
 }
@@ -1144,6 +1178,31 @@ export interface ExceptionEvent {
    */
   queryKind?: string;
   queryShape?: string;
+  /**
+   * This failure is an EXPECTED operational condition, not a code defect.
+   *
+   * Set it and the occurrence is recorded as a `usage_event` (`ok: false`,
+   * carrying the identical `route` / `error_code` / `query_kind` /
+   * `query_shape` attribution) instead of an `$exception`. It stays just as
+   * queryable -- it simply stops being billed against error tracking.
+   *
+   * WHY THIS DISTINCTION EARNS ITS KEEP. Error tracking's free tier is 100K
+   * events/month, the tightest budget in this project; product analytics is
+   * 1M and currently runs at ~40% of it. Three sources measured over
+   * 2026-08-03..04 accounted for ~82K/month of the 100K, and not one of them
+   * was a bug: R2 SQL answering HTTP 429 (an ACCOUNT-level rate limit),
+   * an R2 SQL query hitting its timeout ceiling, and a projection lane
+   * declining to compute (an outcome `runProjectionLane` already returns as
+   * `reason: "compute_declined"` and handles by leaving the previous artifact
+   * in place). Capturing those as exceptions crowded real faults out of the
+   * inbox and spent the budget that exists to report them.
+   *
+   * This is NOT a mute. The condition must remain visible -- a projection
+   * lane that goes permanently dark, or an r2-sql rate-limit storm, are real
+   * operational facts and a watchdog is entitled to see them. Moving product,
+   * not dropping signal, is the whole point.
+   */
+  expected?: boolean;
 }
 
 // ─── $exception storm guard ────────────────────────────────────────────────
@@ -1248,6 +1307,86 @@ export function admitExceptionCapture(
   }
   state.suppressed += 1;
   return null;
+}
+
+/** KV key prefix for the cross-isolate half of the storm guard. */
+export const EXCEPTION_STORM_KV_PREFIX = "exception-storm:";
+
+// Workers KV's own floor for `expirationTtl`. A shorter storm window is legal
+// (and the tests use one), so the TTL is clamped up to this rather than
+// rejected -- a guard that throws on a valid config would be worse than one
+// that holds its key slightly longer than asked.
+const KV_MIN_EXPIRATION_TTL_SECONDS = 60;
+
+/**
+ * The cross-isolate half of the storm guard: has THIS fingerprint already
+ * been reported anywhere in the fleet inside the current window?
+ *
+ * Returns 0 when the caller may emit, or null when it must be held.
+ *
+ * WHY THE LOCAL MAP WAS NEVER ENOUGH (#9900). `admitExceptionCapture` above
+ * throttles on a module-scope `Map`, which in a Worker is PER-ISOLATE state.
+ * Cloudflare recycles isolates constantly, so a fault that recurs across
+ * short-lived isolates arrives as a "first sighting" nearly every time -- and
+ * a first sighting is admitted unconditionally. That is not a theory: across
+ * 6,137 `$exception` events on 2026-08-03..04, exactly ONE carried
+ * `suppressed_occurrences`. It is also why widening the window 60s -> 300s in
+ * #9453 changed nothing for the three loudest sources; the window was never
+ * the binding constraint, the isolate boundary was.
+ *
+ * PRESENCE IS THE WINDOW. The key holds no state -- it is written with an
+ * `expirationTtl` equal to the storm window, so KV expiring it IS the window
+ * closing. That removes any read-modify-write race between isolates, and
+ * means a storm costs READS (cheap, and served from KV's edge cache) while
+ * writes happen at most once per fingerprint per window.
+ *
+ * SUPPRESSION COUNTS STAY LOCAL, DELIBERATELY. Counting globally would need a
+ * KV write per suppressed occurrence -- one write per event during exactly
+ * the burst this exists to make cheap. `suppressed_occurrences` therefore
+ * keeps the meaning it already had: occurrences held by THIS isolate since
+ * its last emission. It is a floor on the real count, not the total.
+ *
+ * FAILS OPEN, ALWAYS. No KV binding (registry-sync-api, wss-lb) or a KV
+ * error degrades to the local-only behaviour that shipped before this, never
+ * to silence. Losing the first report of a genuine outage to a KV blip would
+ * trade a billing problem for an availability one.
+ */
+export async function admitExceptionCaptureShared(
+  env: Env | null | undefined,
+  fingerprint: string,
+  deps: { now?: () => number } = {},
+): Promise<number | null> {
+  const windowMs = exceptionStormWindowMs(env);
+  if (windowMs === 0) return 0;
+
+  const kv = (env as { METAGRAPH_CONTROL?: ExceptionStormKv } | null)
+    ?.METAGRAPH_CONTROL;
+  if (!kv?.get || !kv?.put) return 0;
+
+  const key = `${EXCEPTION_STORM_KV_PREFIX}${fingerprint}`;
+  try {
+    if ((await kv.get(key)) !== null) return null;
+    await kv.put(key, String(deps.now?.() ?? Date.now()), {
+      expirationTtl: Math.max(
+        KV_MIN_EXPIRATION_TTL_SECONDS,
+        Math.ceil(windowMs / 1000),
+      ),
+    });
+    return 0;
+  } catch {
+    return 0;
+  }
+}
+
+/** The slice of the KV binding this guard uses. Structural, so a test can
+ * supply the two methods without standing up a whole KVNamespace. */
+interface ExceptionStormKv {
+  get(key: string): Promise<string | null>;
+  put(
+    key: string,
+    value: string,
+    options?: { expirationTtl?: number },
+  ): Promise<void>;
 }
 
 // The MCP pre-dispatch refusal guard (#9639). Its own map, not a shared
@@ -1427,8 +1566,43 @@ export async function recordExceptionEvent(
 
     // Throttled on the same key PostHog groups by, so a storm of one fault
     // costs one event per window while a genuinely new fault is never delayed.
+    //
+    // TWO GATES, IN THIS ORDER (#9900). The local map is a no-I/O fast path
+    // that also produces `suppressed_occurrences`; the shared gate is the one
+    // that actually bounds a fleet-wide storm, because the local map is
+    // per-isolate and a recycled isolate always looks like a first sighting.
+    // Local first so a burst inside one isolate never reaches KV at all.
     const suppressed = admitExceptionCapture(env, fingerprint);
     if (suppressed === null) return false;
+    const admitShared = deps.admitShared ?? admitExceptionCaptureShared;
+    if ((await admitShared(env, fingerprint)) === null) return false;
+
+    // An EXPECTED condition keeps every dimension it would have carried as an
+    // exception and changes only which product pays for it. Routed through
+    // recordUsageEvent rather than assembled here so it inherits the one
+    // capture path, deployment stamping and sampling gate every other usage
+    // event already goes through -- `ok: false` is never sampled
+    // (resolveUsageSampleRate), so the storm guard above is what bounds it.
+    //
+    // durationMs is 0, not the elapsed query time: these sites report an
+    // OUTCOME, not a timing, and a fabricated duration would pollute the
+    // latency percentiles every other usage event feeds.
+    if (event.expected === true) {
+      return await recordUsageEvent(
+        env,
+        {
+          ok: false,
+          durationMs: 0,
+          expected: true,
+          route,
+          mcpTool,
+          errorCode: event.errorCode,
+          queryKind: event.queryKind,
+          queryShape: event.queryShape,
+        },
+        deps,
+      );
+    }
 
     const properties: Record<string, unknown> = {
       $exception_list: [entry],

--- a/tests/projection-lanes.test.ts
+++ b/tests/projection-lanes.test.ts
@@ -138,7 +138,7 @@ function laneNamed(name: string): ProjectionLane {
 }
 
 describe("runProjectionLane", () => {
-  test("a null compute writes NOTHING and records one routed exception", async () => {
+  test("a null compute writes NOTHING and records one routed EXPECTED condition", async () => {
     const { puts, bucket } = archiveBucket();
     const { events, record } = exceptionRecorder();
     const result = await runProjectionLane(
@@ -160,6 +160,20 @@ describe("runProjectionLane", () => {
     assert.equal(puts.length, 0);
     assert.equal(events.length, 1);
     assert.equal(events[0]!.route, "projection:test-lane");
+    // #9900: a declined compute is a HANDLED outcome (the `reason` above says
+    // so), not a fault. It stays reported under this exact route -- a lane
+    // going permanently dark must remain visible -- but as a counted usage
+    // event rather than an $exception against the 100K error-tracking tier.
+    assert.equal(
+      (events[0] as { expected?: boolean }).expected,
+      true,
+      "a declined compute must not be billed as an error",
+    );
+    assert.equal(
+      (events[0] as { errorCode?: string }).errorCode,
+      "compute_declined",
+      "the reason travels with the event, matching the returned result",
+    );
   });
 
   test("a non-null compute writes the body to the lane's key", async () => {

--- a/tests/r2-sql.test.ts
+++ b/tests/r2-sql.test.ts
@@ -7,6 +7,7 @@ import assert from "node:assert/strict";
 import { afterEach, describe, test } from "vitest";
 import {
   currentR2SqlFailureGeneration,
+  isExpectedR2SqlFailure,
   isR2SqlConfigured,
   r2SqlQuery,
   r2SqlQueryKind,
@@ -908,5 +909,71 @@ describe("r2SqlQueryShape — the precise half of the attribution", () => {
       r2SqlQueryShape("SELECT ss58, net_flow_7d FROM chain.account_events"),
       "SELECT ss58, net_flow_7d FROM chain.account_events",
     );
+  });
+});
+
+// ─── #9900: capacity failures are counted, not billed as errors ─────────────
+
+describe("isExpectedR2SqlFailure (#9900)", () => {
+  test("capacity conditions are expected", () => {
+    for (const code of ["timeout", "http_429", "rate_limited"]) {
+      assert.equal(isExpectedR2SqlFailure(code), true, code);
+    }
+  });
+
+  test("correctness failures are NOT expected -- they are somebody's bug", () => {
+    // http_422 is the load-bearing case: a scan-budget or malformed-query
+    // rejection means a query in this repo needs fixing, and the error inbox
+    // is exactly where that belongs.
+    for (const code of [
+      "http_422",
+      "http_500",
+      "engine_40006",
+      "engine",
+      "transport",
+      "",
+    ]) {
+      assert.equal(isExpectedR2SqlFailure(code), false, code);
+    }
+  });
+});
+
+describe("r2SqlQuery marks capacity failures expected (#9900)", () => {
+  test("a 429 is recorded as an expected condition, with attribution intact", async () => {
+    const { impl } = jsonFetch({}, false, 429);
+    const captured: {
+      route?: string;
+      errorCode?: string;
+      expected?: boolean;
+    }[] = [];
+    const rows = await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+      fetch: impl,
+      recordException: (async (_e: unknown, ev: Record<string, unknown>) => {
+        captured.push(ev);
+        return true;
+      }) as never,
+    });
+    assert.equal(rows, null);
+    assert.equal(captured[0]?.expected, true);
+    assert.equal(captured[0]?.errorCode, "http_429");
+    assert.equal(
+      captured[0]?.route,
+      "r2-sql",
+      "route is unchanged, so the condition stays queryable exactly as before",
+    );
+  });
+
+  test("a 422 stays a real exception", async () => {
+    const { impl } = jsonFetch({}, false, 422);
+    const captured: { expected?: boolean; errorCode?: string }[] = [];
+    await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+      fetch: impl,
+      recordException: (async (_e: unknown, ev: Record<string, unknown>) => {
+        captured.push(ev);
+        return true;
+      }) as never,
+    });
+    assert.equal(captured[0]?.expected, false);
+    assert.equal(captured[0]?.errorCode, "http_422");
   });
 });

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -8,6 +8,8 @@ import {
   USAGE_EVENT_DISTINCT_ID,
   USAGE_EVENT_NAME,
   admitExceptionCapture,
+  admitExceptionCaptureShared,
+  EXCEPTION_STORM_KV_PREFIX,
   isBenignPlatformMessage,
   MCP_PROTOCOL_ROUTE_PREFIX,
   classifyMcpErrorType,
@@ -2880,5 +2882,312 @@ describe("every recorder stamps the deployment dimensions", () => {
       recorders.length,
       `recorders covered: ${recorders.length}, exported: ${exported.join(", ")}`,
     );
+  });
+});
+
+// ─── #9900: the cross-isolate storm gate, and expected-condition routing ────
+
+/** A KV double exposing only the two methods the shared gate touches. */
+function kvDouble(
+  seed: Record<string, string> = {},
+  hooks: { onGet?: () => void; onPut?: () => void } = {},
+) {
+  const store = new Map(Object.entries(seed));
+  const puts: { key: string; value: string; ttl?: number }[] = [];
+  return {
+    puts,
+    store,
+    METAGRAPH_CONTROL: {
+      get: async (key: string) => {
+        hooks.onGet?.();
+        return store.get(key) ?? null;
+      },
+      put: async (
+        key: string,
+        value: string,
+        options?: { expirationTtl?: number },
+      ) => {
+        hooks.onPut?.();
+        puts.push({ key, value, ttl: options?.expirationTtl });
+        store.set(key, value);
+      },
+    },
+  };
+}
+
+const STORM_ON = {
+  [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token",
+  [POSTHOG_EXCEPTION_STORM_WINDOW_MS_ENV]: "300000",
+};
+
+describe("admitExceptionCaptureShared (#9900)", () => {
+  test("admits when the guard is disabled (window 0), without touching KV", async () => {
+    let touched = false;
+    const kv = kvDouble({}, { onGet: () => (touched = true) });
+    const env = mockEnv({
+      ...kv,
+      [POSTHOG_EXCEPTION_STORM_WINDOW_MS_ENV]: "0",
+    });
+    assert.equal(await admitExceptionCaptureShared(env, "r:Error"), 0);
+    assert.equal(touched, false, "a disabled guard must not spend a KV read");
+  });
+
+  test("admits when no KV is bound -- degrades to local-only, never to silence", async () => {
+    assert.equal(
+      await admitExceptionCaptureShared(mockEnv(STORM_ON), "r:Error"),
+      0,
+    );
+  });
+
+  test("holds the emission when another isolate already reported this fingerprint", async () => {
+    const kv = kvDouble({ [`${EXCEPTION_STORM_KV_PREFIX}r:Error`]: "1700" });
+    const env = mockEnv({ ...STORM_ON, ...kv });
+    assert.equal(await admitExceptionCaptureShared(env, "r:Error"), null);
+    assert.equal(
+      kv.puts.length,
+      0,
+      "a suppressed occurrence must cost no write",
+    );
+  });
+
+  test("admits the first sighting and opens the window with a TTL equal to it", async () => {
+    const kv = kvDouble();
+    const env = mockEnv({ ...STORM_ON, ...kv });
+    assert.equal(
+      await admitExceptionCaptureShared(env, "r:Error", { now: () => 42 }),
+      0,
+    );
+    assert.deepEqual(kv.puts, [
+      { key: `${EXCEPTION_STORM_KV_PREFIX}r:Error`, value: "42", ttl: 300 },
+    ]);
+  });
+
+  test("a second isolate is held by the key the first one wrote", async () => {
+    const kv = kvDouble();
+    const env = mockEnv({ ...STORM_ON, ...kv });
+    assert.equal(await admitExceptionCaptureShared(env, "same:Error"), 0);
+    assert.equal(
+      await admitExceptionCaptureShared(env, "same:Error"),
+      null,
+      "this is the whole point: a fresh isolate's first sighting is still held",
+    );
+  });
+
+  test("clamps the TTL up to KV's 60s floor rather than rejecting a short window", async () => {
+    const kv = kvDouble();
+    const env = mockEnv({
+      ...STORM_ON,
+      [POSTHOG_EXCEPTION_STORM_WINDOW_MS_ENV]: "5000",
+      ...kv,
+    });
+    assert.equal(await admitExceptionCaptureShared(env, "r:Error"), 0);
+    assert.equal(kv.puts[0]?.ttl, 60);
+  });
+
+  test("rounds a fractional-second window UP, never down to a shorter window", async () => {
+    const kv = kvDouble();
+    const env = mockEnv({
+      ...STORM_ON,
+      [POSTHOG_EXCEPTION_STORM_WINDOW_MS_ENV]: "300500",
+      ...kv,
+    });
+    await admitExceptionCaptureShared(env, "r:Error");
+    assert.equal(kv.puts[0]?.ttl, 301);
+  });
+
+  test("fails OPEN when the KV read throws", async () => {
+    const kv = kvDouble(
+      {},
+      {
+        onGet: () => {
+          throw new Error("kv down");
+        },
+      },
+    );
+    const env = mockEnv({ ...STORM_ON, ...kv });
+    assert.equal(await admitExceptionCaptureShared(env, "r:Error"), 0);
+  });
+
+  test("fails OPEN when the KV write throws", async () => {
+    const kv = kvDouble(
+      {},
+      {
+        onPut: () => {
+          throw new Error("kv down");
+        },
+      },
+    );
+    const env = mockEnv({ ...STORM_ON, ...kv });
+    assert.equal(await admitExceptionCaptureShared(env, "r:Error"), 0);
+  });
+
+  test("admits when the binding exists but lacks the methods (partial stub)", async () => {
+    const env = mockEnv({ ...STORM_ON, METAGRAPH_CONTROL: {} });
+    assert.equal(await admitExceptionCaptureShared(env, "r:Error"), 0);
+  });
+});
+
+describe("recordExceptionEvent honors the shared gate (#9900)", () => {
+  test("a fingerprint held fleet-wide sends nothing", async () => {
+    let calls = 0;
+    const sent = await recordExceptionEvent(
+      mockEnv(STORM_ON),
+      { error: new Error("boom"), route: "shared-held" },
+      {
+        fetch: (async () => {
+          calls += 1;
+          return { ok: true } as Response;
+        }) as unknown as typeof fetch,
+        admitShared: async () => null,
+      },
+    );
+    assert.equal(sent, false);
+    assert.equal(calls, 0, "held means not captured, not captured-and-dropped");
+  });
+
+  test("a fingerprint the shared gate admits is captured as usual", async () => {
+    let body: Row | undefined;
+    const sent = await recordExceptionEvent(
+      mockEnv(STORM_ON),
+      { error: new Error("boom"), route: "shared-admitted" },
+      {
+        fetch: (async (_url: string, init: Row) => {
+          body = JSON.parse(init.body as string) as Row;
+          return { ok: true } as Response;
+        }) as unknown as typeof fetch,
+        admitShared: async () => 0,
+      },
+    );
+    assert.equal(sent, true);
+    assert.equal(body?.event, "$exception");
+  });
+});
+
+describe("expected conditions bill as usage events, not exceptions (#9900)", () => {
+  test("emits usage_event carrying the identical attribution, not $exception", async () => {
+    let body: Row | undefined;
+    const sent = await recordExceptionEvent(
+      mockEnv(STORM_ON),
+      {
+        error: new Error("r2 sql: HTTP 429"),
+        route: "r2-sql",
+        errorCode: "http_429",
+        queryKind: "chain.account_events",
+        queryShape: "SELECT * FROM t WHERE a = ?",
+        expected: true,
+      },
+      {
+        fetch: (async (_url: string, init: Row) => {
+          body = JSON.parse(init.body as string) as Row;
+          return { ok: true } as Response;
+        }) as unknown as typeof fetch,
+        admitShared: async () => 0,
+      },
+    );
+
+    assert.equal(sent, true);
+    assert.equal(body?.event, USAGE_EVENT_NAME);
+    assert.notEqual(body?.event, "$exception");
+    const props = body?.properties as Row;
+    assert.equal(props.expected, true);
+    assert.equal(props.ok, false);
+    assert.equal(props.route, "r2-sql");
+    assert.equal(props.error_code, "http_429");
+    assert.equal(props.query_kind, "chain.account_events");
+    assert.equal(props.query_shape, "SELECT * FROM t WHERE a = ?");
+    assert.equal(
+      props.$exception_list,
+      undefined,
+      "an expected condition must not carry exception-shaped payload",
+    );
+    assert.equal(
+      props.duration_ms,
+      0,
+      "an outcome report must not pollute latency percentiles",
+    );
+  });
+
+  test("still passes through the storm guard", async () => {
+    let calls = 0;
+    const fetchStub = (async () => {
+      calls += 1;
+      return { ok: true } as Response;
+    }) as unknown as typeof fetch;
+    const env = mockEnv(STORM_ON);
+    const event: ExceptionEvent = {
+      error: new Error("declined"),
+      route: "projection:guarded-lane",
+      expected: true,
+    };
+    assert.equal(
+      await recordExceptionEvent(env, event, {
+        fetch: fetchStub,
+        admitShared: async () => 0,
+      }),
+      true,
+    );
+    assert.equal(
+      await recordExceptionEvent(env, event, {
+        fetch: fetchStub,
+        admitShared: async () => 0,
+      }),
+      false,
+      "the local map holds the second occurrence inside the window",
+    );
+    assert.equal(calls, 1);
+  });
+
+  test("a benign platform message is still dropped before the expected branch", async () => {
+    let calls = 0;
+    const sent = await recordExceptionEvent(
+      mockEnv(STORM_ON),
+      {
+        error: new Error("Durable Object reset because its code was updated"),
+        route: "expected-benign",
+        expected: true,
+      },
+      {
+        fetch: (async () => {
+          calls += 1;
+          return { ok: true } as Response;
+        }) as unknown as typeof fetch,
+        admitShared: async () => 0,
+      },
+    );
+    assert.equal(sent, false);
+    assert.equal(calls, 0);
+  });
+});
+
+describe("usageEventProperties #9900 dimensions", () => {
+  test("omits all three when absent, so existing payloads are byte-identical", () => {
+    const props = usageEventProperties({ ok: true, durationMs: 5 });
+    assert.equal(props?.expected, undefined);
+    assert.equal(props?.query_kind, undefined);
+    assert.equal(props?.query_shape, undefined);
+  });
+
+  test("emits expected only when strictly true", () => {
+    assert.equal(
+      usageEventProperties({ ok: false, durationMs: 0, expected: false })
+        ?.expected,
+      undefined,
+    );
+    assert.equal(
+      usageEventProperties({ ok: false, durationMs: 0, expected: true })
+        ?.expected,
+      true,
+    );
+  });
+
+  test("carries query attribution through", () => {
+    const props = usageEventProperties({
+      ok: false,
+      durationMs: 0,
+      queryKind: "chain.blocks",
+      queryShape: "SELECT 1",
+    });
+    assert.equal(props?.query_kind, "chain.blocks");
+    assert.equal(props?.query_shape, "SELECT 1");
   });
 });

--- a/wrangler.wss-lb.jsonc
+++ b/wrangler.wss-lb.jsonc
@@ -73,6 +73,15 @@
     "NETWORKS": "finney,test",
     "MAX_BLOCK_LAG": "50",
     "HANDSHAKE_TIMEOUT_MS": "5000",
+    // Set HERE, ahead of the token, on purpose (#9900). `vars` are replaced
+    // wholesale per deploy, so this knob is per-config -- and an UNSET value
+    // parses to 0, which is the guard's DISABLED sentinel, not a default
+    // window. This config was the only backend one missing it, which meant
+    // the day someone ran the `wrangler secret put` above, capture would
+    // switch on with the storm guard OFF, on the Worker fronting every WSS
+    // connection. Configuring the guard first makes setting that token safe
+    // rather than a quota hazard.
+    "POSTHOG_EXCEPTION_STORM_WINDOW_MS": "300000",
   },
   // Per-IP connect control, carrying over the Railway service's CONNECT_RATE_LIMIT
   // (30 attempts / 60s). Its OTHER budget -- MAX_CONNECTIONS_PER_IP, a concurrent


### PR DESCRIPTION
Closes #9900

## The problem, measured

Error tracking was projected at **~92-138K events/month against a 100K free tier**. Three conditions accounted for ~82K of it, and not one is a defect (2026-08-03..04, the last two full days before the quota cut ingestion):

| bucket | 2 days | projected/mo | what it actually is |
|---|---|---|---|
| `r2-sql` HTTP error (mostly 429) | 2,003 | ~30,000 | R2 SQL **account-level** rate limit |
| `r2-sql` `AbortError` | 1,780 | ~26,700 | the 15s query timeout |
| `projection:*` compute declined | 1,673 | ~25,100 | a lane's own handled "nothing better to publish" |
| everything else | 681 | ~10,200 | actual faults |

## Why the existing guard could never have stopped it

`admitExceptionCapture` throttles on a module-scope `Map` — **per-isolate** state in a Worker. Cloudflare recycles isolates constantly, so a recurring fault arrives as a *first sighting* nearly every time, and a first sighting is admitted unconditionally.

> Across **6,137** `$exception` events in those two days, exactly **one** carried `suppressed_occurrences`.

That is also why widening the window 60s → 300s in #9453 changed nothing here: the isolate boundary was the binding constraint, never the window.

## What this does

**1. A fleet-wide gate under the local one.** A short-lived per-fingerprint key in `METAGRAPH_CONTROL` KV, where *presence is the window* — written with an `expirationTtl` equal to it, so there's no read-modify-write race between isolates and a storm costs reads, not writes.

Suppression counts stay local on purpose: counting globally would mean one KV write per suppressed occurrence, during exactly the burst this exists to make cheap. `suppressed_occurrences` keeps the meaning it already had (a floor, not a total). No KV binding (`registry-sync-api`, `wss-lb`) or a KV error degrades to today's local-only behaviour — **never to silence**. Trading a billing problem for an availability one would be the wrong fix.

**2. Capacity failures become counted `usage_event`s, not exceptions.** Identical `route` / `error_code` / `query_kind` / `query_shape` attribution — an r2-sql rate-limit storm or a permanently dark projection lane stays exactly as visible and queryable. It moves to the 1M analytics tier (currently ~40% used) instead of the 100K error tier.

`http_422` is **pointedly excluded**: a scan-budget or malformed-query rejection means a query in this repo needs fixing, which is what the inbox is for. Capacity and correctness are different facts, and only one of them is somebody's bug.

## Two adjacent gaps, same failure mode

- **`wrangler.wss-lb.jsonc` set no `POSTHOG_EXCEPTION_STORM_WINDOW_MS`** — and an unset value parses to `0`, the guard's *disabled* sentinel, not a default. Since `vars` are replaced wholesale per deploy, running the `wrangler secret put` that file already documents would have switched on **unguarded** capture on the Worker fronting every WSS connection. Configuring the guard first makes setting that token safe rather than a hazard.
- **`apps/ui/wrangler.jsonc`** was the only one of five configs with neither `upload_source_maps` nor `version_metadata`, so SSR exceptions arrived minified and unattributable to a release. (The *client* bundle's maps go up separately via `@posthog/rollup-plugin`, which is why this looked already-covered.)

## Verification

- `npm run validate` — exit 0; `npm run build` leaves the tree clean (no artifact drift)
- `validate:workflows`, `no-hand-written-mjs`, `module-state-resets`, `contract-drift`, `types`, `private-boundary` — all pass
- `tsc --noEmit` clean; eslint + prettier clean
- **488 tests pass** across the 12 telemetry-adjacent suites
- **Patch coverage: zero uncovered added lines or branches** in all three changed `src/` files, measured by intersecting the diff's added lines with the v8 coverage report

Expected outcome: error-tracking usage drops to roughly **~10K/month** against the 100K tier, with no loss of signal.
