### PR TITLE
feat(neon): reconcile the two probe rollups

### DIFF
--- a/src/neon-backfill.ts
+++ b/src/neon-backfill.ts
@@ -444,6 +444,44 @@ const SURFACE_CHECKS_COLUMNS = [
   "checked_at",
 ] as const;
 
+/** surface_status and surface_uptime_daily, read off pragma_table_info
+ * 2026-08-07. Both are rewritten in place by the rollup, so both compare on
+ * `updated_at` -- COUNT alone would let the stores hold the same number of
+ * rows and different uptime indefinitely. */
+const SURFACE_STATUS_COLUMNS = [
+  "surface_id",
+  "surface_key",
+  "netuid",
+  "kind",
+  "url",
+  "provider",
+  "status",
+  "classification",
+  "latency_ms",
+  "status_code",
+  "last_checked",
+  "last_ok",
+  "consecutive_failures",
+  "updated_at",
+] as const;
+
+const SURFACE_UPTIME_DAILY_COLUMNS = [
+  "surface_id",
+  "surface_key",
+  "netuid",
+  "day",
+  "samples",
+  "ok_count",
+  "uptime_ratio",
+  "avg_latency_ms",
+  "status",
+  "latency_samples",
+  "p50_latency_ms",
+  "p95_latency_ms",
+  "p99_latency_ms",
+  "updated_at",
+] as const;
+
 export const NEON_BACKFILL_PLANS: Readonly<Record<string, BackfillPlan>> = {
   neuron_daily: {
     table: "neuron_daily",
@@ -589,6 +627,39 @@ export const NEON_BACKFILL_PLANS: Readonly<Record<string, BackfillPlan>> = {
   // RECOMPUTED as the day fills in. COUNT alone would let the two stores hold
   // 27 rows each and disagree about today's card indefinitely, so this one
   // compares on computed_at.
+  // The two probe rollups. `whole` rather than `append`, and deliberately:
+  // both are UPDATED IN PLACE -- the hourly rollup rewrites today's and
+  // yesterday's rows -- so an append bound would copy a day once and never see
+  // it change again.
+  //
+  // Neither is pruned, so no retention plan pairs with them. surface_status is
+  // one row per surface (640) and surface_uptime_daily grows ~625 a day, which
+  // makes a whole-table recopy affordable now and worth revisiting when the
+  // latter passes a hundred thousand or so.
+  //
+  // surface_failure_daily is NOT here despite being the third rollup: its key
+  // includes a NULLABLE netuid, and keysetPredicate compares with `>`, which
+  // is NULL against a NULL -- so a single registry-level row would silently
+  // truncate the copy at that page boundary. Zero such rows exist today and
+  // the schema explicitly permits them.
+  surface_status: {
+    table: "surface_status",
+    columns: SURFACE_STATUS_COLUMNS,
+    conflict: ["surface_id"],
+    keyset: ["surface_id"],
+    partition: "whole",
+    booleans: [],
+    freshness: "updated_at",
+  },
+  surface_uptime_daily: {
+    table: "surface_uptime_daily",
+    columns: SURFACE_UPTIME_DAILY_COLUMNS,
+    conflict: ["surface_id", "day"],
+    keyset: ["surface_id", "day"],
+    partition: "whole",
+    booleans: [],
+    freshness: "updated_at",
+  },
   // THE FIRST append PLAN (#9908). `whole` is impossible here -- it would
   // recopy 1.35M rows whenever the signature moved, and copyWholeTableToNeon
   // has no tick budget at all.

--- a/src/neon-parity-watchdog.ts
+++ b/src/neon-parity-watchdog.ts
@@ -82,6 +82,8 @@ export const PARITY_TABLES = [
   // rows, because it is written ~2,000 times an hour and pruned on a cron
   // independent of D1's.
   "surface_checks",
+  "surface_status",
+  "surface_uptime_daily",
 ] as const;
 
 /**

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -204,7 +204,7 @@
     // Naming a latest-only table here would copy 800,000 rows to prove they
     // already agree, which is why this is a third flag rather than a reuse of
     // the write list.
-    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,surface_checks",
+    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,surface_checks,surface_status,surface_uptime_daily",
     "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",
     // THE QUEUE CUTOVER (metagraphed-infra#348). Comma-separated lanes whose D1


### PR DESCRIPTION
Closes #9931. #9894 created the tables; nothing populated them.

| table | rows | conflict | freshness |
|---|---:|---|---|
| `surface_status` | 640 | `(surface_id)` | `updated_at` |
| `surface_uptime_daily` | 14,520 | `(surface_id, day)` | `updated_at` |

## `whole`, not `append`

Both are **updated in place** — the hourly rollup rewrites today's and yesterday's rows — so an append bound would copy a day once and never see it change again. `freshness` is `updated_at` rather than `null` for the same reason: `COUNT` alone would let the stores hold equal row counts and different uptime indefinitely.

Neither is pruned, so no retention plan pairs with them (#9920). `surface_status` is one row per surface; `surface_uptime_daily` grows ~625/day — affordable to recopy now, worth revisiting past ~100k rows.

## The third rollup is held back by a defect, not by scope

`surface_failure_daily`'s key includes a **nullable `netuid`** — by design, since a registry-level surface belongs to no subnet, which is why D1 indexes it `ifnull(netuid,-1)` and Neon uses `NULLS NOT DISTINCT`. But `keysetPredicate` compares with `>`, and `netuid > NULL` is NULL — so one such row would silently drop every row after it from the copy while the lane reported a clean short page.

Zero exist today, so it hasn't bitten. Tracked as **#9930**, and the fix belongs in `keysetPredicate` (any future plan with a nullable keyset has the same hole), not in a per-table workaround.

157 tests pass across the 4 affected suites.
