### PR TITLE
fix(neon): the last two pass ledgers, before their lanes invert (#10056)

### DIFF
--- a/src/ledger-neon-write.ts
+++ b/src/ledger-neon-write.ts
@@ -27,6 +27,11 @@
 // silent regression -- both writes would otherwise succeed.
 
 import {
+  PASS_TABLES,
+  writePassTallyToNeon,
+  type PassTallyInput,
+} from "./pass-completeness.ts";
+import {
   neonDualWriteEnabled,
   recordNeonWriteVerdict,
   writeRowsToNeon,
@@ -127,6 +132,13 @@ export async function mirrorLedgerToNeon(
   lane: string,
   rows: Record<string, unknown>[],
   deps: LedgerMirrorDeps = {},
+  /** This chunk's completeness tally, when the producer declared a pass and
+   * the lane has a table in PASS_TABLES (#10056).
+   *
+   * A SIXTH PARAMETER rather than a field on `deps`, because deps is for
+   * injectables a test swaps out and this is data the producer sent. Optional,
+   * so the lanes with no pass table call this exactly as before. */
+  pass?: PassTallyInput | null,
 ): Promise<{ attempted: boolean; result?: NeonWriteResult }> {
   const plan = LEDGER_MIRROR_PLANS[lane];
   // An unknown lane is a NO-OP rather than a throw, and deliberately so: the
@@ -163,5 +175,28 @@ export async function mirrorLedgerToNeon(
     plan.filter,
   );
   await recordNeonWriteVerdict(laneDb, lane, result, now());
+
+  // THE TALLY GOES LAST, AND ONLY IF THE ROWS LANDED (#10056).
+  //
+  // D1 gets this ordering free by appending the tally to the same batch. Here
+  // it is explicit: a pass marked complete whose rows did not land is the one
+  // failure this ledger exists to make impossible, and it is never revisited,
+  // whereas withholding it costs nothing because the next chunk re-sends.
+  if (pass && PASS_TABLES[lane]) {
+    const tally = result.ok
+      ? await writePassTallyToNeon(sql, lane, pass)
+      : { ok: false, reason: "rows did not land; tally withheld" };
+    await recordNeonWriteVerdict(
+      laneDb,
+      `${lane}-pass`,
+      {
+        ok: tally.ok,
+        rows: tally.ok ? 1 : 0,
+        statements: 1,
+        ...(tally.reason ? { reason: tally.reason } : {}),
+      },
+      now(),
+    );
+  }
   return { attempted: true, result };
 }

--- a/src/nominator-positions-neon-write.ts
+++ b/src/nominator-positions-neon-write.ts
@@ -25,6 +25,10 @@
 // tick -- never delete a position without having written its replacement first.
 
 import {
+  writePassTallyToNeon,
+  type PassTallyInput,
+} from "./pass-completeness.ts";
+import {
   neonDualWriteEnabled,
   pruneKeysInNeon,
   recordNeonWriteVerdict,
@@ -73,7 +77,13 @@ export interface NominatorPositionsMirrorDeps {
 export async function mirrorNominatorPositionsToNeon(
   env: Record<string, unknown> | null | undefined,
   ctx: WaitUntilLike | null | undefined,
-  input: { rows: Row[]; coldkeyMaxCapturedAt: ReadonlyMap<string, number> },
+  input: {
+    rows: Row[];
+    coldkeyMaxCapturedAt: ReadonlyMap<string, number>;
+    /** This chunk's completeness tally (#10056). Written last, and only when
+     * both the upsert and the prune succeeded -- see below. */
+    pass?: PassTallyInput | null;
+  },
   deps: NominatorPositionsMirrorDeps = {},
 ): Promise<NominatorPositionsMirrorOutcome> {
   if (!neonDualWriteEnabled(env, NOMINATOR_POSITIONS_NEON_LANE)) {
@@ -140,5 +150,30 @@ export async function mirrorNominatorPositionsToNeon(
     prune,
     now(),
   );
+
+  // AFTER THE PRUNE, not just after the upsert. This lane's pass is only
+  // whole once the stale rows are gone: a tally written between the two would
+  // declare a complete pass over a table that still holds superseded
+  // positions, which is the state the prune exists to end.
+  if (input.pass) {
+    const tally = prune.ok
+      ? await writePassTallyToNeon(
+          sql,
+          NOMINATOR_POSITIONS_NEON_LANE,
+          input.pass,
+        )
+      : { ok: false, reason: "prune did not land; tally withheld" };
+    await recordNeonWriteVerdict(
+      laneDb,
+      `${NOMINATOR_POSITIONS_NEON_LANE}-pass`,
+      {
+        ok: tally.ok,
+        rows: tally.ok ? 1 : 0,
+        statements: 1,
+        ...(tally.reason ? { reason: tally.reason } : {}),
+      },
+      now(),
+    );
+  }
   return { attempted: true, write, prune };
 }

--- a/tests/passes-remaining-lanes.test.ts
+++ b/tests/passes-remaining-lanes.test.ts
@@ -1,0 +1,158 @@
+// The two lanes that could invert next, and the ledger that would have frozen
+// when they did (#10056).
+//
+// nominator_positions and validator_nominator_counts are at exact parity with
+// D1 on both count AND watermark, so they are the next inversions. Both call
+// passTallyStatement inside the same D1 batch as their rows, which is precisely
+// how neurons_passes froze the moment #10045 skipped that batch. Wiring their
+// tallies is the precondition, not a follow-up.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+import { mirrorLedgerToNeon } from "../src/ledger-neon-write.ts";
+import { mirrorNominatorPositionsToNeon } from "../src/nominator-positions-neon-write.ts";
+import { PASS_TABLES } from "../src/pass-completeness.ts";
+
+const PASS = {
+  capturedAt: 1786106225624,
+  expectedRows: 100,
+  receivedRows: 100,
+  nowMs: 1786106230000,
+};
+const ctx = { waitUntil: () => undefined } as never;
+
+function recordingSql(fail?: RegExp) {
+  const calls: string[] = [];
+  return {
+    calls,
+    sql: {
+      unsafe: async (text: string) => {
+        calls.push(text);
+        if (fail?.test(text)) throw new Error("boom");
+        return [];
+      },
+    },
+  };
+}
+
+describe("validator-nominator-counts", () => {
+  const env = {
+    NEON_DUAL_WRITE_LANES: "validator-nominator-counts",
+    HYPERDRIVE: { connectionString: "postgresql://x" },
+  };
+  const rows = [{ hotkey: "h", captured_at: 1 }];
+
+  test("the tally lands, and AFTER the rows", async () => {
+    const { calls, sql } = recordingSql();
+    await mirrorLedgerToNeon(
+      env,
+      ctx,
+      "validator-nominator-counts",
+      rows,
+      { sql, laneHealthDb: null },
+      PASS,
+    );
+    const tallyAt = calls.findIndex((c) =>
+      c.includes("INSERT INTO validator_nominator_counts_passes"),
+    );
+    const rowsAt = calls.findIndex((c) =>
+      c.includes("INSERT INTO validator_nominator_counts "),
+    );
+    assert.ok(rowsAt >= 0, "no row insert to order against");
+    assert.ok(tallyAt > rowsAt, "the tally was written before its rows");
+  });
+
+  test("NO tally when the rows failed", async () => {
+    const { calls, sql } = recordingSql(
+      /INSERT INTO validator_nominator_counts /,
+    );
+    await mirrorLedgerToNeon(
+      env,
+      ctx,
+      "validator-nominator-counts",
+      rows,
+      { sql, laneHealthDb: null },
+      PASS,
+    );
+    assert.equal(
+      calls.some((c) => c.includes("_passes")),
+      false,
+      "a tally was written for rows that never landed",
+    );
+  });
+
+  test("a lane with no pass table writes no tally", async () => {
+    // hotkey-alpha and account-balances share this mirror but keep their own
+    // bespoke ledgers with extra columns, so PASS_TABLES gates them out.
+    assert.equal(PASS_TABLES["hotkey-alpha"], undefined);
+    const { calls, sql } = recordingSql();
+    await mirrorLedgerToNeon(
+      { ...env, NEON_DUAL_WRITE_LANES: "hotkey-alpha" },
+      ctx,
+      "hotkey-alpha",
+      [{ hotkey: "h", netuid: 1, captured_at: 1 }],
+      { sql, laneHealthDb: null },
+      PASS,
+    );
+    assert.equal(
+      calls.some((c) => c.includes("_passes")),
+      false,
+    );
+  });
+});
+
+describe("nominator-positions", () => {
+  const env = {
+    NEON_DUAL_WRITE_LANES: "nominator-positions",
+    HYPERDRIVE: { connectionString: "postgresql://x" },
+  };
+  const input = {
+    rows: [{ coldkey: "c", hotkey: "h", netuid: 1, captured_at: 5 }],
+    coldkeyMaxCapturedAt: new Map([["c", 5]]),
+  };
+
+  test("the tally lands AFTER the prune, not merely after the upsert", async () => {
+    // This lane's pass is only whole once superseded positions are gone. A
+    // tally written between upsert and prune would declare a complete pass
+    // over a table that still holds stale rows.
+    const { calls, sql } = recordingSql();
+    await mirrorNominatorPositionsToNeon(
+      env,
+      ctx,
+      { ...input, pass: PASS },
+      { sql, laneHealthDb: null },
+    );
+    const tallyAt = calls.findIndex((c) =>
+      c.includes("INSERT INTO nominator_positions_passes"),
+    );
+    const pruneAt = calls.findIndex((c) => c.includes("DELETE FROM"));
+    assert.ok(pruneAt >= 0, "no prune to order against");
+    assert.ok(tallyAt > pruneAt, "the tally was written before the prune");
+  });
+
+  test("NO tally when the prune failed", async () => {
+    const { calls, sql } = recordingSql(/DELETE FROM/);
+    await mirrorNominatorPositionsToNeon(
+      env,
+      ctx,
+      { ...input, pass: PASS },
+      { sql, laneHealthDb: null },
+    );
+    assert.equal(
+      calls.some((c) => c.includes("_passes")),
+      false,
+    );
+  });
+
+  test("no pass declared means no tally", async () => {
+    const { calls, sql } = recordingSql();
+    await mirrorNominatorPositionsToNeon(env, ctx, input, {
+      sql,
+      laneHealthDb: null,
+    });
+    assert.equal(
+      calls.some((c) => c.includes("_passes")),
+      false,
+    );
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -1945,6 +1945,9 @@ async function handleValidatorNominatorCountsSync(
     ctx,
     "validator-nominator-counts",
     rows,
+    {},
+    // The tally follows the rows into whichever store holds them (#10056).
+    pass,
   );
 
   return writeJson({
@@ -2182,7 +2185,7 @@ async function handleNominatorPositionsSync(
   await mirrorNominatorPositionsToNeon(
     env as unknown as Record<string, unknown>,
     ctx,
-    { rows, coldkeyMaxCapturedAt: cutoffs },
+    { rows, coldkeyMaxCapturedAt: cutoffs, pass },
   );
 
   return writeJson({
@@ -7973,7 +7976,7 @@ export default {
             await mirrorNominatorPositionsToNeon(
               env as unknown as Record<string, unknown>,
               ctx,
-              { rows, coldkeyMaxCapturedAt: cutoffs },
+              { rows, coldkeyMaxCapturedAt: cutoffs, pass },
             );
             return result;
           },
@@ -8020,6 +8023,8 @@ export default {
               ctx,
               "validator-nominator-counts",
               rows,
+              {},
+              pass,
             );
             return result;
           },


### PR DESCRIPTION
Refs #10056

nominator_positions and validator_nominator_counts are the next lanes to
invert: measured 2026-08-08 they are at EXACT parity with D1 on both count and
watermark -- 123,511/123,511 and 112,250/112,250, same max(captured_at) on each
side. Nothing else in the migration is that clean.

Both would have taken their pass ledgers down with them. Each calls
passTallyStatement inside the same db.batch as its rows, which is exactly how
neurons_passes froze the moment #10045 skipped that batch: the tally is batched
with the rows deliberately, so that it cannot report a pass complete whose rows
never landed, and that same coupling is what carries it over the cliff. Wiring
these is the precondition for the inversion, not a follow-up to it.

Both mirrors now take the tally and write it LAST, and only if the work before
it succeeded:

- mirrorLedgerToNeon gains an optional sixth parameter rather than a field on
  `deps`, because deps is for injectables a test swaps out and this is data the
  producer sent. Guarded on PASS_TABLES, so hotkey-alpha and account-balances --
  which share this mirror but keep their own bespoke ledgers with extra columns
  (scanned, outcome) -- are gated out rather than writing to a table that does
  not match their shape.
- mirrorNominatorPositionsToNeon writes its tally AFTER THE PRUNE, not merely
  after the upsert. This lane's pass is only whole once superseded positions
  are gone; a tally written between the two would declare a complete pass over
  a table that still holds stale rows.

All four writers are covered. Both lanes have two -- the HTTP path and the
sync-batches queue consumer -- and #9728 is the precedent for why that matters:
a mirror covering one of two writers is a lie the moment traffic takes the
other.