### PR TITLE
feat(neon): prune chain_detail in Neon with the bound D1 just used

### DIFF
--- a/src/chain-detail-prune.ts
+++ b/src/chain-detail-prune.ts
@@ -56,6 +56,12 @@
 // must not.
 
 import { resolveBlocksSeam } from "./blocks-cold-tier.ts";
+import {
+  createPgSql,
+  type HyperdriveLike,
+  type WaitUntilLike,
+} from "./pg-sql.ts";
+import { neonBackfillLanes } from "./neon-write.ts";
 
 /** ~6h at the chain's 12s cadence: 3x the hourly decode lane's worst-case lag. */
 export const CHAIN_DETAIL_MIN_RETAINED_BLOCKS = 1_800;
@@ -147,6 +153,11 @@ export interface ChainDetailPruneResult {
   deleted_below?: number;
   /** How many blocks this run removed, capped per run. */
   blocks_pruned?: number;
+  /** Whether the SAME bound was applied to Neon, and what happened if not.
+   * Reported separately because the two stores prune INDEPENDENTLY -- see the
+   * runner. */
+  neon_pruned?: boolean;
+  neon_detail?: string;
 }
 
 /**
@@ -155,8 +166,16 @@ export interface ChainDetailPruneResult {
  * Returns a summary rather than throwing, matching the cron family: a tick that
  * cannot run is one missed report, not an outage.
  */
+export interface ChainDetailPruneDeps {
+  /** Injectable Postgres runner, so the Neon half is testable without a
+   * database -- the same escape hatch src/neon-prune.ts takes. */
+  sql?: { unsafe(text: string, values?: unknown[]): Promise<unknown> } | null;
+}
+
 export async function pruneChainDetail(
   env: unknown,
+  ctx?: WaitUntilLike,
+  deps: ChainDetailPruneDeps = {},
 ): Promise<ChainDetailPruneResult> {
   const binding = (env as { METAGRAPH_HEALTH_DB?: D1Like } | null | undefined)
     ?.METAGRAPH_HEALTH_DB;
@@ -199,18 +218,82 @@ export async function pruneChainDetail(
           .bind(deletedBelow),
       ),
     );
+    const neon = await pruneChainDetailNeon(env, ctx, deletedBelow, deps);
     return {
       ok: true,
       keep_from: window.keepFrom,
       retained_blocks: window.retainedBlocks,
       deleted_below: deletedBelow,
       blocks_pruned: deletedBelow - floor,
+      ...neon,
     };
   } catch (err) {
     return {
       ok: false,
       reason: "prune_failed",
       ...(err instanceof Error ? { detail: err.message } : {}),
+    };
+  }
+}
+
+/**
+ * The SAME bound, applied to Neon.
+ *
+ * WHY THE BOUND IS PASSED IN AND NEVER RECOMPUTED (#10017). This is the one
+ * decision the whole function exists to make. `src/neon-prune.ts` expresses
+ * retention as a time window -- a column plus a `retentionMs` -- and this tier
+ * does not have one: `chainDetailPruneWindow` derives an adaptive BLOCK
+ * watermark from the lane head and how far back the lakehouse has not reached,
+ * clamped, recomputed every run. No `retentionMs` reproduces it, because block
+ * production is not constant and the seam moves independently of the clock.
+ *
+ * Recomputing a bound per store would be worse than not pruning at all. A
+ * wider Neon window keeps blocks D1 has dropped and `neon-parity` reports a
+ * permanent surplus; a narrower one drops blocks the hot tier is still
+ * expected to serve and the read cutover silently loses coverage at the seam.
+ * Both states look like an in-flight backfill rather than a design error,
+ * which is why this takes `deletedBelow` as an argument: one resolution per
+ * run, so the two stores cannot disagree about the window even transiently.
+ *
+ * THE STORES STILL PRUNE INDEPENDENTLY. A Neon failure is reported and
+ * swallowed, never rethrown -- blocking D1's retention on Neon's availability
+ * would freeze the surviving store's window, which is the same reasoning
+ * health-prober.ts:949 already applies to its own two-store prune. D1 has
+ * already deleted by the time this runs; the worst case is Neon holding a
+ * little extra until the next tick, which the next tick fixes.
+ *
+ * Gated on `neonBackfillLanes`: a table nothing reconciles has no Neon rows to
+ * prune, and issuing the DELETE anyway would be a connection per tick for
+ * nothing.
+ */
+async function pruneChainDetailNeon(
+  env: unknown,
+  ctx: WaitUntilLike | undefined,
+  deletedBelow: number,
+  deps: ChainDetailPruneDeps,
+): Promise<{ neon_pruned?: boolean; neon_detail?: string }> {
+  const bag = env as Record<string, unknown> | null | undefined;
+  const hyperdrive = bag?.HYPERDRIVE as HyperdriveLike | undefined;
+  const injected = deps.sql;
+  if (!injected && (!hyperdrive?.connectionString || !ctx)) return {};
+  // Every one of the four, or none: they are pruned to a single watermark and
+  // a partially-listed set would leave one table holding blocks its siblings
+  // dropped -- a join across the seam would then find a block header with no
+  // events, which reads as corruption rather than as retention.
+  const lanes = neonBackfillLanes(bag);
+  if (!PRUNE_TABLES.every((table) => lanes.has(table))) return {};
+  try {
+    const sql = injected ?? createPgSql(hyperdrive!, ctx!);
+    for (const table of PRUNE_TABLES) {
+      await sql.unsafe(`DELETE FROM ${table} WHERE block_number < $1`, [
+        deletedBelow,
+      ]);
+    }
+    return { neon_pruned: true };
+  } catch (err) {
+    return {
+      neon_pruned: false,
+      neon_detail: err instanceof Error ? err.message : "neon prune failed",
     };
   }
 }

--- a/tests/chain-detail-prune.test.ts
+++ b/tests/chain-detail-prune.test.ts
@@ -202,3 +202,109 @@ describe("pruneChainDetail", () => {
     assert.equal(result.detail, undefined);
   });
 });
+
+describe("the Neon side of the prune (#10017)", () => {
+  /** A D1 double that reports a wide window, so a real prune always runs. */
+  function d1WithWindow(floor: number, head: number) {
+    const deleted: unknown[] = [];
+    return {
+      deleted,
+      binding: {
+        prepare: (sql: string) => ({
+          bind: (...v: unknown[]) => {
+            deleted.push({ sql, v });
+            return { sql, v };
+          },
+          first: async () => ({ floor, head }),
+        }),
+        batch: async (s: unknown[]) => s,
+      },
+    };
+  }
+
+  const NEON_LANES =
+    "chain_detail_blocks,chain_detail_extrinsics," +
+    "chain_detail_chain_events,chain_detail_account_events";
+
+  test("Neon is pruned with the SAME bound D1 was, never a recomputed one", async () => {
+    // The entire point of #10017. chainDetailPruneWindow derives an adaptive
+    // BLOCK watermark from the head and the lakehouse seam; there is no
+    // retentionMs that reproduces it, so a per-store recomputation would drift
+    // and the drift is invisible -- a wider Neon window is a permanent parity
+    // surplus, a narrower one is silent coverage loss at the seam.
+    const d1 = d1WithWindow(1, 10_000_000);
+    const seen: { text: string; values: unknown[] }[] = [];
+    const result = await pruneChainDetail(
+      {
+        METAGRAPH_HEALTH_DB: d1.binding,
+        HYPERDRIVE: { connectionString: "postgresql://example/db" },
+        NEON_BACKFILL_LANES: NEON_LANES,
+      },
+      { waitUntil: () => undefined },
+      {
+        sql: {
+          unsafe: async (text: string, values: unknown[] = []) => {
+            seen.push({ text, values });
+            return [];
+          },
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.neon_pruned, true);
+    // All four tables, and every one of them bound to the SAME number D1 used.
+    assert.equal(seen.length, 4);
+    for (const { text, values } of seen) {
+      assert.match(
+        text,
+        /DELETE FROM chain_detail_\w+ WHERE block_number < \$1/,
+      );
+      assert.deepEqual(values, [result.deleted_below]);
+    }
+    // And it is a real bound, not a vacuous zero that would delete nothing.
+    assert.ok((result.deleted_below ?? 0) > 1);
+  });
+
+  test("no Hyperdrive binding leaves the D1 prune untouched", async () => {
+    const d1 = d1WithWindow(1, 10_000_000);
+    const result = await pruneChainDetail(
+      { METAGRAPH_HEALTH_DB: d1.binding, NEON_BACKFILL_LANES: NEON_LANES },
+      { waitUntil: () => undefined },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.neon_pruned, undefined);
+    assert.ok((result.blocks_pruned ?? 0) > 0);
+  });
+
+  test("ONE unreconciled table skips the Neon prune entirely", async () => {
+    // All four or none. They are pruned to a single watermark, so a
+    // partially-listed set would leave one table holding blocks its siblings
+    // dropped -- a join across the seam then finds a block header with no
+    // events, which reads as corruption rather than as retention.
+    const d1 = d1WithWindow(1, 10_000_000);
+    const result = await pruneChainDetail(
+      {
+        METAGRAPH_HEALTH_DB: d1.binding,
+        HYPERDRIVE: { connectionString: "postgresql://example/db" },
+        NEON_BACKFILL_LANES:
+          "chain_detail_blocks,chain_detail_extrinsics,chain_detail_chain_events",
+      },
+      { waitUntil: () => undefined },
+    );
+    assert.equal(result.neon_pruned, undefined);
+  });
+
+  test("no ctx means no Neon prune, and D1 still runs", async () => {
+    // createPgSql returns its connection via waitUntil; without somewhere to
+    // park the teardown the connection would leak per tick.
+    const d1 = d1WithWindow(1, 10_000_000);
+    const result = await pruneChainDetail({
+      METAGRAPH_HEALTH_DB: d1.binding,
+      HYPERDRIVE: { connectionString: "postgresql://example/db" },
+      NEON_BACKFILL_LANES: NEON_LANES,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.neon_pruned, undefined);
+    assert.ok((result.blocks_pruned ?? 0) > 0);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -2440,7 +2440,7 @@ async function dispatchScheduled(
     // wrapper records the tick either way; `ok:false` on an unbound D1 or a
     // failed delete is a real "did not do the work" outcome, and the wrapper
     // honours it.
-    return pruneChainDetail(env);
+    return pruneChainDetail(env, ctx);
   }
   if (cron === CHAIN_CONCENTRATION_ROLLUP_CRON) {
     // #9628: compute the network-wide concentration card for every COMPLETE

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -605,6 +605,27 @@
   // second thing to operate for tables that comfortably share one. The
   // binding name keeps the pre-2026-07-16 METAGRAPH_HEALTH_DB, matching the
   // resurrected code that uses it.
+  // Hyperdrive to the same Neon this account's data-api Worker already uses
+  // (#10017). Bound HERE because the chain-detail prune cron runs on THIS
+  // Worker, and pruning a table in one store but not the other is how a mirror
+  // diverges permanently -- the reconciler reads the pruned tail as a deficit
+  // it can never close.
+  //
+  // BINDING IT MOVES NO READ, and that separation is #9704's whole lesson.
+  // Every read gate in this codebase asks an explicit flag as well as the
+  // binding, because provisioning Hyperdrive for a WRITE pilot once silently
+  // moved a public route's read onto a store nothing had written to. "This
+  // Worker can reach Neon" and "this route should read Neon" are different
+  // questions; nothing on this Worker asks the second one yet.
+  //
+  // nodejs_compat is already set above, which is what makes the native pg
+  // driver usable here at all.
+  "hyperdrive": [
+    {
+      "binding": "HYPERDRIVE",
+      "id": "8a09dc673733497f987434f59689287e",
+    },
+  ],
   "d1_databases": [
     {
       "binding": "METAGRAPH_HEALTH_DB",


### PR DESCRIPTION
Closes #10017. Part of #9787.

`chain_detail_*` (725,020 rows) cannot use the Neon prune lane, and the reason is a shape mismatch rather than a missing config line.

| | retention expressed as |
|---|---|
| `src/neon-prune.ts` | a **time window** — `column` + `retentionMs` |
| `src/chain-detail-prune.ts` | an adaptive **block watermark** — `WHERE block_number < keepFrom` |

`keepFrom` comes from `chainDetailPruneWindow({ head, seam })`: the lane head minus a depth that tracks how far back the lakehouse has *not* reached, clamped, recomputed every run. No `retentionMs` reproduces it — block production is not constant and the seam moves independently of the clock.

## The decision this PR is

**The bound is passed in, never recomputed per store.**

Recomputing would be worse than not pruning at all:

- Neon's window **wider** → Neon keeps blocks D1 dropped → permanent parity surplus, and the reconciler reads the pruned tail as a deficit it can never close
- Neon's window **narrower** → Neon drops blocks the hot tier must still serve → the read cutover silently loses coverage at the seam

Both states look like an in-flight backfill rather than a design error. One resolution per run means the two stores cannot disagree about the window even transiently.

## Three properties, each deliberate

**The stores prune independently.** A Neon failure is reported in the result and swallowed, never rethrown — blocking D1's retention on Neon's availability would freeze the surviving store's window, which is exactly the reasoning `health-prober.ts:949` already applies to its own two-store prune. D1 has already deleted by the time this runs, so the worst case is Neon holding a little extra until the next tick.

**All four tables or none.** They are pruned to a single watermark; a partially-listed set would leave one table holding blocks its siblings dropped, and a join across the seam would then find a block header with no events — which reads as corruption, not as retention.

**Binding Hyperdrive on the main Worker moves no read.** The cron lives there, so the binding has to. Every read gate in this codebase asks an explicit flag *as well as* the binding, because provisioning Hyperdrive for a write pilot once silently moved a public route's read onto a store nothing had written to (#9704). Nothing on this Worker asks the second question yet.

## Verification

The bound-equality assertion checks all four statements and their bound values against `deleted_below`, through an injected runner. I checked it can fail rather than only that it passes — an off-by-one in the value handed to Neon:

```
Tests  1 failed | 15 passed (16)
```

Restored:

```
Tests  16 passed (16)
```

`neon_pruned` stays absent when Hyperdrive is unbound, when `ctx` is missing, or when any of the four tables is unreconciled — and the D1 prune still runs in all three cases.