### PR TITLE
fix(neon): the parity sweep watches the two lanes #10020 added

### DIFF
--- a/src/neon-parity-watchdog.ts
+++ b/src/neon-parity-watchdog.ts
@@ -87,6 +87,11 @@ export const PARITY_TABLES = [
   "surface_failure_daily",
   "subnet_burn_history",
   "tao_usd_index",
+  // The capture-lane pair (#10019). blocks_head is unpruned, so it is watched
+  // at the default threshold; raw_capture_state is two rows and any drift in
+  // it is total.
+  "blocks_head",
+  "raw_capture_state",
 ] as const;
 
 /**


### PR DESCRIPTION
**`main` is red, and it is my fault.**

#10020 added `blocks_head` and `raw_capture_state` to `NEON_BACKFILL_LANES`. `tests/neon-parity-watchdog.test.ts` asserts that every backfilled table also appears in `PARITY_TABLES` — and that assertion lives in a *different file* from the change that broke it, so the PR was green on its own diff and red the moment it merged.

```
FAIL tests/neon-parity-watchdog.test.ts > the deployed wiring > every mirrored or backfilled table is watched
AssertionError: blocks_head is written to Neon but not in PARITY_TABLES
Tests  1 failed | 17715 passed (17716)
```

## The assertion is right

A table the reconciler copies but the sweep never compares is one whose divergence nothing would report — which is precisely what this watchdog exists to catch, and precisely how `neon:hotkey-alpha` went unnoticed for a day.

So this adds the two tables rather than relaxing the check.

- `blocks_head` — unpruned, so the default threshold applies; no tolerance needed
- `raw_capture_state` — two rows, where any drift at all is total

41/41 green.

## Note for whoever reviews the next one

#10025 adds the four `chain_detail_*` tables to the same flag and will need the same treatment. I will fold it into that PR rather than leave a second landmine.