### PR TITLE
feat(mcp): get_coverage_depth took no arguments and returned 293 KB

### DIFF
--- a/schemas-src/mcp-tools/meta-artifacts-2.ts
+++ b/schemas-src/mcp-tools/meta-artifacts-2.ts
@@ -18,7 +18,21 @@ import { z } from "zod";
 import { ChangelogArtifactSchema } from "../routes/meta-contracts.ts";
 import { CoverageDepthArtifactSchema } from "../routes/coverage.ts";
 import { SelfHealthArtifactSchema } from "../routes/self-health.ts";
-import { CoverageArtifactSchema } from "../routes/coverage.ts";
+import {
+  AGENT_READINESS_STATUSES,
+  BLOCKER_LEVELS,
+  COVERAGE_DEPTH_TIERS,
+  CoverageArtifactSchema,
+} from "../routes/coverage.ts";
+import {
+  COVERAGE_DEPTH_SORT_VALUES,
+  fieldsStringSchema,
+  limitSchema,
+  netuidSchema,
+  numericCursorSchema,
+  orderSchema,
+  sortSchema,
+} from "./shared.ts";
 import { BuildSummaryArtifactSchema } from "../routes/meta-contracts.ts";
 
 export const GetChangelogInputSchema = z.object({}).strict();
@@ -60,7 +74,44 @@ export type GetCoverageInput = z.infer<typeof GetCoverageInputSchema>;
 export const GetCoverageOutputSchema = CoverageArtifactSchema;
 export type GetCoverageOutput = z.infer<typeof GetCoverageOutputSchema>;
 
-export const GetCoverageDepthInputSchema = z.object({}).strict();
+/**
+ * #10011. This took NO arguments and returned ~293 KB -- the whole
+ * coverage-depth scorecard, every subnet, on every call, while
+ * GET /api/v1/coverage/depth publishes every filter below. Not bad defaults:
+ * no lever at all, the same shape get_health_trends had before #9989.
+ *
+ * The vocabularies are the ROUTE's own, so a tier added to the scorecard
+ * cannot become one this tool rejects.
+ */
+export const GetCoverageDepthInputSchema = z
+  .object({
+    netuid: netuidSchema().optional(),
+    tier: z
+      .enum(COVERAGE_DEPTH_TIERS)
+      .optional()
+      .describe(
+        "Restrict to subnets in this readiness tier. Applied across the whole scorecard, not to one page.",
+      )
+      .meta({ examples: ["agent-ready"] }),
+    agent_status: z
+      .enum(AGENT_READINESS_STATUSES)
+      .optional()
+      .describe("Restrict to subnets with this agent-readiness status.")
+      .meta({ examples: ["callable"] }),
+    blocker_level: z
+      .enum(BLOCKER_LEVELS)
+      .optional()
+      .describe(
+        "Restrict to subnets blocked this badly. `none` means nothing is blocking promotion.",
+      )
+      .meta({ examples: ["hard-blocked"] }),
+    sort: sortSchema(COVERAGE_DEPTH_SORT_VALUES).optional(),
+    order: orderSchema().optional(),
+    fields: fieldsStringSchema().optional(),
+    limit: limitSchema(500).optional(),
+    cursor: numericCursorSchema().optional(),
+  })
+  .strict();
 export type GetCoverageDepthInput = z.infer<typeof GetCoverageDepthInputSchema>;
 
 // DERIVED FROM THE ROUTE, NOT COPIED (#9794). The hand-written copy typed

--- a/schemas-src/mcp-tools/registry-summary-gaps.ts
+++ b/schemas-src/mcp-tools/registry-summary-gaps.ts
@@ -28,6 +28,7 @@ import {
 } from "../routes/coverage.ts";
 import {
   AGENT_READINESS_STATUSES,
+  BLOCKER_LEVELS,
   COVERAGE_DEPTH_SEVERITIES,
   COVERAGE_DEPTH_TIERS,
 } from "../routes/coverage.ts";
@@ -73,6 +74,16 @@ export const ListEnrichmentTargetsInputSchema = z
       .optional()
       .describe("How usable the subnet is to an agent right now.")
       .meta({ examples: [AGENT_READINESS_STATUSES[0]] }),
+    // #10011: the fourth filter the coverage-depth collection declares. Its
+    // three siblings above were already here, so this one's absence was an
+    // omission rather than a narrowing.
+    blocker_level: z
+      .enum(BLOCKER_LEVELS)
+      .optional()
+      .describe(
+        "How badly the subnet is blocked. `none` means nothing is blocking promotion.",
+      )
+      .meta({ examples: ["hard-blocked"] }),
     netuid: netuidSchema().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/shared.ts
+++ b/schemas-src/mcp-tools/shared.ts
@@ -71,6 +71,22 @@ export const HEALTH_CLASSIFICATION_VALUES = [
 ] as const;
 
 /** Shared across MCP tools that have no single route owner (#9799). */
+/**
+ * Mirrors API_QUERY_COLLECTIONS["coverage-depth"].sort_fields (#10011).
+ *
+ * A copy because schemas-src imports from neither src/ nor workers/;
+ * validate:schema-vocabularies asserts it still matches (#10005).
+ */
+export const COVERAGE_DEPTH_SORT_VALUES = [
+  "agent_status",
+  "blocker_level",
+  "name",
+  "netuid",
+  "priority_score",
+  "score",
+  "tier",
+] as const;
+
 export const ENDPOINT_SORT_VALUES = [
   "kind",
   "last_checked",

--- a/schemas-src/routes/coverage.ts
+++ b/schemas-src/routes/coverage.ts
@@ -112,6 +112,21 @@ export const COVERAGE_DEPTH_SEVERITIES = [
   "missing-data",
   "needs-review",
 ] as const;
+/**
+ * How badly a subnet is blocked, single-sourced (#10011).
+ *
+ * Declared inline until now while the two sibling fields on the same row --
+ * `tier` and `agent_status` -- were already exported, so the MCP side could
+ * name those two and not this one. API_QUERY_COLLECTIONS["coverage-depth"]
+ * declares the same four as a filter.
+ */
+export const BLOCKER_LEVELS = [
+  "none",
+  "hard-blocked",
+  "needs-review",
+  "missing-data",
+] as const;
+
 export const AGENT_READINESS_STATUSES = [
   "callable",
   "base-layer",
@@ -165,12 +180,7 @@ export const CoverageDepthRowSchema = z
     tier: z.enum(COVERAGE_DEPTH_TIERS),
     priority_score: z.int().min(0).max(100),
     agent_status: z.enum(AGENT_READINESS_STATUSES),
-    blocker_level: z.enum([
-      "none",
-      "hard-blocked",
-      "needs-review",
-      "missing-data",
-    ]),
+    blocker_level: z.enum(BLOCKER_LEVELS),
     readiness_score: z.int().min(0).max(100),
     completeness_score: z.number().nullable().optional(),
     dimensions: CoverageDepthDimensionsSchema,

--- a/scripts/validate-schema-vocabularies.ts
+++ b/scripts/validate-schema-vocabularies.ts
@@ -148,6 +148,7 @@ if (stale.length > 0) {
 // asserting.
 const MIRRORED_VOCABULARIES: Record<string, string> = {
   CANDIDATE_SORT_VALUES: "candidates",
+  COVERAGE_DEPTH_SORT_VALUES: "coverage-depth",
   ENDPOINT_POOL_SORT_VALUES: "endpoint-pools",
   ENDPOINT_SORT_VALUES: "endpoints",
   EVIDENCE_ENTRY_SORT_VALUES: "claims",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -4381,6 +4381,15 @@ function applySubnetListQuery(
   args: Row,
   collection: string,
   dataKey: string,
+  /**
+   * Argument names that are the SUBJECT of this view rather than filters over
+   * it (#10011). A per-subnet tool has already resolved `netuid` by reading
+   * that subnet's artifact, so passing it on as a filter would be redundant at
+   * best. A network-wide tool over the same collection has not, and there
+   * `netuid` is a real filter -- which is why this is a parameter and not the
+   * hard-coded skip it started as.
+   */
+  subjectKeys: readonly string[] = ["netuid"],
 ): Row {
   // Schema-stability guard, same as list_endpoints': an artifact with no rows
   // array must still report an empty list rather than fall through
@@ -4390,7 +4399,8 @@ function applySubnetListQuery(
   const body = Array.isArray(rows) ? data : { ...data, [dataKey]: [] };
   const queryUrl = new URL(`https://mcp.internal/${collection}`);
   for (const [key, value] of Object.entries(args ?? {})) {
-    if (key === "netuid" || key === "context") continue;
+    // `context` is MCP intent telemetry, never a query parameter.
+    if (key === "context" || subjectKeys.includes(key)) continue;
     if (value === undefined || value === null || value === "") continue;
     queryUrl.searchParams.set(key, String(value));
   }
@@ -4401,7 +4411,7 @@ function applySubnetListQuery(
     Object.keys(
       (API_QUERY_COLLECTIONS as Record<string, { filters?: Row }>)[collection]
         ?.filters ?? {},
-    ).filter((name) => name !== "netuid"),
+    ).filter((name) => !subjectKeys.includes(name)),
   );
   if (transformed.error) {
     throw toolError("invalid_params", transformed.error.message);
@@ -12788,8 +12798,19 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         target: "draft-2020-12",
       }),
     ),
-    async handler(_args: unknown, ctx: McpCtx) {
-      return loadArtifactData(ctx, "/metagraph/coverage-depth.json");
+    async handler(args: unknown, ctx: McpCtx) {
+      // #10011: this returned the whole ~293 KB scorecard on every call, with
+      // no way to ask for less. Same engine the route uses, so the two cannot
+      // filter differently. "rows" is the collection's own data_key.
+      return applySubnetListQuery(
+        await loadArtifactData(ctx, "/metagraph/coverage-depth.json"),
+        args as Row,
+        "coverage-depth",
+        "rows",
+        // Network-wide: nothing is the subject here, so `netuid` is a filter
+        // like any other.
+        [],
+      );
     },
   },
   {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -25258,23 +25258,35 @@ describe("MCP health-tier analytics tools — Postgres tier wiring", () => {
 });
 
 describe("get_coverage_depth MCP tool (#6983)", () => {
-  test("is registered as a no-arg read-only tool", () => {
+  test("takes exactly the arguments its route publishes", () => {
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage_depth");
     assert.ok(tool, "get_coverage_depth should be registered");
     assert.equal(typeof tool.description, "string");
     assert.equal(tool.inputSchema.type, "object");
     assert.equal(tool.inputSchema.additionalProperties, false);
-    // #9642 added a universal `context` argument to every tool for agent-intent
-    // capture, so "no-arg" now means "no arguments OF ITS OWN" rather than an
-    // empty properties object. Asserted by subtraction so this keeps testing
-    // what it was written to test -- that this tool takes no input -- instead
-    // of being loosened to a shape check that would also pass if a real
-    // argument were added tomorrow.
+    // This asserted an EMPTY argument set until #10011, "by subtraction so
+    // this keeps testing what it was written to test... instead of being
+    // loosened to a shape check that would also pass if a real argument were
+    // added tomorrow". Tomorrow arrived: the tool returned ~293 KB with no way
+    // to ask for less, so it now takes its route's filters.
+    //
+    // Kept as an EXACT set for the same reason the original was written that
+    // way -- an argument appearing here by accident still fails.
     assert.deepEqual(
-      Object.keys(tool.inputSchema.properties ?? {}).filter(
-        (key) => key !== "context",
-      ),
-      [],
+      Object.keys(tool.inputSchema.properties ?? {})
+        .filter((key) => key !== "context")
+        .sort(),
+      [
+        "agent_status",
+        "blocker_level",
+        "cursor",
+        "fields",
+        "limit",
+        "netuid",
+        "order",
+        "sort",
+        "tier",
+      ],
     );
   });
 
@@ -25290,6 +25302,71 @@ describe("get_coverage_depth MCP tool (#6983)", () => {
     const out = res.body.result.structuredContent;
     assert.equal(out.rows[0].netuid, 1);
     assert.equal(out.ranked_queue[0].severity, "high");
+  });
+
+  test("filters the rows it used to return wholesale (#10011)", async () => {
+    // 293 KB with no arguments was the defect. Assertions check the ROWS: a
+    // filter accepted and dropped would pass a schema-only test while still
+    // returning everything, which is how #10009's third hand-listed array hid.
+    const deps = makeDeps({
+      "/metagraph/coverage-depth.json": {
+        schema_version: 1,
+        rows: [
+          {
+            netuid: 1,
+            tier: "agent-ready",
+            agent_status: "callable",
+            blocker_level: "none",
+          },
+          {
+            netuid: 2,
+            tier: "needs-evidence",
+            agent_status: "needs-evidence",
+            blocker_level: "missing-data",
+          },
+          {
+            netuid: 3,
+            tier: "agent-ready",
+            agent_status: "callable",
+            blocker_level: "none",
+          },
+        ],
+      },
+    });
+    const rows = async (args: Row) =>
+      (
+        (await callTool("get_coverage_depth", args, { deps })).body.result
+          .structuredContent.rows as Row[]
+      ).map((r: Row) => r.netuid);
+
+    assert.deepEqual(await rows({ tier: "agent-ready" }), [1, 3]);
+    assert.deepEqual(await rows({ blocker_level: "missing-data" }), [2]);
+    assert.deepEqual(await rows({ netuid: 3 }), [3]);
+    assert.deepEqual(await rows({ limit: 1 }), [1]);
+    // Two filters intersect rather than either winning.
+    assert.deepEqual(
+      await rows({ tier: "agent-ready", agent_status: "callable" }),
+      [1, 3],
+    );
+    // The compatibility floor: no arguments still returns every row.
+    assert.deepEqual(await rows({}), [1, 2, 3]);
+  });
+
+  test("refuses a tier the scorecard does not define", async () => {
+    const res = await callTool(
+      "get_coverage_depth",
+      { tier: "not-a-tier" },
+      {
+        deps: makeDeps({
+          "/metagraph/coverage-depth.json": { schema_version: 1, rows: [] },
+        }),
+      },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.equal(
+      res.body.result.structuredContent.error.code,
+      "invalid_params",
+    );
   });
 
   test("maps a missing artifact to a clean not_found", async () => {


### PR DESCRIPTION
## Summary

`get_coverage_depth`'s handler was one line:

```ts
async handler(_args: unknown, ctx: McpCtx) {
  return loadArtifactData(ctx, "/metagraph/coverage-depth.json");
}
```

**No arguments at all** — not even `netuid` — returning **~293 KB**, every subnet's scorecard, on every call. Its route publishes `netuid`, `tier`, `agent_status`, `blocker_level`, `fields`, `limit`, `cursor`, `sort` and `order`. Same shape `get_health_trends` had before #9989: not bad defaults, *no lever at all*.

`list_enrichment_targets` shares the `coverage-depth` collection and was missing only `blocker_level` — whose three siblings were already declared, so its absence was an omission rather than a narrowing.

## One vocabulary extracted

`BLOCKER_LEVELS` was declared **inline** in `schemas-src/routes/coverage.ts` while `tier` and `agent_status` — the two fields beside it *on the same row* — were already exported. So the MCP side could name two of the three. Now all three have one owner.

## The mirror gate's first real use

`COVERAGE_DEPTH_SORT_VALUES` is mirrored into `schemas-src` (which imports from neither `src/` nor `workers/`) and registered in `MIRRORED_VOCABULARIES`, so `validate:schema-vocabularies` holds it to the collection that owns it:

```
7 cross-boundary mirrors match the collection that owns them.
```

That gate landed in #10005 an hour ago and picked the new entry up with no changes to itself — which is the behaviour it was built for.

## A bug the tests caught

`applySubnetListQuery` (added in #9998) **hard-coded skipping `netuid`**. That is correct for a per-subnet view — the tool has already resolved the subnet by reading its artifact — and **wrong here**, where `netuid` is an ordinary filter over a network-wide collection.

The row-level assertion caught it immediately: `{ netuid: 3 }` returned all three rows. It is now a `subjectKeys` parameter, so which arguments are *the subject* versus *filters over it* is stated per call site rather than assumed.

That is the second time in this series that a filter looked accepted and did nothing, and the second time only a row-level assertion caught it. Every test here checks which rows come back.

## The registration test

It asserted an **empty** argument set, deliberately, with this comment:

> Asserted by subtraction so this keeps testing what it was written to test — that this tool takes no input — instead of being loosened to a shape check that would also pass if a real argument were added tomorrow.

Tomorrow arrived. It now asserts the **exact** set, for exactly the same reason the original was written that way: an argument appearing here by accident still fails.

## Validation

```
npm run lint && npm run format:check && npm run typecheck && npm run build
npm run validate:mcp && npm run validate:mcp-route-map
npm run validate:schema-vocabularies
npm run validate:contract-drift
npm run validate:single-schema-source
npm run validate:schema-opacity
npx vitest run tests/mcp-server.test.ts tests/mcp-schema-enforcement.test.ts
```

All green — **1,387 tests**. Compatibility floor pinned: a call with no arguments still returns every row.

Closes #10011