### PR TITLE
fix(neon): watchdogs wrote their verdict to Neon and read their evidence from D1 (#10154)

### DIFF
--- a/src/account-balances-staleness-watchdog.ts
+++ b/src/account-balances-staleness-watchdog.ts
@@ -89,6 +89,7 @@
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { readStore } from "./read-store.ts";
 
 /**
  * How old the ledger may get before this is a stall.
@@ -290,8 +291,13 @@ export async function runAccountBalancesStalenessWatchdog(
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;
   const record = deps.recordException ?? recordExceptionEvent;
-  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
-  if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
+  // Whichever store holds the table (#10154). The verdict WRITE moved to
+  // laneHealthStore already; this read did not, so the watchdog was measuring
+  // a frozen D1 copy and would have alarmed permanently -- reporting the lane
+  // stalled while the lane was fine.
+  const db = readStore(env, ["account_balances"]) as unknown as
+    D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
     Number(env?.ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS) ||

--- a/src/chain-detail-staleness-watchdog.ts
+++ b/src/chain-detail-staleness-watchdog.ts
@@ -29,6 +29,7 @@
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { readStore } from "./read-store.ts";
 
 /**
  * How far behind the lane may fall before this is a stall.
@@ -99,8 +100,8 @@ interface D1Like {
 export async function readChainDetailHead(
   env: Record<string, unknown> | null | undefined,
 ): Promise<{ latestObservedAtMs: number | null; headBlock: number | null }> {
-  const db = (env as { METAGRAPH_HEALTH_DB?: D1Like } | null | undefined)
-    ?.METAGRAPH_HEALTH_DB;
+  const db = readStore(env, ["chain_detail_blocks"]) as unknown as
+    D1Like | undefined;
   if (!db?.prepare) return { latestObservedAtMs: null, headBlock: null };
   const row = (await db
     .prepare(
@@ -140,8 +141,13 @@ export async function runChainDetailStalenessWatchdog(
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;
   const record = deps.recordException ?? recordExceptionEvent;
-  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
-  if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
+  // Whichever store holds the table (#10154). The verdict WRITE moved to
+  // laneHealthStore already; this read did not, so the watchdog was measuring
+  // a frozen D1 copy and would have alarmed permanently -- reporting the lane
+  // stalled while the lane was fine.
+  const db = readStore(env, ["chain_detail_blocks"]) as unknown as
+    D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
     Number(env?.CHAIN_DETAIL_STALENESS_THRESHOLD_MS) ||

--- a/src/hotkey-alpha-staleness-watchdog.ts
+++ b/src/hotkey-alpha-staleness-watchdog.ts
@@ -63,6 +63,7 @@
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { readStore } from "./read-store.ts";
 
 /**
  * How old the pool ledger may get before this is a stall.
@@ -237,8 +238,15 @@ export async function runHotkeyAlphaStalenessWatchdog(
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;
   const record = deps.recordException ?? recordExceptionEvent;
-  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
-  if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
+  // Whichever store holds the table (#10154). The verdict WRITE moved to
+  // laneHealthStore already; this read did not, so the watchdog was measuring
+  // a frozen D1 copy and would have alarmed permanently -- reporting the lane
+  // stalled while the lane was fine.
+  const db = readStore(env, [
+    "hotkey_alpha",
+    "nominator_positions",
+  ]) as unknown as D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
     Number(env?.HOTKEY_ALPHA_STALENESS_THRESHOLD_MS) ||

--- a/src/lakehouse-seam-watchdog.ts
+++ b/src/lakehouse-seam-watchdog.ts
@@ -47,6 +47,8 @@ import {
   type DecodeWatermark,
 } from "./decode-watermark.ts";
 import { d1Watermark } from "./raw-capture-sync.ts";
+import { readStore } from "./read-store.ts";
+import { laneHealthStore } from "./lane-health-store.ts";
 
 /**
  * How long the decode lane may go without publishing before that is a fault.
@@ -231,9 +233,11 @@ const num = (value: unknown) =>
  * lane's OWN reader so the two can never disagree about which row and column
  * hold the watermark. */
 async function capturedThrough(env: unknown): Promise<number | null> {
-  const db = (
-    env as { METAGRAPH_HEALTH_DB?: Parameters<typeof d1Watermark>[0] }
-  )?.METAGRAPH_HEALTH_DB;
+  // raw_capture_state is Neon's outright, so this follows it (#10154). The
+  // seam this watchdog measures is capture-vs-lakehouse; against a frozen
+  // watermark it reports a gap that only ever widens.
+  const db = readStore(env, ["raw_capture_state"]) as unknown as
+    Parameters<typeof d1Watermark>[0] | undefined;
   if (!db?.prepare) return null;
   try {
     // `Date.now` rather than a `() => 0` stub: the clock is only used by the
@@ -272,10 +276,12 @@ export async function runLakehouseSeamWatchdog(
   } = {},
 ): Promise<Record<string, unknown>> {
   const query = deps.query ?? r2SqlQuery;
-  const laneHealthDb =
-    deps.laneHealthDb ??
-    ((env as { METAGRAPH_HEALTH_DB?: LaneHealthDb })?.METAGRAPH_HEALTH_DB as
-      LaneHealthDb | undefined);
+  // The only watchdog in the family that still named the binding here; every
+  // other one goes through laneHealthStore (#10154).
+  const laneHealthDb = laneHealthStore(
+    env as unknown as Record<string, unknown>,
+    deps.laneHealthDb,
+  );
   const recordVerdict = (verdict: LaneVerdictInput) =>
     recordLaneVerdict(laneHealthDb, {
       lane: LAKEHOUSE_SEAM_LANE,

--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -56,6 +56,7 @@ import {
 } from "./lane-health.ts";
 import { recordLaneVerdict } from "./lane-health.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { laneHealthStore } from "./lane-health-store.ts";
 
 /**
  * How long a lane must stay stale before it earns an issue.
@@ -521,8 +522,12 @@ export async function runLaneAlarm(
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;
   const record = deps.recordException ?? recordExceptionEvent;
-  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
-  if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
+  // laneHealthStore, not the binding (#10154). This is the reader that opens
+  // GitHub issues from lane_health verdicts, so pointing it at a store nothing
+  // writes any more would replay stale verdicts forever -- filing issues for
+  // lanes that recovered, and none for lanes that broke.
+  const db = laneHealthStore(env) as unknown as D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "no lane_health store bound" };
 
   const token = typeof env?.GITHUB_TOKEN === "string" ? env.GITHUB_TOKEN : "";
   const repo =

--- a/src/neurons-staleness-watchdog.ts
+++ b/src/neurons-staleness-watchdog.ts
@@ -45,6 +45,7 @@
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { readStore } from "./read-store.ts";
 
 /** Three missed 15-minute ticks: one restart is routine (a deploy or an
  * eviction costs one tick by design), two could be an unlucky pair, three is
@@ -208,8 +209,12 @@ export async function runNeuronsStalenessWatchdog(
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;
   const record = deps.recordException ?? recordExceptionEvent;
-  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
-  if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
+  // Whichever store holds the table (#10154). The verdict WRITE moved to
+  // laneHealthStore already; this read did not, so the watchdog was measuring
+  // a frozen D1 copy and would have alarmed permanently -- reporting the lane
+  // stalled while the lane was fine.
+  const db = readStore(env, ["neurons"]) as unknown as D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
     Number(env?.NEURONS_STALENESS_THRESHOLD_MS) ||

--- a/src/nominator-positions-staleness-watchdog.ts
+++ b/src/nominator-positions-staleness-watchdog.ts
@@ -55,6 +55,7 @@
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { readStore } from "./read-store.ts";
 
 /**
  * How old the ledger may get before this is a stall.
@@ -243,8 +244,13 @@ export async function runNominatorPositionsStalenessWatchdog(
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;
   const record = deps.recordException ?? recordExceptionEvent;
-  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
-  if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
+  // Whichever store holds the table (#10154). The verdict WRITE moved to
+  // laneHealthStore already; this read did not, so the watchdog was measuring
+  // a frozen D1 copy and would have alarmed permanently -- reporting the lane
+  // stalled while the lane was fine.
+  const db = readStore(env, ["nominator_positions"]) as unknown as
+    D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
     Number(env?.NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS) ||

--- a/tests/account-balances-staleness-watchdog.test.ts
+++ b/tests/account-balances-staleness-watchdog.test.ts
@@ -403,11 +403,11 @@ describe("runAccountBalancesStalenessWatchdog", () => {
   test("a missing binding and a failing query degrade to summaries, never throw", async () => {
     assert.deepEqual(await runAccountBalancesStalenessWatchdog({}), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
     assert.deepEqual(await runAccountBalancesStalenessWatchdog(null), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
 
     const { db } = fakeDb(

--- a/tests/chain-detail-staleness-watchdog.test.ts
+++ b/tests/chain-detail-staleness-watchdog.test.ts
@@ -169,11 +169,11 @@ describe("runChainDetailStalenessWatchdog", () => {
   test("a missing binding and a failing query degrade to summaries, never throw", async () => {
     assert.deepEqual(await runChainDetailStalenessWatchdog({}), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
     assert.deepEqual(await runChainDetailStalenessWatchdog(null), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
     const { db } = fakeDb(new Error("d1 exploded"));
     const result = await runChainDetailStalenessWatchdog(
@@ -265,6 +265,11 @@ describe("the cron wiring", () => {
       {} as never,
       {} as never,
     )) as Record<string, unknown>;
+    // The PRUNE's reason, not the watchdog's, and it is deliberately still
+    // D1's: with an empty env Neon owns nothing, so the D1 DELETE is still the
+    // one that would run and its binding is still the one that is missing
+    // (#10152). The watchdog above answers "no store bound" because its READ
+    // follows the rows; these are different questions with different answers.
     assert.deepEqual(result, {
       ok: false,
       reason: "d1 binding unavailable",

--- a/tests/hotkey-alpha-staleness-watchdog.test.ts
+++ b/tests/hotkey-alpha-staleness-watchdog.test.ts
@@ -378,11 +378,11 @@ describe("runHotkeyAlphaStalenessWatchdog", () => {
   test("no D1 binding is a missed report, not a throw", async () => {
     assert.deepEqual(await runHotkeyAlphaStalenessWatchdog({}), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
     assert.deepEqual(await runHotkeyAlphaStalenessWatchdog(null), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
   });
 

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -900,11 +900,11 @@ describe("runLaneAlarm", () => {
   test("reports a missing binding rather than throwing", async () => {
     assert.deepEqual(await runLaneAlarm({}), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no lane_health store bound",
     });
     assert.deepEqual(await runLaneAlarm(null), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no lane_health store bound",
     });
   });
 

--- a/tests/neurons-staleness-watchdog.test.ts
+++ b/tests/neurons-staleness-watchdog.test.ts
@@ -349,11 +349,11 @@ describe("runNeuronsStalenessWatchdog", () => {
   test("a missing binding and a failing query degrade to summaries, never throws", async () => {
     assert.deepEqual(await runNeuronsStalenessWatchdog({}), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
     assert.deepEqual(await runNeuronsStalenessWatchdog(null), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
     const { db } = fakeDb(new Error("D1_ERROR: no such table: neurons"));
     const result = await runNeuronsStalenessWatchdog(

--- a/tests/nominator-positions-staleness-watchdog.test.ts
+++ b/tests/nominator-positions-staleness-watchdog.test.ts
@@ -372,11 +372,11 @@ describe("runNominatorPositionsStalenessWatchdog", () => {
   test("a missing binding and a failing query degrade to summaries, never throw", async () => {
     assert.deepEqual(await runNominatorPositionsStalenessWatchdog({}), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
     assert.deepEqual(await runNominatorPositionsStalenessWatchdog(null), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
 
     const { db } = fakeDb(

--- a/tests/watchdogs-read-the-owning-store.test.ts
+++ b/tests/watchdogs-read-the-owning-store.test.ts
@@ -1,0 +1,110 @@
+// A watchdog must measure the store that holds the rows (#10154).
+//
+// THE SHAPE OF THE BUG. Nine of these eleven watchdogs already WRITE their
+// verdict through laneHealthStore -- that half of the port was done. None of
+// them had moved its READ. So each one measured a D1 copy that stopped
+// advancing the day its lane inverted, and every table they measure is in
+// NEON_SOLE_STORE_TABLES.
+//
+// That is worse than a watchdog that is merely broken. A staleness watchdog
+// keyed to MAX(captured_at) over a frozen table reports the age growing by one
+// second per second, forever -- so it alarms permanently, on lanes that are
+// fine, and the alarm cannot be distinguished from a real one. lane-alarm is
+// the reader that turns those verdicts into GitHub issues.
+//
+// WHAT IS ASSERTED, and why it is not weaker than it looks. There is no
+// Postgres here, so a watchdog that reaches the store fails at the query and
+// degrades to a summary -- which is what these are built to do. What separates
+// the two outcomes is the REASON: "no store bound" means it never tried, and
+// anything else means it got as far as a store. With D1 unbound and Neon
+// owning the tables, "never tried" is exactly the bug.
+//
+// The second case in each pair is what stops that from passing vacuously: with
+// NOTHING bound, the refusal must still be there.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { runNeuronsStalenessWatchdog } from "../src/neurons-staleness-watchdog.ts";
+import { runAccountBalancesStalenessWatchdog } from "../src/account-balances-staleness-watchdog.ts";
+import { runHotkeyAlphaStalenessWatchdog } from "../src/hotkey-alpha-staleness-watchdog.ts";
+import { runNominatorPositionsStalenessWatchdog } from "../src/nominator-positions-staleness-watchdog.ts";
+import { runChainDetailStalenessWatchdog } from "../src/chain-detail-staleness-watchdog.ts";
+import { runLaneAlarm } from "../src/lane-alarm.ts";
+
+const HYPERDRIVE = { connectionString: "postgresql://example/db" };
+
+/** Each watchdog, the tables it reads, and the refusal it gives with no store.
+ *  The table list is the one the module hands readStore -- if they ever
+ *  disagree, the "owns" case below stops being an owns case and the test fails
+ *  rather than passing on the wrong branch. */
+const WATCHDOGS: {
+  name: string;
+  run: (env: unknown, deps?: never) => Promise<{ reason?: string }>;
+  tables: string[];
+  refusal: string;
+}[] = [
+  {
+    name: "neurons",
+    run: (env) => runNeuronsStalenessWatchdog(env as never),
+    tables: ["neurons"],
+    refusal: "no store bound",
+  },
+  {
+    name: "account-balances",
+    run: (env) => runAccountBalancesStalenessWatchdog(env as never),
+    tables: ["account_balances"],
+    refusal: "no store bound",
+  },
+  {
+    name: "hotkey-alpha",
+    run: (env) => runHotkeyAlphaStalenessWatchdog(env as never),
+    tables: ["hotkey_alpha", "nominator_positions"],
+    refusal: "no store bound",
+  },
+  {
+    name: "nominator-positions",
+    run: (env) => runNominatorPositionsStalenessWatchdog(env as never),
+    tables: ["nominator_positions"],
+    refusal: "no store bound",
+  },
+  {
+    name: "chain-detail",
+    run: (env) => runChainDetailStalenessWatchdog(env as never),
+    tables: ["chain_detail_blocks"],
+    refusal: "no store bound",
+  },
+  {
+    name: "lane-alarm",
+    run: (env) => runLaneAlarm(env as never),
+    tables: ["lane_health"],
+    refusal: "no lane_health store bound",
+  },
+];
+
+describe("with Neon owning its tables and no D1 bound", () => {
+  for (const { name, run, tables, refusal } of WATCHDOGS) {
+    test(`${name} reaches a store`, async () => {
+      const result = await run({
+        HYPERDRIVE,
+        NEON_SOLE_STORE_TABLES: tables.join(","),
+      });
+      assert.notEqual(
+        result.reason,
+        refusal,
+        `${name} refused to run: its read is still keyed to the D1 binding, ` +
+          `so it measures a table that stopped advancing when the lane inverted`,
+      );
+    });
+  }
+});
+
+describe("with nothing bound at all", () => {
+  for (const { name, run, tables, refusal } of WATCHDOGS) {
+    test(`${name} still refuses`, async () => {
+      // Without this, every assertion above would also pass if the store check
+      // had simply been deleted -- a watchdog that runs against no store at all
+      // and reports whatever a missing database returns.
+      const result = await run({ NEON_SOLE_STORE_TABLES: tables.join(",") });
+      assert.equal(result.reason, refusal, name);
+    });
+  }
+});


### PR DESCRIPTION
Closes #10154

#10127 moved the verdict **write** to `laneHealthStore` for nine of these. None of them moved its **read**, and every table they measure is sole-store on Neon — so each was measuring a D1 copy that stopped advancing the day its lane inverted.

That is worse than a broken watchdog. All of them key on `MAX(captured_at)` over a table that no longer moves, so **the measured age grows by one second per second, forever**. They alarm permanently, on lanes that are fine, and the alarm cannot be told apart from a real one. `lane-alarm` is the reader that turns those verdicts into GitHub issues, so it would file them.

| watchdog | reads |
|---|---|
| neurons | `neurons` |
| account-balances | `account_balances` |
| hotkey-alpha | `hotkey_alpha`, `nominator_positions` |
| nominator-positions | `nominator_positions` |
| chain-detail | `chain_detail_blocks` — both sites |
| lakehouse-seam | `raw_capture_state`, **and** its `lane_health` write, the one in the family that never moved to `laneHealthStore` |
| lane-alarm | `lane_health`, via `laneHealthStore` |

## The refusal reason changes with the read

`"no store bound"` rather than `"d1 binding unavailable"`, because the question is no longer about D1.

The **prune's** own refusal is deliberately left as it was: with nothing owned by Neon, the D1 `DELETE` is still what would run and its binding is still what is missing. Different question, different answer — and a test now says so rather than leaving the next person to wonder why two adjacent things disagree.

## Verification

`tests/watchdogs-read-the-owning-store.test.ts` pairs each watchdog:

- Neon owning + no D1 → must reach a store
- nothing bound → must still refuse

The second half is what stops the first from passing against a watchdog whose store check was simply deleted. Mutation-checked: reverting the neurons read to the binding fails its "reaches a store" case and nothing else.

27 suites touching any of this: **1,156 green.**

## Not in this

`src/table-freshness-watchdog.ts` has the same defect across ~47 tables, but it checks freshness **per table**, so it needs a per-table store choice rather than `readStore`'s all-or-nothing. Left out deliberately.