### PR TITLE
fix(neon): the migration flags were invisible to the Worker running two gates (#10084)

### DIFF
--- a/src/chain-detail-prune.ts
+++ b/src/chain-detail-prune.ts
@@ -61,7 +61,7 @@ import {
   type HyperdriveLike,
   type WaitUntilLike,
 } from "./pg-sql.ts";
-import { neonBackfillLanes } from "./neon-write.ts";
+import { neonBackfillLanes, neonOwnsTable } from "./neon-write.ts";
 
 /** ~6h at the chain's 12s cadence: 3x the hourly decode lane's worst-case lag. */
 export const CHAIN_DETAIL_MIN_RETAINED_BLOCKS = 1_800;
@@ -262,9 +262,22 @@ export async function pruneChainDetail(
  * already deleted by the time this runs; the worst case is Neon holding a
  * little extra until the next tick, which the next tick fixes.
  *
- * Gated on `neonBackfillLanes`: a table nothing reconciles has no Neon rows to
- * prune, and issuing the DELETE anyway would be a connection per tick for
- * nothing.
+ * THE GATE ASKS WHETHER NEON HOLDS THESE ROWS, not whether something is
+ * reconciling them (#10084). It was `neonBackfillLanes` alone, which was wrong
+ * in both directions:
+ *
+ *   * On the main Worker, where this actually runs, NEON_BACKFILL_LANES was
+ *     undefined -- `vars` are per-config -- so the set was empty and this
+ *     returned before opening a connection, every tick, forever. Neon was
+ *     measured holding 1,499 blocks BELOW D1's floor and growing.
+ *   * #10078 established that a table LEAVES the backfill lanes exactly when
+ *     Neon becomes its sole store. So the old gate would have switched the
+ *     prune off at the precise moment Neon held the only copy -- a second,
+ *     worse no-op waiting at the end of the migration.
+ *
+ * Reconciled OR solely owned both mean "Neon has rows here", which is the only
+ * question a prune needs answered. A table that is neither still costs nothing:
+ * the connection is skipped rather than opened for a DELETE matching nothing.
  */
 async function pruneChainDetailNeon(
   env: unknown,
@@ -281,7 +294,9 @@ async function pruneChainDetailNeon(
   // dropped -- a join across the seam would then find a block header with no
   // events, which reads as corruption rather than as retention.
   const lanes = neonBackfillLanes(bag);
-  if (!PRUNE_TABLES.every((table) => lanes.has(table))) return {};
+  const neonHolds = (table: string) =>
+    lanes.has(table) || neonOwnsTable(bag, table);
+  if (!PRUNE_TABLES.every(neonHolds)) return {};
   try {
     const sql = injected ?? createPgSql(hyperdrive!, ctx!);
     for (const table of PRUNE_TABLES) {

--- a/tests/chain-detail-prune.test.ts
+++ b/tests/chain-detail-prune.test.ts
@@ -294,6 +294,51 @@ describe("the Neon side of the prune (#10017)", () => {
     assert.equal(result.neon_pruned, undefined);
   });
 
+  test("a SOLE-STORE table is still pruned, with nothing reconciling it", async () => {
+    // The landmine the old gate was carrying (#10084). #10078 established that
+    // a table leaves NEON_BACKFILL_LANES exactly when Neon becomes its sole
+    // store -- so a gate reading only the backfill lanes would switch this
+    // prune off at the precise moment Neon held the only copy, and these four
+    // tables would grow without bound with no second store to notice.
+    const d1 = d1WithWindow(1, 10_000_000);
+    const seen: string[] = [];
+    const result = await pruneChainDetail(
+      {
+        METAGRAPH_HEALTH_DB: d1.binding,
+        HYPERDRIVE: { connectionString: "postgresql://example/db" },
+        // Reconciled by NOTHING, owned outright by Neon -- the endgame state.
+        NEON_BACKFILL_LANES: "",
+        NEON_SOLE_STORE_TABLES: NEON_LANES,
+      },
+      { waitUntil: () => undefined },
+      {
+        sql: {
+          unsafe: async (text: string) => {
+            seen.push(text);
+            return [];
+          },
+        },
+      },
+    );
+    assert.equal(result.neon_pruned, true);
+    assert.equal(seen.length, 4);
+  });
+
+  test("neither reconciled nor owned still skips, so nothing connects for nothing", async () => {
+    const d1 = d1WithWindow(1, 10_000_000);
+    const result = await pruneChainDetail(
+      {
+        METAGRAPH_HEALTH_DB: d1.binding,
+        HYPERDRIVE: { connectionString: "postgresql://example/db" },
+        NEON_BACKFILL_LANES: "",
+        NEON_SOLE_STORE_TABLES: "",
+      },
+      { waitUntil: () => undefined },
+    );
+    assert.equal(result.neon_pruned, undefined);
+    assert.ok((result.blocks_pruned ?? 0) > 0);
+  });
+
   test("no ctx means no Neon prune, and D1 still runs", async () => {
     // createPgSql returns its connection via waitUntil; without somewhere to
     // park the teardown the connection would leak per tick.

--- a/tests/neon-flag-config-parity.test.ts
+++ b/tests/neon-flag-config-parity.test.ts
@@ -1,0 +1,113 @@
+// The D1->Neon flags must say the SAME thing in every config that runs a
+// gated path (#10084).
+//
+// `vars` in Wrangler are per-config. There is no inheritance between
+// wrangler.jsonc and wrangler.data.jsonc, so a flag set in one is `undefined`
+// in the other -- and every gate in this codebase is written to SKIP on
+// undefined rather than throw, because skipping is right when a Worker
+// genuinely has no Neon binding. That combination makes a missing flag silent.
+//
+// It has now cost two live defects:
+//
+//   * the chain_detail Neon prune never ran, and Neon was measured holding
+//     1,499 blocks below D1's floor, growing without bound
+//   * #10071's observation-family writer could not activate at all, so the
+//     documented flip (adding the tables to NEON_SOLE_STORE_TABLES) would have
+//     been a no-op while the flag claimed the migration had happened
+//
+// Both were invisible from the flag values alone: wrangler.data.jsonc looked
+// correct, and it was -- the Worker reading it was not the Worker running the
+// code.
+//
+// So this asserts agreement rather than presence. A flag that exists in both
+// files with different values is the worse failure of the two: it makes the
+// stores disagree about which one owns a table.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+
+/** Every config whose Worker reaches a Neon-flag gate. Hand-listed, because
+ * "which Workers have gated paths" is the thing being asserted -- deriving it
+ * from which files happen to contain the flags would make a config that
+ * silently dropped them look like a config nobody asked about. */
+const GATED_CONFIGS = ["wrangler.jsonc", "wrangler.data.jsonc"] as const;
+
+const FLAGS = [
+  "NEON_DUAL_WRITE_LANES",
+  "NEON_READ_LANES",
+  "NEON_BACKFILL_LANES",
+  "NEON_SOLE_STORE_TABLES",
+] as const;
+
+/** Read a flag as declared, tolerating the line break Prettier introduces
+ * when a value is long enough to wrap. */
+function declared(config: string, flag: string): string | null {
+  const source = readFileSync(config, "utf8");
+  return new RegExp(`"${flag}":\\s*"([^"]*)"`).exec(source)?.[1] ?? null;
+}
+
+describe("the Neon migration flags", () => {
+  for (const flag of FLAGS) {
+    test(`${flag} is declared in every config with a gated path`, () => {
+      for (const config of GATED_CONFIGS) {
+        assert.notEqual(
+          declared(config, flag),
+          null,
+          `${config} declares no ${flag}; every gate reading it there answers "no" silently`,
+        );
+      }
+    });
+
+    test(`${flag} says the same thing in all of them`, () => {
+      const [first, ...rest] = GATED_CONFIGS;
+      const expected = declared(first, flag);
+      for (const config of rest) {
+        assert.equal(
+          declared(config, flag),
+          expected,
+          `${flag} differs between ${first} and ${config} -- the two Workers ` +
+            `would disagree about which store owns a table`,
+        );
+      }
+    });
+  }
+
+  test("a table Neon SOLELY owns is never also reconciled", () => {
+    // The same invariant tests/neon-backfill.test.ts pins for the data Worker,
+    // asserted here against the copy this Worker reads -- a reconciler pointed
+    // at a frozen D1 would copy it over live Neon rows.
+    for (const config of GATED_CONFIGS) {
+      const sole = new Set(
+        (declared(config, "NEON_SOLE_STORE_TABLES") ?? "")
+          .split(",")
+          .map((t) => t.trim())
+          .filter(Boolean),
+      );
+      const reconciled = (declared(config, "NEON_BACKFILL_LANES") ?? "")
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean);
+      for (const table of reconciled) {
+        assert.equal(
+          sole.has(table),
+          false,
+          `${config}: ${table} is sole-store AND reconciled`,
+        );
+      }
+    }
+  });
+
+  test("the flag list itself has not outgrown this test", () => {
+    // A fifth flag added to the data config and not to this list would go
+    // unchecked, which is the exact failure this file exists for.
+    const source = readFileSync("wrangler.data.jsonc", "utf8");
+    const found = new Set(
+      [...source.matchAll(/"(NEON_[A-Z_]+)":/g)].map((m) => m[1]),
+    );
+    assert.deepEqual(
+      [...found].sort(),
+      [...FLAGS].sort(),
+      "wrangler.data.jsonc declares a NEON_* flag this test does not compare",
+    );
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -57,6 +57,34 @@
     "METAGRAPH_CONTRACT_VERSION": "2026-07-03.2",
     "METAGRAPH_ENABLE_RPC_PROXY": "true",
     "METAGRAPH_R2_LATEST_PREFIX": "latest/",
+    // ---------------------------------------------------------------------
+    // The D1->Neon migration flags. IDENTICAL to wrangler.data.jsonc's, and a
+    // test (tests/neon-flag-config-parity.test.ts) fails CI if they drift.
+    //
+    // WHY THIS WORKER CARRIES THEM AT ALL (#10084). `vars` are PER-CONFIG, and
+    // two Neon-gated paths run on THIS Worker rather than the data Worker:
+    //
+    //   src/chain-detail-prune.ts   the Neon half of the chain_detail prune
+    //   src/health-prober.ts        the observation family's Neon writer
+    //
+    // With the flags declared only next door, both gates read `undefined` and
+    // answered "no" permanently -- silently, because both are written to skip
+    // rather than fail. The prune never ran once: Neon was measured holding
+    // 1,499 blocks BELOW D1's floor and growing, while `chain_detail_chain_events`
+    // reached 628,615 rows against D1's 326,918. And #10071's observation writer
+    // could never activate, so adding those tables to NEON_SOLE_STORE_TABLES --
+    // the documented way to flip them -- would have been a no-op while the flag
+    // claimed otherwise.
+    //
+    // Same shape as #9466's trace rate (set in one wrangler file, unset in the
+    // others) and #10038's dispatcher (a fully-declared cutover that did
+    // nothing). Duplication is the cost of per-config vars; the parity test is
+    // what keeps it from becoming drift.
+    // ---------------------------------------------------------------------
+    "NEON_DUAL_WRITE_LANES": "neurons,nominator-positions,account-balances,hotkey-alpha,validator-nominator-counts,subnet-hyperparams,account-identity,chain-detail,blocks-head,raw-capture-state",
+    "NEON_READ_LANES": "account_position_daily,neurons,neuron_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,subnet_hyperparams_history,account_identity_history",
+    "NEON_BACKFILL_LANES": "subnet_snapshots,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily,subnet_burn_history,tao_usd_index,blocks_head,chain_detail_blocks,chain_detail_extrinsics,chain_detail_chain_events,chain_detail_account_events",
+    "NEON_SOLE_STORE_TABLES": "rpc_accounts,github_accounts,api_keys,api_key_blocks,api_key_usage_daily,api_quota_daily,api_usage_rollup,chain_alert_triggers,chain_alert_deliveries,watch_push_subscriptions,neurons,neuron_daily,account_position_daily",
     // Staging drift tripwire (types-epic B, #7860): when "true", the routes
     // schemas-src/ covers (subnets, subnet-detail, health, economics,
     // subnet-stake-quote) parse their own outgoing envelope against the Zod


### PR DESCRIPTION
## Summary

`vars` are **per-config**. The four `NEON_*` flags were declared only in `wrangler.data.jsonc`, and
two Neon-gated paths run on the **main** Worker:

```
workers/api.entry.ts  (581 modules)     <- wrangler.jsonc, NO NEON_* vars
   src/chain-detail-prune.ts  [neonBackfillLanes]
   src/health-prober.ts       [neonOwnsObservations]
   src/observations-neon.ts   [neonOwnsTable, neonOwnsObservations]
```

Both gates read `undefined` there and answered "no" permanently. Neither *failed* — both are written
to skip, which is correct when a Worker has no Neon binding, and silent when it does.

## Consequence 1 — the chain_detail Neon prune had never run

Measured against both stores, same minute:

| | min_block | max_block | rows | span |
|---|---|---|---|---|
| D1 | 8796086 | 8797897 | 1,812 | 1,812 |
| Neon | 8794587 | 8797895 | 3,309 | 3,309 |

Both windows are contiguous, so this is not a gap — Neon is retaining 1,499 blocks below D1's floor
and the four tables grow without bound. `chain_detail_chain_events` is already **628,615** rows
against D1's **326,918**.

## Consequence 2 — the observation family could not be flipped at all

`runHealthProber` is the main Worker's cron ("every unmatched cron falls through to the health
prober", `workers/api.ts:2121`). Its Neon runner gates on `NEON_SOLE_STORE_TABLES`.

So #10071 shipped a Neon writer for the five observation tables that **cannot activate**, and adding
them to `NEON_SOLE_STORE_TABLES` — the documented flip — would have been a no-op while the flag
claimed the migration had happened. This one had not fired yet; it was waiting for me to flip it.

Same shape as #9466 (a trace rate set in one wrangler file, unset in the others) and #10038 (a fully
declared cutover that did nothing).

## Change

**1. `wrangler.jsonc` declares the same four flags, identical values.** `wrangler deploy --dry-run`
confirms all four land as environment variables on the main Worker.

**2. A parity test, because duplication without a gate is just drift with extra steps.** It fails on
both mutations, verified:

| mutation | result |
|---|---|
| a flag missing from `wrangler.jsonc` | **2 tests fail** |
| a flag present but with a drifted value | **1 test fails** |

It also asserts the flag *list* hasn't outgrown the test — a fifth flag added to one config and not
to this file would otherwise go unchecked, which is precisely the failure being fixed.

**3. The chain_detail Neon prune asks whether Neon HOLDS these rows** (reconciled **or** solely
owned) rather than whether something is reconciling them. The old predicate was wrong in both
directions: empty on the Worker that runs it, and — because #10078 established that a table leaves
`NEON_BACKFILL_LANES` exactly when Neon becomes its sole store — it would have switched the prune off
at the precise moment Neon held the only copy. A second, worse no-op waiting at the end of the
migration. `a SOLE-STORE table is still pruned, with nothing reconciling it` fails on the old gate.

## Blast radius of adding the flags

Checked rather than assumed: no code reads these vars directly (only the helpers in
`src/neon-write.ts`), and the main Worker's transitive reader set is exactly the three modules above.
No table in `NEON_SOLE_STORE_TABLES` is touched by a main-Worker gate today, so the only behaviour
change is the prune starting to run — and the observation flip becoming possible.

## Validation

```
npx tsc --noEmit                                  clean
eslint / prettier --check                         clean
wrangler deploy --dry-run (wrangler.jsonc)        all four vars present
npx vitest run chain-detail-prune neon-flag-config-parity
                neon-backfill observations-neon neon-mirror-watchdog   167 passed
validate:workflows                                26 files
```

Closes #10084
