### PR TITLE
fix(neon): the queue's neurons writer never asked, and three read blocks refused first (#10162)

### DIFF
--- a/src/account-balances-staleness-watchdog.ts
+++ b/src/account-balances-staleness-watchdog.ts
@@ -89,6 +89,7 @@
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { readStore } from "./read-store.ts";
 
 /**
  * How old the ledger may get before this is a stall.
@@ -290,8 +291,13 @@ export async function runAccountBalancesStalenessWatchdog(
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;
   const record = deps.recordException ?? recordExceptionEvent;
-  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
-  if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
+  // Whichever store holds the table (#10154). The verdict WRITE moved to
+  // laneHealthStore already; this read did not, so the watchdog was measuring
+  // a frozen D1 copy and would have alarmed permanently -- reporting the lane
+  // stalled while the lane was fine.
+  const db = readStore(env, ["account_balances"]) as unknown as
+    D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
     Number(env?.ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS) ||

--- a/src/chain-detail-staleness-watchdog.ts
+++ b/src/chain-detail-staleness-watchdog.ts
@@ -29,6 +29,7 @@
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { readStore } from "./read-store.ts";
 
 /**
  * How far behind the lane may fall before this is a stall.
@@ -99,8 +100,8 @@ interface D1Like {
 export async function readChainDetailHead(
   env: Record<string, unknown> | null | undefined,
 ): Promise<{ latestObservedAtMs: number | null; headBlock: number | null }> {
-  const db = (env as { METAGRAPH_HEALTH_DB?: D1Like } | null | undefined)
-    ?.METAGRAPH_HEALTH_DB;
+  const db = readStore(env, ["chain_detail_blocks"]) as unknown as
+    D1Like | undefined;
   if (!db?.prepare) return { latestObservedAtMs: null, headBlock: null };
   const row = (await db
     .prepare(
@@ -140,8 +141,13 @@ export async function runChainDetailStalenessWatchdog(
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;
   const record = deps.recordException ?? recordExceptionEvent;
-  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
-  if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
+  // Whichever store holds the table (#10154). The verdict WRITE moved to
+  // laneHealthStore already; this read did not, so the watchdog was measuring
+  // a frozen D1 copy and would have alarmed permanently -- reporting the lane
+  // stalled while the lane was fine.
+  const db = readStore(env, ["chain_detail_blocks"]) as unknown as
+    D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
     Number(env?.CHAIN_DETAIL_STALENESS_THRESHOLD_MS) ||

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -860,6 +860,18 @@ import type {
   QueryValidator_HistoryArgs,
   QueryValidator_NominatorsArgs,
 } from "../generated/graphql/types.ts";
+import { readStore } from "./read-store.ts";
+import {
+  ALPHA_PRICING_TABLES,
+  CHAIN_CONCENTRATION_HISTORY_TABLES,
+  EMISSION_CHANGES_TABLES,
+  FAILURE_REASONS_TABLES,
+  INDEXER_LAG_TABLES,
+  SUBNET_BURN_HISTORY_TABLES,
+  SUBNET_SNAPSHOT_TABLES,
+  SURFACE_HISTORY_TABLES,
+  TAO_USD_TABLES,
+} from "./read-store-tables.ts";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Row = Record<string, any>;
@@ -2830,7 +2842,7 @@ const rootValue = {
       });
     }
     const rows = await loadTaoUsdSeries(
-      context.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
+      readStore(context.env, TAO_USD_TABLES) as never as unknown as Parameters<
         typeof loadTaoUsdSeries
       >[0],
       { windowHours: TAO_USD_WINDOWS[label] },
@@ -2857,9 +2869,10 @@ const rootValue = {
     }
     const safeLimit = limit ?? SURFACE_HISTORY_LIMIT_DEFAULT;
     const rows = await loadSurfaceHistory(
-      context.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
-        typeof loadSurfaceHistory
-      >[0],
+      readStore(
+        context.env,
+        SURFACE_HISTORY_TABLES,
+      ) as never as unknown as Parameters<typeof loadSurfaceHistory>[0],
       netuid,
       { limit: safeLimit },
     );
@@ -2896,9 +2909,10 @@ const rootValue = {
     const safeLimit = limit ?? EMISSION_CHANGES_LIMIT_DEFAULT;
     const safeKind = kind ?? undefined;
     const rows = await loadEmissionChanges(
-      context.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
-        typeof loadEmissionChanges
-      >[0],
+      readStore(
+        context.env,
+        EMISSION_CHANGES_TABLES,
+      ) as never as unknown as Parameters<typeof loadEmissionChanges>[0],
       { limit: safeLimit, kind: safeKind },
     );
     return buildEmissionChanges(rows, { limit: safeLimit, kind: safeKind });
@@ -2932,9 +2946,10 @@ const rootValue = {
       );
     }
     const read = await loadChainHolders(
-      context.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
-        typeof loadChainHolders
-      >[0],
+      readStore(
+        context.env,
+        ALPHA_PRICING_TABLES,
+      ) as never as unknown as Parameters<typeof loadChainHolders>[0],
     );
     return buildChainHolders(read, {
       sort: sort ?? DEFAULT_CHAIN_HOLDERS_SORT,
@@ -2971,9 +2986,10 @@ const rootValue = {
       kind: kind ?? undefined,
     };
     const rows = await loadFailureReasons(
-      context.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
-        typeof loadFailureReasons
-      >[0],
+      readStore(
+        context.env,
+        FAILURE_REASONS_TABLES,
+      ) as never as unknown as Parameters<typeof loadFailureReasons>[0],
       args,
     );
     return rows === null
@@ -2984,9 +3000,10 @@ const rootValue = {
   async indexer_lag(_args: Record<string, never>, context: GqlContext) {
     // #9620. Shares the REST/MCP loader for #9540's reason.
     const row = await loadIndexerLag(
-      context.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
-        typeof loadIndexerLag
-      >[0],
+      readStore(
+        context.env,
+        INDEXER_LAG_TABLES,
+      ) as never as unknown as Parameters<typeof loadIndexerLag>[0],
     );
     return buildIndexerLag(row, Date.now());
   },
@@ -3009,7 +3026,10 @@ const rootValue = {
       window: window ?? DEFAULT_CHAIN_CONCENTRATION_HISTORY_WINDOW,
     };
     const rows = await loadChainConcentrationHistory(
-      context.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
+      readStore(
+        context.env,
+        CHAIN_CONCENTRATION_HISTORY_TABLES,
+      ) as never as unknown as Parameters<
         typeof loadChainConcentrationHistory
       >[0],
       args,
@@ -3032,9 +3052,10 @@ const rootValue = {
     }
     const args = { window: window ?? DEFAULT_PIPELINE_HISTORY_WINDOW };
     const rows = await loadPipelineHistory(
-      context.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
-        typeof loadPipelineHistory
-      >[0],
+      readStore(
+        context.env,
+        SUBNET_SNAPSHOT_TABLES,
+      ) as never as unknown as Parameters<typeof loadPipelineHistory>[0],
       netuid,
       args,
     );
@@ -3068,9 +3089,10 @@ const rootValue = {
     }
     const safeLimit = limit ?? SUBNET_HOLDERS_LIMIT_DEFAULT;
     const read = await loadSubnetHolders(
-      context.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
-        typeof loadSubnetHolders
-      >[0],
+      readStore(
+        context.env,
+        ALPHA_PRICING_TABLES,
+      ) as never as unknown as Parameters<typeof loadSubnetHolders>[0],
       netuid,
       { limit: safeLimit },
     );
@@ -9038,9 +9060,10 @@ const rootValue = {
     // been recording this subnet" is a real state, and the same convention the
     // sibling history fields already follow.
     const rows = await loadSubnetBurnHistory(
-      context.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
-        typeof loadSubnetBurnHistory
-      >[0],
+      readStore(
+        context.env,
+        SUBNET_BURN_HISTORY_TABLES,
+      ) as never as unknown as Parameters<typeof loadSubnetBurnHistory>[0],
       netuid,
       { windowDays },
     );

--- a/src/health-prober.ts
+++ b/src/health-prober.ts
@@ -1118,7 +1118,12 @@ export async function writeSubnetSnapshotRows(
   // this function touches any more -- so on a deployment with the D1 binding
   // and no sync secret it would have declined with the write sitting right
   // there, ready to run.
-  if (!env?.METAGRAPH_HEALTH_DB) {
+  // Gated on a store, not on the D1 binding (#10158). The write below already
+  // goes through observationsRunner, so this check was asking about a binding
+  // the write no longer uses -- unbinding D1 would have declined here with the
+  // Neon write sitting right there, ready to run. Which is the same shape as
+  // the bug the comment above describes, one binding later.
+  if (!observationsRunner(env, ctx) && !env?.METAGRAPH_HEALTH_DB) {
     return { synced: false, reason: "unavailable" };
   }
   if (!Array.isArray(profiles) || profiles.length === 0) {

--- a/src/hotkey-alpha-staleness-watchdog.ts
+++ b/src/hotkey-alpha-staleness-watchdog.ts
@@ -63,6 +63,7 @@
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { readStore } from "./read-store.ts";
 
 /**
  * How old the pool ledger may get before this is a stall.
@@ -237,8 +238,15 @@ export async function runHotkeyAlphaStalenessWatchdog(
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;
   const record = deps.recordException ?? recordExceptionEvent;
-  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
-  if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
+  // Whichever store holds the table (#10154). The verdict WRITE moved to
+  // laneHealthStore already; this read did not, so the watchdog was measuring
+  // a frozen D1 copy and would have alarmed permanently -- reporting the lane
+  // stalled while the lane was fine.
+  const db = readStore(env, [
+    "hotkey_alpha",
+    "nominator_positions",
+  ]) as unknown as D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
     Number(env?.HOTKEY_ALPHA_STALENESS_THRESHOLD_MS) ||

--- a/src/lakehouse-seam-watchdog.ts
+++ b/src/lakehouse-seam-watchdog.ts
@@ -47,6 +47,8 @@ import {
   type DecodeWatermark,
 } from "./decode-watermark.ts";
 import { d1Watermark } from "./raw-capture-sync.ts";
+import { readStore } from "./read-store.ts";
+import { laneHealthStore } from "./lane-health-store.ts";
 
 /**
  * How long the decode lane may go without publishing before that is a fault.
@@ -231,9 +233,11 @@ const num = (value: unknown) =>
  * lane's OWN reader so the two can never disagree about which row and column
  * hold the watermark. */
 async function capturedThrough(env: unknown): Promise<number | null> {
-  const db = (
-    env as { METAGRAPH_HEALTH_DB?: Parameters<typeof d1Watermark>[0] }
-  )?.METAGRAPH_HEALTH_DB;
+  // raw_capture_state is Neon's outright, so this follows it (#10154). The
+  // seam this watchdog measures is capture-vs-lakehouse; against a frozen
+  // watermark it reports a gap that only ever widens.
+  const db = readStore(env, ["raw_capture_state"]) as unknown as
+    Parameters<typeof d1Watermark>[0] | undefined;
   if (!db?.prepare) return null;
   try {
     // `Date.now` rather than a `() => 0` stub: the clock is only used by the
@@ -272,10 +276,12 @@ export async function runLakehouseSeamWatchdog(
   } = {},
 ): Promise<Record<string, unknown>> {
   const query = deps.query ?? r2SqlQuery;
-  const laneHealthDb =
-    deps.laneHealthDb ??
-    ((env as { METAGRAPH_HEALTH_DB?: LaneHealthDb })?.METAGRAPH_HEALTH_DB as
-      LaneHealthDb | undefined);
+  // The only watchdog in the family that still named the binding here; every
+  // other one goes through laneHealthStore (#10154).
+  const laneHealthDb = laneHealthStore(
+    env as unknown as Record<string, unknown>,
+    deps.laneHealthDb,
+  );
   const recordVerdict = (verdict: LaneVerdictInput) =>
     recordLaneVerdict(laneHealthDb, {
       lane: LAKEHOUSE_SEAM_LANE,

--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -56,6 +56,7 @@ import {
 } from "./lane-health.ts";
 import { recordLaneVerdict } from "./lane-health.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { laneHealthStore } from "./lane-health-store.ts";
 
 /**
  * How long a lane must stay stale before it earns an issue.
@@ -521,8 +522,12 @@ export async function runLaneAlarm(
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;
   const record = deps.recordException ?? recordExceptionEvent;
-  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
-  if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
+  // laneHealthStore, not the binding (#10154). This is the reader that opens
+  // GitHub issues from lane_health verdicts, so pointing it at a store nothing
+  // writes any more would replay stale verdicts forever -- filing issues for
+  // lanes that recovered, and none for lanes that broke.
+  const db = laneHealthStore(env) as unknown as D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "no lane_health store bound" };
 
   const token = typeof env?.GITHUB_TOKEN === "string" ? env.GITHUB_TOKEN : "";
   const repo =

--- a/src/live-economics-refresh.ts
+++ b/src/live-economics-refresh.ts
@@ -61,6 +61,7 @@ import {
 import { encodeAccountId32 } from "./ss58.ts";
 import { createSubtensorPinnedStorage } from "./subtensor-pinned-storage.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
+import { readStore } from "./read-store.ts";
 
 type Row = Record<string, unknown>;
 
@@ -430,8 +431,13 @@ export async function refreshLiveEconomics(
   }
   const kv = env.METAGRAPH_CONTROL as unknown as KvLike | undefined;
   if (!kv?.put) return { ok: false, reason: "kv_binding_missing" };
-  const db = env.METAGRAPH_HEALTH_DB as unknown as D1Like | undefined;
-  if (!db?.prepare) return { ok: false, reason: "d1_binding_missing" };
+  // Whichever store holds the metagraph (#10158). This publishes the
+  // live-economics KV blob from a full neuron aggregate plus the alpha price
+  // history -- off a frozen table it would republish yesterday's economics
+  // every three hours, with a fresh timestamp on it.
+  const db = readStore(env, ["neurons", "subnet_snapshots"]) as unknown as
+    D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "store_unavailable" };
 
   const now = deps.now ?? Date.now;
   try {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1609,6 +1609,22 @@ import {
   NOMINATOR_LIMIT_MAX,
 } from "./validator-nominators.ts";
 import { buildValidatorHistory } from "./validator-history.ts";
+import { readStore } from "./read-store.ts";
+import {
+  ALPHA_PRICING_TABLES,
+  CHAIN_CONCENTRATION_HISTORY_TABLES,
+  COMPARE_SUBNETS_TABLES,
+  EMISSION_CHANGES_TABLES,
+  FAILURE_REASONS_TABLES,
+  HEALTH_CHECK_TABLES,
+  INDEXER_LAG_TABLES,
+  LEADERBOARD_TABLES,
+  SUBNET_BURN_HISTORY_TABLES,
+  SUBNET_SNAPSHOT_TABLES,
+  SURFACE_HISTORY_TABLES,
+  TAO_USD_TABLES,
+  UPTIME_DAILY_TABLES,
+} from "./read-store-tables.ts";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Row = Record<string, any>;
@@ -5122,7 +5138,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         )) ??
         (await loadSubnetHealthTrends(netuid, {
           observedAt: await mcpObservedAt(ctx),
-          db: ctx.env.METAGRAPH_HEALTH_DB,
+          db: readStore(ctx.env, HEALTH_CHECK_TABLES) as never,
         }))
       );
     },
@@ -5181,7 +5197,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       if (postgres) return postgres;
       const { data } = await loadBulkHealthTrends({
         observedAt: await mcpObservedAt(ctx),
-        db: ctx.env.METAGRAPH_HEALTH_DB,
+        db: readStore(ctx.env, UPTIME_DAILY_TABLES) as never,
         window,
         limit,
         offset,
@@ -5224,7 +5240,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         (await loadSubnetPercentiles(netuid, {
           window: label,
           observedAt: await mcpObservedAt(ctx),
-          db: ctx.env.METAGRAPH_HEALTH_DB,
+          db: readStore(ctx.env, HEALTH_CHECK_TABLES) as never,
         }))
       );
     },
@@ -5265,7 +5281,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         (await loadSubnetIncidents(netuid, {
           window: label,
           observedAt: await mcpObservedAt(ctx),
-          db: ctx.env.METAGRAPH_HEALTH_DB,
+          db: readStore(ctx.env, HEALTH_CHECK_TABLES) as never,
         }))
       );
     },
@@ -5656,7 +5672,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
         )) ??
         (await loadSubnetTrajectory(netuid, {
-          db: ctx.env.METAGRAPH_HEALTH_DB,
+          db: readStore(ctx.env, SUBNET_SNAPSHOT_TABLES) as never,
         }))
       );
     },
@@ -5701,7 +5717,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       const { data } = await loadEconomicsTrends({
         windowLabel: label,
         windowDays: days,
-        db: ctx.env.METAGRAPH_HEALTH_DB,
+        db: readStore(ctx.env, SUBNET_SNAPSHOT_TABLES) as never,
       });
       return data;
     },
@@ -7468,7 +7484,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         ((await loadSubnetUptime(netuid, {
           window: window ?? undefined,
           observedAt: await mcpObservedAt(ctx),
-          db: ctx.env.METAGRAPH_HEALTH_DB,
+          db: readStore(ctx.env, UPTIME_DAILY_TABLES) as never,
         })) as Row)
       );
     },
@@ -7501,7 +7517,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         board,
         limit,
         observedAt: await mcpObservedAt(ctx),
-        db: ctx.env.METAGRAPH_HEALTH_DB,
+        db: readStore(ctx.env, LEADERBOARD_TABLES) as never,
       });
     },
   },
@@ -7640,7 +7656,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         netuids,
         dimensions,
         observedAt,
-        db: ctx.env.METAGRAPH_HEALTH_DB,
+        db: readStore(ctx.env, COMPARE_SUBNETS_TABLES) as never,
       });
     },
   },
@@ -7681,7 +7697,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           windowLabel: label,
           windowDays: days,
           observedAt: await mcpObservedAt(ctx),
-          db: ctx.env.METAGRAPH_HEALTH_DB,
+          db: readStore(ctx.env, HEALTH_CHECK_TABLES) as never,
         }));
       return applyGlobalIncidentsListQuery(
         data as Record<string, unknown>,
@@ -8668,9 +8684,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         optionalEnum(args, "window", Object.keys(BURN_HISTORY_WINDOWS)) ??
         DEFAULT_BURN_HISTORY_WINDOW;
       const rows = await loadSubnetBurnHistory(
-        ctx.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
-          typeof loadSubnetBurnHistory
-        >[0],
+        readStore(
+          ctx.env,
+          SUBNET_BURN_HISTORY_TABLES,
+        ) as never as unknown as Parameters<typeof loadSubnetBurnHistory>[0],
         netuid,
         { windowDays: BURN_HISTORY_WINDOWS[label] },
       );
@@ -8709,7 +8726,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         optionalEnum(args, "window", Object.keys(TAO_USD_WINDOWS)) ??
         DEFAULT_TAO_USD_WINDOW;
       const rows = await loadTaoUsdSeries(
-        ctx.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
+        readStore(ctx.env, TAO_USD_TABLES) as never as unknown as Parameters<
           typeof loadTaoUsdSeries
         >[0],
         { windowHours: TAO_USD_WINDOWS[label] },
@@ -8764,9 +8781,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         SURFACE_HISTORY_LIMIT_MAX,
       );
       const rows = await loadSurfaceHistory(
-        ctx.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
-          typeof loadSurfaceHistory
-        >[0],
+        readStore(
+          ctx.env,
+          SURFACE_HISTORY_TABLES,
+        ) as never as unknown as Parameters<typeof loadSurfaceHistory>[0],
         netuid,
         { limit },
       );
@@ -8813,9 +8831,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         EMISSION_CHANGES_LIMIT_MAX,
       );
       const rows = await loadEmissionChanges(
-        ctx.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
-          typeof loadEmissionChanges
-        >[0],
+        readStore(
+          ctx.env,
+          EMISSION_CHANGES_TABLES,
+        ) as never as unknown as Parameters<typeof loadEmissionChanges>[0],
         { limit, kind },
       );
       return buildEmissionChanges(rows, { limit, kind });
@@ -8861,9 +8880,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         CHAIN_HOLDERS_LIMIT_MAX,
       );
       const read = await loadChainHolders(
-        ctx.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
-          typeof loadChainHolders
-        >[0],
+        readStore(
+          ctx.env,
+          ALPHA_PRICING_TABLES,
+        ) as never as unknown as Parameters<typeof loadChainHolders>[0],
       );
       return buildChainHolders(read, { sort, limit });
     },
@@ -8905,9 +8925,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       const netuid = typeof args?.netuid === "number" ? args.netuid : undefined;
       const kind = typeof args?.kind === "string" ? args.kind : undefined;
       const rows = await loadFailureReasons(
-        ctx.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
-          typeof loadFailureReasons
-        >[0],
+        readStore(
+          ctx.env,
+          FAILURE_REASONS_TABLES,
+        ) as never as unknown as Parameters<typeof loadFailureReasons>[0],
         { window, netuid, kind },
       );
       return rows === null
@@ -8944,9 +8965,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       ctx: McpCtx,
     ) {
       const row = await loadIndexerLag(
-        ctx.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
-          typeof loadIndexerLag
-        >[0],
+        readStore(
+          ctx.env,
+          INDEXER_LAG_TABLES,
+        ) as never as unknown as Parameters<typeof loadIndexerLag>[0],
       );
       return buildIndexerLag(row, Date.now());
     },
@@ -8988,7 +9010,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           ...CHAIN_CONCENTRATION_HISTORY_WINDOWS,
         ]) ?? DEFAULT_CHAIN_CONCENTRATION_HISTORY_WINDOW;
       const rows = await loadChainConcentrationHistory(
-        ctx.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
+        readStore(
+          ctx.env,
+          CHAIN_CONCENTRATION_HISTORY_TABLES,
+        ) as never as unknown as Parameters<
           typeof loadChainConcentrationHistory
         >[0],
         { window },
@@ -9035,9 +9060,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         optionalEnum(args, "window", [...PIPELINE_HISTORY_WINDOWS]) ??
         DEFAULT_PIPELINE_HISTORY_WINDOW;
       const rows = await loadPipelineHistory(
-        ctx.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
-          typeof loadPipelineHistory
-        >[0],
+        readStore(
+          ctx.env,
+          SUBNET_SNAPSHOT_TABLES,
+        ) as never as unknown as Parameters<typeof loadPipelineHistory>[0],
         netuid,
         { window },
       );
@@ -9093,9 +9119,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         SUBNET_HOLDERS_LIMIT_MAX,
       );
       const read = await loadSubnetHolders(
-        ctx.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
-          typeof loadSubnetHolders
-        >[0],
+        readStore(
+          ctx.env,
+          ALPHA_PRICING_TABLES,
+        ) as never as unknown as Parameters<typeof loadSubnetHolders>[0],
         netuid,
         { limit },
       );
@@ -12476,7 +12503,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             windowLabel: "30d",
             windowDays: 30,
             observedAt: await mcpObservedAt(ctx),
-            db: ctx.env.METAGRAPH_HEALTH_DB,
+            db: readStore(ctx.env, HEALTH_CHECK_TABLES) as never,
           });
         },
       });

--- a/src/neon-prune.ts
+++ b/src/neon-prune.ts
@@ -35,7 +35,7 @@
 
 import { laneHealthStore } from "./lane-health-store.ts";
 import { assertIdentifier } from "./neon-backfill.ts";
-import { neonBackfillLanes, type PgUnsafe } from "./neon-write.ts";
+import { neonOwnsTable, type PgUnsafe } from "./neon-write.ts";
 import {
   createPgSql,
   type HyperdriveLike,
@@ -60,12 +60,23 @@ export interface NeonPrunePlan {
 }
 
 /**
- * One plan per rolling window, keyed by the NEON_BACKFILL_LANES name.
+ * One plan per rolling window, keyed by table name.
  *
- * A table absent from that flag is skipped entirely rather than pruned to
- * empty: nothing is mirroring it yet, so Neon's copy is not a window with a
- * tail, it is a table that has not been filled. Deleting from it would be
- * deleting a backfill in progress.
+ * GATED ON OWNERSHIP, NOT ON THE BACKFILL FLAG (#10164). This was keyed to
+ * NEON_BACKFILL_LANES, and the reasoning was sound while the reconciler ran: a
+ * table absent from that flag was not being mirrored yet, so Neon's copy was
+ * not a window with a tail but a table still filling, and deleting from it
+ * would delete a backfill in progress.
+ *
+ * That inverted when the lanes finished. A table leaves NEON_BACKFILL_LANES
+ * exactly when Neon becomes its sole store (#10078), so "absent from the flag"
+ * stopped meaning "not filled yet" and started meaning "Neon holds the only
+ * copy" -- the precise moment the window most needs bounding. The flag is now
+ * empty in both configs, so this lane has been pruning NOTHING while reporting
+ * a clean run, and surface_checks is a 30-day rolling window with no other
+ * writer to trim it.
+ *
+ * Same inversion, and the same reason, as the chain-detail prune in #10152.
  */
 export const NEON_PRUNE_PLANS: Readonly<Record<string, NeonPrunePlan>> = {
   surface_checks: {
@@ -203,11 +214,10 @@ export async function runNeonPrune(
   const now = deps.now ?? Date.now;
   if (!sql?.unsafe) return { attempted: false };
 
-  // Only tables Neon is actually being given rows for. One absent from the
-  // flag has an EMPTY Neon copy, not a window with a tail.
-  const enabled = new Set(neonBackfillLanes(env));
+  // Only tables Neon actually owns. See NEON_PRUNE_PLANS' header for why this
+  // is ownership and no longer the backfill flag.
   const plans = Object.entries(NEON_PRUNE_PLANS)
-    .filter(([lane]) => enabled.has(lane))
+    .filter(([table]) => neonOwnsTable(env, table))
     .map(([, plan]) => plan);
 
   const outcomes: PruneTableOutcome[] = [];

--- a/src/neurons-staleness-watchdog.ts
+++ b/src/neurons-staleness-watchdog.ts
@@ -45,6 +45,7 @@
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { readStore } from "./read-store.ts";
 
 /** Three missed 15-minute ticks: one restart is routine (a deploy or an
  * eviction costs one tick by design), two could be an unlucky pair, three is
@@ -208,8 +209,12 @@ export async function runNeuronsStalenessWatchdog(
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;
   const record = deps.recordException ?? recordExceptionEvent;
-  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
-  if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
+  // Whichever store holds the table (#10154). The verdict WRITE moved to
+  // laneHealthStore already; this read did not, so the watchdog was measuring
+  // a frozen D1 copy and would have alarmed permanently -- reporting the lane
+  // stalled while the lane was fine.
+  const db = readStore(env, ["neurons"]) as unknown as D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
     Number(env?.NEURONS_STALENESS_THRESHOLD_MS) ||

--- a/src/nominator-positions-staleness-watchdog.ts
+++ b/src/nominator-positions-staleness-watchdog.ts
@@ -55,6 +55,7 @@
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { readStore } from "./read-store.ts";
 
 /**
  * How old the ledger may get before this is a stall.
@@ -243,8 +244,13 @@ export async function runNominatorPositionsStalenessWatchdog(
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;
   const record = deps.recordException ?? recordExceptionEvent;
-  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
-  if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
+  // Whichever store holds the table (#10154). The verdict WRITE moved to
+  // laneHealthStore already; this read did not, so the watchdog was measuring
+  // a frozen D1 copy and would have alarmed permanently -- reporting the lane
+  // stalled while the lane was fine.
+  const db = readStore(env, ["nominator_positions"]) as unknown as
+    D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
     Number(env?.NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS) ||

--- a/src/raw-capture-sync.ts
+++ b/src/raw-capture-sync.ts
@@ -392,10 +392,25 @@ export async function runRawCaptureSync(
       "METAGRAPH_ARCHIVE is not bound; refusing to run. Captured bytes have nowhere durable to land, and a tick that cannot store is a gap.",
     );
   }
-  if (!env?.METAGRAPH_HEALTH_DB?.prepare) {
+  // A watermark this tick can READ AND WRITE, from whichever store holds
+  // raw_capture_state (#10158). mirroredWatermark already routes both halves to
+  // Neon once it owns the table -- the D1 store it wraps is dead code in that
+  // case -- so this check was refusing to run over a binding the lane no longer
+  // uses. The refusal itself stays: without a durable watermark the next tick
+  // cannot know where to resume, which is exactly how a gap forms.
+  const captureStateOnNeon =
+    neonOwnsTable(
+      env as unknown as Record<string, unknown>,
+      "raw_capture_state",
+    ) &&
+    Boolean(
+      (env as { HYPERDRIVE?: { connectionString?: string } })?.HYPERDRIVE
+        ?.connectionString,
+    );
+  if (!captureStateOnNeon && !env?.METAGRAPH_HEALTH_DB?.prepare) {
     return loud(
       "watermark_unavailable",
-      "METAGRAPH_HEALTH_DB is not bound; refusing to run. Without a durable watermark the next tick cannot know where to resume, which is exactly how a gap forms.",
+      "no store holds raw_capture_state; refusing to run. Without a durable watermark the next tick cannot know where to resume, which is exactly how a gap forms.",
     );
   }
 
@@ -475,7 +490,10 @@ async function runLane(
       // MIRRORED AT THE WATERMARK, not at the row writes: this table IS the
       // watermark, so wrapping the store is the whole write path.
       watermark: mirroredWatermark(
-        d1Watermark(env.METAGRAPH_HEALTH_DB!, now, lane.network),
+        // `as never` where the binding may legitimately be absent: once Neon
+        // owns raw_capture_state, mirroredWatermark never calls through to
+        // this store, and d1Watermark only dereferences inside its methods.
+        d1Watermark(env.METAGRAPH_HEALTH_DB as never, now, lane.network),
         ctx.env as unknown as Record<string, unknown>,
         ctx.waitUntil,
         lane.network,

--- a/src/read-store-tables.ts
+++ b/src/read-store-tables.ts
@@ -1,0 +1,123 @@
+// What each shared loader reads, so its callers can ask readStore for the right
+// store (#10155).
+//
+// ## Why these live here and not beside each loader
+//
+// Twenty-two loaders are called from `src/mcp-server.ts`, `src/graphql.ts` and
+// `workers/request-handlers/entities.ts` -- 45 call sites for 22 loaders, so
+// most sets are needed in two or three files. The loaders themselves take an
+// injected `db` and have no opinion about which store it is; that is the whole
+// reason they are shared. Putting the answer next to each loader would mean 22
+// new exports whose only consumer is this indirection, and putting it inline at
+// each call site would mean the same set written out three times, drifting
+// independently.
+//
+// ## What keeps them honest
+//
+// tests/read-store-tables-match-the-sql.test.ts reads each loader's module and
+// checks the constant against the SQL actually in it. That is the property
+// co-location would have bought, without the 22 exports: a loader that grows a
+// JOIN fails the test rather than quietly reading a table its caller never
+// declared. readStore is all-or-nothing, so an under-declared set is not a
+// smaller check -- it sends the loader to Neon on the strength of the tables it
+// DID name, and the missing one comes back as an empty result rather than an
+// error.
+//
+// ## The unions are deliberate
+//
+// Two loaders vary their FROM list by argument. Both declare every table any
+// branch can reach, because the caller supplies that argument at request time:
+// a narrower set would route a request to a store that does not own one leg of
+// it. `loadCompareSubnets` is the opposite case -- it reads NOTHING unless the
+// caller asks for the health dimension -- and declaring its one table anyway
+// costs a store choice that is then unused.
+
+/** The alpha-pricing trio, which must move together.
+ *
+ * `nominator_positions JOIN hotkey_alpha` split across stores does not error --
+ * it returns no rows, and a holder list that is empty because the join found
+ * nothing looks exactly like an account with no positions. hotkey_alpha_passes
+ * is in the same set because the pricing read gates on the newest COMPLETE
+ * pass; reading that from the other store would price against a scan the alpha
+ * rows do not belong to. */
+export const ALPHA_PRICING_TABLES = [
+  "nominator_positions",
+  "hotkey_alpha",
+  "hotkey_alpha_passes",
+] as const;
+
+/** loadSubnetBurnHistory */
+export const SUBNET_BURN_HISTORY_TABLES = ["subnet_burn_history"] as const;
+
+/** loadTaoUsdSeries */
+export const TAO_USD_TABLES = ["tao_usd_index"] as const;
+
+/** loadSurfaceHistory.
+ *
+ * NOT in NEON_SOLE_STORE_TABLES today, unlike everything else here -- the four
+ * registry tables (surface_history, subnets, surfaces, providers) have Neon
+ * migrations and a Neon writer but have not been declared sole-store. So this
+ * resolves to D1 for now and follows the moment that flag changes, which is the
+ * behaviour readStore exists to give. */
+export const SURFACE_HISTORY_TABLES = ["surface_history"] as const;
+
+/** loadEmissionChanges.
+ *
+ * The UNION of all three arms. `kind` picks one table, or all three joined by
+ * UNION ALL when it is unset, and `kind` is caller-supplied at request time. */
+export const EMISSION_CHANGES_TABLES = [
+  "emission_gate_param_history",
+  "subnet_emission_enabled_history",
+  "emission_flow_watch",
+] as const;
+
+/** loadFailureReasons */
+export const FAILURE_REASONS_TABLES = ["surface_failure_daily"] as const;
+
+/** loadIndexerLag */
+export const INDEXER_LAG_TABLES = ["chain_detail_blocks"] as const;
+
+/** loadChainConcentrationHistory */
+export const CHAIN_CONCENTRATION_HISTORY_TABLES = [
+  "chain_concentration_daily",
+] as const;
+
+/** loadPipelineHistory, loadSubnetTrajectory, loadEconomicsTrends.
+ *
+ * PIPELINE_HISTORY_TABLE in src/emission-pipeline-history.ts is named for the
+ * lane, not the table: its value is "subnet_snapshots". */
+export const SUBNET_SNAPSHOT_TABLES = ["subnet_snapshots"] as const;
+
+/** loadSubnetHealthTrends, loadSubnetPercentiles, loadSubnetIncidents,
+ *  loadGlobalIncidents -- all four read the per-probe check log. */
+export const HEALTH_CHECK_TABLES = ["surface_checks"] as const;
+
+/** loadBulkHealthTrends, loadSubnetUptime */
+export const UPTIME_DAILY_TABLES = ["surface_uptime_daily"] as const;
+
+/** loadRegistryLeaderboards, which issues four statements across three tables
+ *  unconditionally. */
+export const LEADERBOARD_TABLES = [
+  "surface_status",
+  "subnet_snapshots",
+  "surface_uptime_daily",
+] as const;
+
+/** loadCompareSubnets -- read ONLY when the caller asks for the health
+ *  dimension. Declared anyway: the alternative is choosing a store from a
+ *  request parameter, which would make the store depend on the query. */
+export const COMPARE_SUBNETS_TABLES = ["surface_status"] as const;
+
+/** entities.ts's buildSubnetValidatorEconomicsPayload, whose SQL is inline
+ *  rather than in a loader module. */
+export const VALIDATOR_ECONOMICS_TABLES = [
+  "neurons",
+  "subnet_hyperparams",
+] as const;
+
+/** entities.ts's buildValidatorEconomicsRankingPayload, likewise inline. */
+export const VALIDATOR_ECONOMICS_RANKING_TABLES = [
+  "neurons",
+  "subnet_burn_history",
+  "subnet_hyperparams",
+] as const;

--- a/src/read-store.ts
+++ b/src/read-store.ts
@@ -47,15 +47,30 @@ export interface ReadStoreClient {
   ): Promise<{ rows?: unknown[]; rowCount?: number } | undefined>;
 }
 
-/** D1's read surface, as the tier readers actually use it. */
+/** A row with no claimed shape.
+ *
+ * The DEFAULT for `all`/`first`, rather than `unknown`, because that is what
+ * D1's own typing gave these call sites: several read a named column straight
+ * off an untyped `first()`, and `unknown` would break them for no benefit --
+ * neither store validates the shape, so the default is about what the caller is
+ * allowed to write, not about safety. */
+type Row = Record<string, unknown>;
+
+/** D1's read surface, as the callers actually use it.
+ *
+ * `all` and `first` are generic for the same reason D1's are: the ~45 call
+ * sites this replaced write `all<SubnetRow>()` and read named columns off the
+ * result. A non-generic `unknown[]` would compile only after adding a cast at
+ * every one of them, which is churn that hides exactly the mistakes a cast-free
+ * swap makes visible. */
 export interface ReadStoreDb {
   prepare(text: string): {
     bind(...values: unknown[]): {
-      all(): Promise<{ results: unknown[] }>;
-      first(): Promise<unknown>;
+      all<T = Row>(): Promise<{ results: T[] }>;
+      first<T = Row>(): Promise<T | null>;
     };
-    all(): Promise<{ results: unknown[] }>;
-    first(): Promise<unknown>;
+    all<T = Row>(): Promise<{ results: T[] }>;
+    first<T = Row>(): Promise<T | null>;
   };
 }
 
@@ -81,9 +96,16 @@ export function pgReadStore(
       await client.end().catch(() => undefined);
     }
   };
+  // The generic parameter is the CALLER's claim about the row shape, exactly as
+  // it is on D1: Postgres hands back whatever the query selected, and neither
+  // store validates it. Cast here rather than at 45 call sites.
   const ops = (text: string, values: unknown[]) => ({
-    all: async () => ({ results: await run(text, values) }),
-    first: async () => (await run(text, values))[0] ?? null,
+    async all<T = unknown>() {
+      return { results: (await run(text, values)) as T[] };
+    },
+    async first<T = unknown>() {
+      return ((await run(text, values))[0] ?? null) as T | null;
+    },
   });
   return {
     prepare(text: string) {

--- a/src/registry-sync-lane.ts
+++ b/src/registry-sync-lane.ts
@@ -29,6 +29,7 @@ import {
   type ResolvedRegistryFile,
   type Row,
 } from "./registry-sync-payload.ts";
+import { laneHealthStore } from "./lane-health-store.ts";
 
 /** Where the registry lives. Not configurable: this lane exists to mirror THIS
  * repo's registry, and a wrong value would silently sync someone else's. */
@@ -143,16 +144,13 @@ export async function runRegistrySyncLane(
   // lane did its job by looking. Only a tick that could NOT do its job is
   // `stale`, which is what a watcher should act on.
   const bag = (env ?? {}) as Record<string, unknown>;
-  await recordLaneVerdict(
-    deps.laneHealthDb ?? (bag.METAGRAPH_HEALTH_DB as LaneHealthDb | undefined),
-    {
-      lane: REGISTRY_SYNC_LANE,
-      verdict: result.ok ? "ok" : "stale",
-      age_ms: null,
-      detail: laneDetail(result),
-      checked_at: (deps.now ?? Date.now)(),
-    },
-  );
+  await recordLaneVerdict(laneHealthStore(bag, deps.laneHealthDb), {
+    lane: REGISTRY_SYNC_LANE,
+    verdict: result.ok ? "ok" : "stale",
+    age_ms: null,
+    detail: laneDetail(result),
+    checked_at: (deps.now ?? Date.now)(),
+  });
   return result;
 }
 

--- a/src/surface-verification-sync.ts
+++ b/src/surface-verification-sync.ts
@@ -54,6 +54,7 @@ import {
   type SurfaceProbeRecord,
 } from "./surface-verification.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { readStore } from "./read-store.ts";
 
 type Row = Record<string, unknown>;
 
@@ -161,7 +162,14 @@ export async function runSurfaceVerificationSync(
   ctx?: Ctx,
   deps: SurfaceVerificationSyncDeps = {},
 ): Promise<SurfaceVerificationSyncResult> {
-  const db = env.METAGRAPH_HEALTH_DB as ObservationsReadDb | undefined;
+  // The probe evidence follows the prober (#10158): surface_uptime_daily and
+  // surface_checks are Neon's, and this lane republishes their verdict as the
+  // registry's machine-verified tiers. Against a frozen copy it would keep
+  // publishing a verification nobody re-measured.
+  const db = readStore(env, [
+    "surface_uptime_daily",
+    "surface_checks",
+  ]) as unknown as ObservationsReadDb | undefined;
   const loud = (message: string, errorCode: string, reason: string) => {
     console.error(`[surface-verification-sync] ${message}`);
     const pending = Promise.resolve(
@@ -176,11 +184,11 @@ export async function runSurfaceVerificationSync(
   };
   if (!db?.prepare) {
     return loud(
-      "METAGRAPH_HEALTH_DB is not bound; refusing to run. A D1-less sweep " +
+      "no store is bound; refusing to run. A storeless sweep " +
         "reads zero rows for every subnet, which would publish a snapshot " +
         "that strips machine-verified from the whole registry.",
-      "surface_verification_d1_missing",
-      "d1_binding_missing",
+      "surface_verification_store_missing",
+      "store_unavailable",
     );
   }
   const bucket = env.METAGRAPH_ARCHIVE;

--- a/src/table-freshness-watchdog.ts
+++ b/src/table-freshness-watchdog.ts
@@ -32,6 +32,8 @@
 
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { readStore } from "./read-store.ts";
+import { neonOwnsTable } from "./neon-write.ts";
 
 /** This watchdog's own lane. */
 export const TABLE_FRESHNESS_LANE = "table-freshness";
@@ -520,7 +522,6 @@ export async function runTableFreshnessWatchdog(
   env: Record<string, unknown> | null | undefined,
   deps: FreshnessDeps = {},
 ): Promise<FreshnessOutcome> {
-  const db = deps.db ?? (env?.METAGRAPH_HEALTH_DB as FreshnessDb | undefined);
   const laneDb = laneHealthStore(env, deps.laneHealthDb);
   const now = deps.now ?? Date.now;
   const spec = deps.spec ?? TABLE_FRESHNESS;
@@ -529,8 +530,32 @@ export async function runTableFreshnessWatchdog(
     .map(([t]) => t)
     .sort();
 
+  // PARTITIONED BY STORE, not batched across it (#10160).
+  //
+  // This is the one reader that spans the whole estate -- ~47 tables, and they
+  // do not all live in the same place. readStore is all-or-nothing per call for
+  // good reason, so a batch mixing an owned table with an unowned one falls
+  // back to D1 and every Neon-only table in it throws "relation does not
+  // exist". That is not a small loss: the sweep is a single UNION per batch, so
+  // one wrong store condemns the batch, and the retry below then walks it a
+  // table at a time only to fail on each.
+  //
+  // So the tables are split by owner FIRST and batched inside each half. Both
+  // halves keep the same batch size: D1 caps a compound SELECT at 5 terms, and
+  // matching it on the Neon side keeps one number to reason about rather than
+  // two that happen to differ.
+  const partitions: string[][] = deps.db
+    ? [tables]
+    : [
+        tables.filter((t) => neonOwnsTable(env, t)),
+        tables.filter((t) => !neonOwnsTable(env, t)),
+      ].filter((group) => group.length > 0);
+
   const newest = new Map<string, number>();
-  const readBatch = async (group: string[]): Promise<boolean> => {
+  const readBatch = async (
+    group: string[],
+    db: FreshnessDb | undefined,
+  ): Promise<boolean> => {
     try {
       const result = await db?.prepare(freshnessSql(group, spec)).all();
       if (!result) throw new Error("no result");
@@ -550,18 +575,22 @@ export async function runTableFreshnessWatchdog(
   // which was both imprecise (one bad table condemned four) and unactionable
   // ("7 of 12 batches unreadable" names nothing to go and fix).
   const unreadable: string[] = [];
-  for (let i = 0; i < tables.length; i += FRESHNESS_BATCH) {
-    const batch = tables.slice(i, i + FRESHNESS_BATCH);
-    if (await readBatch(batch)) continue;
-    // ONE bad table used to cost its whole batch. The sweep is a single UNION
-    // per batch, so a table that does not exist (or whose column does not)
-    // makes the statement throw and takes its neighbours with it -- which is
-    // how 12 bad entries blinded 7 of 12 batches, 58% of the estate. Retrying
-    // the batch one table at a time costs at most FRESHNESS_BATCH extra round
-    // trips on a path that should be empty, and localises the loss to the
-    // table actually at fault.
-    for (const table of batch) {
-      if (!(await readBatch([table]))) unreadable.push(table);
+  for (const partition of partitions) {
+    const db =
+      deps.db ?? (readStore(env, partition) as FreshnessDb | undefined);
+    for (let i = 0; i < partition.length; i += FRESHNESS_BATCH) {
+      const batch = partition.slice(i, i + FRESHNESS_BATCH);
+      if (await readBatch(batch, db)) continue;
+      // ONE bad table used to cost its whole batch. The sweep is a single UNION
+      // per batch, so a table that does not exist (or whose column does not)
+      // makes the statement throw and takes its neighbours with it -- which is
+      // how 12 bad entries blinded 7 of 12 batches, 58% of the estate. Retrying
+      // the batch one table at a time costs at most FRESHNESS_BATCH extra round
+      // trips on a path that should be empty, and localises the loss to the
+      // table actually at fault.
+      for (const table of batch) {
+        if (!(await readBatch([table], db))) unreadable.push(table);
+      }
     }
   }
 

--- a/tests/account-balances-staleness-watchdog.test.ts
+++ b/tests/account-balances-staleness-watchdog.test.ts
@@ -403,11 +403,11 @@ describe("runAccountBalancesStalenessWatchdog", () => {
   test("a missing binding and a failing query degrade to summaries, never throw", async () => {
     assert.deepEqual(await runAccountBalancesStalenessWatchdog({}), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
     assert.deepEqual(await runAccountBalancesStalenessWatchdog(null), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
 
     const { db } = fakeDb(

--- a/tests/chain-detail-staleness-watchdog.test.ts
+++ b/tests/chain-detail-staleness-watchdog.test.ts
@@ -169,11 +169,11 @@ describe("runChainDetailStalenessWatchdog", () => {
   test("a missing binding and a failing query degrade to summaries, never throw", async () => {
     assert.deepEqual(await runChainDetailStalenessWatchdog({}), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
     assert.deepEqual(await runChainDetailStalenessWatchdog(null), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
     const { db } = fakeDb(new Error("d1 exploded"));
     const result = await runChainDetailStalenessWatchdog(
@@ -265,6 +265,11 @@ describe("the cron wiring", () => {
       {} as never,
       {} as never,
     )) as Record<string, unknown>;
+    // The PRUNE's reason, not the watchdog's, and it is deliberately still
+    // D1's: with an empty env Neon owns nothing, so the D1 DELETE is still the
+    // one that would run and its binding is still the one that is missing
+    // (#10152). The watchdog above answers "no store bound" because its READ
+    // follows the rows; these are different questions with different answers.
     assert.deepEqual(result, {
       ok: false,
       reason: "d1 binding unavailable",

--- a/tests/data-api-hyperparams-identity-d1.test.ts
+++ b/tests/data-api-hyperparams-identity-d1.test.ts
@@ -481,7 +481,7 @@ test("a matched read without the D1 binding answers 503, and a D1 query failure 
   assert.equal(noBinding.status, 503);
   assert.equal(
     ((await noBinding.json()) as Row).error,
-    "d1 binding unavailable",
+    "no store bound for this route",
   );
   db.exec("DROP TABLE account_identity");
   const broken = await call(req("/api/v1/accounts/5Alice/identity"));
@@ -522,7 +522,7 @@ function neonOwnsEnv(tables: string) {
 
 test("hyperparams: Neon owning the family drops the D1 BINDING requirement", async () => {
   // The assertion that actually distinguishes the branch. With no D1 binding
-  // at all, the pre-inversion handler answered 503 "d1 binding unavailable"
+  // at all, the pre-inversion handler answered 503 "no store bound for this route"
   // before doing anything. Once Neon owns the family that requirement is gone,
   // so reaching ANY other outcome proves the D1 dependency was dropped.
   //

--- a/tests/data-api-neurons-d1.test.ts
+++ b/tests/data-api-neurons-d1.test.ts
@@ -526,7 +526,7 @@ test("a neurons route 503s cleanly when the D1 binding is absent", async () => {
     env({ METAGRAPH_HEALTH_DB: null }),
   );
   assert.equal(res.status, 503);
-  assert.deepEqual(await res.json(), { error: "d1 binding unavailable" });
+  assert.deepEqual(await res.json(), { error: "no store bound for this route" });
 });
 
 test("a failing D1 read maps to the dispatcher's opaque 502, never a leaked DB error", async () => {

--- a/tests/data-api-neurons-d1.test.ts
+++ b/tests/data-api-neurons-d1.test.ts
@@ -526,7 +526,9 @@ test("a neurons route 503s cleanly when the D1 binding is absent", async () => {
     env({ METAGRAPH_HEALTH_DB: null }),
   );
   assert.equal(res.status, 503);
-  assert.deepEqual(await res.json(), { error: "no store bound for this route" });
+  assert.deepEqual(await res.json(), {
+    error: "no store bound for this route",
+  });
 });
 
 test("a failing D1 read maps to the dispatcher's opaque 502, never a leaked DB error", async () => {

--- a/tests/dispatcher-asks-the-gate.test.ts
+++ b/tests/dispatcher-asks-the-gate.test.ts
@@ -48,13 +48,32 @@ describe("the read dispatcher", () => {
       dispatches.length >= 3,
       `expected at least the three known dispatcher blocks, found ${dispatches.length}`,
     );
+    // The store is bound to a local now (#10162), because each block has to
+    // test it for undefined before dispatching -- routeStore answers "no store
+    // at all" rather than handing back a runner over an absent binding. So the
+    // first argument is `store`, and what this checks is that `store` in each
+    // block came FROM routeStore and nowhere else.
     const offenders = dispatches
-      .filter(([, , firstArg]) => !firstArg.trim().startsWith("routeStore("))
+      .filter(([, , firstArg]) => firstArg.trim() !== "store")
       .map(([, name, firstArg]) => `${name} <- ${firstArg.trim()}`);
     assert.deepEqual(
       offenders,
       [],
-      "a dispatcher block chose its store without asking neonServesRoute; " +
+      "a dispatcher block dispatched on something other than the `store` " +
+        "local that routeStore fills, so its store choice bypassed the gate",
+    );
+    const bindings = [...body.matchAll(/const store = ([^;]+);/g)].map(
+      ([, expr]) => expr.trim(),
+    );
+    assert.equal(
+      bindings.length,
+      dispatches.length,
+      `${dispatches.length} dispatcher blocks but ${bindings.length} store bindings`,
+    );
+    assert.deepEqual(
+      bindings.filter((expr) => expr !== "routeStore(env, ctx, url)"),
+      [],
+      "a `store` local was filled from something other than routeStore; " +
         "its route's NEON_READ_ROUTE_TABLES entry would be read by nothing",
     );
   });

--- a/tests/hotkey-alpha-staleness-watchdog.test.ts
+++ b/tests/hotkey-alpha-staleness-watchdog.test.ts
@@ -378,11 +378,11 @@ describe("runHotkeyAlphaStalenessWatchdog", () => {
   test("no D1 binding is a missed report, not a throw", async () => {
     assert.deepEqual(await runHotkeyAlphaStalenessWatchdog({}), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
     assert.deepEqual(await runHotkeyAlphaStalenessWatchdog(null), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
   });
 

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -900,11 +900,11 @@ describe("runLaneAlarm", () => {
   test("reports a missing binding rather than throwing", async () => {
     assert.deepEqual(await runLaneAlarm({}), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no lane_health store bound",
     });
     assert.deepEqual(await runLaneAlarm(null), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no lane_health store bound",
     });
   });
 

--- a/tests/live-economics-refresh.test.ts
+++ b/tests/live-economics-refresh.test.ts
@@ -823,7 +823,7 @@ describe("refreshLiveEconomics", () => {
     assert.equal(blob.network, null);
   });
 
-  test("declines without a reader, a KV binding or a D1 binding", async () => {
+  test("declines without a reader, a KV binding or any store", async () => {
     const { env } = harness();
     assert.deepEqual(await refreshLiveEconomics(env), {
       ok: false,
@@ -834,10 +834,13 @@ describe("refreshLiveEconomics", () => {
       await refreshLiveEconomics(noKv.env, { readArtifact: noKv.readArtifact }),
       { ok: false, reason: "kv_binding_missing" },
     );
+    // "store_unavailable" rather than "d1_binding_missing" (#10158): the read
+    // follows whichever store owns neurons and subnet_snapshots, so an absent
+    // D1 is only one of the two ways to have nowhere to read from.
     const noDb = harness({ db: false });
     assert.deepEqual(
       await refreshLiveEconomics(noDb.env, { readArtifact: noDb.readArtifact }),
-      { ok: false, reason: "d1_binding_missing" },
+      { ok: false, reason: "store_unavailable" },
     );
   });
 

--- a/tests/neon-prune.test.ts
+++ b/tests/neon-prune.test.ts
@@ -217,7 +217,7 @@ describe("runNeonPrune", () => {
     const pg = fakeSql({ doomed: 10, survivors: 10 });
     const lane = laneSpy();
     const out = await runNeonPrune(
-      { HYPERDRIVE: {}, NEON_BACKFILL_LANES: "neuron_daily" },
+      { HYPERDRIVE: {}, NEON_SOLE_STORE_TABLES: "neuron_daily" },
       ctx,
       { sql: pg.sql, laneHealthDb: lane.db, now: () => NOW },
     );
@@ -231,7 +231,7 @@ describe("runNeonPrune", () => {
     const pg = fakeSql({ doomed: 7, survivors: 900 });
     const lane = laneSpy();
     await runNeonPrune(
-      { HYPERDRIVE: {}, NEON_BACKFILL_LANES: "surface_checks" },
+      { HYPERDRIVE: {}, NEON_SOLE_STORE_TABLES: "surface_checks" },
       ctx,
       { sql: pg.sql, laneHealthDb: lane.db, now: () => NOW },
     );
@@ -241,13 +241,47 @@ describe("runNeonPrune", () => {
     assert.match(String(lane.written[0]!.detail), /surface_checks -7/);
   });
 
+  test("prunes a table Neon owns even with NEON_BACKFILL_LANES empty (#10164)", async () => {
+    // THE PRODUCTION STATE THIS LANE WAS IN. The gate keyed on the backfill
+    // flag, and a table LEAVES that flag exactly when Neon becomes its sole
+    // store -- so once the lanes finished, the flag went empty and this lane
+    // pruned nothing while reporting a clean run. surface_checks is a 30-day
+    // rolling window with no other writer to trim it.
+    const pg = fakeSql({ doomed: 7, survivors: 900 });
+    const lane = laneSpy();
+    await runNeonPrune(
+      {
+        HYPERDRIVE: {},
+        NEON_BACKFILL_LANES: "",
+        NEON_SOLE_STORE_TABLES: "surface_checks,subnet_burn_history",
+      },
+      ctx,
+      { sql: pg.sql, laneHealthDb: lane.db, now: () => NOW },
+    );
+    assert.equal(pg.deletes().length, 2, "both owned windows must be pruned");
+  });
+
+  test("does not prune a table Neon does not own", async () => {
+    // The other half, and the reason the original gate existed: a table Neon
+    // is not the store for may hold a partial copy, and deleting from that is
+    // deleting a fill in progress rather than trimming a window.
+    const pg = fakeSql({ doomed: 7, survivors: 900 });
+    const lane = laneSpy();
+    await runNeonPrune({ HYPERDRIVE: {}, NEON_SOLE_STORE_TABLES: "" }, ctx, {
+      sql: pg.sql,
+      laneHealthDb: lane.db,
+      now: () => NOW,
+    });
+    assert.equal(pg.deletes().length, 0);
+  });
+
   test("a REFUSAL is stale, not ok", async () => {
     // Silence would make the guard pointless: a plan disagreeing with its own
     // table is exactly the thing somebody has to look at.
     const pg = fakeSql({ doomed: 900, survivors: 0 });
     const lane = laneSpy();
     await runNeonPrune(
-      { HYPERDRIVE: {}, NEON_BACKFILL_LANES: "surface_checks" },
+      { HYPERDRIVE: {}, NEON_SOLE_STORE_TABLES: "surface_checks" },
       ctx,
       { sql: pg.sql, laneHealthDb: lane.db, now: () => NOW },
     );

--- a/tests/neurons-staleness-watchdog.test.ts
+++ b/tests/neurons-staleness-watchdog.test.ts
@@ -349,11 +349,11 @@ describe("runNeuronsStalenessWatchdog", () => {
   test("a missing binding and a failing query degrade to summaries, never throws", async () => {
     assert.deepEqual(await runNeuronsStalenessWatchdog({}), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
     assert.deepEqual(await runNeuronsStalenessWatchdog(null), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
     const { db } = fakeDb(new Error("D1_ERROR: no such table: neurons"));
     const result = await runNeuronsStalenessWatchdog(

--- a/tests/nominator-positions-staleness-watchdog.test.ts
+++ b/tests/nominator-positions-staleness-watchdog.test.ts
@@ -372,11 +372,11 @@ describe("runNominatorPositionsStalenessWatchdog", () => {
   test("a missing binding and a failing query degrade to summaries, never throw", async () => {
     assert.deepEqual(await runNominatorPositionsStalenessWatchdog({}), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
     assert.deepEqual(await runNominatorPositionsStalenessWatchdog(null), {
       ok: false,
-      reason: "d1 binding unavailable",
+      reason: "no store bound",
     });
 
     const { db } = fakeDb(

--- a/tests/producers-need-no-d1.test.ts
+++ b/tests/producers-need-no-d1.test.ts
@@ -1,0 +1,93 @@
+// The last lanes that hard-refused without a D1 binding (#10158).
+//
+// Each of these READS from a table Neon owns, and each answered a refusal
+// before it got there -- `d1_binding_missing`, `watermark_unavailable`,
+// "refusing to run". The refusals were right when D1 was the store. They became
+// a check on a binding the lane no longer uses, and on the day D1 is dropped
+// they stop being harmless: every one of these turns into a lane that declines
+// forever while the Neon read it would have made sits ready.
+//
+// Two of them are worse than a decline if they DON'T refuse, which is why the
+// refusal is kept rather than deleted:
+//
+//   raw-capture-sync without a durable watermark cannot know where to resume,
+//   and that is exactly how a gap forms.
+//
+//   surface-verification-sync over zero rows publishes a snapshot that strips
+//   machine-verified from the entire registry.
+//
+// So each lane gets a pair: with Neon owning its tables it must get past the
+// refusal, and with nothing bound at all it must still refuse.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { refreshLiveEconomics } from "../src/live-economics-refresh.ts";
+import { runSurfaceVerificationSync } from "../src/surface-verification-sync.ts";
+
+const HYPERDRIVE = { connectionString: "postgresql://example/db" };
+
+/** The refusal each lane gives when it has nowhere to read from. */
+const LANES: {
+  name: string;
+  tables: string[];
+  refusal: string;
+  run: (env: Record<string, unknown>) => Promise<{ reason?: string }>;
+}[] = [
+  {
+    name: "live-economics-refresh",
+    tables: ["neurons", "subnet_snapshots"],
+    refusal: "store_unavailable",
+    run: (env) =>
+      refreshLiveEconomics(env as never, {
+        // A reader that answers, so the decline under test is the STORE one and
+        // not the artifact one that runs before it.
+        readArtifact: (async () => ({
+          subnets: [{ netuid: 1 }],
+        })) as never,
+      }) as Promise<{ reason?: string }>,
+  },
+  {
+    name: "surface-verification-sync",
+    tables: ["surface_uptime_daily", "surface_checks"],
+    refusal: "store_unavailable",
+    run: (env) =>
+      runSurfaceVerificationSync(env as never) as Promise<{ reason?: string }>,
+  },
+];
+
+describe("with Neon owning its tables and no D1 bound", () => {
+  for (const { name, tables, refusal, run } of LANES) {
+    test(`${name} gets past its store check`, async () => {
+      const result = await run({
+        HYPERDRIVE,
+        NEON_SOLE_STORE_TABLES: tables.join(","),
+        METAGRAPH_CONTROL: {
+          put: async () => undefined,
+          get: async () => null,
+        },
+      });
+      assert.notEqual(
+        result.reason,
+        refusal,
+        `${name} refused over a binding it no longer reads through`,
+      );
+    });
+  }
+});
+
+describe("with nothing bound at all", () => {
+  for (const { name, tables, refusal, run } of LANES) {
+    test(`${name} still refuses`, async () => {
+      // Without this the assertions above would also pass against a lane whose
+      // store check was simply deleted -- and for these two lanes running with
+      // no store is worse than not running: see this file's header.
+      const result = await run({
+        NEON_SOLE_STORE_TABLES: tables.join(","),
+        METAGRAPH_CONTROL: {
+          put: async () => undefined,
+          get: async () => null,
+        },
+      });
+      assert.equal(result.reason, refusal, name);
+    });
+  }
+});

--- a/tests/read-store-tables-match-the-sql.test.ts
+++ b/tests/read-store-tables-match-the-sql.test.ts
@@ -1,0 +1,127 @@
+// Each constant in src/read-store-tables.ts must cover its loader's SQL.
+//
+// WHY THIS TEST IS THE WHOLE ARGUMENT for putting those constants in one file.
+// Twenty-two shared loaders are called from three modules, most of them from
+// two or three, so the sets live centrally rather than beside each loader. That
+// trade is only safe if something checks the central copy against the SQL --
+// otherwise a loader that grows a JOIN silently starts reading a table its
+// callers never declared.
+//
+// And under-declaring is not a weaker check. readStore is all-or-nothing: it
+// sends the loader to Neon on the strength of the tables that WERE named, and
+// the missing one then resolves against a store that does not have it. In
+// Postgres that is an error; across a LEFT JOIN it is rows with the missing
+// side null. Neither is what the caller asked for, and only one of them is
+// loud.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import * as TABLES from "../src/read-store-tables.ts";
+
+/** constant -> every module whose SQL it has to cover.
+ *
+ * A LIST, because a loader's statements are not always all in one file. The
+ * alpha-pricing set is the reason: `src/subnet-holders.ts` selects only
+ * `nominator_positions`, and the `hotkey_alpha` / `hotkey_alpha_passes` half of
+ * the same read lives in `src/hotkey-alpha-completeness.ts`, which it imports.
+ * Checking one module would have declared that set over-broad and passed while
+ * missing the two tables that actually matter. */
+const OWNER: Record<string, string[]> = {
+  ALPHA_PRICING_TABLES: [
+    "src/subnet-holders.ts",
+    "src/hotkey-alpha-completeness.ts",
+  ],
+  SUBNET_BURN_HISTORY_TABLES: ["src/subnet-burn-history.ts"],
+  TAO_USD_TABLES: ["src/tao-usd-series.ts"],
+  SURFACE_HISTORY_TABLES: ["src/surface-history.ts"],
+  EMISSION_CHANGES_TABLES: ["src/emission-gate-changes.ts"],
+  FAILURE_REASONS_TABLES: ["src/failure-reasons.ts"],
+  INDEXER_LAG_TABLES: ["src/indexer-lag.ts"],
+  CHAIN_CONCENTRATION_HISTORY_TABLES: ["src/chain-concentration-history.ts"],
+  SUBNET_SNAPSHOT_TABLES: ["src/emission-pipeline-history.ts"],
+  UPTIME_DAILY_TABLES: ["src/bulk-health-trends.ts"],
+};
+
+/** The real tables, from the config that declares them. Scanning for KNOWN
+ *  names rather than parsing `FROM x` is what makes this robust against the way
+ *  these modules actually build SQL: several concatenate a query across several
+ *  string literals, so a CTE's `WITH` and its name land in different ones and a
+ *  parser reports `holder` and `ranked` as tables. Prose leaks in too. Known
+ *  names have neither problem. */
+function knownTables(): string[] {
+  const config = readFileSync("wrangler.data.jsonc", "utf8");
+  const sole = /"NEON_SOLE_STORE_TABLES"\s*:\s*"([^"]*)"/.exec(config);
+  assert.ok(sole, "NEON_SOLE_STORE_TABLES not found -- was it renamed?");
+  const names = sole[1]!.split(",").filter(Boolean);
+  assert.ok(names.length > 20, `only ${names.length} tables found`);
+  // The four registry tables have Neon migrations but are not declared
+  // sole-store yet, so they are absent from that flag and still readable.
+  return [...names, "surface_history", "subnets", "surfaces", "providers"];
+}
+
+/** Known table names appearing in the module's SQL string literals. */
+function tablesInSql(source: string, known: string[]): Set<string> {
+  const sql = [
+    ...source
+      .replace(/\/\*[\s\S]*?\*\//g, " ")
+      .replace(/^\s*\/\/.*$/gm, " ")
+      .matchAll(/"([^"\\]*(?:\\.[^"\\]*)*)"|`([^`]*)`/g),
+  ]
+    .map((m) => m[1] ?? m[2] ?? "")
+    .join(" ");
+  const found = new Set<string>();
+  for (const table of known) {
+    // Word-bounded so `surface_check` cannot match inside `surface_checks`,
+    // and preceded by FROM/JOIN/INTO or whitespace so a column name that
+    // happens to equal a table name does not count.
+    if (new RegExp(`\\b${table}\\b`).test(sql)) found.add(table);
+  }
+  return found;
+}
+
+describe("every declared table set covers its loader's SQL", () => {
+  const known = knownTables();
+  for (const [constant, modules] of Object.entries(OWNER)) {
+    test(`${constant} vs ${modules.join(" + ")}`, () => {
+      const declared = new Set(
+        (TABLES as unknown as Record<string, readonly string[]>)[constant],
+      );
+      assert.ok(declared.size > 0, `${constant} is empty`);
+      const module = modules.join(" + ");
+      const used = new Set(
+        modules.flatMap((m) => [
+          ...tablesInSql(readFileSync(m, "utf8"), known),
+        ]),
+      );
+      assert.ok(
+        used.size > 0,
+        `${module} names no known table in a string literal -- the scanner ` +
+          `matched nothing, so this would pass whatever ${constant} said`,
+      );
+      const undeclared = [...used].filter((t) => !declared.has(t));
+      assert.deepEqual(
+        undeclared,
+        [],
+        `${module} reads ${undeclared.join(", ")}, which ${constant} does not ` +
+          `declare -- readStore would route this loader to Neon on the tables ` +
+          `it DID declare, and the rest would resolve against the wrong store`,
+      );
+    });
+  }
+
+  test("every exported constant is a non-empty list of distinct names", () => {
+    // An empty set is the one input readStore treats as "stay on D1" rather
+    // than "Neon owns nothing", so it fails open and would never be noticed.
+    for (const [name, value] of Object.entries(TABLES)) {
+      const list = value as readonly string[];
+      assert.ok(Array.isArray(list) && list.length > 0, `${name} is empty`);
+      assert.equal(
+        new Set(list).size,
+        list.length,
+        `${name} repeats a table name`,
+      );
+      for (const t of list)
+        assert.match(t, /^[a-z_][a-z0-9_]*$/, `${name} has a bad name: ${t}`);
+    }
+  });
+});

--- a/tests/surface-verification-sync.test.ts
+++ b/tests/surface-verification-sync.test.ts
@@ -362,7 +362,7 @@ describe("readProberLastRunAt", () => {
 });
 
 describe("runSurfaceVerificationSync", () => {
-  test("no D1 binding: refuses to run LOUDLY rather than publish a registry-wide demotion", async () => {
+  test("no store bound: refuses to run LOUDLY rather than publish a registry-wide demotion", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const { env, puts } = syncEnv({ METAGRAPH_HEALTH_DB: undefined });
     const deps = syncDeps();
@@ -376,12 +376,12 @@ describe("runSurfaceVerificationSync", () => {
     assert.deepEqual(result, {
       ok: false,
       skipped: true,
-      reason: "d1_binding_missing",
+      reason: "store_unavailable",
     });
     assert.equal(errorSpy.mock.calls.length, 1);
     assert.equal(
       (deps.recordException as Row).mock.calls[0][1].errorCode,
-      "surface_verification_d1_missing",
+      "surface_verification_store_missing",
     );
     assert.equal(puts.length, 0);
     // Never even asked the registry what to sweep.

--- a/tests/table-freshness-partitions-by-store.test.ts
+++ b/tests/table-freshness-partitions-by-store.test.ts
@@ -1,0 +1,138 @@
+// The freshness sweep spans both stores, so it must not batch across them.
+//
+// This is the one reader that touches the whole estate -- ~47 tables -- and
+// they do not all live in the same place. readStore is all-or-nothing per call,
+// deliberately: a call naming one owned table and one unowned one falls back to
+// D1. For every other reader that is the safe answer, because every table it
+// names belongs to one lane. Here it is not: a batch mixing the two would run
+// its UNION against D1 and every Neon-only table in it would throw "relation
+// does not exist".
+//
+// And the loss is not one table. The sweep is a single UNION per batch, so one
+// wrong store condemns the batch; the per-table retry then walks it one at a
+// time and fails on each. That is exactly the shape of the #9866 incident this
+// watchdog's own comments describe, arrived at from the other direction --
+// there 12 bad entries blinded 58% of the estate.
+//
+// Nothing here needs a database. What is asserted is which store each SQL
+// statement was handed to, which is the whole property.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { runTableFreshnessWatchdog } from "../src/table-freshness-watchdog.ts";
+
+const HYPERDRIVE = { connectionString: "postgresql://example/db" };
+
+/** A store that records the SQL it was asked for and answers nothing. */
+function recorder() {
+  const seen: string[] = [];
+  return {
+    seen,
+    binding: {
+      prepare(text: string) {
+        seen.push(text);
+        return { all: async () => ({ results: [] }) };
+      },
+    } as never,
+  };
+}
+
+/** Two tables that exist on opposite sides, and a spec naming only those. */
+const NEON_TABLE = "surface_checks";
+const D1_TABLE = "surfaces";
+const SPEC = {
+  [NEON_TABLE]: { column: "checked_at", maxAgeMs: 60_000, label: "neon side" },
+  [D1_TABLE]: { column: "updated_at", maxAgeMs: 60_000, label: "d1 side" },
+} as never;
+
+describe("the freshness sweep", () => {
+  test("never asks D1 for a table Neon owns", async () => {
+    const d1 = recorder();
+    await runTableFreshnessWatchdog(
+      {
+        METAGRAPH_HEALTH_DB: d1.binding,
+        HYPERDRIVE,
+        // Only one of the two tables is Neon's, which is the mixed estate this
+        // watchdog actually runs against.
+        NEON_SOLE_STORE_TABLES: NEON_TABLE,
+        // The verdict goes to lane_health; keep it off the recorded store so
+        // the assertion below is about the sweep and not about bookkeeping.
+        laneHealthDb: undefined,
+      } as never,
+      {
+        spec: SPEC,
+        laneHealthDb: {
+          prepare: () => ({
+            bind: () => ({
+              run: async () => ({}),
+              all: async () => ({ results: [] }),
+            }),
+          }),
+        } as never,
+      },
+    );
+    const askedD1For = d1.seen.join(" ");
+    assert.ok(
+      !askedD1For.includes(NEON_TABLE),
+      `the sweep asked D1 for ${NEON_TABLE}, which Neon owns -- a batch ` +
+        `spanning both stores falls back to D1 and every Neon-only table in ` +
+        `it throws. Statements seen: ${JSON.stringify(d1.seen)}`,
+    );
+  });
+
+  test("still asks D1 for the tables Neon does not own", async () => {
+    // The other half. Without it the assertion above would pass against a
+    // sweep that stopped reading D1 entirely -- which would blind every table
+    // still living there rather than fixing the mixed batch.
+    const d1 = recorder();
+    await runTableFreshnessWatchdog(
+      {
+        METAGRAPH_HEALTH_DB: d1.binding,
+        HYPERDRIVE,
+        NEON_SOLE_STORE_TABLES: NEON_TABLE,
+      } as never,
+      {
+        spec: SPEC,
+        laneHealthDb: {
+          prepare: () => ({
+            bind: () => ({
+              run: async () => ({}),
+              all: async () => ({ results: [] }),
+            }),
+          }),
+        } as never,
+      },
+    );
+    assert.ok(
+      d1.seen.join(" ").includes(D1_TABLE),
+      `the sweep never asked D1 for ${D1_TABLE}, which still lives there`,
+    );
+  });
+
+  test("an injected db still takes everything, so existing suites are unchanged", async () => {
+    // deps.db is how every other test in this family drives the sweep. It must
+    // keep bypassing the partition, or the partitioning would silently change
+    // what those suites are testing.
+    const injected = recorder();
+    const result = await runTableFreshnessWatchdog(
+      {
+        HYPERDRIVE,
+        NEON_SOLE_STORE_TABLES: NEON_TABLE,
+      } as never,
+      {
+        db: injected.binding,
+        spec: SPEC,
+        laneHealthDb: {
+          prepare: () => ({
+            bind: () => ({
+              run: async () => ({}),
+              all: async () => ({ results: [] }),
+            }),
+          }),
+        } as never,
+      },
+    );
+    const asked = injected.seen.join(" ");
+    assert.ok(asked.includes(NEON_TABLE) && asked.includes(D1_TABLE));
+    assert.equal(result.attempted, true);
+  });
+});

--- a/tests/watchdogs-read-the-owning-store.test.ts
+++ b/tests/watchdogs-read-the-owning-store.test.ts
@@ -1,0 +1,110 @@
+// A watchdog must measure the store that holds the rows (#10154).
+//
+// THE SHAPE OF THE BUG. Nine of these eleven watchdogs already WRITE their
+// verdict through laneHealthStore -- that half of the port was done. None of
+// them had moved its READ. So each one measured a D1 copy that stopped
+// advancing the day its lane inverted, and every table they measure is in
+// NEON_SOLE_STORE_TABLES.
+//
+// That is worse than a watchdog that is merely broken. A staleness watchdog
+// keyed to MAX(captured_at) over a frozen table reports the age growing by one
+// second per second, forever -- so it alarms permanently, on lanes that are
+// fine, and the alarm cannot be distinguished from a real one. lane-alarm is
+// the reader that turns those verdicts into GitHub issues.
+//
+// WHAT IS ASSERTED, and why it is not weaker than it looks. There is no
+// Postgres here, so a watchdog that reaches the store fails at the query and
+// degrades to a summary -- which is what these are built to do. What separates
+// the two outcomes is the REASON: "no store bound" means it never tried, and
+// anything else means it got as far as a store. With D1 unbound and Neon
+// owning the tables, "never tried" is exactly the bug.
+//
+// The second case in each pair is what stops that from passing vacuously: with
+// NOTHING bound, the refusal must still be there.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { runNeuronsStalenessWatchdog } from "../src/neurons-staleness-watchdog.ts";
+import { runAccountBalancesStalenessWatchdog } from "../src/account-balances-staleness-watchdog.ts";
+import { runHotkeyAlphaStalenessWatchdog } from "../src/hotkey-alpha-staleness-watchdog.ts";
+import { runNominatorPositionsStalenessWatchdog } from "../src/nominator-positions-staleness-watchdog.ts";
+import { runChainDetailStalenessWatchdog } from "../src/chain-detail-staleness-watchdog.ts";
+import { runLaneAlarm } from "../src/lane-alarm.ts";
+
+const HYPERDRIVE = { connectionString: "postgresql://example/db" };
+
+/** Each watchdog, the tables it reads, and the refusal it gives with no store.
+ *  The table list is the one the module hands readStore -- if they ever
+ *  disagree, the "owns" case below stops being an owns case and the test fails
+ *  rather than passing on the wrong branch. */
+const WATCHDOGS: {
+  name: string;
+  run: (env: unknown, deps?: never) => Promise<{ reason?: string }>;
+  tables: string[];
+  refusal: string;
+}[] = [
+  {
+    name: "neurons",
+    run: (env) => runNeuronsStalenessWatchdog(env as never),
+    tables: ["neurons"],
+    refusal: "no store bound",
+  },
+  {
+    name: "account-balances",
+    run: (env) => runAccountBalancesStalenessWatchdog(env as never),
+    tables: ["account_balances"],
+    refusal: "no store bound",
+  },
+  {
+    name: "hotkey-alpha",
+    run: (env) => runHotkeyAlphaStalenessWatchdog(env as never),
+    tables: ["hotkey_alpha", "nominator_positions"],
+    refusal: "no store bound",
+  },
+  {
+    name: "nominator-positions",
+    run: (env) => runNominatorPositionsStalenessWatchdog(env as never),
+    tables: ["nominator_positions"],
+    refusal: "no store bound",
+  },
+  {
+    name: "chain-detail",
+    run: (env) => runChainDetailStalenessWatchdog(env as never),
+    tables: ["chain_detail_blocks"],
+    refusal: "no store bound",
+  },
+  {
+    name: "lane-alarm",
+    run: (env) => runLaneAlarm(env as never),
+    tables: ["lane_health"],
+    refusal: "no lane_health store bound",
+  },
+];
+
+describe("with Neon owning its tables and no D1 bound", () => {
+  for (const { name, run, tables, refusal } of WATCHDOGS) {
+    test(`${name} reaches a store`, async () => {
+      const result = await run({
+        HYPERDRIVE,
+        NEON_SOLE_STORE_TABLES: tables.join(","),
+      });
+      assert.notEqual(
+        result.reason,
+        refusal,
+        `${name} refused to run: its read is still keyed to the D1 binding, ` +
+          `so it measures a table that stopped advancing when the lane inverted`,
+      );
+    });
+  }
+});
+
+describe("with nothing bound at all", () => {
+  for (const { name, run, tables, refusal } of WATCHDOGS) {
+    test(`${name} still refuses`, async () => {
+      // Without this, every assertion above would also pass if the store check
+      // had simply been deleted -- a watchdog that runs against no store at all
+      // and reports whatever a missing database returns.
+      const result = await run({ NEON_SOLE_STORE_TABLES: tables.join(",") });
+      assert.equal(result.reason, refusal, name);
+    });
+  }
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -621,6 +621,7 @@ import {
   runProjectionLanes,
 } from "../src/projection-lanes.ts";
 import { TOP_HOLDERS_FLOW_LANE } from "../src/top-holders-flow-tier.ts";
+import { laneHealthStore } from "../src/lane-health-store.ts";
 
 // #8386: anonymous stays the existing, regression-tested DATA_RATE_LIMITER
 // policy (60/60s, unchanged); a caller with a valid mg_... key gets 5x via a
@@ -875,7 +876,12 @@ export async function runFreshnessWatchdog(
   const startedAt = Date.now();
   const readArtifactFn = (deps.readArtifact ??
     (readArtifact as unknown as ArtifactReader)) as ArtifactReader;
-  const laneHealthDb = deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as never);
+  // laneHealthStore, not the binding (#10158) -- one of the last three callers
+  // still reaching past it.
+  const laneHealthDb = laneHealthStore(
+    env as unknown as Record<string, unknown>,
+    deps.laneHealthDb,
+  ) as never;
   try {
     const artifact = (await readArtifactFn(
       env,
@@ -1626,7 +1632,13 @@ export default {
     // has already refused eight times would be POSTed at them a ninth. Acked
     // and recorded, never re-delivered.
     if (isDeadLetterQueue(batch.queue)) {
-      await handleDeadLetterBatch(batch, env.METAGRAPH_HEALTH_DB);
+      // The dead-letter record is a lane verdict, so it goes where the other
+      // 27 do (#10158). recordLaneVerdict swallows failures, so a dead letter
+      // written to a store nobody reads is a message lost twice over.
+      await handleDeadLetterBatch(
+        batch,
+        laneHealthStore(env as unknown as Record<string, unknown>) as never,
+      );
       return;
     }
     return handleWebhookQueue(batch, env, ctx);

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -8191,7 +8191,13 @@ export default {
     // attempt wearing a different hat, writing rows whose write is what killed
     // them. `handleDeadLetterBatch` acks and records; it never retries.
     if (isDeadLetterQueue(batch.queue)) {
-      await handleDeadLetterBatch(batch, env.METAGRAPH_HEALTH_DB);
+      // The dead-letter record is a lane verdict, so it goes where the other
+      // 27 do (#10158). recordLaneVerdict swallows failures, so a dead letter
+      // written to a store nobody reads is a message lost twice over.
+      await handleDeadLetterBatch(
+        batch,
+        laneHealthStore(env as unknown as Record<string, unknown>) as never,
+      );
       return;
     }
     // DECOMPRESS BEFORE ANYTHING READS THE BODY (metagraphed#9759). A
@@ -8410,13 +8416,16 @@ export default {
     }
     if (invalid > 0) {
       ctx.waitUntil(
-        recordLaneVerdict(env.METAGRAPH_HEALTH_DB, {
-          lane: "sync-batches",
-          verdict: "stale",
-          age_ms: null,
-          detail: `${invalid} unparseable message(s) in a batch of ${batch.messages.length}`,
-          checked_at: Date.now(),
-        }).then(() => undefined),
+        recordLaneVerdict(
+          laneHealthStore(env as unknown as Record<string, unknown>),
+          {
+            lane: "sync-batches",
+            verdict: "stale",
+            age_ms: null,
+            detail: `${invalid} unparseable message(s) in a batch of ${batch.messages.length}`,
+            checked_at: Date.now(),
+          },
+        ).then(() => undefined),
       );
     }
   },

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -6443,11 +6443,26 @@ export const NEON_READ_ROUTE_TABLES: readonly {
  * A route with no NEON_READ_ROUTE_TABLES entry gets D1, which is why applying
  * this to two more blocks moves nothing on its own.
  */
-function routeStore(env: Env, ctx: ExecutionContext, url: URL): D1Sql {
-  return env.HYPERDRIVE &&
+function routeStore(
+  env: Env,
+  ctx: ExecutionContext,
+  url: URL,
+): D1Sql | undefined {
+  if (
+    env.HYPERDRIVE &&
     neonServesRoute(env as unknown as Record<string, unknown>, url)
-    ? createPgSql(env.HYPERDRIVE, ctx)
-    : createD1Sql(env.METAGRAPH_HEALTH_DB);
+  ) {
+    return createPgSql(env.HYPERDRIVE, ctx);
+  }
+  // `undefined` rather than a runner over an absent binding (#10162). The three
+  // dispatcher blocks below used to answer 503 on `!env.METAGRAPH_HEALTH_DB`
+  // BEFORE asking this function, so a route Neon already serves was refused
+  // whenever D1 happened to be unbound -- the whole point of the gate, undone
+  // by the check above it. Returning undefined moves the "is there a store"
+  // question here, where the answer is actually known.
+  return env.METAGRAPH_HEALTH_DB
+    ? createD1Sql(env.METAGRAPH_HEALTH_DB)
+    : undefined;
 }
 
 export function neonServesRoute(
@@ -7789,8 +7804,9 @@ async function dispatchDataApiRequest(
     if (neuronsServedFromD1(env)) {
       const neuronsD1Handler = matchNeuronsD1Route(url);
       if (neuronsD1Handler) {
-        if (!env.METAGRAPH_HEALTH_DB) {
-          return json({ error: "d1 binding unavailable" }, 503);
+        const store = routeStore(env, ctx, url);
+        if (!store) {
+          return json({ error: "no store bound for this route" }, 503);
         }
         // `account_position_daily` can be served from Neon
         // (metagraphed-infra#336). The handler is unchanged -- it is written
@@ -7812,7 +7828,7 @@ async function dispatchDataApiRequest(
         // the handler uses ONE runner for all its queries, so a route touching
         // two tables cannot half-move. See NEON_READ_ROUTE_TABLES.
         try {
-          return await neuronsD1Handler(routeStore(env, ctx, url), env);
+          return await neuronsD1Handler(store, env);
         } catch (err) {
           console.error("data-api neurons query failed:", err);
           await captureDataApiError(err, maskRouteParams(url.pathname), env);
@@ -7827,11 +7843,12 @@ async function dispatchDataApiRequest(
     {
       const healthStatusD1Handler = matchHealthStatusD1Route(url, env);
       if (healthStatusD1Handler) {
-        if (!env.METAGRAPH_HEALTH_DB) {
-          return json({ error: "d1 binding unavailable" }, 503);
+        const store = routeStore(env, ctx, url);
+        if (!store) {
+          return json({ error: "no store bound for this route" }, 503);
         }
         try {
-          return await healthStatusD1Handler(routeStore(env, ctx, url), env);
+          return await healthStatusD1Handler(store, env);
         } catch (err) {
           console.error("data-api health-status D1 query failed:", err);
           await captureDataApiError(err, maskRouteParams(url.pathname), env);
@@ -7851,14 +7868,12 @@ async function dispatchDataApiRequest(
         env,
       );
       if (hyperparamsIdentityD1Handler) {
-        if (!env.METAGRAPH_HEALTH_DB) {
-          return json({ error: "d1 binding unavailable" }, 503);
+        const store = routeStore(env, ctx, url);
+        if (!store) {
+          return json({ error: "no store bound for this route" }, 503);
         }
         try {
-          return await hyperparamsIdentityD1Handler(
-            routeStore(env, ctx, url),
-            env,
-          );
+          return await hyperparamsIdentityD1Handler(store, env);
         } catch (err) {
           console.error("data-api hyperparams/identity D1 query failed:", err);
           await captureDataApiError(err, maskRouteParams(url.pathname), env);
@@ -8364,13 +8379,53 @@ export default {
           // only because the message asserted `key_complete` -- the validator
           // rejects a neurons message without it, so this writer never sees a
           // chunk whose prune map would delete rows it did not carry.
-          neurons: (rows, pass) =>
-            writeNeuronSnapshotToD1(
-              env.METAGRAPH_HEALTH_DB as unknown as Parameters<
-                typeof writeNeuronSnapshotToD1
-              >[0],
-              { ...neuronSnapshotWrite(rows, Date.now()), pass },
-            ),
+          neurons: async (rows, pass) => {
+            // THE ONE WRITER IN THIS BLOCK THAT NEVER ASKED (#10162). Every
+            // other lane here gates on neonOwns* and mirrors; this wrote D1
+            // outright and mirrored nothing. It is unreachable today --
+            // SYNC_QUEUE_LANES does not list `neurons` -- which is precisely
+            // why it survived: adding the lane to that flag would have started
+            // writing the only copy of a metagraph snapshot to a store nothing
+            // reads.
+            const neonOwns = neonOwnsNeuronsSnapshot(env);
+            const write = neuronSnapshotWrite(rows, Date.now());
+            const result = neonOwns
+              ? { statements: 0 }
+              : await writeNeuronSnapshotToD1(
+                  env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+                    typeof writeNeuronSnapshotToD1
+                  >[0],
+                  { ...write, pass },
+                );
+            const neon = await mirrorNeuronSnapshotToNeon(
+              env as unknown as Record<string, unknown>,
+              ctx,
+              { ...write, pass },
+            );
+            // THROW, never return, on a failed Neon write once Neon owns the
+            // tables: a normal return acks the queue message and the rows are
+            // gone. writeSyncBatch turns a throw into a retry. Named tables
+            // rather than a fold over neon.results, because the mirror answers
+            // `{ attempted: true, results: {} }` when Hyperdrive is unbound and
+            // a "nothing said not-ok" test reads that as success.
+            if (neonOwns) {
+              const reason = [
+                "neurons",
+                "neuron_daily",
+                "account_position_daily",
+              ]
+                .map((table) => {
+                  const r = neon.results?.[table];
+                  if (!r) return `${table}: no Neon write recorded`;
+                  return r.ok ? null : `${table}: ${r.reason ?? "failed"}`;
+                })
+                .filter(Boolean)
+                .join("; ");
+              if (reason)
+                throw new Error(`neurons queue write failed: ${reason}`);
+            }
+            return result;
+          },
           "validator-nominator-counts": async (rows, pass) => {
             // D1 is not written -- this lane is Neon's outright (#10116) --
             // so the Neon write below is the ONLY one, and its failure must

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -75,6 +75,8 @@ import {
   buildDomainOverview,
   buildDomainSummary,
 } from "../../src/domain-summary.ts";
+import { readStore } from "../../src/read-store.ts";
+import { LEADERBOARD_TABLES } from "../../src/read-store-tables.ts";
 
 type HealthMetaKvReader = (
   env: Env,
@@ -650,7 +652,10 @@ export async function composeLeaderboardsData(
   const meta = await readHealthMetaKv(env);
   const d1Generation = currentD1ReadFailureGeneration();
   const { healthRows, rpcRows, growthSamples, reliabilityRows } =
-    await loadLeaderboardD1Rows(env.METAGRAPH_HEALTH_DB);
+    // The only read in this file that was not already asking observationsReadDb
+    // (#10158). It issues four statements across surface_status,
+    // subnet_snapshots and surface_uptime_daily -- all three Neon's.
+    await loadLeaderboardD1Rows(readStore(env, LEADERBOARD_TABLES) as never);
   const data = formatLeaderboards({
     board,
     limit,

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -486,6 +486,21 @@ import {
   CHAIN_TURNOVER_LIMIT_MAX,
 } from "../../src/chain-turnover.ts";
 import { buildSubnetIdentityHistory } from "../../src/subnet-identity-history.ts";
+import { readStore, type ReadStoreDb } from "../../src/read-store.ts";
+import { laneHealthStore } from "../../src/lane-health-store.ts";
+import {
+  ALPHA_PRICING_TABLES,
+  CHAIN_CONCENTRATION_HISTORY_TABLES,
+  EMISSION_CHANGES_TABLES,
+  FAILURE_REASONS_TABLES,
+  INDEXER_LAG_TABLES,
+  SUBNET_BURN_HISTORY_TABLES,
+  SUBNET_SNAPSHOT_TABLES,
+  SURFACE_HISTORY_TABLES,
+  TAO_USD_TABLES,
+  VALIDATOR_ECONOMICS_RANKING_TABLES,
+  VALIDATOR_ECONOMICS_TABLES,
+} from "../../src/read-store-tables.ts";
 
 const RESPONSE_FORMATS = ["json", "csv"];
 const NEURON_CSV_COLUMNS = [
@@ -1584,7 +1599,7 @@ export async function handleValidatorNominators(
     if ("error" in positionsOffset)
       return analyticsQueryError(positionsOffset.error);
     const read = await loadNominatorPositions(
-      env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
+      readStore(env, ALPHA_PRICING_TABLES) as never as unknown as Parameters<
         typeof loadNominatorPositions
       >[0],
       hotkey,
@@ -2217,7 +2232,11 @@ export async function handleSelfHealth(request: Request, env: Env, url: URL) {
   // that a lane's health must be readable without depending on the analytics vendor --
   // or, here, on which serving tier happened to be reachable.
   const lanes = await loadLatestLaneHealth(
-    env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
+    // laneHealthStore, not the binding (#10155) -- lane_health is Neon's, and
+    // this is /health's own lane floor. Reading it from D1 would render an
+    // empty result as "no alarms", which is the one answer a health endpoint
+    // must never invent.
+    laneHealthStore(env as unknown as Record<string, unknown>) as Parameters<
       typeof loadLatestLaneHealth
     >[0],
   );
@@ -3721,7 +3740,8 @@ export async function buildSubnetValidatorEconomicsPayload(
   const readParams = deps.loadParams ?? loadNetworkParameters;
   const readBurn = deps.loadBurn ?? loadSubnetBurn;
   const readEconomicsRow = deps.loadEconomicsRow ?? resolveSubnetEconomicsRow;
-  const db = env.METAGRAPH_HEALTH_DB;
+  const db = readStore(env, VALIDATOR_ECONOMICS_TABLES) as
+    ReadStoreDb | undefined;
   const rows = db
     ? ((
         await db
@@ -3949,7 +3969,10 @@ export async function buildSubnetValidatorEconomicsHistoryPayload(
   const db = observationsReadDb(
     env as unknown as Record<string, unknown>,
     deps.ctx,
-  ) as typeof env.METAGRAPH_HEALTH_DB | undefined;
+    // Typed against the reader, not the binding: naming METAGRAPH_HEALTH_DB
+    // here kept a reference to a D1 shape in a call that had already moved off
+    // it (#10155), and that type disappears with the binding.
+  ) as ReadStoreDb | undefined;
 
   const neuronRows = db
     ? ((
@@ -4112,7 +4135,8 @@ export async function buildValidatorEconomicsRankingPayload(
       };
     });
 
-  const db = env.METAGRAPH_HEALTH_DB;
+  const db = readStore(env, VALIDATOR_ECONOMICS_RANKING_TABLES) as
+    ReadStoreDb | undefined;
   const neuronRows = db
     ? ((
         await db
@@ -6159,9 +6183,10 @@ export async function handleSubnetBurnHistory(
     });
   }
   const rows = await loadSubnetBurnHistory(
-    env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
-      typeof loadSubnetBurnHistory
-    >[0],
+    readStore(
+      env,
+      SUBNET_BURN_HISTORY_TABLES,
+    ) as never as unknown as Parameters<typeof loadSubnetBurnHistory>[0],
     netuid,
     { windowDays },
   );
@@ -6211,7 +6236,7 @@ export async function handleSubnetHolders(
   if ("error" in limit) return analyticsQueryError(limit.error);
 
   const read = await loadSubnetHolders(
-    env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
+    readStore(env, ALPHA_PRICING_TABLES) as never as unknown as Parameters<
       typeof loadSubnetHolders
     >[0],
     netuid,
@@ -6254,7 +6279,7 @@ export async function handleTaoUsd(request: Request, env: Env, url: URL) {
     });
   }
   const rows = await loadTaoUsdSeries(
-    env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
+    readStore(env, TAO_USD_TABLES) as never as unknown as Parameters<
       typeof loadTaoUsdSeries
     >[0],
     { windowHours },
@@ -6298,7 +6323,7 @@ export async function handleSubnetSurfaceHistory(
   if ("error" in limit) return analyticsQueryError(limit.error);
 
   const rows = await loadSurfaceHistory(
-    env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
+    readStore(env, SURFACE_HISTORY_TABLES) as never as unknown as Parameters<
       typeof loadSurfaceHistory
     >[0],
     netuid,
@@ -6346,7 +6371,7 @@ export async function handleEmissionChanges(
   if ("error" in limit) return analyticsQueryError(limit.error);
 
   const rows = await loadEmissionChanges(
-    env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
+    readStore(env, EMISSION_CHANGES_TABLES) as never as unknown as Parameters<
       typeof loadEmissionChanges
     >[0],
     { limit: limit.value, kind: kindParam ?? undefined },
@@ -6394,7 +6419,7 @@ export async function handleChainHolders(request: Request, env: Env, url: URL) {
   if ("error" in limit) return analyticsQueryError(limit.error);
 
   const read = await loadChainHolders(
-    env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
+    readStore(env, ALPHA_PRICING_TABLES) as never as unknown as Parameters<
       typeof loadChainHolders
     >[0],
   );
@@ -6445,7 +6470,7 @@ export async function handleFailureReasons(
   const kind = url.searchParams.get("kind") ?? undefined;
 
   const rows = await loadFailureReasons(
-    env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
+    readStore(env, FAILURE_REASONS_TABLES) as never as unknown as Parameters<
       typeof loadFailureReasons
     >[0],
     { window, netuid, kind },
@@ -6473,7 +6498,9 @@ export async function handleIndexerLag(request: Request, env: Env, url: URL) {
   if (validationError) return analyticsQueryError(validationError);
 
   const row = await loadIndexerLag(
-    env?.METAGRAPH_HEALTH_DB as unknown as Parameters<typeof loadIndexerLag>[0],
+    readStore(env, INDEXER_LAG_TABLES) as never as unknown as Parameters<
+      typeof loadIndexerLag
+    >[0],
   );
   // The handler owns the clock, so the module whose subject is two clocks does
   // not quietly introduce a third of its own.
@@ -6508,7 +6535,10 @@ export async function handleChainConcentrationHistory(
   }
 
   const rows = await loadChainConcentrationHistory(
-    env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
+    readStore(
+      env,
+      CHAIN_CONCENTRATION_HISTORY_TABLES,
+    ) as never as unknown as Parameters<
       typeof loadChainConcentrationHistory
     >[0],
     { window },
@@ -6548,7 +6578,7 @@ export async function handleSubnetPipelineHistory(
   }
 
   const rows = await loadPipelineHistory(
-    env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
+    readStore(env, SUBNET_SNAPSHOT_TABLES) as never as unknown as Parameters<
       typeof loadPipelineHistory
     >[0],
     netuid,


### PR DESCRIPTION
Closes #10162

> Stack: #10159 → #10161 → this. Retarget as each lands.

Two store choices made in the wrong place.

## The `neurons` queue writer never asked

It was the one lane in the `sync-batches` consumer that neither gated on ownership nor mirrored — it wrote D1 outright, while `neurons`, `neuron_daily` and `account_position_daily` are all sole-store on Neon.

It is unreachable **today**, because `SYNC_QUEUE_LANES` does not list `neurons`. That is exactly why it survived every inversion: adding that lane to the flag would have started writing the only copy of a metagraph snapshot to a store nothing reads.

It now skips D1 when Neon owns the tables, mirrors, and **throws** on a failed Neon write — a normal return acks the queue message and the rows are gone. The three tables are named explicitly rather than folded over `neon.results`, because the mirror answers `{ attempted: true, results: {} }` when Hyperdrive is unbound, and a "nothing said not-ok" test reads that as success.

## Three dispatcher blocks refused before asking the gate

```ts
if (neuronsD1Handler) {
  if (!env.METAGRAPH_HEALTH_DB) return json({ error: "d1 binding unavailable" }, 503);
  return await neuronsD1Handler(routeStore(env, ctx, url), env);
}
```

`routeStore` *is* the gate. The check above it refuses first, so **a route Neon already serves is refused whenever D1 happens to be unbound** — the gate undone by the line above it, which is the same defect #9954 fixed one level down.

`routeStore` now returns `undefined` rather than a runner over an absent binding, and each block tests that. The store question is answered where the answer is actually known.

## The gate test moved with the shape rather than being dropped

`tests/dispatcher-asks-the-gate.test.ts` asserted the first argument of each dispatch was `routeStore(...)`. Since each block now binds a local first, it asserts the first argument is `store` **and** that every `store` local is filled from `routeStore` and nothing else — same property, one indirection later, and it still fails if a fourth block chooses its own store.

## Deliberately unchanged

The sync routes' own `"d1 binding unavailable"`. Those are write paths: with Neon owning nothing, the D1 write is still what would run, so its binding is still what is missing. Two assertions I'd blanket-renamed were reverted for that reason.

165 suites: **7,859 green.** `tsc` and prettier clean.