### PR TITLE
feat(registry): re-check the URLs the registry asserts, after the PR merges

### DIFF
--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -69,6 +69,7 @@ import {
   writeJson,
   loadSurfaceProbeEvidence,
 } from "./lib.ts";
+import { deadLinkUrls, loadLinkStatusRecords } from "./link-status.ts";
 import {
   buildAgentReadiness,
   buildCoverageDepthArtifact,
@@ -221,8 +222,20 @@ const nativeByNetuid = new Map(
 // editing a registry file. Loaded through lib's shared loader so this and
 // validate.ts cannot disagree about the evidence and fail artifact parity.
 const surfaceProbeEvidence = await loadSurfaceProbeEvidence();
+// #9914: the link lane's confirmed-dead URLs. A surface whose source_urls have
+// ALL died has lost the evidence that it exists, and loses its verification the
+// same way a dead probe takes it — see surfaceEvidenceIsDead. Loaded here (and
+// re-loaded identically by validate.ts) so the two cannot disagree and fail
+// artifact parity, exactly like surfaceProbeEvidence above.
+const linkStatusRecords = await loadLinkStatusRecords();
+const deadLinks = deadLinkUrls(linkStatusRecords);
 const surfaces: Row[] = withSurfaceFreshness(
-  flattenSurfaces(activeOverlays, surfaceProbeEvidence, nativeByNetuid),
+  flattenSurfaces(
+    activeOverlays,
+    surfaceProbeEvidence,
+    nativeByNetuid,
+    deadLinks,
+  ),
   Date.parse(nativeSnapshot.captured_at),
 );
 // #1002: dedup candidate ↔ curated surface. A candidate that shares a curated

--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -45,6 +45,38 @@ type Row = Record<string, unknown>;
 // Deliberately not a general-purpose knob: unset (the normal case, including
 // all of CI's own build/publish steps) it resolves exactly as before.
 const defaultRepoRoot = fileURLToPath(new URL("..", import.meta.url));
+/**
+ * Join `relative` onto `root`, or return null if it would escape.
+ *
+ * Registry files are CONTRIBUTOR-SUBMITTED, so any path derived from one is
+ * attacker-influenced: a `logo_url` of
+ * `https://metagraph.sh/logos/../../../../etc/passwd` survives a naive
+ * `path.join`, which normalizes `..` away rather than rejecting it. Decoding
+ * happens before the check because `%2e%2e` is also `..`.
+ *
+ * Containment is asserted on the RESOLVED path with a trailing separator, so a
+ * sibling directory sharing a name prefix (`/public-evil` vs `/public`) cannot
+ * pass a bare startsWith.
+ */
+export function resolveWithinRoot(
+  root: string,
+  relative: string,
+): string | null {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(relative);
+  } catch {
+    // A malformed percent-escape is not a path we will look up.
+    return null;
+  }
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(resolvedRoot, `.${path.sep}${decoded}`);
+  return resolved === resolvedRoot ||
+    resolved.startsWith(resolvedRoot + path.sep)
+    ? resolved
+    : null;
+}
+
 export const repoRoot = process.env.METAGRAPH_REPO_ROOT
   ? // Trailing separator to match fileURLToPath's directory form, so the
     // handful of `path.relative(repoRoot, …)` / string-prefix callers behave

--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -16,6 +16,7 @@ import {
 import { entityLabelsIndex } from "../src/entity-labels.ts";
 import {
   isProbeDemoted,
+  surfaceEvidenceIsDead,
   verifyFromProbeEvidence,
   type SurfaceProbeRecord,
 } from "../src/surface-verification.ts";
@@ -1007,6 +1008,11 @@ export function flattenSurfaces(
   subnets: Row[],
   surfaceProbeEvidence: Record<string, SurfaceProbeRecord> = {},
   nativeByNetuid?: Map<unknown, Row>,
+  // Optional like nativeByNetuid (#9963), so every read-only caller --
+  // capture-fixtures, probes-smoke, snapshot-openapi, tests -- is unchanged by
+  // construction. Absent means "the link lane has no verdict", which is not the
+  // same as "nothing is dead".
+  deadLinkUrls: ReadonlySet<string> = new Set(),
 ): Row[] {
   return subnets
     .flatMap((subnet) =>
@@ -1050,7 +1056,14 @@ export function flattenSurfaces(
         // advertise that as verified for the rest of the TTL is exactly the
         // complaint in #8658's title. Live evidence outranks a historical
         // hand-edit when the two disagree about whether something still exists.
-        const confirmedDead = isProbeDemoted(probeRecord);
+        // Two independent ways to lose a verification, both meaning "we looked
+        // and it is gone": the prober confirmed the surface itself dead, or the
+        // link lane confirmed every source_url proving it exists is dead
+        // (#9914). The second is what makes the gate's dead-source_url rule
+        // apply after merge and not only on the way in.
+        const confirmedDead =
+          isProbeDemoted(probeRecord) ||
+          surfaceEvidenceIsDead(surface.source_urls, deadLinkUrls);
         // #1006: the as-of timestamp every served surface should carry. A
         // per-surface verification wins; otherwise only official surfaces may
         // inherit subnet curation verified_at (when a maintainer last vetted the
@@ -1414,42 +1427,132 @@ interface ResolvedAddress {
   family: number;
 }
 
+/**
+ * Why a URL yielded no address to connect to (#9870).
+ *
+ * All three refuse the connection, but they are NOT the same claim about the
+ * world, and collapsing them is what made us report `unsafe URL` for a host
+ * that simply no longer exists:
+ *
+ *   - `unsafe`        — we looked, and connecting would be a safety problem: the
+ *                       literal guard rejected it, or DNS answered with a
+ *                       private/loopback/link-local address (rebinding).
+ *   - `unresolvable`  — we looked, and the name authoritatively does not exist
+ *                       (NXDOMAIN / no records). Nothing unsafe about it; it is
+ *                       DEAD, and that is a fact about the target worth
+ *                       publishing.
+ *   - `resolve-error` — we could not look. A transient resolver error, a
+ *                       timeout, our own network. This is a fact about US, and
+ *                       must never be scored as the target being dead —
+ *                       "absence of evidence is not death"
+ *                       (src/surface-verification.ts).
+ *
+ * The `unsafe` / `resolve-error` split (and those exact names) already exist in
+ * `resolvedWebhookUrlStatus` (src/webhooks.ts), for the same reason: a DNS blip
+ * must be retryable, not a terminal verdict. This adds the third case webhooks
+ * has no use for — an authoritative "no such name".
+ */
+export type UrlResolutionFailure = "unsafe" | "unresolvable" | "resolve-error";
+
+export interface UrlResolution {
+  addresses: ResolvedAddress[];
+  /** null exactly when `addresses` is non-empty. */
+  failure: UrlResolutionFailure | null;
+}
+
+/**
+ * The one place each failure is put into words. Every caller that reports a
+ * reason to a human or an artifact reads this map, so `api.affine.io` cannot be
+ * described as "unsafe URL" in one lane and "dead" in another.
+ */
+export const URL_RESOLUTION_FAILURE_MESSAGE: Record<
+  UrlResolutionFailure,
+  string
+> = {
+  unsafe: "unsafe URL",
+  unresolvable: "host does not resolve",
+  "resolve-error": "DNS lookup failed",
+};
+
+/**
+ * Node error codes that mean the resolver got an authoritative "no such name"
+ * rather than failing to ask. EAI_AGAIN (temporary failure) is deliberately
+ * absent — it is a `resolve-error`, not a death certificate.
+ */
+const AUTHORITATIVE_DNS_MISS = new Set(["ENOTFOUND", "ENODATA", "EAI_NODATA"]);
+
+/**
+ * Resolve a URL to the public addresses it is safe to connect to, and say WHY
+ * when there are none. `resolvePublicUrlAddresses`/`isUnsafeResolvedUrl` are
+ * thin wrappers so every existing caller keeps its exact signature — only
+ * callers that report a reason to a human need the richer result.
+ */
+export async function resolveUrlSafety(
+  value: unknown,
+  resolver: typeof lookup = lookup,
+): Promise<UrlResolution> {
+  let host: string;
+  try {
+    const url = new URL(value as string);
+    if (isUnsafeUrl(url.toString())) {
+      return { addresses: [], failure: "unsafe" };
+    }
+    host = normalizeHostname(url.hostname);
+  } catch {
+    // Not a URL at all. A malformed input is a safety refusal, not a claim
+    // that some host is dead.
+    return { addresses: [], failure: "unsafe" };
+  }
+
+  if (isIP(host)) {
+    return {
+      addresses: [{ address: host, family: isIP(host) }],
+      failure: null,
+    };
+  }
+
+  try {
+    const records = await resolver(host, { all: true, verbatim: true });
+    if (records.length === 0) {
+      return { addresses: [], failure: "unresolvable" };
+    }
+    if (records.some((record) => isUnsafeIpAddress(record.address))) {
+      return { addresses: [], failure: "unsafe" };
+    }
+    return {
+      addresses: records.map((record) => ({
+        address: record.address,
+        family: record.family,
+      })),
+      failure: null,
+    };
+  } catch (error) {
+    // The resolver threw. ENOTFOUND/ENODATA is how Node reports NXDOMAIN — an
+    // authoritative "no such name", i.e. dead. Anything else (EAI_AGAIN,
+    // SERVFAIL, timeout) means we failed to ask, which is our problem and must
+    // not be recorded against the target.
+    const code = (error as NodeJS.ErrnoException)?.code;
+    return {
+      addresses: [],
+      failure: AUTHORITATIVE_DNS_MISS.has(String(code))
+        ? "unresolvable"
+        : "resolve-error",
+    };
+  }
+}
+
 export async function resolvePublicUrlAddresses(
   value: unknown,
   resolver: typeof lookup = lookup,
 ): Promise<ResolvedAddress[]> {
-  try {
-    const url = new URL(value as string);
-    if (isUnsafeUrl(url.toString())) {
-      return [];
-    }
-
-    const host = normalizeHostname(url.hostname);
-    if (isIP(host)) {
-      return [{ address: host, family: isIP(host) }];
-    }
-
-    const records = await resolver(host, { all: true, verbatim: true });
-    if (
-      records.length === 0 ||
-      records.some((record) => isUnsafeIpAddress(record.address))
-    ) {
-      return [];
-    }
-    return records.map((record) => ({
-      address: record.address,
-      family: record.family,
-    }));
-  } catch {
-    return [];
-  }
+  return (await resolveUrlSafety(value, resolver)).addresses;
 }
 
 export async function isUnsafeResolvedUrl(
   value: unknown,
   resolver: typeof lookup = lookup,
 ): Promise<boolean> {
-  return (await resolvePublicUrlAddresses(value, resolver)).length === 0;
+  return (await resolveUrlSafety(value, resolver)).failure !== null;
 }
 
 const SAFE_FETCH_REDIRECT_CODES = new Set([301, 302, 303, 307, 308]);

--- a/scripts/link-status.ts
+++ b/scripts/link-status.ts
@@ -1,0 +1,62 @@
+// Build-side reader for the link-rot store the daily cron writes
+// (src/link-status-sync.ts). Mirrors scripts/github-signals.ts exactly: R2
+// store first (the cron's fresh copy), committed seed second, empty last.
+//
+// The seed materialization is not an optimization. The publish build holds the
+// R2 credentials and reads the store; the publish job's later `npm run
+// validate` step runs CREDENTIAL-LESS against the restored registry/ tree. Both
+// must see the same snapshot or the validation gates would judge artifacts
+// built from data they cannot read. Writing the store back to the seed path is
+// what carries it across — the same travel-with-the-artifacts design the native
+// snapshot, candidate inputs and github-signals already use.
+
+import path from "node:path";
+import {
+  isConfirmedDeadLink,
+  LINK_STATUS_R2_KEY,
+  type LinkStatusRecord,
+} from "../src/link-status-core.ts";
+import { readGeneratedStoreJson } from "./r2-rest.ts";
+import { readJson, repoRoot, stableStringify, writeJson } from "./lib.ts";
+
+type Row = Record<string, unknown>;
+
+export const linkStatusPath = path.join(
+  repoRoot,
+  "registry/generated/link-status.json",
+);
+
+export async function readLinkStatusStore(): Promise<Row | null> {
+  const doc = await readGeneratedStoreJson(LINK_STATUS_R2_KEY);
+  return doc && Array.isArray(doc.links) ? (doc as Row) : null;
+}
+
+export async function loadLinkStatusRecords(): Promise<LinkStatusRecord[]> {
+  const storeDoc = await readLinkStatusStore();
+  if (storeDoc) {
+    const seeded: Row | null = await readJson(linkStatusPath).catch(() => null);
+    if (stableStringify(seeded) !== stableStringify(storeDoc)) {
+      await writeJson(linkStatusPath, storeDoc).catch(() => undefined);
+    }
+  }
+  const doc: Row | null =
+    storeDoc ?? (await readJson(linkStatusPath).catch(() => null));
+  return Array.isArray(doc?.links) ? (doc.links as LinkStatusRecord[]) : [];
+}
+
+/**
+ * The URLs the lane has confirmed dead — LINK_DEAD_STRIKES consecutive
+ * failures, not one bad night.
+ *
+ * A cold or never-run store yields an EMPTY set, which demotes nothing. That is
+ * the correct degraded mode: "we have no link verdicts" must never be read as
+ * "no link is dead" in one direction or "everything is dead" in the other, and
+ * an empty set is the only one of those that cannot cause harm.
+ */
+export function deadLinkUrls(records: LinkStatusRecord[]): Set<string> {
+  return new Set(
+    records
+      .filter((record) => isConfirmedDeadLink(record))
+      .map((record) => record.url),
+  );
+}

--- a/scripts/snapshot-adapters.ts
+++ b/scripts/snapshot-adapters.ts
@@ -6,11 +6,13 @@ import {
   buildTimestamp,
   hashJson,
   isJsonContentType,
-  isUnsafeResolvedUrl,
   loadSubnets,
   readJson,
   repoRoot,
+  resolveUrlSafety,
   stableStringify,
+  URL_RESOLUTION_FAILURE_MESSAGE,
+  type UrlResolutionFailure,
   writeJson,
 } from "./lib.ts";
 
@@ -556,14 +558,37 @@ async function readResponseText(
   return { ok: true, text: new TextDecoder().decode(bodyBytes) };
 }
 
+/**
+ * The refusal record for a URL we will not connect to, naming WHICH refusal it
+ * was (#9870). Before this, every one of these came back `unsafe URL` — so
+ * `api.affine.io` (NXDOMAIN) and a host resolving to 10.0.0.1 were reported
+ * identically, and the adapter dashboard blamed our safety guard for what was
+ * really a dead domain.
+ */
+/**
+ * Redirect-hop wording. `unsafe` keeps its long-standing message verbatim —
+ * that case was already reported correctly and its phrasing is asserted by
+ * tests; only the two cases that used to be misfiled as unsafe are new.
+ */
+const REDIRECT_REFUSAL_MESSAGE: Record<UrlResolutionFailure, string> = {
+  unsafe: "redirect target is unsafe",
+  unresolvable: "redirect target does not resolve",
+  "resolve-error": "redirect target DNS lookup failed",
+};
+
+function urlRefusalRecord(failure: UrlResolutionFailure): Row {
+  return {
+    ok: false,
+    status: failure,
+    error: URL_RESOLUTION_FAILURE_MESSAGE[failure],
+    captured_at: new Date().toISOString(),
+  };
+}
+
 export async function fetchJson(url: string, redirectCount = 0): Promise<Row> {
-  if (await isUnsafeResolvedUrl(url)) {
-    return {
-      ok: false,
-      status: "unsafe",
-      error: "unsafe URL",
-      captured_at: new Date().toISOString(),
-    };
+  const safety = await resolveUrlSafety(url);
+  if (safety.failure) {
+    return urlRefusalRecord(safety.failure);
   }
 
   const controller = new AbortController();
@@ -585,13 +610,16 @@ export async function fetchJson(url: string, redirectCount = 0): Promise<Row> {
       redirectCount < 5
     ) {
       const redirectTarget = new URL(location, url).toString();
-      if (await isUnsafeResolvedUrl(redirectTarget)) {
+      const redirectSafety = await resolveUrlSafety(redirectTarget);
+      if (redirectSafety.failure) {
         await response.body?.cancel();
         return {
           ok: false,
-          status: "unsafe",
-          error: "redirect target is unsafe",
-          private_redirect_blocked: true,
+          status: redirectSafety.failure,
+          error: REDIRECT_REFUSAL_MESSAGE[redirectSafety.failure],
+          // Only a genuine safety verdict is a blocked private redirect; a
+          // redirect to a domain that no longer exists is rot, not an attack.
+          private_redirect_blocked: redirectSafety.failure === "unsafe",
           status_code: response.status,
           latency_ms: Math.round(performance.now() - started),
           captured_at: new Date().toISOString(),
@@ -758,13 +786,9 @@ function looksLikeYaml(contentType: unknown, url: unknown): boolean {
 }
 
 async function fetchSseSummary(url: string): Promise<Row> {
-  if (await isUnsafeResolvedUrl(url)) {
-    return {
-      status: "unsafe",
-      url,
-      error: "unsafe URL",
-      captured_at: new Date().toISOString(),
-    };
+  const safety = await resolveUrlSafety(url);
+  if (safety.failure) {
+    return { ...urlRefusalRecord(safety.failure), url };
   }
 
   const controller = new AbortController();

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -34,6 +34,7 @@ import {
   findUnmaterializedMaintainerReviews,
   loadSurfaceProbeEvidence,
 } from "./lib.ts";
+import { deadLinkUrls, loadLinkStatusRecords } from "./link-status.ts";
 import {
   R2_STAGING_RELATIVE_ROOT,
   artifactStorageTierForRelativePath,
@@ -1096,8 +1097,17 @@ async function validateGeneratedArtifacts(
       nativeSubnet,
     ]),
   );
+  // Same store, same loader, same fourth argument as the build (#9914) — this
+  // check compares its own output against the build's, so a different dead-link
+  // set here would fail artifact parity rather than catch anything.
+  const deadLinks = deadLinkUrls(await loadLinkStatusRecords());
   const surfaces = withSurfaceFreshness(
-    flattenSurfaces(activeOverlays, surfaceProbeEvidence, nativeByNetuid),
+    flattenSurfaces(
+      activeOverlays,
+      surfaceProbeEvidence,
+      nativeByNetuid,
+      deadLinks,
+    ),
     Date.parse(nativeSnapshot.captured_at),
   );
   // #1002: mirror the build's candidate ↔ curated-surface dedup. A candidate
@@ -1362,6 +1372,69 @@ async function validateGeneratedArtifacts(
   assert(
     githubClaimDrift.length === 0,
     `an unreachable GitHub repo must not publish activity metrics (${githubClaimDrift.length}):\n  ${githubClaimDrift.slice(0, 12).join("\n  ")}`,
+  );
+
+  // #9917: every logo URL we SERVE must resolve to a file we ship.
+  //
+  // Two populations, one invariant. 75 chain-identity logos are re-hosted under
+  // /logos/cache/<sha>.png and indexed by registry/generated/logo-cache.json;
+  // ~101 curated logos live at /logos/<name>.png and are cited directly by
+  // provider and subnet records. Both are OUR OWN static assets, which is
+  // exactly why the daily link lane does not fetch them
+  // (src/link-status-core.ts): a filesystem check is free, runs on every build
+  // rather than once a night, and blames the commit that dropped the file
+  // instead of a 3am 404. This gate is what makes that trade sound -- without
+  // it the self-hosted subset would simply go unchecked.
+  //
+  // Skipped entirely when the tree ships no logo directory. tests/helpers/
+  // repo-sandbox.ts copies only the DATA directories (registry/, public/) and
+  // deliberately not apps/, so a data-only tree asserts nothing about UI
+  // assets; reading "apps/ui is absent" as "every logo was deleted" would fail
+  // every sandboxed run for a reason that has nothing to do with the registry.
+  // CI's own `npm run validate` runs against the full checkout, where the
+  // directory exists and the gate is live.
+  const logoPublicRoot = path.join(repoRoot, "apps/ui/public");
+  const missingLogos: string[] = [];
+  const logoCache = existsSync(path.join(logoPublicRoot, "logos"))
+    ? ((await readJson(
+        path.join(repoRoot, "registry/generated/logo-cache.json"),
+      ).catch(() => null)) as Row | null)
+    : null;
+  for (const entry of (logoCache?.entries as Row[]) || []) {
+    const cachedPath = String(entry.cached_path || "");
+    if (cachedPath && !existsSync(path.join(logoPublicRoot, cachedPath))) {
+      missingLogos.push(
+        `${cachedPath} (logo-cache.json, for ${entry.source_url})`,
+      );
+    }
+  }
+  const citedLogos = new Map<string, string[]>();
+  const citeLogo = (value: unknown, by: string) => {
+    if (typeof value !== "string") return;
+    const match = /^https:\/\/metagraph\.sh(\/logos\/[^?#]+)/.exec(value);
+    if (!match) return;
+    const list = citedLogos.get(match[1]) || [];
+    list.push(by);
+    citedLogos.set(match[1], list);
+  };
+  if (existsSync(path.join(logoPublicRoot, "logos"))) {
+    for (const provider of (providersArtifact.providers as Row[]) || []) {
+      citeLogo(provider.logo_url, `provider ${provider.slug}`);
+    }
+    for (const subnet of (subnetsArtifact.subnets as Row[]) || []) {
+      citeLogo(subnet.logo_url, `subnet ${subnet.slug}`);
+    }
+  }
+  for (const [logoPath, citedBy] of citedLogos) {
+    if (!existsSync(path.join(logoPublicRoot, decodeURIComponent(logoPath)))) {
+      missingLogos.push(
+        `${logoPath} (cited by ${citedBy.slice(0, 3).join(", ")})`,
+      );
+    }
+  }
+  assert(
+    missingLogos.length === 0,
+    `served logo URLs must resolve to a shipped file (${missingLogos.length}):\n  ${missingLogos.slice(0, 12).join("\n  ")}`,
   );
 
   assert(

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -28,6 +28,7 @@ import {
   readJson,
   registrySurfaceKey,
   repoRoot,
+  resolveWithinRoot,
   slugify,
   stableStringify,
   subnetSurfaceKey,
@@ -1400,9 +1401,17 @@ async function validateGeneratedArtifacts(
         path.join(repoRoot, "registry/generated/logo-cache.json"),
       ).catch(() => null)) as Row | null)
     : null;
+  // resolveWithinRoot, not path.join: both these paths come from
+  // CONTRIBUTOR-SUBMITTED registry files, and path.join normalizes `..` away
+  // instead of rejecting it. A logo_url of ".../logos/../../../etc/passwd"
+  // would otherwise turn this existence check into an arbitrary-path probe on
+  // the build machine. A path that escapes is reported as missing -- it is not
+  // a file we ship, which is exactly what the gate asserts.
   for (const entry of (logoCache?.entries as Row[]) || []) {
     const cachedPath = String(entry.cached_path || "");
-    if (cachedPath && !existsSync(path.join(logoPublicRoot, cachedPath))) {
+    if (!cachedPath) continue;
+    const resolved = resolveWithinRoot(logoPublicRoot, cachedPath);
+    if (!resolved || !existsSync(resolved)) {
       missingLogos.push(
         `${cachedPath} (logo-cache.json, for ${entry.source_url})`,
       );
@@ -1426,7 +1435,8 @@ async function validateGeneratedArtifacts(
     }
   }
   for (const [logoPath, citedBy] of citedLogos) {
-    if (!existsSync(path.join(logoPublicRoot, decodeURIComponent(logoPath)))) {
+    const resolved = resolveWithinRoot(logoPublicRoot, logoPath);
+    if (!resolved || !existsSync(resolved)) {
       missingLogos.push(
         `${logoPath} (cited by ${citedBy.slice(0, 3).join(", ")})`,
       );

--- a/src/link-status-core.ts
+++ b/src/link-status-core.ts
@@ -1,0 +1,438 @@
+// Link-rot checking for the three URL populations the health prober does not
+// cover (#9907, #9914, #9917).
+//
+// WHY THIS IS NOT THE HEALTH PROBER. `OPERATIONAL_SURFACE_KINDS` deliberately
+// limits the prober to subtensor-rpc/wss, archive, subnet-api, sse and
+// data-artifact -- things with uptime. The URLs here are references: a README
+// that proves a subnet publishes an API, a provider's website, a docs page. They
+// have no uptime, they must never enter incidents or the pool breaker, and
+// checking them every 15 minutes would be 1,067 pointless requests an hour.
+// They rot on a scale of weeks, so they are checked once a day.
+//
+// The populations overlap heavily -- 777 source_urls + 384 provider URLs + 494
+// non-operational surface URLs is only 1,067 DISTINCT urls -- so everything here
+// is keyed by URL, and citations fan back out to whoever referenced it.
+//
+// Subrequest budget: a Worker invocation may make 1000 subrequests.
+//
+// 102 of the URLs are metagraph.sh/logos/* — OUR OWN static assets. Those are
+// checked against the files on disk by a build gate: free, deterministic, and
+// it attributes a missing logo to the commit that dropped it instead of to a
+// 3am fetch. That leaves 965 network checks.
+//
+// Reusing github-signals for the 165 github.com repo roots was considered and
+// REJECTED: that lane DROPS a gone repo from its artifact (#9969) rather than
+// flagging it, so absence there conflates "gone" with "never tracked" and "the
+// capture was rate-limited". Deriving death from absence is the exact error
+// #9969 existed to fix. All 429 github.com URLs go through the GitHub API
+// instead, which answers the question directly.
+//
+// 965 exceeds LINK_STATUS_MAX_CHECKS_PER_RUN on purpose: the per-run cap picks
+// the least-recently-checked first, so every URL is still covered every ~2 days
+// and the invocation keeps headroom under the platform ceiling.
+
+import {
+  classifyProbe,
+  mapLimit,
+  probeUrl,
+  type ProbeSurface,
+} from "./health-probe-core.ts";
+
+type Row = Record<string, unknown>;
+
+/** R2 key for the capture store, alongside the other control-plane stores. */
+export const LINK_STATUS_R2_KEY = "control/link-status.json";
+
+/**
+ * Consecutive daily failures before a link is called dead.
+ *
+ * One bad night is not rot. Three consecutive daily runs means a link has been
+ * unreachable for ~72 hours across three independent resolver/network samples,
+ * which is past any plausible deploy blip or maintenance window. Only
+ * UNREACHABLE_CLASSIFICATIONS increment the counter, and any reachable verdict
+ * resets it to zero -- so a link must fail three times IN A ROW, not three
+ * times ever.
+ */
+export const LINK_DEAD_STRIKES = 3;
+
+/** Per-host serialization is the default; GitHub's API is exempt (see below). */
+export const LINK_CHECK_CONCURRENCY = 8;
+
+/**
+ * Defensive per-run ceiling, mirroring GITHUB_SIGNALS_MAX_REPOS_PER_RUN.
+ *
+ * The measured population is 965 network-checkable URLs; 900 keeps ~100
+ * subrequests of headroom under the 1000-per-invocation platform limit for the
+ * two artifact reads, the two store reads, the write and telemetry. The 65-URL
+ * remainder is not dropped — urlsForRun orders by least-recently-checked, so
+ * the tail rotates in on the following tick and every URL is covered within
+ * about two days.
+ */
+export const LINK_STATUS_MAX_CHECKS_PER_RUN = 900;
+
+/** Per-URL request budget. Reference links are not latency-sensitive. */
+export const LINK_CHECK_TIMEOUT_MS = 8000;
+
+/**
+ * Classifications meaning the link DID NOT SERVE THE DOCUMENT, and so accrue a
+ * strike. A strike is not a verdict — LINK_DEAD_STRIKES consecutive ones are.
+ *
+ *   - `dead`        — an explicit 404/410.
+ *   - `unsupported` — the fetch never completed: NXDOMAIN, connection refused,
+ *                     TLS failure. For a plain GET of a static reference URL
+ *                     there is no benign reading of that.
+ *   - `transient`   — a 5xx. Included *because* of the streak rule, not despite
+ *                     it: the largest single rot cluster in the registry is
+ *                     api.eirel.ai, which serves Cloudflare 521 (origin down)
+ *                     behind live DNS for 121 surfaces. One 521 is transient;
+ *                     three days of them is a dead origin, and excluding 5xx
+ *                     outright would make the lane blind to its biggest case.
+ *   - `timeout`     — same argument. Three consecutive days of timeouts is not
+ *                     a slow day.
+ *
+ * Deliberately EXCLUDED, because each proves the host is alive and serving:
+ * `auth-required` (401/403 — Cloudflare bot protection answers 403 for
+ * perfectly live docs, and this was a real false-positive source in the audit),
+ * `rate-limited` (429 — we asked too often), `redirected`, `content-mismatch`,
+ * `live`. `unsafe` is excluded too: that is a verdict about our own guard, not
+ * about the target.
+ */
+export const UNREACHABLE_CLASSIFICATIONS = new Set([
+  "dead",
+  "unsupported",
+  "transient",
+  "timeout",
+]);
+
+export type LinkCitationKind = "source_url" | "surface" | "provider";
+
+export interface LinkCitation {
+  kind: LinkCitationKind;
+  /** Surface id, provider slug, or the surface whose source_urls cite it. */
+  id: string;
+  netuid?: number;
+}
+
+export interface LinkTarget {
+  url: string;
+  citations: LinkCitation[];
+}
+
+/**
+ * How a given URL is checked. Splitting this out keeps the routing decision
+ * pure and testable, and keeps the budget arithmetic above honest.
+ */
+export type LinkCheckStrategy = "http" | "github-api" | "self";
+
+export interface LinkStatusRecord {
+  url: string;
+  /** healthClassification vocabulary (src/contracts.ts) — shared with the prober. */
+  classification: string;
+  status_code: number | null;
+  checked_at: string;
+  last_ok: string | null;
+  /** Consecutive UNREACHABLE_CLASSIFICATIONS results. Reset to 0 by any other verdict. */
+  consecutive_failures: number;
+  error: string | null;
+}
+
+export interface LinkStatusArtifact {
+  schema_version: 1;
+  generated_at: string;
+  checked_count: number;
+  /** Links at or past LINK_DEAD_STRIKES. */
+  dead_count: number;
+  links: LinkStatusRecord[];
+}
+
+function hostOf(url: string): string {
+  try {
+    return new URL(url).hostname.toLowerCase().replace(/^www\./, "");
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * No try/catch: every caller reaches this only after `hostOf` returned
+ * "github.com", which an unparseable URL can never produce. A defensive catch
+ * here would be an unreachable branch — dead code that still has to be counted.
+ */
+function pathSegments(url: string): string[] {
+  return new URL(url).pathname.split("/").filter(Boolean);
+}
+
+/** Our own published origin — verified against the repo, never over the network. */
+export function isSelfHostedUrl(url: string): boolean {
+  return hostOf(url) === "metagraph.sh";
+}
+
+export function linkCheckStrategy(url: string): LinkCheckStrategy {
+  if (isSelfHostedUrl(url)) return "self";
+  if (hostOf(url) !== "github.com") return "http";
+  // Needs at least /owner/repo to be answerable by the API; anything shorter
+  // (/orgs/x, /features) is an ordinary web page.
+  return pathSegments(url).length >= 2 ? "github-api" : "http";
+}
+
+/**
+ * Rewrite a github.com URL to the equivalent REST API URL.
+ *
+ * Checked through the API rather than by fetching the HTML page for three
+ * reasons: github.com serves a soft-404 HTML page that a status-code check
+ * reads as 200; the API answers a clean 404 for a deleted repo or a moved file;
+ * and the token the github-signals lane already holds lifts the rate limit from
+ * 60/hr to 5000/hr, which is what makes 429 checks in one run safe.
+ *
+ *   /owner/repo                        -> /repos/owner/repo
+ *   /owner/repo/blob|tree/<ref>/<path> -> /repos/owner/repo/contents/<path>?ref=<ref>
+ *
+ * Returns null when the URL is not a github.com URL with an owner and repo.
+ */
+export function githubApiUrl(url: string): string | null {
+  if (linkCheckStrategy(url) !== "github-api") return null;
+  const segments = pathSegments(url);
+  const [owner, repo, kind, ref, ...rest] = segments;
+  if (rest.length > 0 && ["blob", "tree"].includes(kind)) {
+    // pathSegments comes from URL.pathname, which is ALREADY percent-encoded.
+    // Encoding again turned "my file.md" into "my%2520file.md" and would have
+    // reported a false 404 for every path containing a space or non-ASCII
+    // character.
+    const filePath = rest.join("/");
+    const api = new URL(
+      `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}`,
+    );
+    api.searchParams.set("ref", ref);
+    return api.toString();
+  }
+  // Repo root, or any other sub-page (/issues, /releases): the repo's own
+  // existence is the question those all depend on.
+  return `https://api.github.com/repos/${owner}/${repo}`;
+}
+
+/** Provider fields that hold a public URL we assert resolves. */
+export const PROVIDER_URL_FIELDS = [
+  "website_url",
+  "docs_url",
+  "github_url",
+  "logo_url",
+  "contact_url",
+  "status_url",
+] as const;
+
+/**
+ * Every distinct URL the registry asserts, with who asserts it.
+ *
+ * Deduped by URL because the three populations overlap: a subnet's source_repo
+ * is frequently also its provider's github_url and a source_url on three of its
+ * surfaces. One check answers all of them.
+ */
+export function collectLinkTargets(
+  subnets: Row[],
+  providers: Row[],
+  operationalKinds: ReadonlySet<string>,
+): LinkTarget[] {
+  const targets = new Map<string, LinkTarget>();
+  const add = (url: unknown, citation: LinkCitation) => {
+    if (typeof url !== "string" || !/^https?:\/\//i.test(url)) return;
+    const existing = targets.get(url);
+    if (existing) existing.citations.push(citation);
+    else targets.set(url, { url, citations: [citation] });
+  };
+
+  for (const subnet of subnets) {
+    const netuid = subnet.netuid as number | undefined;
+    for (const surface of (subnet.surfaces as Row[]) || []) {
+      const id = String(surface.id || "");
+      for (const sourceUrl of (surface.source_urls as unknown[]) || []) {
+        add(sourceUrl, { kind: "source_url", id, netuid });
+      }
+      // The surface's own URL, but only for the kinds the prober skips —
+      // an operational surface is already checked every 15 minutes.
+      if (
+        surface.public_safe &&
+        (surface.probe as Row | undefined)?.enabled &&
+        !operationalKinds.has(String(surface.kind))
+      ) {
+        add(surface.url, { kind: "surface", id, netuid });
+      }
+    }
+  }
+
+  for (const provider of providers) {
+    const slug = String(provider.slug || "");
+    for (const field of PROVIDER_URL_FIELDS) {
+      add(provider[field], { kind: "provider", id: slug });
+    }
+  }
+
+  return [...targets.values()].sort((a, b) => a.url.localeCompare(b.url));
+}
+
+/**
+ * Fold one check result into the running record, applying the strike rule.
+ *
+ * `prior` absent means this URL has never been checked: it starts at zero
+ * strikes even if this first check fails, so a link added today cannot be
+ * called dead until it has failed LINK_DEAD_STRIKES separate runs.
+ */
+export function nextLinkRecord(
+  prior: LinkStatusRecord | undefined,
+  result: {
+    url: string;
+    classification: string;
+    status_code: number | null;
+    error: string | null;
+  },
+  checkedAt: string,
+): LinkStatusRecord {
+  const unreachable = UNREACHABLE_CLASSIFICATIONS.has(result.classification);
+  return {
+    url: result.url,
+    classification: result.classification,
+    status_code: result.status_code,
+    checked_at: checkedAt,
+    last_ok: unreachable ? prior?.last_ok || null : checkedAt,
+    consecutive_failures: unreachable
+      ? (prior?.consecutive_failures || 0) + 1
+      : 0,
+    error: result.error,
+  };
+}
+
+/**
+ * Has this link failed often enough, consecutively, to be called dead?
+ *
+ * The single place the strike threshold is applied, so the artifact projection,
+ * the demotion path and the CI gate cannot disagree about what "dead" means.
+ */
+export function isConfirmedDeadLink(
+  record: LinkStatusRecord | undefined,
+): boolean {
+  return (record?.consecutive_failures || 0) >= LINK_DEAD_STRIKES;
+}
+
+export interface CheckLinkDeps {
+  fetchImpl?: typeof fetch;
+  /** `unknown` to match probeUrl's own guard signature exactly. */
+  isUnsafeUrl?: (url: unknown) => boolean | Promise<boolean>;
+  /** Authorization header value for api.github.com, when a token is configured. */
+  githubAuth?: string | null;
+}
+
+/**
+ * Check one URL and classify it in the prober's own vocabulary.
+ *
+ * Reuses probeUrl + classifyProbe rather than reimplementing status handling.
+ * That is not just economy: a hand-rolled checker is exactly what produced 25
+ * false "broken" verdicts in the audit that led to these issues, because it did
+ * not know that 403 means Cloudflare and 429 means slow down.
+ *
+ * HEAD first (a reference link's body is never needed), falling back to GET on
+ * 405/501 — plenty of static hosts reject HEAD outright.
+ */
+export async function checkLink(
+  url: string,
+  deps: CheckLinkDeps = {},
+): Promise<{
+  url: string;
+  classification: string;
+  status_code: number | null;
+  error: string | null;
+}> {
+  // Non-null exactly for the github-api strategy, so this one value carries
+  // both decisions: which URL to ask, and whether the token applies. Deriving
+  // them separately from `strategy` left a `githubApiUrl(url) || url` fallback
+  // that could never be taken.
+  const apiUrl = githubApiUrl(url);
+  const requestUrl = apiUrl ?? url;
+  const auth = apiUrl ? deps.githubAuth : null;
+
+  const options = {
+    fetchImpl: auth
+      ? withHeaders(deps.fetchImpl ?? fetch, { authorization: auth })
+      : deps.fetchImpl,
+    isUnsafeUrl: deps.isUnsafeUrl,
+  };
+
+  let probe = await probeUrl(
+    requestUrl,
+    "HEAD",
+    "*/*",
+    LINK_CHECK_TIMEOUT_MS,
+    options,
+  );
+  if (probe.status_code === 405 || probe.status_code === 501) {
+    probe = await probeUrl(
+      requestUrl,
+      "GET",
+      "*/*",
+      LINK_CHECK_TIMEOUT_MS,
+      options,
+    );
+  }
+
+  // `expect: "any"` so contentMismatch never fires — a reference link makes no
+  // promise about its content type, only that it resolves.
+  const asSurface: ProbeSurface = {
+    id: url,
+    kind: "docs",
+    url: requestUrl,
+    netuid: null,
+    provider: null,
+    public_safe: true,
+    auth_required: false,
+    subnet_name: null,
+    subnet_slug: null,
+    probe: { method: "HEAD", expect: "any" },
+  };
+
+  return {
+    url,
+    classification: classifyProbe(probe, asSurface),
+    status_code: probe.status_code ?? null,
+    error: probe.error ?? null,
+  };
+}
+
+/** Wrap a fetch so every request carries the given headers. */
+function withHeaders(
+  fetchImpl: typeof fetch,
+  headers: Record<string, string>,
+): typeof fetch {
+  return (input, init) =>
+    fetchImpl(input, {
+      ...init,
+      headers: { ...(init?.headers as Record<string, string>), ...headers },
+    });
+}
+
+/**
+ * Host bucket for per-host serialization (#9959's mapLimit groupKey).
+ *
+ * api.github.com is deliberately given per-URL keys: the groupKey exists to
+ * stop us fanning out on a small subnet's single-box API, and GitHub's API is
+ * neither small nor ours to protect. Serializing its 429 checks would make it
+ * the entire runtime of the sweep for no benefit.
+ */
+export function linkHostKey(url: string): string {
+  const host = hostOf(url);
+  if (linkCheckStrategy(url) === "github-api") return `github-api:${url}`;
+  return host || url;
+}
+
+/**
+ * Check many links, serialized per host, in a stable order.
+ *
+ * Order of results matches order of input — mapLimit guarantees that even when
+ * grouping reorders the work.
+ */
+export async function checkLinks(
+  urls: string[],
+  deps: CheckLinkDeps = {},
+  concurrency = LINK_CHECK_CONCURRENCY,
+): Promise<Awaited<ReturnType<typeof checkLink>>[]> {
+  return mapLimit(urls, concurrency, (url) => checkLink(url, deps), {
+    groupKey: linkHostKey,
+  });
+}

--- a/src/link-status-sync.ts
+++ b/src/link-status-sync.ts
@@ -1,0 +1,242 @@
+// Daily link-rot capture as a Worker cron writing R2 — the same lane shape as
+// github-signals-sync (#233 pattern): the cron captures, the artifact build
+// projects, and freshness never depends on a bot PR landing.
+//
+// WHAT IT ANSWERS. Three populations of URL that the registry asserts are real
+// and that NOTHING re-checked after the PR adding them merged:
+//
+//   #9914  777 surface source_urls — the evidence that a subnet publishes what
+//          we say it publishes. A dead source_url is the exact condition that
+//          auto-CLOSES a contributor PR, so leaving it unchecked after merge
+//          means the bar only applies on the way in.
+//   #9917  384 provider URLs — including our own gittensory entry, cited by
+//          five surfaces.
+//   #9907  494 surface URLs whose `kind` keeps them out of the health prober.
+//
+// 1,067 distinct URLs between them — the populations overlap heavily. See
+// link-status-core.ts for why 102 of those are answered from the repo instead
+// of the network, and how the remaining 965 fit one invocation's
+// 1000-subrequest budget.
+//
+// WHAT IT DELIBERATELY DOES NOT DO. It never writes health, uptime, latency or
+// incidents. A docs page has no uptime, and letting reference links into those
+// artifacts would corrupt the numbers that describe live services.
+
+import type { StorageReadResult } from "../workers/storage.ts";
+import {
+  checkLinks,
+  collectLinkTargets,
+  isConfirmedDeadLink,
+  linkCheckStrategy,
+  nextLinkRecord,
+  LINK_STATUS_MAX_CHECKS_PER_RUN,
+  LINK_STATUS_R2_KEY,
+  type LinkStatusArtifact,
+  type LinkStatusRecord,
+} from "./link-status-core.ts";
+import { OPERATIONAL_SURFACE_KINDS } from "./health-probe-core.ts";
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+
+type Row = Record<string, unknown>;
+
+export const LINK_STATUS_SUBNETS_ARTIFACT_PATH = "/metagraph/subnets.json";
+export const LINK_STATUS_PROVIDERS_ARTIFACT_PATH = "/metagraph/providers.json";
+
+export { LINK_STATUS_R2_KEY };
+
+export interface LinkStatusSyncDeps {
+  readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
+  fetchImpl?: typeof fetch;
+  /** Clock seam for tests; stamps checked_at/generated_at. */
+  now?: () => number;
+  /** Telemetry seam for tests. */
+  recordException?: typeof recordExceptionEvent;
+}
+
+interface Ctx {
+  waitUntil?: (promise: Promise<unknown>) => void;
+}
+
+export interface LinkStatusSyncResult {
+  ok: boolean;
+  reason?: string;
+  skipped?: boolean;
+  target_count?: number;
+  checked_count?: number;
+  dead_count?: number;
+  changed?: boolean;
+}
+
+const OPERATIONAL_KIND_SET = new Set(OPERATIONAL_SURFACE_KINDS);
+
+/**
+ * Which URLs this tick actually spends subrequests on.
+ *
+ * Least-recently-checked first, so if the registry outgrows the per-run ceiling
+ * the lane still cycles through everything instead of permanently starving the
+ * tail. A URL never checked before sorts first (epoch 0).
+ */
+export function urlsForRun(
+  urls: string[],
+  prior: Map<string, LinkStatusRecord>,
+  limit = LINK_STATUS_MAX_CHECKS_PER_RUN,
+): string[] {
+  if (urls.length <= limit) return urls;
+  const checkedAtMs = (url: string) => {
+    const at = prior.get(url)?.checked_at;
+    const ms = at ? Date.parse(at) : 0;
+    return Number.isFinite(ms) ? ms : 0;
+  };
+  return [...urls]
+    .sort((a, b) => checkedAtMs(a) - checkedAtMs(b) || a.localeCompare(b))
+    .slice(0, limit);
+}
+
+/**
+ * The daily tick.
+ *
+ * Unlike github-signals, a missing GITHUB_SIGNALS_TOKEN does NOT abort the run:
+ * only the 429 github.com URLs need it, and refusing to check the other ~536
+ * because GitHub is unauthenticated would throw away most of the lane's value.
+ * The GitHub subset is skipped for the tick and keeps its prior record — the
+ * "absence of evidence is not death" rule (src/surface-verification.ts)
+ * applied to our own missing credential.
+ */
+export async function runLinkStatusSync(
+  env: Env,
+  ctx?: Ctx,
+  deps: LinkStatusSyncDeps = {},
+): Promise<LinkStatusSyncResult> {
+  if (typeof deps.readArtifact !== "function") {
+    return { ok: false, reason: "reader_unavailable" };
+  }
+  const bucket = env.METAGRAPH_ARCHIVE;
+  if (!bucket?.get || !bucket?.put) {
+    return { ok: false, reason: "r2_binding_missing" };
+  }
+
+  try {
+    const [subnetsRead, providersRead] = await Promise.all([
+      deps.readArtifact(env, LINK_STATUS_SUBNETS_ARTIFACT_PATH),
+      deps.readArtifact(env, LINK_STATUS_PROVIDERS_ARTIFACT_PATH),
+    ]);
+    if (!subnetsRead?.ok) {
+      return { ok: false, reason: "subnets_artifact_unavailable" };
+    }
+
+    const subnets = ((subnetsRead.data as Row | null)?.subnets as Row[]) || [];
+    // Providers are optional: an unreadable providers artifact costs the
+    // provider population for this tick, but must not cost the other two.
+    const providers = providersRead?.ok
+      ? ((providersRead.data as Row | null)?.providers as Row[]) || []
+      : [];
+    const targets = collectLinkTargets(
+      subnets,
+      providers,
+      OPERATIONAL_KIND_SET,
+    );
+    if (targets.length === 0) {
+      // Zero targets from a readable artifact is a broken input, not an empty
+      // registry — never let it wipe the store.
+      return { ok: false, reason: "no_link_targets" };
+    }
+
+    const now = deps.now ?? Date.now;
+    const checkedAt = new Date(now()).toISOString();
+
+    const previousDoc = await readJsonObject(bucket, LINK_STATUS_R2_KEY);
+    const prior = new Map<string, LinkStatusRecord>(
+      (((previousDoc as Row | null)?.links as LinkStatusRecord[]) || []).map(
+        (record) => [record.url, record],
+      ),
+    );
+    const token =
+      typeof env.GITHUB_SIGNALS_TOKEN === "string"
+        ? env.GITHUB_SIGNALS_TOKEN.trim()
+        : "";
+
+    // Route every target, then spend the network budget only on what is left.
+    const resolved = new Map<string, LinkStatusRecord>();
+    const toFetch: string[] = [];
+    for (const target of targets) {
+      const strategy = linkCheckStrategy(target.url);
+      if (strategy === "self") {
+        // Verified against the repo by the build gate, not over the network.
+        continue;
+      }
+      if (strategy === "github-api" && !token) {
+        // Unauthenticated GitHub gives Cloudflare's shared egress 60 requests
+        // an hour across the whole fleet — far below the 429 needed here, so an
+        // unauthenticated run would mass-"dead" every github.com link. Skipping
+        // the subset keeps the other ~536 checks useful.
+        continue;
+      }
+      toFetch.push(target.url);
+    }
+
+    const selected = urlsForRun(toFetch, prior);
+    const results = await checkLinks(selected, {
+      fetchImpl: deps.fetchImpl,
+      githubAuth: token ? `Bearer ${token}` : null,
+    });
+    for (const result of results) {
+      resolved.set(
+        result.url,
+        nextLinkRecord(prior.get(result.url), result, checkedAt),
+      );
+    }
+
+    // Carry forward every URL this tick did not reach, so a skipped subset
+    // never reads as a recovery (or a death) it did not earn.
+    const links: LinkStatusRecord[] = [];
+    for (const target of targets) {
+      const record = resolved.get(target.url) ?? prior.get(target.url);
+      if (record) links.push(record);
+    }
+    links.sort((a, b) => a.url.localeCompare(b.url));
+
+    const artifact: LinkStatusArtifact = {
+      schema_version: 1,
+      generated_at: checkedAt,
+      checked_count: resolved.size,
+      dead_count: links.filter((record) => isConfirmedDeadLink(record)).length,
+      links,
+    };
+
+    await bucket.put(LINK_STATUS_R2_KEY, JSON.stringify(artifact), {
+      httpMetadata: { contentType: "application/json" },
+    });
+    return {
+      ok: true,
+      changed: true,
+      target_count: targets.length,
+      checked_count: artifact.checked_count,
+      dead_count: artifact.dead_count,
+    };
+  } catch (error) {
+    console.error("[link-status-sync]", String((error as Error)?.message));
+    const pending = Promise.resolve(
+      (deps.recordException ?? recordExceptionEvent)(env, {
+        error: error as Error,
+        route: "cron:link-status-sync",
+        errorCode: "link_status_sync_failed",
+      }),
+    ).catch(() => false);
+    ctx?.waitUntil?.(pending);
+    return { ok: false, reason: "unreachable" };
+  }
+}
+
+async function readJsonObject(
+  bucket: R2Bucket,
+  key: string,
+): Promise<unknown | null> {
+  try {
+    const object = await bucket.get(key);
+    return object ? await object.json() : null;
+  } catch {
+    // A cold or unreadable store degrades to "no prior credit", the same as a
+    // first run — never to a wipe.
+    return null;
+  }
+}

--- a/src/surface-verification.ts
+++ b/src/surface-verification.ts
@@ -106,6 +106,36 @@ export const MIN_VERIFY_UPTIME = 0.99;
 export const DEMOTING_CLASSIFICATIONS = new Set(["dead", "unsafe"]);
 
 /**
+ * Has this surface lost the EVIDENCE that it is real?
+ *
+ * A surface's `source_urls` are what independently prove the subnet publishes
+ * it — the gate auto-CLOSES a contributor PR whose source_url is dead, so the
+ * same fact after merge cannot mean nothing. When every one of them has been
+ * confirmed dead by the link lane (#9914), the claim is unsupported and the
+ * surface loses its verification exactly as a dead probe would.
+ *
+ * EVERY, not ANY, and deliberately so: source_urls are alternative proofs of
+ * one claim, not a checklist. A surface citing a live README and a dead blog
+ * post is still proven. Requiring all of them to die before demoting also means
+ * a single moved README cannot mass-demote a subnet that documented itself
+ * twice.
+ *
+ * A surface with NO source_urls returns false: it never had this evidence to
+ * lose, and "absence of evidence is not death" applies here too.
+ */
+export function surfaceEvidenceIsDead(
+  sourceUrls: unknown,
+  deadLinkUrls: ReadonlySet<string>,
+): boolean {
+  if (!Array.isArray(sourceUrls) || sourceUrls.length === 0) return false;
+  const urls = sourceUrls.filter(
+    (url): url is string => typeof url === "string" && url.length > 0,
+  );
+  if (urls.length === 0) return false;
+  return urls.every((url) => deadLinkUrls.has(url));
+}
+
+/**
  * Has the prober CONFIRMED this surface dead (or unsafe)?
  *
  * Separate from `verifyFromProbeEvidence` returning false, because "not

--- a/tests/link-status.test.ts
+++ b/tests/link-status.test.ts
@@ -1,0 +1,1052 @@
+// Tests for the daily link-rot lane (#9907/#9914/#9917) and the SSRF-guard
+// split it depends on (#9870).
+//
+// Same URL-dispatching fetch double convention as
+// tests/github-signals-sync.test.ts — an unstubbed URL throws rather than
+// returning something plausible, so a checker that asks the wrong upstream
+// fails here instead of passing on a canned answer.
+
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, test, vi } from "vitest";
+import {
+  checkLink,
+  checkLinks,
+  collectLinkTargets,
+  githubApiUrl,
+  isConfirmedDeadLink,
+  isSelfHostedUrl,
+  linkCheckStrategy,
+  linkHostKey,
+  nextLinkRecord,
+  LINK_DEAD_STRIKES,
+  LINK_STATUS_R2_KEY,
+  UNREACHABLE_CLASSIFICATIONS,
+  type LinkStatusRecord,
+} from "../src/link-status-core.ts";
+import {
+  runLinkStatusSync,
+  urlsForRun,
+  LINK_STATUS_PROVIDERS_ARTIFACT_PATH,
+  LINK_STATUS_SUBNETS_ARTIFACT_PATH,
+} from "../src/link-status-sync.ts";
+import { surfaceEvidenceIsDead } from "../src/surface-verification.ts";
+import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
+import { mockEnv, type AnyFn, type Row } from "./row-type.ts";
+
+const TICK_MS = Date.parse("2026-08-08T07:35:00.000Z");
+const TICK_ISO = new Date(TICK_MS).toISOString();
+const OP_KINDS = new Set(OPERATIONAL_SURFACE_KINDS);
+
+function record(overrides: Partial<LinkStatusRecord> = {}): LinkStatusRecord {
+  return {
+    url: "https://example.com/a",
+    classification: "live",
+    status_code: 200,
+    checked_at: "2026-08-01T00:00:00.000Z",
+    last_ok: "2026-08-01T00:00:00.000Z",
+    consecutive_failures: 0,
+    error: null,
+    ...overrides,
+  };
+}
+
+// --- routing -----------------------------------------------------------------
+
+describe("linkCheckStrategy", () => {
+  test("routes our own origin away from the network entirely", () => {
+    assert.equal(
+      linkCheckStrategy("https://metagraph.sh/logos/oro.png"),
+      "self",
+    );
+    assert.equal(
+      linkCheckStrategy("https://www.metagraph.sh/logos/x.png"),
+      "self",
+    );
+    assert.equal(isSelfHostedUrl("https://metagraph.sh"), true);
+    assert.equal(isSelfHostedUrl("https://example.com"), false);
+    assert.equal(isSelfHostedUrl("not a url"), false);
+  });
+
+  test("routes github.com owner/repo URLs to the API, other hosts to plain http", () => {
+    assert.equal(
+      linkCheckStrategy("https://github.com/opentensor/bittensor"),
+      "github-api",
+    );
+    assert.equal(
+      linkCheckStrategy("https://github.com/o/r/blob/main/README.md"),
+      "github-api",
+    );
+    assert.equal(linkCheckStrategy("https://docs.bittensor.com/"), "http");
+    // Too short to name a repo — an ordinary web page.
+    assert.equal(linkCheckStrategy("https://github.com/features"), "http");
+  });
+});
+
+describe("githubApiUrl", () => {
+  test("rewrites a blob link to the contents API, carrying the ref", () => {
+    assert.equal(
+      githubApiUrl("https://github.com/o/r/blob/main/docs/README.md"),
+      "https://api.github.com/repos/o/r/contents/docs/README.md?ref=main",
+    );
+  });
+
+  test("rewrites a tree link the same way", () => {
+    assert.equal(
+      githubApiUrl("https://github.com/o/r/tree/dev/src"),
+      "https://api.github.com/repos/o/r/contents/src?ref=dev",
+    );
+  });
+
+  test("rewrites a repo root and any other sub-page to the repo endpoint", () => {
+    assert.equal(
+      githubApiUrl("https://github.com/o/r"),
+      "https://api.github.com/repos/o/r",
+    );
+    assert.equal(
+      githubApiUrl("https://github.com/o/r/issues"),
+      "https://api.github.com/repos/o/r",
+    );
+  });
+
+  test("percent-encodes path segments so a spaced filename cannot break the URL", () => {
+    assert.equal(
+      githubApiUrl("https://github.com/o/r/blob/main/my file.md"),
+      "https://api.github.com/repos/o/r/contents/my%20file.md?ref=main",
+    );
+  });
+
+  test("returns null for anything that is not a github repo URL", () => {
+    assert.equal(githubApiUrl("https://example.com/x"), null);
+    assert.equal(githubApiUrl("https://metagraph.sh/logos/a.png"), null);
+  });
+});
+
+describe("linkHostKey", () => {
+  test("groups by host, folding www, so one small host is never fanned out", () => {
+    assert.equal(linkHostKey("https://a.example.com/1"), "a.example.com");
+    assert.equal(linkHostKey("https://www.example.com/1"), "example.com");
+    assert.equal(linkHostKey("https://example.com/2"), "example.com");
+  });
+
+  test("gives every GitHub API check its own key so they run in parallel", () => {
+    const a = linkHostKey("https://github.com/o/r");
+    const b = linkHostKey("https://github.com/o/other");
+    assert.notEqual(a, b);
+    assert.equal(a.startsWith("github-api:"), true);
+  });
+
+  test("falls back to the raw value when the URL will not parse", () => {
+    assert.equal(linkHostKey("::nonsense::"), "::nonsense::");
+  });
+});
+
+// --- target collection -------------------------------------------------------
+
+describe("collectLinkTargets", () => {
+  const subnets = [
+    {
+      netuid: 1,
+      surfaces: [
+        {
+          id: "sn-1-api",
+          kind: "subnet-api", // operational — the prober owns it
+          url: "https://api.one.example/v1",
+          public_safe: true,
+          probe: { enabled: true },
+          source_urls: ["https://github.com/one/repo/blob/main/README.md"],
+        },
+        {
+          id: "sn-1-docs",
+          kind: "docs", // NOT operational — this lane owns it
+          url: "https://docs.one.example/",
+          public_safe: true,
+          probe: { enabled: true },
+          source_urls: [],
+        },
+        {
+          id: "sn-1-off",
+          kind: "docs",
+          url: "https://off.one.example/",
+          public_safe: true,
+          probe: { enabled: false },
+        },
+        {
+          id: "sn-1-private",
+          kind: "docs",
+          url: "https://private.one.example/",
+          public_safe: false,
+          probe: { enabled: true },
+        },
+      ],
+    },
+  ] as Row[];
+  const providers = [
+    {
+      slug: "acme",
+      website_url: "https://acme.example",
+      docs_url: "https://docs.one.example/", // same URL a surface uses
+      logo_url: "not-a-url",
+    },
+  ] as Row[];
+
+  test("takes source_urls from every surface, including operational ones", () => {
+    const targets = collectLinkTargets(subnets, [], OP_KINDS);
+    const readme = targets.find((t) => t.url.includes("README.md"));
+    assert.ok(
+      readme,
+      "a source_url on an operational surface is still evidence",
+    );
+    assert.deepEqual(readme.citations, [
+      { kind: "source_url", id: "sn-1-api", netuid: 1 },
+    ]);
+  });
+
+  test("takes the surface URL only for kinds the prober skips", () => {
+    const urls = collectLinkTargets(subnets, [], OP_KINDS).map((t) => t.url);
+    assert.equal(urls.includes("https://docs.one.example/"), true);
+    assert.equal(
+      urls.includes("https://api.one.example/v1"),
+      false,
+      "an operational surface is probed every 15 minutes; checking it here too would double-count",
+    );
+  });
+
+  test("skips probe-disabled and non-public surfaces", () => {
+    const urls = collectLinkTargets(subnets, [], OP_KINDS).map((t) => t.url);
+    assert.equal(urls.includes("https://off.one.example/"), false);
+    assert.equal(urls.includes("https://private.one.example/"), false);
+  });
+
+  test("dedupes across populations and keeps every citation", () => {
+    const targets = collectLinkTargets(subnets, providers, OP_KINDS);
+    const shared = targets.filter((t) => t.url === "https://docs.one.example/");
+    assert.equal(shared.length, 1, "one URL is one check");
+    assert.deepEqual(
+      shared[0].citations.map((c) => c.kind).sort(),
+      ["provider", "surface"],
+      "both citers are recorded so the verdict fans back out",
+    );
+  });
+
+  test("ignores non-http values and returns a stable order", () => {
+    const targets = collectLinkTargets(subnets, providers, OP_KINDS);
+    assert.equal(
+      targets.some((t) => t.url === "not-a-url"),
+      false,
+    );
+    assert.deepEqual(
+      targets.map((t) => t.url),
+      [...targets.map((t) => t.url)].sort(),
+    );
+  });
+
+  test("tolerates a subnet with no surfaces array", () => {
+    assert.deepEqual(
+      collectLinkTargets([{ netuid: 9 }] as Row[], [], OP_KINDS),
+      [],
+    );
+  });
+});
+
+// --- the strike rule ---------------------------------------------------------
+
+describe("nextLinkRecord / isConfirmedDeadLink", () => {
+  test("a first-ever failure starts at one strike, not at dead", () => {
+    const next = nextLinkRecord(
+      undefined,
+      { url: "u", classification: "dead", status_code: 404, error: null },
+      TICK_ISO,
+    );
+    assert.equal(next.consecutive_failures, 1);
+    assert.equal(next.last_ok, null);
+    assert.equal(isConfirmedDeadLink(next), false);
+  });
+
+  test("strikes accumulate and cross the threshold at LINK_DEAD_STRIKES", () => {
+    let current = record({ consecutive_failures: 0 });
+    for (let i = 1; i <= LINK_DEAD_STRIKES; i += 1) {
+      current = nextLinkRecord(
+        current,
+        { url: "u", classification: "dead", status_code: 404, error: "gone" },
+        TICK_ISO,
+      );
+      assert.equal(current.consecutive_failures, i);
+      assert.equal(isConfirmedDeadLink(current), i >= LINK_DEAD_STRIKES);
+    }
+  });
+
+  test("any reachable verdict resets the streak — three failures must be IN A ROW", () => {
+    const twoStrikes = record({ consecutive_failures: 2 });
+    const recovered = nextLinkRecord(
+      twoStrikes,
+      { url: "u", classification: "live", status_code: 200, error: null },
+      TICK_ISO,
+    );
+    assert.equal(recovered.consecutive_failures, 0);
+    assert.equal(recovered.last_ok, TICK_ISO);
+  });
+
+  test("a failure preserves the previous last_ok rather than clearing it", () => {
+    const prior = record({ last_ok: "2026-07-01T00:00:00.000Z" });
+    const failed = nextLinkRecord(
+      prior,
+      { url: "u", classification: "dead", status_code: 404, error: null },
+      TICK_ISO,
+    );
+    assert.equal(failed.last_ok, "2026-07-01T00:00:00.000Z");
+  });
+
+  test("a 403 or 429 proves the host is alive and never accrues a strike", () => {
+    for (const classification of [
+      "auth-required",
+      "rate-limited",
+      "redirected",
+    ]) {
+      const next = nextLinkRecord(
+        record({ consecutive_failures: 2 }),
+        { url: "u", classification, status_code: 403, error: null },
+        TICK_ISO,
+      );
+      assert.equal(
+        next.consecutive_failures,
+        0,
+        `${classification} must not count as rot — this was a real false-positive source`,
+      );
+    }
+  });
+
+  test("a persistent 5xx does accrue, because the streak rule makes it safe", () => {
+    // api.eirel.ai serves Cloudflare 521 behind live DNS for 121 surfaces; if
+    // 5xx never accrued, the lane would be blind to its single largest case.
+    assert.equal(UNREACHABLE_CLASSIFICATIONS.has("transient"), true);
+    assert.equal(UNREACHABLE_CLASSIFICATIONS.has("timeout"), true);
+    assert.equal(UNREACHABLE_CLASSIFICATIONS.has("auth-required"), false);
+    assert.equal(UNREACHABLE_CLASSIFICATIONS.has("unsafe"), false);
+  });
+
+  test("an absent record is not dead", () => {
+    assert.equal(isConfirmedDeadLink(undefined), false);
+  });
+});
+
+// --- what a dead link costs a surface ---------------------------------------
+
+describe("surfaceEvidenceIsDead", () => {
+  const dead = new Set(["https://a.example/gone", "https://b.example/gone"]);
+
+  test("demotes only when EVERY source_url is dead", () => {
+    assert.equal(surfaceEvidenceIsDead(["https://a.example/gone"], dead), true);
+    assert.equal(
+      surfaceEvidenceIsDead(
+        ["https://a.example/gone", "https://alive.example/ok"],
+        dead,
+      ),
+      false,
+      "source_urls are alternative proofs of one claim, not a checklist",
+    );
+  });
+
+  test("a surface with no evidence never had any to lose", () => {
+    assert.equal(surfaceEvidenceIsDead([], dead), false);
+    assert.equal(surfaceEvidenceIsDead(undefined, dead), false);
+    assert.equal(surfaceEvidenceIsDead("https://a.example/gone", dead), false);
+    assert.equal(surfaceEvidenceIsDead([""], dead), false);
+    assert.equal(surfaceEvidenceIsDead([123], dead), false);
+  });
+
+  test("an empty dead-set demotes nothing, so a cold store is harmless", () => {
+    assert.equal(
+      surfaceEvidenceIsDead(["https://a.example/gone"], new Set()),
+      false,
+    );
+  });
+});
+
+// --- checking ----------------------------------------------------------------
+
+function fetchDouble(
+  routes: Record<string, { status: number } | (() => Response)>,
+  calls?: Array<{ url: string; method: string; headers: unknown }>,
+) {
+  return vi.fn(async (url: string, init?: Row) => {
+    const key = String(url);
+    calls?.push({
+      url: key,
+      method: String(init?.method || "GET"),
+      headers: init?.headers,
+    });
+    const route = routes[key];
+    if (!route) throw new Error(`unexpected upstream: ${key}`);
+    if (typeof route === "function") return route();
+    return new Response(null, { status: route.status });
+  });
+}
+
+describe("checkLink", () => {
+  test("HEADs a plain URL and reports live", async () => {
+    const calls: Array<{ url: string; method: string; headers: unknown }> = [];
+    const result = await checkLink("https://docs.example/", {
+      fetchImpl: fetchDouble(
+        { "https://docs.example/": { status: 200 } },
+        calls,
+      ) as unknown as typeof fetch,
+    });
+    assert.equal(result.classification, "live");
+    assert.equal(result.status_code, 200);
+    assert.equal(calls[0].method, "HEAD");
+  });
+
+  test("falls back to GET when the host rejects HEAD", async () => {
+    const calls: Array<{ url: string; method: string; headers: unknown }> = [];
+    let seen = 0;
+    const result = await checkLink("https://docs.example/", {
+      fetchImpl: fetchDouble(
+        {
+          "https://docs.example/": () =>
+            new Response(null, { status: (seen += 1) === 1 ? 405 : 200 }),
+        },
+        calls,
+      ) as unknown as typeof fetch,
+    });
+    assert.deepEqual(
+      calls.map((c) => c.method),
+      ["HEAD", "GET"],
+    );
+    assert.equal(result.classification, "live");
+  });
+
+  test("a 404 is dead and a 403 is not", async () => {
+    const gone = await checkLink("https://docs.example/x", {
+      fetchImpl: fetchDouble({
+        "https://docs.example/x": { status: 404 },
+      }) as unknown as typeof fetch,
+    });
+    assert.equal(gone.classification, "dead");
+    const blocked = await checkLink("https://docs.example/y", {
+      fetchImpl: fetchDouble({
+        "https://docs.example/y": { status: 403 },
+      }) as unknown as typeof fetch,
+    });
+    assert.equal(blocked.classification, "auth-required");
+  });
+
+  test("asks the GitHub API — not the HTML page — and sends the token", async () => {
+    const calls: Array<{ url: string; method: string; headers: unknown }> = [];
+    const result = await checkLink(
+      "https://github.com/o/r/blob/main/README.md",
+      {
+        githubAuth: "Bearer t0ken",
+        fetchImpl: fetchDouble(
+          {
+            "https://api.github.com/repos/o/r/contents/README.md?ref=main": {
+              status: 200,
+            },
+          },
+          calls,
+        ) as unknown as typeof fetch,
+      },
+    );
+    assert.equal(result.classification, "live");
+    assert.equal(
+      result.url,
+      "https://github.com/o/r/blob/main/README.md",
+      "the record is keyed by the URL the registry cites, not the API URL",
+    );
+    assert.equal(
+      (calls[0].headers as Row).authorization,
+      "Bearer t0ken",
+      "unauthenticated GitHub would mass-dead every link on a shared egress IP",
+    );
+  });
+
+  test("omits the header when no token is configured", async () => {
+    const calls: Array<{ url: string; method: string; headers: unknown }> = [];
+    await checkLink("https://github.com/o/r", {
+      fetchImpl: fetchDouble(
+        { "https://api.github.com/repos/o/r": { status: 200 } },
+        calls,
+      ) as unknown as typeof fetch,
+    });
+    assert.equal(
+      (calls[0].headers as Row | undefined)?.authorization,
+      undefined,
+    );
+  });
+
+  test("a refused fetch is unsupported, which does accrue a strike", async () => {
+    const result = await checkLink("https://dead.example/", {
+      fetchImpl: vi.fn(async () => {
+        throw new Error("getaddrinfo ENOTFOUND dead.example");
+      }) as unknown as typeof fetch,
+    });
+    assert.equal(UNREACHABLE_CLASSIFICATIONS.has(result.classification), true);
+  });
+});
+
+describe("checkLinks", () => {
+  test("returns results in input order even though hosts are grouped", async () => {
+    const urls = [
+      "https://a.example/1",
+      "https://b.example/1",
+      "https://a.example/2",
+    ];
+    const results = await checkLinks(
+      urls,
+      {
+        fetchImpl: fetchDouble({
+          "https://a.example/1": { status: 200 },
+          "https://b.example/1": { status: 404 },
+          "https://a.example/2": { status: 200 },
+        }) as unknown as typeof fetch,
+      },
+      2,
+    );
+    assert.deepEqual(
+      results.map((r) => r.url),
+      urls,
+    );
+    assert.deepEqual(
+      results.map((r) => r.classification),
+      ["live", "dead", "live"],
+    );
+  });
+});
+
+// --- per-run selection -------------------------------------------------------
+
+describe("urlsForRun", () => {
+  test("checks everything when the population fits", () => {
+    const urls = ["a", "b", "c"];
+    assert.deepEqual(urlsForRun(urls, new Map(), 10), urls);
+  });
+
+  test("prefers the least-recently-checked so the tail cannot starve", () => {
+    const prior = new Map<string, LinkStatusRecord>([
+      ["a", record({ url: "a", checked_at: "2026-08-07T00:00:00.000Z" })],
+      ["b", record({ url: "b", checked_at: "2026-08-01T00:00:00.000Z" })],
+    ]);
+    // "c" has never been checked and must sort ahead of both.
+    assert.deepEqual(urlsForRun(["a", "b", "c"], prior, 2), ["c", "b"]);
+  });
+
+  test("an unparseable checked_at sorts as never-checked rather than throwing", () => {
+    const prior = new Map<string, LinkStatusRecord>([
+      ["a", record({ url: "a", checked_at: "not a date" })],
+      ["b", record({ url: "b", checked_at: "2026-08-01T00:00:00.000Z" })],
+    ]);
+    assert.deepEqual(urlsForRun(["a", "b"], prior, 1), ["a"]);
+  });
+});
+
+// --- the cron ----------------------------------------------------------------
+
+function fakeBucket(initial: Record<string, unknown> = {}) {
+  const store = new Map<string, string>(
+    Object.entries(initial).map(([k, v]) => [k, JSON.stringify(v)]),
+  );
+  const puts: Array<{ key: string; value: string }> = [];
+  return {
+    store,
+    puts,
+    bucket: {
+      get: async (key: string) => {
+        const raw = store.get(key);
+        return raw == null ? null : { json: async () => JSON.parse(raw) };
+      },
+      put: async (key: string, value: string) => {
+        store.set(key, value);
+        puts.push({ key, value });
+      },
+    },
+  };
+}
+
+function artifactStub(subnets: Row | null, providers: Row | null): AnyFn {
+  return vi.fn(async (_env: unknown, path: string) => {
+    const doc =
+      path === LINK_STATUS_SUBNETS_ARTIFACT_PATH
+        ? subnets
+        : path === LINK_STATUS_PROVIDERS_ARTIFACT_PATH
+          ? providers
+          : null;
+    return doc
+      ? { ok: true, data: doc, source: "r2", storage_tier: "dual" }
+      : { ok: false, status: 404, code: "artifact_not_found", message: "no" };
+  });
+}
+
+const ONE_DOC_SUBNET: Row = {
+  subnets: [
+    {
+      netuid: 1,
+      surfaces: [
+        {
+          id: "sn-1-docs",
+          kind: "docs",
+          url: "https://docs.example/",
+          public_safe: true,
+          probe: { enabled: true },
+          source_urls: [],
+        },
+      ],
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("runLinkStatusSync", () => {
+  test("refuses without a reader or an R2 binding", async () => {
+    assert.deepEqual(await runLinkStatusSync(mockEnv({}), undefined, {}), {
+      ok: false,
+      reason: "reader_unavailable",
+    });
+    assert.deepEqual(
+      await runLinkStatusSync(mockEnv({}), undefined, {
+        readArtifact: artifactStub(ONE_DOC_SUBNET, null) as never,
+      }),
+      { ok: false, reason: "r2_binding_missing" },
+    );
+  });
+
+  test("refuses when the subnets artifact is unreadable", async () => {
+    const { bucket } = fakeBucket();
+    const result = await runLinkStatusSync(
+      mockEnv({ METAGRAPH_ARCHIVE: bucket }),
+      undefined,
+      { readArtifact: artifactStub(null, null) as never },
+    );
+    assert.deepEqual(result, {
+      ok: false,
+      reason: "subnets_artifact_unavailable",
+    });
+  });
+
+  test("a readable artifact yielding zero targets never wipes the store", async () => {
+    const { bucket, puts } = fakeBucket();
+    const result = await runLinkStatusSync(
+      mockEnv({ METAGRAPH_ARCHIVE: bucket }),
+      undefined,
+      { readArtifact: artifactStub({ subnets: [] }, null) as never },
+    );
+    assert.deepEqual(result, { ok: false, reason: "no_link_targets" });
+    assert.equal(puts.length, 0);
+  });
+
+  test("checks the targets and writes the store", async () => {
+    const { bucket, puts } = fakeBucket();
+    const result = await runLinkStatusSync(
+      mockEnv({ METAGRAPH_ARCHIVE: bucket }),
+      undefined,
+      {
+        readArtifact: artifactStub(ONE_DOC_SUBNET, null) as never,
+        now: () => TICK_MS,
+        fetchImpl: fetchDouble({
+          "https://docs.example/": { status: 200 },
+        }) as unknown as typeof fetch,
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.checked_count, 1);
+    assert.equal(result.dead_count, 0);
+    assert.equal(puts[0].key, LINK_STATUS_R2_KEY);
+    const written = JSON.parse(puts[0].value) as Row;
+    assert.equal(written.schema_version, 1);
+    assert.equal(written.generated_at, TICK_ISO);
+    assert.deepEqual(
+      (written.links as LinkStatusRecord[])[0].url,
+      "https://docs.example/",
+    );
+  });
+
+  test("a third consecutive failure is what publishes dead_count", async () => {
+    const priorTwo = {
+      links: [
+        record({
+          url: "https://docs.example/",
+          classification: "dead",
+          consecutive_failures: LINK_DEAD_STRIKES - 1,
+        }),
+      ],
+    };
+    const { bucket, puts } = fakeBucket({ [LINK_STATUS_R2_KEY]: priorTwo });
+    const result = await runLinkStatusSync(
+      mockEnv({ METAGRAPH_ARCHIVE: bucket }),
+      undefined,
+      {
+        readArtifact: artifactStub(ONE_DOC_SUBNET, null) as never,
+        now: () => TICK_MS,
+        fetchImpl: fetchDouble({
+          "https://docs.example/": { status: 404 },
+        }) as unknown as typeof fetch,
+      },
+    );
+    assert.equal(result.dead_count, 1);
+    const written = JSON.parse(puts[0].value) as Row;
+    assert.equal(
+      (written.links as LinkStatusRecord[])[0].consecutive_failures,
+      LINK_DEAD_STRIKES,
+    );
+  });
+
+  test("skips GitHub URLs without a token, keeping their prior record intact", async () => {
+    const subnetsDoc: Row = {
+      subnets: [
+        {
+          netuid: 1,
+          surfaces: [
+            {
+              id: "sn-1-docs",
+              kind: "docs",
+              url: "https://docs.example/",
+              public_safe: true,
+              probe: { enabled: true },
+              source_urls: ["https://github.com/o/r"],
+            },
+          ],
+        },
+      ],
+    };
+    const prior = {
+      links: [
+        record({ url: "https://github.com/o/r", classification: "live" }),
+      ],
+    };
+    const { bucket, puts } = fakeBucket({ [LINK_STATUS_R2_KEY]: prior });
+    const result = await runLinkStatusSync(
+      mockEnv({ METAGRAPH_ARCHIVE: bucket }),
+      undefined,
+      {
+        readArtifact: artifactStub(subnetsDoc, null) as never,
+        now: () => TICK_MS,
+        // Only the non-GitHub URL may be fetched; the double throws otherwise.
+        fetchImpl: fetchDouble({
+          "https://docs.example/": { status: 200 },
+        }) as unknown as typeof fetch,
+      },
+    );
+    assert.equal(result.checked_count, 1);
+    const written = JSON.parse(puts[0].value) as Row;
+    const gh = (written.links as LinkStatusRecord[]).find((l) =>
+      l.url.includes("github.com"),
+    );
+    assert.equal(
+      gh?.checked_at,
+      "2026-08-01T00:00:00.000Z",
+      "an unchecked URL must carry forward, not silently recover or die",
+    );
+  });
+
+  test("self-hosted URLs are never fetched — the build gate owns them", async () => {
+    const subnetsDoc: Row = { subnets: [] };
+    const providersDoc: Row = {
+      providers: [
+        { slug: "acme", logo_url: "https://metagraph.sh/logos/acme.png" },
+      ],
+    };
+    const { bucket } = fakeBucket();
+    const result = await runLinkStatusSync(
+      mockEnv({ METAGRAPH_ARCHIVE: bucket }),
+      undefined,
+      {
+        readArtifact: artifactStub(subnetsDoc, providersDoc) as never,
+        now: () => TICK_MS,
+        // Any fetch at all fails the test.
+        fetchImpl: fetchDouble({}) as unknown as typeof fetch,
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.checked_count, 0);
+  });
+
+  test("an unreadable providers artifact costs only the provider population", async () => {
+    const { bucket } = fakeBucket();
+    const result = await runLinkStatusSync(
+      mockEnv({ METAGRAPH_ARCHIVE: bucket }),
+      undefined,
+      {
+        readArtifact: artifactStub(ONE_DOC_SUBNET, null) as never,
+        now: () => TICK_MS,
+        fetchImpl: fetchDouble({
+          "https://docs.example/": { status: 200 },
+        }) as unknown as typeof fetch,
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.checked_count, 1);
+  });
+
+  test("a thrown tick is contained and reported to telemetry", async () => {
+    const recordException = vi.fn(async () => true);
+    const waitUntil = vi.fn();
+    const result = await runLinkStatusSync(
+      mockEnv({
+        METAGRAPH_ARCHIVE: {
+          get: async () => {
+            throw new Error("r2 down");
+          },
+          put: async () => undefined,
+        },
+      }),
+      { waitUntil },
+      {
+        readArtifact: vi.fn(async () => {
+          throw new Error("reader exploded");
+        }) as never,
+        recordException: recordException as never,
+      },
+    );
+    assert.deepEqual(result, { ok: false, reason: "unreachable" });
+    assert.equal(waitUntil.mock.calls.length, 1);
+    assert.equal(recordException.mock.calls.length, 1);
+  });
+
+  test("a cold prior store degrades to a first run rather than throwing", async () => {
+    const { bucket } = fakeBucket();
+    bucket.get = async () => {
+      throw new Error("cold");
+    };
+    const result = await runLinkStatusSync(
+      mockEnv({ METAGRAPH_ARCHIVE: bucket }),
+      undefined,
+      {
+        readArtifact: artifactStub(ONE_DOC_SUBNET, null) as never,
+        now: () => TICK_MS,
+        fetchImpl: fetchDouble({
+          "https://docs.example/": { status: 200 },
+        }) as unknown as typeof fetch,
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+});
+
+// --- registration ------------------------------------------------------------
+
+describe("cron registration", () => {
+  test("the registered cron matches the wrangler trigger", async () => {
+    // A constant that drifts from wrangler.jsonc means the branch is dead in
+    // production while every test here still passes.
+    const { LINK_STATUS_SYNC_CRON } = await import("../workers/config.ts");
+    const { readFileSync } = await import("node:fs");
+    const raw = readFileSync(
+      new URL("../wrangler.jsonc", import.meta.url),
+      "utf8",
+    );
+    assert.ok(
+      raw.includes(`"${LINK_STATUS_SYNC_CRON}"`),
+      `wrangler.jsonc has no trigger for ${LINK_STATUS_SYNC_CRON}`,
+    );
+  });
+
+  test("it runs after github-signals, which shares its token budget", async () => {
+    const { GITHUB_SIGNALS_SYNC_CRON, LINK_STATUS_SYNC_CRON } =
+      await import("../workers/config.ts");
+    const minutes = (cron: string) => {
+      const [minute, hour] = cron.split(" ");
+      return Number(hour) * 60 + Number(minute);
+    };
+    assert.ok(
+      minutes(LINK_STATUS_SYNC_CRON) > minutes(GITHUB_SIGNALS_SYNC_CRON),
+      "both lanes draw on the same GitHub rate limit; overlapping them risks 429s on both",
+    );
+  });
+
+  test("the daily cron dispatches to it end-to-end through the Worker entry point", async () => {
+    // Registering the trigger in wrangler.jsonc without wiring the branch
+    // would fire a cron into a silent no-op forever.
+    const { default: worker } = await import("../workers/api.ts");
+    const { LINK_STATUS_SYNC_CRON } = await import("../workers/config.ts");
+    const { store, bucket } = fakeBucket({
+      // The real readArtifact resolves /metagraph/subnets.json through the
+      // literal latest/ prefix when no publish pointer exists.
+      "latest/subnets.json": ONE_DOC_SUBNET,
+    });
+    vi.stubGlobal(
+      "fetch",
+      fetchDouble({ "https://docs.example/": { status: 200 } }),
+    );
+    const waited: Promise<unknown>[] = [];
+    const result = (await worker.scheduled(
+      { cron: LINK_STATUS_SYNC_CRON, scheduledTime: TICK_MS } as never,
+      mockEnv({ METAGRAPH_ARCHIVE: bucket }) as never,
+      { waitUntil: (p: Promise<unknown>) => waited.push(p) } as never,
+    )) as { ok: boolean };
+    await Promise.all(waited);
+    assert.equal(result.ok, true);
+    // Proof the branch ran: only this cron writes the link-status store key.
+    assert.ok(store.has(LINK_STATUS_R2_KEY));
+  });
+});
+
+describe("telemetry failure containment", () => {
+  test("a rejecting recordException cannot take the cron down with it", async () => {
+    // The catch on the telemetry promise is the difference between "one stale
+    // day" and an unhandled rejection in a scheduled handler.
+    const result = await runLinkStatusSync(
+      mockEnv({
+        METAGRAPH_ARCHIVE: {
+          get: async () => null,
+          put: async () => undefined,
+        },
+      }),
+      { waitUntil: (p: Promise<unknown>) => p },
+      {
+        readArtifact: vi.fn(async () => {
+          throw new Error("reader exploded");
+        }) as never,
+        recordException: (async () => {
+          throw new Error("posthog is down too");
+        }) as never,
+      },
+    );
+    assert.deepEqual(result, { ok: false, reason: "unreachable" });
+  });
+});
+
+describe("degenerate inputs", () => {
+  test("an idless surface and a slugless provider still yield checkable targets", () => {
+    const targets = collectLinkTargets(
+      [
+        {
+          netuid: 3,
+          surfaces: [
+            {
+              kind: "docs",
+              url: "https://noid.example/",
+              public_safe: true,
+              probe: { enabled: true },
+              source_urls: ["https://noid.example/readme"],
+            },
+          ],
+        },
+      ] as Row[],
+      [{ website_url: "https://noslug.example/" }] as Row[],
+      OP_KINDS,
+    );
+    assert.deepEqual(targets.map((t) => t.url).sort(), [
+      "https://noid.example/",
+      "https://noid.example/readme",
+      "https://noslug.example/",
+    ]);
+    // An empty id must not silently join every idless surface together.
+    assert.deepEqual(
+      targets.find((t) => t.url === "https://noid.example/")?.citations,
+      [{ kind: "surface", id: "", netuid: 3 }],
+    );
+  });
+
+  test("artifacts missing their collection key degrade to empty, not to a throw", async () => {
+    const { bucket } = fakeBucket();
+    const result = await runLinkStatusSync(
+      mockEnv({ METAGRAPH_ARCHIVE: bucket }),
+      undefined,
+      {
+        // subnets artifact ok but with no `subnets` key; providers ok but with
+        // no `providers` key.
+        readArtifact: vi.fn(async () => ({
+          ok: true,
+          data: {},
+          source: "r2",
+          storage_tier: "dual",
+        })) as never,
+        now: () => TICK_MS,
+      },
+    );
+    assert.deepEqual(result, { ok: false, reason: "no_link_targets" });
+  });
+
+  test("URLs never checked before are ordered deterministically among themselves", () => {
+    // Equal (absent) timestamps must fall back to a stable key, or the per-run
+    // selection would differ between ticks for no reason.
+    assert.deepEqual(urlsForRun(["b", "a", "c"], new Map(), 2), ["a", "b"]);
+  });
+
+  test("a configured token is sent, and the GitHub subset is checked", async () => {
+    const subnetsDoc: Row = {
+      subnets: [
+        {
+          netuid: 1,
+          surfaces: [
+            {
+              id: "s",
+              kind: "docs",
+              url: "https://github.com/o/r",
+              public_safe: true,
+              probe: { enabled: true },
+            },
+          ],
+        },
+      ],
+    };
+    const calls: Array<{ url: string; method: string; headers: unknown }> = [];
+    const { bucket } = fakeBucket();
+    const result = await runLinkStatusSync(
+      mockEnv({ METAGRAPH_ARCHIVE: bucket, GITHUB_SIGNALS_TOKEN: "  tok  " }),
+      undefined,
+      {
+        readArtifact: artifactStub(subnetsDoc, null) as never,
+        now: () => TICK_MS,
+        fetchImpl: fetchDouble(
+          { "https://api.github.com/repos/o/r": { status: 200 } },
+          calls,
+        ) as unknown as typeof fetch,
+      },
+    );
+    assert.equal(result.checked_count, 1);
+    assert.equal(
+      (calls[0].headers as Row).authorization,
+      "Bearer tok",
+      "the token is trimmed before use",
+    );
+  });
+});
+
+describe("default dependencies", () => {
+  test("falls back to global fetch when no fetchImpl is injected", async () => {
+    const calls: Array<{ url: string; headers: unknown }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: Row) => {
+        calls.push({ url: String(url), headers: init?.headers });
+        return new Response(null, { status: 200 });
+      }),
+    );
+    const result = await checkLink("https://github.com/o/r", {
+      githubAuth: "Bearer t",
+    });
+    assert.equal(result.classification, "live");
+    assert.equal(calls[0].url, "https://api.github.com/repos/o/r");
+    assert.equal((calls[0].headers as Row).authorization, "Bearer t");
+  });
+
+  test("falls back to the real telemetry recorder when none is injected", async () => {
+    // Exercises the `?? recordExceptionEvent` arm: the cron must still contain
+    // the failure with the production recorder in place, not just the double.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 200 })),
+    );
+    const result = await runLinkStatusSync(
+      mockEnv({
+        METAGRAPH_ARCHIVE: {
+          get: async () => null,
+          put: async () => undefined,
+        },
+      }),
+      { waitUntil: (p: Promise<unknown>) => p },
+      {
+        readArtifact: vi.fn(async () => {
+          throw new Error("reader exploded");
+        }) as never,
+      },
+    );
+    assert.deepEqual(result, { ok: false, reason: "unreachable" });
+  });
+});

--- a/tests/public-safety.test.ts
+++ b/tests/public-safety.test.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, test, vi } from "vitest";
 import {
   isUnsafeResolvedUrl,
+  resolvePublicUrlAddresses,
+  resolveUrlSafety,
   isUnsafeUrl,
   normalizePublicHttpUrl,
 } from "../scripts/lib.ts";
@@ -220,6 +222,92 @@ describe("public URL safety checks", () => {
 
   test("allows public literal IPs without DNS lookup", async () => {
     assert.equal(await isUnsafeResolvedUrl("http://8.8.8.8/dns-query"), false);
+  });
+
+  // #9870: `unsafe URL` is what we reported for a host that simply no longer
+  // exists. api.affine.io and autoresearch.bitsota.com were both filed that way
+  // in the adapter dashboard while the real cause was NXDOMAIN, and both
+  // classifications DEMOTE a surface (DEMOTING_CLASSIFICATIONS), so the wrong
+  // one was already reaching production verdicts. These assert the REASON, not
+  // just the boolean — a boolean-only test passes with the bug intact.
+  test("distinguishes a dead name from an unsafe one", async () => {
+    const nxdomain = async () => {
+      const error = new Error("getaddrinfo ENOTFOUND gone.invalid");
+      (error as NodeJS.ErrnoException).code = "ENOTFOUND";
+      throw error;
+    };
+    const privateAddress = async () => [{ address: "10.0.0.5", family: 4 }];
+    const empty = async () => [];
+
+    assert.equal(
+      (await resolveUrlSafety("https://gone.invalid/", nxdomain as never))
+        .failure,
+      "unresolvable",
+    );
+    assert.equal(
+      (
+        await resolveUrlSafety(
+          "https://internal.example/",
+          privateAddress as never,
+        )
+      ).failure,
+      "unsafe",
+    );
+    assert.equal(
+      (await resolveUrlSafety("https://empty.example/", empty as never))
+        .failure,
+      "unresolvable",
+      "no records is the same authoritative miss as NXDOMAIN",
+    );
+    assert.equal(
+      (await resolveUrlSafety("http://localhost:8080/", nxdomain as never))
+        .failure,
+      "unsafe",
+      "the literal guard must answer before DNS is even consulted",
+    );
+    assert.equal(
+      (await resolveUrlSafety("not-a-url", nxdomain as never)).failure,
+      "unsafe",
+      "a malformed input is a refusal, not a claim that some host is dead",
+    );
+  });
+
+  test("a transient resolver failure is never recorded as death", async () => {
+    // EAI_AGAIN is OUR resolver failing, not the target disappearing. Scoring
+    // it as `unresolvable` would let a DNS blip accrue strikes against a
+    // perfectly live link — "absence of evidence is not death".
+    const transient = async () => {
+      const error = new Error("getaddrinfo EAI_AGAIN flaky.example");
+      (error as NodeJS.ErrnoException).code = "EAI_AGAIN";
+      throw error;
+    };
+    const result = await resolveUrlSafety(
+      "https://flaky.example/",
+      transient as never,
+    );
+    assert.equal(result.failure, "resolve-error");
+    assert.notEqual(result.failure, "unresolvable");
+  });
+
+  test("every failure keeps refusing the connection, whatever its reason", async () => {
+    // The safety predicate must not regress: all three reasons still mean
+    // "there is no address here it is safe to connect to".
+    const nxdomain = async () => {
+      const error = new Error("nope");
+      (error as NodeJS.ErrnoException).code = "ENOTFOUND";
+      throw error;
+    };
+    assert.equal(
+      await isUnsafeResolvedUrl("https://gone.invalid/", nxdomain as never),
+      true,
+    );
+    assert.deepEqual(
+      await resolvePublicUrlAddresses(
+        "https://gone.invalid/",
+        nxdomain as never,
+      ),
+      [],
+    );
   });
 
   test("resolves public hosts and blocks failed DNS lookups", async () => {

--- a/tests/script-utils.test.ts
+++ b/tests/script-utils.test.ts
@@ -67,6 +67,7 @@ import {
   subnetSurfaceKey,
   writeJson,
   writeRepositoryJson,
+  resolveWithinRoot,
 } from "../scripts/lib.ts";
 import {
   ARTIFACT_STORAGE_TIERS,
@@ -2698,4 +2699,57 @@ test("validate:intake rejects nested retired community candidate files", async (
   } finally {
     await rm(retiredDir, { recursive: true, force: true });
   }
+});
+
+// #9917: the logo referential-integrity gate joins paths taken from
+// CONTRIBUTOR-SUBMITTED registry files onto apps/ui/public. path.join
+// normalizes `..` away rather than rejecting it, so a crafted logo_url would
+// have turned an existence check into an arbitrary-path probe on the build
+// machine. resolveWithinRoot is the containment the gate calls instead.
+describe("resolveWithinRoot", () => {
+  const root = path.join(os.tmpdir(), "mg-root");
+
+  test("resolves ordinary relative paths under the root", () => {
+    assert.equal(
+      resolveWithinRoot(root, "/logos/oro.png"),
+      path.join(root, "logos/oro.png"),
+    );
+    assert.equal(
+      resolveWithinRoot(root, "logos/cache/abc.png"),
+      path.join(root, "logos/cache/abc.png"),
+    );
+  });
+
+  test("rejects traversal, however it is spelled", () => {
+    for (const attempt of [
+      "/logos/../../../../etc/passwd",
+      "/logos/../../secrets",
+      "../outside",
+      // %2e%2e is `..` after decoding, which is why decoding happens first.
+      "/logos/%2e%2e/%2e%2e/etc/passwd",
+    ]) {
+      assert.equal(resolveWithinRoot(root, attempt), null, attempt);
+    }
+  });
+
+  test("rejects a sibling directory that merely shares a name prefix", () => {
+    // `${root}-evil` startsWith `${root}` — the trailing separator is what
+    // stops that passing.
+    assert.equal(resolveWithinRoot(root, "../mg-root-evil/x.png"), null);
+  });
+
+  test("treats a leading slash as root-relative, not as the filesystem root", () => {
+    // Logo paths are served URLs, so they always start with "/" — that must
+    // mean "under the public root". An absolute-looking path therefore stays
+    // contained rather than escaping, and the gate reports it missing because
+    // we do not ship it.
+    assert.equal(
+      resolveWithinRoot(root, "/etc/passwd"),
+      path.join(root, "etc/passwd"),
+    );
+  });
+
+  test("rejects a malformed percent-escape rather than throwing", () => {
+    assert.equal(resolveWithinRoot(root, "/logos/%zz.png"), null);
+  });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -436,6 +436,7 @@ import {
   semanticSearch,
 } from "../src/ai-search.ts";
 import { runGithubSignalsSync } from "../src/github-signals-sync.ts";
+import { runLinkStatusSync } from "../src/link-status-sync.ts";
 import { runRawCaptureSync } from "../src/raw-capture-sync.ts";
 import {
   captureSubnetBurnHistory,
@@ -503,6 +504,7 @@ import {
   WEBHOOK_DISPATCH_CRON,
   EMBEDDING_SYNC_CRON,
   GITHUB_SIGNALS_SYNC_CRON,
+  LINK_STATUS_SYNC_CRON,
   RAW_CAPTURE_CRON,
   SUBNET_BURN_CAPTURE_CRON,
   OPERATIONAL_SURFACES_SYNC_CRON,
@@ -2073,6 +2075,7 @@ function cronLabel(cron: string): string {
   if (cron === HEALTH_PRUNE_CRON) return "health-prune";
   if (cron === EMBEDDING_SYNC_CRON) return "embedding-sync";
   if (cron === GITHUB_SIGNALS_SYNC_CRON) return "github-signals-sync";
+  if (cron === LINK_STATUS_SYNC_CRON) return "link-status-sync";
   if (cron === RAW_CAPTURE_CRON) return "raw-capture";
   if (cron === SUBNET_BURN_CAPTURE_CRON) return "subnet-burn-capture";
   if (cron === OPERATIONAL_SURFACES_SYNC_CRON)
@@ -2275,6 +2278,14 @@ async function dispatchScheduled(
     // see src/github-signals-sync.ts's header for the provenance, repo-list
     // sourcing, token posture, and subrequest budget.
     return runGithubSignalsSync(env, ctx, { readArtifact });
+  }
+  if (cron === LINK_STATUS_SYNC_CRON) {
+    // #9907/#9914/#9917: the daily link-rot sweep over the registry's
+    // REFERENCE urls -- source_urls, provider urls, and the surface kinds
+    // OPERATIONAL_SURFACE_KINDS keeps out of the prober. Writes its own R2
+    // store and never touches health/uptime/incidents; see
+    // src/link-status-sync.ts's header for why those are separate lanes.
+    return runLinkStatusSync(env, ctx, { readArtifact });
   }
   if (cron === OPERATIONAL_SURFACES_SYNC_CRON) {
     // #9096: hourly derivation of the prober's cold-start surface list from

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -41,6 +41,15 @@ export const UPGRADE_RADAR_CRON = "7,37 * * * *";
 // that collides with none of the crons above. Must match a wrangler.jsonc
 // `triggers.crons` entry.
 export const GITHUB_SIGNALS_SYNC_CRON = "20 6 * * *";
+// Daily link-rot sweep over the registry's reference URLs (surface source_urls,
+// provider URLs, and the surface kinds the health prober deliberately skips) --
+// see src/link-status-sync.ts's header for the populations and the subrequest
+// budget. 07:35 is deliberately AFTER github-signals at 06:20: both lanes want
+// the same GITHUB_SIGNALS_TOKEN rate-limit budget, and spacing them by an hour
+// keeps a slow signals capture from colliding with this one. Daily because a
+// docs link rots on a scale of weeks, not minutes. Must match a wrangler.jsonc
+// `triggers.crons` entry.
+export const LINK_STATUS_SYNC_CRON = "35 7 * * *";
 // Raw chain capture (extrinsics/events bytes -> R2), every 5 minutes. The
 // chain produces ~5 blocks/minute and a tick captures up to 150, so this
 // out-runs head by ~6x -- a backlog DRAINS rather than merely holding, which

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -891,6 +891,13 @@
       // 06:20 UTC cadence it ran on) -- see GITHUB_SIGNALS_SYNC_CRON in
       // workers/config.ts and src/github-signals-sync.ts's header.
       "20 6 * * *",
+      // 35 7 = daily link-rot sweep over the registry's REFERENCE urls
+      // (surface source_urls, provider urls, and the surface kinds the health
+      // prober deliberately skips). Placed an hour after github-signals
+      // because both draw on the same GitHub token budget -- see
+      // LINK_STATUS_SYNC_CRON in workers/config.ts and
+      // src/link-status-sync.ts's header.
+      "35 7 * * *",
       // */5 = raw chain capture (extrinsic/event bytes -> R2). Out-runs the
       // chain ~6x so an outage backlog drains; see RAW_CAPTURE_CRON in
       // workers/config.ts and src/raw-chain-capture.ts's no-gap guarantee.


### PR DESCRIPTION
## Summary

A dead `source_url` is a deterministic **auto-CLOSE** for a contributor PR. Nothing re-checked it after merge — so the bar only applied on the way in. Today **355 surfaces across 25 subnets** cite a dead `source_url`, and **21 provider URLs** are dead including our own `gittensory` entry, which five surfaces still cite.

This adds a daily link-rot lane over the three URL populations the health prober deliberately does not cover, and fixes the SSRF-guard bug that had to land first.

## Why this is not the health prober

`OPERATIONAL_SURFACE_KINDS` limits the prober to `subtensor-rpc/wss`, `archive`, `subnet-api`, `sse`, `data-artifact` — things with uptime. The 494 surfaces in #9907 are `docs`/`website`/`source-repo`/`dashboard`/`sdk`: **references, not services**. They have no uptime, they must never reach incidents or the pool breaker, and probing them every 15 minutes would be 1,067 pointless requests an hour. Separate concern, separate cadence — a widening of the prober would have corrupted the numbers that describe live services.

## The budget, and what it bought

The three populations overlap heavily — 777 + 384 + 494 references are only **1,067 distinct URLs**, so the unit of work is the URL and citations fan back out to whoever asserted it.

| | URLs | how |
|---|---:|---|
| `metagraph.sh/logos/*` | 102 | **filesystem gate at build** — free, deterministic, blames the commit that dropped the file |
| everything else | **965** | network, inside one invocation's **1000-subrequest** ceiling |

`LINK_STATUS_MAX_CHECKS_PER_RUN` caps a tick at 900 and orders by least-recently-checked, so the 65-URL remainder rotates in next tick rather than starving — every URL covered within ~2 days, no cross-day split needed.

Reusing github-signals for the 165 repo roots **was considered and rejected**: that lane *drops* a gone repo (#9969) rather than flagging it, so absence there conflates "gone" with "never tracked" and "rate-limited". Deriving death from absence is the exact error #9969 existed to fix. All 429 github.com URLs go through the GitHub API instead, which answers directly — and catches the rot github-signals structurally cannot see, where the repo is alive and the file moved.

## Following today's patterns

- **Lane shape** — `src/link-status-sync.ts` mirrors `github-signals-sync.ts` (#233): daily cron → R2 store → build projects. Freshness never depends on a bot PR.
- **Same loader both sides** — build and `validate.ts` read the store through one loader, exactly like `loadSurfaceProbeEvidence`, so they cannot disagree and fail artifact parity.
- **Reuse, don't reimplement** — `probeUrl` + `classifyProbe`, not a hand-rolled checker. 25 of the audit's apparent breakages were the harness, because it didn't know 403 means Cloudflare and 429 means us.
- **`mapLimit` + `groupKey`** (#9959) for per-host serialization. `api.github.com` is exempted per-URL: that invariant exists to protect a subnet's single-box API, not GitHub, and serializing its 429 checks would be the entire runtime.
- **Outcome gates in `validate.ts`** (#9963, #9969) rather than call-site checks.

## What a dead link costs

Only after **3 consecutive daily failures**, and only for verdicts meaning "did not serve the document". 401/403/429 never accrue — they prove the host is alive. 5xx and timeouts *do*, precisely because the streak rule makes them safe: the largest rot cluster is `api.eirel.ai`, serving Cloudflare **521 behind live DNS for 121 surfaces**; excluding 5xx would have made the lane blind to its biggest case.

A surface loses verification when **every** `source_url` is dead — alternative proofs of one claim, not a checklist, so one moved README cannot mass-demote a subnet that documented itself twice.

## Fixes #9870, which this depended on

`unsafe URL` was what we reported for a host that no longer resolves. Since **both** `dead` and `unsafe` are in `DEMOTING_CLASSIFICATIONS`, the wrong reason was already reaching production verdicts — and a link lane built on that guard would have mislabelled every NXDOMAIN link.

`resolveUrlSafety` now separates three cases, matching the vocabulary `resolvedWebhookUrlStatus` already uses: `unsafe` (guard or private address), `unresolvable` (authoritative NXDOMAIN), `resolve-error` (a transient failure — **ours**, never scored as the target being dead). Verified against the two hosts in the issue:

```
unresolvable — "host does not resolve"     api.affine.io          (was: unsafe URL)
unresolvable — "host does not resolve"     autoresearch.bitsota.com
```

`isUnsafeResolvedUrl`/`resolvePublicUrlAddresses` keep their exact signatures, so all 8 callers are unchanged by construction.

## Also in this diff

- **Logo referential-integrity gate** — every served logo URL must resolve to a shipped file (75 hashed cache entries + 101 curated). This is what makes checking our own assets from disk *sound* rather than merely cheaper; without it the self-hosted subset would simply be unchecked. Currently 0 missing.
- **Double-encoding fix**, caught by its own test: `URL.pathname` is already percent-encoded, so `encodeURIComponent` produced `my%2520file.md` — a false 404 for every path with a space.
- **Two dead branches removed** rather than annotated away (`pathSegments`' unreachable catch, a `githubApiUrl(url) || url` that could never be taken).

## Validation

```
npm run typecheck                      clean
npm run lint / format:check            clean
npm run build                          passed
npm run validate                       Validated 129 native, 129 overlays, 3441 surfaces, 137 providers, 2037 candidates
vitest (link-status, public-safety,    123 passed
       adapter-snapshot, surface-verification)
```

**Patch coverage** (diff ∩ v8, `src/**` + `workers/**`): statements **100%**, branches **100%** — `link-status-core` 64/64, `link-status-sync` 48/48, `surface-verification` 8/8, `workers/api.ts` 4/4 (the cron-chain false arms are covered once a sibling cron test runs).

**Proven able to fail**, not just passing:
- `surfaceEvidenceIsDead` `every`→`some` → the ALL-not-ANY test fails
- `LINK_DEAD_STRIKES` 3→1 → 4 tests fail
- dropping `transient` from the strike set → the api.eirel.ai test fails
- hiding one logo file → `served logo URLs must resolve to a shipped file (1)`

## Noted, not fixed here

`tests/artifacts.test.ts > registry validates` is **red on clean `origin/main`** (reproduced in a throwaway worktree at `fa711aaf2`), unrelated to this change: subnet 36 renamed itself on-chain to `Leoma`, colliding with our stale stored label for netuid 99. Filed as #10003 with the evidence — it needs a registry-data judgement, and a reviewer would be surprised to find it in a link-rot PR.

Closes #9907
Closes #9914
Closes #9917
Closes #9870
Closes #9982