### PR TITLE
refactor(mcp): type list_enrichment_targets' three sites as the subsets they are

### DIFF
--- a/schemas-src/mcp-tools/registry-summary-gaps.ts
+++ b/schemas-src/mcp-tools/registry-summary-gaps.ts
@@ -10,7 +10,6 @@ import { RegistrySummaryArtifactSchema } from "../routes/registry-summary-leader
 import {
   McpListPageFields,
   McpSubnetListArtifactStamp,
-  OpenObjectSchema,
   fieldsStringSchema,
   kindSchema,
   limitSchema,
@@ -23,6 +22,10 @@ import {
 import { SubnetGapsArtifactSchema } from "../routes/review-gaps-profile.ts";
 import { SURFACE_KIND_VALUES } from "../routes/subnet-detail.ts";
 import { CURATION_LEVEL_VALUES } from "../shared.ts";
+import {
+  AgentReadinessBlockerSchema,
+  CoverageDepthDimensionsSchema,
+} from "../routes/coverage.ts";
 
 export const RegistrySummaryInputSchema = z.object({}).strict();
 export type RegistrySummaryInput = z.infer<typeof RegistrySummaryInputSchema>;
@@ -104,9 +107,31 @@ const EnrichmentTargetItemSchema = z
     agent_status: z.string().optional(),
     blocker_level: z.string().optional(),
     top_gap_codes: z.array(z.unknown()).optional(),
-    top_gaps: z.array(OpenObjectSchema).optional(),
+    // DERIVED AS A SUBSET, not restated (#9797). This tool is the FILTERED
+    // companion of get_coverage_depth's raw passthrough, and it publishes a
+    // narrower view of the same two shapes -- `top_gaps` without the prose
+    // `message`, `dimensions` with 11 of the row's 18 counters. Both were
+    // censused across 50 live targets on 2026-08-07: every listed key present
+    // on every row, and every one a member of the route's own schema. `omit`
+    // and `pick` state that relationship, so a route field rename still lands
+    // here as a compile error the way a full derivation would.
+    top_gaps: z
+      .array(AgentReadinessBlockerSchema.omit({ message: true }))
+      .optional(),
     recommended_next_action: z.string().nullable().optional(),
-    dimensions: OpenObjectSchema.optional(),
+    dimensions: CoverageDepthDimensionsSchema.pick({
+      callable_service_count: true,
+      candidate_operational_count: true,
+      example_count: true,
+      fixture_available_count: true,
+      fixture_status_counts: true,
+      official_surface_count: true,
+      provider_claimed_surface_count: true,
+      schema_missing_count: true,
+      schema_service_count: true,
+      sdk_count: true,
+      service_kinds: true,
+    }).optional(),
   })
   .passthrough();
 
@@ -117,7 +142,22 @@ export const ListEnrichmentTargetsOutputSchema = z
     total_rows: z.int(),
     queue_count: z.int(),
     returned: z.int(),
-    filters: OpenObjectSchema.optional(),
+    // The filter set ECHOED back, one key per filtering input parameter, each
+    // null when it was not supplied. Modeled from the tool's own inputSchema
+    // rather than from a capture: the echo exists to tell a caller what was
+    // applied, so its keys ARE the parameters and a new filter must appear in
+    // both places or the echo is lying. Verified against production
+    // 2026-08-07.
+    filters: z
+      .object({
+        tier: z.string().nullable(),
+        severity: z.string().nullable(),
+        gap_code: z.string().nullable(),
+        agent_status: z.string().nullable(),
+        netuid: z.int().min(0).nullable(),
+      })
+      .passthrough()
+      .optional(),
     note: z.string().optional(),
     targets: z.array(EnrichmentTargetItemSchema),
   })

--- a/schemas-src/routes/coverage.ts
+++ b/schemas-src/routes/coverage.ts
@@ -130,7 +130,7 @@ export const AgentReadinessBlockerSchema = z
   })
   .strict();
 
-const CoverageDepthDimensionsSchema = z
+export const CoverageDepthDimensionsSchema = z
   .object({
     surface_count: z.int().min(0),
     official_surface_count: z.int().min(0),

--- a/scripts/validate-schema-opacity.ts
+++ b/scripts/validate-schema-opacity.ts
@@ -95,9 +95,6 @@ const ROUTE_OPEN_SITES: Record<string, string> = {
 const MCP_NOT_YET_TYPED: string[] = [
   "find_subnet_for_task.results[]",
   "how_do_i_call.services[]",
-  "list_enrichment_targets.filters",
-  "list_enrichment_targets.targets[].dimensions",
-  "list_enrichment_targets.targets[].top_gaps[]",
   "list_subnet_health.surfaces[]",
   "list_surface_credentials.credentials[]",
 ];


### PR DESCRIPTION
> Stacked on #9953. Base retargets to `main` when that merges.

## Why these are not a straight derivation

`list_enrichment_targets` is the **filtered companion** of `get_coverage_depth`'s raw passthrough, and it publishes a *narrower* view of the same shapes. A full derivation fails:

- `targets[].top_gaps[]` serves `{code, severity, field, next_action}` — the route's `AgentReadinessBlockerSchema` also has a prose `message`.
- `targets[].dimensions` serves 11 counters; the route's `CoverageDepthDimensionsSchema` has 18.

That failure is exactly what made me wrongly write this cluster off as "needs hand-modelling" earlier.

But they are **strict subsets**, not different shapes. Censused across 50 live targets: every key served is present on every row, and every one is a member of the route's own schema.

So `.omit({ message: true })` and `.pick({ … })` **state the relationship** rather than restating the fields. A route field rename still lands here as a compile error, exactly as a full derivation would — which a hand-written copy would not.

## The third site

`filters` is modeled from the tool's **own `inputSchema`**, not from a capture. The echo exists to tell a caller which filters were applied, so its keys *are* the parameters — a new filter has to appear in both places or the echo is lying.

## A verification trap I nearly filed as a bug

`severity` accepts `hard` / `missing-data` / `needs-review`. I passed `critical`; the tool correctly returned a **tool error**, and my ad-hoc script validated that *error envelope* against the success schema — reporting three missing required fields that read exactly like a real production defect.

Guard `isError` before validating. `scripts/check-mcp-conformance.ts` does; an ad-hoc script does not unless you write it. That is the second time today a bad argument produced a meaningless result that looked like a finding (the first was `tag:` vs `domain:` on `get_domain_summary`).

## Verified against production

```
OK   list_enrichment_targets {}                          (10 targets)
OK   list_enrichment_targets {"limit":200}               (50 targets)
OK   list_enrichment_targets {"severity":"hard"}         (0 targets)
OK   list_enrichment_targets {"severity":"needs-review"} (10 targets)
OK   list_enrichment_targets {"netuid":64}               (1 target)

all valid against the emitted outputSchema
```

Including the zero-result case, which is where a required-field bug would hide.

## Result

**MCP opacity debt: 7 → 4** (33 at the start of the day, nine PRs).

All validators pass; 1,700 tests pass across the affected suites.

Closes #9957