### PR TITLE
refactor(mcp): close the last four untyped object sites, taking the debt to zero

### DIFF
--- a/schemas-src/mcp-tools/ai-discovery.ts
+++ b/schemas-src/mcp-tools/ai-discovery.ts
@@ -4,7 +4,8 @@
 // existing schemas-src/routes/ REST schema -- modeled fresh, matching
 // each hand-written literal field-for-field.
 import { z } from "zod";
-import { OpenObjectArraySchema, limitSchema, netuidSchema } from "./shared.ts";
+import { limitSchema, netuidSchema } from "./shared.ts";
+import { AgentCatalogSubnetEntrySchema } from "../routes/agent-catalog.ts";
 
 // Symbolic in the hand-written original (src/health-serving.ts's
 // ECONOMIC_BOARD_SPECS[].key), cross-checked against the actual runtime
@@ -168,7 +169,29 @@ export const FindSubnetForTaskOutputSchema = z
     count: z.int(),
     discovery: z.unknown().optional(),
     note: z.string().nullable().optional(),
-    results: OpenObjectArraySchema,
+    // COMPOSED from the catalog entry, not restated (#9797). Nine of the
+    // eleven keys are AgentCatalogSubnetEntrySchema's own -- this tool ranks
+    // catalog subnets against a task and returns a discovery-shaped slice of
+    // each -- so `pick` states that relationship and a catalog field rename
+    // lands here as a compile error. The two additions are the ranking itself.
+    // Verified against production 2026-08-07 across 18 rows from four task
+    // queries: no key outside the catalog entry other than these two.
+    results: z.array(
+      AgentCatalogSubnetEntrySchema.pick({
+        netuid: true,
+        slug: true,
+        name: true,
+        base_url: true,
+        categories: true,
+        service_kinds: true,
+        callable_count: true,
+        integration_readiness: true,
+        health: true,
+      }).extend({
+        relevance: z.number(),
+        next_step: z.string(),
+      }),
+    ),
   })
   .passthrough();
 export type FindSubnetForTaskOutput = z.infer<

--- a/schemas-src/mcp-tools/ai-integration.ts
+++ b/schemas-src/mcp-tools/ai-integration.ts
@@ -6,7 +6,6 @@
 import { z } from "zod";
 import {
   OpenArraySchema,
-  OpenObjectArraySchema,
   OpenObjectSchema,
   netuidSchema,
   surfaceIdSchema,
@@ -30,6 +29,54 @@ export type HowDoICallInput = z.infer<typeof HowDoICallInputSchema>;
 // several sibling AI tools' loosely-required fields in this batch, were
 // never added to the hand-written original's `required` array -- preserved
 // as-is.
+/**
+ * One callable service, as the integration guide RESHAPES it (#9797).
+ *
+ * Modeled, not derived. This is not a subset of the catalog service record:
+ * `auth` collapses the catalog's auth_required/auth_schemes pair into
+ * `{required, schemes}`, `health` keeps three of its seven fields, and
+ * `schema`/`fixture` are rewritten into "can I use this, and how" answers.
+ * Deriving from AgentCatalogServiceSchema fails against production on
+ * `auth.scheme` alone.
+ *
+ * Censused across 41 rows from three subnets on 2026-08-07: all ten keys
+ * present on every row. The nested blocks stay passthrough with only their
+ * always-present keys declared -- `fetch_with` appears once a schema or
+ * fixture is actually available, which is measured rather than assumed.
+ */
+const HowDoICallServiceSchema = z
+  .object({
+    surface_id: z.string(),
+    kind: z.string(),
+    capability: z.string(),
+    base_url: z.string(),
+    callable: z.boolean(),
+    auth: z
+      .object({ required: z.boolean(), schemes: z.array(z.string()) })
+      .passthrough(),
+    snippets: z
+      .object({ curl: z.string(), python: z.string(), typescript: z.string() })
+      .passthrough(),
+    schema: z
+      .object({ available: z.boolean(), schema_url: z.string().nullable() })
+      .passthrough(),
+    fixture: z.object({ available: z.boolean() }).passthrough(),
+    health: z
+      .object({
+        status: z.string(),
+        stale: z.boolean(),
+        // NULLABLE, and the emitter is the authority here rather than the
+        // capture: src/mcp-server.ts writes `s.health?.observed_by ?? null`.
+        // Production always had an observer so 41/41 censused rows carried a
+        // string, and modelling from the capture alone published a contract
+        // the cold path breaks -- caught by validate:mcp's hermetic harness,
+        // which is the only place that path runs. Same lesson as #9941.
+        observed_by: z.string().nullable(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
 export const HowDoICallOutputSchema = z
   .object({
     netuid: netuidSchema(),
@@ -39,7 +86,7 @@ export const HowDoICallOutputSchema = z
     callable: z.boolean(),
     callable_count: z.int().optional(),
     guidance: z.unknown().optional(),
-    services: OpenObjectArraySchema,
+    services: z.array(HowDoICallServiceSchema),
     next_steps: OpenArraySchema.optional(),
     operational_observed_at: z.string().nullable().optional(),
     health_source: z.string().nullable().optional(),
@@ -215,7 +262,24 @@ export type ListSurfaceCredentialsInput = z.infer<
 
 export const ListSurfaceCredentialsOutputSchema = z
   .object({
-    credentials: OpenObjectArraySchema,
+    // Modeled from the producer, not from a capture (#9797): the store is
+    // authenticated, so production cannot be sampled without a credential.
+    // src/mcp-surface-credentials.ts builds exactly this object and coalesces
+    // every field, so none can be absent -- `expires_at`/`created_at` fall back
+    // to "" rather than undefined, which is why they are required strings
+    // rather than optional. `shape` is the two-value literal that file
+    // narrows to. NO credential VALUE appears here, and none ever should:
+    // this tool reads non-secret metadata and decrypts nothing.
+    credentials: z.array(
+      z
+        .object({
+          surface_id: z.string(),
+          shape: z.enum(["string", "object"]),
+          created_at: z.string(),
+          expires_at: z.string(),
+        })
+        .passthrough(),
+    ),
     count: z.int(),
   })
   .passthrough();

--- a/schemas-src/mcp-tools/subnet-scoped-lists.ts
+++ b/schemas-src/mcp-tools/subnet-scoped-lists.ts
@@ -19,7 +19,6 @@ import { z } from "zod";
 import {
   McpListPageFields,
   McpSubnetListArtifactStamp,
-  OpenObjectSchema,
   fieldsStringSchema,
   kindSchema,
   limitSchema,
@@ -227,19 +226,58 @@ export const ListSubnetHealthInputSchema = z
   .strict();
 export type ListSubnetHealthInput = z.infer<typeof ListSubnetHealthInputSchema>;
 
-// NOT DERIVED, deliberately (#9796). list_subnet_health does not mirror
-// HealthSubnetArtifact's row shape: the route serves overlaySubnetHealth()'s
-// live-merged 12-field row (strict, and requiring `observed_by`), while the
-// tool serves the registry surface record overlaid with health -- 20 fields,
-// including auth_required/public_safe/content_type/method_tested that the
-// route row has no place for. Verified against production: deriving it would
-// publish a contract the live response violates. It stays hand-written until
-// something types the tool's own row (#9797).
+// NOT DERIVED, deliberately (#9796), and now MODELED rather than left open
+// (#9797). list_subnet_health does not mirror HealthSubnetArtifact's row
+// shape: the route serves overlaySubnetHealth()'s live-merged 12-field row
+// (strict, and requiring `observed_by`), while the tool serves the registry
+// surface record overlaid with health. Re-confirmed against production
+// 2026-08-07 -- deriving it fails with `Unrecognized keys: auth_required,
+// content_type, method_tested, private_redirect_blocked, public_safe,
+// subnet_name, subnet_slug, uptime_sample_ratio, verified_at`, which is that
+// difference stated by the validator rather than by a comment.
+//
+// So this one is modeled from the LIVE RESPONSE, censused across 44 rows from
+// four subnets (1, 8, 53, 64) on 2026-08-07. Optionality is measured, not
+// guessed: the five fields below marked optional were genuinely absent on some
+// rows, and `last_ok` is the one that is present-but-null. Passthrough,
+// because a modeled shape should not reject a field the producer adds before
+// this file learns about it.
+const SubnetHealthSurfaceSchema = z
+  .object({
+    surface_id: z.string(),
+    netuid: netuidSchema(),
+    subnet_slug: z.string(),
+    subnet_name: z.string(),
+    kind: z.string(),
+    provider: z.string(),
+    url: z.string(),
+    auth_required: z.boolean(),
+    public_safe: z.boolean(),
+    method_tested: z.string(),
+    status: z.string(),
+    classification: z.string(),
+    latency_ms: z.number(),
+    last_checked: z.string(),
+    // Present on every row, null when the surface has never been seen healthy.
+    last_ok: z.string().nullable(),
+    verified_at: z.string(),
+    uptime_sample_ratio: z.number(),
+    private_redirect_blocked: z.boolean(),
+    // Absent rather than null when the probe did not record one: 43/44 rows
+    // carried a status_code and content_type, 1/44 an error/error_class, 4/44
+    // a redirect_target.
+    status_code: z.int().optional(),
+    content_type: z.string().optional(),
+    error: z.string().optional(),
+    error_class: z.string().optional(),
+    redirect_target: z.string().optional(),
+  })
+  .passthrough();
 export const ListSubnetHealthOutputSchema = z
   .object({
     generated_at: z.string().nullable().optional(),
     netuid: netuidSchema().nullable().optional(),
-    surfaces: z.array(OpenObjectSchema),
+    surfaces: z.array(SubnetHealthSurfaceSchema),
     total: z.int().optional(),
     returned: z.int().optional(),
     limit: z.int().optional(),

--- a/scripts/validate-schema-opacity.ts
+++ b/scripts/validate-schema-opacity.ts
@@ -92,12 +92,7 @@ const ROUTE_OPEN_SITES: Record<string, string> = {
  * from its route yet. One entry per site, so a NEW opaque site still fails
  * this gate -- the list may only shrink, and it is the honest count of what
  * #9797 has left to do. */
-const MCP_NOT_YET_TYPED: string[] = [
-  "find_subnet_for_task.results[]",
-  "how_do_i_call.services[]",
-  "list_subnet_health.surfaces[]",
-  "list_surface_credentials.credentials[]",
-];
+const MCP_NOT_YET_TYPED: string[] = [];
 
 /** MCP sites that are open on purpose, same three categories as the REST list
  * above. Kept separate from the debt below so the two never blur. */

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -3487,8 +3487,34 @@ describe("MCP tools (injected deps)", () => {
       "/metagraph/health/subnets/7.json": {
         generated_at: "2026-07-01T00:00:00.000Z",
         netuid: 7,
+        // A REAL surface row, recaptured from production 2026-08-07 when
+        // list_subnet_health.surfaces[] stopped being a bare object (#9797).
+        // The previous 4-key stub satisfied `{"type":"object"}` and is a shape
+        // the tool never serves -- the overlay always carries the registry
+        // record's identity/auth fields plus the probe's verdict.
         surfaces: [
-          { id: "allways-api", netuid: 7, kind: "subnet-api", status: "ok" },
+          {
+            surface_id: "sn-7-allways-api",
+            netuid: 7,
+            subnet_slug: "sn-7",
+            subnet_name: "Allways",
+            kind: "subnet-api",
+            provider: "allways",
+            url: "https://api.allways.example/v1",
+            auth_required: false,
+            public_safe: true,
+            method_tested: "HEAD",
+            status: "ok",
+            classification: "live",
+            latency_ms: 45,
+            last_checked: "2026-07-01T00:00:00.000Z",
+            last_ok: "2026-07-01T00:00:00.000Z",
+            verified_at: "2026-07-01T00:00:00.000Z",
+            uptime_sample_ratio: 0.5,
+            private_redirect_blocked: false,
+            status_code: 200,
+            content_type: "application/json",
+          },
         ],
       },
     });

--- a/tests/mcp-typed-row-sites.test.ts
+++ b/tests/mcp-typed-row-sites.test.ts
@@ -51,6 +51,10 @@ const ROW_SITES: Array<[tool: string, key: string, projectable: boolean]> = [
   ["get_domain_summary", "domains", false],
   ["get_subnet_gaps", "priorities", false],
   ["list_search", "documents", true],
+  ["list_subnet_health", "surfaces", false],
+  ["how_do_i_call", "services", false],
+  ["find_subnet_for_task", "results", false],
+  ["list_surface_credentials", "credentials", false],
 ];
 
 describe("typed row sites (#9797)", () => {
@@ -211,5 +215,22 @@ describe("typed row sites (#9797)", () => {
         `${tool}.summary declares no rao-precision pattern`,
       );
     }
+  });
+  test("the #9797 debt list is EMPTY", () => {
+    // The whole point of the epic. `validate:schema-opacity` still allows
+    // reasoned-open sites -- an embedded third-party document, decoded chain
+    // arguments -- but nothing is left carrying NOT_YET_TYPED, which was 33
+    // sites at the start of 2026-08-07.
+    const text = readFileSync("scripts/validate-schema-opacity.ts", "utf8");
+    const block = text.slice(
+      text.indexOf("const MCP_NOT_YET_TYPED"),
+      text.indexOf("/** MCP sites that are open on purpose"),
+    );
+    const entries = [...block.matchAll(/"[^"]+"/g)];
+    assert.deepEqual(
+      entries.map((m) => m[0]),
+      [],
+      "MCP_NOT_YET_TYPED is no longer empty -- a new untyped site was added rather than declared with a reason",
+    );
   });
 });


### PR DESCRIPTION
> Stacked on #9958. Base retargets to `main` when that merges.

## The last four — and the debt reaches zero

```
Schema-opacity validation passed: 14 open REST site(s), all reasoned;
14 open MCP site(s), 0 of them standing debt against #9797.
```

**33 at the start of the day.** A test now pins `MCP_NOT_YET_TYPED` empty, so a new untyped site must be declared with a written reason rather than added silently.

## Why each of these four needed modelling — confirmed, not assumed

**`list_subnet_health.surfaces[]`** — the file already recorded that the route serves a strict 12-field row while the tool serves the registry surface record overlaid with health. Re-confirmed: deriving fails with `Unrecognized keys: auth_required, content_type, method_tested, private_redirect_blocked, public_safe, subnet_name, subnet_slug, uptime_sample_ratio, verified_at` — the documented difference stated by the validator instead of by a comment.

**`how_do_i_call.services[]`** — a *reshape*, not a subset. `auth` collapses `auth_required`/`auth_schemes` into `{required, schemes}`, `health` keeps three of seven fields, `schema`/`fixture` become "can I use this, and how" answers.

**`list_surface_credentials.credentials[]`** — the store is authenticated, so production **cannot be sampled at all**. Modeled from the *producer*: `mcp-surface-credentials.ts` coalesces every field, which is why `created_at`/`expires_at` are required strings — they fall back to `""`, never `undefined`.

**`find_subnet_for_task.results[]`** is derivable, and I nearly modelled it by hand. Nine of eleven keys are `AgentCatalogSubnetEntrySchema`'s, so `pick(9).extend({relevance, next_step})` states the relationship.

## Optionality is measured

`list_subnet_health.surfaces[]` censused across 44 rows from four subnets: `status_code` 43/44, `content_type` 43/44, `error`/`error_class` 1/44, `redirect_target` 4/44, and `last_ok` present-but-null. Those are the only optionals — the other 17 fields are on every row.

## One correction the harness caught

`how_do_i_call`'s `health.observed_by` I modeled as a plain string from **41/41** production rows. The emitter writes `?? null`. Production always has an observer; the cold path does not — and only `validate:mcp`'s hermetic harness runs it.

**A capture is not the contract.** The two verification layers catch genuinely different things, which is the same lesson as #9942's cold-path defect.

## A fourth fixture asserting something untrue

`list_subnet_health`'s test used a **4-key** surface stub the tool never serves. Recaptured — after `ECON_BLOB` (#9932), `HEALTH_HISTORY_BLOB` (#9942) and `PROFILES_BLOB` (#9949). Four for four: every typed cluster exposed a fixture that was quietly fiction.

## Verified against production

Ten calls across `list_subnet_health` (4 subnets), `how_do_i_call` (3 subnets) and `find_subnet_for_task` (3 tasks), all valid against the emitted `outputSchema` with Ajv2020.

All validators pass; 1,701 tests pass across the affected suites.

Closes #9960