### PR TITLE
fix(pg): BIGINT arrives as the number D1 would have returned

### DIFF
--- a/src/pg-sql.ts
+++ b/src/pg-sql.ts
@@ -26,7 +26,45 @@
 // wait. Leaking it instead would exhaust the origin's connection limit under
 // load -- the one way to turn a pooled setup back into an unpooled one.
 
-import { Client } from "pg";
+import { Client, types } from "pg";
+
+/** Postgres OID for `int8` / BIGINT. */
+const INT8_OID = 20;
+
+/**
+ * BIGINT comes back as a JS number, not a string.
+ *
+ * WHY THIS IS NOT A PREFERENCE. node-postgres returns `int8` as a STRING by
+ * default, because int8 spans a wider range than a JS number can hold exactly.
+ * D1 returns the same columns as numbers. So without this, moving a route
+ * between the two stores changes the TYPE of every epoch-ms and counter field
+ * in its response -- `created_at: 1785176950652` becomes
+ * `created_at: "1785176950652"` -- with no error anywhere, and a consumer
+ * doing arithmetic or a `>` comparison silently gets a different answer.
+ *
+ * Confirmed against production 2026-08-07, which is what makes this a fix and
+ * not a precaution: `SELECT registered_at_block FROM neurons` over this driver
+ * returns `"1404439"`, while the live `/subnets/1/metagraph` -- a route
+ * already served from Neon -- returns `8692121`. The two agree only because
+ * that handler happens to coerce. Every handler that does not is one field
+ * away from the divergence.
+ *
+ * THE RANGE CHECK IS THE POINT. Silently rounding a value past 2^53 would be a
+ * worse bug than the one this fixes, so anything outside the exactly-
+ * representable range stays a string -- a caller that sees a string knows it
+ * got something a number could not hold. Nothing in this schema is close:
+ * every int8 column here is epoch-milliseconds (~1.79e12) or a row counter,
+ * against a safe ceiling of ~9.01e15, so the guard is a backstop rather than a
+ * live path.
+ *
+ * Set on the module rather than per-connection because both callers of this
+ * file build their Client here, and a parser that applied to only some
+ * connections would reintroduce exactly the inconsistency it removes.
+ */
+types.setTypeParser(INT8_OID, (value: string) => {
+  const asNumber = Number(value);
+  return Number.isSafeInteger(asNumber) ? asNumber : value;
+});
 
 export type PgSqlRows = Record<string, unknown>[];
 

--- a/tests/pg-int8-shape.test.ts
+++ b/tests/pg-int8-shape.test.ts
@@ -1,0 +1,70 @@
+// BIGINT must come out of Neon the same shape it comes out of D1.
+//
+// node-postgres returns `int8` as a STRING by default, because int8 spans a
+// wider range than a JS number holds exactly. D1 returns the same columns as
+// numbers. So without a parser, moving a route between the two stores changes
+// the TYPE of every epoch-ms and counter field in its response -- with no
+// error anywhere, and a consumer doing arithmetic or a `>` comparison silently
+// getting a different answer.
+//
+// Measured against production 2026-08-07, which is what makes this a fix
+// rather than a precaution: `SELECT registered_at_block FROM neurons` over
+// this driver returned "1404439", while the live /subnets/1/metagraph -- a
+// route ALREADY served from Neon -- returned 8692121. They agree only because
+// that one handler happens to coerce.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { types } from "pg";
+
+// Importing for the side effect: the parser is registered at module load, so
+// every Client this codebase builds inherits it. Asserting through
+// `types.getTypeParser` rather than through a live query is what lets this run
+// in CI with no database.
+import "../src/pg-sql.ts";
+
+const INT8_OID = 20;
+const parse = types.getTypeParser(INT8_OID) as (v: string) => unknown;
+
+describe("int8 arrives as the shape D1 would have produced", () => {
+  test("an epoch-ms timestamp is a number", () => {
+    // The actual value of github_accounts.created_at in production.
+    assert.equal(parse("1785176950652"), 1785176950652);
+    assert.equal(typeof parse("1785176950652"), "number");
+  });
+
+  test("a block number is a number", () => {
+    assert.equal(parse("8795218"), 8795218);
+  });
+
+  test("zero and negatives survive", () => {
+    assert.equal(parse("0"), 0);
+    assert.equal(parse("-1"), -1);
+  });
+
+  test("the largest exactly-representable integer still converts", () => {
+    assert.equal(parse("9007199254740991"), Number.MAX_SAFE_INTEGER);
+    assert.equal(typeof parse("9007199254740991"), "number");
+  });
+
+  test("ONE PAST that stays a string rather than rounding", () => {
+    // The guard is the point. Silently rounding a value past 2^53 would be a
+    // worse bug than the one this parser fixes: 9007199254740993 rounds to
+    // ...992, and nothing anywhere would say so. A caller that receives a
+    // string knows it got a value a number could not hold.
+    assert.equal(parse("9007199254740993"), "9007199254740993");
+    assert.equal(typeof parse("9007199254740993"), "string");
+  });
+
+  test("int8's full range stays a string at both ends", () => {
+    assert.equal(typeof parse("9223372036854775807"), "string");
+    assert.equal(typeof parse("-9223372036854775808"), "string");
+  });
+
+  test("every int8 column in this schema is far inside the safe range", () => {
+    // Not a hypothetical bound. Epoch-milliseconds is ~1.79e12 against a
+    // ceiling of ~9.01e15, so the guard above is a backstop rather than a live
+    // path -- which is why converting is safe rather than merely convenient.
+    const nowMs = Date.now();
+    assert.ok(nowMs < Number.MAX_SAFE_INTEGER / 1000);
+  });
+});


### PR DESCRIPTION
Closes #9992. Part of #9787.

node-postgres returns `int8` as a **string**; D1 returns the same columns as **numbers**. Nothing reconciled that — `grep -rn "setTypeParser" src/ workers/` returned nothing.

## Measured against production, not assumed

Through `createPgSql` itself:

```
github_accounts.created_at    string "1785176950652"
neurons.block_number          string "8795218"
neurons.registered_at_block   string "1404439"
```

And the live route, **already served from Neon**:

```
$ curl -s https://api.metagraph.sh/api/v1/subnets/1/metagraph
registered_at_block number 8692121
```

They agree only because that handler happens to coerce. Every handler that does not is one field away from the divergence — and it is a silent one: no error, no failing test, just a different type on the wire.

## Why it bites now

The user-state tier (#9988) is next to move. Its schema is BIGINT-heavy by necessity — epoch-ms does not fit in int4 — and its handlers were all written against D1:

`units_spent`, `request_count`, `keyed_count`, `github_user_id`, and every `*_at` column across `api_keys`, `rpc_accounts`, `github_accounts`, `api_quota_daily`, `chain_alert_*` and `watch_push_subscriptions`.

Setting that flag as-is would have turned all of them into strings in API responses.

## The range check is the point

Silently rounding past 2^53 would be a **worse** bug than the one being fixed: `9007199254740993` rounds to `...992` and nothing anywhere would say so. So anything not exactly representable stays a string — a caller that receives a string knows it got a value a number could not hold.

Nothing in this schema is near it. Epoch-ms is ~1.79e12 against a ceiling of ~9.01e15, roughly 5,000x of headroom, so the guard is a backstop rather than a live path.

## Verified end to end

Through the real runner against production Neon, after the change:

```
github_accounts.created_at    number 1785176950652
neurons.block_number          number 8795218
neurons.registered_at_block   number 1404439
SELECT 9007199254740993::bigint -> string "9007199254740993"
```

The last line is the guard doing its job on a value one past the safe integer.

`tests/pg-int8-shape.test.ts` asserts both directions through `types.getTypeParser(20)`, so it runs in CI with no database.