### PR TITLE
fix(api): three filters the routes enforce but never published (#10096)

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -46905,7 +46905,7 @@ export interface operations {
     validatorEconomicsRanking: {
         parameters: {
             query?: {
-                sort?: string;
+                sort?: "earning_floor_cost_tao" | "permit_floor_cost_tao" | "permit_to_earning_multiple" | "tao_inflow_per_day" | "validator_headroom";
                 /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -7304,6 +7304,13 @@
         {
           "name": "sort",
           "schema": {
+            "enum": [
+              "earning_floor_cost_tao",
+              "permit_floor_cost_tao",
+              "permit_to_earning_multiple",
+              "tao_inflow_per_day",
+              "validator_headroom"
+            ],
             "type": "string"
           }
         },

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -7636,6 +7636,7 @@
         {
           "name": "coldkey",
           "schema": {
+            "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
             "type": "string"
           }
         },
@@ -9925,6 +9926,7 @@
         {
           "name": "call_module",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -94152,6 +94152,13 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "enum": [
+                "earning_floor_cost_tao",
+                "permit_floor_cost_tao",
+                "permit_to_earning_multiple",
+                "tao_inflow_per_day",
+                "validator_headroom"
+              ],
               "type": "string"
             }
           },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -60429,6 +60429,7 @@
             "name": "call_module",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -74913,6 +74914,7 @@
             "name": "call_module",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -94022,6 +94024,7 @@
             "name": "coldkey",
             "required": false,
             "schema": {
+              "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
               "type": "string"
             }
           },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -46905,7 +46905,7 @@ export interface operations {
     validatorEconomicsRanking: {
         parameters: {
             query?: {
-                sort?: string;
+                sort?: "earning_floor_cost_tao" | "permit_floor_cost_tao" | "permit_to_earning_multiple" | "tao_inflow_per_day" | "validator_headroom";
                 /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */

--- a/schemas-src/mcp-tools/chain-calls-fees.ts
+++ b/schemas-src/mcp-tools/chain-calls-fees.ts
@@ -12,6 +12,7 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { CHAIN_CALL_MODULE_MAX_LENGTH } from "../../src/route-limits.ts";
 
 import {
   limitSchema,
@@ -27,12 +28,6 @@ import {
 
 const WINDOWS_2 = ["7d", "30d"] as const;
 
-/** The ceiling /chain/calls, /chain/fees and /chain/signers enforce on
- * `call_module`. validateListQuery reads it off the PUBLISHED schema to
- * decide a 400, so a tool that omits it advertises a value the route
- * rejects (#10131). */
-const CHAIN_ANALYTICS_NAME_MAX = 100;
-
 export const GetChainCallsInputSchema = z
   .object({
     window: windowSchema(WINDOWS_2).optional(),
@@ -44,7 +39,7 @@ export const GetChainCallsInputSchema = z
       )
       .meta({ examples: ["module"] }),
     limit: limitSchema(100).optional(),
-    call_module: runtimeNameSchema(CHAIN_ANALYTICS_NAME_MAX)
+    call_module: runtimeNameSchema(CHAIN_CALL_MODULE_MAX_LENGTH)
       .optional()
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
@@ -64,7 +59,7 @@ export const GetChainSignersInputSchema = z
     window: windowSchema(WINDOWS_2).optional(),
     sort: sortSchema(["tx_count", "total_fee_tao"]).optional(),
     limit: limitSchema(100).optional(),
-    call_module: runtimeNameSchema(CHAIN_ANALYTICS_NAME_MAX)
+    call_module: runtimeNameSchema(CHAIN_CALL_MODULE_MAX_LENGTH)
       .optional()
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
@@ -82,7 +77,7 @@ export const GetChainFeesInputSchema = z
   .object({
     window: windowSchema(WINDOWS_2).optional(),
     limit: limitSchema(100).optional(),
-    call_module: runtimeNameSchema(CHAIN_ANALYTICS_NAME_MAX)
+    call_module: runtimeNameSchema(CHAIN_CALL_MODULE_MAX_LENGTH)
       .optional()
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",

--- a/schemas-src/mcp-tools/extrinsics.ts
+++ b/schemas-src/mcp-tools/extrinsics.ts
@@ -11,6 +11,7 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { CHAIN_CALL_MODULE_MAX_LENGTH } from "../../src/route-limits.ts";
 
 import {
   blockBoundSchema,
@@ -28,11 +29,6 @@ import {
  */
 export const EXTRINSICS_LIMIT_MAX = 100;
 
-/** The ceiling /chain/calls, /chain/fees and /chain/signers enforce on
- * `call_module`. validateListQuery reads it off the PUBLISHED schema to
- * decide a 400, so a tool that omits it advertises a value the route
- * rejects (#10131). */
-const CHAIN_ANALYTICS_NAME_MAX = 100;
 import { AccountEventItemSchema } from "./shared.ts";
 import {
   ExtrinsicSchema,
@@ -54,7 +50,7 @@ export const ListExtrinsicsInputSchema = z
         "Restrict to extrinsics signed by this SS58 account. Unsigned (inherent) extrinsics never match.",
       )
       .meta({ examples: ["5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F"] }),
-    call_module: runtimeNameSchema(CHAIN_ANALYTICS_NAME_MAX)
+    call_module: runtimeNameSchema(CHAIN_CALL_MODULE_MAX_LENGTH)
       .optional()
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -99,6 +99,7 @@ import { CHAIN_TRANSFER_LIMIT_MAX } from "../src/chain-transfers.ts";
 import { CHAIN_WEIGHT_SETTERS_LIMIT_MAX } from "../src/chain-weight-setters.ts";
 import { CHAIN_WEIGHTS_LIMIT_MAX } from "../src/chain-weights.ts";
 import { TOP_HOLDERS_SORTS } from "../src/top-holders.ts";
+import { VALIDATOR_ECONOMICS_SORTS } from "../src/validator-economics.ts";
 import { NOMINATOR_LIMIT_MAX } from "../src/validator-nominators.ts";
 import {
   blockBoundSchema,
@@ -337,13 +338,19 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
     window: windowSchema(["7d", "30d", "90d"] as const).optional(),
   }),
   "/api/v1/validators/economics": z.object({
-    // DIVERGENCE: the only `sort` on the surface published without an enum.
-    // Every other one names its columns, and the handler here does have a
-    // closed set -- so a caller has to guess, and a wrong guess is a silent
-    // no-op rather than a 400.
-    sort: z.string().optional(),
+    // Was the only `sort` on the surface published without an enum, while the
+    // handler has a closed set and says so in its own 400 ("Supported:
+    // earning_floor_cost_tao, ..."). A caller had to guess a column name, and
+    // every wrong guess was a rejected request the contract gave no way to
+    // avoid (#10096). Read from VALIDATOR_ECONOMICS_SORTS, the module that
+    // owns it, not a fourth copy.
+    sort: sortSchema(
+      VALIDATOR_ECONOMICS_SORTS as unknown as [string, ...string[]],
+    ).optional(),
     limit: limitSchema(VALIDATOR_ECONOMICS_LIMIT_MAX).optional(),
-    offset: z.int().min(0).max(512).optional(),
+    // Bounded by the ranking's own ceiling, not the generic deep-paging one:
+    // one row per subnet, so seeking past the limit seeks nothing.
+    offset: z.int().min(0).max(VALIDATOR_ECONOMICS_LIMIT_MAX).optional(),
     emission_gate_open: z.boolean().optional(),
     cap_binding: z.boolean().optional(),
   }),

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -60,8 +60,10 @@ import {
   ACCOUNTS_LIST_LIMIT_MAX,
   BULK_HEALTH_TRENDS_LIMIT_MAX,
   CHAIN_CONCENTRATION_HISTORY_WINDOWS,
+  CHAIN_CALL_MODULE_MAX_LENGTH,
   CHAIN_CONCENTRATION_SUBNETS_LIMIT_MAX,
   CHAIN_EVENTS_LIMIT_MAX,
+  CHAIN_EVENT_NAME_MAX_LENGTH,
   CHAIN_HOLDERS_LIMIT_MAX,
   CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
   CHAIN_TURNOVER_LIMIT_MAX,
@@ -116,6 +118,7 @@ import {
   orderSchema,
   querySchema,
   sortSchema,
+  ss58Schema,
   windowSchema,
 } from "./query-params.ts";
 
@@ -413,11 +416,18 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
     ] as const).optional(),
     limit: limitSchema(NOMINATOR_LIMIT_MAX).optional(),
     offset: uncappedOffsetSchema().optional(),
-    // DIVERGENCE: an SS58 address published as a bare string, while
-    // `ss58Schema()` carries the 47-48 base58 pattern the same value gets on
-    // 26 other parameters. A typo'd address reads as "this nominator has no
-    // stake" instead of as a malformed key.
-    coldkey: z.string().optional(),
+    // The handler DOES validate this -- `?coldkey=notanaddress` is a 400,
+    // verified live -- and the contract simply did not say so, while
+    // ss58Schema() carries the same 47-48 base58 pattern on 26 other
+    // parameters (#10096). Publishing it costs no behaviour change and lets a
+    // generated client catch a typo before the request.
+    //
+    // NOT done for `author` on /blocks or `signer` on /extrinsics: both answer
+    // 200 to a malformed address and filter to nothing, so publishing the
+    // pattern there would claim validation the server does not perform --
+    // the #10073 mistake inverted. Making THEM reject is a behaviour change
+    // and needs its own decision.
+    coldkey: ss58Schema().optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/validators/{hotkey}/history": z.object({
@@ -633,8 +643,8 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
     format: formatSchema().optional(),
   }),
   "/api/v1/chain-events": z.object({
-    pallet: z.string().max(64).optional(),
-    method: z.string().max(64).optional(),
+    pallet: z.string().max(CHAIN_EVENT_NAME_MAX_LENGTH).optional(),
+    method: z.string().max(CHAIN_EVENT_NAME_MAX_LENGTH).optional(),
     block: blockBoundSchema("first").optional(),
     extrinsic: z.int().min(0).optional(),
     cursor: z
@@ -662,10 +672,11 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
     // DIVERGENCE: see `coldkey` on /validators/{hotkey}/nominators -- an SS58
     // published without the shared pattern.
     signer: z.string().optional(),
-    // DIVERGENCE: `call_module` is capped at 100 characters on the three
-    // chain-analytics feeds and uncapped here, for one filter matched the same
-    // way against the same column.
-    call_module: z.string().optional(),
+    // The same cap its three sibling feeds enforce (#10096). This took the
+    // identical filter with no bound at all, so a 150-character value was a
+    // 400 on /chain/calls and a 200 here -- handleExtrinsics now applies
+    // validateMaxLength, so the number is published because it is enforced.
+    call_module: z.string().max(CHAIN_CALL_MODULE_MAX_LENGTH).optional(),
     call_function: z.string().optional(),
     call_hash: z
       .string()
@@ -715,14 +726,14 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
     window: windowSchema(["7d", "30d"] as const).optional(),
     group_by: z.enum(["module", "module_function"] as const).optional(),
     limit: limitSchema(CHAIN_CALLS_LIMIT_MAX).optional(),
-    call_module: z.string().max(100).optional(),
+    call_module: z.string().max(CHAIN_CALL_MODULE_MAX_LENGTH).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/signers": z.object({
     window: windowSchema(["7d", "30d"] as const).optional(),
     sort: sortSchema(["tx_count", "total_fee_tao"] as const).optional(),
     limit: limitSchema(CHAIN_SIGNERS_LIMIT_MAX).optional(),
-    call_module: z.string().max(100).optional(),
+    call_module: z.string().max(CHAIN_CALL_MODULE_MAX_LENGTH).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/transfers": z.object({
@@ -793,7 +804,7 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
   "/api/v1/chain/fees": z.object({
     window: windowSchema(["7d", "30d"] as const).optional(),
     limit: limitSchema(CHAIN_FEES_LIMIT_MAX).optional(),
-    call_module: z.string().max(100).optional(),
+    call_module: z.string().max(CHAIN_CALL_MODULE_MAX_LENGTH).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/concentration/subnets": z.object({

--- a/src/route-limits.ts
+++ b/src/route-limits.ts
@@ -297,6 +297,22 @@ export const CHAIN_EVENTS_LIMIT_DEFAULT = 50;
 export const CHAIN_EVENTS_LIMIT_MAX = 100;
 
 /**
+ * The ceiling on a Substrate runtime NAME in a query filter (#10096).
+ *
+ * `call_module` on the three chain-analytics feeds, and `pallet`/`method` on
+ * the event feed. The number was written out eight times before this: three
+ * `validateMaxLength(url, "call_module", 100)` calls in
+ * workers/request-handlers/analytics.ts, three published schemas, and two
+ * local consts in schemas-src/mcp-tools/.
+ *
+ * The event feed's 64 is deliberately different -- a pallet or method name is
+ * shorter than a module path -- so it is its own number rather than a shared
+ * one pretending the two are the same constraint.
+ */
+export const CHAIN_CALL_MODULE_MAX_LENGTH = 100;
+export const CHAIN_EVENT_NAME_MAX_LENGTH = 64;
+
+/**
  * `/api/v1/health/trends` -- the all-subnet trend matrix (#10089).
  *
  * The same defect the semantic block above records, on a second route: `limit`

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -4,6 +4,7 @@
 // through workers/api.ts.
 
 import assert from "node:assert/strict";
+import { CHAIN_CALL_MODULE_MAX_LENGTH } from "../src/route-limits.ts";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, test } from "vitest";
 import {
@@ -4626,6 +4627,38 @@ describe("handleBlockEvents", () => {
 });
 
 describe("handleExtrinsics", () => {
+  test("rejects an over-length call_module, like its three sibling feeds", async () => {
+    // #10096: /chain/calls, /chain/fees and /chain/signers have always
+    // rejected a call_module over CHAIN_CALL_MODULE_MAX_LENGTH; this route
+    // took the identical filter with no bound, so one value was a 400 on
+    // three doors and a 200 on the fourth. Length taken from the constant, so
+    // raising the cap moves the test with it rather than leaving it asserting
+    // a number nobody enforces any more.
+    const long = "A".repeat(CHAIN_CALL_MODULE_MAX_LENGTH + 1);
+    const path = `/api/v1/extrinsics?call_module=${long}`;
+    const res = await handleExtrinsics(
+      req(path),
+      emptyEnv() as unknown as Env,
+      url(path),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "call_module");
+  });
+
+  test("accepts a call_module at exactly the cap", async () => {
+    // The other side: the bound is inclusive, so the published `maxLength` is
+    // a value a caller may actually send.
+    const atCap = "A".repeat(CHAIN_CALL_MODULE_MAX_LENGTH);
+    const path = `/api/v1/extrinsics?call_module=${atCap}`;
+    const res = await handleExtrinsics(
+      req(path),
+      emptyEnv() as unknown as Env,
+      url(path),
+    );
+    assert.equal(res.status, 200);
+  });
+
   test("rejects an unsupported query param with 400", async () => {
     const res = await handleExtrinsics(
       req("/api/v1/extrinsics"),

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -57,7 +57,10 @@ import {
   tryPostgresTier,
 } from "../postgres-tier.ts";
 import { loadBulkHealthTrends } from "../../src/bulk-health-trends.ts";
-import { BULK_HEALTH_TRENDS_LIMIT_MAX } from "../../src/route-limits.ts";
+import {
+  BULK_HEALTH_TRENDS_LIMIT_MAX,
+  CHAIN_CALL_MODULE_MAX_LENGTH,
+} from "../../src/route-limits.ts";
 import { formatGlobalIncidents } from "../../src/health-serving.ts";
 import {
   applyQueryFilters,
@@ -421,8 +424,15 @@ function validateFormatParam(url: URL): QueryError | null {
   return validateEnumParam(url, "format", ["json", "csv"]);
 }
 
-// Bound an optional free-text filter so an oversized value never reaches D1.
-function validateMaxLength(
+/**
+ * Bound an optional free-text filter so an oversized value never reaches D1.
+ *
+ * Exported (#10096) because /api/v1/extrinsics needed it and did not have it:
+ * the three chain-analytics feeds rejected an over-length `call_module` while
+ * the fourth route taking the same filter accepted any length, so one filter
+ * had two behaviours depending on which door you came through.
+ */
+export function validateMaxLength(
   url: URL,
   parameter: string,
   max: number,
@@ -1415,7 +1425,11 @@ export async function handleChainCalls(
   if ("error" in limitResult) return analyticsQueryError(limitResult.error);
   const { limit } = limitResult;
   const groupBy = url.searchParams.get("group_by") || "module";
-  const callModuleError = validateMaxLength(url, "call_module", 100);
+  const callModuleError = validateMaxLength(
+    url,
+    "call_module",
+    CHAIN_CALL_MODULE_MAX_LENGTH,
+  );
   if (callModuleError) return analyticsQueryError(callModuleError);
   const csv = csvRequested(url, request);
   return withEdgeCache(
@@ -1525,7 +1539,11 @@ export async function handleChainSigners(
   if ("error" in limitResult) return analyticsQueryError(limitResult.error);
   const { limit } = limitResult;
   const sort = url.searchParams.get("sort") || "tx_count";
-  const callModuleError = validateMaxLength(url, "call_module", 100);
+  const callModuleError = validateMaxLength(
+    url,
+    "call_module",
+    CHAIN_CALL_MODULE_MAX_LENGTH,
+  );
   if (callModuleError) return analyticsQueryError(callModuleError);
   const csv = csvRequested(url, request);
   return withEdgeCache(
@@ -2827,7 +2845,11 @@ export async function handleChainFees(
   const { limit } = limitResult;
   // Optional pallet scope (applies to both the daily series and the payer list),
   // backed by idx_extrinsics_module_block.
-  const callModuleError = validateMaxLength(url, "call_module", 100);
+  const callModuleError = validateMaxLength(
+    url,
+    "call_module",
+    CHAIN_CALL_MODULE_MAX_LENGTH,
+  );
   if (callModuleError) return analyticsQueryError(callModuleError);
   const csv = csvRequested(url, request);
   return withEdgeCache(

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -59,8 +59,10 @@ import { validateResponseTripwire } from "../../src/response-validation-tripwire
 import {
   analyticsQueryError,
   markPostgresTierFallbackResponse,
+  validateMaxLength,
   validateQueryParams,
 } from "./analytics.ts";
+import { CHAIN_CALL_MODULE_MAX_LENGTH } from "../../src/route-limits.ts";
 import type { QueryError } from "../list-query.ts";
 import { projectionMeta } from "../../src/field-projection.ts";
 import {
@@ -7138,6 +7140,15 @@ export async function handleExtrinsics(
     "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
+  // The same cap the three chain-analytics feeds apply to `call_module`
+  // (#10096). This route took the identical filter with no bound at all, so a
+  // 150-character value was a 400 on /chain/calls and a 200 here.
+  const callModuleError = validateMaxLength(
+    url,
+    "call_module",
+    CHAIN_CALL_MODULE_MAX_LENGTH,
+  );
+  if (callModuleError) return analyticsQueryError(callModuleError);
   const page = parsePagination(url, BLOCK_PAGINATION);
   if ("error" in page) return analyticsQueryError(page.error);
   const { limit, offset } = page;


### PR DESCRIPTION
Three of the divergences from #10096, each verified against production before changing anything.

## `/api/v1/validators/economics` `sort` — published no enum

The only `sort` on the surface published as a bare `{"type":"string"}`. The handler has a closed set of five and names all five in its own 400:

```
"bogus" is not a supported sort. Supported: earning_floor_cost_tao,
permit_floor_cost_tao, permit_to_earning_multiple, tao_inflow_per_day,
validator_headroom.
```

A caller reading `openapi.json` had to guess a column name, and every wrong guess was a rejected request the contract gave no way to avoid. Now reads `VALIDATOR_ECONOMICS_SORTS` — the list `UnsupportedSortError` already reports.

Its `offset` also picks up the ranking's own ceiling rather than the generic deep-paging one: one row per subnet, so seeking past the limit seeks nothing.

## `coldkey` — the handler validates it, the contract didn't say so

```
GET /api/v1/validators/{hotkey}/nominators?coldkey=notanaddress  ->  400
```

`ss58Schema()` carries the same 47–48 base58 pattern on 26 other parameters. Publishing it costs no behaviour change and lets a generated client catch a typo before the request.

**Deliberately not done for the other two SS58 filters in the issue.** `author` on `/blocks` and `signer` on `/extrinsics` answer **200** to a malformed address and filter to nothing — so publishing the pattern there would claim validation the server does not perform, which is #10073's mistake inverted. Making them *reject* is a behaviour change and needs its own decision; recorded in place rather than guessed at.

## `call_module` — one filter, two behaviours

```
GET /api/v1/chain/calls?call_module=<150 chars>   ->  400  "must be 100 characters or fewer"
GET /api/v1/extrinsics?call_module=<150 chars>    ->  200
```

Same filter, same column, depending on which door you came through. `handleExtrinsics` now applies `validateMaxLength` (exported from `analytics.ts` for it), so the number is published **because it is enforced** — with a regression test for the reject and one for accepting exactly the cap, both sized from the constant.

### The number was written eight times

Three `validateMaxLength(url, "call_module", 100)` calls, three published schemas, and **two local consts I had added earlier in this epic** — my own duplication, found by going looking for the fourth site. `CHAIN_CALL_MODULE_MAX_LENGTH` and `CHAIN_EVENT_NAME_MAX_LENGTH` are now the only declarations.

The event feed's 64 stays its own number: a pallet name is genuinely shorter than a module path, and collapsing them would assert a constraint neither route has.

## Published diff

| route | parameter | change |
|---|---|---|
| `/validators/economics` | `sort` | gains its five values |
| `/validators/{hotkey}/nominators` | `coldkey` | gains the SS58 pattern |
| `/extrinsics` | `call_module` | gains `maxLength: 100`, now enforced |

## Validation

```
npm run typecheck / lint / format:check     clean
npx vitest run                              761 files, 18,275 passed, 22 skipped
validate:mcp-input-parity  validate:route-query-parity  validate:contract-drift
validate:openapi  validate:schema-vocabularies  validate:query-vocabulary    all PASS
```

Also posted a [correction to this issue's `offset` item](https://github.com/JSONbored/metagraphed/issues/10096#issuecomment-5225786454): it was stated too coarsely — some of those 16 routes are *correct* as-is, because `parseNonNegativeIntParam` genuinely applies no ceiling. The comment has the per-path rule and the route list.

Refs #10096