### PR TITLE
feat(neon): invert hyperparams/identity writes and flip five tables (#10086)

### DIFF
--- a/src/subnet-weight-setters-loader.ts
+++ b/src/subnet-weight-setters-loader.ts
@@ -11,6 +11,7 @@
 // emits [netuid, uid]. buildSubnetWeightSetters reads `hotkey` and `uid`
 // independently and is null-safe on the first, so the published row carries the
 // identity the event actually recorded and nothing invents a hotkey.
+import { observationsReadDb } from "./observations-read-runner.ts";
 import { buildSubnetWeightSetters } from "./subnet-weight-setters.ts";
 import {
   CHAIN_WEIGHTS_ROLLUP,
@@ -74,9 +75,14 @@ export async function loadSubnetWeightSettersColdTier(
 async function loadSubnetTempo(
   env: Parameters<typeof r2SqlQuery>[0],
   netuid: number,
+  // Threaded so this follows subnet_hyperparams to whichever store owns it
+  // (#10086). Absent, the selector declines and this reads D1, as before.
+  ctx?: { waitUntil?: (promise: Promise<unknown>) => void } | null,
 ): Promise<unknown> {
-  const db = (env as { METAGRAPH_HEALTH_DB?: D1Like } | null | undefined)
-    ?.METAGRAPH_HEALTH_DB;
+  const db = observationsReadDb(
+    env as unknown as Record<string, unknown>,
+    ctx,
+  ) as D1Like | undefined;
   if (!db?.prepare) return null;
   try {
     const res = await db

--- a/src/validator-nominator-counts-staleness-watchdog.ts
+++ b/src/validator-nominator-counts-staleness-watchdog.ts
@@ -43,6 +43,7 @@
 // COST: one walk of ~112k rows on a `19,49 * * * *` cron, 48 ticks a day, so
 // ~5.4M D1 rows read a day.
 
+import { observationsReadDb } from "./observations-read-runner.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 
@@ -215,6 +216,8 @@ interface D1Like {
 }
 
 export interface ValidatorNominatorCountsStalenessDeps {
+  /** Threaded so the read can follow the table to Neon (#10086). */
+  ctx?: { waitUntil?: (promise: Promise<unknown>) => void } | null;
   /** Injectable durable sink, so a test can assert the verdict was RECORDED and
    * not merely notified — the distinction #9330/#9340 exist about. */
   laneHealthDb?: LaneHealthDb | null;
@@ -234,7 +237,13 @@ export async function runValidatorNominatorCountsStalenessWatchdog(
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;
   const record = deps.recordException ?? recordExceptionEvent;
-  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
+  // Follows validator_nominator_counts to whichever store owns it (#10086).
+  // A watchdog left on the abandoned store reports the frozen copy's staleness,
+  // which is the alarm firing about the wrong thing entirely.
+  const db = observationsReadDb(
+    env as Record<string, unknown> | null | undefined,
+    deps.ctx,
+  ) as D1Like | undefined;
   if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
 
   const thresholdMs =

--- a/tests/data-api-hyperparams-identity-d1.test.ts
+++ b/tests/data-api-hyperparams-identity-d1.test.ts
@@ -501,3 +501,96 @@ test("identity history: cold table 503s; a populated table's empty page serves",
   assert.equal(empty.status, 200);
   assert.equal(((await empty.json()) as Row).entry_count, 0);
 });
+
+// --- the inversion: Neon owns the family, D1 is not written (#10094) --------
+//
+// The branch that actually retires this table. Everything above pins the
+// dual-write era; these pin the one after it, where the D1 statements stop
+// being issued at all rather than being written and ignored. An untested
+// inversion is how a "migrated" table keeps a second copy diverging quietly.
+
+/** Env with the family named as Neon's and a Hyperdrive bound. The Neon write
+ * itself is not exercised here -- that is hyperparams-identity-neon-write's
+ * suite -- so it fails, which is exactly what makes the D1 assertion below
+ * meaningful: D1 stays untouched even when the Neon write does not land. */
+function neonOwnsEnv(tables: string) {
+  return env({
+    HYPERDRIVE: { connectionString: "postgresql://example/db" },
+    NEON_SOLE_STORE_TABLES: tables,
+  });
+}
+
+test("hyperparams: Neon owning the family drops the D1 BINDING requirement", async () => {
+  // The assertion that actually distinguishes the branch. With no D1 binding
+  // at all, the pre-inversion handler answered 503 "d1 binding unavailable"
+  // before doing anything. Once Neon owns the family that requirement is gone,
+  // so reaching ANY other outcome proves the D1 dependency was dropped.
+  //
+  // A count-based assertion looked obvious here and proved nothing: the Neon
+  // history read throws against a fake connection string, so D1 goes unwritten
+  // whether or not the skip exists. Mutating the guard left it green.
+  const res = await postHyperparams(
+    [hyperparamsSyncRow({ netuid: 7 })],
+    env({
+      METAGRAPH_HEALTH_DB: undefined,
+      HYPERDRIVE: { connectionString: "postgresql://example/db" },
+      NEON_SOLE_STORE_TABLES: "subnet_hyperparams,subnet_hyperparams_history",
+    }),
+  );
+  assert.notEqual(res.status, 503, "still demanding a D1 binding");
+});
+
+test("hyperparams: WITHOUT the family owned, the D1 binding is still required", async () => {
+  const res = await postHyperparams(
+    [hyperparamsSyncRow({ netuid: 7 })],
+    env({ METAGRAPH_HEALTH_DB: undefined }),
+  );
+  assert.equal(res.status, 503);
+});
+
+test("hyperparams: owning only ONE table of the family still writes D1", async () => {
+  // The pair moves together. The sync diffs against the history table's
+  // current hashes, so a family split across stores would diff against the
+  // wrong store and append revisions that already exist.
+  const res = await postHyperparams(
+    [hyperparamsSyncRow({ netuid: 8, tempo: 42 })],
+    neonOwnsEnv("subnet_hyperparams"),
+  );
+  assert.equal(res.status, 200);
+  assert.equal(
+    one("SELECT tempo FROM subnet_hyperparams WHERE netuid = 8").tempo,
+    42,
+  );
+});
+
+test("identity: Neon owning the family drops the D1 BINDING requirement", async () => {
+  const res = await postIdentity(
+    [identitySyncRow({ account: "5Inversion" })],
+    env({
+      METAGRAPH_HEALTH_DB: undefined,
+      HYPERDRIVE: { connectionString: "postgresql://example/db" },
+      NEON_SOLE_STORE_TABLES: "account_identity,account_identity_history",
+    }),
+  );
+  assert.notEqual(res.status, 503, "still demanding a D1 binding");
+});
+
+test("identity: WITHOUT the family owned, the D1 binding is still required", async () => {
+  const res = await postIdentity(
+    [identitySyncRow({ account: "5Inversion" })],
+    env({ METAGRAPH_HEALTH_DB: undefined }),
+  );
+  assert.equal(res.status, 503);
+});
+
+test("identity: owning only ONE table of the family still writes D1", async () => {
+  const res = await postIdentity(
+    [identitySyncRow({ account: "5Partial", name: "y" })],
+    neonOwnsEnv("account_identity"),
+  );
+  assert.equal(res.status, 200);
+  assert.equal(
+    one("SELECT name FROM account_identity WHERE account = '5Partial'").name,
+    "y",
+  );
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -384,6 +384,7 @@ import {
   SUBNET_HYPERPARAMS_NEON_LANE,
   failedTables,
   mirrorFamilyToNeon,
+  FAMILY_MIRROR_PLANS,
 } from "../src/hyperparams-identity-neon-write.ts";
 import { mirrorNominatorPositionsToNeon } from "../src/nominator-positions-neon-write.ts";
 import { mirrorLedgerToNeon } from "../src/ledger-neon-write.ts";
@@ -1441,19 +1442,29 @@ async function handleSubnetHyperparamsSync(
   // since the box went away (#9157's contract, applied to this lane). Checked
   // HERE, after parsing and validation, not at the top: a malformed body is a
   // 400 whether or not a store happens to be bound.
-  if (!env.METAGRAPH_HEALTH_DB) {
+  // THE INVERSION (#10094). Once Neon owns both tables of the family the D1
+  // write is skipped outright rather than written and ignored -- a second copy
+  // kept up to date by nothing is the state this migration exists to end.
+  const neonOwns = neonOwnsFamily(env, SUBNET_HYPERPARAMS_NEON_LANE);
+  if (!neonOwns && !env.METAGRAPH_HEALTH_DB) {
     return writeJson({ error: "d1 binding unavailable" }, 503);
   }
 
-  // D1 first, and it must succeed: it is where this family lives now.
-  let d1Statements: number;
+  // 0 when Neon owns the family and the D1 write is skipped entirely.
+  let d1Statements = 0;
   let d1HistoryAppended: number;
   // Hoisted so the Neon write below sees the SAME diff D1 was given -- one
   // derivation, two stores, so the two histories cannot disagree about which
   // revisions exist.
   let neonHistoryRows: Row[];
+  // The latest-hash read comes from the store that HOLDS the history, so the
+  // diff is against the revisions that actually exist. Reading D1's copy while
+  // Neon owns it would re-append every revision Neon already has.
+  const historySql = neonOwns
+    ? createPgSql(env.HYPERDRIVE!, ctx)
+    : createD1Sql(env.METAGRAPH_HEALTH_DB);
   try {
-    const d1Sql = createD1Sql(env.METAGRAPH_HEALTH_DB);
+    const d1Sql = historySql;
     // Latest hash per netuid -- group-wise MAX(id) join, the SQLite spelling
     // of the Postgres side's `DISTINCT ON (netuid) ... ORDER BY netuid, id
     // DESC` below.
@@ -1470,12 +1481,14 @@ async function handleSubnetHyperparamsSync(
     const historyRows = diffHyperparamsHistory(hashedRows, latestByNetuid, now);
     neonHistoryRows = historyRows as Row[];
     d1HistoryAppended = historyRows.length;
-    ({ statements: d1Statements } = await writeSubnetHyperparamsToD1(
-      env.METAGRAPH_HEALTH_DB as unknown as Parameters<
-        typeof writeSubnetHyperparamsToD1
-      >[0],
-      { rows, netuids, historyRows },
-    ));
+    if (!neonOwns) {
+      ({ statements: d1Statements } = await writeSubnetHyperparamsToD1(
+        env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+          typeof writeSubnetHyperparamsToD1
+        >[0],
+        { rows, netuids, historyRows },
+      ));
+    }
   } catch (err) {
     console.error("data-api subnet-hyperparams-sync D1 write failed:", err);
     await captureDataApiError(err, "subnet-hyperparams-sync-d1", env);
@@ -1497,11 +1510,35 @@ async function handleSubnetHyperparamsSync(
     { rows, historyRows: neonHistoryRows },
   );
 
+  // THE OTHER HALF OF THE INVERSION. While D1 served the reads a Neon failure
+  // had to cost a lane verdict and not the pass. Once Neon IS the store that
+  // reasoning flips: a pass that did not reach it did not happen, and ok:true
+  // would tell the producer its rows are safe when nothing holds them.
+  if (neonOwns) {
+    const failed = failedTables(neon);
+    if (!neon.attempted || (failed && failed.length > 0)) {
+      console.error(
+        "data-api subnet-hyperparams-sync Neon write failed:",
+        failed,
+      );
+      await captureDataApiError(
+        new Error(
+          failed && failed.length > 0
+            ? `neon write failed: ${failed.join(", ")}`
+            : "neon write not attempted while Neon owns the family",
+        ),
+        "subnet-hyperparams-sync-neon",
+        env,
+      );
+      return writeJson({ error: "neon write failed" }, 502);
+    }
+  }
+
   return writeJson({
     ok: true,
     subnet_hyperparams_written: rows.length,
-    history_appended: d1HistoryAppended,
-    stores: neon.attempted ? ["d1", "neon"] : ["d1"],
+    history_appended: neonOwns ? neonHistoryRows.length : d1HistoryAppended,
+    stores: neonOwns ? ["neon"] : neon.attempted ? ["d1", "neon"] : ["d1"],
     d1_statements: d1Statements,
     neon: neon.attempted ? neon.results : undefined,
     neon_failed: neon.attempted ? failedTables(neon) : undefined,
@@ -1685,18 +1722,27 @@ async function handleAccountIdentitySync(
   // D1 is the binding this path REQUIRES -- the only store this family has
   // since the box went away (#9157's contract, applied to this lane). Checked
   // after parsing and validation for the same reason as the hyperparams sync.
-  if (!env.METAGRAPH_HEALTH_DB) {
+  // THE INVERSION (#10094), the identity half. Same shape as the hyperparams
+  // sync above: once Neon owns both tables the D1 write is skipped outright.
+  const neonOwns = neonOwnsFamily(env, ACCOUNT_IDENTITY_NEON_LANE);
+  if (!neonOwns && !env.METAGRAPH_HEALTH_DB) {
     return writeJson({ error: "d1 binding unavailable" }, 503);
   }
 
-  let d1Statements: number;
+  let d1Statements = 0;
   let d1HistoryAppended: number;
   // Hoisted so the Neon write sees the SAME diff D1 was given -- one
   // derivation, two stores, so the two histories cannot disagree about which
   // revisions exist.
   let neonHistoryRows: Row[];
+  // The latest-hash read comes from the store that HOLDS the history: diffing
+  // against D1's copy while Neon owns it would re-append every revision Neon
+  // already has.
+  const historySql = neonOwns
+    ? createPgSql(env.HYPERDRIVE!, ctx)
+    : createD1Sql(env.METAGRAPH_HEALTH_DB);
   try {
-    const d1Sql = createD1Sql(env.METAGRAPH_HEALTH_DB);
+    const d1Sql = historySql;
     // Latest hash per account -- group-wise MAX(id) join, the SQLite
     // spelling of the Postgres `DISTINCT ON (account)` below.
     const latest = await d1Sql`
@@ -1712,12 +1758,14 @@ async function handleAccountIdentitySync(
     const historyRows = diffIdentityHistory(hashedRows, latestByAccount, now);
     neonHistoryRows = historyRows as Row[];
     d1HistoryAppended = historyRows.length;
-    ({ statements: d1Statements } = await writeAccountIdentityToD1(
-      env.METAGRAPH_HEALTH_DB as unknown as Parameters<
-        typeof writeAccountIdentityToD1
-      >[0],
-      { rows, historyRows },
-    ));
+    if (!neonOwns) {
+      ({ statements: d1Statements } = await writeAccountIdentityToD1(
+        env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+          typeof writeAccountIdentityToD1
+        >[0],
+        { rows, historyRows },
+      ));
+    }
   } catch (err) {
     console.error("data-api account-identity-sync D1 write failed:", err);
     await captureDataApiError(err, "account-identity-sync-d1", env);
@@ -1735,11 +1783,34 @@ async function handleAccountIdentitySync(
     { rows, historyRows: neonHistoryRows },
   );
 
+  // The other half of the inversion -- see the hyperparams sync for the
+  // reasoning. Once Neon is the store, a pass that did not reach it did not
+  // happen.
+  if (neonOwns) {
+    const failed = failedTables(neon);
+    if (!neon.attempted || (failed && failed.length > 0)) {
+      console.error(
+        "data-api account-identity-sync Neon write failed:",
+        failed,
+      );
+      await captureDataApiError(
+        new Error(
+          failed && failed.length > 0
+            ? `neon write failed: ${failed.join(", ")}`
+            : "neon write not attempted while Neon owns the family",
+        ),
+        "account-identity-sync-neon",
+        env,
+      );
+      return writeJson({ error: "neon write failed" }, 502);
+    }
+  }
+
   return writeJson({
     ok: true,
     account_identity_written: rows.length,
-    history_appended: d1HistoryAppended,
-    stores: neon.attempted ? ["d1", "neon"] : ["d1"],
+    history_appended: neonOwns ? neonHistoryRows.length : d1HistoryAppended,
+    stores: neonOwns ? ["neon"] : neon.attempted ? ["d1", "neon"] : ["d1"],
     d1_statements: d1Statements,
     neon: neon.attempted ? neon.results : undefined,
     neon_failed: neon.attempted ? failedTables(neon) : undefined,
@@ -3069,6 +3140,26 @@ export function neonOwnsNeuronsSnapshot(env: Env): boolean {
   return (
     Boolean(env.HYPERDRIVE?.connectionString) &&
     NEURONS_SNAPSHOT_TABLES.every((table) =>
+      neonOwnsTable(env as unknown as Record<string, unknown>, table),
+    )
+  );
+}
+
+/**
+ * Whether Neon is the ONLY store behind one hyperparams/identity family.
+ *
+ * BOTH tables of the family, never one. The sync derives its history rows by
+ * reading the CURRENT latest hash out of the history table and diffing -- so a
+ * family split across stores would diff against the wrong store's history and
+ * append revisions that already exist, or miss ones that do not. The pair moves
+ * together or not at all.
+ */
+export function neonOwnsFamily(env: Env, lane: string): boolean {
+  const plan = FAMILY_MIRROR_PLANS[lane];
+  if (!plan) return false;
+  return (
+    Boolean(env.HYPERDRIVE?.connectionString) &&
+    [plan.latest.table, plan.history.table].every((table) =>
       neonOwnsTable(env as unknown as Record<string, unknown>, table),
     )
   );

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -226,7 +226,7 @@
     // every advance is mirrored and there is no older row to reconcile.
     // blocks_head STAYS despite gaining the same mirror -- it is an APPEND
     // table, so the mirror only covers blocks polled since it existed.
-    "NEON_BACKFILL_LANES": "account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,subnet_burn_history,tao_usd_index,blocks_head,chain_detail_blocks,chain_detail_extrinsics,chain_detail_chain_events,chain_detail_account_events",
+    "NEON_BACKFILL_LANES": "nominator_positions,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,subnet_burn_history,tao_usd_index,blocks_head,chain_detail_blocks,chain_detail_extrinsics,chain_detail_chain_events,chain_detail_account_events",
     // Tables whose ONLY home is Neon -- D1 is not behind them any more.
     //
     // A FOURTH flag, and the one the other three converge on. All three above
@@ -286,7 +286,7 @@
     // writing and ignoring it, and the Neon write becomes authoritative -- any
     // table's failure is now the request's failure. A pass that did not reach
     // the store did not happen.
-    "NEON_SOLE_STORE_TABLES": "rpc_accounts,github_accounts,api_keys,api_key_blocks,api_key_usage_daily,api_quota_daily,api_usage_rollup,chain_alert_triggers,chain_alert_deliveries,watch_push_subscriptions,neurons,neuron_daily,account_position_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily,subnet_snapshots",
+    "NEON_SOLE_STORE_TABLES": "rpc_accounts,github_accounts,api_keys,api_key_blocks,api_key_usage_daily,api_quota_daily,api_usage_rollup,chain_alert_triggers,chain_alert_deliveries,watch_push_subscriptions,neurons,neuron_daily,account_position_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily,subnet_snapshots,subnet_hyperparams,subnet_hyperparams_history,account_identity,account_identity_history,validator_nominator_counts",
     "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",
     // THE QUEUE CUTOVER (metagraphed-infra#348). Comma-separated lanes whose D1

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -83,8 +83,8 @@
     // ---------------------------------------------------------------------
     "NEON_DUAL_WRITE_LANES": "neurons,nominator-positions,account-balances,hotkey-alpha,validator-nominator-counts,subnet-hyperparams,account-identity,chain-detail,blocks-head,raw-capture-state",
     "NEON_READ_LANES": "account_position_daily,neurons,neuron_daily,subnet_snapshots,subnet_hyperparams,account_identity,validator_nominator_counts,subnet_hyperparams_history,account_identity_history",
-    "NEON_BACKFILL_LANES": "account_identity,validator_nominator_counts,nominator_positions,account_identity_history,subnet_hyperparams_history,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,subnet_burn_history,tao_usd_index,blocks_head,chain_detail_blocks,chain_detail_extrinsics,chain_detail_chain_events,chain_detail_account_events",
-    "NEON_SOLE_STORE_TABLES": "rpc_accounts,github_accounts,api_keys,api_key_blocks,api_key_usage_daily,api_quota_daily,api_usage_rollup,chain_alert_triggers,chain_alert_deliveries,watch_push_subscriptions,neurons,neuron_daily,account_position_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily,subnet_snapshots",
+    "NEON_BACKFILL_LANES": "nominator_positions,emission_gate_param_history,subnet_emission_enabled_history,chain_concentration_daily,subnet_burn_history,tao_usd_index,blocks_head,chain_detail_blocks,chain_detail_extrinsics,chain_detail_chain_events,chain_detail_account_events",
+    "NEON_SOLE_STORE_TABLES": "rpc_accounts,github_accounts,api_keys,api_key_blocks,api_key_usage_daily,api_quota_daily,api_usage_rollup,chain_alert_triggers,chain_alert_deliveries,watch_push_subscriptions,neurons,neuron_daily,account_position_daily,surface_checks,surface_status,surface_uptime_daily,surface_failure_daily,subnet_snapshots,subnet_hyperparams,subnet_hyperparams_history,account_identity,account_identity_history,validator_nominator_counts",
     // Staging drift tripwire (types-epic B, #7860): when "true", the routes
     // schemas-src/ covers (subnets, subnet-detail, health, economics,
     // subnet-stake-quote) parse their own outgoing envelope against the Zod


### PR DESCRIPTION
## Summary

**Five more tables off D1**, with the write-path inversion that makes it real:

```
subnet_hyperparams          subnet_hyperparams_history
account_identity            account_identity_history
validator_nominator_counts
```

D1 is now down to 23 tables sole-owned by Neon, 11 still reconciled.

## The inversion, not just a flag

Both families wrote **D1 first-and-must-succeed**, then mirrored Neon. Correct while D1 serves reads,
wrong once Neon owns the tables — a second copy kept current by nothing is the state this migration
exists to end. `neonOwnsFamily(env, lane)` flips three things together:

- the D1 write is **skipped outright**, not written and ignored
- the latest-hash read comes from the store that **holds the history**
- a Neon failure becomes the request's failure (502), where during dual-write it was a lane verdict

The D1 *binding* requirement drops with them, so the handler no longer 503s for want of a store it
will not use.

**Both tables of a family or neither.** The sync derives its history rows by reading the current
latest hash out of the history table and diffing — a family split across stores would diff against
the wrong store, appending revisions that already exist or missing ones that do not.

## My first version of these tests was vacuous

They asserted "D1 row count unchanged" under a Neon-owned env. But the Neon history read throws
against a fake connection string, so D1 goes unwritten **whether or not the skip exists** — mutating
the guard to `if (true)` left all four green.

Rewritten to assert the one thing that distinguishes the branch: with **no D1 binding at all**, a
Neon-owned family must not answer 503. Reverting the guard fails exactly those two tests.

## Two readers, and three that needed nothing

`src/subnet-weight-setters-loader.ts` and `src/validator-nominator-counts-staleness-watchdog.ts` held
their binding directly and now select their store. The watchdog matters beyond the read: left on the
abandoned store it would report the **frozen** copy's age — alarming about a table nothing writes
while the live one went unwatched.

`account-identity-history`, `economics-trends` and `metagraph-neurons` were flagged by my sweep and
needed **no change** — each takes an injected runner and is already store-agnostic.

## Note on `neon-read-routes`

This flip initially failed `names only tables something writes`, which computed the writer set as
`DUAL_WRITE ∪ BACKFILL` and so counted every completed cutover as an orphaned read. #10100 fixed that
on main while this branch was in flight; the fix written here was **dropped in favour of it** rather
than shipped twice, and main's version verified against this flip.

## Validation

```
npx tsc --noEmit                                    clean
eslint / prettier --check                           clean
vitest run neon-read-routes neon-flag-config-parity neon-backfill
           data-api-hyperparams-identity-d1 observations-flip-readiness
           hyperparams-identity-neon-write neon-mirror-watchdog
           neon-parity-watchdog data-api-neurons-d1 health-prober    402 passed
```

Refs #10086
