### PR TITLE
fix(api): five routes served a CSV export openapi.json never mentioned (#10090)

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -13240,6 +13240,8 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -13251,7 +13253,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -13305,6 +13307,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["BlockEventsArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index,price_at_tx,price_basis
+                     *     8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,440,2026-07-03T00:00:00.000Z,2,0.028409091,trade_exact
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -13359,6 +13366,8 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -13370,7 +13379,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -13434,6 +13443,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["BlockExtrinsicsArtifact"];
                     };
+                    /**
+                     * @example extrinsic_id,block_number,signer,call_module,call_function,success
+                     *     1000000-4,1000000,5Signer_sample,SubtensorModule,set_weights,true
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -19393,6 +19407,8 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -19402,7 +19418,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -19455,6 +19471,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountHistoryArtifact"];
                     };
+                    /**
+                     * @example day,netuid,event_count,event_kinds,first_block,last_block
+                     *     2026-08-07,0,4,StakeRemoved;StakeAdded,8788696,8791411
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -22612,6 +22633,8 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -22621,7 +22644,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -22675,6 +22698,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["BlockEventsArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index,price_at_tx,price_basis
+                     *     8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,440,2026-07-03T00:00:00.000Z,2,0.028409091,trade_exact
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -22729,6 +22757,8 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -22738,7 +22768,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -22802,6 +22832,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["BlockExtrinsicsArtifact"];
                     };
+                    /**
+                     * @example extrinsic_id,block_number,signer,call_module,call_function,success
+                     *     1000000-4,1000000,5Signer_sample,SubtensorModule,set_weights,true
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -44481,6 +44516,8 @@ export interface operations {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `90d`, `1y`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "90d" | "1y";
                 min_samples?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -44490,7 +44527,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -44564,6 +44601,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["UptimeArtifact"];
                     };
+                    /**
+                     * @example surface_id,day,samples,uptime_ratio,avg_latency_ms,latency_sample_count,p50,p95,p99,status
+                     *     sn-1-apex-healthcheck,2026-07-21,17,1,632,17,668,691,702,ok
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -46733,6 +46775,8 @@ export interface operations {
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
                 coldkey?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -46742,7 +46786,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -46806,6 +46850,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ValidatorNominatorsArtifact"];
                     };
+                    /**
+                     * @example coldkey,staked_tao,unstaked_tao,net_staked_tao,gross_staked_tao,event_count,last_observed_at
+                     *     ck_sample,4,0,4,4,1,2026-08-07T21:17:12.000Z
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -7631,6 +7631,17 @@
           "schema": {
             "type": "string"
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },
@@ -8266,6 +8277,17 @@
           "schema": {
             "minimum": 0,
             "type": "integer"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
           }
         }
       ]
@@ -9651,6 +9673,17 @@
             "minimum": 0,
             "type": "integer"
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },
@@ -9685,6 +9718,17 @@
           "schema": {
             "minimum": 0,
             "type": "integer"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
           }
         }
       ]
@@ -11303,6 +11347,17 @@
           "schema": {
             "minimum": 0,
             "type": "integer"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
           }
         }
       ]

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -448,6 +448,9 @@
           "schema_version": 1
         }
       },
+      "AccountHistoryCsv": {
+        "value": "day,netuid,event_count,event_kinds,first_block,last_block\r\n2026-08-07,0,4,StakeRemoved;StakeAdded,8788696,8791411"
+      },
       "AccountIdentityArtifactResponse": {
         "value": {
           "data": {
@@ -1938,6 +1941,9 @@
           "ok": true,
           "schema_version": 1
         }
+      },
+      "BlockExtrinsicsCsv": {
+        "value": "extrinsic_id,block_number,signer,call_module,call_function,success\r\n1000000-4,1000000,5Signer_sample,SubtensorModule,set_weights,true"
       },
       "BlocksFeedArtifactResponse": {
         "value": {
@@ -11481,6 +11487,9 @@
           "schema_version": 1
         }
       },
+      "SubnetUptimeCsv": {
+        "value": "surface_id,day,samples,uptime_ratio,avg_latency_ms,latency_sample_count,p50,p95,p99,status\r\nsn-1-apex-healthcheck,2026-07-21,17,1,632,17,668,691,702,ok"
+      },
       "SubnetValidatorEconomicsArtifactResponse": {
         "value": {
           "data": {
@@ -12440,6 +12449,9 @@
           "ok": true,
           "schema_version": 1
         }
+      },
+      "ValidatorNominatorsCsv": {
+        "value": "coldkey,staked_tao,unstaked_tao,net_staked_tao,gross_staked_tao,event_count,last_observed_at\r\nck_sample,4,0,4,4,1,2026-08-07T21:17:12.000Z"
       },
       "WebhookSubscriptionArtifactResponse": {
         "value": {
@@ -56750,6 +56762,19 @@
               "minimum": 0,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -56776,9 +56801,19 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "examples": {
+                  "AccountEventsCsv": {
+                    "$ref": "#/components/examples/AccountEventsCsv"
+                  }
+                },
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -56896,6 +56931,19 @@
               "minimum": 0,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -56922,9 +56970,19 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "examples": {
+                  "BlockExtrinsicsCsv": {
+                    "$ref": "#/components/examples/BlockExtrinsicsCsv"
+                  }
+                },
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -63631,6 +63689,19 @@
               "minimum": 0,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -63657,9 +63728,19 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "examples": {
+                  "AccountHistoryCsv": {
+                    "$ref": "#/components/examples/AccountHistoryCsv"
+                  }
+                },
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -66840,6 +66921,19 @@
               "minimum": 0,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -66866,9 +66960,19 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "examples": {
+                  "AccountEventsCsv": {
+                    "$ref": "#/components/examples/AccountEventsCsv"
+                  }
+                },
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -66970,6 +67074,19 @@
               "minimum": 0,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -66996,9 +67113,19 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "examples": {
+                  "BlockExtrinsicsCsv": {
+                    "$ref": "#/components/examples/BlockExtrinsicsCsv"
+                  }
+                },
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -91466,6 +91593,19 @@
               "minimum": 0,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -91492,9 +91632,19 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "examples": {
+                  "SubnetUptimeCsv": {
+                    "$ref": "#/components/examples/SubnetUptimeCsv"
+                  }
+                },
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -93874,6 +94024,19 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -93900,9 +94063,19 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "examples": {
+                  "ValidatorNominatorsCsv": {
+                    "$ref": "#/components/examples/ValidatorNominatorsCsv"
+                  }
+                },
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -13240,6 +13240,8 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -13251,7 +13253,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -13305,6 +13307,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["BlockEventsArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index,price_at_tx,price_basis
+                     *     8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,440,2026-07-03T00:00:00.000Z,2,0.028409091,trade_exact
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -13359,6 +13366,8 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -13370,7 +13379,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -13434,6 +13443,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["BlockExtrinsicsArtifact"];
                     };
+                    /**
+                     * @example extrinsic_id,block_number,signer,call_module,call_function,success
+                     *     1000000-4,1000000,5Signer_sample,SubtensorModule,set_weights,true
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -19393,6 +19407,8 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -19402,7 +19418,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -19455,6 +19471,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountHistoryArtifact"];
                     };
+                    /**
+                     * @example day,netuid,event_count,event_kinds,first_block,last_block
+                     *     2026-08-07,0,4,StakeRemoved;StakeAdded,8788696,8791411
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -22612,6 +22633,8 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -22621,7 +22644,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -22675,6 +22698,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["BlockEventsArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index,price_at_tx,price_basis
+                     *     8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,440,2026-07-03T00:00:00.000Z,2,0.028409091,trade_exact
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -22729,6 +22757,8 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -22738,7 +22768,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -22802,6 +22832,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["BlockExtrinsicsArtifact"];
                     };
+                    /**
+                     * @example extrinsic_id,block_number,signer,call_module,call_function,success
+                     *     1000000-4,1000000,5Signer_sample,SubtensorModule,set_weights,true
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -44481,6 +44516,8 @@ export interface operations {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `90d`, `1y`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "90d" | "1y";
                 min_samples?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -44490,7 +44527,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -44564,6 +44601,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["UptimeArtifact"];
                     };
+                    /**
+                     * @example surface_id,day,samples,uptime_ratio,avg_latency_ms,latency_sample_count,p50,p95,p99,status
+                     *     sn-1-apex-healthcheck,2026-07-21,17,1,632,17,668,691,702,ok
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -46733,6 +46775,8 @@ export interface operations {
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
                 coldkey?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -46742,7 +46786,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -46806,6 +46850,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ValidatorNominatorsArtifact"];
                     };
+                    /**
+                     * @example coldkey,staked_tao,unstaked_tao,net_staked_tao,gross_staked_tao,event_count,last_observed_at
+                     *     ck_sample,4,0,4,4,1,2026-08-07T21:17:12.000Z
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -3387,7 +3387,7 @@ export const API_ROUTES = [
     "Fetch the nominator list for one validator: who has staked to it (across every subnet it operates in) over a 7d/30d/90d window, each with staked/unstaked/net/gross TAO and last activity, ranked by net_staked (default), gross_staked, or last_activity. ?coldkey= narrows to one nominator's own flow (exact match). Summed live from the account_events StakeAdded/StakeRemoved stream. Cold/absent hotkey returns an empty list, never a 404. ?basis= selects WHICH QUESTION is answered (#9617), not how well it is answered. basis=flow (the DEFAULT, and everything above) is TAO MOVED within the window, so it cannot see a nominator who staked before the window and has not touched it since -- a dormant delegator is invisible and a long-standing one reads as smaller than they are. basis=positions instead reads the standing position ledger keyed (coldkey, hotkey, netuid): every coldkey (an ss58 address) currently delegating to this hotkey, and how much ALPHA each holds per subnet, whenever they staked. The two are different units over different time semantics -- TAO moved in a window versus alpha held now -- so they are not comparable and the default does not move. On the positions basis, window and sort are REJECTED rather than ignored, because accepting them would imply the snapshot honoured them; nominator_count is the whole delegator set rather than the returned page; and alpha is reported PER SUBNET with no cross-subnet total, since each subnet's alpha is a different token. Nominators are ranked by how many subnets they hold on, then by their largest single-subnet holding, for the same reason. The positions basis DECLINES with degraded.reason pool_totals_unproven while the hotkey_alpha pool ledger has no complete pass -- a partial ledger underprices a nominator rather than dropping them.",
     "short",
     ["validators", "analytics"],
-    [
+    csvRouteQuery([
       {
         name: "basis",
         schema: { type: "string", enum: ["flow", "positions"] },
@@ -3406,7 +3406,7 @@ export const API_ROUTES = [
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
       { name: "coldkey", schema: { type: "string" } },
-    ],
+    ]),
     [{ name: "hotkey", schema: { type: "string" } }],
   ),
   route(
@@ -3657,13 +3657,13 @@ export const API_ROUTES = [
     "Fetch the durable per-day activity series for one account, newest day first, from the hotkey-keyed account_events_daily rollup (#1854). An ss58 with no hotkey activity returns zero days, since the rollup is hotkey-attributed (unlike /events, which matches the hotkey or coldkey). ?netuid filters to one subnet; ?from / ?to are YYYY-MM-DD bounds; ?limit (<=1000) / ?offset.",
     "short",
     ["accounts", "analytics"],
-    [
+    csvRouteQuery([
       { name: "netuid", schema: parameterSchema(netuidSchema()) },
       { name: "from", schema: { type: "string", format: "date" } },
       { name: "to", schema: { type: "string", format: "date" } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
-    ],
+    ]),
     [{ name: "ss58", schema: { type: "string" } }],
   ),
   route(
@@ -4447,10 +4447,10 @@ export const API_ROUTES = [
     "Fetch the extrinsics in one block (by numeric block_number or 0x block_hash), in natural order; ?limit (<=100) / ?offset. Computed live from the first-party extrinsics D1 tier (#1845); 200 with extrinsics:[] when cold/unknown.",
     "short",
     ["blocks", "analytics"],
-    [
+    csvRouteQuery([
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
-    ],
+    ]),
     [{ name: "ref", schema: { type: "string" } }],
   ),
   route(
@@ -4461,10 +4461,10 @@ export const API_ROUTES = [
     "Fetch the ACCOUNT-ATTRIBUTED events in one block (by numeric block_number or 0x block_hash), in natural order; ?limit (<=1000) / ?offset. This is the curated account_events projection -- a deliberate SUBSET of /api/v1/blocks/{ref}/chain-events (the complete pallet-level stream the block header's event_count counts), narrower by design rather than by loss. 200 with events:[] when cold/unknown.",
     "short",
     ["blocks", "analytics"],
-    [
+    csvRouteQuery([
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
-    ],
+    ]),
     [{ name: "ref", schema: { type: "string" } }],
   ),
   route(
@@ -5081,10 +5081,10 @@ export const API_ROUTES = [
     "Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup). Pass `min_samples` to drop low-sample day rows (daily probe count below the threshold, including zero-sample 'unknown' days) from the history.",
     "short",
     ["health", "subnets", "analytics"],
-    [
+    csvRouteQuery([
       { name: "window", schema: { type: "string", enum: ["90d", "1y"] } },
       { name: "min_samples", schema: { type: "integer", minimum: 0 } },
-    ],
+    ]),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(

--- a/src/csv-route-examples.ts
+++ b/src/csv-route-examples.ts
@@ -50,6 +50,37 @@ export const ROUTE_CSV_EXAMPLES: Record<string, string> = {
   ].join("\r\n"),
   "subnet-events": EVENTS_CSV_EXAMPLE,
   "account-events": EVENTS_CSV_EXAMPLE,
+  // #10090: the block-level event feed serializes the SAME formatChainEvent row
+  // shape as the two feeds above, so it shares their example rather than
+  // carrying a third copy of the same header. It has served this CSV since it
+  // was written; it just never published `format`, so nothing generated from
+  // openapi.json could discover the export.
+  "block-events": EVENTS_CSV_EXAMPLE,
+  "block-extrinsics": [
+    "extrinsic_id,block_number,signer,call_module,call_function,success",
+    "1000000-4,1000000,5Signer_sample,SubtensorModule,set_weights,true",
+  ].join("\r\n"),
+  // The DAILY rollup, not the raw events: one row per (day, netuid) with the
+  // kinds seen that day joined by `;`, which is why event_kinds is a single
+  // column rather than one per kind.
+  "account-history": [
+    "day,netuid,event_count,event_kinds,first_block,last_block",
+    "2026-08-07,0,4,StakeRemoved;StakeAdded,8788696,8791411",
+  ].join("\r\n"),
+  // One row per (surface, day). uptime_ratio is 0..1, and the latency columns
+  // are success-only -- latency_sample_count is their denominator, which is why
+  // it rides alongside `samples` rather than being derivable from it.
+  "subnet-uptime": [
+    "surface_id,day,samples,uptime_ratio,avg_latency_ms,latency_sample_count,p50,p95,p99,status",
+    "sn-1-apex-healthcheck,2026-07-21,17,1,632,17,668,691,702,ok",
+  ].join("\r\n"),
+  // VALIDATOR_NOMINATOR_CSV_COLUMNS (workers/request-handlers/entities.ts). The
+  // internal `last_observed_ms` sort key is dropped before the response, so it
+  // is deliberately absent here too.
+  "validator-nominators": [
+    "coldkey,staked_tao,unstaked_tao,net_staked_tao,gross_staked_tao,event_count,last_observed_at",
+    "ck_sample,4,0,4,4,1,2026-08-07T21:17:12.000Z",
+  ].join("\r\n"),
   // The Postgres all-events feed: flat scalar columns of each raw pallet.method
   // event (the nested `args` object is omitted from the CSV projection).
   "chain-events-feed": [

--- a/tests/csv-contract-parity.test.ts
+++ b/tests/csv-contract-parity.test.ts
@@ -1,0 +1,206 @@
+// A route that serves CSV says so, and one that says so serves it (#10090).
+//
+// The bug this exists to stop: five routes answered `?format=csv` with
+// text/csv in production while publishing neither a `format` parameter nor a
+// text/csv 200 response — /accounts/{ss58}/history, /blocks/{ref}/events,
+// /blocks/{ref}/extrinsics, /subnets/{netuid}/uptime and
+// /validators/{hotkey}/nominators. Every one is a real headered projection. A
+// consumer generated from openapi.json had no way to discover they existed.
+//
+// ── Why nothing caught it ───────────────────────────────────────────────────
+//
+// openapi.json was internally CONSISTENT and wrong on both sides at once: 78
+// routes published `format` and exactly the same 78 declared a text/csv
+// response, because both are emitted from one `csvResponse: true` flag. Any
+// check comparing the contract to itself passes. The disagreement was only ever
+// visible against the code that answers the request.
+//
+// So this drives the real router. `handleRequest` + `createLocalArtifactEnv()`
+// is the same in-process seam the CSV export tests in api-coverage already use:
+// a full dispatch, no live Worker, and the response's own content-type as the
+// answer.
+//
+// ── The two directions are not symmetric ────────────────────────────────────
+//
+// SERVES-BUT-UNDECLARED is the defect, and it takes no exemptions: if a route
+// answers text/csv here, it must declare it. A new CSV export cannot land
+// undocumented.
+//
+// DECLARED-BUT-NOT-SERVED is weaker evidence, because a route whose rows come
+// from a live data tier declines to the schema-stable empty JSON envelope under
+// this env rather than emitting a CSV of nothing. That is correct behaviour and
+// not something to assert away, so those routes are declared below with a
+// reason — and a STALE entry FAILS, the same contract as the MCP-parity and
+// schema-opacity allowlists. The list can only shrink.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { createLocalArtifactEnv } from "../scripts/lib.ts";
+import { handleRequest } from "../workers/api.ts";
+import { API_ROUTES } from "../src/contracts.ts";
+import { type Row } from "./row-type.ts";
+
+/**
+ * Path-parameter fixtures.
+ *
+ * Values that resolve against the built local artifacts, so a route is
+ * exercised rather than 404ing before it can answer. A `{param}` with no entry
+ * here fails the coverage check below rather than being skipped — an
+ * unsubstituted path is a route this gate stopped looking at.
+ */
+const PATH_FIXTURES: Record<string, string> = {
+  "{netuid}": "1",
+  "{ss58}": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
+  "{hotkey}": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
+  "{ref}": "1000000",
+  "{uid}": "0",
+  "{slug}": "academia",
+  "{date}": "2026-08-01",
+  "{tag}": "inference",
+  "{surface_id}": "sn-1-apex-healthcheck",
+  "{hash}":
+    "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "{h160}": "0x0000000000000000000000000000000000000000",
+  "{id}": "00000000-0000-0000-0000-000000000000",
+  "{crowdloan_id}": "0",
+};
+
+/**
+ * Routes that declare CSV but cannot demonstrate it under the local artifact
+ * env, and why. Every entry is a statement someone made; a stale one fails.
+ */
+const DECLARED_NOT_LOCALLY_SERVABLE: Record<string, string> = {
+  // Rows come from the chain-events tier, which this env does not bind. The
+  // handler declines to the schema-stable empty JSON envelope rather than
+  // emitting a CSV with a header and no rows. Verified live: production
+  // answers ?format=csv with text/csv and the block_number,event_index,
+  // pallet,method,phase,extrinsic_index,observed_at header.
+  "/api/v1/chain-events":
+    "rows come from the chain-events tier; unbound here, so the handler " +
+    "declines to the empty JSON envelope (production serves text/csv)",
+};
+
+const ORIGIN = "https://api.metagraph.sh";
+
+interface Probe {
+  path: string;
+  status: number;
+  csv: boolean;
+  declared: boolean;
+}
+
+/** Dispatch every plain GET route with ?format=csv and record what came back. */
+async function probeRoutes(): Promise<Probe[]> {
+  const env = createLocalArtifactEnv() as never;
+  const probes: Probe[] = [];
+  for (const entry of API_ROUTES as Row[]) {
+    const path = String(entry.path);
+    // The 42 /api/v1/{network}/… forms are the same handlers behind a prefix,
+    // and csv_response rides on the plain entry they are derived from.
+    if (entry.method !== "GET" || path.includes("{network}")) continue;
+    let concrete = path;
+    for (const [token, value] of Object.entries(PATH_FIXTURES)) {
+      concrete = concrete.replaceAll(token, value);
+    }
+    assert.ok(
+      !concrete.includes("{"),
+      `${path} has a path parameter with no PATH_FIXTURES entry, so this ` +
+        "gate would silently stop covering it",
+    );
+    const response = await handleRequest(
+      new Request(`${ORIGIN}${concrete}?format=csv`),
+      env,
+      {},
+    );
+    probes.push({
+      path,
+      status: response.status,
+      csv: /^text\/csv/.test(response.headers.get("content-type") ?? ""),
+      declared: entry.csv_response === true,
+    });
+  }
+  return probes;
+}
+
+const probes = await probeRoutes();
+
+describe("a route that serves CSV declares it (#10090)", () => {
+  test("nothing answers text/csv without publishing ?format", () => {
+    // The defect direction. No exemptions: an undeclared export is
+    // undiscoverable from our own spec, which is the entire finding.
+    const undeclared = probes
+      .filter((probe) => probe.csv && !probe.declared)
+      .map((probe) => probe.path);
+    assert.deepEqual(
+      undeclared,
+      [],
+      "these routes answer ?format=csv with text/csv but publish no `format` " +
+        "parameter and no text/csv response, so nothing generated from " +
+        "openapi.json can reach the export: " +
+        undeclared.join(", "),
+    );
+  });
+
+  test("every route declaring CSV serves it, or says why it cannot here", () => {
+    const missing = probes
+      .filter((probe) => probe.declared && !probe.csv)
+      .map((probe) => probe.path);
+    const undeclaredMisses = missing.filter(
+      (path) => !(path in DECLARED_NOT_LOCALLY_SERVABLE),
+    );
+    assert.deepEqual(
+      undeclaredMisses,
+      [],
+      "these routes publish a text/csv response the handler did not produce: " +
+        undeclaredMisses.join(", "),
+    );
+  });
+
+  test("the exemption list is not stale", () => {
+    // Same contract as the MCP-parity allowlist: an entry that has started
+    // working must be deleted, so the list can only shrink.
+    const stale = Object.keys(DECLARED_NOT_LOCALLY_SERVABLE).filter((path) => {
+      const probe = probes.find((candidate) => candidate.path === path);
+      return !probe || probe.csv;
+    });
+    assert.deepEqual(
+      stale,
+      [],
+      "these DECLARED_NOT_LOCALLY_SERVABLE entries now serve CSV locally (or " +
+        "name a route that no longer exists) and must be removed: " +
+        stale.join(", "),
+    );
+  });
+
+  test("the sweep is not vacuous", () => {
+    // Guards the guard. Every assertion above passes trivially on an empty
+    // probe set, and the failure mode of a dispatch sweep is silence.
+    assert.ok(
+      probes.length >= 190,
+      `only ${probes.length} routes were dispatched; the sweep stopped ` +
+        "covering the surface",
+    );
+    const served = probes.filter((probe) => probe.csv).length;
+    assert.ok(
+      served >= 60,
+      `only ${served} routes answered text/csv, so the CSV path is not being ` +
+        "exercised and the first assertion proves nothing",
+    );
+  });
+
+  test("the five routes this issue found are among them", () => {
+    // Named rather than left to the generic sweep: these are the ones that
+    // were undeclared, and a failure here should say so.
+    for (const path of [
+      "/api/v1/accounts/{ss58}/history",
+      "/api/v1/blocks/{ref}/events",
+      "/api/v1/blocks/{ref}/extrinsics",
+      "/api/v1/subnets/{netuid}/uptime",
+      "/api/v1/validators/{hotkey}/nominators",
+    ]) {
+      const probe = probes.find((candidate) => candidate.path === path);
+      assert.ok(probe, `${path} is no longer dispatched by this gate`);
+      assert.ok(probe.declared, `${path} stopped declaring its CSV export`);
+      assert.ok(probe.csv, `${path} stopped serving CSV`);
+    }
+  });
+});


### PR DESCRIPTION
Five routes answer `?format=csv` with `text/csv` in production and publish neither a `format` parameter nor a `text/csv` 200 response. Every one is a real headered projection — a deliberate implementation, simply absent from the contract — so a consumer generated from `openapi.json` had no way to discover it.

| Route | `?format=csv` returns |
|---|---|
| `/api/v1/accounts/{ss58}/history` | `day,netuid,event_count,event_kinds,first_block,last_block` |
| `/api/v1/blocks/{ref}/events` | `block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,…` |
| `/api/v1/blocks/{ref}/extrinsics` | `extrinsic_id,block_number,signer,call_module,call_function,success` |
| `/api/v1/subnets/{netuid}/uptime` | `surface_id,day,samples,uptime_ratio,avg_latency_ms,…,status` |
| `/api/v1/validators/{hotkey}/nominators` | `coldkey,staked_tao,unstaked_tao,net_staked_tao,gross_staked_tao,…` |

## Why nothing caught it

`openapi.json` was **internally consistent and wrong on both sides at once**: 78 routes published `format` and exactly the same 78 declared a `text/csv` response, because both are emitted from one `csvResponse: true` flag. Any check comparing the contract to itself passes. The disagreement was only ever visible against the code that answers the request.

Found by probing `?format=csv` against production for all 160 GET routes with a substitutable path and no published `format` (sequential, `-P 2`):

- **5** answered `text/csv` — this PR
- **76** answered `400 format is not supported for this route.`
- **75** answered `200` JSON — `format` accepted and ignored, per the documented `GLOBALLY_ACCEPTED_PARAMS` judgement in `workers/request-handlers/analytics.ts` (rejecting it would break `/chain-events/stats`'s tested no-op). Deliberate, not a finding.
- **4** `404` on the sample path value

The correct fact was already in the repo: `BlockEventsQuerySchema`, `BlockExtrinsicsQuerySchema` and `ValidatorNominatorsQuerySchema` all carry `format` — in the dead `*QuerySchema` layer #10062 is about, which nothing reads.

## Change

All five move to `csvRouteQuery(...)`, which publishes `format` and emits the `text/csv` 200 response, plus a CSV example each in `src/csv-route-examples.ts`. `block-events` reuses the existing `EVENTS_CSV_EXAMPLE` rather than carrying a third copy of the same header — it serializes the same row shape as the subnet and account event feeds.

**No runtime path changes.** All five are dispatched by dedicated handlers (`handleAccountHistory`, `handleBlockEvents`, `handleBlockExtrinsics`, the `UPTIME_PATH_PATTERN` branch, `handleValidatorNominators`) *before* `matchRoute` is consulted, so the `csv_response` flag they now carry is documentation-only.

78 → **85** routes publish `format`, and the same 85 declare `text/csv`. The two beyond the five are the `/api/v1/{network}/blocks/…` twins, derived automatically — both verified serving CSV on testnet.

## The durable half: check CSV against the handler, not the contract

`tests/csv-contract-parity.test.ts` dispatches **all 197 plain GET routes** through `handleRequest` with `createLocalArtifactEnv()` — the same in-process seam the existing CSV export tests use — and reads each response's own `content-type`.

The two directions are deliberately asymmetric:

- **serves-but-undeclared** is the defect and takes **no exemptions**. A new CSV export cannot land undocumented.
- **declared-but-not-served** is weaker evidence: a route whose rows come from a data tier this env does not bind declines to the schema-stable empty JSON envelope rather than emitting a CSV of nothing. That is correct behaviour, so those are declared with a reason and a **stale entry fails** — the list can only shrink. One entry today (`/api/v1/chain-events`; production serves its CSV, verified).

Non-vacuity is asserted (≥190 routes dispatched, ≥60 answering CSV) and demonstrated: reverting `block-events` to its previous declaration fails the gate by name —

```
AssertionError: these routes answer ?format=csv with text/csv but publish no
`format` parameter and no text/csv response, so nothing generated from
openapi.json can reach the export: /api/v1/blocks/{ref}/events
AssertionError: /api/v1/blocks/{ref}/events stopped declaring its CSV export
```

A missing `PATH_FIXTURES` entry also fails rather than skipping, so the sweep cannot quietly stop covering a route.

## Validation

```
npm run typecheck / lint / format:check          clean
npx vitest run                                   755 files, 18,070 passed, 22 skipped
validate:contract-drift  validate:openapi  validate:api
validate:query-vocabulary  validate:mcp  validate:mcp-input-parity     all PASS
```

Rebased onto main after #10091; rebuilt post-rebase with zero artifact drift, and both changesets verified present in the regenerated `openapi.json`.

Closes #10090