### PR TITLE
fix(ci): the Neon read guard counted a sole-store table as unwritten (#10099)

### DIFF
--- a/tests/account-position-history.test.ts
+++ b/tests/account-position-history.test.ts
@@ -422,11 +422,18 @@ describe("the Neon read cutover (metagraphed-infra#336)", () => {
         "chain_detail_account_events",
       ],
     };
+    // A sole-store table has no mirror by design: Neon IS the store, so the
+    // writer targets it directly and there is nothing to copy. See the fuller
+    // note on the same derivation in tests/neon-read-routes.test.ts.
+    const soleStore = (
+      /"NEON_SOLE_STORE_TABLES":\s*"([^"]*)"/.exec(wrangler)?.[1] ?? ""
+    ).split(",");
     const written = new Set(
       [...writes, ...backfills]
         .map((lane) => lane.trim())
         .filter(Boolean)
-        .flatMap((lane) => LANE_TABLES[lane] ?? [lane.replace(/-/g, "_")]),
+        .flatMap((lane) => LANE_TABLES[lane] ?? [lane.replace(/-/g, "_")])
+        .concat(soleStore.map((table) => table.trim()).filter(Boolean)),
     );
     for (const lane of named) {
       assert.ok(

--- a/tests/neon-read-routes.test.ts
+++ b/tests/neon-read-routes.test.ts
@@ -599,11 +599,27 @@ describe("the deployed flag", () => {
         "chain_detail_account_events",
       ],
     };
+    // A SOLE-STORE TABLE HAS NO MIRROR, AND THAT IS THE POINT. The two flags
+    // above name lanes that COPY a table into Neon while D1 keeps the
+    // original. NEON_SOLE_STORE_TABLES names the tables where Neon IS the
+    // store -- the writer targets it directly (subnet_snapshots is written by
+    // src/observations-neon.ts, reached from src/health-prober.ts), so there
+    // is nothing to mirror and #10078 correctly stopped reconciling them.
+    //
+    // Reading membership as "unwritten" is what turned this guard red on main
+    // after #10095: it would have had someone delete a correct read lane for a
+    // table that is written every hour. The hazard this test exists for is
+    // still covered -- a read lane that is neither mirrored nor sole-store has
+    // no writer anywhere, which is exactly #9704's frozen store.
+    const soleStore = (
+      /"NEON_SOLE_STORE_TABLES":\s*"([^"]*)"/.exec(wrangler)?.[1] ?? ""
+    ).split(",");
     const written = new Set(
       [...writes, ...backfills]
         .map((l) => l.trim())
         .filter(Boolean)
-        .flatMap((lane) => LANE_TABLES[lane] ?? [lane.replace(/-/g, "_")]),
+        .flatMap((lane) => LANE_TABLES[lane] ?? [lane.replace(/-/g, "_")])
+        .concat(soleStore.map((t) => t.trim()).filter(Boolean)),
     );
     for (const lane of named) {
       assert.ok(


### PR DESCRIPTION
`main` is red, and every branch cut from it with it. `Validate / test` fails on `c09a4ce9e`:

```
FAIL tests/neon-read-routes.test.ts > the deployed flag > names only tables something writes
  AssertionError: NEON_READ_LANES names "subnet_snapshots" but nothing writes it

FAIL tests/account-position-history.test.ts > the Neon read cutover > only lanes with a mirror behind them may be named
  AssertionError: NEON_READ_LANES names "subnet_snapshots" but nothing writes it --
  a read with no writer behind it serves a frozen store at 200 OK
```

## The store is not frozen — the guard does not know about sole-store

Both guards build their "written" set from `NEON_DUAL_WRITE_LANES` ∪ `NEON_BACKFILL_LANES`. Those name lanes that **copy** a table into Neon while D1 keeps the original.

`subnet_snapshots` is in **`NEON_SOLE_STORE_TABLES`**, where Neon *is* the store. Such a table has no mirror **by design** — the writer targets it directly:

- `src/observations-neon.ts:348` — `INSERT INTO subnet_snapshots`
- reached from `src/health-prober.ts`, which imports it

and #10078 **correctly** removed it from the backfill lanes: reconciling a table Neon solely owns compares it against nothing.

So membership in `NEON_SOLE_STORE_TABLES` is itself the statement that the table is written. Reading it as "unwritten" is not a conservative failure — it points at a correct read lane, for a table written every hour, and says to delete it.

## Not a suppression

I verified the writer exists, is wired, and is reached **before** changing either guard. #9704's hazard — a read cutover with no writer behind it, serving a frozen store at 200 OK — remains fully covered, because a read lane that is neither mirrored **nor** sole-store still has no writer anywhere.

Demonstrated rather than asserted. Adding `frozen_orphan_table` to `NEON_READ_LANES` fails all three assertions after this change:

```
AssertionError: NEON_READ_LANES names "frozen_orphan_table" but nothing writes it --
  a read with no writer behind it serves a frozen store at 200 OK
AssertionError: NEON_READ_LANES names "frozen_orphan_table" but nothing writes it
AssertionError: NEON_READ_LANES names "frozen_orphan_table" but no route declares it
```

## Change

Both guards' `written` set also reads `NEON_SOLE_STORE_TABLES`. The reasoning sits at the derivation rather than only in this description — the next person to hit it will be standing in that function, not reading a PR.

## Validation

```
npm run format:check                clean
npx vitest run                      757 files, 18,094 passed, 22 skipped
```

Tests only; no runtime or contract change.

Closes #10099