### PR TITLE
feat(neon): reconcile surface_checks, the 1.35M-row window

### DIFF
--- a/src/neon-backfill.ts
+++ b/src/neon-backfill.ts
@@ -429,6 +429,21 @@ const CHAIN_CONCENTRATION_DAILY_COLUMNS = [
   "builder_version",
 ] as const;
 
+/** surface_checks, read off pragma_table_info 2026-08-07. The raw probe log:
+ * 1,349,625 rows over a ~27-day window, ~48,000 a day. */
+const SURFACE_CHECKS_COLUMNS = [
+  "surface_id",
+  "surface_key",
+  "netuid",
+  "kind",
+  "status",
+  "classification",
+  "latency_ms",
+  "status_code",
+  "ok",
+  "checked_at",
+] as const;
+
 export const NEON_BACKFILL_PLANS: Readonly<Record<string, BackfillPlan>> = {
   neuron_daily: {
     table: "neuron_daily",
@@ -574,6 +589,33 @@ export const NEON_BACKFILL_PLANS: Readonly<Record<string, BackfillPlan>> = {
   // RECOMPUTED as the day fills in. COUNT alone would let the two stores hold
   // 27 rows each and disagree about today's card indefinitely, so this one
   // compares on computed_at.
+  // THE FIRST append PLAN (#9908). `whole` is impossible here -- it would
+  // recopy 1.35M rows whenever the signature moved, and copyWholeTableToNeon
+  // has no tick budget at all.
+  //
+  // Both preconditions the partition demands are met, and neither is checkable
+  // by the type:
+  //
+  //   the cursor is assigned AT INSERT -- `checked_at` is the probe's own
+  //   clock, written once by the sweep that produced the row, so nothing ever
+  //   arrives below the high-water mark
+  //
+  //   rows are never rewritten -- one probe per surface per millisecond, and
+  //   the writer only ever INSERTs
+  //
+  // freshness IS the cursor here. That the guard it produces can never fire --
+  // checked_at is part of the primary key, so a conflict means equality -- is
+  // correct rather than accidental: a conflicting row is the same probe, and
+  // doing nothing is right.
+  surface_checks: {
+    table: "surface_checks",
+    columns: SURFACE_CHECKS_COLUMNS,
+    conflict: ["surface_id", "checked_at"],
+    keyset: ["checked_at", "surface_id"],
+    partition: "append",
+    booleans: ["ok"],
+    freshness: "checked_at",
+  },
   chain_concentration_daily: {
     table: "chain_concentration_daily",
     columns: CHAIN_CONCENTRATION_DAILY_COLUMNS,

--- a/src/neon-parity-watchdog.ts
+++ b/src/neon-parity-watchdog.ts
@@ -78,6 +78,10 @@ export const PARITY_TABLES = [
   "emission_gate_param_history",
   "subnet_emission_enabled_history",
   "chain_concentration_daily",
+  // The rolling window (#9891). Watched with a tolerance rather than at five
+  // rows, because it is written ~2,000 times an hour and pruned on a cron
+  // independent of D1's.
+  "surface_checks",
 ] as const;
 
 /**
@@ -113,6 +117,27 @@ export const EXPECTED_DIVERGENCE: Readonly<Record<string, string>> = {
 };
 
 export const PARITY_MIN_ROWS = 5;
+
+/**
+ * Tables whose counts are EXPECTED to move by more than PARITY_MIN_ROWS, with
+ * the tolerance each needs and why.
+ *
+ * Five rows is right for a dimension table that changes when a subnet
+ * retunes. It is meaningless for a pruned window written thousands of times an
+ * hour: `surface_checks` takes ~2,000 rows an hour, and the two stores prune
+ * on separate crons, so the counts differ by whatever landed or was deleted
+ * between the two COUNT(*)s. Held to five it would report a gap on every tick
+ * forever, which is how a check stops being read (#9881).
+ *
+ * A tolerance is NOT a silence. The gap still appears in the detail line and a
+ * difference above the tolerance still makes the verdict stale -- what changes
+ * is only where "this is churn" ends and "this is structural" begins.
+ */
+export const PARITY_TOLERANCE: Readonly<Record<string, number>> = {
+  // One hour of writes at the measured rate, plus the prune skew between two
+  // independent hourly crons. Anything past this is not timing.
+  surface_checks: 5_000,
+};
 
 export interface ParityDb {
   prepare(sql: string): { all(): Promise<{ results?: unknown[] } | null> };
@@ -200,7 +225,9 @@ export function parityGaps(
     // answers and this lane should not shout about.
     if (a == null || b == null) continue;
     const delta = a - b;
-    if (Math.abs(delta) >= minRows) out.push({ table, d1: a, neon: b, delta });
+    const tolerance = Math.max(minRows, PARITY_TOLERANCE[table] ?? 0);
+    if (Math.abs(delta) >= tolerance)
+      out.push({ table, d1: a, neon: b, delta });
   }
   return out.sort((x, y) => Math.abs(y.delta) - Math.abs(x.delta));
 }

--- a/tests/neon-parity-watchdog.test.ts
+++ b/tests/neon-parity-watchdog.test.ts
@@ -12,6 +12,7 @@ import {
   NEON_PARITY_LANE,
   PARITY_MIN_ROWS,
   PARITY_TABLES,
+  PARITY_TOLERANCE,
   describeParity,
   parityCountBatches,
   parityCountSql,
@@ -141,6 +142,55 @@ describe("parityCountBatches", () => {
     const batches = parityCountBatches(["a", "b", "c", "d", "e"], 2);
     assert.equal(batches.length, 3);
     assert.equal(batches[2], parityCountSql(["e"]));
+  });
+});
+
+describe("PARITY_TOLERANCE", () => {
+  test("a churny window is judged on its own scale, not five rows", () => {
+    // surface_checks takes ~2,000 rows an hour and the two stores prune on
+    // independent crons, so the counts differ by whatever landed between the
+    // two COUNT(*)s. At five rows it would report a gap on every tick forever,
+    // which is how a check stops being read.
+    const under = parityGaps(
+      new Map([["surface_checks", 1_349_625]]),
+      new Map([["surface_checks", 1_347_000]]),
+    );
+    assert.deepEqual(under, [], "2,625 rows apart is timing, not a fault");
+  });
+
+  test("a tolerance is not a silence -- past it, it still reports", () => {
+    const over = parityGaps(
+      new Map([["surface_checks", 1_349_625]]),
+      new Map([["surface_checks", 900_000]]),
+    );
+    assert.equal(over.length, 1);
+    assert.equal(over[0]!.delta, 449_625);
+  });
+
+  test("it never LOWERS the floor below PARITY_MIN_ROWS", () => {
+    // A tolerance under the default would make a table noisier, not quieter.
+    for (const [table, n] of Object.entries(PARITY_TOLERANCE)) {
+      assert.ok(n >= PARITY_MIN_ROWS, `${table} tolerance is below the floor`);
+    }
+  });
+
+  test("every tolerance names a table actually being watched", () => {
+    // A tolerance for a table absent from PARITY_TABLES is dead config that
+    // reads as protection.
+    for (const table of Object.keys(PARITY_TOLERANCE)) {
+      assert.ok(
+        (PARITY_TABLES as readonly string[]).includes(table),
+        `${table} has a tolerance but is not in PARITY_TABLES`,
+      );
+    }
+  });
+
+  test("the default is untouched for everything else", () => {
+    const gaps = parityGaps(
+      new Map([["neurons", 30_110]]),
+      new Map([["neurons", 30_104]]),
+    );
+    assert.equal(gaps.length, 1, "6 rows on a dimension table is still a gap");
   });
 });
 

--- a/tests/neon-sql-portability.test.ts
+++ b/tests/neon-sql-portability.test.ts
@@ -158,6 +158,11 @@ const BOOLEAN_COLUMNS = [
   "enabled",
   "previous_enabled",
   "predates_capture",
+  // surface_checks' (#9891). The most generic name in this list by far, and
+  // still correct to guard: the rules run only over SQL that can REACH Neon,
+  // and within that set `ok` is a BOOLEAN column. D1-only SQL is never
+  // scanned.
+  "ok",
 ] as const;
 
 /** Comparisons and aggregates that only work against ONE of the two schemas. */

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -204,7 +204,7 @@
     // Naming a latest-only table here would copy 800,000 rows to prove they
     // already agree, which is why this is a third flag rather than a reuse of
     // the write list.
-    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily",
+    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,surface_checks",
     "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",
     // THE QUEUE CUTOVER (metagraphed-infra#348). Comma-separated lanes whose D1


### PR DESCRIPTION
Closes #9925. **86% of everything still on D1** (#9787), and until tonight nothing could carry it.

| prerequisite | merged | why it was needed |
|---|---|---|
| schema | #9894 | no Neon table existed |
| `append` partition | #9913 | `whole` recopies 1.35M rows per signature move, with no tick budget |
| Neon retention | #9920 | it is a **pruned window**; writes without retention diverge permanently |

## The two preconditions, both met, neither type-checkable

- **cursor assigned at insert** — `checked_at` is the probe's own clock, written once by the sweep that produced the row, so nothing arrives below the high-water mark
- **rows never rewritten** — one probe per surface per millisecond, INSERT only

`freshness` *is* the cursor. The guard it produces can never fire (`checked_at` is in the PK, so a conflict means equality) — correct rather than accidental: a conflicting row is the same probe, and doing nothing is right.

Adding it to `NEON_BACKFILL_LANES` also activates the prune, which filters on the same flag. Deliberate: D1's oldest row is ~27 days against 30-day retention, so the prune measures **zero** doomed rows and does nothing until the window actually fills.

## Parity needs a tolerance, or the lane is noise

`PARITY_MIN_ROWS = 5` is right for a dimension table. It's meaningless for a window taking ~2,000 rows/hour whose two copies are pruned by independent crons — the counts differ by whatever landed between the two `COUNT(*)`s. Held to five it reports a gap every tick forever, which is precisely how #9881 happened.

**A tolerance is not a silence.** The gap still appears in the detail line; a difference past it still makes the verdict stale. Tests pin that it never lowers the floor below `PARITY_MIN_ROWS` and never names a table absent from `PARITY_TABLES`.

## Blast radius

Contained — **no route reads `surface_checks` from Neon**. Reads stay on D1. The copy is idempotent upserts; the prune refuses rather than deletes if its cutoff would take everything. Worst case is wasted work in Neon, not a serving regression. Initial copy ≈34 ticks, ~1.7h at the 3-minute cadence.

The portability gate caught `ok` on the way through, exactly as designed — it derives its deny-list from the plans, and `ok` is the most generic column name in it. 206 tests pass across the 6 affected suites.
