### PR TITLE
docs(mcp): applySubnetListQuery's `null` never meant "every row" (#10101)

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -4455,8 +4455,18 @@ function applySubnetListQuery(
    *
    * limitSchema declares a tool's default in the PUBLISHED contract but does
    * not apply it -- deliberately, so handlers keep ownership of the decision.
-   * Applying it here is that ownership: null means "every row", which is the
-   * historical behaviour and still right for a per-subject view.
+   * Passing a number here is that ownership.
+   *
+   * `null` DOES NOT MEAN "every row", though it used to say so. This function
+   * only decides whether to put a `limit` on the internal URL;
+   * applyMcpQueryFilters is called with no options below, so when there is no
+   * `limit` it applies MCP_LIST_LIMIT_DEFAULT (20) anyway. Measured: 30 rows
+   * in, 20 rows out, `pagination.limit: 20`.
+   *
+   * So `null` means "take the shared MCP page default", and a per-subject view
+   * that wants every row has to say so -- there is no way to express it from
+   * here today (#10101). Corrected rather than deleted because a comment
+   * promising unpaginated output is exactly what a caller would rely on.
    */
   defaultLimit: number | null = null,
 ): Row {


### PR DESCRIPTION
The doc comment said:

> `null` means "every row", which is the historical behaviour and still right for a per-subject view.

**It does not.** `defaultLimit: null` only decides whether this function puts a `limit` on the internal URL. `applyMcpQueryFilters` is then called with no options, so when there is no `limit` it applies `MCP_LIST_LIMIT_DEFAULT` (20) anyway.

Measured directly rather than read:

```
applyMcpQueryFilters({ subnets: <30 rows> }, url, "subnets", [])
  -> rows out: 20,  pagination.limit: 20
```

So `null` means "take the shared MCP page default", and a per-subject view that genuinely wants every row **cannot express that from here today**.

Corrected rather than deleted: a comment promising unpaginated output is exactly what a caller would build on, and the gap it hides — no way to say "every row" — is worth leaving stated.

Comment only; no behaviour change.

## Context

Found while grounding #10101. Its remaining work is a per-tool mapping of handler → applied default: **84 of 97 tools** publish a `limit` with no `default`, and 20 is not the right number for all of them (`chain-signers-artifact.ts` documents 50, `chain-fees-artifact.ts` 25). Declaring one value everywhere would be the same defect in a new place — so the [measurements are posted on the issue](https://github.com/JSONbored/metagraphed/issues/10101#issuecomment-5225875985) rather than guessed at here.

Refs #10101