### PR TITLE
refactor(mcp): type six more sites from the routes that already declare them

### DIFF
--- a/schemas-src/mcp-tools/account-summary.ts
+++ b/schemas-src/mcp-tools/account-summary.ts
@@ -13,7 +13,6 @@
 // now publishes.
 import { z } from "zod";
 import {
-  OpenObjectSchema,
   blockBoundSchema,
   keysetCursorSchema,
   kindStringSchema,
@@ -24,6 +23,7 @@ import {
 } from "./shared.ts";
 import { AccountEntitiesArtifactSchema } from "../routes/account-entities.ts";
 import { AccountEventsArtifactSchema } from "../routes/account-events-feed.ts";
+import { AccountActivitySchema } from "../routes/account-summary.ts";
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
@@ -89,7 +89,11 @@ export const GetAccountOutputSchema = z
     ),
     registrations: z.array(AccountRegistrationItemSchema),
     recent_events: z.array(AccountEventItemSchema),
-    activity: OpenObjectSchema.optional(),
+    // Typed from the route's own AccountActivitySchema (#9797) -- the
+    // per-kind event breakdown and first/last block/timestamp seen. This tool
+    // advertises no `fields`, so it is not partial. Verified against
+    // production 2026-08-07.
+    activity: AccountActivitySchema.optional(),
     labels: z.array(AccountLabelItemSchema).optional(),
   })
   .passthrough();

--- a/schemas-src/mcp-tools/account-transfers.ts
+++ b/schemas-src/mcp-tools/account-transfers.ts
@@ -12,7 +12,6 @@
 // now publishes.
 import { z } from "zod";
 import {
-  OpenObjectSchema,
   blockBoundSchema,
   keysetCursorSchema,
   limitSchema,
@@ -20,6 +19,7 @@ import {
   ss58Schema,
 } from "./shared.ts";
 import { AccountTransfersArtifactSchema } from "../routes/account-events-feed.ts";
+import { CounterpartyRelationshipSchema } from "../routes/account-counterparties.ts";
 
 const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 
@@ -90,7 +90,10 @@ export const GetAccountCounterpartiesOutputSchema = z
     counterparties: z.array(CounterpartyItemSchema),
     // Present only in counterparty='<ss58>' drilldown mode (the per-pair
     // detail) -- bare open object, matching the hand-written original.
-    relationship: OpenObjectSchema.optional(),
+    // Typed from the route's own CounterpartyRelationshipSchema (#9797):
+    // the fund-flow totals plus the transfer list for one drilled-into
+    // counterparty. Verified against production 2026-08-07.
+    relationship: CounterpartyRelationshipSchema.optional(),
   })
   .passthrough();
 export type GetAccountCounterpartiesOutput = z.infer<

--- a/schemas-src/mcp-tools/get-domain-summary.ts
+++ b/schemas-src/mcp-tools/get-domain-summary.ts
@@ -11,7 +11,10 @@
 // literal it replaces. Domain enum hardcoded from src/domain-tags.ts's
 // DOMAIN_TAGS at the time of writing.
 import { z } from "zod";
-import { OpenObjectSchema } from "./shared.ts";
+import {
+  ConcentrationScorecardSchema,
+  DomainSummaryArtifactSchema,
+} from "../routes/domains.ts";
 
 const DOMAIN_TAGS = [
   "agents",
@@ -49,9 +52,15 @@ export const GetDomainSummaryOutputSchema = z
     netuids: z.array(z.int()).optional(),
     total_stake_tao: z.number().nullable().optional(),
     total_emission_share: z.number().nullable().optional(),
-    emission_concentration: OpenObjectSchema.nullable().optional(),
+    // Typed from the route's own ConcentrationScorecardSchema (#9797).
+    emission_concentration: ConcentrationScorecardSchema.nullable().optional(),
     domain_count: z.int().optional(),
-    domains: z.array(OpenObjectSchema).optional(),
+    // The LIST form's key: calling without `domain` returns every domain's
+    // summary, so each entry is a whole DomainSummaryArtifact. Optional
+    // because a call WITH `domain` returns that one summary inline instead,
+    // with no `domains` at all. Verified against production 2026-08-07 in
+    // both forms.
+    domains: z.array(DomainSummaryArtifactSchema).optional(),
   })
   .passthrough();
 export type GetDomainSummaryOutput = z.infer<

--- a/schemas-src/mcp-tools/profiles.ts
+++ b/schemas-src/mcp-tools/profiles.ts
@@ -15,7 +15,6 @@
 import { z } from "zod";
 import { SubnetProfileArtifactSchema } from "../routes/subnet-profiles.ts";
 import {
-  OpenObjectArraySchema,
   fieldsStringSchema,
   limitSchema,
   netuidSchema,
@@ -25,6 +24,7 @@ import {
   sortSchema,
 } from "./shared.ts";
 import { CURATION_LEVEL_VALUES } from "../shared.ts";
+import { SubnetProfileSchema } from "../routes/subnet-profile.ts";
 
 const SUBNET_TYPE = ["root", "application"] as const;
 const CURATION_LEVEL = CURATION_LEVEL_VALUES;
@@ -100,7 +100,10 @@ export type GetSubnetProfileInput = z.infer<typeof GetSubnetProfileInputSchema>;
 export const ListProfilesOutputSchema = z
   .object({
     captured_at: z.string().nullable().optional(),
-    profiles: OpenObjectArraySchema,
+    // Typed from the route's own SubnetProfileSchema (#9797), PARTIAL
+    // because this tool advertises `fields` (#9884). Verified against
+    // production 2026-08-07.
+    profiles: z.array(SubnetProfileSchema.partial()),
     total: z.int().optional(),
     returned: z.int().optional(),
     limit: z.int().optional(),

--- a/schemas-src/mcp-tools/validators.ts
+++ b/schemas-src/mcp-tools/validators.ts
@@ -19,7 +19,6 @@
 import { z } from "zod";
 import {
   NeuronFieldsInputSchema,
-  OpenObjectArraySchema,
   accountKeySchema,
   limitSchema,
   netuidSchema,
@@ -36,6 +35,7 @@ import { ValidatorDetailArtifactSchema } from "../routes/validator-detail.ts";
 import { ValidatorHistoryArtifactSchema } from "../routes/validator-history.ts";
 import { ValidatorNominatorsArtifactSchema } from "../routes/validator-nominators.ts";
 import { NeuronSchema } from "../routes/subnet-metagraph.ts";
+import { CompareValidatorEntrySchema } from "../routes/compare-validators.ts";
 
 // Mirrors workers/config.ts's SS58_ADDRESS_PATTERN (inlined rather than
 // cross-imported from workers/, matching this directory's existing
@@ -179,7 +179,12 @@ export const CompareValidatorsOutputSchema = z
     schema_version: z.int().optional(),
     netuid: netuidSchema().nullable().optional(),
     validator_count: z.int(),
-    validators: OpenObjectArraySchema,
+    // Typed from the route's own CompareValidatorEntrySchema (#9797). This
+    // is the SECOND `validators` site in this file -- list_subnet_validators'
+    // is a neuron row, compare_validators' is the side-by-side comparison
+    // entry, and they are deliberately different shapes. Verified against
+    // production 2026-08-07.
+    validators: z.array(CompareValidatorEntrySchema),
   })
   .passthrough();
 export type CompareValidatorsOutput = z.infer<

--- a/schemas-src/routes/account-counterparties.ts
+++ b/schemas-src/routes/account-counterparties.ts
@@ -55,7 +55,7 @@ const CounterpartyTransferSchema = z
   })
   .strict();
 
-const CounterpartyRelationshipSchema = z
+export const CounterpartyRelationshipSchema = z
   .object({
     schema_version: z.int(),
     ss58: z.string(),

--- a/schemas-src/routes/account-summary.ts
+++ b/schemas-src/routes/account-summary.ts
@@ -58,7 +58,7 @@ const AccountEventKindCountSchema = z
   })
   .strict();
 
-const AccountActivitySchema = z
+export const AccountActivitySchema = z
   .object({
     tx_count: z.int().min(0),
     last_tx_block: z.int().nullable(),

--- a/schemas-src/routes/compare-validators.ts
+++ b/schemas-src/routes/compare-validators.ts
@@ -10,7 +10,7 @@ import { successEnvelopeSchema } from "../envelope.ts";
 import { ColdkeyIdentitySchema } from "./global-validators.ts";
 import { ValidatorDetailSubnetSchema } from "./validator-detail.ts";
 
-const CompareValidatorEntrySchema = z
+export const CompareValidatorEntrySchema = z
   .object({
     hotkey: z.string(),
     coldkey: z.string().nullable(),

--- a/scripts/validate-schema-opacity.ts
+++ b/scripts/validate-schema-opacity.ts
@@ -93,19 +93,13 @@ const ROUTE_OPEN_SITES: Record<string, string> = {
  * this gate -- the list may only shrink, and it is the honest count of what
  * #9797 has left to do. */
 const MCP_NOT_YET_TYPED: string[] = [
-  "compare_validators.validators[]",
   "find_subnet_for_task.results[]",
-  "get_account.activity",
-  "get_account_counterparties.relationship",
-  "get_domain_summary.domains[]",
-  "get_domain_summary.emission_concentration",
   "get_subnet_gaps.enrichment_queue[]",
   "get_subnet_gaps.priorities[]",
   "how_do_i_call.services[]",
   "list_enrichment_targets.filters",
   "list_enrichment_targets.targets[].dimensions",
   "list_enrichment_targets.targets[].top_gaps[]",
-  "list_profiles.profiles[]",
   "list_search.documents[]",
   "list_subnet_health.surfaces[]",
   "list_surface_credentials.credentials[]",

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -11301,10 +11301,14 @@ describe("MCP economics + metagraph data tools", () => {
         slug: "allways",
         name: "Allways",
         completeness_score: 82,
-        curation_level: "machine-verified",
-        review_state: "verified",
+        // Real enum members, recaptured from production 2026-08-07 when
+        // list_profiles.profiles[] became SubnetProfileSchema.partial()
+        // (#9797). The stub used "verified"/"complete", neither of which is a
+        // declared value -- invisible while the site published a bare object.
+        curation_level: "maintainer-reviewed",
+        review_state: "maintainer-reviewed",
         confidence: "high",
-        profile_level: "complete",
+        profile_level: "operational",
       },
       {
         netuid: 1,

--- a/tests/mcp-typed-row-sites.test.ts
+++ b/tests/mcp-typed-row-sites.test.ts
@@ -44,6 +44,11 @@ const ROW_SITES: Array<[tool: string, key: string, projectable: boolean]> = [
   ["get_subnet_health", "summary", false],
   ["get_agent_catalog", "subnets", false],
   ["list_subnet_apis", "services", false],
+  ["get_account", "activity", false],
+  ["get_account_counterparties", "relationship", false],
+  ["compare_validators", "validators", false],
+  ["list_profiles", "profiles", true],
+  ["get_domain_summary", "domains", false],
 ];
 
 describe("typed row sites (#9797)", () => {


### PR DESCRIPTION
## Summary

Applying #9946's lesson — **check the route file for an unexported schema before concluding a site needs modelling.** Three of these six needed only an `export` keyword.

| site | route schema | was exported? |
|---|---|---|
| `get_account.activity` | `AccountActivitySchema` | no |
| `get_account_counterparties.relationship` | `CounterpartyRelationshipSchema` | no |
| `compare_validators.validators[]` | `CompareValidatorEntrySchema` | no |
| `list_profiles.profiles[]` | `SubnetProfileSchema` | yes, unused |
| `get_domain_summary.domains[]` | `DomainSummaryArtifactSchema` | yes, unused |
| `get_domain_summary.emission_concentration` | `ConcentrationScorecardSchema` | yes, unused |

## Two things that needed care

**`compare_validators.validators[]` is the second `validators` site in `mcp-tools/validators.ts`, and it is a different shape** from `list_subnet_validators.validators[]`. The first is a neuron row (`NeuronSchema`, typed in #9924); this one is the side-by-side comparison entry. Typing them as the same thing would have been wrong in a way nothing would catch until a caller hit it.

**`get_domain_summary` serves two shapes.** With `domain` it returns that one summary inline; without it, `{schema_version, domain_count, domains}` where each entry is a whole `DomainSummaryArtifact`. So `domains` stays optional and both forms are verified.

Worth noting the parameter is `domain`, **not `tag`** — the debt-list entry reads `get_domain_summary.domains[]` and invites the wrong call. My first verification attempt did exactly that and produced a meaningless "OK" against an errored response. I caught it because the response keys printed as `error`; it is the kind of pass that looks like success.

## A third fixture carrying values that were never valid

`PROFILES_BLOB` had `review_state: "verified"` and `profile_level: "complete"` — **neither is a declared enum member.** Invisible while the site published `{"type": "object"}`. Recaptured from production (`maintainer-reviewed` / `operational`), after `ECON_BLOB` (#9932) and `HEALTH_HISTORY_BLOB` (#9942).

## Verified against production

```
OK   get_account                {"ss58":"5GP7c3…"}
OK   get_account_counterparties {"ss58":"5GP7c3…"}
OK   get_account_counterparties {"ss58":"5GP7c3…","counterparty":"5CzcUx…"}
OK   list_profiles              {"limit":3}
OK   list_profiles              {"limit":3,"fields":"netuid,slug"}
OK   compare_validators         {"hotkeys":["5CzcUx…"]}
OK   get_domain_summary         {}
OK   get_domain_summary         {"domain":"agents"}

all valid against the emitted outputSchema
```

## Result

**MCP opacity debt: 16 → 10** (33 at the start of the day, seven PRs).

All validators pass; 2,798 tests pass across the affected suites. No `src/**`/`workers/**` lines change, so `codecov/patch` has nothing to score.

Closes #9949