### PR TITLE
fix(test): the bulk-health-trends fixtures pinned the absence of a feature

### DIFF
--- a/tests/request-handlers-analytics.test.ts
+++ b/tests/request-handlers-analytics.test.ts
@@ -1035,25 +1035,53 @@ describe("withEdgeCache", () => {
 // ---- D) handleBulkHealthTrends ----------------------------------------------
 
 describe("handleBulkHealthTrends", () => {
-  test("rejects any query param with 400", async () => {
-    for (const qs of ["?window=7d", "?foo=1", "?limit=10&cursor=abc"]) {
+  // #9989 gave this route three narrowing parameters. It took NONE before --
+  // both tests below used `window=7d` as their example of a REJECTED param,
+  // which is now a supported one, so the fixtures move to a param that can
+  // never be supported rather than to another real name that might later be.
+  test("rejects an unsupported query param with 400", async () => {
+    for (const qs of ["?foo=1", "?cursor=abc", "?sort=name"]) {
       const res = await handleBulkHealthTrends(
         req(`/api/v1/health/trends${qs}`),
         emptyEnv(),
         url(`/api/v1/health/trends${qs}`),
       );
       const body = await errorJson(res);
-      assert.equal(body.error.code, "invalid_query");
+      assert.equal(body.error.code, "invalid_query", qs);
     }
   });
 
   test("reports the offending parameter name in error details", async () => {
     const res = await handleBulkHealthTrends(
-      req("/api/v1/health/trends?window=7d"),
+      req("/api/v1/health/trends?foo=1"),
       emptyEnv(),
-      url("/api/v1/health/trends?window=7d"),
+      url("/api/v1/health/trends?foo=1"),
     );
     const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "foo");
+  });
+
+  test("accepts the three parameters it now publishes", async () => {
+    // The other side of the same behaviour, pinned here so the next person
+    // does not rediscover it by breaking the rejection test above.
+    for (const qs of ["?window=7d", "?window=30d", "?limit=5", "?offset=2"]) {
+      const res = await handleBulkHealthTrends(
+        req(`/api/v1/health/trends${qs}`),
+        emptyEnv(),
+        url(`/api/v1/health/trends${qs}`),
+      );
+      assert.equal(res.status, 200, qs);
+    }
+  });
+
+  test("rejects a window the route does not derive", async () => {
+    const res = await handleBulkHealthTrends(
+      req("/api/v1/health/trends?window=90d"),
+      emptyEnv(),
+      url("/api/v1/health/trends?window=90d"),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.error.code, "invalid_query");
     assert.equal(body.meta.parameter, "window");
   });
 


### PR DESCRIPTION
**`main` is red.** #9993 merged with a failing `test` job.

```
FAIL tests/request-handlers-analytics.test.ts > handleBulkHealthTrends > rejects any query param with 400
AssertionError: expected 400, got 200
```

Both failing tests used **`?window=7d`** as their example of a *rejected* parameter. #9989 made `window`, `limit` and `offset` supported on that route — so the route is behaving correctly and the fixtures are asserting the contract it used to have.

The shipped behaviour is fine: every route-level, loader-level and MCP-level test of the new parameters passes, and `validate:api` / `validate:openapi` accept the route.

## My error, stated plainly

Before pushing #9993 I ran `api-coverage`, `bulk-health-trends-loader` and `mcp-server` — and not `request-handlers-analytics`, which owns the handler-level tests for that exact route. Scoped selection missed the one file most likely to encode "this route takes no parameters".

## Fix

Both fixtures move onto `foo`, a parameter that can never become supported — rather than onto another real name that might later be. That is the same reasoning the usage-label fixtures needed in #9980 after rotting twice on real path names: **a fixture that encodes "this is not supported yet" fails the day someone supports it.**

Two tests added for the other side, so the next person does not rediscover the behaviour by breaking the rejection test:

- the three supported parameters answer 200
- a window the route does not derive is still a 400, naming the parameter

## Validation

```
npm run lint && npm run format:check && npm run typecheck
npx vitest run tests/request-handlers-analytics.test.ts
```

158 tests pass.

Closes #10001