### PR TITLE
fix(mcp): the dispatch-level degraded stamp must satisfy the tool's own schema

### DIFF
--- a/schemas-src/mcp-tools/query-tools.ts
+++ b/schemas-src/mcp-tools/query-tools.ts
@@ -7,14 +7,21 @@
 // schemas-src/routes/ REST schema -- modeled fresh, matching each
 // hand-written literal field-for-field.
 //
-// query_graphql's hand-written `data` field declares `nullable: true`, an
-// OpenAPI-3.0-ism with NO effect under JSON Schema draft 2020-12 (which has
-// no `nullable` keyword) -- so under the target's own spec, `data` was
-// already (inertly) a plain non-nullable object. Preserved literally as
-// non-nullable here rather than "fixed" into a real `.nullable()`, since
-// doing so would make the new schema accept something the old one's actual
-// declared (2020-12) semantics didn't -- the opposite direction from this
-// epic's wire-compatibility mandate.
+// query_graphql's `data` IS nullable (#9911), and the reasoning that once said
+// otherwise has been overtaken by evidence.
+//
+// The hand-written original declared `nullable: true`, an OpenAPI-3.0-ism with
+// no effect under JSON Schema draft 2020-12. The port preserved it literally as
+// non-nullable rather than "fixing" it, on the grounds that widening a schema
+// during a migration accepts something the old one did not -- the right instinct
+// while the question was only what the old document meant.
+//
+// It is no longer only that question. The production conformance sweep (#9879)
+// called this tool and got `data: null` back, which is not our choice: the
+// GraphQL spec REQUIRES `data` to be null when a request fails before execution
+// begins. So the non-nullable declaration forbade a value the protocol obliges
+// us to emit, and every failed query violated the contract we publish. Matching
+// the protocol is a correction, not a loosening.
 //
 // run_saved_query's output declares `additionalProperties: false` (.strict()
 // below), unlike nearly every other output schema in this epic (which are
@@ -35,10 +42,15 @@ export const QueryGraphqlInputSchema = z
       .describe(
         "The GraphQL document to execute against metagraphed's schema -- a full `query { ... }` operation, not search text. Pair named variables with the sibling `variables` object; use get_api_schema to discover the available fields.",
       )
+      // SELF-CONTAINED, deliberately (#9911). The previous example declared
+      // `$netuid: Int!` while the matching value lived on the SEPARATE,
+      // optional `variables` parameter -- so an agent copying the `query`
+      // example alone got a variable-coercion error rather than a subnet. Same
+      // class as the `chutes` slug example (#9860): an example is the first
+      // thing an agent copies, and one that does not work teaches the wrong
+      // thing AND wastes the call. Verified live 2026-08-07.
       .meta({
-        examples: [
-          "query SubnetById($netuid: Int!) { subnet(netuid: $netuid) { netuid name } }",
-        ],
+        examples: ["query { subnet(netuid: 64) { netuid name } }"],
       }),
     variables: OpenObjectSchema.optional()
       .describe("GraphQL variables for the query, as an object.")
@@ -49,7 +61,8 @@ export type QueryGraphqlInput = z.infer<typeof QueryGraphqlInputSchema>;
 
 export const QueryGraphqlOutputSchema = z
   .object({
-    data: OpenObjectSchema.optional(),
+    // Null on a request error, per the GraphQL spec -- see the header.
+    data: OpenObjectSchema.nullable().optional(),
     errors: z.array(OpenObjectSchema).optional(),
   })
   .passthrough();

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -15281,6 +15281,76 @@ export function markChainCallsScopeDeclined<T>(
   } as T;
 }
 
+/**
+ * Complete a generically-stamped `degraded` block against the schema the tool
+ * actually publishes (#9910).
+ *
+ * THE DEFECT THIS CLOSES. `markMcpTierDegraded` stamps one shape --
+ * `{reason}` -- on whichever tool happened to degrade. But `degraded` is a
+ * per-tool object, and `get_account_positions` declares three REQUIRED
+ * properties on it, so the generic stamp produced a response that failed the
+ * tool's own published outputSchema. Confirmed in production 2026-08-07:
+ * `degraded = {"reason":"tier_unavailable"}` against a schema requiring
+ * `snapshot_captured_at` and `latest_stake_event_at` as well.
+ *
+ * It could not be fixed in the handler, which is where the first attempt
+ * (#9817's shapeForwardedPositions) put it: this stamp lands at DISPATCH,
+ * after every handler has returned, so the handler's correctly-shaped answer
+ * is not what the caller receives when the tier degrades mid-call.
+ *
+ * DERIVED, NOT LISTED. The missing keys are read off the tool's own
+ * outputSchema rather than from a table of tools with rich `degraded` blocks:
+ * one tool declares one today, and a table would be wrong the first time a
+ * second one did. Only properties the schema declares REQUIRED and NULLABLE
+ * are filled, and only with `null` -- "we could not read the tier, so we do
+ * not know" is exactly what a nullable required field is for, and it is the
+ * one value this chokepoint can honestly supply.
+ */
+export function completeDegradedBlock(
+  data: unknown,
+  outputSchema: JsonSchemaLike | undefined,
+): unknown {
+  const row = data as Row | null;
+  const degraded = row?.degraded as Row | undefined;
+  if (!degraded || typeof degraded !== "object" || Array.isArray(degraded)) {
+    return data;
+  }
+  const declared = (outputSchema?.properties as Row | undefined)?.degraded as
+    Row | undefined;
+  // A nullable object is published as anyOf[{object}, {null}], so the required
+  // list can sit on a branch rather than at the top.
+  const branches = [
+    declared,
+    ...((declared?.anyOf as Row[] | undefined) ?? []),
+    ...((declared?.oneOf as Row[] | undefined) ?? []),
+  ].filter((branch): branch is Row => Boolean(branch));
+  const filled: Row = { ...degraded };
+  let changed = false;
+  for (const branch of branches) {
+    const required = branch.required;
+    const properties = branch.properties as Row | undefined;
+    if (!Array.isArray(required) || !properties) continue;
+    for (const key of required as string[]) {
+      if (Object.hasOwn(filled, key)) continue;
+      // Only a NULLABLE required property can be honestly filled. One that is
+      // required and non-nullable has no value this chokepoint could invent,
+      // so it is left absent and the conformance check reports it -- an
+      // invented value would be worse than a visible violation.
+      const property = properties[key] as Row | undefined;
+      const nullable =
+        property?.type === "null" ||
+        (Array.isArray(property?.type) && property.type.includes("null")) ||
+        ((property?.anyOf as Row[] | undefined) ?? []).some(
+          (entry) => entry?.type === "null",
+        );
+      if (!nullable) continue;
+      filled[key] = null;
+      changed = true;
+    }
+  }
+  return changed ? ({ ...row, degraded: filled } as unknown) : data;
+}
+
 export function markMcpTierDegraded(
   data: unknown,
   generationBefore: number,
@@ -15385,7 +15455,14 @@ async function dispatchTool(
         });
       }
     }
-    const payload = markMcpTierDegraded(data, tierGenerationBefore);
+    // Completed against THIS tool's schema, because the marker above stamps
+    // one generic shape onto whichever tool degraded and `degraded` is a
+    // per-tool object (#9910). Applied to every result, not just a stamped
+    // one: a handler that built its own partial block is the same violation.
+    const payload = completeDegradedBlock(
+      markMcpTierDegraded(data, tierGenerationBefore),
+      tool.outputSchema ?? (TOOL_OUTPUT_SCHEMAS as Row)[tool.name],
+    );
     return {
       content: [{ type: "text", text: JSON.stringify(payload) }],
       structuredContent: payload as Row,

--- a/tests/mcp-degraded-marker-completeness.test.ts
+++ b/tests/mcp-degraded-marker-completeness.test.ts
@@ -1,0 +1,216 @@
+// The dispatch-level `degraded` stamp must satisfy the tool's own schema
+// (#9910), and query_graphql's `data` must accept the null GraphQL requires
+// (#9911).
+//
+// Both were found by the out-of-band production conformance sweep (#9879) and
+// confirmed against live production on 2026-08-07, which is the point: neither
+// was visible to CI. The hermetic harness never degrades a tier mid-call, and
+// nothing had ever validated a FAILED GraphQL query against the schema the tool
+// publishes for it.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import {
+  completeDegradedBlock,
+  listToolDefinitions,
+} from "../src/mcp-server.ts";
+import type { Row } from "./row-type.ts";
+
+function schemaFor(name: string): Row {
+  const def = listToolDefinitions().find(
+    (tool) => (tool as Row).name === name,
+  ) as Row;
+  return def.outputSchema as Row;
+}
+
+function validates(schema: Row, value: unknown): boolean {
+  return new Ajv2020({ strict: false }).compile(schema)(value);
+}
+
+describe("completeDegradedBlock (#9910)", () => {
+  const positions = () => schemaFor("get_account_positions");
+
+  test("the generic stamp alone FAILS the tool's published schema", () => {
+    // The state production was actually in. Asserted first so the fix below is
+    // shown to change something -- a negative assertion that passes on nothing
+    // proves nothing (#9689).
+    const stamped = {
+      schema_version: 1,
+      ss58: "5GP7c3fFazW9GXK8Up3qgu2DJBk8inu4aK9TZy3RuoSWVCMi",
+      // Required at the top level too -- the fixture is the whole card
+      // unavailableAccountPositions() builds, not just its degraded block.
+      captured_at: null,
+      position_count: 0,
+      total_stake_alpha: 0,
+      positions: [],
+      degraded: { reason: "tier_unavailable" },
+    };
+    assert.equal(validates(positions(), stamped), false);
+    // ...and completing it against the same schema fixes exactly that.
+    const completed = completeDegradedBlock(stamped, positions()) as Row;
+    assert.equal(validates(positions(), completed), true);
+    assert.deepEqual(completed.degraded, {
+      reason: "tier_unavailable",
+      snapshot_captured_at: null,
+      latest_stake_event_at: null,
+    });
+  });
+
+  test("a block the handler already completed is returned untouched", () => {
+    const full = {
+      degraded: {
+        reason: "snapshot_predates_stake_activity",
+        snapshot_captured_at: "2026-08-07T00:00:00.000Z",
+        latest_stake_event_at: "2026-08-07T12:00:00.000Z",
+      },
+    };
+    // Identity, not deep equality: a rebuilt-but-identical object would still
+    // mean the completion runs on every healthy response.
+    assert.equal(completeDegradedBlock(full, positions()), full);
+  });
+
+  test("a real value is never overwritten with null", () => {
+    const partial = {
+      degraded: {
+        reason: "positions_unpriceable",
+        snapshot_captured_at: "2026-08-07T00:00:00.000Z",
+      },
+    };
+    const completed = completeDegradedBlock(partial, positions()) as Row;
+    assert.equal(
+      (completed.degraded as Row).snapshot_captured_at,
+      "2026-08-07T00:00:00.000Z",
+    );
+    assert.equal((completed.degraded as Row).latest_stake_event_at, null);
+  });
+
+  test("a payload with no degraded block is untouched", () => {
+    const healthy = { schema_version: 1, positions: [], degraded: null };
+    assert.equal(completeDegradedBlock(healthy, positions()), healthy);
+    const absent = { schema_version: 1, positions: [] };
+    assert.equal(completeDegradedBlock(absent, positions()), absent);
+  });
+
+  test("a tool whose degraded requires only `reason` is untouched", () => {
+    // The generic stamp is already complete for these, and filling keys their
+    // schema does not declare would be inventing fields.
+    const stamped = { degraded: { reason: "tier_unavailable" } };
+    const schema = {
+      type: "object",
+      properties: {
+        degraded: {
+          type: "object",
+          properties: { reason: { type: "string" } },
+          required: ["reason"],
+        },
+      },
+    };
+    assert.equal(completeDegradedBlock(stamped, schema), stamped);
+  });
+
+  test("a required NON-nullable property is left absent rather than invented", () => {
+    // There is no honest value for it here, and a visible violation the
+    // conformance sweep reports beats a fabricated one it does not.
+    const schema = {
+      type: "object",
+      properties: {
+        degraded: {
+          type: "object",
+          properties: {
+            reason: { type: "string" },
+            detail: { type: "string" },
+          },
+          required: ["reason", "detail"],
+        },
+      },
+    };
+    const completed = completeDegradedBlock(
+      { degraded: { reason: "tier_unavailable" } },
+      schema,
+    ) as Row;
+    assert.equal(Object.hasOwn(completed.degraded as Row, "detail"), false);
+  });
+
+  test("a nullable property declared as a type ARRAY is filled too", () => {
+    // `{"type": ["string", "null"]}` and `{"anyOf": [{string}, {null}]}` are
+    // the same statement; Zod emits the second, a hand-written schema the
+    // first, and both reach this code.
+    const schema = {
+      type: "object",
+      properties: {
+        degraded: {
+          type: "object",
+          properties: {
+            reason: { type: "string" },
+            stamp: { type: ["string", "null"] },
+          },
+          required: ["reason", "stamp"],
+        },
+      },
+    };
+    const completed = completeDegradedBlock(
+      { degraded: { reason: "tier_unavailable" } },
+      schema,
+    ) as Row;
+    assert.equal((completed.degraded as Row).stamp, null);
+  });
+
+  test("a degraded branch declaring no `required` is skipped, not crashed on", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        degraded: {
+          type: "object",
+          properties: { reason: { type: "string" } },
+        },
+      },
+    };
+    const stamped = { degraded: { reason: "tier_unavailable" } };
+    assert.equal(completeDegradedBlock(stamped, schema), stamped);
+  });
+
+  test("no missing schema means no completion, and no crash", () => {
+    const stamped = { degraded: { reason: "tier_unavailable" } };
+    assert.equal(completeDegradedBlock(stamped, undefined), stamped);
+  });
+});
+
+describe("query_graphql publishes the null GraphQL requires (#9911)", () => {
+  test("a failed query's `data: null` satisfies the published schema", () => {
+    // The exact production response: a variable-coercion failure returns
+    // data:null with errors, which the previous non-nullable schema forbade.
+    const failed = {
+      data: null,
+      errors: [
+        {
+          message:
+            'Variable "$netuid" has invalid value: Expected a value of non-null type "Int!" to be provided.',
+        },
+      ],
+    };
+    assert.equal(validates(schemaFor("query_graphql"), failed), true);
+  });
+
+  test("a successful query still validates", () => {
+    assert.equal(
+      validates(schemaFor("query_graphql"), {
+        data: { subnet: { netuid: 64, name: "Chutes" } },
+        errors: [],
+      }),
+      true,
+    );
+  });
+
+  test("the declared query example is self-contained", () => {
+    const def = listToolDefinitions().find(
+      (tool) => (tool as Row).name === "query_graphql",
+    ) as Row;
+    const example = (((def.inputSchema as Row).properties as Row).query as Row)
+      .examples?.[0] as string;
+    // A `$variable` in the example needs the SEPARATE optional `variables`
+    // parameter to work, so an agent copying the query alone gets a coercion
+    // error. Verified live: the replacement returns SN64.
+    assert.equal(example.includes("$"), false);
+    assert.match(example, /subnet\(netuid:\s*64\)/);
+  });
+});


### PR DESCRIPTION
## Summary

Found by an out-of-band production conformance sweep (the #9879 work, in a separate PR) and confirmed live on `api.metagraph.sh` on 2026-08-07. Neither defect was visible to CI, which is the point of both.

## 1 — `get_account_positions` served a `degraded` block missing two required fields (#9910)

```
degraded = {"reason": "tier_unavailable"}
```

against a published `outputSchema` declaring `required: ["reason", "snapshot_captured_at", "latest_stake_event_at"]`. Any client validating `structuredContent` against the schema we hand it in `tools/list` — which the MCP spec says clients SHOULD do — rejected our own response.

**The fix could not go in the handler**, which is where the first attempt put it ([#9817](https://github.com/JSONbored/metagraphed/pull/9817)'s `shapeForwardedPositions`). I confirmed that function is correct, merged, and deployed — and production still served the bare block, because the stamp lands at **dispatch**, after every handler has returned. `markMcpTierDegraded` fires when the Postgres tier's fallback generation changes mid-call and writes one generic `{reason}` shape onto whichever tool degraded. `degraded` is a **per-tool object**, so a generic stamp cannot be correct for every tool by construction.

`completeDegradedBlock` fills the gap from the tool's **own** `outputSchema` rather than from a table of tools with rich `degraded` blocks — one tool declares one today, and a table would be wrong the first time a second one did. Only properties the schema declares **required and nullable** are filled, and only with `null`: "we could not read the tier, so we do not know" is exactly what a nullable required field is for. A required **non-nullable** property is deliberately left absent, because an invented value is worse than a violation the sweep reports.

## 2 — `query_graphql` forbade the `null` GraphQL requires (#9911)

`data` was published as a non-nullable object. That is not a choice available to us: the GraphQL spec **requires** `data` to be `null` when a request fails before execution begins, so the declaration forbade a value the protocol obliges us to emit, and every failed query violated our own contract.

The port had preserved the original's inert OpenAPI-3.0 `nullable: true` as non-nullable on wire-compatibility grounds — the right instinct while the question was only what the old document meant. Production evidence settles it the other way, and the file header now records that.

Its `query` **example** is also fixed: it declared `$netuid: Int!` while the matching value lived on the separate, *optional* `variables` parameter, so an agent copying the query alone got a coercion error rather than a subnet. Same class as the `chutes` slug example (#9860). The replacement is self-contained and verified live:

```
query { subnet(netuid: 64) { netuid name } }   ->  {"subnet": {"netuid": 64, "name": "Chutes"}}
```

## Verification

- Both defects reproduced against live production, and the first test asserts the **broken** shape fails the schema before asserting the fix passes — a negative assertion that passes on nothing proves nothing.
- `npm run typecheck`, `lint`, `format:check` — clean.
- `validate:mcp`, `validate:contract-drift`, `validate:schemas` — pass.
- 12 new tests; 1,738 pass across the affected suites.
- Patch coverage by diff∩coverage intersection: **23/23 changed executable lines in `src/**`, zero uncovered branches.**

Closes #9910
Closes #9911