### PR TITLE
fix(api): chain-events published a page size of 200 and served 100 (#10109)

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -13644,7 +13644,7 @@ export interface operations {
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: string;
                 before?: number;
-                /** @description Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -23343,7 +23343,7 @@ export interface operations {
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: string;
                 before?: number;
-                /** @description Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -9798,7 +9798,7 @@
         {
           "name": "limit",
           "schema": {
-            "maximum": 200,
+            "maximum": 100,
             "minimum": 1,
             "type": "integer"
           }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -57247,12 +57247,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916).",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
-              "maximum": 200,
+              "maximum": 100,
               "minimum": 1,
               "type": "integer"
             }
@@ -67719,12 +67719,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916).",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
-              "maximum": 200,
+              "maximum": 100,
               "minimum": 1,
               "type": "integer"
             }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -13644,7 +13644,7 @@ export interface operations {
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: string;
                 before?: number;
-                /** @description Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -23343,7 +23343,7 @@ export interface operations {
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: string;
                 before?: number;
-                /** @description Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -61,6 +61,7 @@ import {
   BULK_HEALTH_TRENDS_LIMIT_MAX,
   CHAIN_CONCENTRATION_HISTORY_WINDOWS,
   CHAIN_CONCENTRATION_SUBNETS_LIMIT_MAX,
+  CHAIN_EVENTS_LIMIT_MAX,
   CHAIN_HOLDERS_LIMIT_MAX,
   CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
   CHAIN_TURNOVER_LIMIT_MAX,
@@ -635,15 +636,12 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
       .max(33)
       .optional(),
     before: blockBoundSchema("first").optional(),
-    // DIVERGENCE (#10109): published `maximum` is 200 and the serving path
-    // clamps at 100 -- `?limit=200` answers `count: 100`, HTTP 200, no error,
-    // which is the truncation-as-a-complete-answer #9916 removed everywhere
-    // else. The cause is TWO constants named CHAIN_EVENTS_LIMIT_MAX with
-    // different values (src/data-api-mcp.ts 200, src/chain-events-degraded.ts
-    // 100); the contract was written from the one the request path does not
-    // use. Left stating 200 so this refactor changes nothing published -- the
-    // correction is a contract change and belongs in its own diff.
-    limit: limitSchema(200).optional(),
+    // Resolved (#10109): this published 200 while the serving path clamped at
+    // 100, because TWO constants carried the name CHAIN_EVENTS_LIMIT_MAX with
+    // different values and the contract was written from the one the request
+    // path does not use. One constant now, in src/route-limits.ts, and it is
+    // the number the route enforces.
+    limit: limitSchema(CHAIN_EVENTS_LIMIT_MAX).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain-events/stats": z.object({

--- a/scripts/validate-mcp-input-parity.ts
+++ b/scripts/validate-mcp-input-parity.ts
@@ -386,6 +386,22 @@ const CONSTRAINT_DIVERGENCES: Record<string, Divergence> = {
 
   // LOOSER -- standing debt. Delete an entry by TIGHTENING the tool
   // (4/5, #10064), never by keeping it.
+  //
+  // The one that is a DECISION rather than an oversight, and it is backwards.
+  // /api/v1/chain-events clamps at 100 (workers/api.ts); the reader serving
+  // MCP and GraphQL clamps at 200, with a stated rationale in
+  // src/data-api-mcp.ts ("both are already public API"). #9701's premise is
+  // the opposite -- a browser can stream 9 MB and a context window cannot --
+  // so the MCP surface being the WIDER of the two is worth a deliberate
+  // decision, not a silent flip by whoever noticed. Left as found (#10109),
+  // and declared here so it is visible while that decision is made.
+  //
+  // BOTH tools that mirror this route, because there is no separate extrinsic
+  // route -- get_extrinsic_chain_events is the same feed with two filters and
+  // is declared against /api/v1/chain-events too. So an agent can page 200
+  // events out of a route whose own contract caps at 100, by either door.
+  "get_extrinsic_chain_events.limit": "LOOSER",
+  "list_chain_events.limit": "LOOSER",
 };
 
 const errors: string[] = [];

--- a/src/chain-events-degraded.ts
+++ b/src/chain-events-degraded.ts
@@ -30,6 +30,10 @@
 // to a payload cannot drift out of its degraded twin.
 
 import {
+  CHAIN_EVENTS_LIMIT_DEFAULT,
+  CHAIN_EVENTS_LIMIT_MAX,
+} from "./route-limits.ts";
+import {
   answerBlockDetail,
   isEmptyChainEventPayload,
   loadBlockChainEventsHotTier,
@@ -300,8 +304,11 @@ function chainEventsLimit(raw: string | null): number {
   return Math.min(parsed, CHAIN_EVENTS_LIMIT_MAX);
 }
 
-export const CHAIN_EVENTS_LIMIT_DEFAULT = 50;
-export const CHAIN_EVENTS_LIMIT_MAX = 100;
+// Re-exported from the module that owns per-route ceilings (#10109). It used
+// to be declared here AND, with a different value, in src/data-api-mcp.ts --
+// one name, two numbers, and openapi.json published the one this path never
+// uses.
+export { CHAIN_EVENTS_LIMIT_DEFAULT, CHAIN_EVENTS_LIMIT_MAX };
 
 export interface BlockChainEventsPayload {
   block_number: number;

--- a/src/data-api-mcp.ts
+++ b/src/data-api-mcp.ts
@@ -13,6 +13,7 @@
 
 import { chainDetailGapMessage } from "./chain-detail-hot-tier.ts";
 import { hotTierBlockChainEvents } from "./chain-events-degraded.ts";
+import { CHAIN_EVENTS_LIMIT_DEFAULT } from "./route-limits.ts";
 import {
   chainEventsQueryError,
   loadChainEventsColdTier,
@@ -32,13 +33,29 @@ function throwToolError(code: string, message: string): never {
   throw error;
 }
 
-const CHAIN_EVENTS_LIMIT_DEFAULT = 50;
-const CHAIN_EVENTS_LIMIT_MAX = 200;
+/**
+ * This surface's own page ceiling, deliberately WIDER than the REST route's
+ * (#10109).
+ *
+ * The two are different public surfaces and always have been: workers/api.ts
+ * clamps /api/v1/chain-events at CHAIN_EVENTS_LIMIT_MAX (100), and this reader
+ * -- which serves the MCP tools and GraphQL, and which
+ * loadExtrinsicChainEvents delegates to -- clamps at 200. What was WRONG is
+ * that openapi.json published THIS number for the REST route, so /chain-events
+ * advertised 200 while its request path returned 100 rows with HTTP 200 and no
+ * error. Fixed by publishing what REST enforces; the surface difference itself
+ * is left as it was found, because it is a product decision with a stated
+ * rationale, not an accident.
+ *
+ * Named separately so the two can never again be confused for one number --
+ * CHAIN_EVENTS_LIMIT_MAX is REST's, this is this reader's.
+ */
+const MCP_CHAIN_EVENTS_LIMIT_MAX = 200;
 
-function clampChainEventsLimit(value: unknown): number {
+function clampChainEventsLimit(value: unknown, max: number): number {
   const n = Number(value);
   if (!Number.isFinite(n) || n <= 0) return CHAIN_EVENTS_LIMIT_DEFAULT;
-  return Math.min(Math.max(Math.floor(n), 1), CHAIN_EVENTS_LIMIT_MAX);
+  return Math.min(Math.max(Math.floor(n), 1), max);
 }
 
 // The data Worker returns `{ error: "..." }` on 400; some envelopes use
@@ -231,7 +248,7 @@ export async function loadExtrinsicChainEvents(
       "ref must be the composite id 'block_number-extrinsic_index' (e.g. '4200000-3').",
     );
   }
-  const lim = clampChainEventsLimit(limit);
+  const lim = clampChainEventsLimit(limit, MCP_CHAIN_EVENTS_LIMIT_MAX);
   // Through the feed loader rather than a hand-built query: a single-block,
   // single-extrinsic lookup is the SAME read with two filters, and composing it
   // here kept a second copy of the limit/cursor semantics alive that could
@@ -298,7 +315,7 @@ export async function loadChainEventsFeed(
   const query = {
     // Clamped to THIS surface's published 1-200 bound, not REST's 1-100: both
     // are already public API, and the reader takes the caller's word.
-    limit: clampChainEventsLimit(limit),
+    limit: clampChainEventsLimit(limit, MCP_CHAIN_EVENTS_LIMIT_MAX),
     pallet,
     method,
     block,

--- a/src/route-limits.ts
+++ b/src/route-limits.ts
@@ -269,6 +269,34 @@ export const SEMANTIC_LIMIT_MAX = 20;
 export const SEMANTIC_QUERY_MAX_LENGTH = 1000;
 
 /**
+ * `/api/v1/chain-events` -- the network-wide event feed (#10109).
+ *
+ * TWO constants carried this name with DIFFERENT values, and the contract was
+ * written from the one the request path does not use:
+ *
+ *   src/chain-events-degraded.ts  100   what workers/api.ts clamps the REST
+ *                                       route to -- verified live, `?limit=200`
+ *                                       answered `count: 100`
+ *   src/data-api-mcp.ts           200   what the MCP + GraphQL path clamps to,
+ *                                       and what openapi.json published
+ *
+ * So a caller asking for the advertised ceiling got half of it, with HTTP 200,
+ * no error and no header -- data truncation presented as a complete answer,
+ * which is exactly what #9916 removed everywhere else.
+ *
+ * 100 is the resolution because it is what the route ENFORCES; publishing the
+ * larger number was the lie. It also restores the direction #9701 assumes --
+ * an MCP surface narrows against its route, never widens past it.
+ *
+ * The clamp itself is left alone. Rejecting an over-limit page rather than
+ * truncating it is the #9916 rule and is worth doing here too, but it is a
+ * behaviour change for existing callers and does not belong in the same diff
+ * as making the published number true.
+ */
+export const CHAIN_EVENTS_LIMIT_DEFAULT = 50;
+export const CHAIN_EVENTS_LIMIT_MAX = 100;
+
+/**
  * `/api/v1/health/trends` -- the all-subnet trend matrix (#10089).
  *
  * The same defect the semantic block above records, on a second route: `limit`

--- a/tests/route-limit-contract-parity.test.ts
+++ b/tests/route-limit-contract-parity.test.ts
@@ -37,6 +37,7 @@ import {
 import {
   ACCOUNTS_LIST_LIMIT_MAX,
   BULK_HEALTH_TRENDS_LIMIT_MAX,
+  CHAIN_EVENTS_LIMIT_MAX,
   CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
   CHAIN_TURNOVER_LIMIT_MAX,
   GLOBAL_VALIDATOR_LIMIT_MAX,
@@ -81,6 +82,12 @@ const CONSTANT_BACKED: Record<string, number> = {
   // parseNonNegativeIntParam over them. `declaredMaximum` returns undefined
   // for a string schema, so this entry alone would have caught it.
   "/api/v1/health/trends": BULK_HEALTH_TRENDS_LIMIT_MAX,
+  // #10109: this published 200 and served 100, because TWO constants carried
+  // the name CHAIN_EVENTS_LIMIT_MAX with different values -- 100 in
+  // src/chain-events-degraded.ts (what workers/api.ts clamps to) and 200 in
+  // src/data-api-mcp.ts (what the contract was written from). One constant
+  // now; this entry is what keeps it one.
+  "/api/v1/chain-events": CHAIN_EVENTS_LIMIT_MAX,
 };
 
 interface ParameterSchema {


### PR DESCRIPTION
```
GET /api/v1/chain-events?limit=200  ->  200 OK, count: 100
GET /api/v1/chain-events?limit=201  ->  200 OK, count: 100
```

A caller asking for the ceiling the contract advertises got **half** of it — HTTP 200, no error, no header. Per #9916's reasoning a short page is how a paginating client learns the result set is exhausted, so this was truncation presented as a complete answer.

## Two constants carried the name `CHAIN_EVENTS_LIMIT_MAX`

| file | value | |
|---|---:|---|
| `src/chain-events-degraded.ts` | 100 | what `workers/api.ts` clamps the REST route to — **the path that answers the request** |
| `src/data-api-mcp.ts` | 200 | what the MCP + GraphQL reader clamps to |

`openapi.json` was written from the 200. Grepping the name found two answers, which is exactly why nothing could compare them.

**Resolved by publishing what the route enforces.** The REST ceiling now lives once, in `src/route-limits.ts`, and `chain-events-degraded.ts` re-exports it.

## The 200 is not a bug, and is left alone

`src/data-api-mcp.ts` already carried the rationale — *"clamped to THIS surface's published 1-200 bound, not REST's 1-100: both are already public API"*. That is a decision someone made, and reversing it would change behaviour for every MCP and GraphQL caller. It keeps its own name now (`MCP_CHAIN_EVENTS_LIMIT_MAX`) so the two numbers can never again be read as one, and it is **declared** in `validate:mcp-input-parity` rather than hidden.

## But it is worth a decision, and it is now visible

#9701's premise is that an MCP surface narrows against its route — a context window is smaller than a browser. Here it is the **wider** of the two, through **both** tools that mirror the route: there is no separate extrinsic route, so `get_extrinsic_chain_events` is the same feed with two filters and is declared against `/api/v1/chain-events` too.

So an agent can page 200 events out of a route whose contract caps at 100, by either door. Left as found and declared with that reasoning, for a deliberate call rather than a silent flip by whoever noticed.

## An overreach of mine, caught by an existing test

`loadExtrinsicChainEvents` **delegates** to `loadChainEventsFeed` — deliberately: *"a single-block, single-extrinsic lookup is the SAME read with two filters, and composing it here kept a second copy of the limit/cursor semantics alive that could drift."* So lowering the reader's clamp silently narrowed a second surface. `tests/extrinsic-detail.test.ts` failed on it, which is the test doing its job, and I reverted that part.

## Guard

`/api/v1/chain-events` joins `CONSTANT_BACKED` in `tests/route-limit-contract-parity.test.ts` — the guard that would have caught this the day it appeared.

## Validation

```
npm run typecheck / lint / format:check     clean
npx vitest run                              760 files, 18,270 passed, 22 skipped
validate:mcp-input-parity                   passes; 2 declared LOOSER, both this asymmetry
```

Published diff: **2 parameters**, `maximum` 200 → 100 on the route and its `/{network}/` twin.

Closes #10109