### PR TITLE
fix(graphql): five SDL fields had no producer and were served as null/false

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2172,6 +2172,22 @@ export type EndpointList = {
   total: Scalars['Int']['output'];
 };
 
+/** Endpoint pool scores (#6570): same pools[] row shape, filter/sort/page surface, and pagination metadata as PoolList. Split from it in #9892 for the one field that differs -- operational_observed_at, which GET /api/v1/endpoint-pools does not serve at all, because endpoint pools carry no live cron eligibility overlay and so have no observation stamp to report. The shared type declared it anyway and GraphQL answered null, which reads as not-observed-yet rather than never-observed-here. */
+export type EndpointPoolList = {
+  __typename?: 'EndpointPoolList';
+  cursor: Scalars['Int']['output'];
+  generated_at?: Maybe<Scalars['String']['output']>;
+  limit: Scalars['Int']['output'];
+  next_cursor?: Maybe<Scalars['Int']['output']>;
+  notes?: Maybe<Scalars['JSON']['output']>;
+  order?: Maybe<Scalars['String']['output']>;
+  pools: Array<Scalars['JSON']['output']>;
+  returned: Scalars['Int']['output'];
+  sort?: Maybe<Scalars['String']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
+  total: Scalars['Int']['output'];
+};
+
 export type EvidenceList = {
   __typename?: 'EvidenceList';
   claims: Array<Scalars['JSON']['output']>;
@@ -2688,7 +2704,7 @@ export type PipelineHistoryPoint = {
   tao_in_pool_tao?: Maybe<Scalars['Float']['output']>;
 };
 
-/** Shared by endpoint_pools and rpc_pools -- same pools[] row shape, filter/sort/page surface, and pagination-metadata fields (#6570); rpc_pools additionally populates source/operational_observed_at from its live cron overlay, which endpoint_pools leaves null. */
+/** RPC pool scores (#6570): same pools[] row shape, filter/sort/page surface, and pagination metadata as EndpointPoolList, plus operational_observed_at -- real here and only here, since the RPC pools are the ones carrying a live 15-minute cron eligibility overlay. */
 export type PoolList = {
   __typename?: 'PoolList';
   cursor: Scalars['Int']['output'];
@@ -2707,6 +2723,7 @@ export type PoolList = {
 
 export type ProfileList = {
   __typename?: 'ProfileList';
+  /** When the profile rows were gathered. Sourced from the artifact's generated_at, which is the only stamp it carries -- profile rows are derived at build time, so there is no separate capture event (#9892). */
   captured_at?: Maybe<Scalars['String']['output']>;
   cursor: Scalars['Int']['output'];
   limit: Scalars['Int']['output'];
@@ -2908,7 +2925,7 @@ export type Query = {
   /** Probe-derived endpoint incident feed -- active endpoint failures/degradations with severity, state, provider, and subnet. Filter by netuid/kind/provider/status/severity/state, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/endpoint-incidents. */
   endpoint_incidents: IncidentList;
   /** Generalized endpoint pool scores -- each pool's kind, eligible/total endpoint count, and probe-derived routing score. Filter by id/kind, threshold with min_/max_eligible_count and min_/max_endpoint_count, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/endpoint-pools. */
-  endpoint_pools: PoolList;
+  endpoint_pools: EndpointPoolList;
   /** Endpoint/resource registry with full REST filter parity: optionally scope to one subnet (netuid) and filter by kind/layer/provider/publication_state/status/pool_eligible, threshold with min_/max_latency_ms and min_/max_score, project with fields, sort with sort/order, and page with limit/cursor. An invalid filter/sort is a GraphQL error (matching endpoint_pools/rpc_pools/rpc_endpoints), not a silently substituted default. Mirrors GET /api/v1/endpoints. */
   endpoints: EndpointList;
   /** Network-wide public evidence ledger -- the append-only provenance record behind registry surfaces. Search with q across subject/claim/source_url/support_summary, sort with sort/order, project with fields, and page with limit (1-100)/cursor. An invalid sort/limit/cursor is a GraphQL error, not a silently substituted default. Distinct from subnet_evidence(netuid) (one subnet's claims). Mirrors GET /api/v1/evidence. */
@@ -6049,7 +6066,8 @@ export type Validator = {
   coldkey?: Maybe<Scalars['String']['output']>;
   coldkey_count?: Maybe<Scalars['Int']['output']>;
   coldkey_identity?: Maybe<Identity>;
-  featured: Scalars['Boolean']['output'];
+  /** Whether this validator is in the featured_validators set. NULL from the single-validator lookup, which carries no featured set (buildValidatorDetail never passes one, keeping that artifact shape unchanged) -- null means unknown, not not-featured (#9892). The source table is currently unported, so the list value is its documented degraded default. */
+  featured?: Maybe<Scalars['Boolean']['output']>;
   hotkey: Scalars['String']['output'];
   max_validator_trust?: Maybe<Scalars['Float']['output']>;
   nominator_count?: Maybe<Scalars['Int']['output']>;
@@ -6470,6 +6488,7 @@ export type ResolversTypes = ResolversObject<{
   Endpoint: ResolverTypeWrapper<Endpoint>;
   EndpointIncident: ResolverTypeWrapper<EndpointIncident>;
   EndpointList: ResolverTypeWrapper<EndpointList>;
+  EndpointPoolList: ResolverTypeWrapper<EndpointPoolList>;
   EvidenceList: ResolverTypeWrapper<EvidenceList>;
   EvmAddressMapping: ResolverTypeWrapper<EvmAddressMapping>;
   Extrinsic: ResolverTypeWrapper<Extrinsic>;
@@ -6815,6 +6834,7 @@ export type ResolversParentTypes = ResolversObject<{
   Endpoint: Endpoint;
   EndpointIncident: EndpointIncident;
   EndpointList: EndpointList;
+  EndpointPoolList: EndpointPoolList;
   EvidenceList: EvidenceList;
   EvmAddressMapping: EvmAddressMapping;
   Extrinsic: Extrinsic;
@@ -8701,6 +8721,20 @@ export type EndpointListResolvers<ContextType = GqlContext, ParentType extends R
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
+export type EndpointPoolListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['EndpointPoolList'] = ResolversParentTypes['EndpointPoolList']> = ResolversObject<{
+  cursor?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  generated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  next_cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  notes?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  order?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  pools?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  source?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
 export type EvidenceListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['EvidenceList'] = ResolversParentTypes['EvidenceList']> = ResolversObject<{
   claims?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
   cursor?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -9255,7 +9289,7 @@ export type QueryResolvers<ContextType = GqlContext, ParentType extends Resolver
   emission_changes?: Resolver<ResolversTypes['EmissionGateChanges'], ParentType, ContextType, Partial<QueryEmission_ChangesArgs>>;
   emission_pipeline?: Resolver<ResolversTypes['EmissionPipeline'], ParentType, ContextType, Partial<QueryEmission_PipelineArgs>>;
   endpoint_incidents?: Resolver<ResolversTypes['IncidentList'], ParentType, ContextType, Partial<QueryEndpoint_IncidentsArgs>>;
-  endpoint_pools?: Resolver<ResolversTypes['PoolList'], ParentType, ContextType, Partial<QueryEndpoint_PoolsArgs>>;
+  endpoint_pools?: Resolver<ResolversTypes['EndpointPoolList'], ParentType, ContextType, Partial<QueryEndpoint_PoolsArgs>>;
   endpoints?: Resolver<ResolversTypes['EndpointList'], ParentType, ContextType, Partial<QueryEndpointsArgs>>;
   evidence?: Resolver<ResolversTypes['EvidenceList'], ParentType, ContextType, Partial<QueryEvidenceArgs>>;
   evm_address?: Resolver<Maybe<ResolversTypes['EvmAddressMapping']>, ParentType, ContextType, RequireFields<QueryEvm_AddressArgs, 'h160'>>;
@@ -10559,7 +10593,7 @@ export type ValidatorResolvers<ContextType = GqlContext, ParentType extends Reso
   coldkey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   coldkey_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   coldkey_identity?: Resolver<Maybe<ResolversTypes['Identity']>, ParentType, ContextType>;
-  featured?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  featured?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   hotkey?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   max_validator_trust?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   nominator_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -10867,6 +10901,7 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   Endpoint?: EndpointResolvers<ContextType>;
   EndpointIncident?: EndpointIncidentResolvers<ContextType>;
   EndpointList?: EndpointListResolvers<ContextType>;
+  EndpointPoolList?: EndpointPoolListResolvers<ContextType>;
   EvidenceList?: EvidenceListResolvers<ContextType>;
   EvmAddressMapping?: EvmAddressMappingResolvers<ContextType>;
   Extrinsic?: ExtrinsicResolvers<ContextType>;

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -435,7 +435,7 @@ export const SDL = /* GraphQL */ `
       fields: String
       limit: Int
       cursor: Int
-    ): PoolList!
+    ): EndpointPoolList!
     "The load-balanced Bittensor RPC pool scores -- the RPC-specific predecessor of endpoint_pools (#6570): same pools[] row shape and filter/sort/page surface, with a live 15-minute cron eligibility overlay applied before filtering/sorting. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/rpc/pools."
     rpc_pools(
       id: String
@@ -2233,7 +2233,22 @@ export const SDL = /* GraphQL */ `
     source_urls: [String!]
   }
 
-  "Shared by endpoint_pools and rpc_pools -- same pools[] row shape, filter/sort/page surface, and pagination-metadata fields (#6570); rpc_pools additionally populates source/operational_observed_at from its live cron overlay, which endpoint_pools leaves null."
+  "Endpoint pool scores (#6570): same pools[] row shape, filter/sort/page surface, and pagination metadata as PoolList. Split from it in #9892 for the one field that differs -- operational_observed_at, which GET /api/v1/endpoint-pools does not serve at all, because endpoint pools carry no live cron eligibility overlay and so have no observation stamp to report. The shared type declared it anyway and GraphQL answered null, which reads as not-observed-yet rather than never-observed-here."
+  type EndpointPoolList {
+    generated_at: String
+    notes: JSON
+    source: String
+    pools: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  "RPC pool scores (#6570): same pools[] row shape, filter/sort/page surface, and pagination metadata as EndpointPoolList, plus operational_observed_at -- real here and only here, since the RPC pools are the ones carrying a live 15-minute cron eligibility overlay."
   type PoolList {
     generated_at: String
     notes: JSON
@@ -2356,6 +2371,7 @@ export const SDL = /* GraphQL */ `
   }
 
   type ProfileList {
+    "When the profile rows were gathered. Sourced from the artifact's generated_at, which is the only stamp it carries -- profile rows are derived at build time, so there is no separate capture event (#9892)."
     captured_at: String
     profiles: [JSON!]!
     total: Int!
@@ -4329,7 +4345,8 @@ export const SDL = /* GraphQL */ `
 
   type Validator {
     hotkey: String!
-    featured: Boolean!
+    "Whether this validator is in the featured_validators set. NULL from the single-validator lookup, which carries no featured set (buildValidatorDetail never passes one, keeping that artifact shape unchanged) -- null means unknown, not not-featured (#9892). The source table is currently unported, so the list value is its documented degraded default."
+    featured: Boolean
     coldkey: String
     coldkey_identity: Identity
     coldkey_count: Int

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1822,7 +1822,16 @@ function extrinsicNode(extrinsic: Row) {
 function validatorNode(validator: Row) {
   return {
     ...validator,
-    featured: validator.featured === true,
+    // `featured` is absent from the validator DETAIL artifact by design --
+    // buildValidatorDetail never passes featuredHotkeys (src/metagraph-neurons.ts:362),
+    // which keeps that artifact's shape unchanged. `=== true` turned that
+    // absence into a confident `false`, indistinguishable from a real "this
+    // validator is not featured" and set to contradict the list outright the
+    // moment anything is featured (#9892). Absent now means null: unknown.
+    //
+    // The LIST builder always emits a boolean here, so this preserves it.
+    featured:
+      typeof validator.featured === "boolean" ? validator.featured : null,
     captured_at: validator.latest_captured_at ?? validator.captured_at ?? null,
     block_number:
       validator.latest_block_number ?? validator.block_number ?? null,
@@ -1838,6 +1847,9 @@ function validatorDetailNode(data: Row, hotkey: string) {
     priceByNetuid: NO_ALPHA_PRICES,
   });
   const raw = data && typeof data === "object" ? data : {};
+  const subnets: unknown[] = Array.isArray(raw.subnets)
+    ? raw.subnets
+    : (base.subnets as unknown[]);
   return validatorNode({
     ...base,
     ...raw,
@@ -1845,7 +1857,22 @@ function validatorDetailNode(data: Row, hotkey: string) {
       typeof raw.hotkey === "string" && raw.hotkey.length > 0
         ? raw.hotkey
         : hotkey,
-    subnets: Array.isArray(raw.subnets) ? raw.subnets : base.subnets,
+    subnets,
+    // The detail artifact carries no `uid_count` (it is the list builder's
+    // entry.uidCount, which buildValidatorDetail has no counterpart for), so
+    // GraphQL answered null while the LIST answered 117 for the same hotkey
+    // (#9892). The detail's `subnets` is the UNCAPPED per-membership row list
+    // -- one entry per UID -- so its length is uid_count exactly; verified
+    // 117 == 117 against production.
+    //
+    // This derivation belongs here rather than in validatorNode because the
+    // list caps `subnets` at the top 10 by stake (GLOBAL_VALIDATOR_SUBNET_LIMIT),
+    // where the same length would be wrong -- and the list already carries a
+    // real uid_count anyway.
+    // `subnets` is always an array here (raw's own array, else base's, and
+    // buildValidatorDetail always returns one), so no second guard.
+    uid_count:
+      typeof raw.uid_count === "number" ? raw.uid_count : subnets.length,
   });
 }
 
@@ -4089,8 +4116,27 @@ const rootValue = {
   // pass. A cold/absent artifact makes the loader throw, which the graphql
   // executor surfaces as a normal GraphQL error, matching REST's 404 and the
   // source_snapshots convention for a missing artifact.
-  changelog(_args: unknown, context: GqlContext) {
-    return loadChangelog(mcpCtx(context), { readArtifact });
+  // `coverage_delta` is declared at the top level of type Changelog, but the
+  // artifact nests it INSIDE `summary` -- so the flattened path never existed
+  // and the field resolved null on every call, reading as "this changelog has
+  // no coverage delta" when in fact every changelog has one (#9892).
+  //
+  // Flattened here rather than taught to a field resolver because the schema is
+  // built with buildSchema(SDL) and carries no resolver map: reshaping in the
+  // Query resolver is the only hook there is, and the same one subnet_trajectory
+  // already uses for its window-keyed deltas.
+  async changelog(_args: unknown, context: GqlContext) {
+    const data = (await loadChangelog(mcpCtx(context), {
+      readArtifact,
+    })) as Row;
+    // loadChangelog throws on a cold/absent artifact (the test below pins that
+    // it surfaces as a GraphQL error), so `data` is always an object here.
+    const { summary } = data;
+    const nested =
+      summary !== null && typeof summary === "object"
+        ? (summary as Row).coverage_delta
+        : undefined;
+    return { ...data, coverage_delta: data.coverage_delta ?? nested ?? null };
   },
 
   contracts(_args: unknown, context: GqlContext) {

--- a/src/profiles-mcp.ts
+++ b/src/profiles-mcp.ts
@@ -174,7 +174,13 @@ export async function loadProfilesList(
   const profiles = Array.isArray(data.profiles) ? (data.profiles as Row[]) : [];
   const profileLen = profiles.length;
   return {
-    captured_at: data.captured_at ?? null,
+    // The profiles artifact has never carried a `captured_at` -- its only
+    // stamp is `generated_at`, and there is no separate capture event to
+    // report: profile rows are derived at build time, unlike a chain snapshot.
+    // So this resolved null on every call for both list_profiles and GraphQL's
+    // `profiles`, which reads as "we don't know when this was gathered" rather
+    // than "nothing published it" (#9892). Falls back to the real stamp.
+    captured_at: data.captured_at ?? data.generated_at ?? null,
     profiles,
     total: page.total ?? profileLen,
     returned: page.returned ?? profileLen,

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -3,6 +3,7 @@ import { Blob } from "node:buffer";
 import {
   buildSchema,
   getIntrospectionQuery,
+  type GraphQLObjectType,
   parse,
   subscribe,
   validate,
@@ -1928,6 +1929,37 @@ describe("graphql — endpoint_pools / rpc_pools / endpoint_incidents", () => {
     ],
   };
 
+  test("only rpc_pools declares operational_observed_at (#9892)", async () => {
+    // /api/v1/endpoint-pools does not serve this field at all -- endpoint pools
+    // carry no live cron eligibility overlay, so there is no observation stamp
+    // to report. A shared PoolList declared it for both, and GraphQL answered
+    // null, which reads as "not observed yet" rather than "never observed
+    // here". Asserted against the SCHEMA rather than a response, because the
+    // defect is what the type promises, not what one call happened to return.
+    const query = chainEventsSchema.getQueryType();
+    const endpointType = String(query?.getFields().endpoint_pools?.type);
+    const rpcType = String(query?.getFields().rpc_pools?.type);
+    assert.equal(endpointType, "EndpointPoolList!");
+    assert.equal(rpcType, "PoolList!");
+
+    const endpointFields = (
+      chainEventsSchema.getType("EndpointPoolList") as GraphQLObjectType
+    ).getFields();
+    const rpcFields = (
+      chainEventsSchema.getType("PoolList") as GraphQLObjectType
+    ).getFields();
+    assert.ok(!("operational_observed_at" in endpointFields));
+    assert.ok("operational_observed_at" in rpcFields);
+    // The split is ONLY that field -- everything else stays identical, so this
+    // fails if the two drift apart for any other reason.
+    assert.deepEqual(
+      Object.keys(endpointFields).sort(),
+      Object.keys(rpcFields)
+        .filter((f) => f !== "operational_observed_at")
+        .sort(),
+    );
+  });
+
   test("endpoint_pools filters by kind and paginates", async () => {
     const env = fixtureEnv({ "/metagraph/endpoint-pools.json": POOLS_BLOB });
     const filtered = await gql(
@@ -2136,6 +2168,31 @@ describe("graphql — source_snapshots", () => {
     assert.ok(body.errors?.length);
   });
 
+  test("coverage_delta is null when no changelog carries one, however summary is shaped", async () => {
+    // The other half of the flattening: it must not invent a value. Both
+    // shapes a real artifact can take when the delta is genuinely absent --
+    // no summary at all, and an explicit null -- resolve to null rather than
+    // throwing on the property read.
+    for (const summary of [undefined, null, { artifacts_changed: 0 }]) {
+      const blob: Record<string, unknown> = {
+        generated_at: "2026-07-01T00:00:00.000Z",
+      };
+      if (summary !== undefined) blob.summary = summary;
+      const env = fixtureEnv({ "/metagraph/changelog.json": blob });
+      const { status, body } = await gql(
+        "{ changelog { coverage_delta } }",
+        env as unknown as Env,
+      );
+      assert.equal(status, 200, JSON.stringify(summary));
+      assert.equal(body.errors, undefined, JSON.stringify(body.errors));
+      assert.equal(
+        body.data.changelog.coverage_delta,
+        null,
+        `summary=${JSON.stringify(summary)}`,
+      );
+    }
+  });
+
   test("surfaces a cold/missing artifact as a GraphQL error, matching REST/MCP", async () => {
     const { body } = await gql("{ source_snapshots { total } }", emptyEnv);
     assert.ok(body.errors?.length);
@@ -2177,6 +2234,37 @@ describe("graphql — changelog", () => {
     assert.deepEqual(changelog.artifacts.added, ["adapters.json"]);
     assert.deepEqual(changelog.subnets.renamed, ["sn-7"]);
     assert.equal(changelog.coverage_delta.surfaces, 4);
+  });
+
+  test("coverage_delta resolves from summary, where the real artifact nests it (#9892)", async () => {
+    // CHANGELOG_BLOB above puts coverage_delta at the TOP level, which the
+    // published artifact never does -- verified against production, where it
+    // lives only under `summary`. So the field resolved null on every real
+    // call while this suite stayed green, and null reads as "this changelog
+    // has no coverage delta" when every changelog has one.
+    const nested = {
+      generated_at: "2026-07-01T00:00:00.000Z",
+      summary: {
+        artifacts_changed: 3,
+        coverage_delta: {
+          surface_count: { before: 3493, after: 3496, delta: 3 },
+        },
+      },
+    };
+    const env = fixtureEnv({ "/metagraph/changelog.json": nested });
+    const { status, body } = await gql(
+      "{ changelog { coverage_delta summary } }",
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.changelog.coverage_delta.surface_count.delta, 3);
+    // Still reachable the long way, so this flattening adds an accessor
+    // rather than moving the data.
+    assert.equal(
+      body.data.changelog.summary.coverage_delta.surface_count.delta,
+      3,
+    );
   });
 
   test("surfaces a cold/missing artifact as a GraphQL error, matching REST/MCP", async () => {
@@ -2489,6 +2577,26 @@ describe("graphql — profiles", () => {
       },
     ],
   };
+
+  test("captured_at falls back to the artifact's generated_at (#9892)", async () => {
+    // PROFILES_BLOB invents a top-level captured_at. The published artifact
+    // has never carried one -- verified against production, whose only stamp
+    // is generated_at -- so the field resolved null on every real call, for
+    // GraphQL AND for the list_profiles MCP tool that shares this loader.
+    const env = fixtureEnv({
+      "/metagraph/profiles.json": {
+        generated_at: "2026-08-07T10:09:17.651Z",
+        profiles: [{ slug: "allways", netuid: 7 }],
+      },
+    });
+    const { status, body } = await gql(
+      "{ profiles { captured_at total } }",
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.profiles.captured_at, "2026-08-07T10:09:17.651Z");
+  });
 
   test("filters by netuid and paginates", async () => {
     const env = fixtureEnv({ "/metagraph/profiles.json": PROFILES_BLOB });
@@ -5266,7 +5374,11 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
     assert.equal(body.errors, undefined);
     assert.deepEqual(body.data.validator, {
       hotkey: "5NoRows",
-      featured: false,
+      // null, not false, since #9892: the detail carries no featured set, and
+      // `featured === true` used to turn that absence into a confident "this
+      // validator is not featured". The point of this test -- that the OBJECT
+      // is schema-stable and never null -- is unchanged.
+      featured: null,
       subnet_count: 0,
       total_stake_tao: 0,
       captured_at: null,
@@ -5333,13 +5445,67 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
     assert.equal(body.errors, undefined);
     assert.deepEqual(body.data.validator, {
       hotkey: "5NoRows",
-      featured: false,
+      // null, not false, since #9892: the detail carries no featured set, and
+      // `featured === true` used to turn that absence into a confident "this
+      // validator is not featured". The point of this test -- that the OBJECT
+      // is schema-stable and never null -- is unchanged.
+      featured: null,
       subnet_count: 0,
       total_stake_tao: 0,
       captured_at: null,
       block_number: null,
       subnets: [],
     });
+  });
+
+  test("validator: uid_count is derived from the uncapped subnets list (#9892)", async () => {
+    // The detail artifact carries no uid_count, so GraphQL answered null while
+    // the LIST answered a real count for the same hotkey -- two views of one
+    // entity disagreeing. The detail's `subnets` is the uncapped
+    // per-membership row list, one entry per UID, so its length IS uid_count.
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          hotkey: "5Validator",
+          subnet_count: 3,
+          subnets: [{ netuid: 1 }, { netuid: 2 }, { netuid: 3 }],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      '{ validator(hotkey: "5Validator") { hotkey uid_count featured } }',
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.validator.uid_count, 3);
+    // Absent featured stays unknown rather than becoming a confident false.
+    assert.equal(body.data.validator.featured, null);
+  });
+
+  test("validator: an explicit uid_count from the tier wins over the derivation", async () => {
+    // The derivation is a fallback, not an override -- if the tier ever starts
+    // serving uid_count, that value is authoritative. Pinned because subnets
+    // and uid_count measure different things (distinct netuids vs rows) and
+    // agree only because a hotkey holds one UID per subnet.
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          hotkey: "5Validator",
+          uid_count: 9,
+          subnets: [{ netuid: 1 }, { netuid: 2 }],
+        }),
+      ),
+    };
+    const { body } = await gql(
+      '{ validator(hotkey: "5Validator") { uid_count } }',
+      env as unknown as Env,
+    );
+    assert.equal(body.data.validator.uid_count, 9);
   });
 
   test("validators / validator are weighted as fan-out fields", () => {


### PR DESCRIPTION
## Summary

Five GraphQL fields were declared in the SDL, resolved to a value on every call, and had **nothing behind them**. GraphQL cannot express "this field does not apply here", so the absence was served as data.

Verified live before and after. Three had a real source and are now wired to it; two are genuinely inapplicable and the schema now says so.

## Wired to their real source

| field | was | now |
|---|---|---|
| `Changelog.coverage_delta` | `null` on every call | the artifact's real delta |
| `ProfileList.captured_at` | `null` on every call | the artifact's `generated_at` |
| `Validator.uid_count` (detail) | `null` | derived, matches the list |

- **`coverage_delta`** was declared at the top level while the artifact nests it inside `summary`, so the flattened path never existed. Every changelog has a coverage delta; GraphQL said none did.
- **`captured_at`** has never been in the profiles artifact — its only stamp is `generated_at`, and profile rows are derived at build time, so there is no separate capture event to report. This also fixes the **`list_profiles` MCP tool**, which shares the loader.
- **`uid_count`** is absent from the detail artifact, so the detail answered `null` while the **list answered 117 for the same hotkey** — two views of one entity disagreeing. The detail's `subnets` is the uncapped per-membership row list, one entry per UID, so its length is `uid_count` exactly (verified 117 == 117). An explicit value from the tier still wins; a test pins that, because `subnet_count` and `uid_count` measure different things (distinct netuids vs rows) and agree only because a hotkey holds one UID per subnet.

## Declared honestly instead

- **`endpoint_pools`** now returns `EndpointPoolList`, which omits `operational_observed_at`. `/api/v1/endpoint-pools` does not serve it at all — endpoint pools carry no live cron eligibility overlay, so there is no observation stamp. A test asserts the split is **that one field and nothing else**. The old shared description also claimed `endpoint_pools` leaves `source` null; the route does serve `source`.
- **`Validator.featured`** is now nullable. `buildValidatorDetail` deliberately passes no featured set to keep that artifact's shape unchanged, and `=== true` turned the absence into a confident **`false`** — indistinguishable from a real "not featured", and set to contradict the list outright the moment anything is featured. Absent now means `null`: unknown. The list still emits a boolean.

### Worth recording on `featured`

`featured_validators` has **no D1 home** (`workers/data-api.ts:6268`) — it stays a maintainer-toggled Postgres side table until its own port, so `loadFeaturedHotkeys` returns its degraded empty set and **0 of 500 validators read as featured anywhere**. Filling the detail from that set would have answered `false` just as confidently. `null` is the only honest value until the table lands.

## Two fixtures were asserting shapes production does not have

This is why the suite stayed green over both defects: `CHANGELOG_BLOB` put `coverage_delta` at the top level and `PROFILES_BLOB` invented a top-level `captured_at` — neither shape exists in the published artifact. Both tests now use the real shape.

## Tests

Every new test was confirmed to **fail without its fix** by reverting all five and re-running:

```
× only rpc_pools declares operational_observed_at (#9892)
× coverage_delta resolves from summary, where the real artifact nests it (#9892)
× captured_at falls back to the artifact's generated_at (#9892)
× validator: uid_count is derived from the uncapped subnets list (#9892)
```

The pool split is asserted against the **schema**, not a response — the defect is what the type promises, not what one call happened to return.

## Commands run

- `npm run build`, `build:graphql-types` — regenerated, committed
- `validate:graphql-route-parity` (0 divergences), `validate:graphql-types-drift`, `validate:contract-drift` — pass
- `npm run typecheck`, `lint`, `format:check` — clean
- `npx vitest run` — **744 files, 17,913 tests, all passing**
- `npm run test:coverage` → patch coverage by diff intersection: **5/5 lines, 16/16 branches (100%)**

Two defensive branches were removed rather than annotated away: `subnets` is always an array at that point, and `loadChangelog` throws on a cold artifact so `data` is always an object.

Closes #9892