### PR TITLE
fix(scripts): never ship a bundle from an unclean $OUTDIR

### DIFF
--- a/scripts/deploy-worker-with-sourcemaps.sh
+++ b/scripts/deploy-worker-with-sourcemaps.sh
@@ -87,6 +87,23 @@ if [[ -n "${POSTHOG_CLI_API_KEY:-}" && -n "${POSTHOG_CLI_PROJECT_ID:-}" ]]; then
 fi
 
 if [[ "$POSTHOG_ENABLED" == "true" ]]; then
+  # Phase 0: start from an empty $OUTDIR. `wrangler --outdir` writes into the
+  # directory without clearing it, so anything left there from an earlier run
+  # SURVIVES -- and phase 3 below resolves the bundle by globbing `*.js`, which
+  # assumes exactly one match. A leftover .js (an entry renamed between builds,
+  # a run that died mid-flight, or a `dist/` restored from Cloudflare Workers
+  # Builds' build cache, which is enabled per-project and persists for 7 days)
+  # turns that glob into two paths.
+  #
+  # Why that is worth a line of defence rather than a shrug: the failure is
+  # SILENT and it corrupts symbolication specifically. `posthog-cli sourcemap
+  # inject` stamps a chunk id into the bundle, phase 3 uploads the map under
+  # that id, and phase 4 ships the file. Ship the wrong .js and PostHog happily
+  # resolves stack traces against a map that describes different code -- line
+  # numbers that point at real-looking, wrong source. That is worse than an
+  # unsymbolicated trace, because nothing about it reads as broken.
+  rm -rf "$OUTDIR"
+
   # Phase 1: build only -- writes $OUTDIR/<entry>.js(.map) without deploying
   # (see this file's own header comment for why a single combined build+
   # deploy command can't be injected into afterward).
@@ -122,6 +139,20 @@ if [[ "$POSTHOG_ENABLED" == "true" ]]; then
   # rather than hardcoded per-Worker, since each of the 3 configs' `main`
   # basename differs.
   ENTRY_JS=$(find "$OUTDIR" -maxdepth 1 -name '*.js')
+
+  # Assert the "single flat bundle" the comment above asserts. Phase 0 makes
+  # a stale leftover impossible, so this covers the other half: wrangler
+  # emitting more than one chunk (code-splitting, a future entry shape), or
+  # none at all because the build silently produced nothing. Unguarded,
+  # ENTRY_JS would become an empty or newline-joined string and get passed
+  # straight to `wrangler deploy` in phase 4 -- which is the point where a
+  # wrong or missing bundle would ship. Failing here costs a red build;
+  # not failing costs mis-symbolicated traces nobody can tell are wrong.
+  if [[ -z "$ENTRY_JS" || "$ENTRY_JS" == *$'\n'* ]]; then
+    echo "deploy-worker-with-sourcemaps: expected exactly one .js in $OUTDIR, found:" >&2
+    echo "${ENTRY_JS:-(none)}" >&2
+    exit 1
+  fi
 
   # Phase 3: upload the sourcemap BEFORE the deploy ships traffic. This
   # order is load-bearing: PostHog symbolicates at INGEST, so an error


### PR DESCRIPTION
Closes #9921

## The bug

`deploy-worker-with-sourcemaps.sh` builds into `$OUTDIR` without clearing it, then picks what to ship with:

```bash
ENTRY_JS=$(find "$OUTDIR" -maxdepth 1 -name '*.js')
```

One match is assumed. Nothing checks.

It has held because each Worker's entry basename is stable, so a rebuild overwrites the previous `.js` in place. Two things make it reachable:

- **an entry renamed between builds**, leaving the old file beside the new one
- **Cloudflare Workers Builds' build cache** — per-project, opt-in, restores `dist/` for up to 7 days

Either way `find` returns two paths, `ENTRY_JS` becomes a newline-joined string, and phase 4 hands it to `wrangler deploy --no-bundle`.

## Why it's worth guarding

The failure is silent, and it corrupts **symbolication specifically**:

1. phase 2 — `posthog-cli sourcemap inject` stamps a chunk id into the freshly built bundle
2. phase 3 — the map is uploaded under that chunk id
3. phase 4 — `$ENTRY_JS` ships

Ship the wrong `.js` and PostHog resolves stack traces against a map describing *different code*: plausible line numbers pointing at the wrong source. Worse than an unsymbolicated trace, because nothing about it reads as broken. The script's own header already names this coupling — "that marker MUST be present in the EXACT bytes Cloudflare actually serves."

## The change

**`rm -rf "$OUTDIR"` before phase 1** — a stale leftover becomes impossible whatever the build cache did.

**An explicit check after the glob** — covers the half phase 0 can't: wrangler emitting more than one chunk, or none at all because the build silently produced nothing. Fails the build rather than deploying an empty or ambiguous path.

## Verification

```
bash -n          OK
shellcheck       clean
```

Guard logic exercised over all three cases:

| input | result |
|---|---|
| `""` (build produced nothing) | **reject** |
| two paths (leftover / code-split) | **reject** |
| one path (normal) | accept |

`validate:no-hand-written-mjs`, `validate:workflows`, `validate:private-boundary` pass; `tests/check-worker-deploy-drift.test.ts` 11/11. Prettier has no parser for `.sh`, so it is out of scope by design. No `src/**` or `workers/**` lines changed, so codecov patch does not apply.

## Context

Found while giving `metagraphed-wss-lb` its first Workers Builds project. That Worker is the fourth this script has always supported (`npm run deploy:wss-lb`) but was never wired to Builds — its setup enables build caching, which is what turns the cached-`dist/` case from theoretical into reachable. The fix covers all four Workers, not just that one.
