### PR TITLE
fix(neon): the neurons pass tally rode inside the D1 batch the inversion skips (#10056)

### DIFF
--- a/src/neurons-neon-write.ts
+++ b/src/neurons-neon-write.ts
@@ -42,6 +42,10 @@ import {
   type WaitUntilLike,
 } from "./pg-sql.ts";
 import type { LaneHealthDb } from "./lane-health.ts";
+import {
+  writePassTallyToNeon,
+  type PassTallyInput,
+} from "./pass-completeness.ts";
 
 /** The lane name this mirror answers to in NEON_DUAL_WRITE_LANES. */
 export const NEURONS_NEON_LANE = "neurons";
@@ -91,6 +95,15 @@ export interface NeuronMirrorInput {
   rows: Row[];
   dailyRows: Row[];
   positionRows: Row[];
+  /** This chunk's completeness tally, when the producer declared a pass.
+   *
+   * Carried here rather than written by the caller because of the invariant
+   * src/neurons-d1-write.ts states for the D1 side: the tally must not be able
+   * to report a pass complete whose rows never landed. D1 gets that from one
+   * atomic batch. Postgres cannot, because writeRowsToNeon chunks -- so it is
+   * enforced below instead, by writing the tally ONLY after every table
+   * succeeded. */
+  pass?: PassTallyInput | null;
 }
 
 export interface NeuronMirrorOutcome {
@@ -164,6 +177,37 @@ export async function mirrorNeuronSnapshotToNeon(
     );
     results[name] = result;
     await recordNeonWriteVerdict(laneDb, name, result, now());
+  }
+
+  // THE TALLY GOES LAST, AND ONLY IF EVERY TABLE LANDED (#10056).
+  //
+  // This is the Postgres form of the ordering src/neurons-d1-write.ts gets for
+  // free by appending the tally to its batch. A pass marked complete whose rows
+  // did not land is the one failure this ledger exists to make impossible, so a
+  // partial write must leave the tally alone: the next chunk re-sends its rows
+  // and the pass completes then, whereas a tally written over missing rows is
+  // never revisited.
+  if (input.pass) {
+    const rowsLanded = Object.values(results).every((r) => r.ok);
+    const tally = rowsLanded
+      ? await writePassTallyToNeon(sql, NEURONS_NEON_LANE, input.pass)
+      : { ok: false, reason: "rows did not land; tally withheld" };
+    const verdict: NeonWriteResult = {
+      ok: tally.ok,
+      rows: tally.ok ? 1 : 0,
+      statements: 1,
+      ...(tally.reason ? { reason: tally.reason } : {}),
+    };
+    // Its OWN lane name, not the snapshot's: a tally that failed while the
+    // three tables landed is a different fault from a table failing, and
+    // folding them into one verdict would hide whichever came second.
+    await recordNeonWriteVerdict(
+      laneDb,
+      `${NEURONS_NEON_LANE}-pass`,
+      verdict,
+      now(),
+    );
+    results[`${NEURONS_NEON_LANE}_passes`] = verdict;
   }
   return { attempted: true, results };
 }

--- a/src/pass-completeness.ts
+++ b/src/pass-completeness.ts
@@ -184,3 +184,83 @@ export function passTallyStatement<S>(
       pass.nowMs,
     );
 }
+
+/** The runner shape `createPgSql` hands out. Structural, so a test can assert
+ * the emitted text and values without a database. */
+export interface PassTallySql {
+  unsafe(text: string, values?: unknown[]): Promise<unknown>;
+}
+
+export interface PassTallyWrite {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * The same tally, against Postgres.
+ *
+ * WHY THIS IS NOT A `?`-TO-`$n` TRANSLATION of the statement above. Postgres
+ * infers a parameter's type from the context it appears in, and inside a VALUES
+ * list the only context is the target column. `completed_at` is filled by a
+ * CASE whose OPERANDS are parameters, and a comparison gives Postgres nothing
+ * to infer from, so `$4 >= $5` resolves to text and the whole statement is
+ * rejected before it runs:
+ *
+ *     column "completed_at" is of type bigint but expression is of type text
+ *
+ * Loud rather than silent, which is luck rather than design -- the same shape
+ * in a context Postgres CAN coerce would compare `'9' >= '100'`, which is TRUE
+ * as text and FALSE as integer, and would stamp an incomplete pass complete.
+ * The casts below are therefore written for the semantics, not for the error.
+ *
+ * ONE STATEMENT, so the read-modify-write of `received_rows` stays inside the
+ * upsert. Reading the running total into the Worker and writing back a sum
+ * would race every other chunk of the same pass.
+ */
+export async function writePassTallyToNeon(
+  sql: PassTallySql,
+  lane: string,
+  pass: PassTallyInput,
+): Promise<PassTallyWrite> {
+  const table = PASS_TABLES[lane];
+  if (!table) {
+    // Same posture as the D1 builder: a writer names its own lane, so an
+    // unknown one is a programming error rather than a runtime condition.
+    throw new Error(
+      `pass-completeness: no pass table for lane ${lane}; add it to PASS_TABLES ` +
+        `and ship the migration, or the tally has nowhere to land`,
+    );
+  }
+  try {
+    await sql.unsafe(
+      `INSERT INTO ${table}
+         (captured_at, expected_rows, received_rows, completed_at)
+       VALUES ($1::bigint, $2::int, $3::int,
+               CASE WHEN $4::int >= $5::int THEN $6::bigint ELSE NULL END)
+       ON CONFLICT (captured_at) DO UPDATE SET
+         expected_rows = EXCLUDED.expected_rows,
+         received_rows = ${table}.received_rows + EXCLUDED.received_rows,
+         completed_at = COALESCE(
+           ${table}.completed_at,
+           CASE
+             WHEN ${table}.received_rows + EXCLUDED.received_rows
+                  >= EXCLUDED.expected_rows
+             THEN $7::bigint
+             ELSE NULL
+           END
+         )`,
+      [
+        pass.capturedAt,
+        pass.expectedRows,
+        pass.receivedRows,
+        pass.receivedRows,
+        pass.expectedRows,
+        pass.nowMs,
+        pass.nowMs,
+      ],
+    );
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, reason: String((error as Error)?.message ?? error) };
+  }
+}

--- a/tests/pass-tally-neon.test.ts
+++ b/tests/pass-tally-neon.test.ts
@@ -1,0 +1,218 @@
+// The completeness tally, against Postgres (#10056).
+//
+// WHAT BROKE, so the tests below read as a fix rather than as coverage. The
+// tally is appended to the SAME D1 batch as the rows it describes, deliberately
+// -- a tally must not be able to report a pass complete whose rows never
+// landed. #10045 then made handleNeuronsSync skip the D1 write outright once
+// Neon owned the snapshot, and the tally went with it: neurons_passes stopped
+// at the exact captured_at the flip froze D1 on, ~11 passes before anyone
+// looked. The invariant that made the tally trustworthy is what carried it off
+// the cliff.
+//
+// So the two things worth asserting are (1) the statement is a real Postgres
+// statement rather than a `?`-swap, and (2) the ordering invariant survived the
+// move to a store that cannot express it as one batch.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+import {
+  PASS_TABLES,
+  writePassTallyToNeon,
+  type PassTallyInput,
+} from "../src/pass-completeness.ts";
+import { mirrorNeuronSnapshotToNeon } from "../src/neurons-neon-write.ts";
+
+const PASS: PassTallyInput = {
+  capturedAt: 1786155508717,
+  expectedRows: 30118,
+  receivedRows: 2500,
+  nowMs: 1786155548405,
+};
+
+/** Records what was sent without a database. */
+function recordingSql(fail?: string) {
+  const calls: { text: string; values: unknown[] }[] = [];
+  return {
+    calls,
+    sql: {
+      unsafe: async (text: string, values: unknown[] = []) => {
+        calls.push({ text, values });
+        if (fail) throw new Error(fail);
+        return [];
+      },
+    },
+  };
+}
+
+describe("writePassTallyToNeon", () => {
+  test("every parameter that feeds a comparison is cast", async () => {
+    // THE REASON THIS IS ASSERTED ON THE TEXT. Inside a VALUES list Postgres
+    // infers a parameter's type from its target column, and completed_at is
+    // filled by a CASE whose operands are parameters -- a comparison offers
+    // nothing to infer from, so they resolve to text. Verified against a real
+    // branch: the uncast form is REJECTED with `column "completed_at" is of
+    // type bigint but expression is of type text`.
+    //
+    // It failing loudly is luck, not design. `'9' >= '100'` is TRUE as text and
+    // FALSE as integer, so the same shape somewhere Postgres can coerce would
+    // stamp an incomplete pass complete and never say so.
+    const { calls, sql } = recordingSql();
+    await writePassTallyToNeon(sql, "neurons", PASS);
+    const { text } = calls[0]!;
+    for (const cast of [
+      "$1::bigint",
+      "$2::int",
+      "$3::int",
+      "$4::int",
+      "$5::int",
+      "$6::bigint",
+      "$7::bigint",
+    ]) {
+      assert.ok(text.includes(cast), `missing cast ${cast}`);
+    }
+    // No bare `?` survived the port.
+    assert.equal(text.includes("?"), false);
+  });
+
+  test("the accumulate-and-never-un-complete semantics are in the statement", async () => {
+    const { calls, sql } = recordingSql();
+    await writePassTallyToNeon(sql, "neurons", PASS);
+    const { text, values } = calls[0]!;
+    // received_rows ACCUMULATES rather than being replaced: chunks of one pass
+    // arrive separately.
+    assert.ok(
+      text.includes("neurons_passes.received_rows + EXCLUDED.received_rows"),
+    );
+    // COALESCE, so the first write that closes the gap owns the stamp and a
+    // replay cannot move or clear it.
+    assert.ok(
+      text.includes("COALESCE(\n           neurons_passes.completed_at"),
+    );
+    // `>=`, never `=`: the transport is at-least-once, so a replayed chunk can
+    // push the total past expected and an equality check would call a finished
+    // pass unfinished.
+    assert.ok(text.includes(">= EXCLUDED.expected_rows"));
+    assert.deepEqual(values, [
+      PASS.capturedAt,
+      PASS.expectedRows,
+      PASS.receivedRows,
+      PASS.receivedRows,
+      PASS.expectedRows,
+      PASS.nowMs,
+      PASS.nowMs,
+    ]);
+  });
+
+  test("the table comes from the allowlist, never from the lane name", async () => {
+    // The table is interpolated -- Postgres has no placeholder for an
+    // identifier -- so an unknown lane must not reach the SQL.
+    const { sql } = recordingSql();
+    await assert.rejects(
+      () => writePassTallyToNeon(sql, "'; DROP TABLE neurons_passes; --", PASS),
+      /no pass table for lane/,
+    );
+  });
+
+  test("a failed write is reported, not thrown", async () => {
+    const { sql } = recordingSql("connection reset");
+    const out = await writePassTallyToNeon(sql, "neurons", PASS);
+    assert.equal(out.ok, false);
+    assert.match(out.reason ?? "", /connection reset/);
+  });
+
+  test("every lane in PASS_TABLES can actually be written", async () => {
+    // The coupling that caused this issue in the first place, asserted: a lane
+    // added to the allowlist with no Neon writer behind it is a ledger that
+    // silently stops the day its lane inverts.
+    for (const lane of Object.keys(PASS_TABLES)) {
+      const { calls, sql } = recordingSql();
+      const out = await writePassTallyToNeon(sql, lane, PASS);
+      assert.equal(out.ok, true, `${lane} did not write`);
+      assert.ok(
+        calls[0]!.text.includes(`INSERT INTO ${PASS_TABLES[lane]}`),
+        `${lane} wrote the wrong table`,
+      );
+    }
+  });
+});
+
+describe("the tally travels with the rows (the #10056 invariant)", () => {
+  const env = {
+    NEON_DUAL_WRITE_LANES: "neurons",
+    HYPERDRIVE: { connectionString: "postgresql://example/db" },
+  };
+  const ctx = { waitUntil: () => undefined } as never;
+  const input = {
+    rows: [{ netuid: 1, uid: 0, captured_at: 1 }],
+    dailyRows: [],
+    positionRows: [],
+  };
+
+  test("a pass is tallied once every table landed", async () => {
+    const { calls, sql } = recordingSql();
+    const out = await mirrorNeuronSnapshotToNeon(
+      env,
+      ctx,
+      { ...input, pass: PASS },
+      { sql, laneHealthDb: null },
+    );
+    assert.equal(out.results.neurons_passes?.ok, true);
+    assert.ok(
+      calls.some((c) => c.text.includes("INSERT INTO neurons_passes")),
+      "the tally never reached Neon",
+    );
+    // LAST. The rows it describes must be in the store before it claims they
+    // are.
+    const tallyAt = calls.findIndex((c) =>
+      c.text.includes("INSERT INTO neurons_passes"),
+    );
+    const lastRowAt = calls.reduce(
+      (n, c, i) => (c.text.includes("INSERT INTO neurons ") ? i : n),
+      -1,
+    );
+    // Pinned so the comparison cannot pass on nothing: if the row insert ever
+    // stops matching, lastRowAt would sit at -1 and `tallyAt > -1` would be
+    // true for any ordering at all. The trailing space is what keeps
+    // `neurons ` from also matching `neurons_passes`.
+    assert.ok(
+      lastRowAt >= 0,
+      "no neurons row insert was observed to order against",
+    );
+    assert.ok(tallyAt > lastRowAt, "the tally was written before its rows");
+  });
+
+  test("NO pass is tallied when a table failed", async () => {
+    // The whole point. A tally over rows that did not land is never revisited,
+    // whereas withholding it costs nothing: the next chunk re-sends its rows
+    // and the pass completes then.
+    const { calls, sql } = recordingSql("neon exploded");
+    const out = await mirrorNeuronSnapshotToNeon(
+      env,
+      ctx,
+      { ...input, pass: PASS },
+      { sql, laneHealthDb: null },
+    );
+    assert.equal(out.results.neurons_passes?.ok, false);
+    assert.match(out.results.neurons_passes?.reason ?? "", /tally withheld/);
+    assert.equal(
+      calls.some((c) => c.text.includes("INSERT INTO neurons_passes")),
+      false,
+      "a tally was written for rows that never landed",
+    );
+  });
+
+  test("no pass declared means no tally, not an empty one", async () => {
+    const { calls, sql } = recordingSql();
+    const out = await mirrorNeuronSnapshotToNeon(
+      env,
+      ctx,
+      { ...input, pass: null },
+      { sql, laneHealthDb: null },
+    );
+    assert.equal(out.results.neurons_passes, undefined);
+    assert.equal(
+      calls.some((c) => c.text.includes("neurons_passes")),
+      false,
+    );
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -822,6 +822,11 @@ async function handleNeuronsSync(
       rows,
       dailyRows,
       positionRows,
+      // The tally follows the rows into whichever store holds them (#10056).
+      // Sent only when Neon owns the snapshot: while D1 is still written, its
+      // batch carries the tally atomically and a second copy in Neon would be
+      // a ledger nothing reconciles.
+      pass: neonOwns ? pass : null,
     },
   );
 


### PR DESCRIPTION
Closes #10056

passTallyStatement is appended to the SAME db.batch as the rows it describes,
and deliberately: a tally must not be able to report a pass complete whose rows
never landed. #10045 then made handleNeuronsSync skip that batch outright once
Neon owned the snapshot, and the tally went with it. neurons_passes stopped at
captured_at 1786155508717 -- the exact watermark the flip froze D1 on -- about
11 passes before this was noticed. The invariant that made the tally
trustworthy is what carried it off the cliff.

Nothing served a wrong answer: latestCompletePass has no production callers,
and the two ledgers that do gate published leaderboards belong to lanes that
have not inverted. What was lost is the ledger, and the ability to invert the
next two lanes without losing theirs the same way.

- writePassTallyToNeon, in the module that already owns PASS_TABLES, so the
  allowlist keeps gating the interpolated table name.
- Every parameter feeding a comparison is CAST. The D1 statement does not port
  as written: inside a VALUES list Postgres infers a parameter from its target
  column, and completed_at is filled by a CASE whose operands are parameters,
  so they resolve to text and the statement is rejected -- completed_at is of
  type bigint but expression is of type text. Verified on a throwaway branch,
  along with the guarded form reproducing D1's semantics exactly: 9/100
  incomplete, then 100/100 stamped, then a replayed chunk taking received_rows
  to 105 without un-completing the pass.
- The tally is written LAST and ONLY if every table landed. D1 gets that
  ordering free from one atomic batch; writeRowsToNeon chunks, so it is
  enforced explicitly instead. A withheld tally costs nothing -- the next chunk
  re-sends its rows -- whereas a tally over rows that never landed is never
  revisited.
- Its own lane verdict (neurons-pass), because a tally failing while the three
  tables landed is a different fault from a table failing.

The casts are written for the semantics, not for the error: '9' >= '100' is
TRUE as text and FALSE as integer, so the same shape somewhere Postgres CAN
coerce would stamp an incomplete pass complete and never say so.