### PR TITLE
fix(health): replay the observation read wiring #10088 merged without (#10092)

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,4 +1,5 @@
 import { loadSubnetWeightSettersColdTier } from "./subnet-weight-setters-loader.ts";
+import { observationsReadDb } from "./observations-read-runner.ts";
 import { loadSubnetWeightsColdTier } from "./subnet-weights-loader.ts";
 import { loadSubnetEventCardColdTier } from "./subnet-event-card-loader.ts";
 import { loadSubnetAlphaVolumeFromArtifact } from "./subnet-alpha-volume-artifact.ts";
@@ -886,6 +887,10 @@ export interface GqlContext {
   env: Env;
   cache: Map<string, unknown>;
   request?: Request;
+  /** The request's ExecutionContext, threaded so resolvers can select a store
+   * (#10086). createPgSql returns its connection via waitUntil, so a resolver
+   * without one cannot read Neon and correctly falls back to D1. */
+  ctx?: { waitUntil?: (promise: Promise<unknown>) => void };
   clientIp?: string | null;
   graphqlWsConnection?: unknown;
   chainFirehose?: unknown;
@@ -2478,7 +2483,10 @@ const rootValue = {
         "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
       )) as Row | null) ??
       (await loadSubnetTrajectory(netuid, {
-        db: context.env.METAGRAPH_HEALTH_DB,
+        db: observationsReadDb(
+          context.env as unknown as Record<string, unknown>,
+          context.ctx,
+        ),
       }));
     return {
       schema_version: data.schema_version ?? 1,
@@ -4299,7 +4307,10 @@ const rootValue = {
       netuids: parsedNetuids,
       dimensions: parsedDimensions!,
       observedAt: await loadObservedAt(context),
-      db: context.env.METAGRAPH_HEALTH_DB,
+      db: observationsReadDb(
+        context.env as unknown as Record<string, unknown>,
+        context.ctx,
+      ),
     });
   },
 
@@ -4805,7 +4816,10 @@ const rootValue = {
       (await loadSubnetPercentiles(netuid, {
         window: label,
         observedAt: await loadObservedAt(context),
-        db: context.env.METAGRAPH_HEALTH_DB,
+        db: observationsReadDb(
+          context.env as unknown as Record<string, unknown>,
+          context.ctx,
+        ),
       }));
     return {
       schema_version: data.schema_version ?? 1,
@@ -5094,7 +5108,10 @@ const rootValue = {
       (await loadSubnetIncidents(netuid, {
         window: label,
         observedAt: await loadObservedAt(context),
-        db: context.env.METAGRAPH_HEALTH_DB,
+        db: observationsReadDb(
+          context.env as unknown as Record<string, unknown>,
+          context.ctx,
+        ),
       }));
     return {
       schema_version: data.schema_version ?? 1,
@@ -7339,7 +7356,10 @@ const rootValue = {
         await loadEconomicsTrends({
           windowLabel: label,
           windowDays: days,
-          db: context.env.METAGRAPH_HEALTH_DB,
+          db: observationsReadDb(
+            context.env as unknown as Record<string, unknown>,
+            context.ctx,
+          ),
         })
       ).data;
     // Normalized the same way blocks/validators/accounts are (schema-stable,
@@ -8545,7 +8565,10 @@ const rootValue = {
       (
         await loadBulkHealthTrends({
           observedAt: await loadObservedAt(context),
-          db: context.env.METAGRAPH_HEALTH_DB,
+          db: observationsReadDb(
+            context.env as unknown as Record<string, unknown>,
+            context.ctx,
+          ),
         })
       ).data;
     return {
@@ -8575,7 +8598,10 @@ const rootValue = {
       )) as Row | null) ??
       (await loadSubnetHealthTrends(netuid, {
         observedAt: await loadObservedAt(context),
-        db: context.env.METAGRAPH_HEALTH_DB,
+        db: observationsReadDb(
+          context.env as unknown as Record<string, unknown>,
+          context.ctx,
+        ),
       }));
     return {
       schema_version: data.schema_version ?? 1,
@@ -8729,7 +8755,10 @@ const rootValue = {
       ((await loadSubnetUptime(netuid, {
         window: windowParam,
         observedAt: await loadObservedAt(context),
-        db: context.env.METAGRAPH_HEALTH_DB,
+        db: observationsReadDb(
+          context.env as unknown as Record<string, unknown>,
+          context.ctx,
+        ),
       })) as Row);
     return {
       schema_version: data.schema_version ?? 1,
@@ -9448,7 +9477,11 @@ function sdlResponse() {
   });
 }
 
-export async function handleGraphQLRequest(request: Request, env: Env) {
+export async function handleGraphQLRequest(
+  request: Request,
+  env: Env,
+  ctx?: { waitUntil?: (promise: Promise<unknown>) => void },
+) {
   if (request.method === "GET") {
     return sdlResponse();
   }
@@ -9535,7 +9568,7 @@ export async function handleGraphQLRequest(request: Request, env: Env) {
     schema,
     document,
     rootValue,
-    contextValue: { env, cache: new Map(), request },
+    contextValue: { env, cache: new Map(), request, ctx },
     variableValues: variables ?? undefined,
     operationName: operationName ?? undefined,
   });

--- a/src/observations-read-runner.ts
+++ b/src/observations-read-runner.ts
@@ -60,6 +60,12 @@ export function pgObservationsReadDb(sql: ReadRunnerSql): ObservationsReadDb {
             all: () => sql.unsafe(text, values),
           };
         },
+        // BOTH SHAPES, because D1 has both and this codebase uses both.
+        // src/top-holders-holdings.ts calls `prepare(sql).all?.()` with no
+        // bind at all -- its statement carries no parameters -- and an adapter
+        // offering only the bind path would throw there rather than fall back,
+        // turning a store swap into a route outage.
+        all: () => sql.unsafe(text, []),
       };
     },
   };

--- a/tests/observations-flip-readiness.test.ts
+++ b/tests/observations-flip-readiness.test.ts
@@ -22,12 +22,76 @@ import { readFileSync, readdirSync } from "node:fs";
 import { describe, test } from "vitest";
 import { OBSERVATION_TABLES } from "../src/observations-neon.ts";
 
-/** Files that serve observation reads. */
-function readSiteFiles(): string[] {
+/** The files that call the observation LOADERS. Narrow on purpose: the
+ * `db:`-shaped scan below looks for a loader argument, and `db:
+ * env.METAGRAPH_HEALTH_DB` is a perfectly correct thing to write for a table
+ * that has nothing to do with this family. */
+function loaderCallSiteFiles(): string[] {
   const handlers = readdirSync("workers/request-handlers")
     .filter((f) => f.endsWith(".ts"))
     .map((f) => `workers/request-handlers/${f}`);
   return ["src/graphql.ts", "src/health-prober.ts", ...handlers];
+}
+
+/** Every source file, for the SQL-shaped scan -- a side reader can live
+ * anywhere. */
+function readSiteFiles(): string[] {
+  const walk = (dir: string): string[] =>
+    readdirSync(dir, { withFileTypes: true }).flatMap((e) =>
+      e.isDirectory()
+        ? walk(`${dir}/${e.name}`)
+        : e.name.endsWith(".ts")
+          ? [`${dir}/${e.name}`]
+          : [],
+    );
+  return [...walk("src"), ...walk("workers")];
+}
+
+/** Modules that legitimately talk to one store on purpose: the two write
+ * halves, the per-store adapters, and the cross-store lanes whose whole job is
+ * to hold both at once. */
+const STORE_AWARE = [
+  "src/observations-neon.ts",
+  "src/observations-d1.ts",
+  "src/observations-read-runner.ts",
+  "src/neon-backfill.ts",
+  "src/neon-parity-watchdog.ts",
+  "src/neon-prune.ts",
+  "src/neon-mirror-watchdog.ts",
+  "src/health-sql.ts",
+];
+
+/** A marker that a module chooses its store rather than assuming one. */
+const SELECTS_A_STORE =
+  /observationsReadDb|createPgSql|routeStore|neonOwnsTable|neonReadLanes/;
+
+/**
+ * Files that name an observation table in SQL but cannot reach Neon.
+ *
+ * The `db:`-shaped scan below is not enough on its own, and believing it was
+ * would have been the whole bug again: `subnet_snapshots` has five readers
+ * (metagraph-neurons, top-holders-holdings, economics-trends,
+ * account-stake-moves, request-handlers/entities) that build their own SQL and
+ * never go near an observation loader. A gate blind to those would have said
+ * "ready" and frozen six more surfaces on the flip.
+ */
+function tableReadersWithoutASelector(): { file: string; tables: string[] }[] {
+  const out: { file: string; tables: string[] }[] = [];
+  for (const file of readSiteFiles()) {
+    if (STORE_AWARE.includes(file)) continue;
+    let source: string;
+    try {
+      source = readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    if (SELECTS_A_STORE.test(source)) continue;
+    const tables = OBSERVATION_TABLES.filter((t) =>
+      new RegExp(`\\b(?:FROM|JOIN|INTO|UPDATE)\\s+${t}\\b`).test(source),
+    );
+    if (tables.length) out.push({ file, tables });
+  }
+  return out;
 }
 
 /**
@@ -41,7 +105,7 @@ const RAW_BINDING =
 
 function unwiredSites(): { file: string; count: number }[] {
   const out: { file: string; count: number }[] = [];
-  for (const file of readSiteFiles()) {
+  for (const file of loaderCallSiteFiles()) {
     let source: string;
     try {
       source = readFileSync(file, "utf8");
@@ -94,6 +158,45 @@ describe("observation flip readiness", () => {
       assert.ok(
         flipped.length === 0 || flipped.length === OBSERVATION_TABLES.length,
         `${config} flips ${flipped.length} of ${OBSERVATION_TABLES.length} observation tables: ${flipped.join(", ")}`,
+      );
+    }
+  });
+
+  test("the family is not flipped while a SIDE reader is stuck on D1", () => {
+    // The loader-shaped scan above misses these entirely: they build their own
+    // SQL over subnet_snapshots and never touch an observation loader. Flipping
+    // with these unported freezes them on a store the prober no longer writes.
+    const stuck = tableReadersWithoutASelector();
+    for (const config of CONFIGS) {
+      const flipped = flippedTables(config);
+      if (stuck.length === 0) continue;
+      assert.deepEqual(
+        flipped,
+        [],
+        `${config} names ${flipped.join(", ")} as Neon's, but these read those tables ` +
+          `from D1 with no store selection:\n` +
+          stuck
+            .map((s) => `    ${s.file} -> ${s.tables.join(", ")}`)
+            .join("\n"),
+      );
+    }
+  });
+
+  test("the side-reader scan actually finds the known ones", () => {
+    // Non-vacuous: these five are D1-only today and MUST be visible to the
+    // scan. When they are ported this assertion is what has to be updated
+    // deliberately, rather than the gate quietly starting to pass on nothing.
+    const files = tableReadersWithoutASelector().map((s) => s.file);
+    for (const known of [
+      "src/metagraph-neurons.ts",
+      "src/top-holders-holdings.ts",
+      "src/economics-trends.ts",
+      "src/account-stake-moves.ts",
+      "workers/request-handlers/entities.ts",
+    ]) {
+      assert.ok(
+        files.includes(known),
+        `${known} reads an observation table from D1 but the scan missed it`,
       );
     }
   });

--- a/tests/observations-read-runner.test.ts
+++ b/tests/observations-read-runner.test.ts
@@ -47,6 +47,27 @@ describe("pgObservationsReadDb", () => {
     assert.equal((await d1All(db, "SELECT 1", [])).length, 2);
   });
 
+  test("prepare().all() works WITHOUT a bind, the shape D1 also offers", async () => {
+    // src/top-holders-holdings.ts calls `db.prepare(sql).all?.()` -- its
+    // statement carries no parameters, so it never binds. An adapter offering
+    // only the bind path would make `.all` undefined there; the `?.` would
+    // swallow it into `undefined` rows and the route would serve an empty
+    // holdings list rather than fail loudly.
+    const seen: unknown[][] = [];
+    const db = pgObservationsReadDb({
+      unsafe: async (_text: string, values: unknown[] = []) => {
+        seen.push(values);
+        return [{ netuid: 1 }];
+      },
+    });
+    const prepared = db.prepare("SELECT netuid FROM subnet_snapshots") as {
+      all?: () => Promise<unknown>;
+    };
+    assert.equal(typeof prepared.all, "function");
+    assert.deepEqual(await prepared.all!(), [{ netuid: 1 }]);
+    assert.deepEqual(seen, [[]]);
+  });
+
   test("a rejected read degrades to zero rows rather than throwing", async () => {
     // d1All's contract, which the adapter must not break: these are serving
     // paths and a failed read is a schema-stable empty payload, not a 500.

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -4381,7 +4381,7 @@ export async function handleRequest(
     }
     const limited = await graphqlRateLimited(request, env);
     if (limited) return limited;
-    return handleGraphQLRequest(request, env);
+    return handleGraphQLRequest(request, env, ctx);
   }
 
   if (!["GET", "HEAD"].includes(request.method)) {

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -43,7 +43,8 @@ import {
 } from "../../src/emission-pipeline-surface.ts";
 import { EMISSION_PIPELINE_LIMIT_MAX } from "../../src/route-limits.ts";
 import type { Row as FieldProjectionRow } from "../../src/field-projection.ts";
-import { economicsCurrentKvReader } from "./analytics.ts";
+import { economicsCurrentKvReader, type EdgeCacheCtx } from "./analytics.ts";
+import { observationsReadDb } from "../../src/observations-read-runner.ts";
 import {
   COMPARE_DIMENSIONS,
   COMPARE_VALIDATORS_MAX,
@@ -261,6 +262,7 @@ export async function handleTrajectory(
   env: Env,
   netuid: number,
   url: URL,
+  ctx: EdgeCacheCtx = {},
 ): Promise<Response> {
   const validationError = validateQueryParams(url, ["format"]);
   if (validationError) return analyticsQueryError(validationError);
@@ -282,7 +284,7 @@ export async function handleTrajectory(
     // handleHealthTrends in analytics.ts).
     const d1Generation = currentD1ReadFailureGeneration();
     data = (await loadSubnetTrajectory(netuid, {
-      db: env.METAGRAPH_HEALTH_DB,
+      db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
     })) as ReturnType<typeof formatTrajectory>;
     isFallback =
       !env.METAGRAPH_HEALTH_DB ||
@@ -323,6 +325,7 @@ export async function handleEconomicsTrends(
   request: Request,
   env: Env,
   url: URL,
+  ctx: EdgeCacheCtx = {},
 ): Promise<Response> {
   const validationError = validateQueryParams(url, ["window", "format"]);
   if (validationError) return analyticsQueryError(validationError);
@@ -347,7 +350,7 @@ export async function handleEconomicsTrends(
     const loaded = await loadEconomicsTrends({
       windowLabel: label,
       windowDays: days,
-      db: env.METAGRAPH_HEALTH_DB,
+      db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
     });
     data = loaded.data;
     isFallback =
@@ -381,6 +384,7 @@ export async function handleUptime(
   env: Env,
   netuid: number,
   url: URL,
+  ctx: EdgeCacheCtx = {},
 ): Promise<Response> {
   const validationError = validateQueryParams(url, [
     "window",
@@ -429,7 +433,7 @@ export async function handleUptime(
       window: windowParam,
       observedAt: healthMeta?.last_run_at || null,
       minSamples: minSamplesResult.value ?? null,
-      db: env.METAGRAPH_HEALTH_DB,
+      db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
     } as unknown as Parameters<typeof loadSubnetUptime>[1])) as ReturnType<
       typeof formatUptime
     >;

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -72,7 +72,6 @@ import {
   loadSubnetHealthTrends,
   loadSubnetIncidents,
   loadSubnetPercentiles,
-  type ObservationsReadDb,
 } from "../../src/analytics-live.ts";
 import { CHAIN_SIGNERS_SORTS } from "../../src/chain-query-loaders.ts";
 import {
@@ -975,12 +974,13 @@ export async function handleHealthIncidents(
 export async function loadGlobalIncidentsLedger(
   env: Env,
   { label = "7d", days = 7 }: { label?: string; days?: number } = {},
+  ctx: EdgeCacheCtx = {},
 ) {
   // D1 reads resurrected (2026-08-02, box decommission): the rows come from
   // the dual-written surface_checks copy in D1 — no binding, no rows, which
   // is exactly the empty stub this was between 2026-07-17 and now.
   const incidentRows = await loadGlobalIncidentRows(
-    env.METAGRAPH_HEALTH_DB as unknown as ObservationsReadDb,
+    observationsReadDb(env as unknown as Record<string, unknown>, ctx),
     days,
   );
   const meta = await readHealthMetaKv(env);
@@ -1015,6 +1015,7 @@ export async function resolveGlobalIncidents(
   request: Request,
   env: Env,
   { label = "7d", days = 7 }: { label?: string; days?: number } = {},
+  ctx: EdgeCacheCtx = {},
 ): Promise<{ data: Record<string, unknown>; isFallback: boolean }> {
   const tiered = (await tryPostgresTier(
     env,
@@ -1023,7 +1024,7 @@ export async function resolveGlobalIncidents(
   )) as Record<string, unknown> | null;
   if (tiered) return { data: tiered, isFallback: false };
   const d1Generation = currentD1ReadFailureGeneration();
-  const result = await loadGlobalIncidentsLedger(env, { label, days });
+  const result = await loadGlobalIncidentsLedger(env, { label, days }, ctx);
   return {
     data: result.data as unknown as Record<string, unknown>,
     // Only an EMPTY ledger counts as a fallback for caching purposes — no D1


### PR DESCRIPTION
## Summary

#10088 was squash-merged while further commits were still being pushed to it. Main carries the
portable SQL, the adapter and the prober wiring — but not the four commits after them. This replays
them.

Verified against `origin/main` rather than assumed:

```
src/observations-read-runner.ts exists                     YES
  ... with the parameterless prepare().all() shape           0   <- missing
tests/observations-flip-readiness.test.ts side-reader scan   0   <- missing
src/graphql.ts observationsReadDb                            0   <- missing
```

## What was missing

**GraphQL could not reach Neon at all.** `GqlContext` carried `env`, `cache` and `request` but no
ExecutionContext, and `createPgSql` returns its connection via `waitUntil`. Eight resolvers fall back
to D1 permanently — after the flip, the worst outcome available: REST advances, GraphQL silently
serves a frozen store. `handleGraphQLRequest` now takes a `ctx`, threaded from `workers/api.ts`.

**Three handlers and the incidents ledger took no ctx** — `handleTrajectory`,
`handleEconomicsTrends`, `handleUptime`, `loadGlobalIncidentsLedger` / `resolveGlobalIncidents`. Each
now accepts an `EdgeCacheCtx` defaulted to `{}`, which the selector correctly reads as "no usable
ctx".

**The flip gate was blind to the readers that matter most.** It only saw a raw binding passed to an
observation *loader*. `subnet_snapshots` has five readers that build their own SQL and never touch a
loader — all D1-only:

```
src/metagraph-neurons.ts      src/account-stake-moves.ts
src/top-holders-holdings.ts   workers/request-handlers/entities.ts
src/economics-trends.ts
```

The gate on main would report "ready" and let a flip freeze six more surfaces — the same false
confidence it exists to prevent, one layer up. The second scan walks every file under `src/` and
`workers/` for SQL naming an observation table and flags any without a store-selection marker.
Verified in both directions: attempting the flip fails naming `economics-trends`,
`metagraph-neurons` and `entities`; and a separate test pins that the scan still *sees* those five,
so it cannot start passing on an empty set.

**The adapter lacked `prepare().all()` without a bind.** `src/top-holders-holdings.ts` calls
`db.prepare(sql).all?.()` — no bind, no parameters. With only the bind path `.all` is `undefined`,
the optional call swallows it, and the route serves an empty holdings list rather than failing
loudly. Verified non-vacuous: removing the direct `.all` fails the test.

## Rebase hygiene

Two commits were already upstream and were dropped by the rebase. Every change was then re-grepped
on the rebased tree rather than assumed to have survived:

```
graphql observationsReadDb        9      adapter direct .all      1
graphql ctx in GqlContext         2      extended gate            3
api.ts passes ctx                 1      unwired loader sites     0
analytics-routes wired            4
```

## Still not flipped

The five side readers above remain D1-only, so the family stays on D1 and the gate enforces that.
Nothing in this PR changes production behaviour: `observationsReadDb` returns the D1 binding until
all five observation tables are named in `NEON_SOLE_STORE_TABLES`.

## Validation

```
npx tsc --noEmit                                  clean
eslint / prettier --check                         clean
vitest run observations-read-runner observations-flip-readiness graphql
           analytics analytics-edge-cache request-handlers-analytics
           health-prober health-sql analytics-live          1,513 passed
```

Closes #10092
