### PR TITLE
feat(neon): reconcile subnet_burn_history and tao_usd_index

### DIFF
--- a/src/neon-backfill.ts
+++ b/src/neon-backfill.ts
@@ -500,6 +500,25 @@ const SURFACE_FAILURE_DAILY_COLUMNS = [
   "updated_at",
 ] as const;
 
+/** subnet_burn_history and tao_usd_index, read off pragma_table_info
+ * 2026-08-07. Both are append plans (#9908) -- 12,255 and 1,440 rows a DAY
+ * measured, which is what makes a whole-table recopy untenable for them. */
+const SUBNET_BURN_HISTORY_COLUMNS = [
+  "netuid",
+  "observed_at",
+  "burn_tao",
+] as const;
+
+const TAO_USD_INDEX_COLUMNS = [
+  "block_number",
+  "observed_at",
+  "usd_per_tao",
+  "price_basis",
+  "eth_usd",
+  "pool_count",
+  "pools",
+] as const;
+
 export const NEON_BACKFILL_PLANS: Readonly<Record<string, BackfillPlan>> = {
   neuron_daily: {
     table: "neuron_daily",
@@ -664,6 +683,43 @@ export const NEON_BACKFILL_PLANS: Readonly<Record<string, BackfillPlan>> = {
   // and `>` (#9930). Its uniqueness is (day, netuid, kind, classification)
   // with netuid nullable by design, and Neon's index spells that
   // NULLS NOT DISTINCT to match D1's ifnull(netuid, -1).
+  // Both preconditions of the append partition hold, and both were CHECKED
+  // rather than assumed.
+  //
+  // The cursor is assigned at insert: every row in a tick shares one
+  // `observedAt`, taken when the tick runs, and it only moves forward.
+  //
+  // Rows are never rewritten. The D1 writer says INSERT OR REPLACE, which
+  // looks like a counterexample and is not -- its own comment gives the
+  // reason: "a retried tick at the same millisecond must be idempotent rather
+  // than a primary-key error". A replace only ever rewrites a row with the
+  // identical values it already held, at the same observed_at.
+  //
+  // This is also a PRUNED window, and adding it here activates its
+  // NEON_PRUNE_PLANS entry too, since that lane filters on the same flag.
+  // Deliberate ordering: the table is three days old against a 90-day
+  // retention, so the prune measures zero doomed rows until it fills.
+  subnet_burn_history: {
+    table: "subnet_burn_history",
+    columns: SUBNET_BURN_HISTORY_COLUMNS,
+    conflict: ["netuid", "observed_at"],
+    keyset: ["observed_at", "netuid"],
+    partition: "append",
+    booleans: [],
+    freshness: "observed_at",
+  },
+  // The cleanest append case in the set: the writer is ON CONFLICT DO NOTHING,
+  // so a row is written once and never touched again, and there is no prune at
+  // all -- it accumulates.
+  tao_usd_index: {
+    table: "tao_usd_index",
+    columns: TAO_USD_INDEX_COLUMNS,
+    conflict: ["block_number", "observed_at"],
+    keyset: ["observed_at", "block_number"],
+    partition: "append",
+    booleans: [],
+    freshness: "observed_at",
+  },
   surface_failure_daily: {
     table: "surface_failure_daily",
     columns: SURFACE_FAILURE_DAILY_COLUMNS,

--- a/src/neon-parity-watchdog.ts
+++ b/src/neon-parity-watchdog.ts
@@ -85,6 +85,8 @@ export const PARITY_TABLES = [
   "surface_status",
   "surface_uptime_daily",
   "surface_failure_daily",
+  "subnet_burn_history",
+  "tao_usd_index",
 ] as const;
 
 /**
@@ -140,6 +142,10 @@ export const PARITY_TOLERANCE: Readonly<Record<string, number>> = {
   // One hour of writes at the measured rate, plus the prune skew between two
   // independent hourly crons. Anything past this is not timing.
   surface_checks: 5_000,
+  // 12,255 rows a day, and pruned on a cron independent of D1's.
+  subnet_burn_history: 1_000,
+  // 1,440 a day, one per minute. No prune, so only write skew applies.
+  tao_usd_index: 200,
 };
 
 export interface ParityDb {

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -204,7 +204,7 @@
     // Naming a latest-only table here would copy 800,000 rows to prove they
     // already agree, which is why this is a third flag rather than a reuse of
     // the write list.
-    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily",
+    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily,subnet_burn_history,tao_usd_index",
     "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",
     // THE QUEUE CUTOVER (metagraphed-infra#348). Comma-separated lanes whose D1


### PR DESCRIPTION
Closes #9939. Both were pulled from #9902 on measurement — 12,255 and 1,440 rows/day make a `whole` plan recopy the table hourly. The `append` partition (#9913) exists for exactly this, and `surface_checks` has now proven it in production.

| table | rows | rows/day | cursor | pruned |
|---|---:|---:|---|---|
| `subnet_burn_history` | 36,894 | 12,255 | `observed_at` | yes, 90d |
| `tao_usd_index` | 7,965 | 1,440 | `observed_at` | no |

## Both preconditions checked, not assumed

**Cursor assigned at insert** — every row in a tick shares one `observedAt`, taken when the tick runs, moving only forward.

**Rows never rewritten** — `tao_usd_index` is `ON CONFLICT DO NOTHING`. `subnet_burn_history` says `INSERT OR REPLACE`, which *looks* like a counterexample and isn't; its own comment explains why:

> INSERT OR REPLACE, not INSERT: a retried tick at the same millisecond must be idempotent rather than a primary-key error

A replace only ever rewrites a row with the identical values it already held, at the same `observed_at`.

## Retention activates in the same step

`subnet_burn_history` already has its `NEON_PRUNE_PLANS` entry (#9920), and that lane filters on `NEON_BACKFILL_LANES` — so enabling the backfill enables retention together. Deliberate: three days of data against a 90-day retention means the prune measures **zero** doomed rows until it fills.

## Parity tolerances

Five rows is meaningless for either. `subnet_burn_history` → 1,000; `tao_usd_index` → 200 (no prune, so only write skew applies).

161 tests pass across the 4 affected suites.
