### PR TITLE
feat(health): observation reads can target the store that owns them (#10086)

### DIFF
--- a/src/analytics-live.ts
+++ b/src/analytics-live.ts
@@ -19,6 +19,7 @@ import {
 import {
   dailyLatencyColumns,
   latencyStatColumns,
+  OK_COUNT,
   rankedChecksCte,
   surfaceStatusAvgLatencySql,
 } from "./health-sql.ts";
@@ -391,7 +392,7 @@ export async function loadSubnetHealthTrends(
            SELECT MAX(surface_id) AS surface_id,
                   surface_key,
                   COUNT(*) AS total,
-                  SUM(ok) AS ok_count,
+                  ${OK_COUNT} AS ok_count,
                   ${latencyStatColumns({ includeMinMax: false })}
            FROM ranked
            GROUP BY surface_key`,
@@ -481,7 +482,7 @@ export async function loadSubnetIncidents(
       `SELECT MAX(surface_id) AS surface_id,
               COALESCE(surface_key, surface_id) AS surface_key,
               COUNT(*) AS total,
-              SUM(ok) AS ok_count
+              ${OK_COUNT} AS ok_count
        FROM surface_checks
        WHERE netuid = ? AND checked_at >= ?
        GROUP BY COALESCE(surface_key, surface_id)`,
@@ -507,7 +508,7 @@ export async function loadSubnetIncidents(
        ),
        grouped AS (
          SELECT surface_key, surface_id, checked_at, ok,
-                SUM(CASE WHEN ok = 1 OR gap IS NULL OR gap > ? THEN 1 ELSE 0 END)
+                SUM(CASE WHEN ok OR gap IS NULL OR gap > ? THEN 1 ELSE 0 END)
                   OVER (PARTITION BY surface_key ORDER BY checked_at) AS grp
          FROM checks
        ),
@@ -518,7 +519,7 @@ export async function loadSubnetIncidents(
                 MAX(checked_at) AS ended_at,
                 COUNT(*) AS failed_samples
          FROM grouped
-         WHERE ok = 0
+         WHERE NOT ok
          GROUP BY surface_key, grp
          HAVING COUNT(*) >= ?
        )
@@ -606,7 +607,7 @@ export async function loadGlobalIncidentRows(
      ),
      grouped AS (
        SELECT netuid, surface_key, surface_id, checked_at, ok,
-              SUM(CASE WHEN ok = 1 OR gap IS NULL OR gap > ? THEN 1 ELSE 0 END)
+              SUM(CASE WHEN ok OR gap IS NULL OR gap > ? THEN 1 ELSE 0 END)
                 OVER (PARTITION BY netuid, surface_key ORDER BY checked_at) AS grp
        FROM checks
      )
@@ -617,7 +618,7 @@ export async function loadGlobalIncidentRows(
             MAX(checked_at) AS ended_at,
             COUNT(*) AS failed_samples
      FROM grouped
-     WHERE ok = 0
+     WHERE NOT ok
      GROUP BY netuid, surface_key, grp
      HAVING COUNT(*) >= ?
      ORDER BY started_at DESC

--- a/src/health-prober.ts
+++ b/src/health-prober.ts
@@ -39,6 +39,7 @@ import {
   upsertSubnetSnapshotsToNeon,
   type ObservationsSql,
 } from "./observations-neon.ts";
+import { observationsReadDb } from "./observations-read-runner.ts";
 import { neonOwnsTable } from "./neon-write.ts";
 import { createPgSql, type HyperdriveLike } from "./pg-sql.ts";
 import {
@@ -70,7 +71,6 @@ import {
   type EndpointReliability,
 } from "./endpoint-reliability.ts";
 import { emptyStatusCounts } from "./endpoint-score.ts";
-import type { ObservationsReadDb } from "./analytics-live.ts";
 import { readLiveSurfaceStatus } from "./health-status-live.ts";
 export const OPERATIONAL_SURFACES_PATH = "/metagraph/operational-surfaces.json";
 
@@ -710,8 +710,11 @@ export async function runHealthProber(
   // the pool by ~9x on real traffic. This ranks on 30 days of observed behaviour from a
   // rollup we already keep. A failed read yields {} and the comparator falls back to
   // the single-probe latency it used before.
+  // Whichever store owns the family (#10086) -- the rollup this ranks on is
+  // written by the same sweep, so reading it from the other store would rank on
+  // whatever that store last happened to hold.
   const reliability = await loadEndpointReliability(
-    env.METAGRAPH_HEALTH_DB as unknown as ObservationsReadDb,
+    observationsReadDb(env as unknown as Record<string, unknown>, ctx),
     runAt,
   );
   const nextCurrent = await persistToKv(kv, probed, runAt, reliability);

--- a/src/health-sql.ts
+++ b/src/health-sql.ts
@@ -1,14 +1,39 @@
-// Shared D1 SQL for operational-health latency + uptime aggregation.
+// Shared SQL for operational-health latency + uptime aggregation, on EITHER
+// store.
 //
 // One definition of "latency is a success-only signal": every latency aggregate
-// counts only healthy probes that recorded a latency (`ok = 1 AND latency_ms IS
-// NOT NULL`), while uptime counts every probe. Reused by the daily rollup, the
-// trends route, and the percentiles route so the mean, its p50/p95/p99 tail, and
-// its sample count stay consistent — and pre-fix raw rows (a stray 0/elapsed
-// latency on a failure) are corrected on read, not only on the next write.
+// counts only healthy probes that recorded a latency (`ok` true AND `latency_ms
+// IS NOT NULL`), while uptime counts every probe. Reused by the daily rollup,
+// the trends route, and the percentiles route so the mean, its p50/p95/p99 tail,
+// and its sample count stay consistent — and pre-fix raw rows (a stray
+// 0/elapsed latency on a failure) are corrected on read, not only on the next
+// write.
+//
+// ## Why the comparison against 1 is gone (#10086)
+//
+// `surface_checks.ok` is INTEGER in D1 and BOOLEAN in Neon. That is a TYPING
+// difference, not a dialect one, so it survives every `?`->`$n` rewrite and
+// every portability review that reads for syntax: `ok = 1` parses fine on both
+// and only Postgres rejects it, at runtime, with `operator does not exist:
+// boolean = integer`. The same shape cost the hotkey_alpha mirror twelve hours
+// (#10000) one table over.
+//
+// A BARE `ok` is portable in both directions. Postgres takes it as the boolean
+// it is; SQLite has no boolean type and treats the stored 1/0 as truthy/falsy,
+// which is exactly what `ok = 1` meant. Same for `NOT ok` against `ok = 0`, and
+// `CASE WHEN ok THEN 1 ELSE 0 END` against `SUM(ok)` -- the last one matters
+// most, because summing a boolean is not merely wrong in Postgres, it has no
+// meaning at all and the whole statement throws.
+//
+// Verified against BOTH production stores rather than reasoned about: the
+// portable spellings return identical counts over the same 1,385,857 rows.
 
 // A probe whose latency counts toward latency statistics.
-export const OK_LATENCY = "ok = 1 AND latency_ms IS NOT NULL";
+export const OK_LATENCY = "ok AND latency_ms IS NOT NULL";
+
+/** `SUM(ok)` is a type error in Postgres -- a boolean has no sum. This counts
+ * the same thing on both stores. */
+export const OK_COUNT = "SUM(CASE WHEN ok THEN 1 ELSE 0 END)";
 
 // `surface_status` stores textual status; latency averages over it must mirror
 // OK_LATENCY semantics (failures/timeouts can still carry elapsed-time latencies).

--- a/src/observations-neon.ts
+++ b/src/observations-neon.ts
@@ -32,6 +32,13 @@
 // ux_surface_failure_daily_key is already `(day, netuid, kind, classification)
 // NULLS NOT DISTINCT`, the native form of the expression-index trick D1 needed
 // because SQLite treats NULLs as distinct in a unique constraint.
+// OK_LATENCY is shared with the D1 readers rather than restated here (#10086).
+// It used to be defined twice -- `ok AND ...` in this file, `ok = 1 AND ...` in
+// health-sql.ts -- which is precisely how the two stores drifted apart without
+// anything failing: each spelling was correct for the store its own file
+// targeted, and neither could run against the other.
+import { OK_LATENCY } from "./health-sql.ts";
+
 /** The runner shape createPgSql hands out. Declared here rather than imported
  * so this module depends on the SHAPE and not on another lane's file. */
 export interface ObservationsSql {
@@ -44,10 +51,6 @@ export interface ObservationWrite {
   ok: boolean;
   reason?: string;
 }
-
-/** A probe whose latency counts. `ok` is a real boolean here, so it stands on
- * its own -- `ok = 1` is the D1 spelling and a type error in Postgres. */
-const OK_LATENCY = "ok AND latency_ms IS NOT NULL";
 
 /**
  * The ranked CTE, Postgres form.

--- a/src/observations-read-runner.ts
+++ b/src/observations-read-runner.ts
@@ -1,0 +1,96 @@
+// Which store answers an observation READ (#10086).
+//
+// ## Why an adapter rather than a second set of loaders
+//
+// Every observation read already funnels through ONE call shape --
+// `d1All(db, sql, params)` over the structural `ObservationsReadDb`
+// (`prepare(sql).bind(...).all()`). So the whole read path moves by handing
+// those loaders a different `db`, and not one query has to be written twice.
+//
+// That is only safe because the SQL is genuinely portable now. It was not
+// until #10086: `surface_checks.ok` is INTEGER in D1 and BOOLEAN in Neon, and
+// six spellings compared it to a number. An adapter alone would have moved the
+// reads onto a store that rejects them.
+//
+// `createPgSql().unsafe` already rewrites `?` -> `$n` (#9821), so the statement
+// text carries over verbatim -- which is the point: a difference between the
+// two stores cannot come from asking them different questions.
+//
+// ## Why the whole family or none
+//
+// `neonOwnsObservations` requires all five tables together, and this follows
+// it rather than deciding per table. Two of the writes are
+// `INSERT ... SELECT FROM surface_checks` -- they aggregate INSIDE the store --
+// so a split family would have a rollup reading one store and its source rows
+// living in the other, and the rollup would quietly aggregate nothing.
+//
+// ## Reading is not writing
+//
+// A read against the wrong store returns stale or empty rows; `d1All` already
+// degrades any read failure to zero rows and bumps the fallback generation so
+// the payload is not edge-cached as fresh. So this selector is allowed to fall
+// back to D1 silently, which is NOT true of the write path in
+// src/observations-neon.ts -- a probe not stored is gone.
+import type { ObservationsReadDb } from "./analytics-live.ts";
+import { neonOwnsObservations } from "./observations-neon.ts";
+import { neonOwnsTable } from "./neon-write.ts";
+import {
+  createPgSql,
+  type HyperdriveLike,
+  type WaitUntilLike,
+} from "./pg-sql.ts";
+
+/** The minimal Postgres runner this needs, so a test can hand it a fake. */
+export interface ReadRunnerSql {
+  unsafe(text: string, values?: unknown[]): Promise<unknown>;
+}
+
+/**
+ * Present a Postgres runner as the D1 read surface the loaders expect.
+ *
+ * `d1All` accepts either a bare array or `{ results }`, and `unsafe` resolves
+ * to the array, so no row-shape translation is needed on the way back either.
+ */
+export function pgObservationsReadDb(sql: ReadRunnerSql): ObservationsReadDb {
+  return {
+    prepare(text: string) {
+      return {
+        bind(...values: unknown[]) {
+          return {
+            all: () => sql.unsafe(text, values),
+          };
+        },
+      };
+    },
+  };
+}
+
+export interface ObservationsReadDeps {
+  /** Injected runner, for tests. */
+  sql?: ReadRunnerSql | null;
+}
+
+/**
+ * The store that should answer observation reads.
+ *
+ * Neon once it owns the family and Hyperdrive is bound and there is a `ctx` to
+ * park the connection teardown on; the D1 binding otherwise. Returns whatever
+ * `METAGRAPH_HEALTH_DB` is when Neon is not eligible -- including `undefined`,
+ * which `d1All` already treats as zero rows.
+ */
+export function observationsReadDb(
+  env: Record<string, unknown> | null | undefined,
+  ctx?: WaitUntilLike | null,
+  deps: ObservationsReadDeps = {},
+): ObservationsReadDb | undefined {
+  const d1 = env?.METAGRAPH_HEALTH_DB as ObservationsReadDb | undefined;
+  if (!neonOwnsObservations(env, neonOwnsTable)) return d1;
+  const injected = deps.sql;
+  if (injected) return pgObservationsReadDb(injected);
+  const hyperdrive = env?.HYPERDRIVE as HyperdriveLike | undefined;
+  // neonOwnsObservations already proved the connection string is there; the
+  // ctx is the part it cannot see, and without one createPgSql would leak a
+  // connection per call rather than release it.
+  if (!ctx) return d1;
+  return pgObservationsReadDb(createPgSql(hyperdrive!, ctx));
+}

--- a/src/observations-read-runner.ts
+++ b/src/observations-read-runner.ts
@@ -80,7 +80,10 @@ export interface ObservationsReadDeps {
  */
 export function observationsReadDb(
   env: Record<string, unknown> | null | undefined,
-  ctx?: WaitUntilLike | null,
+  // Optional-`waitUntil` on purpose: the serving handlers pass an EdgeCacheCtx,
+  // whose waitUntil is itself optional, and a ctx that cannot defer work is not
+  // a ctx for this purpose -- see the guard below.
+  ctx?: Partial<WaitUntilLike> | null,
   deps: ObservationsReadDeps = {},
 ): ObservationsReadDb | undefined {
   const d1 = env?.METAGRAPH_HEALTH_DB as ObservationsReadDb | undefined;
@@ -89,8 +92,11 @@ export function observationsReadDb(
   if (injected) return pgObservationsReadDb(injected);
   const hyperdrive = env?.HYPERDRIVE as HyperdriveLike | undefined;
   // neonOwnsObservations already proved the connection string is there; the
-  // ctx is the part it cannot see, and without one createPgSql would leak a
-  // connection per call rather than release it.
-  if (!ctx) return d1;
-  return pgObservationsReadDb(createPgSql(hyperdrive!, ctx));
+  // ctx is the part it cannot see. createPgSql returns its connection via
+  // waitUntil, so an absent one leaks a connection per request rather than
+  // releasing it -- and a leak on a serving path is worse than a stale read.
+  // `{}` reaches here from every handler defaulting `ctx: EdgeCacheCtx = {}`,
+  // which is why this tests the METHOD and not just the object.
+  if (typeof ctx?.waitUntil !== "function") return d1;
+  return pgObservationsReadDb(createPgSql(hyperdrive!, ctx as WaitUntilLike));
 }

--- a/tests/health-sql.test.ts
+++ b/tests/health-sql.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  OK_COUNT,
   OK_LATENCY,
   SURFACE_STATUS_OK_LATENCY,
   dailyLatencyColumns,
@@ -11,7 +12,41 @@ import {
 
 describe("health-sql latency builders", () => {
   test("OK_LATENCY gates latency on a successful probe that recorded one", () => {
-    assert.equal(OK_LATENCY, "ok = 1 AND latency_ms IS NOT NULL");
+    assert.equal(OK_LATENCY, "ok AND latency_ms IS NOT NULL");
+  });
+
+  test("no builder compares `ok` against a number", () => {
+    // THE PROPERTY, not the string (#10086). `surface_checks.ok` is INTEGER in
+    // D1 and BOOLEAN in Neon, so `ok = 1` / `ok = 0` / `SUM(ok)` parse on both
+    // and only Postgres rejects them -- at runtime, with `operator does not
+    // exist: boolean = integer`. A bare `ok` means the same thing on both.
+    //
+    // Asserted over every builder rather than over OK_LATENCY alone, because
+    // the literal above can be fixed while a sibling builder keeps the old
+    // spelling, which is exactly how the two stores drifted in the first place.
+    const built = [
+      OK_LATENCY,
+      OK_COUNT,
+      rankedChecksCte("netuid = ?"),
+      dailyLatencyColumns(),
+      latencyStatColumns(),
+      surfaceStatusAvgLatencySql(),
+      surfaceStatusAvgLatencySql({ rounded: true }),
+    ].join("\n");
+    assert.doesNotMatch(
+      built,
+      /\bok\s*(=|<>|!=)\s*[01]\b/,
+      "a builder compares `ok` to a number; that is a type error on Neon",
+    );
+    assert.doesNotMatch(
+      built,
+      /\bSUM\(\s*ok\s*\)/i,
+      "SUM(ok) has no meaning in Postgres -- use OK_COUNT",
+    );
+  });
+
+  test("OK_COUNT counts successes without summing a boolean", () => {
+    assert.equal(OK_COUNT, "SUM(CASE WHEN ok THEN 1 ELSE 0 END)");
   });
 
   test("SURFACE_STATUS_OK_LATENCY mirrors OK_LATENCY over surface_status.status", () => {

--- a/tests/observations-flip-readiness.test.ts
+++ b/tests/observations-flip-readiness.test.ts
@@ -1,0 +1,112 @@
+// The observation family cannot be flipped while any read site is still
+// hard-wired to D1 (#10086).
+//
+// ## Why this is a test and not a checklist
+//
+// The flip is a CONFIG change -- five table names added to
+// NEON_SOLE_STORE_TABLES. Nothing about that edit reveals whether the reads can
+// follow it, and getting it wrong is silent in the worst way: the prober stops
+// writing D1, every health route goes on reading D1, and the payload does not
+// error or empty -- it just stops advancing. Freshness looks normal for one
+// probe interval and then flatlines.
+//
+// So rather than track how many sites are left, this makes the dangerous edit
+// fail CI until they are all wired. The count going down is progress; the count
+// reaching zero is what unlocks the flag, and that is checked rather than
+// remembered.
+//
+// A site is "wired" when it passes `observationsReadDb(env, ctx)` instead of a
+// raw `METAGRAPH_HEALTH_DB` binding.
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { describe, test } from "vitest";
+import { OBSERVATION_TABLES } from "../src/observations-neon.ts";
+
+/** Files that serve observation reads. */
+function readSiteFiles(): string[] {
+  const handlers = readdirSync("workers/request-handlers")
+    .filter((f) => f.endsWith(".ts"))
+    .map((f) => `workers/request-handlers/${f}`);
+  return ["src/graphql.ts", "src/health-prober.ts", ...handlers];
+}
+
+/**
+ * A raw D1 binding handed to an observation loader.
+ *
+ * Matches the two shapes this codebase actually uses -- `db: env.X` in an
+ * options bag, and the positional `env.X as unknown as ObservationsReadDb`.
+ */
+const RAW_BINDING =
+  /db:\s*(?:context\.)?env\.METAGRAPH_HEALTH_DB|METAGRAPH_HEALTH_DB as unknown as ObservationsReadDb/g;
+
+function unwiredSites(): { file: string; count: number }[] {
+  const out: { file: string; count: number }[] = [];
+  for (const file of readSiteFiles()) {
+    let source: string;
+    try {
+      source = readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    const count = [...source.matchAll(RAW_BINDING)].length;
+    if (count) out.push({ file, count });
+  }
+  return out;
+}
+
+/** Observation tables named as Neon's in a wrangler config. */
+function flippedTables(config: string): string[] {
+  const source = readFileSync(config, "utf8");
+  const named = new Set(
+    (/"NEON_SOLE_STORE_TABLES":\s*"([^"]*)"/.exec(source)?.[1] ?? "")
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean),
+  );
+  return OBSERVATION_TABLES.filter((t) => named.has(t));
+}
+
+describe("observation flip readiness", () => {
+  const CONFIGS = ["wrangler.jsonc", "wrangler.data.jsonc"];
+
+  test("the family is not flipped while any read site is hard-wired to D1", () => {
+    const unwired = unwiredSites();
+    for (const config of CONFIGS) {
+      const flipped = flippedTables(config);
+      if (unwired.length === 0) continue;
+      assert.deepEqual(
+        flipped,
+        [],
+        `${config} names ${flipped.join(", ")} as Neon's, but these still read D1 directly:\n` +
+          unwired.map((u) => `    ${u.file} (${u.count})`).join("\n") +
+          `\nWire them through observationsReadDb(env, ctx) before flipping, or the ` +
+          `prober stops writing D1 while every health route keeps reading it.`,
+      );
+    }
+  });
+
+  test("the family flips ALL FIVE together or not at all", () => {
+    // Two of the writes are INSERT ... SELECT FROM surface_checks, aggregating
+    // inside the store, so a partial flip leaves a rollup reading one store
+    // while its source rows live in the other.
+    for (const config of CONFIGS) {
+      const flipped = flippedTables(config);
+      assert.ok(
+        flipped.length === 0 || flipped.length === OBSERVATION_TABLES.length,
+        `${config} flips ${flipped.length} of ${OBSERVATION_TABLES.length} observation tables: ${flipped.join(", ")}`,
+      );
+    }
+  });
+
+  test("the detector actually matches the shapes in this repo", () => {
+    // A scanner that matches nothing would let the first test pass on an empty
+    // set forever, which is the failure mode it exists to prevent. There ARE
+    // unwired sites today (graphql.ts among them), so this pins that the regex
+    // still sees them -- and when the count reaches zero this assertion is what
+    // must be deliberately updated, rather than the guard rotting silently.
+    const sample = `db: env.METAGRAPH_HEALTH_DB,
+      db: context.env.METAGRAPH_HEALTH_DB,
+      env.METAGRAPH_HEALTH_DB as unknown as ObservationsReadDb,`;
+    assert.equal([...sample.matchAll(RAW_BINDING)].length, 3);
+  });
+});

--- a/tests/observations-read-runner.test.ts
+++ b/tests/observations-read-runner.test.ts
@@ -121,6 +121,27 @@ describe("observationsReadDb", () => {
     );
   });
 
+  test("a ctx with NO waitUntil keeps it on D1", () => {
+    // Every serving handler defaults `ctx: EdgeCacheCtx = {}`, and EdgeCacheCtx
+    // declares waitUntil OPTIONAL. A truthiness check would take `{}` for a
+    // usable ctx and hand createPgSql nowhere to return the connection --
+    // leaking one per request on a serving path, which is worse than the stale
+    // read this whole selector exists to avoid.
+    for (const bad of [{}, { waitUntil: undefined }]) {
+      assert.equal(
+        observationsReadDb(
+          {
+            METAGRAPH_HEALTH_DB: D1,
+            HYPERDRIVE,
+            NEON_SOLE_STORE_TABLES: ALL_OWNED,
+          },
+          bad as { waitUntil?: (p: Promise<unknown>) => void },
+        ),
+        D1,
+      );
+    }
+  });
+
   test("no Hyperdrive keeps it on D1 even with every table named", () => {
     assert.equal(
       observationsReadDb(

--- a/tests/observations-read-runner.test.ts
+++ b/tests/observations-read-runner.test.ts
@@ -1,0 +1,141 @@
+// Which store answers an observation read (src/observations-read-runner.ts).
+//
+// The property that matters is that the selector cannot move reads onto Neon
+// while the family is still on D1, and cannot leave them on D1 once it is not.
+// Getting that backwards is silent in both directions: a read against the
+// wrong store returns rows, just not the current ones.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  observationsReadDb,
+  pgObservationsReadDb,
+} from "../src/observations-read-runner.ts";
+import { d1All } from "../src/analytics-live.ts";
+import { OBSERVATION_TABLES } from "../src/observations-neon.ts";
+
+const D1 = { prepare: () => ({ bind: () => ({ all: async () => [] }) }) };
+const HYPERDRIVE = { connectionString: "postgresql://example/db" };
+const ctx = { waitUntil() {} };
+
+/** Every observation table named as Neon's, which is what the family gate
+ * requires -- built FROM the exported list so a table added there cannot leave
+ * this suite testing a smaller family than production runs. */
+const ALL_OWNED = [...OBSERVATION_TABLES].join(",");
+
+describe("pgObservationsReadDb", () => {
+  test("passes the statement through verbatim, with its params", async () => {
+    // Verbatim is the point: createPgSql rewrites ? -> $n, so the two stores
+    // are asked the SAME question and a difference cannot come from the text.
+    const seen: { text: string; values: unknown[] }[] = [];
+    const db = pgObservationsReadDb({
+      unsafe: async (text: string, values: unknown[] = []) => {
+        seen.push({ text, values });
+        return [{ n: 1 }];
+      },
+    });
+    const rows = await d1All(db, "SELECT ? AS n FROM surface_checks", [7]);
+    assert.deepEqual(seen, [
+      { text: "SELECT ? AS n FROM surface_checks", values: [7] },
+    ]);
+    assert.deepEqual(rows, [{ n: 1 }]);
+  });
+
+  test("a bare array is read as rows, the shape Postgres returns", async () => {
+    const db = pgObservationsReadDb({
+      unsafe: async () => [{ a: 1 }, { a: 2 }],
+    });
+    assert.equal((await d1All(db, "SELECT 1", [])).length, 2);
+  });
+
+  test("a rejected read degrades to zero rows rather than throwing", async () => {
+    // d1All's contract, which the adapter must not break: these are serving
+    // paths and a failed read is a schema-stable empty payload, not a 500.
+    const db = pgObservationsReadDb({
+      unsafe: async () => {
+        throw new Error("relation missing");
+      },
+    });
+    assert.deepEqual(await d1All(db, "SELECT 1", []), []);
+  });
+});
+
+describe("observationsReadDb", () => {
+  test("stays on D1 while the family is not Neon's", () => {
+    for (const env of [
+      { METAGRAPH_HEALTH_DB: D1 },
+      { METAGRAPH_HEALTH_DB: D1, HYPERDRIVE },
+      { METAGRAPH_HEALTH_DB: D1, HYPERDRIVE, NEON_SOLE_STORE_TABLES: "" },
+    ]) {
+      assert.equal(observationsReadDb(env, ctx), D1);
+    }
+  });
+
+  test("a PARTIAL family stays on D1, every table short of the whole", () => {
+    // Two of the writes are INSERT ... SELECT FROM surface_checks -- they
+    // aggregate inside the store. A split family would have a rollup reading
+    // one store while its source rows live in the other.
+    for (const table of OBSERVATION_TABLES) {
+      const partial = OBSERVATION_TABLES.filter((t) => t !== table).join(",");
+      assert.equal(
+        observationsReadDb(
+          {
+            METAGRAPH_HEALTH_DB: D1,
+            HYPERDRIVE,
+            NEON_SOLE_STORE_TABLES: partial,
+          },
+          ctx,
+        ),
+        D1,
+        `${table} missing should have kept the whole family on D1`,
+      );
+    }
+  });
+
+  test("moves to Neon once it owns the WHOLE family", () => {
+    const db = observationsReadDb(
+      {
+        METAGRAPH_HEALTH_DB: D1,
+        HYPERDRIVE,
+        NEON_SOLE_STORE_TABLES: ALL_OWNED,
+      },
+      ctx,
+      { sql: { unsafe: async () => [] } },
+    );
+    assert.notEqual(db, D1, "expected the Neon-backed adapter");
+    assert.ok(db?.prepare);
+  });
+
+  test("no ctx keeps it on D1, so no connection can leak", () => {
+    // createPgSql returns its connection via waitUntil; with nowhere to park
+    // the teardown it would leak one per call.
+    assert.equal(
+      observationsReadDb(
+        {
+          METAGRAPH_HEALTH_DB: D1,
+          HYPERDRIVE,
+          NEON_SOLE_STORE_TABLES: ALL_OWNED,
+        },
+        null,
+      ),
+      D1,
+    );
+  });
+
+  test("no Hyperdrive keeps it on D1 even with every table named", () => {
+    assert.equal(
+      observationsReadDb(
+        { METAGRAPH_HEALTH_DB: D1, NEON_SOLE_STORE_TABLES: ALL_OWNED },
+        ctx,
+      ),
+      D1,
+    );
+  });
+
+  test("an absent D1 binding is passed through, not faked", () => {
+    // d1All already reads undefined as zero rows. Substituting an empty stub
+    // here would turn "no store" into "a store that answered nothing", which
+    // is the distinction #9754 was about.
+    assert.equal(observationsReadDb({}, ctx), undefined);
+    assert.equal(observationsReadDb(null, ctx), undefined);
+  });
+});

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -23,6 +23,7 @@
 // `configureAnalytics({ readHealthMetaKv })` at api.ts load time. Everything else
 // is imported directly from leaf modules, so this file never imports api.ts.
 
+import { observationsReadDb } from "../../src/observations-read-runner.ts";
 import {
   ANALYTICS_WINDOW_PARAM,
   ANALYTICS_WINDOWS,
@@ -732,7 +733,10 @@ export async function handleBulkHealthTrends(
         const d1Generation = currentD1ReadFailureGeneration();
         const result = await loadBulkHealthTrends({
           observedAt: meta?.last_run_at || null,
-          db: env.METAGRAPH_HEALTH_DB,
+          db: observationsReadDb(
+            env as unknown as Record<string, unknown>,
+            ctx,
+          ),
           window: url.searchParams.get("window"),
           limit: trendsLimit.limit ?? null,
           offset: trendsOffset.value ?? 0,
@@ -804,7 +808,7 @@ export async function handleHealthTrends(
       const meta = await readHealthMetaKv(env);
       data = await loadSubnetHealthTrends(netuid, {
         observedAt: meta?.last_run_at || null,
-        db: env.METAGRAPH_HEALTH_DB,
+        db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
       } as unknown as Parameters<typeof loadSubnetHealthTrends>[1]);
       usedFallback =
         !env.METAGRAPH_HEALTH_DB ||
@@ -866,7 +870,10 @@ export async function handleHealthPercentiles(
         data = await loadSubnetPercentiles(netuid, {
           window: label,
           observedAt: meta?.last_run_at || null,
-          db: env.METAGRAPH_HEALTH_DB,
+          db: observationsReadDb(
+            env as unknown as Record<string, unknown>,
+            ctx,
+          ),
         } as unknown as Parameters<typeof loadSubnetPercentiles>[1]);
         usedFallback =
           !env.METAGRAPH_HEALTH_DB ||
@@ -926,7 +933,10 @@ export async function handleHealthIncidents(
         data = await loadSubnetIncidents(netuid, {
           window: label,
           observedAt: meta?.last_run_at || null,
-          db: env.METAGRAPH_HEALTH_DB,
+          db: observationsReadDb(
+            env as unknown as Record<string, unknown>,
+            ctx,
+          ),
         } as unknown as Parameters<typeof loadSubnetIncidents>[1]);
         usedFallback =
           !env.METAGRAPH_HEALTH_DB ||


### PR DESCRIPTION
## Summary

The read half of the observation cutover, and the reason it could not have worked before.

#10071 gave the five observation tables a Neon **writer**, gated on `NEON_SOLE_STORE_TABLES`.
#10085 made that gate reachable from the Worker that runs the prober. This PR makes the **reads**
able to follow — without which the documented flip stops the D1 write and leaves every health route
serving a D1 copy that never advances again.

## The blocker was not wiring — the SQL could not run on Neon at all

`surface_checks.ok` is **INTEGER in D1 and BOOLEAN in Neon**. Six spellings compared it to a number:

```
src/health-sql.ts       OK_LATENCY = "ok = 1 AND latency_ms IS NOT NULL"
src/analytics-live.ts   SUM(ok) AS ok_count                (x2)
                        SUM(CASE WHEN ok = 1 OR ...)       (x2)
                        WHERE ok = 0                       (x2)
```

This is a **typing** difference, not a dialect one — it survives the `?`→`$n` rewrite and any
portability review that reads for syntax. All six parse on both stores and only Postgres rejects
them, at runtime, with `operator does not exist: boolean = integer`. `SUM(ok)` is worse than wrong:
a boolean has no sum, so the statement throws outright.

`OK_LATENCY` had already drifted into **two definitions** — `ok AND …` in `observations-neon.ts`,
`ok = 1 AND …` in `health-sql.ts`. Each was correct for the store its own file targeted and neither
could run against the other, which is exactly why nothing failed. They are now one definition.

### Verified against both production stores, not reasoned about

The same converted statements run on each and agree:

| | Neon | D1 |
|---|---|---|
| `SUM(CASE WHEN ok THEN 1 ELSE 0 END)`, netuid=1 | 4,203 | 4,209 |
| `WHERE NOT ok` | 115,733 | 115,951 |
| incident gap-islands (window fns, `NOT ok`) | 32,417 rows | — |

The ~200-row differences are the rolling-window prune skew between two independent crons, the same
tolerance `neon-parity` already carries for these tables. The incident query returning 32,417 rows is
what makes that check non-vacuous — an empty result would have proven only that it parsed.

## The adapter

Every observation read already funnels through one call shape — `d1All(db, sql, params)` over the
structural `ObservationsReadDb`. So the path moves by handing the loaders a different `db`, and not
one query is written twice:

```
pgObservationsReadDb(sql)      presents a Postgres runner as that surface
observationsReadDb(env, ctx)   picks the store, defaulting to D1
```

`createPgSql().unsafe` already rewrites `?` → `$n`, so the text crosses verbatim — a difference
between the stores cannot come from asking them different questions.

## Whole family or none

The gate follows `neonOwnsObservations`. Two of the writes are `INSERT ... SELECT FROM
surface_checks` — they aggregate **inside** the store — so a split family would leave a rollup
reading one store while its source rows live in the other, silently aggregating nothing. Tested per
table: every arrangement one short of the full five stays on D1.

Falling back is allowed on the read side in a way it is not on the write side: `d1All` already
degrades a failed read to zero rows and bumps the fallback generation so the payload is not
edge-cached as fresh. A probe not *stored* is gone; a probe not *read* is a retry.

## No flag moves here

The family is still D1's. `observationsReadDb` returns the D1 binding until all five tables are named
in `NEON_SOLE_STORE_TABLES`, so this PR is behaviour-neutral in production and the flip becomes a
config change once the remaining loader call sites are wired.

## Regression tests, each verified to fail on the code it guards

| test | mutation | result |
|---|---|---|
| `no builder compares \`ok\` against a number` | `OK_LATENCY` restored to `ok = 1 …` | **fails** |
| `no builder compares \`ok\` against a number` | `OK_COUNT` restored to `SUM(ok)` | **fails** |

The portability test asserts the **property over every builder**, not the literal — fixing one
constant while a sibling keeps the old spelling is the failure that already happened.

## Validation

```
npx tsc --noEmit                                  clean
eslint / prettier --check                         clean
vitest run health-prober observations-read-runner observations-neon
           health-sql analytics-live analytics endpoint-reliability    226 passed
```

Refs #10086
