### PR TITLE
feat(mcp): four per-subnet tools could not use any of their route's filters

### DIFF
--- a/schemas-src/mcp-tools/endpoints-catalog.ts
+++ b/schemas-src/mcp-tools/endpoints-catalog.ts
@@ -113,10 +113,22 @@ export const ListEndpointsOutputSchema = EndpointsArtifactSchema.extend({
 });
 export type ListEndpointsOutput = z.infer<typeof ListEndpointsOutputSchema>;
 
-export const GetSubnetEndpointsInputSchema = z
-  .object({
-    netuid: netuidSchema(),
-  })
+/**
+ * DERIVED FROM THE NETWORK-WIDE SIBLING, NOT DECLARED FRESH (#9998).
+ *
+ * This took `netuid` alone, so an agent could not filter a subnet's endpoints
+ * by anything -- not by kind, not by status, not even page them -- while any
+ * REST caller could. That is also why the tool was 192 KB: it could not pass a
+ * `limit`.
+ *
+ * The per-subnet view is the network-wide one with `netuid` moved from an
+ * optional FILTER to the required SUBJECT, so it is expressed that way rather
+ * than restating eleven filters that would then be free to drift.
+ */
+export const GetSubnetEndpointsInputSchema = ListEndpointsInputSchema.omit({
+  netuid: true,
+})
+  .extend({ netuid: netuidSchema() })
   .strict();
 export type GetSubnetEndpointsInput = z.infer<
   typeof GetSubnetEndpointsInputSchema

--- a/schemas-src/mcp-tools/get-subnet-health.ts
+++ b/schemas-src/mcp-tools/get-subnet-health.ts
@@ -4,12 +4,21 @@
 // reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
 import { z } from "zod";
 import { netuidSchema } from "./shared.ts";
+import { ListSubnetHealthInputSchema } from "./subnet-scoped-lists.ts";
 import { HealthSubnetSummarySchema } from "../routes/health.ts";
 
-export const GetSubnetHealthInputSchema = z
-  .object({
-    netuid: netuidSchema(),
-  })
+/**
+ * DERIVED FROM THE NETWORK-WIDE SIBLING (#9998).
+ *
+ * `netuid` alone meant an agent could not narrow a subnet's health rows by
+ * kind, provider, status or classification, nor page them, while a REST caller
+ * could. The per-subnet view is list_subnet_health with `netuid` moved from an
+ * optional FILTER to the required SUBJECT.
+ */
+export const GetSubnetHealthInputSchema = ListSubnetHealthInputSchema.omit({
+  netuid: true,
+})
+  .extend({ netuid: netuidSchema() })
   .strict();
 export type GetSubnetHealthInput = z.infer<typeof GetSubnetHealthInputSchema>;
 

--- a/schemas-src/mcp-tools/subnet-registry-lists.ts
+++ b/schemas-src/mcp-tools/subnet-registry-lists.ts
@@ -43,13 +43,25 @@ import {
 } from "../routes/subnet-detail.ts";
 import { CONFIDENCE_LEVEL_VALUES } from "../shared.ts";
 import { CANDIDATE_SORT_VALUES, EVIDENCE_ENTRY_SORT_VALUES } from "./shared.ts";
+// #9998: the per-subnet views below are these two with `netuid` moved from an
+// optional filter to the required subject.
+import {
+  ListCandidatesInputSchema,
+  ListSurfacesInputSchema,
+} from "./registry-catalogs-1.ts";
 
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
 
-export const GetSubnetCandidatesInputSchema = z
-  .object({
-    netuid: netuidSchema(),
-  })
+/**
+ * DERIVED FROM THE NETWORK-WIDE SIBLING (#9998). See
+ * GetSubnetSurfacesInputSchema below for the reasoning -- the per-subnet view
+ * is list_candidates with `netuid` moved from an optional FILTER to the
+ * required SUBJECT.
+ */
+export const GetSubnetCandidatesInputSchema = ListCandidatesInputSchema.omit({
+  netuid: true,
+})
+  .extend({ netuid: netuidSchema() })
   .strict();
 export type GetSubnetCandidatesInput = z.infer<
   typeof GetSubnetCandidatesInputSchema
@@ -152,10 +164,21 @@ export type ListSubnetEvidenceOutput = z.infer<
   typeof ListSubnetEvidenceOutputSchema
 >;
 
-export const GetSubnetSurfacesInputSchema = z
-  .object({
-    netuid: netuidSchema(),
-  })
+/**
+ * DERIVED FROM THE NETWORK-WIDE SIBLING, NOT DECLARED FRESH (#9998).
+ *
+ * This took `netuid` alone, so an agent could not filter or page a subnet's
+ * surfaces at all while any REST caller could -- and it is 159 KB precisely
+ * because it could not pass a `limit`.
+ *
+ * Expressed as the network-wide schema with `netuid` moved from an optional
+ * FILTER to the required SUBJECT, rather than restating filters that would
+ * then be free to drift from the list tool serving the same collection.
+ */
+export const GetSubnetSurfacesInputSchema = ListSurfacesInputSchema.omit({
+  netuid: true,
+})
+  .extend({ netuid: netuidSchema() })
   .strict();
 export type GetSubnetSurfacesInput = z.infer<
   typeof GetSubnetSurfacesInputSchema

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -4358,6 +4358,70 @@ const ENDPOINTS_QUERY_FILTER_NAMES = [
   "status",
 ];
 
+/**
+ * Filter / sort / project / paginate a per-subnet list view (#9998).
+ *
+ * The four per-subnet tools took `netuid` alone: an agent could not narrow a
+ * subnet's endpoints, surfaces, health rows or candidates by anything, nor page
+ * them, while any REST caller could. Three of them were also fat for exactly
+ * that reason -- get_subnet_endpoints was 192 KB because it could not pass a
+ * `limit`. The narrowing already existed; it was never exposed.
+ *
+ * This hands the work to the SAME engine the route handler and the
+ * network-wide sibling both use, over a synthetic query URL -- the path
+ * list_endpoints already describes as "the REST-parity path". Nothing new is
+ * filtered here, which is the point: a second implementation is how the two
+ * surfaces start disagreeing.
+ *
+ * `netuid` and `context` are excluded deliberately. `netuid` is the SUBJECT of
+ * a per-subnet view rather than a filter over it (the artifact already holds
+ * one subnet), and `context` is MCP telemetry, not a query parameter.
+ */
+function applySubnetListQuery(
+  data: Row,
+  args: Row,
+  collection: string,
+  dataKey: string,
+): Row {
+  // Schema-stability guard, same as list_endpoints': an artifact with no rows
+  // array must still report an empty list rather than fall through
+  // applyQueryFilters' unknown-collection passthrough, which would omit
+  // total/returned/cursor entirely.
+  const rows = data?.[dataKey];
+  const body = Array.isArray(rows) ? data : { ...data, [dataKey]: [] };
+  const queryUrl = new URL(`https://mcp.internal/${collection}`);
+  for (const [key, value] of Object.entries(args ?? {})) {
+    if (key === "netuid" || key === "context") continue;
+    if (value === undefined || value === null || value === "") continue;
+    queryUrl.searchParams.set(key, String(value));
+  }
+  const transformed = applyMcpQueryFilters(
+    body,
+    queryUrl,
+    collection,
+    Object.keys(
+      (API_QUERY_COLLECTIONS as Record<string, { filters?: Row }>)[collection]
+        ?.filters ?? {},
+    ).filter((name) => name !== "netuid"),
+  );
+  if (transformed.error) {
+    throw toolError("invalid_params", transformed.error.message);
+  }
+  const page = transformed.meta?.pagination as Row | undefined;
+  return {
+    ...(transformed.data as Row),
+    ...(page
+      ? {
+          total: page.total,
+          returned: page.returned,
+          cursor: page.cursor,
+          limit: page.limit,
+          next_cursor: page.next_cursor,
+        }
+      : {}),
+  };
+}
+
 // z.toJSONSchema() always injects a `$schema` key. get_coverage_depth's own
 // pre-existing test (#6983, predates the Zod-conversion epic) asserts its
 // inputSchema strictly equals the bare {type,properties,additionalProperties}
@@ -4873,7 +4937,19 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       ]);
       const overlaid = overlaySubnetHealth(null, live, netuid);
       if (overlaid) {
-        return { ...overlaid, reliability };
+        // #9998: filter/sort/page the surfaces the same way the route does.
+        // `summary` is deliberately left spanning EVERY surface, not the page --
+        // a caller narrowing to one kind still needs the subnet's real counts,
+        // the same contract subnet_count carries on the trends route.
+        return {
+          ...applySubnetListQuery(
+            overlaid as Row,
+            args as Row,
+            "health-surfaces",
+            "surfaces",
+          ),
+          reliability,
+        };
       }
       return {
         schema_version: 1,
@@ -11924,11 +12000,13 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       ctx: McpCtx,
     ) {
       const netuid = requireNetuid(args);
-      const data = await loadArtifactData(
+      let data = await loadArtifactData(
         ctx,
         `/metagraph/endpoints/${netuid}.json`,
       );
       // Live per-endpoint health overlay, same rule as list_endpoints above.
+      // Applied BEFORE the query so `status`/`latency` filter and sort on the
+      // live values a caller can see, not the baked ones they replaced.
       if (
         Array.isArray(data?.endpoints) &&
         data.endpoints.some((endpoint: Row) => endpoint?.surface_id)
@@ -11937,9 +12015,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           data,
           await mcpLiveHealth(ctx),
         );
-        if (overlaid) return overlaid;
+        if (overlaid) data = overlaid;
       }
-      return data;
+      return applySubnetListQuery(data, args as Row, "endpoints", "endpoints");
     },
   },
   {
@@ -11986,7 +12064,12 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       ctx: McpCtx,
     ) {
       const netuid = requireNetuid(args);
-      return loadArtifactData(ctx, `/metagraph/candidates/${netuid}.json`);
+      return applySubnetListQuery(
+        await loadArtifactData(ctx, `/metagraph/candidates/${netuid}.json`),
+        args as Row,
+        "candidates",
+        "candidates",
+      );
     },
   },
   {
@@ -12043,7 +12126,12 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       ctx: McpCtx,
     ) {
       const netuid = requireNetuid(args);
-      return loadArtifactData(ctx, `/metagraph/surfaces/${netuid}.json`);
+      return applySubnetListQuery(
+        await loadArtifactData(ctx, `/metagraph/surfaces/${netuid}.json`),
+        args as Row,
+        "curated-surfaces",
+        "surfaces",
+      );
     },
   },
   {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -4935,31 +4935,38 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         mcpLiveHealth(ctx),
         loadSubnetReliability(),
       ]);
+      // #9998: filter/sort/page the surfaces the same way the route does.
+      //
+      // BOTH branches go through the query, including the cold one. Validating
+      // only when rows exist would make an out-of-enum filter an ERROR on a
+      // warm tier and a silent empty answer on a cold one -- the argument
+      // check would depend on data availability, which is exactly the
+      // "silently matches nothing" failure mcp-schema-enforcement (#8942)
+      // exists to catch. It caught this.
+      //
+      // `summary` is deliberately left spanning EVERY surface, not the page --
+      // a caller narrowing to one kind still needs the subnet's real counts,
+      // the same contract subnet_count carries on the trends route.
       const overlaid = overlaySubnetHealth(null, live, netuid);
-      if (overlaid) {
-        // #9998: filter/sort/page the surfaces the same way the route does.
-        // `summary` is deliberately left spanning EVERY surface, not the page --
-        // a caller narrowing to one kind still needs the subnet's real counts,
-        // the same contract subnet_count carries on the trends route.
-        return {
-          ...applySubnetListQuery(
-            overlaid as Row,
-            args as Row,
-            "health-surfaces",
-            "surfaces",
-          ),
-          reliability,
-        };
-      }
+      const base: Row = overlaid
+        ? (overlaid as Row)
+        : {
+            schema_version: 1,
+            netuid,
+            // All six required counts, not two (#9797) -- see the builder.
+            summary: emptySubnetHealthSummary(),
+            operational_observed_at: null,
+            health_source: "unavailable",
+            surfaces: [],
+          };
       return {
-        schema_version: 1,
-        netuid,
-        // All six required counts, not two (#9797) -- see the builder.
-        summary: emptySubnetHealthSummary(),
-        operational_observed_at: null,
-        health_source: "unavailable",
+        ...applySubnetListQuery(
+          base,
+          args as Row,
+          "health-surfaces",
+          "surfaces",
+        ),
         reliability,
-        surfaces: [],
       };
     },
   },

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -20614,6 +20614,119 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(out.surfaces[0].kind, "openapi");
   });
 
+  describe("per-subnet list views honour their route's filters (#9998)", () => {
+    // These four took `netuid` alone: an agent could not narrow or page a
+    // subnet's rows at all, while any REST caller could -- and three of them
+    // were fat for exactly that reason. Advertising a filter the handler then
+    // ignores would be worse than not having it (an answer that looks filtered
+    // and is not), so each assertion checks the ROWS, not just the schema.
+    const surfaceDeps = () =>
+      makeDeps({
+        "/metagraph/surfaces/5.json": {
+          generated_at: "2026-01-01T00:00:00Z",
+          netuid: 5,
+          surfaces: [
+            { kind: "openapi", provider: "datura", id: "a" },
+            { kind: "docs", provider: "datura", id: "b" },
+            { kind: "openapi", provider: "opentensor", id: "c" },
+          ],
+        },
+      });
+
+    test("filters the rows, and reports the unfiltered total", async () => {
+      const res = await callTool(
+        "get_subnet_surfaces",
+        { netuid: 5, kind: "openapi" },
+        { deps: surfaceDeps() },
+      );
+      const out = res.body.result.structuredContent;
+      assert.deepEqual(
+        (out.surfaces as Row[]).map((s: Row) => s.id),
+        ["a", "c"],
+      );
+      // `total` is the MATCHING count, not the subnet's whole row count --
+      // the denominator for paging THIS query. That is the engine's semantics
+      // and therefore the route's, which is the property worth pinning: the
+      // two surfaces share one implementation, so they cannot report
+      // different numbers for the same question.
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+    });
+
+    test("two filters intersect rather than either winning", async () => {
+      const res = await callTool(
+        "get_subnet_surfaces",
+        { netuid: 5, kind: "openapi", provider: "datura" },
+        { deps: surfaceDeps() },
+      );
+      assert.deepEqual(
+        (res.body.result.structuredContent.surfaces as Row[]).map(
+          (s: Row) => s.id,
+        ),
+        ["a"],
+      );
+    });
+
+    test("limit pages the rows", async () => {
+      // The payload half: get_subnet_surfaces was 159 KB because it could not
+      // pass this.
+      const res = await callTool(
+        "get_subnet_surfaces",
+        { netuid: 5, limit: 1 },
+        { deps: surfaceDeps() },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal((out.surfaces as Row[]).length, 1);
+      assert.equal(out.total, 3);
+    });
+
+    test("no arguments still returns every row, exactly as before", async () => {
+      // The compatibility floor: every parameter is optional, so an existing
+      // caller sees no change.
+      const res = await callTool(
+        "get_subnet_surfaces",
+        { netuid: 5 },
+        { deps: surfaceDeps() },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal((out.surfaces as Row[]).length, 3);
+      assert.equal(out.netuid, 5);
+    });
+
+    test("an unknown filter value is rejected, not silently ignored", async () => {
+      // The failure this whole change is guarding against: a parameter the
+      // tool accepts and the engine drops returns an answer that LOOKS
+      // filtered. Better to refuse.
+      const res = await callTool(
+        "get_subnet_surfaces",
+        { netuid: 5, sort: "not_a_sort_field" },
+        { deps: surfaceDeps() },
+      );
+      assert.equal(res.body.result.isError, true);
+      assert.equal(
+        res.body.result.structuredContent.error.code,
+        "invalid_params",
+      );
+    });
+
+    test("a subnet artifact with no rows array still reports an empty page", async () => {
+      // Schema stability: it must not fall through the engine's
+      // unknown-collection passthrough, which would omit total/returned.
+      const res = await callTool(
+        "get_subnet_surfaces",
+        { netuid: 5 },
+        {
+          deps: makeDeps({
+            "/metagraph/surfaces/5.json": { netuid: 5, surfaces: null },
+          }),
+        },
+      );
+      const out = res.body.result.structuredContent;
+      assert.deepEqual(out.surfaces, []);
+      assert.equal(out.total, 0);
+    });
+  });
+
   test("get_subnet_surfaces rejects a missing netuid", async () => {
     const res = await callTool("get_subnet_surfaces", {});
     assert.equal(res.body.result.isError, true);


### PR DESCRIPTION
## Summary

Four per-subnet tools accepted **`netuid` and nothing else**:

```
get_subnet_endpoints  : [netuid, context]
get_subnet_surfaces   : [netuid, context]
get_subnet_health     : [netuid, context]
get_subnet_candidates : [netuid, context]
```

while the routes they mirror publish full filter/sort/projection/pagination sets. An agent could not ask *"which of this subnet's endpoints are unhealthy?"* — or page the answer — while any REST caller could. There is no error and no drift signal; it is simply a smaller API wearing the same name.

**It is also why three of them are fat.** `get_subnet_endpoints` is 192 KB *because it could not pass a `limit`*; `get_subnet_surfaces` is 159 KB for the same reason. The narrowing already existed — it was never exposed. So this closes a capability gap and shrinks payloads with one change.

## Input schemas are derived, not restated

Each is its network-wide sibling with `netuid` moved from an optional **filter** to the required **subject**:

```ts
export const GetSubnetEndpointsInputSchema = ListEndpointsInputSchema
  .omit({ netuid: true })
  .extend({ netuid: netuidSchema() })
  .strict();
```

Restating eleven filters would leave them free to drift from the list tool serving the same collection — the exact disease #9796 removed from the output side.

## Handlers use the engine that already exists

`applySubnetListQuery` hands filter/sort/projection/pagination to the **same** `applyMcpQueryFilters` the route handler and the network-wide sibling both use, over a synthetic query URL — the path `list_endpoints` already describes in its own comment as *"the REST-parity path"*. **Nothing new is filtered here, deliberately:** a second implementation is how two surfaces start disagreeing. Filter names come from `API_QUERY_COLLECTIONS[collection].filters`, so those cannot drift either.

### Two details that are decisions, not accidents

- **The endpoints health overlay runs *before* the query**, so `status` and latency filter and sort on the live values a caller can see, not the baked ones they replaced.
- **`get_subnet_health`'s `summary` still spans every surface, not the page.** A caller narrowing to one kind still needs the subnet's real counts — the same contract `subnet_count` carries on the trends route.

`netuid` and `context` are excluded from the query: `netuid` is the *subject* of a per-subnet view rather than a filter over it, and `context` is MCP telemetry.

## Compatibility, and the failure being guarded against

Every parameter is optional, so **a call with no arguments returns exactly what it returned before** — pinned by its own test.

The most important new test asserts that an unknown sort field is **refused**, not ignored. A tool that accepts a filter the engine silently drops returns an answer that *looks* filtered and is not — wrong data, no error. That is the failure this whole change exists to avoid, so it is asserted rather than assumed.

Tests check the **rows**, not just the emitted schema: filtering, two filters intersecting, `limit` paging, `total` semantics, the no-argument floor, and a null rows array still reporting an empty page rather than falling through the engine's unknown-collection passthrough.

One correction found while writing them: `total` is the **matching** count (the paging denominator for that query), not the subnet's whole row count. That is the engine's semantics and therefore the route's — which is the property worth pinning, since both surfaces share one implementation and so cannot report different numbers for the same question.

## Validation

```
npm run lint && npm run format:check && npm run typecheck && npm run build
npm run validate:mcp && npm run validate:mcp-route-map
npm run validate:api && npm run validate:openapi
npm run validate:contract-drift
npm run validate:schema-opacity
npm run validate:schema-vocabularies
npm run validate:single-schema-source
npx vitest run tests/mcp-server.test.ts tests/mcp-route-map.test.ts \
  tests/mcp-tool-annotations.test.ts tests/api-coverage.test.ts
```

All green — **1,724 tests**, including 6 new ones.

Closes #9998