### PR TITLE
fix(schemas): gate the six vocabularies mirrored across the schemas-src boundary

### DIFF
--- a/scripts/validate-schema-vocabularies.ts
+++ b/scripts/validate-schema-vocabularies.ts
@@ -125,6 +125,76 @@ if (stale.length > 0) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Cross-boundary mirrors (#10005).
+//
+// schemas-src/ imports from neither src/ nor workers/ -- a rule the code states
+// itself ("a literal here because schemas-src/ imports from neither"). So a
+// vocabulary owned by API_QUERY_COLLECTIONS in src/contracts.ts CANNOT be
+// imported by the schema layer, and mirroring it is the correct answer to that
+// constraint. What was missing is the other half: nothing asserted the mirror
+// still matched.
+//
+// The cost of a silent divergence is asymmetric and neither half is loud. A
+// sort value added to the collection but not the mirror means the route accepts
+// an order the tool rejects -- an agent told a valid value is invalid. A value
+// REMOVED is worse: the tool keeps advertising a sort the route now ignores, so
+// the caller gets an unsorted answer that looks sorted. Same silent-wrong-data
+// class as the list_gaps `sort` no-op.
+//
+// Declared by name rather than matched by shape: two collections can share a
+// sort_fields set by coincidence (endpoint-pools/rpc-pools/pools do), and
+// "some collection somewhere agrees with this tuple" is not the property worth
+// asserting.
+const MIRRORED_VOCABULARIES: Record<string, string> = {
+  CANDIDATE_SORT_VALUES: "candidates",
+  ENDPOINT_POOL_SORT_VALUES: "endpoint-pools",
+  ENDPOINT_SORT_VALUES: "endpoints",
+  EVIDENCE_ENTRY_SORT_VALUES: "claims",
+  HEALTH_SURFACE_SORT_VALUES: "health-surfaces",
+  SURFACE_SORT_VALUES: "curated-surfaces",
+};
+
+const [{ API_QUERY_COLLECTIONS }, mcpShared] = await Promise.all([
+  import("../src/contracts.ts"),
+  import("../schemas-src/mcp-tools/shared.ts"),
+]);
+const collections = API_QUERY_COLLECTIONS as Record<
+  string,
+  { sort_fields?: readonly string[] }
+>;
+const mirrors = mcpShared as unknown as Record<string, readonly string[]>;
+
+for (const [name, collection] of Object.entries(MIRRORED_VOCABULARIES)) {
+  const mirrored = mirrors[name];
+  if (!Array.isArray(mirrored)) {
+    errors.push(
+      `${name} is declared as a mirror of API_QUERY_COLLECTIONS["${collection}"].sort_fields ` +
+        `but schemas-src/mcp-tools/shared.ts no longer exports it — delete the entry above, ` +
+        `or restore the export.`,
+    );
+    continue;
+  }
+  const source = collections[collection]?.sort_fields;
+  if (!Array.isArray(source)) {
+    errors.push(
+      `${name} mirrors API_QUERY_COLLECTIONS["${collection}"], which no longer declares sort_fields.`,
+    );
+    continue;
+  }
+  const a = [...mirrored].sort().join(",");
+  const b = [...source].sort().join(",");
+  if (a !== b) {
+    errors.push(
+      `${name} has drifted from API_QUERY_COLLECTIONS["${collection}"].sort_fields:\n` +
+        `    schemas-src: ${a || "(empty)"}\n` +
+        `    contracts:   ${b || "(empty)"}\n` +
+        `  The collection OWNS this vocabulary. Update the mirror, never the source, ` +
+        `unless the route's sort set genuinely changed.`,
+    );
+  }
+}
+
 if (errors.length > 0) {
   console.error(
     `Schema-vocabulary validation failed with ${errors.length} issue(s):`,
@@ -135,5 +205,6 @@ if (errors.length > 0) {
 
 console.log(
   `Schema-vocabulary validation passed: ${byVocabulary.size} distinct vocabularies, ` +
-    `${duplicated.length} still restated in more than one file (all per-domain coincidences, not debt — see COINCIDENT_BY_DOMAIN).`,
+    `${duplicated.length} still restated in more than one file (all per-domain coincidences, not debt — see COINCIDENT_BY_DOMAIN); ` +
+    `${Object.keys(MIRRORED_VOCABULARIES).length} cross-boundary mirrors match the collection that owns them.`,
 );

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -4345,18 +4345,17 @@ function coverageDepthMatches(
 // GET /api/v1/endpoints's sort_fields (contracts.ts), read from the same
 // config so the inputSchema enum and applyQueryFilters can't drift.
 const ENDPOINT_SORT_FIELDS = API_QUERY_COLLECTIONS.endpoints.sort_fields;
-// Filter names applyQueryFilters accepts for the "endpoints" collection --
-// list_endpoints's own kind/layer/netuid/provider/publication_state/status/
-// pool_eligible args, matching GET /api/v1/endpoints's full filter set.
-const ENDPOINTS_QUERY_FILTER_NAMES = [
-  "kind",
-  "layer",
-  "netuid",
-  "pool_eligible",
-  "provider",
-  "publication_state",
-  "status",
-];
+// Filter names applyQueryFilters accepts for the "endpoints" collection.
+//
+// DERIVED, for the same reason ENDPOINT_SORT_FIELDS above is (#10005). This
+// hand-listed the seven names, two lines under a constant whose own comment
+// says "read from the same config so the inputSchema enum and applyQueryFilters
+// can't drift" -- the config owns `filters` exactly as it owns `sort_fields`,
+// and this file already imports it, so there was never a boundary forcing a
+// copy here the way there is in schemas-src/.
+const ENDPOINTS_QUERY_FILTER_NAMES = Object.keys(
+  API_QUERY_COLLECTIONS.endpoints.filters,
+);
 
 // z.toJSONSchema() always injects a `$schema` key. get_coverage_depth's own
 // pre-existing test (#6983, predates the Zod-conversion epic) asserts its

--- a/tests/mirrored-sort-vocabularies.test.ts
+++ b/tests/mirrored-sort-vocabularies.test.ts
@@ -1,0 +1,86 @@
+// The cross-boundary vocabulary mirrors (#10005).
+//
+// `schemas-src/` imports from neither `src/` nor `workers/` -- a rule the code
+// states itself. So a vocabulary owned by API_QUERY_COLLECTIONS cannot be
+// imported by the schema layer, and hand-mirroring it is the correct answer to
+// that constraint rather than a shortcut.
+//
+// `validate:schema-vocabularies` enforces the match in CI. This pins the same
+// invariant as a unit test so it also fails in a plain `npm test`, and so the
+// property survives a rewrite of that script.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { API_QUERY_COLLECTIONS } from "../src/contracts.ts";
+import {
+  CANDIDATE_SORT_VALUES,
+  ENDPOINT_POOL_SORT_VALUES,
+  ENDPOINT_SORT_VALUES,
+  EVIDENCE_ENTRY_SORT_VALUES,
+  HEALTH_SURFACE_SORT_VALUES,
+  SURFACE_SORT_VALUES,
+} from "../schemas-src/mcp-tools/shared.ts";
+
+// Declared by NAME, not matched by shape: endpoint-pools / rpc-pools / pools
+// share a sort set by coincidence, and "some collection agrees with this
+// tuple" is not the property worth asserting.
+const MIRRORS: [string, readonly string[], string][] = [
+  ["CANDIDATE_SORT_VALUES", CANDIDATE_SORT_VALUES, "candidates"],
+  ["ENDPOINT_POOL_SORT_VALUES", ENDPOINT_POOL_SORT_VALUES, "endpoint-pools"],
+  ["ENDPOINT_SORT_VALUES", ENDPOINT_SORT_VALUES, "endpoints"],
+  ["EVIDENCE_ENTRY_SORT_VALUES", EVIDENCE_ENTRY_SORT_VALUES, "claims"],
+  ["HEALTH_SURFACE_SORT_VALUES", HEALTH_SURFACE_SORT_VALUES, "health-surfaces"],
+  ["SURFACE_SORT_VALUES", SURFACE_SORT_VALUES, "curated-surfaces"],
+];
+
+const collections = API_QUERY_COLLECTIONS as unknown as Record<
+  string,
+  { sort_fields?: readonly string[]; filters?: Record<string, unknown> }
+>;
+
+describe("mirrored sort vocabularies", () => {
+  for (const [name, mirrored, collection] of MIRRORS) {
+    test(`${name} equals API_QUERY_COLLECTIONS["${collection}"].sort_fields`, () => {
+      const source = collections[collection]?.sort_fields;
+      assert.ok(
+        Array.isArray(source) && source.length > 0,
+        `${collection} must still declare sort_fields, or this mirror has no owner`,
+      );
+      // A value ADDED to the collection and not the mirror means the route
+      // accepts an order the tool rejects. A value REMOVED is worse: the tool
+      // keeps advertising a sort the route now ignores, so the caller gets an
+      // unsorted answer that looks sorted.
+      assert.deepEqual([...mirrored].sort(), [...source!].sort());
+    });
+  }
+
+  test("the mirror list itself is not stale", () => {
+    // Every entry must name a collection that still exists -- otherwise the
+    // list quietly stops checking anything, which is how a gate becomes
+    // decoration.
+    for (const [name, , collection] of MIRRORS) {
+      assert.ok(
+        collections[collection],
+        `${name} names collection "${collection}", which no longer exists`,
+      );
+    }
+  });
+
+  test("the endpoints filter names are DERIVED, not restated", () => {
+    // src/mcp-server.ts is on the same side of the boundary as the config, so
+    // it has no excuse to copy: ENDPOINTS_QUERY_FILTER_NAMES is now
+    // Object.keys(...filters). Asserting the config still HAS filters keeps
+    // that derivation meaningful -- deriving from an empty object would pass
+    // silently while accepting no filters at all.
+    const filters = collections.endpoints?.filters;
+    assert.ok(filters && Object.keys(filters).length > 0);
+    assert.deepEqual(Object.keys(filters).sort(), [
+      "kind",
+      "layer",
+      "netuid",
+      "pool_eligible",
+      "provider",
+      "publication_state",
+      "status",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

`schemas-src/mcp-tools/shared.ts` hand-copies six `*_SORT_VALUES` tuples from `API_QUERY_COLLECTIONS` in `src/contracts.ts`:

```
CANDIDATE_SORT_VALUES        n=7   mirrors  candidates
ENDPOINT_POOL_SORT_VALUES    n=4   mirrors  endpoint-pools
ENDPOINT_SORT_VALUES         n=10  mirrors  endpoints
EVIDENCE_ENTRY_SORT_VALUES   n=4   mirrors  claims
HEALTH_SURFACE_SORT_VALUES   n=11  mirrors  health-surfaces
SURFACE_SORT_VALUES          n=5   mirrors  curated-surfaces
```

**All six match today.** This was an *unguarded* duplication, not a live defect — which is the right time to close it.

## The copy has to stay a copy

`schemas-src/` imports from neither `src/` nor `workers/`, a rule the code states itself:

> `// Ceiling is MAX_LIMIT (workers/request-params.ts:21); a literal here because schemas-src/ imports from neither src/ nor workers/.`

So the schema layer genuinely cannot read `API_QUERY_COLLECTIONS`, and mirroring is the correct answer to that constraint rather than a shortcut. What was missing is the other half: **nothing asserted the mirror still matched.**

## Neither direction of divergence is loud

- A sort value **added** to the collection and not the mirror → the route accepts an order the tool rejects, so an agent is told a valid value is invalid.
- A value **removed** is worse → the tool keeps advertising a sort the route now ignores, and the caller gets an **unsorted answer that looks sorted**. Same silent-wrong-data class as the `list_gaps` `sort` no-op.

## Design

Declared **by name**, not matched by shape. `endpoint-pools`, `rpc-pools` and `pools` share a sort set by coincidence, and *"some collection somewhere agrees with this tuple"* is not the property worth asserting. A mirror naming a collection that no longer exists also fails, so the list cannot quietly stop checking anything — the way a gate becomes decoration.

**Verified the gate actually fails.** Injected a value and watched it reject, then restored:

```
Schema-vocabulary validation failed with 1 issue(s):
- ENDPOINT_SORT_VALUES has drifted from API_QUERY_COLLECTIONS["endpoints"].sort_fields:
    schemas-src: drift_probe,kind,last_checked,latency_ms,…
    contracts:   kind,last_checked,latency_ms,…
  The collection OWNS this vocabulary. Update the mirror, never the source, …
```

A check that cannot fail is worth nothing, and this repo has been bitten by exactly that.

## Second half: one hand-listing removed

`ENDPOINTS_QUERY_FILTER_NAMES` in `src/mcp-server.ts` is now `Object.keys(API_QUERY_COLLECTIONS.endpoints.filters)`.

That file is on the **same side** of the boundary as the config — it already imports it — so it never had the excuse `schemas-src/` has. And it sat two lines under `ENDPOINT_SORT_FIELDS`, which is derived, carrying the comment *"read from the same config so the inputSchema enum and applyQueryFilters can't drift"*.

## Validation

```
npm run lint && npm run format:check && npm run typecheck && npm run build
npm run validate:schema-vocabularies
npm run validate:mcp && npm run validate:mcp-route-map
npm run validate:contract-drift
npm run validate:schema-opacity
npm run validate:single-schema-source
npx vitest run tests/mcp-server.test.ts tests/mirrored-sort-vocabularies.test.ts \
  tests/contracts.test.ts tests/mcp-tool-annotations.test.ts tests/mcp-route-map.test.ts
```

All green — 1,416 tests, including 8 new ones. The gate is already registered in both `scripts/pipeline.ts` step lists and `validate.yml`, so no pipeline-parity gap; the new unit test pins the same invariant so it also fails in a plain `npm test` and survives a rewrite of the script.

No `src/**` behaviour changed beyond replacing a literal with the derivation of the same seven names — verified identical before and after.

Closes #10005