### PR TITLE
feat(neon): serve the last two matcher routes from Neon

### DIFF
--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -6070,6 +6070,18 @@ export const NEON_READ_ROUTE_TABLES: readonly {
   // the same latest revision and the (observed_at, id) cursor means the same
   // thing on either side. Each route reads ONE table -- no side loader to drag
   // along.
+  // The last two public routes in the D1 matchers. Both read a single table
+  // that is already served from Neon and already at exact parity -- 129/129
+  // and 498/498 -- so this is a declaration, not a migration: the tables moved
+  // long ago and these two handlers were simply never pointed at them.
+  {
+    pattern: /^\/api\/v1\/subnets\/\d+\/hyperparameters$/,
+    tables: ["subnet_hyperparams"],
+  },
+  {
+    pattern: /^\/api\/v1\/accounts\/[^/]+\/identity$/,
+    tables: ["account_identity"],
+  },
   {
     pattern: /^\/api\/v1\/subnets\/\d+\/hyperparameters\/history$/,
     tables: ["subnet_hyperparams_history"],


### PR DESCRIPTION
```
/api/v1/subnets/{netuid}/hyperparameters
/api/v1/accounts/{ss58}/identity
```

**With these, all 31 public routes in the three D1 route matchers read Neon.**

## This is a declaration, not a migration

Both read a single table. Both tables have been in `NEON_READ_LANES` since the neurons family moved, and both are at exact parity — **129/129** and **498/498**. The handlers were simply never listed in `NEON_READ_ROUTE_TABLES`, so the dispatcher kept handing them the D1 runner. Nothing about the data or the SQL changes.

## How they were found

By resolving every matcher guard to a **concrete path** and testing it against the read map — not by comparing regex sources, which never match textually because the matchers spell parameters with capture groups (`(\d+)`) and the map without them (`\d+`). Comparing sources reported 22 routes outstanding; comparing paths reported 2, and 2 was right.

A structural baseline is captured for six paths (netuids 1/64/15 and three accounts with identities) for post-deploy comparison on row count, non-zero scalar count, shape and row identity.
