### PR TITLE
fix(build): a schema-index discard now names what it lost, and CI refuses to ship it

### DIFF
--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -351,6 +351,11 @@ const capturedSchemaDetails = new Map<string, Row>();
 // populated on the next refresh (same model as schemas).
 const capturedFixtures = new Map<string, Row>();
 let capturedFixtureReport: Row | null = null;
+/**
+ * The schema-index discard, if one happened, published on the build summary so
+ * CI can gate on it (#9909). Null on a healthy build.
+ */
+let schemaIndexDiscard: Row | null = null;
 {
   const fixturesDir = path.join(r2OutputRoot, "fixtures");
   let fixtureFiles: string[];
@@ -2840,6 +2845,11 @@ await writeJson(artifactFile("build-summary.json"), {
     (sum, artifact) => sum + artifact.size_bytes,
     0,
   ),
+  // #9909: null on a healthy build. Non-null with dropped_captured > 0 means
+  // this build lost every captured schema in the committed index, which
+  // validate.ts fails on -- the control lives in CI rather than in the build,
+  // so a tampered index degrades the catalog instead of denying the pipeline.
+  schema_index_discard: schemaIndexDiscard,
   storage_tier_counts: countByStorageTier(artifactSizes),
   storage_tier_size_bytes: sumBytesByStorageTier(artifactSizes),
   artifacts: reviewArtifactSizes.slice(0, 250),
@@ -4356,6 +4366,49 @@ function reusableSchemaDriftArtifact(
   return previous;
 }
 
+/**
+ * Discarding the committed schema index costs every captured schema in it, so
+ * it never happens quietly (#9912).
+ *
+ * The fallback itself is correct -- an index that cannot be trusted must not be
+ * reused. What was wrong is that it was silent: 227 captured schemas
+ * disappeared from the agent catalog and operational-surfaces.json with nothing
+ * in the build log, and the cause had to be found by diffing a pristine build
+ * against a changed one. One line naming the reason and the cost replaces that.
+ */
+/**
+ * Records a schema-index discard and returns null (#9909 follow-up).
+ *
+ * DOES NOT THROW, deliberately. The fallback is a security property: a
+ * committed index that cannot be trusted must not be reused, and
+ * tests/artifacts-build-schema.test.ts models an attacker forging one. Making
+ * that path fatal would let a tampered file deny the whole pipeline, which is a
+ * worse outcome than degrading.
+ *
+ * But it was also SILENT, which is how it hid: captured schemas disappeared
+ * from the agent catalog and operational-surfaces' schema_source with nothing
+ * in the build log, and the cause had to be found by diffing a pristine build
+ * against a changed one. So the discard is now named, counted, and recorded on
+ * the build summary -- and validate.ts fails when the count is non-zero, which
+ * puts the control in CI where a hostile file cannot reach it.
+ */
+function discardSchemaIndex(
+  reason: string,
+  previous: Row | null | undefined,
+): null {
+  const dropped = Array.isArray(previous?.schemas)
+    ? (previous.schemas as Row[]).filter((s) => s.status === "captured").length
+    : 0;
+  schemaIndexDiscard = { reason, dropped_captured: dropped };
+  console.warn(
+    dropped > 0
+      ? `schema index discarded (${reason}) — dropping ${dropped} captured schema(s). ` +
+          `Re-run the schema capture so the committed index matches the current surfaces.`
+      : `schema index not reusable (${reason}) — building a placeholder`,
+  );
+  return null;
+}
+
 function reusableSchemaIndexArtifact(
   surfaces: Row[],
   previous: Row | null | undefined,
@@ -4367,7 +4420,7 @@ function reusableSchemaIndexArtifact(
     !schemaSnapshotTimestamp(previous) ||
     !Array.isArray(previous.schemas)
   ) {
-    return null;
+    return discardSchemaIndex("no reusable committed index", previous);
   }
   // A captured entry must point at a real schema-detail artifact path; a
   // not-captured entry legitimately has none, so only captured claims are gated.
@@ -4378,7 +4431,10 @@ function reusableSchemaIndexArtifact(
         !schemaDetailArtifactRelativePath(schema.path || ""),
     )
   ) {
-    return null;
+    return discardSchemaIndex(
+      "a captured entry has no schema-detail artifact path",
+      previous,
+    );
   }
   const currentSurfaces = openApiSurfacesById(surfaces);
   // Forgery/staleness guard: a committed entry whose surface still exists but no
@@ -4386,11 +4442,13 @@ function reusableSchemaIndexArtifact(
   // trusted — discard it wholesale and fall back to the build placeholder.
   for (const entry of previous.schemas) {
     const surface = currentSurfaces.get(entry.surface_id);
-    if (
-      surface &&
-      !schemaIndexEntryMatchesSurface(entry, surface, capturedDetails)
-    ) {
-      return null;
+    if (!surface) continue;
+    const mismatch = schemaIndexEntryMismatch(entry, surface, capturedDetails);
+    if (mismatch) {
+      return discardSchemaIndex(
+        `entry ${entry.surface_id} no longer matches its surface on ${mismatch}`,
+        previous,
+      );
     }
   }
   // Reconcile incrementally with the current surface set instead of nuking the
@@ -4497,20 +4555,39 @@ function schemaSurfaceEntryMatchesSurface(
   );
 }
 
-function schemaIndexEntryMatchesSurface(
+/**
+ * Why a committed schema-index entry no longer matches its surface, or null if
+ * it does (#9912 follow-up to #9909).
+ *
+ * A NAMED FIELD, not a boolean, because rejecting one entry discards the ENTIRE
+ * index -- every captured schema, for every subnet -- and until now that
+ * happened in silence. 227 schemas vanished from the agent catalog and
+ * operational-surfaces.json with nothing in the build log saying so, and
+ * finding the cause took isolating a pristine build against a changed one. The
+ * field name turns that into a line of output.
+ *
+ * The comparisons live in one list so the verdict and the explanation cannot
+ * disagree -- a separate explainer beside a separate boolean is exactly the
+ * shape that lets them drift.
+ */
+function schemaIndexEntryMismatch(
   entry: Row,
   surface: Row | undefined,
   capturedDetails: Map<string, Row>,
-): boolean {
+): string | null {
   if (!schemaSurfaceEntryMatchesSurface(entry, surface)) {
-    return false;
+    return "surface identity (id/netuid/subnet_slug/url/schema_url)";
   }
   if (entry.status !== "captured") {
-    return (
-      (entry.path || null) === null &&
-      (entry.hash || null) === null &&
-      (!entry.snapshot || typeof entry.snapshot !== "object")
-    );
+    // A not-captured entry legitimately carries no document.
+    if ((entry.path || null) !== null)
+      return "path set on a not-captured entry";
+    if ((entry.hash || null) !== null)
+      return "hash set on a not-captured entry";
+    if (entry.snapshot && typeof entry.snapshot === "object") {
+      return "snapshot set on a not-captured entry";
+    }
+    return null;
   }
 
   const relativePath = schemaDetailArtifactRelativePath(entry.path);
@@ -4523,36 +4600,39 @@ function schemaIndexEntryMatchesSurface(
     (captured &&
       captured.documentHash === entry.hash &&
       stableStringify(captured.snapshot) === stableStringify(entry.snapshot));
-  return (
-    entry.path === `/metagraph/schemas/${surface.id}.json` &&
-    isJsonContentType(entry.content_type) &&
-    entry.snapshot &&
-    typeof entry.snapshot === "object" &&
-    entry.snapshot.surface_id === surface.id &&
-    entry.snapshot.netuid === surface.netuid &&
-    entry.snapshot.subnet_slug === surface.subnet_slug &&
-    // subnet_name is deliberately NOT compared (#9909). This guard asks "has
-    // this entry been tampered with or drifted from its surface", and answering
-    // yes discards the ENTIRE index wholesale -- every captured schema, for
-    // every subnet. A DISPLAY name cannot carry that weight: since #9748 the
-    // chain names the subnet, so a team renaming on-chain silently nukes the
-    // schema index on the next build. Measured: 26 subnets renamed and all 227
-    // captured schemas were dropped, `schema_source: null` across the whole
-    // agent catalog and operational-surfaces.json.
-    //
-    // Identity is what the guard needs and identity is fully covered without
-    // it -- surface_id, netuid, subnet_slug, the surface url, the schema url
-    // and the document hash all still have to match, which is exactly the set
-    // schemaSurfaceEntryMatchesSurface above compares. The snapshot still
-    // RECORDS subnet_name as provenance of what the subnet was called at
-    // capture time; it just no longer gates trust.
-    entry.snapshot.surface_url === surface.url &&
-    entry.snapshot.schema_url === entry.schema_url &&
-    entry.snapshot.hash === entry.hash &&
-    (entry.snapshot.previous_hash || null) === (entry.previous_hash || null) &&
-    entry.snapshot.drift_status === entry.drift_status &&
-    detailMatches
-  );
+
+  // subnet_name is deliberately absent from this list (#9909). The guard asks
+  // "has this entry been tampered with or drifted from its surface", and
+  // answering yes costs the whole index. A DISPLAY name cannot carry that
+  // weight: since #9748 the chain names the subnet, so a team renaming
+  // on-chain would silently nuke the schema index on the next build --
+  // measured at 26 renamed subnets taking all 227 captured schemas with them.
+  // Identity is fully covered without it, by schemaSurfaceEntryMatchesSurface
+  // above plus the document hash below. The snapshot still RECORDS
+  // subnet_name as provenance of what the subnet was called at capture time;
+  // it just does not gate trust.
+  const snapshot = (entry.snapshot ?? {}) as Row;
+  const checks: Array<[string, unknown]> = [
+    ["path", entry.path === `/metagraph/schemas/${surface.id}.json`],
+    ["content_type", isJsonContentType(entry.content_type)],
+    ["snapshot", Boolean(entry.snapshot) && typeof entry.snapshot === "object"],
+    ["snapshot.surface_id", snapshot.surface_id === surface.id],
+    ["snapshot.netuid", snapshot.netuid === surface.netuid],
+    ["snapshot.subnet_slug", snapshot.subnet_slug === surface.subnet_slug],
+    ["snapshot.surface_url", snapshot.surface_url === surface.url],
+    ["snapshot.schema_url", snapshot.schema_url === entry.schema_url],
+    ["snapshot.hash", snapshot.hash === entry.hash],
+    [
+      "snapshot.previous_hash",
+      (snapshot.previous_hash || null) === (entry.previous_hash || null),
+    ],
+    ["snapshot.drift_status", snapshot.drift_status === entry.drift_status],
+    ["schema detail document", detailMatches],
+  ];
+  for (const [field, ok] of checks) {
+    if (!ok) return field;
+  }
+  return null;
 }
 
 function candidateSchemaUrlsForSurface(surface: Row): string[] {

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -1271,6 +1271,25 @@ async function validateGeneratedArtifacts(
     "candidates artifact: count mismatch",
   );
 
+  // #9909: a build that discarded the committed schema index lost every
+  // captured schema in it -- get_api_schema, the agent catalog and
+  // operational-surfaces' schema_source all go empty, and until now that
+  // happened with nothing in the build log anyone had to act on.
+  //
+  // The control lives HERE rather than in the build because the fallback is a
+  // security property: a committed index that cannot be trusted must not be
+  // reused, and tests/artifacts-build-schema.test.ts models an attacker forging
+  // one. Throwing there would let a tampered file deny the whole pipeline. So
+  // the build degrades and records what it lost, and CI -- which a hostile file
+  // cannot reach -- refuses to pass on it.
+  const buildSummary = await readArtifactJson("build-summary.json");
+  const discard = buildSummary?.schema_index_discard as Row | null | undefined;
+  assert(
+    !discard || (discard.dropped_captured as number) === 0,
+    `the build discarded the committed schema index, dropping ${discard?.dropped_captured} captured schema(s): ${discard?.reason}. ` +
+      "Re-run the schema capture so the committed index matches the current surfaces.",
+  );
+
   // #9909: every SERVED display name must be the one subnetDisplayName resolves.
   //
   // This is an OUTCOME check, not a code check, and deliberately so. The same

--- a/tests/artifacts-build-schema-index.test.ts
+++ b/tests/artifacts-build-schema-index.test.ts
@@ -73,7 +73,7 @@ test("artifact build accepts an OpenAPI-vendor JSON content-type for a captured 
 
   // A real subnet (SN-71 Leadpoet) serves its OpenAPI document as
   // application/vnd.oai.openapi+json rather than plain application/json -- a
-  // spec-valid, OAI-registered media type. schemaIndexEntryMatchesSurface used
+  // spec-valid, OAI-registered media type. schemaIndexEntryMismatch used
   // to require an exact "application/json" match, so this one entry failed the
   // reconciler's forgery/staleness guard and wholesale-discarded the entire
   // committed index down to an empty placeholder (metagraphed#6411).
@@ -173,3 +173,68 @@ test("a renamed subnet does not wholesale-discard the committed schema index", (
     harness.restoreSupportArtifacts(supportArtifacts);
   }
 }, 120_000);
+
+test("a schema-index discard is named, counted, and recorded for CI", () => {
+  const schemaIndexPath = harness.artifactFilePath("schemas/index.json");
+  const summaryPath = harness.artifactFilePath("build-summary.json");
+  const originalSchemaIndex = readFileSync(schemaIndexPath, "utf8");
+  const originalSummary = readFileSync(summaryPath, "utf8");
+  const supportArtifacts = harness.snapshotSupportArtifacts();
+  const schemaIndex = JSON.parse(originalSchemaIndex);
+  const target = schemaIndex.schemas?.find(
+    (schema: Row) => schema.status === "captured",
+  );
+  assert(target, "expected a captured schema index entry to tamper");
+  const capturedBefore = schemaIndex.schemas.filter(
+    (schema: Row) => schema.status === "captured",
+  ).length;
+
+  // #9909: the discard itself is correct and stays -- an index that cannot be
+  // trusted must not be reused. What was wrong is that it was SILENT: captured
+  // schemas vanished from the agent catalog and operational-surfaces'
+  // schema_source with nothing in the build log, and the cause had to be found
+  // by diffing a pristine build against a changed one.
+  (target.snapshot ??= {}).hash = "forged-by-this-test";
+
+  try {
+    writeFileSync(schemaIndexPath, `${JSON.stringify(schemaIndex, null, 2)}\n`);
+    // The build must still SUCCEED. Failing here would let a tampered committed
+    // file deny the whole pipeline, which is why the CI control lives in
+    // validate.ts instead -- see tests/artifacts-build-schema.test.ts for the
+    // attacker case this protects.
+    execFileSync(process.execPath, ["scripts/build-artifacts.ts"], {
+      cwd: harness.scriptCwd,
+      encoding: "utf8",
+      env: harness.env,
+      stdio: "pipe",
+    });
+
+    const discard = JSON.parse(readFileSync(summaryPath, "utf8"))
+      .schema_index_discard as Row;
+    assert(discard, "the discard must be recorded on the build summary");
+    assert.equal(discard.dropped_captured, capturedBefore);
+    // The reason names the entry AND the field, which is the difference between
+    // a one-line diagnosis and an isolation run.
+    assert.match(String(discard.reason), new RegExp(target.surface_id));
+    assert.match(String(discard.reason), /snapshot\.hash/);
+  } finally {
+    writeFileSync(schemaIndexPath, originalSchemaIndex);
+    writeFileSync(summaryPath, originalSummary);
+    execFileSync(process.execPath, ["scripts/build-artifacts.ts"], {
+      cwd: harness.scriptCwd,
+      encoding: "utf8",
+      env: harness.env,
+      stdio: "pipe",
+    });
+    harness.restoreSupportArtifacts(supportArtifacts);
+  }
+}, 120_000);
+
+test("a healthy build records no discard", () => {
+  const summary = JSON.parse(
+    readFileSync(harness.artifactFilePath("build-summary.json"), "utf8"),
+  );
+  // Positive control: without this, the assertions above could pass against a
+  // build that always records a discard.
+  assert.equal(summary.schema_index_discard, null);
+});


### PR DESCRIPTION
Closing the gap I left open on #9963: the schema-index defect there cost **59 captured schemas** and printed **nothing**. Every consumer of the catalog — `get_api_schema`, the agent catalog, `operational-surfaces`' `schema_source` — had already gone empty by the time anyone could notice, and the cause had to be found by diffing a pristine build against a changed one.

## What deliberately does not change

The discard is correct. An index that cannot be trusted must not be reused, and `tests/artifacts-build-schema.test.ts` models an attacker forging one (`attacker.invalid`, `AUTOVALIDATOR_FORGED_METADATA_SHOULD_NOT_SURVIVE_BUILD`).

**I tried making it throw, and backed that out.** A fatal discard lets a tampered committed file deny the entire pipeline — trading silent degradation for a denial-of-service, on the exact input an attacker controls. That test is what caught it, and it was right.

So the fix is not "fail the build". It is: stop the loss being invisible, and put the control somewhere a hostile file cannot reach.

## 1. The guard names the field

`schemaIndexEntryMatchesSurface` returned a bare boolean, so a rejection could say nothing about itself. It is now `schemaIndexEntryMismatch`, returning the failing field, with the comparisons in **one list** so the verdict and the explanation cannot disagree — a separate explainer beside a separate boolean is exactly the shape that lets them drift. The boolean wrapper is deleted rather than kept as a second name for one check.

Silence became:

```
schema index discarded (entry sn-1-apex-orchestrator-openapi no longer matches
its surface on snapshot.hash) — dropping 59 captured schema(s). Re-run the
schema capture so the committed index matches the current surfaces.
```

## 2. CI refuses to ship the loss

A warning in a build that still exits 0 is a log line nobody reads — #9945's lesson, and I am not about to re-learn it. The discard is recorded on `build-summary.json` as `schema_index_discard`, and `validate.ts` fails when `dropped_captured` is non-zero.

**That split is the whole point:**

| | build | CI |
|---|---|---|
| forged/untrusted index | degrades, cannot DoS the pipeline | refuses to pass |
| healthy build | exit 0, no record | exit 0 |

## Verified end to end

Forging a captured entry's `snapshot.hash`:

```
build     exit 0   + the named warning above
validate  exit 1   "the build discarded the committed schema index, dropping 59
                    captured schema(s): entry sn-1-apex-orchestrator-openapi no
                    longer matches its surface on snapshot.hash"
restored  build 0, validate 0
```

## Tests

- a discard is **named, counted and recorded** — asserts the build still exits 0, that `dropped_captured` equals the pre-tamper captured count, and that the reason contains both the surface id **and** `snapshot.hash`
- **positive control:** a healthy build records `schema_index_discard: null`, so the assertions above cannot pass against a build that always records one

**Mutation-tested:**

| mutation | result |
|---|---|
| reason loses the field name | **fails** |
| discard not recorded at all | **fails** |

The pre-existing suite is unchanged and green, including the attacker test that vetoed the throw.

## Validation run

```
npm run lint / format:check / typecheck   clean
npm run build                             exit 0
npm run validate                          exit 0
vitest artifacts-build-schema-index, artifacts-build-schema,
       schema-snapshots-sync, artifacts-build-health, script-utils
                                          93 passed
```

No file under `src/**` or `workers/**` is touched, so `codecov/patch` has no scope. Rebased onto `6c644b4a7`, rebuilt and revalidated on that base.

Closes #9972
