### PR TITLE
feat(neon): mirror blocks_head and raw_capture_state (#9787)

### DIFF
--- a/src/capture-state-neon-write.ts
+++ b/src/capture-state-neon-write.ts
@@ -1,0 +1,179 @@
+// blocks_head and raw_capture_state, mirrored into Neon (#9787).
+//
+// Two tables, two different writers, one module: both are the head poller's
+// idea of "how far have we got", and neither is derivable from anything else.
+// blocks_head is the per-block register the firehose fills; raw_capture_state
+// is the single-row-per-network contiguity watermark the backfill resumes from.
+//
+// WHY THE STATEMENTS ARE REUSED RATHER THAN REBUILT. createPgSql's `unsafe`
+// already rewrites SQLite's `?` to `$n` (#9821 added that after six routes
+// served empty because it only existed on one of three paths), and neither
+// statement uses a construct Postgres lacks -- no json_each, no ifnull, no
+// CAST-as-truncation. So the text carries over verbatim and the COALESCE
+// semantics come with it, which matters more here than brevity:
+//
+//   event_count=COALESCE(excluded.event_count, blocks_head.event_count)
+//   author=COALESCE(excluded.author, blocks_head.author)
+//
+// A re-poll that could not read the event count or derive the author must not
+// erase one an earlier tick already stored. Rebuilding these as a generic
+// upsert would silently drop that and replace a known value with NULL -- the
+// same shape as #9634's last_ok, one table over.
+import {
+  neonDualWriteEnabled,
+  recordNeonWriteVerdict,
+  type NeonWriteResult,
+} from "./neon-write.ts";
+import {
+  createPgSql,
+  type HyperdriveLike,
+  type WaitUntilLike,
+} from "./pg-sql.ts";
+import type { LaneHealthDb } from "./lane-health.ts";
+
+export const BLOCKS_HEAD_NEON_LANE = "blocks-head";
+export const RAW_CAPTURE_STATE_NEON_LANE = "raw-capture-state";
+
+export interface CaptureStateSql {
+  unsafe(text: string, values?: unknown[]): Promise<unknown>;
+}
+
+export interface CaptureStateMirrorDeps {
+  sql?: CaptureStateSql | null;
+  laneHealthDb?: LaneHealthDb | null;
+  now?: () => number;
+}
+
+/** Resolve the runner and lane bookkeeping shared by both mirrors. */
+async function runner(
+  env: Record<string, unknown> | null | undefined,
+  ctx: WaitUntilLike | null | undefined,
+  lane: string,
+  deps: CaptureStateMirrorDeps,
+): Promise<{
+  sql: CaptureStateSql | null;
+  laneDb: LaneHealthDb | undefined;
+  now: () => number;
+  attempted: boolean;
+}> {
+  const now = deps.now ?? Date.now;
+  const laneDb =
+    deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as LaneHealthDb | undefined);
+  if (!neonDualWriteEnabled(env, lane)) {
+    return { sql: null, laneDb, now, attempted: false };
+  }
+  const hyperdrive = env?.HYPERDRIVE as HyperdriveLike | undefined;
+  const sql =
+    deps.sql ??
+    (hyperdrive?.connectionString && ctx ? createPgSql(hyperdrive, ctx) : null);
+  if (!sql) {
+    // Enabled but unbound is a MISCONFIGURATION, not a quiet no-op.
+    await recordNeonWriteVerdict(
+      laneDb,
+      lane,
+      { ok: false, rows: 0, statements: 0, reason: "hyperdrive unbound" },
+      now(),
+    );
+  }
+  return { sql, laneDb, now, attempted: true };
+}
+
+async function record(
+  laneDb: LaneHealthDb | undefined,
+  lane: string,
+  rows: number,
+  now: () => number,
+  run: () => Promise<unknown>,
+): Promise<NeonWriteResult> {
+  let result: NeonWriteResult;
+  try {
+    await run();
+    result = { ok: true, rows, statements: 1 };
+  } catch (error) {
+    result = {
+      ok: false,
+      rows: 0,
+      statements: 1,
+      reason: String((error as Error)?.message ?? error),
+    };
+  }
+  await recordNeonWriteVerdict(laneDb, lane, result, now());
+  return result;
+}
+
+/** One head row. Never throws: while D1 still serves, a mirror failure costs a
+ * lane verdict and nothing the poller can see. */
+export async function mirrorBlocksHeadToNeon(
+  env: Record<string, unknown> | null | undefined,
+  ctx: WaitUntilLike | null | undefined,
+  row: {
+    block_number: unknown;
+    block_hash: unknown;
+    parent_hash: unknown;
+    extrinsic_count: unknown;
+    event_count: unknown;
+    author: unknown;
+    observed_at: unknown;
+  },
+  deps: CaptureStateMirrorDeps = {},
+): Promise<{ attempted: boolean; result?: NeonWriteResult }> {
+  const { sql, laneDb, now, attempted } = await runner(
+    env,
+    ctx,
+    BLOCKS_HEAD_NEON_LANE,
+    deps,
+  );
+  if (!attempted || !sql) return { attempted };
+  const result = await record(laneDb, BLOCKS_HEAD_NEON_LANE, 1, now, () =>
+    sql.unsafe(
+      `INSERT INTO blocks_head (block_number, block_hash, parent_hash, extrinsic_count, event_count, author, observed_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(block_number) DO UPDATE SET
+         block_hash=excluded.block_hash,
+         parent_hash=excluded.parent_hash,
+         extrinsic_count=excluded.extrinsic_count,
+         event_count=COALESCE(excluded.event_count, blocks_head.event_count),
+         author=COALESCE(excluded.author, blocks_head.author),
+         observed_at=excluded.observed_at`,
+      [
+        row.block_number,
+        row.block_hash,
+        row.parent_hash,
+        row.extrinsic_count,
+        row.event_count,
+        row.author,
+        row.observed_at,
+      ],
+    ),
+  );
+  return { attempted: true, result };
+}
+
+/** The contiguity watermark, one row per network. */
+export async function mirrorRawCaptureStateToNeon(
+  env: Record<string, unknown> | null | undefined,
+  ctx: WaitUntilLike | null | undefined,
+  network: string,
+  lastContiguousBlock: number,
+  updatedAt: number,
+  deps: CaptureStateMirrorDeps = {},
+): Promise<{ attempted: boolean; result?: NeonWriteResult }> {
+  const { sql, laneDb, now, attempted } = await runner(
+    env,
+    ctx,
+    RAW_CAPTURE_STATE_NEON_LANE,
+    deps,
+  );
+  if (!attempted || !sql) return { attempted };
+  const result = await record(laneDb, RAW_CAPTURE_STATE_NEON_LANE, 1, now, () =>
+    sql.unsafe(
+      `INSERT INTO raw_capture_state (network, last_contiguous_block, updated_at)
+         VALUES (?, ?, ?)
+         ON CONFLICT(network) DO UPDATE SET
+           last_contiguous_block = excluded.last_contiguous_block,
+           updated_at = excluded.updated_at`,
+      [network, lastContiguousBlock, updatedAt],
+    ),
+  );
+  return { attempted: true, result };
+}

--- a/src/neon-mirror-watchdog.ts
+++ b/src/neon-mirror-watchdog.ts
@@ -55,6 +55,10 @@ import { LEDGER_MIRROR_PLANS } from "./ledger-neon-write.ts";
 import { NEURON_MIRROR_PLANS } from "./neurons-neon-write.ts";
 import { NOMINATOR_POSITIONS_NEON_LANE } from "./nominator-positions-neon-write.ts";
 import { CHAIN_DETAIL_NEON_LANE } from "./chain-detail-neon-write.ts";
+import {
+  BLOCKS_HEAD_NEON_LANE,
+  RAW_CAPTURE_STATE_NEON_LANE,
+} from "./capture-state-neon-write.ts";
 import { FAMILY_MIRROR_PLANS } from "./hyperparams-identity-neon-write.ts";
 import {
   loadLatestLaneHealth,
@@ -118,6 +122,8 @@ export const MIRROR_LANE_TABLES: Readonly<Record<string, string>> = {
   // this lane writes LAST, so it is the one whose freshness means the whole
   // batch landed.
   [CHAIN_DETAIL_NEON_LANE]: "chain_detail_blocks",
+  [BLOCKS_HEAD_NEON_LANE]: "blocks_head",
+  [RAW_CAPTURE_STATE_NEON_LANE]: "raw_capture_state",
 };
 
 /** The minimal D1 surface this needs, so a test can hand it a fake. */
@@ -169,6 +175,11 @@ export function mirrorFreshnessSql(tables: readonly string[]): string {
  * mirror is itself the thing that stops reporting.
  */
 const FRESHNESS_COLUMNS: Readonly<Record<string, string>> = {
+  // The head register stamps when the CHAIN produced the block, and the
+  // watermark row stamps when the lane last advanced -- neither carries a
+  // captured_at either.
+  blocks_head: "observed_at",
+  raw_capture_state: "updated_at",
   chain_detail_blocks: "observed_at",
   chain_detail_extrinsics: "observed_at",
   chain_detail_chain_events: "observed_at",

--- a/src/raw-capture-sync.ts
+++ b/src/raw-capture-sync.ts
@@ -24,6 +24,8 @@ import {
 } from "./raw-chain-capture.ts";
 import { RAW_CAPTURE_CRON } from "../workers/config.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { mirrorRawCaptureStateToNeon } from "./capture-state-neon-write.ts";
+import type { WaitUntilLike } from "./pg-sql.ts";
 import {
   CHAIN_RPC_URLS,
   type ChainNetworkId,
@@ -241,6 +243,31 @@ interface D1LikeDb {
   };
 }
 
+/**
+ * The same store, plus a Neon mirror on every write.
+ *
+ * Wrapping rather than duplicating: `raw_capture_state` has exactly one writer
+ * and it is this store's `write`, so there is no second path to keep in step.
+ * The mirror runs AFTER D1 returns and its failure is a lane verdict only --
+ * the capture must not lose a tick because the copy is unreachable.
+ */
+export function mirroredWatermark(
+  inner: WatermarkStore,
+  env: Record<string, unknown> | null | undefined,
+  waitUntil: WaitUntilLike | undefined,
+  network: string,
+  now: () => number,
+): WatermarkStore {
+  return {
+    read: () => inner.read(),
+    async write(value: number) {
+      const result = await inner.write(value);
+      await mirrorRawCaptureStateToNeon(env, waitUntil, network, value, now());
+      return result;
+    },
+  };
+}
+
 /** The watermark row, read/written through D1. Absent row => null, which the
  * capture treats as "start at the floor". */
 export function d1Watermark(
@@ -296,6 +323,9 @@ export async function runRawCaptureSync(
     recordException?: typeof recordExceptionEvent;
     /** Injectable so a test asserts the PACING without waiting for it (#9430). */
     sleepFn?: (ms: number) => Promise<void>;
+    /** Needed to reach Neon: createPgSql returns the pooled connection through
+     * waitUntil, so without one the mirror is skipped rather than leaking. */
+    ctx?: WaitUntilLike;
   } = {},
 ): Promise<RawCaptureSyncResult> {
   const now = deps.now ?? Date.now;
@@ -350,6 +380,7 @@ export async function runRawCaptureSync(
         store,
         now,
         capture,
+        waitUntil: deps.ctx,
         fetchImpl: deps.fetchImpl,
         sleepFn: deps.sleepFn,
       }),
@@ -390,6 +421,7 @@ async function runLane(
     capture: typeof recordExceptionEvent;
     fetchImpl?: typeof fetch;
     sleepFn?: (ms: number) => Promise<void>;
+    waitUntil?: WaitUntilLike;
   },
 ): Promise<RawCaptureLaneResult> {
   const { env, store, now, capture } = ctx;
@@ -397,7 +429,15 @@ async function runLane(
     const result = await captureTick({
       rpcUrl: (env[lane.rpcUrlEnv] as string | undefined) || lane.defaultRpcUrl,
       store,
-      watermark: d1Watermark(env.METAGRAPH_HEALTH_DB!, now, lane.network),
+      // MIRRORED AT THE WATERMARK, not at the row writes: this table IS the
+      // watermark, so wrapping the store is the whole write path.
+      watermark: mirroredWatermark(
+        d1Watermark(env.METAGRAPH_HEALTH_DB!, now, lane.network),
+        ctx.env as unknown as Record<string, unknown>,
+        ctx.waitUntil,
+        lane.network,
+        now,
+      ),
       genesisFloor: lane.genesisFloor,
       maxPerTick: lane.maxPerTick,
       network: lane.network,

--- a/tests/capture-state-neon-write.test.ts
+++ b/tests/capture-state-neon-write.test.ts
@@ -1,0 +1,124 @@
+// blocks_head and raw_capture_state, mirrored (#9787).
+//
+// Both statements are reused verbatim from the D1 writers rather than rebuilt,
+// which is the point worth testing: the COALESCE guards are what stop a re-poll
+// that could not read a value from erasing one an earlier tick already stored.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+import {
+  BLOCKS_HEAD_NEON_LANE,
+  RAW_CAPTURE_STATE_NEON_LANE,
+  mirrorBlocksHeadToNeon,
+  mirrorRawCaptureStateToNeon,
+} from "../src/capture-state-neon-write.ts";
+
+const ctx = { waitUntil: () => undefined } as never;
+const HD = { connectionString: "postgresql://x" };
+
+function recordingSql(fail?: string) {
+  const calls: { text: string; values: unknown[] }[] = [];
+  return {
+    calls,
+    sql: {
+      unsafe: async (text: string, values: unknown[] = []) => {
+        calls.push({ text, values });
+        if (fail) throw new Error(fail);
+        return [];
+      },
+    },
+  };
+}
+
+const block = {
+  block_number: 10,
+  block_hash: "0xa",
+  parent_hash: "0xb",
+  extrinsic_count: 2,
+  event_count: null,
+  author: null,
+  observed_at: 500,
+};
+
+describe("blocks_head", () => {
+  const env = { NEON_DUAL_WRITE_LANES: BLOCKS_HEAD_NEON_LANE, HYPERDRIVE: HD };
+
+  test("a re-poll that read no event_count or author cannot erase them", async () => {
+    // The whole reason the statement is reused rather than rebuilt as a
+    // generic upsert. Without COALESCE, a tick whose storage read failed
+    // replaces a known value with NULL -- the same shape as #9634's last_ok.
+    const { sql, calls } = recordingSql();
+    await mirrorBlocksHeadToNeon(env, ctx, block, { sql, laneHealthDb: null });
+    const { text } = calls[0]!;
+    assert.ok(
+      text.includes(
+        "event_count=COALESCE(excluded.event_count, blocks_head.event_count)",
+      ),
+    );
+    assert.ok(
+      text.includes("author=COALESCE(excluded.author, blocks_head.author)"),
+    );
+    // Everything else IS overwritten -- that is what "latest head" means.
+    assert.ok(text.includes("block_hash=excluded.block_hash"));
+  });
+
+  test("binds the seven columns in statement order", async () => {
+    const { sql, calls } = recordingSql();
+    await mirrorBlocksHeadToNeon(env, ctx, block, { sql, laneHealthDb: null });
+    assert.deepEqual(calls[0]!.values, [10, "0xa", "0xb", 2, null, null, 500]);
+  });
+
+  test("off unless the flag names the lane", async () => {
+    const { sql, calls } = recordingSql();
+    const out = await mirrorBlocksHeadToNeon(
+      { NEON_DUAL_WRITE_LANES: "neurons", HYPERDRIVE: HD },
+      ctx,
+      block,
+      { sql, laneHealthDb: null },
+    );
+    assert.equal(out.attempted, false);
+    assert.equal(calls.length, 0);
+  });
+
+  test("never throws when the store does", async () => {
+    const { sql } = recordingSql("connection reset");
+    const out = await mirrorBlocksHeadToNeon(env, ctx, block, {
+      sql,
+      laneHealthDb: null,
+    });
+    assert.equal(out.result?.ok, false);
+    assert.match(out.result?.reason ?? "", /connection reset/);
+  });
+});
+
+describe("raw_capture_state", () => {
+  const env = {
+    NEON_DUAL_WRITE_LANES: RAW_CAPTURE_STATE_NEON_LANE,
+    HYPERDRIVE: HD,
+  };
+
+  test("upserts the watermark on the network key", async () => {
+    const { sql, calls } = recordingSql();
+    await mirrorRawCaptureStateToNeon(env, ctx, "mainnet", 4321, 999, {
+      sql,
+      laneHealthDb: null,
+    });
+    const { text, values } = calls[0]!;
+    assert.ok(text.includes("ON CONFLICT(network) DO UPDATE"));
+    assert.ok(text.includes("last_contiguous_block = excluded"));
+    assert.deepEqual(values, ["mainnet", 4321, 999]);
+  });
+
+  test("enabled but unbound is a verdict, not silence", async () => {
+    const out = await mirrorRawCaptureStateToNeon(
+      { NEON_DUAL_WRITE_LANES: RAW_CAPTURE_STATE_NEON_LANE },
+      ctx,
+      "mainnet",
+      1,
+      1,
+      { laneHealthDb: null },
+    );
+    assert.equal(out.attempted, true);
+    assert.equal(out.result, undefined);
+  });
+});

--- a/tests/neon-backfill.test.ts
+++ b/tests/neon-backfill.test.ts
@@ -425,8 +425,15 @@ describe("the deployed wiring", () => {
         // pass -- which is why it left this lane and this one did not.
         "account_identity",
       ]);
+      // ACCUMULATING, not just date-partitioned. "date" and "append" both
+      // grow forever, so for both the mirror only ever covers the passes it
+      // ran for and older rows reach Neon by no other path -- which is this
+      // rule's own stated rationale. Only "whole" is latest-only, and only it
+      // makes a reconciler redundant once a mirror exists. Naming just "date"
+      // here was a shortcut that held until blocks_head, the first APPEND
+      // table to gain a mirror.
       assert.ok(
-        plan.partition === "date" ||
+        plan.partition !== "whole" ||
           !mirrored.has(table) ||
           provenStuck.has(table),
         `${table} is latest-only AND mirrored, so the reconciler would copy ` +

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -2277,7 +2277,7 @@ async function dispatchScheduled(
     // the decommissioned indexer box used to produce. Durable-first on
     // purpose: the bytes land before anything decodes them, because decode is
     // re-runnable and a missed block is not. See src/raw-chain-capture.ts.
-    return runRawCaptureSync(env);
+    return runRawCaptureSync(env, { ctx });
   }
   if (cron === GITHUB_SIGNALS_SYNC_CRON) {
     // #233 pattern: daily GitHub dev-signal capture written straight to the

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -65,6 +65,7 @@ import {
 } from "../src/graphql.ts";
 import { MCP_CHAIN_STREAM_RESOURCE_URI } from "./mcp-session-hub.ts";
 import { registerModuleStateReset } from "../src/module-state-registry.ts";
+import { mirrorBlocksHeadToNeon } from "../src/capture-state-neon-write.ts";
 
 export const CHAIN_FIREHOSE_INGEST_TOKEN_HEADER = "x-chain-firehose-sync-token";
 
@@ -1113,6 +1114,15 @@ export class ChainFirehoseHub implements DurableObject {
             )
             .run();
         }
+        // THE MIRROR, after the D1 write returns and never instead of it.
+        // `this.state` is the waitUntil handle here -- a Durable Object has no
+        // ExecutionContext, and createPgSql needs one to hand the pooled
+        // connection back to Hyperdrive.
+        await mirrorBlocksHeadToNeon(
+          this.env as unknown as Record<string, unknown>,
+          this.state,
+          block as unknown as Parameters<typeof mirrorBlocksHeadToNeon>[2],
+        );
         await this.state.storage.put("head:last_seen", block.block_number);
       }
     } catch (error) {

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -131,7 +131,7 @@
     // same PRIMARY KEY (netuid, uid, snapshot_date) the mirror's ON CONFLICT
     // names. An ON CONFLICT with no unique index behind it is a runtime error,
     // not a slower query.
-    "NEON_DUAL_WRITE_LANES": "neurons,nominator-positions,account-balances,hotkey-alpha,validator-nominator-counts,subnet-hyperparams,account-identity,chain-detail",
+    "NEON_DUAL_WRITE_LANES": "neurons,nominator-positions,account-balances,hotkey-alpha,validator-nominator-counts,subnet-hyperparams,account-identity,chain-detail,blocks-head,raw-capture-state",
     // THE CUTOVER (metagraphed-infra#336). `GET /api/v1/accounts/{ss58}/
     // subnets/{netuid}/history` now reads Neon.
     //
@@ -210,7 +210,13 @@
     // the whole thing. Reconciling it would copy 129 rows every tick to learn
     // what the mirror already wrote. account_identity STAYS despite gaining
     // the same mirror -- see the provenStuck note in tests/neon-backfill.test.ts.
-    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily,subnet_burn_history,tao_usd_index,blocks_head,raw_capture_state,chain_detail_blocks,chain_detail_extrinsics,chain_detail_chain_events,chain_detail_account_events",
+    // raw_capture_state LEFT on 2026-08-08 (#9787). It gained a mirror, and it
+    // is the one table here a mirror finishes completely: ONE ROW PER NETWORK,
+    // written by exactly one writer (the watermark store's own `write`), so
+    // every advance is mirrored and there is no older row to reconcile.
+    // blocks_head STAYS despite gaining the same mirror -- it is an APPEND
+    // table, so the mirror only covers blocks polled since it existed.
+    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily,subnet_burn_history,tao_usd_index,blocks_head,chain_detail_blocks,chain_detail_extrinsics,chain_detail_chain_events,chain_detail_account_events",
     // Tables whose ONLY home is Neon -- D1 is not behind them any more.
     //
     // A FOURTH flag, and the one the other three converge on. All three above


### PR DESCRIPTION
Refs #9787

Stacked on the chain_detail mirror -- same lane, same poller, and the watchdog
pairing they both need lands once rather than twice.

THE STATEMENTS ARE REUSED VERBATIM, not rebuilt. createPgSql's `unsafe` already
rewrites `?` to `$n` (#9821), and neither statement uses a construct Postgres
lacks, so the text carries over and the COALESCE guards come with it:

  event_count=COALESCE(excluded.event_count, blocks_head.event_count)
  author=COALESCE(excluded.author, blocks_head.author)

A re-poll that could not read the event count or derive the author must not
erase one an earlier tick already stored. Rebuilding these as a generic upsert
would silently drop that and replace a known value with NULL -- the same shape
as #9634's last_ok, one table over. Both guards are asserted.

raw_capture_state is mirrored by WRAPPING the watermark store rather than at a
call site: that store's `write` IS the table's only write path, so there is no
second writer to keep in step.

TWO CTX PROBLEMS, both solved rather than shimmed. The firehose hub is a
Durable Object and has no ExecutionContext -- `this.state` is the waitUntil
handle there. runRawCaptureSync had none at all, so it is threaded from the
cron caller. createPgSql returns the pooled connection through waitUntil, so a
fake would leak one per block.

TWO RULES THIS EXPOSED, both generalised rather than special-cased:

- neon-backfill's "names only tables the mirror cannot finish" exempted
  partition === "date". blocks_head is the first APPEND table to gain a mirror,
  and append accumulates exactly as date does -- the mirror only covers blocks
  polled since it existed, so older ones reach Neon by no other path. The rule
  now reads `partition !== "whole"`, which is what its own comment always said.
- raw_capture_state IS "whole" -- one row per network -- so it leaves
  NEON_BACKFILL_LANES. Reconciling it would copy a one-row table every tick to
  learn what the mirror already wrote.

Freshness columns follow: blocks_head stamps observed_at, raw_capture_state
stamps updated_at, and neither carries captured_at.