### PR TITLE
feat(neon): the observation family writes Postgres, behind the sole-store flag (#10069)

### DIFF
--- a/src/health-prober.ts
+++ b/src/health-prober.ts
@@ -31,6 +31,17 @@ import {
 import { ipv6EmbeddedIpv4 } from "./ip-safety.ts";
 import { OPERATIONAL_SURFACES_R2_KEY } from "./operational-surfaces-sync.ts";
 import {
+  neonOwnsObservations,
+  persistProbesToNeon,
+  pruneChecksNeon,
+  rollupFailureReasonsToNeon,
+  rollupUptimeDailyToNeon,
+  upsertSubnetSnapshotsToNeon,
+  type ObservationsSql,
+} from "./observations-neon.ts";
+import { neonOwnsTable } from "./neon-write.ts";
+import { createPgSql, type HyperdriveLike } from "./pg-sql.ts";
+import {
   persistProbesToD1,
   pruneChecksD1,
   rollupFailureReasonsToD1,
@@ -503,10 +514,33 @@ interface RunHealthProberOverrides {
   probeDeadlineMs?: (surface: ProbeSurface) => number;
 }
 
+/**
+ * The Postgres runner for the observation family, or null to stay on D1.
+ *
+ * ALL FIVE TABLES OR NONE (#10069). Two of this family's writes aggregate
+ * INSIDE the store, so a half-listed group would leave a rollup selecting from
+ * a D1 surface_checks that nothing fills any more -- and that failure is a
+ * schema-stable empty, not an error.
+ *
+ * `ctx` is a precondition, not a nicety: createPgSql hands the connection back
+ * to Hyperdrive through ctx.waitUntil, and without one every sweep would leak a
+ * connection. Absent ctx therefore keeps the whole family on D1 rather than
+ * writing to Neon by another route.
+ */
+function observationsRunner(
+  env: Env,
+  ctx?: ExecutionContext,
+): ObservationsSql | null {
+  if (!ctx) return null;
+  const bag = env as unknown as Record<string, unknown>;
+  if (!neonOwnsObservations(bag, neonOwnsTable)) return null;
+  return createPgSql(env.HYPERDRIVE as unknown as HyperdriveLike, ctx);
+}
+
 // Run one full probe sweep and persist results. Returns a small summary object.
 export async function runHealthProber(
   env: Env,
-  _ctx: ExecutionContext,
+  ctx: ExecutionContext,
   overrides: RunHealthProberOverrides = {},
 ): Promise<Row> {
   const now = overrides.now || (() => Date.now());
@@ -691,12 +725,21 @@ export async function runHealthProber(
   // was retired with the box (#9193) and its endpoint has answered 503 ever
   // since; the call stayed behind and fired every sweep for nothing.
   // the copy that keeps accumulating; nothing about this sweep changes.
-  await persistProbesToD1(
-    env.METAGRAPH_HEALTH_DB as unknown as ObservationsDb,
-    probed as unknown as Record<string, unknown>[],
-    runAt,
-    env,
-  );
+  const probeSql = observationsRunner(env, ctx);
+  if (probeSql) {
+    await persistProbesToNeon(
+      probeSql,
+      probed as unknown as Record<string, unknown>[],
+      runAt,
+    );
+  } else {
+    await persistProbesToD1(
+      env.METAGRAPH_HEALTH_DB as unknown as ObservationsDb,
+      probed as unknown as Record<string, unknown>[],
+      runAt,
+      env,
+    );
+  }
 
   const counts = emptyStatusCounts();
   for (const row of probed)
@@ -882,7 +925,7 @@ function utcDayBounds(ms: number): {
 // data-api.ts's handleHealthUptimeRollupSync, keeps this idempotent).
 export async function rollupDailyUptime(
   env: Env,
-  overrides: { now?: () => number } = {},
+  overrides: { now?: () => number; ctx?: ExecutionContext } = {},
 ): Promise<Row> {
   const now = overrides.now || (() => Date.now());
   const runAt = now();
@@ -894,24 +937,38 @@ export async function rollupDailyUptime(
   // rolled-before-prune contract is satisfied when EITHER store rolled: each
   // prune below is likewise per-store, and blocking D1's prune on a dead
   // Postgres (or vice versa) would freeze the surviving store's retention.
-  const d1Rollup = await rollupUptimeDailyToD1(
-    env.METAGRAPH_HEALTH_DB as unknown as ObservationsDb,
-    days,
-    runAt,
-    env,
-  );
+  // Both rollups take the same store as the raw checks they read: they are
+  // INSERT ... SELECT FROM surface_checks, so aggregating in the store that no
+  // longer receives probes would roll up an empty window and report success.
+  const rollupSql = observationsRunner(env, overrides.ctx);
+  const d1Rollup = rollupSql
+    ? await rollupUptimeDailyToNeon(rollupSql, days, runAt).then((r) => ({
+        rolled: r.ok,
+        ...(r.reason ? { error: r.reason } : {}),
+      }))
+    : await rollupUptimeDailyToD1(
+        env.METAGRAPH_HEALTH_DB as unknown as ObservationsDb,
+        days,
+        runAt,
+        env,
+      );
   // #9622: the reason rollup runs beside the uptime one and is folded into
   // `d1_rolled` below, which is what gates the raw prune. Reporting the day as
   // rolled while only the uptime half landed would let pruneHealthHistory
   // delete the raw checks whose classifications never made it anywhere durable
   // -- the exact orphaning `d1_rolled` was introduced to prevent, one table
   // over.
-  const d1Failures = await rollupFailureReasonsToD1(
-    env.METAGRAPH_HEALTH_DB as unknown as ObservationsDb,
-    days,
-    runAt,
-    env,
-  );
+  const d1Failures = rollupSql
+    ? await rollupFailureReasonsToNeon(rollupSql, days, runAt).then((r) => ({
+        rolled: r.ok,
+        ...(r.reason ? { error: r.reason } : {}),
+      }))
+    : await rollupFailureReasonsToD1(
+        env.METAGRAPH_HEALTH_DB as unknown as ObservationsDb,
+        days,
+        runAt,
+        env,
+      );
   // The failure reason used to come from the Postgres mirror, which has
   // returned 503 since #9193 -- so `result.synced` was always false and this
   // guard had already reduced to "did D1 roll". Now it says so, and reports
@@ -947,16 +1004,25 @@ export async function pruneHealthHistory(
     // and deleting D1's raw window without D1's aggregate would silently
     // orphan the one store that survives the box.
     pruneD1Checks?: boolean;
+    ctx?: ExecutionContext;
   } = {},
 ): Promise<Row> {
   const now = overrides.now || (() => Date.now());
   const cutoff = now() - (overrides.retentionMs || HISTORY_RETENTION_MS);
   if (overrides.pruneD1Checks === true) {
-    await pruneChecksD1(
-      env.METAGRAPH_HEALTH_DB as unknown as ObservationsDb,
-      cutoff,
-      env,
-    );
+    // The prune follows the rows: deleting D1's raw window while Neon holds
+    // the checks would drop nothing that matters, but deleting Neon's while D1
+    // holds them would orphan the aggregate the gate above just wrote.
+    const pruneSql = observationsRunner(env, overrides.ctx);
+    if (pruneSql) {
+      await pruneChecksNeon(pruneSql, cutoff);
+    } else {
+      await pruneChecksD1(
+        env.METAGRAPH_HEALTH_DB as unknown as ObservationsDb,
+        cutoff,
+        env,
+      );
+    }
   }
   return { pruned: true, cutoff };
 }
@@ -1029,7 +1095,9 @@ export async function writeSubnetSnapshotRows(
     chainState,
     date,
     capturedAt,
+    ctx,
   }: {
+    ctx?: ExecutionContext;
     profiles?: Row[];
     economicsByNetuid?: Map<unknown, Row>;
     /**
@@ -1101,11 +1169,18 @@ export async function writeSubnetSnapshotRows(
       };
     });
   if (!rows.length) return { synced: false, reason: "no_rows" };
-  return upsertSubnetSnapshotsToD1(
-    env.METAGRAPH_HEALTH_DB as unknown as ObservationsDb,
-    rows as unknown as Record<string, unknown>[],
-    env,
-  ).then((result) =>
+  const snapshotSql = observationsRunner(env, ctx);
+  const write = snapshotSql
+    ? upsertSubnetSnapshotsToNeon(
+        snapshotSql,
+        rows as unknown as Record<string, unknown>[],
+      ).then((r) => ({ ok: r.ok, reason: r.reason }))
+    : upsertSubnetSnapshotsToD1(
+        env.METAGRAPH_HEALTH_DB as unknown as ObservationsDb,
+        rows as unknown as Record<string, unknown>[],
+        env,
+      );
+  return write.then((result) =>
     // The D1 write's own verdict is now the lane's verdict, rather than being
     // discarded in favour of a second store's. upsertSubnetSnapshotsToD1 never
     // throws and reports its own reason, so a genuine write failure still
@@ -1124,6 +1199,9 @@ interface WriteSubnetSnapshotOverrides {
    * D1 and a real PostHog token. */
   laneHealthDb?: LaneHealthDb;
   recordExceptionEvent?: typeof recordExceptionEvent;
+  /** Needed to reach Neon: createPgSql returns the pooled connection through
+   * ctx.waitUntil, so without one this lane stays on D1. */
+  ctx?: ExecutionContext;
 }
 
 // Daily growth snapshot (AI-4). Captures each subnet's structural maturity into
@@ -1249,6 +1327,7 @@ export async function writeSubnetSnapshot(
     chainState: ((economicsResult?.data as Row)?.chain_state as Row) ?? null,
     date,
     capturedAt,
+    ctx: overrides.ctx,
   });
   const rows = profiles.filter((profile) =>
     Number.isInteger(profile.netuid),

--- a/src/observations-neon.ts
+++ b/src/observations-neon.ts
@@ -1,0 +1,322 @@
+// The observation family, against Neon (#10069).
+//
+// FIVE TABLES, ONE UNIT. Two of these writes are `INSERT ... SELECT FROM
+// surface_checks` -- they aggregate INSIDE the store. So the moment
+// surface_checks stops being written to D1, both rollups aggregate an empty
+// table unless they move with it. There is no table-at-a-time path here, which
+// is why this file covers the whole family rather than one lane.
+//
+// Every statement below was checked against the live database rather than
+// translated by eye. The three that do not survive a naive port:
+//
+// 1. `CAST(x AS INTEGER)` TRUNCATES in SQLite and ROUNDS in Postgres --
+//    CAST(1.7) is 1 there and 2 here, CAST(2.5) is 2 and 3. latencyStatColumns
+//    picks p50/p95/p99 by nearest rank with
+//      `CAST(q*n AS INTEGER) + (q*n > CAST(q*n AS INTEGER))`
+//    which is SQLite's ceil written as trunc-plus-carry, because SQLite has no
+//    ceil. In Postgres that breaks twice: the CAST rounds, AND `(a > b)` is a
+//    boolean Postgres will not add to an integer. The second half errors; the
+//    FIRST HALF WOULD NOT -- it would return a confidently wrong percentile.
+//    Postgres has the function SQLite lacked, so the port is simpler than the
+//    original: `ceil(q * lat_cnt)::int`, verified identical to the SQLite
+//    expression at lat_cnt = 1, 3, 7, 20 and 100 for all three quantiles.
+//
+// 2. `surface_checks.ok` is INTEGER 0/1 in D1 and BOOLEAN in Neon, so `SUM(ok)`
+//    and `ok = 1` are both type errors. Counting moves to
+//    `COUNT(*) FILTER (WHERE ok)`, which is also what it always meant.
+//
+// 3. `ROUND(x, 4)` has no double-precision overload in Postgres, so the ratio
+//    is rounded as numeric and cast back.
+//
+// `ifnull(netuid, -1)` needs no translation at all: Neon's
+// ux_surface_failure_daily_key is already `(day, netuid, kind, classification)
+// NULLS NOT DISTINCT`, the native form of the expression-index trick D1 needed
+// because SQLite treats NULLs as distinct in a unique constraint.
+import type { PassTallySql } from "./pass-completeness.ts";
+
+type Row = Record<string, unknown>;
+
+export interface ObservationWrite {
+  ok: boolean;
+  reason?: string;
+}
+
+/** A probe whose latency counts. `ok` is a real boolean here, so it stands on
+ * its own -- `ok = 1` is the D1 spelling and a type error in Postgres. */
+const OK_LATENCY = "ok AND latency_ms IS NOT NULL";
+
+/**
+ * The ranked CTE, Postgres form.
+ *
+ * Ranks each stable surface's ok-latency rows by latency and counts them,
+ * passing every row through so uptime still totals over all checks.
+ */
+function rankedChecksCte(): string {
+  return `WITH ranked AS (
+    SELECT
+      surface_id,
+      COALESCE(surface_key, surface_id) AS surface_key,
+      netuid,
+      ok,
+      latency_ms,
+      CASE WHEN ${OK_LATENCY} THEN ROW_NUMBER() OVER (
+        PARTITION BY COALESCE(surface_key, surface_id), netuid,
+                     CASE WHEN ${OK_LATENCY} THEN 0 ELSE 1 END
+        ORDER BY latency_ms
+      ) END AS rn,
+      COUNT(*) FILTER (WHERE ${OK_LATENCY}) OVER (
+        PARTITION BY COALESCE(surface_key, surface_id), netuid
+      ) AS lat_cnt
+    FROM surface_checks
+    WHERE checked_at >= $1 AND checked_at < $2
+  )`;
+}
+
+/** Nearest-rank order statistic: the value at 1-based position ceil(q*N) among
+ * the N ok-latency rows. `ceil` directly, NOT SQLite's trunc-plus-carry -- see
+ * this file's header for why that expression cannot come across. */
+function pick(q: number, name: string): string {
+  return `MAX(CASE WHEN rn = ceil(${q} * lat_cnt)::int THEN latency_ms END) AS ${name}`;
+}
+
+const LATENCY_COLUMNS = [
+  "MAX(lat_cnt) AS latency_samples",
+  `ROUND(AVG(CASE WHEN ${OK_LATENCY} THEN latency_ms END))::int AS avg_latency_ms`,
+  pick(0.5, "p50"),
+  pick(0.95, "p95"),
+  pick(0.99, "p99"),
+].join(",\n       ");
+
+async function attempt(
+  sql: PassTallySql,
+  run: () => Promise<unknown>,
+  label: string,
+): Promise<ObservationWrite> {
+  try {
+    await run();
+    return { ok: true };
+  } catch (error) {
+    const reason = String((error as Error)?.message ?? error);
+    console.error(`[${label}]`, reason);
+    void sql;
+    return { ok: false, reason };
+  }
+}
+
+/**
+ * One probe sweep: a surface_checks row per surface, plus the latest-status
+ * upsert.
+ *
+ * THE RENAME, AND WHY IT IS TWO STATEMENTS. D1's upsert names two conflict
+ * targets -- surface_key when present, so a display-id rename updates the alias
+ * in place, and surface_id as the fallback for keyless rows. Postgres permits
+ * exactly ONE ON CONFLICT clause per statement, and both arbiters exist in Neon
+ * (idx_surface_status_key partial-unique, surface_status_pkey), so they cannot
+ * be combined.
+ *
+ * Splitting rows by whether surface_key is present would ALMOST work, and fails
+ * on the one case the second arbiter was added for: a keyed row whose
+ * surface_id already exists under a different key raises a unique violation
+ * instead of updating. So the rename is RESOLVED FIRST -- the row holding this
+ * surface_key adopts the new surface_id -- and the upsert then has a single
+ * arbiter with nothing left to collide on. Verified against the live schema:
+ * one row, the new id, and last_ok preserved.
+ *
+ * LAST_OK IS A HIGH-WATER MARK (#9634). Every other column takes what this run
+ * measured; last_ok records when the surface was last seen WORKING, so a run
+ * that did not see it working has observed nothing about it and must not clear
+ * it. COALESCE rather than a WHERE guard, because excluded.last_ok is
+ * authoritative whenever it is non-null and only "we do not know" arrives null.
+ */
+export async function persistProbesToNeon(
+  sql: PassTallySql,
+  probed: Row[],
+  runAt: number,
+): Promise<ObservationWrite> {
+  if (!probed.length) return { ok: false, reason: "no_rows" };
+  return attempt(
+    sql,
+    async () => {
+      for (const row of probed) {
+        await sql.unsafe(
+          `INSERT INTO surface_checks
+             (surface_id, surface_key, netuid, kind, status, classification,
+              latency_ms, status_code, ok, checked_at)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+           ON CONFLICT (surface_id, checked_at) DO NOTHING`,
+          [
+            row.surface_id,
+            row.surface_key ?? null,
+            row.netuid ?? null,
+            row.kind ?? null,
+            row.status ?? null,
+            row.classification ?? null,
+            row.latency_ms ?? null,
+            row.status_code ?? null,
+            row.status === "ok",
+            row.checked_at_ms,
+          ],
+        );
+        if (row.surface_key) {
+          // Resolve the rename before the upsert -- see this function's header.
+          await sql.unsafe(
+            `UPDATE surface_status SET surface_id = $1
+              WHERE surface_key = $2 AND surface_id <> $1`,
+            [row.surface_id, row.surface_key],
+          );
+        }
+        await sql.unsafe(
+          `INSERT INTO surface_status
+             (surface_id, surface_key, netuid, kind, url, provider, status,
+              classification, latency_ms, status_code, last_checked, last_ok,
+              consecutive_failures, updated_at)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+           ON CONFLICT (surface_id) DO UPDATE SET
+             surface_key=excluded.surface_key,
+             netuid=excluded.netuid, kind=excluded.kind, url=excluded.url,
+             provider=excluded.provider, status=excluded.status,
+             classification=excluded.classification,
+             latency_ms=excluded.latency_ms, status_code=excluded.status_code,
+             last_checked=excluded.last_checked,
+             last_ok=COALESCE(excluded.last_ok, surface_status.last_ok),
+             consecutive_failures=excluded.consecutive_failures,
+             updated_at=excluded.updated_at`,
+          [
+            row.surface_id,
+            row.surface_key ?? null,
+            row.netuid ?? null,
+            row.kind ?? null,
+            row.url ?? null,
+            row.provider ?? null,
+            row.status ?? null,
+            row.classification ?? null,
+            row.latency_ms ?? null,
+            row.status_code ?? null,
+            row.checked_at_ms,
+            row.last_ok_ms ?? null,
+            row.consecutive_failures ?? 0,
+            runAt,
+          ],
+        );
+      }
+    },
+    "persistProbesToNeon",
+  );
+}
+
+/**
+ * The failure-REASON rollup: one row per (day, netuid, kind, classification).
+ *
+ * The conflict target is the plain column list, NOT an expression: Neon's
+ * unique index is NULLS NOT DISTINCT, so a NULL netuid collides with itself
+ * the way D1 needed `ifnull(netuid, -1)` to arrange.
+ */
+export async function rollupFailureReasonsToNeon(
+  sql: PassTallySql,
+  days: { date: string; start: number; end: number }[],
+  runAt: number,
+): Promise<ObservationWrite> {
+  return attempt(
+    sql,
+    async () => {
+      for (const { date, start, end } of days) {
+        await sql.unsafe(
+          `INSERT INTO surface_failure_daily
+             (day, netuid, kind, classification, checks, updated_at)
+           SELECT $1, netuid, kind, classification, COUNT(*), $2
+             FROM surface_checks
+            WHERE checked_at >= $3 AND checked_at < $4
+              AND kind IS NOT NULL AND classification IS NOT NULL
+            GROUP BY netuid, kind, classification
+           ON CONFLICT (day, netuid, kind, classification) DO UPDATE SET
+             checks = excluded.checks,
+             updated_at = excluded.updated_at`,
+          [date, runAt, start, end],
+        );
+      }
+    },
+    "rollupFailureReasonsToNeon",
+  );
+}
+
+/**
+ * The day rollup, with the clamped-ratio and status semantics the daily series
+ * has always had.
+ *
+ * The ratio is clamped BELOW 1.0 unless every sample was ok, so a surface with
+ * one failure in ten thousand cannot round to a clean 100%.
+ */
+export async function rollupUptimeDailyToNeon(
+  sql: PassTallySql,
+  days: { date: string; start: number; end: number }[],
+  runAt: number,
+): Promise<ObservationWrite> {
+  const conflictColumns = `
+       surface_key = excluded.surface_key,
+       netuid = excluded.netuid,
+       samples = excluded.samples,
+       ok_count = excluded.ok_count,
+       uptime_ratio = excluded.uptime_ratio,
+       avg_latency_ms = excluded.avg_latency_ms,
+       latency_samples = excluded.latency_samples,
+       p50_latency_ms = excluded.p50_latency_ms,
+       p95_latency_ms = excluded.p95_latency_ms,
+       p99_latency_ms = excluded.p99_latency_ms,
+       status = excluded.status,
+       updated_at = excluded.updated_at`;
+  return attempt(
+    sql,
+    async () => {
+      for (const { date, start, end } of days) {
+        await sql.unsafe(
+          `${rankedChecksCte()}
+           INSERT INTO surface_uptime_daily
+             (surface_id, surface_key, netuid, day, samples, ok_count,
+              uptime_ratio, latency_samples, avg_latency_ms, p50_latency_ms,
+              p95_latency_ms, p99_latency_ms, status, updated_at)
+           SELECT
+             MAX(surface_id),
+             surface_key,
+             netuid,
+             $3,
+             COUNT(*),
+             COUNT(*) FILTER (WHERE ok),
+             CASE
+               WHEN COUNT(*) FILTER (WHERE ok) = COUNT(*) THEN 1.0
+               WHEN ROUND((COUNT(*) FILTER (WHERE ok))::numeric
+                          / COUNT(*), 4) >= 1.0 THEN 0.9999
+               ELSE ROUND((COUNT(*) FILTER (WHERE ok))::numeric
+                          / COUNT(*), 4)::float8
+             END,
+             ${LATENCY_COLUMNS},
+             CASE
+               WHEN COUNT(*) FILTER (WHERE ok) = COUNT(*) THEN 'ok'
+               WHEN COUNT(*) FILTER (WHERE ok) = 0 THEN 'failed'
+               ELSE 'degraded'
+             END,
+             $4
+           FROM ranked
+           GROUP BY surface_key, netuid
+           ON CONFLICT (surface_id, day) DO UPDATE SET${conflictColumns}`,
+          [start, end, date, runAt],
+        );
+      }
+    },
+    "rollupUptimeDailyToNeon",
+  );
+}
+
+/** The raw-window prune. Runs ONLY after the day rollup reported success --
+ * the caller owns that ordering, as it always has. */
+export async function pruneChecksNeon(
+  sql: PassTallySql,
+  cutoff: number,
+): Promise<ObservationWrite> {
+  return attempt(
+    sql,
+    () => sql.unsafe(`DELETE FROM surface_checks WHERE checked_at < $1`, [
+      cutoff,
+    ]),
+    "pruneChecksNeon",
+  );
+}

--- a/src/observations-neon.ts
+++ b/src/observations-neon.ts
@@ -32,7 +32,11 @@
 // ux_surface_failure_daily_key is already `(day, netuid, kind, classification)
 // NULLS NOT DISTINCT`, the native form of the expression-index trick D1 needed
 // because SQLite treats NULLs as distinct in a unique constraint.
-import type { PassTallySql } from "./pass-completeness.ts";
+/** The runner shape createPgSql hands out. Declared here rather than imported
+ * so this module depends on the SHAPE and not on another lane's file. */
+export interface ObservationsSql {
+  unsafe(text: string, values?: unknown[]): Promise<unknown>;
+}
 
 type Row = Record<string, unknown>;
 
@@ -88,7 +92,7 @@ const LATENCY_COLUMNS = [
 ].join(",\n       ");
 
 async function attempt(
-  sql: PassTallySql,
+  sql: ObservationsSql,
   run: () => Promise<unknown>,
   label: string,
 ): Promise<ObservationWrite> {
@@ -129,7 +133,7 @@ async function attempt(
  * authoritative whenever it is non-null and only "we do not know" arrives null.
  */
 export async function persistProbesToNeon(
-  sql: PassTallySql,
+  sql: ObservationsSql,
   probed: Row[],
   runAt: number,
 ): Promise<ObservationWrite> {
@@ -212,7 +216,7 @@ export async function persistProbesToNeon(
  * the way D1 needed `ifnull(netuid, -1)` to arrange.
  */
 export async function rollupFailureReasonsToNeon(
-  sql: PassTallySql,
+  sql: ObservationsSql,
   days: { date: string; start: number; end: number }[],
   runAt: number,
 ): Promise<ObservationWrite> {
@@ -247,7 +251,7 @@ export async function rollupFailureReasonsToNeon(
  * one failure in ten thousand cannot round to a clean 100%.
  */
 export async function rollupUptimeDailyToNeon(
-  sql: PassTallySql,
+  sql: ObservationsSql,
   days: { date: string; start: number; end: number }[],
   runAt: number,
 ): Promise<ObservationWrite> {
@@ -309,14 +313,134 @@ export async function rollupUptimeDailyToNeon(
 /** The raw-window prune. Runs ONLY after the day rollup reported success --
  * the caller owns that ordering, as it always has. */
 export async function pruneChecksNeon(
-  sql: PassTallySql,
+  sql: ObservationsSql,
   cutoff: number,
 ): Promise<ObservationWrite> {
   return attempt(
     sql,
-    () => sql.unsafe(`DELETE FROM surface_checks WHERE checked_at < $1`, [
-      cutoff,
-    ]),
+    () =>
+      sql.unsafe(`DELETE FROM surface_checks WHERE checked_at < $1`, [cutoff]),
     "pruneChecksNeon",
+  );
+}
+
+/** The completeness/economics trajectory upsert: one row per (netuid, day).
+ *
+ * The only member of this family that could have moved on its own -- a plain
+ * row upsert on the primary key, which writeRowsToNeon already covers. It rides
+ * here because it shares a module and a producer with the other four, not
+ * because it shares their constraint. `emission_enabled` and `subtoken_enabled`
+ * are 0/1 with a CHECK in D1 and real BOOLEAN in Neon. */
+export async function upsertSubnetSnapshotsToNeon(
+  sql: ObservationsSql,
+  rows: Row[],
+): Promise<ObservationWrite> {
+  if (!rows.length) return { ok: false, reason: "no_rows" };
+  const toBool = (v: unknown) => (v == null ? null : Boolean(v));
+  return attempt(
+    sql,
+    async () => {
+      for (const row of rows) {
+        await sql.unsafe(
+          `INSERT INTO subnet_snapshots
+             (netuid, snapshot_date, completeness_score, surface_count,
+              endpoint_count, monitored_count, candidate_count, captured_at,
+              validator_count, miner_count, total_stake_tao, alpha_price_tao,
+              emission_share, tao_in_pool_tao, alpha_in_pool, alpha_out_pool,
+              subnet_volume_tao, tao_in_emission_tao, excess_tao,
+              alpha_in_emission, alpha_out_emission, miner_burned_fraction,
+              emission_enabled, subtoken_enabled, first_emission_block,
+              pipeline_block, pipeline_block_hash)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,
+                   $18,$19,$20,$21,$22,$23,$24,$25,$26,$27)
+           ON CONFLICT (netuid, snapshot_date) DO UPDATE SET
+             completeness_score=excluded.completeness_score,
+             surface_count=excluded.surface_count,
+             endpoint_count=excluded.endpoint_count,
+             monitored_count=excluded.monitored_count,
+             candidate_count=excluded.candidate_count,
+             captured_at=excluded.captured_at,
+             validator_count=excluded.validator_count,
+             miner_count=excluded.miner_count,
+             total_stake_tao=excluded.total_stake_tao,
+             alpha_price_tao=excluded.alpha_price_tao,
+             emission_share=excluded.emission_share,
+             tao_in_pool_tao=excluded.tao_in_pool_tao,
+             alpha_in_pool=excluded.alpha_in_pool,
+             alpha_out_pool=excluded.alpha_out_pool,
+             subnet_volume_tao=excluded.subnet_volume_tao,
+             tao_in_emission_tao=excluded.tao_in_emission_tao,
+             excess_tao=excluded.excess_tao,
+             alpha_in_emission=excluded.alpha_in_emission,
+             alpha_out_emission=excluded.alpha_out_emission,
+             miner_burned_fraction=excluded.miner_burned_fraction,
+             emission_enabled=excluded.emission_enabled,
+             subtoken_enabled=excluded.subtoken_enabled,
+             first_emission_block=excluded.first_emission_block,
+             pipeline_block=excluded.pipeline_block,
+             pipeline_block_hash=excluded.pipeline_block_hash`,
+          [
+            row.netuid,
+            row.snapshot_date,
+            row.completeness_score ?? null,
+            row.surface_count ?? null,
+            row.endpoint_count ?? null,
+            row.monitored_count ?? null,
+            row.candidate_count ?? null,
+            row.captured_at ?? null,
+            row.validator_count ?? null,
+            row.miner_count ?? null,
+            row.total_stake_tao ?? null,
+            row.alpha_price_tao ?? null,
+            row.emission_share ?? null,
+            row.tao_in_pool_tao ?? null,
+            row.alpha_in_pool ?? null,
+            row.alpha_out_pool ?? null,
+            row.subnet_volume_tao ?? null,
+            row.tao_in_emission_tao ?? null,
+            row.excess_tao ?? null,
+            row.alpha_in_emission ?? null,
+            row.alpha_out_emission ?? null,
+            row.miner_burned_fraction ?? null,
+            toBool(row.emission_enabled),
+            toBool(row.subtoken_enabled),
+            row.first_emission_block ?? null,
+            row.pipeline_block ?? null,
+            row.pipeline_block_hash ?? null,
+          ],
+        );
+      }
+    },
+    "upsertSubnetSnapshotsToNeon",
+  );
+}
+
+/** The five tables this family writes, as one list, so the sole-store gate is
+ * all-or-nothing over the unit that actually moves. Two of the writes
+ * aggregate INSIDE the store, so a half-listed group would leave a rollup
+ * reading a D1 that nothing fills. */
+export const OBSERVATION_TABLES = [
+  "surface_checks",
+  "surface_status",
+  "surface_uptime_daily",
+  "surface_failure_daily",
+  "subnet_snapshots",
+] as const;
+
+/** True when Neon solely owns every observation table AND Hyperdrive is bound.
+ * Skipping the D1 write with nowhere to put the rows would drop a probe sweep
+ * silently, and a probe not stored is gone. */
+export function neonOwnsObservations(
+  env: Record<string, unknown> | null | undefined,
+  neonOwnsTable: (
+    env: Record<string, unknown> | null | undefined,
+    table: string,
+  ) => boolean,
+): boolean {
+  const hyperdrive = env?.HYPERDRIVE as
+    { connectionString?: string } | undefined;
+  return (
+    Boolean(hyperdrive?.connectionString) &&
+    OBSERVATION_TABLES.every((table) => neonOwnsTable(env, table))
   );
 }

--- a/tests/observations-neon.test.ts
+++ b/tests/observations-neon.test.ts
@@ -1,0 +1,268 @@
+// The observation family against Postgres (#10069).
+//
+// The assertions that matter here are the three things that do not survive a
+// naive port, because each one fails in a way a passing test suite would not
+// notice: a rounded percentile, a boolean bound as 0/1, and a rollup that reads
+// the store its probes stopped going to.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+import {
+  OBSERVATION_TABLES,
+  neonOwnsObservations,
+  persistProbesToNeon,
+  pruneChecksNeon,
+  rollupFailureReasonsToNeon,
+  rollupUptimeDailyToNeon,
+  upsertSubnetSnapshotsToNeon,
+} from "../src/observations-neon.ts";
+
+function recordingSql(fail?: string) {
+  const calls: { text: string; values: unknown[] }[] = [];
+  return {
+    calls,
+    texts: () => calls.map((c) => c.text),
+    sql: {
+      unsafe: async (text: string, values: unknown[] = []) => {
+        calls.push({ text, values });
+        if (fail) throw new Error(fail);
+        return [];
+      },
+    },
+  };
+}
+
+const DAYS = [{ date: "2026-08-08", start: 1000, end: 2000 }];
+
+describe("neonOwnsObservations is all-or-nothing", () => {
+  const owns =
+    (owned: string[]) =>
+    (_e: unknown, table: string): boolean =>
+      owned.includes(table);
+  const bound = { HYPERDRIVE: { connectionString: "postgresql://x" } };
+
+  test("every table owned and Hyperdrive bound", () => {
+    assert.equal(
+      neonOwnsObservations(bound, owns([...OBSERVATION_TABLES])),
+      true,
+    );
+  });
+
+  test("ONE table left out keeps the whole family on D1", () => {
+    // Two of these writes are INSERT ... SELECT FROM surface_checks. A
+    // half-listed group would leave a rollup aggregating a D1 that no longer
+    // receives probes -- and that is a schema-stable empty, not an error, so
+    // the daily series would just quietly go to zero.
+    for (const missing of OBSERVATION_TABLES) {
+      const partial = OBSERVATION_TABLES.filter((t) => t !== missing);
+      assert.equal(
+        neonOwnsObservations(bound, owns([...partial])),
+        false,
+        `${missing} missing should pin the family to D1`,
+      );
+    }
+  });
+
+  test("owned but no Hyperdrive stays on D1", () => {
+    // Skipping the D1 write with nowhere to put the rows drops a probe sweep,
+    // and a probe not stored is gone -- there is no chain to replay it from.
+    assert.equal(
+      neonOwnsObservations({}, owns([...OBSERVATION_TABLES])),
+      false,
+    );
+  });
+
+  test("the declared group is exactly what this module writes", () => {
+    assert.deepEqual([...OBSERVATION_TABLES].sort(), [
+      "subnet_snapshots",
+      "surface_checks",
+      "surface_failure_daily",
+      "surface_status",
+      "surface_uptime_daily",
+    ]);
+  });
+});
+
+describe("persistProbesToNeon", () => {
+  const probe = {
+    surface_id: "s1",
+    surface_key: "k1",
+    netuid: 7,
+    status: "ok",
+    latency_ms: 12,
+    checked_at_ms: 500,
+    last_ok_ms: 500,
+    consecutive_failures: 0,
+  };
+
+  test("the rename is resolved BEFORE the upsert", async () => {
+    // Postgres allows exactly one ON CONFLICT clause, and surface_status needs
+    // two arbiters (surface_key for a display-id rename, surface_id for keyless
+    // rows). Adopting the new id onto the key's row first leaves a single
+    // arbiter with nothing to collide on. Order is the whole mechanism: run the
+    // upsert first and it inserts a second row, then the UPDATE hits the unique
+    // index.
+    const { sql, texts } = recordingSql();
+    await persistProbesToNeon(sql, [probe], 900);
+    const t = texts();
+    const updateAt = t.findIndex((x) => x.includes("UPDATE surface_status"));
+    const upsertAt = t.findIndex((x) =>
+      x.includes("INSERT INTO surface_status"),
+    );
+    assert.ok(updateAt >= 0, "no rename resolution was issued");
+    assert.ok(upsertAt >= 0, "no status upsert was issued");
+    assert.ok(updateAt < upsertAt, "the upsert ran before the rename resolved");
+  });
+
+  test("a keyless row skips the rename step entirely", async () => {
+    const { sql, texts } = recordingSql();
+    await persistProbesToNeon(sql, [{ ...probe, surface_key: null }], 900);
+    assert.equal(
+      texts().some((t) => t.includes("UPDATE surface_status")),
+      false,
+    );
+  });
+
+  test("last_ok is COALESCEd, so a run that saw nothing cannot clear it", async () => {
+    // #9634: last_ok is a high-water mark. readLiveSurfaceStatus degrades to an
+    // empty array on a transport failure, and a bare last_ok=excluded.last_ok
+    // turned that read-side degrade into permanent write-side data loss.
+    const { sql, texts } = recordingSql();
+    await persistProbesToNeon(sql, [probe], 900);
+    const upsert = texts().find((t) =>
+      t.includes("INSERT INTO surface_status"),
+    )!;
+    assert.ok(
+      upsert.includes(
+        "last_ok=COALESCE(excluded.last_ok, surface_status.last_ok)",
+      ),
+    );
+  });
+
+  test("ok binds as a BOOLEAN, not 0/1", async () => {
+    // surface_checks.ok is INTEGER in D1 and BOOLEAN in Neon. Asserted by TYPE:
+    // 0 == false loosely, so a value check would pass on the exact bug.
+    const { sql, calls } = recordingSql();
+    await persistProbesToNeon(
+      sql,
+      [probe, { ...probe, status: "failed" }],
+      900,
+    );
+    const checks = calls.filter((c) =>
+      c.text.includes("INSERT INTO surface_checks"),
+    );
+    assert.equal(typeof checks[0]!.values[8], "boolean");
+    assert.equal(checks[0]!.values[8], true);
+    assert.equal(checks[1]!.values[8], false, "a non-ok probe was not false");
+  });
+
+  test("an empty sweep writes nothing and says why", async () => {
+    const { sql, calls } = recordingSql();
+    const out = await persistProbesToNeon(sql, [], 900);
+    assert.deepEqual(out, { ok: false, reason: "no_rows" });
+    assert.equal(calls.length, 0);
+  });
+
+  test("a failure is reported, never thrown", async () => {
+    // A failed history write must not take the probe sweep down with it.
+    const { sql } = recordingSql("connection reset");
+    const out = await persistProbesToNeon(sql, [probe], 900);
+    assert.equal(out.ok, false);
+    assert.match(out.reason ?? "", /connection reset/);
+  });
+});
+
+describe("the rollups", () => {
+  test("percentiles use ceil(), never SQLite's CAST-plus-carry", async () => {
+    // THE SILENT ONE. CAST(x AS INTEGER) truncates in SQLite and ROUNDS in
+    // Postgres -- CAST(2.5) is 2 there and 3 here -- so the ported expression
+    // would pick the wrong rank without erroring. (Its other half, adding a
+    // boolean to an integer, WOULD error. Relying on that is luck.)
+    const { sql, texts } = recordingSql();
+    await rollupUptimeDailyToNeon(sql, DAYS, 900);
+    const stmt = texts()[0]!;
+    for (const q of ["0.5", "0.95", "0.99"]) {
+      assert.ok(
+        stmt.includes(`ceil(${q} * lat_cnt)::int`),
+        `p${q} does not use ceil`,
+      );
+    }
+    assert.equal(/CAST\(.*AS INTEGER\)/.test(stmt), false);
+  });
+
+  test("ok is counted with FILTER, never SUM(ok)", async () => {
+    // SUM of a boolean is a type error in Postgres.
+    const { sql, texts } = recordingSql();
+    await rollupUptimeDailyToNeon(sql, DAYS, 900);
+    const stmt = texts()[0]!;
+    assert.ok(stmt.includes("COUNT(*) FILTER (WHERE ok)"));
+    assert.equal(/SUM\(ok\)/.test(stmt), false);
+    assert.equal(/ok = 1/.test(stmt), false);
+  });
+
+  test("the uptime ratio is clamped below 1.0 unless every sample was ok", async () => {
+    // One failure in ten thousand must not round to a clean 100%.
+    const { sql, texts } = recordingSql();
+    await rollupUptimeDailyToNeon(sql, DAYS, 900);
+    const stmt = texts()[0]!;
+    assert.ok(stmt.includes("THEN 0.9999"));
+    assert.ok(stmt.includes("::numeric"), "ROUND(x, 4) needs numeric in PG");
+  });
+
+  test("the failure rollup conflicts on plain columns, not ifnull()", async () => {
+    // Neon's ux_surface_failure_daily_key is NULLS NOT DISTINCT, which is the
+    // native form of the expression index D1 needed because SQLite treats
+    // NULLs as distinct in a unique constraint.
+    const { sql, texts } = recordingSql();
+    await rollupFailureReasonsToNeon(sql, DAYS, 900);
+    const stmt = texts()[0]!;
+    assert.ok(stmt.includes("ON CONFLICT (day, netuid, kind, classification)"));
+    assert.equal(/ifnull/i.test(stmt), false);
+  });
+
+  test("one statement per day, both rollups", async () => {
+    const two = [...DAYS, { date: "2026-08-07", start: 0, end: 1000 }];
+    const a = recordingSql();
+    await rollupUptimeDailyToNeon(a.sql, two, 900);
+    assert.equal(a.calls.length, 2);
+    const b = recordingSql();
+    await rollupFailureReasonsToNeon(b.sql, two, 900);
+    assert.equal(b.calls.length, 2);
+  });
+});
+
+describe("subnet_snapshots and the prune", () => {
+  test("the two flags bind as BOOLEANS", async () => {
+    const { sql, calls } = recordingSql();
+    await upsertSubnetSnapshotsToNeon(sql, [
+      {
+        netuid: 1,
+        snapshot_date: "2026-08-08",
+        emission_enabled: 1,
+        subtoken_enabled: 0,
+      },
+    ]);
+    const v = calls[0]!.values;
+    assert.equal(typeof v[22], "boolean");
+    assert.equal(typeof v[23], "boolean");
+    assert.equal(v[22], true);
+    assert.equal(v[23], false);
+  });
+
+  test("a null flag stays null rather than becoming false", async () => {
+    // null means "not observed"; false means "observed and off". Collapsing
+    // them would publish a claim the chain never made.
+    const { sql, calls } = recordingSql();
+    await upsertSubnetSnapshotsToNeon(sql, [
+      { netuid: 1, snapshot_date: "2026-08-08", emission_enabled: null },
+    ]);
+    assert.equal(calls[0]!.values[22], null);
+  });
+
+  test("the prune deletes by the cutoff it was given", async () => {
+    const { sql, calls } = recordingSql();
+    await pruneChecksNeon(sql, 12345);
+    assert.ok(calls[0]!.text.includes("DELETE FROM surface_checks"));
+    assert.deepEqual(calls[0]!.values, [12345]);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -2228,8 +2228,9 @@ async function dispatchScheduled(
     // sibling lane's failure can silence is an alarm that reports "healthy"
     // for exactly the reason it should be shouting.
     const rpcUsageStaleness = await runRpcUsageStalenessWatchdog(env);
-    const uptimeRollup = await rollupDailyUptime(env);
+    const uptimeRollup = await rollupDailyUptime(env, { ctx });
     const snapshotPromise = writeSubnetSnapshot(env, {
+      ctx,
       readArtifact: readArtifact as unknown as (
         env: Env,
         path: string,
@@ -2252,6 +2253,7 @@ async function dispatchScheduled(
       // this tick (see pruneHealthHistory's pruneD1Checks comment) -- the
       // combined `rolled` only proves SOME store aggregated the day.
       pruneHealthHistory(env, {
+        ctx,
         pruneD1Checks:
           (uptimeRollup as { d1_rolled?: boolean }).d1_rolled === true,
       }).catch(() => ({ pruned: false })),


### PR DESCRIPTION
Closes #10069

Five tables in one diff because they are one unit: rollupUptimeDailyToNeon and
rollupFailureReasonsToNeon are INSERT ... SELECT FROM surface_checks, so they
aggregate INSIDE the store. The moment surface_checks stops being written to D1,
a rollup left behind aggregates an empty window and reports success -- a
schema-stable empty, not an error. neonOwnsObservations is all-or-nothing over
all five for exactly that reason, and a test walks every single-table omission.

SHIPPED INERT. NEON_SOLE_STORE_TABLES names none of these yet, so every call
site still takes the D1 branch and the 756 tests across the health suite pass
unchanged. The flag flip is a separate change, after this has deployed --
#9992's BIGINT divergence was caught only because the parser landed before the
flag that would have exposed it.

Three things did not survive a naive port, each verified against Neon rather
than reasoned about:

- CAST(x AS INTEGER) TRUNCATES in SQLite and ROUNDS in Postgres: CAST(1.7) is 1
  there and 2 here, CAST(2.5) is 2 and 3. The percentile pick is SQLite's
  missing ceil written as trunc-plus-carry. Its boolean-add half errors in
  Postgres, but the CAST half would NOT -- it would return a confidently wrong
  rank. Replaced with ceil(q * lat_cnt)::int, verified identical to the SQLite
  expression at lat_cnt 1, 3, 7, 20 and 100 across all three quantiles.
- surface_checks.ok is INTEGER 0/1 in D1 and BOOLEAN in Neon, so SUM(ok) and
  `ok = 1` are type errors. Counting moves to COUNT(*) FILTER (WHERE ok).
- ROUND(x, 4) has no double-precision overload, so the ratio rounds as numeric.

ifnull(netuid, -1) needed no translation at all: Neon's index is already
(day, netuid, kind, classification) NULLS NOT DISTINCT, the native form of the
expression-index trick SQLite forced.

THE RENAME. surface_status's upsert names TWO conflict targets and Postgres
permits exactly one per statement. Splitting rows by whether surface_key is
present almost works and fails on the one case the second arbiter was added for
(#1005): a keyed row whose surface_id already exists under a different key
raises instead of updating. So the rename is resolved FIRST -- the key's row
adopts the new surface_id -- leaving a single arbiter with nothing to collide
on. Verified on a branch: one row, new id, and last_ok preserved through the
COALESCE, so #9634's high-water mark survives.

The whole rollup was run against production surface_checks: p50 < p95 < p99 on
every surface, 2645/2650 -> 0.9981 degraded, and a 2650/2650 surface -> exactly
1.0/ok rather than tripping the sub-1.0 clamp.

ctx is threaded into rollupDailyUptime, pruneHealthHistory and
writeSubnetSnapshot rather than faked. createPgSql returns the pooled
connection through ctx.waitUntil, so a shim would leak one per sweep; absent
ctx keeps the family on D1 instead.