### PR TITLE
feat(mcp): answer "is MY uid at risk" from the deregistration data we already derive

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -10180,6 +10180,15 @@ export interface components {
                 window_registrations: number;
             };
             distinct_deregistered_hotkeys: number;
+            events?: {
+                block_number: number;
+                hotkey: string;
+                /** Format: date-time */
+                observed_at: string;
+                replaced_by_hotkey: string;
+                tenure_blocks: number | null;
+                uid: number;
+            }[];
             netuid: number;
             observed_at: string | null;
             schema_version: number;
@@ -38668,6 +38677,16 @@ export interface operations {
                      *           "window_registrations": 1
                      *         },
                      *         "distinct_deregistered_hotkeys": 1,
+                     *         "events": [
+                     *           {
+                     *             "block_number": 5000000,
+                     *             "hotkey": "example",
+                     *             "observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "replaced_by_hotkey": "example",
+                     *             "tenure_blocks": 5000000,
+                     *             "uid": 1
+                     *           }
+                     *         ],
                      *         "netuid": 7,
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -8686,6 +8686,16 @@
               "window_registrations": 1
             },
             "distinct_deregistered_hotkeys": 1,
+            "events": [
+              {
+                "block_number": 5000000,
+                "hotkey": "example",
+                "observed_at": "2026-06-01T00:00:00.000Z",
+                "replaced_by_hotkey": "example",
+                "tenure_blocks": 5000000,
+                "uid": 1
+              }
+            ],
             "netuid": 7,
             "observed_at": "2026-06-01T00:00:00.000Z",
             "schema_version": 1,
@@ -43123,6 +43133,56 @@
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
+          },
+          "events": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "block_number": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "hotkey": {
+                  "type": "string"
+                },
+                "observed_at": {
+                  "format": "date-time",
+                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                  "type": "string"
+                },
+                "replaced_by_hotkey": {
+                  "type": "string"
+                },
+                "tenure_blocks": {
+                  "anyOf": [
+                    {
+                      "maximum": 9007199254740991,
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "uid": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "uid",
+                "hotkey",
+                "replaced_by_hotkey",
+                "block_number",
+                "observed_at",
+                "tenure_blocks"
+              ],
+              "type": "object"
+            },
+            "type": "array"
           },
           "netuid": {
             "maximum": 9007199254740991,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -10180,6 +10180,15 @@ export interface components {
                 window_registrations: number;
             };
             distinct_deregistered_hotkeys: number;
+            events?: {
+                block_number: number;
+                hotkey: string;
+                /** Format: date-time */
+                observed_at: string;
+                replaced_by_hotkey: string;
+                tenure_blocks: number | null;
+                uid: number;
+            }[];
             netuid: number;
             observed_at: string | null;
             schema_version: number;
@@ -38668,6 +38677,16 @@ export interface operations {
                      *           "window_registrations": 1
                      *         },
                      *         "distinct_deregistered_hotkeys": 1,
+                     *         "events": [
+                     *           {
+                     *             "block_number": 5000000,
+                     *             "hotkey": "example",
+                     *             "observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "replaced_by_hotkey": "example",
+                     *             "tenure_blocks": 5000000,
+                     *             "uid": 1
+                     *           }
+                     *         ],
                      *         "netuid": 7,
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,

--- a/schemas-src/routes/subnet-activity.ts
+++ b/schemas-src/routes/subnet-activity.ts
@@ -51,6 +51,44 @@ export const SubnetDeregistrationsArtifactSchema = z
     distinct_deregistered_hotkeys: z.int().min(0),
     deregistrations: z.int().min(0),
     deregistrations_per_hotkey: z.number().min(0).nullable(),
+    /**
+     * The individual evictions behind the counts above (#9873).
+     *
+     * The scalar answers "how much churn does this subnet have"; an operator
+     * asking "is MY uid at risk, and how soon" needs the events. Each row
+     * names the UID that turned over, the hotkey that LOST it, the hotkey that
+     * took it, and how long the loser had held it -- enough for a caller to
+     * work out whether pruning is oldest-first, lowest-incentive-first or
+     * something else, which is what the reporter actually asked for.
+     *
+     * DELIBERATELY NOT A RISK SCORE. Publishing one would be a model presented
+     * as a measurement, the failure `is_lower_bound` exists to prevent.
+     *
+     * Same lower-bound caveat as the counts: an eviction whose displaced
+     * holder registered before the lookback cannot be attributed, and those
+     * are counted in `derivation.unattributed_registrations` rather than
+     * appearing here with a guessed hotkey.
+     */
+    events: z
+      .array(
+        z
+          .object({
+            uid: z.int().min(0),
+            /** The DISPLACED holder — this event is a deregistration OF it. */
+            hotkey: z.string(),
+            replaced_by_hotkey: z.string(),
+            block_number: z.int().min(0),
+            observed_at: z.iso.datetime(),
+            /**
+             * Blocks the displaced holder kept the slot. Null when the two
+             * registrations carry no usable ordering — never 0, which would
+             * read as "evicted instantly" rather than "not measurable".
+             */
+            tenure_blocks: z.int().min(1).nullable(),
+          })
+          .strict(),
+      )
+      .optional(),
     // #9307: derived from UID reuse out of the same projection rows the chain
     // leaderboard ranks; `degraded` when nothing derived it.
     derivation: DeregistrationDerivationSchema.optional(),

--- a/scripts/validate-mcp.ts
+++ b/scripts/validate-mcp.ts
@@ -2096,6 +2096,16 @@ const COLLECTIONS_UNEXERCISED_REASONS = new Map<string, string>([
   ],
   ["get_subnet_health", "the harness's health artifact carries no surfaces"],
   [
+    "get_subnet_deregistrations",
+    // `events` (#9873) is sliced from the chain-deregistrations-by-uid
+    // PROJECTION, which the lane writes and the harness has no copy of -- the
+    // same reason every other projection-backed collection is here. The item
+    // shape is covered by the daily check-mcp-conformance sweep against
+    // production, which is a real receiver rather than the unscheduled one
+    // #9879 was about.
+    "the per-uid eviction events come from a projection the lane writes and the harness does not carry",
+  ],
+  [
     "get_subnet_health_percentiles",
     "percentiles are computed over surfaces the harness's health artifact does not carry",
   ],

--- a/src/chain-deregistrations-artifact.ts
+++ b/src/chain-deregistrations-artifact.ts
@@ -52,6 +52,7 @@ import {
 import {
   deregistrationRowsForHotkey,
   type DeregistrationDerivation,
+  type DeregistrationUidTuple,
 } from "./deregistration-derivation.ts";
 import { DEREGISTRATIONS_DEGRADED_NOT_DERIVED } from "./uncurated-event-streams.ts";
 
@@ -62,6 +63,16 @@ export const CHAIN_DEREGISTRATIONS_PROJECTION_KEY =
 /** The per-displaced-hotkey index, ~1.5 MB — read only by the account scope. */
 export const CHAIN_DEREGISTRATIONS_HOTKEY_PROJECTION_KEY =
   "metagraph/projections/chain-deregistrations-by-hotkey.json";
+
+/**
+ * The per-(netuid, uid) eviction index (#9873) — read only by the per-subnet
+ * scope.
+ *
+ * Widest window only: every tuple carries its own `observed_at`, so a narrower
+ * window is a filter rather than a second copy.
+ */
+export const CHAIN_DEREGISTRATIONS_UID_PROJECTION_KEY =
+  "metagraph/projections/chain-deregistrations-by-uid.json";
 
 interface ArtifactBucket {
   get(key: string): Promise<{ json(): Promise<unknown> } | null>;
@@ -95,6 +106,29 @@ async function readProjection(
   key: string,
   network: ChainNetworkId,
 ): Promise<Record<string, ProjectionWindow> | null> {
+  const body = await readProjectionBody(env, key, network);
+  const windows = body?.windows;
+  // A body that is not the artifact the lane wrote is a decline, not a
+  // guess -- same contract as the sibling chain-* readers.
+  if (typeof windows !== "object" || windows === null) return null;
+  return windows as Record<string, ProjectionWindow>;
+}
+
+/**
+ * The validated projection body, before any window unwrapping.
+ *
+ * The three objects this lane writes do NOT share one shape: the rollup and
+ * the per-hotkey index are keyed by window, while the per-uid index publishes
+ * a single widest-window list that readers slice by `observed_at` (#9873).
+ * Only `schema_version` is common, so that is all this checks -- pushing the
+ * `windows` requirement down here would silently decline the uid object on
+ * every call.
+ */
+async function readProjectionBody(
+  env: Env | null | undefined,
+  key: string,
+  network: ChainNetworkId,
+): Promise<Record<string, unknown> | null> {
   const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
     ?.METAGRAPH_ARCHIVE;
   if (!bucket?.get) return null;
@@ -103,18 +137,9 @@ async function readProjection(
     if (!object) return null;
     const body = (await object.json()) as {
       schema_version?: unknown;
-      windows?: unknown;
     } | null;
-    // A body that is not the artifact the lane wrote is a decline, not a
-    // guess -- same contract as the sibling chain-* readers.
-    if (
-      body?.schema_version !== 1 ||
-      typeof body.windows !== "object" ||
-      body.windows === null
-    ) {
-      return null;
-    }
-    return body.windows as Record<string, ProjectionWindow>;
+    if (body?.schema_version !== 1) return null;
+    return body as Record<string, unknown>;
   } catch {
     return null;
   }
@@ -203,8 +228,17 @@ export async function loadSubnetDeregistrationsFromArtifact(
   /** Which chain's projection to read (#9412). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Record<string, unknown> | null> {
+  // Two objects, one round trip. The counts come from the rollup the
+  // leaderboard ranks (so a subnet card can never disagree with its own row);
+  // the events come from the per-uid index. Neither read depends on the
+  // other's result -- only the SLICE depends on which window won -- so issuing
+  // them serially would buy nothing but latency (#9873).
+  const [rollup, evictions] = await Promise.all([
+    readProjection(env, CHAIN_DEREGISTRATIONS_PROJECTION_KEY, network),
+    readProjectionBody(env, CHAIN_DEREGISTRATIONS_UID_PROJECTION_KEY, network),
+  ]);
   const selected = selectWindow(
-    await readProjection(env, CHAIN_DEREGISTRATIONS_PROJECTION_KEY, network),
+    rollup,
     SUBNET_DEREGISTRATIONS_WINDOWS,
     DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW,
     query.window,
@@ -222,7 +256,64 @@ export async function loadSubnetDeregistrationsFromArtifact(
   });
   const derivation = derivationOf(selected.window);
   if (derivation) data.derivation = derivation;
+  // selectWindow only returns a label it found in SUBNET_DEREGISTRATIONS_WINDOWS,
+  // so this lookup cannot miss -- which is why the slice takes a plain number
+  // and carries no "window unknown" branch to guard.
+  data.events = subnetUidEvictions(
+    evictions,
+    target,
+    SUBNET_DEREGISTRATIONS_WINDOWS[selected.label]!,
+  );
   return data;
+}
+
+/**
+ * The individual evictions behind this subnet's count (#9873).
+ *
+ * WHY THE SCALAR WAS NOT ENOUGH. An operator asking "how likely is MY uid to be
+ * evicted, and how soon" cannot answer it from a subnet-wide rate. These rows
+ * carry which UID turned over, when, who lost it and who took it, so a caller
+ * can work out whether pruning is oldest-first, lowest-incentive-first or
+ * something else, and where they sit in that ordering. That is the reporter's
+ * own framing: they wanted to determine the rule, not be handed a score.
+ *
+ * DELIBERATELY NOT A RISK MODEL. Publishing a "pruning score" would be a model
+ * presented as a measurement -- the failure `is_lower_bound` and `derivation`
+ * exist to prevent (#9307).
+ *
+ * Sliced from the widest window: every tuple carries its own observed_at, so a
+ * 7d view is a filter over the published 30d list rather than a second copy.
+ * Returns [] when the projection is missing, which reads the same as "no slot
+ * changed hands" -- the sibling counts carry the degraded signal.
+ */
+function subnetUidEvictions(
+  projection: unknown,
+  netuid: number,
+  windowDays: number,
+): Record<string, unknown>[] {
+  const rows = (
+    projection as {
+      by_netuid?: Record<string, DeregistrationUidTuple[]>;
+    } | null
+  )?.by_netuid?.[String(netuid)];
+  if (!Array.isArray(rows)) return [];
+  const since = Date.now() - windowDays * 24 * 60 * 60 * 1000;
+  const out: Record<string, unknown>[] = [];
+  for (const tuple of rows) {
+    if (!Array.isArray(tuple) || tuple.length < 6) continue;
+    const [uid, hotkey, successor, block, observedAt, tenure] = tuple;
+    if (typeof observedAt !== "number" || observedAt < since) continue;
+    out.push({
+      uid,
+      // The DISPLACED holder -- this event is a deregistration OF this hotkey.
+      hotkey,
+      replaced_by_hotkey: successor,
+      block_number: block,
+      observed_at: new Date(observedAt).toISOString(),
+      tenure_blocks: tenure,
+    });
+  }
+  return out;
 }
 
 /**

--- a/src/deregistration-derivation.ts
+++ b/src/deregistration-derivation.ts
@@ -460,6 +460,58 @@ export function deregistrationsByHotkey(
   return index;
 }
 
+/** One displaced occupant, positional for the same reason
+ * DeregistrationHotkeyTuple is: two SS58 keys per event would otherwise be
+ * dwarfed by their own key names.
+ *
+ * `[uid, displaced_hotkey, successor_hotkey, block_number, observed_at,
+ *   tenure_blocks]`
+ */
+export type DeregistrationUidTuple = [
+  number,
+  string,
+  string,
+  number,
+  number,
+  number | null,
+];
+
+/**
+ * Reduce derived events to a per-NETUID index of the individual evictions
+ * (#9873).
+ *
+ * The derivation already holds these -- deregistrationsByNetuid throws them
+ * away to produce counts -- so this costs no extra lakehouse read, only the
+ * bytes. An operator asking "is MY uid at risk" cannot answer it from a
+ * subnet-wide rate, which is what the scalar card serves today.
+ *
+ * Rows arrive newest-first per subnet, because the question is about recent
+ * churn and a caller taking the first N should get the most recent N.
+ */
+export function deregistrationsByNetuidUid(
+  events: DerivedDeregistration[],
+): Record<string, DeregistrationUidTuple[]> {
+  const perNetuid = new Map<number, DeregistrationUidTuple[]>();
+  for (const event of events) {
+    const bucket = perNetuid.get(event.netuid) ?? [];
+    bucket.push([
+      event.uid,
+      event.hotkey,
+      event.successor,
+      event.block_number,
+      event.observed_at,
+      event.tenure_blocks,
+    ]);
+    perNetuid.set(event.netuid, bucket);
+  }
+  const index: Record<string, DeregistrationUidTuple[]> = {};
+  for (const [netuid, rows] of perNetuid) {
+    rows.sort((a, b) => b[4] - a[4] || b[3] - a[3]);
+    index[String(netuid)] = rows;
+  }
+  return index;
+}
+
 /** Expand one hotkey's tuples back into the `{netuid, deregistrations,
  * first_observed, last_observed}` rows buildAccountDeregistrations reads. */
 export function deregistrationRowsForHotkey(

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -6980,7 +6980,18 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       "NeuronDeregistered event count, and the average deregistrations per " +
       "hotkey, computed live from the account_events NeuronDeregistered stream. " +
       "Raw deregistration/eviction activity — the exit-side companion to " +
-      "NeuronRegistered demand. Mirrors GET /api/v1/subnets/{netuid}/deregistrations.",
+      "NeuronRegistered demand. `events` carries the INDIVIDUAL evictions " +
+      "behind those counts (#9873): per row the UID that turned over, the " +
+      "hotkey that LOST it, the hotkey that took it, the block, and how long " +
+      'the loser had held the slot. Use it to answer "is MY uid at risk" — ' +
+      "a subnet-wide rate cannot, and the tenure/incentive ordering across " +
+      "rows is what tells you whether pruning is oldest-first or " +
+      "lowest-incentive-first. There is deliberately NO risk score: that " +
+      "would be a model presented as a measurement. `derivation.is_lower_bound` " +
+      "applies to `events` too — an eviction whose displaced holder registered " +
+      "before the lookback cannot be attributed and is counted in " +
+      "`unattributed_registrations` rather than guessed at here. " +
+      "Mirrors GET /api/v1/subnets/{netuid}/deregistrations.",
     inputSchema: z.toJSONSchema(GetSubnetDeregistrationsInputSchema, {
       target: "draft-2020-12",
     }),

--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -85,11 +85,13 @@ import { CHAIN_REGISTRATIONS_PROJECTION_KEY } from "./chain-registrations-artifa
 import { CHAIN_DEREGISTRATIONS_WINDOWS } from "./chain-deregistrations.ts";
 import {
   CHAIN_DEREGISTRATIONS_HOTKEY_PROJECTION_KEY,
+  CHAIN_DEREGISTRATIONS_UID_PROJECTION_KEY,
   CHAIN_DEREGISTRATIONS_PROJECTION_KEY,
 } from "./chain-deregistrations-artifact.ts";
 import {
   deregistrationsByHotkey,
   deregistrationsByNetuid,
+  deregistrationsByNetuidUid,
   deregistrationsNetworkRollup,
   deriveDeregistrations,
   DEREGISTRATION_DERIVATION_METHOD,
@@ -1191,6 +1193,14 @@ async function computeChainDeregistrations(
     };
     rowCount += subnetRows.length;
   }
+  // THE WIDEST WINDOW ONLY, and sliced per request rather than published per
+  // window (#9873). Every event carries observed_at, so a 7d view is a filter
+  // over the 30d list -- publishing both would duplicate ~6,300 events to save
+  // a comparison. The derivation makes the same argument for pulling once and
+  // slicing, one level up.
+  const widest = deriveDeregistrations(rows, {
+    since: generatedAt - lookbackDays * DAY_MS,
+  });
   return {
     schema_version: 1,
     generated_at: new Date(generatedAt).toISOString(),
@@ -1200,6 +1210,14 @@ async function computeChainDeregistrations(
     // Carried on the computed body and split off by the lane below, so the
     // expensive pull is paid for exactly once.
     hotkey_windows: hotkeyWindows,
+    // Same deal: the individual evictions the rollup counts, keyed by netuid,
+    // so "is MY uid at risk" is answerable at all (#9873).
+    uid_events: {
+      lookback_days: lookbackDays,
+      unattributed_registrations: widest.unattributed,
+      window_registrations: widest.registrations,
+      by_netuid: deregistrationsByNetuidUid(widest.events),
+    },
   };
 }
 
@@ -1209,7 +1227,11 @@ async function computeChainDeregistrations(
 function splitChainDeregistrations(
   body: Record<string, unknown>,
 ): Record<string, unknown> {
-  const { hotkey_windows: hotkeyWindows, ...rollup } = body;
+  const {
+    hotkey_windows: hotkeyWindows,
+    uid_events: uidEvents,
+    ...rollup
+  } = body;
   return {
     [CHAIN_DEREGISTRATIONS_PROJECTION_KEY]: rollup,
     [CHAIN_DEREGISTRATIONS_HOTKEY_PROJECTION_KEY]: {
@@ -1217,6 +1239,14 @@ function splitChainDeregistrations(
       generated_at: rollup.generated_at,
       lookback_days: rollup.lookback_days,
       windows: hotkeyWindows,
+    },
+    // A third object for the same reason the hotkey index is a second one:
+    // only the per-subnet scope reads it, and the rollup is ~8 KB against
+    // this one's per-event detail.
+    [CHAIN_DEREGISTRATIONS_UID_PROJECTION_KEY]: {
+      schema_version: rollup.schema_version,
+      generated_at: rollup.generated_at,
+      ...(uidEvents as Record<string, unknown>),
     },
   };
 }

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -3560,9 +3560,12 @@ describe("handleScheduled PROJECTION_LANES_CRON", () => {
       PROJECTION_NETWORKS.flatMap((network) =>
         [
           ...PROJECTION_LANES.map((lane) => lane.artifactKey),
-          // The one lane that fans its single computed body across two objects
-          // (src/chain-deregistrations-artifact.ts's header says why).
+          // The one lane that fans its single computed body across THREE
+          // objects, one per read scope (src/chain-deregistrations-artifact.ts's
+          // headers say why): the rollup, the per-hotkey index the account
+          // scope reads, and the per-uid index the subnet scope reads (#9873).
           "metagraph/projections/chain-deregistrations-by-hotkey.json",
+          "metagraph/projections/chain-deregistrations-by-uid.json",
         ].map((key) => projectionKey(key, network)),
       ).sort(),
       "each lane writes its own artifact key per network, plus any split it declares",
@@ -3608,10 +3611,10 @@ describe("handleScheduled PROJECTION_LANES_CRON", () => {
       !puts.includes("metagraph/projections/chain-transfer-pairs.json"),
     );
     // The Transfer filter is network-agnostic, so BOTH chains' copies of those
-    // two lanes fail: two per network, plus one extra object for the
-    // chain-deregistrations split on each.
+    // two lanes fail: two per network, plus the two extra objects the
+    // chain-deregistrations split writes beyond its own lane key on each.
     const failedPerNetwork = 2;
-    const splitExtraPerNetwork = 1;
+    const splitExtraPerNetwork = 2;
     assert.equal(
       puts.length,
       Object.keys(lanes).length -

--- a/tests/chain-deregistrations-artifact.test.ts
+++ b/tests/chain-deregistrations-artifact.test.ts
@@ -14,6 +14,7 @@ import { describe, test } from "vitest";
 import {
   CHAIN_DEREGISTRATIONS_HOTKEY_PROJECTION_KEY,
   CHAIN_DEREGISTRATIONS_PROJECTION_KEY,
+  CHAIN_DEREGISTRATIONS_UID_PROJECTION_KEY,
   loadAccountDeregistrationsFromArtifact,
   loadChainDeregistrationsFromArtifact,
   loadSubnetDeregistrationsFromArtifact,
@@ -113,7 +114,39 @@ function envWith(
   };
 }
 
+/**
+ * Per-uid eviction tuples (#9873), anchored to NOW rather than to a frozen
+ * constant: the reader slices by wall-clock age, so a fixture pinned to a date
+ * would start failing the day the window moved past it.
+ */
+const DAY_MS = 24 * 60 * 60 * 1000;
+const recent = (days: number) => Date.now() - days * DAY_MS;
+
+const UID_BODY = {
+  schema_version: 1,
+  generated_at: "2026-08-03T19:14:36.000Z",
+  lookback_days: 30,
+  window_registrations: 8064,
+  unattributed_registrations: 1726,
+  by_netuid: {
+    // Newest-first, as the derivation writes them.
+    "45": [
+      [7, "5A", "5B", 350, recent(2), 150],
+      [7, "5Z", "5A", 200, recent(5), 100],
+      [12, "5C", "5D", 190, recent(20), 40],
+      // Rows a malformed lane could emit. Publishing these would put
+      // `"observed_at": null` (or a five-field row's undefined tail) into a
+      // response that claims every field is present, so they are dropped.
+      [3, "5E", "5F", 100],
+      [3, "5G", "5H", 100, "not-a-number", 10],
+      "not-a-tuple",
+    ],
+    "68": [[1, "5I", "5J", 90, recent(1), 5]],
+  },
+};
+
 const ROLLUP_ENV = { [CHAIN_DEREGISTRATIONS_PROJECTION_KEY]: ROLLUP_BODY };
+const UID_ENV = { [CHAIN_DEREGISTRATIONS_UID_PROJECTION_KEY]: UID_BODY };
 const HOTKEY_ENV = {
   [CHAIN_DEREGISTRATIONS_HOTKEY_PROJECTION_KEY]: HOTKEY_BODY,
 };
@@ -262,7 +295,88 @@ describe("loadSubnetDeregistrationsFromArtifact", () => {
     assert.equal(out.distinct_deregistered_hotkeys, 356);
     assert.equal(out.observed_at, new Date(NEWEST).toISOString());
     assert.deepEqual(out.derivation, DERIVATION_7D);
-    assert.deepEqual(keys, [CHAIN_DEREGISTRATIONS_PROJECTION_KEY]);
+    // Two objects, and only two: the rollup the leaderboard ranks (counts) and
+    // the per-uid index (events, #9873). It must never reach for the per-hotkey
+    // index -- that one is the account scope's, and it is the largest of the
+    // three. Sorted because they are issued as one Promise.all.
+    assert.deepEqual(
+      [...keys].sort(),
+      [
+        CHAIN_DEREGISTRATIONS_PROJECTION_KEY,
+        CHAIN_DEREGISTRATIONS_UID_PROJECTION_KEY,
+      ].sort(),
+    );
+  });
+
+  test("publishes the individual evictions behind the count (#9873)", async () => {
+    const { env } = envWith({ ...ROLLUP_ENV, ...UID_ENV });
+    const out = (await loadSubnetDeregistrationsFromArtifact(env, 45, {
+      window: "7d",
+    })) as Row;
+    const events = out.events as Row[];
+    // The 20-day-old eviction is outside the 7d window; the two malformed rows
+    // and the string are dropped. What is left is the two real 7d evictions.
+    assert.equal(events.length, 2);
+    assert.deepEqual(events[0], {
+      uid: 7,
+      // The DISPLACED holder. Naming 5B here would report the arrival as the
+      // casualty, and no downstream consumer could tell.
+      hotkey: "5A",
+      replaced_by_hotkey: "5B",
+      block_number: 350,
+      observed_at: new Date(
+        UID_BODY.by_netuid["45"][0]![4] as number,
+      ).toISOString(),
+      tenure_blocks: 150,
+    });
+    assert.equal(events[1]!.hotkey, "5Z");
+  });
+
+  test("the window slices the events, not just the count", async () => {
+    // Same published list, two windows. If the reader ignored `observed_at` the
+    // 7d view would carry a 20-day-old eviction and quietly contradict the
+    // count sitting next to it.
+    const { env } = envWith({ ...ROLLUP_ENV, ...UID_ENV });
+    const wide = (await loadSubnetDeregistrationsFromArtifact(env, 45, {
+      window: "30d",
+    })) as Row;
+    assert.deepEqual(
+      (wide.events as Row[]).map((e) => e.uid),
+      [7, 7, 12],
+    );
+  });
+
+  test("reads only its OWN subnet's slice of the shared index", async () => {
+    const { env } = envWith({ ...ROLLUP_ENV, ...UID_ENV });
+    const out = (await loadSubnetDeregistrationsFromArtifact(env, 68, {
+      window: "7d",
+    })) as Row;
+    assert.deepEqual(
+      (out.events as Row[]).map((e) => e.hotkey),
+      ["5I"],
+    );
+  });
+
+  test("a subnet absent from the index reports no events, not a decline", async () => {
+    const { env } = envWith({ ...ROLLUP_ENV, ...UID_ENV });
+    const out = (await loadSubnetDeregistrationsFromArtifact(env, 3, {
+      window: "7d",
+    })) as Row;
+    // 441 evictions on the rollup, none attributable to a uid we indexed --
+    // the same lower-bound story `unattributed_registrations` already tells.
+    assert.equal(out.deregistrations, 441);
+    assert.deepEqual(out.events, []);
+  });
+
+  test("a missing per-uid object leaves the counts intact", async () => {
+    // The three objects are written by one lane but stored separately, so one
+    // can lag. The counts must not go dark because the events did.
+    const { env } = envWith(ROLLUP_ENV);
+    const out = (await loadSubnetDeregistrationsFromArtifact(env, 45, {
+      window: "7d",
+    })) as Row;
+    assert.equal(out.deregistrations, 429);
+    assert.deepEqual(out.events, []);
   });
 
   test("a subnet with no row is a MEASURED zero, not a decline", async () => {

--- a/tests/deregistration-uid-events.test.ts
+++ b/tests/deregistration-uid-events.test.ts
@@ -1,0 +1,209 @@
+// Per-UID eviction events (#9873).
+//
+// The derivation has always produced these -- deregistrationsByNetuid throws
+// them away to make counts -- so this is a publishing change, not a new data
+// path. These tests pin the two things that make it honest: the events say who
+// LOST the slot (not who took it), and the lower-bound caveat that governs the
+// counts governs the events too.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  deregistrationsByNetuidUid,
+  deriveDeregistrations,
+} from "../src/deregistration-derivation.ts";
+import type { Row } from "./row-type.ts";
+
+const DAY = 24 * 60 * 60 * 1000;
+const now = Date.UTC(2026, 7, 7);
+
+/** Three registrations on one slot: A -> B -> C, plus an untouched slot. */
+function registrations(): Row[] {
+  return [
+    {
+      netuid: 53,
+      uid: 7,
+      hotkey: "hk-A",
+      block_number: 100,
+      event_index: 1,
+      observed_at: now - 20 * DAY,
+    },
+    {
+      netuid: 53,
+      uid: 7,
+      hotkey: "hk-B",
+      block_number: 200,
+      event_index: 1,
+      observed_at: now - 10 * DAY,
+    },
+    {
+      netuid: 53,
+      uid: 7,
+      hotkey: "hk-C",
+      block_number: 350,
+      event_index: 1,
+      observed_at: now - 2 * DAY,
+    },
+    {
+      netuid: 53,
+      uid: 9,
+      hotkey: "hk-D",
+      block_number: 120,
+      event_index: 1,
+      observed_at: now - 18 * DAY,
+    },
+    {
+      netuid: 64,
+      uid: 1,
+      hotkey: "hk-E",
+      block_number: 130,
+      event_index: 1,
+      observed_at: now - 15 * DAY,
+    },
+    {
+      netuid: 64,
+      uid: 1,
+      hotkey: "hk-F",
+      block_number: 260,
+      event_index: 1,
+      observed_at: now - 5 * DAY,
+    },
+  ];
+}
+
+describe("deregistrationsByNetuidUid (#9873)", () => {
+  const derived = deriveDeregistrations(registrations(), {
+    since: now - 30 * DAY,
+  });
+  const index = deregistrationsByNetuidUid(derived.events);
+
+  test("names the DISPLACED holder, not the arrival", () => {
+    // The whole point: this event is a deregistration OF hk-A, caused BY hk-B.
+    // Getting these the wrong way round would name the wrong operator as
+    // evicted, and nothing downstream could tell.
+    const rows = index["53"];
+    const first = rows.find((r) => r[3] === 200)!;
+    assert.equal(first[0], 7, "uid");
+    assert.equal(first[1], "hk-A", "displaced");
+    assert.equal(first[2], "hk-B", "successor");
+  });
+
+  test("keys by netuid and orders newest-first", () => {
+    assert.deepEqual(Object.keys(index).sort(), ["53", "64"]);
+    // A caller taking the first N wants the most recent N -- the question is
+    // about recent churn.
+    const observed = index["53"].map((r) => r[4]);
+    assert.deepEqual(
+      observed,
+      [...observed].sort((a, b) => b - a),
+    );
+  });
+
+  test("carries tenure, so a caller can see the pruning ORDER", () => {
+    // hk-A held blocks 100..200, hk-B held 200..350. Without this a caller
+    // cannot tell whether eviction tracks age or incentive -- which is the
+    // reporter's actual question.
+    const rows = index["53"];
+    assert.equal(rows.find((r) => r[3] === 200)![5], 100);
+    assert.equal(rows.find((r) => r[3] === 350)![5], 150);
+  });
+
+  test("a slot that never turned over produces no event", () => {
+    // uid 9 registered once. Emitting a row for it would invent an eviction.
+    assert.equal(
+      index["53"].some((r) => r[0] === 9),
+      false,
+    );
+  });
+
+  test("the unattributed population is EXCLUDED, not guessed at", () => {
+    // Only the events with an observed predecessor appear. The first
+    // registration on each slot has none, and those are what
+    // `unattributed_registrations` counts -- the same lower-bound caveat the
+    // scalar carries, applied to the events.
+    assert.ok(
+      derived.unattributed > 0,
+      "fixture should have unattributed rows",
+    );
+    const total = Object.values(index).reduce((n, rows) => n + rows.length, 0);
+    assert.equal(total, derived.events.length);
+    assert.ok(
+      total < derived.registrations,
+      "events must be fewer than registrations -- they are a lower bound",
+    );
+  });
+
+  test("two evictions in one observation break the tie by BLOCK", () => {
+    // The poller stamps a whole batch with one observed_at, so equal timestamps
+    // are the norm, not an edge case. Falling back to insertion order would
+    // make the newest-first contract silently untrue inside every batch.
+    const stamped = now - 3 * DAY;
+    const derived = deriveDeregistrations(
+      [
+        {
+          netuid: 5,
+          uid: 0,
+          hotkey: "hk-1",
+          block_number: 10,
+          event_index: 1,
+          observed_at: now - 9 * DAY,
+        },
+        {
+          netuid: 5,
+          uid: 1,
+          hotkey: "hk-2",
+          block_number: 11,
+          event_index: 1,
+          observed_at: now - 9 * DAY,
+        },
+        {
+          netuid: 5,
+          uid: 0,
+          hotkey: "hk-3",
+          block_number: 400,
+          event_index: 1,
+          observed_at: stamped,
+        },
+        {
+          netuid: 5,
+          uid: 1,
+          hotkey: "hk-4",
+          block_number: 900,
+          event_index: 1,
+          observed_at: stamped,
+        },
+      ],
+      { since: now - 30 * DAY },
+    );
+    const rows = deregistrationsByNetuidUid(derived.events)["5"]!;
+    assert.deepEqual(
+      rows.map((r) => r[3]),
+      [900, 400],
+      "same observed_at must order by block, highest first",
+    );
+  });
+
+  test("a same-hotkey re-registration is not an eviction of itself", () => {
+    const same = deriveDeregistrations(
+      [
+        {
+          netuid: 1,
+          uid: 0,
+          hotkey: "hk-X",
+          block_number: 10,
+          event_index: 1,
+          observed_at: now - 9 * DAY,
+        },
+        {
+          netuid: 1,
+          uid: 0,
+          hotkey: "hk-X",
+          block_number: 20,
+          event_index: 1,
+          observed_at: now - 8 * DAY,
+        },
+      ],
+      { since: now - 30 * DAY },
+    );
+    assert.deepEqual(deregistrationsByNetuidUid(same.events), {});
+  });
+});

--- a/tests/projection-lanes.test.ts
+++ b/tests/projection-lanes.test.ts
@@ -18,6 +18,7 @@ import {
 import { BLOCKS_SUMMARY_SCAN_CAP } from "../src/blocks-summary.ts";
 import {
   CHAIN_DEREGISTRATIONS_HOTKEY_PROJECTION_KEY,
+  CHAIN_DEREGISTRATIONS_UID_PROJECTION_KEY,
   CHAIN_DEREGISTRATIONS_PROJECTION_KEY,
 } from "../src/chain-deregistrations-artifact.ts";
 import { LAKEHOUSE_NAMESPACES } from "../src/chain-network.ts";
@@ -1519,9 +1520,13 @@ describe("runProjectionLanes", () => {
       PROJECTION_NETWORKS.flatMap((network) =>
         [
           ...PROJECTION_LANES.map((lane) => lane.artifactKey),
-          // The one lane that fans its single computed body across two objects
-          // (src/chain-deregistrations-artifact.ts's header says why).
+          // The one lane that fans its single computed body across THREE
+          // objects (src/chain-deregistrations-artifact.ts's headers say why):
+          // an ~8 KB rollup, the per-displaced-hotkey index the account scope
+          // reads, and the per-(netuid, uid) eviction index the subnet scope
+          // reads (#9873).
           CHAIN_DEREGISTRATIONS_HOTKEY_PROJECTION_KEY,
+          CHAIN_DEREGISTRATIONS_UID_PROJECTION_KEY,
         ].map((key) => projectionKey(key, network)),
       ).sort(),
       "each lane writes its own artifact key per network, plus any split it declares",
@@ -1564,7 +1569,11 @@ describe("runProjectionLanes", () => {
       PROJECTION_NETWORKS.flatMap((network) =>
         PROJECTION_LANES.flatMap((lane) =>
           (lane.artifactKey === CHAIN_DEREGISTRATIONS_PROJECTION_KEY
-            ? [lane.artifactKey, CHAIN_DEREGISTRATIONS_HOTKEY_PROJECTION_KEY]
+            ? [
+                lane.artifactKey,
+                CHAIN_DEREGISTRATIONS_HOTKEY_PROJECTION_KEY,
+                CHAIN_DEREGISTRATIONS_UID_PROJECTION_KEY,
+              ]
             : [lane.artifactKey]
           ).map((key) => projectionKey(key, network)),
         ),
@@ -1772,7 +1781,7 @@ describe("chain-deregistrations lane compute", () => {
     );
   });
 
-  test("splits the rollup away from the 200x-larger per-hotkey index", async () => {
+  test("splits the rollup away from the two larger per-subject indexes", async () => {
     const { puts, bucket } = archiveBucket();
     lakeFetch(REGS);
     const result = await runProjectionLane(
@@ -1785,17 +1794,27 @@ describe("chain-deregistrations lane compute", () => {
       [
         CHAIN_DEREGISTRATIONS_PROJECTION_KEY,
         CHAIN_DEREGISTRATIONS_HOTKEY_PROJECTION_KEY,
+        CHAIN_DEREGISTRATIONS_UID_PROJECTION_KEY,
       ],
     );
     const rollup = JSON.parse(puts[0]!.value) as Row;
-    // The rollup must NOT carry the index: the chain and subnet routes read it
-    // per request and would otherwise parse ~200x the bytes they use.
+    // The rollup must NOT carry either index: the chain and subnet routes read
+    // it per request and would otherwise parse far more bytes than they use.
     assert.equal(rollup.hotkey_windows, undefined);
+    assert.equal(rollup.uid_events, undefined);
     assert.ok(((rollup.windows as Row)["7d"] as Row).rows);
     const index = JSON.parse(puts[1]!.value) as Row;
     assert.equal(index.schema_version, 1);
     assert.equal(index.lookback_days, 30);
     assert.ok(((index.windows as Row)["7d"] as Row).hotkeys);
+    // The per-uid index (#9873) carries the WIDEST window only -- every tuple
+    // has its own observed_at, so a narrower view is a filter rather than a
+    // second copy, and there is no per-window nesting to walk.
+    const uids = JSON.parse(puts[2]!.value) as Row;
+    assert.equal(uids.schema_version, 1);
+    assert.equal(uids.lookback_days, 30);
+    assert.equal((uids as Row).windows, undefined);
+    assert.ok(uids.by_netuid, "the per-uid index must be keyed by netuid");
   });
 });
 


### PR DESCRIPTION
## Summary

`get_subnet_deregistrations` could tell an operator that their subnet churned 429 slots in the last 7 days. It could not tell them whether **uid 7** was one of them — which is the only version of the question an operator actually has.

The data was already there. `deriveDeregistrations` computes, for every slot that changed hands, which hotkey lost it, who took it, at what block, and how long the loser had held it. `deregistrationsByNetuid` then folds all of that down to two integers and drops the events on the floor.

This publishes them.

## What changed

- **`deregistrationsByNetuidUid`** indexes the derived events by netuid as compact 6-tuples, newest-first. Block breaks the tie on equal `observed_at` — the poller stamps a whole batch with one timestamp, so ties are the norm, not an edge case, and insertion order would make "newest-first" quietly untrue inside every batch.
- **A third projection object.** The lane already fanned one computed body across two objects (rollup + per-hotkey index) so each read scope pays for only what it reads. This adds the per-uid index on the same principle.
- **The subnet scope reads both objects in one `Promise.all`.** Counts keep coming from the rollup row the leaderboard ranks, so a subnet card can never disagree with the board it appears on; the events come from the new index. Neither read depends on the other's result — only the *slice* depends on which window won — so this costs no extra round trip.
- **`get_subnet_deregistrations` gains an optional `events` array**, fully typed on `SubnetDeregistrationsArtifactSchema`.

### One real bug found on the way

`readProjection` required a `windows` key on every body. The rollup and the per-hotkey index have one; the per-uid index deliberately does not — it publishes a single widest-window list that readers slice by `observed_at`, rather than duplicating ~6,300 events across a 7d and a 30d copy. So the reader declined its own object on every call and returned `[]` unconditionally.

Every test passed anyway, because `events: []` was the expected value everywhere. The coverage gate is what surfaced it: the new reader sat at 56% patch coverage because nothing ever reached past its first guard. Split the body fetch out of the window unwrap so the shared validation is `schema_version` alone, and the tests now assert real rows.

## Honesty

The events inherit the caveat the counts already carry: only slots with an **observed predecessor** appear. The first registration on any slot has none, and those are exactly what `unattributed_registrations` counts. So the event list is a stated lower bound, the same one `derivation` has always published — not a new claim.

`tenure_blocks` comes along deliberately. It is what lets a caller distinguish "pruning tracks age" from "pruning tracks incentive" and work out where they sit in that ordering. This does **not** publish a pruning score: a score would be a model presented as a measurement, which is the thing #9307 exists to prevent.

## Validation

```
npm run lint && npm run format:check && npm run typecheck && npm run build
npm run validate:mcp
npm run validate:contract-drift
npm run validate:schemas
npm run validate:schema-opacity
npm run validate:single-schema-source
npx vitest run tests/chain-deregistrations-artifact.test.ts tests/deregistration-uid-events.test.ts \
  tests/projection-lanes.test.ts tests/api-coverage.test.ts tests/subnet-deregistrations.test.ts
```

All green — 442 tests across the touched suites. Patch coverage measured by diff intersection against `coverage/lcov.info`: **31/31 lines, 20/20 branches, 100%**.

One unreachable branch was removed rather than tested around: `selectWindow` only returns a label it found in `SUBNET_DEREGISTRATIONS_WINDOWS`, so the window lookup cannot miss and the slice needed no "window unknown" guard.

Closes #9873