### PR TITLE
fix(neon): watch the two backfilled tables nothing was comparing

### DIFF
--- a/src/neon-parity-watchdog.ts
+++ b/src/neon-parity-watchdog.ts
@@ -87,6 +87,12 @@ export const PARITY_TABLES = [
   "surface_failure_daily",
   "subnet_burn_history",
   "tao_usd_index",
+  // Added by migrations/neon/0005 and named in NEON_BACKFILL_LANES, but never
+  // added here -- so both were reconciled into Neon with nothing comparing the
+  // two sides, which is the exact gap this lane exists to close. The deployed
+  // -wiring test caught it and had been failing on main.
+  "blocks_head",
+  "raw_capture_state",
 ] as const;
 
 /**


### PR DESCRIPTION
**`main` is red**, and has been — reproduced on `main` directly, so this is blocking every open PR rather than belonging to any one of them.

```
FAIL tests/neon-parity-watchdog.test.ts > the deployed wiring > every mirrored or backfilled table is watched
AssertionError: blocks_head is written to Neon but not in PARITY_TABLES
```

## What it means

`NEON_BACKFILL_LANES` names 20 tables reconciled D1 → Neon on a cron. `PARITY_TABLES` lists the tables whose row counts are compared between the two stores.

**`blocks_head` and `raw_capture_state` are in the first and not the second.** Both were added to Neon by `migrations/neon/0005_remaining_d1_tables.sql` and wired into the backfill lane; neither reached the watchdog. So both have been written into Neon on a schedule with **nothing comparing the two sides** — in the test's own words, *"the gap this lane exists to close: a table written to both stores with nothing comparing them"*.

The test is doing exactly its job. It should not be relaxed; the list is what changes.

## Why the list can fall behind

`PARITY_TABLES` is deliberately hand-maintained, and its comment explains why:

> Hand-listed rather than discovered, because "what is in Neon" is the thing being checked — deriving the list from Neon would make a table that silently vanished there look like a table nobody asked about.

That reasoning is right. It is also why the list can drift from a lane: nothing forces the two to be edited together **except this test** — which is the point of the test, and why it caught this.

No batching concern: `parityCountBatches` already chunks the sweep because D1 parses at most five `UNION ALL` terms (#9881), so 22 → 24 is free.

## Validation

```
npm run lint && npm run format:check && npm run typecheck
npx vitest run tests/neon-parity-watchdog.test.ts tests/ledger-neon-write.test.ts \
  tests/neon-backfill.test.ts tests/table-freshness-watchdog.test.ts
```

All green — 160 tests across every file naming `PARITY_TABLES`, `neon-parity`, or either table (grepped, not guessed).

Closes #10034