### PR TITLE
fix(prober): give mapLimit a groupKey, so our own fan-out stops marking subnets degraded

### DIFF
--- a/src/health-probe-core.ts
+++ b/src/health-probe-core.ts
@@ -955,22 +955,72 @@ export function parseBlockNumber(
   return Number.isInteger(block) && block >= 0 ? block : null;
 }
 
+export interface MapLimitOptions<T> {
+  /**
+   * Serializes items that share a key: at most ONE item per key is ever in
+   * flight, while `limit` distinct keys still run in parallel (#9904).
+   *
+   * A flat pool decides what runs together purely from list order, which is a
+   * property of how the caller happened to sort its input. When the shared
+   * resource is a remote host, that is how a sweep DDoSes one origin: the
+   * prober's surface list is sorted `(netuid, surface_id)`, so a subnet's five
+   * surfaces sit adjacent and go out together, and the host answers 429.
+   *
+   * Grouping fixes it without a lock or a semaphore, because the pool hands a
+   * worker a whole key-group and the worker drains it in a plain loop --
+   * mutual exclusion falls out of the partition rather than being enforced.
+   *
+   * Groups are dispatched LONGEST-FIRST: a grouped run is bounded by its
+   * largest group rather than by `items.length / limit`, so starting the
+   * biggest one last would strand it after the pool had nothing else to run.
+   */
+  groupKey?: (item: T) => string;
+}
+
+/**
+ * Item indexes partitioned by `groupKey`, largest group first.
+ *
+ * Indexes rather than items so `mapLimit` can write each result back to its
+ * input slot -- grouping changes execution order, never the returned order.
+ */
+function workQueue<T>(items: T[], groupKey?: (item: T) => string): number[][] {
+  if (!groupKey) {
+    // One index per group is exactly the ungrouped pool: every worker takes the
+    // next single item. Same code path, so the grouped case cannot drift from
+    // the plain one.
+    return items.map((_, index) => [index]);
+  }
+  const groups = new Map<string, number[]>();
+  items.forEach((item, index) => {
+    const key = groupKey(item);
+    const group = groups.get(key);
+    if (group) group.push(index);
+    else groups.set(key, [index]);
+  });
+  return [...groups.values()].sort((a, b) => b.length - a.length);
+}
+
 // Bounded-concurrency map. Preserves INPUT order in the returned array (callers
 // that need a different order sort afterwards). Used by both the Node build and
 // the Worker cron prober to respect the runtime's simultaneous-connection cap.
+// Pass `groupKey` to additionally serialize items sharing a resource.
 export async function mapLimit<T, R>(
   items: T[],
   limit: number,
   mapper: (item: T, index: number) => Promise<R>,
+  options: MapLimitOptions<T> = {},
 ): Promise<R[]> {
   const results: R[] = new Array(items.length);
+  const queue = workQueue(items, options.groupKey);
   let cursor = 0;
-  const workerCount = Math.max(1, Math.min(limit, items.length));
+  const workerCount = Math.max(1, Math.min(limit, queue.length));
   const workers = Array.from({ length: workerCount }, async () => {
-    while (cursor < items.length) {
-      const index = cursor;
+    while (cursor < queue.length) {
+      const group = queue[cursor];
       cursor += 1;
-      results[index] = await mapper(items[index], index);
+      for (const index of group) {
+        results[index] = await mapper(items[index], index);
+      }
     }
   });
   await Promise.all(workers);

--- a/src/health-prober.ts
+++ b/src/health-prober.ts
@@ -142,6 +142,23 @@ function normalizedHostname(value: unknown): string {
     .replace(/\.$/, "");
 }
 
+/**
+ * The resource a probe contends for — the remote host, not the surface (#9904).
+ *
+ * Shares `normalizedHostname` with the SSRF guard above so one url can never be
+ * two hosts: a trailing-dot FQDN or a bracketed IPv6 literal has to land in the
+ * same scheduling group as its bare form, or the grouping silently stops
+ * serializing them. An unparseable url is its own key rather than a shared
+ * empty one, so malformed entries cannot collapse into a single serial group.
+ */
+export function probeHostKey(url: unknown): string {
+  try {
+    return normalizedHostname(new URL(String(url)).hostname);
+  } catch {
+    return String(url ?? "");
+  }
+}
+
 function ipv4Octets(value: unknown): number[] | null {
   const parts = String(value || "").split(".");
   if (parts.length !== 4) return null;
@@ -537,7 +554,7 @@ export async function runHealthProber(
     priorStatus.set(row.surface_key || row.surface_id, row);
   }
 
-  const probed = await mapLimit(surfaces, concurrency, async (surface) => {
+  const probeOne = async (surface: Row) => {
     const input: ProbeSurface = {
       id: surface.surface_id,
       netuid: surface.netuid,
@@ -643,6 +660,14 @@ export async function runHealthProber(
       // field on this object is inert for that writer.
       error: base.error ?? null,
     };
+  };
+
+  // Grouped by host (#9904): a flat pool decides what runs together purely from
+  // list order, and operational-surfaces.json is sorted (netuid, surface_id) --
+  // so a subnet's surfaces sit adjacent and went out together. Every
+  // rate-limited verdict in production came from that, on two hosts.
+  const probed = await mapLimit(surfaces, concurrency, probeOne, {
+    groupKey: (surface) => probeHostKey(surface.url),
   });
 
   sanitizeRpcLatestBlocks(probed);

--- a/tests/health-probe-core.test.ts
+++ b/tests/health-probe-core.test.ts
@@ -412,6 +412,129 @@ describe("mapLimit", () => {
   });
 });
 
+describe("mapLimit groupKey (#9904)", () => {
+  // A flat pool decides what runs together purely from list order, which is a
+  // property of how the caller sorted its input. When the shared resource is a
+  // remote host that is how a sweep DDoSes one origin -- the prober's list is
+  // sorted (netuid, surface_id), so a subnet's surfaces sit adjacent, went out
+  // together, and the host answered 429. Every rate-limited verdict in
+  // production sat on two hosts and none on the other 120.
+
+  /** Runs `items` and reports peak concurrency overall and per key. */
+  async function observe(
+    items: string[],
+    limit: number,
+    groupKey?: (item: string) => string,
+  ) {
+    const live = new Map<string, number>();
+    const peakPerKey = new Map<string, number>();
+    let inFlight = 0;
+    let peak = 0;
+    const started: string[] = [];
+    const out = await mapLimit(
+      items,
+      limit,
+      async (item) => {
+        const key = groupKey ? groupKey(item) : item;
+        const now = (live.get(key) ?? 0) + 1;
+        live.set(key, now);
+        peakPerKey.set(key, Math.max(peakPerKey.get(key) ?? 0, now));
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        started.push(item);
+        // Two turns: enough for any overlapping scheduler to interleave here.
+        await Promise.resolve();
+        await Promise.resolve();
+        live.set(key, now - 1);
+        inFlight -= 1;
+        return item.toUpperCase();
+      },
+      groupKey ? { groupKey } : {},
+    );
+    return { out, peak, peakPerKey, started };
+  }
+
+  const host = (item: string) => item.split("/")[0];
+  // Five on one host (the real sn-62-ridges-* shape) plus ten singletons.
+  const items = [
+    ...Array.from({ length: 5 }, (_, i) => `ridges/${i}`),
+    ...Array.from({ length: 10 }, (_, i) => `host${i}/0`),
+  ];
+
+  test("never runs two items with the same key at once", async () => {
+    const { peakPerKey } = await observe(items, 8, host);
+    for (const [key, seen] of peakPerKey) {
+      assert.equal(seen, 1, `${key} peaked at ${seen} concurrent`);
+    }
+  });
+
+  test("WITHOUT groupKey the same items do overlap", async () => {
+    // Positive control. Without it, the assertion above could pass simply
+    // because the harness never overlapped anything.
+    const { peakPerKey } = await observe(items, 8, undefined);
+    const ridges = await observe(
+      Array.from({ length: 5 }, () => "ridges/x"),
+      8,
+    );
+    assert.equal(peakPerKey.size, items.length, "control sanity");
+    assert.ok(
+      (ridges.peakPerKey.get("ridges/x") ?? 0) > 1,
+      "flat pool did not overlap; the control proves nothing",
+    );
+  });
+
+  test("results stay in INPUT order, not group order", async () => {
+    // The prober ranks its RPC pool off these rows; reordering them would
+    // reshuffle tie-breaks between equally-healthy endpoints.
+    const { out } = await observe(items, 8, host);
+    assert.deepEqual(
+      out,
+      items.map((i) => i.toUpperCase()),
+    );
+  });
+
+  test("dispatches the largest group first", async () => {
+    // Not cosmetic: a grouped run is bounded by its largest group, so starting
+    // the biggest one last strands it after the pool has nothing else to run.
+    //
+    // The big group is deliberately LAST in input order here. With it first the
+    // assertion passes on insertion order alone and says nothing about the sort
+    // -- which is exactly what an earlier version of this test did.
+    const bigLast = [
+      ...Array.from({ length: 10 }, (_, i) => `host${i}/0`),
+      ...Array.from({ length: 5 }, (_, i) => `ridges/${i}`),
+    ];
+    const { started } = await observe(bigLast, 1, host);
+    assert.deepEqual(
+      started.slice(0, 5),
+      bigLast.slice(10),
+      "the 5-item group should be dispatched before the singletons",
+    );
+  });
+
+  test("still uses the whole pool when there are more groups than workers", async () => {
+    const { peak } = await observe(items, 8, host);
+    assert.equal(peak, 8);
+  });
+
+  test("one group is drained serially, in order, and nothing is dropped", async () => {
+    const only = Array.from({ length: 5 }, (_, i) => `ridges/${i}`);
+    const { out, peak, started } = await observe(only, 8, host);
+    assert.equal(peak, 1);
+    assert.deepEqual(started, only);
+    assert.deepEqual(
+      out,
+      only.map((i) => i.toUpperCase()),
+    );
+  });
+
+  test("an empty input returns empty without spawning a worker", async () => {
+    const { out, peak } = await observe([], 8, host);
+    assert.deepEqual(out, []);
+    assert.equal(peak, 0);
+  });
+});
+
 describe("probeSurface (injected fetch)", () => {
   const surface = {
     id: "sn7-api",

--- a/tests/health-prober.test.ts
+++ b/tests/health-prober.test.ts
@@ -15,6 +15,7 @@ import {
   syncRpcProxyEventsPruneToPostgres,
   workerResolvedUrlSafetyGuard,
   workerWebSocketConnector,
+  probeHostKey,
 } from "../src/health-prober.ts";
 import { OPERATIONAL_SURFACES_R2_KEY } from "../src/operational-surfaces-sync.ts";
 import { handleScheduled } from "../workers/api.ts";
@@ -2722,6 +2723,107 @@ describe("pipelineProvenance (#8744)", () => {
         CHAIN_STATE,
       ),
       {},
+    );
+  });
+});
+
+// --- #9904: the prober contends per HOST, not per surface --------------------
+
+describe("probeHostKey", () => {
+  test("keys on the hostname, normalized", () => {
+    assert.equal(probeHostKey("https://API.Example.com/a"), "api.example.com");
+    assert.equal(probeHostKey("https://api.example.com/b"), "api.example.com");
+    // Shares normalizedHostname with the SSRF guard on purpose: if a
+    // trailing-dot FQDN or a bracketed IPv6 literal keyed differently from its
+    // bare form, the grouping would quietly stop serializing them.
+    assert.equal(probeHostKey("https://api.example.com./x"), "api.example.com");
+    assert.equal(
+      probeHostKey("https://[2606:4700::1111]/x"),
+      "2606:4700::1111",
+    );
+  });
+
+  test("an unparseable url is its own key, not a shared empty one", () => {
+    assert.equal(probeHostKey("not a url"), "not a url");
+    assert.equal(probeHostKey(null), "");
+    assert.equal(probeHostKey(undefined), "");
+    // Collapsing every malformed entry into one key would make them a single
+    // serial group -- slower, and for no safety reason.
+    assert.notEqual(probeHostKey("not a url"), probeHostKey("also not a url"));
+  });
+});
+
+describe("runHealthProber groups its sweep by host (#9904)", () => {
+  // mapLimit's own tests prove the grouping; this proves the SWEEP asks for it.
+  // Without an end-to-end assertion, dropping the groupKey argument would leave
+  // every other test green.
+  const sameHost = ["a", "b", "c", "d", "e"].map((n) => ({
+    surface_id: `sn-62-ridges-${n}`,
+    surface_key: `srf-ridges-${n}`,
+    netuid: 62,
+    kind: "subnet-api",
+    url: `https://agent-upload.ridges.ai/${n}`,
+    provider: "ridges",
+    authority: "official",
+    auth_required: false,
+    public_safe: true,
+    probe: { enabled: true, method: "GET", expect: "json" },
+  }));
+
+  const okProbe = {
+    status: "ok",
+    classification: "live",
+    latency_ms: 10,
+    status_code: 200,
+  };
+
+  test("five surfaces on one host never overlap", async () => {
+    const { env } = makeProberEnv({ priorStatus: [] });
+    let inFlight = 0;
+    let peak = 0;
+    const started: string[] = [];
+    await runHealthProber(env, FAKE_CTX, {
+      now: () => 50000,
+      kv: makeKv(),
+      loadSurfaces: async () => sameHost,
+      probeSurface: (async (input: Row) => {
+        peak = Math.max(peak, (inFlight += 1));
+        started.push(input.id as string);
+        await Promise.resolve();
+        inFlight -= 1;
+        return okProbe;
+      }) as never,
+      probeOptions: {},
+    });
+    assert.equal(peak, 1, `peaked at ${peak} concurrent probes on one host`);
+    assert.deepEqual(
+      started,
+      sameHost.map((s) => s.surface_id),
+    );
+  });
+
+  test("rows keep input order, so RPC-pool tie-breaks do not move", async () => {
+    const mixed = [
+      { ...sameHost[0], surface_id: "r1", url: "https://one.example/1" },
+      { ...sameHost[1], surface_id: "s1", url: "https://two.example/1" },
+      { ...sameHost[2], surface_id: "r2", url: "https://one.example/2" },
+      { ...sameHost[3], surface_id: "s2", url: "https://two.example/2" },
+    ];
+    const { env } = makeProberEnv({ priorStatus: [] });
+    const kv = makeKv();
+    await runHealthProber(env, FAKE_CTX, {
+      now: () => 50000,
+      kv,
+      loadSurfaces: async () => mixed,
+      probeSurface: (async () => okProbe) as never,
+      probeOptions: {},
+    });
+    const current = JSON.parse(
+      (await kv.get(KV_HEALTH_CURRENT)) as string,
+    ) as Row;
+    assert.deepEqual(
+      (current.surfaces as Row[]).map((r) => r.surface_id),
+      ["r1", "s1", "r2", "s2"],
     );
   });
 });


### PR DESCRIPTION
## The defect

Every `rate-limited` verdict in production sat on exactly **two hosts** — 7 on `api.taomarketcap.com`, 5 on `agent-upload.ridges.ai` — and **zero** on the other 120. All 12 answered `200` to a single sequential request.

The hosts were fine; we were the load. 12 of the 91 degraded surfaces on `/api/v1/health` were ours, and two teams were publicly marked down for answering our requests correctly.

`mapLimit` is a flat pool over one cursor, so what runs together is decided by **list order alone** — a property of how the caller happened to sort its input. `operational-surfaces.json` is sorted `(netuid, surface_id)`, so a subnet's surfaces sit adjacent: all five `sn-62-ridges-*` went out in one concurrency-8 window. From there it is mechanical — `429` → `classifyProbe "rate-limited"` → `statusForClassification "degraded"` → the subnet rollup.

## Where the fix belongs

That is a **scheduling** property, so it goes in the scheduler rather than being hand-managed at a call site.

```ts
const probed = await mapLimit(surfaces, concurrency, probeOne, {
  groupKey: (surface) => probeHostKey(surface.url),
});
```

`mapLimit` takes an optional `groupKey`: items sharing a key are serialized while `limit` distinct keys still run in parallel. The pool hands a worker a whole group and the worker drains it in a plain loop — **mutual exclusion falls out of the partition**, so there is no lock, no semaphore, and no in-flight bookkeeping to get wrong.

Two properties worth calling out:

- **Ungrouped callers are untouched, provably.** The work queue is built as one index per group, which *is* the old per-item cursor. Both cases share one code path, so the grouped one cannot drift from the plain one. The other ~30 `mapLimit` call sites are unchanged.
- **Order is preserved by the primitive.** Results are written back to their input slots, so grouping changes execution order and never the returned order — which matters because `persistToKv` ranks the RPC pool off these rows, and reshuffling equally-healthy endpoints would move which one the proxy picks.

Groups dispatch **longest-first**, because a grouped run is bounded by its largest group rather than by `items/limit`.

## Not a wall-time tradeoff

Measured over the 626 monitored surfaces:

| | |
|---|---:|
| distinct hosts | **122** |
| largest group (`raw.githubusercontent.com`) | 61 |
| flat pool at concurrency 8 | ~78 sequential slots |
| **grouped by host** | **~61 sequential slots** |

Fewer, not more — the flat pool's tail contention cost more than serializing the big groups does. 122 hosts comfortably exceeds the 8 workers, so none idles.

## Tests

**`mapLimit` (`tests/health-probe-core.test.ts`, +8):** never two same-key items in flight; results in input order not group order; largest group dispatched first; full pool utilization when groups exceed workers; a single group drained serially in order with nothing dropped; empty input spawns no worker. Plus a **positive control** proving the ungrouped pool *does* overlap the same items — without it, "never two concurrent" could pass because the harness never overlapped anything.

**`probeHostKey` (`tests/health-prober.test.ts`):** normalization, including that a trailing-dot FQDN and a bracketed IPv6 literal key the same as their bare forms — it shares `normalizedHostname` with the SSRF guard precisely so one url can never become two scheduling groups. An unparseable url is its own key rather than a shared empty one, so malformed entries cannot collapse into a single serial group.

**End-to-end through `runHealthProber`:** five same-host surfaces never overlap, and interleaved input hosts come back interleaved in `KV_HEALTH_CURRENT`. `mapLimit`'s tests prove the grouping; this proves the *sweep asks for it* — dropping the argument would otherwise leave every other test green.

### Mutation-tested, three ways

| mutation | result |
|---|---|
| `mapLimit` ignores `groupKey` | **2 failures** — same-key concurrency, serial drain |
| prober drops the `groupKey` argument | **1 failure** — `peaked at 5 concurrent probes on one host` |
| largest-first sort removed | **1 failure** — `the 5-item group should be dispatched before the singletons` |

The third one is why this matters: my first version of that test put the big group **first in input order**, so it passed on insertion order alone and said nothing about the sort. The mutation caught it, and the test now puts the big group last.

## Validation run

```
npm run lint          clean
npm run format:check  All matched files use Prettier code style!
npm run typecheck     clean
vitest health-probe-core, health-prober, analytics, mcp-server, neon-prune, github-signals
                      1737 passed
```

**Patch coverage**, measured by intersecting the v8 report with `git diff -U0 origin/main` rather than reading a file-level percentage:

```
src/health-probe-core.ts   54 changed lines   0 uncovered statements   0 uncovered branches
src/health-prober.ts       26 changed lines   0 uncovered statements   0 uncovered branches
```

Closes #9904
