### PR TITLE
fix(watchdog): table-freshness said ok while blind to 58% of the estate

### DIFF
--- a/src/table-freshness-watchdog.ts
+++ b/src/table-freshness-watchdog.ts
@@ -62,31 +62,31 @@ export interface FreshnessExpectation {
 export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
   // --- live capture: minutes old in steady state -------------------------
   chain_detail_blocks: {
-    column: "captured_at",
+    column: "observed_at",
     kind: "ms",
     maxAgeMs: 2 * HOUR,
     reason: "firehose poller, continuous",
   },
   chain_detail_extrinsics: {
-    column: "captured_at",
+    column: "observed_at",
     kind: "ms",
     maxAgeMs: 2 * HOUR,
     reason: "firehose poller, continuous",
   },
   chain_detail_chain_events: {
-    column: "captured_at",
+    column: "observed_at",
     kind: "ms",
     maxAgeMs: 2 * HOUR,
     reason: "firehose poller, continuous",
   },
   chain_detail_account_events: {
-    column: "captured_at",
+    column: "observed_at",
     kind: "ms",
     maxAgeMs: 2 * HOUR,
     reason: "firehose poller, continuous",
   },
   blocks_head: {
-    column: "captured_at",
+    column: "observed_at",
     kind: "ms",
     maxAgeMs: 2 * HOUR,
     reason: "head tracker",
@@ -98,13 +98,21 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
     reason: "RAW_CAPTURE_CRON every 5 min",
   },
   raw_capture_state_v2: {
-    column: "updated_at",
+    // EXCLUDED because the table does not exist in production. It is declared
+    // in migrations/d1/0013_raw_capture_network.sql and was never applied (17
+    // migrations later), which #9867 tracks. Sweeping it made its whole batch
+    // throw, and at FRESHNESS_BATCH = 4 that blinded three healthy tables with
+    // it. Left declared rather than deleted so the map still accounts for
+    // every table migrations/d1 names -- the invariant
+    // tests/table-freshness-watchdog.test.ts asserts.
+    column: "",
     kind: "ms",
     maxAgeMs: null,
-    reason: "successor table, not yet cut over",
+    reason:
+      "declared in migrations/d1/0013 but never applied to production (#9867)",
   },
   tao_usd_index: {
-    column: "captured_at",
+    column: "observed_at",
     kind: "ms",
     maxAgeMs: 2 * HOUR,
     reason: "TAO_USD_INDEX_CRON every minute",
@@ -224,7 +232,7 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
     reason: "surface prober",
   },
   surface_status: {
-    column: "checked_at",
+    column: "updated_at",
     kind: "ms",
     maxAgeMs: 4 * HOUR,
     reason: "written with surface_checks",
@@ -291,21 +299,21 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
   // GitHub Actions lane -- and suppressing it here to keep the lane green
   // would be the exact thing a watchdog must never do.
   subnets: {
-    column: "captured_at",
+    column: "updated_at",
     kind: "ms",
     maxAgeMs: 48 * HOUR,
     reason: "registry sync on merge",
     knownIssue: "#9779",
   },
   surfaces: {
-    column: "captured_at",
+    column: "updated_at",
     kind: "ms",
     maxAgeMs: 48 * HOUR,
     reason: "registry sync on merge",
     knownIssue: "#9779",
   },
   providers: {
-    column: "captured_at",
+    column: "updated_at",
     kind: "ms",
     maxAgeMs: 48 * HOUR,
     reason: "registry sync on merge",
@@ -375,7 +383,7 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
     reason: "no timestamp column",
   },
   emission_flow_watch: {
-    column: "updated_at",
+    column: "observed_at",
     kind: "ms",
     maxAgeMs: null,
     reason: "a watch list, edited by hand",
@@ -522,13 +530,9 @@ export async function runTableFreshnessWatchdog(
     .sort();
 
   const newest = new Map<string, number>();
-  let batches = 0;
-  let failed = 0;
-  for (let i = 0; i < tables.length; i += FRESHNESS_BATCH) {
-    const batch = tables.slice(i, i + FRESHNESS_BATCH);
-    batches += 1;
+  const readBatch = async (group: string[]): Promise<boolean> => {
     try {
-      const result = await db?.prepare(freshnessSql(batch, spec)).all();
+      const result = await db?.prepare(freshnessSql(group, spec)).all();
       if (!result) throw new Error("no result");
       for (const [table, at] of parseFreshnessRows(
         result.results ?? [],
@@ -536,12 +540,32 @@ export async function runTableFreshnessWatchdog(
       )) {
         newest.set(table, at);
       }
+      return true;
     } catch {
-      failed += 1;
+      return false;
+    }
+  };
+
+  // Tables the sweep could not read, BY NAME. #9866 counted failed BATCHES,
+  // which was both imprecise (one bad table condemned four) and unactionable
+  // ("7 of 12 batches unreadable" names nothing to go and fix).
+  const unreadable: string[] = [];
+  for (let i = 0; i < tables.length; i += FRESHNESS_BATCH) {
+    const batch = tables.slice(i, i + FRESHNESS_BATCH);
+    if (await readBatch(batch)) continue;
+    // ONE bad table used to cost its whole batch. The sweep is a single UNION
+    // per batch, so a table that does not exist (or whose column does not)
+    // makes the statement throw and takes its neighbours with it -- which is
+    // how 12 bad entries blinded 7 of 12 batches, 58% of the estate. Retrying
+    // the batch one table at a time costs at most FRESHNESS_BATCH extra round
+    // trips on a path that should be empty, and localises the loss to the
+    // table actually at fault.
+    for (const table of batch) {
+      if (!(await readBatch([table]))) unreadable.push(table);
     }
   }
 
-  if (batches > 0 && failed === batches) {
+  if (tables.length > 0 && unreadable.length === tables.length) {
     await recordLaneVerdict(laneDb, {
       lane: TABLE_FRESHNESS_LANE,
       verdict: "unknown",
@@ -553,13 +577,41 @@ export async function runTableFreshnessWatchdog(
   }
 
   const stale = staleTables(newest, now(), spec);
+  // #9866: an unreadable table must reach the VERDICT, not just the detail
+  // string. It used to reach only the prose, so a sweep that read 5 of 12
+  // batches still published `ok` -- "every table is within its expected age |
+  // 7 of 12 batches unreadable" -- and lane-alarm keys on the verdict, so
+  // nothing fired. 58% of the estate was unchecked and the lane called it
+  // healthy, including the frozen registry cluster this watchdog was built
+  // (#9786) to catch.
+  //
+  // Three outcomes, in priority order:
+  //   stale   - we found a real breach. That is a finding, and it outranks an
+  //             incomplete sweep: something IS wrong and the detail says what.
+  //   unknown - nothing measured looks stale, but the sweep did not establish
+  //             that every table is fresh -- either because a table could not
+  //             be read, or because NOTHING was read (D1 can answer without a
+  //             `results` key at all, which the `?? []` absorbs without
+  //             throwing; absorbing the crash must not also manufacture a
+  //             green).
+  //   ok      - a complete sweep, over at least one table, with nothing stale.
+  //             The only state that has earned the word.
+  const measuredNothing = tables.length > 0 && newest.size === 0;
+  const verdict =
+    stale.length > 0
+      ? "stale"
+      : unreadable.length > 0 || measuredNothing
+        ? "unknown"
+        : ("ok" as const);
   await recordLaneVerdict(laneDb, {
     lane: TABLE_FRESHNESS_LANE,
-    verdict: stale.length === 0 ? "ok" : "stale",
+    verdict,
     age_ms: stale.length === 0 ? null : stale[0].ageMs,
     detail:
       describeStaleTables(stale) +
-      (failed > 0 ? ` | ${failed} of ${batches} batches unreadable` : ""),
+      (unreadable.length > 0
+        ? ` | ${unreadable.length} unreadable: ${unreadable.slice(0, 6).join(", ")}`
+        : ""),
     checked_at: now(),
   });
   return { attempted: true, stale, checked: newest.size };

--- a/tests/table-freshness-watchdog.test.ts
+++ b/tests/table-freshness-watchdog.test.ts
@@ -123,6 +123,75 @@ describe("TABLE_FRESHNESS coverage", () => {
     }
   });
 
+  test("every swept column exists on its table (#9866)", () => {
+    // THE GAP THAT LET TWELVE THROUGH. The check above asserts the map names
+    // no missing TABLE; nothing checked the COLUMN. Eleven entries named a
+    // column their table does not have -- chain_detail_* and blocks_head and
+    // tao_usd_index carry `observed_at` not `captured_at`, the registry
+    // cluster carries `updated_at`, surface_status carries `updated_at` not
+    // `checked_at` -- and every one of them threw its whole batch.
+    //
+    // Reads migrations/d1, which is the same source as the table check and
+    // needs no credentials. It cannot see a migration that was never APPLIED
+    // (raw_capture_state_v2, #9867) -- that is a different problem, and the
+    // reason that entry is excluded with column: "" rather than corrected.
+    const dir = path.join(process.cwd(), "migrations/d1");
+    const columns = new Map<string, Set<string>>();
+    for (const file of readdirSync(dir).filter((f) => f.endsWith(".sql"))) {
+      const sql = readFileSync(path.join(dir, file), "utf8");
+      for (const m of sql.matchAll(
+        /CREATE TABLE\s+(?:IF NOT EXISTS\s+)?(\w+)\s*\(([\s\S]*?)\n\s*\);/gi,
+      )) {
+        const table = m[1];
+        // Strip line comments FIRST: they contain commas, and splitting on
+        // those turns a comment word into a phantom column name.
+        const body = m[2].replace(/--[^\n]*/g, "");
+        const names = new Set<string>(columns.get(table) ?? []);
+        let depth = 0;
+        let cur = "";
+        for (const ch of body) {
+          if (ch === "(") depth += 1;
+          if (ch === ")") depth -= 1;
+          if (ch === "," && depth === 0) {
+            cur = "";
+            continue;
+          }
+          cur += ch;
+          if (cur.trim().split(/\s+/).length === 1) continue;
+          const first = cur.trim().split(/\s+/)[0];
+          if (!/^(PRIMARY|UNIQUE|FOREIGN|CHECK|CONSTRAINT)$/i.test(first)) {
+            names.add(first.replace(/^["`[]|["`\]]$/g, ""));
+          }
+        }
+        columns.set(table, names);
+      }
+      // ALTER TABLE ... ADD COLUMN is how several of these arrived.
+      for (const m of sql.matchAll(
+        /ALTER TABLE\s+(\w+)\s+ADD COLUMN\s+(\w+)/gi,
+      )) {
+        const set = columns.get(m[1]) ?? new Set<string>();
+        set.add(m[2]);
+        columns.set(m[1], set);
+      }
+    }
+    const missing: string[] = [];
+    for (const [table, e] of Object.entries(TABLE_FRESHNESS)) {
+      if (e.column === "") continue;
+      const known = columns.get(table);
+      if (!known || known.size === 0) continue; // table check owns that case
+      if (!known.has(e.column)) {
+        missing.push(
+          `${table}.${e.column} (has: ${[...known].sort().join(", ")})`,
+        );
+      }
+    }
+    assert.deepEqual(
+      missing,
+      [],
+      `a swept column does not exist, so its whole batch throws:\n  ${missing.join("\n  ")}`,
+    );
+  });
+
   test("every entry gives a reason, and a threshold or an explicit null", () => {
     for (const [table, e] of Object.entries(TABLE_FRESHNESS)) {
       assert.ok(e.reason.length > 8, `${table} has no real reason`);
@@ -346,8 +415,11 @@ describe("runTableFreshnessWatchdog", () => {
     assert.equal(spy.written[0].age, 9 * HOUR);
   });
 
-  test("ONE failed batch does not hide the healthy tables beside it", async () => {
-    // The other batches still carry real information.
+  test("ONE bad table costs ONLY itself, not the three beside it (#9866)", async () => {
+    // a/b/c/d share a batch (FRESHNESS_BATCH = 4) and the stub fails any SQL
+    // naming 'a'. The batch UNION therefore throws -- and used to take b, c
+    // and d down with it, which is how 12 bad entries blinded 7 of 12 batches
+    // and 58% of the estate. The retry reads them individually.
     const spy = fakeDb({ ...fresh, e: NOW - 9 * HOUR }, ["'a'"]);
     const out = await runTableFreshnessWatchdog(null, {
       db: spy.db,
@@ -355,11 +427,64 @@ describe("runTableFreshnessWatchdog", () => {
       now: () => NOW,
       spec,
     });
+    assert.equal(
+      out.checked,
+      4,
+      "b, c and d must survive their batch-mate; e comes from its own batch",
+    );
     assert.deepEqual(
       out.stale?.map((s) => s.table),
       ["e"],
     );
-    assert.match(String(spy.written[0].detail), /1 of 2 batches unreadable/);
+    // Names the table, not a batch count -- "7 of 12 batches unreadable" gave
+    // nobody anything to go and fix.
+    assert.match(String(spy.written[0].detail), /1 unreadable: a/);
+  });
+
+  test("an unreadable table makes the verdict unknown, never ok (#9866)", async () => {
+    // THE BUG: `failed` reached the detail STRING and never the verdict, so a
+    // sweep that read 5 of 12 batches still published `ok` -- and lane-alarm
+    // keys on the verdict, so nothing fired.
+    const spy = fakeDb(fresh, ["'a'"]);
+    await runTableFreshnessWatchdog(null, {
+      db: spy.db,
+      laneHealthDb: spy.db,
+      now: () => NOW,
+      spec,
+    });
+    assert.equal(
+      spy.written[0].verdict,
+      "unknown",
+      "nothing measured is stale, but the sweep did not establish that every " +
+        "table is fresh — `ok` is the one answer that cannot be right",
+    );
+    assert.match(String(spy.written[0].detail), /1 unreadable: a/);
+  });
+
+  test("a stale finding outranks an incomplete sweep", async () => {
+    // A real breach is information; report it rather than downgrading to
+    // unknown because some other table could not be read.
+    const spy = fakeDb({ ...fresh, e: NOW - 9 * HOUR }, ["'a'"]);
+    await runTableFreshnessWatchdog(null, {
+      db: spy.db,
+      laneHealthDb: spy.db,
+      now: () => NOW,
+      spec,
+    });
+    assert.equal(spy.written[0].verdict, "stale");
+  });
+
+  test("a complete sweep that measured NOTHING is not ok either", async () => {
+    // D1 can answer without a `results` key; the `?? []` absorbs it rather
+    // than throwing. Absorbing the crash must not also manufacture a green.
+    const empty = fakeDb({});
+    await runTableFreshnessWatchdog(null, {
+      db: empty.db,
+      laneHealthDb: empty.db,
+      now: () => NOW,
+      spec,
+    });
+    assert.equal(empty.written[0].verdict, "unknown");
   });
 
   test("EVERY batch failing is unknown, never ok", async () => {


### PR DESCRIPTION
## Three faults, one green light

The lane built by #9786 to catch tables nobody watches was reporting:

```
verdict: ok
detail: "every table is within its expected age | 7 of 12 batches unreadable"
```

**1. `failed` reached the detail string and never the verdict.** The only guard was `failed === batches`, so 11 of 12 batches failing still published `ok` — and `lane-alarm` keys on the verdict, not on prose, so nothing fired.

Now, in priority order: a **stale** finding outranks an incomplete sweep (something *is* wrong, and the detail says what); an unreadable table makes it **unknown**; **ok** requires a complete sweep over at least one table.

That last clause closes a hole the issue didn't name. `runTableFreshnessWatchdog` absorbs a D1 response with no `results` key via `?? []` — deliberately, so it doesn't crash — but absorbing the crash was also manufacturing a green over zero measurements. A sweep that measured nothing is now `unknown` too.

**2. Eleven entries named a column their table does not have**, so every batch they landed in threw. Verified against the live schema rather than assumed:

| tables | declared | actual |
|---|---|---|
| `chain_detail_*` (4), `blocks_head`, `tao_usd_index` | `captured_at` | `observed_at` |
| `subnets`, `surfaces`, `providers` | `captured_at` | `updated_at` |
| `surface_status` | `checked_at` | `updated_at` |
| `emission_flow_watch` | `updated_at` | `observed_at` |

`chain_detail_blocks` carries two clocks. `observed_at` is the right one and not a guess — `src/indexer-lag.ts` already defines `head_age_ms` as `now - newest observed_at` for precisely this "how far behind is the lane right now" question, while `synced_at` is the writer's wall clock.

The twelfth, `raw_capture_state_v2`, is declared in `migrations/d1/0013` and **was never applied** (#9867). Excluded with `column: ""` rather than corrected, so the map still accounts for every table `migrations/d1` names — the invariant the existing suite asserts.

The unchecked set therefore included the **highest-write-rate tables in the estate** alongside the frozen registry cluster the lane exists to catch.

**3. One bad table condemned three healthy neighbours.** At `FRESHNESS_BATCH = 4` the sweep is a single UNION per batch, so one bad entry throws the statement — which is how 12 bad entries cost 7 batches. A failed batch is now retried one table at a time (at most 4 extra round trips on a path that should be empty), and the detail **names** the failures instead of counting batches, because "7 of 12 batches unreadable" gives nobody anything to go and fix.

## The gate that was missing

The suite asserted the map names no missing **table**. Nothing checked the **column** — which is why all eleven survived it. Added, reading `migrations/d1` so it needs no credentials (it also handles `ALTER TABLE … ADD COLUMN`, which is how the registry cluster's arrived).

It cannot see a migration that was never *applied*; that is #9867's problem and the reason entry 12 is excluded rather than corrected.

## Validation

```
npm run typecheck            clean
npm run lint / format:check  clean
vitest table-freshness-watchdog + mcp-route-map    29 passed
```

**Mutation-tested**, since a gate that passes proves nothing on its own:

| mutation | result |
|---|---|
| restore `chain_detail_blocks.captured_at` | column gate fails, naming it |
| corrupt 5 columns incl. the `ALTER`-added registry cluster | all 5 reported, with their real column lists |
| verdict back to `ok`-on-failure | 2 verdict tests fail |

The column-gate check had a `known.size === 0 → continue` escape hatch, so I specifically verified it is not silently validating nothing — the 5-table mutation lists real columns for each, which it could only do from a populated parse.

Closes #9866