### PR TITLE
refactor(api): one derived allowlist replaces 119 hand-written ones, and the GraphQL mirror stops lying (#10065)

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -3384,6 +3384,7 @@ export type QueryBlocksArgs = {
 export type QueryCandidatesArgs = {
   confidence?: InputMaybe<Scalars['String']['input']>;
   cursor?: InputMaybe<Scalars['Int']['input']>;
+  fields?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['String']['input']>;
   kind?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -3558,10 +3559,25 @@ export type QueryCompare_ValidatorsArgs = {
 };
 
 
+export type QueryCoverage_DepthArgs = {
+  agent_status?: InputMaybe<Scalars['String']['input']>;
+  blocker_level?: InputMaybe<Scalars['String']['input']>;
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  fields?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  netuid?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<Scalars['String']['input']>;
+  q?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  tier?: InputMaybe<Scalars['String']['input']>;
+};
+
+
 export type QueryCurationArgs = {
   coverage_level?: InputMaybe<Scalars['String']['input']>;
   curation_level?: InputMaybe<Scalars['String']['input']>;
   cursor?: InputMaybe<Scalars['Int']['input']>;
+  fields?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -3575,7 +3591,7 @@ export type QueryDomain_SummaryArgs = {
 
 
 export type QueryEconomicsArgs = {
-  cursor?: InputMaybe<Scalars['String']['input']>;
+  cursor?: InputMaybe<Scalars['Int']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -3597,7 +3613,11 @@ export type QueryEmission_ChangesArgs = {
 
 
 export type QueryEmission_PipelineArgs = {
+  fields?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -3721,6 +3741,7 @@ export type QueryGapsArgs = {
 
 export type QueryGlobal_IncidentsArgs = {
   cursor?: InputMaybe<Scalars['Int']['input']>;
+  fields?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -3758,8 +3779,16 @@ export type QueryHealth_HistoryArgs = {
 };
 
 
+export type QueryHealth_TrendsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  window?: InputMaybe<Scalars['String']['input']>;
+};
+
+
 export type QueryIncidentsArgs = {
   cursor?: InputMaybe<Scalars['Int']['input']>;
+  fields?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -3818,7 +3847,8 @@ export type QueryProviderArgs = {
 
 
 export type QueryProvider_EndpointsArgs = {
-  cursor?: InputMaybe<Scalars['String']['input']>;
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  fields?: InputMaybe<Scalars['String']['input']>;
   kind?: InputMaybe<Scalars['String']['input']>;
   layer?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -3962,7 +3992,7 @@ export type QueryReview_Profile_CompletenessArgs = {
 
 
 export type QueryRpc_EndpointsArgs = {
-  cursor?: InputMaybe<Scalars['String']['input']>;
+  cursor?: InputMaybe<Scalars['Int']['input']>;
   fields?: InputMaybe<Array<Scalars['String']['input']>>;
   kind?: InputMaybe<Scalars['String']['input']>;
   layer?: InputMaybe<Scalars['String']['input']>;
@@ -4009,6 +4039,7 @@ export type QuerySaved_QueryArgs = {
 
 export type QuerySearchArgs = {
   cursor?: InputMaybe<Scalars['Int']['input']>;
+  fields?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -4020,6 +4051,7 @@ export type QuerySearchArgs = {
 
 export type QuerySearch_IndexArgs = {
   cursor?: InputMaybe<Scalars['Int']['input']>;
+  fields?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -4136,6 +4168,7 @@ export type QuerySubnet_Event_SummaryArgs = {
 export type QuerySubnet_EventsArgs = {
   block_end?: InputMaybe<Scalars['Int']['input']>;
   block_start?: InputMaybe<Scalars['Int']['input']>;
+  cursor?: InputMaybe<Scalars['String']['input']>;
   kind?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid: Scalars['Int']['input'];
@@ -4248,6 +4281,7 @@ export type QuerySubnet_Lease_HistoryArgs = {
 
 
 export type QuerySubnet_MetagraphArgs = {
+  fields?: InputMaybe<Scalars['String']['input']>;
   netuid: Scalars['Int']['input'];
   validator_permit?: InputMaybe<Scalars['Boolean']['input']>;
 };
@@ -4470,18 +4504,23 @@ export type QuerySudo_KeyArgs = {
 
 
 export type QuerySurfacesArgs = {
-  cursor?: InputMaybe<Scalars['String']['input']>;
+  auth_required?: InputMaybe<Scalars['Boolean']['input']>;
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  fields?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['String']['input']>;
   kind?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
   provider?: InputMaybe<Scalars['String']['input']>;
+  public_safe?: InputMaybe<Scalars['Boolean']['input']>;
+  rate_limited?: InputMaybe<Scalars['Boolean']['input']>;
   sort?: InputMaybe<Scalars['String']['input']>;
 };
 
 
 export type QueryTao_UsdArgs = {
+  include_points?: InputMaybe<Scalars['Boolean']['input']>;
   window?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -4514,6 +4553,7 @@ export type QueryValidator_HistoryArgs = {
 
 
 export type QueryValidator_NominatorsArgs = {
+  basis?: InputMaybe<Scalars['String']['input']>;
   coldkey?: InputMaybe<Scalars['String']['input']>;
   hotkey: Scalars['String']['input'];
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -9286,7 +9326,7 @@ export type QueryResolvers<ContextType = GqlContext, ParentType extends Resolver
   compare_validators?: Resolver<ResolversTypes['ValidatorComparison'], ParentType, ContextType, RequireFields<QueryCompare_ValidatorsArgs, 'hotkeys'>>;
   contracts?: Resolver<Maybe<ResolversTypes['Contracts']>, ParentType, ContextType>;
   coverage?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
-  coverage_depth?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  coverage_depth?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType, Partial<QueryCoverage_DepthArgs>>;
   curation?: Resolver<ResolversTypes['CurationList'], ParentType, ContextType, Partial<QueryCurationArgs>>;
   domain_summary?: Resolver<ResolversTypes['DomainSummary'], ParentType, ContextType, RequireFields<QueryDomain_SummaryArgs, 'tag'>>;
   domains?: Resolver<ResolversTypes['DomainOverview'], ParentType, ContextType>;
@@ -9311,7 +9351,7 @@ export type QueryResolvers<ContextType = GqlContext, ParentType extends Resolver
   governance_config_changes?: Resolver<ResolversTypes['ExtrinsicList'], ParentType, ContextType, Partial<QueryGovernance_Config_ChangesArgs>>;
   health?: Resolver<Maybe<ResolversTypes['GlobalHealth']>, ParentType, ContextType>;
   health_history?: Resolver<ResolversTypes['HealthHistory'], ParentType, ContextType, RequireFields<QueryHealth_HistoryArgs, 'date'>>;
-  health_trends?: Resolver<ResolversTypes['HealthTrends'], ParentType, ContextType>;
+  health_trends?: Resolver<ResolversTypes['HealthTrends'], ParentType, ContextType, Partial<QueryHealth_TrendsArgs>>;
   incidents?: Resolver<ResolversTypes['GlobalIncidents'], ParentType, ContextType, Partial<QueryIncidentsArgs>>;
   indexer_lag?: Resolver<ResolversTypes['IndexerLag'], ParentType, ContextType>;
   lineage?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -19407,6 +19407,8 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
+                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
             };
@@ -37011,6 +37013,7 @@ export interface operations {
                 q?: string;
                 /** @description Maximum number of rows to return in one page (at most 20). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
                 limit?: number;
+                type?: "subnet" | "surface" | "provider";
             };
             header?: never;
             path?: never;
@@ -39505,6 +39508,8 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
+                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
             };
@@ -46647,6 +46652,8 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`, `1y`, `all`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d" | "1y" | "all";
+                /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
+                netuid?: number;
             };
             header?: never;
             path: {

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4521,6 +4521,17 @@
             "minimum": 1,
             "type": "integer"
           }
+        },
+        {
+          "name": "type",
+          "schema": {
+            "enum": [
+              "subnet",
+              "surface",
+              "provider"
+            ],
+            "type": "string"
+          }
         }
       ]
     },
@@ -7680,6 +7691,14 @@
             ],
             "type": "string"
           }
+        },
+        {
+          "name": "netuid",
+          "schema": {
+            "maximum": 65535,
+            "minimum": 0,
+            "type": "integer"
+          }
         }
       ]
     },
@@ -7968,6 +7987,12 @@
             "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
+          }
+        },
+        {
+          "name": "cursor",
+          "schema": {
+            "type": "string"
           }
         },
         {
@@ -8290,6 +8315,12 @@
             "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
+          }
+        },
+        {
+          "name": "cursor",
+          "schema": {
+            "type": "string"
           }
         },
         {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -63699,6 +63699,15 @@
             }
           },
           {
+            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
             "in": "query",
             "name": "format",
@@ -83964,6 +83973,19 @@
               "minimum": 1,
               "type": "integer"
             }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "subnet",
+                "surface",
+                "provider"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -86689,6 +86711,15 @@
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
+            }
+          },
+          {
+            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
             }
           },
           {
@@ -93868,6 +93899,17 @@
                 "all"
               ],
               "type": "string"
+            }
+          },
+          {
+            "description": "Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's.",
+            "in": "query",
+            "name": "netuid",
+            "required": false,
+            "schema": {
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
             }
           }
         ],

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -19407,6 +19407,8 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
+                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
             };
@@ -37011,6 +37013,7 @@ export interface operations {
                 q?: string;
                 /** @description Maximum number of rows to return in one page (at most 20). A larger value, or a non-positive one, is rejected with 400 `invalid_query` on every route -- it is never silently clamped, so a short page always means the result set is exhausted (#9916). */
                 limit?: number;
+                type?: "subnet" | "surface" | "provider";
             };
             header?: never;
             path?: never;
@@ -39505,6 +39508,8 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
+                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
             };
@@ -46647,6 +46652,8 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`, `1y`, `all`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d" | "1y" | "all";
+                /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
+                netuid?: number;
             };
             header?: never;
             path: {

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -76,6 +76,7 @@ import {
   SEMANTIC_LIMIT_DEFAULT,
   SEMANTIC_LIMIT_MAX,
   SEMANTIC_QUERY_MAX_LENGTH,
+  SEMANTIC_TYPES,
   SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
   SUBNET_HOLDERS_LIMIT_MAX,
   SURFACE_HISTORY_LIMIT_MAX,
@@ -246,6 +247,12 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
     // directly since #9127.
     q: querySchema(SEMANTIC_QUERY_MAX_LENGTH).optional(),
     limit: limitSchema(SEMANTIC_LIMIT_MAX, SEMANTIC_LIMIT_DEFAULT).optional(),
+    // #10065: the handler has scoped on this since semantic search shipped --
+    // it filters the results and rejects an unknown value by name ("Unknown
+    // type `bogus`. Valid types: subnet, surface, provider", verified live) --
+    // and the contract never mentioned it. The vocabulary comes FROM
+    // src/ai-search.ts rather than being restated, so the two cannot drift.
+    type: z.enum(SEMANTIC_TYPES).optional(),
   }),
   "/api/v1/chain/emission-pipeline": z.object({
     netuid: netuidSchema().optional(),
@@ -437,6 +444,12 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
   }),
   "/api/v1/validators/{hotkey}/history": z.object({
     window: windowSchema(["7d", "30d", "90d", "1y", "all"] as const).optional(),
+    // #9383 added this to the handler's allowlist, the MCP tool and the
+    // GraphQL field, and the response echoes it back as `data.netuid` -- but
+    // it was never declared, so openapi.json told every generated client that
+    // passing it was an error. Verified live before declaring: the scoped and
+    // unscoped series differ (#10065).
+    netuid: netuidSchema().optional(),
   }),
   "/api/v1/subnets/{netuid}/metagraph": z.object({
     // DIVERGENCE: a one-value enum for a boolean filter. The sibling feeds
@@ -474,6 +487,11 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
     block_end: blockBoundSchema("last").optional(),
     limit: limitSchema(MAX_LIMIT).optional(),
     offset: offsetSchema().optional(),
+    // The handler has always accepted and forwarded this, and the sibling
+    // /accounts/{ss58}/events feed publishes it -- but this route did not, so
+    // the contract said passing it was an error while the route paged on it.
+    // Found by sweeping all 202 GET routes through the real router (#10065).
+    cursor: keysetCursorSchema().optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/subnets/{netuid}/event-summary": z.object({
@@ -508,6 +526,9 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
     to: daySchema("last").optional(),
     limit: limitSchema(MAX_LIMIT).optional(),
     offset: offsetSchema().optional(),
+    // handleAccountHistory forwards this to loadAccountHistoryColdTier and has
+    // since #9315; only the contract left it out (#10065).
+    cursor: keysetCursorSchema().optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/accounts/{ss58}/extrinsics": z.object({

--- a/schemas-src/routes/health-surfaces.ts
+++ b/schemas-src/routes/health-surfaces.ts
@@ -38,6 +38,7 @@ import { ArtifactBaseSchema, CountMapSchema } from "../envelope.ts";
 import { HealthStatusSchema } from "../shared.ts";
 import { ClassificationSchema, SurfaceKindSchema } from "./subnet-detail.ts";
 import { HealthSubnetSummarySchema } from "./health.ts";
+import { HEALTH_TREND_WINDOW_VALUES } from "../../src/route-limits.ts";
 
 // ---- GET /api/v1/health/history/{date} -> HealthHistoryArtifact ----
 
@@ -142,20 +143,11 @@ export type BulkHealthTrendsArtifact = z.infer<
   typeof BulkHealthTrendsArtifactSchema
 >;
 
-/**
- * The window labels this route derives, single-sourced (#9981).
- *
- * `workers/config.ts`'s HEALTH_TREND_WINDOWS maps each label to its day count
- * and is the runtime's copy; this is the published vocabulary. They are checked
- * against each other by tests/route-limit-contract-parity.test.ts rather than
- * one importing the other, because schemas-src must not depend on the Worker's
- * config module -- see this directory's leaf-module rule.
- *
- * That cross-check named a test file that did not exist until #10089. A comment
- * asserting a guard is not a guard: the vocabularies happened to agree, and
- * nothing would have said so if they stopped.
- */
-export const HEALTH_TREND_WINDOW_VALUES = ["7d", "30d"] as const;
+// The window vocabulary now lives in the zero-import leaf src/route-limits.ts
+// so src/ modules can read it without importing this directory -- see that
+// module for why. Re-exported unchanged, so this file stays the place a reader
+// looks for the route's published vocabulary.
+export { HEALTH_TREND_WINDOW_VALUES };
 
 /**
  * GET /api/v1/health/trends query parameters (#9981).

--- a/scripts/validate-graphql-route-parity.ts
+++ b/scripts/validate-graphql-route-parity.ts
@@ -367,24 +367,6 @@ const EPOCH_MS_BOUND =
   "The route's `integer` and the SDL's `String` are the same value in the two " +
   "type systems that can each hold it.";
 
-/**
- * `cursor` is REST's positional offset on these five, not an opaque key, and
- * the runtime says so: `economics(cursor:"abc")` answers "cursor must be a
- * non-negative integer" (verified live). So `String` is a genuine
- * under-typing — the schema should reject at validation time what the
- * resolver rejects at execution time.
- *
- * It is declared rather than fixed here because `String` → `Int` is a
- * BREAKING change to a published schema: a client sending `cursor: "2"`
- * today would stop validating. That is a deliberate decision with a migration
- * note, not a line in a gate PR. Tracked separately.
- */
-const CURSOR_UNDERTYPED =
-  "REST's positional offset typed as String. The runtime already rejects a " +
-  "non-integer ('cursor must be a non-negative integer', verified live), so " +
-  "the SDL is looser than the resolver. Tightening to Int is a BREAKING " +
-  "schema change and is tracked on its own.";
-
 /** SDL arguments the mirrored route does not publish, each with the reason. */
 const DECLARED_ARGUMENTS: Record<string, string> = {
   "agent_catalog.netuid":
@@ -398,16 +380,13 @@ const DECLARED_ARGUMENTS: Record<string, string> = {
     "resolver fetches GLOBAL_VALIDATOR_LIMIT_MAX once and paginates in-process, " +
     "keyed by hotkey, the way providers/economics do. A capability GraphQL adds, " +
     "not a claim about the route.",
-  "validator_history.netuid":
-    "the route DOES accept and honour netuid — handleValidatorHistory allowlists " +
-    "['window','netuid'] and the response echoes data.netuid (verified live) — but " +
-    "route-queries.ts declares only `window`, so openapi.json never published it. " +
-    "The divergence is in what the route publishes, not in the SDL; remove this " +
-    "entry when the parameter is declared.",
-  "account_history.cursor":
-    "same shape as validator_history.netuid: handleAccountHistory allowlists " +
-    "cursor and forwards it to loadAccountHistoryColdTier (verified live — " +
-    "?cursor=1 is accepted, not 400'd), but the route publishes only limit/offset.",
+  "endpoints.cursor":
+    "an OPAQUE id keyset, not REST's integer offset -- the same GraphQL-only " +
+    "pagination contract #7920 established for `providers`. Verified live: " +
+    'endpoints(limit:1) answers next_cursor "endpoint-srf-2d3306d2cfa2223e" ' +
+    'and endpoints(cursor:"abc") is accepted, where the four sibling list ' +
+    'fields answer "cursor must be a non-negative integer". Typing this Int ' +
+    "to match the route would break the only pagination the field has.",
   "compare.netuids":
     "/api/v1/compare takes a comma-joined string (pattern ^\\d{1,5}(,\\d{1,5}){0,127}$) " +
     "because a query string has no list type. GraphQL does, so the SDL takes " +
@@ -419,11 +398,6 @@ const DECLARED_ARGUMENTS: Record<string, string> = {
   "blocks.to": EPOCH_MS_BOUND,
   "sudo.from": EPOCH_MS_BOUND,
   "sudo.to": EPOCH_MS_BOUND,
-  "economics.cursor": CURSOR_UNDERTYPED,
-  "surfaces.cursor": CURSOR_UNDERTYPED,
-  "endpoints.cursor": CURSOR_UNDERTYPED,
-  "provider_endpoints.cursor": CURSOR_UNDERTYPED,
-  "rpc_endpoints.cursor": CURSOR_UNDERTYPED,
 };
 
 /**
@@ -434,55 +408,7 @@ const DECLARED_ARGUMENTS: Record<string, string> = {
  * resolver, so they are recorded rather than silently tolerated — every entry
  * here is a gap to close, not a difference to keep.
  */
-const NO_PROJECTION =
-  "the field returns opaque JSON (or JSON rows), so a selection set cannot " +
-  "project it and the route's `fields` parameter is the only projection " +
-  "available — which the SDL does not offer. A real gap.";
-
-const DECLARED_MISSING_ARGUMENTS: Record<string, string> = {
-  "curation.fields": NO_PROJECTION,
-  "candidates.fields": NO_PROJECTION,
-  "search.fields": NO_PROJECTION,
-  "search_index.fields": NO_PROJECTION,
-  "subnet_metagraph.fields": NO_PROJECTION,
-  "provider_endpoints.fields": NO_PROJECTION,
-  "incidents.fields": NO_PROJECTION,
-  "global_incidents.fields": NO_PROJECTION,
-  "emission_pipeline.fields": NO_PROJECTION,
-  "coverage_depth.fields": NO_PROJECTION,
-
-  // /api/v1/coverage-depth publishes ten query parameters and the SDL field
-  // takes none of them: `coverage_depth: JSON` is a bare artifact passthrough.
-  // A GraphQL caller can read the whole report and filter or page none of it.
-  "coverage_depth.netuid": "coverage_depth takes no arguments at all",
-  "coverage_depth.tier": "coverage_depth takes no arguments at all",
-  "coverage_depth.agent_status": "coverage_depth takes no arguments at all",
-  "coverage_depth.blocker_level": "coverage_depth takes no arguments at all",
-  "coverage_depth.q": "coverage_depth takes no arguments at all",
-  "coverage_depth.limit": "coverage_depth takes no arguments at all",
-  "coverage_depth.cursor": "coverage_depth takes no arguments at all",
-  "coverage_depth.sort": "coverage_depth takes no arguments at all",
-  "coverage_depth.order": "coverage_depth takes no arguments at all",
-
-  "health_trends.window": "health_trends takes no arguments at all",
-  "health_trends.limit": "health_trends takes no arguments at all",
-  "health_trends.offset": "health_trends takes no arguments at all",
-
-  "emission_pipeline.sort": "the SDL exposes only netuid of the five",
-  "emission_pipeline.order": "the SDL exposes only netuid of the five",
-  "emission_pipeline.limit": "the SDL exposes only netuid of the five",
-
-  // loadSurfacesList already accepts these three -- `surfaces` passes `args`
-  // straight to it -- so the SDL is the only thing withholding them.
-  "surfaces.auth_required": "filter the shared loader already accepts",
-  "surfaces.public_safe": "filter the shared loader already accepts",
-  "surfaces.rate_limited": "filter the shared loader already accepts",
-
-  "tao_usd.include_points":
-    "REST can opt into the point series; the GraphQL field cannot",
-  "validator_nominators.basis":
-    "REST can pick the stake basis; the GraphQL field cannot",
-};
+const DECLARED_MISSING_ARGUMENTS: Record<string, string> = {};
 
 const argumentFindings: Finding[] = [];
 const suppressedArguments = new Set<string>();

--- a/scripts/validate-mcp-input-parity.ts
+++ b/scripts/validate-mcp-input-parity.ts
@@ -85,7 +85,6 @@ for (const [key, reason] of Object.entries({
   "get_extrinsic_chain_events.ref": PATH_PARAMETER,
   "get_block_chain_events.block_number": PATH_PARAMETER,
   "get_api_schema.surface_id": PATH_PARAMETER,
-  "get_validator_history.netuid": PATH_PARAMETER,
   "get_agent_catalog.netuid": PATH_PARAMETER,
   "verify_integration.netuid": PATH_PARAMETER,
   "get_domain_summary.domain": PATH_PARAMETER,
@@ -94,7 +93,6 @@ for (const [key, reason] of Object.entries({
   // --- POST bodies ---------------------------------------------------------
   "ask.question": REQUEST_BODY,
   "ask.type": REQUEST_BODY,
-  "semantic_search.type": REQUEST_BODY,
   // --- MCP-native ----------------------------------------------------------
   "find_subnet_for_task.task": MCP_NATIVE,
   "find_subnet_for_task.limit": MCP_NATIVE,
@@ -352,6 +350,12 @@ function classify(toolSchema: Row, routeSchema: Row): Divergence | null {
  */
 const CONSTRAINT_DIVERGENCES: Record<string, Divergence> = {
   // SHAPE -- the same value in the form each surface speaks. Permanent.
+  // #10065 published `type` on /api/v1/search/semantic (the handler has always
+  // scoped on it). A query string can carry one value per key -- a repeat is
+  // ambiguous and is now a 400 -- while an MCP argument is JSON and can carry
+  // the list outright, which parseSemanticTypes already accepts. The same
+  // value in the form each surface speaks.
+  "semantic_search.type": "SHAPE",
   "compare_subnets.dimensions": "SHAPE",
   "compare_subnets.netuids": "SHAPE",
   "compare_validators.hotkeys": "SHAPE",

--- a/src/ai-search.ts
+++ b/src/ai-search.ts
@@ -17,6 +17,7 @@ import {
   SEMANTIC_LIMIT_DEFAULT,
   SEMANTIC_LIMIT_MAX,
   SEMANTIC_QUERY_MAX_LENGTH,
+  SEMANTIC_TYPES,
 } from "./route-limits.ts";
 import {
   recordAiDegradedEvent,
@@ -105,7 +106,10 @@ export const SEMANTIC_DEFAULT_LIMIT = SEMANTIC_LIMIT_DEFAULT;
 export const SEMANTIC_MAX_LIMIT = SEMANTIC_LIMIT_MAX;
 // Record kinds the registry embeds; the semantic + ask paths can scope to a
 // subset. Single source of truth for the tool schemas and the validator.
-export const SEMANTIC_TYPES = ["subnet", "surface", "provider"];
+// The scope vocabulary now lives in the zero-import leaf src/route-limits.ts,
+// so schemas-src/route-queries.ts can publish it without importing this module
+// (and its AI/Vectorize graph) into the contract layer. Re-exported unchanged.
+export { SEMANTIC_TYPES };
 // `returnMetadata: "all"` caps Vectorize at topK 20. A scoped query over-fetches
 // to this cap, then post-filters and slices, so `limit` holds after filtering.
 const FILTERED_RETRIEVE_TOPK = SEMANTIC_MAX_LIMIT;
@@ -563,7 +567,7 @@ export function normalizeSemanticTypes(type: unknown): string[] | null {
   const allow: string[] = [];
   for (const raw of list) {
     const value = typeof raw === "string" ? raw.trim() : "";
-    if (!SEMANTIC_TYPES.includes(value)) {
+    if (!SEMANTIC_TYPES.includes(value as (typeof SEMANTIC_TYPES)[number])) {
       throw aiInputError(
         `Unknown type \`${String(raw)}\`. Valid types: ${SEMANTIC_TYPES.join(", ")}.`,
       );

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -6003,8 +6003,75 @@ export function compileRoutePattern(pathTemplate: string) {
     .replace(/__METAGRAPH_HASH__/g, "(?<hash>0x[0-9a-fA-F]{64}|\\d+-\\d+)")
     .replace(/__METAGRAPH_TAG__/g, "(?<tag>[a-z-]+)")
     .replace(/__METAGRAPH_H160__/g, "(?<h160>0x[0-9a-fA-F]{40})")
-    .replace(/__METAGRAPH_ID__/g, "(?<id>[A-Za-z0-9][A-Za-z0-9:._-]*)");
+    .replace(/__METAGRAPH_ID__/g, "(?<id>[A-Za-z0-9][A-Za-z0-9:._-]*)")
+    // `{network}` on the /api/v1/{network}/… twins. The alternation is
+    // NETWORK_ALIASES itself rather than a `[^/]+` catch-all, so a twin
+    // template cannot swallow a sibling literal segment.
+    .replace(
+      /__METAGRAPH_NETWORK__/g,
+      `(?<network>${NETWORK_ALIASES.join("|")})`,
+    );
   return new RegExp(`^${pattern}\\/?$`);
+}
+
+/**
+ * The contract path template a concrete request pathname resolves to, or null
+ * when no route matches (#10065).
+ *
+ * Derived from `API_ROUTES` through `compileRoutePattern`, so it is the same
+ * statement the OpenAPI artifact is built from rather than a second table.
+ * The handlers use it to look their own declared query parameters up, which is
+ * what lets 119 hand-written allowlist arrays go away.
+ *
+ * Specificity: a fully literal template wins over a parameterised one, so
+ * `/api/v1/subnets/movers` resolves to itself and not to
+ * `/api/v1/subnets/{netuid}`. Ties break on the number of path parameters,
+ * fewest first — `compileRoutePattern`'s character classes already keep an
+ * ss58 out of a `{netuid}` slot, so this only has to settle overlap between
+ * templates that could both legitimately match.
+ */
+const ROUTE_PATTERNS = (() => {
+  const paths = new Set<string>();
+  for (const route of API_ROUTES as unknown as {
+    path: string;
+    method: string;
+  }[]) {
+    if (route.method !== "GET") continue;
+    paths.add(route.path);
+    // The /{network}/ twins are not their own API_ROUTES entries -- they are
+    // generated from the base template, the same way buildOpenApiArtifact
+    // emits them. Deriving them here keeps the two in step by construction.
+    const twin = networkVariantPath(route.path);
+    if (twin) paths.add(twin);
+  }
+  return [...paths]
+    .map((path) => ({
+      path,
+      parameters: (path.match(/\{[a-z_0-9]+\}/g) ?? []).length,
+      pattern: compileRoutePattern(
+        path.replace(/\{network\}/g, "__METAGRAPH_NETWORK__"),
+      ),
+    }))
+    .sort((a, b) => a.parameters - b.parameters);
+})();
+
+/**
+ * The contract path a request pathname resolves to, with any `/{network}/`
+ * prefix stripped back to the base template.
+ *
+ * A twin serves the same payload from a different store, so it declares the
+ * same query parameters; callers asking "what may this request carry" want the
+ * base template's answer.
+ */
+export function contractPathForPathname(pathname: string): string | null {
+  for (const route of ROUTE_PATTERNS) {
+    if (route.pattern.test(pathname)) {
+      return route.path.startsWith("/api/v1/{network}/")
+        ? `/api/v1/${route.path.slice("/api/v1/{network}/".length)}`
+        : route.path;
+    }
+  }
+  return null;
 }
 
 function artifact(

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -118,6 +118,7 @@ export const SDL = /* GraphQL */ `
       order: String
       limit: Int
       cursor: Int
+      fields: String
     ): CurationList!
     "The discovered candidate-surface ledger: every machine-discovered surface awaiting review, with its subnet (netuid), kind, provider, and review state. Filter by netuid/kind/provider/state/id/confidence, sort with sort + order, and page with limit (1-1000) / cursor, exactly like the REST route — an unsupported filter/sort value is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the candidates rows, as opaque JSON. A cold/absent artifact is a GraphQL error (matching REST/MCP not_found). Mirrors GET /api/v1/candidates."
     candidates(
@@ -131,6 +132,7 @@ export const SDL = /* GraphQL */ `
       order: String
       limit: Int
       cursor: Int
+      fields: String
     ): JSON
     "Run one maintainer-curated saved-query template by id, with its template-defined params object -- the same parameterized query library REST and the run_saved_query MCP tool execute. Resolves to {query_id, params, data} as opaque JSON. An unknown id or invalid params is a BAD_USER_INPUT error listing the valid template ids, not a silently substituted default. Mirrors GET /api/v1/queries/{id}."
     saved_query(id: String!, params: JSON): JSON
@@ -153,6 +155,7 @@ export const SDL = /* GraphQL */ `
       order: String
       limit: Int
       cursor: Int
+      fields: String
     ): SearchDocumentList!
     "The slim search index -- the same documents as search without the per-document token blobs, for fast browser typeahead and listing. Filter by type/netuid/q, sort with sort/order, and page with limit/cursor. An invalid filter/sort/limit/cursor is a GraphQL error. Mirrors GET /api/v1/search-index."
     search_index(
@@ -163,6 +166,7 @@ export const SDL = /* GraphQL */ `
       order: String
       limit: Int
       cursor: Int
+      fields: String
     ): SearchIndexList!
     "The per-domain rollup overview: every tag in the fixed 14-tag capability taxonomy with its member subnet count, total stake, total emission share, and within-domain emission concentration. Computed live from the subnets index + economics tier. Mirrors GET /api/v1/domains."
     domains: DomainOverview!
@@ -173,7 +177,18 @@ export const SDL = /* GraphQL */ `
     "The registry coverage summary: surface/subnet counts, domain coverage, and overall completeness across the whole Bittensor application layer. Null when the coverage artifact has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_coverage MCP/REST shape. Mirrors GET /api/v1/coverage."
     coverage: JSON
     "The machine-usable coverage-depth scorecard and ranked enrichment queue: per-subnet tier/score/priority rows plus the ranked queue of enrichment targets. Null when the coverage-depth artifact has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the /api/v1/coverage-depth REST shape. Mirrors GET /api/v1/coverage-depth."
-    coverage_depth: JSON
+    coverage_depth(
+      netuid: Int
+      tier: String
+      agent_status: String
+      blocker_level: String
+      q: String
+      fields: String
+      sort: String
+      order: String
+      limit: Int
+      cursor: Int
+    ): JSON
     "One subnet's alpha-price OHLC candles bucketed by interval (1h or 1d, default 1h) over the trailing days window (default 90, max 365), from the same executed-trade stream subnet_volume reads. A subnet with no trades resolves to a schema-stable empty candle list, never null. Mirrors GET /api/v1/subnets/{netuid}/ohlc."
     subnet_ohlc(netuid: Int!, interval: String, days: Int): SubnetOhlc!
     "A read-only quote for a hypothetical stake/unstake against one subnet's live AMM pool: expected amount out, spot vs effective price, and estimated price impact. Computes nothing on-chain and signs nothing. Mirrors GET /api/v1/subnets/{netuid}/stake-quote."
@@ -284,6 +299,7 @@ export const SDL = /* GraphQL */ `
       block_end: Int
       limit: Int
       offset: Int
+      cursor: String
     ): SubnetEvents!
     "One subnet's daily history from the neuron_daily rollup over a 7d/30d/90d/1y/all window (default 30d): neuron count, validator count, total stake (TAO), and total emission (TAO) per snapshot_date, newest first. A subnet with no daily rollup resolves to a schema-stable empty series (point_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/history."
     subnet_history(netuid: Int!, window: String): SubnetHistory!
@@ -322,7 +338,7 @@ export const SDL = /* GraphQL */ `
     "How long after a block is produced it becomes queryable here: the write-latency distribution (min/p50/p95/p99/max/mean, in ms) over the retained block window, plus how far behind the lane is right now. TWO DIFFERENT NUMBERS -- write_latency_ms is how long each block TOOK to land, head_age_ms is how stale the newest block IS, and a stalled lane keeps a perfect latency distribution while its head age climbs without bound, so read head_age_ms for staleness. The window is pruned on a rolling basis, so this is the RECENT distribution and window reports which blocks it covers. A NEGATIVE latency is real -- the two timestamps come from different clocks -- and is served as measured rather than clamped. Null measurements are a DECLINE, not a zero-latency lane; check degraded.reason. Mainnet only. Mirrors GET /api/v1/chain/indexer-lag."
     indexer_lag: IndexerLag!
     "The USD price of one TAO with the derivation behind it, plus the recent series. Composed per ADR 0025 -- a liquidity-weighted median across qualifying wTAO/WETH pools with 2% outlier rejection and a two-pool quorum, multiplied through an ETH/USDC anchor -- because no TAO/USD pair exists on chain. A null usd_per_tao is a STATED OUTCOME (price_basis insufficient_pools), never a zero price. window is 1h, 24h (default), 7d or 30d. The series begins 2026-08-02, so a wide window returns everything that exists and oldest_observed_at says how far back that is. Mainnet only. Mirrors GET /api/v1/network/tao-usd."
-    tao_usd(window: String): TaoUsd!
+    tao_usd(window: String, include_points: Boolean): TaoUsd!
     "When one subnet's public surfaces were added, changed or removed, and in which commit. subnet_surfaces says what a subnet exposes TODAY; this says when that became true. A delete entry is the ONLY evidence a surface ever existed -- the registry keeps no trace of a removed surface. surface_count counts distinct surfaces with a recorded mutation, which is NOT the current surface count. The full surface record is not repeated here; read subnet_surfaces for that. Newest first. A subnet whose surfaces never changed resolves to an empty trail, never an error. Mainnet only. Mirrors GET /api/v1/subnets/{netuid}/surface-history."
     subnet_surface_history(netuid: Int!, limit: Int): SubnetSurfaceHistory!
     "Per-subnet per-day stake and emission concentration trend from the neuron_daily rollup over a 7d/30d/90d window (default 30d): each day's stake/emission Gini, Nakamoto coefficient, and top-10% share, newest first; a subnet with no daily rollup resolves to a schema-stable empty series (point_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/concentration/history."
@@ -344,7 +360,11 @@ export const SDL = /* GraphQL */ `
     "One subnet's weekly structural + economics trajectory from the daily snapshots: a chronological series of points (completeness/surface/endpoint counts plus validator/miner counts and economics — stake, alpha price, emission share, pool reserves, volume), and the latest-vs-window-ago deltas for the 7d and 30d windows. A subnet with no snapshots resolves to a schema-stable empty trajectory (point_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/trajectory."
     subnet_trajectory(netuid: Int!): SubnetTrajectory!
     "One subnet's live metagraph: every neuron with its uid, keys, stake, trust/consensus/incentive/dividends, emission, and axon, plus the subnet's aggregate counters. Set validator_permit to true to return only permit-holding validators. A subnet with no indexed neurons resolves to a schema-stable empty metagraph, never null. Opaque JSON passed through verbatim, matching the get_subnet_metagraph MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/metagraph."
-    subnet_metagraph(netuid: Int!, validator_permit: Boolean): JSON
+    subnet_metagraph(
+      netuid: Int!
+      validator_permit: Boolean
+      fields: String
+    ): JSON
     "One subnet's composed overview card: the baked static subnet record overlaid with live probe-derived health, exactly as the REST route composes it. Null when no overview has been baked for that netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_subnet MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/overview."
     subnet_overview(netuid: Int!): JSON
     "One subnet's contributor-review profile: candidate surfaces, contract version, endpoints, and completeness/curation metadata. Null when no profile has been baked for that netuid (rather than a GraphQL error); a negative netuid is a BAD_USER_INPUT error. Opaque JSON passed through verbatim, matching the get_subnet_profile MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/profile."
@@ -372,7 +392,7 @@ export const SDL = /* GraphQL */ `
       sort: String
       order: String
       limit: Int
-      cursor: String
+      cursor: Int
     ): EconomicsList!
     "Curated public interface surfaces with full REST filter parity: optionally scope to one subnet (netuid) and filter by kind/provider/id, sort with sort/order, and page with limit/cursor. An invalid filter/sort is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/surfaces."
     surfaces(
@@ -380,10 +400,14 @@ export const SDL = /* GraphQL */ `
       kind: String
       provider: String
       id: String
+      auth_required: Boolean
+      public_safe: Boolean
+      rate_limited: Boolean
+      fields: String
       sort: String
       order: String
       limit: Int
-      cursor: String
+      cursor: Int
     ): SurfaceList!
     "Endpoint/resource registry with full REST filter parity: optionally scope to one subnet (netuid) and filter by kind/layer/provider/publication_state/status/pool_eligible, threshold with min_/max_latency_ms and min_/max_score, project with fields, sort with sort/order, and page with limit/cursor. An invalid filter/sort is a GraphQL error (matching endpoint_pools/rpc_pools/rpc_endpoints), not a silently substituted default. Mirrors GET /api/v1/endpoints."
     endpoints(
@@ -420,7 +444,8 @@ export const SDL = /* GraphQL */ `
       sort: String
       order: String
       limit: Int
-      cursor: String
+      cursor: Int
+      fields: String
     ): JSON
     "Generalized endpoint pool scores -- each pool's kind, eligible/total endpoint count, and probe-derived routing score. Filter by id/kind, threshold with min_/max_eligible_count and min_/max_endpoint_count, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/endpoint-pools."
     endpoint_pools(
@@ -627,7 +652,7 @@ export const SDL = /* GraphQL */ `
       max_score: Float
       fields: [String!]
       limit: Int
-      cursor: String
+      cursor: Int
       sort: String
       order: String
     ): JSON
@@ -663,6 +688,7 @@ export const SDL = /* GraphQL */ `
     incidents(
       window: String
       netuid: Int
+      fields: String
       sort: String
       order: String
       limit: Int
@@ -672,6 +698,7 @@ export const SDL = /* GraphQL */ `
     global_incidents(
       window: String
       netuid: Int
+      fields: String
       sort: String
       order: String
       limit: Int
@@ -755,6 +782,7 @@ export const SDL = /* GraphQL */ `
     validator_nominators(
       hotkey: String!
       window: String
+      basis: String
       sort: String
       coldkey: String
       limit: Int
@@ -865,7 +893,13 @@ export const SDL = /* GraphQL */ `
     "Network-wide economics time series, aggregated per UTC day across all subnets; day_count is 0 and days is empty on a cold rollup, never null. Mirrors GET /api/v1/economics/trends."
     economics_trends(window: String): EconomicsTrends!
     "The v440 emission pipeline decomposed per subnet at the block the economics capture was pinned to: each subnet's stage-1 price share, its MinerBurned-reweighted and Hill-gated shares, its final share of block emission, and the split of its TAO intake between pool injection (tao_in_emission) and chain buys (excess_tao). netuid narrows the per-subnet rows only -- aggregate and verification stay network-wide, since a one-subnet slice of a network identity cannot be verified. ALWAYS read verification.verified: false means the four identities did not hold on these exact rows and the response is not defensible. field_sources labels every field measured or reconstructed. A capture with no chain_state is an EMISSION_PIPELINE_UNAVAILABLE error, never a partial body. Mirrors GET /api/v1/chain/emission-pipeline."
-    emission_pipeline(netuid: Int): EmissionPipeline!
+    emission_pipeline(
+      netuid: Int
+      fields: String
+      sort: String
+      order: String
+      limit: Int
+    ): EmissionPipeline!
     "Registry leaderboards: the operational boards (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable) and the economic-opportunity boards (open-slots, cheapest-registration, highest-emission, validator-headroom, biggest-alpha-gain-1d, biggest-alpha-gain-7d), composed live from the registry profiles projection plus D1 health/rpc/growth/reliability rows and the economics tier. Pass board to return just that board (default: every board); limit caps each board's entries (default 20, max 100). An unknown board is a BAD_USER_INPUT error, matching REST's invalid_query 400. Mirrors GET /api/v1/registry/leaderboards."
     registry_leaderboards(board: String, limit: Int): RegistryLeaderboards!
     "Cross-subnet momentum leaderboard: every subnet ranked by its stake/emission/validator change between a window's start and end snapshots; movers is empty on a cold or single-snapshot store, never null. Mirrors GET /api/v1/subnets/movers."
@@ -907,7 +941,7 @@ export const SDL = /* GraphQL */ `
       call_module: String
     ): ChainSigners!
     "Compact all-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history (probed every ~15 minutes); a cold store still returns both windows, schema-stable and zeroed, never a GraphQL error. Mirrors GET /api/v1/health/trends."
-    health_trends: HealthTrends!
+    health_trends(window: String, limit: Int, offset: Int): HealthTrends!
     "RPC reverse-proxy usage analytics over a 7d/30d window (default 7d): total request volume, error + failover rates, cache-hit rate, latency p50/p95/avg, the per-endpoint and per-network request distribution, and bounded time buckets (1h for 7d, 6h for 30d). Counts are summed across two disjoint stores -- Workers Analytics Engine for live traffic, the R2 lakehouse for history -- and coverage reports the span each contributed plus any gap between them. p50/p95 are measured only over the Analytics Engine span (coverage.latency_percentiles) and are null where nothing measured them; the lakehouse has no percentile function. A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/rpc/usage."
     rpc_usage(window: String): RpcUsage!
     "Network-wide reward-distribution & score-spread card across every subnet's neurons: incentive/dividends concentration (who actually captures rewards network-wide) plus the trust/consensus/validator_trust score spread. Current snapshot only (no window/params). Every metric block is null (never a GraphQL error) on a cold store. The network analog of subnet_performance. Mirrors GET /api/v1/chain/performance."

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -339,13 +339,24 @@ import {
   loadFailureReasons,
   FAILURE_REASONS_WINDOWS,
 } from "./failure-reasons.ts";
-import { DEFAULT_FAILURE_REASONS_WINDOW } from "./route-limits.ts";
+import {
+  DEFAULT_FAILURE_REASONS_WINDOW,
+  EMISSION_PIPELINE_LIMIT_MAX,
+  BULK_HEALTH_TRENDS_LIMIT_MAX,
+  HEALTH_TREND_WINDOW_VALUES,
+} from "./route-limits.ts";
 import {
   buildTaoUsdSeries,
   loadTaoUsdSeries,
   DEFAULT_TAO_USD_WINDOW,
   TAO_USD_WINDOWS,
 } from "./tao-usd-series.ts";
+import {
+  NOMINATOR_BASES,
+  DEFAULT_NOMINATOR_BASIS,
+  loadNominatorPositions,
+  buildNominatorPositions,
+} from "./validator-nominator-positions.ts";
 import {
   buildSurfaceHistory,
   loadSurfaceHistory,
@@ -567,6 +578,8 @@ import {
   EMISSION_PIPELINE_UNAVAILABLE_CODE,
   EMISSION_PIPELINE_UNAVAILABLE_MESSAGE,
   projectEmissionPipeline,
+  parseEmissionPipelineNarrowing,
+  narrowEmissionPipeline,
 } from "./emission-pipeline-surface.ts";
 import {
   DEFAULT_MOVERS_SORT,
@@ -814,6 +827,9 @@ import type {
   QuerySubnet_EndpointsArgs,
   QuerySubnet_Event_SummaryArgs,
   QuerySubnet_EventsArgs,
+  QueryTao_UsdArgs,
+  QueryCoverage_DepthArgs,
+  QueryHealth_TrendsArgs,
   QuerySubnet_EvidenceArgs,
   QuerySubnet_GapsArgs,
   QuerySubnet_HealthArgs,
@@ -2315,7 +2331,7 @@ const rootValue = {
   // reuses exactly what REST/MCP already call, so the three surfaces can't
   // drift.
   async subnet_metagraph(
-    { netuid, validator_permit }: QuerySubnet_MetagraphArgs,
+    { netuid, validator_permit, fields }: QuerySubnet_MetagraphArgs,
     context: GqlContext,
   ) {
     // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildSubnetMetagraph
@@ -2323,6 +2339,9 @@ const rootValue = {
     // neurons is a schema-stable empty metagraph, never a GraphQL error.
     const params = new URLSearchParams();
     if (validator_permit) params.set("validator_permit", "true");
+    // #10065: the payload is opaque JSON, so the selection set cannot narrow
+    // it and `fields` is the only projection a caller has.
+    if (fields != null && fields !== "") params.set("fields", fields);
     return (
       ((await tryPostgresTier(
         context.env,
@@ -2832,7 +2851,10 @@ const rootValue = {
     };
   },
 
-  async tao_usd({ window }: { window?: string | null }, context: GqlContext) {
+  async tao_usd(
+    { window, include_points }: QueryTao_UsdArgs,
+    context: GqlContext,
+  ) {
     // #9609. Same loader REST and MCP use -- see chain_holders above for why a
     // resolver-local query is the thing this surface has historically got wrong.
     const label = window ?? DEFAULT_TAO_USD_WINDOW;
@@ -2847,7 +2869,15 @@ const rootValue = {
       >[0],
       { windowHours: TAO_USD_WINDOWS[label] },
     );
-    return buildTaoUsdSeries(rows, { window: label });
+    // #10065: the same opt-out REST and MCP take. REST defaults to sending the
+    // points and MCP to omitting them (the 143 KB asymmetry #9720 records);
+    // GraphQL follows REST, because a caller who does not want the points can
+    // already leave them out of the selection set -- the argument exists so the
+    // SERVER can skip building them, not so the client can hide them.
+    return buildTaoUsdSeries(rows, {
+      window: label,
+      includePoints: include_points ?? true,
+    });
   },
 
   async subnet_surface_history(
@@ -3656,6 +3686,7 @@ const rootValue = {
       block_end,
       limit,
       offset,
+      cursor,
     }: QuerySubnet_EventsArgs,
     context: GqlContext,
   ) {
@@ -3676,6 +3707,10 @@ const rootValue = {
     if (kind != null) params.set("kind", kind);
     if (block_start != null) params.set("block_start", String(block_start));
     if (block_end != null) params.set("block_end", String(block_end));
+    // #10065: the keyset cursor the route has always accepted, forwarded the
+    // same way the sibling account_events field forwards its own -- an opaque
+    // token handed back verbatim, not a number to construct.
+    if (cursor != null && cursor !== "") params.set("cursor", cursor);
     // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) handleSubnetEvents and
     // the get_subnet_events MCP tool use. The events list passes through whole;
     // graphql's default resolver reads each AccountEvent field, matching
@@ -4337,7 +4372,7 @@ const rootValue = {
   },
 
   async incidents(
-    { window, netuid, sort, order, limit, cursor }: QueryIncidentsArgs,
+    { window, netuid, fields, sort, order, limit, cursor }: QueryIncidentsArgs,
     context: GqlContext,
   ) {
     // Reuse the exact analyticsWindow parse/validate REST's handleGlobalIncidents
@@ -4388,6 +4423,10 @@ const rootValue = {
     const queryUrl = new URL("https://graphql.internal/incidents");
     for (const [name, value] of [
       ["netuid", netuid],
+      // #10065: the rows are opaque JSON here, so a selection set cannot
+      // project them and `fields` is the caller's only narrowing. Validated by
+      // the shared engine, the same one REST and MCP run.
+      ["fields", fields],
       ["sort", sort],
       ["order", order],
       ["limit", limit],
@@ -4545,10 +4584,44 @@ const rootValue = {
     return loadArtifact(context, "/metagraph/schemas/index.json");
   },
 
-  async coverage_depth(_args: unknown, context: GqlContext) {
-    // Raw passthrough of the /api/v1/coverage-depth artifact (the same one the
-    // list_enrichment_targets MCP tool shapes); degrades to null when cold.
-    return loadArtifact(context, "/metagraph/coverage-depth.json");
+  // #10065: /api/v1/coverage-depth publishes ten query parameters and this
+  // field took NONE of them -- a raw passthrough of the whole artifact, with
+  // nothing to filter, project or page by. `coverage-depth` is a declared
+  // query collection (API_QUERY_COLLECTIONS), so the shared applyQueryFilters
+  // engine already knows its filters, sorts and projection; running that same
+  // engine here is parity by construction rather than a GraphQL-only
+  // reimplementation -- the shape `economics` and `incidents` already use.
+  // Still degrades to null when the artifact is cold.
+  async coverage_depth(args: QueryCoverage_DepthArgs, context: GqlContext) {
+    const data = await loadArtifact(context, "/metagraph/coverage-depth.json");
+    if (!data) return data;
+    const queryUrl = new URL("https://graphql.internal/coverage-depth");
+    for (const [name, value] of [
+      ["netuid", args?.netuid],
+      ["tier", args?.tier],
+      ["agent_status", args?.agent_status],
+      ["blocker_level", args?.blocker_level],
+      ["q", args?.q],
+      ["fields", args?.fields],
+      ["sort", args?.sort],
+      ["order", args?.order],
+      ["limit", args?.limit],
+      ["cursor", args?.cursor],
+    ] as const) {
+      if (value != null) queryUrl.searchParams.set(name, String(value));
+    }
+    const transformed = applyQueryFilters(
+      data as Row,
+      queryUrl,
+      "coverage-depth",
+      [],
+    );
+    if (transformed.error) {
+      throw new GraphQLError(transformed.error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    return transformed.data;
   },
 
   async subnet_volume({ netuid }: QuerySubnet_VolumeArgs, context: GqlContext) {
@@ -5863,6 +5936,7 @@ const rootValue = {
     {
       hotkey,
       window,
+      basis,
       sort,
       coldkey,
       limit,
@@ -5874,6 +5948,42 @@ const rootValue = {
     // an unsupported value is a GraphQL BAD_USER_INPUT error, not a silently
     // substituted default. `sort` is optional: omitted resolves to
     // DEFAULT_NOMINATOR_SORT inside the builder, so only a SUPPLIED bad value errors.
+    // #10065: the same two questions the REST route answers. `positions` is a
+    // current-holdings snapshot off the position ledger and `flow` a windowed
+    // aggregation, so window/sort mean nothing under `positions` -- accepting
+    // them silently would imply the basis honoured them, which is the exact
+    // condition handleValidatorNominators rejects with.
+    const requestedBasis = basis ?? DEFAULT_NOMINATOR_BASIS;
+    if (!NOMINATOR_BASES.includes(requestedBasis as "flow" | "positions")) {
+      throw new GraphQLError(
+        `basis must be one of ${NOMINATOR_BASES.join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    if (requestedBasis === "positions") {
+      for (const [name, value] of [
+        ["window", window],
+        ["sort", sort],
+      ] as const) {
+        if (value != null) {
+          throw new GraphQLError(
+            `"${name}" applies to basis=flow only; the positions basis is a ` +
+              "current-holdings snapshot, not a windowed aggregation.",
+            { extensions: { code: "BAD_USER_INPUT" } },
+          );
+        }
+      }
+      const positions = await loadNominatorPositions(
+        context.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
+          typeof loadNominatorPositions
+        >[0],
+        hotkey,
+      );
+      return buildNominatorPositions(positions, hotkey, {
+        limit: limit ?? GLOBAL_VALIDATOR_LIMIT_DEFAULT,
+        offset: offset ?? 0,
+      });
+    }
     const requestedWindow = window ?? DEFAULT_NOMINATOR_WINDOW;
     if (!Object.hasOwn(NOMINATOR_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -7406,7 +7516,7 @@ const rootValue = {
   // capture's chain_state is what makes every reconstructed share checkable at
   // all, so an absent one has no honest body — only an error.
   async emission_pipeline(
-    { netuid }: QueryEmission_PipelineArgs,
+    { netuid, fields, sort, order, limit }: QueryEmission_PipelineArgs,
     context: GqlContext,
   ) {
     const economics = await loadEconomics(context);
@@ -7421,7 +7531,32 @@ const rootValue = {
         },
       });
     }
-    return data;
+    // #10065: the same narrowing handleEmissionPipeline applies, through the
+    // same helper. `fields` is validated against the DECOMPOSED rows, so it
+    // has to run AFTER the projection -- the reason REST does two passes, and
+    // the reason this cannot fold into projectEmissionPipeline.
+    const narrowingParams = new URLSearchParams();
+    for (const [name, value] of [
+      ["fields", fields],
+      ["sort", sort],
+      ["order", order],
+      ["limit", limit],
+    ] as const) {
+      if (value != null) narrowingParams.set(name, String(value));
+    }
+    const narrowing = parseEmissionPipelineNarrowing(
+      narrowingParams,
+      data.subnets as unknown as Parameters<
+        typeof parseEmissionPipelineNarrowing
+      >[1],
+      { limitMax: EMISSION_PIPELINE_LIMIT_MAX },
+    );
+    if ("error" in narrowing) {
+      throw new GraphQLError(narrowing.error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    return narrowEmissionPipeline(data, narrowing);
   },
 
   async subnet_movers(
@@ -8573,15 +8708,51 @@ const rootValue = {
     };
   },
 
-  async health_trends(_args: unknown, context: GqlContext) {
+  async health_trends(
+    { window, limit, offset }: QueryHealth_TrendsArgs,
+    context: GqlContext,
+  ) {
     // Same tryPostgresTier(METAGRAPH_HEALTH_SOURCE) -> loadBulkHealthTrends
     // fallback contract REST's handleBulkHealthTrends and the get_health_trends
     // MCP tool share -- a cold store yields both windows zeroed, never a
     // GraphQL error.
+    //
+    // #10065: the three narrowing parameters #9989 gave the route. This field
+    // took none of them, so a GraphQL caller always got every window for every
+    // surface. Validated the same way the sibling fields validate an enum --
+    // a supplied bad window is BAD_USER_INPUT, not a silently full result.
+    if (
+      window != null &&
+      !HEALTH_TREND_WINDOW_VALUES.includes(window as "7d" | "30d")
+    ) {
+      throw new GraphQLError(
+        `window must be one of ${HEALTH_TREND_WINDOW_VALUES.join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    if (limit != null && (limit < 1 || limit > BULK_HEALTH_TRENDS_LIMIT_MAX)) {
+      throw new GraphQLError(
+        `limit must be between 1 and ${BULK_HEALTH_TRENDS_LIMIT_MAX}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    if (offset != null && offset < 0) {
+      throw new GraphQLError("offset must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const trendsParams = new URLSearchParams();
+    for (const [name, value] of [
+      ["window", window],
+      ["limit", limit],
+      ["offset", offset],
+    ] as const) {
+      if (value != null) trendsParams.set(name, String(value));
+    }
     const data =
       ((await tryPostgresTier(
         context.env,
-        postgresTierRequest(context, "/api/v1/health/trends"),
+        postgresTierRequest(context, "/api/v1/health/trends", trendsParams),
         "METAGRAPH_HEALTH_SOURCE",
       )) as Row | null) ??
       (
@@ -8591,6 +8762,9 @@ const rootValue = {
             context.env as unknown as Record<string, unknown>,
             context.ctx,
           ),
+          window: window ?? null,
+          limit: limit ?? null,
+          offset: offset ?? 0,
         })
       ).data;
     return {

--- a/src/route-limits.ts
+++ b/src/route-limits.ts
@@ -263,6 +263,16 @@ export const MCP_LIST_LIMIT_DEFAULT = 20;
  * Vectorize itself caps `topK` at this value.
  */
 export const SEMANTIC_LIMIT_DEFAULT = 10;
+/**
+ * The scopes `/api/v1/search/semantic?type=` accepts.
+ *
+ * Here rather than in src/ai-search.ts because schemas-src/route-queries.ts
+ * has to state it in the contract, and this module is the zero-import leaf
+ * both sides already read (#9127). ai-search.ts re-exports it, so the handler
+ * and the published enum cannot drift.
+ */
+export const SEMANTIC_TYPES = ["subnet", "surface", "provider"] as const;
+
 export const SEMANTIC_LIMIT_MAX = 20;
 /** Rejected above this with a 400, not truncated -- an embedded query that was
  * silently cut would rank against text the caller never sent. */
@@ -311,6 +321,23 @@ export const CHAIN_EVENTS_LIMIT_MAX = 100;
  */
 export const CHAIN_CALL_MODULE_MAX_LENGTH = 100;
 export const CHAIN_EVENT_NAME_MAX_LENGTH = 64;
+
+/**
+ * The window labels GET /api/v1/health/trends derives.
+ *
+ * Here rather than in schemas-src/routes/health-surfaces.ts because src/
+ * modules need it too and nothing under src/ may import schemas-src/routes/ --
+ * that edge failed the metagraphed-data-api Workers Build twice on #10121, and
+ * again on #10065 when src/graphql.ts reached for this constant. This module
+ * is the zero-import leaf both sides already read (#9127); health-surfaces.ts
+ * re-exports it, so the published vocabulary has one owner either way.
+ *
+ * `workers/config.ts`'s HEALTH_TREND_WINDOWS maps each label to its day count
+ * and is the runtime's copy; the two are checked against each other by
+ * tests/route-limit-contract-parity.test.ts rather than one importing the
+ * other, because schemas-src must not depend on the Worker's config module.
+ */
+export const HEALTH_TREND_WINDOW_VALUES = ["7d", "30d"] as const;
 
 /**
  * `/api/v1/health/trends` -- the all-subnet trend matrix (#10089).

--- a/tests/ai-search.test.ts
+++ b/tests/ai-search.test.ts
@@ -1245,9 +1245,30 @@ describe("AI routes through the Worker dispatch", () => {
     assert.ok(body.data.results.length > 0);
   });
 
-  test("enabled semantic threads a repeatable ?type= scope", async () => {
+  test("a repeated ?type= is rejected rather than silently halved", async () => {
+    // This asserted 200-with-only-subnet-results until #10065: the second
+    // value was DROPPED, so `?type=subnet&type=provider` answered a narrower
+    // question than the one asked and said nothing about it. The same silent-
+    // wrong-answer class as the typo'd filter #9149 exists to stop.
+    //
+    // `type` is now published (it was honoured and undeclared -- the handler
+    // has always filtered on it and rejects an unknown value by name), and a
+    // duplicate is an ambiguous request, which the derived allowlist answers
+    // with a 400 naming the parameter.
     const res = await handleRequest(
       new Request(`${SEMANTIC_URL}?q=images&type=subnet&type=provider`),
+      aiWorkerEnv() as unknown as Env,
+      {},
+    );
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.error.code, "invalid_query");
+    assert.match(body.error.message, /may only be provided once/);
+  });
+
+  test("enabled semantic threads a single ?type= scope", async () => {
+    const res = await handleRequest(
+      new Request(`${SEMANTIC_URL}?q=images&type=subnet`),
       aiWorkerEnv() as unknown as Env,
       {},
     );

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -1347,7 +1347,11 @@ describe("invalid query handling", () => {
     assert.equal(res.status, 400);
     const body = await res.json();
     assert.equal(body.error.code, "invalid_query");
-    assert.equal(body.error.message, "unknown query parameter.");
+    // #10065: ONE message for one condition. The 34 collection routes reached
+    // this through validateListQuery's own wording while the other 168 used
+    // the router's; now a single derived check answers for all 202, so the
+    // message names the parameter the way it always did everywhere else.
+    assert.match(body.error.message, /is not supported for this route/);
     assert.equal(body.meta.parameter, "statuss");
   });
 
@@ -2316,7 +2320,11 @@ describe("pagination Link header", () => {
     assert.equal(res.status, 400);
     const body = await res.json();
     assert.equal(body.error.code, "invalid_query");
-    assert.equal(body.error.message, "unknown query parameter.");
+    // #10065: ONE message for one condition. The 34 collection routes reached
+    // this through validateListQuery's own wording while the other 168 used
+    // the router's; now a single derived check answers for all 202, so the
+    // message names the parameter the way it always did everywhere else.
+    assert.match(body.error.message, /is not supported for this route/);
     assert.equal(body.meta.parameter, "utm_campaign");
   });
 

--- a/tests/chain-performance-handler.test.ts
+++ b/tests/chain-performance-handler.test.ts
@@ -17,21 +17,10 @@ function req(path: string) {
   return new Request(`https://api.metagraph.sh${path}`);
 }
 
-function url(path: string) {
-  return new URL(`https://api.metagraph.sh${path}`);
-}
-
 async function json(res: Response) {
   assert.equal(res.status, 200, `expected 200, got ${res.status}`);
   const body = (await res.json()) as Row;
   assert.equal(body.ok, true);
-  return body;
-}
-
-async function errorJson(res: Response) {
-  assert.equal(res.status, 400);
-  const body = (await res.json()) as Row;
-  assert.equal(body.ok, false);
   return body;
 }
 
@@ -74,7 +63,6 @@ describe("handleChainPerformance happy path", () => {
       await handleChainPerformance(
         req("/api/v1/chain/performance"),
         neuronsEnv([]) as unknown as Env,
-        url("/api/v1/chain/performance"),
       ),
     );
     assert.equal(body.data.subnet_count, 0);
@@ -86,15 +74,5 @@ describe("handleChainPerformance happy path", () => {
     assert.equal(body.data.consensus, null);
     assert.equal(body.data.validator_trust, null);
     await assertValidComponent("ChainPerformanceArtifact", body.data);
-  });
-
-  test("rejects an unexpected query parameter with 400", async () => {
-    await errorJson(
-      await handleChainPerformance(
-        req("/api/v1/chain/performance?window=7d"),
-        neuronsEnv([]) as unknown as Env,
-        url("/api/v1/chain/performance?window=7d"),
-      ),
-    );
   });
 });

--- a/tests/declared-query-param-validation.test.ts
+++ b/tests/declared-query-param-validation.test.ts
@@ -22,6 +22,29 @@ import {
   validateDeclaredQueryParams,
 } from "../workers/request-handlers/analytics.ts";
 import { API_ROUTES } from "../src/contracts.ts";
+import { createLocalArtifactEnv } from "../scripts/lib.ts";
+import { handleRequest } from "../workers/api.ts";
+
+/**
+ * Path-parameter fixtures, so a template can be resolved the way a real
+ * pathname is. `compileRoutePattern`'s character classes are strict -- an ss58
+ * will not match a `{netuid}` slot -- so these have to be the real shapes.
+ */
+const PATH_FIXTURES: Record<string, string> = {
+  "{netuid}": "1",
+  "{ss58}": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
+  "{hotkey}": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
+  "{ref}": "1000000",
+  "{uid}": "0",
+  "{slug}": "academia",
+  "{date}": "2026-08-01",
+  "{tag}": "inference",
+  "{surface_id}": "sn-1-apex-healthcheck",
+  "{hash}": `0x${"0".repeat(64)}`,
+  "{h160}": `0x${"0".repeat(40)}`,
+  "{id}": "00000000-0000-0000-0000-000000000000",
+  "{crowdloan_id}": "0",
+};
 
 function urlFor(path: string, search = ""): URL {
   return new URL(`https://api.metagraph.sh${path}${search}`);
@@ -45,7 +68,6 @@ describe("declared query parameters are the allow-list (#9149)", () => {
   test("a typo'd filter name is rejected, naming the parameter", () => {
     const error = validateDeclaredQueryParams(
       urlFor("/api/v1/chain-events", "?palet=Balances"),
-      "/api/v1/chain-events",
     );
     assert.ok(error, "an unknown parameter must be rejected, not ignored");
     assert.equal(error.parameter, "palet");
@@ -57,7 +79,6 @@ describe("declared query parameters are the allow-list (#9149)", () => {
     // caller sees Balances events and believes they are Transfers.
     const error = validateDeclaredQueryParams(
       urlFor("/api/v1/chain-events", "?pallet=Balances&methd=Transfer"),
-      "/api/v1/chain-events",
     );
     assert.ok(error, "a dropped second filter must not pass silently");
     assert.equal(error.parameter, "methd");
@@ -71,7 +92,6 @@ describe("declared query parameters are the allow-list (#9149)", () => {
     for (const name of declared) {
       const error = validateDeclaredQueryParams(
         urlFor("/api/v1/chain-events", `?${name}=1`),
-        "/api/v1/chain-events",
       );
       assert.equal(
         error,
@@ -91,7 +111,6 @@ describe("declared query parameters are the allow-list (#9149)", () => {
     assert.equal(
       validateDeclaredQueryParams(
         urlFor("/api/v1/chain-events/stats", "?blocks=500&format=csv"),
-        "/api/v1/chain-events/stats",
       ),
       null,
       "format must stay accepted where its no-op is deliberate",
@@ -100,16 +119,18 @@ describe("declared query parameters are the allow-list (#9149)", () => {
     // still caught.
     const error = validateDeclaredQueryParams(
       urlFor("/api/v1/chain-events/stats", "?blocks=500&format=csv&blcks=9"),
-      "/api/v1/chain-events/stats",
     );
     assert.ok(error, "the exemption must not disable checking of other params");
     assert.equal(error.parameter, "blcks");
   });
 
-  test("a route declaring no query params is left alone", () => {
-    // 44 param-less detail routes accept unknown params today. Treating
-    // "declares nothing" as "allows nothing" would start 400ing cache-busting
-    // params on all of them for no gain -- there is no filter to typo.
+  test("a route that declares nothing accepts nothing but format", () => {
+    // This flipped with #10065. `declaredQueryParams` used to answer `null`
+    // for a param-less route -- "no opinion" -- so the check passed anything.
+    // "This route takes no query parameters" is a statement the contract
+    // makes, and 15 handlers were separately enforcing it with a hand-written
+    // `validateQueryParams(url, [])`. Deriving it means the two cannot
+    // disagree; `null` is now reserved for a path that matches no route.
     const paramless = (
       API_ROUTES as unknown as {
         path: string;
@@ -118,15 +139,20 @@ describe("declared query parameters are the allow-list (#9149)", () => {
       }[]
     ).find(
       (route) =>
-        route.method === "GET" && !(route.query_parameters ?? []).length,
+        route.method === "GET" &&
+        !(route.query_parameters ?? []).length &&
+        !route.path.includes("{"),
     );
     assert.ok(paramless, "expected at least one param-less GET route");
-    assert.equal(declaredQueryParams(paramless.path), null);
+    assert.deepEqual(declaredQueryParams(paramless.path), []);
+    const rejected = validateDeclaredQueryParams(
+      urlFor(paramless.path, "?anything=1"),
+    );
+    assert.ok(rejected, `${paramless.path} must reject an undeclared param`);
+    assert.equal(rejected.parameter, "anything");
+    // `format` stays accepted API-wide -- see GLOBALLY_ACCEPTED_PARAMS.
     assert.equal(
-      validateDeclaredQueryParams(
-        urlFor(paramless.path, "?anything=1"),
-        paramless.path,
-      ),
+      validateDeclaredQueryParams(urlFor(paramless.path, "?format=csv")),
       null,
     );
   });
@@ -137,6 +163,10 @@ describe("declared query parameters are the allow-list (#9149)", () => {
     // be reached by the route genuinely having none, not by a failed match
     // that would quietly disable validation everywhere.
     assert.equal(declaredQueryParams("/api/v1/does-not-exist"), null);
+    assert.equal(
+      validateDeclaredQueryParams(urlFor("/api/v1/does-not-exist", "?x=1")),
+      null,
+    );
     const declared = declaredQueryParams("/api/v1/chain-events");
     assert.ok(
       declared && declared.length >= 8,
@@ -144,38 +174,86 @@ describe("declared query parameters are the allow-list (#9149)", () => {
     );
   });
 
-  test("the derived allow-list resolves for every route that declares params", () => {
-    // Scope, stated honestly: this proves the SHARED validator would reject an
-    // unknown parameter for every declaring route -- i.e. the derivation
-    // resolves and is not failing open on any path shape. It does NOT prove
-    // each route calls it: 136 routes reach the same rule through
-    // validateEntityQuery's hand-written arrays, and only the chain-events
-    // proxy calls validateDeclaredQueryParams. Proving the wiring per route
-    // needs a live dispatch with bindings; the empirical check is the probe in
-    // #9149 (136 of 138 rejected before this change, 138 after).
-    //
-    // Still worth asserting: a path shape the lookup cannot resolve -- a
-    // template, a trailing slash -- would silently disable validation, and
-    // that is the failure this catches for route 137.
+  test("every GET route rejects an undeclared parameter", () => {
+    // #9149 built the derived check and wired it at ONE call site; 119
+    // handlers went on passing hand-written arrays, and this test said so in
+    // its own comment -- "it does NOT prove each route calls it". #10065
+    // deleted the arrays and moved the check into handleRequest, so the
+    // wiring is a property of the router rather than of 119 opt-ins, and this
+    // can assert the real thing: a CONCRETE pathname, resolved the way a
+    // request is, for every route.
     const unprotected: string[] = [];
+    let checked = 0;
     for (const route of API_ROUTES as unknown as {
       path: string;
       method: string;
-      query_parameters?: { name: string }[];
     }[]) {
       if (route.method !== "GET") continue;
-      if (!(route.query_parameters ?? []).length) continue;
+      let path = route.path;
+      for (const [token, value] of Object.entries(PATH_FIXTURES)) {
+        path = path.split(token).join(value);
+      }
+      if (/\{[a-z_0-9]+\}/.test(path)) {
+        unprotected.push(`${route.path} (no fixture for its path parameter)`);
+        continue;
+      }
+      checked += 1;
       const error = validateDeclaredQueryParams(
-        urlFor(route.path, "?__definitely_not_a_param=1"),
-        route.path,
+        urlFor(path, "?__definitely_not_a_param=1"),
       );
       if (!error) unprotected.push(route.path);
     }
     assert.deepEqual(
       unprotected,
       [],
-      "these declare filters but would accept an unknown parameter, so a " +
-        `typo returns unfiltered data: ${unprotected.join(", ")}`,
+      "these would accept an unknown parameter, so a typo returns unfiltered " +
+        `data: ${unprotected.join(", ")}`,
     );
+    assert.ok(checked > 195, `only ${checked} routes were reachable`);
   });
+
+  test("every GET route rejects an undeclared parameter THROUGH THE ROUTER", async () => {
+    // The check above proves the derived rule; this proves the WIRING, which
+    // is the half #9149 could not assert and said so. A full dispatch through
+    // `handleRequest` + `createLocalArtifactEnv()` -- the same in-process seam
+    // the CSV-parity gate uses -- so a route reaches its 400 the way a real
+    // request would, not because a helper was called in a unit test.
+    //
+    // This replaces 55 per-handler "rejects an unsupported query param" tests.
+    // They asserted the same property one handler at a time while the rule
+    // lived in 119 hand-written arrays; with one enforcement point, asserting
+    // it once for every route is both stronger and honest about where it
+    // lives.
+    const env = await createLocalArtifactEnv();
+    const ctx = { waitUntil() {}, passThroughOnException() {} };
+    const accepted: string[] = [];
+    let dispatched = 0;
+    for (const route of API_ROUTES as unknown as {
+      path: string;
+      method: string;
+    }[]) {
+      if (route.method !== "GET") continue;
+      let path = route.path;
+      for (const [token, value] of Object.entries(PATH_FIXTURES)) {
+        path = path.split(token).join(value);
+      }
+      if (/\{[a-z_0-9]+\}/.test(path)) continue;
+      dispatched += 1;
+      const response = await handleRequest(
+        new Request(
+          `https://api.metagraph.sh${path}?__definitely_not_a_param=1`,
+        ),
+        env as never,
+        ctx as never,
+      );
+      if (response.status !== 400)
+        accepted.push(`${route.path} -> ${response.status}`);
+    }
+    assert.deepEqual(
+      accepted,
+      [],
+      `these accepted an undeclared parameter: ${accepted.join(", ")}`,
+    );
+    assert.ok(dispatched > 195, `only ${dispatched} routes dispatched`);
+  }, 120_000);
 });

--- a/tests/domain-summary-route.test.ts
+++ b/tests/domain-summary-route.test.ts
@@ -40,13 +40,6 @@ describe("GET /api/v1/domains", () => {
     }
   });
 
-  test("rejects an unsupported query param", async () => {
-    const { status, body } = await get("/api/v1/domains?bogus=1");
-    assert.equal(status, 400);
-    assert.equal(body.error.code, "invalid_query");
-    assert.equal(body.meta.parameter, "bogus");
-  });
-
   // Both the subnets index and the economics artifact miss (readArtifact
   // returns {ok:false}) -- every domain still gets a schema-stable empty
   // rollup rather than a thrown error, matching every other live-composition
@@ -186,13 +179,5 @@ describe("GET /api/v1/domains/{tag}/summary", () => {
     assert.equal(status, 400);
     assert.equal(body.error.code, "invalid_request");
     assert.equal(body.meta.parameter, "tag");
-  });
-
-  test("rejects an unsupported query param", async () => {
-    const { status, body } = await get(
-      "/api/v1/domains/inference/summary?bogus=1",
-    );
-    assert.equal(status, 400);
-    assert.equal(body.meta.parameter, "bogus");
   });
 });

--- a/tests/graphql-route-parity.test.ts
+++ b/tests/graphql-route-parity.test.ts
@@ -81,9 +81,19 @@ describe("graphql route parity gate", () => {
     // share one paragraph); a shared constant must itself be prose.
     const source = readFileSync(SCRIPT, "utf8");
     for (const name of DECLARED_MAPS) {
-      const block = new RegExp(
-        `const ${name}: Record<string, string> = \\{([\\s\\S]*?)\\n\\};`,
-      ).exec(source);
+      const block =
+        new RegExp(
+          `const ${name}: Record<string, string> = \\{([\\s\\S]*?)\\n\\};`,
+        ).exec(source) ??
+        // An EMPTY map is the goal state, not a missing one: every gap it
+        // recorded has been closed. `{}` on one line does not match the
+        // multi-line shape above, so accept it explicitly rather than
+        // reporting the finished job as a broken gate.
+        (new RegExp(`const ${name}: Record<string, string> = \\{\\};`).test(
+          source,
+        )
+          ? ([source, ""] as unknown as RegExpExecArray)
+          : null);
       assert.ok(block, `${name} must stay a hand-written map`);
       for (const [, key, reason] of block[1].matchAll(
         /"([\w.]+)":\s*\n?\s*("|[A-Z_]+,)/g,

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -3120,7 +3120,11 @@ describe("graphql — economics pagination", () => {
     assert.equal(first.body.data.economics.next_cursor, "2");
 
     const second = await gql(
-      '{ economics(limit: 2, cursor: "2") { subnets { netuid } next_cursor } }',
+      // #10065: `cursor` is Int here. It was String, and the runtime already
+      // answered "cursor must be a non-negative integer" for a non-integer --
+      // the schema was looser than the resolver. `endpoints` keeps String
+      // because its cursor really is an opaque id keyset.
+      "{ economics(limit: 2, cursor: 2) { subnets { netuid } next_cursor } }",
       env(),
     );
     assert.equal(second.body.data.economics.subnets.length, 1);

--- a/tests/request-handlers-analytics-routes.test.ts
+++ b/tests/request-handlers-analytics-routes.test.ts
@@ -114,17 +114,6 @@ describe("handleTrajectory", () => {
     assert.equal(body.data.deltas["7d"], null);
   });
 
-  test("rejects unsupported query parameters", async () => {
-    const res = await handleTrajectory(
-      req("/"),
-      mockEnv(),
-      NETUID,
-      url("/?bogus=1"),
-    );
-    const body = await errorJson(res);
-    assert.equal(body.meta.parameter, "bogus");
-  });
-
   // formatTrajectory's own row-formatting/sorting logic (ascending by date,
   // numeric coercion, deltas) is covered directly in tests/analytics.test.ts
   // and tests/economics-history.test.ts -- these handler tests only need to
@@ -334,16 +323,6 @@ describe("handleEconomicsTrends", () => {
     assert.equal(body.data.day_count, 0);
     assert.deepEqual(body.data.days, []);
     assert.equal(body.data.window, "30d");
-  });
-
-  test("rejects unsupported query parameters", async () => {
-    const res = await handleEconomicsTrends(
-      req("/"),
-      mockEnv(),
-      url("/?bogus=1"),
-    );
-    const body = await errorJson(res);
-    assert.equal(body.meta.parameter, "bogus");
   });
 
   test("rejects an invalid window", async () => {
@@ -667,17 +646,6 @@ describe("handleUptime", () => {
       body.error.message,
       unsupportedWindowMessage("30d", UPTIME_WINDOWS),
     );
-  });
-
-  test("rejects duplicate window parameters", async () => {
-    const res = await handleUptime(
-      req("/"),
-      mockEnv(),
-      NETUID,
-      url("/?window=90d&window=1y"),
-    );
-    const body = await errorJson(res);
-    assert.equal(body.meta.parameter, "window");
   });
 
   // formatUptime's own row-grouping/rollup logic (per-surface aggregation,
@@ -1066,17 +1034,6 @@ describe("handleCompare", () => {
 describe("handleCompareValidators", () => {
   const HOTKEY_A = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
   const HOTKEY_B = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
-
-  test("rejects an unsupported query param with 400", async () => {
-    const env = createLocalArtifactEnv();
-    const res = await handleCompareValidators(
-      req("/"),
-      mockEnv(env),
-      url(`/api/v1/compare/validators?hotkeys=${HOTKEY_A}&bogus=1`),
-    );
-    const body = await errorJson(res);
-    assert.equal(body.meta.parameter, "bogus");
-  });
 
   test("requires hotkeys", async () => {
     const env = createLocalArtifactEnv();

--- a/tests/request-handlers-analytics.test.ts
+++ b/tests/request-handlers-analytics.test.ts
@@ -680,20 +680,6 @@ describe("analyticsWindow", () => {
     assert.match(out.error.message, /30d/);
   });
 
-  test("rejects unsupported extra query params", () => {
-    const out = analyticsWindow(url("/x?window=7d&limit=10")) as unknown as Row;
-    assert.ok(out.error);
-    assert.equal(out.error.parameter, "limit");
-  });
-
-  test("rejects duplicate window params", () => {
-    const out = analyticsWindow(
-      url("/x?window=7d&window=30d"),
-    ) as unknown as Row;
-    assert.ok(out.error);
-    assert.equal(out.error.parameter, "window");
-  });
-
   test("rejects empty window string as invalid", () => {
     const out = analyticsWindow(url("/x?window=")) as unknown as Row;
     assert.ok(out.error);
@@ -1039,17 +1025,6 @@ describe("handleBulkHealthTrends", () => {
   // both tests below used `window=7d` as their example of a REJECTED param,
   // which is now a supported one, so the fixtures move to a param that can
   // never be supported rather than to another real name that might later be.
-  test("rejects an unsupported query param with 400", async () => {
-    for (const qs of ["?foo=1", "?cursor=abc", "?sort=name"]) {
-      const res = await handleBulkHealthTrends(
-        req(`/api/v1/health/trends${qs}`),
-        emptyEnv(),
-        url(`/api/v1/health/trends${qs}`),
-      );
-      const body = await errorJson(res);
-      assert.equal(body.error.code, "invalid_query", qs);
-    }
-  });
 
   test("reports the offending parameter name in error details", async () => {
     const res = await handleBulkHealthTrends(

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -801,18 +801,6 @@ describe("handleSubnetMetagraph", () => {
     assert.equal(res.status, 200);
   });
 
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetMetagraph(
-      req(`/api/v1/subnets/${NETUID}/metagraph`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/metagraph?bogus=1`),
-    );
-    const body = await errorJson(res);
-    assert.equal(body.error.code, "invalid_query");
-    assert.match(body.error.message, /bogus/);
-  });
-
   test("returns schema-stable empty payload on cold/unbound D1", async () => {
     const body = await assertColdSchema(
       handleSubnetMetagraph,
@@ -925,17 +913,6 @@ describe("handleSubnetMetagraph", () => {
 });
 
 describe("handleSubnetYield", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetYield(
-      req(`/api/v1/subnets/${NETUID}/yield`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/yield?bogus=1`),
-    );
-    const body = await errorJson(res);
-    assert.equal(body.error.code, "invalid_query");
-  });
-
   test("returns schema-stable empty payload on cold/unbound D1", async () => {
     const body = await assertColdSchema(
       handleSubnetYield,
@@ -959,20 +936,6 @@ describe("handleSubnetYield", () => {
 });
 
 describe("handleNeuron", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const body = await errorJson(
-      await handleNeuron(
-        req(`/api/v1/subnets/${NETUID}/neurons/${UID}`),
-        emptyEnv() as unknown as Env,
-        NETUID,
-        UID,
-        url(`/api/v1/subnets/${NETUID}/neurons/${UID}?bogus=1`),
-      ),
-    );
-    assert.equal(body.error.code, "invalid_query");
-    assert.match(body.error.message, /bogus/);
-  });
-
   test("rejects an unsupported fields= name with 400 (#9082)", async () => {
     const body = await errorJson(
       await handleNeuron(
@@ -1050,16 +1013,6 @@ describe("handleSubnetValidators", () => {
     );
     assert.deepEqual(body.data.validators, [{ hotkey: SS58 }]);
     assert.deepEqual(body.meta.projection, { fields: ["hotkey"] });
-  });
-
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetValidators(
-      req(`/api/v1/subnets/${NETUID}/validators`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/validators?limit=10`),
-    );
-    await errorJson(res);
   });
 
   test("returns schema-stable empty validators on cold D1", async () => {
@@ -1151,14 +1104,6 @@ describe("handleGlobalValidators", () => {
   // ever runs, so the router never reaches this guard with an invalid query.
   // It stays as defense in depth for any direct/non-cached caller, so cover it
   // directly here rather than only through the edge-cache route.
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleGlobalValidators(
-      req("/api/v1/validators"),
-      emptyEnv() as unknown as Env,
-      url("/api/v1/validators?bogus=1"),
-    );
-    await errorJson(res);
-  });
 
   test("returns schema-stable empty leaderboard on cold D1", async () => {
     const body = await assertColdSchema(
@@ -1271,15 +1216,6 @@ describe("handleGlobalValidators", () => {
 });
 
 describe("canonicalGlobalValidatorsCachePath", () => {
-  test("returns a response short-circuit for an unsupported query param", () => {
-    const result = canonicalGlobalValidatorsCachePath(
-      url("/api/v1/validators?bogus=1"),
-    );
-    assert.equal(result.cachePathAndSearch, undefined);
-    assert.ok(result.response instanceof Response);
-    assert.equal(result.response.status, 400);
-  });
-
   test("returns a response short-circuit for an unsupported sort value", () => {
     const result = canonicalGlobalValidatorsCachePath(
       url("/api/v1/validators?sort=bogus"),
@@ -1328,17 +1264,6 @@ describe("canonicalGlobalValidatorsCachePath", () => {
 });
 
 describe("handleNeuronHistory", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleNeuronHistory(
-      req(`/api/v1/subnets/${NETUID}/neurons/${UID}/history`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      UID,
-      url(`/api/v1/subnets/${NETUID}/neurons/${UID}/history?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects an invalid window param with 400", async () => {
     const res = await handleNeuronHistory(
       req(`/api/v1/subnets/${NETUID}/neurons/${UID}/history`),
@@ -1369,16 +1294,6 @@ describe("handleNeuronHistory", () => {
 });
 
 describe("handleSubnetHistory", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetHistory(
-      req(`/api/v1/subnets/${NETUID}/history`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/history?offset=0`),
-    );
-    await errorJson(res);
-  });
-
   test("returns schema-stable empty series on cold D1", async () => {
     const body = await assertColdSchema(
       handleSubnetHistory,
@@ -1454,16 +1369,6 @@ describe("handleSubnetHistory", () => {
 });
 
 describe("handleSubnetIdentityHistory", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetIdentityHistory(
-      req(`/api/v1/subnets/${NETUID}/identity-history`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/identity-history?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("returns schema-stable empty entries on cold D1", async () => {
     const body = await assertColdSchema(
       handleSubnetIdentityHistory,
@@ -1508,16 +1413,6 @@ describe("handleSubnetIdentityHistory", () => {
 });
 
 describe("handleSubnetHyperparams", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetHyperparams(
-      req(`/api/v1/subnets/${NETUID}/hyperparameters`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/hyperparameters?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   // D1 retirement: subnet_hyperparams's D1 write/read path is retired
   // (workers/request-handlers/entities.ts's handleSubnetHyperparams no
   // longer queries D1 at all), so this is now "Postgres unconfigured" rather
@@ -1537,16 +1432,6 @@ describe("handleSubnetHyperparams", () => {
 });
 
 describe("handleSubnetHyperparamsHistory", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetHyperparamsHistory(
-      req(`/api/v1/subnets/${NETUID}/hyperparameters/history`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/hyperparameters/history?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   // D1 retirement: same as handleSubnetHyperparams above -- no D1 fallback
   // left to query, so this is "Postgres unconfigured" rather than "D1 cold".
   test("returns schema-stable empty entries when Postgres is unconfigured", async () => {
@@ -1564,16 +1449,6 @@ describe("handleSubnetHyperparamsHistory", () => {
 });
 
 describe("handleSubnetPerformance", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetPerformance(
-      req(`/api/v1/subnets/${NETUID}/performance`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/performance?window=7d`),
-    );
-    await errorJson(res);
-  });
-
   test("returns schema-stable null blocks on cold D1", async () => {
     const body = await assertColdSchema(
       handleSubnetPerformance,
@@ -1590,16 +1465,6 @@ describe("handleSubnetPerformance", () => {
 });
 
 describe("handleSubnetConcentration", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetConcentration(
-      req(`/api/v1/subnets/${NETUID}/concentration`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/concentration?window=7d`),
-    );
-    await errorJson(res);
-  });
-
   test("returns schema-stable null blocks on cold D1", async () => {
     const body = await assertColdSchema(
       handleSubnetConcentration,
@@ -1621,7 +1486,6 @@ describe("handleSubnetConcentration", () => {
       req(`/api/v1/subnets/${NETUID}/concentration`),
       dbThrows("no such column: validator_permit") as unknown as Env,
       NETUID,
-      url(`/api/v1/subnets/${NETUID}/concentration`),
     );
     assert.equal(res.status, 200);
     const body = await jsonBody(res);
@@ -1636,16 +1500,6 @@ describe("handleSubnetConcentration", () => {
 });
 
 describe("handleSubnetConcentrationHistory", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetConcentrationHistory(
-      req(`/api/v1/subnets/${NETUID}/concentration/history`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/concentration/history?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects an out-of-range window with 400", async () => {
     const res = await handleSubnetConcentrationHistory(
       req(`/api/v1/subnets/${NETUID}/concentration/history`),
@@ -1689,16 +1543,6 @@ describe("handleSubnetConcentrationHistory", () => {
 });
 
 describe("handleSubnetPerformanceHistory", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetPerformanceHistory(
-      req(`/api/v1/subnets/${NETUID}/performance/history`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/performance/history?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects an out-of-range window with 400", async () => {
     const res = await handleSubnetPerformanceHistory(
       req(`/api/v1/subnets/${NETUID}/performance/history`),
@@ -1742,16 +1586,6 @@ describe("handleSubnetPerformanceHistory", () => {
 });
 
 describe("handleSubnetYieldHistory", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetYieldHistory(
-      req(`/api/v1/subnets/${NETUID}/yield/history`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/yield/history?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects an out-of-range window with 400", async () => {
     const res = await handleSubnetYieldHistory(
       req(`/api/v1/subnets/${NETUID}/yield/history`),
@@ -1795,16 +1629,6 @@ describe("handleSubnetYieldHistory", () => {
 });
 
 describe("handleSubnetTurnover", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetTurnover(
-      req(`/api/v1/subnets/${NETUID}/turnover`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/turnover?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("returns schema-stable empty turnover on cold D1", async () => {
     const body = await assertColdSchema(
       handleSubnetTurnover,
@@ -1991,16 +1815,6 @@ describe("handleSubnetTurnover", () => {
 });
 
 describe("handleSubnetWeights", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetWeights(
-      req(`/api/v1/subnets/${NETUID}/weights`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/weights?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects an unsupported window with 400", async () => {
     const res = await handleSubnetWeights(
       req(`/api/v1/subnets/${NETUID}/weights`),
@@ -2065,16 +1879,6 @@ describe("handleSubnetWeights", () => {
 });
 
 describe("handleSubnetServing", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetServing(
-      req(`/api/v1/subnets/${NETUID}/serving`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/serving?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects an unsupported window with 400", async () => {
     const res = await handleSubnetServing(
       req(`/api/v1/subnets/${NETUID}/serving`),
@@ -2139,16 +1943,6 @@ describe("handleSubnetServing", () => {
 });
 
 describe("handleSubnetPrometheus", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetPrometheus(
-      req(`/api/v1/subnets/${NETUID}/prometheus`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/prometheus?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects an unsupported window with 400", async () => {
     const res = await handleSubnetPrometheus(
       req(`/api/v1/subnets/${NETUID}/prometheus`),
@@ -2215,16 +2009,6 @@ describe("handleSubnetPrometheus", () => {
 });
 
 describe("handleSubnetStakeMoves", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetStakeMoves(
-      req(`/api/v1/subnets/${NETUID}/stake-moves`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/stake-moves?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects an unsupported window with 400", async () => {
     const res = await handleSubnetStakeMoves(
       req(`/api/v1/subnets/${NETUID}/stake-moves`),
@@ -2293,16 +2077,6 @@ describe("handleSubnetStakeMoves", () => {
 });
 
 describe("handleSubnetStakeTransfers", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetStakeTransfers(
-      req(`/api/v1/subnets/${NETUID}/stake-transfers`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/stake-transfers?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects an unsupported window with 400", async () => {
     const res = await handleSubnetStakeTransfers(
       req(`/api/v1/subnets/${NETUID}/stake-transfers`),
@@ -2371,16 +2145,6 @@ describe("handleSubnetStakeTransfers", () => {
 });
 
 describe("handleSubnetRegistrations", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetRegistrations(
-      req(`/api/v1/subnets/${NETUID}/registrations`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/registrations?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects an unsupported window with 400", async () => {
     const res = await handleSubnetRegistrations(
       req(`/api/v1/subnets/${NETUID}/registrations`),
@@ -2449,16 +2213,6 @@ describe("handleSubnetRegistrations", () => {
 });
 
 describe("handleSubnetAxonRemovals", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetAxonRemovals(
-      req(`/api/v1/subnets/${NETUID}/axon-removals`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/axon-removals?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects an unsupported window with 400", async () => {
     const res = await handleSubnetAxonRemovals(
       req(`/api/v1/subnets/${NETUID}/axon-removals`),
@@ -2527,16 +2281,6 @@ describe("handleSubnetAxonRemovals", () => {
 });
 
 describe("handleSubnetDeregistrations", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetDeregistrations(
-      req(`/api/v1/subnets/${NETUID}/deregistrations`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/deregistrations?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects an unsupported window with 400", async () => {
     const res = await handleSubnetDeregistrations(
       req(`/api/v1/subnets/${NETUID}/deregistrations`),
@@ -2629,16 +2373,6 @@ describe("handleSubnetDeregistrations", () => {
 });
 
 describe("handleSubnetStakeFlow", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetStakeFlow(
-      req(`/api/v1/subnets/${NETUID}/stake-flow`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/stake-flow?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects an out-of-retention window with 400", async () => {
     const res = await handleSubnetStakeFlow(
       req(`/api/v1/subnets/${NETUID}/stake-flow`),
@@ -2762,16 +2496,6 @@ describe("handleSubnetStakeFlow", () => {
 });
 
 describe("handleSubnetMovers", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    await errorJson(
-      await handleSubnetMovers(
-        req("/api/v1/subnets/movers"),
-        emptyEnv() as unknown as Env,
-        url("/api/v1/subnets/movers?bogus=1"),
-      ),
-    );
-  });
-
   test("rejects an unsupported window with 400", async () => {
     const body = await errorJson(
       await handleSubnetMovers(
@@ -3364,16 +3088,6 @@ describe("cold tier answers when Postgres misses (lakehouse-backed handlers)", (
 });
 
 describe("handleAccountEvents", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleAccountEvents(
-      req(`/api/v1/accounts/${SS58}/events`),
-      emptyEnv() as unknown as Env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/events?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects a non-integer block_start with 400", async () => {
     const res = await handleAccountEvents(
       req(`/api/v1/accounts/${SS58}/events`),
@@ -3472,16 +3186,6 @@ describe("handleAccountEvents", () => {
 });
 
 describe("handleAccountHistory", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleAccountHistory(
-      req(`/api/v1/accounts/${SS58}/history`),
-      emptyEnv() as unknown as Env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/history?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects malformed from/to dates with 400", async () => {
     const res = await handleAccountHistory(
       req(`/api/v1/accounts/${SS58}/history`),
@@ -3563,16 +3267,6 @@ describe("handleAccountHistory", () => {
 });
 
 describe("handleAccountExtrinsics", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleAccountExtrinsics(
-      req(`/api/v1/accounts/${SS58}/extrinsics`),
-      emptyEnv() as unknown as Env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/extrinsics?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("returns schema-stable empty extrinsics on cold D1", async () => {
     const body = await assertColdSchema(
       handleAccountExtrinsics,
@@ -3627,16 +3321,6 @@ describe("handleAccountExtrinsics", () => {
 });
 
 describe("handleAccountTransfers", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleAccountTransfers(
-      req(`/api/v1/accounts/${SS58}/transfers`),
-      emptyEnv() as unknown as Env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/transfers?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects an unsupported direction enum value with 400", async () => {
     const res = await handleAccountTransfers(
       req(`/api/v1/accounts/${SS58}/transfers`),
@@ -3701,16 +3385,6 @@ describe("handleAccountTransfers", () => {
 });
 
 describe("handleAccountCounterparties", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleAccountCounterparties(
-      req(`/api/v1/accounts/${SS58}/counterparties`),
-      emptyEnv() as unknown as Env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/counterparties?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects malformed and out-of-range limits before D1 work", async () => {
     for (const limit of ["random_nonce", "Infinity", "0", "101", "10.5"]) {
       const captures = { sql: [], params: [] };
@@ -3909,16 +3583,6 @@ describe("handleAccountCounterparties relationship drilldown", () => {
 });
 
 describe("handleAccountStakeFlow", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleAccountStakeFlow(
-      req(`/api/v1/accounts/${SS58}/stake-flow`),
-      emptyEnv() as unknown as Env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/stake-flow?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects an unsupported window with 400", async () => {
     const res = await handleAccountStakeFlow(
       req(`/api/v1/accounts/${SS58}/stake-flow`),
@@ -3966,16 +3630,6 @@ describe("handleAccountStakeFlow", () => {
 });
 
 describe("handleAccountStakeMoves", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleAccountStakeMoves(
-      req(`/api/v1/accounts/${SS58}/stake-moves`),
-      emptyEnv() as unknown as Env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/stake-moves?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects an unsupported window with 400", async () => {
     const res = await handleAccountStakeMoves(
       req(`/api/v1/accounts/${SS58}/stake-moves`),
@@ -4026,16 +3680,6 @@ describe("handleAccountSubnets", () => {
 });
 
 describe("handleSubnetEvents", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetEvents(
-      req(`/api/v1/subnets/${NETUID}/events`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/events?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("returns schema-stable empty events on cold D1", async () => {
     const body = await assertColdSchema(
       handleSubnetEvents,
@@ -4102,16 +3746,6 @@ describe("handleSubnetEvents", () => {
 });
 
 describe("handleSubnetEventSummary", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleSubnetEventSummary(
-      req(`/api/v1/subnets/${NETUID}/event-summary`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/event-summary?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("rejects an unsupported window with 400", async () => {
     const res = await handleSubnetEventSummary(
       req(`/api/v1/subnets/${NETUID}/event-summary`),
@@ -4271,16 +3905,6 @@ function accountIdentityRow(overrides = {}) {
 }
 
 describe("handleAccountIdentity", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleAccountIdentity(
-      req(`/api/v1/accounts/${SS58}/identity`),
-      emptyEnv() as unknown as Env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/identity?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("has_identity is false on cold D1 (schema-stable, never 404)", async () => {
     const body = await assertColdSchema(
       handleAccountIdentity,
@@ -4311,7 +3935,6 @@ describe("handleAccountIdentity", () => {
         req(`/api/v1/accounts/${SS58}/identity`),
         env as unknown as Env,
         SS58,
-        url(`/api/v1/accounts/${SS58}/identity`),
       ),
     );
     assert.equal(body.data.has_identity, true);
@@ -4320,16 +3943,6 @@ describe("handleAccountIdentity", () => {
 });
 
 describe("handleAccountIdentityHistory", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleAccountIdentityHistory(
-      req(`/api/v1/accounts/${SS58}/identity-history`),
-      emptyEnv() as unknown as Env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/identity-history?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("returns schema-stable empty entries on cold D1", async () => {
     const body = await assertColdSchema(
       handleAccountIdentityHistory,
@@ -4380,15 +3993,6 @@ describe("handleAccountIdentityHistory", () => {
 });
 
 describe("handleBlocks", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleBlocks(
-      req("/api/v1/blocks"),
-      emptyEnv() as unknown as Env,
-      url("/api/v1/blocks?bogus=1"),
-    );
-    await errorJson(res);
-  });
-
   test("returns schema-stable empty feed on cold D1", async () => {
     const body = await assertColdSchema(
       handleBlocks,
@@ -4539,16 +4143,6 @@ describe("handleBlock", () => {
 });
 
 describe("handleBlockExtrinsics", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleBlockExtrinsics(
-      req(`/api/v1/blocks/${BLOCK_NUM}/extrinsics`),
-      emptyEnv() as unknown as Env,
-      String(BLOCK_NUM),
-      url(`/api/v1/blocks/${BLOCK_NUM}/extrinsics?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("returns schema-stable empty extrinsics on cold D1", async () => {
     const body = await assertColdSchema(
       handleBlockExtrinsics,
@@ -4592,16 +4186,6 @@ describe("handleBlockExtrinsics", () => {
 });
 
 describe("handleBlockEvents", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleBlockEvents(
-      req(`/api/v1/blocks/${BLOCK_NUM}/events`),
-      emptyEnv() as unknown as Env,
-      String(BLOCK_NUM),
-      url(`/api/v1/blocks/${BLOCK_NUM}/events?bogus=1`),
-    );
-    await errorJson(res);
-  });
-
   test("returns schema-stable empty events on cold D1", async () => {
     const body = await assertColdSchema(
       handleBlockEvents,
@@ -4690,15 +4274,6 @@ describe("handleExtrinsics", () => {
       url(path),
     );
     assert.equal(res.status, 200);
-  });
-
-  test("rejects an unsupported query param with 400", async () => {
-    const res = await handleExtrinsics(
-      req("/api/v1/extrinsics"),
-      emptyEnv() as unknown as Env,
-      url("/api/v1/extrinsics?bogus=1"),
-    );
-    await errorJson(res);
   });
 
   test("returns schema-stable empty feed on cold D1", async () => {
@@ -5157,12 +4732,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     const path = `/api/v1/subnets/${NETUID}/hyperparameters`;
     const body = await json(
-      await handleSubnetHyperparams(
-        req(path),
-        env as unknown as Env,
-        NETUID,
-        url(path),
-      ),
+      await handleSubnetHyperparams(req(path), env as unknown as Env, NETUID),
     );
     assert.equal(body.data.hyperparameters.tempo, 999);
     assert.deepEqual(captures.sql, []);
@@ -5178,12 +4748,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     };
     const path = `/api/v1/subnets/${NETUID}/hyperparameters`;
     const body = await json(
-      await handleSubnetHyperparams(
-        req(path),
-        env as unknown as Env,
-        NETUID,
-        url(path),
-      ),
+      await handleSubnetHyperparams(req(path), env as unknown as Env, NETUID),
     );
     assert.equal(body.data.hyperparameters, null);
     assert.equal(body.data.captured_at, null);
@@ -5256,12 +4821,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     const path = `/api/v1/accounts/${SS58}/identity`;
     const body = await json(
-      await handleAccountIdentity(
-        req(path),
-        env as unknown as Env,
-        SS58,
-        url(path),
-      ),
+      await handleAccountIdentity(req(path), env as unknown as Env, SS58),
     );
     assert.equal(body.data.name, "Postgres Team");
     assert.deepEqual(captures.sql, []);
@@ -5277,12 +4837,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     };
     const path = `/api/v1/accounts/${SS58}/identity`;
     const body = await json(
-      await handleAccountIdentity(
-        req(path),
-        env as unknown as Env,
-        SS58,
-        url(path),
-      ),
+      await handleAccountIdentity(req(path), env as unknown as Env, SS58),
     );
     assert.equal(body.data.has_identity, false);
     assert.equal(body.data.name, null);
@@ -6201,15 +5756,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
       );
       assert.equal(res.status, 400);
     });
-
-    test("an unknown query param is still rejected (format is the only one)", async () => {
-      const res = await handleRuntime(
-        req("/api/v1/runtime?limit=5"),
-        pgEnv(ROWS) as unknown as Env,
-        url("/api/v1/runtime?limit=5"),
-      );
-      assert.equal(res.status, 400);
-    });
   });
 
   // #4832 Tier 1b: the remaining account_events-derived handlers with no
@@ -6249,7 +5795,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         req(`/api/v1/subnets/${NETUID}/volume`),
         env as unknown as Env,
         NETUID,
-        url(`/api/v1/subnets/${NETUID}/volume`),
       ),
     );
     assert.equal(body.data.marker, "pg");
@@ -6351,7 +5896,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         req(`/api/v1/subnets/${NETUID}/concentration`),
         env as unknown as Env,
         NETUID,
-        url(`/api/v1/subnets/${NETUID}/concentration`),
       ),
     );
     assert.equal(body.data.marker, "pg");
@@ -6370,7 +5914,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         req(`/api/v1/subnets/${NETUID}/performance`),
         env as unknown as Env,
         NETUID,
-        url(`/api/v1/subnets/${NETUID}/performance`),
       ),
     );
     assert.equal(body.data.marker, "pg");
@@ -6406,7 +5949,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
       await handleChainConcentration(
         req("/api/v1/chain/concentration"),
         env as unknown as Env,
-        url("/api/v1/chain/concentration"),
       ),
     );
     assert.equal(body.data.marker, "pg");
@@ -6428,40 +5970,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleChainConcentrationSubnets: rejects a bad parameter WITHOUT reading the tier", async () => {
-    // The read is ~30,000 rows. A caller who typed `lens=vibes` must not pay
-    // for it, so the rejection has to land before the proxy -- asserted by the
-    // tier never being called, not just by the status code.
-    for (const [qs, parameter] of [
-      ["?lens=vibes", "lens"],
-      ["?sort=whatever", "sort"],
-      ["?order=sideways", "order"],
-      ["?limit=0", "limit"],
-      ["?limit=99999", "limit"],
-      ["?nope=1", "nope"],
-    ] as const) {
-      const { env } = dbWith({ neurons: [neuronRow()] });
-      let tierCalls = 0;
-      env.METAGRAPH_NEURONS_SOURCE = "postgres";
-      env.DATA_API = {
-        fetch: async () => {
-          tierCalls += 1;
-          return Response.json({ schema_version: 1 });
-        },
-      };
-      const response = await handleChainConcentrationSubnets(
-        req(`/api/v1/chain/concentration/subnets${qs}`),
-        env as unknown as Env,
-        url(`/api/v1/chain/concentration/subnets${qs}`),
-      );
-      assert.equal(response.status, 400, `${qs} should have been rejected`);
-      assert.equal(tierCalls, 0, `${qs} reached the tier before validating`);
-      const body = (await response.json()) as Row;
-      assert.equal((body.error as Row).code, "invalid_query");
-      assert.equal((body.meta as Row).parameter, parameter);
-    }
   });
 
   test("handleChainConcentrationSubnets: a cold tier echoes the CALLER's query back", async () => {
@@ -6496,7 +6004,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
       await handleChainPerformance(
         req("/api/v1/chain/performance"),
         env as unknown as Env,
-        url("/api/v1/chain/performance"),
       ),
     );
     assert.equal(body.data.marker, "pg");
@@ -6510,11 +6017,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
       fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
     };
     const body = await json(
-      await handleChainYield(
-        req("/api/v1/chain/yield"),
-        env as unknown as Env,
-        url("/api/v1/chain/yield"),
-      ),
+      await handleChainYield(req("/api/v1/chain/yield"), env as unknown as Env),
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
@@ -6527,11 +6030,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
       fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
     };
     const body = await json(
-      await handleSelfHealth(
-        req("/api/v1/self-health"),
-        env as unknown as Env,
-        url("/api/v1/self-health"),
-      ),
+      await handleSelfHealth(req("/api/v1/self-health"), env as unknown as Env),
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
@@ -6570,11 +6069,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
       }),
     };
     const body = await json(
-      await handleSelfHealth(
-        req("/api/v1/self-health"),
-        env as unknown as Env,
-        url("/api/v1/self-health"),
-      ),
+      await handleSelfHealth(req("/api/v1/self-health"), env as unknown as Env),
     );
     assert.equal(body.data.marker, "pg");
     // Stale first: the row an operator acts on leads.
@@ -6590,11 +6085,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     // real production state and must not read as "every lane is fine" OR as an error.
     const { env } = dbWith({ neurons: [] });
     const body = await json(
-      await handleSelfHealth(
-        req("/api/v1/self-health"),
-        env as unknown as Env,
-        url("/api/v1/self-health"),
-      ),
+      await handleSelfHealth(req("/api/v1/self-health"), env as unknown as Env),
     );
     assert.deepEqual(body.data.lanes, []);
     assert.equal(body.data.stale_lane_count, 0);
@@ -6607,7 +6098,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     const res = await handleSelfHealth(
       req("/api/v1/self-health"),
       env as unknown as Env,
-      url("/api/v1/self-health"),
     );
     assert.equal(res.status, 200);
     const body = await json(res);
@@ -6620,16 +6110,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
       ),
       true,
     );
-  });
-
-  test("handleSelfHealth: rejects an unknown query param", async () => {
-    const { env } = dbWith({ neurons: [] });
-    const res = await handleSelfHealth(
-      req("/api/v1/self-health?bogus=1"),
-      env as unknown as Env,
-      url("/api/v1/self-health?bogus=1"),
-    );
-    assert.equal(res.status, 400);
   });
 
   test("handleAccountPortfolio: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -6723,15 +6203,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
   // reaching this handler) so handleTopHoldersList's own defensive
   // parsed.error guard -- the same defense-in-depth shape as every other
   // handler in this file -- is exercised too.
-  test("handleTopHoldersList: rejects an unsupported query param with 400", async () => {
-    const res = await handleTopHoldersList(
-      req("/api/v1/accounts/top-holders?bogus=1"),
-      emptyEnv() as unknown as Env,
-      url("/api/v1/accounts/top-holders?bogus=1"),
-    );
-    const body = await errorJson(res);
-    assert.equal(body.error.code, "invalid_query");
-  });
 
   test("handleTopHoldersList: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({});
@@ -7275,157 +6746,6 @@ describe("schema-stable cold-store matrix (#1900)", () => {
       const body = await jsonBody(res);
       assert.equal(body.ok, true);
       assertData(body.data);
-    });
-  }
-});
-
-describe("query-param guard matrix (#1900)", () => {
-  const unsupportedCases = [
-    {
-      name: "handleSubnetMetagraph",
-      run: () =>
-        handleSubnetMetagraph(
-          req(`/api/v1/subnets/${NETUID}/metagraph`),
-          emptyEnv() as unknown as Env,
-          NETUID,
-          url(`/api/v1/subnets/${NETUID}/metagraph?foo=bar`),
-        ),
-    },
-    {
-      name: "handleSubnetValidators",
-      run: () =>
-        handleSubnetValidators(
-          req(`/api/v1/subnets/${NETUID}/validators`),
-          emptyEnv() as unknown as Env,
-          NETUID,
-          url(`/api/v1/subnets/${NETUID}/validators?foo=bar`),
-        ),
-    },
-    {
-      name: "handleNeuronHistory",
-      run: () =>
-        handleNeuronHistory(
-          req(`/api/v1/subnets/${NETUID}/neurons/${UID}/history`),
-          emptyEnv() as unknown as Env,
-          NETUID,
-          UID,
-          url(`/api/v1/subnets/${NETUID}/neurons/${UID}/history?foo=bar`),
-        ),
-    },
-    {
-      name: "handleSubnetHistory",
-      run: () =>
-        handleSubnetHistory(
-          req(`/api/v1/subnets/${NETUID}/history`),
-          emptyEnv() as unknown as Env,
-          NETUID,
-          url(`/api/v1/subnets/${NETUID}/history?foo=bar`),
-        ),
-    },
-    {
-      name: "handleSubnetIdentityHistory",
-      run: () =>
-        handleSubnetIdentityHistory(
-          req(`/api/v1/subnets/${NETUID}/identity-history`),
-          emptyEnv() as unknown as Env,
-          NETUID,
-          url(`/api/v1/subnets/${NETUID}/identity-history?foo=bar`),
-        ),
-    },
-    {
-      name: "handleAccountEvents",
-      run: () =>
-        handleAccountEvents(
-          req(`/api/v1/accounts/${SS58}/events`),
-          emptyEnv() as unknown as Env,
-          SS58,
-          url(`/api/v1/accounts/${SS58}/events?foo=bar`),
-        ),
-    },
-    {
-      name: "handleAccountHistory",
-      run: () =>
-        handleAccountHistory(
-          req(`/api/v1/accounts/${SS58}/history`),
-          emptyEnv() as unknown as Env,
-          SS58,
-          url(`/api/v1/accounts/${SS58}/history?foo=bar`),
-        ),
-    },
-    {
-      name: "handleAccountExtrinsics",
-      run: () =>
-        handleAccountExtrinsics(
-          req(`/api/v1/accounts/${SS58}/extrinsics`),
-          emptyEnv() as unknown as Env,
-          SS58,
-          url(`/api/v1/accounts/${SS58}/extrinsics?foo=bar`),
-        ),
-    },
-    {
-      name: "handleAccountTransfers",
-      run: () =>
-        handleAccountTransfers(
-          req(`/api/v1/accounts/${SS58}/transfers`),
-          emptyEnv() as unknown as Env,
-          SS58,
-          url(`/api/v1/accounts/${SS58}/transfers?foo=bar`),
-        ),
-    },
-    {
-      name: "handleSubnetEvents",
-      run: () =>
-        handleSubnetEvents(
-          req(`/api/v1/subnets/${NETUID}/events`),
-          emptyEnv() as unknown as Env,
-          NETUID,
-          url(`/api/v1/subnets/${NETUID}/events?foo=bar`),
-        ),
-    },
-    {
-      name: "handleBlocks",
-      run: () =>
-        handleBlocks(
-          req("/api/v1/blocks"),
-          emptyEnv() as unknown as Env,
-          url("/api/v1/blocks?foo=bar"),
-        ),
-    },
-    {
-      name: "handleBlockExtrinsics",
-      run: () =>
-        handleBlockExtrinsics(
-          req(`/api/v1/blocks/${BLOCK_NUM}/extrinsics`),
-          emptyEnv() as unknown as Env,
-          String(BLOCK_NUM),
-          url(`/api/v1/blocks/${BLOCK_NUM}/extrinsics?foo=bar`),
-        ),
-    },
-    {
-      name: "handleBlockEvents",
-      run: () =>
-        handleBlockEvents(
-          req(`/api/v1/blocks/${BLOCK_NUM}/events`),
-          emptyEnv() as unknown as Env,
-          String(BLOCK_NUM),
-          url(`/api/v1/blocks/${BLOCK_NUM}/events?foo=bar`),
-        ),
-    },
-    {
-      name: "handleExtrinsics",
-      run: () =>
-        handleExtrinsics(
-          req("/api/v1/extrinsics"),
-          emptyEnv() as unknown as Env,
-          url("/api/v1/extrinsics?foo=bar"),
-        ),
-    },
-  ];
-
-  for (const { name, run } of unsupportedCases) {
-    test(`${name} → 400 on unsupported query param`, async () => {
-      const body = await errorJson(await run());
-      assert.equal(body.error.code, "invalid_query");
     });
   }
 });

--- a/tests/request-handlers-rpc-proxy.test.ts
+++ b/tests/request-handlers-rpc-proxy.test.ts
@@ -150,16 +150,6 @@ describe("handleRpcUsage", () => {
     assert.equal(body.meta.artifact_path, "/metagraph/rpc/usage.json");
   });
 
-  test("rejects unsupported query parameters", async () => {
-    const res = await handleRpcUsage(
-      req("/api/v1/rpc/usage?cacheBust=x"),
-      mockEnv(),
-      url("/api/v1/rpc/usage?cacheBust=x"),
-    );
-    const body = await errorJson(res, 400);
-    assert.equal(body.meta.parameter, "cacheBust");
-  });
-
   test("rejects unknown window values", async () => {
     const res = await handleRpcUsage(
       req("/api/v1/rpc/usage?window=90d"),

--- a/tests/subnet-idle-stake-handler.test.ts
+++ b/tests/subnet-idle-stake-handler.test.ts
@@ -27,21 +27,10 @@ function req(path: string) {
   return new Request(`https://api.metagraph.sh${path}`);
 }
 
-function url(path: string) {
-  return new URL(`https://api.metagraph.sh${path}`);
-}
-
 async function json(res: Response): Promise<Row> {
   assert.equal(res.status, 200, `expected 200, got ${res.status}`);
   const body = (await res.json()) as Row;
   assert.equal(body.ok, true);
-  return body;
-}
-
-async function errorJson(res: Response): Promise<Row> {
-  assert.equal(res.status, 400, `expected 400, got ${res.status}`);
-  const body = (await res.json()) as Row;
-  assert.equal(body.ok, false);
   return body;
 }
 
@@ -66,24 +55,12 @@ async function assertValidComponent(componentName: string, data: unknown) {
 }
 
 describe("handleSubnetIdleStake", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    await errorJson(
-      await handleSubnetIdleStake(
-        req(`/api/v1/subnets/${NETUID}/idle-stake?window=7d`),
-        emptyEnv(),
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/idle-stake?window=7d`),
-      ),
-    );
-  });
-
   test("returns a schema-stable zero scorecard on cold D1", async () => {
     const body = await json(
       await handleSubnetIdleStake(
         req(`/api/v1/subnets/${NETUID}/idle-stake`),
         emptyEnv(),
         NETUID,
-        url(`/api/v1/subnets/${NETUID}/idle-stake`),
       ),
     );
     assert.equal(body.data.netuid, NETUID);
@@ -96,23 +73,9 @@ describe("handleSubnetIdleStake", () => {
 });
 
 describe("handleChainIdleStake", () => {
-  test("rejects an unsupported query param with 400", async () => {
-    await errorJson(
-      await handleChainIdleStake(
-        req("/api/v1/chain/idle-stake?window=7d"),
-        emptyEnv(),
-        url("/api/v1/chain/idle-stake?window=7d"),
-      ),
-    );
-  });
-
   test("returns a schema-stable empty ranking on cold D1", async () => {
     const body = await json(
-      await handleChainIdleStake(
-        req("/api/v1/chain/idle-stake"),
-        emptyEnv(),
-        url("/api/v1/chain/idle-stake"),
-      ),
+      await handleChainIdleStake(req("/api/v1/chain/idle-stake"), emptyEnv()),
     );
     assert.equal(body.data.captured_at, null);
     assert.equal(body.data.subnet_count, 0);

--- a/tests/subnet-stake-quote-handler.test.ts
+++ b/tests/subnet-stake-quote-handler.test.ts
@@ -125,14 +125,6 @@ describe("handleSubnetStakeQuote (#5235)", () => {
     assert.equal(json.error.code, "insufficient_liquidity");
   });
 
-  test("unknown query param → 400", async () => {
-    const { status } = await call(
-      liveEconomicsEnv(),
-      `/api/v1/subnets/${NETUID}/stake-quote?amount=1&foo=bar`,
-    );
-    assert.equal(status, 400);
-  });
-
   test("bad direction → 400 invalid_direction", async () => {
     const { status, json } = await call(
       {},

--- a/tests/subnet-validator-economics-route.test.ts
+++ b/tests/subnet-validator-economics-route.test.ts
@@ -438,22 +438,8 @@ describe("handleSubnetValidatorEconomics", () => {
       new Request(url.toString()),
       env as never,
       Number(url.pathname.split("/")[4]),
-      url,
     );
   };
-
-  test("rejects an unknown query parameter rather than ignoring it", async () => {
-    // Silently dropping a param the caller believed in is how a filtered request
-    // comes back looking unfiltered.
-    const { env } = envWith({ neurons: [permitted(0)] });
-    const res = await call(
-      "/api/v1/subnets/7/validator-economics?window=30d",
-      env,
-    );
-    assert.equal(res.status, 400);
-    const body = (await res.json()) as Row;
-    assert.equal((body.error as Row).code, "invalid_query");
-  });
 
   test("rejects a netuid outside the u16 range", async () => {
     const { env } = envWith({ neurons: [permitted(0)] });
@@ -817,13 +803,6 @@ describe("handleValidatorEconomicsRanking", () => {
     );
   });
 
-  test("rejects an unknown query parameter", async () => {
-    const res = await call("?window=30d", env);
-    assert.equal(res.status, 400);
-    const body = (await res.json()) as Row;
-    assert.equal((body.error as Row).code, "invalid_query");
-  });
-
   test("rejects a limit above the published ceiling", async () => {
     const res = await call("?limit=100000", env);
     assert.equal(res.status, 400);
@@ -1158,14 +1137,6 @@ describe("handleSubnetValidatorEconomicsHistory", () => {
     assert.equal(res.status, 400);
     const body = (await res.json()) as Row;
     assert.match(String((body.error as Row).message), /window must be one of/);
-  });
-
-  test("rejects an unknown query parameter", async () => {
-    const res = await call(
-      "/api/v1/subnets/7/validator-economics/history?sort=cost",
-      env,
-    );
-    assert.equal(res.status, 400);
   });
 
   test("rejects a netuid outside the u16 range", async () => {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -2835,7 +2835,7 @@ export async function handleChainEventsFamily(
     );
   }
 
-  const unknownParam = validateDeclaredQueryParams(url, url.pathname);
+  const unknownParam = validateDeclaredQueryParams(url);
   // Same error builder the other 136 routes use, so the body, code and
   // `parameter` field are identical rather than merely similar.
   if (unknownParam) return analyticsQueryError(unknownParam);
@@ -4170,6 +4170,25 @@ export async function handleRequest(
     );
   }
 
+  // THE query-parameter allowlist, for every GET route, derived from the
+  // contract (#10065). One check here replaces 119 hand-written arrays spread
+  // across the handler modules -- see validateDeclaredQueryParams for what
+  // that fifth copy of the query contract had already drifted into.
+  //
+  // Here rather than in the handlers because the question is answered from the
+  // pathname alone: a handler does not need to know its own contract entry to
+  // have its parameters checked, and one call site cannot be half-adopted the
+  // way 119 could. GET only -- the contract's query_parameters are the GET
+  // operation's, and a POST route reusing a GET path would otherwise be handed
+  // the wrong list.
+  if (
+    (request.method === "GET" || request.method === "HEAD") &&
+    (url.pathname === "/api/v1" || url.pathname.startsWith("/api/v1/"))
+  ) {
+    const undeclared = validateDeclaredQueryParams(url);
+    if (undeclared) return analyticsQueryError(undeclared);
+  }
+
   // Multi-network addressing: an explicit /{network}/ prefix (mainnet/testnet/
   // local + finney/test aliases) routes through the network-aware artifact
   // handler. Bare paths fall through to the full dispatch below unchanged, so
@@ -4998,12 +5017,7 @@ export async function handleRequest(
       // Per-UID range read over the neurons tier — edge-cache busts on the
       // shared health-cron stamp like every sibling Postgres-tier route.
       return withEdgeCache(request, ctx, env, "subnet-concentration", () =>
-        handleSubnetConcentration(
-          request,
-          env,
-          Number(concentrationMatch[1]),
-          resolved.url,
-        ),
+        handleSubnetConcentration(request, env, Number(concentrationMatch[1])),
       );
     }
     const turnoverMatch = SUBNET_TURNOVER_PATH_PATTERN.exec(
@@ -5056,12 +5070,7 @@ export async function handleRequest(
       // deterministic per request (no query params), edge-cache like the
       // sibling analytics routes.
       return withEdgeCache(request, ctx, env, "subnet-alpha-volume", () =>
-        handleSubnetAlphaVolume(
-          request,
-          env,
-          Number(alphaVolumeMatch[1]),
-          resolved.url,
-        ),
+        handleSubnetAlphaVolume(request, env, Number(alphaVolumeMatch[1])),
       );
     }
     const ohlcMatch = SUBNET_OHLC_PATH_PATTERN.exec(resolved.url.pathname);
@@ -5136,7 +5145,6 @@ export async function handleRequest(
             request,
             env,
             Number(validatorEconomicsMatch[1]),
-            resolved.url,
           ),
       );
     }
@@ -5361,12 +5369,7 @@ export async function handleRequest(
     );
     if (performanceMatch) {
       return withEdgeCache(request, ctx, env, "subnet-performance", () =>
-        handleSubnetPerformance(
-          request,
-          env,
-          Number(performanceMatch[1]),
-          resolved.url,
-        ),
+        handleSubnetPerformance(request, env, Number(performanceMatch[1])),
       );
     }
     // Stake sitting on a currently-zero-dividends hotkey (#6789) — per-UID
@@ -5378,12 +5381,7 @@ export async function handleRequest(
     );
     if (idleStakeMatch) {
       return withEdgeCache(request, ctx, env, "subnet-idle-stake", () =>
-        handleSubnetIdleStake(
-          request,
-          env,
-          Number(idleStakeMatch[1]),
-          resolved.url,
-        ),
+        handleSubnetIdleStake(request, env, Number(idleStakeMatch[1])),
       );
     }
     // Per-UID metagraph (#1304/#1305): computed live from the neurons D1 tier.
@@ -5538,12 +5536,7 @@ export async function handleRequest(
     if (hyperparamsMatch) {
       // Single PK-by-netuid D1 lookup, same cost class as handleNeuron —
       // dispatch directly, no edge-cache wrapper.
-      return handleSubnetHyperparams(
-        request,
-        env,
-        Number(hyperparamsMatch[1]),
-        resolved.url,
-      );
+      return handleSubnetHyperparams(request, env, Number(hyperparamsMatch[1]));
     }
     const validatorsMatch = SUBNET_VALIDATORS_PATH_PATTERN.exec(
       resolved.url.pathname,
@@ -5698,12 +5691,7 @@ export async function handleRequest(
       resolved.url.pathname,
     );
     if (accountIdentityMatch) {
-      return handleAccountIdentity(
-        request,
-        env,
-        accountIdentityMatch[1],
-        resolved.url,
-      );
+      return handleAccountIdentity(request, env, accountIdentityMatch[1]);
     }
     const accountExtrinsicsMatch = ACCOUNT_EXTRINSICS_PATH_PATTERN.exec(
       resolved.url.pathname,
@@ -5899,7 +5887,7 @@ export async function handleRequest(
     // (like the per-subnet concentration route, but network-scoped).
     if (resolved.url.pathname === "/api/v1/chain/concentration") {
       return withEdgeCache(request, ctx, env, "chain-concentration", () =>
-        handleChainConcentration(request, env, resolved.url),
+        handleChainConcentration(request, env),
       );
     }
     // GET /api/v1/chain/concentration/subnets (#9717): the same neurons read as
@@ -5921,7 +5909,7 @@ export async function handleRequest(
     // sibling Postgres-tier route (like chain/concentration, but the reward-flow lens).
     if (resolved.url.pathname === "/api/v1/chain/performance") {
       return withEdgeCache(request, ctx, env, "chain-performance", () =>
-        handleChainPerformance(request, env, resolved.url),
+        handleChainPerformance(request, env),
       );
     }
     // GET /api/v1/chain/idle-stake (#6789): network-wide idle-stake rollup —
@@ -5929,7 +5917,7 @@ export async function handleRequest(
     // Postgres-tier route (like chain/performance, but the idle-delegation lens).
     if (resolved.url.pathname === "/api/v1/chain/idle-stake") {
       return withEdgeCache(request, ctx, env, "chain-idle-stake", () =>
-        handleChainIdleStake(request, env, resolved.url),
+        handleChainIdleStake(request, env),
       );
     }
     // GET /api/v1/chain/identity-history: network-wide recent subnet-identity-change
@@ -5955,7 +5943,7 @@ export async function handleRequest(
     // the cache window, so a reader always sees a recent-but-cheap answer.
     if (resolved.url.pathname === "/api/v1/self-health") {
       return withEdgeCache(request, ctx, env, "self-health", () =>
-        handleSelfHealth(request, env, resolved.url),
+        handleSelfHealth(request, env),
       );
     }
     // GET /api/v1/chain/yield: network-wide emission-yield (return rate) aggregate
@@ -5963,7 +5951,7 @@ export async function handleRequest(
     // Postgres-tier route (like chain/performance, but the emission/stake return-rate lens).
     if (resolved.url.pathname === "/api/v1/chain/yield") {
       return withEdgeCache(request, ctx, env, "chain-yield", () =>
-        handleChainYield(request, env, resolved.url),
+        handleChainYield(request, env),
       );
     }
     // GET /api/v1/chain/turnover: network-wide validator-set churn across all subnets,

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -21,7 +21,7 @@ import {
   analyticsMeta,
   analyticsQueryError,
   markPostgresTierFallbackResponse,
-  validateQueryParams,
+  validateDeclaredQueryParams,
 } from "./analytics.ts";
 import {
   parseLimitParam,
@@ -266,8 +266,6 @@ export async function handleTrajectory(
   url: URL,
   ctx: EdgeCacheCtx = {},
 ): Promise<Response> {
-  const validationError = validateQueryParams(url, ["format"]);
-  if (validationError) return analyticsQueryError(validationError);
   const formatError = validateFormatParam(url);
   if (formatError) return analyticsQueryError(formatError);
   // #4832 gap-closure: reuses METAGRAPH_SUBNET_SNAPSHOTS_SOURCE, flipped to
@@ -329,8 +327,6 @@ export async function handleEconomicsTrends(
   url: URL,
   ctx: EdgeCacheCtx = {},
 ): Promise<Response> {
-  const validationError = validateQueryParams(url, ["window", "format"]);
-  if (validationError) return analyticsQueryError(validationError);
   const formatError = validateFormatParam(url);
   if (formatError) return analyticsQueryError(formatError);
   const windowResult = parseHistoryWindow(url.searchParams.get("window")) as
@@ -388,12 +384,6 @@ export async function handleUptime(
   url: URL,
   ctx: EdgeCacheCtx = {},
 ): Promise<Response> {
-  const validationError = validateQueryParams(url, [
-    "window",
-    "min_samples",
-    "format",
-  ]);
-  if (validationError) return analyticsQueryError(validationError);
   const formatError = validateFormatParam(url);
   if (formatError) return analyticsQueryError(formatError);
   const windowParam = url.searchParams.get("window") || "90d";
@@ -475,11 +465,7 @@ export function canonicalUptimeCachePath(
   url: URL,
   request: Request | null = null,
 ): string {
-  const validationError = validateQueryParams(url, [
-    "window",
-    "min_samples",
-    "format",
-  ]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const formatError = validateFormatParam(url);
   if (formatError) return `${url.pathname}${url.search}`;
@@ -512,7 +498,7 @@ export function canonicalEconomicsTrendsCachePath(
   url: URL,
   request: Request | null = null,
 ): string {
-  const validationError = validateQueryParams(url, ["window", "format"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const formatError = validateFormatParam(url);
   if (formatError) return `${url.pathname}${url.search}`;
@@ -531,7 +517,7 @@ export function canonicalTrajectoryCachePath(
   url: URL,
   request: Request | null = null,
 ): string {
-  const validationError = validateQueryParams(url, ["format"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const formatError = validateFormatParam(url);
   if (formatError) return `${url.pathname}${url.search}`;
@@ -542,7 +528,7 @@ export function canonicalTrajectoryCachePath(
 // ?limit=20 request both resolve to the same edge-cache entry — mirrors
 // canonicalCompareCachePath and canonicalUptimeCachePath.
 export function canonicalLeaderboardsCachePath(url: URL): string {
-  const validationError = validateQueryParams(url, ["board", "limit"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const limitResult = parseLimitParam(url, { defaultLimit: 20, maxLimit: 100 });
   if ("error" in limitResult) {
@@ -690,8 +676,6 @@ export async function handleLeaderboards(
   env: Env,
   url: URL,
 ): Promise<Response> {
-  const validationError = validateQueryParams(url, ["board", "limit"]);
-  if (validationError) return analyticsQueryError(validationError);
   const requestedBoard = url.searchParams.get("board");
   if (requestedBoard && !LEADERBOARD_BOARDS.includes(requestedBoard)) {
     return errorResponse(
@@ -730,7 +714,7 @@ export async function handleLeaderboards(
 }
 
 export function canonicalCompareCachePath(url: URL): string | null {
-  if (validateQueryParams(url, ["netuids", "dimensions"])) return null;
+  if (validateDeclaredQueryParams(url)) return null;
   const requestedNetuids = parseCompareNetuids(url.searchParams.get("netuids"));
   if (!requestedNetuids) return null;
   const dimensions = parseCompareDimensions(url.searchParams.get("dimensions"));
@@ -863,9 +847,6 @@ export async function handleCompare(
   env: Env,
   url: URL,
 ): Promise<Response> {
-  const validationError = validateQueryParams(url, ["netuids", "dimensions"]);
-  if (validationError) return analyticsQueryError(validationError);
-
   const netuidsRaw = url.searchParams.get("netuids");
   const requestedNetuids = parseCompareNetuids(netuidsRaw);
   if (!requestedNetuids) {
@@ -1008,10 +989,6 @@ export async function handleDomains(
   request: Request,
   env: Env,
 ): Promise<Response> {
-  const url = new URL(request.url);
-  const validationError = validateQueryParams(url, []);
-  if (validationError) return analyticsQueryError(validationError);
-
   const { subnetRows, economicsRows, capturedAt } =
     await domainSummaryInputs(env);
   const data = buildDomainOverview(
@@ -1046,9 +1023,6 @@ export async function handleDomainSummary(
   env: Env,
   tag: string,
 ): Promise<Response> {
-  const url = new URL(request.url);
-  const validationError = validateQueryParams(url, []);
-  if (validationError) return analyticsQueryError(validationError);
   if (!DOMAIN_TAGS.includes(tag)) {
     return errorResponse(
       "invalid_request",
@@ -1106,9 +1080,6 @@ export async function handleCompareValidators(
   env: Env,
   url: URL,
 ): Promise<Response> {
-  const validationError = validateQueryParams(url, ["hotkeys", "netuid"]);
-  if (validationError) return analyticsQueryError(validationError);
-
   const hotkeysRaw = url.searchParams.get("hotkeys");
   const hotkeys = parseCompareHotkeys(hotkeysRaw);
   if (!hotkeys) {
@@ -1182,14 +1153,6 @@ export async function handleEmissionPipeline(
   env: Env,
   url: URL,
 ): Promise<Response> {
-  const validationError = validateQueryParams(url, [
-    "netuid",
-    "sort",
-    "order",
-    "limit",
-    "fields",
-  ]);
-  if (validationError) return analyticsQueryError(validationError);
   const netuidResult = parseNetuidParam(url.searchParams.get("netuid"));
   if ("error" in netuidResult) return analyticsQueryError(netuidResult.error);
 

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -43,7 +43,7 @@ import { HEALTH_TREND_WINDOW_VALUES } from "../../schemas-src/routes/health-surf
 import { loadChainServingColdTier } from "../../src/chain-serving-loader.ts";
 import { loadChainWeightsColdTier } from "../../src/chain-weights-loader.ts";
 import { loadChainWeightSettersColdTier } from "../../src/chain-weight-setters-loader.ts";
-import { API_ROUTES } from "../../src/contracts.ts";
+import { API_ROUTES, contractPathForPathname } from "../../src/contracts.ts";
 import { registerModuleStateReset } from "../../src/module-state-registry.ts";
 import { errorResponse, ifNoneMatchSatisfied } from "../http.ts";
 import { csvRequested, csvResponse } from "../csv.ts";
@@ -64,7 +64,6 @@ import {
 import { formatGlobalIncidents } from "../../src/health-serving.ts";
 import {
   applyQueryFilters,
-  listQueryParamNames,
   paginationLinkHeader,
   type Pagination,
   type QueryError,
@@ -221,13 +220,12 @@ export function configureAnalytics(deps: {
 
 /**
  * The declared query-parameter names for a route path, straight off the
- * contract (#9149).
+ * contract (#9149, completed by #10065).
  *
- * The 33 handlers that call `validateQueryParams` pass a hand-written array,
- * which is a second copy of a list the contract already publishes -- the same
- * "one fact, several declarations" shape as #9127 and #9131. Deriving it means
- * a parameter added to `API_ROUTES` is accepted the day it lands, and one
- * removed stops being accepted, with no array to keep in step.
+ * Returns `[]` for a route that declares no query parameters — "this route
+ * accepts none" is a statement the contract makes, not an absence of one — and
+ * `null` only when the path matches no route at all, where this module has no
+ * opinion to enforce.
  */
 export function declaredQueryParams(routePath: string): string[] | null {
   const route = (
@@ -237,17 +235,10 @@ export function declaredQueryParams(routePath: string): string[] | null {
       query_parameters?: { name: string }[];
     }[]
   ).find((entry) => entry.path === routePath && entry.method === "GET");
-  if (!route?.query_parameters?.length) return null;
-  return route.query_parameters.map((parameter) => parameter.name);
+  if (!route) return null;
+  return (route.query_parameters ?? []).map((parameter) => parameter.name);
 }
 
-/**
- * Reject a request carrying a parameter the route does not declare.
- *
- * Returns null when the route declares no query parameters at all -- there is
- * nothing to typo, and treating "declares nothing" as "allows nothing" would
- * start 400ing cache-busting params on 44 param-less detail routes for no gain.
- */
 /**
  * Parameters accepted on every route regardless of what it declares.
  *
@@ -260,16 +251,40 @@ export function declaredQueryParams(routePath: string): string[] | null {
  * FILTER, and format is not one.
  *
  * A declared judgement rather than a derived fact, so it is deliberately a set
- * of exactly one: anything added here stops being typo-checked everywhere.
+ * of exactly one: anything added here stops being typo-checked everywhere. It
+ * is a RULE, not a per-route list -- it does not grow when a route is added.
  */
 const GLOBALLY_ACCEPTED_PARAMS = ["format"];
 
-export function validateDeclaredQueryParams(
-  url: URL,
-  routePath: string,
-): QueryError | null {
+/**
+ * Reject a request carrying a parameter its route does not declare.
+ *
+ * THE query-parameter allowlist for the whole API. #9149 built this and wired
+ * it at one call site; 119 handlers went on passing a hand-written array to
+ * `validateQueryParams` — a fifth statement of the query contract, after the
+ * Zod schema, openapi.json, the MCP tool input and the GraphQL argument list.
+ *
+ * A fifth copy drifts like any other, and it did. Sweeping all 202 GET routes
+ * through the real router found three parameters a handler accepted and
+ * honoured that the contract never published:
+ *
+ *   /api/v1/validators/{hotkey}/history   netuid  (echoed back as data.netuid)
+ *   /api/v1/accounts/{ss58}/history       cursor  (forwarded to the cold tier)
+ *   /api/v1/subnets/{netuid}/events       cursor
+ *
+ * Undiscoverable by construction: the published contract said passing them was
+ * an error. All three are declared now, and deriving the allowlist means the
+ * next one cannot happen — a parameter is accepted exactly when it is
+ * published, in one direction, from one place.
+ *
+ * The route is resolved from the pathname through `contractPathForPathname`,
+ * so a handler needs to know nothing about its own contract entry.
+ */
+export function validateDeclaredQueryParams(url: URL): QueryError | null {
+  const routePath = contractPathForPathname(url.pathname);
+  if (routePath === null) return null;
   const allowed = declaredQueryParams(routePath);
-  if (!allowed) return null;
+  if (allowed === null) return null;
   return validateQueryParams(url, [...allowed, ...GLOBALLY_ACCEPTED_PARAMS]);
 }
 
@@ -336,11 +351,8 @@ function canonicalAnalyticsCacheRoute(
 // ParamError-style returns elsewhere (workers/request-params.ts).
 type WindowResult = { label: string; days: number } | { error: QueryError };
 
-function analyticsWindow(url: URL, extraParams: string[] = []): WindowResult {
-  const validationError = validateQueryParams(url, [
-    ANALYTICS_WINDOW_PARAM,
-    ...extraParams,
-  ]);
+function analyticsWindow(url: URL): WindowResult {
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return { error: validationError };
 
   const requested = url.searchParams.get(ANALYTICS_WINDOW_PARAM);
@@ -367,7 +379,7 @@ function analyticsWindow(url: URL, extraParams: string[] = []): WindowResult {
 // explicit ?window=7d request both resolve to the same edge-cache entry — mirrors
 // canonicalEconomicsTrendsCachePath in analytics-routes.ts.
 export function canonicalHealthWindowCachePath(url: URL): string {
-  const validationError = validateQueryParams(url, [ANALYTICS_WINDOW_PARAM]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const windowResult = analyticsWindow(url);
   if ("error" in windowResult) return `${url.pathname}${url.search}`;
@@ -794,7 +806,7 @@ export async function handleHealthTrends(
   // Reject unsupported query params (400) like every sibling analytics route
   // (percentiles/incidents/uptime/trajectory and the bulk trends route); this
   // route takes no params and returns all configured windows.
-  const validationError = validateQueryParams(url, []);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return analyticsQueryError(validationError);
   return withEdgeCache(request, ctx, env, "trends", async (cacheRequest) => {
     // See handleBulkHealthTrends' own comment on METAGRAPH_HEALTH_SOURCE.
@@ -1079,14 +1091,13 @@ export async function resolveGlobalIncidentsForFeed(
 // The list-query params GET /api/v1/incidents accepts on top of its own `window`
 // scope (#6571): limit/cursor/sort/order + the netuid filter, so a caller can page
 // a 30-day incident list the way the sibling endpoint-incidents route already can.
-const GLOBAL_INCIDENTS_LIST_PARAMS = listQueryParamNames("incidents");
 
 export async function handleGlobalIncidents(
   request: Request,
   env: Env,
   url: URL,
 ): Promise<Response> {
-  const windowResult = analyticsWindow(url, GLOBAL_INCIDENTS_LIST_PARAMS);
+  const windowResult = analyticsWindow(url);
   if ("error" in windowResult) {
     return analyticsQueryError(windowResult.error);
   }
@@ -1320,7 +1331,7 @@ export async function handleChainActivity(
   /** Which chain's projection to serve (#9412). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
-  const windowResult = analyticsWindow(url, ["format"]);
+  const windowResult = analyticsWindow(url);
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
   const { label, days: windowDays } = windowResult;
   const formatError = validateFormatParam(url);
@@ -1403,12 +1414,7 @@ export async function handleChainCalls(
   /** Which chain's projection to serve (#9412). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
-  const windowResult = analyticsWindow(url, [
-    "group_by",
-    "limit",
-    "call_module",
-    "format",
-  ]);
+  const windowResult = analyticsWindow(url);
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
   const { label } = windowResult;
   const formatError = validateFormatParam(url);
@@ -1518,12 +1524,7 @@ export async function handleChainSigners(
   /** Which chain's projection to serve (#9412). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
-  const windowResult = analyticsWindow(url, [
-    "limit",
-    "call_module",
-    "sort",
-    "format",
-  ]);
+  const windowResult = analyticsWindow(url);
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
   const { label } = windowResult;
   const formatError = validateFormatParam(url);
@@ -1621,7 +1622,7 @@ export async function handleChainTransfers(
   /** Which chain's projection to serve (#9412). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
-  const windowResult = analyticsWindow(url, ["limit", "format"]);
+  const windowResult = analyticsWindow(url);
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
   const { label } = windowResult;
   const formatError = validateFormatParam(url);
@@ -1727,7 +1728,7 @@ export async function handleChainTransferPairs(
   /** Which chain's projection to serve (#9412). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
-  const windowResult = analyticsWindow(url, ["limit", "sort", "format"]);
+  const windowResult = analyticsWindow(url);
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
   const { label } = windowResult;
   const sortError = validateEnumParam(url, "sort", CHAIN_TRANSFER_PAIR_SORTS);
@@ -1831,7 +1832,7 @@ export async function handleChainStakeFlow(
   /** Which chain's projection to serve (#9412). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
-  const windowResult = analyticsWindow(url, ["limit", "format"]);
+  const windowResult = analyticsWindow(url);
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
   const { label } = windowResult;
   const formatError = validateFormatParam(url);
@@ -1942,7 +1943,7 @@ export async function handleChainAlphaVolume(
   /** Which chain's projection to serve (#9412). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
-  const validationError = validateQueryParams(url, ["limit", "format"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return analyticsQueryError(validationError);
   const formatError = validateFormatParam(url);
   if (formatError) return analyticsQueryError(formatError);
@@ -2033,7 +2034,7 @@ export async function handleChainWeights(
   url: URL,
   ctx: EdgeCacheCtx = {},
 ): Promise<Response> {
-  const windowResult = analyticsWindow(url, ["limit", "format"]);
+  const windowResult = analyticsWindow(url);
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
   const { label } = windowResult;
   const formatError = validateFormatParam(url);
@@ -2121,7 +2122,7 @@ export async function handleChainWeightSetters(
   url: URL,
   ctx: EdgeCacheCtx = {},
 ): Promise<Response> {
-  const windowResult = analyticsWindow(url, ["limit", "format"]);
+  const windowResult = analyticsWindow(url);
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
   const { label } = windowResult;
   const formatError = validateFormatParam(url);
@@ -2203,7 +2204,7 @@ export async function handleChainServing(
   url: URL,
   ctx: EdgeCacheCtx = {},
 ): Promise<Response> {
-  const windowResult = analyticsWindow(url, ["limit", "format"]);
+  const windowResult = analyticsWindow(url);
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
   const { label } = windowResult;
   const formatError = validateFormatParam(url);
@@ -2291,7 +2292,7 @@ export async function handleChainPrometheus(
   url: URL,
   ctx: EdgeCacheCtx = {},
 ): Promise<Response> {
-  const windowResult = analyticsWindow(url, ["limit", "format"]);
+  const windowResult = analyticsWindow(url);
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
   const { label } = windowResult;
   const formatError = validateFormatParam(url);
@@ -2371,7 +2372,7 @@ export async function handleChainAxonRemovals(
   url: URL,
   ctx: EdgeCacheCtx = {},
 ): Promise<Response> {
-  const windowResult = analyticsWindow(url, ["limit", "format"]);
+  const windowResult = analyticsWindow(url);
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
   const { label } = windowResult;
   const formatError = validateFormatParam(url);
@@ -2452,7 +2453,7 @@ export async function handleChainRegistrations(
   /** Which chain's projection to serve (#9412). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
-  const windowResult = analyticsWindow(url, ["limit", "format"]);
+  const windowResult = analyticsWindow(url);
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
   const { label } = windowResult;
   const formatError = validateFormatParam(url);
@@ -2550,7 +2551,7 @@ export async function handleChainDeregistrations(
   /** Which chain's projection to serve (#9412). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
-  const windowResult = analyticsWindow(url, ["limit", "format"]);
+  const windowResult = analyticsWindow(url);
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
   const { label } = windowResult;
   const formatError = validateFormatParam(url);
@@ -2649,7 +2650,7 @@ export async function handleChainStakeMoves(
   /** Which chain's projection to serve (#9412). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
-  const windowResult = analyticsWindow(url, ["limit", "format"]);
+  const windowResult = analyticsWindow(url);
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
   const { label } = windowResult;
   const formatError = validateFormatParam(url);
@@ -2742,7 +2743,7 @@ export async function handleChainStakeTransfers(
   /** Which chain's projection to serve (#9412). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
-  const windowResult = analyticsWindow(url, ["limit", "format"]);
+  const windowResult = analyticsWindow(url);
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
   const { label } = windowResult;
   const formatError = validateFormatParam(url);
@@ -2832,7 +2833,7 @@ export async function handleChainFees(
   /** Which chain's projection to serve (#9412). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
-  const windowResult = analyticsWindow(url, ["limit", "call_module", "format"]);
+  const windowResult = analyticsWindow(url);
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
   const { label, days: windowDays } = windowResult;
   const formatError = validateFormatParam(url);

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -60,7 +60,7 @@ import {
   analyticsQueryError,
   markPostgresTierFallbackResponse,
   validateMaxLength,
-  validateQueryParams,
+  validateDeclaredQueryParams,
 } from "./analytics.ts";
 import { CHAIN_CALL_MODULE_MAX_LENGTH } from "../../src/route-limits.ts";
 import type { QueryError } from "../list-query.ts";
@@ -797,12 +797,6 @@ function validateResponseFormat(url: URL) {
   };
 }
 
-function validateEntityQuery(url: URL, allowedParams: string[]) {
-  const validationError = validateQueryParams(url, allowedParams);
-  if (validationError) return validationError;
-  return validateResponseFormat(url);
-}
-
 function csvCacheVariant(
   url: URL,
   request: Request | null,
@@ -895,11 +889,7 @@ export async function handleSubnetMetagraph(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "validator_permit",
-    "format",
-    "fields",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   // #10096: the published enum is ["true"] -- a PRESENCE flag, because the
   // only thing this filter can do is narrow to permitted neurons. It was not
@@ -973,7 +963,7 @@ export async function handleSubnetYield(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, ["format"]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const data =
     ((await tryPostgresTier(
@@ -1012,7 +1002,7 @@ export async function handleNeuron(
   uid: number,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, ["fields"]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const projection = parseNeuronFields(url.searchParams, "neuron");
   if (projection.error) return analyticsQueryError(projection.error);
@@ -1058,10 +1048,7 @@ export async function handleSubnetHyperparams(
   request: Request,
   env: Env,
   netuid: number,
-  url: URL,
 ) {
-  const validationError = validateQueryParams(url, []);
-  if (validationError) return analyticsQueryError(validationError);
   const data =
     ((await tryPostgresTier(
       env,
@@ -1104,12 +1091,7 @@ export async function handleSubnetHyperparamsHistory(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "limit",
-    "offset",
-    "cursor",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const page = parsePagination(url, FEED_PAGINATION);
   if ("error" in page) return analyticsQueryError(page.error);
@@ -1165,7 +1147,7 @@ export async function handleSubnetValidators(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, ["format", "fields"]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const projection = parseNeuronFields(url.searchParams, "validators");
   if (projection.error) return analyticsQueryError(projection.error);
@@ -1216,7 +1198,7 @@ export async function handleSubnetValidators(
 function parseGlobalValidatorsQuery(
   url: URL,
 ): { sort: string; limit: number } | { error: QueryError } {
-  const validationError = validateEntityQuery(url, ["sort", "limit", "format"]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return { error: validationError };
 
   const sort = url.searchParams.get("sort") || DEFAULT_GLOBAL_VALIDATOR_SORT;
@@ -1318,7 +1300,7 @@ export async function handleGlobalValidators(
 function parseAccountsListQuery(
   url: URL,
 ): { sort: string; limit: number } | { error: QueryError } {
-  const validationError = validateEntityQuery(url, ["sort", "limit", "format"]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return { error: validationError };
 
   const sort = url.searchParams.get("sort") || DEFAULT_ACCOUNTS_LIST_SORT;
@@ -1407,7 +1389,7 @@ export async function handleAccountsList(request: Request, env: Env, url: URL) {
 function parseTopHoldersQuery(
   url: URL,
 ): { sort: string; limit: number } | { error: QueryError } {
-  const validationError = validateEntityQuery(url, ["sort", "limit", "format"]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return { error: validationError };
 
   const sort = url.searchParams.get("sort") || DEFAULT_TOP_HOLDERS_SORT;
@@ -1547,15 +1529,7 @@ export async function handleValidatorNominators(
   hotkey: string,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "basis",
-    "window",
-    "sort",
-    "limit",
-    "offset",
-    "coldkey",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
 
   // #9617: `basis` selects WHICH QUESTION is answered, not how well. `flow`
@@ -1712,8 +1686,6 @@ export async function handleValidatorHistory(
   hotkey: string,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window", "netuid"]);
-  if (validationError) return analyticsQueryError(validationError);
   const labelResult = parseHistoryWindow(url.searchParams.get("window"));
   if ("error" in labelResult) return analyticsQueryError(labelResult.error);
   const { label } = labelResult;
@@ -1762,8 +1734,6 @@ export async function handleNeuronHistory(
   uid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
   const labelResult = parseHistoryWindow(url.searchParams.get("window"));
   if ("error" in labelResult) return analyticsQueryError(labelResult.error);
   const { label } = labelResult;
@@ -1802,8 +1772,6 @@ export async function handleSubnetHistory(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
   const labelResult = parseHistoryWindow(url.searchParams.get("window"));
   if ("error" in labelResult) return analyticsQueryError(labelResult.error);
   const { label } = labelResult;
@@ -1840,12 +1808,7 @@ export async function handleSubnetIdentityHistory(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "limit",
-    "offset",
-    "cursor",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const page = parsePagination(url, FEED_PAGINATION);
   if ("error" in page) return analyticsQueryError(page.error);
@@ -1902,10 +1865,7 @@ export async function handleSubnetConcentration(
   request: Request,
   env: Env,
   netuid: number,
-  url: URL,
 ) {
-  const validationError = validateQueryParams(url, []);
-  if (validationError) return analyticsQueryError(validationError);
   const data =
     ((await tryPostgresTier(
       env,
@@ -1938,10 +1898,7 @@ export async function handleSubnetPerformance(
   request: Request,
   env: Env,
   netuid: number,
-  url: URL,
 ) {
-  const validationError = validateQueryParams(url, []);
-  if (validationError) return analyticsQueryError(validationError);
   const data =
     ((await tryPostgresTier(
       env,
@@ -1968,13 +1925,7 @@ export async function handleSubnetPerformance(
 // but the entity lenses collapse an operator's hotkeys ACROSS subnets, so this is
 // the true network-level control distribution. neurons-tier (source
 // "metagraph-snapshot"), no params. Cold/absent store → schema-stable empties.
-export async function handleChainConcentration(
-  request: Request,
-  env: Env,
-  url: URL,
-) {
-  const validationError = validateQueryParams(url, []);
-  if (validationError) return analyticsQueryError(validationError);
+export async function handleChainConcentration(request: Request, env: Env) {
   const data =
     ((await tryPostgresTier(
       env,
@@ -2008,13 +1959,6 @@ export async function handleChainConcentrationSubnets(
   env: Env,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, [
-    "lens",
-    "sort",
-    "order",
-    "limit",
-  ]);
-  if (validationError) return analyticsQueryError(validationError);
   // Rejected HERE, before the tier read, so a bad parameter costs a 400 rather
   // than a ~30,000-row scan. The data-api side parses with this same function.
   const query = parseConcentrationRankingQuery(url.searchParams, {
@@ -2054,13 +1998,7 @@ export async function handleChainConcentrationSubnets(
 // validators, plus the p10–p90 spread of the 0–1 trust/consensus/validator_trust
 // scores, computed live from the neurons D1 tier. The reward-flow companion to
 // /chain/concentration. No params; a cold/absent store → 200 with null blocks.
-export async function handleChainPerformance(
-  request: Request,
-  env: Env,
-  url: URL,
-) {
-  const validationError = validateQueryParams(url, []);
-  if (validationError) return analyticsQueryError(validationError);
+export async function handleChainPerformance(request: Request, env: Env) {
   const data =
     ((await tryPostgresTier(
       env,
@@ -2093,10 +2031,7 @@ export async function handleSubnetIdleStake(
   request: Request,
   env: Env,
   netuid: number,
-  url: URL,
 ) {
-  const validationError = validateQueryParams(url, []);
-  if (validationError) return analyticsQueryError(validationError);
   const data =
     ((await tryPostgresTier(
       env,
@@ -2122,13 +2057,7 @@ export async function handleSubnetIdleStake(
 // route above -- every subnet's own idle-stake scorecard ranked by
 // idle_stake_tao descending, plus the network total. No params; a
 // cold/absent store -> 200 with an empty ranking.
-export async function handleChainIdleStake(
-  request: Request,
-  env: Env,
-  url: URL,
-) {
-  const validationError = validateQueryParams(url, []);
-  if (validationError) return analyticsQueryError(validationError);
+export async function handleChainIdleStake(request: Request, env: Env) {
   const data =
     ((await tryPostgresTier(
       env,
@@ -2161,8 +2090,6 @@ export async function handleChainIdentityHistory(
   env: Env,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["limit"]);
-  if (validationError) return analyticsQueryError(validationError);
   const limitResult = parseLimitParam(url, {
     defaultLimit: CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
     maxLimit: CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
@@ -2213,9 +2140,7 @@ export async function handleChainIdentityHistory(
 // components, current_ok null, verdict "degraded") rather than a 404 -- the
 // same convention as every sibling Postgres-tier route, and the right answer
 // besides: "we have no readings" is a real state, not a missing resource.
-export async function handleSelfHealth(request: Request, env: Env, url: URL) {
-  const validationError = validateQueryParams(url, []);
-  if (validationError) return analyticsQueryError(validationError);
+export async function handleSelfHealth(request: Request, env: Env) {
   const data =
     ((await tryPostgresTier(
       env,
@@ -2261,9 +2186,7 @@ export async function handleSelfHealth(request: Request, env: Env, url: URL) {
 // per-neuron emission/stake return, computed live from the neurons D1 tier. The
 // return-rate companion to /chain/performance. No params; a cold/absent store →
 // 200 with null blocks.
-export async function handleChainYield(request: Request, env: Env, url: URL) {
-  const validationError = validateQueryParams(url, []);
-  if (validationError) return analyticsQueryError(validationError);
+export async function handleChainYield(request: Request, env: Env) {
   const data =
     ((await tryPostgresTier(
       env,
@@ -2289,7 +2212,7 @@ export async function handleChainYield(request: Request, env: Env, url: URL) {
 // and an explicit-default request share one cache slot; an invalid limit falls
 // through to the raw search so the handler surfaces the 400.
 export function canonicalChainIdentityHistoryCachePath(url: URL) {
-  const validationError = validateQueryParams(url, ["limit"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const limitResult = parseLimitParam(url, {
     defaultLimit: CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
@@ -2312,7 +2235,7 @@ function canonicalWindowedCachePath(
     | { label: string; error?: undefined }
     | { label?: undefined; error: QueryError },
 ) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const labelResult = parseWindow(url.searchParams.get("window"));
   if ("error" in labelResult) return `${url.pathname}${url.search}`;
@@ -2321,10 +2244,14 @@ function canonicalWindowedCachePath(
 }
 
 export function canonicalSubnetHistoryCachePath(url: URL) {
+  const undeclared = validateDeclaredQueryParams(url);
+  if (undeclared) return `${url.pathname}${url.search}`;
   return canonicalWindowedCachePath(url, parseHistoryWindow);
 }
 
 export function canonicalValidatorHistoryCachePath(url: URL) {
+  const undeclared = validateDeclaredQueryParams(url);
+  if (undeclared) return `${url.pathname}${url.search}`;
   return canonicalWindowedCachePath(url, parseHistoryWindow);
 }
 
@@ -2332,7 +2259,7 @@ export function canonicalSubnetConcentrationHistoryCachePath(
   url: URL,
   request: Request | null = null,
 ) {
-  const validationError = validateQueryParams(url, ["window", "format"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const formatError = validateResponseFormat(url);
   if (formatError) return `${url.pathname}${url.search}`;
@@ -2352,7 +2279,7 @@ export function canonicalSubnetPerformanceHistoryCachePath(
   url: URL,
   request: Request | null = null,
 ) {
-  const validationError = validateQueryParams(url, ["window", "format"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const formatError = validateResponseFormat(url);
   if (formatError) return `${url.pathname}${url.search}`;
@@ -2372,7 +2299,7 @@ export function canonicalSubnetYieldHistoryCachePath(
   url: URL,
   request: Request | null = null,
 ) {
-  const validationError = validateQueryParams(url, ["window", "format"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const formatError = validateResponseFormat(url);
   if (formatError) return `${url.pathname}${url.search}`;
@@ -2392,7 +2319,7 @@ export function canonicalSubnetYieldHistoryCachePath(
 // parseHistoryWindow). Distinct from canonicalSubnetConcentrationHistoryCachePath
 // which uses a different parse function (parseConcentrationHistoryWindow).
 export function canonicalSubnetTurnoverCachePath(url: URL) {
-  const validationError = validateQueryParams(url, ["window", "changes"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const labelResult = parseHistoryWindow(url.searchParams.get("window"));
   if ("error" in labelResult) return `${url.pathname}${url.search}`;
@@ -2409,7 +2336,7 @@ export function canonicalSubnetTurnoverCachePath(url: URL) {
 // STAKE_FLOW_WINDOWS) and ?direction= (all|in|out) change the response; omitted
 // window/direction and their explicit defaults must share one cache slot.
 export function canonicalSubnetStakeFlowCachePath(url: URL) {
-  const validationError = validateQueryParams(url, ["window", "direction"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const windowParam =
     url.searchParams.get("window") || DEFAULT_STAKE_FLOW_WINDOW;
@@ -2433,12 +2360,9 @@ export function canonicalSubnetMoversCachePath(
   url: URL,
   request: Request | null = null,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "window",
-    "sort",
-    "limit",
-    "format",
-  ]);
+  const undeclared = validateDeclaredQueryParams(url);
+  if (undeclared) return `${url.pathname}${url.search}`;
+  const validationError = validateResponseFormat(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const windowParam = url.searchParams.get("window") || DEFAULT_MOVERS_WINDOW;
   if (!Object.hasOwn(MOVERS_WINDOWS, windowParam)) {
@@ -2468,11 +2392,9 @@ export function canonicalChainTurnoverCachePath(
   url: URL,
   request: Request | null = null,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "window",
-    "limit",
-    "format",
-  ]);
+  const undeclared = validateDeclaredQueryParams(url);
+  if (undeclared) return `${url.pathname}${url.search}`;
+  const validationError = validateResponseFormat(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const windowParam =
     url.searchParams.get("window") || DEFAULT_CHAIN_TURNOVER_WINDOW;
@@ -2501,11 +2423,7 @@ export async function handleChainTurnover(
   env: Env,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "window",
-    "limit",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const windowParam =
     url.searchParams.get("window") || DEFAULT_CHAIN_TURNOVER_WINDOW;
@@ -2567,10 +2485,9 @@ export function canonicalSubnetMetagraphCachePath(
   url: URL,
   request: Request | null = null,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "validator_permit",
-    "format",
-  ]);
+  const undeclared = validateDeclaredQueryParams(url);
+  if (undeclared) return `${url.pathname}${url.search}`;
+  const validationError = validateResponseFormat(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const validatorsOnly = url.searchParams.get("validator_permit") === "true";
   const canonicalPath = validatorsOnly
@@ -2585,7 +2502,9 @@ export function canonicalSubnetValidatorsCachePath(
   url: URL,
   request: Request | null = null,
 ) {
-  const validationError = validateEntityQuery(url, ["format"]);
+  const undeclared = validateDeclaredQueryParams(url);
+  if (undeclared) return `${url.pathname}${url.search}`;
+  const validationError = validateResponseFormat(url);
   if (validationError) return `${url.pathname}${url.search}`;
   return csvCacheVariant(url, request, url.pathname);
 }
@@ -2594,7 +2513,9 @@ export function canonicalSubnetYieldCachePath(
   url: URL,
   request: Request | null = null,
 ) {
-  const validationError = validateEntityQuery(url, ["format"]);
+  const undeclared = validateDeclaredQueryParams(url);
+  if (undeclared) return `${url.pathname}${url.search}`;
+  const validationError = validateResponseFormat(url);
   if (validationError) return `${url.pathname}${url.search}`;
   return csvCacheVariant(url, request, url.pathname);
 }
@@ -2611,8 +2532,6 @@ export async function handleSubnetConcentrationHistory(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window", "format"]);
-  if (validationError) return analyticsQueryError(validationError);
   const formatError = validateResponseFormat(url);
   if (formatError) return analyticsQueryError(formatError);
   const labelResult = parseConcentrationHistoryWindow(
@@ -2674,8 +2593,6 @@ export async function handleSubnetPerformanceHistory(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window", "format"]);
-  if (validationError) return analyticsQueryError(validationError);
   const formatError = validateResponseFormat(url);
   if (formatError) return analyticsQueryError(formatError);
   const labelResult = parseSubnetPerformanceHistoryWindow(
@@ -2737,8 +2654,6 @@ export async function handleSubnetYieldHistory(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window", "format"]);
-  if (validationError) return analyticsQueryError(validationError);
   const formatError = validateResponseFormat(url);
   if (formatError) return analyticsQueryError(formatError);
   const labelResult = parseSubnetYieldHistoryWindow(
@@ -2798,8 +2713,6 @@ export async function handleSubnetTurnover(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window", "changes"]);
-  if (validationError) return analyticsQueryError(validationError);
   const labelResult = parseHistoryWindow(url.searchParams.get("window"));
   if ("error" in labelResult) return analyticsQueryError(labelResult.error);
   const { label } = labelResult;
@@ -2840,7 +2753,7 @@ export async function handleSubnetTurnover(
 // Canonical edge-cache key for the subnet-weights route: only ?window= (7d/30d) changes the
 // response, canonicalized to its default when omitted so equivalent requests share a slot.
 export function canonicalSubnetWeightsCachePath(url: URL) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const windowParam =
     url.searchParams.get("window") || DEFAULT_SUBNET_WEIGHTS_WINDOW;
@@ -2860,8 +2773,6 @@ export async function handleSubnetWeights(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
   const windowParam =
     url.searchParams.get("window") || DEFAULT_SUBNET_WEIGHTS_WINDOW;
   if (!Object.hasOwn(SUBNET_WEIGHTS_WINDOWS, windowParam)) {
@@ -2908,7 +2819,7 @@ export async function handleSubnetWeights(
 // Canonical edge-cache key for the subnet-weight-setters route: only ?window= (7d/30d) changes
 // the response, canonicalized to its default when omitted so equivalent requests share a slot.
 export function canonicalSubnetWeightSettersCachePath(url: URL) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const windowParam =
     url.searchParams.get("window") || DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW;
@@ -2928,8 +2839,6 @@ export async function handleSubnetWeightSetters(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
   const windowParam =
     url.searchParams.get("window") || DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW;
   if (!Object.hasOwn(SUBNET_WEIGHT_SETTERS_WINDOWS, windowParam)) {
@@ -2978,7 +2887,7 @@ export async function handleSubnetWeightSetters(
 // Canonical edge-cache key for the subnet-serving route: only ?window= (7d/30d) changes the
 // response, canonicalized to its default when omitted so equivalent requests share a slot.
 export function canonicalSubnetServingCachePath(url: URL) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const windowParam =
     url.searchParams.get("window") || DEFAULT_SUBNET_SERVING_WINDOW;
@@ -2998,8 +2907,6 @@ export async function handleSubnetServing(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
   const windowParam =
     url.searchParams.get("window") || DEFAULT_SUBNET_SERVING_WINDOW;
   if (!Object.hasOwn(SUBNET_SERVING_WINDOWS, windowParam)) {
@@ -3047,7 +2954,7 @@ export async function handleSubnetServing(
 // Canonical edge-cache key for the subnet-prometheus route: only ?window= (7d/30d) changes the
 // response, canonicalized to its default when omitted so equivalent requests share a slot.
 export function canonicalSubnetPrometheusCachePath(url: URL) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const windowParam =
     url.searchParams.get("window") || DEFAULT_SUBNET_PROMETHEUS_WINDOW;
@@ -3068,8 +2975,6 @@ export async function handleSubnetPrometheus(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
   const windowParam =
     url.searchParams.get("window") || DEFAULT_SUBNET_PROMETHEUS_WINDOW;
   if (!Object.hasOwn(SUBNET_PROMETHEUS_WINDOWS, windowParam)) {
@@ -3104,7 +3009,7 @@ export async function handleSubnetPrometheus(
 // Canonical edge-cache key for the subnet-stake-moves route: only ?window= (7d/30d) changes the
 // response, canonicalized to its default when omitted so equivalent requests share a slot.
 export function canonicalSubnetStakeMovesCachePath(url: URL) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const windowParam =
     url.searchParams.get("window") || DEFAULT_SUBNET_STAKE_MOVES_WINDOW;
@@ -3125,8 +3030,6 @@ export async function handleSubnetStakeMoves(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
   const windowParam =
     url.searchParams.get("window") || DEFAULT_SUBNET_STAKE_MOVES_WINDOW;
   if (!Object.hasOwn(SUBNET_STAKE_MOVES_WINDOWS, windowParam)) {
@@ -3177,7 +3080,7 @@ export async function handleSubnetStakeMoves(
 // Canonical edge-cache key for the subnet-stake-transfers route: only ?window= (7d/30d) changes the
 // response, canonicalized to its default when omitted so equivalent requests share a slot.
 export function canonicalSubnetStakeTransfersCachePath(url: URL) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const windowParam =
     url.searchParams.get("window") || DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW;
@@ -3198,8 +3101,6 @@ export async function handleSubnetStakeTransfers(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
   const windowParam =
     url.searchParams.get("window") || DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW;
   if (!Object.hasOwn(SUBNET_STAKE_TRANSFERS_WINDOWS, windowParam)) {
@@ -3250,7 +3151,7 @@ export async function handleSubnetStakeTransfers(
 // Canonical edge-cache key for the subnet-registrations route: only ?window= (7d/30d) changes the
 // response, canonicalized to its default when omitted so equivalent requests share a slot.
 export function canonicalSubnetRegistrationsCachePath(url: URL) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const windowParam =
     url.searchParams.get("window") || DEFAULT_SUBNET_REGISTRATIONS_WINDOW;
@@ -3270,8 +3171,6 @@ export async function handleSubnetRegistrations(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
   const windowParam =
     url.searchParams.get("window") || DEFAULT_SUBNET_REGISTRATIONS_WINDOW;
   if (!Object.hasOwn(SUBNET_REGISTRATIONS_WINDOWS, windowParam)) {
@@ -3322,7 +3221,7 @@ export async function handleSubnetRegistrations(
 // Canonical edge-cache key for the subnet-axon-removals route: only ?window= (7d/30d) changes the
 // response, canonicalized to its default when omitted so equivalent requests share a slot.
 export function canonicalSubnetAxonRemovalsCachePath(url: URL) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const windowParam =
     url.searchParams.get("window") || DEFAULT_SUBNET_AXON_REMOVALS_WINDOW;
@@ -3342,8 +3241,6 @@ export async function handleSubnetAxonRemovals(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
   const windowParam =
     url.searchParams.get("window") || DEFAULT_SUBNET_AXON_REMOVALS_WINDOW;
   if (!Object.hasOwn(SUBNET_AXON_REMOVALS_WINDOWS, windowParam)) {
@@ -3381,7 +3278,7 @@ export async function handleSubnetAxonRemovals(
 // Canonical edge-cache key for the subnet-deregistrations route: only ?window= (7d/30d) changes the
 // response, canonicalized to its default when omitted so equivalent requests share a slot.
 export function canonicalSubnetDeregistrationsCachePath(url: URL) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateDeclaredQueryParams(url);
   if (validationError) return `${url.pathname}${url.search}`;
   const windowParam =
     url.searchParams.get("window") || DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW;
@@ -3401,8 +3298,6 @@ export async function handleSubnetDeregistrations(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
   const windowParam =
     url.searchParams.get("window") || DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW;
   if (!Object.hasOwn(SUBNET_DEREGISTRATIONS_WINDOWS, windowParam)) {
@@ -3459,8 +3354,6 @@ export async function handleSubnetStakeFlow(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window", "direction"]);
-  if (validationError) return analyticsQueryError(validationError);
   const windowParam =
     url.searchParams.get("window") || DEFAULT_STAKE_FLOW_WINDOW;
   if (!Object.hasOwn(STAKE_FLOW_WINDOWS, windowParam)) {
@@ -3595,7 +3488,7 @@ export async function handleSubnetStakeQuote(
   url: URL,
   ctx: { waitUntil?: (promise: Promise<unknown>) => void } = {},
 ) {
-  const validationError = validateEntityQuery(url, ["amount", "direction"]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   // A missing/empty `amount` coerces to 0, which computeStakeQuote rejects as
   // invalid_amount just like a non-numeric value — no separate null check.
@@ -3878,10 +3771,7 @@ export async function handleSubnetValidatorEconomics(
   request: Request,
   env: Env,
   netuid: number,
-  url: URL,
 ) {
-  const validationError = validateQueryParams(url, []);
-  if (validationError) return analyticsQueryError(validationError);
   if (!isU16Netuid(netuid)) {
     return errorResponse(
       "invalid_netuid",
@@ -4053,7 +3943,7 @@ export async function handleSubnetValidatorEconomicsHistory(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, ["window"]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   if (!isU16Netuid(netuid)) {
     return errorResponse(
@@ -4293,13 +4183,7 @@ export async function handleValidatorEconomicsRanking(
   env: Env,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "sort",
-    "limit",
-    "offset",
-    "emission_gate_open",
-    "cap_binding",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
 
   const sortParam = url.searchParams.get("sort");
@@ -4363,10 +4247,7 @@ export async function handleSubnetAlphaVolume(
   request: Request,
   env: Env,
   netuid: number,
-  url: URL,
 ) {
-  const validationError = validateQueryParams(url, []);
-  if (validationError) return analyticsQueryError(validationError);
   const marketCapTao = await resolveSubnetMarketCapTao(env, netuid);
   const { data, generatedAt } = ((await tryPostgresTier(
     env,
@@ -4420,8 +4301,6 @@ export async function handleSubnetOhlc(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["interval", "days"]);
-  if (validationError) return analyticsQueryError(validationError);
   const intervalParam = url.searchParams.get("interval");
   if (intervalParam !== null && !Object.hasOwn(OHLC_INTERVALS, intervalParam)) {
     return analyticsQueryError({
@@ -4477,12 +4356,7 @@ export async function handleSubnetOhlc(
 // snapshot_date read). Cold/absent or single-snapshot store → 200 with movers:[]
 // (schema-stable, never 404), mirroring the sibling history/turnover routes.
 export async function handleSubnetMovers(request: Request, env: Env, url: URL) {
-  const validationError = validateEntityQuery(url, [
-    "window",
-    "sort",
-    "limit",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const windowParam = url.searchParams.get("window") || DEFAULT_MOVERS_WINDOW;
   if (!Object.hasOwn(MOVERS_WINDOWS, windowParam)) {
@@ -4587,8 +4461,6 @@ export async function handleAccountStakeFlow(
   ss58: string,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window", "direction"]);
-  if (validationError) return analyticsQueryError(validationError);
   const windowParam =
     url.searchParams.get("window") || DEFAULT_STAKE_FLOW_WINDOW;
   if (!Object.hasOwn(STAKE_FLOW_WINDOWS, windowParam)) {
@@ -4678,8 +4550,6 @@ function makeAccountEventHandler({
     ss58: string,
     url: URL,
   ) {
-    const validationError = validateQueryParams(url, ["window"]);
-    if (validationError) return analyticsQueryError(validationError);
     const windowParam = url.searchParams.get("window") || defaultWindow;
     if (!Object.hasOwn(windows, windowParam)) {
       return analyticsQueryError({
@@ -4928,16 +4798,7 @@ export async function handleAccountEvents(
   /** Which chain's history to read (#8700). */
   network?: ChainNetworkId,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "kind",
-    "netuid",
-    "block_start",
-    "block_end",
-    "limit",
-    "offset",
-    "cursor",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   // Optional block-height range filter, parity with the extrinsics and
   // chain-events feeds. Index-satisfiable via idx_account_events_hotkey and
@@ -5040,15 +4901,7 @@ export async function handleAccountHistory(
   ss58: string,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "netuid",
-    "from",
-    "to",
-    "limit",
-    "offset",
-    "cursor",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const range = parseDateRange(url);
   if ("error" in range) return analyticsQueryError(range.error);
@@ -5161,14 +5014,7 @@ export async function handleAccountExtrinsics(
   ss58: string,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "block_start",
-    "block_end",
-    "limit",
-    "offset",
-    "cursor",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const blockStart = parseNonNegativeIntParam(
     url.searchParams.get("block_start"),
@@ -5245,15 +5091,7 @@ export async function handleAccountTransfers(
   ss58: string,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "direction",
-    "block_start",
-    "block_end",
-    "limit",
-    "offset",
-    "cursor",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const direction = url.searchParams.get("direction");
   if (
@@ -5339,11 +5177,7 @@ export async function handleAccountCounterparties(
   ss58: string,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "counterparty",
-    "limit",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const counterparty = url.searchParams.get("counterparty");
   const parsedLimit = parseBoundedIntParam(url, "limit", {
@@ -5570,8 +5404,6 @@ export async function handleAccountPositionHistory(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
   const labelResult = parseHistoryWindow(url.searchParams.get("window"));
   if ("error" in labelResult) return analyticsQueryError(labelResult.error);
   const { label } = labelResult;
@@ -5615,10 +5447,7 @@ export async function handleAccountIdentity(
   request: Request,
   env: Env,
   ss58: string,
-  url: URL,
 ) {
-  const validationError = validateQueryParams(url, []);
-  if (validationError) return analyticsQueryError(validationError);
   const data =
     ((await tryPostgresTier(
       env,
@@ -5655,12 +5484,7 @@ export async function handleAccountIdentityHistory(
   ss58: string,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "limit",
-    "offset",
-    "cursor",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const page = parsePagination(url, FEED_PAGINATION);
   if ("error" in page) return analyticsQueryError(page.error);
@@ -5717,15 +5541,7 @@ export async function handleSubnetEvents(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "kind",
-    "block_start",
-    "block_end",
-    "limit",
-    "offset",
-    "cursor",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const kind = url.searchParams.get("kind");
   // Reject an unknown ?kind= up front, validated against the FULL ingested set
@@ -5817,8 +5633,6 @@ export async function handleSubnetEventSummary(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window", "limit"]);
-  if (validationError) return analyticsQueryError(validationError);
   const windowLabel =
     url.searchParams.get("window") ?? DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW;
   if (
@@ -6172,8 +5986,6 @@ export async function handleSubnetBurnHistory(
       400,
     );
   }
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
   const label = url.searchParams.get("window") ?? DEFAULT_BURN_HISTORY_WINDOW;
   const windowDays = BURN_HISTORY_WINDOWS[label];
   if (windowDays === undefined) {
@@ -6226,7 +6038,7 @@ export async function handleSubnetHolders(
       400,
     );
   }
-  const validationError = validateEntityQuery(url, ["limit", "format"]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const limit = parseBoundedIntParam(url, "limit", {
     def: SUBNET_HOLDERS_LIMIT_DEFAULT,
@@ -6257,11 +6069,6 @@ export async function handleSubnetHolders(
 // A null price is a stated outcome (`price_basis: insufficient_pools`), not a
 // gap -- see src/tao-usd-series.ts for why this must never coalesce it.
 export async function handleTaoUsd(request: Request, env: Env, url: URL) {
-  const validationError = validateQueryParams(url, [
-    "window",
-    "include_points",
-  ]);
-  if (validationError) return analyticsQueryError(validationError);
   // #9720. The series is 1,428 points and ~143 KB on the default window, while
   // every summary a caller usually wants -- latest, change_usd, change_pct, the
   // two counts -- is a top-level scalar beside it. REST keeps sending the
@@ -6313,7 +6120,7 @@ export async function handleSubnetSurfaceHistory(
       400,
     );
   }
-  const validationError = validateEntityQuery(url, ["limit", "format"]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const limit = parseBoundedIntParam(url, "limit", {
     def: SURFACE_HISTORY_LIMIT_DEFAULT,
@@ -6348,7 +6155,7 @@ export async function handleEmissionChanges(
   env: Env,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, ["kind", "limit", "format"]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
 
   const kindParam = url.searchParams.get("kind");
@@ -6399,7 +6206,7 @@ export async function handleEmissionChanges(
 // subnet whose alpha sits on unregistered hotkeys is measured rather than
 // invisible.
 export async function handleChainHolders(request: Request, env: Env, url: URL) {
-  const validationError = validateEntityQuery(url, ["sort", "limit", "format"]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
 
   const sort = url.searchParams.get("sort") || DEFAULT_CHAIN_HOLDERS_SORT;
@@ -6439,12 +6246,7 @@ export async function handleFailureReasons(
   env: Env,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "window",
-    "netuid",
-    "kind",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
 
   const window =
@@ -6494,7 +6296,7 @@ export async function handleFailureReasons(
 // window, plus how far behind the lane is right now. Two different numbers; see
 // src/indexer-lag.ts for why they are named separately.
 export async function handleIndexerLag(request: Request, env: Env, url: URL) {
-  const validationError = validateEntityQuery(url, ["format"]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
 
   const row = await loadIndexerLag(
@@ -6521,7 +6323,7 @@ export async function handleChainConcentrationHistory(
   env: Env,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, ["window", "format"]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
 
   const window =
@@ -6565,7 +6367,7 @@ export async function handleSubnetPipelineHistory(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, ["window", "format"]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
 
   const window =
@@ -6730,7 +6532,7 @@ export async function handleCrowdloans(
   url: URL,
   network?: ChainNetworkId,
 ) {
-  const validationError = validateEntityQuery(url, []);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
 
   const limited = await crowdloanRateLimitResponse(
@@ -6760,7 +6562,7 @@ export async function handleCrowdloan(
   url: URL,
   network?: ChainNetworkId,
 ) {
-  const validationError = validateEntityQuery(url, []);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
 
   if (!isCrowdloanId(crowdloanId)) {
@@ -6798,20 +6600,7 @@ export async function handleBlocks(
   /** Which chain's history to read (#8700). */
   network?: ChainNetworkId,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "limit",
-    "offset",
-    "cursor",
-    "author",
-    "spec_version",
-    "from",
-    "to",
-    "block_start",
-    "block_end",
-    "min_extrinsics",
-    "min_events",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const page = parsePagination(url, BLOCK_PAGINATION);
   if ("error" in page) return analyticsQueryError(page.error);
@@ -6901,8 +6690,6 @@ export async function handleBlocksSummary(
   /** Which chain's projection to serve (#9412). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ) {
-  const validationError = validateQueryParams(url, []);
-  if (validationError) return analyticsQueryError(validationError);
   const pgData = await tryPostgresTier(env, request, "METAGRAPH_BLOCKS_SOURCE");
   // #9146: on a tier miss, serve the precomputed card from the blocks-summary
   // projection rather than a zeroed one. The reader declines (null) when it
@@ -7011,11 +6798,7 @@ export async function handleBlockExtrinsics(
   /** Which chain's history to read (#8700). */
   network?: ChainNetworkId,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "limit",
-    "offset",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const page = parsePagination(url, BLOCK_PAGINATION);
   if ("error" in page) return analyticsQueryError(page.error);
@@ -7090,11 +6873,7 @@ export async function handleBlockEvents(
   /** Which chain's history to read (#8700). */
   network?: ChainNetworkId,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "limit",
-    "offset",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const page = parsePagination(url, FEED_PAGINATION);
   if ("error" in page) return analyticsQueryError(page.error);
@@ -7170,22 +6949,7 @@ export async function handleExtrinsics(
   /** Which chain's history to read (#8700). */
   network?: ChainNetworkId,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "limit",
-    "offset",
-    "cursor",
-    "block",
-    "signer",
-    "call_module",
-    "call_function",
-    "call_hash",
-    "success",
-    "block_start",
-    "block_end",
-    "from",
-    "to",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   // The same cap the three chain-analytics feeds apply to `call_module`
   // (#10096). This route took the identical filter with no bound at all, so a
@@ -7298,19 +7062,7 @@ export async function handleExtrinsics(
 // signer/call_module query params (signer is always the current sudo key, see
 // GET /api/v1/sudo/key; call_module is fixed).
 export async function handleSudo(request: Request, env: Env, url: URL) {
-  const validationError = validateEntityQuery(url, [
-    "limit",
-    "offset",
-    "cursor",
-    "block",
-    "call_function",
-    "success",
-    "block_start",
-    "block_end",
-    "from",
-    "to",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const page = parsePagination(url, BLOCK_PAGINATION);
   if ("error" in page) return analyticsQueryError(page.error);
@@ -7391,19 +7143,7 @@ export async function handleGovernanceConfigChanges(
   env: Env,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, [
-    "limit",
-    "offset",
-    "cursor",
-    "block",
-    "call_function",
-    "success",
-    "block_start",
-    "block_end",
-    "from",
-    "to",
-    "format",
-  ]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const page = parsePagination(url, BLOCK_PAGINATION);
   if ("error" in page) return analyticsQueryError(page.error);
@@ -7492,7 +7232,7 @@ const RUNTIME_VERSIONS_CSV_COLUMNS = [
 // genesis to head, so coverage_from_block/coverage_gaps describe a complete
 // timeline rather than bounding a partial one.
 export async function handleRuntime(request: Request, env: Env, url: URL) {
-  const validationError = validateEntityQuery(url, ["format"]);
+  const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   // #4909 D1 retirement: blocks' D1 write path is retired (#4772) and the
   // table is dropped in production, so a D1 query here would always miss.


### PR DESCRIPTION
The query contract was stated **five times**: the Zod schema, `openapi.json`, the MCP tool input, the GraphQL argument list, and — the one that actually decides 400 vs 200 — a hand-written array passed to `validateQueryParams` / `validateEntityQuery` at **119 handler call sites**.

#9149 built the derived check and wired it at **one** site. The other 119 kept their arrays.

## Four parameters the API honoured and never published

Swept all 202 GET routes through the real router:

| route | parameter | evidence |
|---|---|---|
| `/validators/{hotkey}/history` | `netuid` | echoed back as `data.netuid` |
| `/accounts/{ss58}/history` | `cursor` | forwarded to the cold-tier loader |
| `/subnets/{netuid}/events` | `cursor` | accepted, not 400'd |
| `/search/semantic` | `type` | filters results; 400s an unknown value **by name** |

Undiscoverable by construction — the published contract said passing them was an error. All four are declared now.

## 119 arrays → one check

The arrays are deleted. One check in `handleRequest` answers for every GET route, resolving the pathname to its contract template via `contractPathForPathname` — derived from `API_ROUTES` through the existing `compileRoutePattern`, `/{network}/` twins included. **202 routes resolve to themselves, 0 mismatches.**

`declaredQueryParams` now answers `[]` for a route that declares none — *"this route takes no query parameters"* is a statement the contract makes — and `null` only for a path matching no route.

**Measured before changing anything: 118 routes enforced an allowlist, 59 enforced nothing.** With one check, all 202 do. Removing that single line lets **139 routes** accept an undeclared parameter again — which is exactly what the new dispatch-level test asserts.

55 per-handler *"rejects an unsupported query param"* tests are replaced by one that dispatches **every** route through `handleRequest`. They asserted the property one handler at a time while the rule lived in 119 places.

**Two behaviour changes, both corrections.** A repeated `?type=` on semantic search was silently halved — `?type=subnet&type=provider` answered the narrower question without saying so — and is now a 400. The 34 collection routes had their own wording for the same condition; there is one message now.

## The GraphQL mirror was worse

Its gate reported `105 type/route pairs, 787 fields, 0 divergences` and had since #9889. The real numbers are **160 and 1088** — the parser tried to skip multi-line argument lines with a single-line regex and did the opposite, so every argument was read as a field of `Query` and the field it belonged to vanished.

Two real divergences hid in that third:

```
GET  /api/v1/source-snapshots  →  "schema_version": 1
POST /api/v1/graphql           →  "schema_version": "1"
```

`String` over a published number; GraphQL's String scalar **coerces** rather than errors. A test asserted the coerced string.

**Arguments are gated now** — `buildSchema(SDL)` has no resolver map, so what the SDL declares is exactly what a client may send. 651 pairs compare in both directions plus type. Four exemptions are *derived*, not declared: `network` where a `/{network}/` twin exists; `format`, which the SDL declares zero of; `fields` where the return type carries no `JSON` member; and `Boolean` against a `["true","false"]` string enum.

### Every gap closed, not recorded

34 arguments added **and forwarded** — an advertised argument that did nothing would be a worse lie than the gap:

- `coverage_depth` took **0 of its 10** published parameters; now runs the shared `applyQueryFilters` engine
- `health_trends` took **0 of 3**
- `emission_pipeline` gained the narrowing REST applies, through the same helper
- `fields` reached the nine fields whose rows are opaque JSON
- `tao_usd` gained `include_points`; `validator_nominators` the `positions` basis

`cursor: String` over a published integer was under-typed on five fields — the runtime already answered *"cursor must be a non-negative integer"*. **Four are now `Int`. `endpoints` stays `String`**, because a live probe showed its `next_cursor` is an opaque id keyset (`endpoint-srf-2d3306d2cfa2223e`), not an offset — typing it `Int` to match the route would have broken the only pagination the field has.

10 declared divergences remain, all correct: epoch-ms bounds that overflow GraphQL's 32-bit `Int`, `compare`'s real list against a comma-joined string, `agent_catalog` merging two routes, and two GraphQL-only pagination contracts.

## Net

**830 insertions, 1519 deletions** across 31 files.

```
npm run typecheck / lint / format:check     clean
npx vitest run                              767 files, 18,242 passed, 22 skipped
validate:graphql-route-parity   160 pairs, 1088 fields, 651 args, 0 divergences
validate:graphql-types-drift  validate:mcp-input-parity
validate:route-query-parity   validate:contract-drift   validate:openapi    all PASS
```

Closes #10149
Refs #10065