### PR TITLE
fix(adapters): capture OpenAPI documents published as YAML, not just JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,8 @@
         "typescript-eslint": "^8.65.0",
         "vite": "^7.3.6",
         "vitest": "^4.1.10",
-        "wrangler": "4.118.0"
+        "wrangler": "4.118.0",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=22.23.1"
@@ -5059,6 +5060,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@posthog/cli/node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "extraneous": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@posthog/core": {

--- a/package.json
+++ b/package.json
@@ -173,7 +173,8 @@
     "typescript-eslint": "^8.65.0",
     "vite": "^7.3.6",
     "vitest": "^4.1.10",
-    "wrangler": "4.118.0"
+    "wrangler": "4.118.0",
+    "yaml": "^2.9.0"
   },
   "overrides": {
     "esbuild": "^0.28.1",

--- a/scripts/snapshot-adapters.ts
+++ b/scripts/snapshot-adapters.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { CONTRACT_VERSION } from "../src/contracts.ts";
 import { pathToFileURL } from "node:url";
+import { parse } from "yaml";
 import {
   buildTimestamp,
   hashJson,
@@ -651,23 +652,21 @@ export async function fetchJson(url: string, redirectCount = 0): Promise<Row> {
       };
     }
     const text = limitedBody.text;
-    let body = null;
-    try {
-      body = text ? JSON.parse(text) : null;
-    } catch {
-      body = null;
-    }
-    if (!isJsonContentType(contentType) && body === null) {
+    const parsed = parseOpenApiDocument(text, contentType, url);
+    if (!isJsonContentType(contentType) && parsed === null) {
       return {
         ok: false,
         status: "content-mismatch",
-        error: "response was not JSON",
+        // Not "was not JSON" any more: YAML is captured too, so the honest
+        // statement is that nothing parsed as an OpenAPI document at all.
+        error: "response did not parse as JSON or YAML",
         status_code: response.status,
         content_type: contentType || null,
         latency_ms: Math.round(performance.now() - started),
         captured_at: new Date().toISOString(),
       };
     }
+    const body = parsed;
     return {
       ok: true,
       status: "captured",
@@ -688,6 +687,73 @@ export async function fetchJson(url: string, redirectCount = 0): Promise<Row> {
     };
   } finally {
     clearTimeout(timer);
+  }
+}
+
+/**
+ * An OpenAPI document from a response body: JSON first, then YAML (#9893).
+ *
+ * THE SPEC PERMITS BOTH, and YAML is arguably the more common way to publish
+ * one. We only ever tried `JSON.parse`, so a subnet doing everything right --
+ * correct registry kind, correct URL, HTTP 200, correct content-type, a valid
+ * document -- was recorded as `content-mismatch` / "response was not JSON", and
+ * /api/v1/schemas published `status: "not-found"` about it. Measured on the
+ * live registry: SN10's https://taofi-doc.web.app/openapi.yaml serves 44 KB of
+ * valid OpenAPI 3.0.4 as `text/yaml`, and we told the world it had no
+ * machine-readable API.
+ *
+ * JSON IS TRIED FIRST and unconditionally, because every JSON document is also
+ * valid YAML 1.2 -- parsing JSON with the YAML parser would work but would be
+ * slower and would accept YAML-only syntax on a `.json` surface. YAML is the
+ * fallback, so nothing about the existing JSON path changes.
+ *
+ * Returns null when neither parses, which the caller reports as
+ * content-mismatch exactly as before.
+ */
+export function parseOpenApiDocument(
+  text: string | null | undefined,
+  contentType: unknown,
+  url: unknown,
+): Row | null {
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as Row;
+  } catch {
+    // Fall through to YAML.
+  }
+  if (!looksLikeYaml(contentType, url)) return null;
+  try {
+    // maxAliasCount caps anchor/alias expansion -- a YAML document from a
+    // third-party host is untrusted input, and unbounded aliases are the
+    // billion-laughs shape. The parser resolves no custom tags to JS objects,
+    // so there is no code path from a tag to execution.
+    const parsed = parse(text, { maxAliasCount: 100 });
+    // A scalar or a list is not an OpenAPI document; only an object can be one,
+    // and returning a string here would sail through as a "captured" schema.
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Row)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether a response is plausibly YAML, by declared content-type or URL suffix.
+ *
+ * Gated rather than always-try because YAML's parser accepts a great deal of
+ * plain text -- a bare HTML error page can parse as a YAML scalar, and calling
+ * that a captured schema would be worse than the bug being fixed. The type
+ * check comes first; the suffix covers a server that serves YAML as
+ * `text/plain` or `application/octet-stream`.
+ */
+function looksLikeYaml(contentType: unknown, url: unknown): boolean {
+  const type = String(contentType || "").toLowerCase();
+  if (type.includes("yaml") || type.includes("yml")) return true;
+  try {
+    return /\.ya?ml($|\?)/i.test(new URL(String(url)).pathname);
+  } catch {
+    return /\.ya?ml($|\?)/i.test(String(url || ""));
   }
 }
 

--- a/tests/openapi-document-parse.test.ts
+++ b/tests/openapi-document-parse.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { parseOpenApiDocument } from "../scripts/snapshot-adapters.ts";
+
+// #9893: the capture only ever called JSON.parse, so a subnet publishing a
+// spec-legal YAML OpenAPI document was recorded as content-mismatch and
+// /api/v1/schemas published `status: "not-found"` about it. SN10's
+// https://taofi-doc.web.app/openapi.yaml serves 44 KB of valid OpenAPI 3.0.4
+// as text/yaml; the registry told the world it had no machine-readable API.
+
+// A real third-party document, captured verbatim from SN10 on 2026-08-07. Its
+// `3.0.4` is TAOFI'S spec version, not ours -- metagraphed publishes 3.1.0 with
+// draft-2020-12 components. The capture must take whatever a subnet publishes:
+// refusing a 3.0.x document because we prefer 3.1 would recreate exactly the
+// bug this fixes, one version-check later.
+const YAML_DOC = `openapi: 3.0.4
+info:
+  title: TaoFi - OpenAPI 3.0
+  version: 1.0.0
+paths:
+  /quote:
+    get:
+      summary: Get a quote
+`;
+
+describe("parseOpenApiDocument", () => {
+  test("JSON still parses, regardless of how it is labelled", () => {
+    const doc = parseOpenApiDocument(
+      '{"openapi":"3.1.0","info":{"title":"X"}}',
+      "application/json",
+      "https://example.dev/openapi.json",
+    );
+    assert.equal(doc?.openapi, "3.1.0");
+    // JSON is tried first and unconditionally -- the YAML gate must never be
+    // able to reject a JSON body, whatever its content-type says.
+    const odd = parseOpenApiDocument(
+      '{"openapi":"3.1.0"}',
+      "text/plain",
+      "https://example.dev/spec",
+    );
+    assert.equal(odd?.openapi, "3.1.0");
+  });
+
+  test("YAML parses when the content-type says so", () => {
+    const doc = parseOpenApiDocument(
+      YAML_DOC,
+      "text/yaml; charset=utf-8",
+      "https://taofi-doc.web.app/openapi.yaml",
+    );
+    assert.equal(doc?.openapi, "3.0.4");
+    assert.equal(
+      (doc?.info as Record<string, unknown>)?.title,
+      "TaoFi - OpenAPI 3.0",
+    );
+  });
+
+  test("YAML parses on a .yaml URL even when served as text/plain", () => {
+    // A server that mislabels the type should not cost the subnet its schema.
+    const doc = parseOpenApiDocument(
+      YAML_DOC,
+      "text/plain",
+      "https://example.dev/openapi.yaml",
+    );
+    assert.equal(doc?.openapi, "3.0.4");
+    assert.equal(
+      parseOpenApiDocument(
+        YAML_DOC,
+        "text/plain",
+        "https://example.dev/spec.yml",
+      )?.openapi,
+      "3.0.4",
+    );
+  });
+
+  test("YAML is NOT attempted for a body with no YAML signal", () => {
+    // The gate matters: YAML's parser accepts a great deal of plain text, so
+    // always-trying would turn error pages into captured schemas.
+    assert.equal(
+      parseOpenApiDocument(YAML_DOC, "text/html", "https://example.dev/spec"),
+      null,
+    );
+  });
+
+  test("an HTML error page served as YAML is not a captured schema", () => {
+    // The specific hazard the object check exists for: this parses cleanly as a
+    // YAML scalar, and returning that string would sail through as `captured`.
+    assert.equal(
+      parseOpenApiDocument(
+        "<html><body>404 Not Found</body></html>",
+        "text/yaml",
+        "https://example.dev/openapi.yaml",
+      ),
+      null,
+    );
+  });
+
+  test("a YAML scalar or list is not an OpenAPI document", () => {
+    assert.equal(
+      parseOpenApiDocument("just a string", "text/yaml", "x.yaml"),
+      null,
+    );
+    assert.equal(
+      parseOpenApiDocument("- a\n- b\n", "text/yaml", "x.yaml"),
+      null,
+    );
+  });
+
+  test("an alias bomb is bounded rather than expanded", () => {
+    // Untrusted third-party input: unbounded anchor/alias expansion is the
+    // billion-laughs shape. maxAliasCount makes this throw, which the parser
+    // reports as "did not parse" rather than hanging the capture.
+    const bomb = [
+      "a: &a [x,x,x,x,x,x,x,x,x]",
+      "b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]",
+      "c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]",
+      "d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]",
+      "e: [*d,*d,*d,*d,*d,*d,*d,*d,*d]",
+    ].join("\n");
+    assert.equal(parseOpenApiDocument(bomb, "text/yaml", "x.yaml"), null);
+  });
+
+  test("empty and malformed bodies are null, not a capture", () => {
+    assert.equal(parseOpenApiDocument("", "text/yaml", "x.yaml"), null);
+    assert.equal(parseOpenApiDocument(null, "text/yaml", "x.yaml"), null);
+    assert.equal(
+      parseOpenApiDocument("{ unclosed", "text/yaml", "x.yaml"),
+      null,
+    );
+  });
+});


### PR DESCRIPTION
`GET /api/v1/schemas` published this about subnet 10:

```json
{
  "status": "not-found",
  "error":  "no machine-readable OpenAPI JSON found",
  "schema_url": "https://taofi-doc.web.app/openapi.yaml"
}
```

That URL returns `HTTP 200`, `content-type: text/yaml`, and **44 KB of valid OpenAPI 3.0.4** with `info`, `servers` and `paths`. Both statements were false, and they were published about someone else's subnet.

The OpenAPI Specification permits YAML — arguably the more common way to publish a document — and the registry URL literally ends in `.yaml`. The capture only ever called `JSON.parse`, so a subnet doing everything right (correct kind, correct URL, 200, correct content-type, valid document) was recorded as `content-mismatch`. `get_api_schema`, whose entire job is handing an agent a subnet's API contract, had nothing to return.

## The existing JSON path is untouched

JSON is still tried **first and unconditionally**. Every JSON document is also valid YAML 1.2, so the YAML parser *would* handle it — but it would be slower and would accept YAML-only syntax on a `.json` surface. YAML is strictly a fallback.

## Two guards, because this parses untrusted third-party input

**YAML is only attempted on a YAML signal** — content-type, or a `.yaml`/`.yml` URL suffix for a server that mislabels the type. YAML's parser accepts a great deal of plain text: an HTML error page parses cleanly as a scalar. Always-trying would turn error pages into captured schemas, which is worse than the bug being fixed.

**The result must be an object.** A scalar or a list is not an OpenAPI document, and returning one would sail through as `captured`.

**Alias expansion is capped** (`maxAliasCount`) — unbounded anchors from a third-party host are the billion-laughs shape. The parser resolves no custom tags to JS objects, so there is no path from a tag to execution.

## On the dependency

`yaml` is added as a **dev** dependency. `scripts/snapshot-adapters.ts` is a build-time Node script, never bundled into a Worker, so this costs nothing at the edge. It was already present transitively (graphql-codegen, tsup) at the **same 2.9.0**, so the install footprint is unchanged — it is now *declared* rather than borrowed.

## On OpenAPI 3.1

Worth stating explicitly since the fixture shows `3.0.4`: **that is TaoFi's spec version, not ours.** metagraphed publishes `openapi: 3.1.0` with draft-2020-12 components, which is the consistent pairing (3.1 is the version that aligns with 2020-12).

The capture must take whatever a subnet publishes. Refusing a 3.0.x document because we prefer 3.1 would recreate exactly this bug, one version-check later. The test says so in a comment so the fixture is not mistaken for a target.

## Verified against the live document

```
GET https://taofi-doc.web.app/openapi.yaml  →  200, text/yaml; charset=utf-8
parsed: YES
  openapi: 3.0.4 | title: TaoFi - OpenAPI 3.0 | paths: 8
```

## Tests

`tests/openapi-document-parse.test.ts`, 8 tests: JSON parses regardless of label; YAML parses by content-type; YAML parses by `.yaml`/`.yml` suffix when served as `text/plain`; YAML is **not** attempted without a signal; an HTML error page served as YAML is not a capture; a scalar or list is not a document; an alias bomb is bounded rather than expanded; empty/null/malformed bodies are null.

**Mutation-tested:**

| mutation | result |
|---|---|
| YAML fallback removed | **2 failures** — content-type and suffix cases |
| gate removed (always try YAML) | **1 failure** — no-signal body |
| object check removed | **2 failures** — HTML error page, scalar/list |

## Validation run

```
npm run lint / format:check / typecheck   clean
npm run build                             exit 0
npm run validate                          exit 0
vitest openapi-document-parse, adapter-snapshot-security,
       adapter-snapshot-determinism, validate-adapters
                                          23 passed
```

The error message drops its JSON-specific wording, since YAML is captured now too.

No file under `src/**` or `workers/**` is touched, so `codecov/patch` has no scope. Based on `22381aaad`.

Closes #9893
