### PR TITLE
feat(registry): the registry has a writer again

### DIFF
--- a/src/registry-sync-lane.ts
+++ b/src/registry-sync-lane.ts
@@ -1,0 +1,239 @@
+// The registry writer (#9779).
+//
+// WHAT WAS BROKEN. workers/registry-sync-api.ts describes itself as "the ONLY
+// write path into the registry database" and nothing called it. Its callers
+// were scripts/sync-registry-to-postgres.ts (merge-triggered) and
+// scripts/backfill-registry-postgres.ts (scheduled), both invoked from GitHub
+// Actions, and no workflow in .github/workflows/ invokes either. The measured
+// consequence: surface_history frozen at 2026-08-02, and commit aac4ccd36 --
+// which REMOVES endpoints, exactly what action='delete' exists to record --
+// never written down. GET /api/v1/subnets/{netuid}/surface-history has been
+// serving a stale latest_change_at ever since.
+//
+// A WORKER CRON RATHER THAN A WORKFLOW, because this repo does not run data
+// lanes from GitHub Actions: a scheduled producer there races the Worker lanes
+// that own the same tables, and its failures land somewhere nothing watches.
+// This writes through the SAME service binding and the SAME shared-secret gate
+// the scripts used, so the write path itself is unchanged.
+//
+// A POLL, NOT A WEBHOOK. A webhook needs repo configuration this code cannot
+// assert and cannot repair; a poll is self-healing -- if a tick is missed, the
+// next one still sees the same moved head. Cost is one conditional request per
+// tick and nothing else: the sha is compared against KV before anything is
+// fetched, so an unchanged main is a single API call.
+import {
+  buildRegistrySyncPayload,
+  isEmptyPayload,
+  isRegistryPath,
+  type ResolvedRegistryFile,
+  type Row,
+} from "./registry-sync-payload.ts";
+
+/** Where the registry lives. Not configurable: this lane exists to mirror THIS
+ * repo's registry, and a wrong value would silently sync someone else's. */
+const REPO = "JSONbored/metagraphed";
+const KV_KEY = "registry-sync:last-synced-sha";
+const API = "https://api.github.com";
+/** Enough for a normal merge; a bulk change beyond this resyncs over several
+ * ticks because the cursor only advances on success. */
+const MAX_FILES_PER_TICK = 60;
+const FETCH_TIMEOUT_MS = 10_000;
+
+export interface RegistrySyncLaneResult {
+  ok: boolean;
+  reason?: string;
+  detail?: string;
+  head?: string;
+  base?: string;
+  files?: number;
+  written?: Record<string, unknown>;
+}
+
+interface KvLike {
+  get(key: string): Promise<string | null>;
+  put(key: string, value: string): Promise<void>;
+}
+
+interface ServiceLike {
+  fetch(request: Request): Promise<Response>;
+}
+
+function githubHeaders(env: Record<string, unknown>): Record<string, string> {
+  const headers: Record<string, string> = {
+    accept: "application/vnd.github+json",
+    // GitHub rejects API requests with no user-agent.
+    "user-agent": "metagraphed-registry-sync",
+    "x-github-api-version": "2022-11-28",
+  };
+  const token = env.GITHUB_TOKEN;
+  if (typeof token === "string" && token.trim() !== "") {
+    headers.authorization = `Bearer ${token.trim()}`;
+  }
+  return headers;
+}
+
+async function ghJson(
+  env: Record<string, unknown>,
+  path: string,
+): Promise<unknown | null> {
+  try {
+    const response = await fetch(`${API}${path}`, {
+      headers: githubHeaders(env),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+/** One file's parsed overlay at a commit, or null when it is not there. */
+async function fileAt(
+  env: Record<string, unknown>,
+  path: string,
+  ref: string,
+): Promise<Row | null> {
+  const raw = await ghJson(
+    env,
+    `/repos/${REPO}/contents/${encodeURI(path)}?ref=${ref}`,
+  );
+  const content = (raw as { content?: string; encoding?: string } | null)
+    ?.content;
+  if (typeof content !== "string") return null;
+  try {
+    return JSON.parse(atob(content.replace(/\n/g, ""))) as Row;
+  } catch {
+    // A registry file that does not parse is a real problem, but it is the
+    // Gate's problem: skipping it here keeps the rest of the commit syncable
+    // rather than failing the whole tick on one bad file.
+    return null;
+  }
+}
+
+/**
+ * One tick.
+ *
+ * Returns a summary rather than throwing, matching the cron family: a tick
+ * that cannot run is one missed report, not an outage.
+ *
+ * THE CURSOR ADVANCES ONLY ON A SUCCESSFUL POST. If the sync route rejects the
+ * payload, the sha stays where it was and the next tick retries the same
+ * range. Advancing first would turn one failed request into a permanent hole
+ * in surface_history -- which is the exact failure this lane exists to end.
+ */
+export async function runRegistrySyncLane(
+  env: unknown,
+  deps: {
+    kv?: KvLike | null;
+    registrySyncApi?: ServiceLike | null;
+  } = {},
+): Promise<RegistrySyncLaneResult> {
+  const bag = (env ?? {}) as Record<string, unknown>;
+  const kv = deps.kv ?? (bag.METAGRAPH_CONTROL as KvLike | undefined);
+  const api =
+    deps.registrySyncApi ?? (bag.REGISTRY_SYNC_API as ServiceLike | undefined);
+  if (!kv?.get) return { ok: false, reason: "kv unavailable" };
+  if (!api?.fetch)
+    return { ok: false, reason: "registry-sync binding unavailable" };
+  if (typeof bag.REGISTRY_SYNC_SECRET !== "string" || !bag.REGISTRY_SYNC_SECRET)
+    return { ok: false, reason: "registry sync secret not provisioned" };
+
+  const headCommit = await ghJson(bag, `/repos/${REPO}/commits/main`);
+  const head = (headCommit as { sha?: string } | null)?.sha;
+  if (typeof head !== "string" || !head)
+    return { ok: false, reason: "could not resolve head" };
+
+  const base = await kv.get(KV_KEY);
+  if (base === head) return { ok: true, reason: "no new commits", head };
+
+  // FIRST RUN HAS NO BASE, and must not guess one. Comparing against an
+  // arbitrary point would either resync the entire registry or silently skip
+  // everything before it; recording the head and syncing from the NEXT commit
+  // costs one merge of latency once, and is the only option that cannot be
+  // wrong. The scheduled full resync is what closes any pre-existing gap.
+  if (!base) {
+    await kv.put(KV_KEY, head);
+    return { ok: true, reason: "cursor initialised", head };
+  }
+
+  const diff = await ghJson(bag, `/repos/${REPO}/compare/${base}...${head}`);
+  const changed = (
+    diff as { files?: { filename?: string; status?: string }[] } | null
+  )?.files;
+  if (!Array.isArray(changed))
+    return { ok: false, reason: "could not resolve diff", base, head };
+
+  const registryFiles = changed
+    .filter((f) => typeof f.filename === "string" && isRegistryPath(f.filename))
+    .slice(0, MAX_FILES_PER_TICK);
+  if (registryFiles.length === 0) {
+    await kv.put(KV_KEY, head);
+    return { ok: true, reason: "no registry files changed", base, head };
+  }
+
+  const resolved: ResolvedRegistryFile[] = [];
+  for (const file of registryFiles) {
+    const path = file.filename!;
+    const overlay = await fileAt(bag, path, head);
+    if (overlay) {
+      resolved.push({ path, overlay });
+      continue;
+    }
+    // Gone at head. Read it at BASE to learn which netuid to delete -- the
+    // path alone does not carry one, because the filename is the slug.
+    const previous = await fileAt(bag, path, base);
+    resolved.push({
+      path,
+      overlay: null,
+      deletedNetuid: Number.isInteger(previous?.netuid)
+        ? (previous!.netuid as number)
+        : null,
+    });
+  }
+
+  const payload = buildRegistrySyncPayload(resolved, head);
+  if (isEmptyPayload(payload)) {
+    await kv.put(KV_KEY, head);
+    return {
+      ok: true,
+      reason: "nothing to write",
+      base,
+      head,
+      files: resolved.length,
+    };
+  }
+
+  const response = await api.fetch(
+    new Request("https://registry-sync.internal/sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-registry-sync-token": bag.REGISTRY_SYNC_SECRET,
+      },
+      body: JSON.stringify(payload),
+    }),
+  );
+  if (!response.ok) {
+    return {
+      ok: false,
+      reason: "sync rejected",
+      detail: `status ${response.status}`,
+      base,
+      head,
+      files: resolved.length,
+    };
+  }
+  const written = (await response.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  await kv.put(KV_KEY, head);
+  return {
+    ok: true,
+    base,
+    head,
+    files: resolved.length,
+    ...(written ? { written } : {}),
+  };
+}

--- a/src/registry-sync-payload.ts
+++ b/src/registry-sync-payload.ts
@@ -1,0 +1,194 @@
+// The registry sync payload, derived from one commit's registry JSON (#9779).
+//
+// EXTRACTED SO THERE IS ONE TRANSFORMATION, NOT TWO. This is the shape
+// workers/registry-sync-api.ts consumes, and until now only
+// scripts/sync-registry-to-postgres.ts could build it -- a node script that
+// shells out to git, which is exactly why the lane died when its GitHub
+// Actions caller was retired. The Worker lane and the script now call the same
+// functions, so a divergence between them is impossible rather than merely
+// unlikely.
+//
+// PURE ON PURPOSE. Nothing here reads a file, a network or a clock: it takes
+// an already-parsed overlay plus the commit it came from, and returns rows.
+// That is what lets the Worker feed it bytes fetched over HTTPS while the
+// script feeds it bytes read off disk, with no branch between them.
+import { OPERATIONAL_SURFACE_KINDS } from "./health-probe-core.ts";
+import { subnetSurfaceKey } from "./registry-surface-key.ts";
+
+// Registry overlays are validated against the surface schema rather than a TS
+// type; threading `unknown` through every `?.` would add casts without adding
+// safety. Mirrors the readJson precedent in scripts/lib.ts.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Row = Record<string, any>;
+
+const OPERATIONAL_KINDS = new Set<string>(OPERATIONAL_SURFACE_KINDS);
+
+export interface SubnetSyncRows {
+  subnet: Row;
+  surfaces: Row[];
+  prune: Row;
+}
+
+/** True when the overlay carries the three fields a subnet row cannot be built
+ * without. Checked by both callers before building, so a malformed file is
+ * skipped with a reason rather than producing a row with `undefined` in its
+ * primary key. */
+export function isSyncableSubnet(overlay: Row): boolean {
+  return Boolean(
+    Number.isInteger(overlay?.netuid) && overlay?.slug && overlay?.name,
+  );
+}
+
+export function isSyncableProvider(overlay: Row): boolean {
+  return Boolean(overlay?.id);
+}
+
+export function buildProviderRow(overlay: Row, sourceCommit: string): Row {
+  return { id: overlay.id, overlay, source_commit: sourceCommit };
+}
+
+/**
+ * One subnet file -> its subnet row, its surface rows, and its prune entry.
+ *
+ * `source` is unconditionally 'community' because this only ever runs for a
+ * file that CHANGED: a subnet that used to be machine-generated-only correctly
+ * flips the moment a contributor's first manual file for it lands, rather than
+ * staying stale from before that file existed.
+ *
+ * The prune is scoped to `authority: "community"` for a reason that is easy to
+ * get wrong. This file's `surfaces` array is only the community-authored ones;
+ * it has no visibility into machine-discovered or candidate-promoted surfaces
+ * the same subnet may also carry. An unscoped prune would delete rows this
+ * payload has no way to know about.
+ */
+export function buildSubnetRows(
+  overlay: Row,
+  sourceCommit: string,
+): SubnetSyncRows {
+  const { surfaces = [], ...subnetOverlay } = overlay;
+  const surfaceRows: Row[] = [];
+  const currentSurfaces: Row[] = [];
+  for (const surface of surfaces as Row[]) {
+    currentSurfaces.push({ kind: surface.kind, url: surface.url });
+    surfaceRows.push({
+      subnet_netuid: overlay.netuid,
+      provider_id: surface.provider || null,
+      surface_key: subnetSurfaceKey(surface, overlay.netuid),
+      kind: surface.kind,
+      url: surface.url,
+      authority: surface.authority || "community",
+      review_state: surface.review?.state || "community-submitted",
+      probe_eligible: Boolean(
+        surface.probe?.enabled &&
+        surface.public_safe &&
+        OPERATIONAL_KINDS.has(surface.kind),
+      ),
+      public_safe: surface.public_safe !== false,
+      overlay: surface,
+      source_commit: sourceCommit,
+    });
+  }
+  return {
+    subnet: {
+      netuid: overlay.netuid,
+      slug: overlay.slug,
+      name: overlay.name,
+      source: "community",
+      overlay: subnetOverlay,
+      source_commit: sourceCommit,
+    },
+    surfaces: surfaceRows,
+    prune: {
+      subnet_netuid: overlay.netuid,
+      current_surfaces: currentSurfaces,
+      source_commit: sourceCommit,
+      authority_scope: "community",
+    },
+  };
+}
+
+export interface RegistrySyncPayload {
+  providers: Row[];
+  subnets: Row[];
+  surfaces: Row[];
+  prune_surfaces: Row[];
+  delete_subnets: Row[];
+}
+
+/** A file the caller resolved: its path, its parsed overlay when it still
+ * exists at head, and the netuid it USED to have when it does not. */
+export interface ResolvedRegistryFile {
+  path: string;
+  overlay?: Row | null;
+  deletedNetuid?: number | null;
+}
+
+export function isRegistryPath(path: string): boolean {
+  return (
+    /^registry\/subnets\/[^/]+\.json$/.test(path) ||
+    /^registry\/providers\/[^/]+\.json$/.test(path)
+  );
+}
+
+/**
+ * The whole payload, from a set of resolved files.
+ *
+ * A DELETION IS ONLY A DELETION IF NOTHING RE-ADDS IT. A rename shows up as one
+ * removed path and one added path for the same netuid; emitting the delete
+ * would drop the subnet and everything referencing it, and the upsert that
+ * follows in the same request would not bring the surfaces back. So a netuid
+ * present in the upserts is filtered out of the deletes -- the same guard the
+ * script has always applied, kept here because the Worker is now a second
+ * caller that could otherwise miss it.
+ */
+export function buildRegistrySyncPayload(
+  files: readonly ResolvedRegistryFile[],
+  sourceCommit: string,
+): RegistrySyncPayload {
+  const payload: RegistrySyncPayload = {
+    providers: [],
+    subnets: [],
+    surfaces: [],
+    prune_surfaces: [],
+    delete_subnets: [],
+  };
+  for (const file of files) {
+    const isSubnet = file.path.startsWith("registry/subnets/");
+    if (!file.overlay) {
+      if (isSubnet && Number.isInteger(file.deletedNetuid)) {
+        payload.delete_subnets.push({
+          netuid: file.deletedNetuid,
+          source_commit: sourceCommit,
+        });
+      }
+      continue;
+    }
+    if (isSubnet) {
+      if (!isSyncableSubnet(file.overlay)) continue;
+      const rows = buildSubnetRows(file.overlay, sourceCommit);
+      payload.subnets.push(rows.subnet);
+      payload.surfaces.push(...rows.surfaces);
+      payload.prune_surfaces.push(rows.prune);
+    } else if (isSyncableProvider(file.overlay)) {
+      payload.providers.push(buildProviderRow(file.overlay, sourceCommit));
+    }
+  }
+  const upserted = new Set(payload.subnets.map((s) => s.netuid));
+  payload.delete_subnets = payload.delete_subnets.filter(
+    (d) => !upserted.has(d.netuid),
+  );
+  return payload;
+}
+
+/** Whether the payload would change anything. An empty one must not be POSTed:
+ * the sync route counts a request, and a no-op request that reports
+ * `subnets_written: 0` is indistinguishable from a broken one. */
+export function isEmptyPayload(payload: RegistrySyncPayload): boolean {
+  return (
+    payload.providers.length === 0 &&
+    payload.subnets.length === 0 &&
+    payload.surfaces.length === 0 &&
+    payload.prune_surfaces.length === 0 &&
+    payload.delete_subnets.length === 0
+  );
+}

--- a/tests/registry-sync-lane.test.ts
+++ b/tests/registry-sync-lane.test.ts
@@ -1,0 +1,343 @@
+// The registry writer's cursor, which is the part that can lose history.
+//
+// #9779: workers/registry-sync-api.ts called itself the ONLY write path into
+// the registry database and nothing called it, so surface_history froze on
+// 2026-08-02. This lane is the replacement, and the assertions below are all
+// about the ONE property that matters -- the cursor must never advance past
+// work that did not land, because a skipped range is a permanent hole in an
+// append-only audit trail rather than a delay.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+import { runRegistrySyncLane } from "../src/registry-sync-lane.ts";
+import {
+  buildRegistrySyncPayload,
+  isEmptyPayload,
+  isRegistryPath,
+} from "../src/registry-sync-payload.ts";
+
+function kv(initial: string | null = null) {
+  let value = initial;
+  return {
+    get: async () => value,
+    put: async (_k: string, v: string) => {
+      value = v;
+    },
+    read: () => value,
+  };
+}
+
+const OK_API = {
+  fetch: async () =>
+    new Response(JSON.stringify({ subnets_written: 1 }), { status: 200 }),
+};
+
+describe("the lane refuses to run without its dependencies", () => {
+  test("no KV means no cursor, so no tick", async () => {
+    const r = await runRegistrySyncLane(
+      { REGISTRY_SYNC_SECRET: "s" },
+      { kv: null, registrySyncApi: OK_API },
+    );
+    assert.equal(r.ok, false);
+    assert.match(r.reason!, /kv/i);
+  });
+
+  test("no service binding means the write has nowhere to go", async () => {
+    const r = await runRegistrySyncLane(
+      { REGISTRY_SYNC_SECRET: "s" },
+      { kv: kv(), registrySyncApi: null },
+    );
+    assert.equal(r.ok, false);
+    assert.match(r.reason!, /registry-sync binding/i);
+  });
+
+  test("an unprovisioned secret is reported, not sent as undefined", async () => {
+    // The sync route's shared-secret gate is the ONLY auth on that path.
+    // Posting without one would be rejected there, but reporting it here says
+    // which side is unconfigured.
+    const r = await runRegistrySyncLane(
+      {},
+      { kv: kv(), registrySyncApi: OK_API },
+    );
+    assert.equal(r.ok, false);
+    assert.match(r.reason!, /secret/i);
+  });
+});
+
+describe("isRegistryPath", () => {
+  test("accepts the two registry directories and nothing else", () => {
+    assert.equal(isRegistryPath("registry/subnets/apex.json"), true);
+    assert.equal(isRegistryPath("registry/providers/foo.json"), true);
+    assert.equal(isRegistryPath("registry/subnets/nested/apex.json"), false);
+    assert.equal(isRegistryPath("registry/schema.json"), false);
+    assert.equal(isRegistryPath("src/index.ts"), false);
+    // A path that merely CONTAINS the prefix must not match -- the sync would
+    // otherwise try to parse an unrelated file as an overlay.
+    assert.equal(isRegistryPath("docs/registry/subnets/apex.json"), false);
+  });
+});
+
+describe("buildRegistrySyncPayload", () => {
+  const SUBNET = {
+    netuid: 7,
+    slug: "apex",
+    name: "Apex",
+    surfaces: [
+      { kind: "api", url: "https://example.com/api", public_safe: true },
+    ],
+  };
+
+  test("a subnet file yields its row, its surfaces and its prune", () => {
+    const p = buildRegistrySyncPayload(
+      [{ path: "registry/subnets/apex.json", overlay: SUBNET }],
+      "abc123",
+    );
+    assert.equal(p.subnets.length, 1);
+    assert.equal(p.surfaces.length, 1);
+    assert.equal(p.prune_surfaces.length, 1);
+    assert.equal(p.subnets[0]!.source_commit, "abc123");
+    // The prune is scoped, or it would delete machine-discovered surfaces this
+    // payload has no way to know about.
+    assert.equal(p.prune_surfaces[0]!.authority_scope, "community");
+    // The surface array is stripped from the subnet overlay -- it is stored as
+    // rows, not as a blob inside the parent.
+    assert.equal(p.subnets[0]!.overlay.surfaces, undefined);
+  });
+
+  test("a surface carries a real derived key, not a placeholder", () => {
+    const p = buildRegistrySyncPayload(
+      [{ path: "registry/subnets/apex.json", overlay: SUBNET }],
+      "abc123",
+    );
+    assert.equal(p.surfaces[0]!.surface_key, "7|api|https://example.com/api");
+  });
+
+  test("a removed subnet file becomes a delete", () => {
+    const p = buildRegistrySyncPayload(
+      [
+        {
+          path: "registry/subnets/gone.json",
+          overlay: null,
+          deletedNetuid: 42,
+        },
+      ],
+      "abc123",
+    );
+    assert.deepEqual(p.delete_subnets, [
+      { netuid: 42, source_commit: "abc123" },
+    ]);
+  });
+
+  test("A RENAME MUST NOT DELETE THE SUBNET", () => {
+    // The failure this guard exists for. A rename is one removed path and one
+    // added path for the SAME netuid. Emitting the delete would drop the
+    // subnet and everything referencing it, and the upsert in the same request
+    // would not bring the surfaces back.
+    const p = buildRegistrySyncPayload(
+      [
+        { path: "registry/subnets/old.json", overlay: null, deletedNetuid: 7 },
+        { path: "registry/subnets/new.json", overlay: SUBNET },
+      ],
+      "abc123",
+    );
+    assert.deepEqual(p.delete_subnets, []);
+    assert.equal(p.subnets.length, 1);
+  });
+
+  test("a malformed overlay is skipped rather than written with holes", () => {
+    const p = buildRegistrySyncPayload(
+      [
+        { path: "registry/subnets/bad.json", overlay: { slug: "x" } },
+        { path: "registry/providers/bad.json", overlay: { name: "no id" } },
+      ],
+      "abc123",
+    );
+    assert.equal(p.subnets.length, 0);
+    assert.equal(p.providers.length, 0);
+    assert.equal(isEmptyPayload(p), true);
+  });
+
+  test("an empty payload is recognisable, so no no-op request is sent", () => {
+    assert.equal(isEmptyPayload(buildRegistrySyncPayload([], "abc")), true);
+    assert.equal(
+      isEmptyPayload(
+        buildRegistrySyncPayload(
+          [{ path: "registry/subnets/apex.json", overlay: SUBNET }],
+          "abc",
+        ),
+      ),
+      false,
+    );
+  });
+});
+
+describe("the cursor", () => {
+  /** Stubs the GitHub calls the lane makes, in the order it makes them. */
+  function stubGitHub(opts: {
+    head: string;
+    files?: { filename: string; status?: string }[];
+    contents?: Record<string, unknown>;
+  }) {
+    const original = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/commits/main"))
+        return new Response(JSON.stringify({ sha: opts.head }));
+      if (url.includes("/compare/"))
+        return new Response(JSON.stringify({ files: opts.files ?? [] }));
+      if (url.includes("/contents/")) {
+        const path = decodeURIComponent(
+          url.split("/contents/")[1]!.split("?")[0]!,
+        );
+        const overlay = opts.contents?.[path];
+        if (!overlay) return new Response("no", { status: 404 });
+        return new Response(
+          JSON.stringify({ content: btoa(JSON.stringify(overlay)) }),
+        );
+      }
+      return new Response("no", { status: 404 });
+    }) as typeof fetch;
+    return () => {
+      globalThis.fetch = original;
+    };
+  }
+
+  const ENV = { REGISTRY_SYNC_SECRET: "s", GITHUB_TOKEN: "t" };
+
+  test("the FIRST run records the head and syncs nothing", async () => {
+    // There is no honest base to compare against. Picking one would either
+    // resync the whole registry or silently skip everything before it; taking
+    // the head costs one merge of latency, once, and cannot be wrong.
+    const restore = stubGitHub({ head: "head1" });
+    try {
+      const store = kv(null);
+      const r = await runRegistrySyncLane(ENV, {
+        kv: store,
+        registrySyncApi: OK_API,
+      });
+      assert.equal(r.ok, true);
+      assert.match(r.reason!, /initialised/);
+      assert.equal(store.read(), "head1");
+    } finally {
+      restore();
+    }
+  });
+
+  test("an unchanged head costs ONE request and moves nothing", async () => {
+    let calls = 0;
+    const original = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return new Response(JSON.stringify({ sha: "same" }));
+    }) as typeof fetch;
+    try {
+      const store = kv("same");
+      const r = await runRegistrySyncLane(ENV, {
+        kv: store,
+        registrySyncApi: OK_API,
+      });
+      assert.equal(r.ok, true);
+      assert.match(r.reason!, /no new commits/);
+      assert.equal(calls, 1);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test("THE CURSOR DOES NOT ADVANCE WHEN THE SYNC IS REJECTED", async () => {
+    // The property this lane lives or dies on. Advancing past a failed POST
+    // turns one bad request into a permanent hole in surface_history -- which
+    // is the exact failure #9779 is about. The next tick must retry the same
+    // range.
+    const restore = stubGitHub({
+      head: "head2",
+      files: [{ filename: "registry/subnets/apex.json" }],
+      contents: {
+        "registry/subnets/apex.json": {
+          netuid: 7,
+          slug: "apex",
+          name: "Apex",
+          surfaces: [],
+        },
+      },
+    });
+    try {
+      const store = kv("base1");
+      const r = await runRegistrySyncLane(ENV, {
+        kv: store,
+        registrySyncApi: {
+          fetch: async () => new Response("nope", { status: 502 }),
+        },
+      });
+      assert.equal(r.ok, false);
+      assert.match(r.reason!, /rejected/);
+      assert.equal(store.read(), "base1", "cursor moved past a failed write");
+    } finally {
+      restore();
+    }
+  });
+
+  test("the cursor advances when the sync succeeds", async () => {
+    const restore = stubGitHub({
+      head: "head3",
+      files: [{ filename: "registry/subnets/apex.json" }],
+      contents: {
+        "registry/subnets/apex.json": {
+          netuid: 7,
+          slug: "apex",
+          name: "Apex",
+          surfaces: [],
+        },
+      },
+    });
+    try {
+      const store = kv("base1");
+      const r = await runRegistrySyncLane(ENV, {
+        kv: store,
+        registrySyncApi: OK_API,
+      });
+      assert.equal(r.ok, true);
+      assert.equal(store.read(), "head3");
+      assert.equal(r.files, 1);
+    } finally {
+      restore();
+    }
+  });
+
+  test("a commit touching no registry file still advances the cursor", async () => {
+    // Otherwise every unrelated merge would be re-diffed forever and the range
+    // would grow without bound.
+    const restore = stubGitHub({
+      head: "head4",
+      files: [{ filename: "src/index.ts" }],
+    });
+    try {
+      const store = kv("base1");
+      const r = await runRegistrySyncLane(ENV, {
+        kv: store,
+        registrySyncApi: OK_API,
+      });
+      assert.equal(r.ok, true);
+      assert.equal(store.read(), "head4");
+    } finally {
+      restore();
+    }
+  });
+
+  test("an unreachable GitHub leaves the cursor alone", async () => {
+    const original = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response("boom", { status: 500 })) as typeof fetch;
+    try {
+      const store = kv("base1");
+      const r = await runRegistrySyncLane(ENV, {
+        kv: store,
+        registrySyncApi: OK_API,
+      });
+      assert.equal(r.ok, false);
+      assert.equal(store.read(), "base1");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -414,6 +414,7 @@ import {
   readChainDetailHead,
   runChainDetailStalenessWatchdog,
 } from "../src/chain-detail-staleness-watchdog.ts";
+import { runRegistrySyncLane } from "../src/registry-sync-lane.ts";
 import { pruneChainDetail } from "../src/chain-detail-prune.ts";
 import { runRpcUsageStalenessWatchdog } from "../src/rpc-usage-staleness-watchdog.ts";
 import { runTopHoldersStalenessWatchdog } from "../src/top-holders-staleness-watchdog.ts";
@@ -489,6 +490,7 @@ import {
   PROJECTION_STALENESS_WATCHDOG_CRON,
   VALIDATOR_NOMINATOR_COUNTS_STALENESS_WATCHDOG_CRON,
   CHAIN_DETAIL_PRUNE_CRON,
+  REGISTRY_SYNC_CRON,
   CHAIN_CONCENTRATION_ROLLUP_CRON,
   CHAIN_DETAIL_STALENESS_WATCHDOG_CRON,
   TOP_HOLDERS_FLOW_CRON,
@@ -2101,6 +2103,7 @@ function cronLabel(cron: string): string {
   if (cron === VALIDATOR_NOMINATOR_COUNTS_STALENESS_WATCHDOG_CRON)
     return "validator-nominator-counts-staleness-watchdog";
   if (cron === CHAIN_DETAIL_PRUNE_CRON) return "chain-detail-prune";
+  if (cron === REGISTRY_SYNC_CRON) return "registry-sync";
   if (cron === CHAIN_CONCENTRATION_ROLLUP_CRON)
     return "chain-concentration-rollup";
   if (cron === CHAIN_DETAIL_STALENESS_WATCHDOG_CRON)
@@ -2434,6 +2437,13 @@ async function dispatchScheduled(
     return runValidatorNominatorCountsStalenessWatchdog(
       env as unknown as Record<string, unknown>,
     );
+  }
+  if (cron === REGISTRY_SYNC_CRON) {
+    // #9779: the registry had NO writer. Its only sync path was a pair of
+    // scripts invoked from GitHub Actions that no workflow calls, and
+    // surface_history froze on 2026-08-02 as a result. Returns a summary
+    // rather than throwing, like the rest of the cron family.
+    return runRegistrySyncLane(env);
   }
   if (cron === CHAIN_DETAIL_PRUNE_CRON) {
     // #9208 retention. Returns a summary rather than throwing so the #8998

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -208,6 +208,15 @@ export const CHAIN_DETAIL_PRUNE_CRON = "12,27,42,57 * * * *";
 // lane keeps the block list live and merely starts declining drill-down, which
 // is silent in aggregate. Minutes 14/29/44/59 are likewise unused elsewhere.
 export const CHAIN_DETAIL_STALENESS_WATCHDOG_CRON = "14,29,44,59 * * * *";
+// The registry writer (#9779). Four times an hour: registry changes arrive on
+// merges, so the only cost of a slower tick is how stale surface_history is,
+// and the only cost of a faster one is GitHub API calls against a 5,000/hour
+// authenticated budget. An unchanged main is ONE conditional request -- the
+// head sha is compared against KV before anything else is fetched.
+//
+// Minutes 10/25/40/55 tick on none of the hourly crons in this file and stay
+// off the */5 raw-capture and */15 probe grids.
+export const REGISTRY_SYNC_CRON = "10,25,40,55 * * * *";
 // #9464: the top-holders leaderboard's alarm. That lane had NO watchdog and no
 // producer -- `account_balances` died with the box and is not in the poller
 // Container's job set -- so the route served a one-shot pre-decommission

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -987,6 +987,8 @@
       // whole backlog in one D1 transaction. See CHAIN_DETAIL_PRUNE_CRON in
       // workers/config.ts and src/chain-detail-prune.ts's measured sizing.
       "12,27,42,57 * * * *",
+      // #9779 registry writer -- see REGISTRY_SYNC_CRON in workers/config.ts.
+      "10,25,40,55 * * * *",
       // 14,29,44,59 = the chain-detail staleness watchdog (#9208): alarms when
       // the live-follow decode lane stops advancing. Its own trigger rather
       // than a step inside the prune, so a prune failure cannot swallow the


### PR DESCRIPTION
Closes #9779. Part of #9787.

> Stacked on #10029 (the surface-key move). Retarget to `main` once that lands.

`workers/registry-sync-api.ts` calls itself *"the **ONLY** write path into the registry database"* — and **nothing calls it.** Its callers were two scripts invoked from GitHub Actions, and no workflow in `.github/workflows/` invokes either.

Measured consequence: `surface_history` frozen at **2026-08-02**, and commit `aac4ccd36` — which *removes* endpoints, exactly what `action='delete'` exists to record — never written down. `GET /api/v1/subnets/{netuid}/surface-history` has been serving a stale `latest_change_at` ever since.

## Three design calls

**A Worker cron, not a workflow.** This repo doesn't run data lanes from GitHub Actions — a scheduled producer there races the Worker lanes owning the same tables, and its failures land where nothing watches. The write path is otherwise unchanged: same service binding, same shared-secret gate.

**A poll, not a webhook.** A webhook needs repo configuration this code can neither assert nor repair. A poll is self-healing — a missed tick still sees the same moved head. An unchanged `main` costs **one** conditional request, because the head sha is compared against KV before anything else is fetched.

**The transformation is shared.** `src/registry-sync-payload.ts` is pure — no file, no network, no clock. The Worker feeds it bytes from HTTPS, the script feeds it bytes from disk, with no branch between them. Divergence is impossible rather than unlikely.

## The property this lane lives on

**The cursor advances only on a successful POST.** Advancing past a rejected write turns one bad request into a permanent hole in an append-only audit trail — the exact failure #9779 is about.

Verified by removing the guard:

```
FAIL tests/registry-sync-lane.test.ts > the cursor > THE CURSOR DOES NOT ADVANCE WHEN THE SYNC IS REJECTED
Tests  1 failed | 15 passed (16)
```

Restored: 16/16.

## Two cases that would corrupt data silently

- **A rename** is one removed path and one added path for the same netuid. Emitting the delete would drop the subnet and everything referencing it, and the upsert in the same request would *not* bring the surfaces back. A netuid present in the upserts is filtered out of the deletes.
- **The first run** has no honest base. Picking one would either resync the whole registry or silently skip everything before it. It records the head and syncs from the next commit — one merge of latency, once, and it cannot be wrong.

## Still to provision

`REGISTRY_SYNC_SECRET` exists on the registry Worker but **not** on the main Worker, and Cloudflare will not reveal an existing value. It needs rotating on both. Until then the lane returns `ok:false, reason:"registry sync secret not provisioned"` rather than posting an unauthenticated request — which is why that is a tested branch and not an assumption.