### PR TITLE
test: an AJV schema failure said "false" instead of naming the field

### DIFF
--- a/tests/adapters-mcp.test.ts
+++ b/tests/adapters-mcp.test.ts
@@ -13,6 +13,7 @@ import {
 import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type AnyFn, type Row } from "./row-type.ts";
+import { assertValid } from "./helpers/assert-valid.ts";
 
 type ReadArtifact = (env: Env, path: string) => Promise<StorageReadResult>;
 
@@ -183,7 +184,7 @@ describe("adapters-mcp", () => {
     const validate = new Ajv2020({ strict: false }).compile(
       GET_ADAPTER_OUTPUT_SCHEMA,
     );
-    assert.ok(validate(SAMPLE_ADAPTER));
+    assertValid(validate, SAMPLE_ADAPTER);
   });
 
   test("MCP server exports wire get_adapter", () => {

--- a/tests/ai-search.test.ts
+++ b/tests/ai-search.test.ts
@@ -32,6 +32,7 @@ import {
 } from "../src/usage-telemetry.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type AnyFn, type Row } from "./row-type.ts";
+import { assertValid } from "./helpers/assert-valid.ts";
 
 type ReadArtifact = (env: Env, path: string) => Promise<StorageReadResult>;
 
@@ -781,7 +782,7 @@ describe("a provider result satisfies the PUBLISHED schema (#9903)", () => {
         target: "draft-2020-12",
       }),
     );
-    assert.ok(validate(out), JSON.stringify(validate.errors));
+    assertValid(validate, out);
   });
 
   test("the schema would REJECT the pre-fix declaration", () => {

--- a/tests/build-mcp.test.ts
+++ b/tests/build-mcp.test.ts
@@ -12,6 +12,7 @@ import {
 import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type Row } from "./row-type.ts";
+import { assertValid } from "./helpers/assert-valid.ts";
 
 type ReadArtifact = (env: Env, path: string) => Promise<StorageReadResult>;
 
@@ -236,7 +237,7 @@ describe("build-mcp", () => {
     const validate = new Ajv2020({ strict: false }).compile(
       GET_BUILD_OUTPUT_SCHEMA,
     );
-    assert.ok(validate(SAMPLE_BUILD));
+    assertValid(validate, SAMPLE_BUILD);
   });
 
   test("MCP server exports wire get_build", () => {

--- a/tests/changelog-mcp.test.ts
+++ b/tests/changelog-mcp.test.ts
@@ -12,6 +12,7 @@ import {
 import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type Row } from "./row-type.ts";
+import { assertValid } from "./helpers/assert-valid.ts";
 
 type ReadArtifact = (env: Env, path: string) => Promise<StorageReadResult>;
 
@@ -155,7 +156,7 @@ describe("changelog-mcp", () => {
     const validate = new Ajv2020({ strict: false }).compile(
       GET_CHANGELOG_OUTPUT_SCHEMA,
     );
-    assert.ok(validate(SAMPLE_CHANGELOG));
+    assertValid(validate, SAMPLE_CHANGELOG);
   });
 
   test("MCP server exports wire get_changelog", () => {

--- a/tests/contracts-mcp.test.ts
+++ b/tests/contracts-mcp.test.ts
@@ -12,6 +12,7 @@ import {
 import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type Row } from "./row-type.ts";
+import { assertValid } from "./helpers/assert-valid.ts";
 
 type ReadArtifact = (env: Env, path: string) => Promise<StorageReadResult>;
 
@@ -143,7 +144,7 @@ describe("contracts-mcp", () => {
     const validate = new Ajv2020({ strict: false }).compile(
       GET_CONTRACTS_OUTPUT_SCHEMA,
     );
-    assert.ok(validate(SAMPLE_CONTRACTS));
+    assertValid(validate, SAMPLE_CONTRACTS);
   });
 
   test("MCP server exports wire get_contracts", () => {

--- a/tests/helpers/assert-valid.ts
+++ b/tests/helpers/assert-valid.ts
@@ -1,0 +1,41 @@
+// One assertion for "this fixture validates against its schema", so a failure
+// says WHICH field is wrong (#9846).
+//
+// `assert.ok(validate(data))` throws away `validate.errors`, which is where AJV
+// has already computed the instance path, keyword and missing property. The
+// whole failure output was:
+//
+//     AssertionError: The expression evaluated to a falsy value:
+//       ok(validate(SAMPLE_CHANGELOG))
+//     - Expected  + Received
+//     - true      + false
+//
+// Reaching "/summary must have required property 'coverage_delta'" from that
+// took three vitest round trips, one of them down a false trail: a scratch test
+// imported the fixture from the wrong module, validated `undefined`, and got a
+// meaningless root-level `must be object` -- a wrong answer that looks like a
+// real one.
+//
+// This matters more as the schemas move to being DERIVED from artifacts rather
+// than hand-copied (#9796, #9799, #9801, #9830): fixtures now fall behind their
+// schemas by design, so the failure message is the whole developer experience
+// of that transition. The Zod side was already readable -- ZodError prints the
+// path and the expected type -- which is the contrast that motivated this.
+import assert from "node:assert/strict";
+import type { ValidateFunction } from "ajv/dist/2020.js";
+
+export function assertValid(
+  validate: ValidateFunction,
+  data: unknown,
+  label = "value",
+): void {
+  if (validate(data)) return;
+  const detail = (validate.errors ?? [])
+    .map((error) => `${error.instancePath || "/"} ${error.message}`)
+    .join("; ");
+  // `errors` is empty only if a caller passes a validator that has already been
+  // re-run since the failing call; say so rather than printing a bare colon.
+  assert.fail(
+    `${label} does not validate: ${detail || "(validator reported no errors)"}`,
+  );
+}

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -88,6 +88,7 @@ import {
   PROMETHEUS_DEGRADED_NOT_CURATED,
 } from "../src/uncurated-event-streams.ts";
 import type { AnyFn, Row } from "./row-type.ts";
+import { assertValid } from "./helpers/assert-valid.ts";
 
 const MCP_URL = "https://api.metagraph.sh/mcp";
 
@@ -2692,7 +2693,7 @@ describe("MCP tools (injected deps)", () => {
     });
     const res = await callTool("list_curation", { limit: 1 }, { deps });
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("list_gaps returns filtered gap rows", async () => {
@@ -2770,7 +2771,7 @@ describe("MCP tools (injected deps)", () => {
     });
     const res = await callTool("list_gaps", { limit: 1 }, { deps });
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("list_enrichment_queue returns filtered queue rows", async () => {
@@ -2895,7 +2896,7 @@ describe("MCP tools (injected deps)", () => {
     });
     const res = await callTool("list_enrichment_queue", { limit: 1 }, { deps });
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("list_adapter_candidates returns filtered candidate rows", async () => {
@@ -3005,7 +3006,7 @@ describe("MCP tools (injected deps)", () => {
       { deps },
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("list_enrichment_evidence returns filtered evidence rows", async () => {
@@ -3105,7 +3106,7 @@ describe("MCP tools (injected deps)", () => {
       { deps },
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("list_review_gaps returns filtered priority rows", async () => {
@@ -3178,7 +3179,7 @@ describe("MCP tools (injected deps)", () => {
     });
     const res = await callTool("list_review_gaps", { limit: 1 }, { deps });
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("list_review_enrichment_targets returns filtered target rows", async () => {
@@ -3301,7 +3302,7 @@ describe("MCP tools (injected deps)", () => {
       { deps },
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("list_subnet_endpoints returns filtered endpoint rows", async () => {
@@ -3431,7 +3432,7 @@ describe("MCP tools (injected deps)", () => {
       { deps },
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("list_subnet_health returns filtered health rows", async () => {
@@ -3526,7 +3527,7 @@ describe("MCP tools (injected deps)", () => {
       { deps },
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("list_subnet_surfaces returns filtered surface rows", async () => {
@@ -3618,7 +3619,7 @@ describe("MCP tools (injected deps)", () => {
       { deps },
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("list_endpoint_pools returns filtered pool rows", async () => {
@@ -3831,7 +3832,7 @@ describe("MCP tools (injected deps)", () => {
     });
     const res = await callTool("list_endpoint_pools", { limit: 1 }, { deps });
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("list_provider_endpoints returns filtered endpoint rows", async () => {
@@ -3966,7 +3967,7 @@ describe("MCP tools (injected deps)", () => {
       { deps },
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("list_endpoint_incidents returns filtered incident rows", async () => {
@@ -4118,7 +4119,7 @@ describe("MCP tools (injected deps)", () => {
       { deps },
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("registry_summary returns the summary artifact", async () => {
@@ -4314,7 +4315,7 @@ describe("MCP tools (injected deps)", () => {
     });
     const res = await callTool("get_changelog", {}, { deps });
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("get_build returns the build summary artifact", async () => {
@@ -4363,7 +4364,7 @@ describe("MCP tools (injected deps)", () => {
     });
     const res = await callTool("get_build", {}, { deps });
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("list_enrichment_targets returns ranked coverage-depth targets", async () => {
@@ -6633,7 +6634,7 @@ describe("MCP stake-flow and movers economics tools", () => {
       ]),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // account_events' D1 write path is retired (#4772) and the table is dropped in
@@ -6686,7 +6687,7 @@ describe("MCP stake-flow and movers economics tools", () => {
       ]),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // account_events' D1 write path is retired (#4772) and the table is dropped in
@@ -6739,7 +6740,7 @@ describe("MCP stake-flow and movers economics tools", () => {
       ]),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // account_events' D1 write path is retired (#4772) and the table is dropped in
@@ -6792,7 +6793,7 @@ describe("MCP stake-flow and movers economics tools", () => {
       ]),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // account_events' D1 write path is retired (#4772) and the table is dropped in
@@ -6845,7 +6846,7 @@ describe("MCP stake-flow and movers economics tools", () => {
       ]),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // account_events' D1 write path is retired (#4772) and the table is dropped in
@@ -6898,7 +6899,7 @@ describe("MCP stake-flow and movers economics tools", () => {
       ]),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // account_events' D1 write path is retired (#4772) and the table is dropped in
@@ -6951,7 +6952,7 @@ describe("MCP stake-flow and movers economics tools", () => {
       ]),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // neuron_daily's D1 write path is retired (#4772) and the table is dropped in
@@ -7236,7 +7237,7 @@ describe("MCP get_subnet_stake_moves", () => {
       }),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 });
 
@@ -7276,7 +7277,7 @@ describe("MCP get_subnet_stake_transfers", () => {
       }),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 });
 
@@ -7315,7 +7316,7 @@ describe("MCP get_subnet_registrations", () => {
       }),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 });
 
@@ -7358,7 +7359,7 @@ describe("MCP get_subnet_weights", () => {
       }),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 });
 
@@ -7467,7 +7468,7 @@ describe("MCP get_subnet_serving", () => {
       }),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 });
 
@@ -7510,7 +7511,7 @@ describe("MCP get_subnet_prometheus", () => {
       }),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 });
 
@@ -7657,7 +7658,7 @@ describe("MCP get_subnet_yield_history", () => {
       },
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 });
 
@@ -11509,7 +11510,7 @@ describe("MCP economics + metagraph data tools", () => {
         env: {} as unknown as Env,
       },
     );
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("get_economics surfaces not_found when neither tier has data", async () => {
@@ -11705,7 +11706,7 @@ describe("MCP economics + metagraph data tools", () => {
         env: {} as unknown as Env,
       },
     );
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("get_subnet_profile payload validates against its declared outputSchema", async () => {
@@ -11835,7 +11836,7 @@ describe("MCP economics + metagraph data tools", () => {
         env: {} as unknown as Env,
       },
     );
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   const liveAnalyticsDeps = makeDeps({
@@ -12794,7 +12795,7 @@ describe("MCP economics + metagraph data tools", () => {
       ]),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // A grouped account_events aggregate row (one per netuid+event_kind), the
@@ -12905,7 +12906,7 @@ describe("MCP economics + metagraph data tools", () => {
       ]),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // One GROUP BY netuid, event_kind row from account_events, the shape
@@ -13021,7 +13022,7 @@ describe("MCP economics + metagraph data tools", () => {
       ]),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // The network-wide aggregate row loadChainWeights reads first (its COUNT/
@@ -13129,7 +13130,7 @@ describe("MCP economics + metagraph data tools", () => {
       ]),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // D1 fully eliminated (2026-07-16): account_events' D1 write path is
@@ -13280,7 +13281,7 @@ describe("MCP economics + metagraph data tools", () => {
       }),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // The network-wide aggregate row loadChainStakeMoves reads first (its
@@ -13385,7 +13386,7 @@ describe("MCP economics + metagraph data tools", () => {
       ]),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // The network-wide aggregate row loadChainStakeTransfers reads first (its
@@ -13494,7 +13495,7 @@ describe("MCP economics + metagraph data tools", () => {
       ]),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // The network-wide aggregate row loadChainAxonRemovals reads first (its
@@ -13603,7 +13604,7 @@ describe("MCP economics + metagraph data tools", () => {
       ]),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // The network-wide aggregate row loadChainDeregistrations reads first (its
@@ -13712,7 +13713,7 @@ describe("MCP economics + metagraph data tools", () => {
       ]),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // The network-wide aggregate row loadChainServing reads first (its
@@ -13813,7 +13814,7 @@ describe("MCP economics + metagraph data tools", () => {
       ]),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // The network-wide aggregate row loadChainPrometheus reads first (its
@@ -13918,7 +13919,7 @@ describe("MCP economics + metagraph data tools", () => {
       ]),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // The full-window totals row loadChainTransferPairs reads first (its pair_totals
@@ -14068,7 +14069,7 @@ describe("MCP economics + metagraph data tools", () => {
       ]),
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // neuron_daily's D1 write path is retired (#4772) and the table is dropped
@@ -14370,7 +14371,7 @@ describe("MCP economics + metagraph data tools", () => {
     const deps = makeDeps({}, { "health:current": globalLiveKv });
     const res = await callTool("get_network_health", {}, { deps });
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("get_health_history serves a dated snapshot with list-query filters", async () => {
@@ -14525,7 +14526,7 @@ describe("MCP economics + metagraph data tools", () => {
       { deps },
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   // surface_uptime_daily's D1 write path is retired (#4772) and the table is
@@ -15370,7 +15371,7 @@ describe("MCP economics + metagraph data tools", () => {
       { deps: feedDeps },
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("the D1 runner swallows a query error and a missing result set", async () => {
@@ -18962,7 +18963,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     });
     const res = await callTool("list_search_index", { limit: 1 }, { deps });
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("list_search returns document rows across all types", async () => {
@@ -19015,7 +19016,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     });
     const res = await callTool("list_search", { limit: 1 }, { deps });
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("list_providers returns filtered provider rows", async () => {
@@ -19085,7 +19086,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     });
     const res = await callTool("list_providers", { limit: 1 }, { deps });
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   function providersDeps() {
@@ -19372,7 +19373,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     });
     const res = await callTool("list_surfaces", { limit: 1 }, { deps });
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   function surfacesDeps() {
@@ -20082,7 +20083,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     });
     const res = await callTool("list_evidence", { limit: 1 }, { deps });
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("list_rpc_endpoints returns the rpc endpoints artifact", async () => {
@@ -20232,7 +20233,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     });
     const res = await callTool("list_source_snapshots", { limit: 1 }, { deps });
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("list_profile_completeness returns filtered profile-completeness rows", async () => {
@@ -20712,7 +20713,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     });
     const res = await callTool("list_rpc_pools", { limit: 1 }, { deps });
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("get_subnet_endpoints returns one subnet's endpoints artifact", async () => {
@@ -20853,7 +20854,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
       { deps },
     );
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("get_subnet_surfaces returns one subnet's surfaces artifact", async () => {
@@ -21063,7 +21064,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     });
     const res = await callTool("get_contracts", {}, { deps });
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("get_adapter returns the adapter snapshot artifact", async () => {
@@ -21128,7 +21129,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     });
     const res = await callTool("get_adapter", { slug: "gittensor" }, { deps });
     const validate = new Ajv2020({ strict: false }).compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
+    assertValid(validate, res.body.result.structuredContent);
   });
 
   test("get_source_health returns the source-health artifact", async () => {

--- a/tests/self-health-mcp.test.ts
+++ b/tests/self-health-mcp.test.ts
@@ -12,6 +12,7 @@ import {
 import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type Row } from "./row-type.ts";
+import { assertValid } from "./helpers/assert-valid.ts";
 
 type ReadArtifact = (env: Env, path: string) => Promise<StorageReadResult>;
 
@@ -325,7 +326,7 @@ describe("self-health-mcp", () => {
     const validate = new Ajv2020({ strict: false }).compile(
       GET_SELF_HEALTH_OUTPUT_SCHEMA,
     );
-    assert.ok(validate(SAMPLE_SELF_HEALTH));
+    assertValid(validate, SAMPLE_SELF_HEALTH);
   });
 
   // #9330/#9340 + the cold-tier parity gap found live on 2026-08-04.


### PR DESCRIPTION
## Summary

`assert.ok(validate(SAMPLE_CHANGELOG))` threw away `validate.errors` — exactly where AJV had already computed the instance path, keyword and missing property. The entire failure output was:

```
AssertionError: The expression evaluated to a falsy value:
  ok(validate(SAMPLE_CHANGELOG))
- Expected  + Received
- true      + false
```

Now:

```
AssertionError: value does not validate:
  /summary must have required property 'coverage_delta'
```

Verified by breaking the fixture the way the issue describes and re-running — the message above is the actual output, not an illustration.

## Why it was worth doing

Reaching that diagnosis from "false" took **three vitest round trips**, one of them down a false trail: a scratch test imported the fixture from the wrong module, validated `undefined`, and reported a root-level `must be object` — a wrong answer that looks like a real one.

One of the 63 sites already passed `JSON.stringify(validate.errors)` by hand. That's the precedent; it just wasn't shared, so the other 62 did without.

## Scope

All 63 `assert.ok(validate(...))` sites across 7 files now use one `assertValid` helper:

```
tests/mcp-server.test.ts      57
tests/adapters-mcp.test.ts     1
tests/ai-search.test.ts        1
tests/build-mcp.test.ts        1
tests/changelog-mcp.test.ts    1
tests/contracts-mcp.test.ts    1
tests/self-health-mcp.test.ts  1
```

## Why now

The schemas are moving from hand-copied to **derived from artifacts** (#9796, #9799, #9801, #9830). Fixtures now fall behind their schemas *by design*, so the failure message is the whole developer experience of that transition. The Zod side was already readable — `ZodError` prints the path and the expected type — and that contrast is the argument.

## Commands run

- `npm run typecheck`, `lint`, `format:check` — clean
- `npx vitest run` — **744 files, 17,937 tests passing**

Tests only; no `src/**` or `workers/**` lines, so no patch-coverage surface.

Closes #9846