### PR TITLE
perf(mcp): the two network-wide scorecards return a page by default

### DIFF
--- a/schemas-src/mcp-tools/get-health-trends.ts
+++ b/schemas-src/mcp-tools/get-health-trends.ts
@@ -44,7 +44,12 @@ export const GetHealthTrendsInputSchema = BulkHealthTrendsQuerySchema.extend({
         "rows to discard 23. Omit for every window.",
     )
     .meta({ examples: ["7d"] }),
-  limit: limitSchema(512).optional(),
+  // Defaults to a PAGE of subnets per window (#10027). The full matrix
+  // measured 448,827 B -- the largest response this server produces -- and is
+  // a bulk export rather than the usual question. `subnet_count` still spans
+  // every subnet the window measured, so narrowing does not cost the caller
+  // the denominator it is ranking against.
+  limit: limitSchema(512, 25).optional(),
   offset: offsetSchema().optional(),
 }).strict();
 export type GetHealthTrendsInput = z.infer<typeof GetHealthTrendsInputSchema>;

--- a/schemas-src/mcp-tools/meta-artifacts-2.ts
+++ b/schemas-src/mcp-tools/meta-artifacts-2.ts
@@ -108,7 +108,13 @@ export const GetCoverageDepthInputSchema = z
     sort: sortSchema(COVERAGE_DEPTH_SORT_VALUES).optional(),
     order: orderSchema().optional(),
     fields: fieldsStringSchema().optional(),
-    limit: limitSchema(500).optional(),
+    // Defaults to a PAGE, not the whole scorecard (#10027). Measured at
+    // 268,088 B for 129 rows -- ~2 KB each -- so an unbounded call spent most
+    // of an agent's context before it had asked anything specific. `total`
+    // still spans every row and `next_cursor` is emitted, so a paged caller
+    // keeps the denominator and can continue; limitSchema puts the default
+    // into the published contract rather than leaving it in prose.
+    limit: limitSchema(500, 25).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -4427,6 +4427,15 @@ function applySubnetListQuery(
    * hard-coded skip it started as.
    */
   subjectKeys: readonly string[] = ["netuid"],
+  /**
+   * Page size when the caller names none (#10027).
+   *
+   * limitSchema declares a tool's default in the PUBLISHED contract but does
+   * not apply it -- deliberately, so handlers keep ownership of the decision.
+   * Applying it here is that ownership: null means "every row", which is the
+   * historical behaviour and still right for a per-subject view.
+   */
+  defaultLimit: number | null = null,
 ): Row {
   // Schema-stability guard, same as list_endpoints': an artifact with no rows
   // array must still report an empty list rather than fall through
@@ -4435,6 +4444,9 @@ function applySubnetListQuery(
   const rows = data?.[dataKey];
   const body = Array.isArray(rows) ? data : { ...data, [dataKey]: [] };
   const queryUrl = new URL(`https://mcp.internal/${collection}`);
+  if (defaultLimit !== null && args?.limit == null) {
+    queryUrl.searchParams.set("limit", String(defaultLimit));
+  }
   for (const [key, value] of Object.entries(args ?? {})) {
     // `context` is MCP intent telemetry, never a query parameter.
     if (key === "context" || subjectKeys.includes(key)) continue;
@@ -5089,7 +5101,11 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // standing between a typo and a silent fallback to every window, while
       // clamping a limit degrades to a usable page instead of an error.
       const window = optionalEnum(row, "window", HEALTH_TREND_WINDOW_VALUES);
-      const limit = row?.limit == null ? null : clampLimit(row.limit, 512, 512);
+      // A page of subnets per window by default (#10027). The full matrix is
+      // 448,827 B, the largest response this server produces; `subnet_count`
+      // still spans every subnet the window measured, so the denominator
+      // survives the narrowing.
+      const limit = clampLimit(row?.limit, 25, 512);
       const offset = Number.isFinite(row?.offset)
         ? Math.max(0, Math.floor(row.offset as number))
         : 0;
@@ -12859,6 +12875,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         // Network-wide: nothing is the subject here, so `netuid` is a filter
         // like any other.
         [],
+        // A page by default (#10027) -- 268 KB / 129 rows unbounded. `total`
+        // still spans every row, so the denominator survives the narrowing.
+        25,
       );
     },
   },

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -25218,7 +25218,12 @@ describe("MCP health-tier analytics tools — Postgres tier wiring", () => {
     {
       tool: "get_health_trends",
       args: {},
-      path: "/api/v1/health/trends",
+      // The default page size is FORWARDED (#10027). A narrowing honoured on
+      // one tier and dropped on the other is the "looks paged, is not"
+      // failure -- the tool would report `subnet_count` for a page it did not
+      // actually take. So the tier request carries it, exactly as an explicit
+      // limit would.
+      path: "/api/v1/health/trends?limit=25",
     },
     {
       tool: "get_subnet_health_trends",
@@ -25373,6 +25378,60 @@ describe("get_coverage_depth MCP tool (#6983)", () => {
     const out = res.body.result.structuredContent;
     assert.equal(out.rows[0].netuid, 1);
     assert.equal(out.ranked_queue[0].severity, "high");
+  });
+
+  test("returns a PAGE by default, and says so in its contract (#10027)", async () => {
+    // 268,088 B / 129 rows unbounded. The risk of a default page is that it
+    // reads as a complete answer, so all three of these must hold together:
+    // the page is small, `total` still spans every row, and the published
+    // schema advertises the default rather than hiding it in prose.
+    const deps = makeDeps({
+      "/metagraph/coverage-depth.json": {
+        schema_version: 1,
+        rows: Array.from({ length: 40 }, (_, i) => ({
+          netuid: i,
+          tier: "agent-ready",
+        })),
+      },
+    });
+    const res = await callTool("get_coverage_depth", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal((out.rows as Row[]).length, 25);
+    assert.equal(out.total, 40, "total must span every row, not the page");
+    assert.equal(
+      out.next_cursor,
+      25,
+      "a paged caller must be able to continue",
+    );
+
+    const declared = listToolDefinitions().find(
+      (t) => t.name === "get_coverage_depth",
+    )?.inputSchema.properties?.limit;
+    assert.equal(
+      (declared as Row)?.default,
+      25,
+      "the default must be in the published contract, not only in the handler",
+    );
+  });
+
+  test("an explicit limit still overrides the default", async () => {
+    const deps = makeDeps({
+      "/metagraph/coverage-depth.json": {
+        schema_version: 1,
+        rows: Array.from({ length: 40 }, (_, i) => ({ netuid: i })),
+      },
+    });
+    for (const [limit, expected] of [
+      [5, 5],
+      [40, 40],
+    ] as [number, number][]) {
+      const res = await callTool("get_coverage_depth", { limit }, { deps });
+      assert.equal(
+        (res.body.result.structuredContent.rows as Row[]).length,
+        expected,
+        `limit=${limit}`,
+      );
+    }
   });
 
   test("filters the rows it used to return wholesale (#10011)", async () => {


### PR DESCRIPTION
## Summary

Measured against production:

```
/api/v1/coverage-depth   268,088 B   129 rows (~2 KB each)
/api/v1/health/trends    448,827 B   2 windows × ~123 subnets
```

#10012 and #9993 made both **narrowable**; neither changed what a **no-argument** call returns. Both still spent most of an agent's context before it had asked anything specific.

## Scoped to these two, deliberately

The distinction is whether the whole set *is* the answer:

- **network-wide scorecards** — a caller is almost always sampling a ranking or one window; the full matrix is a bulk export.
- **per-subject sets get no default** — `get_subnet_endpoints` is 90,925 B for **one subnet's 76 endpoints**. That is a complete, coherent answer to "what does SN64 expose", and truncating it by default would turn a correct answer into a quietly partial one.

A default page is right where the caller is sampling and wrong where they asked about one thing.

## The risk, and why it's safe here

A default limit converts "large response" into **"looks complete, is not"** — the same failure this epic keeps finding (#10009's client-side filter showing 6 of 1,184; tools that accepted a filter and dropped it).

Three things make it safe, and **all three already existed** — they were groundwork in #9993 and #10012:

1. `total` / `subnet_count` span the **unfiltered** set, so a paged caller keeps its denominator.
2. `next_cursor` is emitted, so continuing is mechanical.
3. `limitSchema(max, fallback)` puts the default **in the published contract** (`"Defaults to 25 when omitted"`), so the tool advertises that it paged instead of leaving it in prose.

The test asserts all three together — page size, unfiltered `total`, `next_cursor`, **and** that the default appears in the emitted schema. A default that worked but wasn't advertised would pass a behaviour-only test and still mislead an agent.

## Implementation notes

`limitSchema` deliberately declares a default **without applying it** — handlers own that decision, per its own comment. So `applySubnetListQuery` gains an explicit `defaultLimit` parameter rather than letting the schema silently take effect; `null` keeps every row, which stays correct for per-subject views.

**The default is forwarded on the tier request.** A narrowing honoured on one tier and dropped on the other would report `subnet_count` for a page the tool never took. The updated path expectation (`/api/v1/health/trends?limit=25`) records that as intent rather than incidental.

## Validation

```
npm run lint && npm run format:check && npm run typecheck && npm run build
npm run validate:mcp && npm run validate:mcp-route-map
npm run validate:mcp-input-parity
npm run validate:contract-drift && npm run validate:single-schema-source
npx vitest run tests/mcp-server.test.ts tests/bulk-health-trends-loader.test.ts \
  tests/graphql.test.ts tests/api-coverage.test.ts tests/mcp-input-parity.test.ts \
  tests/mcp-schema-enforcement.test.ts
```

All green — **2,813 tests** across every file that names a symbol touched (grepped, not guessed).

Closes #10027