### PR TITLE
feat(mcp): add list_crowdloans and get_crowdloan

### DIFF
--- a/schemas-src/mcp-tools/crowdloans.ts
+++ b/schemas-src/mcp-tools/crowdloans.ts
@@ -1,0 +1,53 @@
+// MCP tools `list_crowdloans`, `get_crowdloan`.
+// Mirror GET /api/v1/crowdloans, GET /api/v1/crowdloans/{crowdloan_id}.
+//
+// DERIVED FROM THE ROUTE, NOT COPIED (#9796). Each output schema below IS the
+// route's own ArtifactSchema, so a route field rename is a compile error here
+// instead of silent production drift.
+//
+// These two routes were the only published pair with no tool at all (#9968) --
+// every other entry in mcp-route-map.ts's AGENT_UNREACHABLE is a decision, and
+// this one was an omission. Agents could not read crowdloan data by any path.
+import { z } from "zod";
+import { McpNetworkSchema } from "../shared.ts";
+import {
+  CrowdloanDetailArtifactSchema,
+  CrowdloansArtifactSchema,
+} from "../routes/crowdloans.ts";
+
+export const ListCrowdloansInputSchema = z
+  .object({
+    // #8700: which chain to read. Both routes answer from live storage, and
+    // the storage keys are twox128 hashes of pallet+item names -- identical on
+    // every chain running the same runtime -- so the endpoint is the only
+    // thing that varies. Absent means finney.
+    network: McpNetworkSchema.optional(),
+  })
+  .strict();
+export type ListCrowdloansInput = z.infer<typeof ListCrowdloansInputSchema>;
+
+export const ListCrowdloansOutputSchema = CrowdloansArtifactSchema;
+export type ListCrowdloansOutput = z.infer<typeof ListCrowdloansOutputSchema>;
+
+export const GetCrowdloanInputSchema = z
+  .object({
+    // u32 on-chain, not the u16 a netuid is -- NextCrowdloanId counts every
+    // crowdloan ever created, including dissolved ones.
+    crowdloan_id: z
+      .int()
+      .min(0)
+      .max(4294967295)
+      .meta({
+        description:
+          "The crowdloan id, as reported by list_crowdloans. u32 range " +
+          "0..4294967295. An id can be legitimately absent: `dissolve` removes " +
+          "the record while NextCrowdloanId keeps counting.",
+        examples: [0],
+      }),
+    network: McpNetworkSchema.optional(),
+  })
+  .strict();
+export type GetCrowdloanInput = z.infer<typeof GetCrowdloanInputSchema>;
+
+export const GetCrowdloanOutputSchema = CrowdloanDetailArtifactSchema;
+export type GetCrowdloanOutput = z.infer<typeof GetCrowdloanOutputSchema>;

--- a/scripts/validate-mcp-route-map.ts
+++ b/scripts/validate-mcp-route-map.ts
@@ -32,9 +32,6 @@ const AGENT_UNREACHABLE: Record<string, string> = {
     "The API index. An agent discovers tools through tools/list, not through this.",
   "/api/v1/openapi.json":
     "The contract document itself. get_api_schema serves a SUBNET's captured schema; this one is ours, and get_contracts describes it.",
-  "/api/v1/crowdloans":
-    "Crowdloans have no MCP tool yet. Deliberately listed rather than silently absent -- see #9968.",
-  "/api/v1/crowdloans/{crowdloan_id}": "Same as /api/v1/crowdloans.",
   "/api/v1/search/resolve":
     "Identifier resolution (#9672). search_subnets and semantic_search are the agent-facing discovery paths; resolve is a UI affordance.",
   "/api/v1/subnets/{netuid}/overview":

--- a/scripts/validate-mcp.ts
+++ b/scripts/validate-mcp.ts
@@ -2197,6 +2197,10 @@ const COLLECTIONS_UNEXERCISED_REASONS = new Map<string, string>([
   ["get_subnet_event_summary", HARNESS_SERVES_NO_ROWS],
   ["get_subnet_events", HARNESS_SERVES_NO_ROWS],
   ["get_subnet_history", HARNESS_SERVES_NO_ROWS],
+  // Live RPC against the Crowdloan pallet (#9968): the harness stands up no
+  // chain, so `crowdloans` is empty and the record shape inside it is checked
+  // by the production sweep, where it was verified before this tool shipped.
+  ["list_crowdloans", HARNESS_SERVES_NO_ROWS],
   ["get_subnet_holders", HARNESS_SERVES_NO_ROWS],
   ["get_subnet_hyperparams_history", HARNESS_SERVES_NO_ROWS],
   ["get_subnet_identity_history", HARNESS_SERVES_NO_ROWS],

--- a/src/mcp-route-map.ts
+++ b/src/mcp-route-map.ts
@@ -199,6 +199,8 @@ export const MCP_TOOL_ROUTES: Readonly<Record<string, McpToolRoute>> = {
   },
   get_subnet_holders: { route: "/api/v1/subnets/{netuid}/holders" },
   get_chain_burn: { route: "/api/v1/chain/burn" },
+  list_crowdloans: { route: "/api/v1/crowdloans" },
+  get_crowdloan: { route: "/api/v1/crowdloans/{crowdloan_id}" },
   get_subnet_lease: { route: "/api/v1/subnets/{netuid}/lease" },
   get_subnet_lease_history: { route: "/api/v1/subnets/{netuid}/lease/history" },
   get_account: { route: "/api/v1/accounts/{ss58}" },

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -685,6 +685,12 @@ import {
   GetSubnetLeaseHistoryOutputSchema,
 } from "../schemas-src/mcp-tools/get-subnet-lease.ts";
 import {
+  ListCrowdloansInputSchema,
+  ListCrowdloansOutputSchema,
+  GetCrowdloanInputSchema,
+  GetCrowdloanOutputSchema,
+} from "../schemas-src/mcp-tools/crowdloans.ts";
+import {
   GetGlobalIncidentsInputSchema,
   GetGlobalIncidentsOutputSchema,
 } from "../schemas-src/mcp-tools/get-global-incidents.ts";
@@ -1558,6 +1564,7 @@ import {
   loadSubnetBurnHistory,
 } from "./subnet-burn-history.ts";
 import { loadSubnetLease } from "./subnet-lease.ts";
+import { isCrowdloanId, loadCrowdloan, loadCrowdloans } from "./crowdloans.ts";
 // coldTierChainEventsPayload is still reached for CONVICTION (#9319), which
 // has no composer of its own. The ownership-history branch no longer comes
 // through here -- it has one, and this tool answers from it below.
@@ -1993,6 +2000,8 @@ const TOOL_ANNOTATIONS_BY_NAME: Record<
   get_randomness_status: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
   get_subnet_burn: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
   get_subnet_lease: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  list_crowdloans: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  get_crowdloan: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
   get_subnet_recycled: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
   get_sudo_key: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
   // Two live RPC POSTs (mainnet + testnet) on a cache miss.
@@ -8826,6 +8835,97 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
     },
   },
   {
+    name: "list_crowdloans",
+    title: "List every live crowdloan",
+    description:
+      "Fetch every crowdloan the chain currently holds a record for (#8696, " +
+      "part of the subnet-leasing/crowdloan-tracking epic #6717), decoded " +
+      "from the Crowdloan pallet's storage at request time (not a rollup). " +
+      "Each record carries creator, deposit_tao, min_contribution_tao, " +
+      "cap_tao, raised_tao, end, funds_account, contributors_count, " +
+      "finalized and percent_raised. crowdloan_count can be LOWER than " +
+      "next_crowdloan_id: `dissolve` removes a record while NextCrowdloanId " +
+      "keeps counting, so ids are not dense -- iterate `crowdloans`, do not " +
+      "count up to next_crowdloan_id. percent_raised is null when cap_tao is " +
+      "0 (representable on-chain, and dividing by it is not). " +
+      "has_dispatch_call is presence only: decoding the Option<Bounded<Call>> " +
+      "payload needs the full runtime type registry, which a Worker does not " +
+      "carry. Mirrors GET /api/v1/crowdloans.",
+    inputSchema: z.toJSONSchema(ListCrowdloansInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof ListCrowdloansInputSchema>,
+      ctx: McpCtx,
+    ) {
+      // Live RPC, same budget the REST route charges against: these reads
+      // share the chain's per-client allowance, so the MCP path must pay it
+      // too or it becomes the way around the limit.
+      if (ctx.env.RPC_RATE_LIMITER?.limit) {
+        const { success } = await ctx.env.RPC_RATE_LIMITER.limit({
+          key: `crowdloans:mcp:${ctx.clientIp}`,
+        });
+        if (!success) {
+          throw toolError(
+            "rate_limited",
+            "Too many live crowdloan-state requests from this client; slow down.",
+          );
+        }
+      }
+      return loadCrowdloans(
+        ctx.env,
+        chainNetworkFromChainName(
+          optionalEnum(args, "network", MCP_NETWORK_VALUES),
+        ),
+      );
+    },
+  },
+  {
+    name: "get_crowdloan",
+    title: "Get one crowdloan's live state",
+    description:
+      "Fetch one crowdloan by id (#8696), decoded from the Crowdloan " +
+      "pallet's storage at request time. `exists` is null (NOT false) on an " +
+      "RPC failure, which is deliberately distinct from a confirmed-absent " +
+      "id (exists:false) -- an id can be absent legitimately, because " +
+      "`dissolve` removes the record while NextCrowdloanId keeps counting. " +
+      "Treating null as false would report a crowdloan we could not read as " +
+      "one that does not exist. Use list_crowdloans to discover valid ids " +
+      "rather than counting up to next_crowdloan_id. Mirrors GET " +
+      "/api/v1/crowdloans/{crowdloan_id}.",
+    inputSchema: z.toJSONSchema(GetCrowdloanInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof GetCrowdloanInputSchema>, ctx: McpCtx) {
+      const crowdloanId = (args as Row)?.crowdloan_id;
+      // The route's own guard, mirrored: u32, not the u16 a netuid is.
+      if (!isCrowdloanId(crowdloanId)) {
+        throw toolError(
+          "invalid_params",
+          "Argument `crowdloan_id` must be an integer in the u32 range 0..4294967295.",
+        );
+      }
+      if (ctx.env.RPC_RATE_LIMITER?.limit) {
+        const { success } = await ctx.env.RPC_RATE_LIMITER.limit({
+          key: `crowdloan:mcp:${ctx.clientIp}`,
+        });
+        if (!success) {
+          throw toolError(
+            "rate_limited",
+            "Too many live crowdloan-state requests from this client; slow down.",
+          );
+        }
+      }
+      return loadCrowdloan(
+        ctx.env,
+        Number(crowdloanId),
+        chainNetworkFromChainName(
+          optionalEnum(args, "network", MCP_NETWORK_VALUES),
+        ),
+      );
+    },
+  },
+  {
     name: "get_subnet_lease",
     title: "Get a subnet's live lease state",
     description:
@@ -13898,6 +13998,12 @@ const TOOL_OUTPUT_SCHEMAS = {
     target: "draft-2020-12",
   }),
   get_subnet_burn: z.toJSONSchema(GetSubnetBurnOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  list_crowdloans: z.toJSONSchema(ListCrowdloansOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_crowdloan: z.toJSONSchema(GetCrowdloanOutputSchema, {
     target: "draft-2020-12",
   }),
   get_subnet_lease: z.toJSONSchema(GetSubnetLeaseOutputSchema, {

--- a/src/mcp-tool-cost.ts
+++ b/src/mcp-tool-cost.ts
@@ -60,10 +60,6 @@ export const MCP_TOOL_COST_PATHS: Record<string, string> = {
   get_extrinsic: "/api/v1/extrinsics",
   get_subnet_conviction: "/api/v1/subnets/1/conviction",
   get_subnet_lease: "/api/v1/subnets/1/lease",
-  // Live-RPC reads, same family as the lease tools above: the concrete id is
-  // representative, not routed.
-  list_crowdloans: "/api/v1/crowdloans",
-  get_crowdloan: "/api/v1/crowdloans/1",
   get_subnet_ownership_history: "/api/v1/subnets/1/ownership-history",
 };
 

--- a/src/mcp-tool-cost.ts
+++ b/src/mcp-tool-cost.ts
@@ -60,6 +60,10 @@ export const MCP_TOOL_COST_PATHS: Record<string, string> = {
   get_extrinsic: "/api/v1/extrinsics",
   get_subnet_conviction: "/api/v1/subnets/1/conviction",
   get_subnet_lease: "/api/v1/subnets/1/lease",
+  // Live-RPC reads, same family as the lease tools above: the concrete id is
+  // representative, not routed.
+  list_crowdloans: "/api/v1/crowdloans",
+  get_crowdloan: "/api/v1/crowdloans/1",
   get_subnet_ownership_history: "/api/v1/subnets/1/ownership-history",
 };
 

--- a/tests/crowdloans.test.ts
+++ b/tests/crowdloans.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../src/crowdloans.ts";
 import { encodeAccountId32 } from "../src/ss58.ts";
 import { handleRequest } from "../workers/api.ts";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import { mockEnv } from "./row-type.ts";
 import type { AnyFn, Row } from "./row-type.ts";
 
@@ -788,5 +789,126 @@ describe("the on-chain layout", () => {
     assert.equal(decoded.finalized, true);
     assert.equal(decoded.contributors_count, 3);
     assert.equal(decoded.percent_raised, 100);
+  });
+});
+
+// The MCP half (#9968). Crowdloans were the one published route pair with no
+// tool at all -- every other AGENT_UNREACHABLE entry is a decision, this was an
+// omission, so an agent could not read crowdloan data by any path.
+describe("the crowdloan MCP tools", () => {
+  function callTool(name: string, args: Row, env: Row) {
+    return handleMcpRequest(
+      new Request("https://api.metagraph.sh/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name, arguments: args },
+        }),
+      }),
+      env as unknown as Env,
+    ).then(async (res) => (await res.json()) as Row);
+  }
+
+  const listStub = () =>
+    rpcStub({
+      state_getStorage: () => hex(u32le(1)),
+      state_queryStorageAt: (params: unknown[]) =>
+        queryStorageAtResult([
+          [(params[0] as string[])[0], hex(encodeCrowdloan())],
+        ]),
+    });
+
+  test("list_crowdloans serves the same body the route does", async () => {
+    const env = mockEnv({ METAGRAPH_CONTROL: kvStub() });
+    const body = await withFetchStub(listStub(), () =>
+      callTool("list_crowdloans", {}, env),
+    );
+    const out = body.result.structuredContent as Row;
+    assert.equal(out.crowdloan_count, 1);
+    // #9108: provenance is attached outside the loader, so a tool that reached
+    // the snapshot directly would silently drop it.
+    assert.deepEqual(out.field_sources, CROWDLOANS_FIELD_SOURCES);
+  });
+
+  test("get_crowdloan serves one record", async () => {
+    const env = mockEnv({ METAGRAPH_CONTROL: kvStub() });
+    const body = await withFetchStub(
+      rpcStub({ state_getStorage: () => hex(encodeCrowdloan()) }),
+      () => callTool("get_crowdloan", { crowdloan_id: 2 }, env),
+    );
+    const out = body.result.structuredContent as Row;
+    assert.equal(out.crowdloan_id, 2);
+    assert.equal(out.exists, true);
+    assert.deepEqual(out.field_sources, CROWDLOAN_FIELD_SOURCES);
+  });
+
+  test("an out-of-range id is rejected BEFORE any RPC", async () => {
+    // The router's \\d+ regex is what stops this on the REST side; a tool
+    // argument has no router, so the guard has to live in the handler.
+    const env = mockEnv({ METAGRAPH_CONTROL: kvStub() });
+    const body = await withFetchStub(
+      () => assert.fail("must not reach the RPC"),
+      () => callTool("get_crowdloan", { crowdloan_id: 4294967296 }, env),
+    );
+    assert.equal(body.result.isError, true);
+    assert.equal(
+      (body.result.structuredContent as Row).error.code,
+      "invalid_params",
+    );
+  });
+
+  test("both tools charge the same live-RPC budget the routes do", async () => {
+    // Otherwise the MCP path is simply the way around the per-client limit.
+    const env = mockEnv({
+      METAGRAPH_CONTROL: kvStub(),
+      RPC_RATE_LIMITER: { limit: async () => ({ success: false }) },
+    });
+    for (const [name, args] of [
+      ["list_crowdloans", {}],
+      ["get_crowdloan", { crowdloan_id: 1 }],
+    ] as [string, Row][]) {
+      const body = await withFetchStub(
+        () => assert.fail("a rate-limited call must not reach the RPC"),
+        () => callTool(name, args, env),
+      );
+      assert.equal(body.result.isError, true, name);
+      assert.equal(
+        (body.result.structuredContent as Row).error.code,
+        "rate_limited",
+        name,
+      );
+    }
+  });
+
+  test("a passing limiter lets both through", async () => {
+    const env = mockEnv({
+      METAGRAPH_CONTROL: kvStub(),
+      RPC_RATE_LIMITER: { limit: async () => ({ success: true }) },
+    });
+    const list = await withFetchStub(listStub(), () =>
+      callTool("list_crowdloans", {}, env),
+    );
+    assert.equal(list.result.isError, false);
+    const one = await withFetchStub(
+      rpcStub({ state_getStorage: () => hex(encodeCrowdloan()) }),
+      () => callTool("get_crowdloan", { crowdloan_id: 1 }, env),
+    );
+    assert.equal(one.result.isError, false);
+  });
+
+  test("an unreadable id is exists:null, NOT exists:false", async () => {
+    // The distinction the tool description promises: `dissolve` removes a
+    // record while NextCrowdloanId keeps counting, so a confirmed-absent id
+    // (false) is normal -- collapsing an RPC failure into it would report a
+    // crowdloan we could not read as one that does not exist.
+    const env = mockEnv({ METAGRAPH_CONTROL: kvStub() });
+    const body = await withFetchStub(
+      rpcStub({ state_getStorage: () => null }, { httpError: true }),
+      () => callTool("get_crowdloan", { crowdloan_id: 7 }, env),
+    );
+    assert.equal((body.result.structuredContent as Row).exists, null);
   });
 });

--- a/tests/mcp-tool-annotations.test.ts
+++ b/tests/mcp-tool-annotations.test.ts
@@ -73,7 +73,10 @@ describe("MCP tool annotations", () => {
   // Not a style rule — an accidental widening of the open-world set is how the
   // signal gets diluted back to useless, which is the state this issue fixed.
   test("the open-world set stays small relative to the catalogue", () => {
-    assert.equal(OPEN_WORLD_TOOL_NAMES.length, 20);
+    // 22 since #9968 added list_crowdloans/get_crowdloan, which read the
+    // Crowdloan pallet over live RPC -- genuinely outside our closed world,
+    // the same reason get_subnet_lease carries the annotation.
+    assert.equal(OPEN_WORLD_TOOL_NAMES.length, 22);
     assert.ok(
       definitions.length > 200,
       `expected the full catalogue, saw ${definitions.length}`,


### PR DESCRIPTION
## Summary

`/api/v1/crowdloans` and `/api/v1/crowdloans/{crowdloan_id}` were published, served, and reachable over REST — and **no MCP tool exposed them**. An agent had no way to read crowdloan data by any path.

Of the 267 published routes this was the only pair whose absence was an *omission* rather than a decision. The route↔tool map (#9880) is what forced it into the open: it made every published route either mirrored by a tool or declared unreachable **with a written reason**, and "no tool yet" is not a reason.

## What changed

Two tools, both output schemas derived from the route's own `ArtifactSchema` — `CrowdloansArtifactSchema` and `CrowdloanDetailArtifactSchema` — so a route field rename is a compile error here rather than silent production drift.

### Verified against production before switching

Deriving is a *tightening*: the route schema is stricter than a hand-written copy would have been, so it has to be checked against real bytes rather than assumed.

| request | result |
|---|---|
| `GET /api/v1/crowdloans` | **valid** — 15 live crowdloans, 6,233 B |
| `GET /api/v1/crowdloans/0` | **valid** — 679 B |
| `GET /api/v1/crowdloans/4294967295` | **valid** — the confirmed-absent case, 305 B |

### Two things the handlers carry that the router used to carry for them

- **The u32 range check.** On the REST side an out-of-range id is stopped by the router's `\d+` regex plus the handler's own bound. A tool argument has no router, so without an explicit guard an out-of-range id reaches the RPC. Tested by asserting the RPC is never called.
- **The live-RPC rate limit**, on the same per-client budget the routes charge. Without it the MCP path is simply the way around the limit.

### The two traps, in the descriptions

- **Ids are not dense.** `dissolve` removes a record while `NextCrowdloanId` keeps counting, so `crowdloan_count` can be *lower* than `next_crowdloan_id`. An agent must iterate `crowdloans`, not count up to the id.
- **`exists` is `null`, not `false`, on an RPC failure** — deliberately distinct from a confirmed-absent id. Collapsing the two would report a crowdloan we could not read as one that does not exist.

Both `AGENT_UNREACHABLE` entries are deleted rather than edited. The gate fails on a stale entry, so it confirms the gap is closed instead of taking our word for it:

```
before: 267 routes accounted for (6 declared agent-unreachable)
after:  267 routes accounted for (4 declared agent-unreachable)
        227 tools all classified (214 mirror a route)
```

## Validation

```
npm run lint && npm run format:check && npm run typecheck && npm run build
npm run validate:mcp
npm run validate:mcp-route-map
npm run validate:contract-drift
npm run validate:schemas
npm run validate:schema-opacity
npm run validate:single-schema-source
npm run validate:schema-vocabularies
npx vitest run tests/crowdloans.test.ts tests/mcp-server.test.ts \
  tests/mcp-server-branch-coverage.test.ts
```

All green — 1,478 tests, including 6 new ones covering both tools, the range guard, the rate limit on both, and the `exists: null` distinction.

No generated artifact changed: adding an MCP tool does not touch the REST contract, and the server card is worker-computed.

Patch coverage by diff intersection against `coverage/lcov.info`: **13/13 lines, 10/10 branches, 100%**.

Closes #9968