### PR TITLE
fix(neon): the retention prune stopped pruning when the lanes finished (#10164)

### DIFF
--- a/src/neon-prune.ts
+++ b/src/neon-prune.ts
@@ -35,7 +35,7 @@
 
 import { laneHealthStore } from "./lane-health-store.ts";
 import { assertIdentifier } from "./neon-backfill.ts";
-import { neonBackfillLanes, type PgUnsafe } from "./neon-write.ts";
+import { neonOwnsTable, type PgUnsafe } from "./neon-write.ts";
 import {
   createPgSql,
   type HyperdriveLike,
@@ -60,12 +60,23 @@ export interface NeonPrunePlan {
 }
 
 /**
- * One plan per rolling window, keyed by the NEON_BACKFILL_LANES name.
+ * One plan per rolling window, keyed by table name.
  *
- * A table absent from that flag is skipped entirely rather than pruned to
- * empty: nothing is mirroring it yet, so Neon's copy is not a window with a
- * tail, it is a table that has not been filled. Deleting from it would be
- * deleting a backfill in progress.
+ * GATED ON OWNERSHIP, NOT ON THE BACKFILL FLAG (#10164). This was keyed to
+ * NEON_BACKFILL_LANES, and the reasoning was sound while the reconciler ran: a
+ * table absent from that flag was not being mirrored yet, so Neon's copy was
+ * not a window with a tail but a table still filling, and deleting from it
+ * would delete a backfill in progress.
+ *
+ * That inverted when the lanes finished. A table leaves NEON_BACKFILL_LANES
+ * exactly when Neon becomes its sole store (#10078), so "absent from the flag"
+ * stopped meaning "not filled yet" and started meaning "Neon holds the only
+ * copy" -- the precise moment the window most needs bounding. The flag is now
+ * empty in both configs, so this lane has been pruning NOTHING while reporting
+ * a clean run, and surface_checks is a 30-day rolling window with no other
+ * writer to trim it.
+ *
+ * Same inversion, and the same reason, as the chain-detail prune in #10152.
  */
 export const NEON_PRUNE_PLANS: Readonly<Record<string, NeonPrunePlan>> = {
   surface_checks: {
@@ -203,11 +214,10 @@ export async function runNeonPrune(
   const now = deps.now ?? Date.now;
   if (!sql?.unsafe) return { attempted: false };
 
-  // Only tables Neon is actually being given rows for. One absent from the
-  // flag has an EMPTY Neon copy, not a window with a tail.
-  const enabled = new Set(neonBackfillLanes(env));
+  // Only tables Neon actually owns. See NEON_PRUNE_PLANS' header for why this
+  // is ownership and no longer the backfill flag.
   const plans = Object.entries(NEON_PRUNE_PLANS)
-    .filter(([lane]) => enabled.has(lane))
+    .filter(([table]) => neonOwnsTable(env, table))
     .map(([, plan]) => plan);
 
   const outcomes: PruneTableOutcome[] = [];

--- a/tests/neon-prune.test.ts
+++ b/tests/neon-prune.test.ts
@@ -217,7 +217,7 @@ describe("runNeonPrune", () => {
     const pg = fakeSql({ doomed: 10, survivors: 10 });
     const lane = laneSpy();
     const out = await runNeonPrune(
-      { HYPERDRIVE: {}, NEON_BACKFILL_LANES: "neuron_daily" },
+      { HYPERDRIVE: {}, NEON_SOLE_STORE_TABLES: "neuron_daily" },
       ctx,
       { sql: pg.sql, laneHealthDb: lane.db, now: () => NOW },
     );
@@ -231,7 +231,7 @@ describe("runNeonPrune", () => {
     const pg = fakeSql({ doomed: 7, survivors: 900 });
     const lane = laneSpy();
     await runNeonPrune(
-      { HYPERDRIVE: {}, NEON_BACKFILL_LANES: "surface_checks" },
+      { HYPERDRIVE: {}, NEON_SOLE_STORE_TABLES: "surface_checks" },
       ctx,
       { sql: pg.sql, laneHealthDb: lane.db, now: () => NOW },
     );
@@ -241,13 +241,47 @@ describe("runNeonPrune", () => {
     assert.match(String(lane.written[0]!.detail), /surface_checks -7/);
   });
 
+  test("prunes a table Neon owns even with NEON_BACKFILL_LANES empty (#10164)", async () => {
+    // THE PRODUCTION STATE THIS LANE WAS IN. The gate keyed on the backfill
+    // flag, and a table LEAVES that flag exactly when Neon becomes its sole
+    // store -- so once the lanes finished, the flag went empty and this lane
+    // pruned nothing while reporting a clean run. surface_checks is a 30-day
+    // rolling window with no other writer to trim it.
+    const pg = fakeSql({ doomed: 7, survivors: 900 });
+    const lane = laneSpy();
+    await runNeonPrune(
+      {
+        HYPERDRIVE: {},
+        NEON_BACKFILL_LANES: "",
+        NEON_SOLE_STORE_TABLES: "surface_checks,subnet_burn_history",
+      },
+      ctx,
+      { sql: pg.sql, laneHealthDb: lane.db, now: () => NOW },
+    );
+    assert.equal(pg.deletes().length, 2, "both owned windows must be pruned");
+  });
+
+  test("does not prune a table Neon does not own", async () => {
+    // The other half, and the reason the original gate existed: a table Neon
+    // is not the store for may hold a partial copy, and deleting from that is
+    // deleting a fill in progress rather than trimming a window.
+    const pg = fakeSql({ doomed: 7, survivors: 900 });
+    const lane = laneSpy();
+    await runNeonPrune({ HYPERDRIVE: {}, NEON_SOLE_STORE_TABLES: "" }, ctx, {
+      sql: pg.sql,
+      laneHealthDb: lane.db,
+      now: () => NOW,
+    });
+    assert.equal(pg.deletes().length, 0);
+  });
+
   test("a REFUSAL is stale, not ok", async () => {
     // Silence would make the guard pointless: a plan disagreeing with its own
     // table is exactly the thing somebody has to look at.
     const pg = fakeSql({ doomed: 900, survivors: 0 });
     const lane = laneSpy();
     await runNeonPrune(
-      { HYPERDRIVE: {}, NEON_BACKFILL_LANES: "surface_checks" },
+      { HYPERDRIVE: {}, NEON_SOLE_STORE_TABLES: "surface_checks" },
       ctx,
       { sql: pg.sql, laneHealthDb: lane.db, now: () => NOW },
     );


### PR DESCRIPTION
Closes #10164

> Stack: #10159 → #10161 → #10163 → this. Retarget as each lands.

`runNeonPrune` selected its plans from `NEON_BACKFILL_LANES`, which is `""` in **both** wrangler configs. The plan list was empty, the lane pruned nothing, and it recorded a clean `ok` verdict every tick.

## The gate didn't break — it reversed

Its reasoning was right while the reconciler ran, and `NEON_PRUNE_PLANS`' own header says so: a table absent from the backfill flag was not being mirrored yet, so Neon's copy was not a window with a tail but a table still *filling*, and deleting from it would delete a backfill in progress.

But #10078 established that **a table leaves `NEON_BACKFILL_LANES` exactly when Neon becomes its sole store.** So "absent from the flag" stopped meaning "not filled yet" and started meaning "Neon holds the only copy" — the precise moment the window most needs bounding.

## What was growing

| table | window | other writer that could trim it |
|---|---|---|
| `surface_checks` | 30 days rolling | **none** — #9891 is the standing note that mirroring this without its prune guarantees divergence |
| `subnet_burn_history` | `BURN_HISTORY_RETENTION_MS` | **none** |

Both sole-store on Neon.

Same inversion as #10152 (the chain-detail prune deriving its watermark from a frozen D1), in a second place, failing the same way: **success reported over an empty plan list.**

## Verification

The gate is `neonOwnsTable` now, and both halves have a test:

- **"prunes a table Neon owns even with `NEON_BACKFILL_LANES` empty"** — sets the flag to `""` explicitly, because that is the configuration this was broken in, and asserts both windows are pruned.
- **"does not prune a table Neon does not own"** — what the original gate was protecting, and still right for any table Neon is not the store for.

Mutation-checked: reverting the gate to the backfill flag fails three tests including the endgame one. The existing fixtures were re-keyed from `NEON_BACKFILL_LANES` to `NEON_SOLE_STORE_TABLES`, which is the same change in the tests as in the code.

119 tests across the prune and flag-parity suites. `tsc` and prettier clean.