### PR TITLE
fix(neon): hotkey_alpha mirror is down — the filtered VALUES form has no type context (#10122)

### DIFF
--- a/src/ledger-neon-write.ts
+++ b/src/ledger-neon-write.ts
@@ -56,6 +56,15 @@ interface LedgerPlan {
    * filters too -- a mirror that stores MORE than its source is a mirror in
    * name only (#9832). */
   filter?: string;
+  /**
+   * Target types for the columns the FILTERED form selects (#10121).
+   *
+   * Only the filtered form needs them: `FROM (VALUES ...) AS src (...)` is a
+   * standalone relation whose columns have no declared types, so every untyped
+   * parameter falls back to TEXT and the insert fails against any non-text
+   * column. The unfiltered form takes its types from the target columns.
+   */
+  columnTypes?: Readonly<Record<string, string>>;
 }
 
 /**
@@ -106,6 +115,14 @@ export const LEDGER_MIRROR_PLANS: Readonly<Record<string, LedgerPlan>> = {
     filter:
       "EXISTS (SELECT 1 FROM nominator_positions np" +
       " WHERE np.hotkey = src.hotkey AND np.netuid = src.netuid::int)",
+    // EVERY non-text column, not just the one the error happened to name.
+    // Postgres reports the FIRST mismatch, so fixing them one error at a time
+    // is three deploys; hotkey is text on both sides and needs no cast.
+    columnTypes: {
+      netuid: "int",
+      total_alpha: "double precision",
+      captured_at: "bigint",
+    },
   },
   "validator-nominator-counts": {
     table: "validator_nominator_counts",
@@ -173,6 +190,7 @@ export async function mirrorLedgerToNeon(
     plan.conflict,
     `${plan.table}.captured_at < EXCLUDED.captured_at`,
     plan.filter,
+    plan.columnTypes,
   );
   await recordNeonWriteVerdict(laneDb, lane, result, now());
 

--- a/src/neon-write.ts
+++ b/src/neon-write.ts
@@ -105,6 +105,27 @@ export function buildPgUpsert(
   rowCount: number,
   guard?: string,
   filter?: string,
+  /**
+   * Target types for the FILTERED form's columns, e.g. `{netuid: "int"}`.
+   *
+   * WHY ONLY THE FILTERED FORM NEEDS THEM (#10121). A plain
+   * `INSERT INTO t (a, b) VALUES ($1, $2)` gives Postgres the target columns as
+   * type context, so every parameter is inferred correctly and nothing has to
+   * be declared. Wrapping the same list in `FROM (VALUES ...) AS src (a, b)`
+   * removes that context entirely: `src` is a standalone relation, its columns
+   * have no declared types, and every untyped parameter falls back to TEXT.
+   *
+   * The insert then fails with `column "netuid" is of type integer but
+   * expression is of type text` -- which took the hotkey_alpha mirror down
+   * TWICE. #10000 fixed only the predicate half (`src.netuid::int` inside the
+   * EXISTS) and left the SELECT list handing text to an integer column.
+   *
+   * Declared per plan rather than discovered, because the failure is silent in
+   * the direction that matters: an unlisted column is simply not cast, and if
+   * its target happens to be text the statement works -- so a missing entry
+   * surfaces only on the one table where it breaks.
+   */
+  columnTypes?: Readonly<Record<string, string>>,
 ): string {
   // `filter` switches the row source from a bare VALUES list to a SELECT over
   // it, so a predicate can reject rows before they are inserted. The D1 side
@@ -116,7 +137,9 @@ export function buildPgUpsert(
   // The alias is `src`, and the predicate refers to its columns by name.
   const head = filter
     ? `INSERT INTO ${table} (${columns.join(", ")}) SELECT ${columns
-        .map((c) => `src.${c}`)
+        .map((c) =>
+          columnTypes?.[c] ? `src.${c}::${columnTypes[c]}` : `src.${c}`,
+        )
         .join(", ")} FROM (VALUES ${pgValuesClause(
         rowCount,
         columns.length,
@@ -189,6 +212,8 @@ export async function writeRowsToNeon(
   conflict: readonly string[] = [],
   guard?: string,
   filter?: string,
+  /** Target types for the filtered form -- see buildPgUpsert. */
+  columnTypes?: Readonly<Record<string, string>>,
 ): Promise<NeonWriteResult> {
   if (!sql?.unsafe)
     return { ok: false, rows: 0, statements: 0, reason: "unbound" };
@@ -208,6 +233,7 @@ export async function writeRowsToNeon(
       chunk.length,
       guard,
       filter,
+      columnTypes,
     );
     try {
       await sql.unsafe(text, pgFlatValues(chunk, columns));

--- a/tests/ledger-neon-write.test.ts
+++ b/tests/ledger-neon-write.test.ts
@@ -6,6 +6,7 @@
 // primary key, the out-of-order guard, and a typo'd lane name costing nothing.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
+import { buildPgUpsert } from "../src/neon-write.ts";
 import {
   LEDGER_MIRROR_PLANS,
   mirrorLedgerToNeon,
@@ -270,4 +271,62 @@ describe("the hotkey-alpha filter (#9832)", () => {
       );
     }
   });
+});
+
+// --- the FILTERED form has no type context (#10121) -------------------------
+//
+// `INSERT INTO t (a, b) VALUES ($1, $2)` gives Postgres the target columns as
+// type context, so every parameter is inferred and nothing has to be declared.
+// Wrapping the same list in `FROM (VALUES ...) AS src (a, b)` removes that
+// entirely: `src` is a standalone relation whose columns have no declared
+// types, so every untyped parameter falls back to TEXT.
+//
+// Reproduced against production Neon before the fix and after:
+//   old form -> column "netuid" is of type integer but expression is of type text
+//   new form -> runs, 0 rows (the EXISTS filter rejects the probe hotkey)
+test("the filtered SELECT list casts every non-text column", () => {
+  const plan = LEDGER_MIRROR_PLANS["hotkey-alpha"];
+  const sql = buildPgUpsert(
+    plan.table,
+    plan.columns,
+    plan.conflict,
+    1,
+    undefined,
+    plan.filter,
+    plan.columnTypes,
+  );
+  assert.match(sql, /SELECT src\.hotkey, src\.netuid::int/);
+  assert.match(sql, /src\.total_alpha::double precision/);
+  assert.match(sql, /src\.captured_at::bigint/);
+  // hotkey is text on both sides -- casting it would be noise, not safety.
+  assert.doesNotMatch(sql, /src\.hotkey::/);
+});
+
+test("EVERY non-text column is declared, not just the one Postgres named", () => {
+  // Postgres reports the FIRST mismatch only, so fixing them one error at a
+  // time is one deploy per column. This pins that the plan covers the whole
+  // set, derived from the live Neon schema rather than from the error text.
+  const plan = LEDGER_MIRROR_PLANS["hotkey-alpha"];
+  assert.deepEqual(Object.keys(plan.columnTypes ?? {}).sort(), [
+    "captured_at",
+    "netuid",
+    "total_alpha",
+  ]);
+});
+
+test("the UNFILTERED form is left alone -- it has its type context", () => {
+  // account-balances has no filter, so its parameters are inferred from the
+  // target columns. Adding casts there would be cargo-culted noise.
+  const plan = LEDGER_MIRROR_PLANS["account-balances"];
+  const sql = buildPgUpsert(
+    plan.table,
+    plan.columns,
+    plan.conflict,
+    1,
+    undefined,
+    plan.filter,
+    plan.columnTypes,
+  );
+  assert.doesNotMatch(sql, /::/);
+  assert.match(sql, /VALUES \(\$1/);
 });


### PR DESCRIPTION
## Summary

`neon:hotkey-alpha` is failing on **every pass** in production:

```
0 row(s) written before failure:
  column "netuid" is of type integer but expression is of type text
```

Neon frozen at **17,847** rows (last write 20h ago); D1 at **17,867** and current.

## Root cause: two shapes, one type context

`buildPgUpsert`'s plain form gives Postgres the **target columns** to infer parameter types from:

```sql
INSERT INTO t (a, b) VALUES ($1, $2)
```

The **filtered** form — used since #9558 so the mirror can apply D1's `EXISTS` predicate — takes that
away:

```sql
INSERT INTO t (a, b) SELECT src.a, src.b FROM (VALUES ($1, $2)) AS src (a, b) WHERE ...
```

`src` is a standalone relation whose columns have no declared types, so every untyped parameter falls
back to **TEXT**.

## Second time on this table

#10000 fixed only the **predicate** half — `src.netuid::int` inside the `EXISTS` — and left the
SELECT list handing text to an integer column. Postgres reports only the *first* mismatch, so fixing
them as they surface is one deploy per column.

`hotkey_alpha` needs **three** casts, not one: `netuid` int, `total_alpha` double precision,
`captured_at` bigint. The plan declares all three, derived from the live Neon schema rather than from
the error text.

## Verified against production Neon, both directions

Using the statement `buildPgUpsert` actually emits, not an approximation of it:

| form | result |
|---|---|
| old (no casts) | `column "netuid" is of type integer but expression is of type text` |
| new (casts) | **runs**, 0 rows |

Zero rows because the probe hotkey is one no `nominator_position` references, so the `EXISTS` filter
rejects it — the statement typechecks and executes without touching real data.

## The unfiltered form is left alone

It has its type context. Casting there would be noise dressed as safety, and a test pins that
`account-balances` emits no `::` at all.

## Mutation-verified

| mutation | result |
|---|---|
| declare only `netuid` (the one the error named) | **2 tests fail** |
| drop the casts entirely (the live bug) | **1 test fails** |

## Validation

```
npx tsc --noEmit                                clean
eslint / prettier --check                       clean
vitest run ledger-neon-write neon-write data-api-hotkey-alpha-d1 neon-backfill   173 passed
```

Closes #10122