### PR TITLE
fix(neon): lane_health was flipped against a table Neon does not have (#10135)

### DIFF
--- a/migrations/neon/0006_lane_health.sql
+++ b/migrations/neon/0006_lane_health.sql
@@ -1,0 +1,37 @@
+-- lane_health, the durable sink every watchdog writes to (#10135).
+--
+-- HELD BACK FROM 0005 DELIBERATELY, and that is how it got lost. 0005's header
+-- lists this table as one it excludes -- "it moves LAST and on its own, because
+-- until it does it is the only thing that can report a lane that broke while
+-- being moved" -- which was the right call and left no migration behind. When
+-- #10127 flipped lane_health to sole-store, the flag pointed at a table Neon
+-- did not have.
+--
+-- The failure was exactly as quiet as this table's own design makes it:
+-- recordLaneVerdict swallows its errors on purpose, so every verdict was
+-- dropped with nothing to report the dropping. D1's copy went on filling from
+-- Workers that had not redeployed yet, which made the two stores look merely
+-- out of step rather than one of them missing.
+--
+-- TYPES. INTEGER -> BIGINT for both epoch-ms columns: checked_at is a
+-- millisecond timestamp (1.79e12 today) and age_ms is a duration that can
+-- exceed a 32-bit int on a lane that has been silent for a month. Postgres
+-- INTEGER tops out at 2.1e9 and would have failed on the first write.
+CREATE TABLE IF NOT EXISTS lane_health (
+  lane       TEXT   NOT NULL,
+  -- 'ok' | 'stale' | 'unknown'. `unknown` is deliberately distinct from `ok`: a
+  -- watchdog that could not evaluate has not observed health, and collapsing
+  -- the two would report an unmeasured lane as a healthy one.
+  verdict    TEXT   NOT NULL,
+  age_ms     BIGINT,
+  detail     TEXT,
+  checked_at BIGINT NOT NULL
+);
+
+-- The two reads this table exists for: the newest verdict per lane
+-- (self-health), and "was anything stale in a window" (triage).
+CREATE INDEX IF NOT EXISTS idx_lane_health_lane_checked
+  ON lane_health (lane, checked_at DESC);
+CREATE INDEX IF NOT EXISTS idx_lane_health_stale
+  ON lane_health (checked_at DESC)
+  WHERE verdict = 'stale';

--- a/migrations/neon/0007_hand_created_tables.sql
+++ b/migrations/neon/0007_hand_created_tables.sql
@@ -1,0 +1,134 @@
+-- The six tables Neon has but no migration created (#10135).
+--
+-- WHY THEY WERE MISSING. These were stood up in Neon by hand during the early phase
+-- of the migration, before migrations/neon/ existed as the record. They have
+-- been serving correctly ever since -- which is exactly why nobody noticed that
+-- nothing in the repo could recreate them.
+--
+-- It surfaced from the other direction: a guard added after lane_health was
+-- flipped to sole-store against a table Neon did not have. Asking "does every
+-- sole-store table have a migration" found lane_health AND these six.
+--
+-- WHY IT MATTERS NOW, and not before. While D1 held a copy, the D1 migrations
+-- were a usable record of the schema. Sole-store means D1 is no longer written;
+-- DELETING D1 removes that record too, and these six would exist only as live
+-- objects in one database -- unreproducible on a new Neon branch, a restore, or
+-- a fresh environment.
+--
+-- TRANSCRIBED FROM THE LIVE SCHEMA, not translated from D1's. information_schema
+-- and pg_indexes are the source, so the types are what production actually has
+-- rather than what a mapping table says they should be. The differences are
+-- real and load-bearing:
+--
+--   INTEGER CHECK (x IN (0,1))  ->  BOOLEAN   active, validator_permit,
+--                                             is_immunity_period
+--   INTEGER (epoch ms)          ->  BIGINT    captured_at, updated_at,
+--                                             block_number, registered_at_block
+--   REAL                        ->  DOUBLE PRECISION
+--   TEXT (YYYY-MM-DD)           ->  TEXT      snapshot_date stays TEXT so the
+--                                             value round-trips identically
+--
+-- IF NOT EXISTS throughout: this is a description of what is already there, and
+-- running it against production must be a no-op.
+
+CREATE TABLE IF NOT EXISTS neurons (
+  netuid              INTEGER NOT NULL,
+  uid                 INTEGER NOT NULL,
+  hotkey              TEXT,
+  coldkey             TEXT,
+  active              BOOLEAN,
+  validator_permit    BOOLEAN,
+  rank                DOUBLE PRECISION,
+  trust               DOUBLE PRECISION,
+  validator_trust     DOUBLE PRECISION,
+  consensus           DOUBLE PRECISION,
+  incentive           DOUBLE PRECISION,
+  dividends           DOUBLE PRECISION,
+  emission_tao        DOUBLE PRECISION,
+  stake_tao           DOUBLE PRECISION,
+  registered_at_block BIGINT,
+  is_immunity_period  BOOLEAN,
+  axon                TEXT,
+  block_number        BIGINT,
+  captured_at         BIGINT NOT NULL,
+  take                DOUBLE PRECISION,
+  PRIMARY KEY (netuid, uid)
+);
+CREATE INDEX IF NOT EXISTS idx_neurons_hotkey ON neurons (hotkey);
+CREATE INDEX IF NOT EXISTS idx_neurons_netuid_permit
+  ON neurons (netuid, validator_permit);
+
+CREATE TABLE IF NOT EXISTS neuron_daily (
+  netuid              INTEGER NOT NULL,
+  uid                 INTEGER NOT NULL,
+  hotkey              TEXT,
+  coldkey             TEXT,
+  active              BOOLEAN,
+  validator_permit    BOOLEAN,
+  rank                DOUBLE PRECISION,
+  trust               DOUBLE PRECISION,
+  validator_trust     DOUBLE PRECISION,
+  consensus           DOUBLE PRECISION,
+  incentive           DOUBLE PRECISION,
+  dividends           DOUBLE PRECISION,
+  emission_tao        DOUBLE PRECISION,
+  stake_tao           DOUBLE PRECISION,
+  registered_at_block BIGINT,
+  is_immunity_period  BOOLEAN,
+  axon                TEXT,
+  block_number        BIGINT,
+  captured_at         BIGINT NOT NULL,
+  take                DOUBLE PRECISION,
+  snapshot_date       TEXT   NOT NULL,
+  updated_at          BIGINT NOT NULL,
+  PRIMARY KEY (netuid, uid, snapshot_date)
+);
+CREATE INDEX IF NOT EXISTS idx_neuron_daily_hotkey_date
+  ON neuron_daily (hotkey, snapshot_date);
+
+CREATE TABLE IF NOT EXISTS account_position_daily (
+  account          TEXT    NOT NULL,
+  netuid           INTEGER NOT NULL,
+  snapshot_date    TEXT    NOT NULL,
+  uid              INTEGER,
+  coldkey          TEXT,
+  active           BOOLEAN,
+  validator_permit BOOLEAN,
+  rank             DOUBLE PRECISION,
+  trust            DOUBLE PRECISION,
+  incentive        DOUBLE PRECISION,
+  dividends        DOUBLE PRECISION,
+  stake_tao        DOUBLE PRECISION,
+  emission_tao     DOUBLE PRECISION,
+  captured_at      BIGINT NOT NULL,
+  updated_at       BIGINT NOT NULL,
+  PRIMARY KEY (account, netuid, snapshot_date)
+);
+CREATE INDEX IF NOT EXISTS idx_account_position_daily_account_date
+  ON account_position_daily (account, snapshot_date);
+
+CREATE TABLE IF NOT EXISTS nominator_positions (
+  coldkey        TEXT    NOT NULL,
+  hotkey         TEXT    NOT NULL,
+  netuid         INTEGER NOT NULL,
+  share_fraction DOUBLE PRECISION,
+  captured_at    BIGINT  NOT NULL,
+  PRIMARY KEY (coldkey, hotkey, netuid)
+);
+CREATE INDEX IF NOT EXISTS idx_nominator_positions_hotkey
+  ON nominator_positions (hotkey, netuid);
+
+CREATE TABLE IF NOT EXISTS validator_nominator_counts (
+  hotkey          TEXT    NOT NULL PRIMARY KEY,
+  nominator_count INTEGER NOT NULL,
+  captured_at     BIGINT  NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS account_balances (
+  ss58         TEXT   NOT NULL PRIMARY KEY,
+  free_tao     DOUBLE PRECISION NOT NULL,
+  reserved_tao DOUBLE PRECISION NOT NULL,
+  captured_at  BIGINT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_account_balances_free
+  ON account_balances (free_tao DESC);

--- a/tests/neon-sole-store-tables-exist.test.ts
+++ b/tests/neon-sole-store-tables-exist.test.ts
@@ -1,0 +1,95 @@
+// Every table Neon SOLELY owns must be created by a Neon migration (#10135).
+//
+// ## The failure this exists to stop
+//
+// #10127 added `lane_health` to NEON_SOLE_STORE_TABLES. Neon had no such table:
+// 0005's header lists it as one that migration deliberately excludes, so no
+// migration was ever written for it. The flag pointed at nothing.
+//
+// Nothing reported it, and could not have. lane_health is the sink every
+// watchdog writes to, and recordLaneVerdict swallows its own errors BY DESIGN --
+// a watchdog whose alarm-recording broke its alarm would be worse than the bug
+// it watches for. So every verdict was dropped with the one mechanism that
+// could have complained being the mechanism that was broken. D1's copy went on
+// filling from Workers that had not redeployed, which made the two stores look
+// merely out of step rather than one of them empty.
+//
+// ## Why this is the guard that matters before D1 is deleted
+//
+// Sole-store means "D1 is no longer written for this table". If the table does
+// not exist in Neon either, the rows are going nowhere, and DELETING D1 turns a
+// recoverable gap into permanent loss. This check is cheap and static; the
+// alternative is finding out by querying production, which is how the last one
+// was found.
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { describe, test } from "vitest";
+
+/** Tables created by every migration under migrations/neon/. */
+function tablesInNeonMigrations(): Set<string> {
+  const created = new Set<string>();
+  for (const file of readdirSync("migrations/neon").filter((f) =>
+    f.endsWith(".sql"),
+  )) {
+    const sql = readFileSync(`migrations/neon/${file}`, "utf8");
+    // Comments are stripped first: 0005 NAMES lane_health in its header while
+    // deliberately not creating it, and a scan that read prose would have
+    // called this migration sufficient -- which is precisely the mistake.
+    const code = sql.replace(/--[^\n]*/g, "");
+    for (const m of code.matchAll(
+      /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"?(\w+)"?/gi,
+    )) {
+      created.add(m[1]);
+    }
+  }
+  return created;
+}
+
+function soleStoreTables(config: string): string[] {
+  const source = readFileSync(config, "utf8");
+  return (/"NEON_SOLE_STORE_TABLES":\s*"([^"]*)"/.exec(source)?.[1] ?? "")
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+describe("every sole-store table exists in Neon", () => {
+  const created = tablesInNeonMigrations();
+
+  for (const config of ["wrangler.data.jsonc", "wrangler.jsonc"]) {
+    test(`${config} names no table Neon migrations do not create`, () => {
+      const missing = soleStoreTables(config).filter((t) => !created.has(t));
+      assert.deepEqual(
+        missing,
+        [],
+        `${config}: NEON_SOLE_STORE_TABLES names ${missing.join(", ")}, which no ` +
+          `migration under migrations/neon/ creates. Sole-store means D1 is not ` +
+          `written -- if Neon has no table either, those rows go nowhere, and ` +
+          `deleting D1 makes it permanent.`,
+      );
+    });
+  }
+
+  test("the scan actually finds tables, and ignores prose", () => {
+    // A scanner that matched nothing would make the checks above pass on an
+    // empty set forever -- the exact shape of the bug they exist to catch.
+    assert.ok(created.size > 20, `only found ${created.size} tables`);
+    assert.ok(created.has("lane_health"), "0006 must create lane_health");
+    // 0005 MENTIONS lane_health in its header without creating it. If comments
+    // were not stripped, that prose alone would satisfy the check.
+    const raw = readFileSync(
+      "migrations/neon/0005_remaining_d1_tables.sql",
+      "utf8",
+    );
+    assert.ok(
+      raw.includes("lane_health"),
+      "0005 should still mention it in prose -- that is the trap being handled",
+    );
+    assert.ok(
+      !/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"?lane_health/i.test(
+        raw.replace(/--[^\n]*/g, ""),
+      ),
+      "0005 must not create it; 0006 does",
+    );
+  });
+});


### PR DESCRIPTION
## What happened

#10127 added `lane_health` to `NEON_SOLE_STORE_TABLES`. **Neon had no such table.** 0005's header
lists it among the tables that migration deliberately excludes — *"it moves LAST and on its own"* —
which was the right call and left no migration behind. The flag pointed at nothing.

Confirmed live: `relation "lane_health" does not exist`, while D1's copy kept filling from Workers
that had not redeployed — so the two stores looked merely out of step rather than one of them empty.

**Nothing reported it, and nothing could have.** `lane_health` is the sink every watchdog writes to,
and `recordLaneVerdict` swallows its own errors *by design* — a watchdog whose alarm-recording broke
its alarm would be worse than the bug it watches for. Every verdict was dropped, and the one
mechanism that could have complained was the mechanism that was broken.

The table has been created and is taking writes again.

## The guard found six more

| table | in Neon? | migration? |
|---|---|---|
| `neurons`, `neuron_daily`, `account_position_daily` | yes | **none** |
| `validator_nominator_counts`, `nominator_positions`, `account_balances` | yes | **none** |

They were stood up by hand early in the migration, before `migrations/neon/` was the record, and have
served correctly ever since — which is exactly why nobody noticed nothing in the repo could recreate
them.

**Harmless until now.** While D1 held a copy, the D1 migrations were a usable record of the schema.
Sole-store means D1 is no longer written, and *deleting* D1 removes that record too: those six would
exist only as live objects in one database — unreproducible on a new Neon branch, a restore, or a
fresh environment. That is a loss you only discover when you need them.

## The fix

**`0006_lane_health.sql`** — with `INTEGER` → `BIGINT` for both epoch-ms columns. Postgres `INTEGER`
tops out at 2.1e9 and `checked_at` is 1.79e12 today, so D1's spelling would have failed on the first
write.

**`0007_hand_created_tables.sql`** — the six, transcribed from `information_schema` and `pg_indexes`
rather than translated from D1's DDL, so the types are what production actually has. Verified
column-for-column against the live schema (20/22/15/5/3/4). Every statement is `IF NOT EXISTS`: this
describes what is already there and must be a no-op.

**The test** strips comments before scanning. 0005 *names* `lane_health` in its header without
creating it, and a scan that read prose would have called that migration sufficient — precisely the
mistake being guarded. A separate assertion pins that the scanner finds >20 tables, so it cannot pass
by matching nothing.

## Why this is the guard that matters before D1 dies

Sole-store means D1 is not written. If the table does not exist in Neon either, the rows go nowhere —
and deleting D1 turns a recoverable gap into permanent loss. This check is static and cheap; the
alternative is finding out by querying production, which is how this one was found.

## Validation

```
npx tsc --noEmit                                  clean
eslint / prettier --check                         clean
vitest run neon-sole-store-tables-exist neon-flag-config-parity
           lane-health-store neon-backfill              117 passed
```

Closes #10135