### PR TITLE
fix(registry): the sync lane records a durable verdict

### DIFF
--- a/src/registry-sync-lane.ts
+++ b/src/registry-sync-lane.ts
@@ -21,6 +21,7 @@
 // next one still sees the same moved head. Cost is one conditional request per
 // tick and nothing else: the sha is compared against KV before anything is
 // fetched, so an unchanged main is a single API call.
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import {
   buildRegistrySyncPayload,
   isEmptyPayload,
@@ -33,6 +34,7 @@ import {
  * repo's registry, and a wrong value would silently sync someone else's. */
 const REPO = "JSONbored/metagraphed";
 const KV_KEY = "registry-sync:last-synced-sha";
+export const REGISTRY_SYNC_LANE = "registry-sync";
 const API = "https://api.github.com";
 /** Enough for a normal merge; a bulk change beyond this resyncs over several
  * ticks because the cursor only advances on success. */
@@ -127,7 +129,54 @@ export async function runRegistrySyncLane(
   deps: {
     kv?: KvLike | null;
     registrySyncApi?: ServiceLike | null;
+    laneHealthDb?: LaneHealthDb | null;
+    now?: () => number;
   } = {},
+): Promise<RegistrySyncLaneResult> {
+  const result = await runRegistrySyncTick(env, deps);
+  // RECORDED, ALWAYS. A lane whose outcome lives only in a returned object is
+  // a lane nothing watches -- which is exactly how the thing this replaces
+  // went unnoticed from 2026-08-02 until somebody read surface_history by
+  // hand. The durable verdict is the point, not a nicety.
+  //
+  // "no new commits" is the overwhelmingly common outcome and it is `ok`: the
+  // lane did its job by looking. Only a tick that could NOT do its job is
+  // `stale`, which is what a watcher should act on.
+  const bag = (env ?? {}) as Record<string, unknown>;
+  await recordLaneVerdict(
+    deps.laneHealthDb ?? (bag.METAGRAPH_HEALTH_DB as LaneHealthDb | undefined),
+    {
+      lane: REGISTRY_SYNC_LANE,
+      verdict: result.ok ? "ok" : "stale",
+      age_ms: null,
+      detail: laneDetail(result),
+      checked_at: (deps.now ?? Date.now)(),
+    },
+  );
+  return result;
+}
+
+/** One line a human can act on, rather than a JSON blob in a TEXT column. */
+function laneDetail(result: RegistrySyncLaneResult): string {
+  if (!result.ok) {
+    return result.detail
+      ? `${result.reason}: ${result.detail}`
+      : `${result.reason}`;
+  }
+  if (result.reason) return result.reason;
+  const w = result.written ?? {};
+  return (
+    `${result.files ?? 0} file(s): ${w.subnets_written ?? 0} subnet(s), ` +
+    `${w.surfaces_written ?? 0} surface(s), ${w.surfaces_deleted ?? 0} deleted`
+  );
+}
+
+async function runRegistrySyncTick(
+  env: unknown,
+  deps: {
+    kv?: KvLike | null;
+    registrySyncApi?: ServiceLike | null;
+  },
 ): Promise<RegistrySyncLaneResult> {
   const bag = (env ?? {}) as Record<string, unknown>;
   const kv = deps.kv ?? (bag.METAGRAPH_CONTROL as KvLike | undefined);

--- a/tests/registry-sync-lane.test.ts
+++ b/tests/registry-sync-lane.test.ts
@@ -9,7 +9,10 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 
-import { runRegistrySyncLane } from "../src/registry-sync-lane.ts";
+import {
+  REGISTRY_SYNC_LANE,
+  runRegistrySyncLane,
+} from "../src/registry-sync-lane.ts";
 import {
   buildRegistrySyncPayload,
   isEmptyPayload,
@@ -336,6 +339,105 @@ describe("the cursor", () => {
       });
       assert.equal(r.ok, false);
       assert.equal(store.read(), "base1");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});
+
+describe("the lane records a durable verdict", () => {
+  /** A lane_health double that captures what was written. */
+  function laneDb() {
+    const rows: Record<string, unknown>[] = [];
+    return {
+      rows,
+      db: {
+        prepare: (_sql: string) => ({
+          bind: (...v: unknown[]) => {
+            rows.push({ v });
+            return { run: async () => ({}) };
+          },
+        }),
+      } as never,
+    };
+  }
+
+  test("a tick that could not run is stale, not silent", async () => {
+    // The failure mode this exists for. The lane it replaces reported nothing
+    // at all, which is why nobody noticed surface_history had frozen: an
+    // outcome that lives only in a returned object is an outcome nothing
+    // watches.
+    const sink = laneDb();
+    const r = await runRegistrySyncLane(
+      {},
+      { kv: kv(), registrySyncApi: OK_API, laneHealthDb: sink.db },
+    );
+    assert.equal(r.ok, false);
+    // Asserted on CONTENT, not on a row count: recordLaneVerdict also prunes
+    // the retention window, so it binds more than once per verdict.
+    const written = JSON.stringify(sink.rows);
+    assert.ok(written.includes(REGISTRY_SYNC_LANE));
+    assert.ok(
+      written.includes("stale"),
+      "a tick that could not run must record stale",
+    );
+  });
+
+  test('"no new commits" is ok — the lane did its job by looking', async () => {
+    const original = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ sha: "same" }))) as typeof fetch;
+    try {
+      const sink = laneDb();
+      const r = await runRegistrySyncLane(
+        { REGISTRY_SYNC_SECRET: "s" },
+        { kv: kv("same"), registrySyncApi: OK_API, laneHealthDb: sink.db },
+      );
+      assert.equal(r.ok, true);
+      const written = JSON.stringify(sink.rows);
+      assert.ok(written.includes(REGISTRY_SYNC_LANE));
+      assert.ok(written.includes("no new commits"));
+      // Emphatically NOT stale: an idle tick is the common case, and a lane
+      // that cried stale four times an hour would train everyone to ignore it.
+      assert.ok(!written.includes("stale"));
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test("a rejected sync records the reason, not just a boolean", async () => {
+    const original = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/commits/main"))
+        return new Response(JSON.stringify({ sha: "h" }));
+      if (url.includes("/compare/"))
+        return new Response(
+          JSON.stringify({ files: [{ filename: "registry/subnets/a.json" }] }),
+        );
+      return new Response(
+        JSON.stringify({
+          content: btoa(
+            JSON.stringify({ netuid: 1, slug: "a", name: "A", surfaces: [] }),
+          ),
+        }),
+      );
+    }) as typeof fetch;
+    try {
+      const sink = laneDb();
+      await runRegistrySyncLane(
+        { REGISTRY_SYNC_SECRET: "s" },
+        {
+          kv: kv("base"),
+          registrySyncApi: {
+            fetch: async () => new Response("no", { status: 502 }),
+          },
+          laneHealthDb: sink.db,
+        },
+      );
+      const written = JSON.stringify(sink.rows);
+      assert.ok(written.includes("rejected"));
+      assert.ok(written.includes("502"), "the status belongs in the detail");
     } finally {
       globalThis.fetch = original;
     }


### PR DESCRIPTION
Closes #10039. Part of #9787.

#10033 landed the registry writer. It is deployed, it is ticking, and it records **nothing**.

`lane_health` here is written per-lane, not by the cron wrapper — the wrapper's `laneForCron` label feeds PostHog telemetry, not the durable table. So `runRegistrySyncLane` returns a result object and that object is dropped.

Confirmed against production after the lane had already run:

```sql
SELECT * FROM lane_health WHERE lane LIKE '%registry%'
-- 0 rows
```

## Why this one matters more than usual

The lane this replaces reported nothing at all, and that is **exactly why nobody noticed** `surface_history` had been frozen since 2026-08-02 — it took reading the table by hand to find. Shipping its replacement with the same blind spot would be repeating the bug in a new place, which is worse than not having fixed it.

## The verdict semantics are a judgement, not a default

| outcome | verdict | why |
|---|---|---|
| `no new commits` | **ok** | the overwhelmingly common case, and the lane *did* its job by looking |
| no KV / no binding / no secret / GitHub unreachable / sync rejected | **stale** | the tick could not do its job |

A lane crying `stale` four times an hour trains everyone to ignore it — which is the same failure as silence, arrived at from the other direction.

The detail is one actionable line (reason + status on failure, file and row counts on success) rather than a JSON blob in a TEXT column.

## Verification

Asserted on **content rather than a row count** — `recordLaneVerdict` also prunes its retention window, so it binds more than once per verdict, and a count assertion would have been asserting the wrong thing while passing.

Checked the stale assertion can actually fail by pinning the verdict to `ok`:

```
Failed Tests 1
```

Restored: 19/19.