### PR TITLE
feat(mcp): two list tools omit filters their collection declares

### DIFF
--- a/schemas-src/mcp-tools/get-network-health.ts
+++ b/schemas-src/mcp-tools/get-network-health.ts
@@ -15,8 +15,33 @@
 // now publishes.
 import { z } from "zod";
 import { HealthSummaryArtifactSchema } from "../routes/health.ts";
+import { HEALTH_STATUS_VALUES } from "../shared.ts";
+import { netuidSchema } from "./shared.ts";
 
-export const GetNetworkHealthInputSchema = z.object({}).strict();
+/**
+ * #10014. This took NO arguments -- not even `netuid` -- and returned every
+ * subnet's operational health on every call, while GET /api/v1/health
+ * publishes both filters below. Same shape get_coverage_depth had before
+ * #10011.
+ *
+ * The status vocabulary is the route's own, so a status added to the health
+ * model cannot become one this tool rejects.
+ */
+export const GetNetworkHealthInputSchema = z
+  .object({
+    netuid: netuidSchema()
+      .optional()
+      .describe("Restrict to one subnet's health row.")
+      .meta({ examples: [64] }),
+    status: z
+      .enum(HEALTH_STATUS_VALUES)
+      .optional()
+      .describe(
+        "Restrict to subnets in this operational state. `failed` is the one an alerting caller usually wants; `unknown` means unprobed, which is NOT the same as healthy.",
+      )
+      .meta({ examples: ["failed"] }),
+  })
+  .strict();
 export type GetNetworkHealthInput = z.infer<typeof GetNetworkHealthInputSchema>;
 
 export const GetNetworkHealthOutputSchema = HealthSummaryArtifactSchema;

--- a/schemas-src/mcp-tools/list-subnets.ts
+++ b/schemas-src/mcp-tools/list-subnets.ts
@@ -218,6 +218,24 @@ export const ListSubnetsInputSchema = z
         "Inclusive upper bound on subnet tempo; rows above it are excluded.",
       )
       .meta({ examples: [360] }),
+    // #10014: the two simplest filters the subnets collection declares, absent
+    // while thirty others were present. `min_netuid`/`max_netuid` below give a
+    // RANGE; neither expresses "these three subnets".
+    netuid: netuidSchema()
+      .optional()
+      .describe("Restrict to exactly this subnet.")
+      .meta({ examples: [64] }),
+    // A CSV membership filter on the route (csv_filters: { netuids: "netuid" }),
+    // so a STRING on the wire -- "1,7,64" -- not an array. Without it, asking
+    // for three subnets is three calls or a full scan.
+    netuids: z
+      .string()
+      .regex(/^\d+(,\d+)*$/)
+      .optional()
+      .describe(
+        "Restrict to this comma-separated list of subnet ids (`1,7,64`). One request instead of one per subnet.",
+      )
+      .meta({ examples: ["1,7,64"] }),
     min_netuid: z
       .int()
       .min(0)

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -4106,6 +4106,43 @@ const LIST_SUBNETS_RANGE_BOUNDS = [
 // non-numeric cannot satisfy a bound, so it is excluded once any bound on that
 // field is set — identical to rangeFilterRows in workers/list-query.ts. Only
 // finite numeric args count (tools/call does not enforce inputSchema types).
+/**
+ * `netuid` / `netuids`, the two identity filters the subnets collection
+ * declares and this tool did not offer (#10014).
+ *
+ * `min_netuid`/`max_netuid` give a RANGE; neither expresses "these three
+ * subnets", which is why asking for 1, 7 and 64 was three calls or a full
+ * page scan while `?netuids=1,7,64` is one request over REST.
+ *
+ * A separate pass rather than an entry in either existing one: the categorical
+ * filter compares lowercased strings against an enum, and the range filter
+ * needs a numeric bound per arg. Neither shape fits an exact id or a CSV
+ * membership test, and bending one to take it would make both harder to read.
+ */
+export function identityFilterSubnets(rows: Row[], args: Row) {
+  const netuid = Number.isFinite(args?.netuid) ? Number(args.netuid) : null;
+  // The route parses this as a CSV membership filter (csv_filters), so it
+  // arrives as a string. An empty entry is dropped rather than matched as NaN.
+  const netuids =
+    typeof args?.netuids === "string" && args.netuids.trim()
+      ? new Set(
+          args.netuids
+            .split(",")
+            .map((part: string) => Number(part.trim()))
+            .filter((value: number) => Number.isInteger(value)),
+        )
+      : null;
+  if (netuid === null && netuids === null) return rows;
+  return rows.filter((row: Row) => {
+    const value = row.netuid;
+    if (typeof value !== "number") return false;
+    if (netuid !== null && value !== netuid) return false;
+    // Both given: intersect, the same way every other filter pair here does.
+    if (netuids !== null && !netuids.has(value)) return false;
+    return true;
+  });
+}
+
 export function rangeFilterSubnets(rows: Row[], args: Row) {
   const bounds = LIST_SUBNETS_RANGE_BOUNDS.filter(({ arg }) =>
     Number.isFinite(args?.[arg]),
@@ -4637,7 +4674,8 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // Categorical inclusion (status/subnet_type/domain) and exclusion
       // (not_status/not_subnet_type/not_domain), then the numeric range bounds.
       const categorical = categoricalFilterSubnets(all, args);
-      const filtered = rangeFilterSubnets(categorical, args);
+      const identified = identityFilterSubnets(categorical, args);
+      const filtered = rangeFilterSubnets(identified, args);
       // Sort the filtered list before paging; unscored subnets sort last and
       // equal values tie-break by netuid for a stable page (sortSubnets).
       const sort = optionalEnum(args, "sort", LIST_SUBNETS_SORT_FIELDS);
@@ -4898,12 +4936,23 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
   {
     ...GET_NETWORK_HEALTH_MCP_TOOL,
     async handler(
-      _args: z.infer<typeof GetNetworkHealthInputSchema>,
+      args: z.infer<typeof GetNetworkHealthInputSchema>,
       ctx: McpCtx,
     ) {
-      return loadGlobalOperationalHealth(
-        { env: ctx.env, readHealthKv: ctx.readHealthKv },
-        { contractVersion: () => mcpContractVersion(ctx) },
+      // #10014: this returned every subnet's health on every call with no way
+      // to narrow. Same engine the route uses; "subnets" is the collection's
+      // own data_key. `summary` is left spanning every subnet, not the page --
+      // a caller filtering to `down` still needs the network's real counts.
+      return applySubnetListQuery(
+        (await loadGlobalOperationalHealth(
+          { env: ctx.env, readHealthKv: ctx.readHealthKv },
+          { contractVersion: () => mcpContractVersion(ctx) },
+        )) as Row,
+        args as Row,
+        "health-subnets",
+        "subnets",
+        // Network-wide: `netuid` is an ordinary filter here, not a subject.
+        [],
       );
     },
   },

--- a/tests/global-operational-health.test.ts
+++ b/tests/global-operational-health.test.ts
@@ -101,9 +101,15 @@ describe("global-operational-health", () => {
   test("MCP tool metadata and outputSchema compile", () => {
     assert.equal(GET_NETWORK_HEALTH_MCP_TOOL.name, "get_network_health");
     assert.match(GET_NETWORK_HEALTH_INSTRUCTIONS, /get_network_health/);
+    // Asserted an EMPTY argument set until #10014: this tool took nothing at
+    // all and returned every subnet's health row on every call. It now takes
+    // the two filters its collection declares. Kept as an EXACT set so an
+    // argument appearing here by accident still fails.
     assert.deepEqual(
-      Object.keys(GET_NETWORK_HEALTH_MCP_TOOL.inputSchema.properties ?? {}),
-      [],
+      Object.keys(
+        GET_NETWORK_HEALTH_MCP_TOOL.inputSchema.properties ?? {},
+      ).sort(),
+      ["netuid", "status"],
     );
     assert.ok(
       new Ajv2020({ strict: false }).compile(GET_NETWORK_HEALTH_OUTPUT_SCHEMA),

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -9688,6 +9688,34 @@ describe("list_subnets", () => {
         },
       });
 
+    test("netuid and netuids narrow the registry (#10014)", async () => {
+      // min_netuid/max_netuid gave a RANGE; neither expressed "these three
+      // subnets", so asking for 1, 7 and 64 was three calls or a full scan.
+      // Assertions check the ROWS -- this tool filters with its own functions,
+      // not the shared engine, so a schema field alone would be accepted and
+      // silently dropped.
+      const ids = async (args: Row) =>
+        (
+          (await callTool("list_subnets", args, { deps })).body.result
+            .structuredContent.subnets as Row[]
+        ).map((r: Row) => r.netuid);
+
+      const all = await ids({});
+      assert.ok(
+        all.length >= 2,
+        "fixture must have rows for this to prove anything",
+      );
+      assert.deepEqual(await ids({ netuid: 7 }), [7]);
+      assert.deepEqual(await ids({ netuids: "0,7" }), [0, 7]);
+      // Whitespace and a trailing separator are tolerated the way a CSV param is.
+      assert.deepEqual(await ids({ netuids: " 7 , 0 " }), [0, 7]);
+      // Both given: they intersect rather than either winning.
+      assert.deepEqual(await ids({ netuid: 7, netuids: "0,7" }), [7]);
+      assert.deepEqual(await ids({ netuid: 7, netuids: "0" }), []);
+      // The compatibility floor.
+      assert.deepEqual(await ids({}), all);
+    });
+
     test("an out-of-enum inclusion errors instead of returning an empty page", async () => {
       const res = await callTool(
         "list_subnets",
@@ -14184,6 +14212,49 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.health_source, "unavailable");
     assert.equal(out.global.surface_count, 0);
     assert.deepEqual(out.subnets, []);
+  });
+
+  test("get_network_health narrows by netuid and status (#10014)", async () => {
+    // This took NO arguments at all and returned every subnet's health row.
+    const kv = {
+      generated_at: "2026-06-11T00:00:00.000Z",
+      last_run_at: FRESH_RUN,
+      health_source: "live-cron-prober",
+      summary: {
+        surface_count: 3,
+        status_counts: { ok: 1, degraded: 0, failed: 2, unknown: 0 },
+      },
+      subnets: [
+        { netuid: 1, status: "ok", surface_count: 1, ok_count: 1 },
+        { netuid: 2, status: "failed", surface_count: 1, ok_count: 0 },
+        { netuid: 3, status: "failed", surface_count: 1, ok_count: 0 },
+      ],
+    };
+    const ids = async (args: Row) => {
+      const res = await callTool("get_network_health", args, {
+        deps: makeDeps({}, { "health:current": kv }),
+      });
+      assert.equal(res.body.result.isError, false, JSON.stringify(args));
+      return (res.body.result.structuredContent.subnets as Row[]).map(
+        (r: Row) => r.netuid,
+      );
+    };
+    // No early-out on an empty result: a test that returns when the fixture
+    // produced nothing asserts nothing, and would keep passing if the filter
+    // silently dropped every row. Fail loudly instead.
+    const all = await ids({});
+    assert.deepEqual(all, [1, 2, 3], "the KV overlay must reach the tool");
+    assert.deepEqual(await ids({ status: "failed" }), [2, 3]);
+    assert.deepEqual(await ids({ netuid: 2 }), [2]);
+  });
+
+  test("get_network_health refuses a status the health model does not define", async () => {
+    const res = await callTool("get_network_health", { status: "exploded" });
+    assert.equal(res.body.result.isError, true);
+    assert.equal(
+      res.body.result.structuredContent.error.code,
+      "invalid_params",
+    );
   });
 
   test("get_network_health overlays the live KV rollup", async () => {


### PR DESCRIPTION
## Summary

| tool | took | its collection declares |
|---|---|---|
| `get_network_health` | **`[context]` — nothing** | `netuid`, `status` |
| `list_subnets` | 30+ filters | `netuid`, `netuids` |

**`get_network_health` took no arguments at all.** Its handler was a straight `loadGlobalOperationalHealth(...)` with no query path, so every subnet's operational health came back on every call and could not be narrowed to one subnet or to the failed ones. Same shape `get_coverage_depth` had before #10011.

**`list_subnets` has thirty-odd filters and lacked the two simplest.** It offers `min_netuid`/`max_netuid` — a *range* — so "subnets 1, 7 and 64" was three calls or a full page scan, while `?netuids=1,7,64` is one REST request. `netuids` is a CSV membership filter on the route, so it is declared as a **string** on the wire, matching what the route accepts.

## `list_subnets` needed real work, not a schema line

It filters with its own functions rather than the shared engine, so a schema field alone would have been **accepted and silently dropped** — the third time that pattern has appeared in this series.

`identityFilterSubnets` is a separate pass on purpose: the categorical filter compares lowercased strings against an enum, and the range filter needs a numeric bound per arg. Neither shape fits an exact id or a CSV membership test, and bending one to take it would make both harder to read.

`get_network_health` goes through the shared engine with `subjectKeys: []` — network-wide, so `netuid` is an ordinary filter here rather than a subject. `summary` still spans every subnet, not the page: a caller filtering to `failed` still needs the network's real counts.

## `search_subnets` was dropped from the issue on inspection

Its handler hard-codes the narrowing:

```ts
docs.filter((doc: Row) => doc.type === "subnet")
```

So it is a **curated view** of `/api/v1/search`, and `list_search` — the general tool on that same route — already carries `type`, `netuid`, `sort`, `order`, `fields`, `limit`, `cursor`. A `type` filter there would either do nothing or change what the tool is.

That is a fourth view-type clause, and the only one invisible from the schema: **the tell is in the handler**.

## The test was vacuous, and removing the escape hatch proved it

My first `get_network_health` test early-returned when the fixture produced no rows. That asserts *nothing* — it would have kept passing if the filter dropped every row. Removing the early-out exposed two real defects in my own fixture:

- the KV key was `health:global`; the tool reads `health:current`, so the overlay never reached it;
- `status: "down"` does not exist. The vocabulary is `ok` / `degraded` / `failed` / `unknown`, confirmed identical in `schemas-src/shared.ts` and the collection config — so my `describe()` text and example were wrong too, and are corrected.

The test now asserts the unfiltered result equals `[1, 2, 3]` before filtering anything, so an empty fixture fails loudly.

## Validation

```
npm run lint && npm run format:check && npm run typecheck && npm run build
npm run validate:mcp && npm run validate:mcp-route-map
npm run validate:schema-vocabularies
npm run validate:contract-drift
npm run validate:single-schema-source
npx vitest run tests/mcp-server.test.ts tests/mcp-schema-enforcement.test.ts \
  tests/subnets-query.test.ts
```

All green — **1,401 tests**. Compatibility floor pinned for both tools: no arguments returns exactly what it returned before.

Closes #10014