### PR TITLE
fix(mcp): three tools rejected the parameter names their own route publishes

### DIFF
--- a/schemas-src/mcp-tools/ai-discovery.ts
+++ b/schemas-src/mcp-tools/ai-discovery.ts
@@ -67,10 +67,23 @@ export type FindSubnetOpportunitiesOutput = z.infer<
 
 export const SemanticSearchInputSchema = z
   .object({
+    // The name the ROUTE publishes (#10018). GET /api/v1/search/semantic
+    // documents `q`, so an agent reading our own OpenAPI sends that and was
+    // rejected for an unknown argument. Canonical; `query` stays so existing
+    // callers are unaffected. Exactly one is required -- expressed with
+    // requireAnyOf on the tool, since z.toJSONSchema drops a Zod refinement.
+    q: z
+      .string()
+      .optional()
+      .describe(
+        "The search text, embedded and ranked by meaning. The name GET /api/v1/search/semantic publishes; `query` is the alias this tool shipped with.",
+      )
+      .meta({ examples: ["inference"] }),
     query: z
       .string()
+      .optional()
       .describe(
-        "The request payload or search text this surface expects. Shape depends on the surface; see its schema.",
+        "Alias for `q`, the name this tool shipped with. Search text, embedded and ranked by meaning.",
       )
       .meta({ examples: ["inference"] }),
     limit: limitSchema(20).optional(),

--- a/schemas-src/mcp-tools/list-subnets.ts
+++ b/schemas-src/mcp-tools/list-subnets.ts
@@ -90,13 +90,35 @@ export const ListSubnetsInputSchema = z
         "EXCLUDE rows with this curation level. Applied after any positive `curation_level` filter, so the two can be combined.",
       )
       .meta({ examples: [CurationLevelSchema.options[0]] }),
+    // The route's published names (#10018) -- GET /api/v1/subnets documents
+    // these, so an agent reading our OpenAPI sends them. Canonical.
+    min_integration_readiness: z
+      .int()
+      .min(0)
+      .max(100)
+      .optional()
+      .describe(
+        "Inclusive lower bound on integration-readiness score; rows below it are excluded. The name GET /api/v1/subnets publishes.",
+      )
+      .meta({ examples: [50] }),
+    max_integration_readiness: z
+      .int()
+      .min(0)
+      .max(100)
+      .optional()
+      .describe(
+        "Inclusive upper bound on integration-readiness score; rows above it are excluded. The name GET /api/v1/subnets publishes.",
+      )
+      .meta({ examples: [90] }),
+    // The shorter names this tool shipped with, kept so existing callers are
+    // unaffected. Same field, same semantics.
     min_readiness: z
       .int()
       .min(0)
       .max(100)
       .optional()
       .describe(
-        "Inclusive lower bound on readiness score; rows below it are excluded.",
+        "Alias for `min_integration_readiness`, the name this tool shipped with.",
       )
       .meta({ examples: [50] }),
     max_readiness: z

--- a/schemas-src/mcp-tools/search-subnets.ts
+++ b/schemas-src/mcp-tools/search-subnets.ts
@@ -14,10 +14,23 @@ import { limitSchema, netuidSchema, numericCursorSchema } from "./shared.ts";
 
 export const SearchSubnetsInputSchema = z
   .object({
+    // The name the ROUTE publishes (#10018). GET /api/v1/search documents
+    // `q`, so an agent reading our own OpenAPI sends that and was rejected for
+    // an unknown argument until now. Canonical; `query` stays so existing
+    // callers are unaffected. Exactly one is required -- see requireAnyOf on
+    // the tool, since Zod cannot express it in a way z.toJSONSchema keeps.
+    q: z
+      .string()
+      .optional()
+      .describe(
+        "The search text. The name GET /api/v1/search publishes; `query` is the alias this tool shipped with.",
+      )
+      .meta({ examples: ["inference"] }),
     query: z
       .string()
+      .optional()
       .describe(
-        "The request payload or search text this surface expects. Shape depends on the surface; see its schema.",
+        "Alias for `q`, the name this tool shipped with. The subnet search text.",
       )
       .meta({ examples: ["inference"] }),
     cursor: numericCursorSchema().optional(),

--- a/scripts/validate-mcp-input-parity.ts
+++ b/scripts/validate-mcp-input-parity.ts
@@ -67,7 +67,7 @@ const CURATED_VIEW =
  * too, rather than adding a capability.
  */
 const RENAMED_ON_THE_MCP_SIDE =
-  "RENAMED -- the tool and the route call the same parameter different things (#10018)";
+  "a compatibility ALIAS the route does not publish; the tool also accepts the route's canonical name (#10018)";
 
 /** A header on the route, an argument on the tool. */
 const REQUEST_HEADER =
@@ -153,17 +153,15 @@ for (const [key, reason] of Object.entries({
   "list_subnets.not_curation_level": MCP_NATIVE,
   "list_subnets.min_netuid": MCP_NATIVE,
   "list_subnets.max_netuid": MCP_NATIVE,
-  // --- renames (#10018) ----------------------------------------------------
-  // search_subnets/semantic_search call the route's `q` "query"; list_subnets
-  // calls `min_integration_readiness` "min_readiness".
+  // --- aliases kept for compatibility (#10018 fixed the renames) -----------
+  // These three tools now accept the ROUTE's published name, so the
+  // divergence is gone. What remains is the shorter name each shipped with,
+  // kept so existing callers are unaffected -- an alias the route does not
+  // publish, which is a different (and benign) thing from a rename.
   "search_subnets.query": RENAMED_ON_THE_MCP_SIDE,
-  "search_subnets.q": RENAMED_ON_THE_MCP_SIDE,
   "semantic_search.query": RENAMED_ON_THE_MCP_SIDE,
-  "semantic_search.q": RENAMED_ON_THE_MCP_SIDE,
   "list_subnets.min_readiness": RENAMED_ON_THE_MCP_SIDE,
   "list_subnets.max_readiness": RENAMED_ON_THE_MCP_SIDE,
-  "list_subnets.min_integration_readiness": RENAMED_ON_THE_MCP_SIDE,
-  "list_subnets.max_integration_readiness": RENAMED_ON_THE_MCP_SIDE,
   // --- headers -------------------------------------------------------------
   "get_alert_trigger.owner_token": REQUEST_HEADER,
   // --- standing debt -------------------------------------------------------

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -4082,6 +4082,21 @@ export function sortSubnets(rows: Row[], field: string, order: unknown) {
 // `readiness` alias is kept for `integration_readiness` so existing `min_readiness`
 // callers are unaffected.
 const LIST_SUBNETS_RANGE_BOUNDS = [
+  // The ROUTE's published names (#10018). GET /api/v1/subnets documents
+  // `min_integration_readiness`, so an agent reading our own OpenAPI sends
+  // that -- and was rejected for an unknown argument until now, while the same
+  // value worked over REST. Both names map to the same field; the route's is
+  // canonical and the shorter one stays so existing callers are unaffected.
+  {
+    arg: "min_integration_readiness",
+    field: "integration_readiness",
+    op: "min",
+  },
+  {
+    arg: "max_integration_readiness",
+    field: "integration_readiness",
+    op: "max",
+  },
   { arg: "min_readiness", field: "integration_readiness", op: "min" },
   { arg: "max_readiness", field: "integration_readiness", op: "max" },
   { arg: "min_surface_count", field: "surface_count", op: "min" },
@@ -4500,6 +4515,25 @@ function withoutSchemaMeta(schema: Row): Row {
  * actually validate against, while leaving Zod parsing (and the inferred TS
  * input type) untouched.
  */
+/**
+ * Read a value the caller may name either way (#10018).
+ *
+ * Two tools renamed the route's `q` to `query`, so an agent reading our own
+ * OpenAPI sent the published name and was rejected. Both are accepted now;
+ * `canonical` is the route's name and wins when both are present, so the
+ * outcome is defined rather than dependent on which key is read first.
+ */
+function requireEitherString(args: Row, canonical: string, alias: string) {
+  const value = args?.[canonical] ?? args?.[alias];
+  if (typeof value !== "string" || !value.trim()) {
+    throw toolError(
+      "invalid_params",
+      `Argument \`${canonical}\` (or its alias \`${alias}\`) is required and must be a non-empty string.`,
+    );
+  }
+  return value;
+}
+
 function requireAnyOf(
   schema: Record<string, unknown>,
   keys: string[],
@@ -4622,11 +4656,15 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       "Paginated like list_subnets: pass `cursor` to page past the first " +
       "results; the response carries `total` and a `next_cursor` (null at the " +
       "end) so the whole ranked match set is reachable.",
-    inputSchema: z.toJSONSchema(SearchSubnetsInputSchema, {
-      target: "draft-2020-12",
-    }),
+    inputSchema: requireAnyOf(
+      z.toJSONSchema(SearchSubnetsInputSchema, { target: "draft-2020-12" }),
+      ["q", "query"],
+    ),
     async handler(args: z.infer<typeof SearchSubnetsInputSchema>, ctx: McpCtx) {
-      const query = requireString(args, "query");
+      // Either name (#10018). The route publishes `q`; `query` is the alias
+      // this tool shipped with. Canonical wins when both are given, so the
+      // resolution is stated rather than left to argument order.
+      const query = requireEitherString(args, "q", "query");
       const index = await loadArtifactData(ctx, "/metagraph/search.json");
       const terms = queryTerms(query);
       const docs = Array.isArray(index.documents) ? index.documents : [];
@@ -13048,15 +13086,21 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       "hit, optionally scoped to subnets, surfaces, and/or providers via `type`. " +
       "Requires the AI layer; fall back to search_subnets when it is not " +
       "available.",
-    inputSchema: z.toJSONSchema(SemanticSearchInputSchema, {
-      target: "draft-2020-12",
-    }),
+    inputSchema: requireAnyOf(
+      z.toJSONSchema(SemanticSearchInputSchema, { target: "draft-2020-12" }),
+      // Both optional in Zod so either may be used; without this the published
+      // schema would say NOTHING is required and an agent would call it empty
+      // (#10018, same reasoning as how_do_i_call).
+      ["q", "query"],
+    ),
     async handler(
       args: z.infer<typeof SemanticSearchInputSchema>,
       ctx: McpCtx,
     ) {
       requireAi(ctx);
-      const query = requireString(args, "query");
+      // Either name (#10018) -- the route publishes `q`. NOT applied to
+      // query_graphql, whose `query` is a GraphQL document, not search text.
+      const query = requireEitherString(args, "q", "query");
       await requireAiRateLimit(ctx, "semantic");
       return runAi(() =>
         semanticSearch(ctx.env, query, {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -8514,6 +8514,41 @@ describe("MCP keyword discovery relevance", () => {
     },
   });
 
+  test("search_subnets accepts the route's `q` as well as `query` (#10018)", async () => {
+    // GET /api/v1/search publishes `q`. This tool took only `query`, so an
+    // agent reading our own OpenAPI was rejected for an unknown argument.
+    const byAlias = await callTool("search_subnets", { query: "ai" }, { deps });
+    const byCanonical = await callTool("search_subnets", { q: "ai" }, { deps });
+    assert.equal(byCanonical.body.result.isError, false);
+    // Same ROWS, not merely both accepted.
+    assert.deepEqual(
+      byCanonical.body.result.structuredContent.results,
+      byAlias.body.result.structuredContent.results,
+    );
+  });
+
+  test("search_subnets still requires one of them", async () => {
+    // Both are optional in Zod so either may be used, which means the
+    // requirement lives in the handler and in an `anyOf` on the published
+    // schema. Neither given must still be an error, not an empty search.
+    const res = await callTool("search_subnets", {}, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.equal(
+      res.body.result.structuredContent.error.code,
+      "invalid_params",
+    );
+  });
+
+  test("search_subnets publishes the either-or requirement", () => {
+    // Without the anyOf the schema would say NOTHING is required and an agent
+    // would call it empty -- the failure requireAnyOf exists for.
+    const tool = listToolDefinitions().find((t) => t.name === "search_subnets");
+    assert.deepEqual(tool?.inputSchema.anyOf, [
+      { required: ["q"] },
+      { required: ["query"] },
+    ]);
+  });
+
   test('search_subnets: "ai" matches the real AI subnet, not "brain"/"domain"', async () => {
     const res = await callTool("search_subnets", { query: "ai" }, { deps });
     const out = res.body.result.structuredContent;
@@ -9687,6 +9722,37 @@ describe("list_subnets", () => {
           ],
         },
       });
+
+    test("the route's parameter names work, alongside the tool's own (#10018)", async () => {
+      // GET /api/v1/subnets publishes `min_integration_readiness`. An agent
+      // reading our own OpenAPI sent that and was REJECTED for an unknown
+      // argument, while the same value worked over REST -- both surfaces
+      // correct in isolation, disagreeing only at the boundary.
+      //
+      // Asserts the same ROWS, not merely that the argument is accepted: an
+      // alias wired into the schema and not the filter table would pass a
+      // shape check while filtering nothing.
+      const ids = async (args: Row) =>
+        (
+          (await callTool("list_subnets", args, { deps })).body.result
+            .structuredContent.subnets as Row[]
+        ).map((r: Row) => r.netuid);
+
+      const canonical = await ids({ min_integration_readiness: 20 });
+      const alias = await ids({ min_readiness: 20 });
+      assert.deepEqual(canonical, alias);
+      assert.notDeepEqual(
+        canonical,
+        await ids({}),
+        "the bound must actually exclude rows, or this proves nothing",
+      );
+      // Both given: they intersect, so the tighter bound wins rather than one
+      // silently overwriting the other.
+      assert.deepEqual(
+        await ids({ min_integration_readiness: 20, max_readiness: 20 }),
+        await ids({ min_readiness: 20, max_integration_readiness: 20 }),
+      );
+    });
 
     test("netuid and netuids narrow the registry (#10014)", async () => {
       // min_netuid/max_netuid gave a RANGE; neither expressed "these three


### PR DESCRIPTION
> Stacked on #10021 (the gate that found this). Rebase to `main` once that merges.

## Summary

The input-parity gate caught three on its first run:

```
/api/v1/subnets            publishes  min_integration_readiness
list_subnets                    took  min_readiness

/api/v1/search             publishes  q
search_subnets                  took  query

/api/v1/search/semantic    publishes  q
semantic_search                 took  query
```

An agent that reads our own OpenAPI and sends the published name was **rejected for an unknown argument**, while the same value worked over REST.

This is the worst class of drift precisely because both surfaces are correct in isolation — they disagree only at the boundary, so no test on either side could ever have seen it.

## Each tool now accepts the route's name, and keeps its own

Renaming outright would break every existing MCP caller, and there is no reason to make anyone choose. Canonical wins when both are given, so the outcome is **defined** rather than dependent on which key is read first.

**`list_subnets` needed no new machinery.** `LIST_SUBNETS_RANGE_BOUNDS` is already a `{arg, field, op}` table, and `min_readiness` was *itself* an alias kept when the original one-off bound became symmetric min/max. Two more entries mapping to the same field is what that structure is for.

**The two search tools needed care.** `query` was **required**, so it could not simply become optional — a caller passing only `q` would have been rejected, and one passing neither would have got an empty search instead of an error. Both are optional in Zod now, with the requirement expressed twice:

- a handler check (`requireEitherString`), and
- `anyOf: [{required:["q"]},{required:["query"]}]` on the **published** schema, so it is visible to a client.

That is the same `requireAnyOf` treatment `how_do_i_call` and `verify_integration` already carry, for the same stated reason: `z.toJSONSchema` drops a Zod refinement silently, leaving the constraint invisible.

## One thing that would have been a real bug

`requireString(args, "query")` appears **twice** in `src/mcp-server.ts`. The second is `query_graphql`, whose `query` is a **GraphQL document**, not search text. A blind replace of both call sites would have broken it. Only the `semantic_search` site is changed, and the comment says why.

## The gate proved its own fix

The four rename declarations went **stale** the instant the parameters started matching, and `validate:mcp-input-parity` failed until they were deleted:

```
- 4 DECLARED entr(y/ies) no longer describe a divergence — delete them:
    list_subnets.max_integration_readiness
    list_subnets.min_integration_readiness
    search_subnets.q
    semantic_search.q
```

What remains declared is the compatibility **alias** each tool keeps — a different and benign thing from a rename, and the category comment now says so. **97 declared divergences → 93.**

## Tests

Every assertion compares **rows**, not acceptance — an alias wired into the schema but not the filter table would pass a shape check while filtering nothing. The `list_subnets` test also asserts the bound actually excludes rows, so it cannot pass vacuously.

Ran all nine test files that name any symbol touched (grepped, not guessed): **1,684 tests**, all green.

```
npm run lint && npm run format:check && npm run typecheck && npm run build
npm run validate:mcp-input-parity && npm run validate:mcp && npm run validate:mcp-route-map
npm run validate:contract-drift && npm run validate:single-schema-source
npm run validate:schema-vocabularies && npm run validate:api && npm run validate:openapi
```

Closes #10018