### PR TITLE
fix(mcp): four filters advertised values their route rejects (#10115)

### DIFF
--- a/schemas-src/mcp-tools/account-history.ts
+++ b/schemas-src/mcp-tools/account-history.ts
@@ -5,6 +5,7 @@
 // field-for-field.
 import { z } from "zod";
 import {
+  daySchema,
   keysetCursorSchema,
   limitSchema,
   netuidSchema,
@@ -16,20 +17,14 @@ export const GetAccountHistoryInputSchema = z
   .object({
     ss58: ss58Schema(),
     netuid: netuidSchema().optional(),
-    from: z
-      .string()
-      .optional()
-      .describe(
-        "Inclusive start of the range. A block height on chain tools, an ISO-8601 date on time-series ones.",
-      )
-      .meta({ examples: [8700000] }),
-    to: z
-      .string()
-      .optional()
-      .describe(
-        "Inclusive end of the range. A block height on chain tools, an ISO-8601 date on time-series ones; an EVM address on decode_evm_call.",
-      )
-      .meta({ examples: [8783000] }),
+    // DAYS, not block heights. These carried the generic cross-tool sentence
+    // ("a block height on chain tools, an ISO-8601 date on time-series ones")
+    // and a block-height EXAMPLE, while this route reads a day-partitioned
+    // table and takes YYYY-MM-DD only -- verified live, `?from=8700000` is a
+    // 400 and `?from=2026-08-01` is a 200. An agent following the tool's own
+    // example was rejected (#10115).
+    from: daySchema("first").optional(),
+    to: daySchema("last").optional(),
     limit: limitSchema(1000).optional(),
     offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),

--- a/schemas-src/mcp-tools/ai-discovery.ts
+++ b/schemas-src/mcp-tools/ai-discovery.ts
@@ -4,7 +4,8 @@
 // existing schemas-src/routes/ REST schema -- modeled fresh, matching
 // each hand-written literal field-for-field.
 import { z } from "zod";
-import { limitSchema, netuidSchema } from "./shared.ts";
+import { limitSchema, netuidSchema, querySchema } from "./shared.ts";
+import { SEMANTIC_QUERY_MAX_LENGTH } from "../../src/route-limits.ts";
 import { AgentCatalogSubnetEntrySchema } from "../routes/agent-catalog.ts";
 import { ECONOMIC_LEADERBOARD_BOARDS } from "../routes/registry-summary-leaderboards.ts";
 import { SEARCH_DOCUMENT_TYPE_VALUES } from "../routes/evidence-search.ts";
@@ -72,15 +73,13 @@ export const SemanticSearchInputSchema = z
     // rejected for an unknown argument. Canonical; `query` stays so existing
     // callers are unaffected. Exactly one is required -- expressed with
     // requireAnyOf on the tool, since z.toJSONSchema drops a Zod refinement.
-    q: z
-      .string()
+    q: querySchema(SEMANTIC_QUERY_MAX_LENGTH)
       .optional()
       .describe(
         "The search text, embedded and ranked by meaning. The name GET /api/v1/search/semantic publishes; `query` is the alias this tool shipped with.",
       )
       .meta({ examples: ["inference"] }),
-    query: z
-      .string()
+    query: querySchema(SEMANTIC_QUERY_MAX_LENGTH)
       .optional()
       .describe(
         "Alias for `q`, the name this tool shipped with. Search text, embedded and ranked by meaning.",

--- a/schemas-src/mcp-tools/list-subnets.ts
+++ b/schemas-src/mcp-tools/list-subnets.ts
@@ -12,6 +12,7 @@
 import { z } from "zod";
 import {
   limitSchema,
+  netuidListSchema,
   netuidSchema,
   numericCursorSchema,
   orderSchema,
@@ -250,14 +251,11 @@ export const ListSubnetsInputSchema = z
     // A CSV membership filter on the route (csv_filters: { netuids: "netuid" }),
     // so a STRING on the wire -- "1,7,64" -- not an array. Without it, asking
     // for three subnets is three calls or a full scan.
-    netuids: z
-      .string()
-      .regex(/^\d+(,\d+)*$/)
-      .optional()
-      .describe(
-        "Restrict to this comma-separated list of subnet ids (`1,7,64`). One request instead of one per subnet.",
-      )
-      .meta({ examples: ["1,7,64"] }),
+    // netuidListSchema() carries the bounds the route enforces: at most 128
+    // ids, each at most 5 digits (a netuid is a u16). The `^\d+(,\d+)*$` this
+    // declared was unbounded in count and accepted 9-digit "netuids", so the
+    // tool advertised a list its own route rejects (#10115).
+    netuids: netuidListSchema().optional(),
     min_netuid: z
       .int()
       .min(0)

--- a/schemas-src/mcp-tools/search-subnets.ts
+++ b/schemas-src/mcp-tools/search-subnets.ts
@@ -10,7 +10,12 @@
 // tightening here, only relocating where the schema is defined (#7863's own
 // "hard wire-compatibility constraint").
 import { z } from "zod";
-import { limitSchema, netuidSchema, numericCursorSchema } from "./shared.ts";
+import {
+  limitSchema,
+  netuidSchema,
+  numericCursorSchema,
+  querySchema,
+} from "./shared.ts";
 
 export const SearchSubnetsInputSchema = z
   .object({
@@ -19,15 +24,13 @@ export const SearchSubnetsInputSchema = z
     // an unknown argument until now. Canonical; `query` stays so existing
     // callers are unaffected. Exactly one is required -- see requireAnyOf on
     // the tool, since Zod cannot express it in a way z.toJSONSchema keeps.
-    q: z
-      .string()
+    q: querySchema()
       .optional()
       .describe(
         "The search text. The name GET /api/v1/search publishes; `query` is the alias this tool shipped with.",
       )
       .meta({ examples: ["inference"] }),
-    query: z
-      .string()
+    query: querySchema()
       .optional()
       .describe(
         "Alias for `q`, the name this tool shipped with. The subnet search text.",

--- a/scripts/validate-mcp-input-parity.ts
+++ b/scripts/validate-mcp-input-parity.ts
@@ -386,8 +386,6 @@ const CONSTRAINT_DIVERGENCES: Record<string, Divergence> = {
 
   // LOOSER -- standing debt. Delete an entry by TIGHTENING the tool
   // (4/5, #10064), never by keeping it.
-  "get_account_history.from": "LOOSER",
-  "get_account_history.to": "LOOSER",
   "get_chain_calls.call_module": "LOOSER",
   "get_chain_fees.call_module": "LOOSER",
   "get_chain_signers.call_module": "LOOSER",
@@ -399,12 +397,9 @@ const CONSTRAINT_DIVERGENCES: Record<string, Divergence> = {
   "list_review_enrichment_targets.reason_codes": "LOOSER",
   "list_review_gaps.sort": "LOOSER",
   "list_subnets.domain": "LOOSER",
-  "list_subnets.netuids": "LOOSER",
   "list_subnets.status": "LOOSER",
   "list_subnets.subnet_type": "LOOSER",
   "list_validator_economics.offset": "LOOSER",
-  "search_subnets.q": "LOOSER",
-  "semantic_search.q": "LOOSER",
 };
 
 const errors: string[] = [];


### PR DESCRIPTION
Four more, each closed by reading the vocabulary the route reads.

## `get_account_history.from` / `.to` — the tool's own example was a 400

These carried the generic cross-tool sentence — *"a block height on chain tools, an ISO-8601 date on time-series ones"* — and a **block-height example of `8700000`**. This route reads a day-partitioned table and takes `YYYY-MM-DD` only:

```
?from=8700000     -> 400
?from=2026-08-01  -> 200
?from=bogus       -> 400
```

So an agent following the tool's own example was rejected. This is worse than a missing bound — the example actively misled. `daySchema()` states the day and gives an example that works.

## `list_subnets.netuids`

Published `^\d+(,\d+)*$` — unbounded in count, and accepting a 9-digit "netuid" — where the route publishes `^\d{1,5}(,\d{1,5}){0,127}$`. `netuidListSchema()` carries both real bounds: at most 128 ids, each a u16.

## `search_subnets.q` and `semantic_search.q`

Unbounded where their routes cap at 200 and 1,000. Not only a contract lie: `searchRows` scans per term per row, which is *why* the route bounds it (#5544).

Both keep their per-tool prose and take the bound from `querySchema()`, so the ceiling is stated once. Their `query` aliases are bounded too — same handler, same limit.

## Effect

```
validate:mcp-input-parity LOOSER debt: 19 -> 14

658 shared argument pairs: 526 identical, 87 narrowed for the context window,
14 looser than their route (standing debt), 31 a declared JSON-shape adaptation.
```

Session total: **80 → 14.**

## Validation

```
npm run typecheck / lint / format:check     clean
npx vitest run                              759 files, 18,260 passed, 22 skipped
npm run build                               openapi.json byte-identical
validate:mcp-input-parity                   passes with the counts above
```

All tightenings — nothing that worked stops working. `openapi.json` is untouched; these are MCP input schemas.

Refs #10115, #10064, #10060