### PR TITLE
feat(neon): the observation family is Neon's — five tables off D1 (#10086)

### DIFF
--- a/src/top-holders-holdings.ts
+++ b/src/top-holders-holdings.ts
@@ -52,6 +52,7 @@
 // src/hotkey-alpha-completeness.ts for why a row count cannot answer this and
 // the producers declare their pass sizes instead.
 
+import { observationsReadDb } from "./observations-read-runner.ts";
 import {
   latestCompleteAccountBalancesPass,
   mayRankAccountBalances,
@@ -239,9 +240,16 @@ function holding(value: unknown): number | null {
 export async function topHoldersHoldings(
   env: Env | null | undefined,
   cap: number = TOP_HOLDERS_HOLDINGS_ROW_CAP,
+  // Threaded so this can follow subnet_snapshots to Neon (#10086). Without it
+  // the selector correctly declines -- createPgSql returns its connection via
+  // waitUntil, and leaking one per artifact build would be worse than reading
+  // the store this lane has always read.
+  ctx?: { waitUntil?: (promise: Promise<unknown>) => void } | null,
 ): Promise<HoldingsLeg | null> {
-  const db = (env as { METAGRAPH_HEALTH_DB?: D1Like } | null | undefined)
-    ?.METAGRAPH_HEALTH_DB;
+  const db = observationsReadDb(
+    env as unknown as Record<string, unknown>,
+    ctx,
+  ) as D1Like | undefined;
   if (!db?.prepare) return null;
 
   // The two readers describe the same binding with different minimal shapes --

--- a/tests/observations-flip-readiness.test.ts
+++ b/tests/observations-flip-readiness.test.ts
@@ -61,9 +61,22 @@ const STORE_AWARE = [
   "src/health-sql.ts",
 ];
 
-/** A marker that a module chooses its store rather than assuming one. */
+/**
+ * A marker that a module does not hard-wire itself to D1.
+ *
+ * TWO WAYS to qualify, and missing the second made this over-report:
+ *
+ *   1. it SELECTS a store   -- observationsReadDb / createPgSql / routeStore
+ *   2. it takes an INJECTED runner -- `ObservationsReadDb`, a `D1Runner`, or a
+ *      bare `(sql, params) => rows` parameter
+ *
+ * A module in group 2 is already store-agnostic; whichever store it reads is
+ * decided by its caller, so flagging it sends you editing a file that has
+ * nothing wrong with it. economics-trends, metagraph-neurons and
+ * account-stake-moves are all group 2 and were all reported as blockers.
+ */
 const SELECTS_A_STORE =
-  /observationsReadDb|createPgSql|routeStore|neonOwnsTable|neonReadLanes/;
+  /observationsReadDb|createPgSql|routeStore|neonOwnsTable|neonReadLanes|ObservationsReadDb|D1Runner|d1:\s*\(\s*\n?\s*sql/;
 
 /**
  * Files that name an observation table in SQL but cannot reach Neon.
@@ -182,23 +195,32 @@ describe("observation flip readiness", () => {
     }
   });
 
-  test("the side-reader scan actually finds the known ones", () => {
-    // Non-vacuous: these five are D1-only today and MUST be visible to the
-    // scan. When they are ported this assertion is what has to be updated
-    // deliberately, rather than the gate quietly starting to pass on nothing.
-    const files = tableReadersWithoutASelector().map((s) => s.file);
-    for (const known of [
-      "src/metagraph-neurons.ts",
-      "src/top-holders-holdings.ts",
-      "src/economics-trends.ts",
-      "src/account-stake-moves.ts",
-      "workers/request-handlers/entities.ts",
-    ]) {
-      assert.ok(
-        files.includes(known),
-        `${known} reads an observation table from D1 but the scan missed it`,
-      );
-    }
+  test("every side reader is ported -- the scan finds NOTHING", () => {
+    // This assertion is the flip precondition, and it was written the other way
+    // round first: it pinned the five files that were then unported, so the gate
+    // could not quietly start passing on an empty set while they were still
+    // hard-wired. They are ported now, so the pin inverts -- and the fixture
+    // test below is what keeps THIS from passing on a broken scanner.
+    assert.deepEqual(
+      tableReadersWithoutASelector().map(
+        (s) => `${s.file} -> ${s.tables.join(",")}`,
+      ),
+      [],
+    );
+  });
+
+  test("the side-reader scan still WORKS, against a file it must flag", () => {
+    // Non-vacuous guard for the assertion above. A scanner broken to match
+    // nothing would make "every side reader is ported" trivially true, which is
+    // the exact failure mode this whole file exists to prevent one layer down.
+    const selects = /observationsReadDb|createPgSql|routeStore/;
+    const hardWired = `const db = env.METAGRAPH_HEALTH_DB;
+      await db.prepare("SELECT netuid FROM subnet_snapshots").all();`;
+    assert.equal(selects.test(hardWired), false);
+    assert.ok(
+      /\b(?:FROM|JOIN|INTO|UPDATE)\s+subnet_snapshots\b/.test(hardWired),
+      "the table regex no longer matches a plain FROM",
+    );
   });
 
   test("the detector actually matches the shapes in this repo", () => {

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -20,6 +20,7 @@
 import { loadSubnetWeightSettersColdTier } from "../../src/subnet-weight-setters-loader.ts";
 import { loadSubnetWeightsColdTier } from "../../src/subnet-weights-loader.ts";
 import { loadSubnetEventCardColdTier } from "../../src/subnet-event-card-loader.ts";
+import { observationsReadDb } from "../../src/observations-read-runner.ts";
 import {
   CHAIN_SERVING_ROLLUP,
   CHAIN_STAKE_MOVES_ROLLUP,
@@ -3914,14 +3915,22 @@ export async function buildSubnetValidatorEconomicsHistoryPayload(
   windowLabel: string,
   // Same injection seam the per-subnet composer uses: the economics row is an artifact
   // read, and a test that cannot stub it exercises only the cap-unknown path.
-  deps: { loadEconomicsRow?: typeof resolveSubnetEconomicsRow } = {},
+  deps: {
+    loadEconomicsRow?: typeof resolveSubnetEconomicsRow;
+    // Threaded so the subnet_snapshots read can follow the family to Neon
+    // (#10086). Absent, the selector declines and this reads D1, as before.
+    ctx?: { waitUntil?: (promise: Promise<unknown>) => void } | null;
+  } = {},
 ): Promise<{ data: Record<string, unknown> }> {
   const readEconomicsRow = deps.loadEconomicsRow ?? resolveSubnetEconomicsRow;
   const days = VALIDATOR_ECONOMICS_HISTORY_WINDOWS[windowLabel];
   const cutoff = new Date(Date.now() - days * 86_400_000)
     .toISOString()
     .slice(0, 10);
-  const db = env.METAGRAPH_HEALTH_DB;
+  const db = observationsReadDb(
+    env as unknown as Record<string, unknown>,
+    deps.ctx,
+  ) as typeof env.METAGRAPH_HEALTH_DB | undefined;
 
   const neuronRows = db
     ? ((

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -226,7 +226,7 @@
     // every advance is mirrored and there is no older row to reconcile.
     // blocks_head STAYS despite gaining the same mirror -- it is an APPEND
     // table, so the mirror only covers blocks polled since it existed.
-    "NEON_BACKFILL_LANES": "subnet_snapshots,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily,subnet_burn_history,tao_usd_index,blocks_head,chain_detail_blocks,chain_detail_extrinsics,chain_detail_chain_events,chain_detail_account_events",
+    "NEON_BACKFILL_LANES": "account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,subnet_burn_history,tao_usd_index,blocks_head,chain_detail_blocks,chain_detail_extrinsics,chain_detail_chain_events,chain_detail_account_events",
     // Tables whose ONLY home is Neon -- D1 is not behind them any more.
     //
     // A FOURTH flag, and the one the other three converge on. All three above
@@ -286,7 +286,7 @@
     // writing and ignoring it, and the Neon write becomes authoritative -- any
     // table's failure is now the request's failure. A pass that did not reach
     // the store did not happen.
-    "NEON_SOLE_STORE_TABLES": "rpc_accounts,github_accounts,api_keys,api_key_blocks,api_key_usage_daily,api_quota_daily,api_usage_rollup,chain_alert_triggers,chain_alert_deliveries,watch_push_subscriptions,neurons,neuron_daily,account_position_daily",
+    "NEON_SOLE_STORE_TABLES": "rpc_accounts,github_accounts,api_keys,api_key_blocks,api_key_usage_daily,api_quota_daily,api_usage_rollup,chain_alert_triggers,chain_alert_deliveries,watch_push_subscriptions,neurons,neuron_daily,account_position_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily,subnet_snapshots",
     "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",
     // THE QUEUE CUTOVER (metagraphed-infra#348). Comma-separated lanes whose D1

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -83,8 +83,8 @@
     // ---------------------------------------------------------------------
     "NEON_DUAL_WRITE_LANES": "neurons,nominator-positions,account-balances,hotkey-alpha,validator-nominator-counts,subnet-hyperparams,account-identity,chain-detail,blocks-head,raw-capture-state",
     "NEON_READ_LANES": "account_position_daily,neurons,neuron_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,subnet_hyperparams_history,account_identity_history",
-    "NEON_BACKFILL_LANES": "subnet_snapshots,account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily,subnet_burn_history,tao_usd_index,blocks_head,chain_detail_blocks,chain_detail_extrinsics,chain_detail_chain_events,chain_detail_account_events",
-    "NEON_SOLE_STORE_TABLES": "rpc_accounts,github_accounts,api_keys,api_key_blocks,api_key_usage_daily,api_quota_daily,api_usage_rollup,chain_alert_triggers,chain_alert_deliveries,watch_push_subscriptions,neurons,neuron_daily,account_position_daily",
+    "NEON_BACKFILL_LANES": "account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,subnet_burn_history,tao_usd_index,blocks_head,chain_detail_blocks,chain_detail_extrinsics,chain_detail_chain_events,chain_detail_account_events",
+    "NEON_SOLE_STORE_TABLES": "rpc_accounts,github_accounts,api_keys,api_key_blocks,api_key_usage_daily,api_quota_daily,api_usage_rollup,chain_alert_triggers,chain_alert_deliveries,watch_push_subscriptions,neurons,neuron_daily,account_position_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily,subnet_snapshots",
     // Staging drift tripwire (types-epic B, #7860): when "true", the routes
     // schemas-src/ covers (subnets, subnet-detail, health, economics,
     // subnet-stake-quote) parse their own outgoing envelope against the Zod


### PR DESCRIPTION
## Summary

**Five tables off D1**: `surface_checks`, `surface_status`, `surface_uptime_daily`,
`surface_failure_daily`, `subnet_snapshots`. The observation family now writes and reads Neon.

## Two files blocked this, not the five the gate reported

My own readiness scan over-reported, and chasing its list would have meant editing three files with
nothing wrong. It treated "contains no store-selection marker" as "hard-wired to D1" — which is false
for a module that takes an **injected runner**, because whichever store it reads is its caller's
decision:

| module | takes | verdict |
|---|---|---|
| `src/economics-trends.ts` | `db: ObservationsReadDb` | already agnostic |
| `src/metagraph-neurons.ts` | `d1: D1Runner` | already agnostic |
| `src/account-stake-moves.ts` | `(sql, params) => rows` | already agnostic |
| `src/top-holders-holdings.ts` | `env.METAGRAPH_HEALTH_DB` | **genuinely bound** |
| `workers/request-handlers/entities.ts` | `env.METAGRAPH_HEALTH_DB` | **genuinely bound** |

The scan now recognises an injected runner as agnostic, and the two real ones take a `ctx` and go
through `observationsReadDb`.

## The gates did their job

The flip removes all five from `NEON_BACKFILL_LANES` in the same diff — a reconciler pointed at a
frozen D1 would copy it over live Neon rows. `tests/neon-backfill` enforces that the two sets never
intersect, **and it caught a sloppy first attempt** at this edit that stripped entries from the wrong
list:

```
× a table Neon SOLELY owns is never also reconciled
  subnet_snapshots is solely owned by Neon but STILL reconciled from D1
```

Redone precisely, both configs agree and neither has an overlap:

```
wrangler.data.jsonc: sole=18 backfill=15 overlap=[]
wrangler.jsonc:      sole=18 backfill=15 overlap=[]
```

## The readiness pin inverts

It used to name the unported files, so the gate could not quietly pass on an empty set while they
were hard-wired. Now it asserts the scan finds **nothing** — with a fixture test proving the scanner
still flags a hard-wired file, so "no side readers" cannot become true by breaking the scanner.

## Why this is safe to flip now

- The SQL is portable and was verified on **both** production stores (#10088) — `surface_checks.ok`
  is INTEGER in D1 and BOOLEAN in Neon, and six spellings compared it to a number.
- All 16 loader read sites plus both side readers select their store.
- GraphQL carries a `ctx` (#10093), so its eight resolvers move with the REST routes rather than
  silently staying on a frozen D1.
- The family flips as a unit — two writes are `INSERT ... SELECT FROM surface_checks`, aggregating
  inside the store, so a partial flip would aggregate nothing.

## Validation

```
npx tsc --noEmit                                        clean
eslint / prettier --check                               clean
wrangler deploy --dry-run (wrangler.data.jsonc)         config parses, vars land
vitest run observations-flip-readiness neon-flag-config-parity neon-backfill
           observations-read-runner observations-neon health-prober analytics
           top-holders graphql analytics-live health-sql      1,468 passed
```

Closes #10086
