### PR TITLE
feat(neon): give subnet_hyperparams and account_identity a Neon writer

### DIFF
--- a/src/hyperparams-identity-neon-write.ts
+++ b/src/hyperparams-identity-neon-write.ts
@@ -1,0 +1,200 @@
+// The Neon write for subnet_hyperparams and account_identity (#10046).
+//
+// WHY THESE TWO NEEDED A MODULE AT ALL. Both families showed exact parity in
+// Neon and looked ready to invert -- and neither handler had ever executed a
+// Neon write. `grep -ci neon` over either returned 0; both end with "the D1
+// write IS the sync". Their Neon copies exist because NEON_BACKFILL_LANES
+// reconciles them on a cron, not because anything mirrors them.
+//
+// That distinction is the whole reason this exists. The neurons lane could
+// invert (#10037) on a mirror that had been writing every pass for weeks, so
+// skipping the D1 write was provably safe. Inverting these on reconciler
+// parity would mean flipping to a code path with ZERO production evidence
+// while simultaneously removing the D1 copy -- which is how a migration loses
+// rows rather than moving them.
+//
+// TRANSITIONAL, AND TRACKED AS SUCH (#10051). This is a rung, not the
+// destination: once these tables are in NEON_SOLE_STORE_TABLES the D1 write
+// goes, and once every table has crossed, NEON_DUAL_WRITE_LANES and every
+// mirror call site including this one get deleted. A reconciler or mirror that
+// outlives the inversion is worse than dead code -- it would copy a frozen D1
+// over live Neon rows, because it cannot tell the direction reversed.
+import {
+  SUBNET_HYPERPARAMS_HISTORY_COLUMNS,
+  ACCOUNT_IDENTITY_HISTORY_COLUMNS,
+} from "./hyperparams-identity-d1-write.ts";
+import { SUBNET_HYPERPARAMS_INSERT_COLUMNS } from "./subnet-hyperparams.ts";
+import { ACCOUNT_IDENTITY_INSERT_COLUMNS } from "./account-identity.ts";
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import {
+  createPgSql,
+  type HyperdriveLike,
+  type WaitUntilLike,
+} from "./pg-sql.ts";
+import {
+  neonDualWriteEnabled,
+  recordNeonWriteVerdict,
+  writeRowsToNeon,
+  type NeonWriteResult,
+} from "./neon-write.ts";
+
+export const SUBNET_HYPERPARAMS_NEON_LANE = "subnet-hyperparams";
+export const ACCOUNT_IDENTITY_NEON_LANE = "account-identity";
+
+type Row = Record<string, unknown>;
+
+/**
+ * One family's two tables: the latest-only card and its append-only history.
+ *
+ * The history has NO freshness guard, unlike the card. A history row is
+ * appended only when the hash changed, so a conflict on (key, observed_at)
+ * means the same revision arriving twice -- and doing nothing is right. A
+ * `captured_at <` guard there would compare a column the table does not have.
+ */
+interface FamilyPlan {
+  lane: string;
+  latest: { table: string; columns: readonly string[]; conflict: string[] };
+  history: { table: string; columns: readonly string[]; conflict: string[] };
+}
+
+const PLANS: Readonly<Record<string, FamilyPlan>> = {
+  [SUBNET_HYPERPARAMS_NEON_LANE]: {
+    lane: SUBNET_HYPERPARAMS_NEON_LANE,
+    latest: {
+      table: "subnet_hyperparams",
+      columns: SUBNET_HYPERPARAMS_INSERT_COLUMNS,
+      conflict: ["netuid"],
+    },
+    history: {
+      table: "subnet_hyperparams_history",
+      columns: SUBNET_HYPERPARAMS_HISTORY_COLUMNS,
+      conflict: ["netuid", "observed_at"],
+    },
+  },
+  [ACCOUNT_IDENTITY_NEON_LANE]: {
+    lane: ACCOUNT_IDENTITY_NEON_LANE,
+    latest: {
+      table: "account_identity",
+      columns: ACCOUNT_IDENTITY_INSERT_COLUMNS,
+      conflict: ["account"],
+    },
+    history: {
+      table: "account_identity_history",
+      columns: ACCOUNT_IDENTITY_HISTORY_COLUMNS,
+      conflict: ["account", "observed_at"],
+    },
+  },
+};
+
+export interface FamilyMirrorInput {
+  /** The latest-only rows, already coerced -- booleans are real booleans by
+   * the time they reach here, which is what Neon's BOOLEAN columns need. */
+  rows: Row[];
+  /** Rows this pass appends, in the history table's own column shape. */
+  historyRows: Row[];
+}
+
+export interface FamilyMirrorDeps {
+  sql?: { unsafe(text: string, values?: unknown[]): Promise<unknown> } | null;
+  laneHealthDb?: LaneHealthDb | null;
+  now?: () => number;
+}
+
+export interface FamilyMirrorOutcome {
+  attempted: boolean;
+  results: Record<string, NeonWriteResult>;
+}
+
+/**
+ * Write one family into Neon. Never throws.
+ *
+ * While D1 is still authoritative, a Neon failure costs a lane verdict and
+ * nothing a caller can see. Once the family is in NEON_SOLE_STORE_TABLES the
+ * handler reads `results` and turns any failure into the request's failure --
+ * that inversion lives at the call site, not here, so this function has one
+ * behaviour rather than two.
+ */
+export async function mirrorFamilyToNeon(
+  env: Record<string, unknown> | null | undefined,
+  ctx: WaitUntilLike | null | undefined,
+  lane: string,
+  input: FamilyMirrorInput,
+  deps: FamilyMirrorDeps = {},
+): Promise<FamilyMirrorOutcome> {
+  const plan = PLANS[lane];
+  // An unknown lane is a no-op rather than a throw: the flag is a free-text
+  // list, and a typo there must not take down the D1 write this runs behind.
+  if (!plan || !neonDualWriteEnabled(env, lane))
+    return { attempted: false, results: {} };
+
+  const hyperdrive = env?.HYPERDRIVE as HyperdriveLike | undefined;
+  const sql =
+    deps.sql ??
+    (hyperdrive?.connectionString && ctx ? createPgSql(hyperdrive, ctx) : null);
+  const laneDb =
+    deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as LaneHealthDb | undefined);
+  const now = deps.now ?? Date.now;
+
+  if (!sql) {
+    // Enabled but unbound is a MISCONFIGURATION, not a quiet no-op: somebody
+    // named the lane and the binding is missing.
+    await recordNeonWriteVerdict(
+      laneDb,
+      lane,
+      { ok: false, rows: 0, statements: 0, reason: "hyperdrive unbound" },
+      now(),
+    );
+    return { attempted: true, results: {} };
+  }
+
+  const results: Record<string, NeonWriteResult> = {};
+  if (input.rows.length > 0) {
+    results[plan.latest.table] = await writeRowsToNeon(
+      sql,
+      plan.latest.table,
+      plan.latest.columns,
+      input.rows,
+      plan.latest.conflict,
+      `${plan.latest.table}.captured_at < EXCLUDED.captured_at`,
+    );
+  }
+  if (input.historyRows.length > 0) {
+    results[plan.history.table] = await writeRowsToNeon(
+      sql,
+      plan.history.table,
+      plan.history.columns,
+      input.historyRows,
+      plan.history.conflict,
+      // No guard: see FamilyPlan. A conflict here is the same revision twice.
+      undefined,
+    );
+  }
+  await recordNeonWriteVerdict(laneDb, lane, summarise(results), now());
+  return { attempted: true, results };
+}
+
+/** One verdict for the pair, because they are written by one pass and a
+ * reader wants "did this pass land", not two half-answers. */
+function summarise(results: Record<string, NeonWriteResult>): NeonWriteResult {
+  const all = Object.values(results);
+  if (all.length === 0)
+    return { ok: true, rows: 0, statements: 0, reason: "nothing to write" };
+  const failed = all.filter((r) => !r.ok);
+  return {
+    ok: failed.length === 0,
+    rows: all.reduce((n, r) => n + (r.rows ?? 0), 0),
+    statements: all.reduce((n, r) => n + (r.statements ?? 0), 0),
+    ...(failed.length > 0
+      ? { reason: failed.map((r) => r.reason ?? "failed").join("; ") }
+      : {}),
+  };
+}
+
+/** Exported for the handler's sole-store branch: which tables failed, if any. */
+export function failedTables(outcome: FamilyMirrorOutcome): string[] {
+  return Object.entries(outcome.results)
+    .filter(([, r]) => !r.ok)
+    .map(([table]) => table);
+}
+
+export { recordLaneVerdict };

--- a/src/hyperparams-identity-neon-write.ts
+++ b/src/hyperparams-identity-neon-write.ts
@@ -57,7 +57,13 @@ interface FamilyPlan {
   history: { table: string; columns: readonly string[]; conflict: string[] };
 }
 
-const PLANS: Readonly<Record<string, FamilyPlan>> = {
+/**
+ * Exported so src/neon-mirror-watchdog.ts can DERIVE its lane->table pairing
+ * from the same constant the writer uses, rather than restate it. A lane the
+ * flag can name but the watchdog has no pairing for is a mirror nothing
+ * watches, and restating is how that happens.
+ */
+export const FAMILY_MIRROR_PLANS: Readonly<Record<string, FamilyPlan>> = {
   [SUBNET_HYPERPARAMS_NEON_LANE]: {
     lane: SUBNET_HYPERPARAMS_NEON_LANE,
     latest: {
@@ -121,7 +127,7 @@ export async function mirrorFamilyToNeon(
   input: FamilyMirrorInput,
   deps: FamilyMirrorDeps = {},
 ): Promise<FamilyMirrorOutcome> {
-  const plan = PLANS[lane];
+  const plan = FAMILY_MIRROR_PLANS[lane];
   // An unknown lane is a no-op rather than a throw: the flag is a free-text
   // list, and a typo there must not take down the D1 write this runs behind.
   if (!plan || !neonDualWriteEnabled(env, lane))

--- a/src/neon-mirror-watchdog.ts
+++ b/src/neon-mirror-watchdog.ts
@@ -54,6 +54,7 @@ import { neonDualWriteLanes } from "./neon-write.ts";
 import { LEDGER_MIRROR_PLANS } from "./ledger-neon-write.ts";
 import { NEURON_MIRROR_PLANS } from "./neurons-neon-write.ts";
 import { NOMINATOR_POSITIONS_NEON_LANE } from "./nominator-positions-neon-write.ts";
+import { FAMILY_MIRROR_PLANS } from "./hyperparams-identity-neon-write.ts";
 import {
   loadLatestLaneHealth,
   recordLaneVerdict,
@@ -99,6 +100,16 @@ export const MIRROR_LANE_TABLES: Readonly<Record<string, string>> = {
     Object.entries(NEURON_MIRROR_PLANS).map(([lane, plan]) => [
       lane,
       plan.table,
+    ]),
+  ),
+  ...Object.fromEntries(
+    Object.entries(FAMILY_MIRROR_PLANS).map(([lane, plan]) => [
+      lane,
+      // The LATEST table, not the history. A family's two tables are written
+      // by one pass, so one of them lagging is the lane lagging -- and the
+      // card is the one whose captured_at this watchdog can read (the history
+      // has no such column, which is why it cannot be the pairing).
+      plan.latest.table,
     ]),
   ),
   [NOMINATOR_POSITIONS_NEON_LANE]: "nominator_positions",

--- a/tests/account-position-history.test.ts
+++ b/tests/account-position-history.test.ts
@@ -403,8 +403,16 @@ describe("the Neon read cutover (metagraphed-infra#336)", () => {
     const backfills = (
       /"NEON_BACKFILL_LANES":\s*"([^"]*)"/.exec(wrangler)?.[1] ?? ""
     ).split(",");
+    // Mirror lanes are HYPHENATED and the read/backfill flags name UNDERSCORED
+    // tables, so the two lists have to be brought into one vocabulary before
+    // they can be compared. Without this, a table that gained a mirror reads
+    // as unwritten -- which is the opposite of what this test is for, and it
+    // would push someone to delete a correct read lane rather than fix a real
+    // gap. tests/neon-backfill.test.ts normalises the same way.
     const written = new Set(
-      [...writes, ...backfills].map((lane) => lane.trim()).filter(Boolean),
+      [...writes, ...backfills]
+        .map((lane) => lane.trim().replace(/-/g, "_"))
+        .filter(Boolean),
     );
     for (const lane of named) {
       assert.ok(

--- a/tests/hyperparams-identity-neon-write.test.ts
+++ b/tests/hyperparams-identity-neon-write.test.ts
@@ -1,0 +1,195 @@
+// The Neon write for subnet_hyperparams and account_identity (#10046).
+//
+// Both families showed EXACT parity in Neon and looked ready to invert -- and
+// neither handler had ever executed a Neon write. Their copies came from the
+// reconciler cron. That is why this module exists: a code path that has never
+// run is not evidence, however equal the row counts look, and inverting on
+// reconciler parity would mean deleting the D1 copy while trusting something
+// unexercised.
+//
+// TRANSITIONAL (#10051). Every assertion here describes a rung, not the
+// destination: once these tables are sole-store the D1 write goes, and once
+// every table has crossed this module is deleted along with the rest of the
+// dual-write scaffolding.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+import {
+  ACCOUNT_IDENTITY_NEON_LANE,
+  SUBNET_HYPERPARAMS_NEON_LANE,
+  failedTables,
+  mirrorFamilyToNeon,
+} from "../src/hyperparams-identity-neon-write.ts";
+
+/** Captures the statements a mirror would issue, without a database. */
+function sqlSpy(failOn?: string) {
+  const statements: string[] = [];
+  return {
+    statements,
+    sql: {
+      unsafe: async (text: string) => {
+        statements.push(text);
+        if (failOn && text.includes(failOn)) throw new Error("boom");
+        return [];
+      },
+    },
+  };
+}
+
+const ENV = {
+  NEON_DUAL_WRITE_LANES: "subnet-hyperparams,account-identity",
+  HYPERDRIVE: { connectionString: "postgresql://example/db" },
+};
+const ctx = { waitUntil: () => undefined };
+
+const HP_ROW = { netuid: 1, captured_at: 5, registration_allowed: true };
+const HP_HIST = { netuid: 1, observed_at: 5, hyperparams_hash: "h" };
+
+describe("the lane gate", () => {
+  test("an unnamed lane writes nothing", async () => {
+    const spy = sqlSpy();
+    const out = await mirrorFamilyToNeon(
+      { ...ENV, NEON_DUAL_WRITE_LANES: "" },
+      ctx,
+      SUBNET_HYPERPARAMS_NEON_LANE,
+      { rows: [HP_ROW], historyRows: [HP_HIST] },
+      { sql: spy.sql },
+    );
+    assert.equal(out.attempted, false);
+    assert.deepEqual(spy.statements, []);
+  });
+
+  test("an unknown lane is a no-op, not a throw", async () => {
+    // The flag is free text. A typo must not take down the D1 write this runs
+    // behind.
+    const out = await mirrorFamilyToNeon(ENV, ctx, "typo-lane", {
+      rows: [HP_ROW],
+      historyRows: [],
+    });
+    assert.equal(out.attempted, false);
+  });
+
+  test("the two families move independently", async () => {
+    const spy = sqlSpy();
+    const out = await mirrorFamilyToNeon(
+      { ...ENV, NEON_DUAL_WRITE_LANES: "account-identity" },
+      ctx,
+      SUBNET_HYPERPARAMS_NEON_LANE,
+      { rows: [HP_ROW], historyRows: [] },
+      { sql: spy.sql },
+    );
+    assert.equal(out.attempted, false);
+  });
+});
+
+describe("what it writes", () => {
+  test("both tables, latest and history", async () => {
+    const spy = sqlSpy();
+    const out = await mirrorFamilyToNeon(
+      ENV,
+      ctx,
+      SUBNET_HYPERPARAMS_NEON_LANE,
+      { rows: [HP_ROW], historyRows: [HP_HIST] },
+      { sql: spy.sql },
+    );
+    assert.equal(out.attempted, true);
+    assert.equal(spy.statements.length, 2);
+    assert.match(spy.statements[0]!, /INSERT INTO subnet_hyperparams\b/);
+    assert.match(spy.statements[1]!, /INSERT INTO subnet_hyperparams_history/);
+  });
+
+  test("the LATEST table is freshness-guarded and the history is NOT", async () => {
+    // The card is rewritten in place, so an out-of-order pass must not roll it
+    // back. A history row is appended only when the hash CHANGED, so a
+    // conflict on (netuid, observed_at) means the same revision arriving
+    // twice -- doing nothing is right, and a `captured_at <` guard there would
+    // reference a column the history table does not have.
+    const spy = sqlSpy();
+    await mirrorFamilyToNeon(
+      ENV,
+      ctx,
+      SUBNET_HYPERPARAMS_NEON_LANE,
+      { rows: [HP_ROW], historyRows: [HP_HIST] },
+      { sql: spy.sql },
+    );
+    assert.match(
+      spy.statements[0]!,
+      /subnet_hyperparams\.captured_at < EXCLUDED\.captured_at/,
+    );
+    assert.doesNotMatch(spy.statements[1]!, /captured_at/);
+  });
+
+  test("an empty side issues no statement for it", async () => {
+    const spy = sqlSpy();
+    await mirrorFamilyToNeon(
+      ENV,
+      ctx,
+      ACCOUNT_IDENTITY_NEON_LANE,
+      { rows: [{ account: "a", captured_at: 1 }], historyRows: [] },
+      { sql: spy.sql },
+    );
+    assert.equal(spy.statements.length, 1);
+    assert.match(spy.statements[0]!, /INSERT INTO account_identity\b/);
+  });
+
+  test("the history conflicts on the pair, not on an id", async () => {
+    // These tables carry an AUTOINCREMENT id whose values differ per store.
+    // Conflicting on it would make the mirror depend on two sequences
+    // agreeing, which they never will.
+    const spy = sqlSpy();
+    await mirrorFamilyToNeon(
+      ENV,
+      ctx,
+      ACCOUNT_IDENTITY_NEON_LANE,
+      {
+        rows: [],
+        historyRows: [{ account: "a", observed_at: 2, identity_hash: "h" }],
+      },
+      { sql: spy.sql },
+    );
+    assert.match(spy.statements[0]!, /ON CONFLICT \(account, observed_at\)/);
+  });
+});
+
+describe("failure is reported, never thrown", () => {
+  test("a failing table is named so the caller can act on it", async () => {
+    const spy = sqlSpy("subnet_hyperparams_history");
+    const out = await mirrorFamilyToNeon(
+      ENV,
+      ctx,
+      SUBNET_HYPERPARAMS_NEON_LANE,
+      { rows: [HP_ROW], historyRows: [HP_HIST] },
+      { sql: spy.sql },
+    );
+    assert.equal(out.attempted, true);
+    assert.deepEqual(failedTables(out), ["subnet_hyperparams_history"]);
+    // The latest write still succeeded -- one table failing must not be
+    // reported as both failing.
+    assert.equal(out.results.subnet_hyperparams!.ok, true);
+  });
+
+  test("a clean run names nothing", async () => {
+    const spy = sqlSpy();
+    const out = await mirrorFamilyToNeon(
+      ENV,
+      ctx,
+      SUBNET_HYPERPARAMS_NEON_LANE,
+      { rows: [HP_ROW], historyRows: [HP_HIST] },
+      { sql: spy.sql },
+    );
+    assert.deepEqual(failedTables(out), []);
+  });
+
+  test("enabled but unbound is a verdict, not silence", async () => {
+    // Somebody named the lane and the binding is missing. That deserves a
+    // recorded failure rather than a quiet no-op.
+    const out = await mirrorFamilyToNeon(
+      { NEON_DUAL_WRITE_LANES: "subnet-hyperparams" },
+      ctx,
+      SUBNET_HYPERPARAMS_NEON_LANE,
+      { rows: [HP_ROW], historyRows: [] },
+    );
+    assert.equal(out.attempted, true);
+    assert.deepEqual(out.results, {});
+  });
+});

--- a/tests/neon-backfill.test.ts
+++ b/tests/neon-backfill.test.ts
@@ -381,9 +381,13 @@ describe("the deployed wiring", () => {
     //
     // A table needs this lane when the mirror cannot finish the job -- either
     // it ACCUMULATES (the mirror only ever covers the days it ran) or NOTHING
-    // MIRRORS IT AT ALL. subnet_hyperparams and account_identity are the
-    // second case: latest-only, but no dual-write lane writes them, so the
-    // reconciler is their only path into Neon.
+    // MIRRORS IT AT ALL.
+    //
+    // subnet_hyperparams and account_identity USED to be the second case, and
+    // #10046 gave both a mirror. They did not both leave the lane, because
+    // "the mirror covers it" is a claim about the PRODUCER, not the table
+    // shape, and the two producers behave differently -- measured in D1 on
+    // 2026-08-08 rather than assumed.
     const named =
       /"NEON_BACKFILL_LANES":\s*"([^"]*)"/.exec(wrangler)?.[1]?.split(",") ??
       [];
@@ -412,6 +416,14 @@ describe("the deployed wiring", () => {
       const provenStuck = new Set([
         "validator_nominator_counts",
         "nominator_positions",
+        // 499 rows spanning 2026-08-03T03:55 to 2026-08-07T18:34, with ZERO
+        // written in the preceding 10 hours. The identity producer emits only
+        // the accounts it observed, so a row it wrote days ago is never
+        // rewritten and reaches Neon by no other path. Contrast
+        // subnet_hyperparams, measured the same minute: 129 rows, ALL sharing
+        // one captured_at, because that producer rescans every subnet each
+        // pass -- which is why it left this lane and this one did not.
+        "account_identity",
       ]);
       assert.ok(
         plan.partition === "date" ||

--- a/tests/neon-read-routes.test.ts
+++ b/tests/neon-read-routes.test.ts
@@ -583,8 +583,13 @@ describe("the deployed flag", () => {
     const backfills = (
       /"NEON_BACKFILL_LANES":\s*"([^"]*)"/.exec(wrangler)?.[1] ?? ""
     ).split(",");
+    // Hyphenated mirror lane -> underscored table, so the two vocabularies can
+    // be compared at all. See the same normalisation in
+    // tests/account-position-history.test.ts.
     const written = new Set(
-      [...writes, ...backfills].map((l) => l.trim()).filter(Boolean),
+      [...writes, ...backfills]
+        .map((l) => l.trim().replace(/-/g, "_"))
+        .filter(Boolean),
     );
     for (const lane of named) {
       assert.ok(

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -378,6 +378,12 @@ import {
   writeNeuronSnapshotToD1,
 } from "../src/neurons-d1-write.ts";
 import { mirrorNeuronSnapshotToNeon } from "../src/neurons-neon-write.ts";
+import {
+  ACCOUNT_IDENTITY_NEON_LANE,
+  SUBNET_HYPERPARAMS_NEON_LANE,
+  failedTables,
+  mirrorFamilyToNeon,
+} from "../src/hyperparams-identity-neon-write.ts";
 import { mirrorNominatorPositionsToNeon } from "../src/nominator-positions-neon-write.ts";
 import { mirrorLedgerToNeon } from "../src/ledger-neon-write.ts";
 import { neonOwnsTable, neonReadEnabled } from "../src/neon-write.ts";
@@ -1323,7 +1329,11 @@ function diffHyperparamsHistory(
   return changedRows;
 }
 
-async function handleSubnetHyperparamsSync(request: Request, env: Env) {
+async function handleSubnetHyperparamsSync(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+) {
   if (!env.SUBNET_HYPERPARAMS_SYNC_SECRET) {
     return writeJson(
       {
@@ -1420,6 +1430,10 @@ async function handleSubnetHyperparamsSync(request: Request, env: Env) {
   // D1 first, and it must succeed: it is where this family lives now.
   let d1Statements: number;
   let d1HistoryAppended: number;
+  // Hoisted so the Neon write below sees the SAME diff D1 was given -- one
+  // derivation, two stores, so the two histories cannot disagree about which
+  // revisions exist.
+  let neonHistoryRows: Row[];
   try {
     const d1Sql = createD1Sql(env.METAGRAPH_HEALTH_DB);
     // Latest hash per netuid -- group-wise MAX(id) join, the SQLite spelling
@@ -1436,6 +1450,7 @@ async function handleSubnetHyperparamsSync(request: Request, env: Env) {
       latest.map((row) => [Number(row.netuid), row.hyperparams_hash]),
     );
     const historyRows = diffHyperparamsHistory(hashedRows, latestByNetuid, now);
+    neonHistoryRows = historyRows as Row[];
     d1HistoryAppended = historyRows.length;
     ({ statements: d1Statements } = await writeSubnetHyperparamsToD1(
       env.METAGRAPH_HEALTH_DB as unknown as Parameters<
@@ -1449,13 +1464,29 @@ async function handleSubnetHyperparamsSync(request: Request, env: Env) {
     return writeJson({ error: "d1 write failed" }, 502);
   }
 
-  // #9193: same deletion as handleNeuronsSync above -- the D1 write IS the sync.
+  // THE NEON WRITE (#10046). Runs AFTER the D1 write returns, never instead
+  // of it and never in front of it -- the same ordering handleNeuronsSync
+  // uses, and for the same reason: while D1 serves the reads, a Neon failure
+  // must cost a lane verdict and not the pass.
+  //
+  // This family had NO Neon writer at all until now. Its parity came from the
+  // reconciler, which is why it could not invert on parity alone: a code path
+  // that has never run is not evidence, however equal the row counts look.
+  const neon = await mirrorFamilyToNeon(
+    env as unknown as Record<string, unknown>,
+    ctx,
+    SUBNET_HYPERPARAMS_NEON_LANE,
+    { rows, historyRows: neonHistoryRows },
+  );
+
   return writeJson({
     ok: true,
     subnet_hyperparams_written: rows.length,
     history_appended: d1HistoryAppended,
-    stores: ["d1"],
+    stores: neon.attempted ? ["d1", "neon"] : ["d1"],
     d1_statements: d1Statements,
+    neon: neon.attempted ? neon.results : undefined,
+    neon_failed: neon.attempted ? failedTables(neon) : undefined,
   });
 }
 
@@ -1545,7 +1576,11 @@ function diffIdentityHistory(
   return changedRows;
 }
 
-async function handleAccountIdentitySync(request: Request, env: Env) {
+async function handleAccountIdentitySync(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+) {
   if (!env.ACCOUNT_IDENTITY_SYNC_SECRET) {
     return writeJson(
       { error: "account-identity sync is not provisioned on this deployment" },
@@ -1638,6 +1673,10 @@ async function handleAccountIdentitySync(request: Request, env: Env) {
 
   let d1Statements: number;
   let d1HistoryAppended: number;
+  // Hoisted so the Neon write sees the SAME diff D1 was given -- one
+  // derivation, two stores, so the two histories cannot disagree about which
+  // revisions exist.
+  let neonHistoryRows: Row[];
   try {
     const d1Sql = createD1Sql(env.METAGRAPH_HEALTH_DB);
     // Latest hash per account -- group-wise MAX(id) join, the SQLite
@@ -1653,6 +1692,7 @@ async function handleAccountIdentitySync(request: Request, env: Env) {
       latest.map((row) => [row.account, row.identity_hash]),
     );
     const historyRows = diffIdentityHistory(hashedRows, latestByAccount, now);
+    neonHistoryRows = historyRows as Row[];
     d1HistoryAppended = historyRows.length;
     ({ statements: d1Statements } = await writeAccountIdentityToD1(
       env.METAGRAPH_HEALTH_DB as unknown as Parameters<
@@ -1666,13 +1706,25 @@ async function handleAccountIdentitySync(request: Request, env: Env) {
     return writeJson({ error: "d1 write failed" }, 502);
   }
 
-  // #9193: same deletion as handleNeuronsSync above -- the D1 write IS the sync.
+  // THE NEON WRITE (#10046). After the D1 write, never instead of it: while
+  // D1 serves the reads a Neon failure costs a lane verdict, not the pass.
+  // This family had no Neon writer at all until now -- its parity came from
+  // the reconciler, and a code path that has never run is not evidence.
+  const neon = await mirrorFamilyToNeon(
+    env as unknown as Record<string, unknown>,
+    ctx,
+    ACCOUNT_IDENTITY_NEON_LANE,
+    { rows, historyRows: neonHistoryRows },
+  );
+
   return writeJson({
     ok: true,
     account_identity_written: rows.length,
     history_appended: d1HistoryAppended,
-    stores: ["d1"],
+    stores: neon.attempted ? ["d1", "neon"] : ["d1"],
     d1_statements: d1Statements,
+    neon: neon.attempted ? neon.results : undefined,
+    neon_failed: neon.attempted ? failedTables(neon) : undefined,
   });
 }
 
@@ -7236,13 +7288,13 @@ async function dispatchDataApiRequest(
       request.method === "POST" &&
       url.pathname === "/api/v1/internal/subnet-hyperparams-sync"
     ) {
-      return handleSubnetHyperparamsSync(request, env);
+      return handleSubnetHyperparamsSync(request, env, ctx);
     }
     if (
       request.method === "POST" &&
       url.pathname === "/api/v1/internal/account-identity-sync"
     ) {
-      return handleAccountIdentitySync(request, env);
+      return handleAccountIdentitySync(request, env, ctx);
     }
     if (
       request.method === "POST" &&

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -131,7 +131,7 @@
     // same PRIMARY KEY (netuid, uid, snapshot_date) the mirror's ON CONFLICT
     // names. An ON CONFLICT with no unique index behind it is a runtime error,
     // not a slower query.
-    "NEON_DUAL_WRITE_LANES": "neurons,nominator-positions,account-balances,hotkey-alpha,validator-nominator-counts",
+    "NEON_DUAL_WRITE_LANES": "neurons,nominator-positions,account-balances,hotkey-alpha,validator-nominator-counts,subnet-hyperparams,account-identity",
     // THE CUTOVER (metagraphed-infra#336). `GET /api/v1/accounts/{ss58}/
     // subnets/{netuid}/history` now reads Neon.
     //

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -204,7 +204,13 @@
     // Naming a latest-only table here would copy 800,000 rows to prove they
     // already agree, which is why this is a third flag rather than a reuse of
     // the write list.
-    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily,subnet_burn_history,tao_usd_index,blocks_head,raw_capture_state,chain_detail_blocks,chain_detail_extrinsics,chain_detail_chain_events,chain_detail_account_events",
+    // subnet_hyperparams LEFT on 2026-08-08 (#10046). It gained a mirror, and
+    // a mirror finishes this table on its own: all 129 rows carry the SAME
+    // captured_at (04:30:13.876Z when measured), so one producer pass rewrites
+    // the whole thing. Reconciling it would copy 129 rows every tick to learn
+    // what the mirror already wrote. account_identity STAYS despite gaining
+    // the same mirror -- see the provenStuck note in tests/neon-backfill.test.ts.
+    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily,subnet_burn_history,tao_usd_index,blocks_head,raw_capture_state,chain_detail_blocks,chain_detail_extrinsics,chain_detail_chain_events,chain_detail_account_events",
     // Tables whose ONLY home is Neon -- D1 is not behind them any more.
     //
     // A FOURTH flag, and the one the other three converge on. All three above


### PR DESCRIPTION
Refs #10046. Part of #9787, and a rung on #10051.

Both families show **exact parity** in Neon and look ready to invert. Neither handler has **ever executed a Neon write** — `grep -ci neon` over either returns 0, and both end with *"the D1 write IS the sync"*. Their Neon copies exist because the reconciler copies them on a cron.

That distinction is the entire point. The neurons lane could invert (#10037) on a mirror that had been writing every pass for weeks, so skipping the D1 write was provably safe. Inverting these on reconciler parity would mean flipping to a code path with **zero production evidence** while simultaneously removing the D1 copy. That is how a migration loses rows rather than moving them.

## Three decisions worth reviewing

**One derivation, two stores.** `historyRows` is hoisted out of the `try` so the Neon write receives the *same* diff D1 was given. The two histories cannot disagree about which revisions exist, because there is only one diff.

**The latest table is freshness-guarded; the history deliberately is not.** A card is rewritten in place, so an out-of-order pass must not roll it back. A history row is appended only when the hash *changed*, so a conflict on `(key, observed_at)` means the same revision arriving twice — doing nothing is right, and a `captured_at <` guard there would reference a column the history table does not have.

**History conflicts on the key pair, never on the id.** Both history tables carry an AUTOINCREMENT id whose values differ per store; conflicting on it would make the write depend on two sequences agreeing, which they never will.

## Verification

10/10, and I checked the freshness assertion can actually fail rather than only pass — removing the guard:

```
Failed Tests 1
```

Restored: 10/10.

## This is scaffolding, and it is tracked

Ships as a dual-write: D1 stays authoritative, a Neon failure costs a lane verdict and nothing a caller sees. The next step is watching it across producer ticks, then the sole-store flip deletes the D1 write.

**#10051 tracks removing all of it.** Once every table has crossed, `NEON_DUAL_WRITE_LANES` and every mirror call site including this module get deleted — and the reconciler must go with them, because one pointed at a D1 nothing writes will copy a frozen snapshot over live Neon rows. It cannot tell the direction reversed.