### PR TITLE
fix(telemetry): count a WebSocket firehose disconnect, not just an SSE one

### DIFF
--- a/tests/chain-firehose-hub.test.ts
+++ b/tests/chain-firehose-hub.test.ts
@@ -2384,3 +2384,98 @@ test("#9440: the guard's state does not leak across test files", () => {
   resetModuleState();
   assert.equal(shouldEmitAlerterUnreachable(1), true);
 });
+
+// --- #9900 follow-up: the WS transport emits a disconnect event too ---------
+//
+// SSE has had sse-open/sse-close since #8997; WS had neither, so "is anyone
+// consuming the firehose" was answerable for one transport and silent for the
+// other. The RELEASE half is testable here for the same reason the per-IP
+// quota tests above are — webSocketClose/webSocketError run under plain Node
+// with a stubbed `ws`. The ACCEPT half stays untested (and therefore
+// un-emitted); see releaseWsIpSlot's own comment in the source.
+
+test("#9900: a WS disconnect emits one ws-close event", () => {
+  const cap = captureFirehoseTelemetry();
+  try {
+    const hub = new ChainFirehoseHub(
+      stubState(),
+      mockEnv(FIREHOSE_TELEMETRY_ENV),
+    );
+    hub.wsClientsByIp.set("203.0.113.9", 1);
+    hub.webSocketClose(
+      {
+        deserializeAttachment: () => ({ ip: "203.0.113.9" }),
+        close: () => {},
+      } as unknown as WebSocket,
+      1000,
+      "bye",
+    );
+    assert.deepEqual(cap.routes(), ["chain-firehose-hub:ws-close"]);
+  } finally {
+    cap.restore();
+  }
+});
+
+test("#9900: webSocketError also emits ws-close, so an errored socket is not a silent disconnect", () => {
+  const cap = captureFirehoseTelemetry();
+  try {
+    const hub = new ChainFirehoseHub(
+      stubState(),
+      mockEnv(FIREHOSE_TELEMETRY_ENV),
+    );
+    hub.wsClientsByIp.set("198.51.100.4", 1);
+    hub.webSocketError(
+      {
+        deserializeAttachment: () => ({ ip: "198.51.100.4" }),
+      } as unknown as WebSocket,
+      new Error("boom"),
+    );
+    assert.deepEqual(cap.routes(), ["chain-firehose-hub:ws-close"]);
+  } finally {
+    cap.restore();
+  }
+});
+
+// Same guarantee removeSseClient's own test asserts: releaseWsIpSlot is
+// reached from BOTH webSocketClose and webSocketError, and its early returns
+// mean an already-released socket must not emit a second disconnect.
+test("#9900: a repeated release counts one disconnect, not several", () => {
+  const cap = captureFirehoseTelemetry();
+  try {
+    const hub = new ChainFirehoseHub(
+      stubState(),
+      mockEnv(FIREHOSE_TELEMETRY_ENV),
+    );
+    hub.wsClientsByIp.set("203.0.113.9", 1);
+    const ws = {
+      deserializeAttachment: () => ({ ip: "203.0.113.9" }),
+      close: () => {},
+    } as unknown as WebSocket;
+    hub.webSocketClose(ws, 1000, "bye");
+    hub.webSocketClose(ws, 1000, "bye");
+    hub.webSocketClose(ws, 1000, "bye");
+    assert.equal(
+      cap.routes().filter((r) => r === "chain-firehose-hub:ws-close").length,
+      1,
+    );
+  } finally {
+    cap.restore();
+  }
+});
+
+test("#9900: a release with no ip in the attachment emits nothing", () => {
+  const cap = captureFirehoseTelemetry();
+  try {
+    const hub = new ChainFirehoseHub(
+      stubState(),
+      mockEnv(FIREHOSE_TELEMETRY_ENV),
+    );
+    hub.wsClientsByIp.set("203.0.113.9", 1);
+    hub.releaseWsIpSlot({
+      deserializeAttachment: () => ({ topics: null }),
+    } as unknown as WebSocket);
+    assert.deepEqual(cap.routes(), []);
+  } finally {
+    cap.restore();
+  }
+});

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -1576,6 +1576,25 @@ export class ChainFirehoseHub implements DurableObject {
     } else {
       this.wsClientsByIp.set(ip, count - 1);
     }
+    // #9900 follow-up: the WS transport had no usage events at all, while SSE
+    // has had `sse-open`/`sse-close` since #8364 -- so "is anyone consuming the
+    // firehose" was answerable for one transport and silent for the other,
+    // which reads as "nobody uses WS" rather than "we never asked".
+    //
+    // Emitted from HERE, after the decrement guards above, for the same reason
+    // sse-close is emitted after its delete guard: this method is reached from
+    // both webSocketClose and webSocketError, and an already-released socket
+    // returns early above, so one disconnect counts once.
+    //
+    // THERE IS DELIBERATELY NO MATCHING `ws-open`, and that asymmetry is a
+    // constraint, not an oversight. The accept path (handleSubscribe's
+    // upgrade branch) is inside this file's `/* v8 ignore */` block because
+    // WebSocketPair/state.acceptWebSocket have no Node equivalent and the
+    // plain-vitest harness cannot drive them -- and codecov counts
+    // v8-ignored lines against the 99%/0%-threshold patch gate, so an emit
+    // there cannot land green. Closing that half needs a workerd-backed
+    // harness for this DO, not another annotation.
+    this.emitTelemetry("ws-close", true);
   }
 
   // Bounds-check helper for the hibernation-survival bug described in


### PR DESCRIPTION
Closes #9934

## The gap

`ChainFirehoseHub` has emitted `sse-open`/`sse-close` since #8997 and **nothing at all** for the WebSocket transport — though both serve the same firehose, and GraphQL subscriptions plus the plain-firehose WS mode both land there.

That's worse than a missing metric. "Is anyone consuming the firehose" was answerable for one transport and silent for the other, so a WS-only consumer base read as *nobody uses it* rather than *we never asked*.

`withUsageTelemetry` deliberately skips `upgrade: websocket` — correctly, since a long-lived socket has no meaningful request duration — so the DO is the only place this is observable at all.

## The change

Emit `ws-close` from `releaseWsIpSlot`, **after** its decrement guards, for exactly the reason `sse-close` sits after its delete guard: the method is reached from both `webSocketClose` and `webSocketError`, and an already-released socket returns early, so one disconnect counts once.

## On the missing `ws-open`

There deliberately isn't one, and the source says so at the emit site rather than leaving it to look like an oversight.

The accept path (`handleSubscribe`'s upgrade branch) is inside this file's `/* v8 ignore */` block — `WebSocketPair`/`state.acceptWebSocket` have no Node equivalent and the plain-vitest harness cannot drive them. Codecov counts v8-ignored lines against the `99%` / `0% threshold` patch gate, so an emit there cannot land green. Closing that half needs a workerd-backed harness for this DO, not another annotation.

Half the signal with the reason written down beats no signal, and beats an annotation that makes the gate pass without making the code testable.

## Verification

4 new tests: a close emits exactly one event, `webSocketError` emits too (an errored socket is not a silent disconnect), a repeated release counts one not several, and a release with no `ip` emits nothing.

- **165/165** tests pass in this file
- **Patch coverage: zero uncovered statements, zero uncovered branches** across all 19 added lines, measured by intersecting the diff with the v8 report
- `tsc`, eslint, prettier all clean
