### PR TITLE
feat(neon): reconcile the four chain_detail tables

### DIFF
--- a/src/neon-backfill.ts
+++ b/src/neon-backfill.ts
@@ -512,6 +512,57 @@ const SURFACE_FAILURE_DAILY_COLUMNS = [
   "updated_at",
 ] as const;
 
+/** The four chain_detail tables, read off pragma_table_info 2026-08-07. */
+const CHAIN_DETAIL_BLOCKS_COLUMNS = [
+  "block_number",
+  "block_hash",
+  "spec_version",
+  "extrinsic_count",
+  "chain_event_count",
+  "account_event_count",
+  "observed_at",
+  "synced_at",
+] as const;
+
+const CHAIN_DETAIL_EXTRINSICS_COLUMNS = [
+  "block_number",
+  "extrinsic_index",
+  "extrinsic_hash",
+  "signer",
+  "call_module",
+  "call_function",
+  "success",
+  "fee_tao",
+  "tip_tao",
+  "call_args",
+  "observed_at",
+] as const;
+
+const CHAIN_DETAIL_CHAIN_EVENTS_COLUMNS = [
+  "block_number",
+  "event_index",
+  "pallet",
+  "method",
+  "args",
+  "phase",
+  "extrinsic_index",
+  "observed_at",
+] as const;
+
+const CHAIN_DETAIL_ACCOUNT_EVENTS_COLUMNS = [
+  "block_number",
+  "event_index",
+  "extrinsic_index",
+  "event_kind",
+  "hotkey",
+  "coldkey",
+  "netuid",
+  "uid",
+  "amount_tao",
+  "alpha_amount",
+  "observed_at",
+] as const;
+
 /** blocks_head, read off pragma_table_info 2026-08-07. */
 const BLOCKS_HEAD_COLUMNS = [
   "block_number",
@@ -848,6 +899,59 @@ export const NEON_BACKFILL_PLANS: Readonly<Record<string, BackfillPlan>> = {
     // can never fire, and that is correct rather than accidental: block_number
     // is the whole key, so a conflict means equality, and a conflicting row is
     // the same block. Same shape as surface_checks.
+    freshness: "block_number",
+  },
+  // The decoded seam (#10021). All four are append: the poller assigns
+  // block_number as it decodes, so nothing arrives below the mark, and a
+  // decoded block is written once and never rewritten.
+  //
+  // SAFE ONLY BECAUSE THE NEON PRUNE EXISTS NOW (#10017). These are a pruned
+  // ROLLING WINDOW, not an archive -- D1 deletes below an adaptive block
+  // watermark every run. Mirroring the writes without the prune is the shape
+  // that burned surface_checks (#9891): Neon grows forever, the reconciler
+  // reads the pruned tail as a deficit it can never close, and neon-parity
+  // alarms permanently. The prune now applies the SAME resolved bound to both
+  // stores, which is what makes reconciling these converge.
+  //
+  // freshness IS block_number rather than observed_at, on all four, because
+  // the keyset has to BE the primary key -- one that drifts from it resumes a
+  // page from the wrong place and skips rows silently.
+  chain_detail_blocks: {
+    table: "chain_detail_blocks",
+    columns: CHAIN_DETAIL_BLOCKS_COLUMNS,
+    conflict: ["block_number"],
+    keyset: ["block_number"],
+    partition: "append",
+    booleans: [],
+    freshness: "block_number",
+  },
+  chain_detail_extrinsics: {
+    table: "chain_detail_extrinsics",
+    columns: CHAIN_DETAIL_EXTRINSICS_COLUMNS,
+    conflict: ["block_number", "extrinsic_index"],
+    keyset: ["block_number", "extrinsic_index"],
+    partition: "append",
+    // The only boolean in the family. D1 stores 0/1 with a CHECK; Neon
+    // declares BOOLEAN, and Postgres refuses to compare the two.
+    booleans: ["success"],
+    freshness: "block_number",
+  },
+  chain_detail_chain_events: {
+    table: "chain_detail_chain_events",
+    columns: CHAIN_DETAIL_CHAIN_EVENTS_COLUMNS,
+    conflict: ["block_number", "event_index"],
+    keyset: ["block_number", "event_index"],
+    partition: "append",
+    booleans: [],
+    freshness: "block_number",
+  },
+  chain_detail_account_events: {
+    table: "chain_detail_account_events",
+    columns: CHAIN_DETAIL_ACCOUNT_EVENTS_COLUMNS,
+    conflict: ["block_number", "event_index"],
+    keyset: ["block_number", "event_index"],
+    partition: "append",
+    booleans: [],
     freshness: "block_number",
   },
   // Two rows, one per network, rewritten in place on every capture tick. The

--- a/src/neon-parity-watchdog.ts
+++ b/src/neon-parity-watchdog.ts
@@ -92,6 +92,13 @@ export const PARITY_TABLES = [
   // it is total.
   "blocks_head",
   "raw_capture_state",
+  // The decoded seam (#10024). Both stores now prune these to the SAME
+  // resolved block watermark (#10017), so a persistent gap here is a real
+  // fault rather than the two windows disagreeing.
+  "chain_detail_blocks",
+  "chain_detail_extrinsics",
+  "chain_detail_chain_events",
+  "chain_detail_account_events",
 ] as const;
 
 /**

--- a/tests/neon-sql-portability.test.ts
+++ b/tests/neon-sql-portability.test.ts
@@ -163,6 +163,12 @@ const BOOLEAN_COLUMNS = [
   // and within that set `ok` is a BOOLEAN column. D1-only SQL is never
   // scanned.
   "ok",
+  // chain_detail_extrinsics (#10024). The only boolean in the decoded seam,
+  // and nullable there -- an extrinsic whose outcome was not decoded has NULL,
+  // not false. That makes `success = 0` doubly wrong on Postgres: rejected
+  // for the type, and it would exclude the undecoded rows a caller counting
+  // failures probably wants.
+  "success",
 ] as const;
 
 /** Comparisons and aggregates that only work against ONE of the two schemas. */

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -204,7 +204,7 @@
     // Naming a latest-only table here would copy 800,000 rows to prove they
     // already agree, which is why this is a third flag rather than a reuse of
     // the write list.
-    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily,subnet_burn_history,tao_usd_index,blocks_head,raw_capture_state",
+    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily,subnet_burn_history,tao_usd_index,blocks_head,raw_capture_state,chain_detail_blocks,chain_detail_extrinsics,chain_detail_chain_events,chain_detail_account_events",
     // Tables whose ONLY home is Neon -- D1 is not behind them any more.
     //
     // A FOURTH flag, and the one the other three converge on. All three above


### PR DESCRIPTION
Closes #10024. Part of #9787.

> Stacked on #10023 — the prune has to exist first, and that is the whole point. Retarget to `main` once it merges.

725,020 rows, the largest single block left in D1, with Neon schemas since #9984 and nothing putting rows in them.

| table | D1 rows |
|---|---:|
| `chain_detail_chain_events` | 388,577 |
| `chain_detail_account_events` | 293,286 |
| `chain_detail_extrinsics` | 41,352 |
| `chain_detail_blocks` | 1,805 |

## Why the ordering against #10023 is not optional

These are a **pruned rolling window**, not an archive. Mirroring the writes without a matching prune is exactly the shape that burned `surface_checks` (#9891): Neon grows forever, the reconciler reads the pruned tail as a deficit it can never close, and `neon-parity` alarms permanently — and it reads as an in-flight backfill the whole time.

#10023 makes both stores prune to the **same resolved bound**. That is what makes reconciling these converge rather than diverge.

## `freshness` is `block_number`, not `observed_at`

On all four, and for the same reason #10019 hit on `blocks_head`: the keyset has to **be** the primary key. One that drifts from it resumes a page from the wrong place and skips rows silently, so the deficit shrinks and never reaches zero. `observed_at` reads like the natural cursor on a table like this, and it is the wrong answer twice now.

## `chain_detail_extrinsics.success`

The only boolean in the family, and named in the plan's `booleans` list. D1 stores 0/1 with a CHECK; Neon declares BOOLEAN; Postgres refuses to compare the two, so an unnamed boolean column is not a slow write, it is a throwing one.

110/110 green across the reconciler and prune suites.