### PR TITLE
fix(api): the metagraph accepted a validator_permit it published as invalid (#10096)

### DIFF
--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -768,6 +768,39 @@ function dbThrows(message = "no such column") {
 }
 
 describe("handleSubnetMetagraph", () => {
+  test("rejects a validator_permit that is not `true`", async () => {
+    // #10096: the published enum is ["true"] -- a presence flag -- and it was
+    // not enforced. `?validator_permit=false` returned ALL 256 rows, which a
+    // caller asking for non-permitted neurons reads as "none hold a permit".
+    // Measured on SN1 before the fix: no filter 256, =true 10, =false 256,
+    // =bogus 256.
+    for (const value of ["false", "bogus", "1"]) {
+      const path = `/api/v1/subnets/${NETUID}/metagraph?validator_permit=${value}`;
+      const res = await handleSubnetMetagraph(
+        req(path),
+        emptyEnv() as unknown as Env,
+        NETUID,
+        url(path),
+      );
+      const body = await errorJson(res);
+      assert.equal(body.error.code, "invalid_query", value);
+      assert.equal(body.meta.parameter, "validator_permit", value);
+    }
+  });
+
+  test("accepts validator_permit=true, the one value it publishes", async () => {
+    // The other side: the published enum must name a value that works, or the
+    // rejection above would just be a parameter nobody can use.
+    const path = `/api/v1/subnets/${NETUID}/metagraph?validator_permit=true`;
+    const res = await handleSubnetMetagraph(
+      req(path),
+      emptyEnv() as unknown as Env,
+      NETUID,
+      url(path),
+    );
+    assert.equal(res.status, 200);
+  });
+
   test("rejects an unsupported query param with 400", async () => {
     const res = await handleSubnetMetagraph(
       req(`/api/v1/subnets/${NETUID}/metagraph`),

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -886,6 +886,23 @@ export async function handleSubnetMetagraph(
     "fields",
   ]);
   if (validationError) return analyticsQueryError(validationError);
+  // #10096: the published enum is ["true"] -- a PRESENCE flag, because the
+  // only thing this filter can do is narrow to permitted neurons. It was not
+  // enforced, and the failure was silent in the worst direction: `?validator
+  // _permit=false` returned all 256 rows, which a caller asking for
+  // non-permitted neurons reads as "none of them hold a permit". Measured on
+  // SN1: no filter 256, `=true` 10, `=false` 256, `=bogus` 256.
+  //
+  // Rejected now, exactly as ?changes= is on /subnets/{netuid}/turnover, which
+  // publishes the identical one-value enum for the identical reason. A caller
+  // who wants the complement omits the parameter and filters the rows.
+  const permit = url.searchParams.get("validator_permit");
+  if (permit != null && permit !== "true") {
+    return analyticsQueryError({
+      parameter: "validator_permit",
+      message: `"${permit}" is not a valid validator_permit flag. Supported: true.`,
+    });
+  }
   // #9082. Parsed before the tier read so an unsupported field costs a 400
   // rather than a full 256-row fetch the caller never sees.
   const projection = parseNeuronFields(url.searchParams, "neurons");


### PR DESCRIPTION
`?validator_permit=false` returned **all 256 neurons**. A caller asking for non-permitted neurons got every neuron on the subnet — and would read that as *"none of them hold a permit."* A wrong answer, HTTP 200, no error: the confident-zero class #9803 exists about.

Measured on SN1 before the fix:

| request | rows |
|---|---:|
| no parameter | 256 |
| `?validator_permit=true` | **10** — filters, as intended |
| `?validator_permit=false` | 256 — silently ignored |
| `?validator_permit=bogus` | 256 — silently ignored |

## The published contract was already right

`enum: ["true"]` says exactly what this is — a **presence flag**, because narrowing to permitted neurons is the only thing it can do. It simply was not enforced: `validateEntityQuery` checks that the parameter *name* is allowed, and the value is forwarded to the data Worker unchanged.

Enforced now, exactly as `?changes=` is on `/subnets/{netuid}/turnover`, which publishes the identical one-value enum for the identical reason and rejects anything else. A caller who wants the complement omits the parameter and filters the rows.

## This corrects my own framing in #10096

I described the boolean filters there as a *"trichotomy — three behaviours for one shape"*. Re-probed, they are not:

| filter | published | enforced? |
|---|---|---|
| `changes` (turnover) | `["true"]` | ✅ 400 on `false`/`bogus` |
| `success` (extrinsics/sudo/blocks) | `["true","false"]` | ✅ 400 on `bogus` |
| `validator_permit` (metagraph) | `["true"]` | ❌ **accepted anything** |

A presence flag and a real boolean — each correct, each internally consistent. `validator_permit` was the only one out of step, and it was the **enforcement** missing rather than the enum being wrong. Two of the three "divergences" I filed were not divergences at all.

## Tests

Both directions: `false`, `bogus` and `1` each rejected with `parameter: validator_permit`, and `true` still returns 200 — because a published enum whose only value fails would just be an unusable parameter.

## Validation

```
npm run typecheck / lint / format:check     clean
npx vitest run                              761 files, 18,275 passed, 22 skipped
npm run build                               openapi.json byte-identical
```

`openapi.json` is unchanged: the contract already said this. Only the server changed, to start meaning it.

Refs #10096