### PR TITLE
fix(neon): six sync routes refused a write D1 no longer holds (#10144)

### DIFF
--- a/migrations/neon/0008_hotkey_alpha.sql
+++ b/migrations/neon/0008_hotkey_alpha.sql
@@ -1,0 +1,62 @@
+-- hotkey_alpha: the table #10139 made sole-store and no migration creates (#10145).
+--
+-- 0007 transcribed six hand-created tables for exactly this reason, and this is
+-- the seventh -- missed there by SCOPE, not by oversight. That sweep asked
+-- "which SOLE-STORE table has no migration", and on the day it ran hotkey_alpha
+-- was still dual-written, so D1's 0019_hotkey_alpha.sql was still a usable
+-- record of its shape. #10139 flipped it to sole-store the next day and the
+-- record stopped being usable, without anything changing about this table.
+--
+-- The rows are fine. hotkey_alpha holds 17,837 rows in Neon and was verified
+-- row-for-row against D1 before the flip (identical rows, identical max, same
+-- newest-pass count, SUM(total_alpha) matching to the cent). What is missing is
+-- only the repo's ability to RECREATE the table -- on a new Neon branch, a
+-- restore, or a fresh environment. Deleting D1 removes the last copy of that
+-- knowledge.
+--
+-- IF NOT EXISTS, so this is a no-op against the live table and a record for
+-- everything downstream of it. It changes nothing in production by design.
+--
+-- ON THE TYPES, and how they are known without reading information_schema.
+-- Unlike 0007 these were not read back off the live database. They are the
+-- types the WRITER already declares and production already accepts:
+-- src/ledger-neon-write.ts's hotkey-alpha plan carries
+--
+--   columnTypes: { netuid: "int", total_alpha: "double precision",
+--                  captured_at: "bigint" }
+--
+-- and those casts exist because the filtered VALUES form resolves every
+-- parameter to TEXT, which Postgres rejected against these columns. A cast that
+-- is load-bearing in production is direct evidence of the column type it casts
+-- to -- if `netuid` were TEXT the cast would be unnecessary, and if it were
+-- BIGINT the `int` cast would still be wrong to write here. `hotkey` takes no
+-- cast because it is TEXT on both sides.
+--
+-- Same three translations from D1 that 0007 documents:
+--
+--   INTEGER (netuid)      ->  INTEGER           a subnet id, not an epoch
+--   REAL                  ->  DOUBLE PRECISION
+--   INTEGER (epoch ms)    ->  BIGINT            captured_at
+--
+-- WHY total_alpha IS NOT NULL, carried over from 0019: a genuine zero is a real
+-- pool size, so a missing read must be an ABSENT ROW rather than a zero one.
+-- The distinction is the whole reason #9414 exists.
+CREATE TABLE IF NOT EXISTS hotkey_alpha (
+  hotkey      TEXT             NOT NULL,
+  netuid      INTEGER          NOT NULL,
+  total_alpha DOUBLE PRECISION NOT NULL,
+  -- Epoch MILLISECONDS, like every other captured_at in this database. #9382 is
+  -- the standing reminder of what a seconds value does here: read as ms it
+  -- lands in 1970, and a staleness guard then pins the row permanently.
+  captured_at BIGINT           NOT NULL,
+  PRIMARY KEY (hotkey, netuid)
+);
+
+-- The serving read: price one coldkey's positions, which are looked up by the
+-- (hotkey, netuid) pairs those positions name.
+CREATE INDEX IF NOT EXISTS idx_hotkey_alpha_netuid
+  ON hotkey_alpha (netuid, hotkey);
+
+-- The staleness watchdog scans by capture time across every hotkey.
+CREATE INDEX IF NOT EXISTS idx_hotkey_alpha_captured
+  ON hotkey_alpha (captured_at);

--- a/tests/alert-triggers-route.test.ts
+++ b/tests/alert-triggers-route.test.ts
@@ -181,7 +181,7 @@ test("create: 400 on a validation failure, without ever touching Postgres", asyn
   assert.equal(sqlCalls.length, 0);
 });
 
-test("create: 503 when METAGRAPH_HEALTH_DB is unbound", async () => {
+test("create: 503 when no user-state store is bound", async () => {
   const res = await fetch(
     req("/api/v1/alerts/triggers", {
       method: "POST",
@@ -191,7 +191,10 @@ test("create: 503 when METAGRAPH_HEALTH_DB is unbound", async () => {
     { ...env, METAGRAPH_HEALTH_DB: undefined } as unknown as Env,
   );
   assert.equal(res.status, 503);
-  assert.deepEqual(await res.json(), { error: "d1 binding unavailable" });
+  // The message names the STORE GROUP, not D1 (#10144): userStateRunner
+  // answers for whichever store owns api_keys/alert_triggers, so an unbound
+  // D1 is only half of what "nothing here" can mean.
+  assert.deepEqual(await res.json(), { error: "no user-state store bound" });
 });
 
 test("create: 502 when the insert fails", async () => {

--- a/tests/sync-routes-need-no-d1.test.ts
+++ b/tests/sync-routes-need-no-d1.test.ts
@@ -1,0 +1,303 @@
+// The sync routes must reach their write with no D1 binding at all (#10144).
+//
+// THE BUG THIS EXISTS TO STOP. Every one of these handlers already skipped its
+// D1 write once Neon owned the tables -- but the BINDING CHECK above the write
+// did not know that. So with the tables sole-store on Neon and D1 unbound, the
+// route answered `503 {"error":"d1 binding unavailable"}` and never reached the
+// Neon write that would have succeeded. Nothing failed while D1 stayed bound,
+// which is why it survived the inversions: the check was dead code that only
+// wakes up on the day the database is dropped.
+//
+// WHAT IS ASSERTED, and why it is not a weaker test than it looks. There is no
+// Postgres here, so a route that gets past the check fails at the write instead
+// -- 502, or a swallowed verdict. That is the point. 503 means "I refused
+// before trying"; anything else means the request reached the store. The pair
+// of cases per route is what carries the weight:
+//
+//   Neon owns + no D1  ->  must NOT be 503 (the fix)
+//   Neon does not own + no D1  ->  must STILL be 503 (the check is not gone)
+//
+// Without the second case every assertion here would also pass if the binding
+// check had simply been deleted, which is a different and much worse change.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+const { default: worker } = await import("../workers/data-api.ts");
+
+const HYPERDRIVE = { connectionString: "postgresql://example/db" };
+const NEURONS_SYNC_SECRET = "neurons-secret";
+const NEURON_DAILY_BACKFILL_SECRET = "backfill-secret";
+const CHAIN_DETAIL_SYNC_SECRET = "chain-detail-secret";
+const POLLER_LANE_HEALTH_SYNC_SECRET = "poller-secret";
+
+// The three tables neonOwnsNeuronsSnapshot requires together, and the four
+// chain_detail families. Listed in full because both gates are all-or-nothing:
+// a partial list is the "not owned" case, not a weaker version of owned.
+const NEURON_TABLES = "neurons,neuron_daily,account_position_daily";
+const CHAIN_DETAIL_TABLES =
+  "chain_detail_blocks,chain_detail_extrinsics," +
+  "chain_detail_account_events,chain_detail_chain_events";
+
+const ctx = { waitUntil() {} } as unknown as ExecutionContext;
+
+/** An env with NO D1 binding: `owned` decides whether Neon is the store. */
+function env(owned: string): Record<string, unknown> {
+  return {
+    HYPERDRIVE,
+    NEON_SOLE_STORE_TABLES: owned,
+    NEON_DUAL_WRITE_LANES: "neurons,chain-detail",
+    NEURONS_SYNC_SECRET,
+    NEURON_DAILY_BACKFILL_SECRET,
+    CHAIN_DETAIL_SYNC_SECRET,
+    POLLER_LANE_HEALTH_SYNC_SECRET,
+  };
+}
+
+function post(
+  path: string,
+  header: string,
+  token: string,
+  body: unknown,
+  owned: string,
+) {
+  return worker.fetch(
+    new Request(`https://d/api/v1/internal/${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json", [header]: token },
+      body: JSON.stringify(body),
+    }),
+    env(owned) as unknown as Env,
+    ctx,
+  );
+}
+
+function neuronRow() {
+  return {
+    netuid: 8,
+    uid: 3,
+    hotkey: "5Hot",
+    coldkey: "5Cold",
+    active: 1,
+    validator_permit: 1,
+    rank: 1,
+    trust: 0,
+    validator_trust: 0.5,
+    consensus: 0.4,
+    incentive: 0.3,
+    dividends: 0.2,
+    emission_tao: 1.5,
+    stake_tao: 100.25,
+    registered_at_block: 1000,
+    is_immunity_period: 0,
+    axon: "1.2.3.4:9000",
+    block_number: 5_000_000,
+    captured_at: 1_780_000_000_000,
+  };
+}
+
+/** Asserts the route got PAST the binding check -- see the header.
+ *
+ * 400 is rejected as loudly as 503: a payload the handler refuses never gets
+ * near the store, so a fixture that drifts out of shape would turn every one of
+ * these into a test of the validator. That is how the chain-detail case passed
+ * while sending a body the parser threw out. */
+async function assertReachedTheStore(res: Response, label: string) {
+  const body = (await res.json()) as { error?: string };
+  assert.notEqual(
+    res.status,
+    400,
+    `${label}: the fixture is malformed, so this proves nothing -- ${JSON.stringify(body)}`,
+  );
+  assert.notEqual(
+    body.error,
+    "d1 binding unavailable",
+    `${label}: refused before the write with D1 unbound while Neon owns the tables`,
+  );
+  assert.notEqual(
+    res.status,
+    503,
+    `${label}: answered 503, body ${JSON.stringify(body)}`,
+  );
+}
+
+async function assertStillRefuses(res: Response, label: string) {
+  assert.equal(
+    res.status,
+    503,
+    `${label}: the D1 requirement was removed outright`,
+  );
+  assert.deepEqual(
+    await res.json(),
+    { error: "d1 binding unavailable" },
+    label,
+  );
+}
+
+describe("neurons-sync", () => {
+  const send = (owned: string) =>
+    post(
+      "neurons-sync",
+      "x-neurons-sync-token",
+      NEURONS_SYNC_SECRET,
+      [neuronRow()],
+      owned,
+    );
+
+  test("reaches the store when Neon owns the three tables", async () => {
+    await assertReachedTheStore(await send(NEURON_TABLES), "neurons-sync");
+  });
+
+  test("still refuses when Neon owns only part of the family", async () => {
+    // Two of three. neonOwnsNeuronsSnapshot is all-or-nothing, so this is the
+    // "not owned" case -- and the D1 write it would fall back to has no
+    // binding, which is exactly what the 503 is for.
+    await assertStillRefuses(
+      await send("neurons,neuron_daily"),
+      "neurons-sync (partial)",
+    );
+  });
+});
+
+describe("backfill-neuron-daily", () => {
+  const send = (owned: string) =>
+    post(
+      "backfill-neuron-daily",
+      "x-neuron-daily-backfill-token",
+      NEURON_DAILY_BACKFILL_SECRET,
+      [{ ...neuronRow(), snapshot_date: "2026-08-01" }],
+      owned,
+    );
+
+  test("reaches the store, and a Neon failure is the request's failure", async () => {
+    // This route did not merely have a stale check -- it wrote D1 first,
+    // returned 502 if that failed, then mirrored to Neon best-effort and
+    // reported stores:["d1","neon"]. With both tables Neon's, that had the
+    // authoritative store in the mirror's position: an operator replaying a
+    // year of history could be told `ok` for rows that landed nowhere.
+    const res = await send(NEURON_TABLES);
+    await assertReachedTheStore(res, "backfill-neuron-daily");
+    // No Postgres behind the fake Hyperdrive, so the write cannot succeed --
+    // and now that Neon is authoritative, that has to surface as a failure
+    // rather than a 200 with a mirror block nobody reads.
+    assert.equal(res.status, 502);
+  });
+
+  test("still refuses when Neon owns only part of the family", async () => {
+    await assertStillRefuses(
+      await send("neuron_daily,account_position_daily"),
+      "backfill-neuron-daily (partial)",
+    );
+  });
+});
+
+describe("chain-detail-sync", () => {
+  const send = (owned: string) =>
+    post(
+      "chain-detail-sync",
+      "x-chain-detail-sync-token",
+      CHAIN_DETAIL_SYNC_SECRET,
+      {
+        // Same shape as tests/chain-detail-sync-route.test.ts's fixture --
+        // parseChainDetailSync wants the nested per-block families, not a flat
+        // block row.
+        blocks: [
+          {
+            block_number: 5_000_000,
+            block_hash: "0x" + "a".repeat(64),
+            observed_at: 1_785_799_000_000,
+            spec_version: 441,
+            extrinsics: [
+              {
+                block_number: 5_000_000,
+                extrinsic_index: 0,
+                extrinsic_hash: "0x" + "b".repeat(64),
+                signer: null,
+                call_module: "Timestamp",
+                call_function: "set",
+                success: null,
+                fee_tao: null,
+                tip_tao: null,
+                call_args: null,
+                observed_at: 1_785_799_000_000,
+              },
+            ],
+            chain_events: [
+              {
+                block_number: 5_000_000,
+                event_index: 0,
+                pallet: "System",
+                method: "ExtrinsicSuccess",
+                args: null,
+                phase: "ApplyExtrinsic",
+                extrinsic_index: 0,
+                observed_at: 1_785_799_000_000,
+              },
+            ],
+            account_events: [],
+          },
+        ],
+      },
+      owned,
+    );
+
+  test("reaches the store when Neon owns all four families", async () => {
+    await assertReachedTheStore(
+      await send(CHAIN_DETAIL_TABLES),
+      "chain-detail-sync",
+    );
+  });
+
+  test("still refuses when Neon owns only part of the families", async () => {
+    await assertStillRefuses(
+      await send("chain_detail_blocks,chain_detail_extrinsics"),
+      "chain-detail-sync (partial)",
+    );
+  });
+});
+
+describe("poller-lane-health-sync", () => {
+  const outcome = {
+    lane: "hotkey-alpha",
+    verdict: "ok",
+    age_ms: 95_600,
+    detail: null,
+    checked_at: 1_785_960_000_000,
+  };
+  const send = (owned: string) =>
+    post(
+      "poller-lane-health-sync",
+      "x-poller-lane-health-sync-token",
+      POLLER_LANE_HEALTH_SYNC_SECRET,
+      [outcome],
+      owned,
+    );
+
+  test("writes through the lane_health store rather than the D1 binding", async () => {
+    // Every other verdict writer in the repo already goes through
+    // laneHealthStore. This route reached for METAGRAPH_HEALTH_DB by name, so
+    // the poller's job outcomes were the one class of verdict that would have
+    // stopped landing when D1 went away -- silently, because recordLaneVerdict
+    // swallows its failures by design.
+    const res = await send("lane_health");
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { stores?: string[] };
+    assert.deepEqual(body.stores, ["neon"]);
+  });
+
+  test("503s only when NEITHER store is bound", async () => {
+    const res = await worker.fetch(
+      new Request("https://d/api/v1/internal/poller-lane-health-sync", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-poller-lane-health-sync-token": POLLER_LANE_HEALTH_SYNC_SECRET,
+        },
+        body: JSON.stringify([outcome]),
+      }),
+      { POLLER_LANE_HEALTH_SYNC_SECRET } as unknown as Env,
+      ctx,
+    );
+    assert.equal(res.status, 503);
+    assert.deepEqual(await res.json(), { error: "no lane_health store bound" });
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -453,6 +453,7 @@ import { BLOCKLIST_KV_KEY, BLOCKLIST_KV_TTL } from "./tiered-rate-limit.ts";
 import { MCP_TIERED_RATE_LIMIT } from "../src/mcp-server.ts";
 import { createPgSql } from "../src/pg-sql.ts";
 import { recordLaneVerdict } from "../src/lane-health.ts";
+import { laneHealthStore } from "../src/lane-health-store.ts";
 import {
   handleDeadLetterBatch,
   isDeadLetterQueue,
@@ -775,14 +776,22 @@ async function handleNeuronsSync(
     });
   }
 
-  // D1 is the binding this path REQUIRES -- it is the only store left (#9146,
-  // #9193), so the sync has to keep working with nothing else bound or the
-  // only live-refreshed family in the product stops advancing.
+  // THE INVERSION (#9787). Once Neon solely owns all three tables the D1
+  // write is skipped outright rather than written and ignored -- leaving it in
+  // would keep a second copy diverging quietly, which is the state this whole
+  // migration exists to end.
+  const neonOwns = neonOwnsNeuronsSnapshot(env);
+
+  // D1 is the binding this path requires UNTIL Neon owns the tables (#10144).
+  // Asked before the write, and only when the write is going to happen: the
+  // check used to be unconditional, so unbinding D1 answered 503 here and the
+  // Neon write below -- the one that would have succeeded -- was never
+  // reached.
   //
   // Checked HERE, after parsing and validation, not at the top: a malformed
   // body is a 400 whether or not a store happens to be bound, and answering
   // 503 to it would blame the infrastructure for the caller's payload.
-  if (!env.METAGRAPH_HEALTH_DB) {
+  if (!neonOwns && !env.METAGRAPH_HEALTH_DB) {
     return writeJson({ error: "d1 binding unavailable" }, 503);
   }
 
@@ -792,11 +801,6 @@ async function handleNeuronsSync(
   // left un-pruned.
   // 0 when Neon owns the tables and the D1 write is skipped entirely.
   let d1Statements = 0;
-  // THE INVERSION (#9787). Once Neon solely owns all three tables the D1
-  // write is skipped outright rather than written and ignored -- leaving it in
-  // would keep a second copy diverging quietly, which is the state this whole
-  // migration exists to end.
-  const neonOwns = neonOwnsNeuronsSnapshot(env);
   if (!neonOwns) {
     try {
       ({ statements: d1Statements } = await writeNeuronSnapshotToD1(
@@ -940,14 +944,15 @@ async function handleChainDetailSync(
   const batch = parseChainDetailSync(parsed, Date.now());
   if (!batch.ok) return writeJson({ error: batch.error }, batch.status);
 
-  // D1 is the binding this path REQUIRES -- it is the only store (data-api's
-  // Postgres tier was deleted in #9202), so the lane has nowhere else to land.
+  // D1 is the binding this path requires UNTIL Neon owns the four families
+  // (#10144) -- asked only when the D1 write below is going to happen, since an
+  // unconditional check answered 503 here and never reached the Neon write.
   //
   // Checked HERE, after parsing and validation, not at the top: a malformed
   // body is a 400 whether or not a store happens to be bound, and answering 503
   // to it would blame the infrastructure for the caller's payload. Same
   // ordering, and the same reason, as handleNeuronsSync above.
-  if (!env.METAGRAPH_HEALTH_DB) {
+  if (!neonOwnsChainDetail(env) && !env.METAGRAPH_HEALTH_DB) {
     return writeJson({ error: "d1 binding unavailable" }, 503);
   }
 
@@ -1070,6 +1075,16 @@ async function handleChainDetailSync(
 async function handleChainDetailSyncHead(request: Request, env: Env) {
   const denied = chainDetailSyncAuth(request, env);
   if (denied) return denied;
+  // DELIBERATELY still unconditional, unlike its sibling above (#10144).
+  //
+  // chainDetailCoverage reads chain_detail_blocks out of src/chain-detail-hot-
+  // tier.ts, which is D1-only -- it has no Neon path to fall through to yet.
+  // Relaxing this check would turn "I cannot tell you" into `head: null`, and
+  // `head: null` is a documented real answer that tells the producer to start
+  // from the current finalized head. A 503 makes it retry; a wrong null makes
+  // it skip, and leaves a hole nothing will ever fill.
+  //
+  // This unblocks when the hot tier moves (#9773).
   if (!env.METAGRAPH_HEALTH_DB) {
     return writeJson({ error: "d1 binding unavailable" }, 503);
   }
@@ -1194,25 +1209,35 @@ async function handleNeuronDailyBackfill(
 
   // Same write shape as handleNeuronsSync's #9157 port, minus the `neurons`
   // write and the prune this handler must never run (see the header comment
-  // above -- that invariant is store-independent). D1 is the binding this
-  // path REQUIRES; it is also how the operator replays the box's
-  // neuron_daily/account_position_daily history into D1. Checked after
-  // validation for the same 400-before-503 reasoning as the sync handler.
-  if (!env.METAGRAPH_HEALTH_DB) {
+  // above -- that invariant is store-independent).
+  //
+  // THE INVERSION (#10144). This route was still ordered the way the whole
+  // system used to be: write D1, fail the request if that write fails, then
+  // mirror to Neon and report `stores: ["d1","neon"]`. Both tables it writes
+  // are Neon's outright, so that ordering had the authoritative store in the
+  // mirror's position -- a backfill could report success on a D1 write nothing
+  // reads, and a Neon failure was invisible.
+  //
+  // Checked after validation for the same 400-before-503 reasoning as the sync
+  // handler, and only when the D1 write is still going to happen.
+  const neonOwns = neonOwnsNeuronsSnapshot(env);
+  if (!neonOwns && !env.METAGRAPH_HEALTH_DB) {
     return writeJson({ error: "d1 binding unavailable" }, 503);
   }
-  let d1Statements: number;
-  try {
-    ({ statements: d1Statements } = await writeNeuronDailyBackfillToD1(
-      env.METAGRAPH_HEALTH_DB as unknown as Parameters<
-        typeof writeNeuronDailyBackfillToD1
-      >[0],
-      { dailyRows, positionRows },
-    ));
-  } catch (err) {
-    console.error("data-api neuron-daily-backfill D1 write failed:", err);
-    await captureDataApiError(err, "neuron-daily-backfill-d1", env);
-    return writeJson({ error: "d1 write failed" }, 502);
+  let d1Statements = 0;
+  if (!neonOwns) {
+    try {
+      ({ statements: d1Statements } = await writeNeuronDailyBackfillToD1(
+        env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+          typeof writeNeuronDailyBackfillToD1
+        >[0],
+        { dailyRows, positionRows },
+      ));
+    } catch (err) {
+      console.error("data-api neuron-daily-backfill D1 write failed:", err);
+      await captureDataApiError(err, "neuron-daily-backfill-d1", env);
+      return writeJson({ error: "d1 write failed" }, 502);
+    }
   }
 
   // THE SECOND WRITER, mirrored too (#9717).
@@ -1238,11 +1263,43 @@ async function handleNeuronDailyBackfill(
     { rows: [], dailyRows, positionRows },
   );
 
+  // Once Neon owns the tables, a backfill that did not reach Neon did not
+  // happen -- and the operator replaying a year of history is precisely the
+  // caller who must not be told `ok` for rows that landed nowhere. Below the
+  // inversion this stays best-effort, exactly as it was.
+  //
+  // The two tables are named rather than folded over `neon.results`, because
+  // the mirror returns `{ attempted: true, results: {} }` when Hyperdrive is
+  // unbound -- a failure a "no result said not-ok" test would read as success.
+  // Absent has to fail here, not just present-and-false.
+  if (neonOwns) {
+    const reason = ["neuron_daily", "account_position_daily"]
+      .map((table) => {
+        const result = neon.results?.[table];
+        if (!result) return `${table}: no Neon write recorded`;
+        return result.ok ? null : `${table}: ${result.reason ?? "failed"}`;
+      })
+      .filter(Boolean)
+      .join("; ");
+    if (reason) {
+      console.error(
+        "data-api neuron-daily-backfill Neon write failed:",
+        reason,
+      );
+      await captureDataApiError(
+        new Error(reason),
+        "neuron-daily-backfill-neon",
+        env,
+      );
+      return writeJson({ error: "neon write failed" }, 502);
+    }
+  }
+
   return writeJson({
     ok: true,
     neuron_daily_written: dailyRows.length,
     account_position_daily_written: positionRows.length,
-    stores: neon.attempted ? ["d1", "neon"] : ["d1"],
+    stores: neonOwns ? ["neon"] : neon.attempted ? ["d1", "neon"] : ["d1"],
     d1_statements: d1Statements,
     neon: neon.attempted ? neon.results : undefined,
   });
@@ -2961,8 +3018,15 @@ async function handlePollerLaneHealthSync(request: Request, env: Env) {
   if (!incoming.length || !incoming.every(validPollerJobOutcome)) {
     return writeJson({ error: "rows must match the outcome shape" }, 400);
   }
-  if (!env.METAGRAPH_HEALTH_DB) {
-    return writeJson({ error: "d1 binding unavailable" }, 503);
+  // Whichever store holds lane_health (#10127). Every one of this repo's 27
+  // watchdogs already writes its verdicts through laneHealthStore; this route
+  // was the one writer still reaching for the D1 binding by name, so the
+  // poller's job outcomes were the only verdicts that would have stopped
+  // landing when D1 went away -- and recordLaneVerdict swallows failures, so
+  // they would have stopped silently.
+  const laneDb = laneHealthStore(env as unknown as Record<string, unknown>);
+  if (!laneDb) {
+    return writeJson({ error: "no lane_health store bound" }, 503);
   }
 
   // recordLaneVerdict swallows its own failures by design -- an alarm whose
@@ -2970,9 +3034,17 @@ async function handlePollerLaneHealthSync(request: Request, env: Env) {
   // that actually landed is reported rather than assumed.
   let written = 0;
   for (const row of incoming.map(coercePollerJobOutcome)) {
-    if (await recordLaneVerdict(env.METAGRAPH_HEALTH_DB, row)) written += 1;
+    if (await recordLaneVerdict(laneDb, row)) written += 1;
   }
-  return writeJson({ ok: true, lane_health_written: written, stores: ["d1"] });
+  return writeJson({
+    ok: true,
+    lane_health_written: written,
+    stores: [
+      neonOwnsTable(env as unknown as Record<string, unknown>, "lane_health")
+        ? "neon"
+        : "d1",
+    ],
+  });
 }
 
 function json(data: unknown, status: number = 200) {
@@ -3317,7 +3389,10 @@ async function withAlertTriggersSql(
 ) {
   const sql = userStateRunner(env, ctx, ALERT_TRIGGER_TABLES);
   if (!sql) {
-    return writeJson({ error: "d1 binding unavailable" }, 503);
+    // userStateRunner is store-neutral (#10106): nothing back from it means
+    // NEITHER store is bound, so naming D1 here pointed at the wrong half of
+    // a two-store answer.
+    return writeJson({ error: "no user-state store bound" }, 503);
   }
   try {
     return await fn(sql);
@@ -4437,7 +4512,8 @@ async function withAccountsSql<T>(
 ): Promise<T | Response> {
   const sql = userStateRunner(env, ctx, ACCOUNT_STATE_TABLES);
   if (!sql) {
-    return writeJson({ error: "d1 binding unavailable" }, 503);
+    // Store-neutral, same as withAlertTriggersSql above.
+    return writeJson({ error: "no user-state store bound" }, 503);
   }
   try {
     return await fn(sql);


### PR DESCRIPTION
Closes #10144

> Stacked on #10146 — `main` is red on `tests/neon-sole-store-tables-exist.test.ts`, so this targets that branch. Retarget to `main` once #10146 lands.

Every table these routes write is in `NEON_SOLE_STORE_TABLES`, and each handler already skipped its D1 write once Neon owned the tables. **The binding check above the write did not know that.** Unbind D1 and the route answers `503 {"error":"d1 binding unavailable"}` before ever reaching the Neon write that would have succeeded.

Nothing fails while D1 stays bound, which is why it survived every inversion: it is dead code that only wakes up on the day the database is dropped.

`handleSubnetHyperparamsSync` and `handleAccountIdentitySync` already had the right shape (`if (!neonOwns && !env.METAGRAPH_HEALTH_DB)`). The others now match it.

| handler | change |
|---|---|
| `handleNeuronsSync` | the `neonOwnsNeuronsSnapshot` gate moves above the check |
| `handleChainDetailSync` | same, via `neonOwnsChainDetail` |
| `handleNeuronDailyBackfill` | **inverted outright** — see below |
| `handlePollerLaneHealthSync` | writes through `laneHealthStore` |

## `handleNeuronDailyBackfill` was more than a stale guard

It wrote D1 first, failed the request if that write failed, then mirrored to Neon best-effort and reported `stores: ["d1","neon"]`. With `neuron_daily` and `account_position_daily` both sole-store on Neon, that put the **authoritative store in the mirror's position** — an operator replaying a year of history could be told `ok` for rows that landed nowhere, and a Neon failure was invisible.

Neon failing is now the request failing. The two tables are named explicitly rather than folded over `neon.results`, because the mirror returns `{ attempted: true, results: {} }` when Hyperdrive is unbound — a failure that a "no result said not-ok" test reads as success. Absent has to fail, not just present-and-false.

## `handlePollerLaneHealthSync`

The last verdict writer still reaching for `METAGRAPH_HEALTH_DB` by name; the other 27 already go through `laneHealthStore` (#10127). The poller's job outcomes were the one class of verdict that would have stopped landing when D1 went away — **silently**, because `recordLaneVerdict` swallows its failures by design.

## Deliberately NOT changed

`handleChainDetailSyncHead` keeps its unconditional check. `chainDetailHead` reads `chain_detail_blocks` out of `src/chain-detail-hot-tier.ts`, which is D1-only and has no Neon path to fall through to. `head: null` is a *documented real answer* telling the producer to start from the current finalized head — a 503 makes it retry, a wrong null makes it skip and leave a hole nothing will ever fill. It unblocks when the hot tier moves (#9773).

The three read-lane checks in `dispatchDataApiRequest` sit behind `matchNeuronsD1Route` / `matchHealthStatusD1Route` / `matchHyperparamsIdentityD1Route` and belong to the same read-path teardown.

Also: `withAlertTriggersSql` and `withAccountsSql` answered `"d1 binding unavailable"` when the store-neutral `userStateRunner` returned nothing, which since #10106 means *neither* store.

## Verification

New `tests/sync-routes-need-no-d1.test.ts`, 8 tests. Each route gets a pair, and the pair is what carries the weight:

- **Neon owns + no D1** → must NOT be 503 (the fix)
- **Neon owns only part of the family + no D1** → must STILL be 503 (the check is not gone)

Without the second case every assertion would also pass if the check had simply been deleted, which is a different and much worse change. Both directions were checked by mutation:

- reverting the guards to `if (!env.METAGRAPH_HEALTH_DB)` → the 3 "reaches the store" tests fail
- deleting the checks outright → the 3 "still refuses" tests fail

`assertReachedTheStore` also rejects 400, after the chain-detail case initially passed while sending a body `parseChainDetailSync` threw out — a drifted fixture would otherwise turn these into tests of the validator.

61 suites naming any touched symbol: green.