### PR TITLE
fix(api): 14 routes clamp `offset` and published no ceiling (#10096)

### DIFF
--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -7793,6 +7793,7 @@
         {
           "name": "offset",
           "schema": {
+            "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
           }
@@ -7964,6 +7965,7 @@
         {
           "name": "offset",
           "schema": {
+            "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
           }
@@ -8103,6 +8105,7 @@
         {
           "name": "offset",
           "schema": {
+            "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
           }
@@ -8212,6 +8215,7 @@
         {
           "name": "offset",
           "schema": {
+            "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
           }
@@ -8283,6 +8287,7 @@
         {
           "name": "offset",
           "schema": {
+            "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
           }
@@ -8340,6 +8345,7 @@
         {
           "name": "offset",
           "schema": {
+            "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
           }
@@ -8414,6 +8420,7 @@
         {
           "name": "offset",
           "schema": {
+            "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
           }
@@ -8836,6 +8843,7 @@
         {
           "name": "offset",
           "schema": {
+            "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
           }
@@ -9533,6 +9541,7 @@
         {
           "name": "offset",
           "schema": {
+            "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
           }
@@ -9678,6 +9687,7 @@
         {
           "name": "offset",
           "schema": {
+            "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
           }
@@ -9724,6 +9734,7 @@
         {
           "name": "offset",
           "schema": {
+            "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
           }
@@ -9900,6 +9911,7 @@
         {
           "name": "offset",
           "schema": {
+            "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
           }
@@ -10040,6 +10052,7 @@
         {
           "name": "offset",
           "schema": {
+            "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
           }
@@ -10140,6 +10153,7 @@
         {
           "name": "offset",
           "schema": {
+            "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
           }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -56259,6 +56259,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
             }
@@ -56759,6 +56760,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
             }
@@ -56928,6 +56930,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
             }
@@ -60394,6 +60397,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
             }
@@ -63320,6 +63324,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
             }
@@ -63498,6 +63503,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
             }
@@ -63687,6 +63693,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
             }
@@ -63944,6 +63951,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
             }
@@ -65423,6 +65431,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
             }
@@ -66467,6 +66476,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
             }
@@ -66919,6 +66929,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
             }
@@ -67072,6 +67083,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
             }
@@ -74879,6 +74891,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
             }
@@ -77935,6 +77948,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
             }
@@ -86672,6 +86686,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
             }
@@ -88190,6 +88205,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
             }
@@ -88351,6 +88367,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
             }
@@ -92896,6 +92913,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
             }

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -115,6 +115,7 @@ import {
   limitSchema,
   netuidListSchema,
   netuidSchema,
+  offsetSchema,
   orderSchema,
   querySchema,
   sortSchema,
@@ -123,21 +124,25 @@ import {
 } from "./query-params.ts";
 
 /**
- * DIVERGENCE: `offset` is published two different ways.
+ * `offset` on the two routes that genuinely enforce NO ceiling.
  *
- * The 34 collection routes publish `offsetSchema()`, which carries
- * `maximum: MAX_OFFSET` -- the deep-paging bound `clampOffset()` applies. Every
- * one of the 17 sites below publishes the same parameter with no ceiling, while
- * running through the same clamp. One enforcement, two published statements,
- * and the split is total: not a single non-collection route publishes the
- * bounded form, which is why nobody noticed one of them was different.
+ * Everything else clamps at MAX_OFFSET via `clampOffset`/`parsePagination` and
+ * publishes `offsetSchema()` for it. These two read the parameter with
+ * `parseNonNegativeIntParam`, which applies no upper bound at all, so
+ * publishing one would claim a limit the handler does not impose.
  *
- * Reproduced as-published so this step stays byte-identical. The correction is
- * to publish the bound everywhere, which is a contract change and belongs with
- * the other content fixes rather than in a refactor that claims to change
- * nothing.
+ * Told apart by probe rather than by reading, because the two paths are
+ * indistinguishable from a normal request: a non-safe integer
+ * (`?offset=99999999999999999999`) is a 400 from parseNonNegativeIntParam and
+ * a clamp-to-empty 200 from clampOffset. Measured 2026-08-08 -- these two
+ * answered 400, the other 14 answered 200 with zero rows, which is the clamp
+ * honouring the parameter rather than ignoring it (`?offset=0` returns rows).
+ *
+ * #10096 originally recorded all 16 as one divergence. They are not: two of
+ * them are correct, and publishing MAX_OFFSET on those would have been a new
+ * contract lie rather than a fix.
  */
-const uncappedOffsetSchema = () => z.int().min(0);
+const unboundedOffsetSchema = () => z.int().min(0);
 
 /**
  * Routes that accept no query parameters at all.
@@ -273,7 +278,7 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
     // carries no ceiling because the handler enforces none.
     window: windowSchema(["7d", "30d"] as const).optional(),
     limit: limitSchema(BULK_HEALTH_TRENDS_LIMIT_MAX).optional(),
-    offset: uncappedOffsetSchema().optional(),
+    offset: unboundedOffsetSchema().optional(),
   }),
   "/api/v1/subnets/{netuid}/health/percentiles": z.object({
     window: windowSchema(["7d", "30d"] as const).optional(),
@@ -415,7 +420,7 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
       "last_activity",
     ] as const).optional(),
     limit: limitSchema(NOMINATOR_LIMIT_MAX).optional(),
-    offset: uncappedOffsetSchema().optional(),
+    offset: unboundedOffsetSchema().optional(),
     // The handler DOES validate this -- `?coldkey=notanaddress` is a 400,
     // verified live -- and the contract simply did not say so, while
     // ss58Schema() carries the same 47-48 base58 pattern on 26 other
@@ -448,7 +453,7 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
   }),
   "/api/v1/subnets/{netuid}/hyperparameters/history": z.object({
     limit: limitSchema(MAX_LIMIT).optional(),
-    offset: uncappedOffsetSchema().optional(),
+    offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     format: formatSchema().optional(),
   }),
@@ -468,7 +473,7 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
     limit: limitSchema(MAX_LIMIT).optional(),
-    offset: uncappedOffsetSchema().optional(),
+    offset: offsetSchema().optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/subnets/{netuid}/event-summary": z.object({
@@ -483,7 +488,7 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
   }),
   "/api/v1/subnets/{netuid}/identity-history": z.object({
     limit: limitSchema(MAX_LIMIT).optional(),
-    offset: uncappedOffsetSchema().optional(),
+    offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     format: formatSchema().optional(),
   }),
@@ -493,7 +498,7 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
     limit: limitSchema(MAX_LIMIT).optional(),
-    offset: uncappedOffsetSchema().optional(),
+    offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     format: formatSchema().optional(),
   }),
@@ -502,14 +507,14 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
     from: daySchema("first").optional(),
     to: daySchema("last").optional(),
     limit: limitSchema(MAX_LIMIT).optional(),
-    offset: uncappedOffsetSchema().optional(),
+    offset: offsetSchema().optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/accounts/{ss58}/extrinsics": z.object({
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
     limit: limitSchema(MAX_LIMIT).optional(),
-    offset: uncappedOffsetSchema().optional(),
+    offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     format: formatSchema().optional(),
   }),
@@ -518,7 +523,7 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
     limit: limitSchema(MAX_LIMIT).optional(),
-    offset: uncappedOffsetSchema().optional(),
+    offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     format: formatSchema().optional(),
   }),
@@ -560,7 +565,7 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
   }),
   "/api/v1/accounts/{ss58}/identity-history": z.object({
     limit: limitSchema(MAX_LIMIT).optional(),
-    offset: uncappedOffsetSchema().optional(),
+    offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     format: formatSchema().optional(),
   }),
@@ -619,7 +624,7 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
   }),
   "/api/v1/blocks": z.object({
     limit: limitSchema(BLOCK_PAGINATION.maxLimit).optional(),
-    offset: uncappedOffsetSchema().optional(),
+    offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     // DIVERGENCE: the block author is an SS58 and publishes no pattern.
     author: z.string().optional(),
@@ -634,12 +639,12 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
   }),
   "/api/v1/blocks/{ref}/extrinsics": z.object({
     limit: limitSchema(BLOCK_PAGINATION.maxLimit).optional(),
-    offset: uncappedOffsetSchema().optional(),
+    offset: offsetSchema().optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/blocks/{ref}/events": z.object({
     limit: limitSchema(MAX_LIMIT).optional(),
-    offset: uncappedOffsetSchema().optional(),
+    offset: offsetSchema().optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain-events": z.object({
@@ -666,7 +671,7 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
   }),
   "/api/v1/extrinsics": z.object({
     limit: limitSchema(BLOCK_PAGINATION.maxLimit).optional(),
-    offset: uncappedOffsetSchema().optional(),
+    offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     block: blockBoundSchema("first").optional(),
     // DIVERGENCE: see `coldkey` on /validators/{hotkey}/nominators -- an SS58
@@ -691,7 +696,7 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
   }),
   "/api/v1/sudo": z.object({
     limit: limitSchema(BLOCK_PAGINATION.maxLimit).optional(),
-    offset: uncappedOffsetSchema().optional(),
+    offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     block: blockBoundSchema("first").optional(),
     call_function: z.string().optional(),
@@ -704,7 +709,7 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
   }),
   "/api/v1/governance/config-changes": z.object({
     limit: limitSchema(BLOCK_PAGINATION.maxLimit).optional(),
-    offset: uncappedOffsetSchema().optional(),
+    offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     block: blockBoundSchema("first").optional(),
     call_function: z.string().optional(),


### PR DESCRIPTION
Every paginated route runs its `offset` through one of two paths, and they enforce different things:

| path | ceiling |
|---|---|
| `clampOffset` / `parsePagination` | bounded at `MAX_OFFSET` (1,000,000) |
| `parseNonNegativeIntParam` | **none** |

The 34 collection routes publish `offsetSchema()`, which carries `MAX_OFFSET`. Sixteen non-collection routes published no ceiling — **14 of them clamp**, so their contract understated what the route does. The other two genuinely enforce nothing, and were right.

## Told apart by probe, not by reading

The two paths look identical from a normal request: both answer an over-large offset with an empty page. A **non-safe integer** separates them — `parseNonNegativeIntParam` rejects it, `clampOffset` clamps it.

```
?offset=99999999999999999999

400  /health/trends, /validators/{hotkey}/nominators     -> unbounded, correct as-is
200  the other 14                                        -> clamped
```

And the 200s *honour* the parameter rather than ignoring it — the same routes return rows at `?offset=0` and zero rows at the huge offset, so the clamp is real:

```
/api/v1/blocks?offset=0&limit=2                     rows: 2
/api/v1/blocks?offset=99999999999999999999&limit=2  rows: 0
```

## This corrects #10096

That issue — which I wrote — recorded all 16 as one divergence, "running through the same clamp". They don't. Publishing `MAX_OFFSET` on the two that never clamp would have been a **new contract lie rather than a fix**: the exact mistake this epic keeps finding, made by me in the issue describing it.

`uncappedOffsetSchema` is renamed `unboundedOffsetSchema` and now documents which two routes use it and how that was established, so the next reader doesn't have to redo the probe.

## Published diff

**18 parameters** gain `maximum: 1000000` — the 14 routes plus four `/{network}/` twins. Nothing else changed in `openapi.json`.

## Validation

```
npm run typecheck / lint / format:check     clean
npx vitest run                              761 files, 18,275 passed, 22 skipped
validate:mcp-input-parity  validate:route-query-parity
validate:contract-drift  validate:openapi                  all PASS
```

Refs #10096