### PR TITLE
feat(neon): mirror the four chain_detail tables (#9787)

### DIFF
--- a/src/chain-detail-neon-write.ts
+++ b/src/chain-detail-neon-write.ts
@@ -1,0 +1,207 @@
+// The chain-detail lane's Neon mirror (#9787).
+//
+// Four tables written by one producer pass, so they mirror as one unit and in
+// the SAME ORDER the D1 writer uses. That order is load-bearing rather than
+// incidental: `chain_detail_blocks` is the COVERAGE REGISTER -- it is what says
+// "this block's detail is stored" -- so it goes LAST, after the rows it
+// vouches for. Written first, a failure below it would leave the register
+// claiming coverage for detail that is not there, and nothing downstream
+// re-derives that; it would simply read as a block with no extrinsics.
+//
+// Same shape as the neurons mirror, and deliberately so -- it runs AFTER the D1
+// write returns, never instead of it, and never throws past its own boundary.
+// While D1 is still the store the routes read, a Neon failure costs a mirror
+// and a lane verdict and nothing else.
+import {
+  neonDualWriteEnabled,
+  recordNeonWriteVerdict,
+  writeRowsToNeon,
+  type NeonWriteResult,
+} from "./neon-write.ts";
+import {
+  CHAIN_DETAIL_ACCOUNT_EVENT_COLUMNS,
+  CHAIN_DETAIL_BLOCK_COLUMNS,
+  CHAIN_DETAIL_CHAIN_EVENT_COLUMNS,
+  CHAIN_DETAIL_CONFLICT_KEYS,
+  CHAIN_DETAIL_EXTRINSIC_COLUMNS,
+} from "./chain-detail-d1-write.ts";
+import {
+  createPgSql,
+  type HyperdriveLike,
+  type WaitUntilLike,
+} from "./pg-sql.ts";
+import type { LaneHealthDb } from "./lane-health.ts";
+
+/** The lane name this mirror answers to in NEON_DUAL_WRITE_LANES. */
+export const CHAIN_DETAIL_NEON_LANE = "chain-detail";
+
+type Row = Record<string, unknown>;
+
+interface DetailPlan {
+  table: string;
+  columns: readonly string[];
+  conflict: readonly string[];
+  /** Columns that are 0/1 INTEGER in D1 and BOOLEAN in Neon.
+   *
+   * `success` is the only one, and it is NULLABLE unlike every other boolean in
+   * the schema -- an extrinsic whose outcome was not decoded is genuinely
+   * unknown, which is a third state that must not collapse to false. */
+  booleans?: readonly string[];
+}
+
+/**
+ * In WRITE ORDER, and the object literal's order is what the loop below
+ * follows. blocks last -- see this module's header.
+ */
+export const CHAIN_DETAIL_MIRROR_PLANS: readonly DetailPlan[] = [
+  {
+    table: "chain_detail_extrinsics",
+    columns: CHAIN_DETAIL_EXTRINSIC_COLUMNS,
+    conflict: CHAIN_DETAIL_CONFLICT_KEYS.chain_detail_extrinsics,
+    booleans: ["success"],
+  },
+  {
+    table: "chain_detail_chain_events",
+    columns: CHAIN_DETAIL_CHAIN_EVENT_COLUMNS,
+    conflict: CHAIN_DETAIL_CONFLICT_KEYS.chain_detail_chain_events,
+  },
+  {
+    table: "chain_detail_account_events",
+    columns: CHAIN_DETAIL_ACCOUNT_EVENT_COLUMNS,
+    conflict: CHAIN_DETAIL_CONFLICT_KEYS.chain_detail_account_events,
+  },
+  {
+    table: "chain_detail_blocks",
+    columns: CHAIN_DETAIL_BLOCK_COLUMNS,
+    conflict: CHAIN_DETAIL_CONFLICT_KEYS.chain_detail_blocks,
+  },
+];
+
+export interface ChainDetailMirrorInput {
+  blockRows: Row[];
+  extrinsicRows: Row[];
+  chainEventRows: Row[];
+  accountEventRows: Row[];
+}
+
+export interface ChainDetailMirrorOutcome {
+  attempted: boolean;
+  results: Record<string, NeonWriteResult>;
+}
+
+export interface ChainDetailMirrorDeps {
+  sql?: { unsafe(text: string, values?: unknown[]): Promise<unknown> } | null;
+  laneHealthDb?: LaneHealthDb | null;
+  now?: () => number;
+}
+
+/**
+ * D1 stores these flags as 0/1 with a CHECK; Neon's columns are BOOLEAN, and
+ * binding a number to one is a type error rather than a coercion.
+ *
+ * null is PRESERVED. `success` is nullable because an undecoded outcome is
+ * unknown, and `Boolean(null)` would publish "it failed" -- a claim the chain
+ * never made.
+ */
+function coerceBooleans(rows: Row[], booleans?: readonly string[]): Row[] {
+  if (!booleans?.length || !rows.length) return rows;
+  return rows.map((row) => {
+    const out: Row = { ...row };
+    for (const key of booleans) {
+      if (out[key] != null) out[key] = Boolean(out[key]);
+    }
+    return out;
+  });
+}
+
+/**
+ * Mirror one chain-detail batch into Neon. Never throws.
+ *
+ * Sequential rather than parallel: the four share one Hyperdrive connection,
+ * and the write order is the point.
+ */
+export async function mirrorChainDetailToNeon(
+  env: Record<string, unknown> | null | undefined,
+  ctx: WaitUntilLike | null | undefined,
+  input: ChainDetailMirrorInput,
+  deps: ChainDetailMirrorDeps = {},
+): Promise<ChainDetailMirrorOutcome> {
+  if (!neonDualWriteEnabled(env, CHAIN_DETAIL_NEON_LANE)) {
+    return { attempted: false, results: {} };
+  }
+
+  const hyperdrive = env?.HYPERDRIVE as HyperdriveLike | undefined;
+  const sql =
+    deps.sql ??
+    (hyperdrive?.connectionString && ctx ? createPgSql(hyperdrive, ctx) : null);
+  const laneDb =
+    deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as LaneHealthDb | undefined);
+  const now = deps.now ?? Date.now;
+
+  if (!sql) {
+    // Enabled but unbound is a MISCONFIGURATION, not a quiet no-op.
+    await recordNeonWriteVerdict(
+      laneDb,
+      CHAIN_DETAIL_NEON_LANE,
+      { ok: false, rows: 0, statements: 0, reason: "hyperdrive unbound" },
+      now(),
+    );
+    return { attempted: true, results: {} };
+  }
+
+  const byTable: Record<string, Row[]> = {
+    chain_detail_extrinsics: input.extrinsicRows,
+    chain_detail_chain_events: input.chainEventRows,
+    chain_detail_account_events: input.accountEventRows,
+    chain_detail_blocks: input.blockRows,
+  };
+
+  const results: Record<string, NeonWriteResult> = {};
+  for (const plan of CHAIN_DETAIL_MIRROR_PLANS) {
+    // THE REGISTER DOES NOT VOUCH FOR ROWS THAT DID NOT LAND. blocks is last,
+    // and skipped outright when any detail table failed -- a coverage row over
+    // missing detail reads downstream as "this block genuinely had no
+    // extrinsics", which is indistinguishable from the truth and never
+    // revisited. Withholding it costs nothing: the producer resumes from the
+    // head the register reports, so the block is simply re-sent.
+    if (
+      plan.table === "chain_detail_blocks" &&
+      Object.values(results).some((r) => !r.ok)
+    ) {
+      results[plan.table] = {
+        ok: false,
+        rows: 0,
+        statements: 0,
+        reason: "detail did not land; coverage register withheld",
+      };
+      continue;
+    }
+    const result = await writeRowsToNeon(
+      sql,
+      plan.table,
+      plan.columns,
+      coerceBooleans(byTable[plan.table] ?? [], plan.booleans),
+      plan.conflict,
+    );
+    results[plan.table] = result;
+  }
+
+  // One verdict for the batch: these are written by one pass, and a reader
+  // wants "did this batch land", not four half-answers.
+  const all = Object.values(results);
+  const failed = all.filter((r) => !r.ok);
+  await recordNeonWriteVerdict(
+    laneDb,
+    CHAIN_DETAIL_NEON_LANE,
+    {
+      ok: failed.length === 0,
+      rows: all.reduce((n, r) => n + (r.rows ?? 0), 0),
+      statements: all.reduce((n, r) => n + (r.statements ?? 0), 0),
+      ...(failed.length > 0
+        ? { reason: failed.map((r) => r.reason ?? "failed").join("; ") }
+        : {}),
+    },
+    now(),
+  );
+  return { attempted: true, results };
+}

--- a/src/neon-mirror-watchdog.ts
+++ b/src/neon-mirror-watchdog.ts
@@ -54,6 +54,7 @@ import { neonDualWriteLanes } from "./neon-write.ts";
 import { LEDGER_MIRROR_PLANS } from "./ledger-neon-write.ts";
 import { NEURON_MIRROR_PLANS } from "./neurons-neon-write.ts";
 import { NOMINATOR_POSITIONS_NEON_LANE } from "./nominator-positions-neon-write.ts";
+import { CHAIN_DETAIL_NEON_LANE } from "./chain-detail-neon-write.ts";
 import { FAMILY_MIRROR_PLANS } from "./hyperparams-identity-neon-write.ts";
 import {
   loadLatestLaneHealth,
@@ -113,6 +114,10 @@ export const MIRROR_LANE_TABLES: Readonly<Record<string, string>> = {
     ]),
   ),
   [NOMINATOR_POSITIONS_NEON_LANE]: "nominator_positions",
+  // The coverage register, not one of the three detail tables: it is the one
+  // this lane writes LAST, so it is the one whose freshness means the whole
+  // batch landed.
+  [CHAIN_DETAIL_NEON_LANE]: "chain_detail_blocks",
 };
 
 /** The minimal D1 surface this needs, so a test can hand it a fake. */
@@ -144,9 +149,34 @@ export interface MirrorLag {
 export function mirrorFreshnessSql(tables: readonly string[]): string {
   return tables
     .map(
-      (table) => `SELECT '${table}' AS t, MAX(captured_at) AS mx FROM ${table}`,
+      (table) =>
+        `SELECT '${table}' AS t, MAX(${freshnessColumn(table)}) AS mx FROM ${table}`,
     )
     .join(" UNION ALL ");
+}
+
+/**
+ * Which column carries "when was this row last written", per table.
+ *
+ * `captured_at` for everything the producers stamp, which is nearly all of
+ * them -- so this is an OVERRIDE LIST rather than a full map, and a table
+ * absent from it keeps the default.
+ *
+ * chain_detail_* are the exception: they record `observed_at` (when the chain
+ * produced the block) and `synced_at`, and have no captured_at at all. Naming
+ * them here without this would have made the watchdog query fail on a missing
+ * column -- which for THIS watchdog means the check built to catch a frozen
+ * mirror is itself the thing that stops reporting.
+ */
+const FRESHNESS_COLUMNS: Readonly<Record<string, string>> = {
+  chain_detail_blocks: "observed_at",
+  chain_detail_extrinsics: "observed_at",
+  chain_detail_chain_events: "observed_at",
+  chain_detail_account_events: "observed_at",
+};
+
+export function freshnessColumn(table: string): string {
+  return FRESHNESS_COLUMNS[table] ?? "captured_at";
 }
 
 export interface MirrorSurvey {

--- a/tests/chain-detail-neon-write.test.ts
+++ b/tests/chain-detail-neon-write.test.ts
@@ -1,0 +1,173 @@
+// The chain-detail mirror (#9787).
+//
+// Four tables, one producer pass, and an ORDER that is load-bearing:
+// chain_detail_blocks is the coverage register -- the thing that says "this
+// block's detail is stored" -- so it goes last and is withheld entirely when
+// any detail table failed. A register over missing detail reads downstream as
+// "this block genuinely had no extrinsics", which is indistinguishable from the
+// truth and is never revisited.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+import {
+  CHAIN_DETAIL_MIRROR_PLANS,
+  CHAIN_DETAIL_NEON_LANE,
+  mirrorChainDetailToNeon,
+} from "../src/chain-detail-neon-write.ts";
+
+const env = {
+  NEON_DUAL_WRITE_LANES: CHAIN_DETAIL_NEON_LANE,
+  HYPERDRIVE: { connectionString: "postgresql://x" },
+};
+const ctx = { waitUntil: () => undefined } as never;
+
+function recordingSql(fail?: RegExp) {
+  const calls: { text: string; values: unknown[] }[] = [];
+  return {
+    calls,
+    texts: () => calls.map((c) => c.text),
+    sql: {
+      unsafe: async (text: string, values: unknown[] = []) => {
+        calls.push({ text, values });
+        if (fail?.test(text)) throw new Error("boom");
+        return [];
+      },
+    },
+  };
+}
+
+const input = {
+  blockRows: [{ block_number: 10 }],
+  extrinsicRows: [{ block_number: 10, extrinsic_index: 0, success: 1 }],
+  chainEventRows: [{ block_number: 10, event_index: 0 }],
+  accountEventRows: [{ block_number: 10, event_index: 0 }],
+};
+
+describe("write order", () => {
+  test("the coverage register is written LAST", async () => {
+    const { sql, texts } = recordingSql();
+    await mirrorChainDetailToNeon(env, ctx, input, {
+      sql,
+      laneHealthDb: null,
+    });
+    const t = texts();
+    const blocksAt = t.findIndex((x) => x.includes("INTO chain_detail_blocks"));
+    assert.ok(blocksAt >= 0, "the register was never written");
+    for (const table of [
+      "chain_detail_extrinsics",
+      "chain_detail_chain_events",
+      "chain_detail_account_events",
+    ]) {
+      const at = t.findIndex((x) => x.includes(`INTO ${table}`));
+      assert.ok(at >= 0, `${table} was not written`);
+      assert.ok(at < blocksAt, `${table} was written after the register`);
+    }
+  });
+
+  test("the register is WITHHELD when any detail table failed", async () => {
+    const { sql, texts } = recordingSql(/chain_detail_chain_events/);
+    const out = await mirrorChainDetailToNeon(env, ctx, input, {
+      sql,
+      laneHealthDb: null,
+    });
+    assert.equal(
+      texts().some((t) => t.includes("INTO chain_detail_blocks")),
+      false,
+      "coverage was claimed over detail that did not land",
+    );
+    assert.equal(out.results.chain_detail_blocks?.ok, false);
+    assert.match(
+      out.results.chain_detail_blocks?.reason ?? "",
+      /register withheld/,
+    );
+  });
+
+  test("the declared plans are the four tables, register last", () => {
+    assert.deepEqual(
+      CHAIN_DETAIL_MIRROR_PLANS.map((p) => p.table),
+      [
+        "chain_detail_extrinsics",
+        "chain_detail_chain_events",
+        "chain_detail_account_events",
+        "chain_detail_blocks",
+      ],
+    );
+  });
+});
+
+describe("the nullable boolean", () => {
+  test("success binds as a BOOLEAN, not 0/1", async () => {
+    // D1 stores it 0/1 with a CHECK; Neon's column is BOOLEAN and a number is
+    // a type error there, not a coercion.
+    const { sql, calls } = recordingSql();
+    await mirrorChainDetailToNeon(env, ctx, input, {
+      sql,
+      laneHealthDb: null,
+    });
+    const ext = calls.find((c) => c.text.includes("chain_detail_extrinsics"))!;
+    assert.ok(
+      ext.values.includes(true),
+      "success 1 did not become boolean true",
+    );
+    assert.equal(
+      ext.values.includes(1),
+      false,
+      "a 0/1 flag reached a BOOLEAN column",
+    );
+  });
+
+  test("a NULL success stays null, never false", async () => {
+    // An undecoded outcome is UNKNOWN -- a third state. Boolean(null) would
+    // publish "it failed", a claim the chain never made.
+    const { sql, calls } = recordingSql();
+    await mirrorChainDetailToNeon(
+      env,
+      ctx,
+      {
+        ...input,
+        extrinsicRows: [
+          { block_number: 10, extrinsic_index: 0, success: null },
+        ],
+      },
+      { sql, laneHealthDb: null },
+    );
+    const ext = calls.find((c) => c.text.includes("chain_detail_extrinsics"))!;
+    assert.ok(ext.values.includes(null));
+    assert.equal(ext.values.includes(false), false);
+  });
+});
+
+describe("gating", () => {
+  test("off unless the flag names the lane", async () => {
+    const { sql, calls } = recordingSql();
+    const out = await mirrorChainDetailToNeon(
+      { ...env, NEON_DUAL_WRITE_LANES: "neurons" },
+      ctx,
+      input,
+      { sql, laneHealthDb: null },
+    );
+    assert.equal(out.attempted, false);
+    assert.equal(calls.length, 0);
+  });
+
+  test("enabled but unbound is a verdict, not silence", async () => {
+    const out = await mirrorChainDetailToNeon(
+      { NEON_DUAL_WRITE_LANES: CHAIN_DETAIL_NEON_LANE },
+      ctx,
+      input,
+      { laneHealthDb: null },
+    );
+    assert.equal(out.attempted, true);
+    assert.deepEqual(out.results, {});
+  });
+
+  test("never throws when the store does", async () => {
+    const { sql } = recordingSql(/./);
+    const out = await mirrorChainDetailToNeon(env, ctx, input, {
+      sql,
+      laneHealthDb: null,
+    });
+    assert.equal(out.attempted, true);
+    assert.ok(Object.values(out.results).some((r) => !r.ok));
+  });
+});

--- a/tests/neon-parity-watchdog.test.ts
+++ b/tests/neon-parity-watchdog.test.ts
@@ -566,11 +566,26 @@ describe("the deployed wiring", () => {
   test("every mirrored or backfilled table is watched", () => {
     // The gap this lane exists to close: a table written to both stores with
     // nothing comparing them. Anything named in either flag must be here.
+    // A LANE IS NOT ALWAYS A TABLE. Most mirror lanes are named after the one
+    // table they write, so hyphen-to-underscore resolves them -- but a lane
+    // that writes a FAMILY is not, and `chain-detail` would resolve to
+    // `chain_detail`, which does not exist. Munging the name was only ever a
+    // shortcut for the common case; the lanes that write several tables
+    // declare them, so ask the declaration first and fall back to the shortcut.
+    const LANE_TABLES: Readonly<Record<string, readonly string[]>> = {
+      "chain-detail": [
+        "chain_detail_blocks",
+        "chain_detail_extrinsics",
+        "chain_detail_chain_events",
+        "chain_detail_account_events",
+      ],
+    };
     const named = (re: RegExp) =>
       (re.exec(wrangler)?.[1] ?? "")
         .split(",")
-        .map((s) => s.trim().replace(/-/g, "_"))
-        .filter(Boolean);
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .flatMap((lane) => LANE_TABLES[lane] ?? [lane.replace(/-/g, "_")]);
     const watched = new Set<string>(PARITY_TABLES);
     for (const t of [
       ...named(/"NEON_DUAL_WRITE_LANES":\s*"([^"]*)"/),

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -378,6 +378,7 @@ import {
   writeNeuronSnapshotToD1,
 } from "../src/neurons-d1-write.ts";
 import { mirrorNeuronSnapshotToNeon } from "../src/neurons-neon-write.ts";
+import { mirrorChainDetailToNeon } from "../src/chain-detail-neon-write.ts";
 import {
   ACCOUNT_IDENTITY_NEON_LANE,
   SUBNET_HYPERPARAMS_NEON_LANE,
@@ -908,7 +909,11 @@ function chainDetailSyncAuth(request: Request, env: Env): Response | null {
   return null;
 }
 
-async function handleChainDetailSync(request: Request, env: Env) {
+async function handleChainDetailSync(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+) {
   const denied = chainDetailSyncAuth(request, env);
   if (denied) return denied;
 
@@ -994,6 +999,14 @@ async function handleChainDetailSync(request: Request, env: Env) {
       >[0],
       batch.rows,
     ));
+    // ONE OF THIS LANE'S TWO WRITERS. The sync-batches queue consumer is the
+    // other and mirrors too -- #9728 is the precedent for why covering one of
+    // two is worse than covering neither: the row count looks nearly right.
+    await mirrorChainDetailToNeon(
+      env as unknown as Record<string, unknown>,
+      ctx,
+      batch.rows as unknown as Parameters<typeof mirrorChainDetailToNeon>[2],
+    );
   } catch (err) {
     console.error("data-api chain-detail-sync D1 write failed:", err);
     await captureDataApiError(err, "chain-detail-sync-d1", env);
@@ -7284,7 +7297,7 @@ async function dispatchDataApiRequest(
       request.method === "POST" &&
       url.pathname === "/api/v1/internal/chain-detail-sync"
     ) {
-      return handleChainDetailSync(request, env);
+      return handleChainDetailSync(request, env, ctx);
     }
     if (
       request.method === "GET" &&
@@ -7920,18 +7933,28 @@ export default {
     // hand-off rather than four writes.
     const familyWriters: SyncBatchFamilyWriters = env.METAGRAPH_HEALTH_DB
       ? {
-          "chain-detail": (families) =>
-            writeChainDetailToD1(
+          "chain-detail": async (families) => {
+            const rows = {
+              blockRows: families.blockRows ?? [],
+              extrinsicRows: families.extrinsicRows ?? [],
+              chainEventRows: families.chainEventRows ?? [],
+              accountEventRows: families.accountEventRows ?? [],
+            };
+            const result = await writeChainDetailToD1(
               env.METAGRAPH_HEALTH_DB as unknown as Parameters<
                 typeof writeChainDetailToD1
               >[0],
-              {
-                blockRows: families.blockRows ?? [],
-                extrinsicRows: families.extrinsicRows ?? [],
-                chainEventRows: families.chainEventRows ?? [],
-                accountEventRows: families.accountEventRows ?? [],
-              } as Parameters<typeof writeChainDetailToD1>[1],
-            ),
+              rows as Parameters<typeof writeChainDetailToD1>[1],
+            );
+            // THE LANE'S OTHER WRITER, mirrored here as well as on the HTTP
+            // path.
+            await mirrorChainDetailToNeon(
+              env as unknown as Record<string, unknown>,
+              ctx,
+              rows,
+            );
+            return result;
+          },
         }
       : {};
     const writers: SyncBatchWriters = env.METAGRAPH_HEALTH_DB

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -131,7 +131,7 @@
     // same PRIMARY KEY (netuid, uid, snapshot_date) the mirror's ON CONFLICT
     // names. An ON CONFLICT with no unique index behind it is a runtime error,
     // not a slower query.
-    "NEON_DUAL_WRITE_LANES": "neurons,nominator-positions,account-balances,hotkey-alpha,validator-nominator-counts,subnet-hyperparams,account-identity",
+    "NEON_DUAL_WRITE_LANES": "neurons,nominator-positions,account-balances,hotkey-alpha,validator-nominator-counts,subnet-hyperparams,account-identity,chain-detail",
     // THE CUTOVER (metagraphed-infra#336). `GET /api/v1/accounts/{ss58}/
     // subnets/{netuid}/history` now reads Neon.
     //


### PR DESCRIPTION
Refs #9787

The chain-detail lane had a reconciler and no mirror -- its Neon rows came from
NEON_BACKFILL_LANES alone, which is the same state subnet_hyperparams and
account_identity were in before #10053. A reconciler cannot be the thing a write
path inverts onto.

Both writers are covered: the HTTP sync route and the sync-batches queue
consumer. #9728 is the precedent for why half is worse than none -- the row
count looks nearly right.

THE WRITE ORDER IS THE POINT, and it is preserved from the D1 writer.
chain_detail_blocks is the COVERAGE REGISTER -- it is what says "this block's
detail is stored" -- so it goes last, after the rows it vouches for, AND it is
withheld entirely when any detail table failed. Coverage claimed over missing
detail reads downstream as "this block genuinely had no extrinsics", which is
indistinguishable from the truth and never revisited. Withholding costs nothing:
the producer resumes from the head the register reports, so the block is re-sent.

`success` is the only 0/1-to-BOOLEAN column here and it is NULLABLE, unlike
every other boolean in the schema -- an undecoded outcome is a third state.
Boolean(null) would publish "it failed", so null is preserved rather than
coerced, with a test for each.

TWO CROSS-FILE COUPLINGS this lane exposed, both fixed here rather than left
for the merge to find:

- neon-mirror-watchdog hardcoded MAX(captured_at), and the chain_detail tables
  have no such column -- they carry observed_at. Naming the lane without this
  would have made the watchdog query fail on a missing column, which for THIS
  watchdog means the check built to catch a frozen mirror is itself what stops
  reporting. Freshness is now per-table with captured_at as the default, so it
  is an override list rather than a map to keep in sync.
- neon-parity-watchdog's coverage test derives a table name by replacing
  hyphens with underscores, which works only because most lanes are named after
  the single table they write. `chain-detail` writes four and would have
  resolved to `chain_detail`, which does not exist. Lanes that write a family
  now declare their tables, with the munge kept as the fallback.