### PR TITLE
fix(neon): a NULL in the keyset silently truncated every copy after it

### DIFF
--- a/src/neon-backfill.ts
+++ b/src/neon-backfill.ts
@@ -487,6 +487,19 @@ const SURFACE_UPTIME_DAILY_COLUMNS = [
   "updated_at",
 ] as const;
 
+/** surface_failure_daily, read off pragma_table_info 2026-08-07. Its key
+ * carries a NULLABLE netuid -- a registry-level surface belongs to no subnet --
+ * which is why it could not be reconciled until keysetPredicate became
+ * null-safe (#9930). */
+const SURFACE_FAILURE_DAILY_COLUMNS = [
+  "day",
+  "netuid",
+  "kind",
+  "classification",
+  "checks",
+  "updated_at",
+] as const;
+
 export const NEON_BACKFILL_PLANS: Readonly<Record<string, BackfillPlan>> = {
   neuron_daily: {
     table: "neuron_daily",
@@ -647,6 +660,19 @@ export const NEON_BACKFILL_PLANS: Readonly<Record<string, BackfillPlan>> = {
   // is NULL against a NULL -- so a single registry-level row would silently
   // truncate the copy at that page boundary. Zero such rows exist today and
   // the schema explicitly permits them.
+  // Reconcilable only since keysetPredicate stopped comparing NULLs with `=`
+  // and `>` (#9930). Its uniqueness is (day, netuid, kind, classification)
+  // with netuid nullable by design, and Neon's index spells that
+  // NULLS NOT DISTINCT to match D1's ifnull(netuid, -1).
+  surface_failure_daily: {
+    table: "surface_failure_daily",
+    columns: SURFACE_FAILURE_DAILY_COLUMNS,
+    conflict: ["day", "netuid", "kind", "classification"],
+    keyset: ["day", "netuid", "kind", "classification"],
+    partition: "whole",
+    booleans: [],
+    freshness: "updated_at",
+  },
   surface_status: {
     table: "surface_status",
     columns: SURFACE_STATUS_COLUMNS,
@@ -739,9 +765,35 @@ export function keysetPredicate(
   const terms: string[] = [];
   const values: unknown[] = [];
   for (let i = 0; i < keyset.length; i += 1) {
-    const equals = keyset.slice(0, i).map((column) => `${column} = ?`);
-    terms.push([...equals, `${keyset[i]} > ?`].join(" AND "));
-    values.push(...cursor.slice(0, i), cursor[i]);
+    const parts: string[] = [];
+    // The EQUALITY prefix uses `IS`, not `=`. In SQL `NULL = NULL` is NULL,
+    // never true, so a `=` prefix makes every term containing a NULL cursor
+    // value unsatisfiable -- the page returns nothing matching and the copy
+    // stops there, silently, reporting a clean short page (#9930).
+    //
+    // SQLite's `IS` is null-safe equality and behaves exactly like `=` for
+    // non-null operands, so this is a strict widening. All three callers read
+    // D1, never Neon, which is why the SQLite spelling is the right one here;
+    // Postgres would need IS NOT DISTINCT FROM.
+    for (let j = 0; j < i; j += 1) {
+      if (cursor[j] == null) {
+        parts.push(`${keyset[j]} IS NULL`);
+      } else {
+        parts.push(`${keyset[j]} IS ?`);
+        values.push(cursor[j]);
+      }
+    }
+    // The ORDERING term. `NULL > x` is also NULL, so "strictly after a NULL"
+    // cannot be written with `>` at all. SQLite sorts NULLs FIRST in ASC
+    // order -- which is the order these pages read in -- so everything after a
+    // NULL is exactly everything that is not NULL.
+    if (cursor[i] == null) {
+      parts.push(`${keyset[i]} IS NOT NULL`);
+    } else {
+      parts.push(`${keyset[i]} > ?`);
+      values.push(cursor[i]);
+    }
+    terms.push(parts.join(" AND "));
   }
   return { sql: `(${terms.map((term) => `(${term})`).join(" OR ")})`, values };
 }

--- a/src/neon-parity-watchdog.ts
+++ b/src/neon-parity-watchdog.ts
@@ -84,6 +84,7 @@ export const PARITY_TABLES = [
   "surface_checks",
   "surface_status",
   "surface_uptime_daily",
+  "surface_failure_daily",
 ] as const;
 
 /**

--- a/tests/neon-backfill.test.ts
+++ b/tests/neon-backfill.test.ts
@@ -437,9 +437,51 @@ describe("neonBackfillLanes", () => {
 describe("keysetPredicate", () => {
   test("expands to one OR term per key column, with positional values", () => {
     assert.deepEqual(keysetPredicate(["netuid", "uid"], [12, 500]), {
-      sql: "((netuid > ?) OR (netuid = ? AND uid > ?))",
+      sql: "((netuid > ?) OR (netuid IS ? AND uid > ?))",
       values: [12, 12, 500],
     });
+  });
+
+  test("a NULL in the cursor does not make the term unsatisfiable", () => {
+    // THE BUG THIS PREVENTS (#9930). `NULL = NULL` is NULL, never true, so a
+    // `=` prefix makes every term containing a NULL cursor value match
+    // nothing: the page comes back empty, the copy stops there, and the lane
+    // reports a clean short page. Every row after that boundary is silently
+    // lost.
+    //
+    // `NULL > x` is NULL too, so "strictly after a NULL" cannot be written
+    // with `>` at all. SQLite sorts NULLs FIRST in the ASC order these pages
+    // read in, so everything after a NULL is everything that is not NULL.
+    const { sql, values } = keysetPredicate(
+      ["day", "netuid", "kind"],
+      ["2026-08-07", null, "openapi"],
+    );
+    assert.equal(
+      sql,
+      "((day > ?) OR (day IS ? AND netuid IS NOT NULL) OR " +
+        "(day IS ? AND netuid IS NULL AND kind > ?))",
+    );
+    // A NULL is never BOUND -- `IS NULL` and `IS NOT NULL` take no parameter,
+    // and binding one would shift every later value by a position.
+    assert.deepEqual(values, [
+      "2026-08-07",
+      "2026-08-07",
+      "2026-08-07",
+      "openapi",
+    ]);
+    assert.ok(
+      !/= \?/.test(sql),
+      "a plain = would be unsatisfiable against NULL",
+    );
+  });
+
+  test("a leading NULL still advances past every NULL-keyed row", () => {
+    const { sql, values } = keysetPredicate(["netuid", "kind"], [null, "rpc"]);
+    assert.equal(
+      sql,
+      "((netuid IS NOT NULL) OR (netuid IS NULL AND kind > ?))",
+    );
+    assert.deepEqual(values, ["rpc"]);
   });
 
   test("a single-column keyset is a plain comparison", () => {
@@ -609,7 +651,7 @@ describe("readDatePage", () => {
     await readDatePage(d1.db, PLAN, "2026-08-07", [12, 500], 500);
     assert.match(
       d1.calls[0].sql,
-      /WHERE snapshot_date = \? AND \(\(netuid > \?\) OR \(netuid = \? AND uid > \?\)\)/,
+      /WHERE snapshot_date = \? AND \(\(netuid > \?\) OR \(netuid IS \? AND uid > \?\)\)/,
     );
     assert.deepEqual(d1.calls[0].values, ["2026-08-07", 12, 12, 500, 500]);
   });

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -204,7 +204,7 @@
     // Naming a latest-only table here would copy 800,000 rows to prove they
     // already agree, which is why this is a third flag rather than a reuse of
     // the write list.
-    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,surface_checks,surface_status,surface_uptime_daily",
+    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily",
     "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",
     // THE QUEUE CUTOVER (metagraphed-infra#348). Comma-separated lanes whose D1


### PR DESCRIPTION
Closes #9930.

`keysetPredicate` built its resume cursor from `= ?` and `> ?`. Both are **NULL against a NULL** — never true — so any term containing a NULL cursor value matched nothing. The page came back empty, the copy stopped, and the lane reported a clean short page. Every row past that boundary was silently dropped.

## Measured against real SQLite

12 rows, 4 with a NULL keyset column, paged with the original predicate:

| page size | paged | |
|---|---|---|
| 1 | 2/12 | **lost 10** |
| 2 | 4/12 | **lost 8** |
| 3 | 12/12 | ok |
| 5 | 12/12 | ok |
| 7 | 7/12 | **lost 5** |

**It depends on page size.** That is what makes it dangerous — it passes at some sizes and not others, so a fixture that happens to pick a lucky one proves nothing. With the fix, every size pages all 12.

## The fix

- the equality prefix uses **`IS`**, which is null-safe and identical to `=` for non-null operands — a strict widening
- the ordering term cannot use `>` at all for a NULL cursor value. SQLite sorts NULLs **first** in the ASC order these pages read in, so "after a NULL" is exactly "not NULL"
- a NULL is **never bound** — `IS NULL` takes no parameter, and binding one would shift every later value by a position

All three callers read D1, never Neon, so the SQLite spelling is the correct one here; Postgres would want `IS NOT DISTINCT FROM`.

## And the table it unblocks

`surface_failure_daily` gets its plan. Its key carries a nullable `netuid` by design — a registry-level surface belongs to no subnet — which is precisely why it was held back from #9933.

161 tests pass across the 4 affected suites.
