### PR TITLE
fix(queue): export queue from the deployed entry, so the consumers register

### DIFF
--- a/tests/api-entry-handlers.test.ts
+++ b/tests/api-entry-handlers.test.ts
@@ -1,0 +1,102 @@
+// The deployed entry must expose every handler the raw handler does.
+//
+// wrangler.jsonc's "main" is workers/api.entry.ts, NOT workers/api.ts -- the
+// entry composes GitHub OAuth on top and re-exports the rest. Cloudflare only
+// sees what THAT object exports, and a queue consumer is registered at deploy
+// time only if the deployed Worker exports a `queue` handler.
+//
+// #9655 added queue() to api.ts and declared both consumers in wrangler.jsonc,
+// but the composed object here was never extended. Measured on the live
+// account before the fix:
+//
+//   webhook-deliveries      producers 1 (worker:metagraphed)  consumers 0
+//   webhook-deliveries-dlq  producers 0                       consumers 0
+//   sync-batches            producers 1 (data-api)            consumers 1
+//
+// The producer registered from the SAME config block, because a producer is
+// only a binding and needs no handler -- which is what made this read as a
+// Cloudflare-side inconsistency between two Workers rather than a missing
+// export. metagraphed-data-api's queues work because its wrangler "main"
+// points straight at the raw handler.
+//
+// api.entry.ts is excluded from COVERAGE (vitest.config.ts) as a thin
+// composition layer. That is a statement about line coverage, not about
+// whether the composition is correct: nothing else in the suite can catch a
+// handler being added to api.ts and silently not reaching production.
+
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+
+// The real provider imports `cloudflare:` modules the node test environment
+// cannot resolve, and it is irrelevant to the question this file asks -- which
+// KEYS the composed object carries, not what fetch does with them.
+vi.mock("@cloudflare/workers-oauth-provider", () => ({
+  OAuthProvider: class {
+    fetch() {
+      return new Response("stub");
+    }
+  },
+}));
+
+async function entryHandler() {
+  return (await import("../workers/api.entry.ts")).default as Record<
+    string,
+    unknown
+  >;
+}
+
+async function rawHandler() {
+  return (await import("../workers/api.ts")).default as Record<string, unknown>;
+}
+
+describe("api.entry handler parity", () => {
+  test("exposes every handler the raw handler does", async () => {
+    const entry = await entryHandler();
+    const handler = await rawHandler();
+    assert.deepEqual(
+      Object.keys(entry).sort(),
+      Object.keys(handler).sort(),
+      "workers/api.ts gained a handler that workers/api.entry.ts does not " +
+        "re-export, so the deployed Worker does not have it. For `queue` this " +
+        "silently leaves the queue consumers unregistered; for a future " +
+        "handler it would be the same class of bug.",
+    );
+  });
+
+  test("exports `queue`, which is what registers the consumers", async () => {
+    // Named separately from the parity check so the failure says WHY, and so
+    // the specific regression stays pinned even if the parity assertion is
+    // ever relaxed.
+    const entry = await entryHandler();
+    assert.equal(
+      typeof entry.queue,
+      "function",
+      "without a queue handler on the DEPLOYED entry, Cloudflare registers no " +
+        "consumer for webhook-deliveries or webhook-deliveries-dlq, and an " +
+        "enqueued delivery is never processed",
+    );
+  });
+
+  test("the entry's queue delegates to the raw handler, not a reimplementation", async () => {
+    const entry = await entryHandler();
+    const seen: unknown[] = [];
+    const handler = await rawHandler();
+    const original = handler.queue;
+    handler.queue = async (batch: unknown) => {
+      seen.push(batch);
+    };
+    try {
+      await (
+        entry.queue as (b: unknown, e: unknown, c: unknown) => Promise<void>
+      )({ queue: "webhook-deliveries", messages: [] }, {}, {});
+    } finally {
+      handler.queue = original;
+    }
+    assert.equal(seen.length, 1, "the entry must forward the batch through");
+    assert.equal(
+      (seen[0] as { queue: string }).queue,
+      "webhook-deliveries",
+      "the batch must arrive unmodified — the DLQ branch in api.ts keys off it",
+    );
+  });
+});

--- a/workers/api.entry.ts
+++ b/workers/api.entry.ts
@@ -86,4 +86,26 @@ export default {
   ): Promise<void> => {
     await handler.scheduled(controller, env, ctx);
   },
+  // #9847: this MUST be here, for exactly the reason the
+  // .scheduled note above gives.
+  //
+  // A queue consumer is registered at deploy time only if the deployed Worker
+  // actually exports a `queue` handler -- and "deployed Worker" means THIS
+  // file, not api.ts. #9655 added queue() to api.ts and wired both consumers
+  // in wrangler.jsonc, but the composed object here was never extended, so
+  // Cloudflare saw a Worker with no queue handler and registered neither:
+  //
+  //   webhook-deliveries      producers 1 (worker:metagraphed)  consumers 0
+  //   webhook-deliveries-dlq  producers 0                       consumers 0
+  //
+  // The PRODUCER registered from the same config block, because a producer is
+  // just a binding and needs no handler -- which is what made this look like a
+  // Cloudflare-side inconsistency rather than a missing export. metagraphed-
+  // data-api's queues work because its wrangler "main" points straight at the
+  // raw handler, so its queue() is on the deployed entry by construction.
+  queue: (
+    batch: MessageBatch<unknown>,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<void> => handler.queue(batch, env, ctx),
 };


### PR DESCRIPTION
## The cause is in this repo, not on Cloudflare's side

#9847 established that the config was correct, the Worker current, and that registration differed between two Workers for no visible reason. It is a missing export.

`wrangler.jsonc`'s `"main"` is **`workers/api.entry.ts`**, not `workers/api.ts`. The entry composes GitHub OAuth over the raw handler and re-exports what the runtime needs. A queue consumer is registered at deploy time **only if the deployed Worker exports a `queue` handler** — and the deployed Worker is that entry. #9655 added `queue()` to `api.ts` and declared both consumers, but the composed object was never extended.

Re-measured on the account before the fix:

```
webhook-deliveries      producers 1 (worker:metagraphed)  consumers 0
webhook-deliveries-dlq  producers 0                       consumers 0
sync-batches            producers 1 (data-api)            consumers 1
sync-batches-dlq        producers 0                       consumers 1
```

**The asymmetry inside a single Worker is the tell.** `webhook-deliveries` shows `producers: 1, worker:metagraphed` — the producer from the *same config block* registered fine, because a producer is only a binding and needs no handler. That is what made this read as a Cloudflare-side inconsistency between two Workers rather than a missing export.

`metagraphed-data-api` is unaffected for a structural reason: its wrangler `"main"` points straight at `workers/data-api.ts`, so its `queue()` is on the deployed entry by construction.

The entry file already documents this exact failure mode one export higher, for `.scheduled`:

> Swapping the top-level export for a bare OAuthProvider instance would silently drop every one of those — Cloudflare would just never find a `.scheduled` to call.

Same sentence, one export lower.

## Scope

Audited all four Workers:

| worker | `main` | declares consumers | `queue` on entry |
|---|---|---|---|
| metagraphed | `workers/api.entry.ts` | yes | **was missing** → fixed |
| metagraphed-data-api | `workers/data-api.ts` | yes | present |
| registry-sync-api | `workers/registry-sync-api.ts` | no | n/a |
| wss-lb | `workers/wss-lb.ts` | no | n/a |

Only the main Worker was affected.

## The regression guard

`tests/api-entry-handlers.test.ts` asserts three things: the entry exposes **every** handler the raw handler does, `queue` specifically is a function, and it forwards the batch **unmodified** (api.ts's dead-letter branch keys off `batch.queue`, so a wrapper that rebuilt the batch would re-deliver a message a subscriber already refused eight times).

The entry imports `cloudflare:` modules through the OAuth provider, which the node test environment cannot resolve, so the provider is mocked — the question this file asks is which keys the composed object carries, not what `fetch` does with them.

Worth stating: `api.entry.ts` is excluded from **coverage** in `vitest.config.ts` as a thin composition layer. That is a statement about line coverage, not about whether the composition is correct — and nothing else in the suite could catch a handler being added to `api.ts` and silently not reaching production.

**Mutation-tested**: deleting the `queue` property from the entry (i.e. reintroducing the exact bug) fails all three tests.

## Validation

```
npm run typecheck            clean
npm run lint / format:check  clean
wrangler deploy --dry-run    succeeds
vitest (20 webhook/queue-related files + the new one)   2,522 passed
```

## What this PR cannot prove

Consumer registration happens **server-side at deploy**, so the fix is only observable after this merges and Workers Builds deploys. The check afterwards is:

```bash
npx wrangler queues info webhook-deliveries
```

expecting `Number of Consumers: 1` / `Consumers: worker:metagraphed`, and the same for `webhook-deliveries-dlq`. I'll confirm it post-merge rather than claim it now.

Impact remains latent either way — there are currently zero webhook subscriptions, so nothing is being dropped today. It bites the moment somebody subscribes, which is exactly the state #354 was written to end.

Closes #9847