### PR TITLE
feat(ci): schedule an MCP conformance sweep, so CI's deferral has a receiver

### DIFF
--- a/.github/workflows/check-mcp-conformance.yml
+++ b/.github/workflows/check-mcp-conformance.yml
@@ -1,0 +1,77 @@
+name: Check MCP conformance
+
+# Do the MCP responses we SERVE match the outputSchemas we PUBLISH? (#9879)
+#
+# The REST half of this question has been answered out of band since #9141
+# (check-response-conformance.yml). The MCP half was answered nowhere.
+# `validate:mcp` runs in CI against a hermetic harness and reports, honestly,
+# that it cannot finish the job -- 97 of 225 tools are validated only over EMPTY
+# collections, where every declared property of an item is vacuously fine
+# because there are no items. It deferred those to "the production sweep", and
+# that sweep was never scheduled anywhere. CI said something else checks these
+# and nothing did.
+#
+# #9884 is the worked example: deriving MCP schemas from route schemas made row
+# objects strict, and 25 tools began failing their own published schema the
+# moment a caller used the `fields` parameter they advertise. CI stayed green
+# throughout, because the harness serves no rows to project.
+#
+# The first run of this check found three real violations in production
+# (#9910, #9911), both fixed before it was scheduled.
+#
+# Green is the steady state, and the summary prints every run so a healthy run
+# is still legible -- same shape as check-response-conformance.yml.
+on:
+  schedule:
+    # Daily, offset from check-response-conformance's 06:41 so the two are not
+    # sweeping the same Worker at once. Schema drift arrives with a deploy, not
+    # with traffic, so hourly would add noise without shortening the window
+    # that matters.
+    - cron: "17 7 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-mcp-conformance
+  cancel-in-progress: false
+
+jobs:
+  conformance:
+    name: Validate live MCP responses against their published outputSchemas
+    runs-on: ubuntu-latest
+    # ~225 tools plus ~32 projection calls at the endpoint's measured ~1.6s
+    # floor is ~8 minutes; the ceiling leaves room for rate-limit backoff
+    # without letting a hung fetch hold a runner all day.
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.2
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Enumerates tools from the LIVE server's own tools/list, not from this
+      # checkout: the question is whether what we serve matches what we
+      # publish, and both halves have to come from production for the answer
+      # to mean anything.
+      - name: Validate live MCP responses against their published outputSchemas
+        run: |
+          node scripts/check-mcp-conformance.ts | tee mcp-conformance.log
+          {
+            echo '## MCP conformance'
+            echo '```'
+            cat mcp-conformance.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "deploy:wss-lb:preview": "scripts/deploy-worker-with-sourcemaps.sh wrangler.wss-lb.jsonc --preview",
     "smoke:live": "node scripts/smoke-live-api.ts",
     "smoke:mcp": "node scripts/mcp-smoke-sweep.ts",
+    "conformance:mcp": "node scripts/check-mcp-conformance.ts",
     "lint": "eslint .",
     "format:check": "prettier --check .",
     "pretypecheck": "npm run build --workspace=packages/chain-summaries",

--- a/schemas-src/mcp-tools/query-tools.ts
+++ b/schemas-src/mcp-tools/query-tools.ts
@@ -7,14 +7,21 @@
 // schemas-src/routes/ REST schema -- modeled fresh, matching each
 // hand-written literal field-for-field.
 //
-// query_graphql's hand-written `data` field declares `nullable: true`, an
-// OpenAPI-3.0-ism with NO effect under JSON Schema draft 2020-12 (which has
-// no `nullable` keyword) -- so under the target's own spec, `data` was
-// already (inertly) a plain non-nullable object. Preserved literally as
-// non-nullable here rather than "fixed" into a real `.nullable()`, since
-// doing so would make the new schema accept something the old one's actual
-// declared (2020-12) semantics didn't -- the opposite direction from this
-// epic's wire-compatibility mandate.
+// query_graphql's `data` IS nullable (#9911), and the reasoning that once said
+// otherwise has been overtaken by evidence.
+//
+// The hand-written original declared `nullable: true`, an OpenAPI-3.0-ism with
+// no effect under JSON Schema draft 2020-12. The port preserved it literally as
+// non-nullable rather than "fixing" it, on the grounds that widening a schema
+// during a migration accepts something the old one did not -- the right instinct
+// while the question was only what the old document meant.
+//
+// It is no longer only that question. The production conformance sweep (#9879)
+// called this tool and got `data: null` back, which is not our choice: the
+// GraphQL spec REQUIRES `data` to be null when a request fails before execution
+// begins. So the non-nullable declaration forbade a value the protocol obliges
+// us to emit, and every failed query violated the contract we publish. Matching
+// the protocol is a correction, not a loosening.
 //
 // run_saved_query's output declares `additionalProperties: false` (.strict()
 // below), unlike nearly every other output schema in this epic (which are
@@ -35,10 +42,15 @@ export const QueryGraphqlInputSchema = z
       .describe(
         "The GraphQL document to execute against metagraphed's schema -- a full `query { ... }` operation, not search text. Pair named variables with the sibling `variables` object; use get_api_schema to discover the available fields.",
       )
+      // SELF-CONTAINED, deliberately (#9911). The previous example declared
+      // `$netuid: Int!` while the matching value lived on the SEPARATE,
+      // optional `variables` parameter -- so an agent copying the `query`
+      // example alone got a variable-coercion error rather than a subnet. Same
+      // class as the `chutes` slug example (#9860): an example is the first
+      // thing an agent copies, and one that does not work teaches the wrong
+      // thing AND wastes the call. Verified live 2026-08-07.
       .meta({
-        examples: [
-          "query SubnetById($netuid: Int!) { subnet(netuid: $netuid) { netuid name } }",
-        ],
+        examples: ["query { subnet(netuid: 64) { netuid name } }"],
       }),
     variables: OpenObjectSchema.optional()
       .describe("GraphQL variables for the query, as an object.")
@@ -49,7 +61,8 @@ export type QueryGraphqlInput = z.infer<typeof QueryGraphqlInputSchema>;
 
 export const QueryGraphqlOutputSchema = z
   .object({
-    data: OpenObjectSchema.optional(),
+    // Null on a request error, per the GraphQL spec -- see the header.
+    data: OpenObjectSchema.nullable().optional(),
     errors: z.array(OpenObjectSchema).optional(),
   })
   .passthrough();

--- a/scripts/check-mcp-conformance.ts
+++ b/scripts/check-mcp-conformance.ts
@@ -1,0 +1,306 @@
+// Do the MCP responses we SERVE match the outputSchemas we PUBLISH? (#9879)
+//
+// The REST half of this question has been answered out of band since #9141
+// (scripts/check-response-conformance.ts, scheduled daily). The MCP half was
+// not answered anywhere. `validate:mcp` runs in CI against a hermetic harness
+// and reports, honestly, that it cannot finish the job:
+//
+//   MCP response coverage: 209/225 tools validated against a real response;
+//   97 validated over empty collections, so their item shapes rely on the
+//   production sweep.
+//
+// That sweep (scripts/mcp-smoke-sweep.ts) was never scheduled anywhere. So CI
+// said "something else checks these" and nothing did -- an unexercised check
+// reporting success, which is the exact failure the coverage line was written
+// to avoid.
+//
+// WHAT THIS CATCHES THAT THE HERMETIC GATE CANNOT. A tool answering
+// `{items: []}` satisfies its outputSchema completely: every declared property
+// of `items[]` is vacuously fine because there are no items. Only production
+// has the rows. #9884 is the worked example -- deriving MCP schemas from route
+// schemas made row objects strict, and 25 tools began failing their own
+// published schema the moment a caller used the `fields` parameter they
+// advertise. CI stayed green throughout, because the harness serves no rows to
+// project.
+//
+// SO THE PROJECTED PATH IS SWEPT TOO, not just the plain one. Each
+// `fields`-capable tool is called twice: once whole, then again projected onto
+// a field name taken off its own first response.
+//
+// A SCHEMA VIOLATION FAILS THIS CHECK. That is the difference between this and
+// mcp-smoke-sweep.ts, which is a deliberately noisy TRIAGE list where a SUSPECT
+// flag never fails. "The response does not match the schema we publish" needs
+// no judgement to confirm, so it is an error rather than a flag.
+import { Ajv2020 } from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+
+// Live MCP JSON-RPC payloads, read for reporting. Same `Row` precedent as
+// scripts/mcp-smoke-sweep.ts and scripts/lib.ts: an unexpected shape is what
+// this exists to surface, so typing each hop through `unknown` would force a
+// cast at every `?.` for no real safety.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+
+import {
+  buildToolArguments,
+  projectableFieldFrom,
+  projectionArgumentFor,
+} from "./mcp-tool-arguments.ts";
+
+const ENDPOINT =
+  process.env.MCP_CONFORMANCE_ENDPOINT || "https://api.metagraph.sh/mcp";
+// Serial, and spaced. The endpoint rate-limits per CLIENT, not per tool: a
+// first pass at concurrency 2 turned 34 healthy tools into
+// `-32600 Too many MCP requests`, a parallel sweep manufacturing failures that
+// read exactly like real defects (scripts/mcp-smoke-sweep.ts records the same
+// finding). ~1.6s is the measured floor.
+const CALL_SPACING_MS = Number(process.env.MCP_CONFORMANCE_SPACING_MS ?? 1600);
+const RATE_LIMIT_RETRIES = 4;
+const RATE_LIMIT_BACKOFF_MS = 2000;
+const REQUEST_TIMEOUT_MS = 30000;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export interface ConformanceViolation {
+  tool: string;
+  /** "plain" or "projected" -- which of the two calls failed. */
+  call: string;
+  path: string;
+  message: string;
+}
+
+let rpcId = 0;
+
+async function rpc(method: string, params: Row): Promise<Row> {
+  for (let attempt = 0; ; attempt += 1) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    let body: Row;
+    try {
+      const res = await fetch(ENDPOINT, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: (rpcId += 1),
+          method,
+          params,
+        }),
+        signal: controller.signal,
+      });
+      body = (await res.json()) as Row;
+    } finally {
+      clearTimeout(timer);
+    }
+    // A rate-limited call is not a result. Retrying rather than reporting it is
+    // what keeps "this tool is broken" out of the same bucket as "we asked too
+    // fast" -- the one distinction a conformance report must not lose.
+    const rateLimited = /Too many MCP requests/i.test(
+      String(body?.error?.message ?? ""),
+    );
+    if (rateLimited && attempt < RATE_LIMIT_RETRIES) {
+      await sleep(RATE_LIMIT_BACKOFF_MS * (attempt + 1));
+      continue;
+    }
+    return body;
+  }
+}
+
+/** Every tool the live server advertises, following tools/list pagination. */
+export async function listLiveTools(): Promise<Row[]> {
+  const tools: Row[] = [];
+  let cursor: string | undefined;
+  do {
+    const body = await rpc("tools/list", cursor ? { cursor } : {});
+    if (body?.error) {
+      throw new Error(`tools/list failed: ${JSON.stringify(body.error)}`);
+    }
+    for (const tool of (body?.result?.tools ?? []) as Row[]) tools.push(tool);
+    cursor = body?.result?.nextCursor as string | undefined;
+    if (cursor) await sleep(CALL_SPACING_MS);
+  } while (cursor);
+  return tools;
+}
+
+function ajv() {
+  const instance = new Ajv2020({
+    strict: false,
+    allErrors: true,
+    validateFormats: true,
+  });
+  // Same cast as scripts/check-response-conformance.ts: ajv-formats' CJS
+  // default export has no call signature under this module resolution.
+  (addFormats as unknown as (a: unknown) => void)(instance);
+  return instance;
+}
+
+/**
+ * Validate one structured result against one outputSchema.
+ *
+ * Exported for the unit test: the transport is the part that needs production,
+ * the comparison is not, and a comparison nobody can test offline is a
+ * comparison nobody checks.
+ */
+export function violationsFor(
+  schema: Row,
+  structured: unknown,
+  tool: string,
+  call: string,
+): ConformanceViolation[] {
+  const validate = ajv().compile(schema);
+  if (validate(structured)) return [];
+  return (validate.errors ?? []).map((error) => ({
+    tool,
+    call,
+    path: error.instancePath || "(root)",
+    message: error.message ?? "failed validation",
+  }));
+}
+
+export interface ConformanceReport {
+  checked: number;
+  projectionChecked: number;
+  projectionUnexercised: string[];
+  declined: string[];
+  undocumented: string[];
+  violations: ConformanceViolation[];
+}
+
+async function callTool(name: string, args: Row): Promise<Row> {
+  const body = await rpc("tools/call", { name, arguments: args });
+  await sleep(CALL_SPACING_MS);
+  return body;
+}
+
+/** The tool's structured result, or null when it declined. */
+function structuredOf(body: Row): Row | null {
+  if (body?.error) return null;
+  if (body?.result?.isError) return null;
+  const structured = body?.result?.structuredContent;
+  return structured && typeof structured === "object" ? structured : null;
+}
+
+export async function run(): Promise<ConformanceReport> {
+  const tools = await listLiveTools();
+  const report: ConformanceReport = {
+    checked: 0,
+    projectionChecked: 0,
+    projectionUnexercised: [],
+    declined: [],
+    undocumented: [],
+    violations: [],
+  };
+
+  for (const tool of tools) {
+    const name = String(tool.name);
+    const schema = tool.outputSchema as Row | undefined;
+    // A tool with no published outputSchema promises nothing about its shape,
+    // so there is nothing here to conform to. That is a real gap, but it is
+    // #9797's gap, not a conformance failure.
+    if (!schema) continue;
+    const { args, undocumented } = buildToolArguments(tool.inputSchema as Row);
+    if (undocumented.length > 0) {
+      report.undocumented.push(`${name} (${undocumented.join(", ")})`);
+      continue;
+    }
+    const body = await callTool(name, args);
+    const structured = structuredOf(body);
+    if (structured === null) {
+      // A decline is not a conformance failure: production legitimately
+      // answers not_found for an example subject that has since changed, and a
+      // scheduled check that pages on that would be turned off within a week.
+      // Reported so the count is legible rather than silently smaller.
+      report.declined.push(name);
+      continue;
+    }
+    report.checked += 1;
+    report.violations.push(...violationsFor(schema, structured, name, "plain"));
+
+    // The projected path -- the one #9884 broke while CI stayed green.
+    const properties = ((tool.inputSchema as Row)?.properties ?? {}) as Row;
+    if (!properties.fields) continue;
+    const field = projectableFieldFrom(structured);
+    if (!field) {
+      // Production served no rows either, so the projection is genuinely
+      // unexercisable right now. Named rather than counted, so a tool that is
+      // permanently empty is visible instead of quietly absent.
+      report.projectionUnexercised.push(name);
+      continue;
+    }
+    const projected = await callTool(name, {
+      ...args,
+      fields: projectionArgumentFor(tool.inputSchema as Row, field),
+    });
+    const projectedStructured = structuredOf(projected);
+    if (projectedStructured === null) {
+      report.projectionUnexercised.push(`${name} (declined when projected)`);
+      continue;
+    }
+    report.projectionChecked += 1;
+    report.violations.push(
+      ...violationsFor(schema, projectedStructured, name, `projected:${field}`),
+    );
+  }
+  return report;
+}
+
+export function formatReport(report: ConformanceReport): string {
+  const lines = [
+    `tools validated against their own published outputSchema: ${report.checked}`,
+    `of those, also validated under their own \`fields\` projection: ${report.projectionChecked}`,
+  ];
+  if (report.projectionUnexercised.length > 0) {
+    lines.push(
+      `projection unexercised (served no rows): ${report.projectionUnexercised.join(", ")}`,
+    );
+  }
+  if (report.declined.length > 0) {
+    lines.push(
+      `declined for their example arguments: ${report.declined.join(", ")}`,
+    );
+  }
+  if (report.undocumented.length > 0) {
+    lines.push(
+      `not callable -- a required parameter declares no example: ${report.undocumented.join(", ")}`,
+    );
+  }
+  if (report.violations.length === 0) {
+    lines.push("");
+    lines.push("No response violated the schema it publishes.");
+    return lines.join("\n");
+  }
+  lines.push("");
+  lines.push(`${report.violations.length} SCHEMA VIOLATION(S):`);
+  for (const violation of report.violations) {
+    lines.push(
+      `  ${violation.tool} [${violation.call}] ${violation.path}: ${violation.message}`,
+    );
+  }
+  return lines.join("\n");
+}
+
+// Guarded so the module can be imported by its test without sweeping
+// production, matching scripts/check-response-conformance.ts.
+if (
+  process.argv[1] &&
+  import.meta.url.endsWith(process.argv[1].split("/").pop() ?? "")
+) {
+  const report = await run();
+  console.log(formatReport(report));
+  // A violation is a real contract defect -- the response does not match the
+  // schema we publish, which needs no judgement to confirm. Unlike the triage
+  // sweep's SUSPECT flags, it fails.
+  if (report.violations.length > 0) process.exitCode = 1;
+  // Zero validated tools means the sweep did not run, not that everything
+  // passed. Without this the check reports "No response violated the schema it
+  // publishes" after a total outage.
+  if (report.checked === 0) {
+    console.error(
+      "No tool was validated at all -- treating as a failure rather than a clean run.",
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/mcp-tool-arguments.ts
+++ b/scripts/mcp-tool-arguments.ts
@@ -1,0 +1,154 @@
+// How to call an MCP tool from nothing but its own published inputSchema.
+//
+// Extracted from scripts/validate-mcp.ts (#9879) so the hermetic gate and the
+// scheduled production conformance check build their arguments the SAME way.
+// Two copies of this rule would drift, and the direction they would drift is
+// the dangerous one: the production check exists to catch what the hermetic one
+// cannot see, so a production check calling tools differently would report
+// differences that are its own.
+//
+// Nothing here is hand-maintained. A newly registered tool is swept correctly
+// the day it lands, because every argument comes from the tool's own schema.
+
+type Row = Record<string, unknown>;
+
+/**
+ * The first declared example for one parameter's schema.
+ *
+ * Arguments come from each parameter's OWN declared example, not from a table.
+ * That makes the examples load-bearing rather than decorative: an example that
+ * is not a valid argument fails the sweep that uses it, which matters because
+ * an example is the first thing an agent copies.
+ */
+export function declaredExample(schema: Row | undefined): {
+  found: boolean;
+  value?: unknown;
+} {
+  if (!schema) return { found: false };
+  const direct = schema.examples;
+  if (Array.isArray(direct) && direct.length > 0) {
+    return { found: true, value: direct[0] };
+  }
+  for (const key of ["anyOf", "oneOf"]) {
+    const branch = schema[key];
+    if (!Array.isArray(branch)) continue;
+    for (const entry of branch) {
+      const nested = declaredExample(entry as Row);
+      if (nested.found) return nested;
+    }
+  }
+  return { found: false };
+}
+
+/**
+ * Which arguments must be supplied to call this tool at all.
+ *
+ * `required` alone is not the whole answer once a tool publishes a choice
+ * (#9872): `get_neuron` takes EITHER `uid` OR `hotkey`, so neither can appear
+ * in `required` -- and a sweep reading only `required` would call it with no
+ * identifier at all and be told so, which looks exactly like a broken contract.
+ * Taking the first `oneOf`/`anyOf` branch's own `required` picks one side of
+ * the choice, which is what a caller does too.
+ *
+ * Only a branch that constrains PRESENCE is followed. `get_feed` publishes a
+ * value-conditional one -- `kind: "subnet"` requires `netuid`, the other kinds
+ * forbid it -- and adopting its first branch's `required` produced
+ * `{kind: "registry", netuid: 64}`, which the server rightly rejects. Resolving
+ * that needs the condition, not just the requirement, so a branch carrying
+ * `properties`/`not`/`if` is left alone and the tool is called from `required`
+ * as before.
+ */
+export function requiredArgumentNames(inputSchema: Row | undefined): string[] {
+  const base = ((inputSchema?.required ?? []) as string[]).slice();
+  for (const key of ["oneOf", "anyOf"]) {
+    const branches = inputSchema?.[key];
+    if (!Array.isArray(branches) || branches.length === 0) continue;
+    const presenceOnly = branches.filter((branch) => {
+      const keys = Object.keys((branch ?? {}) as Row);
+      return keys.length === 1 && keys[0] === "required";
+    });
+    if (presenceOnly.length !== branches.length) break;
+    for (const name of ((presenceOnly[0] as Row)?.required ?? []) as string[]) {
+      if (!base.includes(name)) base.push(name);
+    }
+    break;
+  }
+  return base;
+}
+
+/**
+ * A complete argument object for one tool, plus the parameters that declared no
+ * example.
+ *
+ * `undocumented` is returned rather than thrown on, because the two callers
+ * want different things from it: the hermetic gate FAILS (a required parameter
+ * with no example means its tool can never be swept), while the production
+ * check reports it and moves on rather than turning a documentation gap into a
+ * paging alarm.
+ */
+export function buildToolArguments(inputSchema: Row | undefined): {
+  args: Row;
+  undocumented: string[];
+} {
+  const properties = (inputSchema?.properties ?? {}) as Row;
+  const args: Row = {};
+  const undocumented: string[] = [];
+  for (const key of requiredArgumentNames(inputSchema)) {
+    const example = declaredExample(properties[key] as Row);
+    if (!example.found) {
+      undocumented.push(key);
+      continue;
+    }
+    args[key] = example.value;
+  }
+  return { args, undocumented };
+}
+
+/**
+ * One real field name off a tool's response, for exercising its `fields`
+ * projection.
+ *
+ * Derived from the response rather than hardcoded, because the valid `fields`
+ * values are per-tool: a hardcoded list would be one more hand-maintained copy,
+ * and a wrong entry would make the projection check fail for its own reasons.
+ *
+ * Returns null when the response carries no rows -- which is the whole reason
+ * this check has to run against PRODUCTION. In the hermetic harness 30 of the
+ * 32 `fields`-capable tools serve nothing, so their projected shape is
+ * unexercised there however carefully the gate is written.
+ */
+export function projectionArgumentFor(
+  inputSchema: Row | undefined,
+  field: string,
+): string | string[] {
+  // `fields` has TWO published shapes, and sending the wrong one is rejected
+  // rather than ignored: 28 tools take a comma-separated STRING, and the three
+  // neuron-row tools take an ARRAY (their own description says so -- "an ARRAY
+  // of names, unlike the comma-separated string `fields` takes elsewhere").
+  //
+  // Read off the tool's own schema rather than listed, because the first
+  // version of the production check sent an array to all of them and 27 tools
+  // answered `invalid_params`. That looked exactly like "these tools serve no
+  // rows", which is the report this check exists to make trustworthy.
+  const schema = ((inputSchema?.properties ?? {}) as Row).fields as
+    Row | undefined;
+  const type = schema?.type;
+  const isArray = Array.isArray(type)
+    ? type.includes("array")
+    : type === "array";
+  return isArray ? [field] : field;
+}
+
+export function projectableFieldFrom(response: Row | undefined): string | null {
+  if (!response) return null;
+  const rows = Object.values(response).find(
+    (value) =>
+      Array.isArray(value) &&
+      value.length > 0 &&
+      typeof value[0] === "object" &&
+      value[0] !== null,
+  ) as Row[] | undefined;
+  const row = rows?.[0] ?? (response.neuron as Row | undefined);
+  if (!row || typeof row !== "object") return null;
+  return Object.keys(row)[0] ?? null;
+}

--- a/scripts/validate-mcp.ts
+++ b/scripts/validate-mcp.ts
@@ -23,6 +23,11 @@ import {
 } from "../src/route-limits.ts";
 import { MCP_SERVER_INFO } from "../src/mcp-server.ts";
 import {
+  buildToolArguments,
+  projectableFieldFrom,
+  projectionArgumentFor,
+} from "./mcp-tool-arguments.ts";
+import {
   MCP_SERVER_VERSION,
   MCP_TOOLS,
   listToolDefinitions,
@@ -1904,68 +1909,11 @@ const RESPONSE_UNVALIDATED_REASONS = new Map<string, string>([
 ]);
 
 // Arguments come from each parameter's OWN declared example, not from a table
-// kept here. Every one of the published input parameters carries one, so there
-// is nothing to hand-maintain and a newly registered tool is swept correctly the
-// day it lands. It also means the examples are load-bearing rather than
-// decorative: an example that is not a valid argument now fails this gate, which
-// matters because an example is the first thing an agent copies.
-function declaredExample(schema: Row | undefined): {
-  found: boolean;
-  value?: unknown;
-} {
-  if (!schema) return { found: false };
-  const direct = schema.examples;
-  if (Array.isArray(direct) && direct.length > 0) {
-    return { found: true, value: direct[0] };
-  }
-  for (const key of ["anyOf", "oneOf"]) {
-    const branch = schema[key];
-    if (!Array.isArray(branch)) continue;
-    for (const entry of branch) {
-      const nested = declaredExample(entry as Row);
-      if (nested.found) return nested;
-    }
-  }
-  return { found: false };
-}
-
-// Which arguments must be supplied to call this tool at all.
-//
-// `required` alone is not the whole answer once a tool publishes a choice
-// (#9872): `get_neuron` takes EITHER `uid` OR `hotkey`, so neither can appear
-// in `required` -- and a sweep that reads only `required` would call it with
-// no identifier at all and be told so, which looks exactly like a broken
-// contract. Taking the first `oneOf`/`anyOf` branch's own `required` picks one
-// side of the choice, which is what a caller does too.
-//
-// Only a branch that constrains PRESENCE is followed. `get_feed` publishes a
-// value-conditional one -- `kind: "subnet"` requires `netuid`, the other kinds
-// forbid it -- and adopting its first branch's `required` produced
-// `{kind: "registry", netuid: 64}`, which the server rightly rejects. Resolving
-// that needs the condition, not just the requirement, so a branch carrying
-// `properties`/`not`/`if` is left alone and the tool is swept from `required`
-// as before.
-//
-// Derived from the published schema rather than from a table of tools that
-// have a choice: a tool that grows one is swept correctly the day it lands,
-// and this cannot fall out of date because there is nothing to update.
-function requiredArgumentNames(inputSchema: Row | undefined): string[] {
-  const base = ((inputSchema?.required ?? []) as string[]).slice();
-  for (const key of ["oneOf", "anyOf"]) {
-    const branches = inputSchema?.[key];
-    if (!Array.isArray(branches) || branches.length === 0) continue;
-    const presenceOnly = branches.filter((branch) => {
-      const keys = Object.keys((branch ?? {}) as Row);
-      return keys.length === 1 && keys[0] === "required";
-    });
-    if (presenceOnly.length !== branches.length) break;
-    for (const name of ((presenceOnly[0] as Row)?.required ?? []) as string[]) {
-      if (!base.includes(name)) base.push(name);
-    }
-    break;
-  }
-  return base;
-}
+// kept here -- and the rule for building them lives in
+// scripts/mcp-tool-arguments.ts, shared with the scheduled production
+// conformance check (#9879). Two copies would drift, and the production check
+// exists to catch what this one cannot see, so it has to call tools the same
+// way this one does or its findings would be its own.
 
 // --- Declared slug examples must name something that exists (#9860) --------
 //
@@ -2010,18 +1958,7 @@ for (const def of listToolDefinitions()) {
   if (RESPONSE_VALIDATED.has(def.name)) continue;
   if (RESPONSE_UNVALIDATED_REASONS.has(def.name)) continue;
   const inputSchema = def.inputSchema as Row | undefined;
-  const properties = (inputSchema?.properties ?? {}) as Row;
-  const required = requiredArgumentNames(inputSchema);
-  const args: Row = {};
-  const undocumented: string[] = [];
-  for (const key of required) {
-    const example = declaredExample(properties[key] as Row);
-    if (!example.found) {
-      undocumented.push(key);
-      continue;
-    }
-    args[key] = example.value;
-  }
+  const { args, undocumented } = buildToolArguments(inputSchema);
   assert.deepEqual(
     undocumented,
     [],
@@ -2070,11 +2007,7 @@ for (const def of listToolDefinitions()) {
     {}) as Row;
   if (!properties.fields) continue;
   if (RESPONSE_UNVALIDATED_REASONS.has(def.name)) continue;
-  const args: Row = {};
-  for (const key of requiredArgumentNames(def.inputSchema as Row | undefined)) {
-    const example = declaredExample(properties[key] as Row);
-    if (example.found) args[key] = example.value;
-  }
+  const { args } = buildToolArguments(def.inputSchema as Row | undefined);
   const plain = await call(def.name, args);
   if (plain.isError) {
     projectionUnexercised.push(def.name);
@@ -2083,16 +2016,7 @@ for (const def of listToolDefinitions()) {
   // The collection this tool returns, and one real field name off it. Derived
   // rather than hardcoded: the valid `fields` values are per-tool, and a
   // hardcoded list would be one more hand-maintained copy.
-  const rows = Object.values(plain).find(
-    (value) =>
-      Array.isArray(value) &&
-      value.length > 0 &&
-      typeof value[0] === "object" &&
-      value[0] !== null,
-  ) as Row[] | undefined;
-  const row = rows?.[0] ?? (plain.neuron as Row | undefined);
-  const field =
-    row && typeof row === "object" ? Object.keys(row)[0] : undefined;
+  const field = projectableFieldFrom(plain);
   if (!field) {
     // The harness has no rows for this tool, so there is nothing to project.
     // Counted rather than skipped silently: an unexercised check that reports
@@ -2100,7 +2024,13 @@ for (const def of listToolDefinitions()) {
     projectionUnexercised.push(def.name);
     continue;
   }
-  const projected = await call(def.name, { ...args, fields: field });
+  // The SHAPE comes from the tool's own `fields` schema, not from a guess:
+  // 28 tools take a comma-separated string and three take an array, and
+  // sending the wrong one is rejected rather than ignored (#9879).
+  const projected = await call(def.name, {
+    ...args,
+    fields: projectionArgumentFor(def.inputSchema as Row, field),
+  });
   if (projected.isError) {
     projectionUnexercised.push(def.name);
     continue;
@@ -2126,7 +2056,7 @@ console.log(
   `MCP projection coverage: ${projectionChecked} of ${projectionChecked + projectionUnexercised.length} ` +
     `\`fields\`-capable tools had their PROJECTED response validated` +
     (projectionUnexercised.length > 0
-      ? ` (${projectionUnexercised.length} serve no rows in the hermetic harness, so their projected shape rests on the production sweep: ${projectionUnexercised.join(", ")})`
+      ? ` (${projectionUnexercised.length} serve no rows in the hermetic harness, so their projected shape rests on the daily check-mcp-conformance workflow, which sweeps production and validates all 32: ${projectionUnexercised.join(", ")})`
       : ""),
 );
 
@@ -2356,7 +2286,13 @@ const COLLECTIONS_UNEXERCISED_REASONS = new Map<string, string>([
     `MCP response coverage: ${RESPONSE_VALIDATED.size}/${listToolDefinitions().length} tools ` +
       `validated against a real response (${RESPONSE_UNVALIDATED_REASONS.size} declared ` +
       `unanswerable by the hermetic harness); ${COLLECTIONS_UNEXERCISED_REASONS.size} validated ` +
-      `over empty collections, so their item shapes rely on the production sweep.`,
+      // NAMED, and it exists (#9879). This line used to say "the production
+      // sweep", which was `npm run smoke:mcp` -- an opt-in script scheduled
+      // nowhere. CI claimed something else covered these and nothing did.
+      // check-mcp-conformance.yml runs daily against api.metagraph.sh and
+      // FAILS on a schema violation, so the deferral now has a receiver.
+      `over empty collections, so their item shapes are covered by the daily ` +
+      `check-mcp-conformance workflow rather than by this run.`,
   );
 }
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -15281,6 +15281,76 @@ export function markChainCallsScopeDeclined<T>(
   } as T;
 }
 
+/**
+ * Complete a generically-stamped `degraded` block against the schema the tool
+ * actually publishes (#9910).
+ *
+ * THE DEFECT THIS CLOSES. `markMcpTierDegraded` stamps one shape --
+ * `{reason}` -- on whichever tool happened to degrade. But `degraded` is a
+ * per-tool object, and `get_account_positions` declares three REQUIRED
+ * properties on it, so the generic stamp produced a response that failed the
+ * tool's own published outputSchema. Confirmed in production 2026-08-07:
+ * `degraded = {"reason":"tier_unavailable"}` against a schema requiring
+ * `snapshot_captured_at` and `latest_stake_event_at` as well.
+ *
+ * It could not be fixed in the handler, which is where the first attempt
+ * (#9817's shapeForwardedPositions) put it: this stamp lands at DISPATCH,
+ * after every handler has returned, so the handler's correctly-shaped answer
+ * is not what the caller receives when the tier degrades mid-call.
+ *
+ * DERIVED, NOT LISTED. The missing keys are read off the tool's own
+ * outputSchema rather than from a table of tools with rich `degraded` blocks:
+ * one tool declares one today, and a table would be wrong the first time a
+ * second one did. Only properties the schema declares REQUIRED and NULLABLE
+ * are filled, and only with `null` -- "we could not read the tier, so we do
+ * not know" is exactly what a nullable required field is for, and it is the
+ * one value this chokepoint can honestly supply.
+ */
+export function completeDegradedBlock(
+  data: unknown,
+  outputSchema: JsonSchemaLike | undefined,
+): unknown {
+  const row = data as Row | null;
+  const degraded = row?.degraded as Row | undefined;
+  if (!degraded || typeof degraded !== "object" || Array.isArray(degraded)) {
+    return data;
+  }
+  const declared = (outputSchema?.properties as Row | undefined)?.degraded as
+    Row | undefined;
+  // A nullable object is published as anyOf[{object}, {null}], so the required
+  // list can sit on a branch rather than at the top.
+  const branches = [
+    declared,
+    ...((declared?.anyOf as Row[] | undefined) ?? []),
+    ...((declared?.oneOf as Row[] | undefined) ?? []),
+  ].filter((branch): branch is Row => Boolean(branch));
+  const filled: Row = { ...degraded };
+  let changed = false;
+  for (const branch of branches) {
+    const required = branch.required;
+    const properties = branch.properties as Row | undefined;
+    if (!Array.isArray(required) || !properties) continue;
+    for (const key of required as string[]) {
+      if (Object.hasOwn(filled, key)) continue;
+      // Only a NULLABLE required property can be honestly filled. One that is
+      // required and non-nullable has no value this chokepoint could invent,
+      // so it is left absent and the conformance check reports it -- an
+      // invented value would be worse than a visible violation.
+      const property = properties[key] as Row | undefined;
+      const nullable =
+        property?.type === "null" ||
+        (Array.isArray(property?.type) && property.type.includes("null")) ||
+        ((property?.anyOf as Row[] | undefined) ?? []).some(
+          (entry) => entry?.type === "null",
+        );
+      if (!nullable) continue;
+      filled[key] = null;
+      changed = true;
+    }
+  }
+  return changed ? ({ ...row, degraded: filled } as unknown) : data;
+}
+
 export function markMcpTierDegraded(
   data: unknown,
   generationBefore: number,
@@ -15385,7 +15455,14 @@ async function dispatchTool(
         });
       }
     }
-    const payload = markMcpTierDegraded(data, tierGenerationBefore);
+    // Completed against THIS tool's schema, because the marker above stamps
+    // one generic shape onto whichever tool degraded and `degraded` is a
+    // per-tool object (#9910). Applied to every result, not just a stamped
+    // one: a handler that built its own partial block is the same violation.
+    const payload = completeDegradedBlock(
+      markMcpTierDegraded(data, tierGenerationBefore),
+      tool.outputSchema ?? (TOOL_OUTPUT_SCHEMAS as Row)[tool.name],
+    );
     return {
       content: [{ type: "text", text: JSON.stringify(payload) }],
       structuredContent: payload as Row,

--- a/tests/check-mcp-conformance.test.ts
+++ b/tests/check-mcp-conformance.test.ts
@@ -1,0 +1,212 @@
+// The MCP production conformance check (#9879).
+//
+// The TRANSPORT needs production; the two decisions it makes do not, and a
+// decision nobody can test offline is a decision nobody checks. So the
+// argument-building rules and the schema comparison are exercised here, and
+// only the sweep loop itself is left to the scheduled workflow.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  buildToolArguments,
+  declaredExample,
+  projectableFieldFrom,
+  projectionArgumentFor,
+  requiredArgumentNames,
+} from "../scripts/mcp-tool-arguments.ts";
+import {
+  formatReport,
+  violationsFor,
+  type ConformanceReport,
+} from "../scripts/check-mcp-conformance.ts";
+import { listToolDefinitions } from "../src/mcp-server.ts";
+import type { Row } from "./row-type.ts";
+
+describe("argument building is shared with validate:mcp (#9879)", () => {
+  test("a presence-only oneOf contributes one side of the choice", () => {
+    // get_neuron's real shape: EITHER uid OR hotkey, so neither can sit in
+    // `required` -- and a sweep reading only `required` would call it with no
+    // identifier and read its correct rejection as a broken contract.
+    const schema = {
+      required: ["netuid"],
+      oneOf: [{ required: ["uid"] }, { required: ["hotkey"] }],
+    };
+    assert.deepEqual(requiredArgumentNames(schema), ["netuid", "uid"]);
+  });
+
+  test("a VALUE-conditional branch is left alone", () => {
+    // get_feed's real shape. Following it produced `{kind: "registry",
+    // netuid: 64}`, which the server rightly refuses -- resolving the choice
+    // needs the condition, not just the requirement.
+    const schema = {
+      required: ["kind"],
+      anyOf: [
+        {
+          properties: { kind: { const: "subnet" } },
+          required: ["kind", "netuid"],
+        },
+        {
+          properties: { kind: { enum: ["registry", "incidents"] } },
+          not: { required: ["netuid"] },
+        },
+      ],
+    };
+    assert.deepEqual(requiredArgumentNames(schema), ["kind"]);
+  });
+
+  test("an example is found through anyOf, and its absence is reported not thrown", () => {
+    assert.deepEqual(
+      declaredExample({ anyOf: [{ type: "null" }, { examples: [7] }] }),
+      { found: true, value: 7 },
+    );
+    const { args, undocumented } = buildToolArguments({
+      required: ["netuid", "slug"],
+      properties: { netuid: { examples: [64] }, slug: { type: "string" } },
+    });
+    assert.deepEqual(args, { netuid: 64 });
+    assert.deepEqual(undocumented, ["slug"]);
+  });
+});
+
+describe("the `fields` projection argument matches each tool's own shape", () => {
+  test("array-typed tools get an array, string-typed tools get a string", () => {
+    assert.deepEqual(
+      projectionArgumentFor(
+        { properties: { fields: { type: "array" } } },
+        "uid",
+      ),
+      ["uid"],
+    );
+    assert.equal(
+      projectionArgumentFor(
+        { properties: { fields: { type: "string" } } },
+        "uid",
+      ),
+      "uid",
+    );
+    // A nullable array is published as type: ["array","null"].
+    assert.deepEqual(
+      projectionArgumentFor(
+        { properties: { fields: { type: ["array", "null"] } } },
+        "uid",
+      ),
+      ["uid"],
+    );
+  });
+
+  test("every live tool's shape is derivable, and both shapes really exist", () => {
+    // The first version of the check sent an array to all of them and 27 tools
+    // answered invalid_params -- which read exactly like "these tools serve no
+    // rows", the report this check exists to make trustworthy. Asserting BOTH
+    // shapes are present keeps this test from passing vacuously if the enum
+    // ever collapses to one.
+    const shapes = new Set<string>();
+    for (const tool of listToolDefinitions() as Row[]) {
+      const properties = ((tool.inputSchema as Row)?.properties ?? {}) as Row;
+      if (!properties.fields) continue;
+      const argument = projectionArgumentFor(tool.inputSchema as Row, "uid");
+      shapes.add(Array.isArray(argument) ? "array" : "string");
+    }
+    assert.deepEqual([...shapes].sort(), ["array", "string"]);
+  });
+
+  test("a field name is taken off the response, including the single-row shape", () => {
+    assert.equal(
+      projectableFieldFrom({ items: [{ uid: 1, hotkey: "x" }] }),
+      "uid",
+    );
+    // get_neuron returns one row under `neuron`, not a collection.
+    assert.equal(projectableFieldFrom({ neuron: { uid: 1 } }), "uid");
+    // No rows is a real answer -- it means the projection is unexercisable,
+    // which the report names rather than counting as a pass.
+    assert.equal(projectableFieldFrom({ items: [] }), null);
+    assert.equal(projectableFieldFrom(undefined), null);
+  });
+});
+
+describe("violations are reported against the published schema", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      degraded: {
+        type: "object",
+        properties: { reason: { type: "string" } },
+        required: ["reason"],
+      },
+    },
+    required: ["degraded"],
+  };
+
+  test("a conforming response yields nothing", () => {
+    assert.deepEqual(
+      violationsFor(schema, { degraded: { reason: "x" } }, "t", "plain"),
+      [],
+    );
+  });
+
+  test("a violation carries the tool, the call and the path", () => {
+    const found = violationsFor(schema, {}, "get_x", "projected:uid");
+    assert.equal(found.length, 1);
+    assert.equal(found[0].tool, "get_x");
+    assert.equal(found[0].call, "projected:uid");
+    assert.match(found[0].message, /degraded/);
+  });
+});
+
+describe("the report is legible on a clean run and on a failing one", () => {
+  const base: ConformanceReport = {
+    checked: 219,
+    projectionChecked: 32,
+    projectionUnexercised: [],
+    declined: [],
+    undocumented: [],
+    violations: [],
+  };
+
+  test("a clean run says so in words, not by silence", () => {
+    const text = formatReport(base);
+    assert.match(text, /219/);
+    assert.match(text, /No response violated the schema it publishes/);
+  });
+
+  test("violations are listed individually, not counted", () => {
+    const text = formatReport({
+      ...base,
+      violations: [
+        { tool: "get_x", call: "plain", path: "/degraded", message: "boom" },
+      ],
+    });
+    assert.match(text, /1 SCHEMA VIOLATION/);
+    assert.match(text, /get_x \[plain\] \/degraded: boom/);
+  });
+
+  test("an unexercised projection is NAMED, so it cannot hide in a count", () => {
+    const text = formatReport({ ...base, projectionUnexercised: ["list_y"] });
+    assert.match(text, /projection unexercised.*list_y/);
+  });
+});
+
+describe("the scheduled workflow that runs it (#9879)", () => {
+  const workflow = readFileSync(
+    ".github/workflows/check-mcp-conformance.yml",
+    "utf8",
+  );
+
+  test("is actually scheduled, which is the whole point of the issue", () => {
+    // The defect being closed is a check that existed and ran nowhere. A test
+    // that only asserted the script works would reproduce it exactly.
+    assert.match(workflow, /^\s+- cron: /m);
+    assert.match(workflow, /workflow_dispatch/);
+  });
+
+  test("runs the checker rather than the noisy triage sweep", () => {
+    // mcp-smoke-sweep.ts is a TRIAGE list where a SUSPECT flag never fails;
+    // this workflow must run the check that fails on a schema violation.
+    assert.match(workflow, /scripts\/check-mcp-conformance\.ts/);
+    assert.equal(workflow.includes("mcp-smoke-sweep"), false);
+  });
+
+  test("does not mask a failure", () => {
+    assert.equal(/continue-on-error:\s*true/.test(workflow), false);
+  });
+});

--- a/tests/mcp-degraded-marker-completeness.test.ts
+++ b/tests/mcp-degraded-marker-completeness.test.ts
@@ -1,0 +1,216 @@
+// The dispatch-level `degraded` stamp must satisfy the tool's own schema
+// (#9910), and query_graphql's `data` must accept the null GraphQL requires
+// (#9911).
+//
+// Both were found by the out-of-band production conformance sweep (#9879) and
+// confirmed against live production on 2026-08-07, which is the point: neither
+// was visible to CI. The hermetic harness never degrades a tier mid-call, and
+// nothing had ever validated a FAILED GraphQL query against the schema the tool
+// publishes for it.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import {
+  completeDegradedBlock,
+  listToolDefinitions,
+} from "../src/mcp-server.ts";
+import type { Row } from "./row-type.ts";
+
+function schemaFor(name: string): Row {
+  const def = listToolDefinitions().find(
+    (tool) => (tool as Row).name === name,
+  ) as Row;
+  return def.outputSchema as Row;
+}
+
+function validates(schema: Row, value: unknown): boolean {
+  return new Ajv2020({ strict: false }).compile(schema)(value);
+}
+
+describe("completeDegradedBlock (#9910)", () => {
+  const positions = () => schemaFor("get_account_positions");
+
+  test("the generic stamp alone FAILS the tool's published schema", () => {
+    // The state production was actually in. Asserted first so the fix below is
+    // shown to change something -- a negative assertion that passes on nothing
+    // proves nothing (#9689).
+    const stamped = {
+      schema_version: 1,
+      ss58: "5GP7c3fFazW9GXK8Up3qgu2DJBk8inu4aK9TZy3RuoSWVCMi",
+      // Required at the top level too -- the fixture is the whole card
+      // unavailableAccountPositions() builds, not just its degraded block.
+      captured_at: null,
+      position_count: 0,
+      total_stake_alpha: 0,
+      positions: [],
+      degraded: { reason: "tier_unavailable" },
+    };
+    assert.equal(validates(positions(), stamped), false);
+    // ...and completing it against the same schema fixes exactly that.
+    const completed = completeDegradedBlock(stamped, positions()) as Row;
+    assert.equal(validates(positions(), completed), true);
+    assert.deepEqual(completed.degraded, {
+      reason: "tier_unavailable",
+      snapshot_captured_at: null,
+      latest_stake_event_at: null,
+    });
+  });
+
+  test("a block the handler already completed is returned untouched", () => {
+    const full = {
+      degraded: {
+        reason: "snapshot_predates_stake_activity",
+        snapshot_captured_at: "2026-08-07T00:00:00.000Z",
+        latest_stake_event_at: "2026-08-07T12:00:00.000Z",
+      },
+    };
+    // Identity, not deep equality: a rebuilt-but-identical object would still
+    // mean the completion runs on every healthy response.
+    assert.equal(completeDegradedBlock(full, positions()), full);
+  });
+
+  test("a real value is never overwritten with null", () => {
+    const partial = {
+      degraded: {
+        reason: "positions_unpriceable",
+        snapshot_captured_at: "2026-08-07T00:00:00.000Z",
+      },
+    };
+    const completed = completeDegradedBlock(partial, positions()) as Row;
+    assert.equal(
+      (completed.degraded as Row).snapshot_captured_at,
+      "2026-08-07T00:00:00.000Z",
+    );
+    assert.equal((completed.degraded as Row).latest_stake_event_at, null);
+  });
+
+  test("a payload with no degraded block is untouched", () => {
+    const healthy = { schema_version: 1, positions: [], degraded: null };
+    assert.equal(completeDegradedBlock(healthy, positions()), healthy);
+    const absent = { schema_version: 1, positions: [] };
+    assert.equal(completeDegradedBlock(absent, positions()), absent);
+  });
+
+  test("a tool whose degraded requires only `reason` is untouched", () => {
+    // The generic stamp is already complete for these, and filling keys their
+    // schema does not declare would be inventing fields.
+    const stamped = { degraded: { reason: "tier_unavailable" } };
+    const schema = {
+      type: "object",
+      properties: {
+        degraded: {
+          type: "object",
+          properties: { reason: { type: "string" } },
+          required: ["reason"],
+        },
+      },
+    };
+    assert.equal(completeDegradedBlock(stamped, schema), stamped);
+  });
+
+  test("a required NON-nullable property is left absent rather than invented", () => {
+    // There is no honest value for it here, and a visible violation the
+    // conformance sweep reports beats a fabricated one it does not.
+    const schema = {
+      type: "object",
+      properties: {
+        degraded: {
+          type: "object",
+          properties: {
+            reason: { type: "string" },
+            detail: { type: "string" },
+          },
+          required: ["reason", "detail"],
+        },
+      },
+    };
+    const completed = completeDegradedBlock(
+      { degraded: { reason: "tier_unavailable" } },
+      schema,
+    ) as Row;
+    assert.equal(Object.hasOwn(completed.degraded as Row, "detail"), false);
+  });
+
+  test("a nullable property declared as a type ARRAY is filled too", () => {
+    // `{"type": ["string", "null"]}` and `{"anyOf": [{string}, {null}]}` are
+    // the same statement; Zod emits the second, a hand-written schema the
+    // first, and both reach this code.
+    const schema = {
+      type: "object",
+      properties: {
+        degraded: {
+          type: "object",
+          properties: {
+            reason: { type: "string" },
+            stamp: { type: ["string", "null"] },
+          },
+          required: ["reason", "stamp"],
+        },
+      },
+    };
+    const completed = completeDegradedBlock(
+      { degraded: { reason: "tier_unavailable" } },
+      schema,
+    ) as Row;
+    assert.equal((completed.degraded as Row).stamp, null);
+  });
+
+  test("a degraded branch declaring no `required` is skipped, not crashed on", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        degraded: {
+          type: "object",
+          properties: { reason: { type: "string" } },
+        },
+      },
+    };
+    const stamped = { degraded: { reason: "tier_unavailable" } };
+    assert.equal(completeDegradedBlock(stamped, schema), stamped);
+  });
+
+  test("no missing schema means no completion, and no crash", () => {
+    const stamped = { degraded: { reason: "tier_unavailable" } };
+    assert.equal(completeDegradedBlock(stamped, undefined), stamped);
+  });
+});
+
+describe("query_graphql publishes the null GraphQL requires (#9911)", () => {
+  test("a failed query's `data: null` satisfies the published schema", () => {
+    // The exact production response: a variable-coercion failure returns
+    // data:null with errors, which the previous non-nullable schema forbade.
+    const failed = {
+      data: null,
+      errors: [
+        {
+          message:
+            'Variable "$netuid" has invalid value: Expected a value of non-null type "Int!" to be provided.',
+        },
+      ],
+    };
+    assert.equal(validates(schemaFor("query_graphql"), failed), true);
+  });
+
+  test("a successful query still validates", () => {
+    assert.equal(
+      validates(schemaFor("query_graphql"), {
+        data: { subnet: { netuid: 64, name: "Chutes" } },
+        errors: [],
+      }),
+      true,
+    );
+  });
+
+  test("the declared query example is self-contained", () => {
+    const def = listToolDefinitions().find(
+      (tool) => (tool as Row).name === "query_graphql",
+    ) as Row;
+    const example = (((def.inputSchema as Row).properties as Row).query as Row)
+      .examples?.[0] as string;
+    // A `$variable` in the example needs the SEPARATE optional `variables`
+    // parameter to work, so an agent copying the query alone gets a coercion
+    // error. Verified live: the replacement returns SN64.
+    assert.equal(example.includes("$"), false);
+    assert.match(example, /subnet\(netuid:\s*64\)/);
+  });
+});


### PR DESCRIPTION
> Stacked on #9915 (the three violations this check found). Base retargets to `main` when that merges.

## The gap

`validate:mcp` runs against a hermetic harness and reports, honestly, that it cannot finish the job:

```
97 validated over empty collections, so their item shapes rely on the production sweep.
```

That sweep was `npm run smoke:mcp`, and grepping the repo for it outside its own definition returned **nothing** — no workflow, no cron, no runbook step. CI said something else checked these and nothing did: an unexercised check reporting success, which is the exact failure the coverage line was written to avoid.

A tool answering `{items: []}` satisfies its `outputSchema` completely, because every declared property of `items[]` is vacuously fine when there are no items. **Only production has the rows.** [#9884](https://github.com/JSONbored/metagraphed/pull/9884) is the worked example — deriving MCP schemas from route schemas made row objects strict, and 25 tools began failing their own published schema the moment a caller used the `fields` parameter they advertise, while CI stayed green throughout.

## What this adds

`check-mcp-conformance.yml`, daily, the MCP sibling of `check-response-conformance.yml`. It enumerates tools from the **live** server's own `tools/list`, calls each with arguments built from its own declared examples, and validates the response against the `outputSchema` we hand clients. Then it calls every `fields`-capable tool **a second time with a projection** taken off its own first response — the path #9884 broke invisibly.

A schema violation **fails the run**, unlike `mcp-smoke-sweep.ts`'s deliberately noisy SUSPECT triage: "the response does not match the schema we publish" needs no judgement to confirm.

## What it found

**First run — three real violations in production**, both fixed in #9915 (#9910, #9911).

**Second run — a bug in the check itself**, worth recording because it is the kind that makes a report untrustworthy rather than wrong:

`fields` has **two published shapes** — 28 tools take a comma-separated string, three take an array — and sending the wrong one is *rejected*, not ignored. So 27 tools reported as "serving no rows" were really answering `invalid_params`, which reads exactly like the thing the check exists to measure. Reading the shape off each tool's own schema fixed it:

| | projections validated |
|---|---:|
| hermetic `validate:mcp` | 2 of 32 |
| first production run | 5 of 32 |
| **corrected production run** | **32 of 32** |

Final run: 219 tools validated, 32 of 32 projections, 3 violations (now fixed), 6 declined for their example arguments (webhook/alert/credential tools that need state production does not have).

## Shared, not copied

The argument-building rules moved to `scripts/mcp-tool-arguments.ts`, used by both checks. Two copies would drift, and the direction is the dangerous one: this check exists to catch what the hermetic one cannot see, so a check calling tools *differently* would report differences that are its own.

`validate:mcp`'s message now names this workflow instead of pointing at a sweep nobody ran.

## Verification

- Run end-to-end against production twice; output quoted above.
- `npm run validate:workflows` — passes (26 workflows).
- `typecheck`, `lint`, `format:check` — clean.
- 14 new tests, including that the workflow is **actually scheduled** — a test that only asserted the script works would reproduce the very defect being closed.

Closes #9879