### PR TITLE
fix(data-api): every dispatcher block asks the gate, not just one of three

### DIFF
--- a/tests/dispatcher-asks-the-gate.test.ts
+++ b/tests/dispatcher-asks-the-gate.test.ts
@@ -1,0 +1,90 @@
+// Every D1 dispatcher block must choose its store through the gate.
+//
+// THE BUG THIS EXISTS TO STOP, which is the one it was written after. There
+// are three blocks in dispatchDataApiRequest that match a route to a handler
+// and then hand that handler a runner. Only ONE of them consulted
+// neonServesRoute; the other two called createD1Sql outright.
+//
+// That made a whole cutover a no-op without failing anything. #9954 added
+// NEON_READ_ROUTE_TABLES entries for /subnets/{netuid}/hyperparameters, its
+// /history, /accounts/{ss58}/identity and its -history, and put all four
+// tables in NEON_READ_LANES. None of those routes is matched by
+// matchNeuronsD1Route -- they belong to the hyperparams/identity block -- so
+// the declarations were read by nothing and the routes kept answering from
+// D1. Every part of the cutover was in place except the line that asks.
+//
+// A route-by-route assertion could not have caught it: the declaration was
+// correct, the flag was correct, the table was at parity. The defect was that
+// nobody called the function. So this test asserts the CALL, structurally.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+
+const SOURCE = readFileSync("workers/data-api.ts", "utf8");
+
+/** The body of dispatchDataApiRequest, which is where route dispatch lives.
+ * Bounded rather than scanning the file, because createD1Sql is legitimate
+ * outside it -- the write paths and the user-state helpers own their store
+ * choice for reasons that have nothing to do with a read gate. */
+function dispatcherBody(): string {
+  const start = SOURCE.indexOf("async function dispatchDataApiRequest(");
+  assert.ok(start > 0, "dispatchDataApiRequest not found -- was it renamed?");
+  const end = SOURCE.indexOf("\n// --- TAO/USD index ingestion", start);
+  assert.ok(end > start, "could not find the end of the dispatcher");
+  return SOURCE.slice(start, end);
+}
+
+describe("the read dispatcher", () => {
+  test("hands every matched handler a gate-chosen store", () => {
+    const body = dispatcherBody();
+    // Each `return await <name>Handler(` is a block dispatching to a matched
+    // handler. Discovered by shape rather than listed, so a FOURTH block added
+    // later is covered the day it is written -- listing them is how the third
+    // one went unnoticed.
+    const dispatches = [
+      ...body.matchAll(/return await (\w*Handler)\(\s*([^,)]+)/g),
+    ];
+    assert.ok(
+      dispatches.length >= 3,
+      `expected at least the three known dispatcher blocks, found ${dispatches.length}`,
+    );
+    const offenders = dispatches
+      .filter(([, , firstArg]) => !firstArg.trim().startsWith("routeStore("))
+      .map(([, name, firstArg]) => `${name} <- ${firstArg.trim()}`);
+    assert.deepEqual(
+      offenders,
+      [],
+      "a dispatcher block chose its store without asking neonServesRoute; " +
+        "its route's NEON_READ_ROUTE_TABLES entry would be read by nothing",
+    );
+  });
+
+  test("chooses the store in exactly one place", () => {
+    // The property that makes the test above sufficient. Three call sites
+    // spelling the same ternary would drift, and the drift is invisible: a
+    // block that reads the flag wrongly still returns a schema-stable 200.
+    const body = dispatcherBody();
+    const direct = [...body.matchAll(/createD1Sql\(/g)].length;
+    assert.equal(
+      direct,
+      0,
+      "the dispatcher constructs a D1 runner directly; routeStore is the only " +
+        "place that should decide, so the gate cannot be skipped by one block",
+    );
+  });
+
+  test("routeStore still gates on the flag, not the binding's presence", () => {
+    // #9704: reading `env.HYPERDRIVE && ...` alone meant binding Hyperdrive
+    // for a WRITE pilot silently moved a READ onto a store nothing had written
+    // to, and it served a two-day-old snapshot until the binding was pulled.
+    // "The binding exists" and "this route should read Neon" are different
+    // questions and both must be answered yes.
+    const fn = SOURCE.slice(
+      SOURCE.indexOf("function routeStore("),
+      SOURCE.indexOf("export function neonServesRoute("),
+    );
+    assert.match(fn, /env\.HYPERDRIVE/);
+    assert.match(fn, /neonServesRoute\(/);
+    assert.match(fn, /createD1Sql\(env\.METAGRAPH_HEALTH_DB\)/);
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -6003,6 +6003,41 @@ export const NEON_READ_ROUTE_TABLES: readonly {
  * with no entry is never served from Neon, which is the safe default: an
  * unmapped route is one whose tables nobody has enumerated.
  */
+/**
+ * The store this request's handler should run against.
+ *
+ * ONE function because there are THREE dispatcher blocks, and until now only
+ * one of them asked. `matchNeuronsD1Route`'s block chose its runner from
+ * `neonServesRoute`; `matchHealthStatusD1Route`'s and
+ * `matchHyperparamsIdentityD1Route`'s both called `createD1Sql` outright.
+ *
+ * That was not a stylistic gap, it was a silent no-op. #9954 added
+ * NEON_READ_ROUTE_TABLES entries for `/subnets/{netuid}/hyperparameters`,
+ * `/subnets/{netuid}/hyperparameters/history`, `/accounts/{ss58}/identity` and
+ * `/accounts/{ss58}/identity-history`, and put all four of their tables in
+ * NEON_READ_LANES. None of those four routes is matched by
+ * matchNeuronsD1Route -- they are served by the hyperparams/identity block --
+ * so the declarations were read by nothing and the routes kept reading D1.
+ * Every piece of the cutover was in place except the line that consults it.
+ *
+ * Nothing about the decision changes here; it moves. The gate is still an
+ * explicit flag rather than the binding's presence (#9704: reading
+ * `env.HYPERDRIVE && ...` alone meant binding Hyperdrive for a WRITE pilot
+ * silently moved a READ onto a store nothing had written to). Every table a
+ * route touches must still be enabled, not just one, because a handler uses
+ * one runner for all its queries and a route touching two tables cannot
+ * half-move.
+ *
+ * A route with no NEON_READ_ROUTE_TABLES entry gets D1, which is why applying
+ * this to two more blocks moves nothing on its own.
+ */
+function routeStore(env: Env, ctx: ExecutionContext, url: URL): D1Sql {
+  return env.HYPERDRIVE &&
+    neonServesRoute(env as unknown as Record<string, unknown>, url)
+    ? createPgSql(env.HYPERDRIVE, ctx)
+    : createD1Sql(env.METAGRAPH_HEALTH_DB);
+}
+
 export function neonServesRoute(
   env: Record<string, unknown> | null | undefined,
   url: URL,
@@ -7364,13 +7399,8 @@ async function dispatchDataApiRequest(
         // Every table this route reads must be read-enabled, not just one --
         // the handler uses ONE runner for all its queries, so a route touching
         // two tables cannot half-move. See NEON_READ_ROUTE_TABLES.
-        const store =
-          env.HYPERDRIVE &&
-          neonServesRoute(env as unknown as Record<string, unknown>, url)
-            ? createPgSql(env.HYPERDRIVE, ctx)
-            : createD1Sql(env.METAGRAPH_HEALTH_DB);
         try {
-          return await neuronsD1Handler(store, env);
+          return await neuronsD1Handler(routeStore(env, ctx, url), env);
         } catch (err) {
           console.error("data-api neurons query failed:", err);
           await captureDataApiError(err, maskRouteParams(url.pathname), env);
@@ -7389,10 +7419,7 @@ async function dispatchDataApiRequest(
           return json({ error: "d1 binding unavailable" }, 503);
         }
         try {
-          return await healthStatusD1Handler(
-            createD1Sql(env.METAGRAPH_HEALTH_DB),
-            env,
-          );
+          return await healthStatusD1Handler(routeStore(env, ctx, url), env);
         } catch (err) {
           console.error("data-api health-status D1 query failed:", err);
           await captureDataApiError(err, maskRouteParams(url.pathname), env);
@@ -7417,7 +7444,7 @@ async function dispatchDataApiRequest(
         }
         try {
           return await hyperparamsIdentityD1Handler(
-            createD1Sql(env.METAGRAPH_HEALTH_DB),
+            routeStore(env, ctx, url),
             env,
           );
         } catch (err) {


### PR DESCRIPTION
Closes #9990. Part of #9787.

Reopened from `fix/every-dispatcher-block-asks-the-gate` (#9991), which I force-pushed a mid-rebase state onto while restacking it after #9988 merged. The branch content was wrong for a few seconds and the gate closed it, correctly. This branch is the same change, rebased cleanly on `main`, typechecked and green.

## The defect

`dispatchDataApiRequest` has three blocks that match a route to a handler and then hand it a runner. Only one asked the gate:

```
matchNeuronsD1Route             -> neonServesRoute ? createPgSql : createD1Sql
matchHealthStatusD1Route        -> createD1Sql
matchHyperparamsIdentityD1Route -> createD1Sql
```

`grep -n "neonServesRoute(" workers/data-api.ts` returned the definition and **exactly one** call site.

## What it silently undid

#9954 cut four routes over to Neon — `/subnets/{netuid}/hyperparameters`, its `/history`, `/accounts/{ss58}/identity` and its `-history`. It added their `NEON_READ_ROUTE_TABLES` entries and put all four tables in `NEON_READ_LANES`, with both stores at exact parity (129/129, 498/498, 137/137, 531/531).

**None of those four routes is matched by `matchNeuronsD1Route`.** They belong to the hyperparams/identity block, which never asks. So the declarations were read by nothing and all four kept answering from D1. Every part of the cutover was in place except the line that consults it.

## Why nothing caught it

`tests/neon-read-routes.test.ts` checks that a route's declared tables cover what its handler reads — and that assertion is *true*. The declaration is correct, the flag is correct, the tables are at parity. The defect is that **nobody called the function**, which no per-route assertion is looking at.

It is invisible from outside too: both stores hold the same rows, so both return the same bytes. The only symptom is a flag that is supposed to move a route and doesn't.

## The fix

`routeStore(env, ctx, url)` is the only place that decides, and all three blocks use it. The decision is unchanged — still `env.HYPERDRIVE && the flag`, because #9704 showed that gating on the binding alone means provisioning Hyperdrive for a *write* pilot silently moves a *read*.

## The test

`tests/dispatcher-asks-the-gate.test.ts` asserts it structurally, and discovers the blocks **by shape** (`return await <name>Handler(`) rather than from a list — listing them is exactly how the third block went unnoticed. A fourth block added later is covered the day it is written.

Verified it can fail, not just pass. Reverting one block to `createD1Sql`:

```
Tests  2 failed | 1 passed (3)
```

On this branch:

```
Tests  3 passed (3)
```

## Effect on production

Those four routes begin reading Neon — which is what #9954 intended and verified the data for.

`/api/v1/internal/health-status-live` deliberately does **not** move: `surface_status` is still absent from `NEON_READ_LANES`, because its writer is the prober and the prober writes D1. Moving that read before its write would hand the prober a lagging prior map, and the prober resetting `last_ok` is exactly the failure #9522 fixed. A route with no declaration gets D1, so applying `routeStore` to two more blocks moves nothing on its own.