### PR TITLE
perf(mcp): stop serializing every tool payload twice

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1631,6 +1631,11 @@ interface McpCtx {
   env: Env;
   domain?: string;
   sessionId?: string | null;
+  // #9789: the protocol revision THIS request declared, which decides whether
+  // a tool result still needs the compatibility text block. Optional because
+  // every direct-call test builds a context without a request to read it from
+  // -- and absent means the spec's assumed 2025-03-26, i.e. keep the block.
+  protocolVersion?: string | null;
   clientIp?: string | null;
   // #8994: the session id a single `initialize` will hand back, generated
   // before dispatch so the $mcp_initialize event can carry the session it is
@@ -1732,6 +1737,62 @@ export const MCP_PROTOCOL_VERSIONS = [
   "2024-11-05",
 ];
 const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
+
+/**
+ * The revision that introduced `outputSchema` + `structuredContent`. A client
+ * negotiating this or later reads the structured channel directly (#9789).
+ */
+export const MCP_STRUCTURED_CONTENT_PROTOCOL = "2025-06-18";
+
+/**
+ * Per spec, a client that negotiated 2025-06-18+ MUST send
+ * `MCP-Protocol-Version` on every request after `initialize`, and a server that
+ * sees no header MUST assume 2025-03-26. That default is what makes this safe
+ * to act on: a client too old to send the header is also too old to read
+ * `structuredContent`, and lands on the compatibility path either way.
+ *
+ * The version IDs are ISO dates, so lexicographic order is chronological.
+ */
+export const MCP_ASSUMED_PROTOCOL_WITHOUT_HEADER = "2025-03-26";
+
+export function clientReadsStructuredContent(
+  protocolVersion: string | null | undefined,
+): boolean {
+  return (
+    (protocolVersion ?? MCP_ASSUMED_PROTOCOL_WITHOUT_HEADER) >=
+    MCP_STRUCTURED_CONTENT_PROTOCOL
+  );
+}
+
+/**
+ * The `content` blocks a successful tool result carries (#9789).
+ *
+ * This server used to serialize every payload TWICE -- once here as text, once
+ * as `structuredContent` -- so a 437 KB body went out at 924 KB, on every call.
+ *
+ * The spec makes the text block a SHOULD and says what it is for: "backwards
+ * compatibility". So it is spent only on the clients that need it. BOTH
+ * conditions are load-bearing:
+ *
+ *   - the client must have negotiated 2025-06-18+, the revision that
+ *     introduced `structuredContent`;
+ *   - the tool must publish an `outputSchema`, because a client that sees no
+ *     declared output schema has no reason to look at `structuredContent` at
+ *     all -- it renders `content`, and an empty one would be a silent break,
+ *     not an optimisation.
+ *
+ * Every tool publishes an outputSchema today (a gate asserts it), so the
+ * second condition is currently always true. It stays because it is the
+ * reason the rule is correct, not a guess about the future.
+ */
+export function toolResultContent(
+  payload: unknown,
+  outputSchema: unknown,
+  protocolVersion: string | null | undefined,
+): { type: string; text: string }[] {
+  if (outputSchema && clientReadsStructuredContent(protocolVersion)) return [];
+  return [{ type: "text", text: JSON.stringify(payload) }];
+}
 
 // The MCP server's own SemVer — the tool surface is a public contract agents
 // depend on, so it needs a version signal distinct from CONTRACT_VERSION (the
@@ -15473,12 +15534,14 @@ async function dispatchTool(
     // one generic shape onto whichever tool degraded and `degraded` is a
     // per-tool object (#9910). Applied to every result, not just a stamped
     // one: a handler that built its own partial block is the same violation.
+    const outputSchema =
+      tool.outputSchema ?? (TOOL_OUTPUT_SCHEMAS as Row)[tool.name];
     const payload = completeDegradedBlock(
       markMcpTierDegraded(data, tierGenerationBefore),
-      tool.outputSchema ?? (TOOL_OUTPUT_SCHEMAS as Row)[tool.name],
+      outputSchema,
     );
     return {
-      content: [{ type: "text", text: JSON.stringify(payload) }],
+      content: toolResultContent(payload, outputSchema, ctx?.protocolVersion),
       structuredContent: payload as Row,
       isError: false,
     };
@@ -15857,6 +15920,9 @@ function buildContext(
     env,
     domain,
     sessionId,
+    // Already validated by handleMcpRequest, so this is either a version we
+    // support or absent (#9789).
+    protocolVersion: request.headers.get("mcp-protocol-version"),
     clientIp: mcpClientKey(request),
     clientName,
     clientVersion,

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -5,6 +5,8 @@ import { summarizeEvent } from "@jsonbored/chain-summaries";
 import {
   MCP_TOOLS,
   MCP_PROTOCOL_VERSIONS,
+  clientReadsStructuredContent,
+  toolResultContent,
   MCP_SERVER_INFO,
   MAX_MCP_BATCH_LENGTH,
   MAX_MCP_BODY_BYTES,
@@ -4122,6 +4124,113 @@ describe("MCP tools (injected deps)", () => {
   test("registry_summary returns the summary artifact", async () => {
     const res = await callTool("registry_summary", {}, { deps });
     assert.equal(res.body.result.structuredContent.completeness, 0.42);
+  });
+
+  describe("the compatibility text block is version-gated (#9789)", () => {
+    // This server used to serialize every payload twice. The duplicate exists
+    // only for clients that predate `structuredContent`, so it is now spent
+    // only on those clients -- which makes the negotiated version part of the
+    // response contract, and worth pinning from both sides.
+    const summaryOf = (res: Row) => res.body.result.structuredContent;
+
+    test("a 2025-06-18+ client gets the payload ONCE", async () => {
+      const res = await callTool(
+        "registry_summary",
+        {},
+        { deps, headers: { "mcp-protocol-version": "2025-06-18" } },
+      );
+      assert.deepEqual(res.body.result.content, []);
+      // The data itself must be untouched -- this is a transport change, not
+      // a narrowing.
+      assert.equal(summaryOf(res).completeness, 0.42);
+    });
+
+    test("every version at or after that one is treated the same", async () => {
+      for (const version of MCP_PROTOCOL_VERSIONS.filter(
+        (v: string) => v >= "2025-06-18",
+      )) {
+        const res = await callTool(
+          "registry_summary",
+          {},
+          { deps, headers: { "mcp-protocol-version": version } },
+        );
+        assert.deepEqual(res.body.result.content, [], version);
+      }
+    });
+
+    test("a 2025-03-26 client still gets the text block", async () => {
+      const res = await callTool(
+        "registry_summary",
+        {},
+        { deps, headers: { "mcp-protocol-version": "2025-03-26" } },
+      );
+      const text = res.body.result.content[0].text;
+      assert.equal(text, JSON.stringify(summaryOf(res)));
+    });
+
+    test("an absent header keeps the text block, per the spec's assumed 2025-03-26", async () => {
+      // The single most important case: a client that sends no header is a
+      // client that cannot read structuredContent, and dropping the text for
+      // it would be a silent break rather than an optimisation.
+      const res = await callTool("registry_summary", {}, { deps });
+      assert.equal(
+        res.body.result.content[0].text,
+        JSON.stringify(summaryOf(res)),
+      );
+    });
+
+    test("an ERROR result keeps its text on every version", async () => {
+      // Error text is a short `code: message`, not a copy of the payload, and
+      // it is what a human reads when a call fails.
+      const res = await callTool(
+        "get_coverage",
+        {},
+        {
+          deps: makeDeps(),
+          headers: { "mcp-protocol-version": MCP_PROTOCOL_VERSIONS[0] },
+        },
+      );
+      assert.equal(res.body.result.isError, true);
+      assert.match(res.body.result.content[0].text, /No resource at/);
+    });
+
+    test("clientReadsStructuredContent is the one place that ordering lives", () => {
+      assert.equal(clientReadsStructuredContent("2025-11-25"), true);
+      assert.equal(clientReadsStructuredContent("2025-06-18"), true);
+      assert.equal(clientReadsStructuredContent("2025-03-26"), false);
+      assert.equal(clientReadsStructuredContent("2024-11-05"), false);
+      assert.equal(clientReadsStructuredContent(null), false);
+      assert.equal(clientReadsStructuredContent(undefined), false);
+    });
+
+    test("BOTH conditions are required to drop the block", () => {
+      // The schema half cannot be exercised through a real tool -- all 225
+      // publish one (asserted below) -- so it is pinned here, where the rule
+      // actually lives. A tool without a declared output schema gives the
+      // client no reason to read structuredContent, so dropping its text
+      // would leave that client with nothing to render.
+      const payload = { a: 1 };
+      const text = [{ type: "text", text: JSON.stringify(payload) }];
+      const schema = { type: "object" };
+      assert.deepEqual(toolResultContent(payload, schema, "2025-06-18"), []);
+      assert.deepEqual(
+        toolResultContent(payload, undefined, "2025-06-18"),
+        text,
+        "no outputSchema -> keep the text however new the client is",
+      );
+      assert.deepEqual(toolResultContent(payload, schema, "2025-03-26"), text);
+      assert.deepEqual(toolResultContent(payload, undefined, null), text);
+    });
+
+    test("every published tool declares an outputSchema", () => {
+      // This is the invariant the guard above leans on, and the reason the
+      // optimisation reaches the whole fleet rather than part of it. A new
+      // tool without one would quietly opt itself out.
+      const missing = listToolDefinitions()
+        .filter((tool: Row) => !tool.outputSchema)
+        .map((tool: Row) => tool.name);
+      assert.deepEqual(missing, []);
+    });
   });
 
   test("get_coverage returns the coverage artifact", async () => {


### PR DESCRIPTION
## Summary

Every successful MCP tool result carried its payload **twice** — once as a JSON text block, once as `structuredContent`. On `get_health_trends` that is 924 KB for a body REST serves in 437 KB. **2.1×, on every tool, on every call.**

The MCP spec makes the text block a `SHOULD`, and states the reason inline: *backwards compatibility*. It exists so clients that predate `structuredContent` — introduced in revision **2025-06-18** alongside `outputSchema` — still receive something renderable. That makes it a compatibility cost, not a requirement, and it should be spent only on the clients that actually need it.

## The rule

`toolResultContent` drops the duplicate when **both** hold:

| condition | why it is load-bearing |
|---|---|
| client negotiated **≥ 2025-06-18** | that is the revision that introduced `structuredContent`. Per spec such a client MUST send `MCP-Protocol-Version` on every request after `initialize`, and a server that sees no header MUST assume `2025-03-26`. |
| the tool publishes an **`outputSchema`** | a client that sees no declared output schema has no reason to look at `structuredContent` — it renders `content`, and an empty one would be a silent break, not an optimisation. |

The spec's assumed-`2025-03-26` default is what makes this safe rather than risky: **a client too old to send the header is also too old to read the structured channel, and lands on the compatibility path either way.** Nothing has to opt in, and nothing that works today stops working.

All 225 tools publish an `outputSchema` (now asserted by a test), so the second condition is always true in production. It stays because it is *why* the rule is correct, not a prediction about the future.

**Error results are untouched.** Their text is a short `code: message` — not a copy of the payload — and it is what a human reads when a call fails.

## On the shape of the change

The rule lives in one exported function rather than inline in `dispatchTool`. That is deliberate: the `outputSchema` half of the condition cannot be reached through any real tool, so inline it would have been an untestable branch. As a function it is pinned by direct unit tests across all four combinations, with no coverage annotation.

## Validation

```
npm run lint && npm run format:check && npm run typecheck && npm run build
npm run validate:mcp
npm run validate:contract-drift
npm run validate:schemas
npm run validate:schema-opacity
npm run validate:single-schema-source
npm run validate:mcp-route-map
npx vitest run tests/mcp-server.test.ts tests/mcp-server-branch-coverage.test.ts \
  tests/call-subnet-surface-mcp.test.ts
```

All green — **1,536 tests**, of which **1,528 are the pre-existing MCP suite passing unchanged**. That is the most useful number here: none of those 337 assertions on `content[0].text` sends a protocol header, so every one of them exercises the compatibility path and confirms it still behaves exactly as before.

The 8 new tests cover the other side: each supported version, the absent-header default, an error result on the newest version, and both halves of the condition in isolation.

Patch coverage by diff intersection against `coverage/lcov.info`: **6/6 lines, 8/8 branches, 100%**.

Closes #9977