### PR TITLE
refactor(schemas): 273 MCP arguments read their route instead of restating it (#10064)

### DIFF
--- a/schemas-src/mcp-tools/account-extrinsics.ts
+++ b/schemas-src/mcp-tools/account-extrinsics.ts
@@ -11,23 +11,21 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import {
-  blockBoundSchema,
-  keysetCursorSchema,
-  limitSchema,
-  offsetSchema,
-  ss58Schema,
-} from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { blockBoundSchema, ss58Schema } from "./shared.ts";
 import { AccountExtrinsicsArtifactSchema } from "../routes/account-extrinsics.ts";
+
+const RouteQuery_accounts_ss58_extrinsics =
+  ROUTE_QUERY_SCHEMAS["/api/v1/accounts/{ss58}/extrinsics"];
 
 export const GetAccountExtrinsicsInputSchema = z
   .object({
     ss58: ss58Schema(),
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    limit: limitSchema(1000).optional(),
-    offset: offsetSchema().optional(),
-    cursor: keysetCursorSchema().optional(),
+    limit: RouteQuery_accounts_ss58_extrinsics.shape.limit,
+    offset: RouteQuery_accounts_ss58_extrinsics.shape.offset,
+    cursor: RouteQuery_accounts_ss58_extrinsics.shape.cursor,
   })
   .strict();
 export type GetAccountExtrinsicsInput = z.infer<

--- a/schemas-src/mcp-tools/account-footprints.ts
+++ b/schemas-src/mcp-tools/account-footprints.ts
@@ -19,7 +19,8 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { ss58Schema, windowSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { ss58Schema } from "./shared.ts";
 import {
   AccountAxonRemovalsArtifactSchema,
   AccountDeregistrationsArtifactSchema,
@@ -31,18 +32,37 @@ import {
   AccountServingArtifactSchema,
   AccountStakeMovesArtifactSchema,
 } from "../routes/account-activity.ts";
-import { WINDOW_ENUM_90D } from "../routes/account-activity-registrations.ts";
 
 // Symbolic in each hand-written original (src/account-*.ts's own
 // *_WINDOWS/DEFAULT_*_WINDOW constants), cross-checked against the actual
 // runtime source at the time of writing. Six of the seven tools share the
 // same 3-way set; get_account_weight_setters uses a 2-way set.
-const WEIGHT_SETTERS_WINDOWS_2 = ["7d", "30d"] as const;
+
+const RouteQuery_accounts_ss58_stake_moves =
+  ROUTE_QUERY_SCHEMAS["/api/v1/accounts/{ss58}/stake-moves"];
+
+const RouteQuery_accounts_ss58_axon_removals =
+  ROUTE_QUERY_SCHEMAS["/api/v1/accounts/{ss58}/axon-removals"];
+
+const RouteQuery_accounts_ss58_deregistrations =
+  ROUTE_QUERY_SCHEMAS["/api/v1/accounts/{ss58}/deregistrations"];
+
+const RouteQuery_accounts_ss58_serving =
+  ROUTE_QUERY_SCHEMAS["/api/v1/accounts/{ss58}/serving"];
+
+const RouteQuery_accounts_ss58_weight_setters =
+  ROUTE_QUERY_SCHEMAS["/api/v1/accounts/{ss58}/weight-setters"];
+
+const RouteQuery_accounts_ss58_registrations =
+  ROUTE_QUERY_SCHEMAS["/api/v1/accounts/{ss58}/registrations"];
+
+const RouteQuery_accounts_ss58_prometheus =
+  ROUTE_QUERY_SCHEMAS["/api/v1/accounts/{ss58}/prometheus"];
 
 export const GetAccountStakeMovesInputSchema = z
   .object({
     ss58: ss58Schema(),
-    window: windowSchema(WINDOW_ENUM_90D).optional(),
+    window: RouteQuery_accounts_ss58_stake_moves.shape.window,
   })
   .strict();
 export type GetAccountStakeMovesInput = z.infer<
@@ -57,7 +77,7 @@ export type GetAccountStakeMovesOutput = z.infer<
 export const GetAccountAxonRemovalsInputSchema = z
   .object({
     ss58: ss58Schema(),
-    window: windowSchema(WINDOW_ENUM_90D).optional(),
+    window: RouteQuery_accounts_ss58_axon_removals.shape.window,
   })
   .strict();
 export type GetAccountAxonRemovalsInput = z.infer<
@@ -73,7 +93,7 @@ export type GetAccountAxonRemovalsOutput = z.infer<
 export const GetAccountPrometheusInputSchema = z
   .object({
     ss58: ss58Schema(),
-    window: windowSchema(WINDOW_ENUM_90D).optional(),
+    window: RouteQuery_accounts_ss58_prometheus.shape.window,
   })
   .strict();
 export type GetAccountPrometheusInput = z.infer<
@@ -88,7 +108,7 @@ export type GetAccountPrometheusOutput = z.infer<
 export const GetAccountRegistrationsInputSchema = z
   .object({
     ss58: ss58Schema(),
-    window: windowSchema(WINDOW_ENUM_90D).optional(),
+    window: RouteQuery_accounts_ss58_registrations.shape.window,
   })
   .strict();
 export type GetAccountRegistrationsInput = z.infer<
@@ -104,7 +124,7 @@ export type GetAccountRegistrationsOutput = z.infer<
 export const GetAccountWeightSettersInputSchema = z
   .object({
     ss58: ss58Schema(),
-    window: windowSchema(WEIGHT_SETTERS_WINDOWS_2).optional(),
+    window: RouteQuery_accounts_ss58_weight_setters.shape.window,
   })
   .strict();
 export type GetAccountWeightSettersInput = z.infer<
@@ -120,7 +140,7 @@ export type GetAccountWeightSettersOutput = z.infer<
 export const GetAccountServingInputSchema = z
   .object({
     ss58: ss58Schema(),
-    window: windowSchema(WINDOW_ENUM_90D).optional(),
+    window: RouteQuery_accounts_ss58_serving.shape.window,
   })
   .strict();
 export type GetAccountServingInput = z.infer<
@@ -135,7 +155,7 @@ export type GetAccountServingOutput = z.infer<
 export const GetAccountDeregistrationsInputSchema = z
   .object({
     ss58: ss58Schema(),
-    window: windowSchema(WINDOW_ENUM_90D).optional(),
+    window: RouteQuery_accounts_ss58_deregistrations.shape.window,
   })
   .strict();
 export type GetAccountDeregistrationsInput = z.infer<

--- a/schemas-src/mcp-tools/account-history.ts
+++ b/schemas-src/mcp-tools/account-history.ts
@@ -4,30 +4,27 @@
 // reuse. Modeled fresh, matching the hand-written literal it replaces
 // field-for-field.
 import { z } from "zod";
-import {
-  daySchema,
-  keysetCursorSchema,
-  limitSchema,
-  netuidSchema,
-  offsetSchema,
-  ss58Schema,
-} from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { netuidSchema, ss58Schema } from "./shared.ts";
+
+const RouteQuery_accounts_ss58_history =
+  ROUTE_QUERY_SCHEMAS["/api/v1/accounts/{ss58}/history"];
 
 export const GetAccountHistoryInputSchema = z
   .object({
     ss58: ss58Schema(),
-    netuid: netuidSchema().optional(),
+    netuid: RouteQuery_accounts_ss58_history.shape.netuid,
     // DAYS, not block heights. These carried the generic cross-tool sentence
     // ("a block height on chain tools, an ISO-8601 date on time-series ones")
     // and a block-height EXAMPLE, while this route reads a day-partitioned
     // table and takes YYYY-MM-DD only -- verified live, `?from=8700000` is a
     // 400 and `?from=2026-08-01` is a 200. An agent following the tool's own
     // example was rejected (#10115).
-    from: daySchema("first").optional(),
-    to: daySchema("last").optional(),
-    limit: limitSchema(1000).optional(),
-    offset: offsetSchema().optional(),
-    cursor: keysetCursorSchema().optional(),
+    from: RouteQuery_accounts_ss58_history.shape.from,
+    to: RouteQuery_accounts_ss58_history.shape.to,
+    limit: RouteQuery_accounts_ss58_history.shape.limit,
+    offset: RouteQuery_accounts_ss58_history.shape.offset,
+    cursor: RouteQuery_accounts_ss58_history.shape.cursor,
   })
   .strict();
 export type GetAccountHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/account-identity.ts
+++ b/schemas-src/mcp-tools/account-identity.ts
@@ -12,16 +12,15 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import {
-  keysetCursorSchema,
-  limitSchema,
-  offsetSchema,
-  ss58Schema,
-} from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { ss58Schema } from "./shared.ts";
 import {
   AccountIdentityArtifactSchema,
   AccountIdentityHistoryArtifactSchema,
 } from "../routes/account-identity.ts";
+
+const RouteQuery_accounts_ss58_identity_history =
+  ROUTE_QUERY_SCHEMAS["/api/v1/accounts/{ss58}/identity-history"];
 
 export const GetAccountIdentityInputSchema = z
   .object({
@@ -40,9 +39,9 @@ export type GetAccountIdentityOutput = z.infer<
 export const GetAccountIdentityHistoryInputSchema = z
   .object({
     ss58: ss58Schema(),
-    limit: limitSchema(1000).optional(),
-    offset: offsetSchema().optional(),
-    cursor: keysetCursorSchema().optional(),
+    limit: RouteQuery_accounts_ss58_identity_history.shape.limit,
+    offset: RouteQuery_accounts_ss58_identity_history.shape.offset,
+    cursor: RouteQuery_accounts_ss58_identity_history.shape.cursor,
   })
   .strict();
 export type GetAccountIdentityHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/account-position-history.ts
+++ b/schemas-src/mcp-tools/account-position-history.ts
@@ -14,14 +14,18 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { netuidSchema, ss58Schema, windowSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { netuidSchema, ss58Schema } from "./shared.ts";
 import { AccountPositionHistoryArtifactSchema } from "../routes/account-positions.ts";
+
+const RouteQuery_accounts_ss58_subnets_netuid_history =
+  ROUTE_QUERY_SCHEMAS["/api/v1/accounts/{ss58}/subnets/{netuid}/history"];
 
 export const GetAccountPositionHistoryInputSchema = z
   .object({
     ss58: ss58Schema(),
     netuid: netuidSchema(),
-    window: windowSchema(["7d", "30d", "90d", "1y", "all"]).optional(),
+    window: RouteQuery_accounts_ss58_subnets_netuid_history.shape.window,
   })
   .strict();
 export type GetAccountPositionHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/account-stake-flow.ts
+++ b/schemas-src/mcp-tools/account-stake-flow.ts
@@ -11,20 +11,21 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { kindSchema, ss58Schema, windowSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { kindSchema, ss58Schema } from "./shared.ts";
 import { AccountStakeFlowArtifactSchema } from "../routes/account-activity.ts";
-import {
-  ACCOUNT_ACTIVITY_FLOW_DIRECTIONS_VALUES,
-  WINDOW_ENUM,
-} from "../routes/account-activity.ts";
+import { ACCOUNT_ACTIVITY_FLOW_DIRECTIONS_VALUES } from "../routes/account-activity.ts";
 
 // Symbolic in the hand-written original (src/stake-flow.ts's
 // STAKE_FLOW_WINDOWS/STAKE_FLOW_DIRECTIONS), cross-checked against the
 // actual runtime source at the time of writing.
+const RouteQuery_accounts_ss58_stake_flow =
+  ROUTE_QUERY_SCHEMAS["/api/v1/accounts/{ss58}/stake-flow"];
+
 export const GetAccountStakeFlowInputSchema = z
   .object({
     ss58: ss58Schema(),
-    window: windowSchema(WINDOW_ENUM).optional(),
+    window: RouteQuery_accounts_ss58_stake_flow.shape.window,
     direction: kindSchema(ACCOUNT_ACTIVITY_FLOW_DIRECTIONS_VALUES).optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/account-summary.ts
+++ b/schemas-src/mcp-tools/account-summary.ts
@@ -12,15 +12,8 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import {
-  blockBoundSchema,
-  keysetCursorSchema,
-  kindStringSchema,
-  limitSchema,
-  netuidSchema,
-  offsetSchema,
-  ss58Schema,
-} from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { blockBoundSchema, netuidSchema, ss58Schema } from "./shared.ts";
 import { AccountEntitiesArtifactSchema } from "../routes/account-entities.ts";
 import { AccountEventsArtifactSchema } from "../routes/account-events-feed.ts";
 import { AccountActivitySchema } from "../routes/account-summary.ts";
@@ -61,6 +54,9 @@ const AccountLabelItemSchema = z
     source_urls: z.array(z.string()).optional(),
   })
   .passthrough();
+
+const RouteQuery_accounts_ss58_events =
+  ROUTE_QUERY_SCHEMAS["/api/v1/accounts/{ss58}/events"];
 
 export const GetAccountInputSchema = z
   .object({
@@ -116,13 +112,13 @@ export type GetAccountEntitiesOutput = z.infer<
 export const GetAccountEventsInputSchema = z
   .object({
     ss58: ss58Schema(),
-    kind: kindStringSchema().optional(),
-    netuid: netuidSchema().optional(),
+    kind: RouteQuery_accounts_ss58_events.shape.kind,
+    netuid: RouteQuery_accounts_ss58_events.shape.netuid,
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    limit: limitSchema(1000).optional(),
-    offset: offsetSchema().optional(),
-    cursor: keysetCursorSchema().optional(),
+    limit: RouteQuery_accounts_ss58_events.shape.limit,
+    offset: RouteQuery_accounts_ss58_events.shape.offset,
+    cursor: RouteQuery_accounts_ss58_events.shape.cursor,
   })
   .strict();
 export type GetAccountEventsInput = z.infer<typeof GetAccountEventsInputSchema>;

--- a/schemas-src/mcp-tools/account-transfers.ts
+++ b/schemas-src/mcp-tools/account-transfers.ts
@@ -11,33 +11,30 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import {
-  blockBoundSchema,
-  keysetCursorSchema,
-  limitSchema,
-  offsetSchema,
-  ss58Schema,
-} from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { blockBoundSchema, limitSchema, ss58Schema } from "./shared.ts";
 import { AccountTransfersArtifactSchema } from "../routes/account-events-feed.ts";
 import { CounterpartyRelationshipSchema } from "../routes/account-counterparties.ts";
 
-const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+const RouteQuery_accounts_ss58_transfers =
+  ROUTE_QUERY_SCHEMAS["/api/v1/accounts/{ss58}/transfers"];
+
+const RouteQuery_accounts_ss58_counterparties =
+  ROUTE_QUERY_SCHEMAS["/api/v1/accounts/{ss58}/counterparties"];
 
 export const GetAccountTransfersInputSchema = z
   .object({
     ss58: ss58Schema(),
-    direction: z
-      .enum(["all", "sent", "received"])
-      .optional()
+    direction: RouteQuery_accounts_ss58_transfers.shape.direction
       .describe(
         "Which side of the flow to include: everything, only outgoing, or only incoming.",
       )
       .meta({ examples: ["all"] }),
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    limit: limitSchema(1000).optional(),
-    offset: offsetSchema().optional(),
-    cursor: keysetCursorSchema().optional(),
+    limit: RouteQuery_accounts_ss58_transfers.shape.limit,
+    offset: RouteQuery_accounts_ss58_transfers.shape.offset,
+    cursor: RouteQuery_accounts_ss58_transfers.shape.cursor,
   })
   .strict();
 export type GetAccountTransfersInput = z.infer<
@@ -54,7 +51,7 @@ export type GetAccountTransfersOutput = z.infer<
 export const GetAccountCounterpartiesInputSchema = z
   .object({
     ss58: ss58Schema(),
-    counterparty: Ss58Schema.optional()
+    counterparty: RouteQuery_accounts_ss58_counterparties.shape.counterparty
       .describe(
         "The other SS58 account in the transfer pair — results are restricted to flows between the subject account and this one.",
       )

--- a/schemas-src/mcp-tools/accounts-leaderboards.ts
+++ b/schemas-src/mcp-tools/accounts-leaderboards.ts
@@ -11,20 +11,23 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { limitSchema, sortSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { AccountsListArtifactSchema } from "../routes/accounts-list.ts";
 import { TopHoldersArtifactSchema } from "../routes/top-holders.ts";
-import { ACCOUNTS_LIST_LIST_SORTS_VALUES } from "../routes/accounts-list.ts";
-import { TOP_HOLDERS_SORT_VALUES } from "../routes/top-holders.ts";
 
 // Symbolic in the hand-written originals (src/accounts-list.ts's
 // ACCOUNTS_LIST_LIST_SORTS_VALUES/*_LIMIT_*, src/top-holders.ts's TOP_HOLDERS_SORT_VALUES/
 // *_LIMIT_*), cross-checked against the actual runtime source at the time
 // of writing.
+const RouteQuery_accounts = ROUTE_QUERY_SCHEMAS["/api/v1/accounts"];
+
+const RouteQuery_accounts_top_holders =
+  ROUTE_QUERY_SCHEMAS["/api/v1/accounts/top-holders"];
+
 export const ListAccountsInputSchema = z
   .object({
-    sort: sortSchema(ACCOUNTS_LIST_LIST_SORTS_VALUES).optional(),
-    limit: limitSchema(100).optional(),
+    sort: RouteQuery_accounts.shape.sort,
+    limit: RouteQuery_accounts.shape.limit,
   })
   .strict();
 export type ListAccountsInput = z.infer<typeof ListAccountsInputSchema>;
@@ -36,8 +39,8 @@ export type ListAccountsOutput = z.infer<typeof ListAccountsOutputSchema>;
 
 export const GetTopHoldersInputSchema = z
   .object({
-    sort: sortSchema(TOP_HOLDERS_SORT_VALUES).optional(),
-    limit: limitSchema(100).optional(),
+    sort: RouteQuery_accounts_top_holders.shape.sort,
+    limit: RouteQuery_accounts_top_holders.shape.limit,
   })
   .strict();
 export type GetTopHoldersInput = z.infer<typeof GetTopHoldersInputSchema>;

--- a/schemas-src/mcp-tools/ai-discovery.ts
+++ b/schemas-src/mcp-tools/ai-discovery.ts
@@ -4,6 +4,7 @@
 // existing schemas-src/routes/ REST schema -- modeled fresh, matching
 // each hand-written literal field-for-field.
 import { z } from "zod";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { limitSchema, netuidSchema, querySchema } from "./shared.ts";
 import { SEMANTIC_QUERY_MAX_LENGTH } from "../../src/route-limits.ts";
 import { AgentCatalogSubnetEntrySchema } from "../routes/agent-catalog.ts";
@@ -23,6 +24,9 @@ const SemanticTypeSchema = z
     z.array(z.enum(SEARCH_DOCUMENT_TYPE_VALUES)),
   ])
   .optional();
+
+const RouteQuery_search_semantic =
+  ROUTE_QUERY_SCHEMAS["/api/v1/search/semantic"];
 
 export const FindSubnetOpportunitiesInputSchema = z
   .object({
@@ -73,8 +77,7 @@ export const SemanticSearchInputSchema = z
     // rejected for an unknown argument. Canonical; `query` stays so existing
     // callers are unaffected. Exactly one is required -- expressed with
     // requireAnyOf on the tool, since z.toJSONSchema drops a Zod refinement.
-    q: querySchema(SEMANTIC_QUERY_MAX_LENGTH)
-      .optional()
+    q: RouteQuery_search_semantic.shape.q
       .describe(
         "The search text, embedded and ranked by meaning. The name GET /api/v1/search/semantic publishes; `query` is the alias this tool shipped with.",
       )

--- a/schemas-src/mcp-tools/blocks.ts
+++ b/schemas-src/mcp-tools/blocks.ts
@@ -12,17 +12,21 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import {
-  blockBoundSchema,
-  keysetCursorSchema,
-  limitSchema,
-  offsetSchema,
-} from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { blockBoundSchema } from "./shared.ts";
 import { BlockEventsArtifactSchema } from "../routes/block-events.ts";
 import { BlockExtrinsicsArtifactSchema } from "../routes/block-extrinsics.ts";
 import { BlockSchema, BlocksFeedArtifactSchema } from "../routes/blocks.ts";
 
 const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+
+const RouteQuery_blocks = ROUTE_QUERY_SCHEMAS["/api/v1/blocks"];
+
+const RouteQuery_blocks_ref_extrinsics =
+  ROUTE_QUERY_SCHEMAS["/api/v1/blocks/{ref}/extrinsics"];
+
+const RouteQuery_blocks_ref_events =
+  ROUTE_QUERY_SCHEMAS["/api/v1/blocks/{ref}/events"];
 
 export const ListBlocksInputSchema = z
   .object({
@@ -73,9 +77,9 @@ export const ListBlocksInputSchema = z
         "Inclusive lower bound on a block's event count; quieter blocks are excluded.",
       )
       .meta({ examples: [20] }),
-    limit: limitSchema(100).optional(),
-    offset: offsetSchema().optional(),
-    cursor: keysetCursorSchema().optional(),
+    limit: RouteQuery_blocks.shape.limit,
+    offset: RouteQuery_blocks.shape.offset,
+    cursor: RouteQuery_blocks.shape.cursor,
   })
   .strict();
 export type ListBlocksInput = z.infer<typeof ListBlocksInputSchema>;
@@ -129,8 +133,8 @@ export const ListBlockExtrinsicsInputSchema = z
           "0x9f1e2d3c4b5a69788796a5b4c3d2e1f009182736455463728190abcdef012345",
         ],
       }),
-    limit: limitSchema(100).optional(),
-    offset: offsetSchema().optional(),
+    limit: RouteQuery_blocks_ref_extrinsics.shape.limit,
+    offset: RouteQuery_blocks_ref_extrinsics.shape.offset,
   })
   .strict();
 export type ListBlockExtrinsicsInput = z.infer<
@@ -155,8 +159,8 @@ export const GetBlockEventsInputSchema = z
           "0x9f1e2d3c4b5a69788796a5b4c3d2e1f009182736455463728190abcdef012345",
         ],
       }),
-    limit: limitSchema(1000).optional(),
-    offset: offsetSchema().optional(),
+    limit: RouteQuery_blocks_ref_events.shape.limit,
+    offset: RouteQuery_blocks_ref_events.shape.offset,
   })
   .strict();
 export type GetBlockEventsInput = z.infer<typeof GetBlockEventsInputSchema>;

--- a/schemas-src/mcp-tools/chain-calls-fees.ts
+++ b/schemas-src/mcp-tools/chain-calls-fees.ts
@@ -12,35 +12,30 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { CHAIN_CALL_MODULE_MAX_LENGTH } from "../../src/route-limits.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 
-import {
-  limitSchema,
-  runtimeNameSchema,
-  sortSchema,
-  windowSchema,
-} from "./shared.ts";
 import {
   ChainCallsArtifactSchema,
   ChainFeesArtifactSchema,
   ChainSignersArtifactSchema,
 } from "../routes/chain-analytics.ts";
 
-const WINDOWS_2 = ["7d", "30d"] as const;
+const RouteQuery_chain_calls = ROUTE_QUERY_SCHEMAS["/api/v1/chain/calls"];
+
+const RouteQuery_chain_signers = ROUTE_QUERY_SCHEMAS["/api/v1/chain/signers"];
+
+const RouteQuery_chain_fees = ROUTE_QUERY_SCHEMAS["/api/v1/chain/fees"];
 
 export const GetChainCallsInputSchema = z
   .object({
-    window: windowSchema(WINDOWS_2).optional(),
-    group_by: z
-      .enum(["module", "module_function"])
-      .optional()
+    window: RouteQuery_chain_calls.shape.window,
+    group_by: RouteQuery_chain_calls.shape.group_by
       .describe(
         "How to bucket the counts: by pallet, or by pallet and call together.",
       )
       .meta({ examples: ["module"] }),
-    limit: limitSchema(100).optional(),
-    call_module: runtimeNameSchema(CHAIN_CALL_MODULE_MAX_LENGTH)
-      .optional()
+    limit: RouteQuery_chain_calls.shape.limit,
+    call_module: RouteQuery_chain_calls.shape.call_module
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
       )
@@ -56,11 +51,10 @@ export type GetChainCallsOutput = z.infer<typeof GetChainCallsOutputSchema>;
 
 export const GetChainSignersInputSchema = z
   .object({
-    window: windowSchema(WINDOWS_2).optional(),
-    sort: sortSchema(["tx_count", "total_fee_tao"]).optional(),
-    limit: limitSchema(100).optional(),
-    call_module: runtimeNameSchema(CHAIN_CALL_MODULE_MAX_LENGTH)
-      .optional()
+    window: RouteQuery_chain_signers.shape.window,
+    sort: RouteQuery_chain_signers.shape.sort,
+    limit: RouteQuery_chain_signers.shape.limit,
+    call_module: RouteQuery_chain_signers.shape.call_module
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
       )
@@ -75,10 +69,9 @@ export type GetChainSignersOutput = z.infer<typeof GetChainSignersOutputSchema>;
 
 export const GetChainFeesInputSchema = z
   .object({
-    window: windowSchema(WINDOWS_2).optional(),
-    limit: limitSchema(100).optional(),
-    call_module: runtimeNameSchema(CHAIN_CALL_MODULE_MAX_LENGTH)
-      .optional()
+    window: RouteQuery_chain_fees.shape.window,
+    limit: RouteQuery_chain_fees.shape.limit,
+    call_module: RouteQuery_chain_fees.shape.call_module
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
       )

--- a/schemas-src/mcp-tools/chain-events-activity.ts
+++ b/schemas-src/mcp-tools/chain-events-activity.ts
@@ -12,12 +12,8 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import {
-  blockEventCursorSchema,
-  limitSchema,
-  runtimeNameSchema,
-  windowSchema,
-} from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { blockEventCursorSchema, limitSchema } from "./shared.ts";
 import { McpNetworkSchema } from "../shared.ts";
 import { ChainActivityArtifactSchema } from "../routes/chain-analytics.ts";
 import {
@@ -25,19 +21,19 @@ import {
   ChainEventsStatsArtifactSchema,
 } from "../routes/chain-events.ts";
 
-const WINDOWS_2 = ["7d", "30d"] as const;
-
 /** The ceiling /chain-events enforces on `pallet` and `method` --
  * validateListQuery reads it off the PUBLISHED schema to decide a 400. */
-const EVENT_FEED_NAME_MAX = 64;
+
+const RouteQuery_chain_activity = ROUTE_QUERY_SCHEMAS["/api/v1/chain/activity"];
+
+const RouteQuery_chain_events_stats =
+  ROUTE_QUERY_SCHEMAS["/api/v1/chain-events/stats"];
+
+const RouteQuery_chain_events = ROUTE_QUERY_SCHEMAS["/api/v1/chain-events"];
 
 export const GetChainActivityInputSchema = z
   .object({
-    blocks: z
-      .int()
-      .min(1)
-      .max(5000)
-      .optional()
+    blocks: RouteQuery_chain_events_stats.shape.blocks
       .describe("How many trailing blocks to cover, ending at the chain head.")
       .meta({ examples: [1200] }),
     // #8700: which chain's decoded history to aggregate. The same published
@@ -57,8 +53,7 @@ export type GetChainActivityOutput = z.infer<
 
 export const ListChainEventsInputSchema = z
   .object({
-    pallet: runtimeNameSchema(EVENT_FEED_NAME_MAX)
-      .optional()
+    pallet: RouteQuery_chain_events.shape.pallet
       .describe(
         "Restrict to events emitted by this pallet, by runtime name (`SubtensorModule`). Case-sensitive.",
       )
@@ -66,8 +61,7 @@ export const ListChainEventsInputSchema = z
     // NOT an HTTP method. This said "HTTP method to use for the call" beside
     // an example of `set_weights` -- the prose contradicted its own example,
     // on a parameter whose whole job is naming a runtime call (#10131).
-    method: runtimeNameSchema(EVENT_FEED_NAME_MAX)
-      .optional()
+    method: RouteQuery_chain_events.shape.method
       .describe(
         "Restrict to events emitted by this runtime call, by name (`set_weights`). Case-sensitive.",
       )
@@ -115,7 +109,7 @@ export type ListChainEventsOutput = z.infer<typeof ListChainEventsOutputSchema>;
 
 export const GetNetworkActivityInputSchema = z
   .object({
-    window: windowSchema(WINDOWS_2).optional(),
+    window: RouteQuery_chain_activity.shape.window,
   })
   .strict();
 export type GetNetworkActivityInput = z.infer<

--- a/schemas-src/mcp-tools/chain-leaderboards.ts
+++ b/schemas-src/mcp-tools/chain-leaderboards.ts
@@ -18,7 +18,7 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { limitSchema, windowSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { ChainAlphaVolumeArtifactSchema } from "../routes/chain-alpha-volume.ts";
 import {
   ChainAxonRemovalsArtifactSchema,
@@ -31,15 +31,38 @@ import {
 import { ChainStakeFlowArtifactSchema } from "../routes/chain-stake-flow.ts";
 import { ChainTurnoverArtifactSchema } from "../routes/chain-turnover.ts";
 import { ChainWeightSettersArtifactSchema } from "../routes/chain-weight-setters.ts";
-import { CHAIN_TURNOVER_WINDOW_VALUES } from "../routes/chain-turnover.ts";
 
-const WINDOWS_2 = ["7d", "30d"] as const;
-const LIMIT_MAX_100 = 100;
+const RouteQuery_chain_turnover = ROUTE_QUERY_SCHEMAS["/api/v1/chain/turnover"];
+
+const RouteQuery_chain_stake_flow =
+  ROUTE_QUERY_SCHEMAS["/api/v1/chain/stake-flow"];
+
+const RouteQuery_chain_prometheus =
+  ROUTE_QUERY_SCHEMAS["/api/v1/chain/prometheus"];
+
+const RouteQuery_chain_serving = ROUTE_QUERY_SCHEMAS["/api/v1/chain/serving"];
+
+const RouteQuery_chain_axon_removals =
+  ROUTE_QUERY_SCHEMAS["/api/v1/chain/axon-removals"];
+
+const RouteQuery_chain_stake_transfers =
+  ROUTE_QUERY_SCHEMAS["/api/v1/chain/stake-transfers"];
+
+const RouteQuery_chain_stake_moves =
+  ROUTE_QUERY_SCHEMAS["/api/v1/chain/stake-moves"];
+
+const RouteQuery_chain_weights_setters =
+  ROUTE_QUERY_SCHEMAS["/api/v1/chain/weights/setters"];
+
+const RouteQuery_chain_weights = ROUTE_QUERY_SCHEMAS["/api/v1/chain/weights"];
+
+const RouteQuery_chain_alpha_volume =
+  ROUTE_QUERY_SCHEMAS["/api/v1/chain/alpha-volume"];
 
 export const GetChainTurnoverInputSchema = z
   .object({
-    window: windowSchema(CHAIN_TURNOVER_WINDOW_VALUES).optional(),
-    limit: limitSchema(LIMIT_MAX_100).optional(),
+    window: RouteQuery_chain_turnover.shape.window,
+    limit: RouteQuery_chain_turnover.shape.limit,
   })
   .strict();
 export type GetChainTurnoverInput = z.infer<typeof GetChainTurnoverInputSchema>;
@@ -51,8 +74,8 @@ export type GetChainTurnoverOutput = z.infer<
 
 export const GetChainStakeFlowInputSchema = z
   .object({
-    window: windowSchema(WINDOWS_2).optional(),
-    limit: limitSchema(LIMIT_MAX_100).optional(),
+    window: RouteQuery_chain_stake_flow.shape.window,
+    limit: RouteQuery_chain_stake_flow.shape.limit,
   })
   .strict();
 export type GetChainStakeFlowInput = z.infer<
@@ -66,7 +89,7 @@ export type GetChainStakeFlowOutput = z.infer<
 
 export const GetChainAlphaVolumeInputSchema = z
   .object({
-    limit: limitSchema(LIMIT_MAX_100).optional(),
+    limit: RouteQuery_chain_alpha_volume.shape.limit,
   })
   .strict();
 export type GetChainAlphaVolumeInput = z.infer<
@@ -84,8 +107,8 @@ export type GetChainAlphaVolumeOutput = z.infer<
 
 export const GetChainWeightsInputSchema = z
   .object({
-    window: windowSchema(WINDOWS_2).optional(),
-    limit: limitSchema(LIMIT_MAX_100).optional(),
+    window: RouteQuery_chain_weights.shape.window,
+    limit: RouteQuery_chain_weights.shape.limit,
   })
   .strict();
 export type GetChainWeightsInput = z.infer<typeof GetChainWeightsInputSchema>;
@@ -95,8 +118,8 @@ export type GetChainWeightsOutput = z.infer<typeof GetChainWeightsOutputSchema>;
 
 export const GetChainWeightSettersInputSchema = z
   .object({
-    window: windowSchema(WINDOWS_2).optional(),
-    limit: limitSchema(LIMIT_MAX_100).optional(),
+    window: RouteQuery_chain_weights_setters.shape.window,
+    limit: RouteQuery_chain_weights_setters.shape.limit,
   })
   .strict();
 export type GetChainWeightSettersInput = z.infer<
@@ -113,8 +136,8 @@ export type GetChainWeightSettersOutput = z.infer<
 
 export const GetChainStakeMovesInputSchema = z
   .object({
-    window: windowSchema(WINDOWS_2).optional(),
-    limit: limitSchema(LIMIT_MAX_100).optional(),
+    window: RouteQuery_chain_stake_moves.shape.window,
+    limit: RouteQuery_chain_stake_moves.shape.limit,
   })
   .strict();
 export type GetChainStakeMovesInput = z.infer<
@@ -128,8 +151,8 @@ export type GetChainStakeMovesOutput = z.infer<
 
 export const GetChainStakeTransfersInputSchema = z
   .object({
-    window: windowSchema(WINDOWS_2).optional(),
-    limit: limitSchema(LIMIT_MAX_100).optional(),
+    window: RouteQuery_chain_stake_transfers.shape.window,
+    limit: RouteQuery_chain_stake_transfers.shape.limit,
   })
   .strict();
 export type GetChainStakeTransfersInput = z.infer<
@@ -144,8 +167,8 @@ export type GetChainStakeTransfersOutput = z.infer<
 
 export const GetChainAxonRemovalsInputSchema = z
   .object({
-    window: windowSchema(WINDOWS_2).optional(),
-    limit: limitSchema(LIMIT_MAX_100).optional(),
+    window: RouteQuery_chain_axon_removals.shape.window,
+    limit: RouteQuery_chain_axon_removals.shape.limit,
   })
   .strict();
 export type GetChainAxonRemovalsInput = z.infer<
@@ -159,8 +182,8 @@ export type GetChainAxonRemovalsOutput = z.infer<
 
 export const GetChainServingInputSchema = z
   .object({
-    window: windowSchema(WINDOWS_2).optional(),
-    limit: limitSchema(LIMIT_MAX_100).optional(),
+    window: RouteQuery_chain_serving.shape.window,
+    limit: RouteQuery_chain_serving.shape.limit,
   })
   .strict();
 export type GetChainServingInput = z.infer<typeof GetChainServingInputSchema>;
@@ -170,8 +193,8 @@ export type GetChainServingOutput = z.infer<typeof GetChainServingOutputSchema>;
 
 export const GetChainPrometheusInputSchema = z
   .object({
-    window: windowSchema(WINDOWS_2).optional(),
-    limit: limitSchema(LIMIT_MAX_100).optional(),
+    window: RouteQuery_chain_prometheus.shape.window,
+    limit: RouteQuery_chain_prometheus.shape.limit,
   })
   .strict();
 export type GetChainPrometheusInput = z.infer<

--- a/schemas-src/mcp-tools/chain-registrations.ts
+++ b/schemas-src/mcp-tools/chain-registrations.ts
@@ -14,19 +14,22 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { limitSchema, windowSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import {
   ChainDeregistrationsArtifactSchema,
   ChainRegistrationsArtifactSchema,
 } from "../routes/chain-network-rollups.ts";
 
-const WINDOWS_2 = ["7d", "30d"] as const;
-const LIMIT_MAX_100 = 100;
+const RouteQuery_chain_registrations =
+  ROUTE_QUERY_SCHEMAS["/api/v1/chain/registrations"];
+
+const RouteQuery_chain_deregistrations =
+  ROUTE_QUERY_SCHEMAS["/api/v1/chain/deregistrations"];
 
 export const GetChainRegistrationsInputSchema = z
   .object({
-    window: windowSchema(WINDOWS_2).optional(),
-    limit: limitSchema(LIMIT_MAX_100).optional(),
+    window: RouteQuery_chain_registrations.shape.window,
+    limit: RouteQuery_chain_registrations.shape.limit,
   })
   .strict();
 export type GetChainRegistrationsInput = z.infer<
@@ -46,8 +49,8 @@ export type GetChainRegistrationsOutput = z.infer<
 
 export const GetChainDeregistrationsInputSchema = z
   .object({
-    window: windowSchema(WINDOWS_2).optional(),
-    limit: limitSchema(LIMIT_MAX_100).optional(),
+    window: RouteQuery_chain_deregistrations.shape.window,
+    limit: RouteQuery_chain_deregistrations.shape.limit,
   })
   .strict();
 export type GetChainDeregistrationsInput = z.infer<

--- a/schemas-src/mcp-tools/chain-scorecards.ts
+++ b/schemas-src/mcp-tools/chain-scorecards.ts
@@ -14,30 +14,28 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { ChainConcentrationArtifactSchema } from "../routes/chain-concentration.ts";
 import { ChainConcentrationSubnetsArtifactSchema } from "../routes/chain-concentration-subnets.ts";
 import { ChainPerformanceArtifactSchema } from "../routes/chain-performance.ts";
-import { limitSchema, orderSchema, sortSchema } from "./shared.ts";
+import { limitSchema } from "./shared.ts";
 import {
   CHAIN_CONCENTRATION_SUBNETS_LIMIT_DEFAULT,
   CHAIN_CONCENTRATION_SUBNETS_LIMIT_MAX,
 } from "../../src/route-limits.ts";
 import { ChainIdleStakeArtifactSchema } from "../routes/chain-idle-stake.ts";
 import { ChainYieldArtifactSchema } from "../routes/chain-yield.ts";
-import {
-  CONCENTRATION_LENSES,
-  CONCENTRATION_RANKING_SORTS,
-} from "../routes/chain-concentration-subnets.ts";
 
 // --- get_chain_concentration_subnets (#9717) ---------------------------------
 // The cross-subnet RANKING, as opposed to get_chain_concentration's single
 // network aggregate over the same read.
 
+const RouteQuery_chain_concentration_subnets =
+  ROUTE_QUERY_SCHEMAS["/api/v1/chain/concentration/subnets"];
+
 export const GetChainConcentrationSubnetsInputSchema = z
   .object({
-    lens: z
-      .enum(CONCENTRATION_LENSES)
-      .optional()
+    lens: RouteQuery_chain_concentration_subnets.shape.lens
       .describe(
         "Which distribution to rank subnets by. `emission` (the default) is " +
           "the reward question — who actually receives emissions. `stake` is " +
@@ -45,8 +43,8 @@ export const GetChainConcentrationSubnetsInputSchema = z
           "hotkeys into one holder, so a Sybil running twenty UIDs counts once.",
       )
       .meta({ examples: ["emission"] }),
-    sort: sortSchema(CONCENTRATION_RANKING_SORTS).optional(),
-    order: orderSchema().optional(),
+    sort: RouteQuery_chain_concentration_subnets.shape.sort,
+    order: RouteQuery_chain_concentration_subnets.shape.order,
     limit: limitSchema(
       CHAIN_CONCENTRATION_SUBNETS_LIMIT_MAX,
       CHAIN_CONCENTRATION_SUBNETS_LIMIT_DEFAULT,

--- a/schemas-src/mcp-tools/chain-transfers.ts
+++ b/schemas-src/mcp-tools/chain-transfers.ts
@@ -11,21 +11,25 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { limitSchema, sortSchema, windowSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import {
   ChainTransferPairsArtifactSchema,
   ChainTransfersArtifactSchema,
 } from "../routes/chain-transfers.ts";
 
-const WINDOWS_2 = ["7d", "30d"] as const;
-
 // Mirrors mcp-server.ts's shared CHAIN_TRANSFER_PARTY_ITEM object literal
 // (this batch's last consumer -- get_chain_transfer_pairs.pairs items have
 // their own distinct shape, not this one).
+const RouteQuery_chain_transfers =
+  ROUTE_QUERY_SCHEMAS["/api/v1/chain/transfers"];
+
+const RouteQuery_chain_transfer_pairs =
+  ROUTE_QUERY_SCHEMAS["/api/v1/chain/transfer-pairs"];
+
 export const GetChainTransfersInputSchema = z
   .object({
-    window: windowSchema(WINDOWS_2).optional(),
-    limit: limitSchema(100).optional(),
+    window: RouteQuery_chain_transfers.shape.window,
+    limit: RouteQuery_chain_transfers.shape.limit,
   })
   .strict();
 export type GetChainTransfersInput = z.infer<
@@ -39,9 +43,9 @@ export type GetChainTransfersOutput = z.infer<
 
 export const GetChainTransferPairsInputSchema = z
   .object({
-    window: windowSchema(WINDOWS_2).optional(),
-    sort: sortSchema(["volume", "count"]).optional(),
-    limit: limitSchema(100).optional(),
+    window: RouteQuery_chain_transfer_pairs.shape.window,
+    sort: RouteQuery_chain_transfer_pairs.shape.sort,
+    limit: RouteQuery_chain_transfer_pairs.shape.limit,
   })
   .strict();
 export type GetChainTransferPairsInput = z.infer<

--- a/schemas-src/mcp-tools/curation-and-gaps.ts
+++ b/schemas-src/mcp-tools/curation-and-gaps.ts
@@ -10,13 +10,13 @@
 // notes shape, see shared.ts's NotesFieldSchema) -- a genuine difference,
 // preserved as-is.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   McpListArtifactStamp,
   McpListPageFields,
   fieldsSchema,
   kindSchema,
   limitSchema,
-  netuidSchema,
   numericCursorSchema,
   orderSchema,
   projectableRows,
@@ -25,25 +25,21 @@ import {
 import { CurationArtifactSchema } from "../routes/curation-gaps.ts";
 import { GapsArtifactSchema } from "../routes/curation-gaps.ts";
 import { COVERAGE_LEVEL_VALUES, CURATION_LEVEL_VALUES } from "../shared.ts";
-import {
-  CURATION_SORT_FIELDS,
-  GAPS_SORT_FIELDS,
-} from "../routes/curation-gaps.ts";
+import {} from "../routes/curation-gaps.ts";
 
 const COVERAGE_LEVELS = COVERAGE_LEVEL_VALUES;
 const CURATION_LEVELS = CURATION_LEVEL_VALUES;
 export const ListCurationInputSchema = z
   .object({
-    netuid: netuidSchema().optional(),
-    coverage_level: z
-      .enum(COVERAGE_LEVELS)
+    netuid: API_QUERY_COLLECTIONS.curation.filter_schemas.netuid.optional(),
+    coverage_level: API_QUERY_COLLECTIONS.curation.filter_schemas.coverage_level
       .optional()
       .describe(
         "How much of the subnet is covered: on-chain data only, a manifest, or actively probed surfaces.",
       )
       .meta({ examples: [COVERAGE_LEVELS[0]] }),
     curation_level: kindSchema(CURATION_LEVELS).optional(),
-    sort: sortSchema(CURATION_SORT_FIELDS).optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.curation.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -63,16 +59,15 @@ export type ListCurationOutput = z.infer<typeof ListCurationOutputSchema>;
 
 export const ListGapsInputSchema = z
   .object({
-    netuid: netuidSchema().optional(),
-    coverage_level: z
-      .enum(COVERAGE_LEVELS)
+    netuid: API_QUERY_COLLECTIONS.gaps.filter_schemas.netuid.optional(),
+    coverage_level: API_QUERY_COLLECTIONS.gaps.filter_schemas.coverage_level
       .optional()
       .describe(
         "How much of the subnet is covered: on-chain data only, a manifest, or actively probed surfaces.",
       )
       .meta({ examples: [COVERAGE_LEVELS[0]] }),
     curation_level: kindSchema(CURATION_LEVELS).optional(),
-    sort: sortSchema(GAPS_SORT_FIELDS).optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.gaps.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),

--- a/schemas-src/mcp-tools/endpoint-pools-and-provider.ts
+++ b/schemas-src/mcp-tools/endpoint-pools-and-provider.ts
@@ -11,6 +11,7 @@
 // REQUIRED (a path param, not a filter), unlike every other filter in this
 // file.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   McpListArtifactStamp,
   McpListPageFields,
@@ -19,7 +20,6 @@ import {
   idFilterSchema,
   kindSchema,
   limitSchema,
-  netuidSchema,
   numericCursorSchema,
   orderSchema,
   projectableRows,
@@ -36,7 +36,6 @@ import {
 } from "../routes/subnet-detail.ts";
 import { HEALTH_STATUS_VALUES } from "../shared.ts";
 import { ENDPOINT_INCIDENT_SEVERITY_VALUES } from "../routes/endpoints-pools.ts";
-import { ENDPOINT_POOL_SORT_VALUES, ENDPOINT_SORT_VALUES } from "./shared.ts";
 
 export const ListEndpointPoolsInputSchema = z
   .object({
@@ -73,7 +72,9 @@ export const ListEndpointPoolsInputSchema = z
         "Inclusive upper bound on endpoint count; rows above it are excluded.",
       )
       .meta({ examples: [10] }),
-    sort: sortSchema(ENDPOINT_POOL_SORT_VALUES).optional(),
+    sort: sortSchema(
+      API_QUERY_COLLECTIONS["endpoint-pools"].sort_fields,
+    ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -98,35 +99,29 @@ export type ListEndpointPoolsOutput = z.infer<
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
 const HEALTH_STATUSES = HEALTH_STATUS_VALUES;
 const INCIDENT_STATES = ["active", "resolved"] as const;
-const INCIDENT_SORT_FIELDS = [
-  "detected_at",
-  "endpoint_id",
-  "kind",
-  "last_checked",
-  "netuid",
-  "provider",
-  "severity",
-  "state",
-  "status",
-] as const;
 
 export const ListEndpointIncidentsInputSchema = z
   .object({
-    netuid: netuidSchema().optional(),
+    netuid:
+      API_QUERY_COLLECTIONS[
+        "endpoint-incidents"
+      ].filter_schemas.netuid.optional(),
     kind: kindSchema(SURFACE_KINDS).optional(),
     provider: providerSlugSchema().optional(),
     status: kindSchema(HEALTH_STATUSES).optional(),
-    severity: z
-      .enum(ENDPOINT_INCIDENT_SEVERITY_VALUES)
+    severity: API_QUERY_COLLECTIONS[
+      "endpoint-incidents"
+    ].filter_schemas.severity
       .optional()
       .describe("How serious the incident is.")
       .meta({ examples: [ENDPOINT_INCIDENT_SEVERITY_VALUES[0]] }),
-    state: z
-      .enum(INCIDENT_STATES)
+    state: API_QUERY_COLLECTIONS["endpoint-incidents"].filter_schemas.state
       .optional()
       .describe("The incident's lifecycle state.")
       .meta({ examples: [INCIDENT_STATES[0]] }),
-    sort: sortSchema(INCIDENT_SORT_FIELDS).optional(),
+    sort: sortSchema(
+      API_QUERY_COLLECTIONS["endpoint-incidents"].sort_fields,
+    ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -169,14 +164,14 @@ export const ListProviderEndpointsInputSchema = z
         "Which layer of the stack the endpoint belongs to: the Bittensor base chain, a data or docs provider, or a subnet's own app.",
       )
       .meta({ examples: [ENDPOINT_LAYERS[0]] }),
-    netuid: netuidSchema().optional(),
-    publication_state: z
-      .enum(ENDPOINT_PUBLICATION_STATES)
-      .optional()
-      .describe(
-        "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
-      )
-      .meta({ examples: [ENDPOINT_PUBLICATION_STATES[0]] }),
+    netuid: API_QUERY_COLLECTIONS.endpoints.filter_schemas.netuid.optional(),
+    publication_state:
+      API_QUERY_COLLECTIONS.endpoints.filter_schemas.publication_state
+        .optional()
+        .describe(
+          "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
+        )
+        .meta({ examples: [ENDPOINT_PUBLICATION_STATES[0]] }),
     status: kindSchema(HEALTH_STATUSES).optional(),
     pool_eligible: z
       .boolean()
@@ -213,7 +208,7 @@ export const ListProviderEndpointsInputSchema = z
         "Inclusive upper bound on endpoint score; rows above it are excluded.",
       )
       .meta({ examples: [100] }),
-    sort: sortSchema(ENDPOINT_SORT_VALUES).optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.endpoints.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),

--- a/schemas-src/mcp-tools/endpoints-catalog.ts
+++ b/schemas-src/mcp-tools/endpoints-catalog.ts
@@ -15,6 +15,7 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   fieldsSchema,
   kindSchema,
@@ -36,7 +37,6 @@ import {
   SURFACE_KIND_VALUES,
 } from "../routes/subnet-detail.ts";
 import { HEALTH_STATUS_VALUES } from "../shared.ts";
-import { ENDPOINT_SORT_VALUES } from "./shared.ts";
 
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
 const ENDPOINT_LAYERS = ENDPOINT_LAYER_VALUES;
@@ -52,15 +52,15 @@ export const ListEndpointsInputSchema = z
         "Which layer of the stack the endpoint belongs to: the Bittensor base chain, a data or docs provider, or a subnet's own app.",
       )
       .meta({ examples: [ENDPOINT_LAYERS[0]] }),
-    netuid: netuidSchema().optional(),
+    netuid: API_QUERY_COLLECTIONS.endpoints.filter_schemas.netuid.optional(),
     provider: providerSlugSchema().optional(),
-    publication_state: z
-      .enum(ENDPOINT_PUBLICATION_STATES)
-      .optional()
-      .describe(
-        "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
-      )
-      .meta({ examples: [ENDPOINT_PUBLICATION_STATES[0]] }),
+    publication_state:
+      API_QUERY_COLLECTIONS.endpoints.filter_schemas.publication_state
+        .optional()
+        .describe(
+          "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
+        )
+        .meta({ examples: [ENDPOINT_PUBLICATION_STATES[0]] }),
     status: kindSchema(HEALTH_STATUSES).optional(),
     pool_eligible: z
       .boolean()
@@ -97,7 +97,7 @@ export const ListEndpointsInputSchema = z
         "Inclusive upper bound on endpoint score; rows above it are excluded.",
       )
       .meta({ examples: [100] }),
-    sort: sortSchema(ENDPOINT_SORT_VALUES).optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.endpoints.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     // Ceiling is MAX_LIMIT (workers/request-params.ts:21); a literal here
@@ -134,7 +134,17 @@ export type GetSubnetEndpointsInput = z.infer<
   typeof GetSubnetEndpointsInputSchema
 >;
 
-export const GetSubnetEndpointsOutputSchema = SubnetEndpointsArtifactSchema;
+// #10064 production sweep: this tool advertises `fields`, so a caller can ask
+// for a SUBSET of each row -- and the artifact schema requires every property
+// on it. Production answered `?fields=` with rows that failed the tool's own
+// published schema; `projectableRows` is the convention the sibling tools
+// already use. Field names and types still come from the route, so a rename
+// there is still a compile error here; only requiredness changes, because the
+// caller controls it.
+export const GetSubnetEndpointsOutputSchema =
+  SubnetEndpointsArtifactSchema.extend({
+    endpoints: projectableRows(SubnetEndpointsArtifactSchema.shape.endpoints),
+  });
 export type GetSubnetEndpointsOutput = z.infer<
   typeof GetSubnetEndpointsOutputSchema
 >;

--- a/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
+++ b/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
@@ -9,6 +9,7 @@
 // mirror an existing schemas-src/routes/ REST schema -- modeled fresh,
 // matching each hand-written literal field-for-field.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   reasonCodesSchema,
   reviewStateSchema,
@@ -17,7 +18,6 @@ import {
   fieldsSchema,
   kindSchema,
   limitSchema,
-  netuidSchema,
   numericCursorSchema,
   orderSchema,
   projectableRows,
@@ -36,10 +36,7 @@ import { ReviewGapPrioritiesArtifactSchema } from "../routes/review-gaps-profile
 import { ReviewEnrichmentTargetsArtifactSchema } from "../routes/review-enrichment.ts";
 import { SURFACE_KIND_VALUES } from "../routes/subnet-detail.ts";
 import { CURATION_LEVEL_VALUES } from "../shared.ts";
-import {
-  EVIDENCE_SORT_FIELDS,
-  TARGET_SORT_FIELDS,
-} from "../routes/review-enrichment.ts";
+import {} from "../routes/review-enrichment.ts";
 import { PRIORITY_SORT_FIELDS } from "../routes/review-gaps-profile.ts";
 import { IDENTITY_LEVEL_VALUES, PROFILE_LEVEL_VALUES } from "../shared.ts";
 
@@ -49,14 +46,17 @@ const LANES = REVIEW_ENRICHMENT_LANE_VALUES;
 export const ListEnrichmentEvidenceInputSchema = z
   .object({
     q: querySchema().optional(),
-    netuid: netuidSchema().optional(),
-    lane: z
-      .enum(LANES)
+    netuid:
+      API_QUERY_COLLECTIONS[
+        "enrichment-evidence"
+      ].filter_schemas.netuid.optional(),
+    lane: API_QUERY_COLLECTIONS["enrichment-evidence"].filter_schemas.lane
       .optional()
       .describe("Which contribution lane the item belongs to.")
       .meta({ examples: [LANES[0]] }),
-    evidence_action: z
-      .enum(EVIDENCE_ACTIONS)
+    evidence_action: API_QUERY_COLLECTIONS[
+      "enrichment-evidence"
+    ].filter_schemas.evidence_action
       .optional()
       .describe("What the evidence is asking a contributor to do.")
       .meta({ examples: [EVIDENCE_ACTIONS[0]] }),
@@ -74,7 +74,9 @@ export const ListEnrichmentEvidenceInputSchema = z
         "Restrict to subnets where surfaces of this kind the subnet is MISSING. One kind per call; see this parameter's enum.",
       )
       .meta({ examples: [SURFACE_KINDS[0]] }),
-    sort: sortSchema(EVIDENCE_SORT_FIELDS).optional(),
+    sort: sortSchema(
+      API_QUERY_COLLECTIONS["enrichment-evidence"].sort_fields,
+    ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -102,7 +104,7 @@ export type ListEnrichmentEvidenceOutput = z.infer<
 const CURATION_LEVELS = CURATION_LEVEL_VALUES;
 export const ListReviewGapsInputSchema = z
   .object({
-    netuid: netuidSchema().optional(),
+    netuid: API_QUERY_COLLECTIONS.gaps.filter_schemas.netuid.optional(),
     curation_level: kindSchema(CURATION_LEVELS).optional(),
     missing_kinds: z
       .enum(SURFACE_KINDS)
@@ -140,52 +142,62 @@ const TARGET_TYPES = REVIEW_ENRICHMENT_TARGET_TYPE_VALUES;
 export const ListReviewEnrichmentTargetsInputSchema = z
   .object({
     q: querySchema().optional(),
-    netuid: netuidSchema().optional(),
-    target_type: z
-      .enum(TARGET_TYPES)
+    netuid:
+      API_QUERY_COLLECTIONS[
+        "enrichment-targets"
+      ].filter_schemas.netuid.optional(),
+    target_type: API_QUERY_COLLECTIONS[
+      "enrichment-targets"
+    ].filter_schemas.target_type
       .optional()
       .describe("What kind of enrichment target this is.")
       .meta({ examples: [TARGET_TYPES[0]] }),
-    target_action: z
-      .enum(TARGET_ACTIONS)
+    target_action: API_QUERY_COLLECTIONS[
+      "enrichment-targets"
+    ].filter_schemas.target_action
       .optional()
       .describe("What the target is asking a contributor to do.")
       .meta({ examples: [TARGET_ACTIONS[0]] }),
     kind: kindSchema(SURFACE_KINDS).optional(),
-    lane: z
-      .enum(LANES)
+    lane: API_QUERY_COLLECTIONS["enrichment-targets"].filter_schemas.lane
       .optional()
       .describe("Which contribution lane the item belongs to.")
       .meta({ examples: [LANES[0]] }),
-    evidence_action: z
-      .enum(EVIDENCE_ACTIONS)
+    evidence_action: API_QUERY_COLLECTIONS[
+      "enrichment-targets"
+    ].filter_schemas.evidence_action
       .optional()
       .describe("What the evidence is asking a contributor to do.")
       .meta({ examples: [EVIDENCE_ACTIONS[0]] }),
-    identity_level: z
-      .enum(IDENTITY_LEVEL_VALUES)
+    identity_level: API_QUERY_COLLECTIONS[
+      "enrichment-targets"
+    ].filter_schemas.identity_level
       .optional()
       .describe("How complete the subnet's published identity is.")
       .meta({ examples: [IDENTITY_LEVEL_VALUES[0]] }),
-    profile_level: z
-      .enum(PROFILE_LEVEL_VALUES)
+    profile_level: API_QUERY_COLLECTIONS[
+      "enrichment-targets"
+    ].filter_schemas.profile_level
       .optional()
       .describe(
         "How complete the subnet's profile is, from directory-only upward.",
       )
       .meta({ examples: [PROFILE_LEVEL_VALUES[0]] }),
-    submission_route: z
-      .enum(SUBMISSION_ROUTES)
+    submission_route: API_QUERY_COLLECTIONS[
+      "enrichment-targets"
+    ].filter_schemas.submission_route
       .optional()
       .describe("How a contribution for this gap should be submitted.")
       .meta({ examples: [SUBMISSION_ROUTES[0]] }),
-    auto_review_candidate: z
-      .enum(BOOLEAN_STRINGS)
+    auto_review_candidate: API_QUERY_COLLECTIONS[
+      "enrichment-targets"
+    ].filter_schemas.auto_review_candidate
       .optional()
       .describe("Restrict to items eligible for automated review.")
       .meta({ examples: [BOOLEAN_STRINGS[0]] }),
-    manual_review_required: z
-      .enum(BOOLEAN_STRINGS)
+    manual_review_required: API_QUERY_COLLECTIONS[
+      "enrichment-targets"
+    ].filter_schemas.manual_review_required
       .optional()
       .describe("Restrict to items that do (or do not) need a human reviewer.")
       .meta({ examples: [BOOLEAN_STRINGS[0]] }),
@@ -197,7 +209,9 @@ export const ListReviewEnrichmentTargetsInputSchema = z
       )
       .meta({ examples: [SURFACE_KINDS[0]] }),
     reason_codes: reasonCodesSchema().optional(),
-    sort: sortSchema(TARGET_SORT_FIELDS).optional(),
+    sort: sortSchema(
+      API_QUERY_COLLECTIONS["enrichment-targets"].sort_fields,
+    ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),

--- a/schemas-src/mcp-tools/enrichment-queue-and-candidates.ts
+++ b/schemas-src/mcp-tools/enrichment-queue-and-candidates.ts
@@ -8,6 +8,7 @@
 // REST schema -- modeled fresh, matching each hand-written literal
 // field-for-field.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   reasonCodesSchema,
   reviewStateSchema,
@@ -16,7 +17,6 @@ import {
   fieldsSchema,
   kindSchema,
   limitSchema,
-  netuidSchema,
   numericCursorSchema,
   orderSchema,
   projectableRows,
@@ -31,11 +31,7 @@ import {
 import { ReviewAdapterCandidatesArtifactSchema } from "../routes/review-enrichment.ts";
 import { SURFACE_KIND_VALUES } from "../routes/subnet-detail.ts";
 import { CURATION_LEVEL_VALUES } from "../shared.ts";
-import {
-  ADAPTER_CANDIDATES_SORT_FIELDS,
-  QUEUE_SORT_FIELDS,
-  RECOMMENDED_ADAPTER_KINDS,
-} from "../routes/review-enrichment.ts";
+import { RECOMMENDED_ADAPTER_KINDS } from "../routes/review-enrichment.ts";
 import { IDENTITY_LEVEL_VALUES, PROFILE_LEVEL_VALUES } from "../shared.ts";
 
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
@@ -46,25 +42,30 @@ const BOOLEAN_STRINGS = ["true", "false"] as const;
 export const ListEnrichmentQueueInputSchema = z
   .object({
     q: querySchema().optional(),
-    netuid: netuidSchema().optional(),
-    lane: z
-      .enum(LANES)
+    netuid:
+      API_QUERY_COLLECTIONS[
+        "enrichment-queue"
+      ].filter_schemas.netuid.optional(),
+    lane: API_QUERY_COLLECTIONS["enrichment-queue"].filter_schemas.lane
       .optional()
       .describe("Which contribution lane the item belongs to.")
       .meta({ examples: [LANES[0]] }),
-    evidence_action: z
-      .enum(EVIDENCE_ACTIONS)
+    evidence_action: API_QUERY_COLLECTIONS[
+      "enrichment-queue"
+    ].filter_schemas.evidence_action
       .optional()
       .describe("What the evidence is asking a contributor to do.")
       .meta({ examples: [EVIDENCE_ACTIONS[0]] }),
-    identity_level: z
-      .enum(IDENTITY_LEVEL_VALUES)
+    identity_level: API_QUERY_COLLECTIONS[
+      "enrichment-queue"
+    ].filter_schemas.identity_level
       .optional()
       .describe("How complete the subnet's published identity is.")
       .meta({ examples: [IDENTITY_LEVEL_VALUES[0]] }),
     curation_level: kindSchema(CURATION_LEVELS).optional(),
-    profile_level: z
-      .enum(PROFILE_LEVEL_VALUES)
+    profile_level: API_QUERY_COLLECTIONS[
+      "enrichment-queue"
+    ].filter_schemas.profile_level
       .optional()
       .describe(
         "How complete the subnet's profile is, from directory-only upward.",
@@ -84,14 +85,17 @@ export const ListEnrichmentQueueInputSchema = z
         "Restrict to subnets where surfaces of this kind the subnet is MISSING. One kind per call; see this parameter's enum.",
       )
       .meta({ examples: [SURFACE_KINDS[0]] }),
-    manual_review_required: z
-      .enum(BOOLEAN_STRINGS)
+    manual_review_required: API_QUERY_COLLECTIONS[
+      "enrichment-queue"
+    ].filter_schemas.manual_review_required
       .optional()
       .describe("Restrict to items that do (or do not) need a human reviewer.")
       .meta({ examples: [BOOLEAN_STRINGS[0]] }),
     reason_codes: reasonCodesSchema().optional(),
     review_state: reviewStateSchema().optional(),
-    sort: sortSchema(QUEUE_SORT_FIELDS).optional(),
+    sort: sortSchema(
+      API_QUERY_COLLECTIONS["enrichment-queue"].sort_fields,
+    ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -116,7 +120,10 @@ export type ListEnrichmentQueueOutput = z.infer<
 
 export const ListAdapterCandidatesInputSchema = z
   .object({
-    netuid: netuidSchema().optional(),
+    netuid:
+      API_QUERY_COLLECTIONS[
+        "adapter-candidates"
+      ].filter_schemas.netuid.optional(),
     curation_level: kindSchema(CURATION_LEVELS).optional(),
     candidate_api_kinds: z
       .enum(SURFACE_KINDS)
@@ -132,13 +139,16 @@ export const ListAdapterCandidatesInputSchema = z
         "Restrict to subnets where surfaces of this kind are operational. One kind per call; see this parameter's enum.",
       )
       .meta({ examples: [SURFACE_KINDS[0]] }),
-    recommended_adapter_kind: z
-      .enum(RECOMMENDED_ADAPTER_KINDS)
+    recommended_adapter_kind: API_QUERY_COLLECTIONS[
+      "adapter-candidates"
+    ].filter_schemas.recommended_adapter_kind
       .optional()
       .describe("Which adapter shape suits this surface.")
       .meta({ examples: [RECOMMENDED_ADAPTER_KINDS[0]] }),
     reason_codes: reasonCodesSchema().optional(),
-    sort: sortSchema(ADAPTER_CANDIDATES_SORT_FIELDS).optional(),
+    sort: sortSchema(
+      API_QUERY_COLLECTIONS["adapter-candidates"].sort_fields,
+    ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),

--- a/schemas-src/mcp-tools/extrinsics.ts
+++ b/schemas-src/mcp-tools/extrinsics.ts
@@ -11,22 +11,17 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { CHAIN_CALL_MODULE_MAX_LENGTH } from "../../src/route-limits.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 
-import {
-  blockBoundSchema,
-  hashSchema,
-  keysetCursorSchema,
-  limitSchema,
-  offsetSchema,
-  runtimeNameSchema,
-} from "./shared.ts";
+import { blockBoundSchema } from "./shared.ts";
 
 /**
  * Page-size ceiling for the extrinsics feeds and the two fixed-call_module feeds
  * modelled on them (get_sudo, get_governance_config_changes). Exported so those two
  * read it rather than restating it — they previously declared no maximum at all.
  */
+const RouteQuery_extrinsics = ROUTE_QUERY_SCHEMAS["/api/v1/extrinsics"];
+
 export const EXTRINSICS_LIMIT_MAX = 100;
 
 import { AccountEventItemSchema } from "./shared.ts";
@@ -50,21 +45,17 @@ export const ListExtrinsicsInputSchema = z
         "Restrict to extrinsics signed by this SS58 account. Unsigned (inherent) extrinsics never match.",
       )
       .meta({ examples: ["5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F"] }),
-    call_module: runtimeNameSchema(CHAIN_CALL_MODULE_MAX_LENGTH)
-      .optional()
+    call_module: RouteQuery_extrinsics.shape.call_module
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
       )
       .meta({ examples: ["SubtensorModule"] }),
-    call_function: z
-      .string()
-      .optional()
+    call_function: RouteQuery_extrinsics.shape.call_function
       .describe(
         "Restrict to one call within the pallet (`add_stake`). Case-sensitive; pair with `call_module` to disambiguate.",
       )
       .meta({ examples: ["add_stake"] }),
-    call_hash: hashSchema("extrinsic's call hash")
-      .optional()
+    call_hash: RouteQuery_extrinsics.shape.call_hash
       .describe("Restrict to the extrinsic with this 0x-prefixed hash.")
       .meta({
         examples: [
@@ -96,9 +87,9 @@ export const ListExtrinsicsInputSchema = z
         "Inclusive end of the range. A block height on chain tools, an ISO-8601 date on time-series ones; an EVM address on decode_evm_call.",
       )
       .meta({ examples: [8783000] }),
-    limit: limitSchema(EXTRINSICS_LIMIT_MAX).optional(),
-    offset: offsetSchema().optional(),
-    cursor: keysetCursorSchema().optional(),
+    limit: RouteQuery_extrinsics.shape.limit,
+    offset: RouteQuery_extrinsics.shape.offset,
+    cursor: RouteQuery_extrinsics.shape.cursor,
   })
   .strict();
 export type ListExtrinsicsInput = z.infer<typeof ListExtrinsicsInputSchema>;

--- a/schemas-src/mcp-tools/get-chain-concentration-history.ts
+++ b/schemas-src/mcp-tools/get-chain-concentration-history.ts
@@ -1,14 +1,16 @@
 // get_chain_concentration_history (#9628): the network-wide concentration
 // series, mirroring GET /api/v1/chain/concentration/history.
 import { z } from "zod";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { ChainConcentrationHistoryArtifactSchema } from "../routes/chain-concentration-history.ts";
 import { CHAIN_CONCENTRATION_HISTORY_WINDOWS } from "../../src/route-limits.ts";
 
+const RouteQuery_chain_concentration_history =
+  ROUTE_QUERY_SCHEMAS["/api/v1/chain/concentration/history"];
+
 export const GetChainConcentrationHistoryInputSchema = z
   .object({
-    window: z
-      .enum(CHAIN_CONCENTRATION_HISTORY_WINDOWS as [string, ...string[]])
-      .optional()
+    window: RouteQuery_chain_concentration_history.shape.window
       .describe(
         "Trailing time window to aggregate over, ending at the latest data point rather than a calendar boundary. Options are per-tool; see this parameter's enum.",
       )

--- a/schemas-src/mcp-tools/get-chain-holders.ts
+++ b/schemas-src/mcp-tools/get-chain-holders.ts
@@ -11,23 +11,19 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { limitSchema, sortSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { limitSchema } from "./shared.ts";
 import {
   CHAIN_HOLDERS_LIMIT_DEFAULT,
   CHAIN_HOLDERS_LIMIT_MAX,
 } from "../../src/route-limits.ts";
 import { ChainHoldersArtifactSchema } from "../routes/chain-holders.ts";
 
+const RouteQuery_chain_holders = ROUTE_QUERY_SCHEMAS["/api/v1/chain/holders"];
+
 export const GetChainHoldersInputSchema = z
   .object({
-    sort: sortSchema([
-      "top1_share",
-      "top5_share",
-      "top10_share",
-      "top20_share",
-      "holder_count",
-      "total_alpha",
-    ]).optional(),
+    sort: RouteQuery_chain_holders.shape.sort,
     limit: limitSchema(
       CHAIN_HOLDERS_LIMIT_MAX,
       CHAIN_HOLDERS_LIMIT_DEFAULT,

--- a/schemas-src/mcp-tools/get-economics-trends.ts
+++ b/schemas-src/mcp-tools/get-economics-trends.ts
@@ -19,13 +19,15 @@
 // schema files and is tracked separately in #9799 -- single-sourcing it is that
 // issue's job, not this one's.
 import { z } from "zod";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { EconomicsTrendsArtifactSchema } from "../routes/economics-trends.ts";
-import { windowSchema } from "./shared.ts";
-import { ECONOMICS_TRENDS_WINDOW_VALUES } from "../routes/economics-trends.ts";
+
+const RouteQuery_economics_trends =
+  ROUTE_QUERY_SCHEMAS["/api/v1/economics/trends"];
 
 export const GetEconomicsTrendsInputSchema = z
   .object({
-    window: windowSchema(ECONOMICS_TRENDS_WINDOW_VALUES).optional(),
+    window: RouteQuery_economics_trends.shape.window,
   })
   .strict();
 export type GetEconomicsTrendsInput = z.infer<

--- a/schemas-src/mcp-tools/get-economics.ts
+++ b/schemas-src/mcp-tools/get-economics.ts
@@ -12,10 +12,10 @@
 // constraint means NOT tightening beyond what already shipped, even though
 // the real per-row data happens to satisfy the deeper REST schema too.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   fieldsSchema,
   limitSchema,
-  netuidSchema,
   offsetSchema,
   orderSchema,
   querySchema,
@@ -24,44 +24,16 @@ import {
 import { EconomicsSummarySchema } from "../routes/economics.ts";
 import { SubnetEconomicsSchema } from "../shared.ts";
 
-const ECONOMICS_SORT_FIELDS = [
-  "alpha_fdv_tao",
-  "alpha_market_cap_tao",
-  "alpha_price_change_1d",
-  "alpha_price_change_1h",
-  "alpha_price_change_1m",
-  "alpha_price_change_7d",
-  "alpha_price_tao",
-  "block",
-  "emission_share",
-  // The column is denominated in the subnet's ALPHA token, which is the
-  // name /api/v1/economics publishes and accepts. `max_stake_tao` was a
-  // `_tao` suffix applied by habit, and the route answers it with a 400
-  // (#10118).
-  "max_stake_alpha",
-  "max_uids",
-  "max_validators",
-  "miner_count",
-  "miner_readiness",
-  "name",
-  "netuid",
-  "open_slots",
-  "registration_cost_tao",
-  "subnet_volume_tao",
-  "total_stake_alpha",
-  "validator_count",
-] as const;
-
 export const GetEconomicsInputSchema = z
   .object({
-    netuid: netuidSchema().optional(),
-    registration_allowed: z
-      .enum(["true", "false"])
-      .optional()
-      .describe("Restrict to subnets currently accepting registrations.")
-      .meta({ examples: ["true"] }),
+    netuid: API_QUERY_COLLECTIONS.economics.filter_schemas.netuid.optional(),
+    registration_allowed:
+      API_QUERY_COLLECTIONS.economics.filter_schemas.registration_allowed
+        .optional()
+        .describe("Restrict to subnets currently accepting registrations.")
+        .meta({ examples: ["true"] }),
     q: querySchema().optional(),
-    sort: sortSchema(ECONOMICS_SORT_FIELDS).optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.economics.sort_fields).optional(),
     order: orderSchema().optional(),
     // `sort` and `order` were enums while this was a bare string with no stated
     // format anywhere — comma-separated? a JSON array? — so the one parameter an agent

--- a/schemas-src/mcp-tools/get-emission-changes.ts
+++ b/schemas-src/mcp-tools/get-emission-changes.ts
@@ -11,16 +11,20 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { kindSchema, limitSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { limitSchema } from "./shared.ts";
 import {
   EMISSION_CHANGES_LIMIT_DEFAULT,
   EMISSION_CHANGES_LIMIT_MAX,
 } from "../../src/route-limits.ts";
 import { EmissionGateChangesArtifactSchema } from "../routes/emission-gate-changes.ts";
 
+const RouteQuery_chain_governance_emission_changes =
+  ROUTE_QUERY_SCHEMAS["/api/v1/chain/governance/emission-changes"];
+
 export const GetEmissionChangesInputSchema = z
   .object({
-    kind: kindSchema(["param", "subnet", "flow"]).optional(),
+    kind: RouteQuery_chain_governance_emission_changes.shape.kind,
     limit: limitSchema(
       EMISSION_CHANGES_LIMIT_MAX,
       EMISSION_CHANGES_LIMIT_DEFAULT,

--- a/schemas-src/mcp-tools/get-emission-pipeline.ts
+++ b/schemas-src/mcp-tools/get-emission-pipeline.ts
@@ -11,35 +11,31 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import {
-  fieldsSchema,
-  limitSchema,
-  netuidSchema,
-  orderSchema,
-  projectableRows,
-  sortSchema,
-} from "./shared.ts";
-import { EMISSION_PIPELINE_SORT_FIELDS } from "../../src/emission-pipeline-surface.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { limitSchema, projectableRows } from "./shared.ts";
 import {
   EMISSION_PIPELINE_LIMIT_MAX,
   EMISSION_PIPELINE_MCP_LIMIT_DEFAULT,
 } from "../../src/route-limits.ts";
 import { EmissionPipelineArtifactSchema } from "../routes/emission-pipeline.ts";
 
+const RouteQuery_chain_emission_pipeline =
+  ROUTE_QUERY_SCHEMAS["/api/v1/chain/emission-pipeline"];
+
 export const GetEmissionPipelineInputSchema = z
   .object({
     // Narrows the per-subnet rows only; the aggregate and the identity checks
     // stay network-wide, matching ?netuid= on the REST route.
-    netuid: netuidSchema().optional(),
+    netuid: RouteQuery_chain_emission_pipeline.shape.netuid,
     // #9720. 129 subnets x 16 fields is ~56 KB, and `netuid` was the only
     // filter -- it narrows to ONE subnet or leaves all of them, with nothing in
     // between. NARROWING THE RESPONSE NEVER NARROWS THE MEASUREMENT: the
     // aggregate and the four identity checks are computed over every subnet
     // before any of this applies, so `verification` still covers the whole
     // distribution.
-    sort: sortSchema(EMISSION_PIPELINE_SORT_FIELDS).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
+    sort: RouteQuery_chain_emission_pipeline.shape.sort,
+    order: RouteQuery_chain_emission_pipeline.shape.order,
+    fields: RouteQuery_chain_emission_pipeline.shape.fields,
     limit: limitSchema(
       EMISSION_PIPELINE_LIMIT_MAX,
       EMISSION_PIPELINE_MCP_LIMIT_DEFAULT,

--- a/schemas-src/mcp-tools/get-failure-reasons.ts
+++ b/schemas-src/mcp-tools/get-failure-reasons.ts
@@ -11,21 +11,22 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { kindStringSchema, netuidSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { FAILURE_REASONS_WINDOWS } from "../../src/route-limits.ts";
 import { FailureReasonsArtifactSchema } from "../routes/failure-reasons.ts";
 
+const RouteQuery_health_failure_reasons =
+  ROUTE_QUERY_SCHEMAS["/api/v1/health/failure-reasons"];
+
 export const GetFailureReasonsInputSchema = z
   .object({
-    window: z
-      .enum(FAILURE_REASONS_WINDOWS as [string, ...string[]])
-      .optional()
+    window: RouteQuery_health_failure_reasons.shape.window
       .describe(
         "Trailing time window to aggregate over, ending at the latest data point rather than a calendar boundary. Options are per-tool; see this parameter's enum.",
       )
       .meta({ examples: [FAILURE_REASONS_WINDOWS[0]] }),
-    netuid: netuidSchema().optional(),
-    kind: kindStringSchema().optional(),
+    netuid: RouteQuery_health_failure_reasons.shape.netuid,
+    kind: RouteQuery_health_failure_reasons.shape.kind,
   })
   .strict();
 export type GetFailureReasonsInput = z.infer<

--- a/schemas-src/mcp-tools/get-global-incidents.ts
+++ b/schemas-src/mcp-tools/get-global-incidents.ts
@@ -14,9 +14,9 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   limitSchema,
-  netuidSchema,
   numericCursorSchema,
   orderSchema,
   sortSchema,
@@ -27,18 +27,12 @@ import { GlobalIncidentsArtifactSchema } from "../routes/health-surfaces.ts";
 // Symbolic in the hand-written original (src/contracts.ts's
 // API_QUERY_COLLECTIONS.incidents.sort_fields), cross-checked against the
 // actual runtime array at the time of writing.
-const GLOBAL_INCIDENTS_SORT_FIELDS = [
-  "downtime_ms",
-  "incident_count",
-  "netuid",
-  "surface_id",
-] as const;
 
 export const GetGlobalIncidentsInputSchema = z
   .object({
     window: windowSchema(["7d", "30d"]).optional(),
-    netuid: netuidSchema().optional(),
-    sort: sortSchema(GLOBAL_INCIDENTS_SORT_FIELDS).optional(),
+    netuid: API_QUERY_COLLECTIONS.incidents.filter_schemas.netuid.optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.incidents.sort_fields).optional(),
     order: orderSchema().optional(),
     limit: limitSchema(100).optional(),
     cursor: numericCursorSchema().optional(),

--- a/schemas-src/mcp-tools/get-health-history.ts
+++ b/schemas-src/mcp-tools/get-health-history.ts
@@ -9,11 +9,11 @@
 // .sort_fields at the time of writing (mirrors the pilot batch's
 // ECONOMICS_SORT_FIELDS precedent -- not cross-imported).
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   fieldsSchema,
   kindSchema,
   limitSchema,
-  netuidSchema,
   numericCursorSchema,
   orderSchema,
   providerSlugSchema,
@@ -25,10 +25,7 @@ import {
   HealthHistorySummarySchema,
   HealthHistorySurfaceSchema,
 } from "../routes/health-surfaces.ts";
-import {
-  HEALTH_CLASSIFICATION_VALUES,
-  HEALTH_SURFACE_SORT_VALUES,
-} from "./shared.ts";
+import { HEALTH_CLASSIFICATION_VALUES } from "./shared.ts";
 
 const SURFACE_KIND = SURFACE_KIND_VALUES;
 const HEALTH_STATUS = HEALTH_STATUS_VALUES;
@@ -45,22 +42,25 @@ export const GetHealthHistoryInputSchema = z
       .regex(/^\d{4}-\d{2}-\d{2}$/)
       .describe("A single UTC day, `YYYY-MM-DD`.")
       .meta({ format: "date", examples: ["2026-08-05"] }),
-    netuid: netuidSchema().optional(),
+    netuid:
+      API_QUERY_COLLECTIONS["health-surfaces"].filter_schemas.netuid.optional(),
     kind: kindSchema(SURFACE_KIND).optional(),
     provider: providerSlugSchema().optional(),
-    status: z
-      .enum(HEALTH_STATUS)
+    status: API_QUERY_COLLECTIONS["health-surfaces"].filter_schemas.status
       .optional()
       .describe("Restrict to rows with this health status.")
       .meta({ examples: [HEALTH_STATUS[0]] }),
-    classification: z
-      .enum(HEALTH_CLASSIFICATION_VALUES)
+    classification: API_QUERY_COLLECTIONS[
+      "health-surfaces"
+    ].filter_schemas.classification
       .optional()
       .describe(
         "Why a probe ended as it did — the reason behind the status, not the status itself.",
       )
       .meta({ examples: [HEALTH_CLASSIFICATION_VALUES[0]] }),
-    sort: sortSchema(HEALTH_SURFACE_SORT_VALUES).optional(),
+    sort: sortSchema(
+      API_QUERY_COLLECTIONS["health-surfaces"].sort_fields,
+    ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(1000).optional(),

--- a/schemas-src/mcp-tools/get-network-health.ts
+++ b/schemas-src/mcp-tools/get-network-health.ts
@@ -14,9 +14,8 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import { HealthSummaryArtifactSchema } from "../routes/health.ts";
-import { HEALTH_STATUS_VALUES } from "../shared.ts";
-import { netuidSchema } from "./shared.ts";
 
 /**
  * #10014. This took NO arguments -- not even `netuid` -- and returned every
@@ -29,12 +28,11 @@ import { netuidSchema } from "./shared.ts";
  */
 export const GetNetworkHealthInputSchema = z
   .object({
-    netuid: netuidSchema()
+    netuid: API_QUERY_COLLECTIONS["health-subnets"].filter_schemas.netuid
       .optional()
       .describe("Restrict to one subnet's health row.")
       .meta({ examples: [64] }),
-    status: z
-      .enum(HEALTH_STATUS_VALUES)
+    status: API_QUERY_COLLECTIONS["health-subnets"].filter_schemas.status
       .optional()
       .describe(
         "Restrict to subnets in this operational state. `failed` is the one an alerting caller usually wants; `unknown` means unprobed, which is NOT the same as healthy.",

--- a/schemas-src/mcp-tools/get-registry-leaderboards.ts
+++ b/schemas-src/mcp-tools/get-registry-leaderboards.ts
@@ -14,7 +14,7 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { limitSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { RegistryLeaderboardsArtifactSchema } from "../routes/registry-summary-leaderboards.ts";
 
 const LEADERBOARD_BOARDS = [
@@ -32,14 +32,15 @@ const LEADERBOARD_BOARDS = [
   "biggest-alpha-gain-7d",
 ] as const;
 
+const RouteQuery_registry_leaderboards =
+  ROUTE_QUERY_SCHEMAS["/api/v1/registry/leaderboards"];
+
 export const GetRegistryLeaderboardsInputSchema = z
   .object({
-    board: z
-      .enum(LEADERBOARD_BOARDS)
-      .optional()
+    board: RouteQuery_registry_leaderboards.shape.board
       .describe("Which leaderboard to return.")
       .meta({ examples: [LEADERBOARD_BOARDS[0]] }),
-    limit: limitSchema(100).optional(),
+    limit: RouteQuery_registry_leaderboards.shape.limit,
   })
   .strict();
 export type GetRegistryLeaderboardsInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-concentration-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-concentration-history.ts
@@ -4,14 +4,17 @@
 // Zod schema to reuse. Modeled fresh, shallow, from the hand-written
 // literal it replaces.
 import { z } from "zod";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { SubnetConcentrationHistoryArtifactSchema } from "../routes/subnet-concentration.ts";
-import { netuidSchema, windowSchema } from "./shared.ts";
-import { SUBNET_CONCENTRATION_WINDOW_VALUES } from "../routes/subnet-concentration.ts";
+import { netuidSchema } from "./shared.ts";
+
+const RouteQuery_subnets_netuid_concentration_history =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/concentration/history"];
 
 export const GetSubnetConcentrationHistoryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(SUBNET_CONCENTRATION_WINDOW_VALUES).optional(),
+    window: RouteQuery_subnets_netuid_concentration_history.shape.window,
   })
   .strict();
 export type GetSubnetConcentrationHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-event-summary.ts
+++ b/schemas-src/mcp-tools/get-subnet-event-summary.ts
@@ -14,20 +14,23 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import {
   SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
   SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
 } from "../../src/route-limits.ts";
-import { limitSchema, netuidSchema, windowSchema } from "./shared.ts";
+import { limitSchema, netuidSchema } from "./shared.ts";
 import { SubnetEventSummaryArtifactSchema } from "../routes/subnet-event-summary.ts";
-import { SUBNET_EVENT_SUMMARY_WINDOW_VALUES } from "../routes/subnet-event-summary.ts";
 
 // objectItems(...) properties, none required at the item level (see
 // search-subnets.ts's same note from the pilot batch).
+const RouteQuery_subnets_netuid_event_summary =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/event-summary"];
+
 export const GetSubnetEventSummaryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(SUBNET_EVENT_SUMMARY_WINDOW_VALUES).optional(),
+    window: RouteQuery_subnets_netuid_event_summary.shape.window,
     limit: limitSchema(
       SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
       SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,

--- a/schemas-src/mcp-tools/get-subnet-events.ts
+++ b/schemas-src/mcp-tools/get-subnet-events.ts
@@ -11,25 +11,22 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import {
-  blockBoundSchema,
-  keysetCursorSchema,
-  kindStringSchema,
-  limitSchema,
-  netuidSchema,
-  offsetSchema,
-} from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { blockBoundSchema, netuidSchema } from "./shared.ts";
 import { SubnetEventsArtifactSchema } from "../routes/subnet-events.ts";
+
+const RouteQuery_subnets_netuid_events =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/events"];
 
 export const GetSubnetEventsInputSchema = z
   .object({
     netuid: netuidSchema(),
-    kind: kindStringSchema().optional(),
+    kind: RouteQuery_subnets_netuid_events.shape.kind,
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    limit: limitSchema(1000).optional(),
-    offset: offsetSchema().optional(),
-    cursor: keysetCursorSchema().optional(),
+    limit: RouteQuery_subnets_netuid_events.shape.limit,
+    offset: RouteQuery_subnets_netuid_events.shape.offset,
+    cursor: RouteQuery_subnets_netuid_events.shape.cursor,
   })
   .strict();
 export type GetSubnetEventsInput = z.infer<typeof GetSubnetEventsInputSchema>;

--- a/schemas-src/mcp-tools/get-subnet-health-incidents.ts
+++ b/schemas-src/mcp-tools/get-subnet-health-incidents.ts
@@ -11,15 +11,17 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { netuidSchema, windowSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { netuidSchema } from "./shared.ts";
 import { HealthIncidentsArtifactSchema } from "../routes/health-surfaces.ts";
 
-const HEALTH_WINDOWS = ["7d", "30d"] as const;
+const RouteQuery_subnets_netuid_health_incidents =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/health/incidents"];
 
 export const GetSubnetHealthIncidentsInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(HEALTH_WINDOWS).optional(),
+    window: RouteQuery_subnets_netuid_health_incidents.shape.window,
   })
   .strict();
 export type GetSubnetHealthIncidentsInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-health-percentiles.ts
+++ b/schemas-src/mcp-tools/get-subnet-health-percentiles.ts
@@ -11,15 +11,17 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { netuidSchema, windowSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { netuidSchema } from "./shared.ts";
 import { HealthPercentilesArtifactSchema } from "../routes/health-surfaces.ts";
 
-const HEALTH_WINDOWS = ["7d", "30d"] as const;
+const RouteQuery_subnets_netuid_health_percentiles =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/health/percentiles"];
 
 export const GetSubnetHealthPercentilesInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(HEALTH_WINDOWS).optional(),
+    window: RouteQuery_subnets_netuid_health_percentiles.shape.window,
   })
   .strict();
 export type GetSubnetHealthPercentilesInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-history.ts
@@ -11,14 +11,17 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { netuidSchema, windowSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { netuidSchema } from "./shared.ts";
 import { SubnetHistoryArtifactSchema } from "../routes/subnet-history.ts";
-import { SUBNET_HISTORY_WINDOW_VALUES } from "../routes/subnet-history.ts";
+
+const RouteQuery_subnets_netuid_history =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/history"];
 
 export const GetSubnetHistoryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(SUBNET_HISTORY_WINDOW_VALUES).optional(),
+    window: RouteQuery_subnets_netuid_history.shape.window,
   })
   .strict();
 export type GetSubnetHistoryInput = z.infer<typeof GetSubnetHistoryInputSchema>;

--- a/schemas-src/mcp-tools/get-subnet-hyperparams.ts
+++ b/schemas-src/mcp-tools/get-subnet-hyperparams.ts
@@ -15,16 +15,15 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import {
-  keysetCursorSchema,
-  limitSchema,
-  netuidSchema,
-  offsetSchema,
-} from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { netuidSchema } from "./shared.ts";
 import {
   SubnetHyperparametersArtifactSchema,
   SubnetHyperparamsHistoryArtifactSchema,
 } from "../routes/subnet-hyperparameters.ts";
+
+const RouteQuery_subnets_netuid_hyperparameters_history =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/hyperparameters/history"];
 
 export const GetSubnetHyperparamsInputSchema = z
   .object({
@@ -44,9 +43,9 @@ export type GetSubnetHyperparamsOutput = z.infer<
 export const GetSubnetHyperparamsHistoryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    limit: limitSchema(1000).optional(),
-    offset: offsetSchema().optional(),
-    cursor: keysetCursorSchema().optional(),
+    limit: RouteQuery_subnets_netuid_hyperparameters_history.shape.limit,
+    offset: RouteQuery_subnets_netuid_hyperparameters_history.shape.offset,
+    cursor: RouteQuery_subnets_netuid_hyperparameters_history.shape.cursor,
   })
   .strict();
 export type GetSubnetHyperparamsHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-identity-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-identity-history.ts
@@ -11,20 +11,19 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import {
-  keysetCursorSchema,
-  limitSchema,
-  netuidSchema,
-  offsetSchema,
-} from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { netuidSchema } from "./shared.ts";
 import { SubnetIdentityHistoryArtifactSchema } from "../routes/subnet-identity-history.ts";
+
+const RouteQuery_subnets_netuid_identity_history =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/identity-history"];
 
 export const GetSubnetIdentityHistoryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    limit: limitSchema(1000).optional(),
-    offset: offsetSchema().optional(),
-    cursor: keysetCursorSchema().optional(),
+    limit: RouteQuery_subnets_netuid_identity_history.shape.limit,
+    offset: RouteQuery_subnets_netuid_identity_history.shape.offset,
+    cursor: RouteQuery_subnets_netuid_identity_history.shape.cursor,
   })
   .strict();
 export type GetSubnetIdentityHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-movers.ts
+++ b/schemas-src/mcp-tools/get-subnet-movers.ts
@@ -11,21 +11,21 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import {
   MOVERS_LIMIT_DEFAULT,
   MOVERS_LIMIT_MAX,
 } from "../../src/route-limits.ts";
-import { limitSchema, sortSchema, windowSchema } from "./shared.ts";
+import { limitSchema } from "./shared.ts";
 import { SubnetMoversArtifactSchema } from "../routes/subnet-movers.ts";
-import {
-  SUBNET_MOVERS_MOVERS_SORTS_VALUES,
-  SUBNET_MOVERS_WINDOW_VALUES,
-} from "../routes/subnet-movers.ts";
+import {} from "../routes/subnet-movers.ts";
+
+const RouteQuery_subnets_movers = ROUTE_QUERY_SCHEMAS["/api/v1/subnets/movers"];
 
 export const GetSubnetMoversInputSchema = z
   .object({
-    window: windowSchema(SUBNET_MOVERS_WINDOW_VALUES).optional(),
-    sort: sortSchema(SUBNET_MOVERS_MOVERS_SORTS_VALUES).optional(),
+    window: RouteQuery_subnets_movers.shape.window,
+    sort: RouteQuery_subnets_movers.shape.sort,
     limit: limitSchema(MOVERS_LIMIT_MAX, MOVERS_LIMIT_DEFAULT).optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/get-subnet-performance-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-performance-history.ts
@@ -4,14 +4,17 @@
 // schema to reuse. Modeled fresh, shallow, from the hand-written literal it
 // replaces.
 import { z } from "zod";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { SubnetPerformanceHistoryArtifactSchema } from "../routes/subnet-performance.ts";
-import { netuidSchema, windowSchema } from "./shared.ts";
-import { SUBNET_PERFORMANCE_WINDOW_VALUES } from "../routes/subnet-performance.ts";
+import { netuidSchema } from "./shared.ts";
+
+const RouteQuery_subnets_netuid_performance_history =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/performance/history"];
 
 export const GetSubnetPerformanceHistoryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(SUBNET_PERFORMANCE_WINDOW_VALUES).optional(),
+    window: RouteQuery_subnets_netuid_performance_history.shape.window,
   })
   .strict();
 export type GetSubnetPerformanceHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-recycled-burn.ts
+++ b/schemas-src/mcp-tools/get-subnet-recycled-burn.ts
@@ -14,7 +14,8 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { netuidSchema, windowSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { netuidSchema } from "./shared.ts";
 import { McpNetworkSchema } from "../shared.ts";
 import {
   ChainBurnArtifactSchema,
@@ -22,6 +23,9 @@ import {
   SubnetBurnHistoryArtifactSchema,
   SubnetRecycledArtifactSchema,
 } from "../routes/subnet-registration-cost.ts";
+
+const RouteQuery_subnets_netuid_burn_history =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/burn/history"];
 
 export const GetSubnetRecycledInputSchema = z
   .object({
@@ -72,7 +76,7 @@ export type GetChainBurnOutput = z.infer<typeof GetChainBurnOutputSchema>;
 export const GetSubnetBurnHistoryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(["24h", "7d", "30d", "90d"]).optional(),
+    window: RouteQuery_subnets_netuid_burn_history.shape.window,
   })
   .strict();
 export type GetSubnetBurnHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-stake-flow.ts
+++ b/schemas-src/mcp-tools/get-subnet-stake-flow.ts
@@ -11,17 +11,18 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { kindSchema, netuidSchema, windowSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { kindSchema, netuidSchema } from "./shared.ts";
 import { SubnetStakeFlowArtifactSchema } from "../routes/subnet-stake-flow.ts";
-import {
-  SUBNET_STAKE_FLOW_FLOW_DIRECTIONS_VALUES,
-  SUBNET_STAKE_FLOW_WINDOW_VALUES,
-} from "../routes/subnet-stake-flow.ts";
+import { SUBNET_STAKE_FLOW_FLOW_DIRECTIONS_VALUES } from "../routes/subnet-stake-flow.ts";
+
+const RouteQuery_subnets_netuid_stake_flow =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/stake-flow"];
 
 export const GetSubnetStakeFlowInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(SUBNET_STAKE_FLOW_WINDOW_VALUES).optional(),
+    window: RouteQuery_subnets_netuid_stake_flow.shape.window,
     direction: kindSchema(SUBNET_STAKE_FLOW_FLOW_DIRECTIONS_VALUES).optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/get-subnet-turnover.ts
+++ b/schemas-src/mcp-tools/get-subnet-turnover.ts
@@ -6,14 +6,17 @@
 // writing (mirrors the pilot batch's ECONOMICS_SORT_FIELDS precedent -- not
 // cross-imported).
 import { z } from "zod";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { SubnetTurnoverArtifactSchema } from "../routes/subnet-turnover.ts";
-import { netuidSchema, windowSchema } from "./shared.ts";
-import { SUBNET_TURNOVER_WINDOW_VALUES } from "../routes/subnet-turnover.ts";
+import { netuidSchema } from "./shared.ts";
+
+const RouteQuery_subnets_netuid_turnover =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/turnover"];
 
 export const GetSubnetTurnoverInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(SUBNET_TURNOVER_WINDOW_VALUES).optional(),
+    window: RouteQuery_subnets_netuid_turnover.shape.window,
     changes: z
       .boolean()
       .optional()

--- a/schemas-src/mcp-tools/get-subnet-uptime.ts
+++ b/schemas-src/mcp-tools/get-subnet-uptime.ts
@@ -14,15 +14,17 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { netuidSchema, windowSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { netuidSchema } from "./shared.ts";
 import { UptimeArtifactSchema } from "../routes/health-surfaces.ts";
 
-const UPTIME_WINDOWS = ["90d", "1y"] as const;
+const RouteQuery_subnets_netuid_uptime =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/uptime"];
 
 export const GetSubnetUptimeInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(UPTIME_WINDOWS).optional(),
+    window: RouteQuery_subnets_netuid_uptime.shape.window,
     min_samples: z
       .int()
       .min(0)

--- a/schemas-src/mcp-tools/get-subnet-validator-economics.ts
+++ b/schemas-src/mcp-tools/get-subnet-validator-economics.ts
@@ -14,20 +14,24 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import {
   SubnetValidatorEconomicsArtifactSchema,
   ValidatorEconomicsRankingArtifactSchema,
   SubnetValidatorEconomicsHistoryArtifactSchema,
 } from "../routes/validator-economics.ts";
-import { limitSchema, netuidSchema, sortSchema } from "./shared.ts";
+import { limitSchema, netuidSchema } from "./shared.ts";
 import {
   VALIDATOR_ECONOMICS_LIMIT_DEFAULT,
   VALIDATOR_ECONOMICS_LIMIT_MAX,
 } from "../../src/route-limits.ts";
-import {
-  VALIDATOR_ECONOMICS_HISTORY_WINDOWS,
-  VALIDATOR_ECONOMICS_SORTS,
-} from "../../src/validator-economics.ts";
+import { VALIDATOR_ECONOMICS_HISTORY_WINDOWS } from "../../src/validator-economics.ts";
+
+const RouteQuery_validators_economics =
+  ROUTE_QUERY_SCHEMAS["/api/v1/validators/economics"];
+
+const RouteQuery_subnets_netuid_validator_economics_history =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/validator-economics/history"];
 
 export const GetSubnetValidatorEconomicsInputSchema = z
   .object({
@@ -54,7 +58,7 @@ export const ListValidatorEconomicsInputSchema = z
     // ranked by the default, echoing that default back as `sort`. A model that guessed
     // got a plausible list answering a question nobody asked. Read from the same
     // constant the ranking and the REST validator use.
-    sort: sortSchema(VALIDATOR_ECONOMICS_SORTS).optional(),
+    sort: RouteQuery_validators_economics.shape.sort,
     // Was unbounded while the mirrored route rejected anything over 512.
     limit: limitSchema(
       VALIDATOR_ECONOMICS_LIMIT_MAX,
@@ -64,25 +68,18 @@ export const ListValidatorEconomicsInputSchema = z
     // generic MAX_OFFSET offsetSchema() carries -- this ranking is bounded by
     // the subnet count, so paging past it seeks nothing. The tool advertised
     // 1,000,000 (#10131).
-    offset: z
-      .int()
-      .min(0)
-      .max(VALIDATOR_ECONOMICS_LIMIT_MAX)
+    offset: RouteQuery_validators_economics.shape.offset
       .describe(
         `Rows to skip before the first returned row (0-${VALIDATOR_ECONOMICS_LIMIT_MAX}).`,
       )
       .meta({ examples: [0] })
       .optional(),
-    emission_gate_open: z
-      .boolean()
-      .optional()
+    emission_gate_open: RouteQuery_validators_economics.shape.emission_gate_open
       .describe(
         "Restrict to subnets whose emission gate is open (`true`) or closed (`false`).",
       )
       .meta({ examples: [true] }),
-    cap_binding: z
-      .boolean()
-      .optional()
+    cap_binding: RouteQuery_validators_economics.shape.cap_binding
       .describe(
         "Restrict to subnets where the validator cap is actually binding (`true`).",
       )
@@ -106,14 +103,7 @@ export const GetSubnetValidatorEconomicsHistoryInputSchema = z
     // The one window parameter of 55 that was not an enum. Its sibling
     // get_subnet_burn_history already declared one, so a model reading the two
     // together had no way to know this was the same kind of closed set.
-    window: z
-      .enum(
-        Object.keys(VALIDATOR_ECONOMICS_HISTORY_WINDOWS) as [
-          string,
-          ...string[],
-        ],
-      )
-      .optional()
+    window: RouteQuery_subnets_netuid_validator_economics_history.shape.window
       .describe(
         "Trailing time window to aggregate over, ending at the latest data point rather than a calendar boundary. Options are per-tool; see this parameter's enum.",
       )

--- a/schemas-src/mcp-tools/get-subnet-volume-ohlc.ts
+++ b/schemas-src/mcp-tools/get-subnet-volume-ohlc.ts
@@ -12,9 +12,13 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { netuidSchema } from "./shared.ts";
 import { SubnetAlphaVolumeArtifactSchema } from "../routes/subnet-alpha-volume.ts";
 import { SubnetOhlcArtifactSchema } from "../routes/subnet-ohlc.ts";
+
+const RouteQuery_subnets_netuid_ohlc =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/ohlc"];
 
 export const GetSubnetVolumeInputSchema = z
   .object({
@@ -27,21 +31,14 @@ export const GetSubnetVolumeOutputSchema = SubnetAlphaVolumeArtifactSchema;
 export type GetSubnetVolumeOutput = z.infer<typeof GetSubnetVolumeOutputSchema>;
 
 const OHLC_INTERVALS = ["1h", "1d"] as const;
-const MAX_OHLC_WINDOW_DAYS = 365;
 
 export const GetSubnetOhlcInputSchema = z
   .object({
     netuid: netuidSchema(),
-    interval: z
-      .enum(OHLC_INTERVALS)
-      .optional()
+    interval: RouteQuery_subnets_netuid_ohlc.shape.interval
       .describe("Bucket size for the returned series.")
       .meta({ examples: [OHLC_INTERVALS[0]] }),
-    days: z
-      .int()
-      .min(1)
-      .max(MAX_OHLC_WINDOW_DAYS)
-      .optional()
+    days: RouteQuery_subnets_netuid_ohlc.shape.days
       .describe("How many trailing days to cover, ending today (UTC).")
       .meta({ examples: [7, 30] }),
   })

--- a/schemas-src/mcp-tools/get-subnet-weight-setters.ts
+++ b/schemas-src/mcp-tools/get-subnet-weight-setters.ts
@@ -11,15 +11,17 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { netuidSchema, windowSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { netuidSchema } from "./shared.ts";
 import { SubnetWeightSettersArtifactSchema } from "../routes/subnet-weights.ts";
 
-const SUBNET_WEIGHT_SETTERS_WINDOWS = ["7d", "30d"] as const;
+const RouteQuery_subnets_netuid_weights_setters =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/weights/setters"];
 
 export const GetSubnetWeightSettersInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(SUBNET_WEIGHT_SETTERS_WINDOWS).optional(),
+    window: RouteQuery_subnets_netuid_weights_setters.shape.window,
   })
   .strict();
 export type GetSubnetWeightSettersInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-weights.ts
+++ b/schemas-src/mcp-tools/get-subnet-weights.ts
@@ -11,15 +11,17 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { netuidSchema, windowSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { netuidSchema } from "./shared.ts";
 import { SubnetWeightsArtifactSchema } from "../routes/subnet-weights.ts";
 
-const SUBNET_WEIGHTS_WINDOWS = ["7d", "30d"] as const;
+const RouteQuery_subnets_netuid_weights =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/weights"];
 
 export const GetSubnetWeightsInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(SUBNET_WEIGHTS_WINDOWS).optional(),
+    window: RouteQuery_subnets_netuid_weights.shape.window,
   })
   .strict();
 export type GetSubnetWeightsInput = z.infer<typeof GetSubnetWeightsInputSchema>;

--- a/schemas-src/mcp-tools/get-subnet-yield-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-yield-history.ts
@@ -14,14 +14,17 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { netuidSchema, windowSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { netuidSchema } from "./shared.ts";
 import { SubnetYieldHistoryArtifactSchema } from "../routes/subnet-yield.ts";
-import { SUBNET_YIELD_WINDOW_VALUES } from "../routes/subnet-yield.ts";
+
+const RouteQuery_subnets_netuid_yield_history =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/yield/history"];
 
 export const GetSubnetYieldHistoryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    window: windowSchema(SUBNET_YIELD_WINDOW_VALUES).optional(),
+    window: RouteQuery_subnets_netuid_yield_history.shape.window,
   })
   .strict();
 export type GetSubnetYieldHistoryInput = z.infer<

--- a/schemas-src/mcp-tools/get-tao-usd.ts
+++ b/schemas-src/mcp-tools/get-tao-usd.ts
@@ -1,11 +1,14 @@
 // get_tao_usd (#9609): the TAO/USD index, mirroring GET
 // /api/v1/network/tao-usd.
 import { z } from "zod";
-import { windowSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+
+const RouteQuery_network_tao_usd =
+  ROUTE_QUERY_SCHEMAS["/api/v1/network/tao-usd"];
 
 export const GetTaoUsdInputSchema = z
   .object({
-    window: windowSchema(["1h", "24h", "7d", "30d"]).optional(),
+    window: RouteQuery_network_tao_usd.shape.window,
     // #9720. The series is ~1,428 points and ~143 KB on the default window,
     // while every summary a caller usually wants -- latest, change_usd,
     // change_pct, point_count, priced_point_count, oldest_observed_at -- sits
@@ -13,9 +16,7 @@ export const GetTaoUsdInputSchema = z
     // the REST route: a browser can stream 143 KB and a context window cannot,
     // so the surface with the hard constraint carries the default (the same
     // asymmetry #9701 established for list_candidates).
-    include_points: z
-      .boolean()
-      .optional()
+    include_points: RouteQuery_network_tao_usd.shape.include_points
       .describe(
         "Include the full per-point price series. Defaults to FALSE here — " +
           "the summary above it (latest, change_usd, change_pct, the counts) " +

--- a/schemas-src/mcp-tools/governance-feeds.ts
+++ b/schemas-src/mcp-tools/governance-feeds.ts
@@ -12,16 +12,16 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import {
-  blockBoundSchema,
-  keysetCursorSchema,
-  limitSchema,
-  offsetSchema,
-} from "./shared.ts";
-import { EXTRINSICS_LIMIT_MAX } from "./extrinsics.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
+import { blockBoundSchema } from "./shared.ts";
 import { McpNetworkSchema } from "../shared.ts";
 import { ExtrinsicsFeedArtifactSchema } from "../routes/extrinsics.ts";
 import { SudoKeyArtifactSchema } from "../routes/network-singletons.ts";
+
+const RouteQuery_sudo = ROUTE_QUERY_SCHEMAS["/api/v1/sudo"];
+
+const RouteQuery_governance_config_changes =
+  ROUTE_QUERY_SCHEMAS["/api/v1/governance/config-changes"];
 
 export const GetSudoInputSchema = z
   .object({
@@ -31,9 +31,7 @@ export const GetSudoInputSchema = z
       .optional()
       .describe("Restrict to this exact block height.")
       .meta({ examples: [8783000] }),
-    call_function: z
-      .string()
-      .optional()
+    call_function: RouteQuery_sudo.shape.call_function
       .describe(
         "Restrict to one call within the pallet (`add_stake`). Case-sensitive; pair with `call_module` to disambiguate.",
       )
@@ -66,9 +64,9 @@ export const GetSudoInputSchema = z
     // Both feeds say "same filters as list_extrinsics" and were modelled on it,
     // but dropped its `.max(100)` — declaring unbounded while the tier they forward to
     // caps at 100. A copy-paste omission, not a wider ceiling.
-    limit: limitSchema(EXTRINSICS_LIMIT_MAX).optional(),
-    offset: offsetSchema().optional(),
-    cursor: keysetCursorSchema().optional(),
+    limit: RouteQuery_sudo.shape.limit,
+    offset: RouteQuery_sudo.shape.offset,
+    cursor: RouteQuery_sudo.shape.cursor,
   })
   .strict();
 export type GetSudoInput = z.infer<typeof GetSudoInputSchema>;
@@ -97,9 +95,7 @@ export const GetGovernanceConfigChangesInputSchema = z
       .optional()
       .describe("Restrict to this exact block height.")
       .meta({ examples: [8783000] }),
-    call_function: z
-      .string()
-      .optional()
+    call_function: RouteQuery_governance_config_changes.shape.call_function
       .describe(
         "Restrict to one call within the pallet (`add_stake`). Case-sensitive; pair with `call_module` to disambiguate.",
       )
@@ -132,9 +128,9 @@ export const GetGovernanceConfigChangesInputSchema = z
     // Both feeds say "same filters as list_extrinsics" and were modelled on it,
     // but dropped its `.max(100)` — declaring unbounded while the tier they forward to
     // caps at 100. A copy-paste omission, not a wider ceiling.
-    limit: limitSchema(EXTRINSICS_LIMIT_MAX).optional(),
-    offset: offsetSchema().optional(),
-    cursor: keysetCursorSchema().optional(),
+    limit: RouteQuery_governance_config_changes.shape.limit,
+    offset: RouteQuery_governance_config_changes.shape.offset,
+    cursor: RouteQuery_governance_config_changes.shape.cursor,
   })
   .strict();
 export type GetGovernanceConfigChangesInput = z.infer<

--- a/schemas-src/mcp-tools/list-subnets.ts
+++ b/schemas-src/mcp-tools/list-subnets.ts
@@ -10,6 +10,7 @@
 // only coverage_level/curation_level/sort/order were actually enum-
 // constrained on the wire, and only those reuse a shared enum.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 // The route's own filter vocabularies. These three published a bare
 // `{"type":"string"}` while the route named its values, so an agent had to
 // guess and a wrong guess filtered to nothing rather than erroring (#10115).
@@ -17,11 +18,8 @@ import { z } from "zod";
 // (#10131) -- importing that from here is the edge that broke the data-api
 // build on #10121.
 import { QUERY_ENUMS } from "../query-enums.ts";
-import { DOMAIN_TAGS } from "../../src/domain-tags.ts";
 import {
-  kindSchema,
   limitSchema,
-  netuidListSchema,
   netuidSchema,
   numericCursorSchema,
   orderSchema,
@@ -49,15 +47,15 @@ export const ListSubnetsInputSchema = z
     // whose route accepts active | inactive. The prose and the example both
     // named a different parameter, and neither could be seen to be wrong while
     // the enum was a bare string (#10131).
-    status: kindSchema(QUERY_ENUMS.subnetStatus as [string, ...string[]])
+    status: API_QUERY_COLLECTIONS.subnets.filter_schemas.status
       .optional()
       .describe("Restrict to subnets in this lifecycle state.")
       .meta({ examples: [QUERY_ENUMS.subnetStatus[0]] }),
-    subnet_type: kindSchema(QUERY_ENUMS.subnetType as [string, ...string[]])
+    subnet_type: API_QUERY_COLLECTIONS.subnets.filter_schemas.subnet_type
       .optional()
       .describe("Root subnet or an application subnet.")
       .meta({ examples: ["application"] }),
-    domain: kindSchema(DOMAIN_TAGS as [string, ...string[]])
+    domain: API_QUERY_COLLECTIONS.subnets.filter_schemas.domain
       .optional()
       .describe("The subnet's primary domain of use.")
       .meta({ examples: ["inference"] }),
@@ -82,7 +80,8 @@ export const ListSubnetsInputSchema = z
         "EXCLUDE rows with this domain. Applied after any positive `domain` filter, so the two can be combined.",
       )
       .meta({ examples: ["media"] }),
-    coverage_level: CoverageLevelSchema.optional()
+    coverage_level: API_QUERY_COLLECTIONS.subnets.filter_schemas.coverage_level
+      .optional()
       .describe(
         "How much of the subnet is covered: on-chain data only, a manifest, or actively probed surfaces.",
       )
@@ -92,7 +91,8 @@ export const ListSubnetsInputSchema = z
         "EXCLUDE rows with this coverage level. Applied after any positive `coverage_level` filter, so the two can be combined.",
       )
       .meta({ examples: [CoverageLevelSchema.options[0]] }),
-    curation_level: CurationLevelSchema.optional()
+    curation_level: API_QUERY_COLLECTIONS.subnets.filter_schemas.curation_level
+      .optional()
       .describe(
         "How the record entered the registry — native chain data, discovered candidate, community submission, or machine-derived.",
       )
@@ -255,7 +255,7 @@ export const ListSubnetsInputSchema = z
     // #10014: the two simplest filters the subnets collection declares, absent
     // while thirty others were present. `min_netuid`/`max_netuid` below give a
     // RANGE; neither expresses "these three subnets".
-    netuid: netuidSchema()
+    netuid: API_QUERY_COLLECTIONS.subnets.filter_schemas.netuid
       .optional()
       .describe("Restrict to exactly this subnet.")
       .meta({ examples: [64] }),
@@ -266,7 +266,7 @@ export const ListSubnetsInputSchema = z
     // ids, each at most 5 digits (a netuid is a u16). The `^\d+(,\d+)*$` this
     // declared was unbounded in count and accepted 9-digit "netuids", so the
     // tool advertised a list its own route rejects (#10115).
-    netuids: netuidListSchema().optional(),
+    netuids: API_QUERY_COLLECTIONS.subnets.filter_schemas.netuids.optional(),
     min_netuid: z
       .int()
       .min(0)

--- a/schemas-src/mcp-tools/meta-artifacts-2.ts
+++ b/schemas-src/mcp-tools/meta-artifacts-2.ts
@@ -15,23 +15,18 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import { ChangelogArtifactSchema } from "../routes/meta-contracts.ts";
 import { CoverageDepthArtifactSchema } from "../routes/coverage.ts";
 import { SelfHealthArtifactSchema } from "../routes/self-health.ts";
+import { CoverageArtifactSchema } from "../routes/coverage.ts";
 import {
-  AGENT_READINESS_STATUSES,
-  BLOCKER_LEVELS,
-  COVERAGE_DEPTH_TIERS,
-  CoverageArtifactSchema,
-} from "../routes/coverage.ts";
-import {
-  COVERAGE_DEPTH_SORT_VALUES,
   fieldsSchema,
   limitSchema,
-  netuidSchema,
   numericCursorSchema,
   orderSchema,
   sortSchema,
+  projectableRows,
 } from "./shared.ts";
 import { BuildSummaryArtifactSchema } from "../routes/meta-contracts.ts";
 
@@ -85,27 +80,31 @@ export type GetCoverageOutput = z.infer<typeof GetCoverageOutputSchema>;
  */
 export const GetCoverageDepthInputSchema = z
   .object({
-    netuid: netuidSchema().optional(),
-    tier: z
-      .enum(COVERAGE_DEPTH_TIERS)
+    netuid:
+      API_QUERY_COLLECTIONS["coverage-depth"].filter_schemas.netuid.optional(),
+    tier: API_QUERY_COLLECTIONS["coverage-depth"].filter_schemas.tier
       .optional()
       .describe(
         "Restrict to subnets in this readiness tier. Applied across the whole scorecard, not to one page.",
       )
       .meta({ examples: ["agent-ready"] }),
-    agent_status: z
-      .enum(AGENT_READINESS_STATUSES)
+    agent_status: API_QUERY_COLLECTIONS[
+      "coverage-depth"
+    ].filter_schemas.agent_status
       .optional()
       .describe("Restrict to subnets with this agent-readiness status.")
       .meta({ examples: ["callable"] }),
-    blocker_level: z
-      .enum(BLOCKER_LEVELS)
+    blocker_level: API_QUERY_COLLECTIONS[
+      "coverage-depth"
+    ].filter_schemas.blocker_level
       .optional()
       .describe(
         "Restrict to subnets blocked this badly. `none` means nothing is blocking promotion.",
       )
       .meta({ examples: ["hard-blocked"] }),
-    sort: sortSchema(COVERAGE_DEPTH_SORT_VALUES).optional(),
+    sort: sortSchema(
+      API_QUERY_COLLECTIONS["coverage-depth"].sort_fields,
+    ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     // Defaults to a PAGE, not the whole scorecard (#10027). Measured at
@@ -130,7 +129,17 @@ export type GetCoverageDepthInput = z.infer<typeof GetCoverageDepthInputSchema>;
 // and CoverageDepthQueueEntrySchema in full, so an agent now gets the shape of
 // the thing it is ranking instead of {"type":"object"}. Verified against
 // production before the switch.
-export const GetCoverageDepthOutputSchema = CoverageDepthArtifactSchema;
+// #10064 production sweep: this tool advertises `fields`, so a caller can ask
+// for a SUBSET of each row -- and the artifact schema requires every property
+// on it. Production answered `?fields=` with rows that failed the tool's own
+// published schema; `projectableRows` is the convention the sibling tools
+// already use. Field names and types still come from the route, so a rename
+// there is still a compile error here; only requiredness changes, because the
+// caller controls it.
+export const GetCoverageDepthOutputSchema = CoverageDepthArtifactSchema.extend({
+  rows: projectableRows(CoverageDepthArtifactSchema.shape.rows),
+  ranked_queue: projectableRows(CoverageDepthArtifactSchema.shape.ranked_queue),
+});
 export type GetCoverageDepthOutput = z.infer<
   typeof GetCoverageDepthOutputSchema
 >;

--- a/schemas-src/mcp-tools/neurons.ts
+++ b/schemas-src/mcp-tools/neurons.ts
@@ -14,12 +14,12 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import {
   NeuronFieldsInputSchema,
   accountKeySchema,
   netuidSchema,
   uidSchema,
-  windowSchema,
 } from "./shared.ts";
 import {
   NeuronHistoryArtifactSchema,
@@ -38,6 +38,9 @@ import {
 // The handler still enforces it (this server validates arguments in the
 // handler by design, #8942). The published constraint is what an agent READS
 // before calling; the handler is what makes the reading true.
+const RouteQuery_subnets_netuid_neurons_uid_history =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/neurons/{uid}/history"];
+
 export const GetNeuronInputSchema = z
   .object({
     netuid: netuidSchema(),
@@ -87,7 +90,7 @@ export const GetNeuronHistoryInputSchema = z
   .object({
     netuid: netuidSchema(),
     uid: uidSchema(),
-    window: windowSchema(["7d", "30d", "90d", "1y", "all"]).optional(),
+    window: RouteQuery_subnets_netuid_neurons_uid_history.shape.window,
   })
   .strict();
 export type GetNeuronHistoryInput = z.infer<typeof GetNeuronHistoryInputSchema>;

--- a/schemas-src/mcp-tools/profiles.ts
+++ b/schemas-src/mcp-tools/profiles.ts
@@ -13,6 +13,7 @@
 // subnetType,curationLevel,profileLevel} and the "profiles" query
 // collection's sort_fields at the time of writing.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import { SubnetProfileArtifactSchema } from "../routes/subnet-profiles.ts";
 import {
   reviewStateSchema,
@@ -30,49 +31,33 @@ import { PROFILE_LEVEL_VALUES } from "../shared.ts";
 
 const SUBNET_TYPE = ["root", "application"] as const;
 const CURATION_LEVEL = CURATION_LEVEL_VALUES;
-const PROFILES_SORT_FIELDS = [
-  "candidate_count",
-  "completeness_score",
-  "curation_level",
-  "interface_count",
-  "missing_critical_count",
-  "name",
-  "netuid",
-  "operational_interface_count",
-  "profile_level",
-  "review_state",
-] as const;
 
 export const ListProfilesInputSchema = z
   .object({
-    netuid: netuidSchema().optional(),
-    subnet_type: z
-      .enum(SUBNET_TYPE)
+    netuid: API_QUERY_COLLECTIONS.profiles.filter_schemas.netuid.optional(),
+    subnet_type: API_QUERY_COLLECTIONS.profiles.filter_schemas.subnet_type
       .optional()
       .describe("Root subnet or an application subnet.")
       .meta({ examples: [SUBNET_TYPE[0]] }),
-    curation_level: z
-      .enum(CURATION_LEVEL)
+    curation_level: API_QUERY_COLLECTIONS.profiles.filter_schemas.curation_level
       .optional()
       .describe(
         "How the record entered the registry — native chain data, discovered candidate, community submission, or machine-derived.",
       )
       .meta({ examples: [CURATION_LEVEL[0]] }),
     review_state: reviewStateSchema().optional(),
-    confidence: z
-      .enum(["low", "medium", "high"])
+    confidence: API_QUERY_COLLECTIONS.profiles.filter_schemas.confidence
       .optional()
       .describe("How confident the machine assessment is.")
       .meta({ examples: ["low"] }),
-    profile_level: z
-      .enum(PROFILE_LEVEL_VALUES)
+    profile_level: API_QUERY_COLLECTIONS.profiles.filter_schemas.profile_level
       .optional()
       .describe(
         "How complete the subnet's profile is, from directory-only upward.",
       )
       .meta({ examples: [PROFILE_LEVEL_VALUES[0]] }),
     q: querySchema().optional(),
-    sort: sortSchema(PROFILES_SORT_FIELDS).optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.profiles.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(1000).optional(),

--- a/schemas-src/mcp-tools/registry-catalogs-1.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-1.ts
@@ -16,12 +16,12 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   idFilterSchema,
   fieldsSchema,
   kindSchema,
   limitSchema,
-  netuidSchema,
   numericCursorSchema,
   orderSchema,
   projectableRows,
@@ -40,14 +40,12 @@ import {
   SURFACE_KIND_VALUES,
 } from "../routes/subnet-detail.ts";
 import { CONFIDENCE_LEVEL_VALUES } from "../shared.ts";
-import { CANDIDATE_SORT_VALUES, SURFACE_SORT_VALUES } from "./shared.ts";
 
 // Symbolic in each hand-written original (src/contracts.ts's QUERY_ENUMS /
 // API_QUERY_COLLECTIONS.*.sort_fields), cross-checked against the actual
 // runtime source at the time of writing.
 const PROVIDER_KINDS = PROVIDER_KIND_VALUES;
 const PROVIDER_AUTHORITIES = AUTHORITY_VALUES;
-const PROVIDER_SORT_FIELDS = ["authority", "id", "kind", "name"] as const;
 
 export const ListProvidersInputSchema = z
   .object({
@@ -60,7 +58,7 @@ export const ListProvidersInputSchema = z
         "Who asserts this record: the operator, the community, a provider, or the registry's own probes.",
       )
       .meta({ examples: [PROVIDER_AUTHORITIES[0]] }),
-    sort: sortSchema(PROVIDER_SORT_FIELDS).optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.providers.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -77,7 +75,10 @@ export type ListProvidersOutput = z.infer<typeof ListProvidersOutputSchema>;
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
 export const ListSurfacesInputSchema = z
   .object({
-    netuid: netuidSchema().optional(),
+    netuid:
+      API_QUERY_COLLECTIONS[
+        "curated-surfaces"
+      ].filter_schemas.netuid.optional(),
     kind: kindSchema(SURFACE_KINDS).optional(),
     provider: providerSlugSchema().optional(),
     id: idFilterSchema().optional(),
@@ -93,28 +94,33 @@ export const ListSurfacesInputSchema = z
     // "a filter that silently under-reports by 99% is worse than one that
     // errors, because it looks like it worked". An agent narrowing a page it
     // fetched is in exactly that position.
-    auth_required: z
-      .enum(["true", "false"])
+    auth_required: API_QUERY_COLLECTIONS[
+      "curated-surfaces"
+    ].filter_schemas.auth_required
       .optional()
       .describe(
         "Restrict to surfaces that do (`true`) or do not (`false`) require authentication. Applied server-side across the whole catalog, not to one page.",
       )
       .meta({ examples: ["false"] }),
-    public_safe: z
-      .enum(["true", "false"])
+    public_safe: API_QUERY_COLLECTIONS[
+      "curated-surfaces"
+    ].filter_schemas.public_safe
       .optional()
       .describe(
         "Restrict to surfaces marked safe (`true`) or unsafe (`false`) to call from a public client.",
       )
       .meta({ examples: ["true"] }),
-    rate_limited: z
-      .enum(["true", "false"])
+    rate_limited: API_QUERY_COLLECTIONS[
+      "curated-surfaces"
+    ].filter_schemas.rate_limited
       .optional()
       .describe(
         "Restrict to surfaces that declare rate-limit notes (`true`) or declare none (`false`). A presence filter over `rate_limit_notes`, not a claim that an unlimited surface exists.",
       )
       .meta({ examples: ["true"] }),
-    sort: sortSchema(SURFACE_SORT_VALUES).optional(),
+    sort: sortSchema(
+      API_QUERY_COLLECTIONS["curated-surfaces"].sort_fields,
+    ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -131,21 +137,19 @@ export type ListSurfacesOutput = z.infer<typeof ListSurfacesOutputSchema>;
 const CANDIDATE_STATES = CANDIDATE_STATE_VALUES;
 export const ListCandidatesInputSchema = z
   .object({
-    netuid: netuidSchema().optional(),
+    netuid: API_QUERY_COLLECTIONS.candidates.filter_schemas.netuid.optional(),
     kind: kindSchema(SURFACE_KINDS).optional(),
     provider: providerSlugSchema().optional(),
-    state: z
-      .enum(CANDIDATE_STATES)
+    state: API_QUERY_COLLECTIONS.candidates.filter_schemas.state
       .optional()
       .describe("The incident's lifecycle state.")
       .meta({ examples: [CANDIDATE_STATES[0]] }),
     id: idFilterSchema().optional(),
-    confidence: z
-      .enum(CONFIDENCE_LEVEL_VALUES)
+    confidence: API_QUERY_COLLECTIONS.candidates.filter_schemas.confidence
       .optional()
       .describe("How confident the machine assessment is.")
       .meta({ examples: [CONFIDENCE_LEVEL_VALUES[0]] }),
-    sort: sortSchema(CANDIDATE_SORT_VALUES).optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.candidates.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(1000).optional(),

--- a/schemas-src/mcp-tools/registry-catalogs-2.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-2.ts
@@ -17,6 +17,7 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   idFilterSchema,
   McpListArtifactStamp,
@@ -25,7 +26,6 @@ import {
   fieldsSchema,
   kindSchema,
   limitSchema,
-  netuidSchema,
   numericCursorSchema,
   orderSchema,
   projectableRows,
@@ -44,23 +44,18 @@ import {
   SURFACE_KIND_VALUES,
 } from "../routes/subnet-detail.ts";
 import { HEALTH_STATUS_VALUES } from "../shared.ts";
-import { PROFILE_SORT_FIELDS } from "../routes/review-gaps-profile.ts";
 import {
   CONFIDENCE_LEVEL_VALUES,
   IDENTITY_LEVEL_VALUES,
   NATIVE_NAME_QUALITY_VALUES,
   PROFILE_LEVEL_VALUES,
 } from "../shared.ts";
-import {
-  ENDPOINT_POOL_SORT_VALUES,
-  ENDPOINT_SORT_VALUES,
-  EVIDENCE_ENTRY_SORT_VALUES,
-} from "./shared.ts";
+import {} from "./shared.ts";
 
 export const ListEvidenceInputSchema = z
   .object({
     q: querySchema().optional(),
-    sort: sortSchema(EVIDENCE_ENTRY_SORT_VALUES).optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.claims.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -88,15 +83,15 @@ export const ListRpcEndpointsInputSchema = z
         "Which layer of the stack the endpoint belongs to: the Bittensor base chain, a data or docs provider, or a subnet's own app.",
       )
       .meta({ examples: [ENDPOINT_LAYERS[0]] }),
-    netuid: netuidSchema().optional(),
+    netuid: API_QUERY_COLLECTIONS.endpoints.filter_schemas.netuid.optional(),
     provider: providerSlugSchema().optional(),
-    publication_state: z
-      .enum(ENDPOINT_PUBLICATION_STATES)
-      .optional()
-      .describe(
-        "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
-      )
-      .meta({ examples: [ENDPOINT_PUBLICATION_STATES[0]] }),
+    publication_state:
+      API_QUERY_COLLECTIONS.endpoints.filter_schemas.publication_state
+        .optional()
+        .describe(
+          "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
+        )
+        .meta({ examples: [ENDPOINT_PUBLICATION_STATES[0]] }),
     status: kindSchema(HEALTH_STATUSES).optional(),
     pool_eligible: z
       .boolean()
@@ -133,7 +128,7 @@ export const ListRpcEndpointsInputSchema = z
         "Inclusive upper bound on endpoint score; rows above it are excluded.",
       )
       .meta({ examples: [100] }),
-    sort: sortSchema(ENDPOINT_SORT_VALUES).optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.endpoints.sort_fields).optional(),
     order: orderSchema().optional(),
     // Both `fields` and `cursor` are UNIONS here, unlike everywhere else, so
     // neither can take a shared builder -- the sentence has to say which forms
@@ -205,7 +200,7 @@ export const ListRpcPoolsInputSchema = z
         "Inclusive upper bound on endpoint count; rows above it are excluded.",
       )
       .meta({ examples: [10] }),
-    sort: sortSchema(ENDPOINT_POOL_SORT_VALUES).optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS["rpc-pools"].sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -228,12 +223,10 @@ export const ListRpcPoolsOutputSchema = RpcPoolsArtifactSchema.pick({
 });
 export type ListRpcPoolsOutput = z.infer<typeof ListRpcPoolsOutputSchema>;
 
-const SOURCE_SORT_FIELDS = ["id", "kind", "path", "record_count"] as const;
-
 export const ListSourceSnapshotsInputSchema = z
   .object({
     q: querySchema().optional(),
-    sort: sortSchema(SOURCE_SORT_FIELDS).optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.sources.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -254,21 +247,27 @@ export type ListSourceSnapshotsOutput = z.infer<
 
 export const ListProfileCompletenessInputSchema = z
   .object({
-    netuid: netuidSchema().optional(),
-    profile_level: z
-      .enum(PROFILE_LEVEL_VALUES)
+    netuid:
+      API_QUERY_COLLECTIONS[
+        "profile-completeness"
+      ].filter_schemas.netuid.optional(),
+    profile_level: API_QUERY_COLLECTIONS[
+      "profile-completeness"
+    ].filter_schemas.profile_level
       .optional()
       .describe(
         "How complete the subnet's profile is, from directory-only upward.",
       )
       .meta({ examples: [PROFILE_LEVEL_VALUES[0]] }),
-    confidence: z
-      .enum(CONFIDENCE_LEVEL_VALUES)
+    confidence: API_QUERY_COLLECTIONS[
+      "profile-completeness"
+    ].filter_schemas.confidence
       .optional()
       .describe("How confident the machine assessment is.")
       .meta({ examples: [CONFIDENCE_LEVEL_VALUES[0]] }),
-    identity_level: z
-      .enum(IDENTITY_LEVEL_VALUES)
+    identity_level: API_QUERY_COLLECTIONS[
+      "profile-completeness"
+    ].filter_schemas.identity_level
       .optional()
       .describe("How complete the subnet's published identity is.")
       .meta({ examples: [IDENTITY_LEVEL_VALUES[0]] }),
@@ -279,12 +278,15 @@ export const ListProfileCompletenessInputSchema = z
         "Restrict to subnets where surfaces of this kind would promote the subnet's identity. One kind per call; see this parameter's enum.",
       )
       .meta({ examples: [SURFACE_KINDS[0]] }),
-    native_name_quality: z
-      .enum(NATIVE_NAME_QUALITY_VALUES)
+    native_name_quality: API_QUERY_COLLECTIONS[
+      "profile-completeness"
+    ].filter_schemas.native_name_quality
       .optional()
       .describe("Whether the on-chain name is real, a placeholder, or empty.")
       .meta({ examples: [NATIVE_NAME_QUALITY_VALUES[0]] }),
-    sort: sortSchema(PROFILE_SORT_FIELDS).optional(),
+    sort: sortSchema(
+      API_QUERY_COLLECTIONS["profile-completeness"].sort_fields,
+    ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),

--- a/schemas-src/mcp-tools/registry-summary-gaps.ts
+++ b/schemas-src/mcp-tools/registry-summary-gaps.ts
@@ -6,6 +6,7 @@
 // array). None mirror an existing schemas-src/routes/ REST schema --
 // modeled fresh, matching each hand-written literal field-for-field.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import { RegistrySummaryArtifactSchema } from "../routes/registry-summary-leaderboards.ts";
 import {
   reviewStateSchema,
@@ -29,11 +30,9 @@ import {
 } from "../routes/coverage.ts";
 import {
   AGENT_READINESS_STATUSES,
-  BLOCKER_LEVELS,
   COVERAGE_DEPTH_SEVERITIES,
   COVERAGE_DEPTH_TIERS,
 } from "../routes/coverage.ts";
-import { PRIORITY_SORT_FIELDS } from "../routes/review-gaps-profile.ts";
 
 export const RegistrySummaryInputSchema = z.object({}).strict();
 export type RegistrySummaryInput = z.infer<typeof RegistrySummaryInputSchema>;
@@ -51,8 +50,7 @@ export type RegistrySummaryOutput = z.infer<typeof RegistrySummaryOutputSchema>;
 export const ListEnrichmentTargetsInputSchema = z
   .object({
     limit: limitSchema(50).optional(),
-    tier: z
-      .enum(COVERAGE_DEPTH_TIERS)
+    tier: API_QUERY_COLLECTIONS["coverage-depth"].filter_schemas.tier
       .optional()
       .describe("How agent-ready the subnet is.")
       .meta({ examples: [COVERAGE_DEPTH_TIERS[0]] }),
@@ -70,22 +68,25 @@ export const ListEnrichmentTargetsInputSchema = z
           "and hyphenated — not the human-readable label shown beside it.",
       )
       .meta({ examples: ["missing-openapi"] }),
-    agent_status: z
-      .enum(AGENT_READINESS_STATUSES)
+    agent_status: API_QUERY_COLLECTIONS[
+      "coverage-depth"
+    ].filter_schemas.agent_status
       .optional()
       .describe("How usable the subnet is to an agent right now.")
       .meta({ examples: [AGENT_READINESS_STATUSES[0]] }),
     // #10011: the fourth filter the coverage-depth collection declares. Its
     // three siblings above were already here, so this one's absence was an
     // omission rather than a narrowing.
-    blocker_level: z
-      .enum(BLOCKER_LEVELS)
+    blocker_level: API_QUERY_COLLECTIONS[
+      "coverage-depth"
+    ].filter_schemas.blocker_level
       .optional()
       .describe(
         "How badly the subnet is blocked. `none` means nothing is blocking promotion.",
       )
       .meta({ examples: ["hard-blocked"] }),
-    netuid: netuidSchema().optional(),
+    netuid:
+      API_QUERY_COLLECTIONS["coverage-depth"].filter_schemas.netuid.optional(),
   })
   .strict();
 export type ListEnrichmentTargetsInput = z.infer<
@@ -208,7 +209,9 @@ export const ListSubnetGapsInputSchema = z
       )
       .meta({ examples: [SURFACE_KINDS[0]] }),
     review_state: reviewStateSchema().optional(),
-    sort: sortSchema(PRIORITY_SORT_FIELDS).optional(),
+    sort: sortSchema(
+      API_QUERY_COLLECTIONS["review-gap-priorities"].sort_fields,
+    ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),

--- a/schemas-src/mcp-tools/rpc-tools.ts
+++ b/schemas-src/mcp-tools/rpc-tools.ts
@@ -8,17 +8,20 @@
 // the same bytes, and the fresh model disagreed with it on `observed_at`
 // (#9794). It now reuses the route schema outright.
 import { z } from "zod";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { RpcUsageArtifactSchema } from "../routes/providers-rpc.ts";
 import { McpNetworkSchema } from "../shared.ts";
-import { OpenObjectSchema, limitSchema, windowSchema } from "./shared.ts";
+import { OpenObjectSchema, limitSchema } from "./shared.ts";
 import {
   SAFE_RPC_METHODS,
   SAFE_RPC_STATE_QUERY_METHODS,
 } from "../../workers/config.ts";
 
+const RouteQuery_rpc_usage = ROUTE_QUERY_SCHEMAS["/api/v1/rpc/usage"];
+
 export const GetRpcUsageInputSchema = z
   .object({
-    window: windowSchema(["7d", "30d"]).optional(),
+    window: RouteQuery_rpc_usage.shape.window,
   })
   .strict();
 export type GetRpcUsageInput = z.infer<typeof GetRpcUsageInputSchema>;

--- a/schemas-src/mcp-tools/search-documents.ts
+++ b/schemas-src/mcp-tools/search-documents.ts
@@ -11,13 +11,13 @@
 // schemas-src/routes/ REST schema -- modeled fresh, matching each
 // hand-written literal field-for-field.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   McpListArtifactStamp,
   McpListPageFields,
   NotesFieldSchema,
   fieldsSchema,
   limitSchema,
-  netuidSchema,
   numericCursorSchema,
   orderSchema,
   projectableRows,
@@ -28,18 +28,15 @@ import { SearchIndexArtifactSchema } from "../routes/evidence-search.ts";
 import { SearchArtifactSchema } from "../routes/evidence-search.ts";
 import { SEARCH_DOCUMENT_TYPE_VALUES } from "../routes/evidence-search.ts";
 
-const DOCUMENT_SORT_FIELDS = ["netuid", "slug", "title", "type"] as const;
-
 export const ListSearchIndexInputSchema = z
   .object({
     q: querySchema().optional(),
-    type: z
-      .enum(SEARCH_DOCUMENT_TYPE_VALUES)
+    type: API_QUERY_COLLECTIONS.documents.filter_schemas.type
       .optional()
       .describe("Which entity kind to search over.")
       .meta({ examples: [SEARCH_DOCUMENT_TYPE_VALUES[0]] }),
-    netuid: netuidSchema().optional(),
-    sort: sortSchema(DOCUMENT_SORT_FIELDS).optional(),
+    netuid: API_QUERY_COLLECTIONS.documents.filter_schemas.netuid.optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.documents.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -60,13 +57,12 @@ export type ListSearchIndexOutput = z.infer<typeof ListSearchIndexOutputSchema>;
 export const ListSearchInputSchema = z
   .object({
     q: querySchema().optional(),
-    type: z
-      .enum(SEARCH_DOCUMENT_TYPE_VALUES)
+    type: API_QUERY_COLLECTIONS.documents.filter_schemas.type
       .optional()
       .describe("Which entity kind to search over.")
       .meta({ examples: [SEARCH_DOCUMENT_TYPE_VALUES[0]] }),
-    netuid: netuidSchema().optional(),
-    sort: sortSchema(DOCUMENT_SORT_FIELDS).optional(),
+    netuid: API_QUERY_COLLECTIONS.documents.filter_schemas.netuid.optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.documents.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),

--- a/schemas-src/mcp-tools/subnet-registry-lists.ts
+++ b/schemas-src/mcp-tools/subnet-registry-lists.ts
@@ -18,6 +18,7 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   idFilterSchema,
   McpListPageFields,
@@ -43,7 +44,6 @@ import {
   SURFACE_KIND_VALUES,
 } from "../routes/subnet-detail.ts";
 import { CONFIDENCE_LEVEL_VALUES } from "../shared.ts";
-import { CANDIDATE_SORT_VALUES, EVIDENCE_ENTRY_SORT_VALUES } from "./shared.ts";
 // #9998: the per-subnet views below are these two with `netuid` moved from an
 // optional filter to the required subject.
 import {
@@ -68,7 +68,19 @@ export type GetSubnetCandidatesInput = z.infer<
   typeof GetSubnetCandidatesInputSchema
 >;
 
-export const GetSubnetCandidatesOutputSchema = SubnetCandidatesArtifactSchema;
+// #10064 production sweep: this tool advertises `fields`, so a caller can ask
+// for a SUBSET of each row -- and the artifact schema requires every property
+// on it. Production answered `?fields=` with rows that failed the tool's own
+// published schema; `projectableRows` is the convention the sibling tools
+// already use. Field names and types still come from the route, so a rename
+// there is still a compile error here; only requiredness changes, because the
+// caller controls it.
+export const GetSubnetCandidatesOutputSchema =
+  SubnetCandidatesArtifactSchema.extend({
+    candidates: projectableRows(
+      SubnetCandidatesArtifactSchema.shape.candidates,
+    ),
+  });
 export type GetSubnetCandidatesOutput = z.infer<
   typeof GetSubnetCandidatesOutputSchema
 >;
@@ -79,18 +91,16 @@ export const ListSubnetCandidatesInputSchema = z
     netuid: netuidSchema(),
     kind: kindSchema(SURFACE_KINDS).optional(),
     provider: providerSlugSchema().optional(),
-    state: z
-      .enum(CANDIDATE_STATES)
+    state: API_QUERY_COLLECTIONS.candidates.filter_schemas.state
       .optional()
       .describe("The incident's lifecycle state.")
       .meta({ examples: [CANDIDATE_STATES[0]] }),
     id: idFilterSchema().optional(),
-    confidence: z
-      .enum(CONFIDENCE_LEVEL_VALUES)
+    confidence: API_QUERY_COLLECTIONS.candidates.filter_schemas.confidence
       .optional()
       .describe("How confident the machine assessment is.")
       .meta({ examples: [CONFIDENCE_LEVEL_VALUES[0]] }),
-    sort: sortSchema(CANDIDATE_SORT_VALUES).optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.candidates.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -134,7 +144,7 @@ export const ListSubnetEvidenceInputSchema = z
   .object({
     netuid: netuidSchema(),
     q: querySchema().optional(),
-    sort: sortSchema(EVIDENCE_ENTRY_SORT_VALUES).optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.claims.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -179,7 +189,17 @@ export type GetSubnetSurfacesInput = z.infer<
   typeof GetSubnetSurfacesInputSchema
 >;
 
-export const GetSubnetSurfacesOutputSchema = SubnetSurfacesArtifactSchema;
+// #10064 production sweep: this tool advertises `fields`, so a caller can ask
+// for a SUBSET of each row -- and the artifact schema requires every property
+// on it. Production answered `?fields=` with rows that failed the tool's own
+// published schema; `projectableRows` is the convention the sibling tools
+// already use. Field names and types still come from the route, so a rename
+// there is still a compile error here; only requiredness changes, because the
+// caller controls it.
+export const GetSubnetSurfacesOutputSchema =
+  SubnetSurfacesArtifactSchema.extend({
+    surfaces: projectableRows(SubnetSurfacesArtifactSchema.shape.surfaces),
+  });
 export type GetSubnetSurfacesOutput = z.infer<
   typeof GetSubnetSurfacesOutputSchema
 >;

--- a/schemas-src/mcp-tools/subnet-scoped-lists.ts
+++ b/schemas-src/mcp-tools/subnet-scoped-lists.ts
@@ -16,6 +16,7 @@
 // list_subnet_surfaces/list_subnet_health have no `fields` projection param
 // at all, unlike every other list_* tool in this epic.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   McpListPageFields,
   McpSubnetListArtifactStamp,
@@ -41,11 +42,7 @@ import {
   SURFACE_KIND_VALUES,
 } from "../routes/subnet-detail.ts";
 import { HEALTH_STATUS_VALUES } from "../shared.ts";
-import {
-  ENDPOINT_SORT_VALUES,
-  HEALTH_CLASSIFICATION_VALUES,
-  HEALTH_SURFACE_SORT_VALUES,
-} from "./shared.ts";
+import { HEALTH_CLASSIFICATION_VALUES } from "./shared.ts";
 
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
 const ENDPOINT_LAYERS = ENDPOINT_LAYER_VALUES;
@@ -64,16 +61,15 @@ export const ListSubnetEndpointsInputSchema = z
       )
       .meta({ examples: [ENDPOINT_LAYERS[0]] }),
     provider: providerSlugSchema().optional(),
-    publication_state: z
-      .enum(ENDPOINT_PUBLICATION_STATES)
-      .optional()
-      .describe(
-        "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
-      )
-      .meta({ examples: [ENDPOINT_PUBLICATION_STATES[0]] }),
+    publication_state:
+      API_QUERY_COLLECTIONS.endpoints.filter_schemas.publication_state
+        .optional()
+        .describe(
+          "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
+        )
+        .meta({ examples: [ENDPOINT_PUBLICATION_STATES[0]] }),
     status: kindSchema(HEALTH_STATUSES).optional(),
-    pool_eligible: z
-      .enum(BOOLEAN_STRINGS)
+    pool_eligible: API_QUERY_COLLECTIONS.endpoints.filter_schemas.pool_eligible
       .optional()
       .describe(
         "Restrict to endpoints that are (or are not) eligible for the public RPC pool.",
@@ -107,7 +103,7 @@ export const ListSubnetEndpointsInputSchema = z
         "Inclusive upper bound on endpoint score; rows above it are excluded.",
       )
       .meta({ examples: [100] }),
-    sort: sortSchema(ENDPOINT_SORT_VALUES).optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.endpoints.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
     limit: limitSchema(100).optional(),
@@ -173,14 +169,17 @@ export const ListSubnetHealthInputSchema = z
     kind: kindSchema(SURFACE_KINDS).optional(),
     provider: providerSlugSchema().optional(),
     status: kindSchema(HEALTH_STATUSES).optional(),
-    classification: z
-      .enum(HEALTH_CLASSIFICATION_VALUES)
+    classification: API_QUERY_COLLECTIONS[
+      "health-surfaces"
+    ].filter_schemas.classification
       .optional()
       .describe(
         "Why a probe ended as it did — the reason behind the status, not the status itself.",
       )
       .meta({ examples: [HEALTH_CLASSIFICATION_VALUES[0]] }),
-    sort: sortSchema(HEALTH_SURFACE_SORT_VALUES).optional(),
+    sort: sortSchema(
+      API_QUERY_COLLECTIONS["health-surfaces"].sort_fields,
+    ).optional(),
     order: orderSchema().optional(),
     limit: limitSchema(100).optional(),
     cursor: numericCursorSchema().optional(),

--- a/schemas-src/mcp-tools/validators.ts
+++ b/schemas-src/mcp-tools/validators.ts
@@ -17,14 +17,13 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import {
   NeuronFieldsInputSchema,
   accountKeySchema,
   limitSchema,
   netuidSchema,
   offsetSchema,
-  sortSchema,
-  windowSchema,
 } from "./shared.ts";
 import {
   GLOBAL_VALIDATOR_LIMIT_DEFAULT,
@@ -36,17 +35,24 @@ import { ValidatorHistoryArtifactSchema } from "../routes/validator-history.ts";
 import { ValidatorNominatorsArtifactSchema } from "../routes/validator-nominators.ts";
 import { NeuronSchema } from "../routes/subnet-metagraph.ts";
 import { CompareValidatorEntrySchema } from "../routes/compare-validators.ts";
-import { GLOBAL_VALIDATORS_VALIDATOR_SORTS_VALUES } from "../routes/global-validators.ts";
-import {
-  VALIDATOR_NOMINATORS_NOMINATOR_SORTS_VALUES,
-  VALIDATOR_NOMINATORS_WINDOW_VALUES,
-} from "../routes/validator-nominators.ts";
+import {} from "../routes/validator-nominators.ts";
 
 // Mirrors workers/config.ts's SS58_ADDRESS_PATTERN (inlined rather than
 // cross-imported from workers/, matching this directory's existing
 // convention of inlining its own regex constants, e.g. subnets.ts's
 // HttpUrlSchema).
 const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+
+const RouteQuery_validators = ROUTE_QUERY_SCHEMAS["/api/v1/validators"];
+
+const RouteQuery_compare_validators =
+  ROUTE_QUERY_SCHEMAS["/api/v1/compare/validators"];
+
+const RouteQuery_validators_hotkey_history =
+  ROUTE_QUERY_SCHEMAS["/api/v1/validators/{hotkey}/history"];
+
+const RouteQuery_validators_hotkey_nominators =
+  ROUTE_QUERY_SCHEMAS["/api/v1/validators/{hotkey}/nominators"];
 
 export const ListSubnetValidatorsInputSchema = z
   .object({
@@ -110,7 +116,7 @@ export type ListSubnetValidatorsOutput = z.infer<
 // checked against the actual runtime source at the time of writing.
 export const ListGlobalValidatorsInputSchema = z
   .object({
-    sort: sortSchema(GLOBAL_VALIDATORS_VALIDATOR_SORTS_VALUES).optional(),
+    sort: RouteQuery_validators.shape.sort,
     // Was a hardcoded 100 while this tool's own description — interpolated from
     // GLOBAL_VALIDATOR_LIMIT_MAX — said "max 2000", and the handler clamped to 2000.
     // The tool advertised 2000 in prose, 100 in schema, and served 2000. Now the
@@ -162,7 +168,7 @@ export const CompareValidatorsInputSchema = z
       .meta({
         examples: [["5CS3g6nVJM6ouns8n9buN9CzFf2C1YDHVcVGRcxoirKs2xbV"]],
       }),
-    netuid: netuidSchema().optional(),
+    netuid: RouteQuery_compare_validators.shape.netuid,
   })
   .strict();
 export type CompareValidatorsInput = z.infer<
@@ -192,9 +198,9 @@ export type CompareValidatorsOutput = z.infer<
 export const GetValidatorNominatorsInputSchema = z
   .object({
     hotkey: accountKeySchema("hotkey"),
-    window: windowSchema(VALIDATOR_NOMINATORS_WINDOW_VALUES).optional(),
-    sort: sortSchema(VALIDATOR_NOMINATORS_NOMINATOR_SORTS_VALUES).optional(),
-    limit: limitSchema(100).optional(),
+    window: RouteQuery_validators_hotkey_nominators.shape.window,
+    sort: RouteQuery_validators_hotkey_nominators.shape.sort,
+    limit: RouteQuery_validators_hotkey_nominators.shape.limit,
     offset: offsetSchema().optional(),
     coldkey: accountKeySchema("coldkey").optional(),
   })
@@ -213,10 +219,10 @@ export type GetValidatorNominatorsOutput = z.infer<
 export const GetValidatorHistoryInputSchema = z
   .object({
     hotkey: accountKeySchema("hotkey"),
-    window: windowSchema(["7d", "30d", "90d", "1y", "all"]).optional(),
+    window: RouteQuery_validators_hotkey_history.shape.window,
     // #9383: scopes the series to one subnet and switches the points to the
     // per-subnet shape (vTrust, consensus, dividends, take, native alpha).
-    netuid: netuidSchema().optional(),
+    netuid: RouteQuery_validators_hotkey_history.shape.netuid,
   })
   .strict();
 export type GetValidatorHistoryInput = z.infer<

--- a/schemas-src/query-params.ts
+++ b/schemas-src/query-params.ts
@@ -161,8 +161,17 @@ export const windowSchema = <T extends readonly [string, ...string[]]>(
 
 /**
  * Which side of a two-sided flow to count. Values are per-route -- the transfer
- * feeds say `all|sent|received`, the stake feeds `all|in|out`, the stake quote
- * `stake|unstake` -- so, like `window` and `sort`, only the meaning is shared.
+ * feeds say `all|sent|received` and the stake feeds `all|in|out` -- so, like
+ * `window` and `sort`, only the meaning is shared.
+ *
+ * NOT the stake quote's `direction`, which this used to cover on the strength
+ * of the shared name. That one selects an ACTION (`stake|unstake`), omitting it
+ * quotes a `stake` rather than "both", and there is no flow to have a side of
+ * -- so the sentence below was false on that route. It went unnoticed while the
+ * prose lived only in the MCP copy, which said something generic instead;
+ * deriving the tool input from the route (#10064) would have published the
+ * wrong sentence to every agent. A coincident name, not a shared meaning --
+ * the distinction #9799 drew. See `stakeActionSchema`.
  *
  * The sentence carries the part no enum can: that the default is BOTH sides,
  * and that a direction is relative to the account or subnet in the path rather
@@ -179,6 +188,23 @@ export const directionSchema = <T extends readonly [string, ...string[]]>(
         "see this parameter's enum.",
     )
     .meta({ examples: [values[0]] });
+
+/**
+ * Which side of a stake quote to price.
+ *
+ * Distinct from `directionSchema` despite the shared parameter name: this is an
+ * action, not a side of a flow, and omitting it prices a `stake` rather than
+ * returning both. Verified live -- /subnets/1/stake-quote?amount=1 answers
+ * `direction: "stake"`.
+ */
+export const stakeActionSchema = () =>
+  z
+    .enum(["stake", "unstake"] as const)
+    .describe(
+      "Which side of the trade to price: `stake` buys alpha with TAO, " +
+        "`unstake` sells alpha for TAO. Omit for `stake`.",
+    )
+    .meta({ examples: ["stake"] });
 
 /** Which column the result is ranked by. Values are per-tool. */
 export const sortSchema = <T extends readonly [string, ...string[]]>(

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -120,6 +120,7 @@ import {
   orderSchema,
   querySchema,
   sortSchema,
+  stakeActionSchema,
   ss58Schema,
   windowSchema,
 } from "./query-params.ts";
@@ -235,7 +236,15 @@ export const NO_QUERY_PARAMETERS: readonly string[] = [
  * and a route-specific one is not forced into a vocabulary it does not belong
  * to.
  */
-export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
+/**
+ * The literal-keyed map is the point: `Record<string, z.ZodObject>` erased the
+ * per-route type, so a consumer indexing it got a generic object and could not
+ * `z.infer<>` the real shape. `satisfies` keeps the annotation's guarantee
+ * (every value is a ZodObject) while preserving each key's own type, which is
+ * what lets schemas-src/mcp-tools/* build a tool input FROM its route instead
+ * of restating it (#10064).
+ */
+export const ROUTE_QUERY_SCHEMAS = {
   "/api/v1/search/semantic": z.object({
     // Both were wrong before #10075: `q` published no ceiling though the
     // handler rejects one over SEMANTIC_QUERY_MAX_LENGTH, and `limit`
@@ -347,7 +356,7 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
   }),
   "/api/v1/subnets/{netuid}/stake-quote": z.object({
     amount: z.number().gt(0).optional(),
-    direction: directionSchema(["stake", "unstake"] as const).optional(),
+    direction: stakeActionSchema().optional(),
   }),
   "/api/v1/subnets/{netuid}/validator-economics/history": z.object({
     window: windowSchema(["7d", "30d", "90d"] as const).optional(),
@@ -903,4 +912,4 @@ export const ROUTE_QUERY_SCHEMAS: Record<string, z.ZodObject> = {
   "/api/v1/rpc/usage": z.object({
     window: windowSchema(["7d", "30d"] as const).optional(),
   }),
-};
+} satisfies Record<string, z.ZodObject>;

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -6245,7 +6245,10 @@ function parameterSchemaFor(
     : { description: inSchemaDescription, ...constraints };
 }
 
-function queryCollection(dataKey: string, options: Row = {}) {
+function queryCollection<
+  Filters extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+  Sort extends readonly [string, ...string[]] = readonly [string, ...string[]],
+>(dataKey: string, options: Row & { filters?: Filters; sort?: Sort } = {}) {
   // `filters` is authored as ZOD and stored twice (#10080): once as the emitted
   // JSON every existing reader already uses, and once as the Zod itself so
   // `listQuerySchema()` can compose with it.
@@ -6255,7 +6258,12 @@ function queryCollection(dataKey: string, options: Row = {}) {
   // `validateListQuery` reads at RUNTIME (`type`, `enum`, `maxLength`,
   // `pattern`, `maximum`) to decide a 400, so it cannot become a second thing
   // somebody edits.
-  const filterSchemas = (options.filters || {}) as Record<string, z.ZodType>;
+  // Typed as the AUTHORED filters, not widened to Record<string, ZodType>.
+  // Widening erased which filters a collection has, so a reader could not
+  // reference `API_QUERY_COLLECTIONS.curation.filter_schemas.netuid` and had to
+  // restate the schema instead -- which is exactly what the 34 collection
+  // routes' MCP tools were doing (#10064).
+  const filterSchemas = (options.filters || {}) as Filters;
   return {
     data_key: dataKey,
     filters: Object.fromEntries(
@@ -6287,7 +6295,10 @@ function queryCollection(dataKey: string, options: Row = {}) {
     // /apis had to filter this one client-side over a single page (#9117).
     presence_filters: options.presenceFilters || {},
     search_keys: options.search || [],
-    sort_fields: options.sort || [],
+    // Typed as the AUTHORED list for the same reason `filter_schemas` is: a
+    // reader that cannot see WHICH columns a collection sorts by has to
+    // restate the enum, and 30 MCP tools did (#10064).
+    sort_fields: (options.sort || []) as Sort,
   };
 }
 
@@ -6410,7 +6421,12 @@ export function querySchemaForRoute(entry: {
       extend: LIST_QUERY_ROUTE_EXTRAS[entry.path] ?? {},
     });
   }
-  const declared = ROUTE_QUERY_SCHEMAS[entry.path];
+  // ROUTE_QUERY_SCHEMAS is literal-keyed so mcp-tools can `z.infer<>` a single
+  // route's shape (#10064); this lookup is by a runtime string, which that
+  // typing deliberately does not admit.
+  const declared = (ROUTE_QUERY_SCHEMAS as Record<string, z.ZodObject>)[
+    entry.path
+  ];
   if (declared) return declared;
   return NO_QUERY_PARAMETERS.includes(entry.path)
     ? z.object({}).strict()

--- a/tests/mcp-schema-enforcement.test.ts
+++ b/tests/mcp-schema-enforcement.test.ts
@@ -222,3 +222,50 @@ describe("published MCP enums are enforced at runtime (#8942)", () => {
     );
   }, 120_000);
 });
+
+describe("a tool that advertises `fields` publishes projectable rows (#10064)", () => {
+  // Found by a PRODUCTION sweep, which is the wrong place to find it.
+  //
+  // `?fields=auth_required` returns rows carrying ONLY that key. Four tools
+  // published their route's whole artifact schema, which requires every
+  // property on a row, so the projected answer failed the tool's own published
+  // schema: 1,060 violations across get_subnet_endpoints, get_subnet_candidates,
+  // get_subnet_surfaces and get_coverage_depth. A generated client validating
+  // the response would reject data the server considers correct.
+  //
+  // conformance:mcp catches this, but only against production and only out of
+  // band -- #9884 is the same failure, and the same gap let it recur. The rule
+  // is decidable offline from the EMITTED schemas alone: if a tool takes
+  // `fields`, any subset of a row is a legal answer, so no row property may be
+  // required. `projectableRows()` is how the sibling tools say that.
+  test("no fields-capable tool requires properties on a row it can project", () => {
+    const offenders: string[] = [];
+    let checked = 0;
+    for (const tool of listToolDefinitions() as Row[]) {
+      const input = tool.inputSchema as Row | undefined;
+      if (!(input?.properties as Row)?.fields) continue;
+      checked += 1;
+      for (const [key, value] of Object.entries(
+        ((tool.outputSchema as Row)?.properties ?? {}) as Row,
+      )) {
+        const node = value as Row;
+        const items = node?.items as Row | undefined;
+        const required = (items?.required ?? []) as string[];
+        if (
+          node?.type === "array" &&
+          items?.type === "object" &&
+          required.length
+        ) {
+          offenders.push(`${tool.name}.${key} requires ${required.length}`);
+        }
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      "these answer a `fields` request with rows that fail their own published " +
+        `schema — wrap the row array in projectableRows(): ${offenders.join(", ")}`,
+    );
+    assert.ok(checked >= 30, `only ${checked} fields-capable tools found`);
+  });
+});


### PR DESCRIPTION
MCP input schemas were the last hand-written mirror of the query contract.

The *constraints* were already single-sourced — #9986 hoisted the vocabulary so both surfaces build a `limit` from one definition. What was still duplicated is each tool restating **which** parameters it takes and **with what bound**.

**273 arguments across 67 files** now read their route's own declaration — 159 via `RouteQuery_x.shape.<name>`, 114 via `API_QUERY_COLLECTIONS.<c>`.

## All 227 emitted schemas are byte-identical

Property order included. This refactor changes **no published bytes**. That's the acceptance criterion #10064 asked for.

## Three typing changes made it possible, and each caught a bug

| change | what it caught on first compile |
|---|---|
| `ROUTE_QUERY_SCHEMAS` literal-keyed (`satisfies`) | a file where two tools with **different routes** shared one alias |
| `queryCollection` generic in `filters` | widening to `Record<string, ZodType>` was *why* a tool had to restate a filter |
| `queryCollection` generic in `sort` | 30 tools restating the sort enum `sort_fields` already owns |

## A field converts only when the prose matches too

`keysetCursorSchema` and `blockEventCursorSchema` both produce a string — swapping one for the other silently rewrote what an agent reads, and comparing constraints alone dropped a cursor's `block_number.event_index` explanation.

## The rewriter had a bug worth 91 arguments

It iterated a file's schemas **forward** while rewriting the source, so every schema after the first in a file was sliced at a stale offset — the file's first tool converted and the rest silently did not. Reversed.

## Two real defects found

**1. `directionSchema` lied on one of its three routes.** Its sentence — *"Which side of the flow to count … Omit to count both"* — is false on the stake quote, where `direction` selects an **action** and omitting it prices a `stake`:

```
/api/v1/subnets/1/stake-quote?amount=1  →  "direction": "stake"
```

Split into `stakeActionSchema`. A coincident name, not a shared meaning — visible only once the route's wording was about to become the tool's.

**2. Four tools failed their own published schema in production — 1,060 violations.**

Found by the `conformance:mcp` sweep against production. `get_subnet_endpoints`, `get_subnet_candidates`, `get_subnet_surfaces` and `get_coverage_depth` publish their route's whole artifact schema, which **requires** every property on a row — but they advertise `fields`, so a projected call returns rows carrying only what was asked for:

```
get_subnet_surfaces netuid=1 fields=auth_required
  → surfaces: [{"auth_required": false}, …]     ← fails its own outputSchema
```

Fixed with `projectableRows()`, the convention the sibling tools already use. **And gated offline** — the rule is decidable from the emitted schemas alone, so CI now catches it instead of a scheduled production sweep. #9884 was the same failure; the missing offline gate is why it recurred. Verified the gate bites by reverting one tool.

## What is left, and why none of it is duplication

| count | reason |
|---|---|
| 160 | genuinely diverge from the route — the input-parity gate declares every one |
| 155 | path parameters / MCP-native args with no route counterpart — the shape #10064 describes |
| 103 | `order`/`fields`/`q`/`limit`/range bounds where tool and route call the **same** zero-arg or shared-constant helper; the fact already lives in `query-params.ts` |
| 54 | constraint matches but prose comes from a different helper — converting means inlining the sentence, which #10064 explicitly says not to do |

## Validation

```
emitted inputSchemas       0 diff across all 227 tools
npm run typecheck / lint / format:check    clean
npx vitest run             767 files, 18,243 passed, 22 skipped
validate:mcp  validate:mcp-input-parity  validate:route-query-parity
validate:graphql-route-parity  validate:contract-drift  validate:openapi   all PASS
conformance:mcp            re-run after the fix
```

`openapi.json` unchanged.

Closes #10064