### PR TITLE
fix(registry): stale:false meant "never checked" for 78% of served surfaces

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -11704,7 +11704,8 @@ export interface components {
             schema_status?: "machine-readable" | "ui-only" | "not-captured";
             schema_url?: string;
             source_urls?: string[];
-            stale?: boolean;
+            /** @description Whether this surface's verification has aged past its per-kind freshness TTL. NULL when there is no verification to judge (`last_verified_at` is null, or unparseable) — distinct from a measured `false`, which means we checked and it is current. Filtering on `stale === false` therefore selects surfaces with a CURRENT verification, not merely surfaces that are not known to be stale. */
+            stale?: boolean | null;
             status?: components["schemas"]["HealthStatus"];
             subnet_name?: string;
             subnet_slug?: string;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -52454,7 +52454,15 @@
             "type": "array"
           },
           "stale": {
-            "type": "boolean"
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Whether this surface's verification has aged past its per-kind freshness TTL. NULL when there is no verification to judge (`last_verified_at` is null, or unparseable) — distinct from a measured `false`, which means we checked and it is current. Filtering on `stale === false` therefore selects surfaces with a CURRENT verification, not merely surfaces that are not known to be stale."
           },
           "status": {
             "$ref": "#/components/schemas/HealthStatus"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -11704,7 +11704,8 @@ export interface components {
             schema_status?: "machine-readable" | "ui-only" | "not-captured";
             schema_url?: string;
             source_urls?: string[];
-            stale?: boolean;
+            /** @description Whether this surface's verification has aged past its per-kind freshness TTL. NULL when there is no verification to judge (`last_verified_at` is null, or unparseable) — distinct from a measured `false`, which means we checked and it is current. Filtering on `stale === false` therefore selects surfaces with a CURRENT verification, not merely surfaces that are not known to be stale. */
+            stale?: boolean | null;
             status?: components["schemas"]["HealthStatus"];
             subnet_name?: string;
             subnet_slug?: string;

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -550,7 +550,17 @@ export const SurfaceSchema = z
       .optional(),
     schema_url: HttpOrWssUrlSchema.optional(),
     source_urls: z.array(z.url()).optional(),
-    stale: z.boolean().optional(),
+    stale: z
+      .boolean()
+      .nullable()
+      .optional()
+      .describe(
+        "Whether this surface's verification has aged past its per-kind freshness TTL. " +
+          "NULL when there is no verification to judge (`last_verified_at` is null, or " +
+          "unparseable) — distinct from a measured `false`, which means we checked and it " +
+          "is current. Filtering on `stale === false` therefore selects surfaces with a " +
+          "CURRENT verification, not merely surfaces that are not known to be stale.",
+      ),
     status: HealthStatusSchema.optional(),
     subnet_name: z.string().optional(),
     subnet_slug: z.string().optional(),

--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -1111,14 +1111,38 @@ export function surfaceFreshnessTtlDays(kind: string): number {
 // deterministic reference — never wall-clock — so the flag is reproducible). A
 // surface with no last_verified_at is NOT stale: that's "unverified", a distinct
 // state the null timestamp already signals.
+/**
+ * Is this surface's verification stale? `null` when there is nothing to judge.
+ *
+ * #9906: this used to answer `false` for a surface that had never been verified,
+ * which published `stale: false` for 2,731 of 3,493 live surfaces (78%) -- so a
+ * consumer filtering on `stale === false` to mean "this verification is current"
+ * got a set where four in five entries had no verification behind them at all.
+ *
+ * Read narrowly -- "is this verification stale?" -- `false` for "there is no
+ * verification" is defensible. Read as the field name reads to an API consumer
+ * -- "is this surface's status stale?" -- it is backwards: a surface nobody has
+ * ever checked is the MOST unknown, not the least.
+ *
+ * `null` is the same distinction this codebase already keeps elsewhere:
+ * `exists` is null rather than false on RPC failure in /crowdloans/{id},
+ * `leased` is null rather than false in /subnets/{netuid}/lease, and
+ * `verdict: "unknown"` stays distinct from `"ok"` in lane_health -- "a watchdog
+ * that could not evaluate has not observed health, and collapsing the two would
+ * report an unmeasured lane as a healthy one" (migrations/d1/0014).
+ *
+ * The two unmeasurable cases return `null` for the same reason: an unparseable
+ * `last_verified_at` and a non-finite `nowMs` are both "we could not evaluate",
+ * not "we evaluated and it is fine".
+ */
 export function isSurfaceStale(
   lastVerifiedAt: unknown,
   kind: string,
   nowMs: number,
-): boolean {
-  if (!lastVerifiedAt) return false;
+): boolean | null {
+  if (!lastVerifiedAt) return null;
   const verifiedMs = Date.parse(lastVerifiedAt as string);
-  if (!Number.isFinite(verifiedMs) || !Number.isFinite(nowMs)) return false;
+  if (!Number.isFinite(verifiedMs) || !Number.isFinite(nowMs)) return null;
   return nowMs - verifiedMs > surfaceFreshnessTtlDays(kind) * 86_400_000;
 }
 
@@ -1133,6 +1157,12 @@ export function withSurfaceFreshness(surfaces: Row[], nowMs: number): Row[] {
       surface.kind as string,
       nowMs,
     );
+    // `stale === true`, not a truthiness check (#9906). `null` is falsy so the
+    // two agree TODAY and no test can separate them -- the explicit compare is
+    // here because the value is no longer a boolean, and any future
+    // representation of "unmeasured" that is truthy (a "unknown" sentinel, an
+    // object) would silently start demoting all 2,731 never-verified surfaces.
+    const demotedByStaleness = stale === true;
     return {
       ...surface,
       stale,
@@ -1142,7 +1172,7 @@ export function withSurfaceFreshness(surfaces: Row[], nowMs: number): Row[] {
       // elsewhere. subnet_curation_level isn't carried on the flattened row, so
       // an already-resolved maintainer-reviewed/adapter-backed level (set in
       // flattenSurfaces from the subnet ceiling) is preserved when still fresh.
-      curation_level: stale
+      curation_level: demotedByStaleness
         ? resolveSurfaceCurationLevel({
             authority: surface.authority ?? null,
             lastVerifiedAt: surface.last_verified_at,

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -1356,8 +1356,16 @@ test("public artifacts are internally consistent", () => {
     true,
   );
   // #1006: per-field provenance. Every served surface exposes last_verified_at
-  // (string|null) + a `stale` boolean, and `stale` is reproducible from the
-  // helper against the committed native-snapshot captured_at.
+  // (string|null) + a `stale` flag reproducible from the helper against the
+  // committed native-snapshot captured_at.
+  //
+  // #9906: `stale` is boolean|NULL, and the null is load-bearing -- it means
+  // "never verified, so there is nothing to judge", as opposed to a measured
+  // `false` meaning "checked, and current". Asserting the CORRELATION rather
+  // than just the type is what stops the two collapsing back together: 78% of
+  // served surfaces have no verification, and publishing `false` for them made
+  // `stale === false` select 3,435 surfaces of which only 820 had a current
+  // verification behind them.
   const surfaceNowMs = Date.parse(native.captured_at);
   for (const surface of surfaces.surfaces) {
     assert.ok(
@@ -1365,10 +1373,16 @@ test("public artifacts are internally consistent", () => {
         typeof surface.last_verified_at === "string",
       `surface ${surface.id} last_verified_at must be a string or null`,
     );
+    assert.ok(
+      surface.stale === null || typeof surface.stale === "boolean",
+      `surface ${surface.id} stale must be a boolean or null`,
+    );
     assert.equal(
-      typeof surface.stale,
-      "boolean",
-      `surface ${surface.id} must carry a boolean stale flag`,
+      surface.stale === null,
+      surface.last_verified_at === null,
+      `surface ${surface.id}: stale is null exactly when last_verified_at is null — ` +
+        `a null stale with a verification date (or a boolean stale without one) means ` +
+        `the freshness flag and the evidence it describes have drifted apart`,
     );
     assert.equal(
       surface.stale,

--- a/tests/script-utils.test.ts
+++ b/tests/script-utils.test.ts
@@ -32,6 +32,7 @@ import {
   isCredentialedUrl,
   isLikelyExampleLink,
   isSurfaceStale,
+  resolveSurfaceCurationLevel,
   surfaceFreshnessTtlDays,
   withSurfaceFreshness,
   SURFACE_FRESHNESS_DEFAULT_TTL_DAYS,
@@ -1859,12 +1860,16 @@ describe("script utility contracts", () => {
     const now = Date.parse("2026-06-14T00:00:00.000Z");
     const daysAgo = (n: number) => new Date(now - n * 86_400_000).toISOString();
 
-    // Unverified surfaces are NOT stale — null is a distinct state the agent reads.
-    assert.equal(isSurfaceStale(null, "subnet-api", now), false);
-    assert.equal(isSurfaceStale(undefined, "docs", now), false);
-    // Unparseable inputs never throw and never flag stale.
-    assert.equal(isSurfaceStale("not-a-date", "docs", now), false);
-    assert.equal(isSurfaceStale(daysAgo(999), "docs", Number.NaN), false);
+    // #9906: never verified is NULL, not false. `false` here published
+    // "this verification is current" for 2,731 of 3,493 live surfaces that had
+    // no verification at all, making the field useless for the one filter it
+    // exists to serve.
+    assert.equal(isSurfaceStale(null, "subnet-api", now), null);
+    assert.equal(isSurfaceStale(undefined, "docs", now), null);
+    // Unparseable inputs never throw, and are "could not evaluate" -- the same
+    // unknown, not a measured pass.
+    assert.equal(isSurfaceStale("not-a-date", "docs", now), null);
+    assert.equal(isSurfaceStale(daysAgo(999), "docs", Number.NaN), null);
     // Fresh: age below the kind TTL.
     assert.equal(isSurfaceStale(daysAgo(10), "subnet-api", now), false);
     // Boundary: exactly at the TTL is still fresh (strict greater-than).
@@ -1891,10 +1896,77 @@ describe("script utility contracts", () => {
       [
         ["a", true],
         ["b", false],
-        ["c", false],
+        // Never verified: null, distinguishable from b's measured-and-fresh.
+        ["c", null],
       ],
     );
     assert.equal(stamped[0].kind, "openapi");
+  });
+
+  test("#9906: a null `stale` must not change which surfaces are demoted", () => {
+    // The nullable `stale` is a LABELLING fix; the trust ordering must come out
+    // byte-identical. This asserts the OUTCOME -- which tier each of the three
+    // states resolves to -- because that is what consumers see. It does not
+    // (and cannot) distinguish `stale === true` from a truthiness check, since
+    // null is falsy; see the comment on demotedByStaleness in scripts/lib.ts
+    // for why the explicit compare is still the right form.
+    const now = Date.parse("2026-06-14T00:00:00.000Z");
+    const daysAgo = (n: number) => new Date(now - n * 86_400_000).toISOString();
+
+    const stamped = withSurfaceFreshness(
+      [
+        // never verified -> stale null, must NOT be demoted BY STALENESS
+        {
+          id: "never",
+          kind: "docs",
+          authority: "official",
+          last_verified_at: null,
+        },
+        // verified and fresh -> stale false, not demoted
+        {
+          id: "fresh",
+          kind: "openapi",
+          authority: "official",
+          last_verified_at: daysAgo(1),
+        },
+        // verified and aged out -> stale true, demoted
+        {
+          id: "aged",
+          kind: "openapi",
+          authority: "official",
+          last_verified_at: daysAgo(45),
+        },
+      ],
+      now,
+    );
+    const byId = new Map(stamped.map((row) => [row.id, row]));
+
+    assert.equal(byId.get("never")?.stale, null);
+    assert.equal(byId.get("fresh")?.stale, false);
+    assert.equal(byId.get("aged")?.stale, true);
+
+    // A never-verified surface resolves to the same tier it did when `stale`
+    // was false -- it floors through resolveSurfaceCurationLevel on the
+    // missing last_verified_at, not through the staleness demotion.
+    assert.equal(
+      byId.get("never")?.curation_level,
+      resolveSurfaceCurationLevel({
+        authority: "official",
+        lastVerifiedAt: null,
+        stale: false,
+        subnetCurationLevel: null,
+      }),
+    );
+    // And the measured-stale one still takes the demotion path.
+    assert.equal(
+      byId.get("aged")?.curation_level,
+      resolveSurfaceCurationLevel({
+        authority: "official",
+        lastVerifiedAt: daysAgo(45),
+        stale: true,
+        subnetCurationLevel: null,
+      }),
+    );
   });
 
   test("classifies code-example / quickstart links (#1008)", () => {


### PR DESCRIPTION
## The measurement

Paging the whole live collection (`GET /api/v1/surfaces`, 7 pages, 3,493 rows):

| `last_verified_at` | `stale` | count |
|---|---|---:|
| never | `false` | **2,731** |
| ever | `false` | 753 |
| ever | `true` | 9 |

A consumer filtering on `stale === false` to mean *"this verification is current"* got a set in which **four out of five entries had no verification behind them at all**.

## Why `false` was the wrong answer

Read narrowly — *"is this verification stale?"* — `false` for "there is no verification" is defensible. Read as the field name reads to an API consumer — *"is this surface's status stale?"* — it is backwards: a surface nobody has ever checked is the **most** unknown, not the least.

`null` is the distinction this codebase already keeps everywhere else: `exists` is null rather than false on RPC failure in `/crowdloans/{id}`, `leased` is null rather than false in `/subnets/{netuid}/lease`, and `verdict: "unknown"` stays distinct from `"ok"` in `lane_health` — *"a watchdog that could not evaluate has not observed health, and collapsing the two would report an unmeasured lane as a healthy one"* (`migrations/d1/0014`).

The two unmeasurable cases go the same way: an unparseable `last_verified_at` and a non-finite `nowMs` are both "could not evaluate", not "evaluated and fine".

## One change covers all three contract surfaces

`SurfaceSchema` backs REST `/surfaces`, the MCP `list_surfaces` output (through `SurfacesArtifactSchema` → `z.array(SurfaceSchema)`), and the committed artifact — so the fix lands in one place. I confirmed the live MCP tool reproduced the identical bug first:

```json
{"last_verified_at":null, ... ,"stale":false}
```

The GraphQL SDL already declares `stale: Boolean`, which permits null, so it needed no change. I checked the other `stale` occurrences and they are a **different field** — `health.stale`, nested under `health` in `health-serving.ts`, `mcp-server.ts:13294` and `schemas-src/mcp-tools/ai-integration.ts` — deliberately untouched. `apps/ui` has no consumer of the surface-level flag.

## This is a labelling fix, not a trust change

Never-verified surfaces already floor at `candidate-discovered` through `resolveSurfaceCurationLevel`, so the tier ordering comes out byte-identical. A new test asserts that **outcome** for all three states.

The demotion branch now compares `stale === true` rather than relying on truthiness. Being straight about this: `null` is falsy, so the two agree today and **no test can separate them** — I verified that by mutation. The explicit compare is there because the value is no longer a boolean, and any future truthy representation of "unmeasured" would silently start demoting all 2,731. I corrected a comment that had overclaimed the test pinned this.

## The artifact invariant got stronger, not weaker

`tests/artifacts.test.ts` asserted `typeof surface.stale === "boolean"`. Rather than relax that to accept null, it now asserts the **correlation**:

> `stale` is null **exactly when** `last_verified_at` is null

so the flag and the evidence it describes cannot drift apart again. Mutation-tested — reverting `isSurfaceStale` to return `false` fails it with that message.

## Validation

```
npm run typecheck              clean
npm run lint / format:check    clean
npm run build                  passed (openapi.json + client/contract types regenerated)
npm run validate               129 subnets, 3441 surfaces, 137 providers, 2037 candidates
npm run validate:contract-drift  passed
vitest (9 files: mcp-server, script-utils, artifacts, graphql,
        surfaces-mcp, zod-schemas, lib-helpers, …)   3,176 passed
```

Built artifact after the change:

```
last_verified=never  stale=None   -> 2615
last_verified=ever   stale=False  ->  820
last_verified=ever   stale=True   ->    6
```

`stale === false` now selects the 820 surfaces that actually have a current verification.

The published schema is `anyOf: [boolean, null]` with the three states described, so the contract states the distinction rather than leaving consumers to infer it.

Closes #9906