### PR TITLE
refactor(schemas): the 34 collection routes had no query schema to derive from (#10080)

### DIFF
--- a/schemas-src/query-params.ts
+++ b/schemas-src/query-params.ts
@@ -39,6 +39,28 @@ export const netuidSchema = () =>
     .meta({ examples: [64, 0] });
 
 /**
+ * A comma-separated list of subnet ids, for the routes that filter on a SET.
+ *
+ * Both bounds are real and both matter: at most 128 ids, each at most 5 digits
+ * (a netuid is a u16), which is exactly the 767-character ceiling — 128 ids
+ * plus 127 commas. The MCP side published `^\d+(,\d+)*$` for the same
+ * parameter: unbounded in count and accepting a 9-digit "netuid", so a tool
+ * caller could send a list its own route rejects.
+ */
+export const NETUID_LIST_MAX_LENGTH = 767;
+export const NETUID_LIST_PATTERN = /^\d{1,5}(,\d{1,5}){0,127}$/;
+export const netuidListSchema = () =>
+  z
+    .string()
+    .max(NETUID_LIST_MAX_LENGTH)
+    .regex(NETUID_LIST_PATTERN)
+    .describe(
+      "Comma-separated subnet ids to restrict the result to, e.g. `1,7,64`. " +
+        "At most 128 ids, each 0-65535. Unknown ids match nothing rather than erroring.",
+    )
+    .meta({ examples: ["1,7,64"] });
+
+/**
  * A page size, capped at the mirrored route's own ceiling.
  *
  * `fallback` is the value the handler uses when the argument is omitted, and

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -3,10 +3,13 @@ import {
   fieldsSchema,
   filterTokenSchema,
   limitSchema,
+  netuidListSchema,
   netuidSchema,
   numericCursorSchema,
   orderSchema,
   querySchema,
+  sortSchema,
+  windowSchema,
 } from "../schemas-src/query-params.ts";
 import { MAX_LIMIT } from "../workers/request-params.ts";
 // Surface-agnostic despite the module name: the sentinel bounds Zod stamps on
@@ -275,9 +278,15 @@ function parameterSchema(schema: z.ZodType): Row {
 // `netuid` is the ONLY parameter this shape was ever used for (20 sites), and
 // it is a u16 on chain — so it publishes the real ceiling now rather than
 // leaving 65536..2^53 looking like a subnet id nobody has registered yet.
-const integerSchema = parameterSchema(netuidSchema());
+//
+// `integerSchema` and `filterTextSchema` are the two used as COLLECTION FILTER
+// values, so they stay Zod (#10080): queryCollection() renders each filter to
+// JSON for the readers that need it and keeps the Zod for listQuerySchema() to
+// compose with. `searchTextSchema` and `fieldListSchema` are only ever used at
+// a direct parameter site, so they are rendered here.
+const integerSchema = netuidSchema();
+const filterTextSchema = filterTokenSchema();
 const searchTextSchema = parameterSchema(querySchema());
-const filterTextSchema = parameterSchema(filterTokenSchema());
 // Every route that publishes `fields` resolves it through the SAME
 // `parseFieldsParam` (src/field-projection.ts), so they all publish the same
 // syntax. Four routes outside the list collections -- chain/emission-pipeline
@@ -287,6 +296,23 @@ const filterTextSchema = parameterSchema(filterTokenSchema());
 // emission-pipeline, and `?fields=uid,%20hotkey` is a 200 on the metagraph
 // read, which is exactly what this pattern says.
 const fieldListSchema = parameterSchema(fieldsSchema());
+
+/**
+ * Query parameters a LIST route adds on top of its collection's own (#6571).
+ *
+ * Keyed by route path and held as Zod, so the published parameter and
+ * `listQuerySchema()`'s property come from ONE object rather than from a
+ * literal at the route() call and a copy in the schema. One entry today; this
+ * is where the second one goes.
+ */
+export const LIST_QUERY_ROUTE_EXTRAS: Record<
+  string,
+  Record<string, z.ZodType>
+> = {
+  // The incidents feed is scoped by a trailing window on top of the
+  // collection's filters.
+  "/api/v1/incidents": { window: windowSchema(["7d", "30d"]) },
+};
 
 export const API_QUERY_COLLECTIONS = {
   candidates: queryCollection("candidates", {
@@ -776,11 +802,7 @@ export const API_QUERY_COLLECTIONS = {
     arrayFilters: { domain: ["categories", "derived_categories"] },
     filters: {
       netuid: integerSchema,
-      netuids: {
-        type: "string",
-        maxLength: 767,
-        pattern: "^\\d{1,5}(,\\d{1,5}){0,127}$",
-      },
+      netuids: netuidListSchema(),
       coverage_level: enumSchema(QUERY_ENUMS.coverageLevel),
       curation_level: enumSchema(QUERY_ENUMS.curationLevel),
       domain: enumSchema(DOMAIN_TAGS),
@@ -2618,8 +2640,11 @@ export const API_ROUTES = [
     {
       parameters: [
         { name: "netuid", schema: { type: "integer", minimum: 0 } },
-        { name: "sort", schema: enumSchema(EMISSION_PIPELINE_SORT_FIELDS) },
-        { name: "order", schema: enumSchema(["asc", "desc"]) },
+        {
+          name: "sort",
+          schema: parameterSchema(enumSchema(EMISSION_PIPELINE_SORT_FIELDS)),
+        },
+        { name: "order", schema: parameterSchema(orderSchema()) },
         {
           name: "limit",
           schema: {
@@ -4908,9 +4933,15 @@ export const API_ROUTES = [
     "short",
     ["chain", "analytics", "subnets"],
     [
-      { name: "lens", schema: enumSchema(CONCENTRATION_LENSES) },
-      { name: "sort", schema: enumSchema(CONCENTRATION_RANKING_SORTS) },
-      { name: "order", schema: enumSchema(["asc", "desc"]) },
+      {
+        name: "lens",
+        schema: parameterSchema(enumSchema(CONCENTRATION_LENSES)),
+      },
+      {
+        name: "sort",
+        schema: parameterSchema(enumSchema(CONCENTRATION_RANKING_SORTS)),
+      },
+      { name: "order", schema: parameterSchema(orderSchema()) },
       {
         name: "limit",
         schema: {
@@ -5123,7 +5154,7 @@ export const API_ROUTES = [
     [
       {
         name: "tag",
-        schema: enumSchema(DOMAIN_TAGS),
+        schema: parameterSchema(enumSchema(DOMAIN_TAGS)),
       },
     ],
   ),
@@ -5244,9 +5275,12 @@ export const API_ROUTES = [
     "Fetch recent cross-subnet downtime incidents reconstructed from probe history over a 7d or 30d window (computed live from D1). Pair with /api/v1/health for the overall status summary.",
     "short",
     ["health", "analytics"],
-    listQueryWith("incidents", [
-      { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
-    ]),
+    listQueryWith(
+      "incidents",
+      Object.entries(LIST_QUERY_ROUTE_EXTRAS["/api/v1/incidents"]).map(
+        ([name, schema]) => ({ name, schema: parameterSchema(schema) }),
+      ),
+    ),
   ),
   route(
     "schemas",
@@ -6722,9 +6756,25 @@ function route(
 }
 
 function queryCollection(dataKey: string, options: Row = {}) {
+  // `filters` is authored as ZOD and stored twice (#10080): once as the emitted
+  // JSON every existing reader already uses, and once as the Zod itself so
+  // `listQuerySchema()` can compose with it.
+  //
+  // Two renderings of ONE authored input, both computed here -- not two
+  // declarations. The distinction matters: the JSON form is what
+  // `validateListQuery` reads at RUNTIME (`type`, `enum`, `maxLength`,
+  // `pattern`, `maximum`) to decide a 400, so it cannot become a second thing
+  // somebody edits.
+  const filterSchemas = (options.filters || {}) as Record<string, z.ZodType>;
   return {
     data_key: dataKey,
-    filters: options.filters || {},
+    filters: Object.fromEntries(
+      Object.entries(filterSchemas).map(([name, schema]) => [
+        name,
+        parameterSchema(schema),
+      ]),
+    ),
+    filter_schemas: filterSchemas,
     // CSV membership filters: param name -> the row field it matches against.
     // e.g. { netuids: "netuid" } makes `?netuids=1,7,74` return those rows.
     csv_filters: options.csvFilters || {},
@@ -6751,8 +6801,82 @@ function queryCollection(dataKey: string, options: Row = {}) {
   };
 }
 
+// A closed-set filter. Returns Zod so a collection's filters are all one kind
+// of thing (#10080); queryCollection() renders it to `{type:"string", enum}`,
+// byte-for-byte what this used to return directly.
 function enumSchema(values: readonly string[]) {
-  return { type: "string", enum: values };
+  return z.enum(values as [string, ...string[]]);
+}
+
+/**
+ * One collection list route's query parameters, as Zod (#10080).
+ *
+ * The 34 collection routes are the ones no hand-written `*QuerySchema` can
+ * cover: `listQuery()` GENERATES their 9-18 parameters from the collection
+ * config, so a hand-written copy would be a second declaration of a computed
+ * thing — the exact failure #10073 removed one layer of.
+ *
+ * This composes the same parameter set from the same config, so 3/5 can emit
+ * the published parameters from Zod and 4/5 can derive the MCP tool's inputs
+ * from it. `tests/query-collection-schema.test.ts` asserts the two agree for
+ * every collection, because two producers of one parameter list is precisely
+ * what must not be able to drift.
+ *
+ * Everything is `.optional()`: a query parameter is, and the handlers own their
+ * own defaults (see limitSchema's note on why the default is declared rather
+ * than applied).
+ */
+export function listQuerySchema(
+  collection: string,
+  {
+    exclude = [],
+    csvResponse = false,
+    extend = {},
+  }: ListQuerySchemaOptions = {},
+): z.ZodObject {
+  const config = (API_QUERY_COLLECTIONS as Record<string, Row>)[collection];
+  /* v8 ignore next 3 -- same developer config invariant listQuery() guards */
+  if (!config) {
+    throw new Error(`Unknown API query collection: ${collection}`);
+  }
+  const excluded = new Set(exclude);
+  const shape: Record<string, z.ZodType> = { ...extend };
+
+  for (const [name, schema] of Object.entries(
+    config.filter_schemas as Record<string, z.ZodType>,
+  )) {
+    if (!excluded.has(name)) shape[name] = schema.optional();
+  }
+  if ((config.search_keys as string[]).length > 0) {
+    shape.q = querySchema().optional();
+  }
+  // Each numeric range field F -> an inclusive `min_F` + `max_F` pair. Plain
+  // numbers, not integers: `numberParam` is what validateListQuery accepts, and
+  // several of these fields are ratios.
+  for (const field of config.range_filters as string[]) {
+    shape[`min_${field}`] = z.number().optional();
+    shape[`max_${field}`] = z.number().optional();
+  }
+  shape.fields = fieldsSchema().optional();
+  shape.limit = limitSchema(MAX_LIMIT).optional();
+  shape.cursor = numericCursorSchema().optional();
+  // A collection that declares no sort keys publishes `enum: []`, which
+  // `z.enum()` cannot express — it stays absent rather than being invented.
+  const sortFields = config.sort_fields as string[];
+  if (sortFields.length > 0) {
+    shape.sort = sortSchema(sortFields as [string, ...string[]]).optional();
+  }
+  shape.order = orderSchema().optional();
+  if (csvResponse) shape.format = z.enum(["json", "csv"]).optional();
+
+  return z.object(shape).strict();
+}
+
+interface ListQuerySchemaOptions {
+  exclude?: string[];
+  csvResponse?: boolean;
+  /** Route-level parameters on top of the collection's, from LIST_QUERY_ROUTE_EXTRAS. */
+  extend?: Record<string, z.ZodType>;
 }
 
 function listQuery(collection: string, options: { exclude?: string[] } = {}) {

--- a/tests/query-collection-schema.test.ts
+++ b/tests/query-collection-schema.test.ts
@@ -1,0 +1,129 @@
+// `listQuerySchema(c)` and `listQuery(c)` describe the same parameters (#10080).
+//
+// The 34 collection list routes are the ones no hand-written `*QuerySchema` can
+// cover: `listQuery()` GENERATES their 9-18 parameters from
+// `API_QUERY_COLLECTIONS`, so a hand-written copy would be a second declaration
+// of a computed thing — the exact failure #10073 removed one layer of.
+//
+// `listQuerySchema()` composes the same set from the same config so that 3/5
+// can emit the published parameters from Zod and 4/5 can derive the MCP tool
+// inputs from it. Until 3/5 flips the emission, the two producers coexist —
+// which is precisely the window in which they could drift, and this is what
+// makes that impossible rather than merely unlikely.
+//
+// Compared on the EMITTED JSON, canonically: openapi.json is written with
+// sorted keys and Zod emits in declaration order, so a raw string compare
+// reports every parameter as divergent and reads as catastrophic failure
+// rather than as a bug in the comparison.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { z } from "zod";
+import {
+  API_QUERY_COLLECTIONS,
+  API_ROUTES,
+  LIST_QUERY_ROUTE_EXTRAS,
+  listQuerySchema,
+} from "../src/contracts.ts";
+import { stripSentinelIntegerBounds } from "../src/mcp-input-schema.ts";
+import type { Row } from "./row-type.ts";
+
+function canonical(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") {
+    const row = value as Row;
+    return `{${Object.keys(row)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonical(row[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+/** Each property of the schema, as a published parameter carries it. */
+function emitted(schema: z.ZodObject): Map<string, string> {
+  const document = z.toJSONSchema(schema, {
+    target: "draft-2020-12",
+    io: "input",
+  }) as Row;
+  const out = new Map<string, string>();
+  for (const [name, property] of Object.entries(
+    (document.properties ?? {}) as Record<string, Row>,
+  )) {
+    const {
+      $schema: _schema,
+      description: _description,
+      examples: _examples,
+      ...rest
+    } = property;
+    out.set(name, canonical(stripSentinelIntegerBounds(rest)));
+  }
+  return out;
+}
+
+/** Every route built on this collection, with the parameters it publishes. */
+function routesFor(collection: string): { path: string; parameters: Row[] }[] {
+  return (API_ROUTES as Row[])
+    .filter((route) => route.query_collection === collection)
+    .map((route) => ({
+      path: String(route.path),
+      parameters: (route.query_parameters ?? []) as Row[],
+    }));
+}
+
+const collections = Object.keys(API_QUERY_COLLECTIONS as Row);
+
+describe("listQuerySchema mirrors the parameters listQuery publishes (#10080)", () => {
+  test("every collection is reachable and at least one route uses it", () => {
+    // A comparison that silently matched nothing is the failure mode here: it
+    // would pass forever the moment the collection key stopped resolving.
+    assert.ok(
+      collections.length >= 20,
+      `only ${collections.length} collections`,
+    );
+    const used = collections.filter((c) => routesFor(c).length > 0);
+    assert.ok(used.length >= 20, `only ${used.length} collections are routed`);
+  });
+
+  for (const collection of collections) {
+    const routes = routesFor(collection);
+    if (routes.length === 0) continue;
+    test(`${collection}: the schema and the route agree on every parameter`, () => {
+      // `format` is appended by csvListQuery, and `exclude` narrows a route's
+      // filters, so read both off the route rather than assuming.
+      for (const route of routes) {
+        const published = new Map(
+          route.parameters.map((parameter) => [
+            String(parameter.name),
+            canonical(parameter.schema),
+          ]),
+        );
+        const schema = emitted(
+          listQuerySchema(collection, {
+            // A route may add parameters on top of its collection's (#6571);
+            // both producers read them from the same object.
+            extend: LIST_QUERY_ROUTE_EXTRAS[route.path] ?? {},
+            csvResponse: published.has("format"),
+            exclude: [...published.keys()].length
+              ? Object.keys(
+                  (API_QUERY_COLLECTIONS as Row)[collection]
+                    .filter_schemas as Row,
+                ).filter((name) => !published.has(name))
+              : [],
+          }),
+        );
+        assert.deepEqual(
+          [...schema.keys()].sort(),
+          [...published.keys()].sort(),
+          `${route.path}: parameter NAMES differ`,
+        );
+        for (const [name, want] of published) {
+          assert.equal(
+            schema.get(name),
+            want,
+            `${route.path} ?${name}: constraints differ`,
+          );
+        }
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary

134 routes publish query parameters. 100 are literal arrays, and **87 of those already match an
existing `*QuerySchema` by property set** — those are #10062's other half. The remaining **34 are
the collection list routes, and no hand-written schema can cover them**: `listQuery()` *generates*
their 9–18 parameters from `API_QUERY_COLLECTIONS`, so a hand-written copy would be a second
declaration of a computed thing — the exact failure #10073 removed one layer of.

One builder, not 34 schemas.

## One authored input, two renderings

`queryCollection()` takes **zod** filters and stores both:

```ts
filters:        <the emitted JSON>   // what all 4 existing readers use
filter_schemas: <the zod>            // what listQuerySchema() composes with
```

Both computed in the same place from one input — not two declarations. The distinction is
load-bearing: `validateListQuery` reads `type`, `enum`, `maxLength`, `pattern` and `maximum` off the
JSON form **at runtime** to decide a 400, so that form must not become something edited separately.
The four modules that read `.filters` (`src/contracts.ts`, `workers/list-query.ts`,
`src/mcp-server.ts`, `src/subnet-surfaces-mcp.ts`) are untouched.

`listQuerySchema(collection)` then composes the filters with the same `q` / range / `fields` /
`limit` / `cursor` / `sort` / `order` / `format` set `listQuery()` appends.

## The proof

**`openapi.json`, `api-index.json`, `types.d.ts` and `packages/contract/index.d.ts` are all
byte-identical.** `parameterSchema(netuidSchema())` is exactly what was stored before, so any change
would have meant the composition diverged from `listQuery()`.

And `tests/query-collection-schema.test.ts` asserts the two producers agree for **all 26
collections**, parameter by parameter, on the emitted JSON. They coexist until 3/5 flips the
emission — that window is precisely when they could drift, and this makes it impossible rather than
merely unlikely. It compares canonically, because openapi.json is written with sorted keys and zod
emits in declaration order; a raw compare reports every parameter as divergent and reads as
catastrophic failure rather than as a bug in the comparison.

## Two things the conversion surfaced

**`netuids` was the last raw filter literal**, and its bound is real: at most 128 ids of at most 5
digits each, which *is* the 767-character ceiling (128 ids + 127 commas). The MCP side publishes
`^\d+(,\d+)*$` for the same parameter — unbounded in count, and accepting a 9-digit "netuid" — so a
tool caller could send a list its own route rejects. It is `netuidListSchema()` now, one definition
for both surfaces.

**Six parameters used `enumSchema()` as a direct parameter value** rather than as a collection
filter, so nothing rendered them to JSON — they showed up in the diff as raw `ZodEnum` internals
(`{"def":{"entries":…},"options":[…]}`) leaking into the published contract. They go through
`parameterSchema()` like every other parameter now. The two `["asc","desc"]` pairs among them are
the vocabulary's `orderSchema()` and say so.

That leak is worth noting as the reason the byte-identity check is the acceptance criterion and not
a nicety: it was invisible to typecheck, lint and every existing test, and only the artifact diff
caught it.

## Validation

```
npm run typecheck / lint / format:check      clean
npx vitest run                               754 files, 18,047 passed, 22 skipped
```

```
validate:contract-drift  validate:openapi  validate:api  validate:schemas
validate:query-vocabulary  validate:schema-vocabularies  validate:mcp  validate:mcp-input-parity
```
all pass.

Part of #10060. Closes #10080
