### PR TITLE
refactor(mcp): type the agent-catalog rows the route already declares

### DIFF
--- a/schemas-src/mcp-tools/agent-catalog-resources.ts
+++ b/schemas-src/mcp-tools/agent-catalog-resources.ts
@@ -7,7 +7,8 @@
 // modeled fresh, matching each hand-written literal field-for-field.
 import { z } from "zod";
 import { AgentResourcesArtifactSchema } from "../routes/agent-catalog.ts";
-import { OpenObjectSchema, netuidSchema } from "./shared.ts";
+import { netuidSchema } from "./shared.ts";
+import { AgentCatalogSubnetEntrySchema } from "../routes/agent-catalog.ts";
 
 export const GetAgentCatalogInputSchema = z
   .object({
@@ -28,7 +29,11 @@ export const GetAgentCatalogOutputSchema = z
     content_hash: z.string().nullable().optional(),
     generated_at: z.string().nullable().optional(),
     published_at: z.string().nullable().optional(),
-    subnets: z.array(OpenObjectSchema).optional(),
+    // Typed from the route's own AgentCatalogSubnetEntrySchema (#9797).
+    // Optional because it is the GLOBAL form's key -- a per-netuid call
+    // returns that subnet's own catalog instead, with no `subnets` at all.
+    // Verified against production 2026-08-07 over all 126 rows.
+    subnets: z.array(AgentCatalogSubnetEntrySchema).optional(),
     operational_observed_at: z.string().nullable().optional(),
     health_source: z.string().nullable().optional(),
   })

--- a/schemas-src/mcp-tools/catalog-detail.ts
+++ b/schemas-src/mcp-tools/catalog-detail.ts
@@ -21,6 +21,7 @@ import {
   surfaceIdSchema,
 } from "./shared.ts";
 import { ProviderArtifactSchema } from "../routes/providers-rpc.ts";
+import { AgentCatalogServiceSchema } from "../routes/agent-catalog.ts";
 
 export const ListSubnetApisInputSchema = z
   .object({
@@ -33,7 +34,12 @@ export const ListSubnetApisOutputSchema = z
   .object({
     netuid: netuidSchema(),
     service_count: z.int(),
-    services: z.array(OpenObjectSchema),
+    // Typed from the route's own AgentCatalogServiceSchema (#9797) -- the
+    // 18-field callable-service record, including the eligibility/health/
+    // fixture/snippets blocks an agent needs to decide whether it can call
+    // this surface. This tool advertises no `fields`, so it is not partial.
+    // Verified against production 2026-08-07.
+    services: z.array(AgentCatalogServiceSchema),
     operational_observed_at: z.string().nullable().optional(),
     health_source: z.string().nullable().optional(),
   })

--- a/schemas-src/routes/agent-catalog.ts
+++ b/schemas-src/routes/agent-catalog.ts
@@ -80,7 +80,7 @@ const AgentServiceEligibilitySchema = z
   })
   .passthrough();
 
-const AgentCatalogSubnetEntrySchema = z
+export const AgentCatalogSubnetEntrySchema = z
   .object({
     netuid: z.int().min(0),
     slug: z.string().optional(),
@@ -185,7 +185,7 @@ const SurfaceFixtureReferenceSchema = z
   })
   .strict();
 
-const AgentCatalogServiceSchema = z
+export const AgentCatalogServiceSchema = z
   .object({
     surface_id: z.string(),
     kind: z.string(),

--- a/scripts/validate-schema-opacity.ts
+++ b/scripts/validate-schema-opacity.ts
@@ -97,7 +97,6 @@ const MCP_NOT_YET_TYPED: string[] = [
   "find_subnet_for_task.results[]",
   "get_account.activity",
   "get_account_counterparties.relationship",
-  "get_agent_catalog.subnets[]",
   "get_domain_summary.domains[]",
   "get_domain_summary.emission_concentration",
   "get_subnet_gaps.enrichment_queue[]",
@@ -108,7 +107,6 @@ const MCP_NOT_YET_TYPED: string[] = [
   "list_enrichment_targets.targets[].top_gaps[]",
   "list_profiles.profiles[]",
   "list_search.documents[]",
-  "list_subnet_apis.services[]",
   "list_subnet_health.surfaces[]",
   "list_surface_credentials.credentials[]",
 ];

--- a/tests/mcp-typed-row-sites.test.ts
+++ b/tests/mcp-typed-row-sites.test.ts
@@ -42,6 +42,8 @@ const ROW_SITES: Array<[tool: string, key: string, projectable: boolean]> = [
   ["get_subnet_economics", "economics", false],
   ["get_health_history", "surfaces", true],
   ["get_subnet_health", "summary", false],
+  ["get_agent_catalog", "subnets", false],
+  ["list_subnet_apis", "services", false],
 ];
 
 describe("typed row sites (#9797)", () => {


### PR DESCRIPTION
## Summary — and a correction to my own triage

I posted a note on #9797 classifying the remaining sites as "all need hand-modelling". **That was too pessimistic for these two.** `routes/agent-catalog.ts` already declares `AgentCatalogSubnetEntrySchema` (16 fields) and `AgentCatalogServiceSchema` (18) — they were simply not *exported*, so the MCP side could not reach them. Both validate against live production unchanged.

The lesson is the mirror of the gaps cluster, where four candidate derivations all failed: **check the route file for an unexported schema before concluding a site needs modelling** — the same way `EconomicsSummarySchema` (#9932) and `HealthHistorySummarySchema` (#9942) only needed naming.

## The sites

| site | what it actually is |
|---|---|
| `get_agent_catalog.subnets[]` | `AgentCatalogSubnetEntrySchema` — incl. `agent_readiness`, `readiness`, `service_kinds` |
| `list_subnet_apis.services[]` | `AgentCatalogServiceSchema` — incl. the `eligibility` / `health` / `fixture` / `snippets` blocks |

`list_subnet_apis` is described as *"the agent integration path"* — it is how an agent decides whether it can call a surface at all. Publishing `{"type": "object"}` for the record carrying `eligibility.callable`, `auth_required`, `schema_url` and the ready-to-run `snippets` meant none of that was discoverable without calling the tool first.

`subnets` stays **optional** on `get_agent_catalog`: it is the *global* form's key, and a per-netuid call returns that subnet's own catalog with no `subnets` at all. Neither tool advertises `fields`, so neither is partial.

## Verified against production

```
OK   get_agent_catalog {}              (all 126 rows)
OK   get_agent_catalog {"netuid":64}
OK   list_subnet_apis  {"netuid":64}
OK   list_subnet_apis  {"netuid":1}

all valid against the emitted outputSchema
```

## Result

**MCP opacity debt: 18 → 16** (33 at the start of the day, six PRs).

All validators pass; 1,700 tests pass across the affected suites. No `src/**`/`workers/**` lines change, so `codecov/patch` has nothing to score.

Closes #9944