### PR TITLE
feat(neon): serve the two history routes from Neon

### DIFF
--- a/tests/neon-read-routes.test.ts
+++ b/tests/neon-read-routes.test.ts
@@ -126,7 +126,9 @@ function loaderTables(name: string, seen = new Set<string>()): string[] {
  * shows up as a drop in `checked` rather than as silent success.
  */
 function routePath(block: string): string | null {
-  const literal = /pathname === "([^"]+)"/.exec(block)?.[1];
+  const literal =
+    /pathname === "([^"]+)"/.exec(block)?.[1] ??
+    /pathname !== "([^"]+)"/.exec(block)?.[1];
   if (literal) return literal;
   const re = /pathname\.match\(\s*\/\^([^\n]*?)\$\//.exec(block)?.[1];
   if (!re) return null;
@@ -137,6 +139,34 @@ function routePath(block: string): string | null {
     .replace(/\\d\+/g, "7")
     .replace(/\[\^\/\]\+/g, "5Abc")
     .replace(/\\\./g, ".");
+}
+/**
+ * Every D1 route matcher in workers/data-api.ts, concatenated.
+ *
+ * NOT just matchNeuronsD1Route. One function was enough only while every
+ * route in NEON_READ_ROUTE_TABLES lived in it; the moment
+ * `/subnets/{n}/hyperparameters/history` and
+ * `/accounts/{ss58}/identity-history` moved, their SQL sat in
+ * matchHyperparamsIdentityD1Route where no scan reached it (#9947).
+ * Discovering matchers by NAME means the next one cannot fall outside the
+ * scan silently.
+ */
+function allMatcherSource(): string {
+  const src = readFileSync("workers/data-api.ts", "utf8");
+  const names = [...src.matchAll(/^function (match\w*D1Route)\b/gm)].map(
+    (m) => m[1]!,
+  );
+  assert.ok(
+    names.length >= 3,
+    `only ${names.length} D1 route matchers found -- discovery stopped working`,
+  );
+  return names
+    .map((name) => {
+      const start = src.indexOf(`function ${name}`);
+      const end = src.indexOf("\nfunction ", start + 10);
+      return src.slice(start, end > 0 ? end : undefined);
+    })
+    .join("\n");
 }
 
 describe("NEON_READ_ROUTE_TABLES", () => {
@@ -215,11 +245,7 @@ describe("NEON_READ_ROUTE_TABLES", () => {
     // So: split the matcher into its per-route blocks, resolve each block to a
     // concrete path, and compare the mirrored tables its SQL names against
     // what NEON_READ_ROUTE_TABLES declares for that path.
-    const src = readFileSync("workers/data-api.ts", "utf8");
-    const start = src.indexOf("function matchNeuronsD1Route");
-    assert.ok(start > 0, "matchNeuronsD1Route not found");
-    const end = src.indexOf("\nfunction ", start + 10);
-    const body = src.slice(start, end > 0 ? end : undefined);
+    const body = allMatcherSource();
 
     // One block per route, split at each mention of `url.pathname`.
     //
@@ -238,7 +264,12 @@ describe("NEON_READ_ROUTE_TABLES", () => {
     //
     // Splitting at `url.pathname` puts the path expression FIRST in its own
     // block, both spellings alike, with the handler that follows it.
-    const marks = [...body.matchAll(/url\.pathname(?: ===|\.match)/g)].map(
+    // `!==` is in here because a matcher may guard by EARLY RETURN --
+    // `if (url.pathname !== "...") return null;` -- which is how
+    // matchHealthStatusD1Route spells it. Without that alternative its SQL
+    // creates no mark and folds into the previous route's block, which is
+    // exactly the misattribution #9826 fixed for parameterised guards.
+    const marks = [...body.matchAll(/url\.pathname(?: ===| !==|\.match)/g)].map(
       (m) => m.index!,
     );
     const blocks = marks.map((start, i) =>
@@ -363,11 +394,7 @@ describe("NEON_READ_ROUTE_TABLES", () => {
       },
     ];
 
-    const src = readFileSync("workers/data-api.ts", "utf8");
-    const start = src.indexOf("function matchNeuronsD1Route");
-    assert.ok(start > 0, "matchNeuronsD1Route not found");
-    const end = src.indexOf("\nfunction ", start + 10);
-    const body = src.slice(start, end > 0 ? end : undefined);
+    const body = allMatcherSource();
 
     // Only the SQL, not the comments around it: this file explains the bug in
     // prose directly above the fix, and a scan that cannot tell those apart
@@ -393,23 +420,22 @@ describe("NEON_READ_ROUTE_TABLES", () => {
   });
 
   test("the scan actually covers every route the read map may move", () => {
-    // The scan reads ONE function. That is only sufficient while every route in
-    // NEON_READ_ROUTE_TABLES is dispatched from it -- and the map is the thing
-    // that grows as tables move off D1. Without this, adding a route whose
-    // handler lives elsewhere silently shrinks the scan's coverage to nothing
-    // in particular, and it would still report green.
-    const src = readFileSync("workers/data-api.ts", "utf8");
-    const start = src.indexOf("function matchNeuronsD1Route");
-    const end = src.indexOf("\nfunction ", start + 10);
-    const body = src.slice(start, end > 0 ? end : undefined);
+    // The scan reads EVERY match*D1Route function, discovered by name. It read
+    // only matchNeuronsD1Route until #9947, which was sufficient exactly as
+    // long as every route in NEON_READ_ROUTE_TABLES lived there -- and the map
+    // is the thing that grows as tables move off D1. A route whose handler
+    // lives in another matcher would otherwise shrink this check's coverage
+    // silently and still report green.
+    const body = allMatcherSource();
 
     // Compare on a CONCRETE PATH, not on regex source: the dispatcher spells
     // the parameterised routes with capture groups (`(\d+)`) and the map
     // without them, so the two sources never match textually even when they
     // describe the same route.
     const guards = [
-      // `if (url.pathname === "...")`
-      ...[...body.matchAll(/pathname === "([^"]+)"/g)].map(
+      // `if (url.pathname === "...")` and its early-return twin
+      // `if (url.pathname !== "...") return null;`
+      ...[...body.matchAll(/pathname [!=]== "([^"]+)"/g)].map(
         (m) => (path: string) => path === m[1],
       ),
       // `url.pathname.match(/^\/api\/v1\/.../)`

--- a/tests/neon-sql-portability.test.ts
+++ b/tests/neon-sql-portability.test.ts
@@ -257,12 +257,33 @@ function stripComments(source: string): string {
 }
 
 /** The matcher body, which is where the inline route SQL lives. */
+/**
+ * Every D1 route matcher in workers/data-api.ts, concatenated.
+ *
+ * NOT just matchNeuronsD1Route. Scanning one function was sufficient only
+ * while every route in NEON_READ_ROUTE_TABLES lived in it, and the moment
+ * `/subnets/{n}/hyperparameters/history` and `/accounts/{ss58}/identity-history`
+ * moved, their SQL sat in matchHyperparamsIdentityD1Route where no scan
+ * reached it (#9947). Discovering the matchers by NAME rather than listing
+ * them means the next one cannot silently fall outside the scan -- which is
+ * the failure this whole family of checks exists to prevent.
+ */
 function matcherSource(): string {
   const src = readFileSync("workers/data-api.ts", "utf8");
-  const start = src.indexOf("function matchNeuronsD1Route");
-  assert.ok(start > 0, "matchNeuronsD1Route not found");
-  const end = src.indexOf("\nfunction ", start + 10);
-  return src.slice(start, end > 0 ? end : undefined);
+  const names = [...src.matchAll(/^function (match\w*D1Route)\b/gm)].map(
+    (m) => m[1]!,
+  );
+  assert.ok(
+    names.length >= 3,
+    `only ${names.length} D1 route matchers found -- the discovery regex stopped working`,
+  );
+  return names
+    .map((name) => {
+      const start = src.indexOf(`function ${name}`);
+      const end = src.indexOf("\nfunction ", start + 10);
+      return src.slice(start, end > 0 ? end : undefined);
+    })
+    .join("\n");
 }
 
 /** Per-route blocks, keyed by the literal path each guard matches. */

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -6065,6 +6065,18 @@ export const NEON_READ_ROUTE_TABLES: readonly {
       "validator_nominator_counts",
     ],
   },
+  // Cut over once both stores agreed exactly -- 137/137 and 531/531 measured,
+  // and the cursor stopped depending on a surrogate id whose value differs
+  // between them (#9947). Each reads ONE table, so there is no side loader to
+  // drag along.
+  {
+    pattern: /^\/api\/v1\/subnets\/\d+\/hyperparameters\/history$/,
+    tables: ["subnet_hyperparams_history"],
+  },
+  {
+    pattern: /^\/api\/v1\/accounts\/[^/]+\/identity-history$/,
+    tables: ["account_identity_history"],
+  },
   {
     pattern: /^\/api\/v1\/subnets\/\d+\/concentration\/history$/,
     tables: [
@@ -7047,9 +7059,8 @@ function matchHyperparamsIdentityD1Route(
     }
 
     // GET /api/v1/subnets/:netuid/hyperparameters/history?limit=&offset=
-    // &cursor= -- same FEED_PAGINATION bounds and (observed_at, id) keyset
-    // cursor as the Postgres route; SQLite supports the row-value comparison
-    // directly, so only the placeholder style moves.
+    // &cursor= -- FEED_PAGINATION bounds, keyed on observed_at alone so the
+    // cursor means the same thing in both stores (#9947).
     const subnetHyperparamsHistory = url.pathname.match(
       /^\/api\/v1\/subnets\/(\d+)\/hyperparameters\/history$/,
     );
@@ -7061,20 +7072,38 @@ function matchHyperparamsIdentityD1Route(
           FEED_PAGINATION,
         );
         const offset = clampRequestOffset(url.searchParams.get("offset"));
-        const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+        // ONE component, and it is observed_at -- NOT (observed_at, id).
+        //
+        // The id is a surrogate, and Neon assigns its own: the backfill
+        // inserted in keyset order while D1 numbered by insertion order, so
+        // `id = 1` is a different row in each store (verified, #9947). Putting
+        // it in a cursor made that difference part of the PUBLIC API, and a
+        // cursor minted before a read moved to Neon would be compared against
+        // ids that never meant the same thing.
+        //
+        // It was never carrying any weight. (netuid, observed_at) is unique --
+        // 137 rows, 137 distinct, measured -- so within the `netuid = ?` this
+        // query already pins, observed_at alone totally orders the rows and
+        // the id could not break a tie that cannot happen.
+        //
+        // An old two-part cursor now fails decodeCursor's arity check and
+        // returns null, which falls through to the offset path below. That is
+        // the right degradation: a stale cursor restarts a page rather than
+        // seeking to a row that is not there.
+        const cursor = decodeCursor(url.searchParams.get("cursor"), 1);
         const rows = cursor
           ? await sql.unsafe(
               `SELECT ${SUBNET_HYPERPARAMS_HISTORY_D1_READ_COLUMNS}
                FROM subnet_hyperparams_history
-               WHERE netuid = ? AND (observed_at, id) < (?, ?)
-               ORDER BY observed_at DESC, id DESC LIMIT ?`,
-              [netuid, cursor[0], cursor[1], limit],
+               WHERE netuid = ? AND observed_at < ?
+               ORDER BY observed_at DESC LIMIT ?`,
+              [netuid, cursor[0], limit],
             )
           : await sql.unsafe(
               `SELECT ${SUBNET_HYPERPARAMS_HISTORY_D1_READ_COLUMNS}
                FROM subnet_hyperparams_history
                WHERE netuid = ?
-               ORDER BY observed_at DESC, id DESC LIMIT ? OFFSET ?`,
+               ORDER BY observed_at DESC LIMIT ? OFFSET ?`,
               [netuid, limit, offset],
             );
         if (
@@ -7084,10 +7113,7 @@ function matchHyperparamsIdentityD1Route(
           return d1TierCold();
         const last = rows.length === limit ? rows[rows.length - 1] : null;
         const nextCursor = last
-          ? encodeCursor([
-              numberOrNull(last.observed_at),
-              numberOrNull(last.id),
-            ])
+          ? encodeCursor([numberOrNull(last.observed_at)])
           : null;
         return json(
           buildSubnetHyperparamsHistory(rows, netuid, {
@@ -7132,20 +7158,25 @@ function matchHyperparamsIdentityD1Route(
           FEED_PAGINATION,
         );
         const offset = clampRequestOffset(url.searchParams.get("offset"));
-        const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+        // observed_at alone -- see the hyperparams-history route above for why
+        // the surrogate id must not appear in a cursor (#9947). (account,
+        // observed_at) is unique at 531 rows / 531 distinct, measured, so
+        // within the `account = ?` this query pins, observed_at totally orders
+        // the rows.
+        const cursor = decodeCursor(url.searchParams.get("cursor"), 1);
         const rows = cursor
           ? await sql.unsafe(
               `SELECT ${ACCOUNT_IDENTITY_HISTORY_D1_READ_COLUMNS}
                FROM account_identity_history
-               WHERE account = ? AND (observed_at, id) < (?, ?)
-               ORDER BY observed_at DESC, id DESC LIMIT ?`,
-              [ss58, cursor[0], cursor[1], limit],
+               WHERE account = ? AND observed_at < ?
+               ORDER BY observed_at DESC LIMIT ?`,
+              [ss58, cursor[0], limit],
             )
           : await sql.unsafe(
               `SELECT ${ACCOUNT_IDENTITY_HISTORY_D1_READ_COLUMNS}
                FROM account_identity_history
                WHERE account = ?
-               ORDER BY observed_at DESC, id DESC LIMIT ? OFFSET ?`,
+               ORDER BY observed_at DESC LIMIT ? OFFSET ?`,
               [ss58, limit, offset],
             );
         if (
@@ -7155,10 +7186,7 @@ function matchHyperparamsIdentityD1Route(
           return d1TierCold();
         const last = rows.length === limit ? rows[rows.length - 1] : null;
         const nextCursor = last
-          ? encodeCursor([
-              numberOrNull(last.observed_at),
-              numberOrNull(last.id),
-            ])
+          ? encodeCursor([numberOrNull(last.observed_at)])
           : null;
         return json(
           buildAccountIdentityHistory(rows, ss58, {

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -190,7 +190,7 @@
     // the loader modules they reach and fails the build on either construct.
     //
     // Rollback remains deleting the entry.
-    "NEON_READ_LANES": "account_position_daily,neurons,neuron_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts",
+    "NEON_READ_LANES": "account_position_daily,neurons,neuron_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,subnet_hyperparams_history,account_identity_history",
     // The two ACCUMULATING tables, and only those (src/neon-backfill.ts).
     //
     // The mirror above writes what each request carries, which finishes the job


### PR DESCRIPTION
Closes #9947. **The first read cutover of this family** — `/subnets/{netuid}/hyperparameters/history` and `/accounts/{ss58}/identity-history` now read Neon. Both tables are at exact parity (137/137, 531/531) and each route reads one table, so there's no side loader to drag along.

## The cursor had to stop carrying a surrogate id

#9896 gave these tables `id GENERATED ALWAYS`, reasoning the id is "a tiebreaker that can never tie". Right about **ordering**, wrong about **exposure** — both routes encoded `(observed_at, id)` into their pagination cursor, putting a store-local surrogate into the public API.

The ids genuinely differ. Both stores hold 531 rows numbered 1–531, which is a coincidence of count:

```
D1    id=1  5HdThE9WvusfeFpk7R3Lnc9wfP4zsDje3GeRew6mrQHNNFiY
Neon  id=1  5C5LVkCfXk4LyUGozdk9FC65gauUVuAoRqAPpXdrhHYQeF4y
```

D1 numbered by insertion order; the backfill inserted in keyset order.

The cursor now carries `observed_at` alone — which was always sufficient, since within the `account = ?` / `netuid = ?` each query already pins, the natural key is unique. An old two-part cursor fails `decodeCursor`'s arity check and falls through to the offset path: restarts a page rather than seeking to a row that isn't there.

## Both scanners were blind to these routes

They read `matchNeuronsD1Route` only; these routes live in `matchHyperparamsIdentityD1Route`. Moving them would have shipped SQL **no portability or dialect check had ever seen** — and the gate caught exactly that.

Fixed by **discovering matchers by name** rather than naming one, so the next matcher can't silently fall outside the scan.

That widening then exposed a second blind spot: `matchHealthStatusD1Route` guards by early return (`if (url.pathname !== "...") return null`), which the block splitter didn't recognise — so its `surface_status` SQL was folding into a neighbour's block and being attributed to `/subnets/movers`. Same misattribution class as #9826, in a form that didn't exist then.

201 tests pass across the 7 affected suites.
