### PR TITLE
fix(burn): the capture wrote SQLite-only SQL that Postgres rejects (#10172)

### DIFF
--- a/src/subnet-burn-history.ts
+++ b/src/subnet-burn-history.ts
@@ -123,11 +123,24 @@ export async function captureSubnetBurnHistory(
   }
 
   try {
-    // INSERT OR REPLACE, not INSERT: a retried tick at the same millisecond must be
-    // idempotent rather than a primary-key error that fails the whole batch.
+    // ON CONFLICT DO UPDATE, not INSERT OR REPLACE (#10172).
+    //
+    // Both spellings are idempotent, and idempotence is the requirement: a
+    // retried tick at the same millisecond must not be a primary-key error
+    // that fails the whole batch. But `INSERT OR REPLACE` is SQLite's, and
+    // POSTGRES REJECTS IT OUTRIGHT as a syntax error -- so the moment
+    // subnet_burn_history became sole-store on Neon and producerStore started
+    // handing this lane a Postgres runner, every write in this batch failed.
+    //
+    // It failed silently, which is the part that cost five hours: the catch
+    // below turns it into `{ ok: false, reason }`, the cron dispatch ignores
+    // the return, and this lane had no lane_health verdict. `ON CONFLICT ...
+    // DO UPDATE` is understood by BOTH engines (SQLite has supported it since
+    // 3.24), so one statement serves whichever store owns the table.
     const insert = db.prepare(
-      `INSERT OR REPLACE INTO ${SUBNET_BURN_HISTORY_TABLE}` +
-        ` (netuid, observed_at, burn_tao) VALUES (?, ?, ?)`,
+      `INSERT INTO ${SUBNET_BURN_HISTORY_TABLE}` +
+        ` (netuid, observed_at, burn_tao) VALUES (?, ?, ?)` +
+        ` ON CONFLICT (netuid, observed_at) DO UPDATE SET burn_tao = EXCLUDED.burn_tao`,
     );
     await db.batch(
       rows.map((r) => insert.bind(r.netuid, observedAt, r.burn_tao)),

--- a/tests/no-sqlite-only-sql.test.ts
+++ b/tests/no-sqlite-only-sql.test.ts
@@ -1,0 +1,113 @@
+// No SQLite-only SQL in a path that can be handed a Postgres runner (#10172).
+//
+// THE OUTAGE THIS EXISTS TO STOP, exactly as it happened. The subnet-burn
+// capture wrote its batch with
+//
+//   INSERT OR REPLACE INTO subnet_burn_history (...) VALUES (?, ?, ?)
+//
+// which is correct, idempotent SQLite and a SYNTAX ERROR in Postgres. Nothing
+// changed in that file. What changed was underneath it: subnet_burn_history
+// became sole-store on Neon, `producerStore` started handing the lane a
+// Postgres runner, and every write began failing.
+//
+// It failed INVISIBLY, which is what made it expensive. captureSubnetBurnHistory
+// never throws -- a capture lane that could take down its own cron would be
+// worse than a gap -- so the failure came back as `{ ok: false, reason }` that
+// the cron dispatch discarded, and the lane had no lane_health verdict. The
+// series sat frozen for five hours in BOTH stores and every signal read green.
+//
+// A dialect review could not have found it either: the statement is not
+// "D1-flavoured", it is valid SQL that one engine happens not to accept. So
+// this scans for the spellings that are SQLite's alone, in the files that can
+// now reach either store.
+//
+// The equivalent that works on both is `ON CONFLICT (...) DO UPDATE` -- SQLite
+// has supported it since 3.24, so there is no reason to reach for the
+// SQLite-only form at all.
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+
+/** Spellings SQLite accepts and Postgres does not. */
+const SQLITE_ONLY: [RegExp, string][] = [
+  [
+    /\bINSERT\s+OR\s+(REPLACE|IGNORE|ABORT|FAIL|ROLLBACK)\b/i,
+    "INSERT OR ... — use ON CONFLICT ... DO UPDATE/DO NOTHING",
+  ],
+  [/\bAUTOINCREMENT\b/i, "AUTOINCREMENT — Postgres uses GENERATED/serial"],
+  [/\bstrftime\s*\(/i, "strftime() — Postgres uses to_char/date_trunc"],
+  [/\bjulianday\s*\(/i, "julianday() — no Postgres equivalent"],
+  [/\bdatetime\s*\(\s*'now'/i, "datetime('now') — Postgres uses now()"],
+  [/\bLIMIT\s+\d+\s*,\s*\d+/i, "LIMIT a, b — Postgres needs LIMIT b OFFSET a"],
+  [/\bPRAGMA\b/i, "PRAGMA — SQLite only"],
+];
+
+/** SQL lives in string literals; the prose around it does not. Scanning raw
+ *  source reports every one of these from the comments that EXPLAIN them --
+ *  including this repo's own notes about the bug above. */
+function sqlLiterals(source: string): string {
+  const withoutComments = source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/^\s*\/\/.*$/gm, " ")
+    .replace(/([^:])\/\/.*$/gm, "$1 ");
+  return [
+    ...withoutComments.matchAll(
+      /"([^"\\]*(?:\\.[^"\\]*)*)"|`([^`]*)`|'([^'\\]*(?:\\.[^'\\]*)*)'/g,
+    ),
+  ]
+    .map((m) => m[1] ?? m[2] ?? m[3] ?? "")
+    .join("\n");
+}
+
+function walk(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const path = `${dir}/${e.name}`;
+    if (e.isDirectory()) return e.name === "node_modules" ? [] : walk(path);
+    return e.name.endsWith(".ts") ? [path] : [];
+  });
+}
+
+describe("store-neutral SQL", () => {
+  test("no file that can reach either store uses SQLite-only syntax", () => {
+    const offenders: string[] = [];
+    // Everything shipped. The `*-d1-write.ts` modules are exempt only while
+    // they exist: they are D1's by name and are being deleted with it, and a
+    // file that is deleted cannot be handed a Postgres runner.
+    for (const file of [...walk("src"), ...walk("workers")]) {
+      if (/-d1-write\.ts$/.test(file) || /\/observations-d1\.ts$/.test(file)) {
+        continue;
+      }
+      const sql = sqlLiterals(readFileSync(file, "utf8"));
+      for (const [pattern, why] of SQLITE_ONLY) {
+        const hit = pattern.exec(sql);
+        if (hit) offenders.push(`${file}: ${hit[0].trim()} — ${why}`);
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      "SQLite-only SQL in a path that may be handed a Postgres runner:\n" +
+        offenders.join("\n"),
+    );
+  });
+
+  test("the scanner would actually catch the statement that broke", () => {
+    // A negative assertion passes on nothing. This proves the pattern set
+    // recognises the real statement, byte for byte, so a green run above means
+    // "no offenders" rather than "the scanner matched nothing".
+    const real =
+      "const insert = db.prepare(`INSERT OR REPLACE INTO ${T} (netuid, observed_at, burn_tao) VALUES (?, ?, ?)`);";
+    const sql = sqlLiterals(real);
+    assert.ok(
+      SQLITE_ONLY.some(([p]) => p.test(sql)),
+      "the scanner no longer recognises the INSERT OR REPLACE that caused #10172",
+    );
+    // And the replacement must NOT trip it.
+    const fixed =
+      "db.prepare(`INSERT INTO ${T} (netuid, observed_at, burn_tao) VALUES (?, ?, ?) ON CONFLICT (netuid, observed_at) DO UPDATE SET burn_tao = EXCLUDED.burn_tao`)";
+    assert.ok(
+      !SQLITE_ONLY.some(([p]) => p.test(sqlLiterals(fixed))),
+      "the portable form is being reported as SQLite-only",
+    );
+  });
+});

--- a/tests/subnet-burn-history.test.ts
+++ b/tests/subnet-burn-history.test.ts
@@ -127,14 +127,33 @@ describe("captureSubnetBurnHistory", () => {
     );
   });
 
-  test("the write is idempotent, so a retried tick is not a key error", async () => {
+  test("the write is idempotent in a form BOTH engines accept", async () => {
+    // Idempotence is still the requirement -- a retried tick at the same
+    // millisecond must not be a primary-key error that fails the whole batch.
+    // What changed is the spelling (#10172): this was `INSERT OR REPLACE`,
+    // which is SQLite's alone and a SYNTAX ERROR in Postgres. The moment
+    // subnet_burn_history became sole-store on Neon and producerStore handed
+    // this lane a Postgres runner, every write failed -- silently, for five
+    // hours, because the capture never throws and had no lane_health verdict.
+    //
+    // `ON CONFLICT ... DO UPDATE` is understood by both, so the assertion is
+    // now that the statement is PORTABLE, not that it is D1's.
     const { db, calls } = fakeDb();
     await captureSubnetBurnHistory({} as never, {
       db,
       now: () => NOW,
       load: card([{ netuid: 1, burn_tao: 1 }]) as never,
     });
-    assert.match(calls[0].sql, /^INSERT OR REPLACE INTO /);
+    assert.match(calls[0].sql, /^INSERT INTO /);
+    assert.match(
+      calls[0].sql,
+      /ON CONFLICT \(netuid, observed_at\) DO UPDATE SET burn_tao = EXCLUDED\.burn_tao/,
+    );
+    assert.doesNotMatch(
+      calls[0].sql,
+      /INSERT\s+OR\s+REPLACE/i,
+      "the SQLite-only spelling is back; Postgres rejects it outright",
+    );
   });
 
   test("expired rows are swept, bounded by the retention horizon", async () => {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -2323,9 +2323,31 @@ async function dispatchScheduled(
     {
       const store = producerStore(env, ctx, [SUBNET_BURN_HISTORY_TABLE]);
       try {
-        return await captureSubnetBurnHistory(env, {
+        const result = await captureSubnetBurnHistory(env, {
           db: store.db as BurnHistoryDb,
         });
+        // A VERDICT, because this lane had none (#10172). captureSubnetBurnHistory
+        // never throws by design -- a capture lane that could take down its own
+        // cron would be worse than a gap -- so its failures arrive as a returned
+        // `{ ok: false, reason }` that nothing was reading. That is how an
+        // INSERT OR REPLACE rejected by Postgres went unnoticed for five hours
+        // while the series sat frozen. Now it lands where every other lane's
+        // does, and lane-alarm can see it.
+        ctx.waitUntil(
+          recordLaneVerdict(
+            laneHealthStore(env as unknown as Record<string, unknown>),
+            {
+              lane: "subnet-burn",
+              verdict: result.ok ? "ok" : "stale",
+              age_ms: null,
+              detail: result.ok
+                ? `captured ${result.captured}${result.pruned ? ", pruned" : ""}`
+                : (result.reason ?? "capture failed"),
+              checked_at: Date.now(),
+            },
+          ).then(() => undefined),
+        );
+        return result;
       } finally {
         store.close();
       }


### PR DESCRIPTION
Closes #10172

`captureSubnetBurnHistory` batched with:

```sql
INSERT OR REPLACE INTO subnet_burn_history (netuid, observed_at, burn_tao) VALUES (?, ?, ?)
```

Correct, idempotent **SQLite**. A **syntax error in Postgres**.

Nothing in that file changed. What changed was underneath it: `subnet_burn_history` became sole-store on Neon, `producerStore` started handing the lane a Postgres runner, and every write began failing.

## It failed invisibly

The capture never throws by design — a lane that could take down its own cron would be worse than a gap — so the failure returned as `{ ok: false, reason }`, `handleScheduled` discarded it, and the lane had **no `lane_health` verdict at all** (`SELECT DISTINCT lane` returns 29 lanes; `subnet-burn` was not one).

Measured against its 15-minute cron:

| store | newest row | age |
|---|---|---|
| Neon | 07:46 UTC | ~6h |
| D1 | 08:31 UTC | ~5.3h |

D1 was 387 rows ahead — 3 ticks × 129 subnets, the last captures before the flag flipped — then **both froze**. Every signal read green.

## Three changes

1. **`ON CONFLICT (netuid, observed_at) DO UPDATE`** — idempotent *and* understood by both engines (SQLite since 3.24), so there was never a reason to reach for the SQLite-only form. The conflict target matches the Neon primary key in `migrations/neon/0003`.
2. **A `lane_health` verdict** from the returned result, so this lane reports like the other 29 and `lane-alarm` can act on it.
3. **`tests/no-sqlite-only-sql.test.ts`** — a repo-wide scan for SQLite-only spellings (`INSERT OR ...`, `AUTOINCREMENT`, `strftime`, `julianday`, `datetime('now')`, `LIMIT a,b`, `PRAGMA`) in any file that can be handed a Postgres runner. **A dialect review could not have caught this**: the statement is not "D1-flavoured", it is valid SQL one engine happens to reject. It scans string literals with comments stripped — otherwise the comments *explaining* the bug trip it — and asserts the scanner still recognises the exact statement that broke, because a negative assertion passes on nothing.

## Data

The 387 rows are backfilled. `subnet_burn_history` is **45,408 in both stores** with the same max `observed_at`.

## Wider parity

A full exact-`COUNT(*)` sweep of all 48 tables now reports **0 tables where Neon is short**. Six were, before this session's backfills: `subnet_burn_history` (387), `lane_health` (12,849 — every row verified present by a per-row containment check, not counts), and four `*_passes` ledgers.

Worth recording: `pg_stat_user_tables.n_live_tup` reported `neuron_daily` 382 rows short when it was in fact 8 **ahead**. That estimate must never back a parity claim.