### PR TITLE
feat(neon): add an append partition, so a growing table costs its tail

### DIFF
--- a/src/neon-backfill.ts
+++ b/src/neon-backfill.ts
@@ -1080,6 +1080,31 @@ async function reconcileWholeTable(
 }
 
 /**
+ * Guard for an identifier that is about to be INTERPOLATED into SQL.
+ *
+ * Every table and column name in this module comes from NEON_BACKFILL_PLANS,
+ * which is a frozen const in this file -- none of it is reachable from a
+ * request, so there is no injection path today. This exists because "today"
+ * is doing a lot of work in that sentence: the plans are the kind of thing a
+ * later change makes configurable, and `sql.unsafe` interpolation is exactly
+ * where that becomes a vulnerability rather than a bug.
+ *
+ * Throwing rather than escaping is deliberate. A plan naming something that is
+ * not a bare identifier is a mistake in the plan, and the loud failure belongs
+ * at the lane, not quoted into a query that then does something unintended.
+ */
+const BARE_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function assertIdentifier(name: string, what: string): string {
+  if (!BARE_IDENTIFIER.test(name)) {
+    throw new Error(
+      `${what} is not a bare SQL identifier: ${JSON.stringify(name)}`,
+    );
+  }
+  return name;
+}
+
+/**
  * Neon's high-water mark for an append plan, or null when it holds nothing.
  *
  * Null and 0 are different answers and the difference is the whole table: null
@@ -1100,7 +1125,8 @@ export async function neonHighWaterMark(
   if (!sql?.unsafe) return undefined;
   try {
     const rows = (await sql.unsafe(
-      `SELECT MAX(${cursor}) AS high FROM ${table}`,
+      `SELECT MAX(${assertIdentifier(cursor, "append cursor")}) AS high ` +
+        `FROM ${assertIdentifier(table, "table")}`,
     )) as unknown[];
     if (!Array.isArray(rows) || rows.length === 0) return undefined;
     const raw = (rows[0] as Row)?.high;
@@ -1136,7 +1162,7 @@ export async function readAppendPage(
   const bounds: string[] = [];
   const values: unknown[] = [];
   if (highWater != null) {
-    bounds.push(`${column} >= ?`);
+    bounds.push(`${assertIdentifier(column, "append cursor")} >= ?`);
     values.push(highWater);
   }
   if (keyset) {
@@ -1146,8 +1172,9 @@ export async function readAppendPage(
   const where = bounds.length > 0 ? ` WHERE ${bounds.join(" AND ")}` : "";
   const result = await db
     .prepare(
-      `SELECT ${plan.columns.join(", ")} FROM ${plan.table}${where} ` +
-        `ORDER BY ${plan.keyset.join(", ")} LIMIT ?`,
+      `SELECT ${plan.columns.map((c) => assertIdentifier(c, "column")).join(", ")} ` +
+        `FROM ${assertIdentifier(plan.table, "table")}${where} ` +
+        `ORDER BY ${plan.keyset.map((c) => assertIdentifier(c, "keyset column")).join(", ")} LIMIT ?`,
     )
     .bind(...values, limit)
     .all();

--- a/src/neon-backfill.ts
+++ b/src/neon-backfill.ts
@@ -146,8 +146,24 @@ export interface BackfillDb {
  * have no date column to divide on and are rewritten in place. They are small
  * enough that the whole table IS a reasonable unit: 129 rows for
  * subnet_hyperparams and 497 for account_identity, measured 2026-08-07.
+ *
+ * `append` -- the tail above Neon's high-water mark. Right for the tables that
+ * only ever gain rows, in increasing order of a time column, and never rewrite
+ * one. `whole` is pathological for these: it recopies the ENTIRE table
+ * whenever the signature moves, which measured against production is 36,894
+ * rows an hour to add ~510 for subnet_burn_history, and exceeds the tick
+ * budget outright for surface_checks at 1,349,625 (#9908).
+ *
+ * Two properties a plan MUST have before claiming it, neither of which the
+ * type can check:
+ *
+ *   the cursor is assigned AT INSERT, so no row ever arrives with a timestamp
+ *   below the high-water mark -- a backdated row is invisible to this partition
+ *
+ *   rows are never rewritten, so "already above the mark" means "already
+ *   copied"
  */
-export type BackfillPartition = "date" | "whole";
+export type BackfillPartition = "date" | "whole" | "append";
 
 export interface BackfillPlan {
   table: string;
@@ -1063,6 +1079,206 @@ async function reconcileWholeTable(
   };
 }
 
+/**
+ * Neon's high-water mark for an append plan, or null when it holds nothing.
+ *
+ * Null and 0 are different answers and the difference is the whole table: null
+ * means "copy everything", 0 would mean "copy everything above the epoch",
+ * which for a millisecond timestamp is the same set but for a signed or
+ * negative cursor would not be. Returning null explicitly keeps the caller's
+ * branch honest.
+ *
+ * `undefined` is returned for a store that would not ANSWER, which is again a
+ * third thing -- see d1DateCounts. Copying from the beginning because Neon was
+ * briefly unreachable would re-send the entire table.
+ */
+export async function neonHighWaterMark(
+  sql: PgUnsafe | null | undefined,
+  table: string,
+  cursor: string,
+): Promise<number | null | undefined> {
+  if (!sql?.unsafe) return undefined;
+  try {
+    const rows = (await sql.unsafe(
+      `SELECT MAX(${cursor}) AS high FROM ${table}`,
+    )) as unknown[];
+    if (!Array.isArray(rows) || rows.length === 0) return undefined;
+    const raw = (rows[0] as Row)?.high;
+    if (raw == null) return null;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * One page of the tail, at or above the high-water mark.
+ *
+ * THE BOUND IS `>=`, NOT `>`, AND THAT IS NOT AN OFF-BY-ONE. Several rows can
+ * share the newest cursor value -- one probe sweep writes many rows and only
+ * the millisecond distinguishes them -- so `>` would skip every row that ties
+ * with the mark but had not been copied when the tick ended. `>=` re-sends the
+ * boundary rows instead, which the ON CONFLICT upsert makes free. Given a
+ * choice between re-sending a handful of rows and silently dropping them,
+ * this lane re-sends.
+ */
+export async function readAppendPage(
+  db: BackfillDb,
+  plan: BackfillPlan,
+  cursor: readonly unknown[] | null,
+  highWater: number | null,
+  limit: number,
+): Promise<Row[]> {
+  const column = freshnessColumn(plan);
+  if (!column) throw new Error(`${plan.table}: an append plan needs a cursor`);
+  const keyset = cursor ? keysetPredicate(plan.keyset, cursor) : null;
+  const bounds: string[] = [];
+  const values: unknown[] = [];
+  if (highWater != null) {
+    bounds.push(`${column} >= ?`);
+    values.push(highWater);
+  }
+  if (keyset) {
+    bounds.push(keyset.sql);
+    values.push(...keyset.values);
+  }
+  const where = bounds.length > 0 ? ` WHERE ${bounds.join(" AND ")}` : "";
+  const result = await db
+    .prepare(
+      `SELECT ${plan.columns.join(", ")} FROM ${plan.table}${where} ` +
+        `ORDER BY ${plan.keyset.join(", ")} LIMIT ?`,
+    )
+    .bind(...values, limit)
+    .all();
+  return (result?.results ?? []) as Row[];
+}
+
+/**
+ * Copy the tail, stopping on the tick budget.
+ *
+ * UNLIKE copyWholeTableToNeon THIS IS BUDGETED, and it has to be: that one
+ * loops until the table is exhausted, which is fine for 129 rows and fatal for
+ * 1,349,625. A tick that stops early is not a failure here -- the next tick
+ * recomputes the high-water mark, which has moved, and continues. That is the
+ * same "the deficit IS the cursor" property the dated path has, and it is why
+ * no progress is stored anywhere.
+ *
+ * A partial copy reports `ok: false` with `remaining`, deliberately: a lane
+ * that said `ok` after copying 40,000 of 1,300,000 rows would read as in sync
+ * to every watcher.
+ */
+export async function copyAppendTailToNeon(
+  db: BackfillDb,
+  sql: PgUnsafe,
+  plan: BackfillPlan,
+  highWater: number | null,
+  budgetRows: number = TICK_ROW_BUDGET,
+  pageRows: number = D1_PAGE_ROWS,
+): Promise<DateCopyResult> {
+  let cursor: unknown[] | null = null;
+  let rows = 0;
+  let statements = 0;
+  let pages = 0;
+  const date = WHOLE_TABLE_UNIT;
+  for (;;) {
+    let page: Row[];
+    try {
+      page = await readAppendPage(db, plan, cursor, highWater, pageRows);
+    } catch (error) {
+      return {
+        ok: false,
+        rows,
+        statements,
+        pages,
+        date,
+        reason: reason(error),
+      };
+    }
+    if (page.length === 0) return { ok: true, rows, statements, pages, date };
+    pages += 1;
+    const result = await writeRowsToNeon(
+      sql,
+      plan.table,
+      plan.columns,
+      page.map((row) => shapeRowForNeon(row, plan.booleans)),
+      plan.conflict,
+      backfillGuard(plan.table, freshnessColumn(plan)),
+    );
+    rows += result.rows;
+    statements += result.statements;
+    if (!result.ok) {
+      return {
+        ok: false,
+        rows,
+        statements,
+        pages,
+        date,
+        reason: result.reason,
+      };
+    }
+    if (page.length < pageRows)
+      return { ok: true, rows, statements, pages, date };
+    if (rows >= budgetRows) {
+      return {
+        ok: false,
+        rows,
+        statements,
+        pages,
+        date,
+        reason: "tick budget reached",
+      };
+    }
+    const last = page[page.length - 1];
+    cursor = plan.keyset.map((column) => last[column]);
+  }
+}
+
+async function reconcileAppendTable(
+  db: BackfillDb,
+  sql: PgUnsafe,
+  plan: BackfillPlan,
+): Promise<BackfillTableOutcome> {
+  const table = plan.table;
+  const base = { table, deficits: 0, missing: 0, remaining: 0, copied: [] };
+  const column = freshnessColumn(plan);
+  if (!column) {
+    return { ...base, ok: false, reason: "append plan has no cursor column" };
+  }
+  const [d1Sig, highWater] = await Promise.all([
+    d1TableSignature(db, table, column),
+    neonHighWaterMark(sql, table, column),
+  ]);
+  if (!d1Sig || highWater === undefined) {
+    return {
+      ...base,
+      ok: false,
+      reason: `signature failed: ${!d1Sig ? "d1" : "neon"}`,
+    };
+  }
+  // Nothing above the mark means nothing to do. Note this compares the CURSOR,
+  // not the count: for a pruned table (#9891) D1's oldest rows are gone while
+  // Neon still holds them, so the counts legitimately differ forever and only
+  // the tail is this lane's business.
+  if (
+    highWater != null &&
+    d1Sig.maxCapturedAt != null &&
+    d1Sig.maxCapturedAt <= highWater
+  ) {
+    return { ...base, ok: true };
+  }
+  const result = await copyAppendTailToNeon(db, sql, plan, highWater);
+  return {
+    table,
+    deficits: 1,
+    missing: 0,
+    remaining: result.ok ? 0 : 1,
+    copied: [result],
+    ok: result.ok,
+    ...(result.ok ? {} : { reason: result.reason }),
+  };
+}
+
 export async function reconcileTableToNeon(
   db: BackfillDb | null | undefined,
   sql: PgUnsafe | null | undefined,
@@ -1082,6 +1298,9 @@ export async function reconcileTableToNeon(
   }
   if (plan.partition === "whole") {
     return await reconcileWholeTable(db, sql, plan);
+  }
+  if (plan.partition === "append") {
+    return await reconcileAppendTable(db, sql, plan);
   }
   const [d1Counts, neonCounts] = await Promise.all([
     d1DateCounts(db, table),

--- a/tests/neon-backfill.test.ts
+++ b/tests/neon-backfill.test.ts
@@ -24,6 +24,7 @@ import {
   WHOLE_TABLE_UNIT,
   backfillGuard,
   copyDateToNeon,
+  copyAppendTailToNeon,
   copyWholeTableToNeon,
   d1DateCounts,
   d1TableSignature,
@@ -32,7 +33,9 @@ import {
   describeOutcome,
   keysetPredicate,
   neonDateCounts,
+  neonHighWaterMark,
   neonTableSignature,
+  readAppendPage,
   readDatePage,
   readWholePage,
   reconcileTableToNeon,
@@ -1437,5 +1440,125 @@ describe("runNeonBackfill", () => {
         detail: "0 row(s) copied before failure: count failed: neon",
       },
     ]);
+  });
+});
+
+describe("the append partition (#9908)", () => {
+  const APPEND_PLAN = {
+    table: "surface_checks",
+    columns: ["surface_id", "checked_at", "ok"],
+    conflict: ["surface_id", "checked_at"],
+    keyset: ["checked_at", "surface_id"],
+    partition: "append" as const,
+    booleans: ["ok"],
+    freshness: "checked_at",
+  };
+
+  test("the high-water mark distinguishes empty, present and UNREACHABLE", () => {
+    // Three answers, not two. `null` means Neon holds nothing, so copy
+    // everything. `undefined` means Neon would not answer -- and copying from
+    // the beginning because it was briefly unreachable would re-send 1.3M rows.
+    return Promise.all([
+      neonHighWaterMark(
+        fakeSql([{ high: 1786000000000 }]).sql,
+        "t",
+        "checked_at",
+      ).then((v) => assert.equal(v, 1786000000000)),
+      neonHighWaterMark(fakeSql([{ high: null }]).sql, "t", "checked_at").then(
+        (v) => assert.equal(v, null),
+      ),
+      neonHighWaterMark(null, "t", "checked_at").then((v) =>
+        assert.equal(v, undefined),
+      ),
+      neonHighWaterMark(fakeSql([], "SELECT").sql, "t", "checked_at").then(
+        (v) => assert.equal(v, undefined),
+      ),
+    ]);
+  });
+
+  test("the bound is >=, so rows TYING with the mark are re-sent not skipped", async () => {
+    // The failure this prevents: one probe sweep writes many rows and only the
+    // millisecond separates them. With `>`, every row sharing the newest
+    // timestamp that had not yet been copied would be skipped forever -- a
+    // silent hole no count comparison would reveal, because the lane would
+    // report itself in sync.
+    const d1 = fakeDb([[]]);
+    await readAppendPage(d1.db, APPEND_PLAN, null, 1786000000000, 500);
+    const call = d1.calls[0]!;
+    assert.match(call.sql, /checked_at >= \?/);
+    assert.ok(
+      !/checked_at > \?/.test(call.sql),
+      "a strict > would drop rows tying with the high-water mark",
+    );
+    assert.deepEqual(call.values, [1786000000000, 500]);
+  });
+
+  test("an empty Neon side reads the table from the beginning", async () => {
+    const d1 = fakeDb([[]]);
+    await readAppendPage(d1.db, APPEND_PLAN, null, null, 500);
+    assert.ok(!/WHERE/.test(d1.calls[0]!.sql), d1.calls[0]!.sql);
+    assert.deepEqual(d1.calls[0]!.values, [500]);
+  });
+
+  test("it orders by the keyset so a page resumes where the last ended", async () => {
+    const d1 = fakeDb([[]]);
+    await readAppendPage(
+      d1.db,
+      APPEND_PLAN,
+      [1786000000000, "s1"],
+      1786000000000,
+      500,
+    );
+    assert.match(d1.calls[0]!.sql, /ORDER BY checked_at, surface_id LIMIT \?/);
+  });
+
+  test("a tick that hits the budget reports NOT ok, with what it did", async () => {
+    // The whole point. copyWholeTableToNeon loops until the table is
+    // exhausted, which is fine for 129 rows and impossible for 1,349,625. A
+    // budgeted tick that claimed `ok` would read as in sync to every watcher
+    // while 97% of the table was still missing.
+    const page = Array.from({ length: 4 }, (_, i) => ({
+      surface_id: `s${i}`,
+      checked_at: 1786000000000 + i,
+      ok: 1,
+    }));
+    const d1 = fakeDb([page, page, page, page]);
+    const pg = fakeSql([]);
+    const out = await copyAppendTailToNeon(
+      d1.db,
+      pg.sql,
+      APPEND_PLAN,
+      null,
+      6,
+      4,
+    );
+    assert.equal(out.ok, false);
+    assert.equal(out.reason, "tick budget reached");
+    assert.ok(out.rows >= 6, `copied ${out.rows}`);
+  });
+
+  test("a short page means the tail is exhausted, and that IS ok", async () => {
+    const d1 = fakeDb([[{ surface_id: "s1", checked_at: 1, ok: 1 }]]);
+    const out = await copyAppendTailToNeon(
+      d1.db,
+      fakeSql([]).sql,
+      APPEND_PLAN,
+      null,
+      1000,
+      500,
+    );
+    assert.equal(out.ok, true);
+    assert.equal(out.pages, 1);
+  });
+
+  test("D1 booleans still become Neon booleans on this path", async () => {
+    const d1 = fakeDb([[{ surface_id: "s1", checked_at: 1, ok: 1 }]]);
+    const pg = fakeSql([]);
+    await copyAppendTailToNeon(d1.db, pg.sql, APPEND_PLAN, null, 1000, 500);
+    const write = pg.calls.find((c) => c.text.startsWith("INSERT"))!;
+    assert.ok(
+      write.values.includes(true),
+      `0/1 reached Neon unconverted: ${JSON.stringify(write.values)}`,
+    );
   });
 });

--- a/tests/neon-backfill.test.ts
+++ b/tests/neon-backfill.test.ts
@@ -24,6 +24,7 @@ import {
   WHOLE_TABLE_UNIT,
   backfillGuard,
   copyDateToNeon,
+  assertIdentifier,
   copyAppendTailToNeon,
   copyWholeTableToNeon,
   d1DateCounts,
@@ -1560,5 +1561,37 @@ describe("the append partition (#9908)", () => {
       write.values.includes(true),
       `0/1 reached Neon unconverted: ${JSON.stringify(write.values)}`,
     );
+  });
+});
+
+describe("assertIdentifier", () => {
+  test("it passes the identifiers the real plans actually use", () => {
+    for (const [name, plan] of Object.entries(NEON_BACKFILL_PLANS)) {
+      assertIdentifier(plan.table, `${name} table`);
+      for (const c of [...plan.columns, ...plan.keyset, ...plan.conflict]) {
+        assertIdentifier(c, `${name} column`);
+      }
+      const f = freshnessColumn(plan);
+      if (f) assertIdentifier(f, `${name} freshness`);
+    }
+  });
+
+  test("it throws rather than escaping", () => {
+    // Escaping would put the value into the query anyway. A plan naming
+    // something that is not a bare identifier is a mistake in the PLAN, and
+    // the loud failure belongs at the lane.
+    for (const bad of [
+      "surface_checks; DROP TABLE neurons",
+      "checked_at)--",
+      'a" OR "1"="1',
+      "",
+      "1_starts_with_a_digit",
+    ]) {
+      assert.throws(
+        () => assertIdentifier(bad, "test"),
+        /not a bare SQL identifier/,
+        `accepted: ${JSON.stringify(bad)}`,
+      );
+    }
   });
 });


### PR DESCRIPTION
Closes #9908. **No plan uses it yet** — the machinery lands separately from the first table that needs it, so the two are reviewable apart.

## Why `whole` doesn't work for what's left

It recopies the entire table whenever the signature moves. Right for a 129-row dimension table, pathological for one that only grows:

| table | rows | rows/day | `whole` costs |
|---|---:|---:|---|
| `surface_checks` | 1,349,625 | ~48,000 | exceeds the tick budget outright |
| `subnet_burn_history` | 36,894 | 12,255 | 36,894 upserts/hour to add ~510 |
| `tao_usd_index` | 7,965 | 1,440 | 7,965 upserts/hour to add ~60 |

`copyWholeTableToNeon` also loops until the table is exhausted with **no budget at all** — fine at 129 rows, impossible at 1.3M.

## Three things that are silent failures if got wrong

**The bound is `>=`, not `>`.** Several rows can share the newest cursor — one probe sweep writes many and only the millisecond separates them — so `>` would skip every row tying with the mark that hadn't been copied yet. That hole is invisible: the lane would report itself in sync. Verified the test catches it — flipping to `>` fails exactly one test.

**The mark has three answers.** `null` = Neon holds nothing, copy everything. `undefined` = Neon wouldn't *answer*, and copying from the beginning because it was briefly unreachable would re-send the whole table.

**A budgeted tick reports `ok: false`.** A lane claiming `ok` after copying 40,000 of 1,300,000 rows would read as in sync to every watcher. The next tick recomputes the mark, which has moved, and continues — the same "the deficit IS the cursor" property the dated path has.

## What it does NOT solve

- **Backdated rows are invisible** — the bound is on the cursor, so a plan must assert its cursor is assigned at insert. Documented as a precondition, not a default.
- **It does not remove the prune requirement.** For a pruned table (#9891) D1's oldest rows vanish while Neon keeps them, so retention still has to be made symmetric separately. `append` makes the *copy* cheap, not retention correct.

220 tests pass across the 7 affected suites.
