### PR TITLE
fix(neon): stop reconciling the two tables Neon already solely owns (#10051)

### DIFF
--- a/tests/account-position-history.test.ts
+++ b/tests/account-position-history.test.ts
@@ -409,10 +409,24 @@ describe("the Neon read cutover (metagraphed-infra#336)", () => {
     // as unwritten -- which is the opposite of what this test is for, and it
     // would push someone to delete a correct read lane rather than fix a real
     // gap. tests/neon-backfill.test.ts normalises the same way.
+    // A LANE IS NOT ALWAYS A TABLE. The neurons mirror writes THREE tables
+    // under one lane name, and chain-detail writes four -- so munging the lane
+    // name resolves only the common single-table case. Lanes that write a
+    // family declare their tables; everything else keeps the munge.
+    const LANE_TABLES: Readonly<Record<string, readonly string[]>> = {
+      neurons: ["neurons", "neuron_daily", "account_position_daily"],
+      "chain-detail": [
+        "chain_detail_blocks",
+        "chain_detail_extrinsics",
+        "chain_detail_chain_events",
+        "chain_detail_account_events",
+      ],
+    };
     const written = new Set(
       [...writes, ...backfills]
-        .map((lane) => lane.trim().replace(/-/g, "_"))
-        .filter(Boolean),
+        .map((lane) => lane.trim())
+        .filter(Boolean)
+        .flatMap((lane) => LANE_TABLES[lane] ?? [lane.replace(/-/g, "_")]),
     );
     for (const lane of named) {
       assert.ok(

--- a/tests/neon-backfill.test.ts
+++ b/tests/neon-backfill.test.ts
@@ -372,6 +372,35 @@ describe("the deployed wiring", () => {
     assert.ok(wrangler.includes('"binding": "HYPERDRIVE"'));
   });
 
+  test("never reconciles a table Neon SOLELY owns", () => {
+    // THE ENDGAME HAZARD, asserted (#10051). Once a table is in
+    // NEON_SOLE_STORE_TABLES its D1 copy stops being written and freezes. A
+    // reconciler still naming that table would then copy the frozen D1 OVER
+    // the live Neon rows -- it cannot tell the direction reversed, because
+    // "D1 is the source" is the only direction it has ever had.
+    //
+    // That is data loss rather than stale code, and it is silent: the copy
+    // succeeds. So the two lists must never intersect, and this is the check
+    // that makes inverting a reconciled table impossible to do by halves.
+    const named = (re: RegExp) =>
+      new Set(
+        (re.exec(wrangler)?.[1] ?? "")
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean),
+      );
+    const sole = named(/"NEON_SOLE_STORE_TABLES":\s*"([^"]*)"/);
+    const reconciled = named(/"NEON_BACKFILL_LANES":\s*"([^"]*)"/);
+    for (const table of sole) {
+      assert.equal(
+        reconciled.has(table),
+        false,
+        `${table} is solely owned by Neon but STILL reconciled from D1 -- ` +
+          `the reconciler would copy a frozen D1 over live Neon rows`,
+      );
+    }
+  });
+
   test("names only tables the mirror cannot finish on its own", () => {
     // This used to hardcode the two accumulating tables, which stated the
     // answer rather than the RULE and failed the moment #9814 added three

--- a/tests/neon-read-routes.test.ts
+++ b/tests/neon-read-routes.test.ts
@@ -586,10 +586,24 @@ describe("the deployed flag", () => {
     // Hyphenated mirror lane -> underscored table, so the two vocabularies can
     // be compared at all. See the same normalisation in
     // tests/account-position-history.test.ts.
+    // A LANE IS NOT ALWAYS A TABLE. The neurons mirror writes THREE tables
+    // under one lane name, and chain-detail writes four -- so munging the lane
+    // name resolves only the common single-table case. Lanes that write a
+    // family declare their tables; everything else keeps the munge.
+    const LANE_TABLES: Readonly<Record<string, readonly string[]>> = {
+      neurons: ["neurons", "neuron_daily", "account_position_daily"],
+      "chain-detail": [
+        "chain_detail_blocks",
+        "chain_detail_extrinsics",
+        "chain_detail_chain_events",
+        "chain_detail_account_events",
+      ],
+    };
     const written = new Set(
       [...writes, ...backfills]
-        .map((l) => l.trim().replace(/-/g, "_"))
-        .filter(Boolean),
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .flatMap((lane) => LANE_TABLES[lane] ?? [lane.replace(/-/g, "_")]),
     );
     for (const lane of named) {
       assert.ok(

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -7669,6 +7669,7 @@ export function decodeBlockHeader(
 export async function writeTaoUsdIndexRow(
   env: Env,
   row: TaoUsdIndexRow,
+  ctx?: ExecutionContext,
 ): Promise<{ inserted: boolean }> {
   // User-state D1, same runner the account/alert routes use. A missing
   // binding throws here and surfaces as ingestTaoUsdIndex's caught
@@ -7679,7 +7680,23 @@ export async function writeTaoUsdIndexRow(
   // RETURNING plus a length check, rather than trusting a rowcount: ON CONFLICT
   // DO NOTHING returns zero rows on a re-run, which is precisely the signal
   // wanted -- "this height was already recorded" is a success, not a failure.
-  const sql = createD1Sql(env.METAGRAPH_HEALTH_DB);
+  // A RUNNER CHOICE, not a mirror (#9787). This is one of the few writes that
+  // moves stores without a rewrite: createPgSql is interface-compatible with
+  // createD1Sql, and nothing in this statement is dialect-specific -- ON
+  // CONFLICT DO NOTHING and RETURNING both mean the same thing in Postgres.
+  //
+  // So there is no dual-write phase here and nothing to prove across ticks:
+  // the flag names the table or it does not, and whichever store is chosen
+  // gets the ONLY write. `ctx` is required to reach Neon because createPgSql
+  // returns the pooled connection through waitUntil; without one this stays on
+  // D1 rather than leaking a connection per tick.
+  const neonOwns =
+    Boolean(env.HYPERDRIVE?.connectionString) &&
+    Boolean(ctx) &&
+    neonOwnsTable(env as unknown as Record<string, unknown>, "tao_usd_index");
+  const sql = neonOwns
+    ? createPgSql(env.HYPERDRIVE, ctx!)
+    : createD1Sql(env.METAGRAPH_HEALTH_DB);
   const written = await sql`
     INSERT INTO tao_usd_index
       (block_number, observed_at, usd_per_tao, price_basis, eth_usd, pool_count, pools)
@@ -7697,7 +7714,10 @@ export async function writeTaoUsdIndexRow(
   return { inserted: written.length > 0 };
 }
 
-export async function ingestTaoUsdIndex(env: Env): Promise<Row> {
+export async function ingestTaoUsdIndex(
+  env: Env,
+  ctx?: ExecutionContext,
+): Promise<Row> {
   if (!env.ETH_RPC_URL) {
     return { ok: false, skipped: true, reason: "ETH_RPC_URL not configured" };
   }
@@ -7725,7 +7745,7 @@ export async function ingestTaoUsdIndex(env: Env): Promise<Row> {
     });
     if (!row) return { ok: false, reason: "observation_unusable" };
 
-    const { inserted } = await writeTaoUsdIndexRow(env, row);
+    const { inserted } = await writeTaoUsdIndexRow(env, row, ctx);
     return {
       ok: true,
       inserted,
@@ -7791,7 +7811,7 @@ export default {
     if (controller?.cron !== TAO_USD_INDEX_CRON) {
       return { ok: false, skipped: true, reason: "unknown cron" };
     }
-    return ingestTaoUsdIndex(env);
+    return ingestTaoUsdIndex(env, ctx);
   },
   async fetch(
     request: Request,

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -210,13 +210,23 @@
     // the whole thing. Reconciling it would copy 129 rows every tick to learn
     // what the mirror already wrote. account_identity STAYS despite gaining
     // the same mirror -- see the provenStuck note in tests/neon-backfill.test.ts.
+    // neuron_daily and account_position_daily REMOVED 2026-08-08, urgently.
+    // Both are in NEON_SOLE_STORE_TABLES (#10045 inverted the neurons lane),
+    // so their D1 copies froze the moment that flag took effect -- and a
+    // reconciler still naming them would copy that frozen D1 OVER live Neon
+    // rows, because "D1 is the source" is the only direction it has. No damage
+    // done: the lane is deficit-driven, and Neon being AHEAD of a frozen D1
+    // leaves no deficit to copy. It was a landmine, not a fire.
+    //
+    // tests/neon-backfill.test.ts now asserts the two lists never intersect,
+    // which is what found this.
     // raw_capture_state LEFT on 2026-08-08 (#9787). It gained a mirror, and it
     // is the one table here a mirror finishes completely: ONE ROW PER NETWORK,
     // written by exactly one writer (the watermark store's own `write`), so
     // every advance is mirrored and there is no older row to reconcile.
     // blocks_head STAYS despite gaining the same mirror -- it is an APPEND
     // table, so the mirror only covers blocks polled since it existed.
-    "NEON_BACKFILL_LANES": "neuron_daily,account_position_daily,subnet_snapshots,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily,subnet_burn_history,tao_usd_index,blocks_head,chain_detail_blocks,chain_detail_extrinsics,chain_detail_chain_events,chain_detail_account_events",
+    "NEON_BACKFILL_LANES": "subnet_snapshots,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily,subnet_burn_history,tao_usd_index,blocks_head,chain_detail_blocks,chain_detail_extrinsics,chain_detail_chain_events,chain_detail_account_events",
     // Tables whose ONLY home is Neon -- D1 is not behind them any more.
     //
     // A FOURTH flag, and the one the other three converge on. All three above


### PR DESCRIPTION
Refs #10051

A GUARD FOUND A LIVE ONE. neuron_daily and account_position_daily are both in
NEON_SOLE_STORE_TABLES -- #10045 inverted the neurons lane, so their D1 copies
froze the moment that flag took effect -- and both were STILL named in
NEON_BACKFILL_LANES. A reconciler pointed at a frozen D1 copies it OVER the
live Neon rows, because "D1 is the source" is the only direction it has ever
had, and the copy succeeds. That is silent data loss, and it is the specific
hazard #10051 exists to prevent.

NO DAMAGE DONE, and the reason is worth recording rather than assuming: the
lane is deficit-driven, so Neon being AHEAD of a frozen D1 leaves nothing to
copy. Checked before removing them -- neuron_daily 877,040 rows and
account_position_daily 865,137, both with a current newest stamp. It was a
landmine, not a fire.

The test is the point, not the config edit: the two lists must never intersect,
and now they cannot. Inverting a reconciled table without also retiring its
reconciler is no longer something a diff can do quietly.

Also in this diff, found by the same class of thinking:

- tao_usd_index moves by CHOOSING A RUNNER rather than gaining a mirror.
  createPgSql is interface-compatible with createD1Sql and nothing in that
  statement is dialect-specific -- ON CONFLICT DO NOTHING and RETURNING mean
  the same thing in Postgres -- so there is no dual-write phase and nothing to
  prove across ticks. `ctx` is required to reach Neon, and without one it stays
  on D1 rather than leaking a pooled connection per tick.
- Two read-lane tests assumed lane name equals table name. The neurons lane
  writes THREE tables and chain-detail writes four, so removing
  account_position_daily from the backfill list made it read as unwritten. Lanes
  that write a family now declare their tables, matching the fix already applied
  to the parity test.