### PR TITLE
fix(api): a provider result has no netuid or slug, and the schema said it must

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5752,10 +5752,10 @@ export interface components {
         AskArtifact: {
             answer: string;
             citations: {
-                netuid: number;
+                netuid: number | null;
                 ref: number;
                 score: number;
-                slug: string;
+                slug: string | null;
                 title: string;
                 url: string;
             }[];
@@ -9867,10 +9867,10 @@ export interface components {
             query: string;
             results: ({
                 categories: string[];
-                netuid: number;
+                netuid: number | null;
                 score: number;
                 service_kinds: string[];
-                slug: string;
+                slug: string | null;
                 subtitle?: string | null;
                 title: string;
                 type: string;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -18072,9 +18072,16 @@
               "additionalProperties": false,
               "properties": {
                 "netuid": {
-                  "maximum": 9007199254740991,
-                  "minimum": 0,
-                  "type": "integer"
+                  "anyOf": [
+                    {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "ref": {
                   "maximum": 9007199254740991,
@@ -18085,7 +18092,14 @@
                   "type": "number"
                 },
                 "slug": {
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "title": {
                   "type": "string"
@@ -41322,9 +41336,16 @@
                   "type": "array"
                 },
                 "netuid": {
-                  "maximum": 9007199254740991,
-                  "minimum": 0,
-                  "type": "integer"
+                  "anyOf": [
+                    {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "score": {
                   "type": "number"
@@ -41336,7 +41357,14 @@
                   "type": "array"
                 },
                 "slug": {
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "subtitle": {
                   "anyOf": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5752,10 +5752,10 @@ export interface components {
         AskArtifact: {
             answer: string;
             citations: {
-                netuid: number;
+                netuid: number | null;
                 ref: number;
                 score: number;
-                slug: string;
+                slug: string | null;
                 title: string;
                 url: string;
             }[];
@@ -9867,10 +9867,10 @@ export interface components {
             query: string;
             results: ({
                 categories: string[];
-                netuid: number;
+                netuid: number | null;
                 score: number;
                 service_kinds: string[];
-                slug: string;
+                slug: string | null;
                 subtitle?: string | null;
                 title: string;
                 type: string;

--- a/schemas-src/routes/ai-native.ts
+++ b/schemas-src/routes/ai-native.ts
@@ -23,8 +23,15 @@ export const AskCitationSchema = z
     ref: z.int().min(1),
     score: z.number(),
     title: z.string(),
-    netuid: z.int().min(0),
-    slug: z.string(),
+    // NULL for a provider document (#9903). The retrieval index holds three
+    // kinds of document -- subnets, their surfaces, and the PROVIDER teams
+    // behind them -- and a team is not a subnet, so it has neither. Declared
+    // non-nullable until now, which made half of a live `ask` response fail
+    // the contract we publish for it. The MCP copies of this shape already
+    // declared both nullable and were right; this is the canonical source
+    // catching up, not a loosening.
+    netuid: z.int().min(0).nullable(),
+    slug: z.string().nullable(),
     url: z.string(),
   })
   .strict();
@@ -61,10 +68,14 @@ export type AskQuery = z.infer<typeof AskQuerySchema>;
 export const SemanticSearchResultSchema = z
   .object({
     score: z.number(),
-    /** What was matched — a subnet, or one of its surfaces. */
+    /**
+     * What was matched — a subnet, one of its surfaces, or a PROVIDER (the
+     * team behind them). The third case is why the two fields below are
+     * nullable: a team has no netuid and no slug (#9903).
+     */
     type: z.string(),
-    netuid: z.int().min(0),
-    slug: z.string(),
+    netuid: z.int().min(0).nullable(),
+    slug: z.string().nullable(),
     title: z.string(),
     subtitle: z.string().nullable().optional(),
     url: z.string().nullable().optional(),

--- a/tests/ai-search.test.ts
+++ b/tests/ai-search.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { ReadableStream } from "node:stream/web";
 import { describe, test } from "vitest";
-import Ajv2020 from "ajv/dist/2020.js";
-import addFormats from "ajv-formats";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import addFormatsPlugin from "ajv-formats";
 import { z } from "zod";
 import { SemanticSearchArtifactSchema } from "../schemas-src/routes/ai-native.ts";
 import {
@@ -757,9 +757,10 @@ describe("a provider result satisfies the PUBLISHED schema (#9903)", () => {
   // Validating the payload against its own published schema is the assertion
   // that catches this class; asserting the handler's own output shape never
   // could, because the handler and the test agreed with each other.
+  const addFormats = addFormatsPlugin as unknown as (i: Ajv2020) => void;
   const ajv = () => {
     const instance = new Ajv2020({ strict: false, allErrors: true });
-    (addFormats as unknown as (a: unknown) => void)(instance);
+    addFormats(instance);
     return instance;
   };
 

--- a/tests/ai-search.test.ts
+++ b/tests/ai-search.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { ReadableStream } from "node:stream/web";
 import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { z } from "zod";
+import { SemanticSearchArtifactSchema } from "../schemas-src/routes/ai-native.ts";
 import {
   EMBED_MODEL,
   ASK_MODEL,
@@ -707,7 +711,10 @@ function stubVectorizeMixed({ honorFilter = true, rejectFilter = false } = {}) {
     metadata: {
       type: m.type,
       netuid: m.netuid,
-      slug: `${m.type}-${i}`,
+      // A provider is a TEAM, not a subnet: no netuid and no slug. The fixture
+      // used to give it one, which is why the schema violation (#9903) lived
+      // here undetected -- production returns null for both.
+      slug: m.netuid === null ? null : `${m.type}-${i}`,
       title: `${m.type} ${i}`,
       subtitle: `summary ${i}`,
       url: `https://api.metagraph.sh/x/${i}`,
@@ -737,6 +744,59 @@ function stubVectorizeMixed({ honorFilter = true, rejectFilter = false } = {}) {
     },
   };
 }
+
+describe("a provider result satisfies the PUBLISHED schema (#9903)", () => {
+  // The behaviour was already covered -- stubVectorizeMixed has carried
+  // `{ type: "provider", netuid: null }` rows for as long as it has existed.
+  // What was missing is this: nothing validated the emitted payload against
+  // the schema we publish for it, so `netuid`/`slug` sat declared as required
+  // non-nullable integers/strings while production served null for every
+  // provider document. 1 of 10 semantic-search results and 3 of 6 `ask`
+  // citations, live.
+  //
+  // Validating the payload against its own published schema is the assertion
+  // that catches this class; asserting the handler's own output shape never
+  // could, because the handler and the test agreed with each other.
+  const ajv = () => {
+    const instance = new Ajv2020({ strict: false, allErrors: true });
+    (addFormats as unknown as (a: unknown) => void)(instance);
+    return instance;
+  };
+
+  test("semantic_search results validate with a provider row present", async () => {
+    const env = { AI: stubAi(), VECTORIZE: stubVectorizeMixed() };
+    const out = (await semanticSearch(mockEnv(env), "q", {})) as Row;
+    const providers = (out.results as Row[]).filter(
+      (r) => r.type === "provider",
+    );
+    assert.ok(
+      providers.length > 0,
+      "fixture must actually contain a provider, or this proves nothing",
+    );
+    assert.equal(providers[0]!.netuid, null);
+    assert.equal(providers[0]!.slug, null);
+    const validate = ajv().compile(
+      z.toJSONSchema(SemanticSearchArtifactSchema, {
+        target: "draft-2020-12",
+      }),
+    );
+    assert.ok(validate(out), JSON.stringify(validate.errors));
+  });
+
+  test("the schema would REJECT the pre-fix declaration", () => {
+    // Proves the fix is not a no-op: the same provider row against the
+    // non-nullable shape this replaced.
+    const validate = ajv().compile({
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        slug: { type: "string" },
+      },
+      required: ["netuid", "slug"],
+    });
+    assert.equal(validate({ netuid: null, slug: null }), false);
+  });
+});
 
 describe("semanticSearch type scope", () => {
   for (const type of ["subnet", "surface", "provider"]) {


### PR DESCRIPTION
## Summary

The retrieval index behind `/api/v1/ask` and `/api/v1/search/semantic` holds **three** kinds of document: subnets, their surfaces, and the **provider teams** behind them. A team is not a subnet — it has neither a `netuid` nor a `slug` — and both schemas declared both fields **required and non-nullable**.

The doc comment was the bug in one line: *"What was matched — a subnet, or one of its surfaces."*

Live, that is:

| surface | violating |
|---|---|
| `GET /api/v1/search/semantic?q=inference` | **1 of 10** results |
| `POST /api/v1/ask` | **3 of 6** citations |

`AskCitationSchema` is `.strict()`, so half of a flagship grounded answer did not satisfy the contract we publish for it.

## The MCP copies were already right

Worth pausing on, because it inverts this epic's premise. #9793 frames the MCP tool schemas as hand-copied mirrors that risk drifting from the routes they mirror. Here the **copies are correct and the canonical source is wrong**:

| | `netuid` | `slug` |
|---|---|---|
| routes (canonical) | `z.int().min(0)` | `z.string()` |
| MCP `ask` / `semantic_search` | `anyOf: [integer, **null**]` | `anyOf: [string, **null**]` |

So this is the canonical source catching up, not a loosening — and a reminder that "derive from the route" is right about *where the shape should live*, not about which copy currently happens to be true.

## Verified against production, both directions

After the change, both live responses validate:

```
GET /api/v1/search/semantic?q=inference : VALID   (10 results, 1 with null netuid/slug — "Inference Labs")
POST /api/v1/ask                        : VALID   (6 citations, 1 with null netuid/slug)
```

And the pre-fix declaration **rejects** the same row, so this is not a no-op:

```
old schema vs the live provider row: REJECTED
   /netuid must be integer
   /slug must be string
```

## Why the tests missed it, and what now catches it

`stubVectorizeMixed` has carried `{ type: "provider", netuid: null }` rows for as long as it has existed — the **behaviour** was covered. Two things hid the defect anyway:

1. The fixture handed providers a `slug`, which production does not. Corrected to match production.
2. **Nothing validated the emitted payload against the published schema.** Asserting the handler's own output shape could never have caught this, because the handler and the test agreed with each other — they were both wrong in the same direction.

The new test compiles the published schema with Ajv2020 and validates the real payload against it, asserting first that the fixture actually contains a provider so the test cannot pass vacuously. A second test pins the pre-fix declaration rejecting the same row.

## Validation

```
npm run lint && npm run format:check && npm run typecheck && npm run build
npm run validate:mcp
npm run validate:contract-drift
npm run validate:schemas
npm run validate:schema-opacity
npm run validate:single-schema-source
npm run validate:mcp-route-map
npm run validate:api && npm run validate:openapi
npx vitest run tests/ai-search.test.ts tests/mcp-server.test.ts
```

All green — 1,473 tests.

Closes #9903