### PR TITLE
fix(api): a mistyped ss58 read as an empty account on 21 of 25 routes

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -15422,7 +15422,7 @@ export interface operations {
                      *             "from": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                      *             "last_block": 5000000,
                      *             "last_observed_at": "2026-06-01T00:00:00.000Z",
-                     *             "to": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *             "to": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                      *             "transfer_count": 5,
                      *             "volume_tao": 80
                      *           }
@@ -15551,7 +15551,7 @@ export interface operations {
                      *         "schema_version": 1,
                      *         "top_receivers": [
                      *           {
-                     *             "address": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *             "address": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                      *             "transfer_count": 4,
                      *             "volume_tao": 55
                      *           },
@@ -15569,7 +15569,7 @@ export interface operations {
                      *             "volume_tao": 60
                      *           },
                      *           {
-                     *             "address": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *             "address": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                      *             "transfer_count": 2,
                      *             "volume_tao": 20
                      *           }
@@ -18730,7 +18730,7 @@ export interface operations {
                      *       "data": {
                      *         "counterparties": [
                      *           {
-                     *             "address": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *             "address": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                      *             "last_block": 5000000,
                      *             "net_tao": -0.5,
                      *             "received_tao": 0,
@@ -18740,7 +18740,7 @@ export interface operations {
                      *         ],
                      *         "counterparty_count": 1,
                      *         "relationship": {
-                     *           "counterparty": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *           "counterparty": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                      *           "first_block": 5000000,
                      *           "first_seen_at": "2026-06-01T00:00:00.000Z",
                      *           "last_block": 5000000,
@@ -18762,7 +18762,7 @@ export interface operations {
                      *               "from": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                      *               "netuid": 7,
                      *               "observed_at": "2026-06-01T00:00:00.000Z",
-                     *               "to": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ"
+                     *               "to": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy"
                      *             }
                      *           ],
                      *           "transfers_scanned": 1
@@ -21109,7 +21109,7 @@ export interface operations {
                      *           {
                      *             "block_number": 5000000,
                      *             "from": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
-                     *             "to": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ"
+                     *             "to": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy"
                      *           }
                      *         ]
                      *       },
@@ -26901,7 +26901,7 @@ export interface operations {
                      *             "from": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                      *             "last_block": 5000000,
                      *             "last_observed_at": "2026-06-01T00:00:00.000Z",
-                     *             "to": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *             "to": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                      *             "transfer_count": 5,
                      *             "volume_tao": 80
                      *           }
@@ -27027,7 +27027,7 @@ export interface operations {
                      *         "schema_version": 1,
                      *         "top_receivers": [
                      *           {
-                     *             "address": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *             "address": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                      *             "transfer_count": 4,
                      *             "volume_tao": 55
                      *           },
@@ -27045,7 +27045,7 @@ export interface operations {
                      *             "volume_tao": 60
                      *           },
                      *           {
-                     *             "address": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *             "address": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                      *             "transfer_count": 2,
                      *             "volume_tao": 20
                      *           }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -146,7 +146,7 @@
           "data": {
             "counterparties": [
               {
-                "address": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                "address": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                 "last_block": 5000000,
                 "net_tao": -0.5,
                 "received_tao": 0,
@@ -156,7 +156,7 @@
             ],
             "counterparty_count": 1,
             "relationship": {
-              "counterparty": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+              "counterparty": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
               "first_block": 5000000,
               "first_seen_at": "2026-06-01T00:00:00.000Z",
               "last_block": 5000000,
@@ -178,7 +178,7 @@
                   "from": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                   "netuid": 7,
                   "observed_at": "2026-06-01T00:00:00.000Z",
-                  "to": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ"
+                  "to": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy"
                 }
               ],
               "transfers_scanned": 1
@@ -1248,7 +1248,7 @@
               {
                 "block_number": 5000000,
                 "from": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
-                "to": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ"
+                "to": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy"
               }
             ]
           },
@@ -3750,7 +3750,7 @@
                 "from": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                 "last_block": 5000000,
                 "last_observed_at": "2026-06-01T00:00:00.000Z",
-                "to": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                "to": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                 "transfer_count": 5,
                 "volume_tao": 80
               }
@@ -3799,7 +3799,7 @@
             "schema_version": 1,
             "top_receivers": [
               {
-                "address": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                "address": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                 "transfer_count": 4,
                 "volume_tao": 55
               },
@@ -3817,7 +3817,7 @@
                 "volume_tao": 60
               },
               {
-                "address": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                "address": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                 "transfer_count": 2,
                 "volume_tao": 20
               }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -15422,7 +15422,7 @@ export interface operations {
                      *             "from": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                      *             "last_block": 5000000,
                      *             "last_observed_at": "2026-06-01T00:00:00.000Z",
-                     *             "to": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *             "to": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                      *             "transfer_count": 5,
                      *             "volume_tao": 80
                      *           }
@@ -15551,7 +15551,7 @@ export interface operations {
                      *         "schema_version": 1,
                      *         "top_receivers": [
                      *           {
-                     *             "address": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *             "address": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                      *             "transfer_count": 4,
                      *             "volume_tao": 55
                      *           },
@@ -15569,7 +15569,7 @@ export interface operations {
                      *             "volume_tao": 60
                      *           },
                      *           {
-                     *             "address": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *             "address": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                      *             "transfer_count": 2,
                      *             "volume_tao": 20
                      *           }
@@ -18730,7 +18730,7 @@ export interface operations {
                      *       "data": {
                      *         "counterparties": [
                      *           {
-                     *             "address": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *             "address": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                      *             "last_block": 5000000,
                      *             "net_tao": -0.5,
                      *             "received_tao": 0,
@@ -18740,7 +18740,7 @@ export interface operations {
                      *         ],
                      *         "counterparty_count": 1,
                      *         "relationship": {
-                     *           "counterparty": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *           "counterparty": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                      *           "first_block": 5000000,
                      *           "first_seen_at": "2026-06-01T00:00:00.000Z",
                      *           "last_block": 5000000,
@@ -18762,7 +18762,7 @@ export interface operations {
                      *               "from": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                      *               "netuid": 7,
                      *               "observed_at": "2026-06-01T00:00:00.000Z",
-                     *               "to": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ"
+                     *               "to": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy"
                      *             }
                      *           ],
                      *           "transfers_scanned": 1
@@ -21109,7 +21109,7 @@ export interface operations {
                      *           {
                      *             "block_number": 5000000,
                      *             "from": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
-                     *             "to": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ"
+                     *             "to": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy"
                      *           }
                      *         ]
                      *       },
@@ -26901,7 +26901,7 @@ export interface operations {
                      *             "from": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                      *             "last_block": 5000000,
                      *             "last_observed_at": "2026-06-01T00:00:00.000Z",
-                     *             "to": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *             "to": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                      *             "transfer_count": 5,
                      *             "volume_tao": 80
                      *           }
@@ -27027,7 +27027,7 @@ export interface operations {
                      *         "schema_version": 1,
                      *         "top_receivers": [
                      *           {
-                     *             "address": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *             "address": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                      *             "transfer_count": 4,
                      *             "volume_tao": 55
                      *           },
@@ -27045,7 +27045,7 @@ export interface operations {
                      *             "volume_tao": 60
                      *           },
                      *           {
-                     *             "address": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *             "address": "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
                      *             "transfer_count": 2,
                      *             "volume_tao": 20
                      *           }

--- a/schemas-src/mcp-tools/get-subnet-metagraph.ts
+++ b/schemas-src/mcp-tools/get-subnet-metagraph.ts
@@ -42,7 +42,7 @@ export const GetSubnetMetagraphInputSchema = z
           "is the answer to 'is it registered', not an error.",
       )
       .meta({
-        examples: [["5CzcUxRe7rFbtGjw4DGfoJZTFqPnMwUFMTiMFURxCWmwBhqK"]],
+        examples: [["5CDYzuoN75FE8fBEJ3A587zsra9ee7xBLEwxrSgSpB3s4nsp"]],
       }),
     active: z
       .boolean()

--- a/src/analytics-live.ts
+++ b/src/analytics-live.ts
@@ -29,10 +29,10 @@ import {
   MAX_GLOBAL_INCIDENT_SOURCE_ROWS,
   MAX_INCIDENT_ROWS,
   MAX_UPTIME_ROWS,
-  SS58_ADDRESS_PATTERN,
   UPTIME_WINDOWS,
 } from "../workers/config.ts";
 import { composeCompareData } from "../workers/request-handlers/analytics-routes.ts";
+import { isFinneySs58Address } from "./account-balance.ts";
 import { registerModuleStateReset } from "./module-state-registry.ts";
 
 export { composeCompareData };
@@ -248,7 +248,7 @@ export function parseCompareHotkeyList(hotkeys: unknown): string[] | null {
   const result: string[] = [];
   const seen = new Set<string>();
   for (const value of hotkeys) {
-    if (typeof value !== "string" || !SS58_ADDRESS_PATTERN.test(value)) {
+    if (typeof value !== "string" || !isFinneySs58Address(value)) {
       return null;
     }
     if (seen.has(value)) continue;

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -538,7 +538,6 @@ import { KV_HEALTH_META } from "./kv-keys.ts";
 import {
   ANALYTICS_WINDOWS,
   DEFAULT_ANALYTICS_WINDOW,
-  SS58_ADDRESS_PATTERN,
 } from "../workers/config.ts";
 import { answerRpcUsage } from "./rpc-usage-answer.ts";
 import { loadChainServingColdTier } from "./chain-serving-loader.ts";
@@ -5808,7 +5807,7 @@ const rootValue = {
     // BAD_USER_INPUT error (same guard MCP applies), not a silent no-op. The
     // filter is applied at the Postgres tier's SQL WHERE, so it only needs to
     // ride the request params; the empty-rows builder fallback is unaffected.
-    if (coldkey != null && !SS58_ADDRESS_PATTERN.test(coldkey)) {
+    if (coldkey != null && !isFinneySs58Address(coldkey)) {
       throw new GraphQLError("coldkey must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -5962,7 +5961,7 @@ const rootValue = {
     { ss58, netuid, window }: QueryAccount_Position_HistoryArgs,
     context: GqlContext,
   ) {
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -6045,7 +6044,7 @@ const rootValue = {
   },
 
   async account({ ss58 }: QueryAccountArgs, context: GqlContext) {
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -6088,7 +6087,7 @@ const rootValue = {
     { ss58, window }: QueryAccount_PrometheusArgs,
     context: GqlContext,
   ) {
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -6138,7 +6137,7 @@ const rootValue = {
     { ss58, window, direction }: QueryAccount_Stake_FlowArgs,
     context: GqlContext,
   ) {
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -6208,7 +6207,7 @@ const rootValue = {
     { ss58 }: QueryAccount_PortfolioArgs,
     context: GqlContext,
   ) {
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -6249,7 +6248,7 @@ const rootValue = {
     { ss58 }: QueryAccount_PositionsArgs,
     context: GqlContext,
   ) {
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -6287,7 +6286,7 @@ const rootValue = {
     { ss58 }: QueryAccount_SubnetsArgs,
     context: GqlContext,
   ) {
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -6321,7 +6320,7 @@ const rootValue = {
     // Same SS58 + window validation handleAccountRegistrations (via
     // makeAccountEventHandler) uses -- a malformed address or unsupported
     // window is a GraphQL BAD_USER_INPUT error, not a silent card.
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -6382,7 +6381,7 @@ const rootValue = {
     // Same SS58 + window validation handleAccountDeregistrations (via
     // makeAccountEventHandler) uses -- a malformed address or unsupported
     // window is a GraphQL BAD_USER_INPUT error, not a silent card.
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -6448,7 +6447,7 @@ const rootValue = {
     // Same SS58 + window validation handleAccountServing (via
     // makeAccountEventHandler) uses -- a malformed address or unsupported
     // window is a GraphQL BAD_USER_INPUT error, not a silent card.
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -6509,7 +6508,7 @@ const rootValue = {
     // Same SS58 + window validation handleAccountAxonRemovals (via
     // makeAccountEventHandler) uses -- a malformed address or unsupported
     // window is a GraphQL BAD_USER_INPUT error, not a silent card.
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -6566,7 +6565,7 @@ const rootValue = {
     // Same SS58 + window validation handleAccountStakeMoves (via
     // makeAccountEventHandler) uses -- a malformed address or unsupported
     // window is a GraphQL BAD_USER_INPUT error, not a silent card.
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -6625,7 +6624,7 @@ const rootValue = {
     { ss58, window }: QueryAccount_Weight_SettersArgs,
     context: GqlContext,
   ) {
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -6680,7 +6679,7 @@ const rootValue = {
     { ss58 }: QueryAccount_EntitiesArgs,
     context: GqlContext,
   ) {
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -6727,7 +6726,7 @@ const rootValue = {
   ) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
     // is a GraphQL BAD_USER_INPUT error, not a silent empty card.
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -6767,7 +6766,7 @@ const rootValue = {
   ) {
     // Same SS58 validation every account_* resolver uses -- a malformed
     // address is a GraphQL BAD_USER_INPUT error, not a silent empty timeline.
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -6823,7 +6822,7 @@ const rootValue = {
   ) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
     // is a GraphQL BAD_USER_INPUT error, not a silent empty card.
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -6831,7 +6830,7 @@ const rootValue = {
     // The relationship drilldown needs a second, distinct SS58 -- the same two
     // guards the get_account_counterparties MCP tool applies to `counterparty`.
     if (counterparty != null) {
-      if (!SS58_ADDRESS_PATTERN.test(counterparty)) {
+      if (!isFinneySs58Address(counterparty)) {
         throw new GraphQLError("counterparty must be a valid SS58 address.", {
           extensions: { code: "BAD_USER_INPUT" },
         });
@@ -6961,7 +6960,7 @@ const rootValue = {
   ) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
     // is a GraphQL BAD_USER_INPUT error, not a silent empty feed.
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -7040,7 +7039,7 @@ const rootValue = {
   ) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
     // is a GraphQL BAD_USER_INPUT error, not a silent empty feed.
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -7113,7 +7112,7 @@ const rootValue = {
   ) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
     // is a GraphQL BAD_USER_INPUT error, not a silent empty feed.
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
@@ -7191,7 +7190,7 @@ const rootValue = {
   ) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
     // is a GraphQL BAD_USER_INPUT error, not a silent empty series.
-    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+    if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -207,7 +207,7 @@ import {
   recordTraceSpan,
   shouldSampleTrace,
 } from "./tracing.ts";
-import { resolveClientIp, SS58_ADDRESS_PATTERN } from "../workers/config.ts";
+import { resolveClientIp } from "../workers/config.ts";
 import {
   applyTieredRateLimit,
   spendDeferredDailyQuota,
@@ -3852,14 +3852,21 @@ function requireKnownEventKind(kind: unknown) {
   }
 }
 
-// Require a bare SS58 address (hotkey or coldkey) — the same shape the REST
-// account routes accept, from the shared SS58_ADDRESS_PATTERN.
+// Require a bare SS58 address (hotkey or coldkey) — the same verdict the REST
+// account routes reach, via the shared isFinneySs58Address.
+//
+// This checks the CHECKSUM, not just the base58 shape (#10036). A shape-only
+// test accepts a one-character typo — right alphabet, right length, wrong
+// bytes — and every account tool then answered it with a confident empty
+// result that reads as "this account holds nothing" rather than "that is not
+// an address". isFinneySs58Address subsumes the shape check, so this is
+// strictly narrower than the SS58_ADDRESS_PATTERN test it replaced.
 function requireSs58(args: Row) {
   const value = requireString(args, "ss58");
-  if (!SS58_ADDRESS_PATTERN.test(value)) {
+  if (!isFinneySs58Address(value)) {
     throw toolError(
       "invalid_params",
-      "Argument `ss58` must be a valid SS58 account address (base58, 47-48 chars).",
+      "Argument `ss58` must be a valid finney SS58 account address.",
     );
   }
   return value;
@@ -3867,16 +3874,17 @@ function requireSs58(args: Row) {
 
 // The optional forms of requireHotkey, for the two neuron tools that take a
 // hotkey as an ALTERNATIVE to a UID rather than as the subject (#9872). Each
-// element is pattern-checked, so a caller who passes a coldkey-looking typo
+// element is checksum-checked, so a caller who passes a coldkey-looking typo
 // or a name gets `invalid_params` naming the bad element rather than an empty
-// result they would read as "not registered".
+// result they would read as "not registered" — which is the whole reason this
+// validates at all, and why a shape-only test was not enough (#10036).
 function optionalHotkey(args: Row, key: string): string | null {
   const value = args?.[key];
   if (value === undefined || value === null) return null;
-  if (typeof value !== "string" || !SS58_ADDRESS_PATTERN.test(value)) {
+  if (typeof value !== "string" || !isFinneySs58Address(value)) {
     throw toolError(
       "invalid_params",
-      `Argument \`${key}\` must be a valid SS58 hotkey (base58, 47-48 chars).`,
+      `Argument \`${key}\` must be a valid finney SS58 hotkey.`,
     );
   }
   return value;
@@ -3892,25 +3900,25 @@ function optionalHotkeyArray(args: Row, key: string): string[] | null {
     );
   }
   for (const entry of value) {
-    if (typeof entry !== "string" || !SS58_ADDRESS_PATTERN.test(entry)) {
+    if (typeof entry !== "string" || !isFinneySs58Address(entry)) {
       throw toolError(
         "invalid_params",
-        `Argument \`${key}\` contains an entry that is not a valid SS58 hotkey (base58, 47-48 chars).`,
+        `Argument \`${key}\` contains an entry that is not a valid finney SS58 hotkey.`,
       );
     }
   }
   return value as string[];
 }
 
-// A validator identity is the same SS58 shape as an account, just a different
+// A validator identity is the same SS58 address as an account, just a different
 // argument name (a hotkey the caller already knows, not one they're looking
-// up) -- same runtime pattern check as requireSs58, distinct error text.
+// up) -- same runtime checksum check as requireSs58, distinct error text.
 function requireHotkey(args: Row) {
   const value = requireString(args, "hotkey");
-  if (!SS58_ADDRESS_PATTERN.test(value)) {
+  if (!isFinneySs58Address(value)) {
     throw toolError(
       "invalid_params",
-      "Argument `hotkey` must be a valid SS58 account address (base58, 47-48 chars).",
+      "Argument `hotkey` must be a valid finney SS58 account address.",
     );
   }
   return value;
@@ -8050,10 +8058,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       );
       const offset = optionalNonNegativeInt(args, "offset") ?? 0;
       const coldkey = optionalString(args, "coldkey");
-      if (coldkey && !SS58_ADDRESS_PATTERN.test(coldkey)) {
+      if (coldkey && !isFinneySs58Address(coldkey)) {
         throw toolError(
           "invalid_params",
-          "Argument `coldkey` must be a valid SS58 account address (base58, 47-48 chars).",
+          "Argument `coldkey` must be a valid finney SS58 account address.",
         );
       }
       // The DATA_API route (workers/data-api.ts) wraps its response as
@@ -10500,10 +10508,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       const ss58 = requireSs58(args);
       const counterparty = optionalString(args, "counterparty");
       if (counterparty != null) {
-        if (!SS58_ADDRESS_PATTERN.test(counterparty)) {
+        if (!isFinneySs58Address(counterparty)) {
           throw toolError(
             "invalid_params",
-            "Argument `counterparty` must be a valid SS58 account address (base58, 47-48 chars).",
+            "Argument `counterparty` must be a valid finney SS58 account address.",
           );
         }
         if (counterparty === ss58) {

--- a/src/openapi-sample.ts
+++ b/src/openapi-sample.ts
@@ -22,7 +22,7 @@ const CURSOR3 = "100.123.4";
 const HEX64 = "a3f1".repeat(16); // 64 hex chars, matches ^[a-f0-9]{64}$
 const SAMPLE_SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 const SAMPLE_COUNTERPARTY_SS58 =
-  "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ";
+  "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy";
 
 function valueForPattern(pattern: string, name = ""): string {
   const n = String(name || "").toLowerCase();

--- a/tests/account-ss58-checksum-guard.test.ts
+++ b/tests/account-ss58-checksum-guard.test.ts
@@ -1,0 +1,100 @@
+// The single checksum guard over every /api/v1/accounts/{ss58}/… route (#10036).
+//
+// Before it, 21 of the 25 account routes shape-checked the address with a
+// base58 regex and never verified its checksum, so a one-character typo — the
+// exact shape a mistyped address has — came back as a confident empty result
+// rather than an error. Only the four live-chain routes (balance, root-claim,
+// children, parents) rejected it, and only because they had to decode the
+// address before spending an RPC call.
+//
+// The route list is read from the published contract rather than hand-listed,
+// so an account route added later is covered without anyone remembering to.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { handleRequest } from "../workers/api.ts";
+import { mockEnv } from "./row-type.ts";
+
+// A real finney address (a live top holder), and the same address with its
+// checksum broken: base58 alphabet, correct length, wrong trailing bytes.
+const VALID = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";
+const BAD_CHECKSUM = "5EYCAe5jLQhn6ofDSvqFmCXAEZUZ2VZbtnPZmZmnUJVEexHY";
+
+const openapi = JSON.parse(
+  readFileSync("public/metagraph/openapi.json", "utf8"),
+) as { paths: Record<string, unknown> };
+
+const ACCOUNT_ROUTES = Object.keys(openapi.paths).filter((path) =>
+  path.includes("/accounts/{ss58}"),
+);
+
+function fill(route: string, ss58: string) {
+  return route
+    .replace("{ss58}", ss58)
+    .replace("{network}", "finney")
+    .replace("{netuid}", "3");
+}
+
+async function call(path: string) {
+  return handleRequest(
+    new Request(`https://api.metagraph.sh${path}`),
+    mockEnv(),
+    {},
+  );
+}
+
+describe("account ss58 checksum guard", () => {
+  test("the contract publishes the account routes this guard covers", () => {
+    // If the filter stops matching, every assertion below passes vacuously.
+    assert.ok(
+      ACCOUNT_ROUTES.length >= 25,
+      `expected the account route family, found ${ACCOUNT_ROUTES.length}`,
+    );
+  });
+
+  test("every account route rejects a bad-checksum address", async () => {
+    const accepted: string[] = [];
+    for (const route of ACCOUNT_ROUTES) {
+      const res = await call(fill(route, BAD_CHECKSUM));
+      const body = (await res.json()) as { error?: { code?: string } };
+      if (res.status !== 400 || body.error?.code !== "invalid_ss58") {
+        accepted.push(`${route} -> ${res.status} ${body.error?.code ?? "ok"}`);
+      }
+    }
+    assert.deepEqual(accepted, []);
+  });
+
+  test("a shape-valid address is not rejected by the guard", async () => {
+    // The guard must not over-reject: with no bindings these routes fail or
+    // serve empty for their own reasons, but never with invalid_ss58. This is
+    // what makes the test above meaningful rather than "everything 400s".
+    for (const route of ACCOUNT_ROUTES) {
+      const res = await call(fill(route, VALID));
+      const body = (await res.json().catch(() => ({}))) as {
+        error?: { code?: string };
+      };
+      assert.notEqual(
+        body.error?.code,
+        "invalid_ss58",
+        `${route} rejected a valid address`,
+      );
+    }
+  });
+
+  test("an address-unshaped segment still 404s at the router", async () => {
+    // The two failure modes are different answers and both are correct: a
+    // segment that is not address-SHAPED matches no account route at all, so
+    // the path identifies nothing and 404 is the honest reply. Only a segment
+    // that IS shaped and fails the checksum is a malformed path parameter.
+    // Widening the guard's capture to any segment collapses the first into the
+    // second — two pre-existing tests caught exactly that, and this pins it
+    // from the guard's own side.
+    for (const path of [
+      "/api/v1/accounts/not-an-address/children",
+      "/api/v1/accounts/not-a-valid-address/subnets/7/history",
+    ]) {
+      const res = await call(path);
+      assert.equal(res.status, 404, path);
+    }
+  });
+});

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -9495,8 +9495,8 @@ describe("graphql — subnet_concentration_history (#5901, neuron_daily trend + 
 });
 
 describe("graphql — discovery parity (#6989, search/domains/compare_validators)", () => {
-  const HOTKEY_A = "5FnPunMdSFTr8swMhMTdSGFqiZAJTBEDaAgTmrKfSpvRQyaR";
-  const HOTKEY_B = "5CXRfP2ZfvGCe8EQoZnjuBVUkado1RyfHf1zPTMhVpvSJHnp";
+  const HOTKEY_A = "5CdBXrFknELV1B3FwPTzwA4Qc5hhne7WknsX2ZNfS6vGrgta";
+  const HOTKEY_B = "5C4tRBiY1m1W3TC7WiJk8K5cmHGTtPCzz64JHgaYQLQfAxmX";
 
   test("search pages the baked full index", async () => {
     const env = fixtureEnv({

--- a/tests/mcp-neuron-hotkey-lookup.test.ts
+++ b/tests/mcp-neuron-hotkey-lookup.test.ts
@@ -11,8 +11,8 @@ import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import type { Row } from "./row-type.ts";
 
 const HOTKEY_A = "5GP7c3fFazW9GXK8Up3qgu2DJBk8inu4aK9TZy3RuoSWVCMi";
-const HOTKEY_B = "5CzcUxRe7rFbtGjw4DGfoJZTFqPnMwUFMTiMFURxCWmwBhqK";
-const HOTKEY_ABSENT = "5DkwfxC9mZTTCsRUt6nrnwQEWVQ4xnWDkGDMDkFHqTfxNZTP";
+const HOTKEY_B = "5CDYzuoN75FE8fBEJ3A587zsra9ee7xBLEwxrSgSpB3s4nsp";
+const HOTKEY_ABSENT = "5CS3g6nVJM6ouns8n9buN9CzFf2C1YDHVcVGRcxoirKs2xbV";
 
 function snapshotRows(): Row[] {
   return [

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -21531,7 +21531,7 @@ describe("MCP validator detail/nominators/history tools (#5225 parity)", () => {
   // compare_validators (#6035): a read-only side-by-side of several validators
   // for a stake/delegate decision, one get_validator_detail-shaped load per
   // hotkey, projected to take/APY/nominator-count/identity + aggregates.
-  const HOTKEY2 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc6";
+  const HOTKEY2 = "5Co8xWUK9MXiSuLevkfFgUpEnSMx6TfziFax9JcTRY4V6LcU";
 
   test("compare_validators returns a schema-stable comparison over the empty base", async () => {
     const res = await callTool("compare_validators", {

--- a/tests/openapi-sample.test.ts
+++ b/tests/openapi-sample.test.ts
@@ -104,8 +104,8 @@ describe("sampleFromSchema", () => {
       method: "GET",
       ss58: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
       from: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
-      counterparty: "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
-      to: "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+      counterparty: "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
+      to: "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
       surface_id: "example",
       unmatched_field: "example",
     };
@@ -164,7 +164,7 @@ describe("sampleFromSchema", () => {
         { type: "string", pattern: "^[1-9A-HJ-NP-Za-km-z]{47,48}$" },
         "counterparty",
       ),
-      "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+      "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
     );
     assert.match(
       s({ type: "string", pattern: "^[a-z0-9][a-z0-9-]*$" }),
@@ -349,7 +349,7 @@ describe("sampleFromSchema", () => {
     assert.equal(sample.total_received_tao, 0);
     assert.deepEqual(sample.counterparties, [
       {
-        address: "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+        address: "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
         sent_tao: 0.5,
         received_tao: 0,
         net_tao: -0.5,
@@ -513,14 +513,14 @@ describe("sampleFromSchema", () => {
         transfer_count: 3,
       },
       {
-        address: "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+        address: "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
         volume_tao: 20,
         transfer_count: 2,
       },
     ]);
     assert.deepEqual(sample.top_receivers, [
       {
-        address: "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+        address: "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
         volume_tao: 55,
         transfer_count: 4,
       },
@@ -1390,7 +1390,7 @@ describe("sampleFromSchema", () => {
     assert.deepEqual(sample.pairs, [
       {
         from: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
-        to: "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+        to: "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy",
         volume_tao: 80,
         transfer_count: 5,
         last_block: 5000000,

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -115,7 +115,7 @@ import {
 const addFormats = addFormatsPlugin as unknown as (instance: Ajv2020) => void;
 
 const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
-const COUNTERPARTY = "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ";
+const COUNTERPARTY = "5D7FVSM1fJM56zHJuMBuQ5LH32mkLni52JonoeppFrezvyHy";
 const HASH = `0x${"a".repeat(64)}`;
 const NETUID = 7;
 const UID = 3;

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -409,6 +409,7 @@ import { runNominatorPositionsStalenessWatchdog } from "../src/nominator-positio
 import { runProjectionStalenessWatchdog } from "../src/projection-staleness-watchdog.ts";
 import { runValidatorNominatorCountsStalenessWatchdog } from "../src/validator-nominator-counts-staleness-watchdog.ts";
 import { runAccountBalancesStalenessWatchdog } from "../src/account-balances-staleness-watchdog.ts";
+import { isFinneySs58Address } from "../src/account-balance.ts";
 import { runHotkeyAlphaStalenessWatchdog } from "../src/hotkey-alpha-staleness-watchdog.ts";
 import {
   readChainDetailHead,
@@ -452,6 +453,7 @@ import {
   ACCOUNT_CHILDREN_PATH_PATTERN,
   ACCOUNT_PARENTS_PATH_PATTERN,
   ACCOUNT_ENTITIES_PATH_PATTERN,
+  ACCOUNT_SS58_SEGMENT_PATH_PATTERN,
   ACCOUNT_EVENTS_PATH_PATTERN,
   ACCOUNT_HISTORY_PATH_PATTERN,
   ACCOUNT_EXTRINSICS_PATH_PATTERN,
@@ -5489,6 +5491,29 @@ export async function handleRequest(
         env,
         Number(subnetEventsMatch[1]),
         resolved.url,
+      );
+    }
+    // One checksum guard for every stored-data account route below (#10036).
+    // The four live-chain ones (balance/root-claim/children/parents) already
+    // reject a bad address in their handlers before spending an RPC call, and
+    // dispatchLiveChainRoute runs above, so they never reach this. Everything
+    // below reads a STORED address and used to answer a bad-checksum address
+    // with a confident empty result — the exact output a one-character typo
+    // produces, and indistinguishable from "this account holds nothing". The
+    // guard sits here, once, rather than in 21 handlers: an account route
+    // added tomorrow inherits it instead of having to remember it.
+    //
+    // Only ADDRESS-SHAPED segments reach this. An unshaped one matches no
+    // account route and keeps 404ing at the router, which is the honest answer
+    // for a path that identifies nothing.
+    const accountSs58Match = ACCOUNT_SS58_SEGMENT_PATH_PATTERN.exec(
+      resolved.url.pathname,
+    );
+    if (accountSs58Match && !isFinneySs58Address(accountSs58Match[1])) {
+      return errorResponse(
+        "invalid_ss58",
+        "ss58 address must be a valid finney SS58 account address.",
+        400,
       );
     }
     // Account entity routes (#1347): computed live from the account_events +

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -601,6 +601,23 @@ export const SUBNET_IDENTITY_HISTORY_PATH_PATTERN =
 // A bare, anchored SS58 address — the same shape the route patterns capture,
 // reused by the MCP account tools so REST and MCP validate the address identically.
 export const SS58_ADDRESS_PATTERN = /^[1-9A-HJ-NP-Za-km-z]{47,48}$/;
+// The {ss58} segment of ANY /api/v1/accounts/… route, for the single checksum
+// guard in handleRequest (#10036). The per-route patterns below shape-check
+// base58 + length, which rejects obvious junk but cannot see a bad checksum —
+// so a one-character typo used to route through to a confident empty result on
+// 21 of the 25 account routes.
+//
+// This deliberately repeats the {47,48} base58 shape rather than capturing any
+// segment, because the two failure modes are different answers and both are
+// correct: a segment that is not address-SHAPED (`not-an-address`) matches no
+// account route at all and must stay a 404, while a segment that IS shaped and
+// fails the checksum is a malformed path parameter and must be a 400. Widening
+// this to `([^/]+)` collapses the first into the second.
+//
+// The two literal-segment routes (/accounts, /accounts/top-holders) are
+// dispatched before the guard runs, so they never reach it.
+export const ACCOUNT_SS58_SEGMENT_PATH_PATTERN =
+  /^\/api\/v1\/accounts\/([1-9A-HJ-NP-Za-km-z]{47,48})(?:\/|$)/;
 export const ACCOUNT_PATH_PATTERN =
   /^\/api\/v1\/accounts\/([1-9A-HJ-NP-Za-km-z]{47,48})$/;
 export const ACCOUNT_EVENTS_PATH_PATTERN =

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -31,7 +31,7 @@ import {
   networkKvKey,
   type ChainNetworkId,
 } from "../../src/chain-network.ts";
-import { SS58_ADDRESS_PATTERN, resolveClientIp } from "../config.ts";
+import { resolveClientIp } from "../config.ts";
 import {
   BLOCK_PAGINATION,
   FEED_PAGINATION,
@@ -1605,7 +1605,7 @@ export async function handleValidatorNominators(
   });
   if ("error" in offset) return analyticsQueryError(offset.error);
   const coldkeyParam = url.searchParams.get("coldkey");
-  if (coldkeyParam !== null && !SS58_ADDRESS_PATTERN.test(coldkeyParam)) {
+  if (coldkeyParam !== null && !isFinneySs58Address(coldkeyParam)) {
     return analyticsQueryError({
       parameter: "coldkey",
       message: `"coldkey" must be a valid SS58 address.`,
@@ -5314,7 +5314,7 @@ export async function handleAccountCounterparties(
           "format=csv is not supported with counterparty; remove counterparty to export the list-mode counterparties CSV.",
       });
     }
-    if (!SS58_ADDRESS_PATTERN.test(counterparty)) {
+    if (!isFinneySs58Address(counterparty)) {
       return analyticsQueryError({
         parameter: "counterparty",
         message: "counterparty must be a valid SS58 account address.",


### PR DESCRIPTION
## Summary

`SS58_ADDRESS_PATTERN` checks the base58 alphabet and length. It cannot see a checksum, so an address with **one character wrong** — the shape a real typo produces — passed every validator built on it and came back as a confident empty result.

A caller who mistyped an address was told by `balance` that it was invalid, and by 21 sibling routes that **the account holds nothing**. There is no way to tell that apart from a genuinely empty account.

`isFinneySs58Address` already existed and already did this correctly. The four live-chain routes used it because they had to decode the address before spending an RPC call — the other surfaces just never reached it.

## Scope

Enumerated from the published contract rather than from the three routes I first probed:

| surface | sites | before |
|---|---|---|
| REST path params | 21 of 25 account routes | accepted, returned an empty card |
| GraphQL | 23 resolver arguments | accepted |
| MCP | 6 validators | `get_account_subnets` → `subnet_count: 0` |
| REST query params | 2 (`coldkey`, `counterparty`) | accepted |

The REST path fix is **one guard at the dispatch boundary**, not 21 handler edits, so an account route added later inherits it instead of having to remember it. Everywhere else the predicate is swapped for the checksum check, which subsumes the shape test.

## The distinction this preserves

Shape-invalid and checksum-invalid are **different answers and both current behaviours are correct**:

- a segment that is not address-*shaped* (`not-an-address`) matches no account route — the path identifies nothing, so it stays a **404**
- a *shaped* segment that fails the checksum is a malformed path parameter — **400 `invalid_ss58`**

My first attempt captured any segment and collapsed the first into the second. Two pre-existing tests caught it, which is exactly what they were written for; the guard now repeats the `{47,48}` shape deliberately, and a new test pins the distinction from the guard's own side.

## Also fixed: the published examples were themselves invalid

`src/openapi-sample.ts` and one `schemas-src/mcp-tools/` example carried checksum-invalid addresses — our own documented samples would have been rejected by our own API once this landed. Fixed, contract regenerated.

## Verification

Against **753 real addresses** pulled from production (chain holders, validators, a subnet metagraph, chain signers):

```
real addresses: 753
rejected by isFinneySs58Address: 0
bad-checksum control rejected: true
```

Every account route probed against production before the fix:

```
balance children parents root-claim  -> invalid_ss58
the other 21                         -> ACCEPTED
```

The new test derives its route list from `openapi.json`, so a future account route is covered without anyone remembering to add it. It was confirmed to **fail without the guard** (not a test that passes on nothing).

## Commands run

- `npm run build` (contract regenerated; deploy-owned artifacts reverted against `origin/main`)
- `npm run typecheck` — clean
- `npm run lint`, `npm run format:check` — clean
- `npm run validate`, `validate:contract-drift`, `validate:mcp` — pass (227 tools)
- `npx vitest run` — **743 files, 17,895 tests, all passing**
- `npm run test:coverage` → patch coverage by diff intersection: **41/41 lines, 82/82 branches (100%)**

Closes #10036