### PR TITLE
refactor(mcp): type the gaps and search rows, correcting a wrong negative result

### DIFF
--- a/schemas-src/mcp-tools/registry-summary-gaps.ts
+++ b/schemas-src/mcp-tools/registry-summary-gaps.ts
@@ -141,8 +141,15 @@ export const GetSubnetGapsOutputSchema = z
     netuid: netuidSchema(),
     slug: z.string().nullable().optional(),
     name: z.string().nullable().optional(),
-    priorities: z.array(OpenObjectSchema),
-    enrichment_queue: z.array(OpenObjectSchema),
+    // Typed from the route's own SubnetGapsArtifactSchema (#9797) --
+    // routes/review-gaps-profile.ts, which is what
+    // /api/v1/subnets/{netuid}/gaps resolves to in openapi.json. An earlier
+    // attempt tested these against coverage.ts's CoverageDepth schemas on a
+    // filename guess and they failed; resolving the route through its
+    // published $ref finds the right one. Verified against production
+    // 2026-08-07.
+    priorities: SubnetGapsArtifactSchema.shape.priorities,
+    enrichment_queue: SubnetGapsArtifactSchema.shape.enrichment_queue,
   })
   .passthrough();
 export type GetSubnetGapsOutput = z.infer<typeof GetSubnetGapsOutputSchema>;

--- a/schemas-src/mcp-tools/search-documents.ts
+++ b/schemas-src/mcp-tools/search-documents.ts
@@ -15,7 +15,6 @@ import {
   McpListArtifactStamp,
   McpListPageFields,
   NotesFieldSchema,
-  OpenObjectSchema,
   fieldsStringSchema,
   limitSchema,
   netuidSchema,
@@ -26,6 +25,7 @@ import {
   sortSchema,
 } from "./shared.ts";
 import { SearchIndexArtifactSchema } from "../routes/evidence-search.ts";
+import { SearchArtifactSchema } from "../routes/evidence-search.ts";
 
 const DOCUMENT_TYPES = ["subnet", "surface", "provider"] as const;
 const DOCUMENT_SORT_FIELDS = ["netuid", "slug", "title", "type"] as const;
@@ -79,7 +79,10 @@ export const ListSearchOutputSchema = z
   .object({
     generated_at: z.string().nullable().optional(),
     notes: NotesFieldSchema,
-    documents: z.array(OpenObjectSchema),
+    // Typed from the route's own SearchArtifactSchema (#9797), PARTIAL
+    // because this tool advertises `fields` (#9884). Verified against
+    // production 2026-08-07, whole and projected.
+    documents: z.array(SearchArtifactSchema.shape.documents.element.partial()),
     total: z.int().optional(),
     returned: z.int().optional(),
     limit: z.int().optional(),

--- a/scripts/validate-schema-opacity.ts
+++ b/scripts/validate-schema-opacity.ts
@@ -94,13 +94,10 @@ const ROUTE_OPEN_SITES: Record<string, string> = {
  * #9797 has left to do. */
 const MCP_NOT_YET_TYPED: string[] = [
   "find_subnet_for_task.results[]",
-  "get_subnet_gaps.enrichment_queue[]",
-  "get_subnet_gaps.priorities[]",
   "how_do_i_call.services[]",
   "list_enrichment_targets.filters",
   "list_enrichment_targets.targets[].dimensions",
   "list_enrichment_targets.targets[].top_gaps[]",
-  "list_search.documents[]",
   "list_subnet_health.surfaces[]",
   "list_surface_credentials.credentials[]",
 ];

--- a/tests/mcp-typed-row-sites.test.ts
+++ b/tests/mcp-typed-row-sites.test.ts
@@ -49,6 +49,8 @@ const ROW_SITES: Array<[tool: string, key: string, projectable: boolean]> = [
   ["compare_validators", "validators", false],
   ["list_profiles", "profiles", true],
   ["get_domain_summary", "domains", false],
+  ["get_subnet_gaps", "priorities", false],
+  ["list_search", "documents", true],
 ];
 
 describe("typed row sites (#9797)", () => {


### PR DESCRIPTION
> Stacked on #9950. Base retargets to `main` when that merges.

## This one starts with a correction

I posted a negative result on #9797 saying the gaps cluster was **not derivable**. That was wrong.

I had tested `get_subnet_gaps.priorities[]` / `.enrichment_queue[]` against `routes/coverage.ts`'s `CoverageDepthRowSchema` — picked **by filename association**, because "gaps" and "coverage-depth" sound related. They failed, and I concluded the sites were composed shapes needing hand-modelling.

The route resolves somewhere else entirely:

```
/api/v1/subnets/{netuid}/gaps  ->  #/components/schemas/SubnetGapsArtifact
```

registered from `routes/review-gaps-profile.ts`. Both sites validate against it **unchanged** — and `mcp-tools/registry-summary-gaps.ts` **already imported `SubnetGapsArtifactSchema`**. The schema was sitting in the file, unused, while the sites next to it published bare objects.

**A failed derivation means "not this schema", never "no schema."** I stated the stronger conclusion from the weaker evidence.

## The method that would have got it right

Resolve the route through the published document instead of guessing:

```
openapi.json → paths[route].get.responses["200"]
             .content["application/json"].schema.allOf[1].properties.data.$ref
```

then find that component in `schemas-src/openapi-registry.ts`. Mechanical, and immune to a plausible-sounding neighbour. `list_search.documents[]` resolves the same way (`/api/v1/search` → `SearchArtifact` → `routes/evidence-search.ts`).

## The sites

| site | schema | partial? |
|---|---|---|
| `get_subnet_gaps.priorities[]` | `SubnetGapsArtifactSchema.shape.priorities` | no |
| `get_subnet_gaps.enrichment_queue[]` | `…shape.enrichment_queue` | no |
| `list_search.documents[]` | `SearchArtifactSchema.shape.documents` | **yes** — advertises `fields` |

## Verified against production

```
OK   get_subnet_gaps {"netuid":1}
OK   get_subnet_gaps {"netuid":64}
OK   list_search     {"limit":3}
OK   list_search     {"limit":3,"fields":"id,title"}

all valid against the emitted outputSchema
```

## Result

**MCP opacity debt: 10 → 7** (33 at the start of the day, eight PRs).

All validators pass; 1,700 tests pass across the affected suites. No `src/**`/`workers/**` lines change.

Closes #9952