### PR TITLE
feat(neon): serve the two history routes from Neon

### DIFF
--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -6065,6 +6065,19 @@ export const NEON_READ_ROUTE_TABLES: readonly {
       "validator_nominator_counts",
     ],
   },
+  // Cut over once the two stores agreed on BOTH the rows and the ids
+  // (#9954): 137/137 and 531/531, with `id` copied from D1 so `MAX(id)` picks
+  // the same latest revision and the (observed_at, id) cursor means the same
+  // thing on either side. Each route reads ONE table -- no side loader to drag
+  // along.
+  {
+    pattern: /^\/api\/v1\/subnets\/\d+\/hyperparameters\/history$/,
+    tables: ["subnet_hyperparams_history"],
+  },
+  {
+    pattern: /^\/api\/v1\/accounts\/[^/]+\/identity-history$/,
+    tables: ["account_identity_history"],
+  },
   {
     pattern: /^\/api\/v1\/subnets\/\d+\/concentration\/history$/,
     tables: [

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -190,7 +190,7 @@
     // the loader modules they reach and fails the build on either construct.
     //
     // Rollback remains deleting the entry.
-    "NEON_READ_LANES": "account_position_daily,neurons,neuron_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts",
+    "NEON_READ_LANES": "account_position_daily,neurons,neuron_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,subnet_hyperparams_history,account_identity_history",
     // The two ACCUMULATING tables, and only those (src/neon-backfill.ts).
     //
     // The mirror above writes what each request carries, which finishes the job


### PR DESCRIPTION
**The first read cutover of this family** — these routes now *read* Neon rather than merely having a copy there.

```
/api/v1/subnets/{netuid}/hyperparameters/history
/api/v1/accounts/{ss58}/identity-history
```

## Both preconditions verified against production

**The rows agree** — 137/137 and 532/532.

**The ids agree**, which is what #9956 was for:

| | D1 | Neon |
|---|---|---|
| id=1 | `5HdThE9Wvusf…` | `5HdThE9Wvusf…` |
| id=2 | `5GsbTgfvgCH4…` | `5GsbTgfvgCH4…` |
| id=3 | `5EBuUXD6eXSS…` | `5EBuUXD6eXSS…` |

Before #9956 those were completely different rows. Now `MAX(id)` picks the same latest revision in both stores, and the `(observed_at, id)` cursor means the same thing on either side.

Each route reads exactly **one** table, so there's no side loader to drag across — the failure that emptied `/validators` in #9802.

## The cursor is unchanged

Dropping the id from it was tried and was wrong: two revisions written in the same millisecond share `observed_at` and are ordered by the id alone, which `tests/data-api-hyperparams-identity-d1.test.ts` asserts directly.

## Verification

A pre-cutover structural baseline is captured for six concrete paths (netuids 15/103/0, three accounts with real history, 2–4 rows each) and will be compared after deploy on row count, non-zero scalar count, payload shape and row identity.
