### PR TITLE
feat(data-api): the user-state tier lives in Neon

### DIFF
--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -232,7 +232,23 @@
     //
     // Rollback is deleting a name. When this holds every table D1 has, the D1
     // binding comes off.
-    "NEON_SOLE_STORE_TABLES": "",
+    //
+    // THE FIRST TEN (#9987). The whole user-state tier, moved together because
+    // its two runner-acquiring helpers are the unit that moves -- see
+    // userStateRunner. Copied and verified before this line changed, and
+    // verified structurally rather than by row count alone: github_accounts
+    // 3/3, rpc_accounts 2/2, api_usage_rollup 1162/1162, the other seven empty
+    // on both sides. The two identity sequences were setval-ed past D1's max,
+    // because an explicit insert does not advance them and the next mint would
+    // otherwise collide on id 1.
+    //
+    // ORDERED AFTER #9992, and that ordering is load bearing. node-postgres
+    // returns int8 as a STRING where D1 returns a number, and this tier's
+    // schema is BIGINT-heavy by necessity -- epoch-ms does not fit in int4.
+    // Setting this flag before that parser existed would have turned
+    // created_at, units_spent, request_count, github_user_id and every other
+    // *_at column into strings on the wire, with nothing failing anywhere.
+    "NEON_SOLE_STORE_TABLES": "rpc_accounts,github_accounts,api_keys,api_key_blocks,api_key_usage_daily,api_quota_daily,api_usage_rollup,chain_alert_triggers,chain_alert_deliveries,watch_push_subscriptions",
     "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",
     // THE QUEUE CUTOVER (metagraphed-infra#348). Comma-separated lanes whose D1


### PR DESCRIPTION
Closes #9996. Part of #9787.

> **Draft until #9994 merges and deploys.** The ordering is load bearing, not tidiness — see below.

#9988 added `NEON_SOLE_STORE_TABLES` and shipped it empty. This is the flip. Ten tables come off D1.

## The tier

| group | tables |
|---|---|
| `ACCOUNT_STATE_TABLES` | `rpc_accounts`, `github_accounts`, `api_keys`, `api_key_blocks`, `api_key_usage_daily`, `api_quota_daily`, `api_usage_rollup` |
| `ALERT_TRIGGER_TABLES` | `chain_alert_triggers`, `chain_alert_deliveries`, `watch_push_subscriptions` |

They move together because the two runner-acquiring helpers are the unit that moves — `userStateRunner` hands out a Postgres runner only when **every** table in a group is listed.

## Copies verified before this line changed

Structurally, not by row count alone:

| table | D1 | Neon |
|---|---:|---:|
| `api_usage_rollup` | 1,162 | 1,162 |
| `github_accounts` | 3 | 3 |
| `rpc_accounts` | 2 | 2 |
| the other seven | 0 | 0 |

Both identity sequences `setval`'d past D1's max. An explicit insert does **not** advance an identity sequence, so without that the next minted account would collide on `id = 1`.

## Why this must land after #9994

node-postgres returns `int8` as a **string** where D1 returns a **number**, and this tier's schema is BIGINT-heavy by necessity — epoch-ms does not fit in int4. Flipping the flag before that parser exists turns `created_at`, `units_spent`, `request_count`, `github_user_id` and every other `*_at` column into strings on the wire. Nothing errors, nothing fails, and a consumer doing arithmetic or a `>` comparison silently gets a different answer.

That is the whole reason #9992 was filed before this one rather than after it went wrong.

## Rollback

Delete names from the flag. The D1 rows are untouched and still current — nothing is dropped by this PR, and nothing is dropped until the whole estate has moved and the binding comes off.