### PR TITLE
fix(neon): a budget stop is progress, and the lane should say so

### DIFF
--- a/src/neon-backfill.ts
+++ b/src/neon-backfill.ts
@@ -115,6 +115,11 @@ export const TICK_ROW_BUDGET = 40_000;
  * rather than an overlap. */
 export const TICK_BUDGET_MS = 20_000;
 
+/** The reason an append tick stops early. Named, because describeOutcome has
+ * to tell it apart from a real failure and a copied string in two places is
+ * how that stops working. */
+export const TICK_BUDGET_REASON = "tick budget reached";
+
 /** How long a clean verdict suppresses the next comparison.
  *
  * The comparison is two grouped counts over ~840,000 rows each. During the
@@ -1366,7 +1371,7 @@ export async function copyAppendTailToNeon(
         statements,
         pages,
         date,
-        reason: "tick budget reached",
+        reason: TICK_BUDGET_REASON,
       };
     }
     const last = page[page.length - 1];
@@ -1510,6 +1515,17 @@ export function describeOutcome(outcome: BackfillTableOutcome): string {
   if (outcome.skipped) return "no deficit at last check";
   if (!outcome.ok) {
     const rows = outcome.copied.reduce((sum, c) => sum + c.rows, 0);
+    // A BUDGET STOP IS NOT A FAILURE, and the line has to say so. An append
+    // plan reports ok:false when it hits TICK_ROW_BUDGET -- deliberately, so
+    // a tick that copied 40,000 of 1,300,000 rows cannot read as in sync --
+    // but the reason it gives is "tick budget reached", and wrapping that in
+    // "copied before failure" describes healthy progress as a fault. Whoever
+    // reads this lane mid-backfill sees it once every three minutes for two
+    // hours; if it says failure, either they investigate nothing that is
+    // wrong or they learn to ignore the lane.
+    if (outcome.reason === TICK_BUDGET_REASON) {
+      return `${rows} row(s) copied, more to do next tick`;
+    }
     return `${rows} row(s) copied before failure: ${outcome.reason ?? "unknown"}`;
   }
   if (outcome.deficits === 0) return "in sync";

--- a/tests/neon-backfill.test.ts
+++ b/tests/neon-backfill.test.ts
@@ -21,6 +21,7 @@ import {
   TICK_ROW_BUDGET,
   NEON_BACKFILL_PLANS,
   TICK_BUDGET_MS,
+  TICK_BUDGET_REASON,
   WHOLE_TABLE_UNIT,
   backfillGuard,
   copyDateToNeon,
@@ -1534,7 +1535,7 @@ describe("the append partition (#9908)", () => {
       4,
     );
     assert.equal(out.ok, false);
-    assert.equal(out.reason, "tick budget reached");
+    assert.equal(out.reason, TICK_BUDGET_REASON);
     assert.ok(out.rows >= 6, `copied ${out.rows}`);
   });
 
@@ -1593,5 +1594,39 @@ describe("assertIdentifier", () => {
         `accepted: ${JSON.stringify(bad)}`,
       );
     }
+  });
+});
+
+describe("describeOutcome — a budget stop is not a failure", () => {
+  test("it reads as progress, because that is what it is", () => {
+    // This line is what a human sees every three minutes for the ~1.7 hours
+    // surface_checks takes to copy. Calling healthy progress a failure either
+    // sends someone chasing nothing or teaches them to ignore the lane.
+    const line = describeOutcome({
+      table: "surface_checks",
+      deficits: 1,
+      missing: 0,
+      remaining: 1,
+      copied: [
+        { ok: false, rows: 40000, statements: 20, pages: 20, date: "*" },
+      ],
+      ok: false,
+      reason: TICK_BUDGET_REASON,
+    });
+    assert.equal(line, "40000 row(s) copied, more to do next tick");
+    assert.ok(!/failure/.test(line));
+  });
+
+  test("a REAL failure still says so, with its reason", () => {
+    const line = describeOutcome({
+      table: "surface_checks",
+      deficits: 1,
+      missing: 0,
+      remaining: 1,
+      copied: [{ ok: false, rows: 12, statements: 1, pages: 1, date: "*" }],
+      ok: false,
+      reason: "relation missing",
+    });
+    assert.match(line, /before failure: relation missing/);
   });
 });


### PR DESCRIPTION
Closes #9936. Live on `neon:backfill:surface_checks` right now:

```
stale   40000 row(s) copied before failure: tick budget reached
```

**Nothing failed.** The `append` partition reports `ok: false` on hitting `TICK_ROW_BUDGET` deliberately (#9913) — a tick that copied 40,000 of 1,349,625 rows must not read as in sync. But `describeOutcome` wraps every `!ok` in *"copied before failure"*, so budgeted progress reads as a fault.

That line is what a human sees **every 3 minutes for the ~1.7 hours** the initial copy takes. Either they investigate a problem that doesn't exist, or they learn the lane cries wolf — which is how #9881 stayed invisible for its entire life.

## After

```
40000 row(s) copied, more to do next tick
```

`before failure: <reason>` is kept for everything else, and a test pins both branches. `TICK_BUDGET_REASON` is named rather than repeated — the producer and the formatter comparing copied literals is how this breaks the next time either moves.

**The verdict stays `stale`.** That part is correct and is the whole point: a partial copy is not in sync. Only the sentence changes.

92 tests pass.
