### PR TITLE
refactor(schemas): give every duplicated vocabulary one owner, or say why not

### DIFF
--- a/schemas-src/artifacts/review-intake.ts
+++ b/schemas-src/artifacts/review-intake.ts
@@ -17,10 +17,11 @@ import { ArtifactBaseSchema, CountMapSchema } from "../envelope.ts";
 import { CandidatesArtifactSchema } from "../routes/candidates-evidence.ts";
 import { ReviewAdapterCandidateSchema } from "../routes/review-enrichment.ts";
 import { ReviewGapPrioritySchema } from "../routes/review-gaps-profile.ts";
+import { CONFIDENCE_LEVEL_VALUES } from "../shared.ts";
 
 export const ReviewDecisionSchema = z
   .object({
-    confidence: z.enum(["low", "medium", "high"]),
+    confidence: z.enum(CONFIDENCE_LEVEL_VALUES),
     decision: z.enum([
       "maintainer-reviewed",
       "needs-review",

--- a/schemas-src/mcp-tools/account-footprints.ts
+++ b/schemas-src/mcp-tools/account-footprints.ts
@@ -31,18 +31,18 @@ import {
   AccountServingArtifactSchema,
   AccountStakeMovesArtifactSchema,
 } from "../routes/account-activity.ts";
+import { WINDOW_ENUM_90D } from "../routes/account-activity-registrations.ts";
 
 // Symbolic in each hand-written original (src/account-*.ts's own
 // *_WINDOWS/DEFAULT_*_WINDOW constants), cross-checked against the actual
 // runtime source at the time of writing. Six of the seven tools share the
 // same 3-way set; get_account_weight_setters uses a 2-way set.
-const FOOTPRINT_WINDOWS_3 = ["7d", "30d", "90d"] as const;
 const WEIGHT_SETTERS_WINDOWS_2 = ["7d", "30d"] as const;
 
 export const GetAccountStakeMovesInputSchema = z
   .object({
     ss58: ss58Schema(),
-    window: windowSchema(FOOTPRINT_WINDOWS_3).optional(),
+    window: windowSchema(WINDOW_ENUM_90D).optional(),
   })
   .strict();
 export type GetAccountStakeMovesInput = z.infer<
@@ -57,7 +57,7 @@ export type GetAccountStakeMovesOutput = z.infer<
 export const GetAccountAxonRemovalsInputSchema = z
   .object({
     ss58: ss58Schema(),
-    window: windowSchema(FOOTPRINT_WINDOWS_3).optional(),
+    window: windowSchema(WINDOW_ENUM_90D).optional(),
   })
   .strict();
 export type GetAccountAxonRemovalsInput = z.infer<
@@ -73,7 +73,7 @@ export type GetAccountAxonRemovalsOutput = z.infer<
 export const GetAccountPrometheusInputSchema = z
   .object({
     ss58: ss58Schema(),
-    window: windowSchema(FOOTPRINT_WINDOWS_3).optional(),
+    window: windowSchema(WINDOW_ENUM_90D).optional(),
   })
   .strict();
 export type GetAccountPrometheusInput = z.infer<
@@ -88,7 +88,7 @@ export type GetAccountPrometheusOutput = z.infer<
 export const GetAccountRegistrationsInputSchema = z
   .object({
     ss58: ss58Schema(),
-    window: windowSchema(FOOTPRINT_WINDOWS_3).optional(),
+    window: windowSchema(WINDOW_ENUM_90D).optional(),
   })
   .strict();
 export type GetAccountRegistrationsInput = z.infer<
@@ -120,7 +120,7 @@ export type GetAccountWeightSettersOutput = z.infer<
 export const GetAccountServingInputSchema = z
   .object({
     ss58: ss58Schema(),
-    window: windowSchema(FOOTPRINT_WINDOWS_3).optional(),
+    window: windowSchema(WINDOW_ENUM_90D).optional(),
   })
   .strict();
 export type GetAccountServingInput = z.infer<
@@ -135,7 +135,7 @@ export type GetAccountServingOutput = z.infer<
 export const GetAccountDeregistrationsInputSchema = z
   .object({
     ss58: ss58Schema(),
-    window: windowSchema(FOOTPRINT_WINDOWS_3).optional(),
+    window: windowSchema(WINDOW_ENUM_90D).optional(),
   })
   .strict();
 export type GetAccountDeregistrationsInput = z.infer<

--- a/schemas-src/mcp-tools/account-stake-flow.ts
+++ b/schemas-src/mcp-tools/account-stake-flow.ts
@@ -13,18 +13,19 @@
 import { z } from "zod";
 import { kindSchema, ss58Schema, windowSchema } from "./shared.ts";
 import { AccountStakeFlowArtifactSchema } from "../routes/account-activity.ts";
+import {
+  ACCOUNT_ACTIVITY_FLOW_DIRECTIONS_VALUES,
+  WINDOW_ENUM,
+} from "../routes/account-activity.ts";
 
 // Symbolic in the hand-written original (src/stake-flow.ts's
 // STAKE_FLOW_WINDOWS/STAKE_FLOW_DIRECTIONS), cross-checked against the
 // actual runtime source at the time of writing.
-const ACCOUNT_STAKE_FLOW_WINDOWS = ["7d", "30d", "90d"] as const;
-const ACCOUNT_STAKE_FLOW_DIRECTIONS = ["all", "in", "out"] as const;
-
 export const GetAccountStakeFlowInputSchema = z
   .object({
     ss58: ss58Schema(),
-    window: windowSchema(ACCOUNT_STAKE_FLOW_WINDOWS).optional(),
-    direction: kindSchema(ACCOUNT_STAKE_FLOW_DIRECTIONS).optional(),
+    window: windowSchema(WINDOW_ENUM).optional(),
+    direction: kindSchema(ACCOUNT_ACTIVITY_FLOW_DIRECTIONS_VALUES).optional(),
   })
   .strict();
 export type GetAccountStakeFlowInput = z.infer<

--- a/schemas-src/mcp-tools/accounts-leaderboards.ts
+++ b/schemas-src/mcp-tools/accounts-leaderboards.ts
@@ -14,32 +14,16 @@ import { z } from "zod";
 import { limitSchema, sortSchema } from "./shared.ts";
 import { AccountsListArtifactSchema } from "../routes/accounts-list.ts";
 import { TopHoldersArtifactSchema } from "../routes/top-holders.ts";
+import { ACCOUNTS_LIST_LIST_SORTS_VALUES } from "../routes/accounts-list.ts";
+import { TOP_HOLDERS_SORT_VALUES } from "../routes/top-holders.ts";
 
 // Symbolic in the hand-written originals (src/accounts-list.ts's
-// ACCOUNTS_LIST_SORTS/*_LIMIT_*, src/top-holders.ts's TOP_HOLDERS_SORTS/
+// ACCOUNTS_LIST_LIST_SORTS_VALUES/*_LIMIT_*, src/top-holders.ts's TOP_HOLDERS_SORT_VALUES/
 // *_LIMIT_*), cross-checked against the actual runtime source at the time
 // of writing.
-const ACCOUNTS_LIST_SORTS = [
-  "total_stake",
-  "total_emission",
-  "subnet_count",
-  "uid_count",
-  "validator_count",
-  "stake_dominance",
-  "last_active",
-] as const;
-const TOP_HOLDERS_SORTS = [
-  "total_tao",
-  "free_tao",
-  "delegated_tao",
-  "net_flow_7d",
-  "net_flow_30d",
-  "net_flow_90d",
-] as const;
-
 export const ListAccountsInputSchema = z
   .object({
-    sort: sortSchema(ACCOUNTS_LIST_SORTS).optional(),
+    sort: sortSchema(ACCOUNTS_LIST_LIST_SORTS_VALUES).optional(),
     limit: limitSchema(100).optional(),
   })
   .strict();
@@ -52,7 +36,7 @@ export type ListAccountsOutput = z.infer<typeof ListAccountsOutputSchema>;
 
 export const GetTopHoldersInputSchema = z
   .object({
-    sort: sortSchema(TOP_HOLDERS_SORTS).optional(),
+    sort: sortSchema(TOP_HOLDERS_SORT_VALUES).optional(),
     limit: limitSchema(100).optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/ai-discovery.ts
+++ b/schemas-src/mcp-tools/ai-discovery.ts
@@ -6,26 +6,21 @@
 import { z } from "zod";
 import { limitSchema, netuidSchema } from "./shared.ts";
 import { AgentCatalogSubnetEntrySchema } from "../routes/agent-catalog.ts";
+import { ECONOMIC_LEADERBOARD_BOARDS } from "../routes/registry-summary-leaderboards.ts";
+import { SEARCH_DOCUMENT_TYPE_VALUES } from "../routes/evidence-search.ts";
 
 // Symbolic in the hand-written original (src/health-serving.ts's
 // ECONOMIC_BOARD_SPECS[].key), cross-checked against the actual runtime
 // source at the time of writing.
-const ECONOMIC_LEADERBOARD_BOARDS = [
-  "open-slots",
-  "cheapest-registration",
-  "highest-emission",
-  "validator-headroom",
-  "biggest-alpha-gain-1d",
-  "biggest-alpha-gain-7d",
-] as const;
-
-// Symbolic in the hand-written original (src/ai-search.ts's SEMANTIC_TYPES),
+// Symbolic in the hand-written original (src/ai-search.ts's SEARCH_DOCUMENT_TYPE_VALUES),
 // cross-checked against the actual runtime source at the time of writing.
 // Shared by semantic_search and ask's `type` input field below (mirrors
 // mcp-server.ts's own semanticTypeSchema() helper, used by both).
-const SEMANTIC_TYPES = ["subnet", "surface", "provider"] as const;
 const SemanticTypeSchema = z
-  .union([z.enum(SEMANTIC_TYPES), z.array(z.enum(SEMANTIC_TYPES))])
+  .union([
+    z.enum(SEARCH_DOCUMENT_TYPE_VALUES),
+    z.array(z.enum(SEARCH_DOCUMENT_TYPE_VALUES)),
+  ])
   .optional();
 
 export const FindSubnetOpportunitiesInputSchema = z

--- a/schemas-src/mcp-tools/chain-leaderboards.ts
+++ b/schemas-src/mcp-tools/chain-leaderboards.ts
@@ -31,14 +31,14 @@ import {
 import { ChainStakeFlowArtifactSchema } from "../routes/chain-stake-flow.ts";
 import { ChainTurnoverArtifactSchema } from "../routes/chain-turnover.ts";
 import { ChainWeightSettersArtifactSchema } from "../routes/chain-weight-setters.ts";
+import { CHAIN_TURNOVER_WINDOW_VALUES } from "../routes/chain-turnover.ts";
 
 const WINDOWS_2 = ["7d", "30d"] as const;
-const WINDOWS_3 = ["7d", "30d", "90d"] as const;
 const LIMIT_MAX_100 = 100;
 
 export const GetChainTurnoverInputSchema = z
   .object({
-    window: windowSchema(WINDOWS_3).optional(),
+    window: windowSchema(CHAIN_TURNOVER_WINDOW_VALUES).optional(),
     limit: limitSchema(LIMIT_MAX_100).optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/chain-scorecards.ts
+++ b/schemas-src/mcp-tools/chain-scorecards.ts
@@ -24,27 +24,14 @@ import {
 } from "../../src/route-limits.ts";
 import { ChainIdleStakeArtifactSchema } from "../routes/chain-idle-stake.ts";
 import { ChainYieldArtifactSchema } from "../routes/chain-yield.ts";
+import {
+  CONCENTRATION_LENSES,
+  CONCENTRATION_RANKING_SORTS,
+} from "../routes/chain-concentration-subnets.ts";
 
 // --- get_chain_concentration_subnets (#9717) ---------------------------------
 // The cross-subnet RANKING, as opposed to get_chain_concentration's single
 // network aggregate over the same read.
-
-const CONCENTRATION_LENSES = [
-  "emission",
-  "stake",
-  "entity_emission",
-  "entity_stake",
-  "validator_stake",
-] as const;
-
-const CONCENTRATION_RANKING_SORTS = [
-  "nakamoto_coefficient",
-  "gini",
-  "holders",
-  "top_1pct_share",
-  "total",
-  "netuid",
-] as const;
 
 export const GetChainConcentrationSubnetsInputSchema = z
   .object({

--- a/schemas-src/mcp-tools/curation-and-gaps.ts
+++ b/schemas-src/mcp-tools/curation-and-gaps.ts
@@ -25,16 +25,13 @@ import {
 import { CurationArtifactSchema } from "../routes/curation-gaps.ts";
 import { GapsArtifactSchema } from "../routes/curation-gaps.ts";
 import { COVERAGE_LEVEL_VALUES, CURATION_LEVEL_VALUES } from "../shared.ts";
+import {
+  CURATION_SORT_FIELDS,
+  GAPS_SORT_FIELDS,
+} from "../routes/curation-gaps.ts";
 
 const COVERAGE_LEVELS = COVERAGE_LEVEL_VALUES;
 const CURATION_LEVELS = CURATION_LEVEL_VALUES;
-const CURATION_SORT_FIELDS = [
-  "coverage_level",
-  "curation_level",
-  "name",
-  "netuid",
-] as const;
-
 export const ListCurationInputSchema = z
   .object({
     netuid: netuidSchema().optional(),
@@ -63,14 +60,6 @@ export const ListCurationOutputSchema = CurationArtifactSchema.pick({
   ...McpListPageFields,
 });
 export type ListCurationOutput = z.infer<typeof ListCurationOutputSchema>;
-
-const GAPS_SORT_FIELDS = [
-  "coverage_level",
-  "curation_level",
-  "gap_count",
-  "name",
-  "netuid",
-] as const;
 
 export const ListGapsInputSchema = z
   .object({

--- a/schemas-src/mcp-tools/endpoint-pools-and-provider.ts
+++ b/schemas-src/mcp-tools/endpoint-pools-and-provider.ts
@@ -33,14 +33,8 @@ import {
   SURFACE_KIND_VALUES,
 } from "../routes/subnet-detail.ts";
 import { HEALTH_STATUS_VALUES } from "../shared.ts";
-
-const POOL_KINDS = ["subtensor-rpc", "subtensor-wss", "archive"] as const;
-const POOL_SORT_FIELDS = [
-  "eligible_count",
-  "endpoint_count",
-  "id",
-  "kind",
-] as const;
+import { ENDPOINT_INCIDENT_SEVERITY_VALUES } from "../routes/endpoints-pools.ts";
+import { ENDPOINT_POOL_SORT_VALUES, ENDPOINT_SORT_VALUES } from "./shared.ts";
 
 export const ListEndpointPoolsInputSchema = z
   .object({
@@ -51,7 +45,7 @@ export const ListEndpointPoolsInputSchema = z
         "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
       )
       .meta({ examples: ["sn-64-chutes-subnet-api"] }),
-    kind: kindSchema(POOL_KINDS).optional(),
+    kind: kindSchema(ENDPOINT_LAYER_VALUES).optional(),
     min_eligible_count: z
       .number()
       .optional()
@@ -80,7 +74,7 @@ export const ListEndpointPoolsInputSchema = z
         "Inclusive upper bound on endpoint count; rows above it are excluded.",
       )
       .meta({ examples: [10] }),
-    sort: sortSchema(POOL_SORT_FIELDS).optional(),
+    sort: sortSchema(ENDPOINT_POOL_SORT_VALUES).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -104,7 +98,6 @@ export type ListEndpointPoolsOutput = z.infer<
 
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
 const HEALTH_STATUSES = HEALTH_STATUS_VALUES;
-const INCIDENT_SEVERITIES = ["critical", "warning", "info"] as const;
 const INCIDENT_STATES = ["active", "resolved"] as const;
 const INCIDENT_SORT_FIELDS = [
   "detected_at",
@@ -125,10 +118,10 @@ export const ListEndpointIncidentsInputSchema = z
     provider: providerSlugSchema().optional(),
     status: kindSchema(HEALTH_STATUSES).optional(),
     severity: z
-      .enum(INCIDENT_SEVERITIES)
+      .enum(ENDPOINT_INCIDENT_SEVERITY_VALUES)
       .optional()
       .describe("How serious the incident is.")
-      .meta({ examples: [INCIDENT_SEVERITIES[0]] }),
+      .meta({ examples: [ENDPOINT_INCIDENT_SEVERITY_VALUES[0]] }),
     state: z
       .enum(INCIDENT_STATES)
       .optional()
@@ -160,19 +153,6 @@ export type ListEndpointIncidentsOutput = z.infer<
 
 const ENDPOINT_LAYERS = ENDPOINT_LAYER_VALUES;
 const ENDPOINT_PUBLICATION_STATES = ENDPOINT_PUBLICATION_STATE_VALUES;
-const ENDPOINT_SORT_FIELDS = [
-  "kind",
-  "last_checked",
-  "latency_ms",
-  "layer",
-  "netuid",
-  "pool_eligible",
-  "provider",
-  "publication_state",
-  "score",
-  "status",
-] as const;
-
 export const ListProviderEndpointsInputSchema = z
   .object({
     slug: z
@@ -234,7 +214,7 @@ export const ListProviderEndpointsInputSchema = z
         "Inclusive upper bound on endpoint score; rows above it are excluded.",
       )
       .meta({ examples: [100] }),
-    sort: sortSchema(ENDPOINT_SORT_FIELDS).optional(),
+    sort: sortSchema(ENDPOINT_SORT_VALUES).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
     limit: limitSchema(100).optional(),

--- a/schemas-src/mcp-tools/endpoints-catalog.ts
+++ b/schemas-src/mcp-tools/endpoints-catalog.ts
@@ -36,24 +36,12 @@ import {
   SURFACE_KIND_VALUES,
 } from "../routes/subnet-detail.ts";
 import { HEALTH_STATUS_VALUES } from "../shared.ts";
+import { ENDPOINT_SORT_VALUES } from "./shared.ts";
 
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
 const ENDPOINT_LAYERS = ENDPOINT_LAYER_VALUES;
 const ENDPOINT_PUBLICATION_STATES = ENDPOINT_PUBLICATION_STATE_VALUES;
 const HEALTH_STATUSES = HEALTH_STATUS_VALUES;
-const ENDPOINT_SORT_FIELDS = [
-  "kind",
-  "last_checked",
-  "latency_ms",
-  "layer",
-  "netuid",
-  "pool_eligible",
-  "provider",
-  "publication_state",
-  "score",
-  "status",
-] as const;
-
 export const ListEndpointsInputSchema = z
   .object({
     kind: kindSchema(SURFACE_KINDS).optional(),
@@ -109,7 +97,7 @@ export const ListEndpointsInputSchema = z
         "Inclusive upper bound on endpoint score; rows above it are excluded.",
       )
       .meta({ examples: [100] }),
-    sort: sortSchema(ENDPOINT_SORT_FIELDS).optional(),
+    sort: sortSchema(ENDPOINT_SORT_VALUES).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
     // Ceiling is MAX_LIMIT (workers/request-params.ts:21); a literal here

--- a/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
+++ b/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
@@ -34,18 +34,16 @@ import { ReviewGapPrioritiesArtifactSchema } from "../routes/review-gaps-profile
 import { ReviewEnrichmentTargetsArtifactSchema } from "../routes/review-enrichment.ts";
 import { SURFACE_KIND_VALUES } from "../routes/subnet-detail.ts";
 import { CURATION_LEVEL_VALUES } from "../shared.ts";
+import {
+  EVIDENCE_SORT_FIELDS,
+  TARGET_SORT_FIELDS,
+} from "../routes/review-enrichment.ts";
+import { PRIORITY_SORT_FIELDS } from "../routes/review-gaps-profile.ts";
+import { IDENTITY_LEVEL_VALUES, PROFILE_LEVEL_VALUES } from "../shared.ts";
 
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
 const EVIDENCE_ACTIONS = REVIEW_EVIDENCE_ACTION_VALUES;
 const LANES = REVIEW_ENRICHMENT_LANE_VALUES;
-const EVIDENCE_SORT_FIELDS = [
-  "evidence_action",
-  "lane",
-  "name",
-  "netuid",
-  "priority_score",
-] as const;
-
 export const ListEnrichmentEvidenceInputSchema = z
   .object({
     q: querySchema().optional(),
@@ -100,17 +98,6 @@ export type ListEnrichmentEvidenceOutput = z.infer<
 >;
 
 const CURATION_LEVELS = CURATION_LEVEL_VALUES;
-const PRIORITY_SORT_FIELDS = [
-  "candidate_count",
-  "curation_level",
-  "missing_kinds",
-  "name",
-  "netuid",
-  "priority_score",
-  "surface_count",
-  "verified_candidate_count",
-] as const;
-
 export const ListReviewGapsInputSchema = z
   .object({
     netuid: netuidSchema().optional(),
@@ -148,34 +135,10 @@ export const ListReviewGapsOutputSchema =
   });
 export type ListReviewGapsOutput = z.infer<typeof ListReviewGapsOutputSchema>;
 
-const PROFILE_LEVELS = [
-  "directory-only",
-  "identity-partial",
-  "identity-complete",
-  "operational",
-  "adapter-backed",
-] as const;
-const IDENTITY_LEVELS = ["none", "directory", "partial", "complete"] as const;
 const BOOLEAN_STRINGS = ["true", "false"] as const;
 const SUBMISSION_ROUTES = REVIEW_ENRICHMENT_SUBMISSION_ROUTE_VALUES;
 const TARGET_ACTIONS = REVIEW_ENRICHMENT_TARGET_ACTION_VALUES;
 const TARGET_TYPES = REVIEW_ENRICHMENT_TARGET_TYPE_VALUES;
-const TARGET_SORT_FIELDS = [
-  "auto_review_candidate",
-  "evidence_action",
-  "identity_level",
-  "kind",
-  "lane",
-  "manual_review_required",
-  "name",
-  "netuid",
-  "priority_score",
-  "profile_level",
-  "submission_route",
-  "target_action",
-  "target_type",
-] as const;
-
 export const ListReviewEnrichmentTargetsInputSchema = z
   .object({
     q: querySchema().optional(),
@@ -202,17 +165,17 @@ export const ListReviewEnrichmentTargetsInputSchema = z
       .describe("What the evidence is asking a contributor to do.")
       .meta({ examples: [EVIDENCE_ACTIONS[0]] }),
     identity_level: z
-      .enum(IDENTITY_LEVELS)
+      .enum(IDENTITY_LEVEL_VALUES)
       .optional()
       .describe("How complete the subnet's published identity is.")
-      .meta({ examples: [IDENTITY_LEVELS[0]] }),
+      .meta({ examples: [IDENTITY_LEVEL_VALUES[0]] }),
     profile_level: z
-      .enum(PROFILE_LEVELS)
+      .enum(PROFILE_LEVEL_VALUES)
       .optional()
       .describe(
         "How complete the subnet's profile is, from directory-only upward.",
       )
-      .meta({ examples: [PROFILE_LEVELS[0]] }),
+      .meta({ examples: [PROFILE_LEVEL_VALUES[0]] }),
     submission_route: z
       .enum(SUBMISSION_ROUTES)
       .optional()

--- a/schemas-src/mcp-tools/enrichment-queue-and-candidates.ts
+++ b/schemas-src/mcp-tools/enrichment-queue-and-candidates.ts
@@ -29,41 +29,18 @@ import {
 import { ReviewAdapterCandidatesArtifactSchema } from "../routes/review-enrichment.ts";
 import { SURFACE_KIND_VALUES } from "../routes/subnet-detail.ts";
 import { CURATION_LEVEL_VALUES } from "../shared.ts";
+import {
+  ADAPTER_CANDIDATES_SORT_FIELDS,
+  QUEUE_SORT_FIELDS,
+  RECOMMENDED_ADAPTER_KINDS,
+} from "../routes/review-enrichment.ts";
+import { IDENTITY_LEVEL_VALUES, PROFILE_LEVEL_VALUES } from "../shared.ts";
 
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
 const CURATION_LEVELS = CURATION_LEVEL_VALUES;
-const PROFILE_LEVELS = [
-  "directory-only",
-  "identity-partial",
-  "identity-complete",
-  "operational",
-  "adapter-backed",
-] as const;
 const EVIDENCE_ACTIONS = REVIEW_EVIDENCE_ACTION_VALUES;
-const IDENTITY_LEVELS = ["none", "directory", "partial", "complete"] as const;
 const LANES = REVIEW_ENRICHMENT_LANE_VALUES;
 const BOOLEAN_STRINGS = ["true", "false"] as const;
-const QUEUE_SORT_FIELDS = [
-  "adapter_score",
-  "candidate_count",
-  "completeness_score",
-  "curation_level",
-  "endpoint_count",
-  "evidence_action",
-  "identity_level",
-  "identity_surface_count",
-  "lane",
-  "name",
-  "netuid",
-  "operational_interface_count",
-  "priority_score",
-  "profile_level",
-  "review_state",
-  "stale_candidate_count",
-  "surface_count",
-  "verified_candidate_count",
-] as const;
-
 export const ListEnrichmentQueueInputSchema = z
   .object({
     q: querySchema().optional(),
@@ -79,18 +56,18 @@ export const ListEnrichmentQueueInputSchema = z
       .describe("What the evidence is asking a contributor to do.")
       .meta({ examples: [EVIDENCE_ACTIONS[0]] }),
     identity_level: z
-      .enum(IDENTITY_LEVELS)
+      .enum(IDENTITY_LEVEL_VALUES)
       .optional()
       .describe("How complete the subnet's published identity is.")
-      .meta({ examples: [IDENTITY_LEVELS[0]] }),
+      .meta({ examples: [IDENTITY_LEVEL_VALUES[0]] }),
     curation_level: kindSchema(CURATION_LEVELS).optional(),
     profile_level: z
-      .enum(PROFILE_LEVELS)
+      .enum(PROFILE_LEVEL_VALUES)
       .optional()
       .describe(
         "How complete the subnet's profile is, from directory-only upward.",
       )
-      .meta({ examples: [PROFILE_LEVELS[0]] }),
+      .meta({ examples: [PROFILE_LEVEL_VALUES[0]] }),
     direct_submission_kinds: z
       .enum(SURFACE_KINDS)
       .optional()
@@ -144,24 +121,6 @@ export const ListEnrichmentQueueOutputSchema =
 export type ListEnrichmentQueueOutput = z.infer<
   typeof ListEnrichmentQueueOutputSchema
 >;
-
-const RECOMMENDED_ADAPTER_KINDS = [
-  "custom-adapter",
-  "data-artifact-adapter",
-  "generic-openapi-or-custom",
-  "stream-adapter",
-] as const;
-const ADAPTER_CANDIDATES_SORT_FIELDS = [
-  "candidate_api_count",
-  "candidate_api_kinds",
-  "curation_level",
-  "name",
-  "netuid",
-  "operational_kinds",
-  "operational_surface_count",
-  "priority_score",
-  "recommended_adapter_kind",
-] as const;
 
 export const ListAdapterCandidatesInputSchema = z
   .object({

--- a/schemas-src/mcp-tools/get-economics-trends.ts
+++ b/schemas-src/mcp-tools/get-economics-trends.ts
@@ -21,12 +21,11 @@
 import { z } from "zod";
 import { EconomicsTrendsArtifactSchema } from "../routes/economics-trends.ts";
 import { windowSchema } from "./shared.ts";
-
-const HISTORY_WINDOWS = ["7d", "30d", "90d", "1y", "all"] as const;
+import { ECONOMICS_TRENDS_WINDOW_VALUES } from "../routes/economics-trends.ts";
 
 export const GetEconomicsTrendsInputSchema = z
   .object({
-    window: windowSchema(HISTORY_WINDOWS).optional(),
+    window: windowSchema(ECONOMICS_TRENDS_WINDOW_VALUES).optional(),
   })
   .strict();
 export type GetEconomicsTrendsInput = z.infer<

--- a/schemas-src/mcp-tools/get-health-history.ts
+++ b/schemas-src/mcp-tools/get-health-history.ts
@@ -25,36 +25,13 @@ import {
   HealthHistorySummarySchema,
   HealthHistorySurfaceSchema,
 } from "../routes/health-surfaces.ts";
+import {
+  HEALTH_CLASSIFICATION_VALUES,
+  HEALTH_SURFACE_SORT_VALUES,
+} from "./shared.ts";
 
 const SURFACE_KIND = SURFACE_KIND_VALUES;
 const HEALTH_STATUS = HEALTH_STATUS_VALUES;
-const HEALTH_CLASSIFICATION = [
-  "auth-required",
-  "content-mismatch",
-  "dead",
-  "live",
-  "rate-limited",
-  "redirected",
-  "timeout",
-  "transient",
-  "unsupported",
-  "unsafe",
-  "wrong-chain",
-] as const;
-const HEALTH_SURFACE_SORT_FIELDS = [
-  "classification",
-  "kind",
-  "last_checked",
-  "last_ok",
-  "latency_ms",
-  "netuid",
-  "provider",
-  "status",
-  "status_code",
-  "surface_id",
-  "verified_at",
-] as const;
-
 export const GetHealthHistoryInputSchema = z
   .object({
     // `format` as an ANNOTATION, keeping the existing pattern as the enforced
@@ -77,13 +54,13 @@ export const GetHealthHistoryInputSchema = z
       .describe("Restrict to rows with this health status.")
       .meta({ examples: [HEALTH_STATUS[0]] }),
     classification: z
-      .enum(HEALTH_CLASSIFICATION)
+      .enum(HEALTH_CLASSIFICATION_VALUES)
       .optional()
       .describe(
         "Why a probe ended as it did — the reason behind the status, not the status itself.",
       )
-      .meta({ examples: [HEALTH_CLASSIFICATION[0]] }),
-    sort: sortSchema(HEALTH_SURFACE_SORT_FIELDS).optional(),
+      .meta({ examples: [HEALTH_CLASSIFICATION_VALUES[0]] }),
+    sort: sortSchema(HEALTH_SURFACE_SORT_VALUES).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
     limit: limitSchema(1000).optional(),

--- a/schemas-src/mcp-tools/get-subnet-concentration-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-concentration-history.ts
@@ -6,13 +6,12 @@
 import { z } from "zod";
 import { SubnetConcentrationHistoryArtifactSchema } from "../routes/subnet-concentration.ts";
 import { netuidSchema, windowSchema } from "./shared.ts";
-
-const CONCENTRATION_HISTORY_WINDOWS = ["7d", "30d", "90d"] as const;
+import { SUBNET_CONCENTRATION_WINDOW_VALUES } from "../routes/subnet-concentration.ts";
 
 export const GetSubnetConcentrationHistoryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(CONCENTRATION_HISTORY_WINDOWS).optional(),
+    window: windowSchema(SUBNET_CONCENTRATION_WINDOW_VALUES).optional(),
   })
   .strict();
 export type GetSubnetConcentrationHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-event-summary.ts
+++ b/schemas-src/mcp-tools/get-subnet-event-summary.ts
@@ -20,15 +20,14 @@ import {
 } from "../../src/route-limits.ts";
 import { limitSchema, netuidSchema, windowSchema } from "./shared.ts";
 import { SubnetEventSummaryArtifactSchema } from "../routes/subnet-event-summary.ts";
-
-const SUBNET_EVENT_SUMMARY_WINDOWS = ["7d", "30d", "90d"] as const;
+import { SUBNET_EVENT_SUMMARY_WINDOW_VALUES } from "../routes/subnet-event-summary.ts";
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
 export const GetSubnetEventSummaryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(SUBNET_EVENT_SUMMARY_WINDOWS).optional(),
+    window: windowSchema(SUBNET_EVENT_SUMMARY_WINDOW_VALUES).optional(),
     limit: limitSchema(
       SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
       SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,

--- a/schemas-src/mcp-tools/get-subnet-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-history.ts
@@ -13,13 +13,12 @@
 import { z } from "zod";
 import { netuidSchema, windowSchema } from "./shared.ts";
 import { SubnetHistoryArtifactSchema } from "../routes/subnet-history.ts";
-
-const HISTORY_WINDOWS = ["7d", "30d", "90d", "1y", "all"] as const;
+import { SUBNET_HISTORY_WINDOW_VALUES } from "../routes/subnet-history.ts";
 
 export const GetSubnetHistoryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(HISTORY_WINDOWS).optional(),
+    window: windowSchema(SUBNET_HISTORY_WINDOW_VALUES).optional(),
   })
   .strict();
 export type GetSubnetHistoryInput = z.infer<typeof GetSubnetHistoryInputSchema>;

--- a/schemas-src/mcp-tools/get-subnet-movers.ts
+++ b/schemas-src/mcp-tools/get-subnet-movers.ts
@@ -17,14 +17,15 @@ import {
 } from "../../src/route-limits.ts";
 import { limitSchema, sortSchema, windowSchema } from "./shared.ts";
 import { SubnetMoversArtifactSchema } from "../routes/subnet-movers.ts";
-
-const MOVERS_WINDOW_KEYS = ["7d", "30d", "90d"] as const;
-const MOVERS_SORTS = ["stake", "emission", "validators", "neurons"] as const;
+import {
+  SUBNET_MOVERS_MOVERS_SORTS_VALUES,
+  SUBNET_MOVERS_WINDOW_VALUES,
+} from "../routes/subnet-movers.ts";
 
 export const GetSubnetMoversInputSchema = z
   .object({
-    window: windowSchema(MOVERS_WINDOW_KEYS).optional(),
-    sort: sortSchema(MOVERS_SORTS).optional(),
+    window: windowSchema(SUBNET_MOVERS_WINDOW_VALUES).optional(),
+    sort: sortSchema(SUBNET_MOVERS_MOVERS_SORTS_VALUES).optional(),
     limit: limitSchema(MOVERS_LIMIT_MAX, MOVERS_LIMIT_DEFAULT).optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/get-subnet-performance-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-performance-history.ts
@@ -6,13 +6,12 @@
 import { z } from "zod";
 import { SubnetPerformanceHistoryArtifactSchema } from "../routes/subnet-performance.ts";
 import { netuidSchema, windowSchema } from "./shared.ts";
-
-const PERFORMANCE_HISTORY_WINDOWS = ["7d", "30d", "90d"] as const;
+import { SUBNET_PERFORMANCE_WINDOW_VALUES } from "../routes/subnet-performance.ts";
 
 export const GetSubnetPerformanceHistoryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(PERFORMANCE_HISTORY_WINDOWS).optional(),
+    window: windowSchema(SUBNET_PERFORMANCE_WINDOW_VALUES).optional(),
   })
   .strict();
 export type GetSubnetPerformanceHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-stake-flow.ts
+++ b/schemas-src/mcp-tools/get-subnet-stake-flow.ts
@@ -13,15 +13,16 @@
 import { z } from "zod";
 import { kindSchema, netuidSchema, windowSchema } from "./shared.ts";
 import { SubnetStakeFlowArtifactSchema } from "../routes/subnet-stake-flow.ts";
-
-const STAKE_FLOW_WINDOWS = ["7d", "30d", "90d"] as const;
-const STAKE_FLOW_DIRECTIONS = ["all", "in", "out"] as const;
+import {
+  SUBNET_STAKE_FLOW_FLOW_DIRECTIONS_VALUES,
+  SUBNET_STAKE_FLOW_WINDOW_VALUES,
+} from "../routes/subnet-stake-flow.ts";
 
 export const GetSubnetStakeFlowInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(STAKE_FLOW_WINDOWS).optional(),
-    direction: kindSchema(STAKE_FLOW_DIRECTIONS).optional(),
+    window: windowSchema(SUBNET_STAKE_FLOW_WINDOW_VALUES).optional(),
+    direction: kindSchema(SUBNET_STAKE_FLOW_FLOW_DIRECTIONS_VALUES).optional(),
   })
   .strict();
 export type GetSubnetStakeFlowInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-turnover.ts
+++ b/schemas-src/mcp-tools/get-subnet-turnover.ts
@@ -2,19 +2,18 @@
 // /api/v1/subnets/{netuid}/turnover, which is not one of schemas-src/routes/'s
 // covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
 // shallow, from the hand-written literal it replaces. Window enum
-// hardcoded from src/neuron-history.ts's HISTORY_WINDOWS at the time of
+// hardcoded from src/neuron-history.ts's SUBNET_TURNOVER_WINDOW_VALUES at the time of
 // writing (mirrors the pilot batch's ECONOMICS_SORT_FIELDS precedent -- not
 // cross-imported).
 import { z } from "zod";
 import { SubnetTurnoverArtifactSchema } from "../routes/subnet-turnover.ts";
 import { netuidSchema, windowSchema } from "./shared.ts";
-
-const HISTORY_WINDOWS = ["7d", "30d", "90d", "1y", "all"] as const;
+import { SUBNET_TURNOVER_WINDOW_VALUES } from "../routes/subnet-turnover.ts";
 
 export const GetSubnetTurnoverInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(HISTORY_WINDOWS).optional(),
+    window: windowSchema(SUBNET_TURNOVER_WINDOW_VALUES).optional(),
     changes: z
       .boolean()
       .optional()

--- a/schemas-src/mcp-tools/get-subnet-yield-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-yield-history.ts
@@ -16,13 +16,12 @@
 import { z } from "zod";
 import { netuidSchema, windowSchema } from "./shared.ts";
 import { SubnetYieldHistoryArtifactSchema } from "../routes/subnet-yield.ts";
-
-const YIELD_HISTORY_WINDOWS = ["7d", "30d", "90d"] as const;
+import { SUBNET_YIELD_WINDOW_VALUES } from "../routes/subnet-yield.ts";
 
 export const GetSubnetYieldHistoryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(YIELD_HISTORY_WINDOWS).optional(),
+    window: windowSchema(SUBNET_YIELD_WINDOW_VALUES).optional(),
   })
   .strict();
 export type GetSubnetYieldHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/profiles.ts
+++ b/schemas-src/mcp-tools/profiles.ts
@@ -25,16 +25,10 @@ import {
 } from "./shared.ts";
 import { CURATION_LEVEL_VALUES } from "../shared.ts";
 import { SubnetProfileSchema } from "../routes/subnet-profile.ts";
+import { PROFILE_LEVEL_VALUES } from "../shared.ts";
 
 const SUBNET_TYPE = ["root", "application"] as const;
 const CURATION_LEVEL = CURATION_LEVEL_VALUES;
-const PROFILE_LEVEL = [
-  "directory-only",
-  "identity-partial",
-  "identity-complete",
-  "operational",
-  "adapter-backed",
-] as const;
 const PROFILES_SORT_FIELDS = [
   "candidate_count",
   "completeness_score",
@@ -74,12 +68,12 @@ export const ListProfilesInputSchema = z
       .describe("How confident the machine assessment is.")
       .meta({ examples: ["low"] }),
     profile_level: z
-      .enum(PROFILE_LEVEL)
+      .enum(PROFILE_LEVEL_VALUES)
       .optional()
       .describe(
         "How complete the subnet's profile is, from directory-only upward.",
       )
-      .meta({ examples: [PROFILE_LEVEL[0]] }),
+      .meta({ examples: [PROFILE_LEVEL_VALUES[0]] }),
     q: querySchema().optional(),
     sort: sortSchema(PROFILES_SORT_FIELDS).optional(),
     order: orderSchema().optional(),

--- a/schemas-src/mcp-tools/registry-catalogs-1.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-1.ts
@@ -38,6 +38,8 @@ import {
   CANDIDATE_STATE_VALUES,
   SURFACE_KIND_VALUES,
 } from "../routes/subnet-detail.ts";
+import { CONFIDENCE_LEVEL_VALUES } from "../shared.ts";
+import { CANDIDATE_SORT_VALUES, SURFACE_SORT_VALUES } from "./shared.ts";
 
 // Symbolic in each hand-written original (src/contracts.ts's QUERY_ENUMS /
 // API_QUERY_COLLECTIONS.*.sort_fields), cross-checked against the actual
@@ -78,14 +80,6 @@ export const ListProvidersOutputSchema = ProvidersArtifactSchema.extend({
 export type ListProvidersOutput = z.infer<typeof ListProvidersOutputSchema>;
 
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
-const SURFACE_SORT_FIELDS = [
-  "id",
-  "kind",
-  "name",
-  "netuid",
-  "provider",
-] as const;
-
 export const ListSurfacesInputSchema = z
   .object({
     netuid: netuidSchema().optional(),
@@ -98,7 +92,7 @@ export const ListSurfacesInputSchema = z
         "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
       )
       .meta({ examples: ["sn-64-chutes-subnet-api"] }),
-    sort: sortSchema(SURFACE_SORT_FIELDS).optional(),
+    sort: sortSchema(SURFACE_SORT_VALUES).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -113,17 +107,6 @@ export const ListSurfacesOutputSchema = SurfacesArtifactSchema.extend({
 export type ListSurfacesOutput = z.infer<typeof ListSurfacesOutputSchema>;
 
 const CANDIDATE_STATES = CANDIDATE_STATE_VALUES;
-const CONFIDENCE_LEVELS = ["low", "medium", "high"] as const;
-const CANDIDATES_SORT_FIELDS = [
-  "confidence",
-  "id",
-  "kind",
-  "name",
-  "netuid",
-  "provider",
-  "state",
-] as const;
-
 export const ListCandidatesInputSchema = z
   .object({
     netuid: netuidSchema().optional(),
@@ -142,11 +125,11 @@ export const ListCandidatesInputSchema = z
       )
       .meta({ examples: ["sn-64-chutes-subnet-api"] }),
     confidence: z
-      .enum(CONFIDENCE_LEVELS)
+      .enum(CONFIDENCE_LEVEL_VALUES)
       .optional()
       .describe("How confident the machine assessment is.")
-      .meta({ examples: [CONFIDENCE_LEVELS[0]] }),
-    sort: sortSchema(CANDIDATES_SORT_FIELDS).optional(),
+      .meta({ examples: [CONFIDENCE_LEVEL_VALUES[0]] }),
+    sort: sortSchema(CANDIDATE_SORT_VALUES).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
     limit: limitSchema(1000).optional(),

--- a/schemas-src/mcp-tools/registry-catalogs-2.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-2.ts
@@ -42,18 +42,23 @@ import {
   SURFACE_KIND_VALUES,
 } from "../routes/subnet-detail.ts";
 import { HEALTH_STATUS_VALUES } from "../shared.ts";
-
-const CLAIM_SORT_FIELDS = [
-  "claim",
-  "source_url",
-  "subject",
-  "verified_at",
-] as const;
+import { PROFILE_SORT_FIELDS } from "../routes/review-gaps-profile.ts";
+import {
+  CONFIDENCE_LEVEL_VALUES,
+  IDENTITY_LEVEL_VALUES,
+  NATIVE_NAME_QUALITY_VALUES,
+  PROFILE_LEVEL_VALUES,
+} from "../shared.ts";
+import {
+  ENDPOINT_POOL_SORT_VALUES,
+  ENDPOINT_SORT_VALUES,
+  EVIDENCE_ENTRY_SORT_VALUES,
+} from "./shared.ts";
 
 export const ListEvidenceInputSchema = z
   .object({
     q: querySchema().optional(),
-    sort: sortSchema(CLAIM_SORT_FIELDS).optional(),
+    sort: sortSchema(EVIDENCE_ENTRY_SORT_VALUES).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -71,19 +76,6 @@ const SURFACE_KINDS = SURFACE_KIND_VALUES;
 const ENDPOINT_LAYERS = ENDPOINT_LAYER_VALUES;
 const HEALTH_STATUSES = HEALTH_STATUS_VALUES;
 const ENDPOINT_PUBLICATION_STATES = ENDPOINT_PUBLICATION_STATE_VALUES;
-const ENDPOINT_SORT_FIELDS = [
-  "kind",
-  "last_checked",
-  "latency_ms",
-  "layer",
-  "netuid",
-  "pool_eligible",
-  "provider",
-  "publication_state",
-  "score",
-  "status",
-] as const;
-
 export const ListRpcEndpointsInputSchema = z
   .object({
     kind: kindSchema(SURFACE_KINDS).optional(),
@@ -139,7 +131,7 @@ export const ListRpcEndpointsInputSchema = z
         "Inclusive upper bound on endpoint score; rows above it are excluded.",
       )
       .meta({ examples: [100] }),
-    sort: sortSchema(ENDPOINT_SORT_FIELDS).optional(),
+    sort: sortSchema(ENDPOINT_SORT_VALUES).optional(),
     order: orderSchema().optional(),
     // Both `fields` and `cursor` are UNIONS here, unlike everywhere else, so
     // neither can take a shared builder -- the sentence has to say which forms
@@ -175,14 +167,6 @@ export type ListRpcEndpointsOutput = z.infer<
   typeof ListRpcEndpointsOutputSchema
 >;
 
-const POOL_KINDS = ["subtensor-rpc", "subtensor-wss", "archive"] as const;
-const POOL_SORT_FIELDS = [
-  "eligible_count",
-  "endpoint_count",
-  "id",
-  "kind",
-] as const;
-
 export const ListRpcPoolsInputSchema = z
   .object({
     id: z
@@ -192,7 +176,7 @@ export const ListRpcPoolsInputSchema = z
         "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
       )
       .meta({ examples: ["sn-64-chutes-subnet-api"] }),
-    kind: kindSchema(POOL_KINDS).optional(),
+    kind: kindSchema(ENDPOINT_LAYER_VALUES).optional(),
     min_eligible_count: z
       .number()
       .optional()
@@ -221,7 +205,7 @@ export const ListRpcPoolsInputSchema = z
         "Inclusive upper bound on endpoint count; rows above it are excluded.",
       )
       .meta({ examples: [10] }),
-    sort: sortSchema(POOL_SORT_FIELDS).optional(),
+    sort: sortSchema(ENDPOINT_POOL_SORT_VALUES).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -268,53 +252,26 @@ export type ListSourceSnapshotsOutput = z.infer<
   typeof ListSourceSnapshotsOutputSchema
 >;
 
-const PROFILE_LEVELS = [
-  "directory-only",
-  "identity-partial",
-  "identity-complete",
-  "operational",
-  "adapter-backed",
-] as const;
-const CONFIDENCE_LEVELS = ["low", "medium", "high"] as const;
-const IDENTITY_LEVELS = ["none", "directory", "partial", "complete"] as const;
-const NATIVE_NAME_QUALITIES = ["chain", "placeholder", "empty"] as const;
-const PROFILE_SORT_FIELDS = [
-  "candidate_count",
-  "completeness_score",
-  "identity_level",
-  "identity_promotion_kind_count",
-  "identity_surface_count",
-  "live_identity_candidate_kind_count",
-  "missing_critical_count",
-  "name",
-  "native_identity_signal_count",
-  "native_name_quality",
-  "netuid",
-  "priority_score",
-  "profile_level",
-  "stale_identity_candidate_kind_count",
-] as const;
-
 export const ListProfileCompletenessInputSchema = z
   .object({
     netuid: netuidSchema().optional(),
     profile_level: z
-      .enum(PROFILE_LEVELS)
+      .enum(PROFILE_LEVEL_VALUES)
       .optional()
       .describe(
         "How complete the subnet's profile is, from directory-only upward.",
       )
-      .meta({ examples: [PROFILE_LEVELS[0]] }),
+      .meta({ examples: [PROFILE_LEVEL_VALUES[0]] }),
     confidence: z
-      .enum(CONFIDENCE_LEVELS)
+      .enum(CONFIDENCE_LEVEL_VALUES)
       .optional()
       .describe("How confident the machine assessment is.")
-      .meta({ examples: [CONFIDENCE_LEVELS[0]] }),
+      .meta({ examples: [CONFIDENCE_LEVEL_VALUES[0]] }),
     identity_level: z
-      .enum(IDENTITY_LEVELS)
+      .enum(IDENTITY_LEVEL_VALUES)
       .optional()
       .describe("How complete the subnet's published identity is.")
-      .meta({ examples: [IDENTITY_LEVELS[0]] }),
+      .meta({ examples: [IDENTITY_LEVEL_VALUES[0]] }),
     identity_promotion_kinds: z
       .enum(SURFACE_KINDS)
       .optional()
@@ -323,10 +280,10 @@ export const ListProfileCompletenessInputSchema = z
       )
       .meta({ examples: [SURFACE_KINDS[0]] }),
     native_name_quality: z
-      .enum(NATIVE_NAME_QUALITIES)
+      .enum(NATIVE_NAME_QUALITY_VALUES)
       .optional()
       .describe("Whether the on-chain name is real, a placeholder, or empty.")
-      .meta({ examples: [NATIVE_NAME_QUALITIES[0]] }),
+      .meta({ examples: [NATIVE_NAME_QUALITY_VALUES[0]] }),
     sort: sortSchema(PROFILE_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),

--- a/schemas-src/mcp-tools/registry-summary-gaps.ts
+++ b/schemas-src/mcp-tools/registry-summary-gaps.ts
@@ -26,6 +26,12 @@ import {
   AgentReadinessBlockerSchema,
   CoverageDepthDimensionsSchema,
 } from "../routes/coverage.ts";
+import {
+  AGENT_READINESS_STATUSES,
+  COVERAGE_DEPTH_SEVERITIES,
+  COVERAGE_DEPTH_TIERS,
+} from "../routes/coverage.ts";
+import { PRIORITY_SORT_FIELDS } from "../routes/review-gaps-profile.ts";
 
 export const RegistrySummaryInputSchema = z.object({}).strict();
 export type RegistrySummaryInput = z.infer<typeof RegistrySummaryInputSchema>;
@@ -40,27 +46,6 @@ export type RegistrySummaryOutput = z.infer<typeof RegistrySummaryOutputSchema>;
 // QUERY_ENUMS.agentReadinessStatus and mcp-server.ts's own
 // COVERAGE_DEPTH_TIERS/COVERAGE_DEPTH_SEVERITIES constants), cross-checked
 // against the actual runtime source at the time of writing.
-const COVERAGE_DEPTH_TIERS = [
-  "agent-ready",
-  "machine-usable",
-  "candidate-review",
-  "needs-evidence",
-  "hard-blocked",
-  "missing-interface",
-] as const;
-const COVERAGE_DEPTH_SEVERITIES = [
-  "hard",
-  "missing-data",
-  "needs-review",
-] as const;
-const AGENT_READINESS_STATUSES = [
-  "callable",
-  "base-layer",
-  "candidate",
-  "needs-evidence",
-  "blocked",
-] as const;
-
 export const ListEnrichmentTargetsInputSchema = z
   .object({
     limit: limitSchema(50).optional(),
@@ -199,17 +184,6 @@ const SURFACE_KINDS = SURFACE_KIND_VALUES;
 // The REST route pages this artifact through the review-gap-priorities
 // collection (rows live under `priorities`), not the network-wide `gaps`
 // collection -- same sort fields as list_review_gaps (batch 10, #8074).
-const GAP_PRIORITY_SORT_FIELDS = [
-  "candidate_count",
-  "curation_level",
-  "missing_kinds",
-  "name",
-  "netuid",
-  "priority_score",
-  "surface_count",
-  "verified_candidate_count",
-] as const;
-
 export const ListSubnetGapsInputSchema = z
   .object({
     netuid: netuidSchema(),
@@ -226,7 +200,7 @@ export const ListSubnetGapsInputSchema = z
       .optional()
       .describe("Where the item sits in maintainer review.")
       .meta({ examples: ["pending"] }),
-    sort: sortSchema(GAP_PRIORITY_SORT_FIELDS).optional(),
+    sort: sortSchema(PRIORITY_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
     limit: limitSchema(100).optional(),

--- a/schemas-src/mcp-tools/search-documents.ts
+++ b/schemas-src/mcp-tools/search-documents.ts
@@ -26,18 +26,18 @@ import {
 } from "./shared.ts";
 import { SearchIndexArtifactSchema } from "../routes/evidence-search.ts";
 import { SearchArtifactSchema } from "../routes/evidence-search.ts";
+import { SEARCH_DOCUMENT_TYPE_VALUES } from "../routes/evidence-search.ts";
 
-const DOCUMENT_TYPES = ["subnet", "surface", "provider"] as const;
 const DOCUMENT_SORT_FIELDS = ["netuid", "slug", "title", "type"] as const;
 
 export const ListSearchIndexInputSchema = z
   .object({
     q: querySchema().optional(),
     type: z
-      .enum(DOCUMENT_TYPES)
+      .enum(SEARCH_DOCUMENT_TYPE_VALUES)
       .optional()
       .describe("Which entity kind to search over.")
-      .meta({ examples: [DOCUMENT_TYPES[0]] }),
+      .meta({ examples: [SEARCH_DOCUMENT_TYPE_VALUES[0]] }),
     netuid: netuidSchema().optional(),
     sort: sortSchema(DOCUMENT_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
@@ -61,10 +61,10 @@ export const ListSearchInputSchema = z
   .object({
     q: querySchema().optional(),
     type: z
-      .enum(DOCUMENT_TYPES)
+      .enum(SEARCH_DOCUMENT_TYPE_VALUES)
       .optional()
       .describe("Which entity kind to search over.")
-      .meta({ examples: [DOCUMENT_TYPES[0]] }),
+      .meta({ examples: [SEARCH_DOCUMENT_TYPE_VALUES[0]] }),
     netuid: netuidSchema().optional(),
     sort: sortSchema(DOCUMENT_SORT_FIELDS).optional(),
     order: orderSchema().optional(),

--- a/schemas-src/mcp-tools/shared.ts
+++ b/schemas-src/mcp-tools/shared.ts
@@ -12,6 +12,93 @@ import { z } from "zod";
 import { NeuronSchema } from "../routes/subnet-metagraph.ts";
 import { MAX_OFFSET } from "../../workers/request-params.ts";
 
+/** Shared across MCP tools that have no single route owner (#9799). */
+export const EVIDENCE_ENTRY_SORT_VALUES = [
+  "claim",
+  "source_url",
+  "subject",
+  "verified_at",
+] as const;
+
+/** Shared across MCP tools that have no single route owner (#9799). */
+export const CANDIDATE_SORT_VALUES = [
+  "confidence",
+  "id",
+  "kind",
+  "name",
+  "netuid",
+  "provider",
+  "state",
+] as const;
+
+/** Shared across MCP tools that have no single route owner (#9799). */
+export const SURFACE_SORT_VALUES = [
+  "id",
+  "kind",
+  "name",
+  "netuid",
+  "provider",
+] as const;
+
+/** Shared across MCP tools that have no single route owner (#9799). */
+export const HEALTH_SURFACE_SORT_VALUES = [
+  "classification",
+  "kind",
+  "last_checked",
+  "last_ok",
+  "latency_ms",
+  "netuid",
+  "provider",
+  "status",
+  "status_code",
+  "surface_id",
+  "verified_at",
+] as const;
+
+/** Shared across MCP tools that have no single route owner (#9799). */
+export const HEALTH_CLASSIFICATION_VALUES = [
+  "auth-required",
+  "content-mismatch",
+  "dead",
+  "live",
+  "rate-limited",
+  "redirected",
+  "timeout",
+  "transient",
+  "unsupported",
+  "unsafe",
+  "wrong-chain",
+] as const;
+
+/** Shared across MCP tools that have no single route owner (#9799). */
+export const ENDPOINT_SORT_VALUES = [
+  "kind",
+  "last_checked",
+  "latency_ms",
+  "layer",
+  "netuid",
+  "pool_eligible",
+  "provider",
+  "publication_state",
+  "score",
+  "status",
+] as const;
+
+/** Shared across MCP tools that have no single route owner (#9799). */
+export const ENDPOINT_POOL_SORT_VALUES = [
+  "eligible_count",
+  "endpoint_count",
+  "id",
+  "kind",
+] as const;
+
+/** Shared across MCP tools that have no single route owner (#9799). */
+export const ENDPOINT_LAYER_VALUES = [
+  "subtensor-rpc",
+  "subtensor-wss",
+  "archive",
+] as const;
+
 // --- Bounded input primitives --------------------------------------
 //
 // Every tool author wrote `z.int().min(0)` inline, so no parameter declared a real

--- a/schemas-src/mcp-tools/subnet-registry-lists.ts
+++ b/schemas-src/mcp-tools/subnet-registry-lists.ts
@@ -41,6 +41,8 @@ import {
   CANDIDATE_STATE_VALUES,
   SURFACE_KIND_VALUES,
 } from "../routes/subnet-detail.ts";
+import { CONFIDENCE_LEVEL_VALUES } from "../shared.ts";
+import { CANDIDATE_SORT_VALUES, EVIDENCE_ENTRY_SORT_VALUES } from "./shared.ts";
 
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
 
@@ -59,17 +61,6 @@ export type GetSubnetCandidatesOutput = z.infer<
 >;
 
 const CANDIDATE_STATES = CANDIDATE_STATE_VALUES;
-const CONFIDENCE_LEVELS = ["low", "medium", "high"] as const;
-const CANDIDATES_SORT_FIELDS = [
-  "confidence",
-  "id",
-  "kind",
-  "name",
-  "netuid",
-  "provider",
-  "state",
-] as const;
-
 export const ListSubnetCandidatesInputSchema = z
   .object({
     netuid: netuidSchema(),
@@ -88,11 +79,11 @@ export const ListSubnetCandidatesInputSchema = z
       )
       .meta({ examples: ["sn-64-chutes-subnet-api"] }),
     confidence: z
-      .enum(CONFIDENCE_LEVELS)
+      .enum(CONFIDENCE_LEVEL_VALUES)
       .optional()
       .describe("How confident the machine assessment is.")
-      .meta({ examples: [CONFIDENCE_LEVELS[0]] }),
-    sort: sortSchema(CANDIDATES_SORT_FIELDS).optional(),
+      .meta({ examples: [CONFIDENCE_LEVEL_VALUES[0]] }),
+    sort: sortSchema(CANDIDATE_SORT_VALUES).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -132,18 +123,11 @@ export type GetSubnetEvidenceOutput = z.infer<
   typeof GetSubnetEvidenceOutputSchema
 >;
 
-const CLAIM_SORT_FIELDS = [
-  "claim",
-  "source_url",
-  "subject",
-  "verified_at",
-] as const;
-
 export const ListSubnetEvidenceInputSchema = z
   .object({
     netuid: netuidSchema(),
     q: querySchema().optional(),
-    sort: sortSchema(CLAIM_SORT_FIELDS).optional(),
+    sort: sortSchema(EVIDENCE_ENTRY_SORT_VALUES).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
     limit: limitSchema(100).optional(),

--- a/schemas-src/mcp-tools/subnet-scoped-lists.ts
+++ b/schemas-src/mcp-tools/subnet-scoped-lists.ts
@@ -37,25 +37,18 @@ import {
   SURFACE_KIND_VALUES,
 } from "../routes/subnet-detail.ts";
 import { HEALTH_STATUS_VALUES } from "../shared.ts";
+import {
+  ENDPOINT_SORT_VALUES,
+  HEALTH_CLASSIFICATION_VALUES,
+  HEALTH_SURFACE_SORT_VALUES,
+  SURFACE_SORT_VALUES,
+} from "./shared.ts";
 
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
 const ENDPOINT_LAYERS = ENDPOINT_LAYER_VALUES;
 const ENDPOINT_PUBLICATION_STATES = ENDPOINT_PUBLICATION_STATE_VALUES;
 const HEALTH_STATUSES = HEALTH_STATUS_VALUES;
 const BOOLEAN_STRINGS = ["true", "false"] as const;
-const ENDPOINT_SORT_FIELDS = [
-  "kind",
-  "last_checked",
-  "latency_ms",
-  "layer",
-  "netuid",
-  "pool_eligible",
-  "provider",
-  "publication_state",
-  "score",
-  "status",
-] as const;
-
 export const ListSubnetEndpointsInputSchema = z
   .object({
     netuid: netuidSchema(),
@@ -111,7 +104,7 @@ export const ListSubnetEndpointsInputSchema = z
         "Inclusive upper bound on endpoint score; rows above it are excluded.",
       )
       .meta({ examples: [100] }),
-    sort: sortSchema(ENDPOINT_SORT_FIELDS).optional(),
+    sort: sortSchema(ENDPOINT_SORT_VALUES).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -135,14 +128,6 @@ export type ListSubnetEndpointsOutput = z.infer<
   typeof ListSubnetEndpointsOutputSchema
 >;
 
-const SURFACE_SORT_FIELDS = [
-  "id",
-  "kind",
-  "name",
-  "netuid",
-  "provider",
-] as const;
-
 export const ListSubnetSurfacesInputSchema = z
   .object({
     netuid: netuidSchema(),
@@ -155,7 +140,7 @@ export const ListSubnetSurfacesInputSchema = z
         "The record's stable identifier, as returned by the corresponding list tool. Exact match; an unknown id yields an empty result rather than an error.",
       )
       .meta({ examples: ["sn-64-chutes-subnet-api"] }),
-    sort: sortSchema(SURFACE_SORT_FIELDS).optional(),
+    sort: sortSchema(SURFACE_SORT_VALUES).optional(),
     order: orderSchema().optional(),
     limit: limitSchema(100).optional(),
     cursor: numericCursorSchema().optional(),
@@ -178,33 +163,6 @@ export type ListSubnetSurfacesOutput = z.infer<
   typeof ListSubnetSurfacesOutputSchema
 >;
 
-const HEALTH_CLASSIFICATIONS = [
-  "auth-required",
-  "content-mismatch",
-  "dead",
-  "live",
-  "rate-limited",
-  "redirected",
-  "timeout",
-  "transient",
-  "unsupported",
-  "unsafe",
-  "wrong-chain",
-] as const;
-const HEALTH_SORT_FIELDS = [
-  "classification",
-  "kind",
-  "last_checked",
-  "last_ok",
-  "latency_ms",
-  "netuid",
-  "provider",
-  "status",
-  "status_code",
-  "surface_id",
-  "verified_at",
-] as const;
-
 export const ListSubnetHealthInputSchema = z
   .object({
     netuid: netuidSchema(),
@@ -212,13 +170,13 @@ export const ListSubnetHealthInputSchema = z
     provider: providerSlugSchema().optional(),
     status: kindSchema(HEALTH_STATUSES).optional(),
     classification: z
-      .enum(HEALTH_CLASSIFICATIONS)
+      .enum(HEALTH_CLASSIFICATION_VALUES)
       .optional()
       .describe(
         "Why a probe ended as it did — the reason behind the status, not the status itself.",
       )
-      .meta({ examples: [HEALTH_CLASSIFICATIONS[0]] }),
-    sort: sortSchema(HEALTH_SORT_FIELDS).optional(),
+      .meta({ examples: [HEALTH_CLASSIFICATION_VALUES[0]] }),
+    sort: sortSchema(HEALTH_SURFACE_SORT_VALUES).optional(),
     order: orderSchema().optional(),
     limit: limitSchema(100).optional(),
     cursor: numericCursorSchema().optional(),

--- a/schemas-src/mcp-tools/validators.ts
+++ b/schemas-src/mcp-tools/validators.ts
@@ -36,6 +36,11 @@ import { ValidatorHistoryArtifactSchema } from "../routes/validator-history.ts";
 import { ValidatorNominatorsArtifactSchema } from "../routes/validator-nominators.ts";
 import { NeuronSchema } from "../routes/subnet-metagraph.ts";
 import { CompareValidatorEntrySchema } from "../routes/compare-validators.ts";
+import { GLOBAL_VALIDATORS_VALIDATOR_SORTS_VALUES } from "../routes/global-validators.ts";
+import {
+  VALIDATOR_NOMINATORS_NOMINATOR_SORTS_VALUES,
+  VALIDATOR_NOMINATORS_WINDOW_VALUES,
+} from "../routes/validator-nominators.ts";
 
 // Mirrors workers/config.ts's SS58_ADDRESS_PATTERN (inlined rather than
 // cross-imported from workers/, matching this directory's existing
@@ -101,21 +106,11 @@ export type ListSubnetValidatorsOutput = z.infer<
 >;
 
 // Symbolic in the hand-written original (src/metagraph-neurons.ts's
-// GLOBAL_VALIDATOR_SORTS/DEFAULT_GLOBAL_VALIDATOR_SORT/*_LIMIT_*), cross-
+// GLOBAL_VALIDATORS_VALIDATOR_SORTS_VALUES/DEFAULT_GLOBAL_VALIDATOR_SORT/*_LIMIT_*), cross-
 // checked against the actual runtime source at the time of writing.
-const GLOBAL_VALIDATOR_SORTS = [
-  "avg_validator_trust",
-  "max_validator_trust",
-  "stake_dominance",
-  "subnet_count",
-  "total_emission",
-  "total_stake",
-  "uid_count",
-] as const;
-
 export const ListGlobalValidatorsInputSchema = z
   .object({
-    sort: sortSchema(GLOBAL_VALIDATOR_SORTS).optional(),
+    sort: sortSchema(GLOBAL_VALIDATORS_VALIDATOR_SORTS_VALUES).optional(),
     // Was a hardcoded 100 while this tool's own description — interpolated from
     // GLOBAL_VALIDATOR_LIMIT_MAX — said "max 2000", and the handler clamped to 2000.
     // The tool advertised 2000 in prose, 100 in schema, and served 2000. Now the
@@ -192,20 +187,13 @@ export type CompareValidatorsOutput = z.infer<
 >;
 
 // Symbolic in the hand-written original (src/validator-nominators.ts's
-// NOMINATOR_WINDOWS/NOMINATOR_SORTS/*_LIMIT_*), cross-checked against the
+// VALIDATOR_NOMINATORS_WINDOW_VALUES/VALIDATOR_NOMINATORS_NOMINATOR_SORTS_VALUES/*_LIMIT_*), cross-checked against the
 // actual runtime source at the time of writing.
-const NOMINATOR_WINDOWS = ["7d", "30d", "90d"] as const;
-const NOMINATOR_SORTS = [
-  "net_staked",
-  "gross_staked",
-  "last_activity",
-] as const;
-
 export const GetValidatorNominatorsInputSchema = z
   .object({
     hotkey: accountKeySchema("hotkey"),
-    window: windowSchema(NOMINATOR_WINDOWS).optional(),
-    sort: sortSchema(NOMINATOR_SORTS).optional(),
+    window: windowSchema(VALIDATOR_NOMINATORS_WINDOW_VALUES).optional(),
+    sort: sortSchema(VALIDATOR_NOMINATORS_NOMINATOR_SORTS_VALUES).optional(),
     limit: limitSchema(100).optional(),
     offset: offsetSchema().optional(),
     coldkey: accountKeySchema("coldkey").optional(),

--- a/schemas-src/routes/account-activity-registrations.ts
+++ b/schemas-src/routes/account-activity-registrations.ts
@@ -15,7 +15,7 @@ import {
   EventStreamDegradedSchema,
 } from "./event-stream-honesty.ts";
 
-const WINDOW_ENUM_90D = ["7d", "30d", "90d"] as const;
+export const WINDOW_ENUM_90D = ["7d", "30d", "90d"] as const;
 const WINDOW_ENUM_7_30D = ["7d", "30d"] as const;
 
 export const AccountAxonRemovalsArtifactSchema = z

--- a/schemas-src/routes/account-activity.ts
+++ b/schemas-src/routes/account-activity.ts
@@ -20,7 +20,14 @@ import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
 import { EventStreamDegradedSchema } from "./event-stream-honesty.ts";
 
-const WINDOW_ENUM = ["7d", "30d", "90d"] as const;
+/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
+export const ACCOUNT_ACTIVITY_FLOW_DIRECTIONS_VALUES = [
+  "all",
+  "in",
+  "out",
+] as const;
+
+export const WINDOW_ENUM = ["7d", "30d", "90d"] as const;
 
 export const AccountServingArtifactSchema = z
   .object({
@@ -176,7 +183,7 @@ export const AccountStakeFlowResponseSchema = successEnvelopeSchema(
 export const AccountStakeFlowQuerySchema = z
   .object({
     window: z.enum(WINDOW_ENUM).optional(),
-    direction: z.enum(["all", "in", "out"]).optional(),
+    direction: z.enum(ACCOUNT_ACTIVITY_FLOW_DIRECTIONS_VALUES).optional(),
   })
   .strict();
 export type AccountStakeFlowQuery = z.infer<typeof AccountStakeFlowQuerySchema>;

--- a/schemas-src/routes/accounts-list.ts
+++ b/schemas-src/routes/accounts-list.ts
@@ -27,6 +27,17 @@
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
 
+/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
+export const ACCOUNTS_LIST_LIST_SORTS_VALUES = [
+  "total_stake",
+  "total_emission",
+  "subnet_count",
+  "uid_count",
+  "validator_count",
+  "stake_dominance",
+  "last_active",
+] as const;
+
 const AccountsListSubnetSchema = z
   .object({
     netuid: z.int().min(0),
@@ -77,15 +88,7 @@ const AccountsListEntrySchema = z
 export const AccountsListArtifactSchema = z
   .object({
     schema_version: z.int(),
-    sort: z.enum([
-      "total_stake",
-      "total_emission",
-      "subnet_count",
-      "uid_count",
-      "validator_count",
-      "stake_dominance",
-      "last_active",
-    ]),
+    sort: z.enum(ACCOUNTS_LIST_LIST_SORTS_VALUES),
     limit: z.int().min(1).max(100),
     captured_at: z.string().nullable().optional(),
     block_number: z.int().nullable().optional(),

--- a/schemas-src/routes/candidates-evidence.ts
+++ b/schemas-src/routes/candidates-evidence.ts
@@ -24,6 +24,7 @@
 import { z } from "zod";
 import { ArtifactBaseSchema } from "../envelope.ts";
 import { CandidateSurfaceSchema, SourceTierSchema } from "./subnet-detail.ts";
+import { CONFIDENCE_LEVEL_VALUES } from "../shared.ts";
 
 // ---- GET /api/v1/candidates -> CandidatesArtifact ----
 
@@ -61,7 +62,7 @@ export const EvidenceClaimSchema = z
     source_url: z.string(),
     source_type: z.string(),
     source_tier: SourceTierSchema,
-    confidence: z.enum(["low", "medium", "high"]),
+    confidence: z.enum(CONFIDENCE_LEVEL_VALUES),
     support_summary: z.string(),
     limits: z.string(),
     verified_at: z.string().nullable().optional(),

--- a/schemas-src/routes/chain-concentration-subnets.ts
+++ b/schemas-src/routes/chain-concentration-subnets.ts
@@ -10,7 +10,7 @@
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
 
-const CONCENTRATION_LENSES = [
+export const CONCENTRATION_LENSES = [
   "emission",
   "stake",
   "entity_emission",
@@ -18,7 +18,7 @@ const CONCENTRATION_LENSES = [
   "validator_stake",
 ] as const;
 
-const CONCENTRATION_RANKING_SORTS = [
+export const CONCENTRATION_RANKING_SORTS = [
   "nakamoto_coefficient",
   "gini",
   "holders",

--- a/schemas-src/routes/chain-turnover.ts
+++ b/schemas-src/routes/chain-turnover.ts
@@ -5,6 +5,9 @@
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
 
+/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
+export const CHAIN_TURNOVER_WINDOW_VALUES = ["7d", "30d", "90d"] as const;
+
 const StabilityDistributionSchema = z
   .object({
     count: z.int().min(0),
@@ -21,7 +24,7 @@ const StabilityDistributionSchema = z
 export const ChainTurnoverArtifactSchema = z
   .object({
     schema_version: z.int(),
-    window: z.enum(["7d", "30d", "90d"]).nullable(),
+    window: z.enum(CHAIN_TURNOVER_WINDOW_VALUES).nullable(),
     start_date: z
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}$/)

--- a/schemas-src/routes/coverage.ts
+++ b/schemas-src/routes/coverage.ts
@@ -99,7 +99,7 @@ export const CoverageResponseSchema = successEnvelopeSchema(
 // #8074) -- symbolic in the hand-written original (mcp-server.ts's own
 // COVERAGE_DEPTH_TIERS/COVERAGE_DEPTH_SEVERITIES constants), cross-checked
 // against the actual runtime source at the time of writing.
-const COVERAGE_DEPTH_TIERS = [
+export const COVERAGE_DEPTH_TIERS = [
   "agent-ready",
   "machine-usable",
   "candidate-review",
@@ -107,12 +107,12 @@ const COVERAGE_DEPTH_TIERS = [
   "hard-blocked",
   "missing-interface",
 ] as const;
-const COVERAGE_DEPTH_SEVERITIES = [
+export const COVERAGE_DEPTH_SEVERITIES = [
   "hard",
   "missing-data",
   "needs-review",
 ] as const;
-const AGENT_READINESS_STATUSES = [
+export const AGENT_READINESS_STATUSES = [
   "callable",
   "base-layer",
   "candidate",

--- a/schemas-src/routes/curation-gaps.ts
+++ b/schemas-src/routes/curation-gaps.ts
@@ -11,11 +11,12 @@ import { z } from "zod";
 import { ArtifactBaseSchema, successEnvelopeSchema } from "../envelope.ts";
 import { COVERAGE_LEVEL_VALUES, CurationLevelSchema } from "../shared.ts";
 import { CurationMetadataSchema, GapsSchema } from "./subnet-detail.ts";
+import { ENDPOINT_INCIDENT_SEVERITY_VALUES } from "./endpoints-pools.ts";
 
 const COVERAGE_LEVELS = COVERAGE_LEVEL_VALUES;
 export const CoverageLevelSchema = z.enum(COVERAGE_LEVELS);
 
-const CURATION_SORT_FIELDS = [
+export const CURATION_SORT_FIELDS = [
   "coverage_level",
   "curation_level",
   "name",
@@ -61,7 +62,7 @@ export const CurationResponseSchema = successEnvelopeSchema(
   CurationArtifactSchema,
 );
 
-const GAPS_SORT_FIELDS = [
+export const GAPS_SORT_FIELDS = [
   "coverage_level",
   "curation_level",
   "gap_count",
@@ -95,7 +96,7 @@ export const GapsEntrySchema = z
     // a required field would reject a body that is otherwise exactly correct.
     gap_count: z.int().min(0).optional(),
     gaps: GapsSchema,
-    gap_severity: z.enum(["critical", "warning", "info"]).optional(),
+    gap_severity: z.enum(ENDPOINT_INCIDENT_SEVERITY_VALUES).optional(),
     gap_priority: z.int().min(0).optional(),
   })
   .strict();

--- a/schemas-src/routes/economics-trends.ts
+++ b/schemas-src/routes/economics-trends.ts
@@ -6,6 +6,15 @@
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
 
+/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
+export const ECONOMICS_TRENDS_WINDOW_VALUES = [
+  "7d",
+  "30d",
+  "90d",
+  "1y",
+  "all",
+] as const;
+
 const RaoPrecisionTaoStringSchema = z.string().regex(/^\d+\.\d{9}$/);
 
 const EconomicsTrendsDaySchema = z
@@ -38,7 +47,7 @@ export const EconomicsTrendsResponseSchema = successEnvelopeSchema(
 
 export const EconomicsTrendsQuerySchema = z
   .object({
-    window: z.enum(["7d", "30d", "90d", "1y", "all"]).optional(),
+    window: z.enum(ECONOMICS_TRENDS_WINDOW_VALUES).optional(),
   })
   .strict();
 export type EconomicsTrendsQuery = z.infer<typeof EconomicsTrendsQuerySchema>;

--- a/schemas-src/routes/endpoints-pools.ts
+++ b/schemas-src/routes/endpoints-pools.ts
@@ -53,6 +53,13 @@ import {
   RpcPoolSchema,
 } from "./providers-rpc.ts";
 
+/** This route's own vocabulary, owned here so its MCP tools import rather than restate it (#9799). */
+export const ENDPOINT_INCIDENT_SEVERITY_VALUES = [
+  "critical",
+  "warning",
+  "info",
+] as const;
+
 // ---- GET /api/v1/surfaces -> SurfacesArtifact ----
 
 export const SurfacesArtifactSchema = ArtifactBaseSchema.extend({
@@ -134,7 +141,7 @@ export const EndpointIncidentSchema = z
     // declared-but-currently-unproducible enum value, kept for contract
     // stability (matches QUERY_ENUMS.endpointIncidentSeverity, the same list
     // validate-schema-enums.ts checks this field against).
-    severity: z.enum(["critical", "warning", "info"]),
+    severity: z.enum(ENDPOINT_INCIDENT_SEVERITY_VALUES),
     // Always "active" in real output -- "resolved" is declared-but-
     // currently-unproducible (the builder hardcodes state: "active"), kept
     // for the same contract-stability/enum-drift-check reason as severity.

--- a/schemas-src/routes/evidence-search.ts
+++ b/schemas-src/routes/evidence-search.ts
@@ -24,6 +24,13 @@ import { HealthStatusSchema } from "../shared.ts";
 import { AuthoritySchema } from "./subnet-detail.ts";
 import { ProviderKindSchema } from "./providers-rpc.ts";
 
+/** This route's own vocabulary, owned here so its MCP tools import rather than restate it (#9799). */
+export const SEARCH_DOCUMENT_TYPE_VALUES = [
+  "subnet",
+  "surface",
+  "provider",
+] as const;
+
 const CountMapSchema = z.record(z.string(), z.int().min(0));
 
 const FreshnessSourceSchema = z
@@ -156,7 +163,7 @@ export type SourceSnapshotsArtifact = z.infer<
 const SearchDocumentSchema = z
   .object({
     id: z.string(),
-    type: z.enum(["subnet", "surface", "provider"]),
+    type: z.enum(SEARCH_DOCUMENT_TYPE_VALUES),
     netuid: z.int().min(0).optional(),
     slug: z.string().optional(),
     title: z.string(),

--- a/schemas-src/routes/global-validators.ts
+++ b/schemas-src/routes/global-validators.ts
@@ -14,6 +14,17 @@
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
 
+/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
+export const GLOBAL_VALIDATORS_VALIDATOR_SORTS_VALUES = [
+  "avg_validator_trust",
+  "max_validator_trust",
+  "stake_dominance",
+  "subnet_count",
+  "total_emission",
+  "total_stake",
+  "uid_count",
+] as const;
+
 export const ColdkeyIdentitySchema = z
   .object({
     has_identity: z.boolean(),
@@ -91,15 +102,7 @@ export const GlobalValidatorEntrySchema = z
 export const GlobalValidatorsArtifactSchema = z
   .object({
     schema_version: z.int(),
-    sort: z.enum([
-      "avg_validator_trust",
-      "max_validator_trust",
-      "stake_dominance",
-      "subnet_count",
-      "total_emission",
-      "total_stake",
-      "uid_count",
-    ]),
+    sort: z.enum(GLOBAL_VALIDATORS_VALIDATOR_SORTS_VALUES),
     // #8251: 2000 cap (was 100) so the directory page can fetch the full
     // validator set in one request -- mirrors GLOBAL_VALIDATOR_LIMIT_MAX in
     // src/metagraph-neurons.ts.

--- a/schemas-src/routes/registry-summary-leaderboards.ts
+++ b/schemas-src/routes/registry-summary-leaderboards.ts
@@ -79,7 +79,7 @@ export const RegistrySummaryResponseSchema = successEnvelopeSchema(
   RegistrySummaryArtifactSchema,
 );
 
-const ECONOMIC_LEADERBOARD_BOARDS = [
+export const ECONOMIC_LEADERBOARD_BOARDS = [
   "open-slots",
   "cheapest-registration",
   "highest-emission",

--- a/schemas-src/routes/review-enrichment.ts
+++ b/schemas-src/routes/review-enrichment.ts
@@ -23,17 +23,10 @@ import {
   SURFACE_KIND_VALUES,
   SurfaceKindSchema,
 } from "./subnet-detail.ts";
+import { IDENTITY_LEVEL_VALUES, PROFILE_LEVEL_VALUES } from "../shared.ts";
 
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
 const CURATION_LEVELS = CURATION_LEVEL_VALUES;
-const PROFILE_LEVELS = [
-  "directory-only",
-  "identity-partial",
-  "identity-complete",
-  "operational",
-  "adapter-backed",
-] as const;
-const IDENTITY_LEVELS = ["none", "directory", "partial", "complete"] as const;
 const BOOLEAN_STRINGS = ["true", "false"] as const;
 
 /** The vocabulary, exported as a tuple so every other schema that needs
@@ -130,7 +123,7 @@ export const ReviewEnrichmentTargetQueueContextSchema = z
     endpoint_count: z.int().min(0),
     identity_surface_count: z.int().min(0).max(3),
     operational_interface_count: z.int().min(0),
-    profile_level: z.enum(PROFILE_LEVELS),
+    profile_level: z.enum(PROFILE_LEVEL_VALUES),
     review_state: ReviewStateSchema,
     source_url_count: z.int().min(0),
     stale_candidate_count: z.int().min(0),
@@ -139,7 +132,7 @@ export const ReviewEnrichmentTargetQueueContextSchema = z
   })
   .strict();
 
-const QUEUE_SORT_FIELDS = [
+export const QUEUE_SORT_FIELDS = [
   "adapter_score",
   "candidate_count",
   "completeness_score",
@@ -166,9 +159,9 @@ export const EnrichmentQueueQuerySchema = z
     netuid: z.int().min(0).optional(),
     lane: ReviewEnrichmentLaneSchema.optional(),
     evidence_action: ReviewEvidenceActionSchema.optional(),
-    identity_level: z.enum(IDENTITY_LEVELS).optional(),
+    identity_level: z.enum(IDENTITY_LEVEL_VALUES).optional(),
     curation_level: z.enum(CURATION_LEVELS).optional(),
-    profile_level: z.enum(PROFILE_LEVELS).optional(),
+    profile_level: z.enum(PROFILE_LEVEL_VALUES).optional(),
     direct_submission_kinds: z.enum(SURFACE_KINDS).optional(),
     missing_kinds: z.enum(SURFACE_KINDS).optional(),
     manual_review_required: z.enum(BOOLEAN_STRINGS).optional(),
@@ -194,7 +187,7 @@ export const ReviewEnrichmentQueueEntrySchema = z
     direct_submission_kinds: z.array(SurfaceKindSchema),
     endpoint_count: z.int().min(0),
     evidence_action: ReviewEvidenceActionSchema,
-    identity_level: z.enum(IDENTITY_LEVELS),
+    identity_level: z.enum(IDENTITY_LEVEL_VALUES),
     identity_surface_count: z.int().min(0).max(3),
     lane: ReviewEnrichmentLaneSchema,
     manual_review_required: z.boolean(),
@@ -204,7 +197,7 @@ export const ReviewEnrichmentQueueEntrySchema = z
     netuid: z.int().min(0),
     operational_interface_count: z.int().min(0),
     priority_score: z.int().min(0),
-    profile_level: z.enum(PROFILE_LEVELS),
+    profile_level: z.enum(PROFILE_LEVEL_VALUES),
     reason_codes: z.array(z.string()),
     recommended_action: z.string(),
     review_state: ReviewStateSchema,
@@ -247,7 +240,7 @@ export const ReviewEnrichmentQueueResponseSchema = successEnvelopeSchema(
   ReviewEnrichmentQueueArtifactSchema,
 );
 
-const EVIDENCE_SORT_FIELDS = [
+export const EVIDENCE_SORT_FIELDS = [
   "evidence_action",
   "lane",
   "name",
@@ -314,7 +307,7 @@ export const ReviewEnrichmentEvidenceResponseSchema = successEnvelopeSchema(
   ReviewEnrichmentEvidenceArtifactSchema,
 );
 
-const TARGET_SORT_FIELDS = [
+export const TARGET_SORT_FIELDS = [
   "auto_review_candidate",
   "evidence_action",
   "identity_level",
@@ -339,8 +332,8 @@ export const EnrichmentTargetsQuerySchema = z
     kind: z.enum(SURFACE_KINDS).optional(),
     lane: ReviewEnrichmentLaneSchema.optional(),
     evidence_action: ReviewEvidenceActionSchema.optional(),
-    identity_level: z.enum(IDENTITY_LEVELS).optional(),
-    profile_level: z.enum(PROFILE_LEVELS).optional(),
+    identity_level: z.enum(IDENTITY_LEVEL_VALUES).optional(),
+    profile_level: z.enum(PROFILE_LEVEL_VALUES).optional(),
     submission_route: ReviewEnrichmentSubmissionRouteSchema.optional(),
     auto_review_candidate: z.enum(BOOLEAN_STRINGS).optional(),
     manual_review_required: z.enum(BOOLEAN_STRINGS).optional(),
@@ -364,7 +357,7 @@ export const ReviewEnrichmentTargetSchema = z
     candidate_evidence: ReviewCandidateEvidenceSchema.nullable(),
     contribution_prompt: z.string(),
     evidence_action: ReviewEvidenceActionSchema,
-    identity_level: z.enum(IDENTITY_LEVELS),
+    identity_level: z.enum(IDENTITY_LEVEL_VALUES),
     kind: SurfaceKindSchema.nullable(),
     lane: ReviewEnrichmentLaneSchema,
     manual_review_required: z.boolean(),
@@ -372,7 +365,7 @@ export const ReviewEnrichmentTargetSchema = z
     name: z.string(),
     netuid: z.int().min(0),
     priority_score: z.int().min(0),
-    profile_level: z.enum(PROFILE_LEVELS),
+    profile_level: z.enum(PROFILE_LEVEL_VALUES),
     queue_context: ReviewEnrichmentTargetQueueContextSchema,
     reason_codes: z.array(z.string()),
     recommended_action: z.string(),
@@ -427,13 +420,13 @@ export const ReviewEnrichmentTargetsResponseSchema = successEnvelopeSchema(
   ReviewEnrichmentTargetsArtifactSchema,
 );
 
-const RECOMMENDED_ADAPTER_KINDS = [
+export const RECOMMENDED_ADAPTER_KINDS = [
   "custom-adapter",
   "data-artifact-adapter",
   "generic-openapi-or-custom",
   "stream-adapter",
 ] as const;
-const ADAPTER_CANDIDATES_SORT_FIELDS = [
+export const ADAPTER_CANDIDATES_SORT_FIELDS = [
   "candidate_api_count",
   "candidate_api_kinds",
   "curation_level",

--- a/schemas-src/routes/review-gaps-profile.ts
+++ b/schemas-src/routes/review-gaps-profile.ts
@@ -23,10 +23,16 @@ import {
 } from "./subnet-detail.ts";
 import { SubnetProfileIdentityEvidenceSchema } from "./subnet-profile.ts";
 import { ReviewEnrichmentQueueEntrySchema } from "./review-enrichment.ts";
+import {
+  CONFIDENCE_LEVEL_VALUES,
+  IDENTITY_LEVEL_VALUES,
+  NATIVE_NAME_QUALITY_VALUES,
+  PROFILE_LEVEL_VALUES,
+} from "../shared.ts";
 
 const CURATION_LEVELS = CURATION_LEVEL_VALUES;
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
-const PRIORITY_SORT_FIELDS = [
+export const PRIORITY_SORT_FIELDS = [
   "candidate_count",
   "curation_level",
   "missing_kinds",
@@ -90,17 +96,7 @@ export const SubnetGapsResponseSchema = successEnvelopeSchema(
   SubnetGapsArtifactSchema,
 );
 
-const PROFILE_LEVELS = [
-  "directory-only",
-  "identity-partial",
-  "identity-complete",
-  "operational",
-  "adapter-backed",
-] as const;
-const CONFIDENCE_LEVELS = ["low", "medium", "high"] as const;
-const IDENTITY_LEVELS = ["none", "directory", "partial", "complete"] as const;
-const NATIVE_NAME_QUALITIES = ["chain", "placeholder", "empty"] as const;
-const PROFILE_SORT_FIELDS = [
+export const PROFILE_SORT_FIELDS = [
   "candidate_count",
   "completeness_score",
   "identity_level",
@@ -120,11 +116,11 @@ const PROFILE_SORT_FIELDS = [
 export const ReviewProfileCompletenessQuerySchema = z
   .object({
     netuid: z.int().min(0).optional(),
-    profile_level: z.enum(PROFILE_LEVELS).optional(),
-    confidence: z.enum(CONFIDENCE_LEVELS).optional(),
-    identity_level: z.enum(IDENTITY_LEVELS).optional(),
+    profile_level: z.enum(PROFILE_LEVEL_VALUES).optional(),
+    confidence: z.enum(CONFIDENCE_LEVEL_VALUES).optional(),
+    identity_level: z.enum(IDENTITY_LEVEL_VALUES).optional(),
     identity_promotion_kinds: z.enum(SURFACE_KINDS).optional(),
-    native_name_quality: z.enum(NATIVE_NAME_QUALITIES).optional(),
+    native_name_quality: z.enum(NATIVE_NAME_QUALITY_VALUES).optional(),
     sort: z.enum(PROFILE_SORT_FIELDS).optional(),
     order: z.enum(["asc", "desc"]).optional(),
     fields: z.string().optional(),
@@ -140,10 +136,10 @@ export const ReviewProfileCompletenessEntrySchema = z
   .object({
     candidate_count: z.int().min(0),
     completeness_score: z.int().min(0).max(100),
-    confidence: z.enum(CONFIDENCE_LEVELS),
+    confidence: z.enum(CONFIDENCE_LEVEL_VALUES),
     curation_level: CurationLevelSchema,
     gap_reasons: z.array(z.string()),
-    identity_level: z.enum(IDENTITY_LEVELS),
+    identity_level: z.enum(IDENTITY_LEVEL_VALUES),
     identity_evidence: SubnetProfileIdentityEvidenceSchema,
     identity_promotion_kind_count: z.int().min(0),
     identity_promotion_kinds: z.array(SurfaceKindSchema),
@@ -154,12 +150,12 @@ export const ReviewProfileCompletenessEntrySchema = z
     missing_operational: z.array(SurfaceKindSchema),
     missing_required: z.array(SurfaceKindSchema),
     name: z.string(),
-    native_name_quality: z.enum(NATIVE_NAME_QUALITIES),
+    native_name_quality: z.enum(NATIVE_NAME_QUALITY_VALUES),
     native_identity_signal_count: z.int().min(0),
     netuid: z.int().min(0),
     operational_interface_count: z.int().min(0),
     priority_score: z.int().min(0),
-    profile_level: z.enum(PROFILE_LEVELS),
+    profile_level: z.enum(PROFILE_LEVEL_VALUES),
     review_state: ReviewStateSchema,
     slug: z.string(),
     source_count: z.int().min(0),

--- a/schemas-src/routes/subnet-concentration.ts
+++ b/schemas-src/routes/subnet-concentration.ts
@@ -13,6 +13,9 @@
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
 
+/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
+export const SUBNET_CONCENTRATION_WINDOW_VALUES = ["7d", "30d", "90d"] as const;
+
 const ConcentrationLensSchema = z
   .object({
     holders: z.int().min(0).optional(),
@@ -86,7 +89,7 @@ export const SubnetConcentrationHistoryResponseSchema = successEnvelopeSchema(
 );
 export const SubnetConcentrationHistoryQuerySchema = z
   .object({
-    window: z.enum(["7d", "30d", "90d"]).optional(),
+    window: z.enum(SUBNET_CONCENTRATION_WINDOW_VALUES).optional(),
   })
   .strict();
 export type SubnetConcentrationHistoryQuery = z.infer<

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -26,6 +26,10 @@ import {
   SubnetStatusSchema,
   SubnetTypeSchema,
 } from "../shared.ts";
+import {
+  CONFIDENCE_LEVEL_VALUES,
+  NATIVE_NAME_QUALITY_VALUES,
+} from "../shared.ts";
 
 const HttpUrlSchema = z.string().regex(/^[Hh][Tt][Tt][Pp][Ss]?:\/\//);
 const HttpOrWssUrlSchema = z
@@ -192,7 +196,7 @@ export const CandidateSurfaceSchema = z
   .object({
     auth: AuthSchema,
     auth_required: z.boolean(),
-    confidence: z.enum(["low", "medium", "high"]).optional(),
+    confidence: z.enum(CONFIDENCE_LEVEL_VALUES).optional(),
     confirmed_by: z.array(z.string()).optional(),
     id: z.string(),
     kind: SurfaceKindSchema,
@@ -441,7 +445,7 @@ export const SubnetDetailSchema = z
     mechanism_count: z.int().min(0).optional(),
     name: z.string(),
     native_name: z.string().nullable().optional(),
-    native_name_quality: z.enum(["chain", "placeholder", "empty"]).optional(),
+    native_name_quality: z.enum(NATIVE_NAME_QUALITY_VALUES).optional(),
     native_slug: z.string().nullable().optional(),
     netuid: z.int().min(0),
     notes: z.string().nullable().optional(),
@@ -529,7 +533,7 @@ export const SurfaceSchema = z
     rate_limit_notes: z.string().optional(),
     review: z
       .object({
-        confidence: z.enum(["low", "medium", "high"]).optional(),
+        confidence: z.enum(CONFIDENCE_LEVEL_VALUES).optional(),
         review_notes: z.string().optional(),
         state: z.enum([
           "community-submitted",

--- a/schemas-src/routes/subnet-event-summary.ts
+++ b/schemas-src/routes/subnet-event-summary.ts
@@ -10,6 +10,9 @@ import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
 import { AccountEventSchema } from "./subnet-events.ts";
 
+/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
+export const SUBNET_EVENT_SUMMARY_WINDOW_VALUES = ["7d", "30d", "90d"] as const;
+
 const EVENT_CATEGORIES = [
   "registration",
   "stake",
@@ -62,7 +65,7 @@ export const SubnetEventSummaryArtifactSchema = z
   .object({
     schema_version: z.int(),
     netuid: z.int(),
-    window: z.enum(["7d", "30d", "90d"]),
+    window: z.enum(SUBNET_EVENT_SUMMARY_WINDOW_VALUES),
     observed_at: z.iso.datetime().nullable(),
     total_events: z.int().min(0),
     kind_count: z.int().min(0),

--- a/schemas-src/routes/subnet-history.ts
+++ b/schemas-src/routes/subnet-history.ts
@@ -10,6 +10,15 @@
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
 
+/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
+export const SUBNET_HISTORY_WINDOW_VALUES = [
+  "7d",
+  "30d",
+  "90d",
+  "1y",
+  "all",
+] as const;
+
 const SubnetHistoryPointSchema = z
   .object({
     snapshot_date: z.string(),
@@ -36,7 +45,7 @@ export const SubnetHistoryResponseSchema = successEnvelopeSchema(
 
 export const SubnetHistoryQuerySchema = z
   .object({
-    window: z.enum(["7d", "30d", "90d", "1y", "all"]).optional(),
+    window: z.enum(SUBNET_HISTORY_WINDOW_VALUES).optional(),
   })
   .strict();
 export type SubnetHistoryQuery = z.infer<typeof SubnetHistoryQuerySchema>;

--- a/schemas-src/routes/subnet-movers.ts
+++ b/schemas-src/routes/subnet-movers.ts
@@ -5,6 +5,17 @@
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
 
+/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
+export const SUBNET_MOVERS_MOVERS_SORTS_VALUES = [
+  "stake",
+  "emission",
+  "validators",
+  "neurons",
+] as const;
+
+/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
+export const SUBNET_MOVERS_WINDOW_VALUES = ["7d", "30d", "90d"] as const;
+
 // Cumulative totals are never negative; a boundary delta genuinely can be
 // (network stake/emission can net-decrease over a window) -- two separate
 // patterns, matching the hand-written original exactly rather than loosening
@@ -54,7 +65,7 @@ const MoverEntrySchema = z
 export const SubnetMoversArtifactSchema = z
   .object({
     schema_version: z.int(),
-    window: z.enum(["7d", "30d", "90d"]).nullable(),
+    window: z.enum(SUBNET_MOVERS_WINDOW_VALUES).nullable(),
     start_date: z
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}$/)
@@ -63,7 +74,7 @@ export const SubnetMoversArtifactSchema = z
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}$/)
       .nullable(),
-    sort: z.enum(["stake", "emission", "validators", "neurons"]),
+    sort: z.enum(SUBNET_MOVERS_MOVERS_SORTS_VALUES),
     subnet_count: z.int().min(0),
     network: MoversNetworkSummarySchema,
     movers: z.array(MoverEntrySchema),

--- a/schemas-src/routes/subnet-performance.ts
+++ b/schemas-src/routes/subnet-performance.ts
@@ -14,6 +14,9 @@ import {
   ScoreDistributionSchema,
 } from "../shared.ts";
 
+/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
+export const SUBNET_PERFORMANCE_WINDOW_VALUES = ["7d", "30d", "90d"] as const;
+
 export const SubnetPerformanceArtifactSchema = z
   .object({
     schema_version: z.int(),
@@ -78,7 +81,7 @@ export const SubnetPerformanceHistoryResponseSchema = successEnvelopeSchema(
 );
 export const SubnetPerformanceHistoryQuerySchema = z
   .object({
-    window: z.enum(["7d", "30d", "90d"]).optional(),
+    window: z.enum(SUBNET_PERFORMANCE_WINDOW_VALUES).optional(),
     format: z.enum(["json", "csv"]).optional(),
   })
   .strict();

--- a/schemas-src/routes/subnet-profile.ts
+++ b/schemas-src/routes/subnet-profile.ts
@@ -18,6 +18,12 @@ import {
   SubnetTypeSchema,
 } from "../shared.ts";
 import { ReviewStateSchema, SurfaceKindSchema } from "./subnet-detail.ts";
+import {
+  CONFIDENCE_LEVEL_VALUES,
+  IDENTITY_LEVEL_VALUES,
+  NATIVE_NAME_QUALITY_VALUES,
+  PROFILE_LEVEL_VALUES,
+} from "../shared.ts";
 
 export const SubnetProfileNativeIdentitySchema = z
   .object({
@@ -84,23 +90,13 @@ export type SubnetProfileIdentityEvidence = z.infer<
   typeof SubnetProfileIdentityEvidenceSchema
 >;
 
-const PROFILE_CONFIDENCE = ["low", "medium", "high"] as const;
-const PROFILE_LEVEL = [
-  "directory-only",
-  "identity-partial",
-  "identity-complete",
-  "operational",
-  "adapter-backed",
-] as const;
-const IDENTITY_LEVEL = ["none", "directory", "partial", "complete"] as const;
-
 export const SubnetProfileCompletenessSchema = z
   .object({
     score: z.int().min(0).max(100),
-    profile_level: z.enum(PROFILE_LEVEL),
-    identity_level: z.enum(IDENTITY_LEVEL),
+    profile_level: z.enum(PROFILE_LEVEL_VALUES),
+    identity_level: z.enum(IDENTITY_LEVEL_VALUES),
     identity_surface_count: z.int().min(0).max(3),
-    confidence: z.enum(PROFILE_CONFIDENCE),
+    confidence: z.enum(CONFIDENCE_LEVEL_VALUES),
     missing_identity: z.array(SurfaceKindSchema),
     missing_required: z.array(SurfaceKindSchema),
     missing_operational: z.array(SurfaceKindSchema),
@@ -156,15 +152,13 @@ export const IntegrationReadinessSchema = z
   .strict();
 export type IntegrationReadiness = z.infer<typeof IntegrationReadinessSchema>;
 
-const NATIVE_NAME_QUALITY = ["chain", "placeholder", "empty"] as const;
-
 export const SubnetProfileSchema = z
   .object({
     netuid: z.int().min(0),
     slug: z.string(),
     name: z.string(),
     native_name: z.string().nullable().optional(),
-    native_name_quality: z.enum(NATIVE_NAME_QUALITY).optional(),
+    native_name_quality: z.enum(NATIVE_NAME_QUALITY_VALUES).optional(),
     native_identity: SubnetProfileNativeIdentitySchema,
     injection_scrubbed: z.boolean().optional(),
     subnet_type: SubnetTypeSchema,
@@ -239,9 +233,9 @@ export const SubnetProfileSchema = z
     provenance: SubnetProfileProvenanceSchema,
     curation_level: CurationLevelSchema,
     review_state: ReviewStateSchema,
-    confidence: z.enum(PROFILE_CONFIDENCE),
-    profile_level: z.enum(PROFILE_LEVEL),
-    identity_level: z.enum(IDENTITY_LEVEL),
+    confidence: z.enum(CONFIDENCE_LEVEL_VALUES),
+    profile_level: z.enum(PROFILE_LEVEL_VALUES),
+    identity_level: z.enum(IDENTITY_LEVEL_VALUES),
     identity_surface_count: z.int().min(0).max(3),
     completeness_score: z.int().min(0).max(100),
     missing_identity: z.array(SurfaceKindSchema),

--- a/schemas-src/routes/subnet-stake-flow.ts
+++ b/schemas-src/routes/subnet-stake-flow.ts
@@ -5,11 +5,21 @@
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
 
+/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
+export const SUBNET_STAKE_FLOW_FLOW_DIRECTIONS_VALUES = [
+  "all",
+  "in",
+  "out",
+] as const;
+
+/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
+export const SUBNET_STAKE_FLOW_WINDOW_VALUES = ["7d", "30d", "90d"] as const;
+
 export const SubnetStakeFlowArtifactSchema = z
   .object({
     schema_version: z.int(),
     netuid: z.int().min(0),
-    window: z.enum(["7d", "30d", "90d"]).nullable(),
+    window: z.enum(SUBNET_STAKE_FLOW_WINDOW_VALUES).nullable(),
     total_staked_tao: z.number(),
     total_unstaked_tao: z.number(),
     net_flow_tao: z.number(),
@@ -27,7 +37,7 @@ export const SubnetStakeFlowResponseSchema = successEnvelopeSchema(
 export const SubnetStakeFlowQuerySchema = z
   .object({
     window: z.enum(["7d", "30d", "90d"]).optional(),
-    direction: z.enum(["all", "in", "out"]).optional(),
+    direction: z.enum(SUBNET_STAKE_FLOW_FLOW_DIRECTIONS_VALUES).optional(),
   })
   .strict();
 export type SubnetStakeFlowQuery = z.infer<typeof SubnetStakeFlowQuerySchema>;

--- a/schemas-src/routes/subnet-turnover.ts
+++ b/schemas-src/routes/subnet-turnover.ts
@@ -5,6 +5,15 @@
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
 
+/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
+export const SUBNET_TURNOVER_WINDOW_VALUES = [
+  "7d",
+  "30d",
+  "90d",
+  "1y",
+  "all",
+] as const;
+
 const ValidatorDetailSchema = z
   .object({
     hotkey: z.string(),
@@ -61,7 +70,7 @@ export const SubnetTurnoverResponseSchema = successEnvelopeSchema(
 
 export const SubnetTurnoverQuerySchema = z
   .object({
-    window: z.enum(["7d", "30d", "90d", "1y", "all"]).optional(),
+    window: z.enum(SUBNET_TURNOVER_WINDOW_VALUES).optional(),
     changes: z.enum(["true"]).optional(),
   })
   .strict();

--- a/schemas-src/routes/subnet-yield.ts
+++ b/schemas-src/routes/subnet-yield.ts
@@ -6,6 +6,9 @@
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
 
+/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
+export const SUBNET_YIELD_WINDOW_VALUES = ["7d", "30d", "90d"] as const;
+
 const SubnetYieldNeuronSchema = z
   .object({
     uid: z.int().min(0),
@@ -89,7 +92,7 @@ export const SubnetYieldHistoryResponseSchema = successEnvelopeSchema(
 );
 export const SubnetYieldHistoryQuerySchema = z
   .object({
-    window: z.enum(["7d", "30d", "90d"]).optional(),
+    window: z.enum(SUBNET_YIELD_WINDOW_VALUES).optional(),
   })
   .strict();
 export type SubnetYieldHistoryQuery = z.infer<

--- a/schemas-src/routes/subnets.ts
+++ b/schemas-src/routes/subnets.ts
@@ -18,6 +18,7 @@ import {
   SubnetStatusSchema,
   SubnetTypeSchema,
 } from "../shared.ts";
+import { NATIVE_NAME_QUALITY_VALUES } from "../shared.ts";
 
 const HttpUrlSchema = z.string().regex(/^[Hh][Tt][Tt][Pp][Ss]?:\/\//);
 
@@ -85,7 +86,7 @@ export const SubnetIndexEntrySchema = z
     mechanism_count: z.int().min(0).optional(),
     name: z.string(),
     native_name: z.string().nullable().optional(),
-    native_name_quality: z.enum(["chain", "placeholder", "empty"]).optional(),
+    native_name_quality: z.enum(NATIVE_NAME_QUALITY_VALUES).optional(),
     native_slug: z.string().nullable().optional(),
     netuid: z.int().min(0),
     official_surface_count: z.int().min(0).optional(),

--- a/schemas-src/routes/top-holders.ts
+++ b/schemas-src/routes/top-holders.ts
@@ -26,7 +26,7 @@
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
 
-const TOP_HOLDERS_SORT_VALUES = [
+export const TOP_HOLDERS_SORT_VALUES = [
   "total_tao",
   "free_tao",
   "delegated_tao",

--- a/schemas-src/routes/validator-nominators.ts
+++ b/schemas-src/routes/validator-nominators.ts
@@ -11,6 +11,16 @@
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
 
+/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
+export const VALIDATOR_NOMINATORS_NOMINATOR_SORTS_VALUES = [
+  "net_staked",
+  "gross_staked",
+  "last_activity",
+] as const;
+
+/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
+export const VALIDATOR_NOMINATORS_WINDOW_VALUES = ["7d", "30d", "90d"] as const;
+
 const ValidatorNominatorEntrySchema = z
   .object({
     coldkey: z.string(),
@@ -28,7 +38,7 @@ export const ValidatorNominatorsArtifactSchema = z
     schema_version: z.int(),
     hotkey: z.string(),
     window: z.string().nullable(),
-    sort: z.enum(["net_staked", "gross_staked", "last_activity"]),
+    sort: z.enum(VALIDATOR_NOMINATORS_NOMINATOR_SORTS_VALUES),
     limit: z.int().min(0).max(100),
     offset: z.int().min(0),
     nominator_count: z
@@ -55,7 +65,7 @@ export const ValidatorNominatorsResponseSchema = successEnvelopeSchema(
 );
 export const ValidatorNominatorsQuerySchema = z
   .object({
-    window: z.enum(["7d", "30d", "90d"]).optional(),
+    window: z.enum(VALIDATOR_NOMINATORS_WINDOW_VALUES).optional(),
     sort: z.enum(["net_staked", "gross_staked", "last_activity"]).optional(),
     limit: z.int().min(1).max(100).optional(),
     offset: z.int().min(0).optional(),

--- a/schemas-src/shared.ts
+++ b/schemas-src/shared.ts
@@ -10,6 +10,37 @@
 // against real handler output — see tests/zod-schemas.test.ts.
 import { z } from "zod";
 
+/** One vocabulary, owned by the leaf module so routes AND tools can import it
+ * without the cycle that owning it on a route would create (#9799). */
+export const NATIVE_NAME_QUALITY_VALUES = [
+  "chain",
+  "placeholder",
+  "empty",
+] as const;
+
+/** One vocabulary, owned by the leaf module so routes AND tools can import it
+ * without the cycle that owning it on a route would create (#9799). */
+export const CONFIDENCE_LEVEL_VALUES = ["low", "medium", "high"] as const;
+
+/** One vocabulary, owned by the leaf module so routes AND tools can import it
+ * without the cycle that owning it on a route would create (#9799). */
+export const IDENTITY_LEVEL_VALUES = [
+  "none",
+  "directory",
+  "partial",
+  "complete",
+] as const;
+
+/** One vocabulary, owned by the leaf module so routes AND tools can import it
+ * without the cycle that owning it on a route would create (#9799). */
+export const PROFILE_LEVEL_VALUES = [
+  "directory-only",
+  "identity-partial",
+  "identity-complete",
+  "operational",
+  "adapter-backed",
+] as const;
+
 /** The vocabulary, exported as a tuple so every other schema that needs
  * these values imports them instead of restating them (#9799). */
 export const COVERAGE_LEVEL_VALUES = [

--- a/scripts/validate-schema-vocabularies.ts
+++ b/scripts/validate-schema-vocabularies.ts
@@ -32,49 +32,23 @@ const SCHEMA_DIRS = [
  * owner has not been extracted yet -- delete the entry when it is, never add
  * one to silence a NEW copy. Keyed by the sorted value set, so a copy that
  * merely reorders the list is the same entry. */
-const NOT_YET_OWNED: string[] = [
+const COINCIDENT_BY_DOMAIN: string[] = [
+  // WINDOW SETS. Each route chooses the windows it serves, and schemas-src
+  // declares six DIFFERENT sets -- 30d|7d, 30d|7d|90d, 1y|30d|7d|90d|all,
+  // 24h|30d|7d|90d, 1h|24h|30d|7d, 1d|1h. Six sets is the proof each route
+  // chose: coupling them would let one domain's change silently alter every
+  // other. Each route now owns its own tuple and its MCP tool imports THAT --
+  // what is left below is two routes happening to offer the same three.
   "1y|30d|7d|90d|all",
   "30d|7d|90d",
+  // Per-domain lifecycle/verdict sets that coincide in value only.
   "active|deprecated|parked|pending",
-  "adapter-backed|directory-only|identity-complete|identity-partial|operational",
-  "adapter_score|candidate_count|completeness_score|curation_level|endpoint_count|evidence_action|identity_level|identity_surface_count|lane|name|netuid|operational_interface_count|priority_score|profile_level|review_state|stale_candidate_count|surface_count|verified_candidate_count",
-  "agent-ready|candidate-review|hard-blocked|machine-usable|missing-interface|needs-evidence",
   "all|in|out",
-  "archive|subtensor-rpc|subtensor-wss",
-  "auth-required|content-mismatch|dead|live|rate-limited|redirected|timeout|transient|unsafe|unsupported|wrong-chain",
-  "auto_review_candidate|evidence_action|identity_level|kind|lane|manual_review_required|name|netuid|priority_score|profile_level|submission_route|target_action|target_type",
-  "avg_validator_trust|max_validator_trust|stake_dominance|subnet_count|total_emission|total_stake|uid_count",
   "base-layer|blocked|callable|candidate|needs-evidence",
   "bearish|bullish|neutral",
-  "biggest-alpha-gain-1d|biggest-alpha-gain-7d|cheapest-registration|highest-emission|open-slots|validator-headroom",
-  "candidate_api_count|candidate_api_kinds|curation_level|name|netuid|operational_kinds|operational_surface_count|priority_score|recommended_adapter_kind",
-  "candidate_count|completeness_score|identity_level|identity_promotion_kind_count|identity_surface_count|live_identity_candidate_kind_count|missing_critical_count|name|native_identity_signal_count|native_name_quality|netuid|priority_score|profile_level|stale_identity_candidate_kind_count",
-  "candidate_count|curation_level|missing_kinds|name|netuid|priority_score|surface_count|verified_candidate_count",
-  "chain|empty|placeholder",
-  "claim|source_url|subject|verified_at",
-  "classification|kind|last_checked|last_ok|latency_ms|netuid|provider|status|status_code|surface_id|verified_at",
-  "complete|directory|none|partial",
-  "confidence|id|kind|name|netuid|provider|state",
-  "coverage_level|curation_level|gap_count|name|netuid",
-  "coverage_level|curation_level|name|netuid",
-  "critical|info|warning",
-  "custom-adapter|data-artifact-adapter|generic-openapi-or-custom|stream-adapter",
-  "delegated_tao|free_tao|net_flow_30d|net_flow_7d|net_flow_90d|total_tao",
   "dual|git|r2",
-  "eligible_count|endpoint_count|id|kind",
-  "emission|entity_emission|entity_stake|stake|validator_stake",
-  "emission|neurons|stake|validators",
-  "evidence_action|lane|name|netuid|priority_score",
-  "gini|holders|nakamoto_coefficient|netuid|top_1pct_share|total",
-  "gross_staked|last_activity|net_staked",
   "hard-blocked|missing-data|needs-review|none",
-  "hard|missing-data|needs-review",
-  "high|low|medium",
-  "id|kind|name|netuid|provider",
-  "kind|last_checked|latency_ms|layer|netuid|pool_eligible|provider|publication_state|score|status",
-  "last_active|stake_dominance|subnet_count|total_emission|total_stake|uid_count|validator_count",
   "missing-probe|not-monitored|probe-derived",
-  "provider|subnet|surface",
 ];
 
 const errors: string[] = [];
@@ -115,7 +89,7 @@ for (const site of sites) {
   byVocabulary.get(key)!.add(site.file);
 }
 
-const allowed = new Set(NOT_YET_OWNED);
+const allowed = new Set(COINCIDENT_BY_DOMAIN);
 const duplicated = [...byVocabulary.entries()].filter(
   ([, files]) => files.size > 1,
 );
@@ -146,7 +120,7 @@ const stale = [...allowed]
   .sort();
 if (stale.length > 0) {
   errors.push(
-    `${stale.length} allowlist entr(y/ies) no longer name a duplicated vocabulary — delete them:\n` +
+    `${stale.length} allowlist entr(y/ies) no longer name a duplicated vocabulary — delete them (the coincidence resolved itself):\n` +
       stale.map((key) => `    [${key.split("|").join(", ")}]`).join("\n"),
   );
 }
@@ -161,5 +135,5 @@ if (errors.length > 0) {
 
 console.log(
   `Schema-vocabulary validation passed: ${byVocabulary.size} distinct vocabularies, ` +
-    `${duplicated.length} still restated in more than one file (all declared debt against #9799).`,
+    `${duplicated.length} still restated in more than one file (all per-domain coincidences, not debt — see COINCIDENT_BY_DOMAIN).`,
 );


### PR DESCRIPTION
## Result

**42 duplicated vocabularies → 9, and zero of the 9 is a tool copying a route.**

```
Schema-vocabulary validation passed: 114 distinct vocabularies,
9 still restated in more than one file
(all per-domain coincidences, not debt — see COINCIDENT_BY_DOMAIN)
```

## Two kinds of duplication, resolved differently

**The same vocabulary → one owner.** 50 sites wired:

- **33 tools** now import the tuple from **their own route**, hoisted to a named export where the route declared it inline.
- **17 vocabularies** shared across several routes *and* tools got an explicit owner — four profile-shape ones (`PROFILE_LEVEL`, `IDENTITY_LEVEL`, `CONFIDENCE_LEVEL`, `NATIVE_NAME_QUALITY`) to `schemas-src/shared.ts`, eight cross-tool list vocabularies to `mcp-tools/shared.ts`.

**Coincident values → left alone, and now labelled honestly.** The allowlist was `NOT_YET_OWNED`, its entries described as "standing admissions". For the survivors that reading is wrong and *actively dangerous*, so it is now `COINCIDENT_BY_DOMAIN` with the evidence beside it.

The load-bearing measurement: `schemas-src` declares **six distinct window vocabularies** — `30d|7d`, `30d|7d|90d`, `1y|30d|7d|90d|all`, `24h|30d|7d|90d`, `1h|24h|30d|7d`, `1d|1h`. Six sets is the proof each route *chose*. Extracting them into one constant would let a change to one domain silently alter nineteen others — worse than the duplication, and invisible at every call site.

## The mistake the build caught

Owning the profile vocabularies on `routes/subnet-profile.ts` looked natural. It produced a **runtime circular import** — `subnet-detail` ↔ `subnet-profile`, `Cannot access 'SurfaceKindSchema' before initialization`.

**`typecheck` passed. `npm run build` caught it.** That is why the owner has to be a leaf module, and why the build is not optional on a refactor like this.

## Method

An **AST codemod over the TypeScript compiler API** (already a dependency), not regex. It locates `VariableStatement`s whose initializer is an `as const` string array and `z.enum([…])` call expressions, and edits by node span.

A first regex attempt matched only the `z.enum` form and **silently missed every `as const` copy** — reporting success while doing a fraction of the work. That is the failure mode that makes hand-rolled codemods untrustworthy, and the reason for the rewrite.

## Verification

`typecheck`, `lint`, `format:check`, `build`, and all six schema validators pass; 1,701 tests pass across the affected suites. 61 files, +504/−665 — a net deletion, which is the point.

Closes #9965