### PR TITLE
feat(neon): move the tier readers off the frozen D1 copy (#10148)

### DIFF
--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -94,6 +94,7 @@ import {
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
 import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
+import { readStore } from "./read-store.ts";
 
 /** Kept identical to the Postgres tier's SELECT list so both tiers hand the
  * formatter the same shape. */
@@ -434,8 +435,7 @@ async function neuronSlots(
   env: Env | null | undefined,
   addr: string,
 ): Promise<{ netuid: number; uid: number }[] | null> {
-  const db = (env as { METAGRAPH_HEALTH_DB?: D1Like } | null | undefined)
-    ?.METAGRAPH_HEALTH_DB;
+  const db = readStore(env, ["neurons"]) as unknown as D1Like | undefined;
   if (!db?.prepare) return null;
   let results: unknown[];
   try {

--- a/src/account-summary-card.ts
+++ b/src/account-summary-card.ts
@@ -42,6 +42,7 @@ import {
 } from "./account-events.ts";
 import { loadAccountSummaryColdTier } from "./account-feeds-cold-tier.ts";
 import { isR2SqlConfigured } from "./r2-sql.ts";
+import { readStore } from "./read-store.ts";
 
 /** The D1 surface this module needs -- structural, so tests can hand it a
  * plain object (the same pattern as src/blocks-cold-tier.ts). */
@@ -77,8 +78,7 @@ export async function loadAccountRegistrationsD1(
   env: Env | null | undefined,
   ss58: string,
 ): Promise<Record<string, unknown>[] | null> {
-  const db = (env as { METAGRAPH_HEALTH_DB?: D1Like } | null | undefined)
-    ?.METAGRAPH_HEALTH_DB;
+  const db = readStore(env, ["neurons"]) as unknown as D1Like | undefined;
   if (!db?.prepare) return [];
   try {
     const res = await db.prepare(ACCOUNT_REGISTRATIONS_SQL).bind(ss58).all?.();

--- a/src/blocks-cold-tier.ts
+++ b/src/blocks-cold-tier.ts
@@ -47,6 +47,7 @@ import {
 import { safeBlockNumber, safeHexLiteral } from "./r2-sql.ts";
 import { type ChainNetworkId, DEFAULT_CHAIN_NETWORK } from "./chain-network.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
+import { readStore } from "./read-store.ts";
 import {
   resolveDecodeWatermark,
   type DecodeWatermarkDeps,
@@ -118,12 +119,18 @@ interface D1Like {
   };
 }
 
-/** The two bindings this module reads, independent of the full Env shape so
- * the module stays testable with a plain object. */
+/** The one binding this module still reads directly, independent of the full
+ * Env shape so the module stays testable with a plain object. The store behind
+ * the SQL comes from readStore now (#10148), not from a binding read here. */
 interface ColdTierBindings {
-  METAGRAPH_HEALTH_DB?: D1Like;
   ICEBERG_BLOCKS_MAX?: unknown;
 }
+
+/** Both tables D1_FROM joins. Neon owns them together or the read stays where
+ *  it is: a LEFT JOIN with one side in the other store returns rows with every
+ *  `c.` column null, which reads exactly like a block the hot lane never
+ *  wrote -- a wrong answer with a valid shape. */
+const BLOCKS_SEAM_TABLES = ["blocks_head", "chain_detail_blocks"] as const;
 
 function bindings(env: unknown): ColdTierBindings {
   return (env ?? {}) as ColdTierBindings;
@@ -235,7 +242,8 @@ async function d1HeadRows(
   seam: number,
   want: number,
 ): Promise<Record<string, unknown>[] | null> {
-  const db = bindings(env).METAGRAPH_HEALTH_DB;
+  const db = readStore(env, BLOCKS_SEAM_TABLES) as unknown as
+    D1Like | undefined;
   if (!db?.prepare || want <= 0) return null;
 
   // Every predicate is qualified to `b`: block_number, observed_at and
@@ -399,7 +407,7 @@ export async function loadBlockColdTier(
   // Mainnet-only, for the same reason the feed's head leg is.
   const db =
     network === DEFAULT_CHAIN_NETWORK
-      ? bindings(env).METAGRAPH_HEALTH_DB
+      ? (readStore(env, BLOCKS_SEAM_TABLES) as unknown as D1Like | undefined)
       : undefined;
   // "Above the seam" means "too new for the lakehouse, so D1 is the only
   // source" — a statement that is only true on mainnet, because only mainnet

--- a/src/chain-detail-hot-tier.ts
+++ b/src/chain-detail-hot-tier.ts
@@ -45,6 +45,7 @@ import { decodeChainEventArgs } from "./chain-event-args.ts";
 import { resolveBlocksSeam } from "./blocks-cold-tier.ts";
 import { type ChainNetworkId, DEFAULT_CHAIN_NETWORK } from "./chain-network.ts";
 import { safeBlockNumber } from "./r2-sql.ts";
+import { readStore } from "./read-store.ts";
 import { summarizeEvent } from "@jsonbored/chain-summaries";
 
 type Row = Record<string, unknown>;
@@ -57,13 +58,19 @@ interface D1Statement {
 interface D1Like {
   prepare(sql: string): D1Statement;
 }
-interface HotTierBindings {
-  METAGRAPH_HEALTH_DB?: D1Like;
-}
+/** The four tables every statement in this module reads (#10148). Handed to
+ *  readStore as one set: a hot tier split across stores would answer a block
+ *  detail with extrinsics from one and events from the other. */
+export const CHAIN_DETAIL_HOT_TIER_TABLES = [
+  "chain_detail_blocks",
+  "chain_detail_extrinsics",
+  "chain_detail_chain_events",
+  "chain_detail_account_events",
+] as const;
 
 function db(env: unknown): D1Like | null {
-  const binding = (env as HotTierBindings | null | undefined)
-    ?.METAGRAPH_HEALTH_DB;
+  const binding = readStore(env, CHAIN_DETAIL_HOT_TIER_TABLES) as unknown as
+    D1Like | undefined;
   return binding?.prepare ? binding : null;
 }
 

--- a/src/nominator-positions-cold-tier.ts
+++ b/src/nominator-positions-cold-tier.ts
@@ -60,6 +60,7 @@ import {
 import { STAKE_ADDED_KIND, STAKE_REMOVED_KIND } from "./account-stake-flow.ts";
 import { registerModuleStateReset } from "./module-state-registry.ts";
 import { r2SqlQuery, safeSs58Literal } from "./r2-sql.ts";
+import { readStore } from "./read-store.ts";
 
 /** Kept identical to the retired Postgres tier's SELECT list (minus `coldkey`,
  * which the predicate already fixes) so both tiers hand the formatter the
@@ -109,8 +110,7 @@ export async function neuronStakeByHotkeys(
   hotkeys: string[],
 ): Promise<Map<string, number> | null> {
   if (hotkeys.length === 0) return new Map();
-  const db = (env as { METAGRAPH_HEALTH_DB?: D1Like } | null | undefined)
-    ?.METAGRAPH_HEALTH_DB;
+  const db = readStore(env, ["neurons"]) as unknown as D1Like | undefined;
   if (!db?.prepare) return null;
   const chunks: string[][] = [];
   for (let i = 0; i < hotkeys.length; i += D1_BIND_PARAM_CAP) {

--- a/src/nominator-positions-hot-tier.ts
+++ b/src/nominator-positions-hot-tier.ts
@@ -35,6 +35,7 @@ import {
   neuronStakeByHotkeys,
   POSITION_SCAN_CAP,
 } from "./nominator-positions-cold-tier.ts";
+import { readStore } from "./read-store.ts";
 
 /** The D1 surface this module needs -- structural, so tests can hand a plain
  * object (same pattern as src/nominator-positions-cold-tier.ts). */
@@ -66,8 +67,8 @@ export async function loadAccountPositionsD1(
   env: Env | null | undefined,
   ss58: string,
 ): Promise<ReturnType<typeof buildAccountPositions> | null> {
-  const db = (env as { METAGRAPH_HEALTH_DB?: D1Like } | null | undefined)
-    ?.METAGRAPH_HEALTH_DB;
+  const db = readStore(env, ["nominator_positions"]) as unknown as
+    D1Like | undefined;
   if (!db?.prepare) return null;
 
   let rows: Record<string, unknown>[];

--- a/src/read-store.ts
+++ b/src/read-store.ts
@@ -1,0 +1,124 @@
+// Which store a READ should go to, for callers that have no ExecutionContext.
+//
+// ## Why this exists when createPgSql already does
+//
+// createPgSql hands its connection back through `ctx.waitUntil(client.end())`,
+// so every caller needs an ExecutionContext. That is fine on a route handler
+// and impossible on the tier readers: chain-detail-hot-tier, blocks-cold-tier,
+// nominator-positions-hot-tier and the rest are `(env, ...)` functions called
+// from resolvers, MCP handlers and other loaders, several layers below anything
+// holding a ctx. Threading one through all of them, and through every caller of
+// every one of them, is a far larger and riskier change than the reads deserve.
+//
+// So this takes lane-health-store's approach instead, for the same reason and
+// with the same trade: each operation opens, runs and closes its own
+// connection, awaiting the teardown rather than deferring it. Hyperdrive pools,
+// so `connect()` is against the pool rather than a fresh TCP handshake -- which
+// is what makes per-operation connections affordable here and would not be
+// against a bare Postgres.
+//
+// ## Why the shape is D1's
+//
+// Every call site already speaks `prepare(text).bind(...).all()`. Returning
+// that shape means the swap is the binding expression and nothing else -- no
+// query rewriting, no signature changes, no behaviour to re-verify at ~60 sites
+// across the tier readers. `?` placeholders are rewritten to `$n` on the way
+// through, which is the only dialect difference these queries have: they are
+// plain SELECTs with no SQLite-specific functions.
+//
+// ## All-or-nothing, deliberately
+//
+// A reader is handed EVERY table its statements name. Neon has to own all of
+// them or the D1 binding is returned unchanged. A reader split across stores
+// would run a JOIN against a store missing one side, and that failure is an
+// empty result set rather than an error -- a schema-stable wrong answer, which
+// is the failure mode this whole migration keeps having to design against.
+import { Client } from "pg";
+import { neonOwnsTable } from "./neon-write.ts";
+import { toPositionalPlaceholders, type HyperdriveLike } from "./pg-sql.ts";
+
+/** The minimal pg client this needs, so a test can hand it a fake. */
+export interface ReadStoreClient {
+  connect(): Promise<void>;
+  end(): Promise<void>;
+  query(
+    text: string,
+    values?: unknown[],
+  ): Promise<{ rows?: unknown[]; rowCount?: number } | undefined>;
+}
+
+/** D1's read surface, as the tier readers actually use it. */
+export interface ReadStoreDb {
+  prepare(text: string): {
+    bind(...values: unknown[]): {
+      all(): Promise<{ results: unknown[] }>;
+      first(): Promise<unknown>;
+    };
+    all(): Promise<{ results: unknown[] }>;
+    first(): Promise<unknown>;
+  };
+}
+
+export interface ReadStoreDeps {
+  clientFactory?: (connectionString: string) => ReadStoreClient;
+}
+
+/** A D1-shaped read handle over Postgres, one connection per operation. */
+export function pgReadStore(
+  connectionString: string,
+  deps: ReadStoreDeps = {},
+): ReadStoreDb {
+  const run = async (text: string, values: unknown[]) => {
+    const client =
+      deps.clientFactory?.(connectionString) ??
+      (new Client({ connectionString }) as unknown as ReadStoreClient);
+    await client.connect();
+    try {
+      const result = await client.query(toPositionalPlaceholders(text), values);
+      return (result?.rows ?? []) as unknown[];
+    } finally {
+      // Awaited, unlike createPgSql's waitUntil -- see this module's header.
+      await client.end().catch(() => undefined);
+    }
+  };
+  const ops = (text: string, values: unknown[]) => ({
+    all: async () => ({ results: await run(text, values) }),
+    first: async () => (await run(text, values))[0] ?? null,
+  });
+  return {
+    prepare(text: string) {
+      return {
+        bind: (...values: unknown[]) => ops(text, values),
+        ...ops(text, []),
+      };
+    },
+  };
+}
+
+/**
+ * The store to read `tables` from: Neon once it solely owns every one of them
+ * and Hyperdrive is bound, the D1 binding until then.
+ *
+ * `injected` wins outright so a test can hand in its own fake, and `undefined`
+ * comes back when neither store is available -- which every caller already
+ * handles, because an unbound D1 has always been possible.
+ */
+export function readStore(
+  // Deliberately loose: callers hand in an `Env`, a bag, or `unknown`, and a
+  // narrower type would push a cast to every one of them.
+  env: unknown,
+  tables: readonly string[],
+  injected?: ReadStoreDb | null,
+  deps: ReadStoreDeps = {},
+): ReadStoreDb | undefined {
+  if (injected) return injected;
+  const bag = env as Record<string, unknown> | null | undefined;
+  const d1 = bag?.METAGRAPH_HEALTH_DB as ReadStoreDb | undefined;
+  const hyperdrive = bag?.HYPERDRIVE as HyperdriveLike | undefined;
+  if (!hyperdrive?.connectionString) return d1;
+  // Empty `tables` must never read as "Neon owns them all" -- that would send a
+  // caller who forgot to declare its tables to Postgres unconditionally.
+  if (tables.length === 0) return d1;
+  if (!tables.every((table) => neonOwnsTable(bag, table))) return d1;
+  return pgReadStore(hyperdrive.connectionString, deps);
+}

--- a/src/self-health-mcp.ts
+++ b/src/self-health-mcp.ts
@@ -40,6 +40,7 @@ import { z } from "zod";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { loadSelfHealthColdTier } from "./self-health-cold-tier.ts";
 import { loadLatestLaneHealth } from "./lane-health.ts";
+import { laneHealthStore } from "./lane-health-store.ts";
 import { withLaneHealth, type SelfHealth } from "./self-health.ts";
 import {
   GetSelfHealthInputSchema,
@@ -203,9 +204,13 @@ export async function loadSelfHealth(
   // and the empty floor are both buildSelfHealth output, and withLaneHealth only
   // spreads the value and appends two fields.
   const lanes = await loadLatestLaneHealth(
-    ctx.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
-      typeof loadLatestLaneHealth
-    >[0],
+    // laneHealthStore, not the binding (#10148). Every other lane_health
+    // reader already goes through it; this one still named D1, so self-health
+    // would have reported an empty lane floor -- which renders as "no alarms"
+    // -- the moment D1 went away.
+    laneHealthStore(
+      ctx.env as unknown as Record<string, unknown>,
+    ) as unknown as Parameters<typeof loadLatestLaneHealth>[0],
   );
   return withLaneHealth(card as SelfHealth, lanes);
 }

--- a/tests/read-store-declares-its-tables.test.ts
+++ b/tests/read-store-declares-its-tables.test.ts
@@ -1,0 +1,133 @@
+// A ported reader must declare every table its SQL names.
+//
+// THE FAILURE THIS EXISTS TO STOP, which no unit test of readStore can reach.
+// readStore is all-or-nothing on purpose: it goes to Neon only when Neon owns
+// EVERY table it was handed. That rule is only as good as the list. A reader
+// that names three tables in its SQL and declares two gets sent to Neon on the
+// strength of the two -- and then runs a statement against a store where the
+// third does not exist. On a LEFT JOIN that is not an error; it is rows with
+// every column of the missing side null, which reads exactly like a block the
+// lane never wrote.
+//
+// The list is also the thing most likely to drift. It sits at the top of the
+// module while the SQL that has to agree with it sits hundreds of lines down,
+// and adding a table to a query is the natural change that forgets it.
+//
+// So this reads the SQL back out of each ported module and checks it against
+// what that module actually hands readStore. Nothing is listed here that the
+// modules do not already state themselves -- a list in this file would be one
+// more copy to forget.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+
+/** Ported in #10148. Each still owns its own table declaration; this only
+ *  checks that the declaration covers the SQL. */
+const PORTED = [
+  "src/chain-detail-hot-tier.ts",
+  "src/blocks-cold-tier.ts",
+  "src/nominator-positions-hot-tier.ts",
+  "src/nominator-positions-cold-tier.ts",
+  "src/account-summary-card.ts",
+  "src/account-feeds-cold-tier.ts",
+];
+
+/** The module's STRING LITERALS, with comments removed first.
+ *
+ * Both halves are load-bearing. These modules are heavily commented and the
+ * prose is full of English "from the" and "join a", so a scan over raw source
+ * reports `the`, `a` and `whichever` as tables. And even comment-free source
+ * has identifiers and prose in JSDoc; SQL only ever lives in a string. */
+function sqlLiterals(source: string): string {
+  const withoutComments = source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/^\s*\/\/.*$/gm, " ");
+  return [...withoutComments.matchAll(/"([^"\\]*(?:\\.[^"\\]*)*)"|`([^`]*)`/g)]
+    .map((m) => m[1] ?? m[2] ?? "")
+    .join("\n");
+}
+
+/** Tables named after FROM or JOIN, ignoring an alias.
+ *
+ * A `WITH x AS (...)` name is subtracted: a CTE is a name bound inside the
+ * statement, not a table any store has to own. account-feeds-cold-tier's
+ * lakehouse summary query is the live example -- it selects `FROM scan`, and
+ * `scan` exists only for the length of that statement. */
+function tablesInSql(source: string): Set<string> {
+  const sql = sqlLiterals(source);
+  const ctes = new Set(
+    [...sql.matchAll(/\bWITH\s+([a-z_][a-z0-9_]*)\s+AS\s*\(/gi)].map(([, n]) =>
+      n!.toLowerCase(),
+    ),
+  );
+  const found = new Set<string>();
+  for (const [, name] of sql.matchAll(
+    // `chain.` excluded in the pattern: the lakehouse is a different engine
+    // (R2 SQL) and is not readStore's business.
+    /\b(?:FROM|JOIN)\s+(?!chain\.)([a-z_][a-z0-9_]*)/gi,
+  )) {
+    const table = name!.toLowerCase();
+    if (!ctes.has(table)) found.add(table);
+  }
+  return found;
+}
+
+/** Every table name appearing in a readStore(...) call in the module. */
+function tablesDeclared(source: string): Set<string> {
+  const declared = new Set<string>();
+  // Inline array: readStore(env, ["neurons"])
+  for (const [, list] of source.matchAll(/readStore\([^,]+,\s*\[([^\]]*)\]/g)) {
+    for (const [, name] of list.matchAll(/"([a-z_][a-z0-9_]*)"/gi))
+      declared.add(name.toLowerCase());
+  }
+  // Named constant: readStore(env, BLOCKS_SEAM_TABLES) -> read the constant.
+  for (const [, ident] of source.matchAll(
+    /readStore\([^,]+,\s*([A-Z][A-Z0-9_]*)\s*\)/g,
+  )) {
+    const decl = source.match(
+      new RegExp(`${ident}\\s*=\\s*\\[([\\s\\S]*?)\\]\\s*as const`),
+    );
+    assert.ok(decl, `${ident} is passed to readStore but never declared`);
+    for (const [, name] of decl[1]!.matchAll(/"([a-z_][a-z0-9_]*)"/gi))
+      declared.add(name.toLowerCase());
+  }
+  return declared;
+}
+
+describe("every ported reader declares the tables it reads", () => {
+  for (const file of PORTED) {
+    test(file, () => {
+      const source = readFileSync(file, "utf8");
+      const declared = tablesDeclared(source);
+      // A module in this list that calls readStore nowhere means the port was
+      // reverted, or the file was renamed and this list went stale -- both of
+      // which would otherwise show up as a vacuous pass.
+      assert.ok(
+        declared.size > 0,
+        `${file} is listed as ported but hands readStore no tables`,
+      );
+      const used = tablesInSql(source);
+      assert.ok(
+        used.size > 0,
+        `${file} has no FROM/JOIN -- the scanner matched nothing, so this test proves nothing`,
+      );
+      const undeclared = [...used].filter((t) => !declared.has(t));
+      assert.deepEqual(
+        undeclared,
+        [],
+        `${file} reads ${undeclared.join(", ")} but does not hand it to readStore; ` +
+          `readStore would send this module to Neon on the strength of the tables it DID declare`,
+      );
+    });
+  }
+
+  test("no ported reader still reaches for the D1 binding", () => {
+    // The port is a swap, so a leftover binding read is a second store choice
+    // in a module that already made one -- and the two would disagree exactly
+    // when it matters, which is once Neon owns the tables.
+    const offenders = PORTED.filter((file) =>
+      readFileSync(file, "utf8").includes("METAGRAPH_HEALTH_DB"),
+    );
+    assert.deepEqual(offenders, []);
+  });
+});

--- a/tests/read-store.test.ts
+++ b/tests/read-store.test.ts
@@ -1,0 +1,192 @@
+// readStore: which store a ctx-less READ goes to, and the handle it hands back.
+//
+// The tier readers all had the same shape -- `env.METAGRAPH_HEALTH_DB`, taken
+// unconditionally -- and every table they read is now Neon's outright, so they
+// were serving a frozen copy. What made them skip the earlier ports is that
+// none has an ExecutionContext: createPgSql returns its connection through
+// ctx.waitUntil, so moving them looked like threading a ctx through five
+// modules and every caller of every one of them.
+//
+// This helper takes lane-health-store's way out instead -- open, run, close,
+// awaiting the teardown -- so the swap is the binding expression and nothing
+// else. What is asserted below is therefore mostly about the CHOICE (which
+// store, and when it must refuse to be Neon) and the connection LIFETIME, since
+// a per-operation connection that leaks is worse than the stale read it fixed.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  pgReadStore,
+  readStore,
+  type ReadStoreClient,
+} from "../src/read-store.ts";
+
+const HYPERDRIVE = { connectionString: "postgresql://example/db" };
+
+/** A D1 binding that records what it was asked to prepare, so a test can tell
+ *  WHICH store came back without a real database on either side. */
+function recordingD1() {
+  const seen: string[] = [];
+  return {
+    seen,
+    binding: {
+      prepare(text: string) {
+        seen.push(text);
+        return { bind: () => ({ all: async () => ({ results: [] }) }) };
+      },
+    },
+  };
+}
+
+/** A pg client that records every call, so the lifetime is observable. */
+function fakeClient(rows: unknown[] = [], failWith?: Error) {
+  const calls: string[] = [];
+  const client: ReadStoreClient & { calls: string[] } = {
+    calls,
+    async connect() {
+      calls.push("connect");
+    },
+    async end() {
+      calls.push("end");
+    },
+    async query(text: string, values?: unknown[]) {
+      calls.push(`query:${text}:${JSON.stringify(values ?? [])}`);
+      if (failWith) throw failWith;
+      return { rows };
+    },
+  };
+  return client;
+}
+
+describe("readStore chooses the store", () => {
+  test("stays on D1 until Neon owns every table it was handed", () => {
+    const d1 = recordingD1();
+    const env = {
+      METAGRAPH_HEALTH_DB: d1.binding,
+      HYPERDRIVE,
+      // Two of the three. A reader split across stores would run its JOIN
+      // against a store missing one side, and that comes back as an empty
+      // result set rather than an error -- a wrong answer with a valid shape.
+      NEON_SOLE_STORE_TABLES: "chain_detail_blocks,chain_detail_extrinsics",
+    };
+    const tables = [
+      "chain_detail_blocks",
+      "chain_detail_extrinsics",
+      "chain_detail_chain_events",
+    ];
+    assert.equal(readStore(env, tables), d1.binding);
+  });
+
+  test("goes to Neon when it owns all of them and Hyperdrive is bound", () => {
+    const d1 = recordingD1();
+    const env = {
+      METAGRAPH_HEALTH_DB: d1.binding,
+      HYPERDRIVE,
+      NEON_SOLE_STORE_TABLES: "blocks_head,chain_detail_blocks",
+    };
+    const store = readStore(env, ["blocks_head", "chain_detail_blocks"]);
+    assert.notEqual(store, d1.binding);
+    assert.equal(typeof store?.prepare, "function");
+  });
+
+  test("stays on D1 when Hyperdrive is unbound, however the flag reads", () => {
+    // The flag can say Neon owns the table while the binding to reach it is
+    // missing -- a config half-applied, or a Worker whose wrangler file was not
+    // updated. Sole-store is a claim about the data, not about this isolate.
+    const d1 = recordingD1();
+    const env = {
+      METAGRAPH_HEALTH_DB: d1.binding,
+      NEON_SOLE_STORE_TABLES: "neurons",
+    };
+    assert.equal(readStore(env, ["neurons"]), d1.binding);
+  });
+
+  test("an empty table list is never 'Neon owns them all'", () => {
+    // `every` on an empty array is true, so the natural implementation sends a
+    // caller who forgot to declare its tables to Postgres unconditionally --
+    // the one case where the all-or-nothing rule inverts into its opposite.
+    const d1 = recordingD1();
+    const env = {
+      METAGRAPH_HEALTH_DB: d1.binding,
+      HYPERDRIVE,
+      NEON_SOLE_STORE_TABLES: "neurons",
+    };
+    assert.equal(readStore(env, []), d1.binding);
+  });
+
+  test("an injected store wins, and a missing binding is undefined not a throw", () => {
+    const injected = { prepare: () => ({}) } as never;
+    assert.equal(readStore({}, ["neurons"], injected), injected);
+    // Every caller already handles undefined -- an unbound D1 has always been
+    // possible, and each one declines rather than failing the request.
+    assert.equal(readStore({}, ["neurons"]), undefined);
+    assert.equal(readStore(null, ["neurons"]), undefined);
+  });
+});
+
+describe("the Postgres handle", () => {
+  test("rewrites ? to $n and returns D1's envelope", async () => {
+    const client = fakeClient([{ block_number: 5 }]);
+    const db = pgReadStore("postgresql://x/y", { clientFactory: () => client });
+    const res = await db
+      .prepare(
+        "SELECT block_number FROM chain_detail_blocks WHERE a = ? AND b = ?",
+      )
+      .bind(1, 2)
+      .all();
+    assert.deepEqual(res, { results: [{ block_number: 5 }] });
+    assert.deepEqual(client.calls, [
+      "connect",
+      "query:SELECT block_number FROM chain_detail_blocks WHERE a = $1 AND b = $2:[1,2]",
+      "end",
+    ]);
+  });
+
+  test("closes the connection even when the query throws", async () => {
+    // The whole reason this handle can exist without a ctx is that it closes
+    // its own connection. A throw that skips the close leaks one per failed
+    // read, which on a serving path is worse than the stale read it replaced.
+    const client = fakeClient([], new Error("boom"));
+    const db = pgReadStore("postgresql://x/y", { clientFactory: () => client });
+    await assert.rejects(() => db.prepare("SELECT 1").bind().all(), /boom/);
+    assert.deepEqual(client.calls.at(-1), "end");
+  });
+
+  test("opens one connection per operation, not one per handle", async () => {
+    const clients: ReturnType<typeof fakeClient>[] = [];
+    const db = pgReadStore("postgresql://x/y", {
+      clientFactory: () => {
+        const c = fakeClient([]);
+        clients.push(c);
+        return c;
+      },
+    });
+    await db.prepare("SELECT 1").bind().all();
+    await db.prepare("SELECT 2").bind().all();
+    assert.equal(clients.length, 2);
+    for (const c of clients) assert.deepEqual(c.calls.at(-1), "end");
+  });
+
+  test("serves an unbound statement, which several readers use", async () => {
+    // chain-detail-hot-tier's coverage read takes no parameters, and D1 lets a
+    // caller skip .bind() entirely. Dropping that would turn the read into a
+    // TypeError caught as "hot tier unavailable" -- a silent decline.
+    const client = fakeClient([{ head: 9 }]);
+    const db = pgReadStore("postgresql://x/y", { clientFactory: () => client });
+    assert.deepEqual(await db.prepare("SELECT MAX(x) AS head FROM t").all(), {
+      results: [{ head: 9 }],
+    });
+  });
+
+  test("first() returns the row or null, never undefined", async () => {
+    const withRow = pgReadStore("postgresql://x/y", {
+      clientFactory: () => fakeClient([{ a: 1 }, { a: 2 }]),
+    });
+    assert.deepEqual(await withRow.prepare("SELECT a FROM t").bind().first(), {
+      a: 1,
+    });
+    const empty = pgReadStore("postgresql://x/y", {
+      clientFactory: () => fakeClient([]),
+    });
+    assert.equal(await empty.prepare("SELECT a FROM t").bind().first(), null);
+  });
+});


### PR DESCRIPTION
Closes #10148

Every table these seven modules read is in `NEON_SOLE_STORE_TABLES`. D1 stopped being written when those lanes inverted, so they serve a **frozen snapshot today** and answer nothing at all once D1 is dropped.

| module | tables |
|---|---|
| `src/chain-detail-hot-tier.ts` | all four `chain_detail_*` |
| `src/blocks-cold-tier.ts` | `blocks_head` JOIN `chain_detail_blocks` |
| `src/nominator-positions-hot-tier.ts` | `nominator_positions` |
| `src/nominator-positions-cold-tier.ts` | `neurons` |
| `src/account-summary-card.ts` | `neurons` |
| `src/account-feeds-cold-tier.ts` | `neurons` |
| `src/self-health-mcp.ts` | `lane_health` — via the `laneHealthStore` it already had |

## Why these were skipped before, and why that reasoning was wrong

None of them has an `ExecutionContext`. `createPgSql` returns its connection through `ctx.waitUntil`, so porting them looked like threading a ctx through five modules and every caller of every one of them — a signature refactor far larger than the reads deserve.

`src/lane-health-store.ts` already solved exactly this, for exactly this reason: **one connection per operation, teardown awaited rather than deferred.** Hyperdrive pools, so `connect()` is against the pool rather than a fresh TCP handshake, which is what makes that affordable. `src/read-store.ts` generalises it — and each port becomes the binding expression and nothing else. No query rewriting, no signature changes, no behaviour to re-verify. `?` → `$n` on the way through is the only dialect difference these plain SELECTs have.

## All-or-nothing, and the case where that inverts

A reader is handed **every** table its statements name; Neon has to own all of them or the read stays on D1. A reader split across stores runs its JOIN against a store missing one side, and a LEFT JOIN answers that with rows whose every column of the missing side is null — indistinguishable from a block the lane never wrote. A wrong answer with a valid shape.

An empty table list is explicitly **not** "Neon owns them all". `Array.every` on `[]` is `true`, so the natural implementation sends a caller who forgot to declare its tables to Postgres unconditionally — the one case where the rule flips into its opposite. Covered by a test.

## Verification

**`tests/read-store.test.ts`** (10) — the choice and the connection lifetime. The lifetime matters because a per-operation connection that leaks is worse than the stale read it replaced, so there are tests that the connection closes on a throwing query and that two operations open two clients. Also that an unbound statement works (`prepare().all()` with no `.bind()`), which chain-detail-hot-tier's coverage read uses — dropping it would turn that read into a TypeError caught as "hot tier unavailable", a silent decline.

**`tests/read-store-declares-its-tables.test.ts`** (7) — the all-or-nothing rule is only as good as the list, and the list sits at the top of the module while the SQL that must agree with it is hundreds of lines down. This reads each module's SQL back out and checks it. Two things were needed to make it mean anything:

- **strip comments and scan only string literals.** Over raw source these heavily-commented modules report `the`, `a` and `whichever` as tables — English prose contains "from the" and "join a".
- **subtract CTE names.** `account-feeds-cold-tier` selects `FROM scan` where `scan` is a `WITH scan AS (...)` in a lakehouse query — a name bound inside the statement, not a table any store owns.

Mutation-checked: deleting `chain_detail_account_events` from the hot tier's declared list fails the guard with that table named.

23 suites touching any of these modules: **1,888 tests green.**

## Still on D1 after this

From the same sweep, filed or noted separately so this stays mechanical — `src/mcp-server.ts` (21 sites), `workers/request-handlers/entities.ts` (14), `src/graphql.ts` (10), eight watchdogs whose verdict writes are already ported but whose reads are not, and `src/chain-detail-prune.ts`, which derives Neon's retention watermark from D1's frozen `MIN/MAX(block_number)` and will stop pruning Neon entirely — reporting `{ ok: true }` — once D1 is empty.