### PR TITLE
feat(data-api): invert the neurons write path behind the flag

### DIFF
--- a/tests/neon-sole-store.test.ts
+++ b/tests/neon-sole-store.test.ts
@@ -16,6 +16,8 @@ import { neonOwnsTable, neonSoleStoreTables } from "../src/neon-write.ts";
 import {
   ACCOUNT_STATE_TABLES,
   ALERT_TRIGGER_TABLES,
+  NEURONS_SNAPSHOT_TABLES,
+  neonOwnsNeuronsSnapshot,
   userStateRunner,
 } from "../workers/data-api.ts";
 
@@ -163,6 +165,52 @@ describe("userStateRunner", () => {
       // which is precisely the under-declaration the all-or-nothing rule
       // exists to make harmless -- and this assertion is what caught it.
       "watch_push_subscriptions",
+    ]);
+  });
+});
+
+describe("neonOwnsNeuronsSnapshot (the write-path inversion)", () => {
+  const ALL = ["neurons", "neuron_daily", "account_position_daily"];
+
+  function env(owned: string[], hyperdrive = true) {
+    return {
+      NEON_SOLE_STORE_TABLES: owned.join(","),
+      HYPERDRIVE: hyperdrive
+        ? { connectionString: "postgresql://example/db" }
+        : undefined,
+    } as never;
+  }
+
+  test("all three owned and Hyperdrive bound", () => {
+    assert.equal(neonOwnsNeuronsSnapshot(env(ALL)), true);
+  });
+
+  test("ONE table left out keeps the whole snapshot on D1", () => {
+    // The pass writes all three from one derivation. A half-listed group would
+    // leave neuron_daily in D1 while its parent moved, and the two would never
+    // agree again -- which no read gate would notice, because each table
+    // answers fine on its own.
+    for (const missing of ALL) {
+      const partial = ALL.filter((t) => t !== missing);
+      assert.equal(
+        neonOwnsNeuronsSnapshot(env(partial)),
+        false,
+        `${missing} missing should pin the snapshot to D1`,
+      );
+    }
+  });
+
+  test("owned but no Hyperdrive binding stays on D1", () => {
+    // Skipping the D1 write with nowhere to put the rows would drop a whole
+    // pass silently. The binding is a precondition, not an optimisation.
+    assert.equal(neonOwnsNeuronsSnapshot(env(ALL, false)), false);
+  });
+
+  test("the declared group is exactly what one snapshot writes", () => {
+    assert.deepEqual([...NEURONS_SNAPSHOT_TABLES].sort(), [
+      "account_position_daily",
+      "neuron_daily",
+      "neurons",
     ]);
   });
 });

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -776,18 +776,26 @@ async function handleNeuronsSync(
   // snapshot. db.batch() runs its statements in one implicit transaction --
   // a mid-batch failure must never leave `neurons` upserted with stale UIDs
   // left un-pruned.
-  let d1Statements: number;
-  try {
-    ({ statements: d1Statements } = await writeNeuronSnapshotToD1(
-      env.METAGRAPH_HEALTH_DB as unknown as Parameters<
-        typeof writeNeuronSnapshotToD1
-      >[0],
-      { rows, dailyRows, positionRows, netuidMaxCapturedAt, pass },
-    ));
-  } catch (err) {
-    console.error("data-api neurons-sync D1 write failed:", err);
-    await captureDataApiError(err, "neurons-sync-d1", env);
-    return writeJson({ error: "d1 write failed" }, 502);
+  // 0 when Neon owns the tables and the D1 write is skipped entirely.
+  let d1Statements = 0;
+  // THE INVERSION (#9787). Once Neon solely owns all three tables the D1
+  // write is skipped outright rather than written and ignored -- leaving it in
+  // would keep a second copy diverging quietly, which is the state this whole
+  // migration exists to end.
+  const neonOwns = neonOwnsNeuronsSnapshot(env);
+  if (!neonOwns) {
+    try {
+      ({ statements: d1Statements } = await writeNeuronSnapshotToD1(
+        env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+          typeof writeNeuronSnapshotToD1
+        >[0],
+        { rows, dailyRows, positionRows, netuidMaxCapturedAt, pass },
+      ));
+    } catch (err) {
+      console.error("data-api neurons-sync D1 write failed:", err);
+      await captureDataApiError(err, "neurons-sync-d1", env);
+      return writeJson({ error: "d1 write failed" }, 502);
+    }
   }
 
   // THE NEON MIRROR (metagraphed-infra#336), and it runs AFTER the D1 write
@@ -811,6 +819,28 @@ async function handleNeuronsSync(
     },
   );
 
+  // AUTHORITATIVE ONCE NEON OWNS THE TABLES. During dual-write a Neon failure
+  // cost a mirror and a lane verdict, never the pass, because D1 was still the
+  // store every route read. Once Neon IS the store that reasoning inverts: a
+  // pass that did not reach it did not happen, and reporting ok:true would
+  // tell the producer its rows are safe when nothing holds them.
+  if (neonOwns) {
+    const failed = Object.entries(neon.results).filter(([, r]) => !r.ok);
+    if (!neon.attempted || failed.length > 0) {
+      console.error("data-api neurons-sync Neon write failed:", failed);
+      await captureDataApiError(
+        new Error(
+          failed.length > 0
+            ? `neon write failed: ${failed.map(([t]) => t).join(", ")}`
+            : "neon write not attempted while Neon owns the tables",
+        ),
+        "neurons-sync-neon",
+        env,
+      );
+      return writeJson({ error: "neon write failed" }, 502);
+    }
+  }
+
   // `stores` stays REPORTED rather than inferred, so a reader can see which
   // stores this snapshot actually reached -- which is precisely the question
   // nobody could answer while Neon was frozen.
@@ -820,7 +850,7 @@ async function handleNeuronsSync(
     neuron_daily_written: dailyRows.length,
     account_position_daily_written: positionRows.length,
     netuids_covered: netuids.length,
-    stores: neon.attempted ? ["d1", "neon"] : ["d1"],
+    stores: neonOwns ? ["neon"] : neon.attempted ? ["d1", "neon"] : ["d1"],
     d1_statements: d1Statements,
     neon: neon.attempted ? neon.results : undefined,
   });
@@ -2939,6 +2969,38 @@ function normalizeDeliveryRow(row: Row): Row {
  * accident -- a table added to one of these groups cannot move until someone
  * puts its name in the flag.
  */
+/**
+ * The three tables one neurons snapshot writes.
+ *
+ * All or nothing, the same rule every other group in this file follows: the
+ * pass writes them from ONE derivation, so a half-listed group would leave
+ * neuron_daily in D1 while its parent moved and the two would never agree
+ * again.
+ */
+export const NEURONS_SNAPSHOT_TABLES = [
+  "neurons",
+  "neuron_daily",
+  "account_position_daily",
+] as const;
+
+/**
+ * Whether Neon is the ONLY store behind a neurons snapshot on this deployment.
+ *
+ * When true the D1 write is skipped outright and the Neon write becomes
+ * authoritative -- its failure is the request's failure, where during
+ * dual-write it was only a lane verdict. That inversion is the point: while D1
+ * still served reads, a Neon failure had to cost a mirror and not the pass;
+ * once Neon is the store, a pass that did not reach it did not happen.
+ */
+export function neonOwnsNeuronsSnapshot(env: Env): boolean {
+  return (
+    Boolean(env.HYPERDRIVE?.connectionString) &&
+    NEURONS_SNAPSHOT_TABLES.every((table) =>
+      neonOwnsTable(env as unknown as Record<string, unknown>, table),
+    )
+  );
+}
+
 export const ALERT_TRIGGER_TABLES = [
   "chain_alert_triggers",
   "chain_alert_deliveries",


### PR DESCRIPTION
Closes #10037. Part of #9787.

Every producer lane still writes D1 first and mirrors to Neon after. That was correct while D1 served the reads — a Neon failure had to cost a mirror and a lane verdict, not the pass. It is the opposite of what the end state needs.

## Why neurons goes first

It is the only lane where **both stores are at exact parity right now**, measured rather than assumed:

| table | D1 | Neon |
|---|---:|---:|
| `neurons` | 30,118 | 30,118 |
| `neuron_daily` | 877,039 | 877,039 |
| `account_position_daily` | 864,953 | 864,953 |

The mirror demonstrably writes everything the D1 path does. That is the precondition for skipping the D1 path at all — without it, inverting is just deleting a copy.

## What inverts

When the flag names all three **and** Hyperdrive is bound:

- **the D1 write is skipped outright**, not written and ignored. Leaving it in would keep a second copy diverging quietly, which is the state this migration exists to end.
- **the Neon write becomes authoritative** — any table's failure is the request's failure.

The second half is the point. A pass that did not reach the store did not happen, and reporting `ok:true` would tell the producer its rows are safe when nothing holds them.

`stores` in the response becomes `["neon"]`, so a reader can still see which stores a snapshot actually reached — the question nobody could answer while Neon was frozen.

## Two guards, both tested

**All or nothing.** One pass writes all three tables from one derivation. A half-listed group would leave `neuron_daily` in D1 while its parent moved, and the two would never agree again — which **no read gate would notice**, because each table answers fine on its own. The test asserts each of the three individually pins the snapshot to D1 when omitted.

**Hyperdrive is a precondition, not an optimisation.** Skipping the D1 write with nowhere to put the rows drops a whole pass silently.

## Ships inert

The flag stays empty here, so every deployment writes D1 exactly as today. Flipping it is a separate change after this deploys — the same order that caught the BIGINT type divergence before it reached a response (#9992 landed before #9996 for exactly this reason).