### PR TITLE
fix(surfaces): stale:false was published for 2,615 surfaces nobody has ever verified

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -11704,7 +11704,8 @@ export interface components {
             schema_status?: "machine-readable" | "ui-only" | "not-captured";
             schema_url?: string;
             source_urls?: string[];
-            stale?: boolean;
+            /** @description Whether this surface's verification is older than its kind's freshness TTL. NULL when the surface has never been verified (#9906): that is unverified, not fresh, and 78% of surfaces were in that state while publishing false. Same unknown-is-not-a-value convention as `exists` on /crowdloans/{id}, `leased` on /subnets/{netuid}/lease, and lane_health's `verdict: unknown`. */
+            stale?: boolean | null;
             status?: components["schemas"]["HealthStatus"];
             subnet_name?: string;
             subnet_slug?: string;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -52454,7 +52454,15 @@
             "type": "array"
           },
           "stale": {
-            "type": "boolean"
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Whether this surface's verification is older than its kind's freshness TTL. NULL when the surface has never been verified (#9906): that is unverified, not fresh, and 78% of surfaces were in that state while publishing false. Same unknown-is-not-a-value convention as `exists` on /crowdloans/{id}, `leased` on /subnets/{netuid}/lease, and lane_health's `verdict: unknown`."
           },
           "status": {
             "$ref": "#/components/schemas/HealthStatus"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -11704,7 +11704,8 @@ export interface components {
             schema_status?: "machine-readable" | "ui-only" | "not-captured";
             schema_url?: string;
             source_urls?: string[];
-            stale?: boolean;
+            /** @description Whether this surface's verification is older than its kind's freshness TTL. NULL when the surface has never been verified (#9906): that is unverified, not fresh, and 78% of surfaces were in that state while publishing false. Same unknown-is-not-a-value convention as `exists` on /crowdloans/{id}, `leased` on /subnets/{netuid}/lease, and lane_health's `verdict: unknown`. */
+            stale?: boolean | null;
             status?: components["schemas"]["HealthStatus"];
             subnet_name?: string;
             subnet_slug?: string;

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -550,7 +550,10 @@ export const SurfaceSchema = z
       .optional(),
     schema_url: HttpOrWssUrlSchema.optional(),
     source_urls: z.array(z.url()).optional(),
-    stale: z.boolean().optional(),
+    stale: z.boolean().nullable().optional().meta({
+      description:
+        "Whether this surface's verification is older than its kind's freshness TTL. NULL when the surface has never been verified (#9906): that is unverified, not fresh, and 78% of surfaces were in that state while publishing false. Same unknown-is-not-a-value convention as `exists` on /crowdloans/{id}, `leased` on /subnets/{netuid}/lease, and lane_health's `verdict: unknown`.",
+    }),
     status: HealthStatusSchema.optional(),
     subnet_name: z.string().optional(),
     subnet_slug: z.string().optional(),

--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -1108,17 +1108,26 @@ export function surfaceFreshnessTtlDays(kind: string): number {
 
 // True when a surface's verification is older than its kind's TTL, measured
 // against `nowMs` (the dataset's native-snapshot captured_at, a committed +
-// deterministic reference — never wall-clock — so the flag is reproducible). A
-// surface with no last_verified_at is NOT stale: that's "unverified", a distinct
-// state the null timestamp already signals.
+// deterministic reference — never wall-clock — so the flag is reproducible).
+//
+// NULL when there is nothing to measure: no last_verified_at, an unparseable
+// one, or a non-finite reference. This used to return `false` on the reasoning
+// that the null timestamp already signalled "unverified" — but `stale` is
+// published as its own field, and read as one: 2,731 of 3,493 surfaces (78%)
+// had never been verified and every one of them published `stale: false`, so a
+// consumer filtering on `stale === false` for "this verification is current"
+// got a set in which four out of five entries had no verification behind them
+// (#9906). Null is the same unknown-is-not-a-value convention this codebase
+// already uses for `exists` on /crowdloans/{id}, `leased` on
+// /subnets/{netuid}/lease, and lane_health's `verdict: "unknown"`.
 export function isSurfaceStale(
   lastVerifiedAt: unknown,
   kind: string,
   nowMs: number,
-): boolean {
-  if (!lastVerifiedAt) return false;
+): boolean | null {
+  if (!lastVerifiedAt) return null;
   const verifiedMs = Date.parse(lastVerifiedAt as string);
-  if (!Number.isFinite(verifiedMs) || !Number.isFinite(nowMs)) return false;
+  if (!Number.isFinite(verifiedMs) || !Number.isFinite(nowMs)) return null;
   return nowMs - verifiedMs > surfaceFreshnessTtlDays(kind) * 86_400_000;
 }
 
@@ -1139,7 +1148,13 @@ export function withSurfaceFreshness(surfaces: Row[], nowMs: number): Row[] {
       // #1757: re-resolve the trust tier now that staleness is known — a stale
       // verification demotes machine-verified/maintainer-reviewed down to
       // candidate-discovered, the same demotion the freshness model applies
-      // elsewhere. subnet_curation_level isn't carried on the flattened row, so
+      // elsewhere.
+      //
+      // A NULL `stale` (never verified, #9906) takes the else branch, which is
+      // correct and unchanged: resolveSurfaceCurationLevel already floors a
+      // never-verified surface at candidate-discovered on its own, which is
+      // exactly where a demoted stale surface lands. Only the published label
+      // changed, not the trust ordering. subnet_curation_level isn't carried on the flattened row, so
       // an already-resolved maintainer-reviewed/adapter-backed level (set in
       // flattenSurfaces from the subnet ceiling) is preserved when still fresh.
       curation_level: stale

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -1356,8 +1356,13 @@ test("public artifacts are internally consistent", () => {
     true,
   );
   // #1006: per-field provenance. Every served surface exposes last_verified_at
-  // (string|null) + a `stale` boolean, and `stale` is reproducible from the
-  // helper against the committed native-snapshot captured_at.
+  // (string|null) + a `stale` boolean-or-null, and `stale` is reproducible from
+  // the helper against the committed native-snapshot captured_at.
+  //
+  // #9906: null is the never-verified case, and it is REQUIRED to line up with
+  // last_verified_at rather than merely being allowed -- the pairing below is
+  // what stops a future change silently reintroducing a confident `false` for
+  // a surface nobody has checked.
   const surfaceNowMs = Date.parse(native.captured_at);
   for (const surface of surfaces.surfaces) {
     assert.ok(
@@ -1365,10 +1370,16 @@ test("public artifacts are internally consistent", () => {
         typeof surface.last_verified_at === "string",
       `surface ${surface.id} last_verified_at must be a string or null`,
     );
+    assert.ok(
+      surface.stale === null || typeof surface.stale === "boolean",
+      `surface ${surface.id} must carry a boolean-or-null stale flag`,
+    );
     assert.equal(
-      typeof surface.stale,
-      "boolean",
-      `surface ${surface.id} must carry a boolean stale flag`,
+      surface.stale === null,
+      surface.last_verified_at === null,
+      `surface ${surface.id}: stale must be null exactly when it has never ` +
+        `been verified (stale=${JSON.stringify(surface.stale)}, ` +
+        `last_verified_at=${JSON.stringify(surface.last_verified_at)})`,
     );
     assert.equal(
       surface.stale,

--- a/tests/script-utils.test.ts
+++ b/tests/script-utils.test.ts
@@ -1859,12 +1859,17 @@ describe("script utility contracts", () => {
     const now = Date.parse("2026-06-14T00:00:00.000Z");
     const daysAgo = (n: number) => new Date(now - n * 86_400_000).toISOString();
 
-    // Unverified surfaces are NOT stale — null is a distinct state the agent reads.
-    assert.equal(isSurfaceStale(null, "subnet-api", now), false);
-    assert.equal(isSurfaceStale(undefined, "docs", now), false);
-    // Unparseable inputs never throw and never flag stale.
-    assert.equal(isSurfaceStale("not-a-date", "docs", now), false);
-    assert.equal(isSurfaceStale(daysAgo(999), "docs", Number.NaN), false);
+    // Never verified is NULL, not false (#9906): there is no verification to
+    // call fresh, and `false` asserted freshness for 78% of all surfaces.
+    assert.equal(isSurfaceStale(null, "subnet-api", now), null);
+    assert.equal(isSurfaceStale(undefined, "docs", now), null);
+    // Unparseable inputs never throw, and are likewise unknown rather than
+    // fresh -- an unreadable timestamp is not evidence of a recent check.
+    assert.equal(isSurfaceStale("not-a-date", "docs", now), null);
+    assert.equal(isSurfaceStale(daysAgo(999), "docs", Number.NaN), null);
+    // The distinction the field exists to make: null vs false vs true are
+    // three states, and only `false` means "verified, and still fresh".
+    assert.notEqual(isSurfaceStale(null, "docs", now), false);
     // Fresh: age below the kind TTL.
     assert.equal(isSurfaceStale(daysAgo(10), "subnet-api", now), false);
     // Boundary: exactly at the TTL is still fresh (strict greater-than).
@@ -1891,7 +1896,8 @@ describe("script utility contracts", () => {
       [
         ["a", true],
         ["b", false],
-        ["c", false],
+        // Never verified: null, not false (#9906).
+        ["c", null],
       ],
     );
     assert.equal(stamped[0].kind, "openapi");


### PR DESCRIPTION
## Summary

**78% of surfaces had never been verified even once, and every one of them published `stale: false`.** A consumer filtering on `stale === false` to mean "this verification is current" got a set in which four out of five entries had no verification behind them at all.

Rebuilt artifact, before → after:

```
                                  before      after
never verified                     2,615   ->  stale: null
verified and still fresh             820   ->  stale: false
verified and past its TTL              6   ->  stale: true
never verified, published false    2,615   ->  0
```

## Cause

`isSurfaceStale` opened with `if (!lastVerifiedAt) return false`.

Read narrowly — *"is this verification stale?"* — `false` for "there is no verification" is defensible, and the original comment argued exactly that: the null `last_verified_at` already signals unverified. But `stale` is **published as its own field and read as one**, so it now returns `null` there. An unparseable timestamp is null too: an unreadable date is not evidence of a recent check.

## This is the codebase's own convention

Unknown-is-not-a-value is already applied in three other places:

- `exists` is null rather than false on RPC failure in `/crowdloans/{id}`
- `leased` is null rather than false in `/subnets/{netuid}/lease`
- `lane_health` keeps `verdict: "unknown"` distinct from `"ok"` — *"a watchdog that could not evaluate has not observed health, and collapsing the two would report an unmeasured lane as a healthy one"* (`migrations/d1/0014`)

## Trust ordering is unchanged — deliberately

The issue checked this and the fix preserves it: a null `stale` takes `withSurfaceFreshness`'s else branch, and `resolveSurfaceCurationLevel` already floors a never-verified surface at `candidate-discovered` — exactly where a demoted stale surface lands. **Only the published label changed.** Now stated in the code so it is deliberate rather than incidental.

## The invariant is now a requirement, not a permission

`tests/artifacts.test.ts` previously asserted `typeof stale === "boolean"`. Rather than loosening it to "boolean or null" and stopping there, it now asserts the **pairing**:

```ts
assert.equal(surface.stale === null, surface.last_verified_at === null);
```

so a future change cannot quietly reintroduce a confident `false` for a surface nobody has checked. That is the assertion that would have caught this originally.

## Consumers checked

The only reader of a surface `stale` outside the builder is `apps/ui/src/lib/metagraphed/queries.ts`, which already guards with `typeof s.stale === "boolean" ? s.stale : false` — and is operating on source snapshots, not registry surfaces. No UI change needed. The MCP `health.stale` is a different field (probe staleness) and is untouched.

## Commands run

- `npm run build` — contract + artifacts regenerated and committed
- `npm run typecheck`, `lint`, `format:check` — clean
- `npm run validate`, `validate:contract-drift` — pass
- `npx vitest run` — **744 files, 17,937 tests passing**

No `src/**` or `workers/**` lines in the diff (the logic lives in `scripts/lib.ts` and the schema in `schemas-src/`), so there is no codecov patch surface; the behaviour is covered by the two suites above.

Closes #9906