### PR TITLE
fix(api): top-holders hid its three live sorts and health/trends typed pages as strings (#10089)

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -21342,7 +21342,7 @@ export interface operations {
     topHolders: {
         parameters: {
             query?: {
-                sort?: "total_tao" | "free_tao" | "delegated_tao";
+                sort?: "total_tao" | "free_tao" | "delegated_tao" | "net_flow_7d" | "net_flow_30d" | "net_flow_90d";
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
@@ -32782,10 +32782,10 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page. A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
-                limit?: string;
+                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
+                limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
-                offset?: string;
+                offset?: number;
             };
             header?: never;
             path?: never;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -6598,13 +6598,16 @@
         {
           "name": "limit",
           "schema": {
-            "type": "string"
+            "maximum": 512,
+            "minimum": 1,
+            "type": "integer"
           }
         },
         {
           "name": "offset",
           "schema": {
-            "type": "string"
+            "minimum": 0,
+            "type": "integer"
           }
         }
       ]
@@ -7516,7 +7519,10 @@
             "enum": [
               "total_tao",
               "free_tao",
-              "delegated_tao"
+              "delegated_tao",
+              "net_flow_7d",
+              "net_flow_30d",
+              "net_flow_90d"
             ],
             "type": "string"
           }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -65604,7 +65604,10 @@
               "enum": [
                 "total_tao",
                 "free_tao",
-                "delegated_tao"
+                "delegated_tao",
+                "net_flow_7d",
+                "net_flow_30d",
+                "net_flow_90d"
               ],
               "type": "string"
             }
@@ -78590,12 +78593,14 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page. A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916).",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
-              "type": "string"
+              "maximum": 512,
+              "minimum": 1,
+              "type": "integer"
             }
           },
           {
@@ -78604,7 +78609,8 @@
             "name": "offset",
             "required": false,
             "schema": {
-              "type": "string"
+              "minimum": 0,
+              "type": "integer"
             }
           }
         ],

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -21342,7 +21342,7 @@ export interface operations {
     topHolders: {
         parameters: {
             query?: {
-                sort?: "total_tao" | "free_tao" | "delegated_tao";
+                sort?: "total_tao" | "free_tao" | "delegated_tao" | "net_flow_7d" | "net_flow_30d" | "net_flow_90d";
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
@@ -32782,10 +32782,10 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page. A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
-                limit?: string;
+                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
+                limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
-                offset?: string;
+                offset?: number;
             };
             header?: never;
             path?: never;

--- a/schemas-src/routes/health-surfaces.ts
+++ b/schemas-src/routes/health-surfaces.ts
@@ -147,9 +147,13 @@ export type BulkHealthTrendsArtifact = z.infer<
  *
  * `workers/config.ts`'s HEALTH_TREND_WINDOWS maps each label to its day count
  * and is the runtime's copy; this is the published vocabulary. They are checked
- * against each other by tests/bulk-health-trends.test.ts rather than one
- * importing the other, because schemas-src must not depend on the Worker's
+ * against each other by tests/route-limit-contract-parity.test.ts rather than
+ * one importing the other, because schemas-src must not depend on the Worker's
  * config module -- see this directory's leaf-module rule.
+ *
+ * That cross-check named a test file that did not exist until #10089. A comment
+ * asserting a guard is not a guard: the vocabularies happened to agree, and
+ * nothing would have said so if they stopped.
  */
 export const HEALTH_TREND_WINDOW_VALUES = ["7d", "30d"] as const;
 

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -52,8 +52,10 @@ import {
   SEMANTIC_LIMIT_DEFAULT,
   SEMANTIC_LIMIT_MAX,
   SEMANTIC_QUERY_MAX_LENGTH,
+  BULK_HEALTH_TRENDS_LIMIT_MAX,
 } from "./route-limits.ts";
 import { EMISSION_PIPELINE_SORT_FIELDS } from "./emission-pipeline-surface.ts";
+import { TOP_HOLDERS_SORTS } from "./top-holders.ts";
 import {
   CONCENTRATION_LENSES,
   CONCENTRATION_RANKING_SORTS,
@@ -2883,8 +2885,19 @@ export const API_ROUTES = [
     ["health", "analytics"],
     [
       { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
-      { name: "limit", schema: { type: "string" } },
-      { name: "offset", schema: { type: "string" } },
+      // Integers, not strings (#10089). handleBulkHealthTrends runs
+      // parseLimitParam/parseNonNegativeIntParam, so `?limit=abc` has always
+      // been a 400 -- the published `{"type":"string"}` said otherwise.
+      // `offset` carries no ceiling because the handler enforces none.
+      {
+        name: "limit",
+        schema: {
+          type: "integer",
+          minimum: 1,
+          maximum: BULK_HEALTH_TRENDS_LIMIT_MAX,
+        },
+      },
+      { name: "offset", schema: { type: "integer", minimum: 0 } },
     ],
   ),
   route(
@@ -3340,10 +3353,13 @@ export const API_ROUTES = [
     csvRouteQuery([
       {
         name: "sort",
-        schema: {
-          type: "string",
-          enum: ["total_tao", "free_tao", "delegated_tao"],
-        },
+        // From TOP_HOLDERS_SORTS, not a literal copy of it. The copy that used
+        // to sit here listed the three HOLDINGS sorts and omitted
+        // net_flow_7d/30d/90d (#10089) -- so the published enum offered exactly
+        // the three that DECLINE to a fixed 2026-08-02 materialization when
+        // their producer's last pass is unproven, and withheld the three that
+        // are recomputed daily. The route's own 400 has always named all six.
+        schema: parameterSchema(enumSchema(TOP_HOLDERS_SORTS)),
       },
       {
         name: "limit",

--- a/src/route-limits.ts
+++ b/src/route-limits.ts
@@ -267,3 +267,22 @@ export const SEMANTIC_LIMIT_MAX = 20;
 /** Rejected above this with a 400, not truncated -- an embedded query that was
  * silently cut would rank against text the caller never sent. */
 export const SEMANTIC_QUERY_MAX_LENGTH = 1000;
+
+/**
+ * `/api/v1/health/trends` -- the all-subnet trend matrix (#10089).
+ *
+ * The same defect the semantic block above records, on a second route: `limit`
+ * and `offset` were published as `{"type":"string"}` while
+ * `handleBulkHealthTrends` runs `parseLimitParam(url, { maxLimit: 512 })` and
+ * `parseNonNegativeIntParam`, so `?limit=abc` is a 400 the contract gave a
+ * caller no way to anticipate.
+ *
+ * `BulkHealthTrendsQuerySchema` stated the correct bounds the whole time and is
+ * the ONE route query schema runtime code imports -- it just was not the copy
+ * being published. schemas-src is a leaf and cannot import this module, so
+ * tests/route-limit-contract-parity.test.ts checks the two against each other.
+ *
+ * Rejected rather than clamped, per #9916: a truncated page reads as an
+ * exhausted result set.
+ */
+export const BULK_HEALTH_TRENDS_LIMIT_MAX = 512;

--- a/tests/route-limit-contract-parity.test.ts
+++ b/tests/route-limit-contract-parity.test.ts
@@ -23,6 +23,7 @@
 // facts, declare the judgements, let the test hold them together.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
+import { z } from "zod";
 import { API_ROUTES } from "../src/contracts.ts";
 import {
   canonicalAccountsListCachePath,
@@ -35,6 +36,7 @@ import {
 } from "../workers/request-params.ts";
 import {
   ACCOUNTS_LIST_LIMIT_MAX,
+  BULK_HEALTH_TRENDS_LIMIT_MAX,
   CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
   CHAIN_TURNOVER_LIMIT_MAX,
   GLOBAL_VALIDATOR_LIMIT_MAX,
@@ -42,6 +44,12 @@ import {
   SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
   TOP_HOLDERS_LIMIT_MAX,
 } from "../src/route-limits.ts";
+import { TOP_HOLDERS_SORTS } from "../src/top-holders.ts";
+import {
+  BulkHealthTrendsQuerySchema,
+  HEALTH_TREND_WINDOW_VALUES,
+} from "../schemas-src/routes/health-surfaces.ts";
+import { HEALTH_TREND_WINDOWS } from "../workers/config.ts";
 
 /** Route path -> the constant its handler enforces as the `limit` ceiling. */
 const CONSTANT_BACKED: Record<string, number> = {
@@ -67,13 +75,26 @@ const CONSTANT_BACKED: Record<string, number> = {
   "/api/v1/accounts/{ss58}/transfers": FEED_PAGINATION.maxLimit,
   "/api/v1/extrinsics": BLOCK_PAGINATION.maxLimit,
   "/api/v1/blocks": BLOCK_PAGINATION.maxLimit,
+  // #10089: this one did not merely publish the WRONG ceiling, it published
+  // no ceiling at all -- `limit` and `offset` were `{"type":"string"}` while
+  // handleBulkHealthTrends has always run parseLimitParam/
+  // parseNonNegativeIntParam over them. `declaredMaximum` returns undefined
+  // for a string schema, so this entry alone would have caught it.
+  "/api/v1/health/trends": BULK_HEALTH_TRENDS_LIMIT_MAX,
 };
+
+interface ParameterSchema {
+  type?: string;
+  minimum?: number;
+  maximum?: number;
+  enum?: string[];
+}
 
 interface Route {
   path: string;
   method: string;
   description?: string;
-  query_parameters?: { name: string; schema?: { maximum?: number } }[];
+  query_parameters?: { name: string; schema?: ParameterSchema }[];
 }
 
 function route(path: string): Route {
@@ -84,9 +105,16 @@ function route(path: string): Route {
   return found;
 }
 
+function declaredParameter(
+  path: string,
+  name: string,
+): ParameterSchema | undefined {
+  return (route(path).query_parameters ?? []).find((q) => q.name === name)
+    ?.schema;
+}
+
 function declaredMaximum(path: string): number | undefined {
-  return (route(path).query_parameters ?? []).find((q) => q.name === "limit")
-    ?.schema?.maximum;
+  return declaredParameter(path, "limit")?.maximum;
 }
 
 describe("a route's published limit ceiling is the one it enforces (#9127)", () => {
@@ -222,6 +250,97 @@ describe("a route's published limit ceiling is the one it enforces (#9127)", () 
         typeof declaredMaximum(path),
         "number",
         `${path} declares no limit maximum, so its ceiling is unpublished`,
+      );
+    }
+  });
+});
+
+// ── The same defect, on the parameter's TYPE and its enum (#10089) ──────────
+//
+// The block above is about one number. These are the other two ways a
+// published parameter can contradict the handler, and both were live:
+//
+//   TYPE   /api/v1/health/trends published `limit`/`offset` as
+//          `{"type":"string"}`. `?limit=abc` has always been a 400.
+//   ENUM   /api/v1/accounts/top-holders published three of the six values in
+//          TOP_HOLDERS_SORTS. The route's own 400 names all six, and the three
+//          it omitted are the LIVE tier -- so a generated client could reach
+//          only the rankings that may be serving a fixed 2026-08-02
+//          materialization, and not the ones recomputed daily.
+//
+// Both are read from the owning module rather than restated here, for the
+// reason the file exists: a third copy is how the first two drifted.
+
+describe("a route's published parameter TYPE is the one it parses (#10089)", () => {
+  test("/api/v1/health/trends publishes bounded integers, not strings", () => {
+    const limit = declaredParameter("/api/v1/health/trends", "limit");
+    const offset = declaredParameter("/api/v1/health/trends", "offset");
+    assert.equal(
+      limit?.type,
+      "integer",
+      "handleBulkHealthTrends runs parseLimitParam over `limit`, so a " +
+        'published `{"type":"string"}` documents a request the route rejects',
+    );
+    assert.equal(limit?.minimum, 1);
+    assert.equal(limit?.maximum, BULK_HEALTH_TRENDS_LIMIT_MAX);
+    assert.equal(offset?.type, "integer");
+    assert.equal(offset?.minimum, 0);
+    // No ceiling on purpose: parseNonNegativeIntParam enforces none, and
+    // publishing one we do not apply is this file's whole subject inverted.
+    assert.equal(offset?.maximum, undefined);
+  });
+
+  test("the schemas-src query schema agrees with the enforced ceiling", () => {
+    // BulkHealthTrendsQuerySchema is the one route query schema runtime code
+    // imports (src/bulk-health-trends.ts). schemas-src is a leaf and cannot
+    // import route-limits.ts, so this is where the two meet.
+    const emitted = z.toJSONSchema(BulkHealthTrendsQuerySchema, {
+      target: "draft-2020-12",
+      io: "input",
+    }) as { properties: Record<string, ParameterSchema> };
+    assert.equal(
+      emitted.properties.limit.maximum,
+      BULK_HEALTH_TRENDS_LIMIT_MAX,
+    );
+    assert.equal(emitted.properties.limit.minimum, 1);
+    assert.equal(emitted.properties.offset.minimum, 0);
+  });
+
+  test("the published window vocabulary is the runtime's", () => {
+    // The cross-check schemas-src/routes/health-surfaces.ts has claimed since
+    // #9981 and that did not exist until #10089. The two agreed by luck.
+    assert.deepEqual(
+      [...HEALTH_TREND_WINDOW_VALUES].sort(),
+      Object.keys(HEALTH_TREND_WINDOWS).sort(),
+      "the published window labels and workers/config.ts's day-count map name " +
+        "different windows, so one of them describes a route that does not exist",
+    );
+  });
+});
+
+describe("a route's published enum is the one it accepts (#10089)", () => {
+  test("/api/v1/accounts/top-holders publishes every sort it serves", () => {
+    assert.deepEqual(
+      declaredParameter("/api/v1/accounts/top-holders", "sort")?.enum,
+      TOP_HOLDERS_SORTS,
+      "the published enum must BE TOP_HOLDERS_SORTS -- it listed only the " +
+        "three holdings sorts, hiding net_flow_7d/30d/90d, which are the " +
+        "ones that cannot go stale",
+    );
+  });
+
+  test("the three flow sorts are specifically reachable", () => {
+    // Named rather than left to the deepEqual: these are the ones that were
+    // missing, and #9469 makes them the only sorts guaranteed to be live.
+    const published = declaredParameter(
+      "/api/v1/accounts/top-holders",
+      "sort",
+    )?.enum;
+    for (const sort of ["net_flow_7d", "net_flow_30d", "net_flow_90d"]) {
+      assert.ok(
+        published?.includes(sort),
+        `${sort} is served but unpublished, so a client generated from ` +
+          "openapi.json cannot reach the live tier",
       );
     }
   });

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -56,6 +56,7 @@ import {
   tryPostgresTier,
 } from "../postgres-tier.ts";
 import { loadBulkHealthTrends } from "../../src/bulk-health-trends.ts";
+import { BULK_HEALTH_TRENDS_LIMIT_MAX } from "../../src/route-limits.ts";
 import { formatGlobalIncidents } from "../../src/health-serving.ts";
 import {
   applyQueryFilters,
@@ -690,7 +691,9 @@ export async function handleBulkHealthTrends(
     ...HEALTH_TREND_WINDOW_VALUES,
   ]);
   if (windowError) return analyticsQueryError(windowError);
-  const trendsLimit = parseLimitParam(url, { maxLimit: 512 });
+  const trendsLimit = parseLimitParam(url, {
+    maxLimit: BULK_HEALTH_TRENDS_LIMIT_MAX,
+  });
   if ("error" in trendsLimit) return analyticsQueryError(trendsLimit.error);
   const trendsOffset = parseNonNegativeIntParam(
     url.searchParams.get("offset"),


### PR DESCRIPTION
Two routes published a query contract the handler contradicts. Same class as #10075 (a published `netuid` bound nothing enforced) and #9916 (a page size silently truncated): a client generated from `openapi.json` is told a parameter has a type it does not, or is refused input the server accepts.

Found while measuring every route's published parameters against its `*QuerySchema` for #10062.

## `/api/v1/accounts/top-holders` hid the three sorts that cannot go stale

The route published `sort` as a three-value enum written out at `src/contracts.ts`. `src/top-holders.ts` owns the list and it has **six**. Two other surfaces already agreed with the module:

```
GET /api/v1/accounts/top-holders?sort=net_flow_7d  -> 200
GET /api/v1/accounts/top-holders?sort=bogus        -> 400
  "bogus" is not a supported sort. Supported: total_tao, free_tao,
  delegated_tao, net_flow_7d, net_flow_30d, net_flow_90d.
```

and the `get_top_holders` MCP tool has advertised all six the whole time. **REST was the only surface hiding them.**

The three it hid are the LIVE tier. Per #9469/#9502 `net_flow_7d/30d/90d` are recomputed daily from `chain.account_events`, while each holdings sort DECLINES to a fixed 2026-08-02 materialization whenever its producer's last pass is not recorded complete. The published enum offered exactly the three rankings that may be months old and withheld the three that cannot be.

## `/api/v1/health/trends` published its pagination as strings

```
GET /api/v1/health/trends?limit=abc -> 400  limit must be an integer between 1 and 512.
```

Published: `limit: {"type":"string"}`, `offset: {"type":"string"}`. `handleBulkHealthTrends` has always run `parseLimitParam(url, { maxLimit: 512 })` and `parseNonNegativeIntParam`.

`BulkHealthTrendsQuerySchema` stated the correct bounds all along — and it is the ONE route query schema runtime code imports (`src/bulk-health-trends.ts`). The right answer was in the tree; it just was not the copy being published. Identical to the `/api/v1/search/semantic` string-`limit` fixed in #10087.

## Approach

Both now read from the module that owns the fact rather than a second literal:

- `sort` from `TOP_HOLDERS_SORTS`
- `limit`/`offset` from a new `BULK_HEALTH_TRENDS_LIMIT_MAX` in `src/route-limits.ts`, which the **handler** reads too — replacing its own literal `512`, so there is no copy left to drift

## A guard that was claimed but never written

`schemas-src/routes/health-surfaces.ts` has said since #9981 that its published window vocabulary is checked against `workers/config.ts`'s `HEALTH_TREND_WINDOWS` by `tests/bulk-health-trends.test.ts`. **That file does not exist.** The two vocabularies agreed by luck and nothing would have reported it if they stopped. The guard is written rather than the claim deleted.

## Published diff — 3 parameters

| Route | Parameter | Before | After |
|---|---|---|---|
| `/accounts/top-holders` | `sort` | 3-value enum | 6-value enum |
| `/health/trends` | `limit` | `{"type":"string"}` | `{"type":"integer","minimum":1,"maximum":512}` |
| `/health/trends` | `offset` | `{"type":"string"}` | `{"type":"integer","minimum":0}` |

`offset` gets no `maximum` on purpose: `parseNonNegativeIntParam` enforces none, and publishing a bound we do not apply is this PR's subject inverted.

The generated client follows:

```diff
- sort?: "total_tao" | "free_tao" | "delegated_tao";
+ sort?: "total_tao" | "free_tao" | "delegated_tao" | "net_flow_7d" | "net_flow_30d" | "net_flow_90d";
- limit?: string;
+ limit?: number;
```

## Tests

Extended `tests/route-limit-contract-parity.test.ts` — the file that already holds "published vs enforced" parity with a declared pairing:

- `/api/v1/health/trends` joins `CONSTANT_BACKED`. `declaredMaximum` returns `undefined` for a string schema, so this entry alone would have caught the original defect.
- the published `limit`/`offset` **types** are asserted, not just the ceiling
- `BulkHealthTrendsQuerySchema`'s emitted bounds are checked against the constant (schemas-src is a leaf and cannot import `route-limits.ts`, so the test is where they meet)
- the window-vocabulary cross-check that #9981 claimed
- the published `sort` enum must **be** `TOP_HOLDERS_SORTS`, plus a named check that the three flow sorts are specifically reachable

Neither new assertion can pass vacuously: `route()` fails on an unknown path, and both compare against a concrete imported value.

## Validation

```
npm run typecheck / lint / format:check          clean
npx vitest run                                   754 files, 18,070 passed, 22 skipped
validate:contract-drift  validate:openapi  validate:api
validate:query-vocabulary  validate:schema-vocabularies
validate:mcp  validate:mcp-input-parity  validate:single-schema-source    all PASS
```

Behaviour is unchanged — every handler already did what the contract now says.

Closes #10089