### PR TITLE
fix(watchdog): neon-mirror-lag swept 10 terms and D1 parses 5 (#10081)

### DIFF
--- a/src/d1-compound.ts
+++ b/src/d1-compound.ts
@@ -1,0 +1,58 @@
+// D1's compound-SELECT ceiling, and how to sweep a table list without hitting it.
+//
+// ## The ceiling
+//
+// Upstream SQLite defaults `SQLITE_MAX_COMPOUND_SELECT` to 500. D1 builds it at
+// FIVE. Probed directly against the production database on 2026-08-07 and again
+// on 2026-08-08, both times by generating the statement with the SAME builder
+// the watchdog uses rather than a hand-written approximation of it:
+//
+//     n=3   ok        n=6   too many terms in compound SELECT: SQLITE_ERROR
+//     n=5   ok        n=7+  the same, all the way up
+//
+// ## Why this lives in its own module
+//
+// It is a property of D1, not of whichever caller discovered it, and it has now
+// been discovered twice. `neon-parity` shipped in #9850 sweeping ten tables in
+// one UNION ALL and recorded `unknown: counts unreadable` every hour from the
+// moment it deployed; #9881 found the ceiling and batched that lane, but left
+// the constant private to that watchdog. `neon-mirror-lag` then walked into the
+// identical failure (#10081) the moment #10053 took it from five watched tables
+// to seven -- a second literal `5` would have been a second thing to keep in
+// step with the first.
+//
+// ## Why the failure mode deserves the emphasis
+//
+// Exceeding the ceiling does not truncate the sweep, it throws before a single
+// row is read. So a watchdog over the limit reports the truth about ITSELF
+// ("I could not read") and nothing whatsoever about the thing it watches -- and
+// both times, the lane went on being green-adjacent enough that nobody looked.
+// Batching is therefore not an optimisation; it is the difference between a
+// check that works and a check that cannot run.
+
+/** D1's hard limit on `UNION ALL` terms in one statement. Measured, not
+ * documented upstream -- see this module's header for the probe. */
+export const D1_MAX_COMPOUND_TERMS = 5;
+
+/**
+ * Split a table sweep into statements no wider than D1 will parse.
+ *
+ * `build` renders one statement from a slice of the list, so each caller keeps
+ * its own projection (`COUNT(*)`, `MAX(captured_at)`, …) and only the splitting
+ * is shared.
+ *
+ * Postgres has no comparable limit, but callers that run the same sweep against
+ * both stores should run the SAME batches on each: identical row shapes on both
+ * sides means one reader serves both halves of a comparison.
+ */
+export function compoundBatches(
+  tables: readonly string[],
+  build: (batch: readonly string[]) => string,
+  perBatch: number = D1_MAX_COMPOUND_TERMS,
+): string[] {
+  const batches: string[] = [];
+  for (let i = 0; i < tables.length; i += perBatch) {
+    batches.push(build(tables.slice(i, i + perBatch)));
+  }
+  return batches;
+}

--- a/src/neon-mirror-watchdog.ts
+++ b/src/neon-mirror-watchdog.ts
@@ -50,6 +50,7 @@
 // its own cron and would report health whether or not the producer ever ran.
 // Table freshness is the one signal every mirrored lane actually has.
 
+import { compoundBatches, D1_MAX_COMPOUND_TERMS } from "./d1-compound.ts";
 import { neonDualWriteLanes } from "./neon-write.ts";
 import { LEDGER_MIRROR_PLANS } from "./ledger-neon-write.ts";
 import { NEURON_MIRROR_PLANS } from "./neurons-neon-write.ts";
@@ -146,11 +147,15 @@ export interface MirrorLag {
 }
 
 /**
- * A table's newest write, per table, in one statement.
+ * A table's newest write, for up to D1_MAX_COMPOUND_TERMS tables at a time.
  *
- * One query rather than one per table: this runs on a cron beside five other
- * lanes, and six round trips to answer "did anything move" is five more than
- * the question needs.
+ * Unioned rather than one query per table: this runs on a cron beside five
+ * other lanes, and a round trip per table to answer "did anything move" is
+ * more than the question needs.
+ *
+ * NEVER call this with the whole watched list -- use mirrorFreshnessBatches.
+ * Past the ceiling D1 throws on the statement instead of truncating it, so an
+ * over-wide sweep reads NOTHING (#10081).
  */
 export function mirrorFreshnessSql(tables: readonly string[]): string {
   return tables
@@ -159,6 +164,22 @@ export function mirrorFreshnessSql(tables: readonly string[]): string {
         `SELECT '${table}' AS t, MAX(${freshnessColumn(table)}) AS mx FROM ${table}`,
     )
     .join(" UNION ALL ");
+}
+
+/**
+ * The freshness sweep, split into statements D1 will actually parse.
+ *
+ * This lane sat at exactly five watched tables -- the ceiling -- until #10053
+ * added `subnet-hyperparams` and `account-identity` to NEON_DUAL_WRITE_LANES,
+ * and it reported `unknown: table freshness unreadable` on every run from the
+ * next hour onward. Every lane the D1->Neon migration adds widens it further,
+ * so the split belongs here rather than in a caller that must remember to ask.
+ */
+export function mirrorFreshnessBatches(
+  tables: readonly string[],
+  perBatch: number = D1_MAX_COMPOUND_TERMS,
+): string[] {
+  return compoundBatches(tables, mirrorFreshnessSql, perBatch);
 }
 
 /**
@@ -317,10 +338,19 @@ export async function runNeonMirrorWatchdog(
 
   let freshness: Map<string, number>;
   try {
-    const result = await db?.prepare(mirrorFreshnessSql(tables)).all();
-    if (!result) throw new Error("no result");
+    // Batched, and every batch must answer. A partial read would understate
+    // freshness for the tables in a batch that failed, and this watchdog reads
+    // a MISSING table as "never written" -- which is the shape of an alarm,
+    // not of a missing measurement. Failing the whole sweep keeps `unknown`
+    // meaning "I could not look" rather than quietly meaning "some of it".
+    const results = await Promise.all(
+      mirrorFreshnessBatches(tables).map((statement) =>
+        db?.prepare(statement).all(),
+      ),
+    );
+    if (results.some((result) => !result)) throw new Error("no result");
     freshness = new Map();
-    for (const raw of result.results ?? []) {
+    for (const raw of results.flatMap((result) => result?.results ?? [])) {
       const row = raw as Record<string, unknown>;
       // NULL CHECKED BEFORE Number(), because `Number(null)` is 0 and 0 passes
       // Number.isFinite. `MAX(captured_at)` over an empty table returns NULL,

--- a/src/neon-parity-watchdog.ts
+++ b/src/neon-parity-watchdog.ts
@@ -34,6 +34,7 @@
 // than D1, because the D1 write is lossy (#9832) -- so a check written as "is
 // Neon behind D1" would have reported that table healthy while it was the
 // worst broken of the three. Both directions are surfaced.
+import { compoundBatches, D1_MAX_COMPOUND_TERMS } from "./d1-compound.ts";
 import {
   loadLatestLaneHealth,
   recordLaneVerdict,
@@ -173,43 +174,22 @@ export interface TableParity {
 }
 
 /**
- * D1's compound-SELECT ceiling, MEASURED against production 2026-08-07.
+ * The sweep, split into statements no wider than D1 will parse.
  *
- * Upstream SQLite defaults `SQLITE_MAX_COMPOUND_SELECT` to 500. D1 builds it
- * at FIVE. Probed directly against the production database: 3 and 5 terms
- * answer, 6 and up fail with
- *
- *     D1_ERROR: too many terms in compound SELECT: SQLITE_ERROR
- *
- * This is not a tuning knob, it is the reason this lane never worked. It
- * shipped in #9850 sweeping ten tables in one UNION ALL -- five past the
- * limit -- so the D1 half of the comparison threw before it read a single row
- * and the watchdog recorded `unknown: counts unreadable` every hour from the
- * moment it deployed. A watchdog that cannot read its subject reports the
- * truth about itself and nothing about what it watches, which is why this was
- * only caught by looking at the lane rather than trusting that it was green.
+ * The ceiling itself, and why exceeding it is total rather than partial, live
+ * in src/d1-compound.ts -- this lane is where it was first measured (#9881),
+ * and `neon-mirror-lag` walked into the identical failure later (#10081), which
+ * is what moved the constant somewhere both can read.
  *
  * Batching here rather than at the call site because the ceiling grows more
  * dangerous as PARITY_TABLES grows: every table added to the migration adds a
- * term, and the failure is total (no counts at all) rather than partial.
- */
-export const D1_MAX_COMPOUND_TERMS = 5;
-
-/**
- * The sweep, split into statements no wider than D1 will parse.
- *
- * Postgres has no comparable limit, but both stores run the SAME batches so
- * the two halves stay symmetric and one row-shape reader serves both.
+ * term.
  */
 export function parityCountBatches(
   tables: readonly string[],
   perBatch: number = D1_MAX_COMPOUND_TERMS,
 ): string[] {
-  const batches: string[] = [];
-  for (let i = 0; i < tables.length; i += perBatch) {
-    batches.push(parityCountSql(tables.slice(i, i + perBatch)));
-  }
-  return batches;
+  return compoundBatches(tables, parityCountSql, perBatch);
 }
 
 /** One `SELECT count` per table, unioned. Never call with more than

--- a/tests/neon-mirror-watchdog.test.ts
+++ b/tests/neon-mirror-watchdog.test.ts
@@ -13,10 +13,12 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
+import { D1_MAX_COMPOUND_TERMS } from "../src/d1-compound.ts";
 import {
   describeMirrorLags,
   MIRROR_LAG_THRESHOLD_MS,
   MIRROR_LANE_TABLES,
+  mirrorFreshnessBatches,
   mirrorFreshnessSql,
   mirrorLags,
   NEON_MIRROR_LAG_LANE,
@@ -97,13 +99,71 @@ describe("MIRROR_LANE_TABLES", () => {
 });
 
 describe("mirrorFreshnessSql", () => {
-  test("asks every table in ONE statement", () => {
+  test("asks every table of one batch in ONE statement", () => {
     const sql = mirrorFreshnessSql(["a", "b"]);
     assert.equal(
       sql,
       "SELECT 'a' AS t, MAX(captured_at) AS mx FROM a UNION ALL " +
         "SELECT 'b' AS t, MAX(captured_at) AS mx FROM b",
     );
+  });
+});
+
+describe("mirrorFreshnessBatches", () => {
+  const everyTable = [...new Set(Object.values(MIRROR_LANE_TABLES))];
+
+  test("no batch is wider than D1 will parse", () => {
+    // Measured against production, twice (#9881, #10081): five terms answer,
+    // six throw. Past the ceiling the sweep does not degrade -- it reads
+    // NOTHING, and this watchdog then has nothing to say about ten mirrors.
+    for (const sql of mirrorFreshnessBatches(everyTable)) {
+      assert.ok(
+        sql.split(/\bUNION ALL\b/).length <= D1_MAX_COMPOUND_TERMS,
+        `batch too wide: ${sql}`,
+      );
+    }
+  });
+
+  test("every table is asked exactly once", () => {
+    const named = mirrorFreshnessBatches(everyTable)
+      .flatMap((sql) => [...sql.matchAll(/SELECT '(\w+)' AS t/g)])
+      .map((m) => m[1]);
+    assert.deepEqual(named.sort(), [...everyTable].sort());
+  });
+
+  test("the live table list ACTUALLY needs splitting", () => {
+    // A negative assertion passes on nothing. If the watched set ever shrank
+    // back to five, the two tests above would hold on a single batch and stop
+    // proving the split works -- so pin that the real pairing exercises it.
+    assert.ok(
+      everyTable.length > D1_MAX_COMPOUND_TERMS,
+      "MIRROR_LANE_TABLES no longer exceeds one batch; this suite stopped testing the split",
+    );
+    assert.ok(mirrorFreshnessBatches(everyTable).length > 1);
+  });
+
+  test("a table list that fits stays one statement", () => {
+    assert.equal(mirrorFreshnessBatches(["a", "b"]).length, 1);
+  });
+
+  test("the width is overridable, and the remainder is not dropped", () => {
+    const batches = mirrorFreshnessBatches(["a", "b", "c", "d", "e"], 2);
+    assert.equal(batches.length, 3);
+    assert.equal(batches[2].split(/\bUNION ALL\b/).length, 1);
+  });
+
+  test("each batch carries the right freshness column per table", () => {
+    // The override list is per-table, so a batch boundary must not shift which
+    // column a table is read by. chain_detail_* and the capture-state pair have
+    // no captured_at at all -- naming the default there is a missing-column
+    // error, which for THIS watchdog is the failure it exists to catch.
+    const joined = mirrorFreshnessBatches(everyTable, 1).join(" ");
+    assert.ok(
+      joined.includes("MAX(observed_at) AS mx FROM chain_detail_blocks"),
+    );
+    assert.ok(joined.includes("MAX(observed_at) AS mx FROM blocks_head"));
+    assert.ok(joined.includes("MAX(updated_at) AS mx FROM raw_capture_state"));
+    assert.ok(joined.includes("MAX(captured_at) AS mx FROM neurons"));
   });
 });
 
@@ -442,6 +502,103 @@ describe("runNeonMirrorWatchdog", () => {
     });
     assert.equal(out.attempted, true);
     assert.ok(MIRROR_LAG_THRESHOLD_MS > 0);
+  });
+});
+
+describe("the sweep against a store that enforces D1's ceiling", () => {
+  /** A fake that behaves like D1: it THROWS on an over-wide statement rather
+   * than truncating it, and answers each batch only about its own tables. A
+   * fake that answered everything regardless of what was asked would pass on
+   * the unbatched code this describe exists to keep out. */
+  function ceilingDb(freshness: Readonly<Record<string, number>>) {
+    const statements: string[] = [];
+    return {
+      statements,
+      db: {
+        prepare(sql: string) {
+          return {
+            async all() {
+              if (sql.startsWith("SELECT lane")) return { results: [] };
+              statements.push(sql);
+              const terms = sql.split(/\bUNION ALL\b/).length;
+              if (terms > D1_MAX_COMPOUND_TERMS) {
+                throw new Error(
+                  "D1_ERROR: too many terms in compound SELECT: SQLITE_ERROR",
+                );
+              }
+              const asked = [...sql.matchAll(/SELECT '(\w+)' AS t/g)].map(
+                (m) => m[1],
+              );
+              return {
+                results: asked
+                  .filter((t) => freshness[t] != null)
+                  .map((t) => ({ t, mx: freshness[t] })),
+              };
+            },
+            bind() {
+              return {
+                async run() {},
+                async all() {
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("reads every watched table, across more batches than one", async () => {
+    // The whole deployed lane set, which is well past the ceiling -- this is
+    // the exact shape that reported `unknown` in production for an hour.
+    const lanes = Object.keys(MIRROR_LANE_TABLES);
+    const tables = [...new Set(Object.values(MIRROR_LANE_TABLES))];
+    const spy = ceilingDb(Object.fromEntries(tables.map((t) => [t, NOW])));
+
+    const out = await runNeonMirrorWatchdog(
+      { NEON_DUAL_WRITE_LANES: lanes.join(",") },
+      { db: spy.db, laneHealthDb: spy.db, now: () => NOW },
+    );
+
+    assert.ok(spy.statements.length > 1, "expected the sweep to be split");
+    // Every table answered, so no lane can be reported as never-mirrored for
+    // want of a freshness reading.
+    const seen = spy.statements
+      .flatMap((sql) => [...sql.matchAll(/SELECT '(\w+)' AS t/g)])
+      .map((m) => m[1]);
+    assert.deepEqual(seen.sort(), [...tables].sort());
+    assert.notEqual(out.attempted, false);
+    assert.ok(out.survey, "expected a survey rather than an unreadable sweep");
+  });
+
+  test("one unreadable batch fails the whole sweep, not part of it", async () => {
+    // A partial read would understate freshness for the missing tables, and a
+    // missing table reads as "never written" -- an alarm manufactured from a
+    // measurement that was never taken.
+    const lanes = Object.keys(MIRROR_LANE_TABLES);
+    const spy = ceilingDb({});
+    let calls = 0;
+    const db = {
+      prepare(sql: string) {
+        const inner = spy.db.prepare(sql);
+        return {
+          async all() {
+            if (!sql.startsWith("SELECT lane") && calls++ === 1) {
+              throw new Error("D1_ERROR: overloaded");
+            }
+            return inner.all();
+          },
+          bind: inner.bind,
+        };
+      },
+    };
+    const out = await runNeonMirrorWatchdog(
+      { NEON_DUAL_WRITE_LANES: lanes.join(",") },
+      { db, laneHealthDb: db, now: () => NOW },
+    );
+    assert.equal(out.reason, "freshness unreadable");
+    assert.equal(out.survey, undefined);
   });
 });
 

--- a/tests/neon-parity-watchdog.test.ts
+++ b/tests/neon-parity-watchdog.test.ts
@@ -6,8 +6,8 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
+import { D1_MAX_COMPOUND_TERMS } from "../src/d1-compound.ts";
 import {
-  D1_MAX_COMPOUND_TERMS,
   NEON_PARITY_CRON,
   NEON_PARITY_LANE,
   PARITY_MIN_ROWS,


### PR DESCRIPTION
## Summary

`neon-mirror-lag` — the watchdog that answers "is any Neon mirror falling behind the table it
mirrors" — has reported `unknown` on every run since **05:26 UTC today**, and said nothing about the
ten mirrors it watches.

```
lane             verdict   detail
neon-mirror-lag  unknown   table freshness unreadable: D1_ERROR: too many terms in compound SELECT
```

`mirrorFreshnessSql` sends one `UNION ALL` term per watched table as a single statement. D1 parses at
most **five** — the same ceiling that made `neon-parity` blind from the day it shipped (#9881).

## When it broke, and why it looked fine before

The lane sat at exactly five watched tables — the cap — until #10053 added `subnet-hyperparams` and
`account-identity` to `NEON_DUAL_WRITE_LANES` at 05:06. `lane_health` records the flip on the very
next hourly run:

```
ok       … 04:26:03
unknown    05:26:03   (first)
unknown    06:26:02
```

It is at **ten** watched tables now, and every lane the D1→Neon migration adds widens it further.

## Measured, not inferred

Probed against production D1 by generating the statement with **this module's own builder** rather
than a hand-written approximation of it — the first attempt at this used a shell re-implementation
and produced a wrong answer twice, once from a `grep` that matched row-count digits and once from a
malformed statement:

```
n=3   OK                    n=6 … n=12   too many terms in compound SELECT
n=5   OK
```

Batched, all three statements execute against production.

## Change

The sweep batches at the cap, the way `parityCountBatches` already does. `D1_MAX_COMPOUND_TERMS`
moves to `src/d1-compound.ts` — two watchdogs need it now, and a second literal `5` would be a second
thing to keep in step with the first.

**The sweep is all-or-nothing.** Exceeding the ceiling throws before reading a row, so the failure is
total rather than partial — but a batched sweep *could* fail partially, and that would be worse than
the bug. A missing table is absent from the freshness map, and this watchdog reads an absent table as
"never written". Tolerating a failed batch would manufacture alarms from measurements never taken, so
any failed batch fails the whole sweep and `unknown` keeps meaning "I could not look".

## Both regression tests were verified to fail on the code they guard

A test that passes on the broken code proves nothing, so each was run against the defect it exists
for:

| test | mutation | result |
|---|---|---|
| `reads every watched table, across more batches than one` | runner reverted to the unbatched statement | **fails** |
| `one unreadable batch fails the whole sweep, not part of it` | runner mutated to `.catch(() => ({results: []}))` | **fails** |

The fake D1 in that suite enforces the ceiling itself — it throws on an over-wide statement and
answers each batch only about its own tables, so a fake that answered everything regardless of what
was asked cannot let the unbatched code through.

`the live table list ACTUALLY needs splitting` pins that the real pairing exceeds one batch, so the
suite cannot quietly stop testing the split if the watched set ever shrinks.

## Validation

```
npx tsc --noEmit                                        clean
eslint / prettier --check (5 changed files)             clean
npx vitest run neon-mirror-watchdog neon-parity-watchdog
                hyperparams-identity-neon-write neon-backfill    180 passed
```

Closes #10081
