### PR TITLE
fix(test): let an e2e navigation wait out the dev-server restart it already expects

### DIFF
--- a/apps/ui/playwright.config.ts
+++ b/apps/ui/playwright.config.ts
@@ -10,6 +10,18 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
+  // #10013: Playwright's default per-test budget is 30s, and these specs were
+  // already spending most of it before any restart: sticky-table-header waits
+  // up to 5s for networkidle and then up to 20s for the <thead> (measured --
+  // /chain/extrinsics needs ~10s to paint its table), leaving under 5s of
+  // slack on a route that was expected to be slow. That left no room for
+  // gotoThroughRestart to wait out a supervised `wrangler dev` restart, so a
+  // test landing in the restart window failed on the timeout instead.
+  //
+  // A cap is not a cost: a passing test finishes when it finishes, and this
+  // only changes how long a genuinely stuck one is allowed to hang. 90s is the
+  // 45s restart budget plus the ~25s these specs already use, rounded up.
+  timeout: 90_000,
   reporter: process.env.CI ? "github" : "list",
   // #8928: pinned, because Playwright's default is os.cpus().length / 2 -- 2
   // workers on the 4-core ubuntu-latest runner, leaving half the machine idle

--- a/apps/ui/tests/e2e/evidence-deep-link.spec.ts
+++ b/apps/ui/tests/e2e/evidence-deep-link.spec.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { test, expect } from "@playwright/test";
 import { harPathForRoute, DATED_ENDPOINT_PATTERNS, findHarFixture } from "./har-path.ts";
+import { gotoThroughRestart } from "./server-restart.ts";
 
 // #6434 (historical): /subnets/:netuid used to render EvidencePanel twice -- a
 // preview embedded in the Overview tab and the full section under a dedicated
@@ -47,7 +48,7 @@ async function openWithHar(page: import("@playwright/test").Page, url: string) {
       await page.route(pattern, (route) => route.fulfill(fixture));
     }
   }
-  await page.goto(url);
+  await gotoThroughRestart(page, url);
   // HAR responses resolve instantly, which starves "networkidle" of the quiet
   // window it needs on a route with recurring refetches -- fall back to a fixed
   // settle rather than hanging (same rationale as responsive-overflow.spec.ts).

--- a/apps/ui/tests/e2e/multisig-related-error.spec.ts
+++ b/apps/ui/tests/e2e/multisig-related-error.spec.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { test, expect } from "@playwright/test";
+import { gotoThroughRestart } from "./server-restart.ts";
 
 // #6426: extrinsics.$hash.tsx's "Related Multisig calls" section had no isError
 // branch. A failed relatedQuery fetch left `data` undefined, so relatedCalls
@@ -69,7 +70,7 @@ async function openExtrinsic(
   // The related-calls lookup -- the request under test.
   await page.route((url) => isRelatedCalls(url.toString()), relatedResponder);
 
-  await page.goto(ROUTE);
+  await gotoThroughRestart(page, ROUTE);
   // The client retries a failed query 3x with backoff (router.tsx), so give the
   // error state time to settle rather than asserting on a mid-retry skeleton.
   const section = page.locator("section#multisig-chain");

--- a/apps/ui/tests/e2e/offline.spec.ts
+++ b/apps/ui/tests/e2e/offline.spec.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { test, expect } from "@playwright/test";
 import { harPathForRoute, DATED_ENDPOINT_PATTERNS, findHarFixture } from "./har-path.ts";
+import { gotoThroughRestart } from "./server-restart.ts";
 
 // #8384: the PWA foundation's own e2e coverage (issue requirement 7) --
 // registers public/sw.js against the SAME HAR-replay fixtures every other
@@ -66,7 +67,7 @@ test.describe.fixme("#8384 offline PWA shell", () => {
       if (fixture) await context.route(pattern, (route) => route.fulfill(fixture));
     }
 
-    await page.goto(ROUTE);
+    await gotoThroughRestart(page, ROUTE);
     await page.waitForFunction(() => navigator.serviceWorker?.controller != null, {
       timeout: 15_000,
     });
@@ -105,7 +106,7 @@ test.describe.fixme("#8384 offline PWA shell", () => {
     // Register the service worker via a real (HAR-served) load of the home
     // route first -- a worker can only ever serve public/offline.html once
     // it's actually installed and controlling the page.
-    await page.goto(ROUTE);
+    await gotoThroughRestart(page, ROUTE);
     await page.waitForFunction(() => navigator.serviceWorker?.controller != null, {
       timeout: 15_000,
     });

--- a/apps/ui/tests/e2e/responsive-overflow.spec.ts
+++ b/apps/ui/tests/e2e/responsive-overflow.spec.ts
@@ -8,6 +8,7 @@ import {
   EMPTY_LIST_ALLOWED,
 } from "./overflow-check.config.ts";
 import { harPathForRoute, DATED_ENDPOINT_PATTERNS, findHarFixture } from "./har-path.ts";
+import { gotoThroughRestart } from "./server-restart.ts";
 
 // Baseline-diff, not zero-tolerance: this app has pre-existing, already-tracked
 // overflow bugs (#3930, #3931, #3985, etc.) that are separately-scored
@@ -95,7 +96,7 @@ for (const route of ROUTES) {
           }
         }
         await page.setViewportSize({ width: viewport.width, height: viewport.height });
-        await page.goto(route);
+        await gotoThroughRestart(page, route);
         // HAR-replayed responses resolve near-instantly (no real network
         // latency), which removes the natural gaps "networkidle" needs to
         // detect quiet -- pages with any recurring refetch/poll (/, /subnets/1,

--- a/apps/ui/tests/e2e/server-restart.ts
+++ b/apps/ui/tests/e2e/server-restart.ts
@@ -1,0 +1,122 @@
+// Navigate across a supervised `wrangler dev` restart.
+//
+// tests/e2e/serve-e2e.ts restarts the dev server when wrangler dies of the
+// upstream ProxyController "Network connection lost" crash, and its log line
+// promises "Tests hitting the gap retry." That promise was not kept: the port
+// stops answering for the seconds the restart takes, `page.goto` fails
+// INSTANTLY with ERR_CONNECTION_REFUSED, and Playwright's retry starts soon
+// enough to land in the same window and fail identically.
+//
+// Measured on main (#10013): the sticky-header spec failed on `673f567c`, and
+// on its retry, three seconds after
+//
+//   [e2e-server] wrangler exited (code=1 signal=null) after 226648ms
+//     -- restarting (1/10). Expected cause: ProxyController "Network
+//     connection lost". Tests hitting the gap retry.
+//
+// The commit changed only src/mcp-server.ts and three schemas-src files --
+// nothing that can affect how a table header pins at 1280px. The next commit
+// went green with no fix. A required check that fails on unchanged code spends
+// the signal it exists to provide, so the gap is closed here rather than by
+// quarantining a spec that was never wrong.
+//
+// This waits for the restart INSTEAD of failing, and only for the one error
+// class that means "nothing is listening yet". Any other navigation failure --
+// a 500, a redirect loop, a genuine timeout -- propagates on the first try, so
+// a real breakage is never masked into a slow pass.
+
+import type { Page, Response } from "@playwright/test";
+
+/**
+ * How long a navigation may wait for the supervisor to bring the server back.
+ *
+ * Sized from serve-e2e.ts's own restart path, not guessed: `waitForPortFree`
+ * polls for up to 15s (killing stray port holders at 2s) before wrangler is
+ * even respawned, and booting a Worker plus its assets binding is the slower
+ * part after that. 45s covers both with room, and still fails fast enough to
+ * be readable when the server is genuinely gone -- the supervisor's own
+ * FAST_EXIT_LIMIT is what fails the run in that case.
+ */
+export const SERVER_RESTART_BUDGET_MS = 45_000;
+
+const POLL_MS = 500;
+
+/**
+ * Set once a full budget has elapsed with the server still refusing. Module
+ * scope = per Playwright worker process, which is exactly the right blast
+ * radius: one worker discovering the server is gone must not make the other
+ * three re-derive it, and a fresh run starts fresh.
+ *
+ * Exported only so the unit test can clear it between cases.
+ */
+let serverPresumedGone = false;
+
+export function __resetServerPresumedGone(): void {
+  serverPresumedGone = false;
+}
+
+/**
+ * Errors that mean "the port is not answering yet", as opposed to "the server
+ * answered and something is wrong".
+ *
+ * Chromium reports the restart window as ERR_CONNECTION_REFUSED; the other two
+ * are what a navigation in flight when wrangler dies surfaces instead, since
+ * the socket is torn down mid-response rather than never opened.
+ */
+const SERVER_DOWN =
+  /ERR_CONNECTION_REFUSED|ERR_CONNECTION_RESET|ERR_EMPTY_RESPONSE|ECONNREFUSED|socket hang up/i;
+
+export function isServerUnavailable(error: unknown): boolean {
+  return SERVER_DOWN.test(String((error as Error)?.message ?? ""));
+}
+
+/**
+ * `page.goto`, but tolerant of the supervised restart window.
+ *
+ * Deliberately NOT applied to navigations a test makes while it has set the
+ * context offline on purpose (offline.spec.ts) -- there, a refused connection
+ * IS the thing under test, and retrying it would be retrying the assertion.
+ */
+export async function gotoThroughRestart(
+  page: Page,
+  url: string,
+  options?: Parameters<Page["goto"]>[1],
+  budgetMs = SERVER_RESTART_BUDGET_MS,
+): Promise<Response | null> {
+  // Once the budget has been spent WITHOUT the server returning, it is not
+  // restarting -- it is gone. Waiting again on every later navigation turns a
+  // dead server into a suite that fails one slow test at a time; measured by
+  // killing the port holder mid-run, where each remaining test then took the
+  // full 45s. The latch is per worker process (Playwright forks one per
+  // worker), so the cost of discovering it is paid at most once each, and it
+  // is deliberately NOT reset: nothing in a run brings the server back except
+  // the supervisor, and the supervisor returning would have satisfied the wait.
+  if (serverPresumedGone) return page.goto(url, options);
+
+  const deadline = Date.now() + budgetMs;
+  let attempts = 0;
+  for (;;) {
+    try {
+      return await page.goto(url, options);
+    } catch (error) {
+      attempts += 1;
+      // A failure the server ANSWERED (a 500, a redirect loop, a real timeout)
+      // is never retried -- retrying it would turn a breakage into a slow pass.
+      if (!isServerUnavailable(error)) throw error;
+      if (Date.now() >= deadline) {
+        // The full budget elapsed and the port never came back, so this is not
+        // a restart. Latch, so the rest of this worker fails fast instead of
+        // re-deriving it one budget at a time, and say what we waited for.
+        serverPresumedGone = true;
+        console.error(
+          `[e2e] ${url}: server never came back within ${budgetMs}ms ` +
+            `(${attempts} attempts). If serve-e2e.ts logged no restart, this ` +
+            `is not the ProxyController crash. Later navigations in this ` +
+            `worker will fail fast rather than wait again.`,
+        );
+        throw error;
+      }
+      await page.waitForTimeout(POLL_MS);
+    }
+  }
+}

--- a/apps/ui/tests/e2e/server-restart.unit.ts
+++ b/apps/ui/tests/e2e/server-restart.unit.ts
@@ -1,0 +1,151 @@
+// Unit coverage for the e2e harness's restart tolerance (#10013).
+//
+// This helper decides whether the suite is TRUSTWORTHY: too eager and it hides
+// a real breakage behind a slow pass, too timid and main goes red on unchanged
+// code. Both directions are asserted here, with a fake page rather than a
+// browser -- `.unit.ts` so Playwright's testMatch does not collect it (see
+// vitest.config.ts).
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  __resetServerPresumedGone,
+  gotoThroughRestart,
+  isServerUnavailable,
+  SERVER_RESTART_BUDGET_MS,
+} from "./server-restart.ts";
+
+// The presumed-gone latch is module state by design (one Playwright worker =
+// one process), so each case starts from a clean one.
+beforeEach(() => __resetServerPresumedGone());
+
+type FakePage = {
+  goto: ReturnType<typeof vi.fn>;
+  waitForTimeout: ReturnType<typeof vi.fn>;
+};
+
+/**
+ * A page whose goto throws the given errors in order, then succeeds.
+ *
+ * `waitMs` makes the stubbed waitForTimeout actually sleep, so a test can let a
+ * real budget elapse across several retries -- the latch only arms after more
+ * than one attempt, which a zero-budget call can never reach.
+ */
+function fakePage(failures: Error[], waitMs = 0): FakePage {
+  let call = 0;
+  return {
+    goto: vi.fn(async () => {
+      const failure = failures[call];
+      call += 1;
+      if (failure) throw failure;
+      return { status: () => 200 };
+    }),
+    waitForTimeout: vi.fn(async () => await new Promise((r) => setTimeout(r, waitMs))),
+  };
+}
+
+const refused = () =>
+  new Error("page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:8080/chain/extrinsics");
+
+describe("isServerUnavailable", () => {
+  test("recognises the restart window, in the shapes Chromium reports it", () => {
+    for (const message of [
+      "net::ERR_CONNECTION_REFUSED at http://localhost:8080/x",
+      "net::ERR_CONNECTION_RESET",
+      "net::ERR_EMPTY_RESPONSE",
+      "connect ECONNREFUSED 127.0.0.1:8080",
+      "socket hang up",
+    ]) {
+      expect(isServerUnavailable(new Error(message)), message).toBe(true);
+    }
+  });
+
+  test("does not claim a real failure is a restart", () => {
+    // If any of these were treated as "server down", a genuine breakage would
+    // be retried until the budget expired and then reported as a timeout --
+    // the failure mode this helper exists to avoid creating.
+    for (const message of [
+      "page.goto: Timeout 30000ms exceeded",
+      "net::ERR_TOO_MANY_REDIRECTS",
+      "net::ERR_NAME_NOT_RESOLVED",
+      "Target page, context or browser has been closed",
+      "expect(received).toBe(expected)",
+    ]) {
+      expect(isServerUnavailable(new Error(message)), message).toBe(false);
+    }
+    expect(isServerUnavailable(undefined)).toBe(false);
+    expect(isServerUnavailable({})).toBe(false);
+  });
+});
+
+describe("gotoThroughRestart", () => {
+  test("navigates once when the server is up", async () => {
+    const page = fakePage([]);
+    await gotoThroughRestart(page as never, "/chain/extrinsics");
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  test("waits out a restart and returns the eventual response", async () => {
+    const page = fakePage([refused(), refused(), refused()]);
+    const response = await gotoThroughRestart(page as never, "/x");
+    expect(page.goto).toHaveBeenCalledTimes(4);
+    expect((response as { status: () => number }).status()).toBe(200);
+  });
+
+  test("rethrows a non-restart error on the FIRST attempt", async () => {
+    // The safety property: a real failure must not be masked into a slow pass.
+    const page = fakePage([new Error("net::ERR_TOO_MANY_REDIRECTS")]);
+    await expect(gotoThroughRestart(page as never, "/x")).rejects.toThrow("ERR_TOO_MANY_REDIRECTS");
+    expect(page.goto).toHaveBeenCalledTimes(1);
+  });
+
+  test("gives up once the budget is spent rather than hanging", async () => {
+    const page = fakePage(Array.from({ length: 500 }, refused));
+    // A budget of 0 means the deadline has already passed on the first catch.
+    await expect(gotoThroughRestart(page as never, "/x", undefined, 0)).rejects.toThrow(
+      "ERR_CONNECTION_REFUSED",
+    );
+    expect(page.goto).toHaveBeenCalledTimes(1);
+  });
+
+  test("the default budget covers the supervisor's own restart path", () => {
+    // serve-e2e.ts polls up to 15s for the port to free before respawning
+    // wrangler, and booting a Worker takes longer still. A budget under that
+    // would time out on exactly the restarts this exists to survive.
+    expect(SERVER_RESTART_BUDGET_MS).toBeGreaterThanOrEqual(30_000);
+  });
+});
+
+describe("presumed-gone latch", () => {
+  test("stops re-waiting the full budget once the server is confirmed gone", async () => {
+    // Without the latch, a dead server costs every remaining test the whole
+    // budget -- measured at 45s each by killing the port holder mid-run.
+    // 30ms per retry against a 50ms budget: attempt 1 fails, one retry fails,
+    // and the third finds the deadline passed. The latch arms only after MORE
+    // than one attempt, so a zero-budget call could never reach it.
+    const first = fakePage(Array.from({ length: 500 }, refused), 30);
+    await expect(gotoThroughRestart(first as never, "/x", undefined, 50)).rejects.toThrow();
+    expect(first.goto.mock.calls.length).toBeGreaterThan(1);
+
+    const second = fakePage(Array.from({ length: 500 }, refused));
+    await expect(gotoThroughRestart(second as never, "/y")).rejects.toThrow(
+      "ERR_CONNECTION_REFUSED",
+    );
+    expect(
+      second.goto,
+      "the second navigation must fail on its first attempt, not retry",
+    ).toHaveBeenCalledTimes(1);
+    expect(second.waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  test("a single refused navigation that then succeeds does NOT latch", async () => {
+    // Latching on a transient refusal would disable the whole mitigation after
+    // the first restart it successfully rode out.
+    const page = fakePage([refused()]);
+    await gotoThroughRestart(page as never, "/x");
+
+    const later = fakePage([refused()]);
+    await gotoThroughRestart(later as never, "/y");
+    expect(later.goto).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/ui/tests/e2e/sticky-table-header.spec.ts
+++ b/apps/ui/tests/e2e/sticky-table-header.spec.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { test, expect } from "@playwright/test";
 import { harPathForRoute, DATED_ENDPOINT_PATTERNS, findHarFixture } from "./har-path.ts";
+import { gotoThroughRestart } from "./server-restart.ts";
 
 // A sticky <thead> pins against ITS OWN scroll container, and nothing else.
 // Every regression in this area has come from getting that one sentence
@@ -160,7 +161,7 @@ for (const route of ROUTES) {
           if (fixture) await page.route(pattern, (r) => r.fulfill(fixture));
         }
         await page.setViewportSize({ width: viewport.width, height: viewport.height });
-        await page.goto(route);
+        await gotoThroughRestart(page, route);
         try {
           await page.waitForLoadState("networkidle", { timeout: 5000 });
         } catch {

--- a/apps/ui/vitest.config.ts
+++ b/apps/ui/vitest.config.ts
@@ -14,7 +14,17 @@ export default defineConfig({
     // a browser environment, in keeping with this suite's "plain node is
     // enough" scope -- real component/interaction behavior stays covered
     // by the separate Playwright e2e suite.
-    include: ["src/**/*.test.{ts,tsx}"],
+    // `tests/e2e/**/*.unit.ts` covers the e2e HARNESS itself -- helpers whose
+    // logic decides whether the suite is trustworthy (see server-restart.ts,
+    // which must retry a restarting server and must NOT retry a real failure).
+    // Those live beside the specs they serve, but are plain node logic and
+    // should not need a browser to test.
+    //
+    // `.unit.ts`, deliberately not `.test.ts`: playwright.config.ts sets
+    // testDir to ./tests/e2e, and Playwright's default testMatch claims BOTH
+    // *.spec.ts and *.test.ts -- so a .test.ts here would be collected by
+    // Playwright as an e2e test with no test() calls in it.
+    include: ["src/**/*.test.{ts,tsx}", "tests/e2e/**/*.unit.ts"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## The diagnosis in #10013 was right that the commit was innocent, and wrong about why

`main` went red on `673f567c` and green on the next commit with no fix. The issue reasoned it must be a timing-sensitive sticky-position assertion and suggested awaiting a settled layout signal or quarantining the spec.

The CI log says otherwise — the assertion never ran:

```
23:19:22  [e2e-server] wrangler exited (code=1 signal=null) after 226648ms
          -- restarting (1/10). Expected cause: ProxyController
          "Network connection lost". Tests hitting the gap retry.

23:19:25  Error: page.goto: net::ERR_CONNECTION_REFUSED
          at http://localhost:8080/chain/extrinsics
```

The dev server was **down**. `tests/e2e/serve-e2e.ts` already anticipates this crash and restarts it — the failure is three seconds into that restart, and Playwright's retry fired in the same second and hit the same window.

So the supervisor's own closing promise, *"Tests hitting the gap retry"*, was the bug: nothing made a navigation wait for the server to come back. Quarantining the spec would have removed a check that was never wrong.

## The fix

`gotoThroughRestart` waits out the restart, and **only** for the error class meaning "nothing is listening yet". A failure the server *answered* — a 500, a redirect loop, a genuine timeout — still propagates on the first attempt, so a real breakage is never converted into a slow pass. That safety property is the one I care most about and it is mutation-tested.

Three details worth calling out:

- **`offline.spec.ts` is deliberately excluded at one site.** Its third navigation runs after `context.setOffline(true)`, where a refused connection *is* the assertion. Retrying it would be retrying the thing under test. The two pre-offline navigations do use the helper.
- **A per-worker latch.** Once a full budget elapses with the server still refusing, it is gone rather than restarting, so the rest of that worker fails fast. This came from measurement, not theory: when I killed the port holder mid-run, every remaining test paid the full 45s. The latch caps that at one budget per worker.
- **Per-test timeout 30s → 90s.** The default was already marginal — `sticky-table-header` spends up to 5s on `networkidle` plus up to 20s waiting for the `<thead>` (`/chain/extrinsics` needs ~10s to paint), leaving under 5s of slack *before* any restart. A cap is not a cost; a passing test still finishes when it finishes.

`.unit.ts`, not `.test.ts`: `playwright.config.ts` sets `testDir` to `./tests/e2e`, and Playwright's default `testMatch` claims both `*.spec.ts` and `*.test.ts` — a `.test.ts` there would be collected by Playwright as an e2e file with no `test()` calls. `vitest.config.ts` is widened to pick up `tests/e2e/**/*.unit.ts`, with that reason recorded. Verified: `playwright test --list` does not collect it.

## Validation

```
apps/ui typecheck            clean
apps/ui vitest               235 files, 1869 tests passed
apps/ui lint                 0 errors (9 pre-existing warnings elsewhere)
prettier --check             clean
playwright --project=interaction   104 passed, 2 skipped (2.1m)
```

**Mutation-tested** — each of these makes a test fail, so the tests are load-bearing:

| mutation | caught by |
|---|---|
| drop the `isServerUnavailable` guard (retry everything) | `rethrows a non-restart error on the FIRST attempt` |
| remove the latch short-circuit | `stops re-waiting the full budget once the server is confirmed gone` |
| never set the latch | same |

One thing I removed rather than tested: an earlier `attempts > 1` guard on the latch. Mutating it to `attempts > 0` changed nothing any test could see — with a real 45s budget the two are behaviorally identical, so it encoded a distinction that does not exist. Simplified it away instead of writing a test that pretended to cover it.

## Not claimed

I could not reproduce the ProxyController crash on demand. Killing the port holder externally does **not** trigger the supervisor (it watches the `wrangler` child, not the port), so that run exercised the "server never came back" path instead — which is how the latch got measured. The restart path itself is covered by the unit tests against a fake page, plus a full clean e2e run.

Closes #10013