### PR TITLE
fix(registry): stop publishing activity metrics for GitHub repos that are gone

### DIFF
--- a/scripts/github-signals.ts
+++ b/scripts/github-signals.ts
@@ -212,7 +212,28 @@ export function githubSignalsForSubnet(
     github_commits_weekly: signals?.commits_weekly ?? null,
     // #8704: feeds the `release` item kind on the per-subnet feed.
     github_releases: signals?.releases ?? null,
-    github_unreachable: signals?.unreachable ?? false,
+    // ABSENT means unreachable, not fine (#9912). Reaching this line means
+    // `parsed` succeeded, so a GitHub repo IS configured for this subnet --
+    // and resolveTrackedRepos builds the capture list from exactly these
+    // resolved source_repos, so the capture WAS asked about it. No entry
+    // therefore means fetchRepoSignals dropped it: gone, or a failure with no
+    // last-good value left inside the retention window.
+    //
+    // `?? false` published that as a healthy repo that simply has no numbers.
+    // netuid 92's tensorclaw/tensorclaw 404s, and we served
+    // `github_unreachable: false` with every metric null -- indistinguishable
+    // from a live repo nobody has starred.
+    //
+    // The `?? null`s above are different and correct: those are VALUES the
+    // capture has no answer for. This is a VERDICT, and the honest verdict for
+    // "we asked and have nothing" is true.
+    //
+    // Unless we never asked at all: an EMPTY map is a cold start with no
+    // capture behind it (no artifact yet, or a run that produced none), and
+    // calling all 129 subnets unreachable off the back of that would be the
+    // same overclaim in the other direction.
+    github_unreachable:
+      signals?.unreachable ?? (signalsByRepo.size > 0 ? true : false),
   };
 }
 

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -1315,6 +1315,36 @@ async function validateGeneratedArtifacts(
       candidate.subnet_name,
     );
   }
+  // #9912: an unreachable repo may not also publish activity metrics.
+  //
+  // Same class as the display-name gate above -- a served claim the source
+  // contradicts -- and the same reasoning for gating the OUTCOME rather than
+  // the call sites. We published `github_stars: 43` and a push "3 days ago" for
+  // AffineFoundation/affine-cortex while it returned 404 from api.github.com,
+  // and `github_unreachable: false` with every metric null for
+  // tensorclaw/tensorclaw, which also 404s. Both are "the numbers and the
+  // verdict disagree", so assert they cannot.
+  const githubClaimDrift: string[] = [];
+  for (const subnet of subnets) {
+    if (!subnet.github_unreachable) continue;
+    const claimed = [
+      "github_stars",
+      "github_last_push_at",
+      "github_commits_weekly",
+      "github_languages",
+      "github_releases",
+    ].filter((field) => (subnet as Row)[field] != null);
+    if (claimed.length > 0) {
+      githubClaimDrift.push(
+        `${subnet.slug} (netuid ${subnet.netuid}): github_unreachable but still serves ${claimed.join(", ")}`,
+      );
+    }
+  }
+  assert(
+    githubClaimDrift.length === 0,
+    `an unreachable GitHub repo must not publish activity metrics (${githubClaimDrift.length}):\n  ${githubClaimDrift.slice(0, 12).join("\n  ")}`,
+  );
+
   assert(
     displayNameDrift.length === 0,
     `served display names must come from subnetDisplayName (${displayNameDrift.length}):\n  ${displayNameDrift.slice(0, 12).join("\n  ")}`,

--- a/src/github-signals-core.ts
+++ b/src/github-signals-core.ts
@@ -233,6 +233,16 @@ export interface CaptureEntryOptions extends GithubFetchOptions {
 // when one exists and is still within the 30-day retention window, or drops
 // the repo from this run's output entirely when it doesn't -- never throws,
 // so one bad repo can't abort the whole run.
+/**
+ * Statuses that mean the repository is GONE, not temporarily unreachable
+ * (#9912). 404 is a deleted or renamed-away repo -- GitHub redirects a rename,
+ * so a 404 survives that -- and 410 is an explicit tombstone. Everything else a
+ * failed metadata call can return (403/429 rate limit, 5xx, a transport throw)
+ * is a blip the repo will come back from, and the retain-last-good path below
+ * is correct for those.
+ */
+const GONE_STATUSES = new Set([404, 410]);
+
 export async function fetchRepoSignals(
   { owner, repo }: GithubRepoRef,
   previousEntry: RepoSignal | undefined,
@@ -266,6 +276,22 @@ export async function fetchRepoSignals(
     // The `?? Date.now()` keeps the direct callers that pass no capturedAt
     // (none in this repo today) on the previous behaviour rather than
     // treating a missing tick as time zero.
+    // A GONE repo keeps nothing (#9912). Retaining the last-good entry is the
+    // right answer for a blip -- a rate limit, a 5xx, a dropped connection --
+    // because the repo is still there and the numbers are still true. It is the
+    // wrong answer for 404/410: the repository has been deleted or renamed
+    // away, so `stars` and `last_push_at` are claims about something that no
+    // longer exists. Measured on the live registry, we served 43 stars and a
+    // push "3 days ago" for AffineFoundation/affine-cortex, which returns 404
+    // from api.github.com; Djinn-Inc/djinn was the same shape.
+    //
+    // Dropping it here is what the module header already asks for -- a repo
+    // with nothing behind it is not published -- and githubSignalFields turns
+    // that absence into `github_unreachable: true` with null metrics, so the
+    // subnet still says "we looked and found nothing" rather than going quiet.
+    if (GONE_STATUSES.has(metaRes.status as number)) {
+      return null;
+    }
     const agedAt = options.capturedAt
       ? Date.parse(options.capturedAt)
       : Date.now();

--- a/tests/github-signals.test.ts
+++ b/tests/github-signals.test.ts
@@ -177,9 +177,29 @@ describe("githubSignalsForSubnet", () => {
     assert.deepEqual(result, emptyShape);
   });
 
-  test("returns the empty shape when the repo resolves but has no captured signals yet", () => {
+  test("a resolved repo missing from a populated capture is UNREACHABLE (#9912)", () => {
+    // This used to assert the empty shape -- i.e. github_unreachable:false --
+    // and that expectation was the bug. resolveTrackedRepos builds the capture
+    // list from exactly these resolved source_repos, so a repo absent from a
+    // capture that DID run is one fetchRepoSignals dropped, not one nobody
+    // asked about. Live: netuid 92's tensorclaw/tensorclaw 404s and we served
+    // `github_unreachable: false` with every metric null.
     const result = githubSignalsForSubnet(
       signalsByRepo,
+      { source_repo: "https://github.com/some/uncaptured-repo" },
+      {},
+    );
+    assert.deepEqual(result, { ...emptyShape, github_unreachable: true });
+    // The metrics stay null -- absence is a verdict, never invented data.
+    assert.equal(result.github_stars, null);
+    assert.equal(result.github_last_push_at, null);
+  });
+
+  test("but a cold start with NO capture at all is not a verdict", () => {
+    // The other overclaim: an empty map means no artifact yet, and calling all
+    // 129 subnets unreachable off the back of that is just as wrong.
+    const result = githubSignalsForSubnet(
+      new Map(),
       { source_repo: "https://github.com/some/uncaptured-repo" },
       {},
     );
@@ -386,6 +406,58 @@ describe("fetchRepoSignals", () => {
     assert.equal(result?.unreachable, false);
     assert.equal(result?.stars, 500);
     assert.equal(result?.last_push_at, "2026-07-20T00:00:00Z");
+  });
+
+  test("a 404 drops the repo instead of retaining its last-good numbers (#9912)", async () => {
+    // The retain-last-good path is right for a BLIP -- the repo is still there
+    // and 99 stars is still true. It is wrong for a deleted repo: live, we
+    // served 43 stars and a push "3 days ago" for AffineFoundation/affine-cortex,
+    // which returns 404 from api.github.com. Djinn-Inc/djinn was the same.
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockImplementation(() => jsonResponse(404, { message: "Not Found" })),
+    );
+    const result = await fetchRepoSignals(
+      { owner: "opentensor", repo: "subtensor" },
+      previousEntry,
+      { capturedAt: new Date().toISOString() },
+    );
+    // Dropped, so githubSignalFields reports unreachable with null metrics --
+    // rather than republishing numbers about something that no longer exists.
+    assert.equal(result, null);
+  });
+
+  test("410 Gone is treated the same as 404", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() => jsonResponse(410, { message: "Gone" })),
+    );
+    const result = await fetchRepoSignals(
+      { owner: "opentensor", repo: "subtensor" },
+      previousEntry,
+      { capturedAt: new Date().toISOString() },
+    );
+    assert.equal(result, null);
+  });
+
+  test("a rate limit still retains last-good, because the repo is still there", async () => {
+    // The other half of the same decision: 403/429/5xx are blips, and throwing
+    // away a live repo's real numbers over one would be its own defect.
+    for (const status of [403, 429, 500, 502]) {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockImplementation(() => jsonResponse(status, {})),
+      );
+      const result = await fetchRepoSignals(
+        { owner: "opentensor", repo: "subtensor" },
+        previousEntry,
+        { capturedAt: new Date().toISOString() },
+      );
+      assert.equal(result?.unreachable, true, `status ${status}`);
+      assert.equal(result?.stars, 99, `status ${status} kept its stars`);
+    }
   });
 
   test("stamps the caller-supplied capturedAt on a successful capture", async () => {


### PR DESCRIPTION
We served `github_stars: 43` and a push **"3 days ago"** for `AffineFoundation/affine-cortex`, which returns `404` from `api.github.com`. `Djinn-Inc/djinn` was the same shape. A deleted repository is the strongest *"not maintained"* signal there is, and we rendered it as the opposite.

Two independent causes. Neither was the capture being wrong.

## 1. A gone repo kept its numbers

`fetchRepoSignals` degrades a failed metadata call to the retained last-good entry, marked unreachable. That is **right for a blip** — a rate limit, a 5xx, a dropped connection — because the repo is still there and the numbers are still true.

It is wrong for `404`/`410`: the repository has been deleted or renamed away (GitHub redirects a rename, so a 404 survives that), and its stars are a claim about something that no longer exists.

Those statuses now drop the repo, which is what this module's own header already asks for — *"never published as `unreachable` forever with no data behind it"*.

## 2. An absent repo read as a healthy one

`githubSignalFields` resolved a missing entry to `github_unreachable: false`. But `resolveTrackedRepos` builds the capture list from exactly these resolved `source_repo`s — so a repo absent from a capture that **did** run is one the capture *dropped*, not one nobody asked about.

netuid 92's `tensorclaw/tensorclaw` 404s, and we published `github_unreachable: false` with every metric null — indistinguishable from a live repo nobody has starred.

Absence is now a verdict of unreachable. Three deliberate boundaries:

- The **null metrics** beside it stay null. Absence is a verdict; it never invents data.
- An **empty map** is still `false`. A cold start with no capture behind it has not asked anything, and calling all 129 subnets unreachable would be the same overclaim in the other direction.
- The `?? null`s on the metric fields are unchanged — those are *values* the capture has no answer for, not verdicts.

## 3. And a gate

Same class as #9909's display names — a served claim the source contradicts — so it gets the same treatment. `validate.ts` asserts the **outcome**: no subnet flagged `github_unreachable` may also publish `github_stars`, `github_last_push_at`, `github_commits_weekly`, `github_languages` or `github_releases`. Any future path that reintroduces the pairing fails, regardless of how it is written.

**Measured after the fix**, from the rebuilt artifact:

```
netuid 92   unreachable=True   stars=None   last_push=None    ← was false / null / null

subnets flagged github_unreachable: 3
  netuid 53  engy                 stars=None  last_push=None
  netuid 90  KubeTEE AI Factory   stars=None  last_push=None
  netuid 92  Enclave              stars=None  last_push=None
```

## A limit worth stating plainly

The gate **cannot** catch a repo that died *after* its capture. The committed store records `djinn` and `affine-cortex` as `unreachable: false` with real stars, because they were alive when it ran — and `validate` has no way to know otherwise without calling GitHub. Fix 1 is what resolves those, on the next capture: the 404 drops them, absence makes them unreachable, and the gate then holds the line.

(Separately, and not this PR: that committed store's `generated_at` is `1970-01-01T00:00:00.000Z` — the deterministic epoch stamp — so the seed itself never refreshes.)

## Tests

`tests/github-signals.test.ts`:
- a `404` drops the repo instead of retaining its last-good numbers; `410` likewise
- `403`/`429`/`500`/`502` **still retain** last-good with its stars — throwing away a live repo's real numbers over a rate limit would be its own defect
- a resolved repo missing from a populated capture is unreachable, with metrics still null
- a cold start with no capture at all is not a verdict

One existing test changed expectation: *"returns the empty shape when the repo resolves but has no captured signals yet"* asserted `github_unreachable: false` for exactly the netuid-92 case. **That expectation was the bug**, so it now asserts unreachable, with the cold-start case split out into its own test to keep the benign half covered.

### Mutation-tested

| mutation | result |
|---|---|
| gone repos retain last-good again | **2 failures** — 404 and 410 |
| absent entry reads reachable again | **1 failure** — resolved-but-missing |
| cold start also reads unreachable | **1 failure** — not a verdict |

## Validation run

```
npm run lint / format:check / typecheck   clean
npm run build                             exit 0
npm run validate                          exit 0   (gate active)
vitest github-signals, github-signals-sync, lib-helpers
                                          222 passed
```

**Patch coverage:** `src/github-signals-core.ts` is the only file in codecov scope — 26 changed lines, **0 uncovered statements and 0 uncovered branches**, by diff∩report intersection.

Verified there is no second projection to keep in sync: `build-artifacts.ts` passes `subnet.github_unreachable` straight through, and the Worker cron shares `fetchRepoSignals` rather than forking it.

Rebased onto `385bc8e63`, rebuilt and revalidated on that base.

Closes #9912
