### PR TITLE
fix(api): four routes published a netuid they never enforced (#10075)

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -36974,8 +36974,8 @@ export interface operations {
             query?: {
                 /** @description Free-text search query, matched case-insensitively against the collection's indexed text fields. Whitespace-separated terms narrow the result (AND), and an empty or whitespace-only value is treated as no filter rather than as a search matching nothing. */
                 q?: string;
-                /** @description Maximum number of rows to return in one page. A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
-                limit?: string;
+                /** @description Maximum number of rows to return in one page (at most 20). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
+                limit?: number;
             };
             header?: never;
             path?: never;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4509,13 +4509,17 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 1000,
             "type": "string"
           }
         },
         {
           "name": "limit",
           "schema": {
-            "type": "string"
+            "default": 10,
+            "maximum": 20,
+            "minimum": 1,
+            "type": "integer"
           }
         }
       ]
@@ -4554,6 +4558,7 @@
         {
           "name": "netuid",
           "schema": {
+            "maximum": 65535,
             "minimum": 0,
             "type": "integer"
           }
@@ -8152,6 +8157,7 @@
         {
           "name": "netuid",
           "schema": {
+            "maximum": 65535,
             "minimum": 0,
             "type": "integer"
           }
@@ -8222,6 +8228,7 @@
         {
           "name": "netuid",
           "schema": {
+            "maximum": 65535,
             "minimum": 0,
             "type": "integer"
           }
@@ -11396,6 +11403,7 @@
         {
           "name": "netuid",
           "schema": {
+            "maximum": 65535,
             "minimum": 0,
             "type": "integer"
           }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -63221,6 +63221,7 @@
             "name": "netuid",
             "required": false,
             "schema": {
+              "maximum": 65535,
               "minimum": 0,
               "type": "integer"
             }
@@ -63587,6 +63588,7 @@
             "name": "netuid",
             "required": false,
             "schema": {
+              "maximum": 65535,
               "minimum": 0,
               "type": "integer"
             }
@@ -69036,6 +69038,7 @@
             "name": "netuid",
             "required": false,
             "schema": {
+              "maximum": 65535,
               "minimum": 0,
               "type": "integer"
             }
@@ -72130,6 +72133,7 @@
             "name": "netuid",
             "required": false,
             "schema": {
+              "maximum": 65535,
               "minimum": 0,
               "type": "integer"
             }
@@ -83796,16 +83800,20 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 1000,
               "type": "string"
             }
           },
           {
-            "description": "Maximum number of rows to return in one page. A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 20). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916).",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
-              "type": "string"
+              "default": 10,
+              "maximum": 20,
+              "minimum": 1,
+              "type": "integer"
             }
           }
         ],

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -36974,8 +36974,8 @@ export interface operations {
             query?: {
                 /** @description Free-text search query, matched case-insensitively against the collection's indexed text fields. Whitespace-separated terms narrow the result (AND), and an empty or whitespace-only value is treated as no filter rather than as a search matching nothing. */
                 q?: string;
-                /** @description Maximum number of rows to return in one page. A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
-                limit?: string;
+                /** @description Maximum number of rows to return in one page (at most 20). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
+                limit?: number;
             };
             header?: never;
             path?: never;

--- a/schemas-src/query-params.ts
+++ b/schemas-src/query-params.ts
@@ -202,11 +202,15 @@ export const FILTER_TEXT_MAX_LENGTH = 100;
 /**
  * A free-text search query. Substring/keyword, not a query language — worth
  * saying, because an agent that assumes operators will silently get no match.
+ *
+ * `max` defaults to the list collections' ceiling; a route with its own takes
+ * it from `src/route-limits.ts`, the same shape as `limitSchema`. Semantic
+ * search embeds the query rather than scanning with it, so it affords far more.
  */
-export const querySchema = () =>
+export const querySchema = (max: number = SEARCH_TEXT_MAX_LENGTH) =>
   z
     .string()
-    .max(SEARCH_TEXT_MAX_LENGTH)
+    .max(max)
     .describe(
       "Free-text search terms, matched as case-insensitive substrings. " +
         "Not a query language: operators, quotes and wildcards are matched literally.",

--- a/scripts/validate-query-vocabulary.ts
+++ b/scripts/validate-query-vocabulary.ts
@@ -59,17 +59,18 @@ const VOCABULARY: Record<string, z.ZodType> = {
  * decision somebody made, and a STALE entry FAILS, so the list can only shrink
  * or stay honest.
  */
-const NOT_YET_ENFORCED =
-  "the route publishes `netuid` but does not reject an out-of-u16 value -- " +
-  "it answers 200 with an empty result. Publishing the bound before enforcing " +
-  "it would move the lie rather than fix it; see #10075";
-
-const DECLARED: Record<string, string> = {
-  "/api/v1/accounts/{ss58}/events ?netuid": NOT_YET_ENFORCED,
-  "/api/v1/accounts/{ss58}/history ?netuid": NOT_YET_ENFORCED,
-  "/api/v1/chain/emission-pipeline ?netuid": NOT_YET_ENFORCED,
-  "/api/v1/compare/validators ?netuid": NOT_YET_ENFORCED,
-};
+/**
+ * Standing debt: `route ?parameter` -> why it does not yet state the bound.
+ *
+ * Same contract as validate-mcp-input-parity's DECLARED -- every entry is a
+ * decision somebody made, and a STALE entry FAILS, so the list can only shrink
+ * or stay honest.
+ *
+ * EMPTY since #10075: the four routes that published `netuid` without rejecting
+ * an out-of-u16 value now reject it (`parseNetuidParam`), so the bound they
+ * publish is real and they need no admission.
+ */
+const DECLARED: Record<string, string> = {};
 
 /**
  * Key order differs between the two producers -- openapi.json is written

--- a/src/ai-search.ts
+++ b/src/ai-search.ts
@@ -14,6 +14,11 @@ import type { StorageReadResult } from "../workers/storage.ts";
 import type { TieredRateLimitConfig } from "../workers/tiered-rate-limit.ts";
 import { buildTierPolicies } from "./api-tiers.ts";
 import {
+  SEMANTIC_LIMIT_DEFAULT,
+  SEMANTIC_LIMIT_MAX,
+  SEMANTIC_QUERY_MAX_LENGTH,
+} from "./route-limits.ts";
+import {
   recordAiDegradedEvent,
   recordAiEmbeddingEvent,
   recordAiGenerationEvent,
@@ -92,8 +97,12 @@ export const EMBED_MANIFEST_KEY = [
   EMBED_DIMENSIONS,
 ].join(":");
 
-export const SEMANTIC_DEFAULT_LIMIT = 10;
-export const SEMANTIC_MAX_LIMIT = 20;
+// The ceilings live in route-limits.ts so the published parameter and the
+// enforcement read one constant (#10075); re-exported under their existing
+// names so every current import site keeps working, the same pattern the other
+// six feature modules use.
+export const SEMANTIC_DEFAULT_LIMIT = SEMANTIC_LIMIT_DEFAULT;
+export const SEMANTIC_MAX_LIMIT = SEMANTIC_LIMIT_MAX;
 // Record kinds the registry embeds; the semantic + ask paths can scope to a
 // subset. Single source of truth for the tool schemas and the validator.
 export const SEMANTIC_TYPES = ["subnet", "surface", "provider"];
@@ -102,7 +111,7 @@ export const SEMANTIC_TYPES = ["subnet", "surface", "provider"];
 const FILTERED_RETRIEVE_TOPK = SEMANTIC_MAX_LIMIT;
 export const ASK_CONTEXT_COUNT = 6;
 export const ASK_MAX_QUESTION_LENGTH = 1000;
-export const SEMANTIC_MAX_QUERY_LENGTH = 1000;
+export const SEMANTIC_MAX_QUERY_LENGTH = SEMANTIC_QUERY_MAX_LENGTH;
 export const ASK_MAX_TOKENS = 512;
 const EMBED_BATCH_SIZE = 100;
 const VECTOR_ID_MAX_BYTES = 64;

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -49,6 +49,9 @@ import {
   CHAIN_CONCENTRATION_SUBNETS_LIMIT_DEFAULT,
   CHAIN_CONCENTRATION_SUBNETS_LIMIT_MAX,
   EMISSION_PIPELINE_LIMIT_MAX,
+  SEMANTIC_LIMIT_DEFAULT,
+  SEMANTIC_LIMIT_MAX,
+  SEMANTIC_QUERY_MAX_LENGTH,
 } from "./route-limits.ts";
 import { EMISSION_PIPELINE_SORT_FIELDS } from "./emission-pipeline-surface.ts";
 import {
@@ -2613,8 +2616,21 @@ export const API_ROUTES = [
     "short",
     ["search"],
     [
-      { name: "q", schema: { type: "string" } },
-      { name: "limit", schema: { type: "string" } },
+      // Both were wrong (#10075): `q` published no ceiling though the handler
+      // rejects one over SEMANTIC_QUERY_MAX_LENGTH, and `limit` published
+      // `{"type":"string"}` for a value the handler reads as an integer and
+      // clamps -- so a client generated from this spec sent a string where an
+      // integer was wanted, with no way to learn either bound.
+      {
+        name: "q",
+        schema: parameterSchema(querySchema(SEMANTIC_QUERY_MAX_LENGTH)),
+      },
+      {
+        name: "limit",
+        schema: parameterSchema(
+          limitSchema(SEMANTIC_LIMIT_MAX, SEMANTIC_LIMIT_DEFAULT),
+        ),
+      },
     ],
     [],
   ),
@@ -2639,7 +2655,7 @@ export const API_ROUTES = [
     ["subnets", "analytics"],
     {
       parameters: [
-        { name: "netuid", schema: { type: "integer", minimum: 0 } },
+        { name: "netuid", schema: parameterSchema(netuidSchema()) },
         {
           name: "sort",
           schema: parameterSchema(enumSchema(EMISSION_PIPELINE_SORT_FIELDS)),
@@ -3608,7 +3624,7 @@ export const API_ROUTES = [
     ["accounts", "analytics"],
     csvRouteQuery([
       { name: "kind", schema: { type: "string" } },
-      { name: "netuid", schema: { type: "integer", minimum: 0 } },
+      { name: "netuid", schema: parameterSchema(netuidSchema()) },
       { name: "block_start", schema: { type: "integer", minimum: 0 } },
       { name: "block_end", schema: { type: "integer", minimum: 0 } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
@@ -3626,7 +3642,7 @@ export const API_ROUTES = [
     "short",
     ["accounts", "analytics"],
     [
-      { name: "netuid", schema: { type: "integer", minimum: 0 } },
+      { name: "netuid", schema: parameterSchema(netuidSchema()) },
       { name: "from", schema: { type: "string", format: "date" } },
       { name: "to", schema: { type: "string", format: "date" } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
@@ -5127,7 +5143,7 @@ export const API_ROUTES = [
             "^[1-9A-HJ-NP-Za-km-z]{47,48}(,[1-9A-HJ-NP-Za-km-z]{47,48}){0,15}$",
         },
       },
-      { name: "netuid", schema: { type: "integer", minimum: 0 } },
+      { name: "netuid", schema: parameterSchema(netuidSchema()) },
     ],
     [],
   ),

--- a/src/route-limits.ts
+++ b/src/route-limits.ts
@@ -247,3 +247,23 @@ export const EMISSION_PIPELINE_MCP_LIMIT_DEFAULT = 20;
  * shape of a collection, small enough that a wrong guess costs nothing.
  */
 export const MCP_LIST_LIMIT_DEFAULT = 20;
+
+/**
+ * `/api/v1/search/semantic` -- the meaning-ranked registry search (#10075).
+ *
+ * Here for the reason this module exists: the route published `limit` as
+ * `{"type":"string"}` and `q` as unbounded, while the handler runs
+ * `clampLimit(value, 10, 20)` and rejects a `q` over 1,000 characters. A client
+ * generated from our own spec sent a string where the handler wanted an
+ * integer, and had no way to know either ceiling. Reading them from here means
+ * the published parameter and the enforcement cannot say different things.
+ *
+ * `limit` is CLAMPED rather than rejected, unlike the #9916 routes -- a
+ * similarity ranking has no meaningful page beyond the top matches, and
+ * Vectorize itself caps `topK` at this value.
+ */
+export const SEMANTIC_LIMIT_DEFAULT = 10;
+export const SEMANTIC_LIMIT_MAX = 20;
+/** Rejected above this with a 400, not truncated -- an embedded query that was
+ * silently cut would rank against text the caller never sent. */
+export const SEMANTIC_QUERY_MAX_LENGTH = 1000;

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -3463,7 +3463,9 @@ describe("handleAccountHistory", () => {
   test("rejects malformed netuid filters with 400", async () => {
     // 9007199254740993 = Number.MAX_SAFE_INTEGER + 2: passes /^\d+$/ but loses
     // precision under Number(), so the safe-integer guard rejects it.
-    for (const netuid of ["abc", "-1", "7.5", "", "9007199254740993"]) {
+    // 70000 is past the u16 ceiling (#10075): a value no subnet can carry used
+    // to come back 200 with an empty result, which reads as "no activity".
+    for (const netuid of ["abc", "-1", "7.5", "9007199254740993", "70000"]) {
       const res = await handleAccountHistory(
         req(`/api/v1/accounts/${SS58}/history`),
         emptyEnv() as unknown as Env,
@@ -3474,6 +3476,21 @@ describe("handleAccountHistory", () => {
       assert.equal(body.error.code, "invalid_query");
       assert.equal(body.meta.parameter, "netuid");
     }
+  });
+
+  // A BLANK `?netuid=` is unscoped, not malformed (#10075). This route used to
+  // be the only one of the four netuid-filtered feeds that rejected it: its
+  // siblings all run parseNonNegativeIntParam, whose documented contract is
+  // "absent/blank -> no filter". One mistake answered two different ways across
+  // four routes is the defect, so they agree now.
+  test("a blank netuid filters nothing rather than 400ing", async () => {
+    const res = await handleAccountHistory(
+      req(`/api/v1/accounts/${SS58}/history`),
+      emptyEnv() as unknown as Env,
+      SS58,
+      url(`/api/v1/accounts/${SS58}/history?netuid=`),
+    );
+    assert.equal(res.status, 200);
   });
 
   test("returns schema-stable empty days on cold D1", async () => {

--- a/tests/request-params.test.ts
+++ b/tests/request-params.test.ts
@@ -12,6 +12,8 @@ import {
   BLOCK_PAGINATION,
   DAY_PATTERN,
   DEFAULT_LIMIT,
+  MAX_U16_NETUID,
+  parseNetuidParam,
   FEED_PAGINATION,
   MAX_LIMIT,
   MAX_OFFSET,
@@ -350,5 +352,59 @@ describe("parseNonNegativeIntParam", () => {
   test("returns a parsed value for a valid non-negative integer", () => {
     assert.deepEqual(parseNonNegativeIntParam("0", "offset"), { value: 0 });
     assert.deepEqual(parseNonNegativeIntParam("42", "offset"), { value: 42 });
+  });
+});
+
+// A published bound the handler does not enforce is a contract lie (#10075).
+//
+// `netuid` is a u16, and openapi.json says `maximum: 65535` on every route that
+// takes one. Four routes -- the two account feeds, chain/emission-pipeline and
+// compare/validators -- answered `?netuid=70000` with 200 and an empty result,
+// which is indistinguishable from "that subnet exists and matches nothing" for
+// a value no subnet could ever carry. Same rule as #9916 for page sizes: an
+// out-of-range value is rejected, never answered.
+describe("parseNetuidParam enforces the u16 bound the contract publishes", () => {
+  test("absent or blank is unscoped, not an error", () => {
+    assert.deepEqual(parseNetuidParam(null), { value: null });
+    assert.deepEqual(parseNetuidParam(""), { value: null });
+  });
+
+  test("a netuid inside the range parses", () => {
+    assert.deepEqual(parseNetuidParam("0"), { value: 0 });
+    assert.deepEqual(parseNetuidParam("64"), { value: 64 });
+  });
+
+  test("the ceiling is inclusive", () => {
+    assert.deepEqual(parseNetuidParam(String(MAX_U16_NETUID)), {
+      value: MAX_U16_NETUID,
+    });
+  });
+
+  test("one past the ceiling is rejected, and says the range", () => {
+    assert.deepEqual(parseNetuidParam(String(MAX_U16_NETUID + 1)), {
+      error: {
+        parameter: "netuid",
+        message: "netuid must be an integer between 0 and 65535.",
+      },
+    });
+    assert.deepEqual(parseNetuidParam("70000"), {
+      error: {
+        parameter: "netuid",
+        message: "netuid must be an integer between 0 and 65535.",
+      },
+    });
+  });
+
+  test("a negative or non-numeric value keeps the shared message", () => {
+    // parseNonNegativeIntParam rejects these first, so the ceiling check never
+    // sees them and the caller gets the message it always got.
+    for (const raw of ["-1", "abc", "1.5", "99999999999999999999"]) {
+      assert.deepEqual(parseNetuidParam(raw), {
+        error: {
+          parameter: "netuid",
+          message: "netuid must be a non-negative integer.",
+        },
+      });
+    }
   });
 });

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -25,6 +25,7 @@ import {
 } from "./analytics.ts";
 import {
   parseLimitParam,
+  parseNetuidParam,
   parseNonNegativeIntParam,
 } from "../request-params.ts";
 import {
@@ -1110,10 +1111,7 @@ export async function handleCompareValidators(
     );
   }
 
-  const netuidResult = parseNonNegativeIntParam(
-    url.searchParams.get("netuid"),
-    "netuid",
-  );
+  const netuidResult = parseNetuidParam(url.searchParams.get("netuid"));
   if ("error" in netuidResult) return analyticsQueryError(netuidResult.error);
 
   // Sequential, not parallel -- matches compare_validators' own fan-out
@@ -1183,10 +1181,7 @@ export async function handleEmissionPipeline(
     "fields",
   ]);
   if (validationError) return analyticsQueryError(validationError);
-  const netuidResult = parseNonNegativeIntParam(
-    url.searchParams.get("netuid"),
-    "netuid",
-  );
+  const netuidResult = parseNetuidParam(url.searchParams.get("netuid"));
   if ("error" in netuidResult) return analyticsQueryError(netuidResult.error);
 
   const economics = await resolveEmissionPipelineEconomics({

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -37,6 +37,7 @@ import {
   FEED_PAGINATION,
   parseDateRange,
   parseLimitParam,
+  parseNetuidParam,
   parseNonNegativeIntParam,
   parsePagination,
 } from "../request-params.ts";
@@ -4900,10 +4901,7 @@ export async function handleAccountEvents(
     "block_end",
   );
   if ("error" in blockEnd) return analyticsQueryError(blockEnd.error);
-  const netuid = parseNonNegativeIntParam(
-    url.searchParams.get("netuid"),
-    "netuid",
-  );
+  const netuid = parseNetuidParam(url.searchParams.get("netuid"));
   if ("error" in netuid) return analyticsQueryError(netuid.error);
   const kind = url.searchParams.get("kind");
   // Reject an unknown ?kind= up front, validated against the FULL ingested set
@@ -5006,16 +5004,9 @@ export async function handleAccountHistory(
   const page = parsePagination(url, FEED_PAGINATION);
   if ("error" in page) return analyticsQueryError(page.error);
   const { limit, offset } = page;
+  const netuidParsed = parseNetuidParam(url.searchParams.get("netuid"));
+  if ("error" in netuidParsed) return analyticsQueryError(netuidParsed.error);
   const netuid = url.searchParams.get("netuid");
-  if (
-    netuid != null &&
-    (!/^\d+$/.test(netuid) || !Number.isSafeInteger(Number(netuid)))
-  ) {
-    return analyticsQueryError({
-      parameter: "netuid",
-      message: "netuid must be a non-negative integer.",
-    });
-  }
   // Inverted YYYY-MM-DD bounds are a deterministic no-match. Short-circuit before
   // D1 so callers cannot force a scan to prove an impossible empty page.
   if (from && to && from > to) {

--- a/workers/request-params.ts
+++ b/workers/request-params.ts
@@ -158,6 +158,42 @@ export function parseNonNegativeIntParam(
   return { value };
 }
 
+/**
+ * The largest netuid the chain can express. `netuid` is a u16, so 65536 does
+ * not name a subnet that has not been registered yet — it names nothing, ever.
+ */
+export const MAX_U16_NETUID = 65535;
+
+/**
+ * Validate an optional `netuid` query filter (#10075).
+ *
+ * `parseNonNegativeIntParam` already rejects a negative or non-numeric value.
+ * The ceiling is what nothing checked: `?netuid=70000` came back 200 with an
+ * empty result, which is indistinguishable from "that subnet exists and matches
+ * nothing" for a value no subnet could ever carry. The published schema says
+ * `maximum: 65535` (#10073), and a published bound the handler does not enforce
+ * is a contract lie, not a nicety — same rule as #9916 for page sizes.
+ *
+ * The list-collection routes get this from `validateListQuery`, which reads the
+ * bound off the published schema. These are the routes that do not run through
+ * it and so need it stated.
+ */
+export function parseNetuidParam(
+  raw: string | null,
+): { value: number | null } | ParamError {
+  const parsed = parseNonNegativeIntParam(raw, "netuid");
+  if ("error" in parsed) return parsed;
+  if (parsed.value !== null && parsed.value > MAX_U16_NETUID) {
+    return {
+      error: {
+        parameter: "netuid",
+        message: `netuid must be an integer between 0 and ${MAX_U16_NETUID}.`,
+      },
+    };
+  }
+  return parsed;
+}
+
 export function parseDateRange(
   url: URL,
 ): { from: string | null; to: string | null } | ParamError {


### PR DESCRIPTION
## Summary

#10073 published `maximum: 65535` on every `netuid` — it is a u16 on chain — and made
`validateListQuery` enforce it for the list collections. **Four routes do not run through that
validator** and were left as declared debt in `scripts/validate-query-vocabulary.ts`:

```
GET /api/v1/accounts/{ss58}/events?netuid=70000    -> 200, empty
GET /api/v1/accounts/{ss58}/history?netuid=70000   -> 200, empty
GET /api/v1/chain/emission-pipeline?netuid=70000   -> 200, empty
GET /api/v1/compare/validators?netuid=70000        -> 200, empty
```

70000 cannot name a subnet, so that is a confident empty answer to a malformed request —
indistinguishable from "that subnet exists and matches nothing". A published bound the handler does
not enforce is a contract lie, not a nicety; the same rule as #9916 applied to a filter instead of a
page size.

`parseNetuidParam` puts the check where the other shared parsers live, so all four say the same
thing in the same words. Three already called `parseNonNegativeIntParam` and needed only the
ceiling; the fourth had hand-rolled the same regex inline.

**`validate:query-vocabulary` now reports 108 of 108 built from the vocabulary, 0 declared.**

## One behaviour change beyond the ceiling — stated plainly

A blank `?netuid=` on `/accounts/{ss58}/history` was a 400 and is now unscoped. That route was the
**only one of the four** to reject it; its three siblings run `parseNonNegativeIntParam`, whose
documented contract is "absent/blank → no filter". One mistake answered two different ways across
four sibling routes is the defect being removed, not a regression — but it is a loosening on that
route, so it is called out here rather than buried. Pinned by its own test.

## Also fixed, found by the same measurement

`/api/v1/search/semantic` published two parameters that contradicted its handler:

| | published | handler | now |
|---|---|---|---|
| `limit` | `{"type":"string"}` | `clampLimit(v, 10, 20)` | `{type:integer, minimum:1, maximum:20, default:10}` |
| `q` | `{"type":"string"}` | rejects over 1,000 chars | `{type:string, maxLength:1000}` |

A client generated from our own spec sent a **string** where the handler wanted an integer, and had
no way to learn either ceiling. Verified live before changing: a 1,100-character `q` returns
`400 invalid_query: Field \`q\` must be at most 1000 characters.`

Both ceilings moved into `src/route-limits.ts`, which exists for exactly this — "the constant the
handler enforces and the `maximum` the contract publishes" in one place — and `ai-search.ts`
re-exports them under their existing names, the same pattern the other six feature modules use.

**`/api/v1/search/resolve` keeps its unbounded `q` deliberately**: `resolveIdentifier` returns `[]`
above 128 characters rather than erroring, and "not an identifier" is that route's documented
answer, so publishing `maxLength: 128` would wrongly imply rejection. Recorded so it does not get
"fixed" later.

## The published diff — 6 parameters, 1058 → 1058

```
4x  ?netuid  {"minimum":0,"type":"integer"} -> +"maximum":65535
1x  ?q       {"type":"string"} -> {"maxLength":1000,"type":"string"}
1x  ?limit   {"type":"string"} -> {"default":10,"maximum":20,"minimum":1,"type":"integer"}
```

## Validation

```
npm run typecheck / lint / format:check     clean
npx vitest run                              754 files, 18,064 passed, 22 skipped
```

```
validate:contract-drift  validate:openapi  validate:api
validate:query-vocabulary  validate:schema-vocabularies  validate:mcp  validate:mcp-input-parity
```
all pass.

Closes #10075
