### PR TITLE
fix(build): stop printing 1MB of schemas nothing reads into every build log

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -97,7 +97,13 @@ function localSteps(): Step[] {
     // consumed by anything -- it exists to fail the build fast, and
     // separately, if the Zod schemas break. The bundle-schemas step that used
     // to run first is gone with the hand-written layer it compiled (#9830).
-    nodeStep("openapi-zod", "scripts/generate-openapi-zod-components.ts"),
+    // --check because of that: printing the payload nothing reads was 99.8%
+    // of the build log (#9945).
+    nodeStep(
+      "openapi-zod",
+      "scripts/generate-openapi-zod-components.ts",
+      "--check",
+    ),
     nodeStep("build-artifacts", "scripts/build-artifacts.ts", {
       METAGRAPH_PRESERVE_PROBE_HEALTH: "1",
     }),
@@ -115,8 +121,13 @@ function localSteps(): Step[] {
 function productionSteps(): Step[] {
   return [
     // See localSteps' own comment -- early, independently-failing checkpoint;
-    // build-artifacts further down is what writes them into openapi.json.
-    nodeStep("openapi-zod", "scripts/generate-openapi-zod-components.ts"),
+    // build-artifacts further down is what writes them into openapi.json,
+    // and --check keeps the payload out of the publish log (#9945).
+    nodeStep(
+      "openapi-zod",
+      "scripts/generate-openapi-zod-components.ts",
+      "--check",
+    ),
     // Refresh the finney native chain snapshot fresh each publish (ADR 0006
     // step 2) so the registry stays current without the retired scheduled
     // sync-subnets PR. Tolerant: a chain RPC failure keeps the last snapshot and

--- a/scripts/generate-openapi-zod-components.ts
+++ b/scripts/generate-openapi-zod-components.ts
@@ -46,6 +46,28 @@ export function generateOpenApiZodComponents(): Record<string, Row> {
   return components;
 }
 
+// `--check` compiles the registry and reports the count; bare prints the JSON.
+//
+// The build passes --check (scripts/build.ts). Without it this step wrote
+// ~1,040,000 bytes / 42,664 lines to stdout -- 99.8% of the whole build log,
+// against 2,358 bytes from every other step combined -- and nothing read a
+// byte of it: both real consumers (scripts/openapi-components.ts,
+// scripts/validate-single-schema-source.ts) import the function and call it
+// in-process. A log that noisy is a log nobody reads, which is how a healthy
+// build got reported as a failing one (#9945).
+//
+// The step still earns its place: compiling the registry is exactly the
+// fast-fail check build.ts wants, and it fails identically either way -- the
+// count line just proves it ran. Same shape as generate-client.ts's flagged
+// summary-vs-payload split, and the same --check verb as
+// generate-registry-readme-section.ts.
 if (import.meta.url === `file://${process.argv[1]}`) {
-  console.log(JSON.stringify(generateOpenApiZodComponents(), null, 2));
+  const components = generateOpenApiZodComponents();
+  if (process.argv.includes("--check")) {
+    console.log(
+      `openapi-zod: ${Object.keys(components).length} component schema(s) compiled.`,
+    );
+  } else {
+    console.log(JSON.stringify(components, null, 2));
+  }
 }

--- a/tests/openapi-zod-cli.test.ts
+++ b/tests/openapi-zod-cli.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, test } from "vitest";
+import { repoRoot } from "../scripts/lib.ts";
+import { generateOpenApiZodComponents } from "../scripts/generate-openapi-zod-components.ts";
+
+// #9945: this step ran bare and printed the whole component map -- ~1,040,000
+// bytes / 42,664 lines, 99.8% of the build log, against 2,358 bytes from every
+// other step combined -- while nothing read a byte of it. A healthy build got
+// reported as a failing one because the outcome was unfindable in the noise.
+//
+// Two things have to hold together for that to stay fixed, so both are asserted
+// here: the script has to be quiet under --check, AND the build has to pass it.
+// Testing only the script would let build.ts silently drop the flag and restore
+// the megabyte.
+
+const SCRIPT = "scripts/generate-openapi-zod-components.ts";
+
+function run(args: string[]): string {
+  return execFileSync(process.execPath, [SCRIPT, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    // The bare mode legitimately emits ~1MB; the default 1MB stdout cap would
+    // truncate it and fail the JSON.parse below for the wrong reason.
+    maxBuffer: 64 * 1024 * 1024,
+  });
+}
+
+/** Every `nodeStep("openapi-zod", ...)` argument list in scripts/build.ts. */
+function openApiZodStepCalls(source: string): string[] {
+  return [...source.matchAll(/nodeStep\(\s*"openapi-zod",([^)]*)\)/g)].map(
+    (match) => match[1],
+  );
+}
+
+describe("generate-openapi-zod-components CLI", () => {
+  test("--check reports a count instead of the payload", () => {
+    const out = run(["--check"]);
+    const lines = out.trimEnd().split("\n");
+    assert.equal(lines.length, 1, "--check must emit exactly one line");
+    // The count is real, not a hardcoded string: it has to match what the
+    // function returns, so a registry that silently emptied still fails.
+    const expected = Object.keys(generateOpenApiZodComponents()).length;
+    assert.ok(expected > 0, "registry should compile at least one component");
+    assert.equal(
+      lines[0],
+      `openapi-zod: ${expected} component schema(s) compiled.`,
+    );
+    // The whole point: no JSON body.
+    assert.ok(!out.includes('"type": "object"'), "--check must not print JSON");
+    assert.ok(out.length < 200, `--check output was ${out.length} bytes`);
+  });
+
+  test("bare still prints the full component JSON", () => {
+    const out = run([]);
+    const parsed = JSON.parse(out) as Record<string, unknown>;
+    assert.deepEqual(
+      Object.keys(parsed).sort(),
+      Object.keys(generateOpenApiZodComponents()).sort(),
+    );
+    // Guards the escape hatch the fix deliberately kept: `npm run
+    // build:openapi-zod` runs bare and must keep emitting the payload.
+    assert.ok(out.length > 100_000, `bare output was only ${out.length} bytes`);
+  });
+});
+
+describe("scripts/build.ts wires --check", () => {
+  const source = readFileSync(path.join(repoRoot, "scripts/build.ts"), "utf8");
+  const calls = openApiZodStepCalls(source);
+
+  test("both step lists run the openapi-zod step", () => {
+    // localSteps + productionSteps. If a third list ever appears this fails
+    // rather than silently checking two of three.
+    assert.equal(calls.length, 2, "expected exactly two openapi-zod steps");
+  });
+
+  test("every openapi-zod step passes --check", () => {
+    for (const args of calls) {
+      assert.ok(
+        args.includes('"--check"'),
+        `openapi-zod step missing --check: nodeStep("openapi-zod",${args})`,
+      );
+    }
+  });
+
+  test("the parser would notice a step that dropped the flag", () => {
+    // Positive control -- a matcher that silently found nothing would pass the
+    // assertion above over an empty list, which is the failure mode this whole
+    // test exists to prevent.
+    const withoutFlag = openApiZodStepCalls(
+      'nodeStep("openapi-zod", "scripts/generate-openapi-zod-components.ts"),',
+    );
+    assert.equal(withoutFlag.length, 1);
+    assert.ok(!withoutFlag[0].includes('"--check"'));
+  });
+});


### PR DESCRIPTION
## Summary

The `openapi-zod` build step ran its CLI bare, so the `import.meta.url` guard in `scripts/generate-openapi-zod-components.ts` dumped the entire component map to stdout on every build.

| | |
|---|---:|
| that one step's stdout | **1,040,727 bytes / 42,664 lines** |
| every other build step combined | 2,358 bytes |
| share of the build log | **99.8%** |

And nothing read a byte of it. `scripts/build.ts`'s own comment already said so — *"this step's own stdout isn't consumed by anything — it exists to fail the build fast"* — and both real consumers, `scripts/openapi-components.ts:17` and `scripts/validate-single-schema-source.ts:28`, `import { generateOpenApiZodComponents }` and call it in-process.

This was reported as *"metagraphed worker builds appear to be failing"*, with a Workers Builds log as evidence: ~40,000 lines of `"type": "object"` and `"anyOf": [...]`, the outcome unfindable inside it. The build was fine.

## What changed

`--check` reports the count; bare still prints the JSON. Both step lists in `build.ts` pass `--check`.

```
openapi-zod: 298 component schema(s) compiled.
```

**The step keeps its job.** Compiling the registry is exactly the fast-fail check `build.ts` wants, and it fails identically either way — the count line just proves it ran, and is derived from the real result rather than hardcoded, so a registry that silently emptied still fails the test.

**The escape hatch is deliberate.** `npm run build:openapi-zod` runs bare and is unchanged; anyone who wants the payload still gets it.

## Result

```
build stdout:  1,043,085 → 2,406 bytes   (42,748 → 85 lines)
npm run build: exit 0, all 7 steps passed, 7s
```

The per-step pass/fail table `build.ts` prints at the end — previously buried under a megabyte — is now visible in the log.

## Anchored on existing code

Not a new convention:

- `scripts/generate-client.ts:7-18` — same flagged summary-vs-payload split (`--write` logs one line, bare writes the payload to stdout), and `build.ts` already passes it a flag for exactly this reason.
- `scripts/generate-registry-readme-section.ts:32` — same `--check` verb for "verify, don't emit".

## Tests

`tests/openapi-zod-cli.test.ts`, 5 tests. It asserts **both** halves, because testing only the script would let `build.ts` silently drop the flag and restore the megabyte:

- `--check` emits exactly one line, matching the real component count, containing no JSON, under 200 bytes.
- Bare output parses as JSON with the same keys the function returns, and is still >100 KB.
- Both `nodeStep("openapi-zod", …)` call sites in `build.ts` pass `--check`, and there are exactly **two** — a third step list appearing fails rather than silently checking two of three.
- A positive control proving the source matcher would notice a step that dropped the flag, so the assertion above can't pass over an empty list.

**Mutation-tested:** reverting *one* of the two `build.ts` call sites to bare fails `every openapi-zod step passes --check` with the offending call quoted, and passes again when restored.

## Validation run

```
npm run lint            clean
npm run format:check    All matched files use Prettier code style!
npm run typecheck       clean
npm run validate        exit 0 — 129 native subnets, 129 overlays, 3441 surfaces, 137 providers, 2037 candidates
npm run build           exit 0 — 7/7 steps passed
vitest tests/openapi-zod-cli.test.ts tests/workflow-observability.test.ts tests/zod-schemas.test.ts
                        347 passed
```

`tests/workflow-observability.test.ts` is included because it parses `build.ts`'s step lists — the change does not disturb its `buildStepScripts()` extraction.

No generated artifacts are committed: the only build output that went dirty was `public/metagraph/r2-manifest.json`, which `revertDeployOwnedArtifactsIfDirty` auto-reverted, as designed.

Closes #9945
