### PR TITLE
refactor(schemas): the query vocabularies live where both surfaces can read them (#10131)

### DIFF
--- a/schemas-src/mcp-tools/chain-calls-fees.ts
+++ b/schemas-src/mcp-tools/chain-calls-fees.ts
@@ -12,7 +12,13 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { limitSchema, sortSchema, windowSchema } from "./shared.ts";
+
+import {
+  limitSchema,
+  runtimeNameSchema,
+  sortSchema,
+  windowSchema,
+} from "./shared.ts";
 import {
   ChainCallsArtifactSchema,
   ChainFeesArtifactSchema,
@@ -20,6 +26,12 @@ import {
 } from "../routes/chain-analytics.ts";
 
 const WINDOWS_2 = ["7d", "30d"] as const;
+
+/** The ceiling /chain/calls, /chain/fees and /chain/signers enforce on
+ * `call_module`. validateListQuery reads it off the PUBLISHED schema to
+ * decide a 400, so a tool that omits it advertises a value the route
+ * rejects (#10131). */
+const CHAIN_ANALYTICS_NAME_MAX = 100;
 
 export const GetChainCallsInputSchema = z
   .object({
@@ -32,8 +44,7 @@ export const GetChainCallsInputSchema = z
       )
       .meta({ examples: ["module"] }),
     limit: limitSchema(100).optional(),
-    call_module: z
-      .string()
+    call_module: runtimeNameSchema(CHAIN_ANALYTICS_NAME_MAX)
       .optional()
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
@@ -53,8 +64,7 @@ export const GetChainSignersInputSchema = z
     window: windowSchema(WINDOWS_2).optional(),
     sort: sortSchema(["tx_count", "total_fee_tao"]).optional(),
     limit: limitSchema(100).optional(),
-    call_module: z
-      .string()
+    call_module: runtimeNameSchema(CHAIN_ANALYTICS_NAME_MAX)
       .optional()
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
@@ -72,8 +82,7 @@ export const GetChainFeesInputSchema = z
   .object({
     window: windowSchema(WINDOWS_2).optional(),
     limit: limitSchema(100).optional(),
-    call_module: z
-      .string()
+    call_module: runtimeNameSchema(CHAIN_ANALYTICS_NAME_MAX)
       .optional()
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",

--- a/schemas-src/mcp-tools/chain-events-activity.ts
+++ b/schemas-src/mcp-tools/chain-events-activity.ts
@@ -12,7 +12,12 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { blockEventCursorSchema, limitSchema, windowSchema } from "./shared.ts";
+import {
+  blockEventCursorSchema,
+  limitSchema,
+  runtimeNameSchema,
+  windowSchema,
+} from "./shared.ts";
 import { McpNetworkSchema } from "../shared.ts";
 import { ChainActivityArtifactSchema } from "../routes/chain-analytics.ts";
 import {
@@ -21,6 +26,10 @@ import {
 } from "../routes/chain-events.ts";
 
 const WINDOWS_2 = ["7d", "30d"] as const;
+
+/** The ceiling /chain-events enforces on `pallet` and `method` --
+ * validateListQuery reads it off the PUBLISHED schema to decide a 400. */
+const EVENT_FEED_NAME_MAX = 64;
 
 export const GetChainActivityInputSchema = z
   .object({
@@ -48,17 +57,20 @@ export type GetChainActivityOutput = z.infer<
 
 export const ListChainEventsInputSchema = z
   .object({
-    pallet: z
-      .string()
+    pallet: runtimeNameSchema(EVENT_FEED_NAME_MAX)
       .optional()
       .describe(
         "Restrict to events emitted by this pallet, by runtime name (`SubtensorModule`). Case-sensitive.",
       )
       .meta({ examples: ["SubtensorModule"] }),
-    method: z
-      .string()
+    // NOT an HTTP method. This said "HTTP method to use for the call" beside
+    // an example of `set_weights` -- the prose contradicted its own example,
+    // on a parameter whose whole job is naming a runtime call (#10131).
+    method: runtimeNameSchema(EVENT_FEED_NAME_MAX)
       .optional()
-      .describe("HTTP method to use for the call.")
+      .describe(
+        "Restrict to events emitted by this runtime call, by name (`set_weights`). Case-sensitive.",
+      )
       .meta({ examples: ["set_weights"] }),
     block: z
       .int()

--- a/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
+++ b/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
@@ -10,6 +10,7 @@
 // matching each hand-written literal field-for-field.
 import { z } from "zod";
 import {
+  reasonCodesSchema,
   reviewStateSchema,
   McpListArtifactStamp,
   McpListPageFields,
@@ -195,13 +196,7 @@ export const ListReviewEnrichmentTargetsInputSchema = z
         "Restrict to subnets where surfaces of this kind the subnet is MISSING. One kind per call; see this parameter's enum.",
       )
       .meta({ examples: [SURFACE_KINDS[0]] }),
-    reason_codes: z
-      .string()
-      .optional()
-      .describe(
-        "Comma-separated reason codes to filter by; an item matches if it carries any of them.",
-      )
-      .meta({ examples: ["stale-evidence"] }),
+    reason_codes: reasonCodesSchema().optional(),
     sort: sortSchema(TARGET_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),

--- a/schemas-src/mcp-tools/enrichment-queue-and-candidates.ts
+++ b/schemas-src/mcp-tools/enrichment-queue-and-candidates.ts
@@ -9,6 +9,7 @@
 // field-for-field.
 import { z } from "zod";
 import {
+  reasonCodesSchema,
   reviewStateSchema,
   McpListArtifactStamp,
   McpListPageFields,
@@ -88,13 +89,7 @@ export const ListEnrichmentQueueInputSchema = z
       .optional()
       .describe("Restrict to items that do (or do not) need a human reviewer.")
       .meta({ examples: [BOOLEAN_STRINGS[0]] }),
-    reason_codes: z
-      .string()
-      .optional()
-      .describe(
-        "Comma-separated reason codes to filter by; an item matches if it carries any of them.",
-      )
-      .meta({ examples: ["stale-evidence"] }),
+    reason_codes: reasonCodesSchema().optional(),
     review_state: reviewStateSchema().optional(),
     sort: sortSchema(QUEUE_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
@@ -142,13 +137,7 @@ export const ListAdapterCandidatesInputSchema = z
       .optional()
       .describe("Which adapter shape suits this surface.")
       .meta({ examples: [RECOMMENDED_ADAPTER_KINDS[0]] }),
-    reason_codes: z
-      .string()
-      .optional()
-      .describe(
-        "Comma-separated reason codes to filter by; an item matches if it carries any of them.",
-      )
-      .meta({ examples: ["stale-evidence"] }),
+    reason_codes: reasonCodesSchema().optional(),
     sort: sortSchema(ADAPTER_CANDIDATES_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),

--- a/schemas-src/mcp-tools/extrinsics.ts
+++ b/schemas-src/mcp-tools/extrinsics.ts
@@ -11,11 +11,14 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+
 import {
   blockBoundSchema,
+  hashSchema,
   keysetCursorSchema,
   limitSchema,
   offsetSchema,
+  runtimeNameSchema,
 } from "./shared.ts";
 
 /**
@@ -24,6 +27,12 @@ import {
  * read it rather than restating it — they previously declared no maximum at all.
  */
 export const EXTRINSICS_LIMIT_MAX = 100;
+
+/** The ceiling /chain/calls, /chain/fees and /chain/signers enforce on
+ * `call_module`. validateListQuery reads it off the PUBLISHED schema to
+ * decide a 400, so a tool that omits it advertises a value the route
+ * rejects (#10131). */
+const CHAIN_ANALYTICS_NAME_MAX = 100;
 import { AccountEventItemSchema } from "./shared.ts";
 import {
   ExtrinsicSchema,
@@ -45,8 +54,7 @@ export const ListExtrinsicsInputSchema = z
         "Restrict to extrinsics signed by this SS58 account. Unsigned (inherent) extrinsics never match.",
       )
       .meta({ examples: ["5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F"] }),
-    call_module: z
-      .string()
+    call_module: runtimeNameSchema(CHAIN_ANALYTICS_NAME_MAX)
       .optional()
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
@@ -59,8 +67,7 @@ export const ListExtrinsicsInputSchema = z
         "Restrict to one call within the pallet (`add_stake`). Case-sensitive; pair with `call_module` to disambiguate.",
       )
       .meta({ examples: ["add_stake"] }),
-    call_hash: z
-      .string()
+    call_hash: hashSchema("extrinsic's call hash")
       .optional()
       .describe("Restrict to the extrinsic with this 0x-prefixed hash.")
       .meta({

--- a/schemas-src/mcp-tools/get-domain-summary.ts
+++ b/schemas-src/mcp-tools/get-domain-summary.ts
@@ -8,35 +8,24 @@
 // rationale) the output stays deliberately loose rather than reusing either
 // REST schema or forcing a discriminated union that doesn't reflect how the
 // original was ever validated. Modeled fresh, shallow, from the hand-written
-// literal it replaces. Domain enum hardcoded from src/domain-tags.ts's
-// DOMAIN_TAGS at the time of writing.
+// literal it replaces.
+//
+// The domain enum is READ from src/domain-tags.ts rather than hardcoded. It
+// used to be a local copy whose own comment said "at the time of writing" --
+// a list that announced it could drift and had no way to be told when it did
+// (#10131). That module is a zero-import leaf, the same shape as
+// src/route-limits.ts, which this directory has read since #9127.
 import { z } from "zod";
+import { DOMAIN_TAGS } from "../../src/domain-tags.ts";
 import {
   ConcentrationScorecardSchema,
   DomainSummaryArtifactSchema,
 } from "../routes/domains.ts";
 
-const DOMAIN_TAGS = [
-  "agents",
-  "compute",
-  "data",
-  "finance",
-  "inference",
-  "media",
-  "prediction",
-  "privacy",
-  "robotics",
-  "science",
-  "search",
-  "security",
-  "storage",
-  "training",
-] as const;
-
 export const GetDomainSummaryInputSchema = z
   .object({
     domain: z
-      .enum(DOMAIN_TAGS)
+      .enum(DOMAIN_TAGS as [string, ...string[]])
       .optional()
       .describe("The subnet's primary domain of use.")
       .meta({ examples: [DOMAIN_TAGS[0]] }),

--- a/schemas-src/mcp-tools/get-subnet-validator-economics.ts
+++ b/schemas-src/mcp-tools/get-subnet-validator-economics.ts
@@ -19,12 +19,7 @@ import {
   ValidatorEconomicsRankingArtifactSchema,
   SubnetValidatorEconomicsHistoryArtifactSchema,
 } from "../routes/validator-economics.ts";
-import {
-  limitSchema,
-  netuidSchema,
-  offsetSchema,
-  sortSchema,
-} from "./shared.ts";
+import { limitSchema, netuidSchema, sortSchema } from "./shared.ts";
 import {
   VALIDATOR_ECONOMICS_LIMIT_DEFAULT,
   VALIDATOR_ECONOMICS_LIMIT_MAX,
@@ -65,7 +60,19 @@ export const ListValidatorEconomicsInputSchema = z
       VALIDATOR_ECONOMICS_LIMIT_MAX,
       VALIDATOR_ECONOMICS_LIMIT_DEFAULT,
     ).optional(),
-    offset: offsetSchema().optional(),
+    // The route caps `offset` at VALIDATOR_ECONOMICS_LIMIT_MAX, not at the
+    // generic MAX_OFFSET offsetSchema() carries -- this ranking is bounded by
+    // the subnet count, so paging past it seeks nothing. The tool advertised
+    // 1,000,000 (#10131).
+    offset: z
+      .int()
+      .min(0)
+      .max(VALIDATOR_ECONOMICS_LIMIT_MAX)
+      .describe(
+        `Rows to skip before the first returned row (0-${VALIDATOR_ECONOMICS_LIMIT_MAX}).`,
+      )
+      .meta({ examples: [0] })
+      .optional(),
     emission_gate_open: z
       .boolean()
       .optional()

--- a/schemas-src/mcp-tools/list-subnets.ts
+++ b/schemas-src/mcp-tools/list-subnets.ts
@@ -10,7 +10,16 @@
 // only coverage_level/curation_level/sort/order were actually enum-
 // constrained on the wire, and only those reuse a shared enum.
 import { z } from "zod";
+// The route's own filter vocabularies. These three published a bare
+// `{"type":"string"}` while the route named its values, so an agent had to
+// guess and a wrong guess filtered to nothing rather than erroring (#10115).
+// They were unreachable until QUERY_ENUMS moved out of src/contracts.ts
+// (#10131) -- importing that from here is the edge that broke the data-api
+// build on #10121.
+import { QUERY_ENUMS } from "../query-enums.ts";
+import { DOMAIN_TAGS } from "../../src/domain-tags.ts";
 import {
+  kindSchema,
   limitSchema,
   netuidListSchema,
   netuidSchema,
@@ -35,18 +44,20 @@ export const ListSubnetsInputSchema = z
   .object({
     cursor: numericCursorSchema().optional(),
     limit: limitSchema(100).optional(),
-    status: z
-      .string()
+    // A SUBNET status, not a health one. This described "rows with this health
+    // status" and gave `ok` as the example -- a health verdict, on a parameter
+    // whose route accepts active | inactive. The prose and the example both
+    // named a different parameter, and neither could be seen to be wrong while
+    // the enum was a bare string (#10131).
+    status: kindSchema(QUERY_ENUMS.subnetStatus as [string, ...string[]])
       .optional()
-      .describe("Restrict to rows with this health status.")
-      .meta({ examples: ["ok"] }),
-    subnet_type: z
-      .string()
+      .describe("Restrict to subnets in this lifecycle state.")
+      .meta({ examples: [QUERY_ENUMS.subnetStatus[0]] }),
+    subnet_type: kindSchema(QUERY_ENUMS.subnetType as [string, ...string[]])
       .optional()
       .describe("Root subnet or an application subnet.")
       .meta({ examples: ["application"] }),
-    domain: z
-      .string()
+    domain: kindSchema(DOMAIN_TAGS as [string, ...string[]])
       .optional()
       .describe("The subnet's primary domain of use.")
       .meta({ examples: ["inference"] }),

--- a/schemas-src/query-enums.ts
+++ b/schemas-src/query-enums.ts
@@ -1,0 +1,122 @@
+// The closed value sets a query FILTER accepts, shared by both published
+// surfaces (#10131).
+//
+// These lived in `src/contracts.ts`, which meant an MCP tool could not read
+// them: importing `contracts.ts` from `schemas-src/` is the dependency edge
+// that failed the metagraphed-data-api Workers Build twice on #10121. So the
+// tools restated the values instead -- and restating an enum is how
+// `list_subnets.status` came to publish a bare `{"type":"string"}` while its
+// route named `active | inactive`, leaving an agent to guess (#10115).
+//
+// Pure literals, zero imports, so any surface can read them. `contracts.ts`
+// re-exports the symbol, so the 31 existing import sites are unchanged.
+
+export const QUERY_ENUMS = {
+  candidateState: [
+    "schema-invalid",
+    "schema-valid",
+    "maintainer-review",
+    "verified",
+    "stale",
+    "rejected",
+  ],
+  coverageLevel: ["native-only", "manifested", "probed"],
+  curationLevel: [
+    "native",
+    "candidate-discovered",
+    "community-seeded",
+    "machine-verified",
+    "maintainer-reviewed",
+    "adapter-backed",
+  ],
+  healthClassification: [
+    "auth-required",
+    "content-mismatch",
+    "dead",
+    "live",
+    "rate-limited",
+    "redirected",
+    "timeout",
+    "transient",
+    "unsupported",
+    "unsafe",
+    "wrong-chain",
+  ],
+  healthStatus: ["ok", "degraded", "failed", "unknown"],
+  providerAuthority: [
+    "community",
+    "official",
+    "provider-claimed",
+    "registry-observed",
+  ],
+  providerKind: [
+    "data-provider",
+    "docs-provider",
+    "infrastructure-provider",
+    "registry",
+    "subnet-team",
+  ],
+  profileLevel: [
+    "directory-only",
+    "identity-partial",
+    "identity-complete",
+    "operational",
+    "adapter-backed",
+  ],
+  subnetStatus: ["active", "inactive"],
+  subnetType: ["root", "application"],
+  endpointLayer: [
+    "bittensor-base",
+    "data-provider",
+    "docs-provider",
+    "subnet-app",
+  ],
+  endpointPublicationState: [
+    "candidate",
+    "verified",
+    "monitored",
+    "pool-eligible",
+    "disabled",
+    "rejected",
+  ],
+  coverageDepthTier: [
+    "agent-ready",
+    "machine-usable",
+    "candidate-review",
+    "needs-evidence",
+    "hard-blocked",
+    "missing-interface",
+  ],
+  agentReadinessStatus: [
+    "callable",
+    "base-layer",
+    "candidate",
+    "needs-evidence",
+    "blocked",
+  ],
+  agentBlockerLevel: ["none", "hard-blocked", "needs-review", "missing-data"],
+  endpointIncidentSeverity: ["critical", "warning", "info"],
+  endpointIncidentState: ["active", "resolved"],
+  recommendedAdapterKind: [
+    "custom-adapter",
+    "data-artifact-adapter",
+    "generic-openapi-or-custom",
+    "stream-adapter",
+  ],
+  surfaceKind: [
+    "archive",
+    "dashboard",
+    "data-artifact",
+    "docs",
+    "example",
+    "openapi",
+    "repo-registry",
+    "sdk",
+    "source-repo",
+    "sse",
+    "subnet-api",
+    "subtensor-rpc",
+    "subtensor-wss",
+    "website",
+  ],
+};

--- a/schemas-src/query-params.ts
+++ b/schemas-src/query-params.ts
@@ -431,6 +431,63 @@ export const kindStringSchema = () =>
     .meta({ examples: ["subnet-api"] });
 
 /**
+ * A 32-byte chain hash -- a block hash, an extrinsic hash, a call hash.
+ *
+ * `identifier-resolver.ts` recognises exactly this shape, and the routes that
+ * filter on one publish the pattern. `list_extrinsics.call_hash` declared a
+ * bare string, so a malformed hash reached the route and came back as an empty
+ * result rather than as "that is not a hash" (#10131).
+ */
+export const HASH_HEX_PATTERN = /^0x[0-9a-fA-F]{64}$/;
+export const hashSchema = (what: string) =>
+  z
+    .string()
+    .regex(HASH_HEX_PATTERN)
+    .describe(`The ${what}, 0x-prefixed and 64 hex characters.`)
+    .meta({
+      examples: [
+        "0x9f1e2d3c4b5a69788796a5b4c3d2e1f009182736455463728190abcdef012345",
+      ],
+    });
+
+/**
+ * A Substrate runtime NAME -- a pallet, or a call module.
+ *
+ * `max` differs by route and is passed in, because the routes genuinely differ:
+ * the chain-analytics feeds cap `call_module` at 100 and the event feeds cap
+ * `pallet`/`method` at 64. What is shared is the meaning -- a runtime
+ * identifier, matched case-sensitively -- and the fact that it is bounded at
+ * all, which four tool sites did not say (#10131).
+ */
+export const runtimeNameSchema = (max: number) =>
+  z
+    .string()
+    .max(max)
+    .describe(
+      "A Substrate runtime name, matched case-sensitively as the runtime " +
+        "spells it (`SubtensorModule`, `set_weights`).",
+    )
+    .meta({ examples: ["SubtensorModule"] });
+
+/**
+ * A `reason_codes` filter -- the codes an item carries, any of which matches.
+ *
+ * The sentence was written out at 3 tool sites and the bound at none of them.
+ * Matched by `validateListQuery`, which reads `maxLength` off the PUBLISHED
+ * schema to decide a 400, so an unbounded declaration advertises a value the
+ * route rejects.
+ */
+export const reasonCodesSchema = () =>
+  z
+    .string()
+    .max(FILTER_TEXT_MAX_LENGTH)
+    .describe(
+      "Comma-separated reason codes to filter by; an item matches if it " +
+        "carries any of them.",
+    )
+    .meta({ examples: ["stale-evidence"] });
+
+/**
  * A `review_state` filter -- where an item sits in maintainer review.
  *
  * The sentence was written out at 4 tool sites and the bound at none of them.

--- a/scripts/validate-mcp-input-parity.ts
+++ b/scripts/validate-mcp-input-parity.ts
@@ -386,20 +386,6 @@ const CONSTRAINT_DIVERGENCES: Record<string, Divergence> = {
 
   // LOOSER -- standing debt. Delete an entry by TIGHTENING the tool
   // (4/5, #10064), never by keeping it.
-  "get_chain_calls.call_module": "LOOSER",
-  "get_chain_fees.call_module": "LOOSER",
-  "get_chain_signers.call_module": "LOOSER",
-  "list_adapter_candidates.reason_codes": "LOOSER",
-  "list_chain_events.method": "LOOSER",
-  "list_chain_events.pallet": "LOOSER",
-  "list_enrichment_queue.reason_codes": "LOOSER",
-  "list_extrinsics.call_hash": "LOOSER",
-  "list_review_enrichment_targets.reason_codes": "LOOSER",
-  "list_review_gaps.sort": "LOOSER",
-  "list_subnets.domain": "LOOSER",
-  "list_subnets.status": "LOOSER",
-  "list_subnets.subnet_type": "LOOSER",
-  "list_validator_economics.offset": "LOOSER",
 };
 
 const errors: string[] = [];
@@ -413,8 +399,26 @@ let compared = 0;
 let aligned = 0;
 
 for (const tool of listToolDefinitions()) {
-  const route = MCP_TOOL_ROUTES[tool.name]?.route;
+  const declaration = MCP_TOOL_ROUTES[tool.name];
+  const route = declaration?.route;
   const parameters = route ? published.get(route) : undefined;
+  /**
+   * The route schemas to compare a shared argument's CONSTRAINTS against.
+   *
+   * Two tools genuinely answer for more than one route (#9880's
+   * `additionalRoutes`) -- `list_review_gaps` reads both gap feeds, and their
+   * `sort` enums differ. Comparing only the primary reported the tool as
+   * LOOSER for naming values its OTHER route accepts, which is the opposite of
+   * a defect. A value any declared route takes is a value the tool may
+   * advertise, so the comparison is against the union.
+   */
+  const constraintSources = [
+    route,
+    ...(declaration?.additionalRoutes ?? []),
+  ].flatMap((path) => {
+    const entry = path ? published.get(path) : undefined;
+    return entry ? [entry.querySchemas] : [];
+  });
   // A route-less tool (declared with a reason in the map) has nothing to
   // compare against; the map already gates that decision.
   if (!parameters) continue;
@@ -442,10 +446,22 @@ for (const tool of listToolDefinitions()) {
   const toolProperties = ((tool.inputSchema as Row)?.properties ??
     {}) as Record<string, Row>;
   for (const [argument, toolSchema] of Object.entries(toolProperties)) {
-    const routeSchema = parameters.querySchemas.get(argument);
-    if (!routeSchema) continue;
+    const routeSchemas = constraintSources
+      .map((source) => source.get(argument))
+      .filter((entry): entry is Row => entry !== undefined);
+    if (routeSchemas.length === 0) continue;
     sharedPairs += 1;
-    const divergence = classify(toolSchema, routeSchema);
+    // Agreeing with ANY route it answers for is agreement. Only a value no
+    // declared route accepts is a divergence.
+    const verdicts = routeSchemas.map((routeSchema) =>
+      classify(toolSchema, routeSchema),
+    );
+    const divergence = verdicts.includes(null)
+      ? null
+      : verdicts.includes("NARROWED")
+        ? "NARROWED"
+        : (verdicts[0] as Divergence);
+    const routeSchema = routeSchemas[0];
     if (divergence === null) {
       identicalPairs += 1;
       continue;

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -16,7 +16,13 @@ import {
   NO_QUERY_PARAMETERS,
   ROUTE_QUERY_SCHEMAS,
 } from "../schemas-src/route-queries.ts";
+import { QUERY_ENUMS } from "../schemas-src/query-enums.ts";
 import { MAX_LIMIT } from "../workers/request-params.ts";
+
+// Re-exported so the 31 modules that read the filter vocabularies from here
+// keep working; the values themselves live in schemas-src so BOTH surfaces
+// can read them (#10131).
+export { QUERY_ENUMS };
 // Surface-agnostic despite the module name: the sentinel bounds Zod stamps on
 // every `z.int()` are not an MCP concern, and both published surfaces drop them.
 import { stripSentinelIntegerBounds } from "./mcp-input-schema.ts";
@@ -126,116 +132,6 @@ export const CACHE_SECONDS = {
   short: 60,
   standard: 300,
   static: 600,
-};
-
-export const QUERY_ENUMS = {
-  candidateState: [
-    "schema-invalid",
-    "schema-valid",
-    "maintainer-review",
-    "verified",
-    "stale",
-    "rejected",
-  ],
-  coverageLevel: ["native-only", "manifested", "probed"],
-  curationLevel: [
-    "native",
-    "candidate-discovered",
-    "community-seeded",
-    "machine-verified",
-    "maintainer-reviewed",
-    "adapter-backed",
-  ],
-  healthClassification: [
-    "auth-required",
-    "content-mismatch",
-    "dead",
-    "live",
-    "rate-limited",
-    "redirected",
-    "timeout",
-    "transient",
-    "unsupported",
-    "unsafe",
-    "wrong-chain",
-  ],
-  healthStatus: ["ok", "degraded", "failed", "unknown"],
-  providerAuthority: [
-    "community",
-    "official",
-    "provider-claimed",
-    "registry-observed",
-  ],
-  providerKind: [
-    "data-provider",
-    "docs-provider",
-    "infrastructure-provider",
-    "registry",
-    "subnet-team",
-  ],
-  profileLevel: [
-    "directory-only",
-    "identity-partial",
-    "identity-complete",
-    "operational",
-    "adapter-backed",
-  ],
-  subnetStatus: ["active", "inactive"],
-  subnetType: ["root", "application"],
-  endpointLayer: [
-    "bittensor-base",
-    "data-provider",
-    "docs-provider",
-    "subnet-app",
-  ],
-  endpointPublicationState: [
-    "candidate",
-    "verified",
-    "monitored",
-    "pool-eligible",
-    "disabled",
-    "rejected",
-  ],
-  coverageDepthTier: [
-    "agent-ready",
-    "machine-usable",
-    "candidate-review",
-    "needs-evidence",
-    "hard-blocked",
-    "missing-interface",
-  ],
-  agentReadinessStatus: [
-    "callable",
-    "base-layer",
-    "candidate",
-    "needs-evidence",
-    "blocked",
-  ],
-  agentBlockerLevel: ["none", "hard-blocked", "needs-review", "missing-data"],
-  endpointIncidentSeverity: ["critical", "warning", "info"],
-  endpointIncidentState: ["active", "resolved"],
-  recommendedAdapterKind: [
-    "custom-adapter",
-    "data-artifact-adapter",
-    "generic-openapi-or-custom",
-    "stream-adapter",
-  ],
-  surfaceKind: [
-    "archive",
-    "dashboard",
-    "data-artifact",
-    "docs",
-    "example",
-    "openapi",
-    "repo-registry",
-    "sdk",
-    "source-repo",
-    "sse",
-    "subnet-api",
-    "subtensor-rpc",
-    "subtensor-wss",
-    "website",
-  ],
 };
 
 // The published query-parameter schemas, derived from the ONE vocabulary in


### PR DESCRIPTION
The last 14 MCP arguments that were looser than their route — **and the reason three of them could not be fixed at all.**

## The structural blocker

`QUERY_ENUMS` lived in `src/contracts.ts`, so an MCP tool could not read it: importing `contracts.ts` from `schemas-src/` is the dependency edge that **failed the `metagraphed-data-api` Workers Build twice** on #10121.

So the tools restated the values. And restating an enum is how `list_subnets.status` came to publish a bare `{"type":"string"}` while its route named `active | inactive` — leaving an agent to guess, with a wrong guess filtering to nothing rather than erroring.

It is now `schemas-src/query-enums.ts`: **pure literals, zero imports, readable by anything.** `contracts.ts` re-exports the symbol, so all **31** existing import sites are unchanged.

## Two more copies went with it

- **`get-domain-summary.ts` kept a local domain-tag list** whose own comment said *"at the time of writing"* — a list that announced it could drift, with no way to be told when it had. Deleted; it reads `src/domain-tags.ts`, a zero-import leaf, the same way this directory has read `src/route-limits.ts` since #9127.
- **The four unbounded runtime-name filters** now share `runtimeNameSchema(max)` — the ceiling differs by route (100 on the chain-analytics feeds, 64 on the event feeds) but the meaning does not.

Plus `reasonCodesSchema()` (3 sites, 3 copies of one sentence), `hashSchema()` (the `0x` + 64-hex pattern), and a bound on `list_validator_economics.offset`, which advertised **1,000,000** against a route that caps at **512**.

## The gate was comparing against the wrong route

Two tools answer for more than one route (#9880's `additionalRoutes`), and `validate:mcp-input-parity` only ever read the primary. `list_review_gaps` was reported `LOOSER` for naming the sort values of *the other gap feed it serves* — the opposite of a defect.

It now compares against the **union** of every route a tool declares. Agreeing with any of them is agreement.

## Two wrong descriptions surfaced

Both were invisible while the parameter was a bare string:

- **`list_chain_events.method`** said *"HTTP method to use for the call"* — beside an example of `set_weights`. It is a runtime call name.
- **`list_subnets.status`** said *"rows with this health status"* and gave `ok`. Its route accepts `active | inactive`.

`tests/mcp-input-schema.test.ts` caught the second one the moment the enum stopped being a bare string — that gate doing exactly its job.

## Result

```
validate:mcp-input-parity LOOSER debt: 14 -> 0

660 shared argument pairs: 540 identical, 89 narrowed for the context window,
0 looser than their route, 31 a declared JSON-shape adaptation.
```

**Every MCP tool argument now accepts exactly what its route accepts**, or is a declared narrowing for the context window, or a declared JSON-shape adaptation. Session total: **80 → 0.**

## Validation

```
npm run typecheck / lint / format:check          clean
npx vitest run                                   760 files, 18,249 passed
npm run build                                    openapi.json byte-identical
validate:mcp  validate:mcp-route-map  validate:mcp-input-parity
validate:schema-vocabularies  validate:contract-drift  validate:openapi
validate:route-query-parity  validate:query-vocabulary
validate:single-schema-source                    all PASS
```

Closes #10131
Refs #10064, #10060