### PR TITLE
fix(neon): cast src.netuid, or the hotkey-alpha mirror writes nothing

### DIFF
--- a/src/ledger-neon-write.ts
+++ b/src/ledger-neon-write.ts
@@ -80,9 +80,27 @@ export const LEDGER_MIRROR_PLANS: Readonly<Record<string, LedgerPlan>> = {
     //
     // Postgres spelling of the same EXISTS the D1 writer passes to
     // chunkStatements; `src` is the alias buildPgUpsert gives the VALUES list.
+    //
+    // `::int` IS LOad BEARING, and its absence broke this lane outright. A
+    // bare parameter inside a `VALUES` list has no type context, so Postgres
+    // resolves every one of `src`'s columns to TEXT. `np.hotkey = src.hotkey`
+    // is text = text and passes; `np.netuid = src.netuid` is `integer = text`
+    // and there is no such operator, so the whole statement throws before a
+    // single row is written.
+    //
+    // Measured, not inferred: lane_health has `neon:hotkey-alpha` reporting
+    // `0 row(s) written before failure: operator does not exist: integer =
+    // text` on every pass since this filter shipped. The lane did not degrade,
+    // it stopped -- and `neon-parity` read the resulting divergence as the
+    // KNOWN one this filter was added to fix, which is why it looked like
+    // progress.
+    //
+    // Cast on the src side rather than the column side: `np.netuid::text`
+    // would also typecheck and would silently discard the index on
+    // nominator_positions.
     filter:
       "EXISTS (SELECT 1 FROM nominator_positions np" +
-      " WHERE np.hotkey = src.hotkey AND np.netuid = src.netuid)",
+      " WHERE np.hotkey = src.hotkey AND np.netuid = src.netuid::int)",
   },
   "validator-nominator-counts": {
     table: "validator_nominator_counts",

--- a/tests/ledger-neon-write.test.ts
+++ b/tests/ledger-neon-write.test.ts
@@ -227,6 +227,36 @@ describe("the hotkey-alpha filter (#9832)", () => {
     assert.match(plan.filter!, /np\.netuid = src\.netuid/);
   });
 
+  test("every non-text src column in the predicate is CAST", () => {
+    // The bug this exists to stop, which it did not stop the first time. A
+    // bare parameter inside a `VALUES` list has no type context, so Postgres
+    // resolves EVERY column of `src` to text. `np.hotkey = src.hotkey` is
+    // text = text and passes; `np.netuid = src.netuid` is `integer = text`,
+    // for which there is no operator, and the whole statement throws before a
+    // single row is written.
+    //
+    // Measured against production 2026-08-07: lane_health had
+    // `neon:hotkey-alpha` reporting `0 row(s) written before failure:
+    // operator does not exist: integer = text` on every pass since the filter
+    // shipped. The lane did not degrade, it STOPPED -- and neon-parity read
+    // the resulting divergence as the known one this filter was added to fix,
+    // which is why it looked like progress.
+    //
+    // Confirmed both directions against real Postgres: the predicate without
+    // `::int` raises exactly that error, and with it returns the row.
+    const plan = LEDGER_MIRROR_PLANS["hotkey-alpha"]!;
+    // `netuid` is INTEGER on both sides everywhere in this schema.
+    assert.match(
+      plan.filter!,
+      /src\.netuid::int/,
+      "src.netuid is compared to an integer column and must be cast; " +
+        "without it the statement throws and the lane writes nothing",
+    );
+    // Cast on the SRC side, never the column side: `np.netuid::text` also
+    // typechecks and silently discards the index on nominator_positions.
+    assert.doesNotMatch(plan.filter!, /np\.\w+::/);
+  });
+
   test("the predicate names only columns the plan actually sends", () => {
     // `src` is the VALUES alias, so a predicate referring to a column outside
     // the plan's list is a runtime error on every write.


### PR DESCRIPTION
Closes #9999. Part of #9787.

Found by reading `lane_health` on production, not by a failing test.

```
neon:hotkey-alpha  stale  0 row(s) written before failure: operator does not exist: integer = text
```

Every pass since #9832 shipped. The lane did not degrade — it **stopped**.

## Cause

`buildPgUpsert` switches the row source to `FROM (VALUES ($1, $2, ...)) AS src (cols)` when a plan carries a `filter`. A bare parameter inside a `VALUES` list has **no type context**, so Postgres resolves every one of `src`'s columns to `text`:

| comparison | resolves to | result |
|---|---|---|
| `np.hotkey = src.hotkey` | `text = text` | fine |
| `np.netuid = src.netuid` | `integer = text` | **no such operator** |

The statement throws before a single row is inserted.

## Verified against the production database, both directions

```
WITHOUT ::int -> FAILS: operator does not exist: integer = text
WITH    ::int -> OK, rows: 1
```

The failure message is character-for-character the one in `lane_health`.

## Why it read as progress rather than an outage

#9832 added this filter *because* Neon held ~29,000 rows D1 refuses on purpose. `neon-parity` still reports `hotkey_alpha -29468` — and that is the **known** divergence the filter was added to fix. Anyone checking parity sees the expected gap and moves on. The gap stopped closing because the mirror is dead, not because it is catching up.

## The fix

Cast on the `src` side: `np.netuid = src.netuid::int`.

Deliberately **not** on the column side — `np.netuid::text` also typechecks and silently discards the index on `nominator_positions`, turning the per-row `EXISTS` into a scan.

## The test

Asserts the cast is present, and that no `np.<col>::` cast appears. The existing tests in that block asserted the predicate's *shape* — both key columns present, only plan columns referenced — and all of them passed throughout the outage, because the shape was never wrong. The types were.