### PR TITLE
fix(mcp): three page-size rules and 77 tools that published a limit without one (#10174, #10101)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/shadowbook/Documents/metagraphed/.claude/worktrees/metagraph-api-snapshot-bug-d897a4/node_modules

--- a/schemas-src/mcp-tools/account-extrinsics.ts
+++ b/schemas-src/mcp-tools/account-extrinsics.ts
@@ -23,7 +23,9 @@ export const GetAccountExtrinsicsInputSchema = z
     ss58: ss58Schema(),
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    limit: RouteQuery_accounts_ss58_extrinsics.shape.limit,
+    limit: RouteQuery_accounts_ss58_extrinsics.shape.limit.meta({
+      default: 100,
+    }),
     offset: RouteQuery_accounts_ss58_extrinsics.shape.offset,
     cursor: RouteQuery_accounts_ss58_extrinsics.shape.cursor,
   })

--- a/schemas-src/mcp-tools/account-history.ts
+++ b/schemas-src/mcp-tools/account-history.ts
@@ -22,7 +22,7 @@ export const GetAccountHistoryInputSchema = z
     // example was rejected (#10115).
     from: RouteQuery_accounts_ss58_history.shape.from,
     to: RouteQuery_accounts_ss58_history.shape.to,
-    limit: RouteQuery_accounts_ss58_history.shape.limit,
+    limit: RouteQuery_accounts_ss58_history.shape.limit.meta({ default: 100 }),
     offset: RouteQuery_accounts_ss58_history.shape.offset,
     cursor: RouteQuery_accounts_ss58_history.shape.cursor,
   })

--- a/schemas-src/mcp-tools/account-identity.ts
+++ b/schemas-src/mcp-tools/account-identity.ts
@@ -39,7 +39,9 @@ export type GetAccountIdentityOutput = z.infer<
 export const GetAccountIdentityHistoryInputSchema = z
   .object({
     ss58: ss58Schema(),
-    limit: RouteQuery_accounts_ss58_identity_history.shape.limit,
+    limit: RouteQuery_accounts_ss58_identity_history.shape.limit.meta({
+      default: 100,
+    }),
     offset: RouteQuery_accounts_ss58_identity_history.shape.offset,
     cursor: RouteQuery_accounts_ss58_identity_history.shape.cursor,
   })

--- a/schemas-src/mcp-tools/account-summary.ts
+++ b/schemas-src/mcp-tools/account-summary.ts
@@ -116,7 +116,7 @@ export const GetAccountEventsInputSchema = z
     netuid: RouteQuery_accounts_ss58_events.shape.netuid,
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    limit: RouteQuery_accounts_ss58_events.shape.limit,
+    limit: RouteQuery_accounts_ss58_events.shape.limit.meta({ default: 100 }),
     offset: RouteQuery_accounts_ss58_events.shape.offset,
     cursor: RouteQuery_accounts_ss58_events.shape.cursor,
   })

--- a/schemas-src/mcp-tools/account-transfers.ts
+++ b/schemas-src/mcp-tools/account-transfers.ts
@@ -32,7 +32,9 @@ export const GetAccountTransfersInputSchema = z
       .meta({ examples: ["all"] }),
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    limit: RouteQuery_accounts_ss58_transfers.shape.limit,
+    limit: RouteQuery_accounts_ss58_transfers.shape.limit.meta({
+      default: 100,
+    }),
     offset: RouteQuery_accounts_ss58_transfers.shape.offset,
     cursor: RouteQuery_accounts_ss58_transfers.shape.cursor,
   })

--- a/schemas-src/mcp-tools/accounts-leaderboards.ts
+++ b/schemas-src/mcp-tools/accounts-leaderboards.ts
@@ -11,6 +11,10 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import {
+  ACCOUNTS_LIST_LIMIT_DEFAULT,
+  TOP_HOLDERS_LIMIT_DEFAULT,
+} from "../../src/route-limits.ts";
 import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { AccountsListArtifactSchema } from "../routes/accounts-list.ts";
 import { TopHoldersArtifactSchema } from "../routes/top-holders.ts";
@@ -27,7 +31,9 @@ const RouteQuery_accounts_top_holders =
 export const ListAccountsInputSchema = z
   .object({
     sort: RouteQuery_accounts.shape.sort,
-    limit: RouteQuery_accounts.shape.limit,
+    limit: RouteQuery_accounts.shape.limit.meta({
+      default: ACCOUNTS_LIST_LIMIT_DEFAULT,
+    }),
   })
   .strict();
 export type ListAccountsInput = z.infer<typeof ListAccountsInputSchema>;
@@ -40,7 +46,9 @@ export type ListAccountsOutput = z.infer<typeof ListAccountsOutputSchema>;
 export const GetTopHoldersInputSchema = z
   .object({
     sort: RouteQuery_accounts_top_holders.shape.sort,
-    limit: RouteQuery_accounts_top_holders.shape.limit,
+    limit: RouteQuery_accounts_top_holders.shape.limit.meta({
+      default: TOP_HOLDERS_LIMIT_DEFAULT,
+    }),
   })
   .strict();
 export type GetTopHoldersInput = z.infer<typeof GetTopHoldersInputSchema>;

--- a/schemas-src/mcp-tools/ai-discovery.ts
+++ b/schemas-src/mcp-tools/ai-discovery.ts
@@ -4,6 +4,7 @@
 // existing schemas-src/routes/ REST schema -- modeled fresh, matching
 // each hand-written literal field-for-field.
 import { z } from "zod";
+import { SEMANTIC_LIMIT_DEFAULT } from "../../src/route-limits.ts";
 import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { limitSchema, netuidSchema, querySchema } from "./shared.ts";
 import { SEMANTIC_QUERY_MAX_LENGTH } from "../../src/route-limits.ts";
@@ -35,7 +36,7 @@ export const FindSubnetOpportunitiesInputSchema = z
       .optional()
       .describe("Which leaderboard to return.")
       .meta({ examples: [ECONOMIC_LEADERBOARD_BOARDS[0]] }),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 10).optional(),
   })
   .strict();
 export type FindSubnetOpportunitiesInput = z.infer<
@@ -88,7 +89,7 @@ export const SemanticSearchInputSchema = z
         "Alias for `q`, the name this tool shipped with. Search text, embedded and ranked by meaning.",
       )
       .meta({ examples: ["inference"] }),
-    limit: limitSchema(20).optional(),
+    limit: limitSchema(20, SEMANTIC_LIMIT_DEFAULT).optional(),
     type: SemanticTypeSchema.describe("Which entity kind to search over.").meta(
       { examples: ["subnet"] },
     ),
@@ -163,7 +164,7 @@ export const FindSubnetForTaskInputSchema = z
         "Describe the task in plain language; subnets are ranked by how well their published capabilities match it.",
       )
       .meta({ examples: ["summarise long documents"] }),
-    limit: limitSchema(20).optional(),
+    limit: limitSchema(20, 5).optional(),
   })
   .strict();
 export type FindSubnetForTaskInput = z.infer<

--- a/schemas-src/mcp-tools/blocks.ts
+++ b/schemas-src/mcp-tools/blocks.ts
@@ -77,7 +77,7 @@ export const ListBlocksInputSchema = z
         "Inclusive lower bound on a block's event count; quieter blocks are excluded.",
       )
       .meta({ examples: [20] }),
-    limit: RouteQuery_blocks.shape.limit,
+    limit: RouteQuery_blocks.shape.limit.meta({ default: 50 }),
     offset: RouteQuery_blocks.shape.offset,
     cursor: RouteQuery_blocks.shape.cursor,
   })
@@ -133,7 +133,7 @@ export const ListBlockExtrinsicsInputSchema = z
           "0x9f1e2d3c4b5a69788796a5b4c3d2e1f009182736455463728190abcdef012345",
         ],
       }),
-    limit: RouteQuery_blocks_ref_extrinsics.shape.limit,
+    limit: RouteQuery_blocks_ref_extrinsics.shape.limit.meta({ default: 50 }),
     offset: RouteQuery_blocks_ref_extrinsics.shape.offset,
   })
   .strict();
@@ -159,7 +159,7 @@ export const GetBlockEventsInputSchema = z
           "0x9f1e2d3c4b5a69788796a5b4c3d2e1f009182736455463728190abcdef012345",
         ],
       }),
-    limit: RouteQuery_blocks_ref_events.shape.limit,
+    limit: RouteQuery_blocks_ref_events.shape.limit.meta({ default: 100 }),
     offset: RouteQuery_blocks_ref_events.shape.offset,
   })
   .strict();

--- a/schemas-src/mcp-tools/chain-calls-fees.ts
+++ b/schemas-src/mcp-tools/chain-calls-fees.ts
@@ -34,7 +34,7 @@ export const GetChainCallsInputSchema = z
         "How to bucket the counts: by pallet, or by pallet and call together.",
       )
       .meta({ examples: ["module"] }),
-    limit: RouteQuery_chain_calls.shape.limit,
+    limit: RouteQuery_chain_calls.shape.limit.meta({ default: 50 }),
     call_module: RouteQuery_chain_calls.shape.call_module
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
@@ -53,7 +53,7 @@ export const GetChainSignersInputSchema = z
   .object({
     window: RouteQuery_chain_signers.shape.window,
     sort: RouteQuery_chain_signers.shape.sort,
-    limit: RouteQuery_chain_signers.shape.limit,
+    limit: RouteQuery_chain_signers.shape.limit.meta({ default: 50 }),
     call_module: RouteQuery_chain_signers.shape.call_module
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
@@ -70,7 +70,7 @@ export type GetChainSignersOutput = z.infer<typeof GetChainSignersOutputSchema>;
 export const GetChainFeesInputSchema = z
   .object({
     window: RouteQuery_chain_fees.shape.window,
-    limit: RouteQuery_chain_fees.shape.limit,
+    limit: RouteQuery_chain_fees.shape.limit.meta({ default: 25 }),
     call_module: RouteQuery_chain_fees.shape.call_module
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",

--- a/schemas-src/mcp-tools/chain-events-activity.ts
+++ b/schemas-src/mcp-tools/chain-events-activity.ts
@@ -12,6 +12,7 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { CHAIN_EVENTS_LIMIT_DEFAULT } from "../../src/route-limits.ts";
 import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { blockEventCursorSchema, limitSchema } from "./shared.ts";
 import { McpNetworkSchema } from "../shared.ts";
@@ -93,7 +94,7 @@ export const ListChainEventsInputSchema = z
         "Legacy cursor: return rows strictly BEFORE this block height. Prefer `cursor` where a tool offers one.",
       )
       .meta({ examples: [8783000] }),
-    limit: limitSchema(200).optional(),
+    limit: limitSchema(200, CHAIN_EVENTS_LIMIT_DEFAULT).optional(),
     network: McpNetworkSchema.optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/chain-events.ts
+++ b/schemas-src/mcp-tools/chain-events.ts
@@ -4,6 +4,7 @@
 // covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
 // matching each hand-written literal field-for-field.
 import { z } from "zod";
+import { CHAIN_EVENTS_LIMIT_DEFAULT } from "../../src/route-limits.ts";
 import { blockEventCursorSchema, limitSchema } from "./shared.ts";
 import { McpNetworkSchema } from "../shared.ts";
 
@@ -73,7 +74,7 @@ export const GetExtrinsicChainEventsInputSchema = z
         "Extrinsic reference, as the composite id `block_number-extrinsic_index` -- the index is the extrinsic's position within that block, from 0. A bare block number or block hash is NOT accepted here, unlike the sibling block-scoped tools.",
       )
       .meta({ examples: ["8791987-0"] }),
-    limit: limitSchema(200).optional(),
+    limit: limitSchema(200, CHAIN_EVENTS_LIMIT_DEFAULT).optional(),
     // `block_number.event_index`, not an opaque token -- the route publishes
     // and enforces that shape, so a bare string advertised a value it rejects
     // (#10118). keysetCursorSchema() stays for the genuinely opaque base64

--- a/schemas-src/mcp-tools/chain-leaderboards.ts
+++ b/schemas-src/mcp-tools/chain-leaderboards.ts
@@ -18,6 +18,16 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { CHAIN_SERVING_LIMIT_DEFAULT } from "../../src/chain-serving.ts";
+import { CHAIN_TURNOVER_LIMIT_DEFAULT } from "../../src/route-limits.ts";
+import { CHAIN_WEIGHTS_LIMIT_DEFAULT } from "../../src/chain-weights.ts";
+import { CHAIN_PROMETHEUS_LIMIT_DEFAULT } from "../../src/chain-prometheus.ts";
+import { CHAIN_STAKE_TRANSFERS_LIMIT_DEFAULT } from "../../src/chain-stake-transfers.ts";
+import { CHAIN_STAKE_FLOW_LIMIT_DEFAULT } from "../../src/chain-stake-flow.ts";
+import { CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT } from "../../src/chain-weight-setters.ts";
+import { CHAIN_AXON_REMOVALS_LIMIT_DEFAULT } from "../../src/chain-axon-removals.ts";
+import { CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT } from "../../src/chain-alpha-volume.ts";
+import { CHAIN_STAKE_MOVES_LIMIT_DEFAULT } from "../../src/chain-stake-moves.ts";
 import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { ChainAlphaVolumeArtifactSchema } from "../routes/chain-alpha-volume.ts";
 import {
@@ -62,7 +72,9 @@ const RouteQuery_chain_alpha_volume =
 export const GetChainTurnoverInputSchema = z
   .object({
     window: RouteQuery_chain_turnover.shape.window,
-    limit: RouteQuery_chain_turnover.shape.limit,
+    limit: RouteQuery_chain_turnover.shape.limit.meta({
+      default: CHAIN_TURNOVER_LIMIT_DEFAULT,
+    }),
   })
   .strict();
 export type GetChainTurnoverInput = z.infer<typeof GetChainTurnoverInputSchema>;
@@ -75,7 +87,9 @@ export type GetChainTurnoverOutput = z.infer<
 export const GetChainStakeFlowInputSchema = z
   .object({
     window: RouteQuery_chain_stake_flow.shape.window,
-    limit: RouteQuery_chain_stake_flow.shape.limit,
+    limit: RouteQuery_chain_stake_flow.shape.limit.meta({
+      default: CHAIN_STAKE_FLOW_LIMIT_DEFAULT,
+    }),
   })
   .strict();
 export type GetChainStakeFlowInput = z.infer<
@@ -89,7 +103,9 @@ export type GetChainStakeFlowOutput = z.infer<
 
 export const GetChainAlphaVolumeInputSchema = z
   .object({
-    limit: RouteQuery_chain_alpha_volume.shape.limit,
+    limit: RouteQuery_chain_alpha_volume.shape.limit.meta({
+      default: CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT,
+    }),
   })
   .strict();
 export type GetChainAlphaVolumeInput = z.infer<
@@ -108,7 +124,9 @@ export type GetChainAlphaVolumeOutput = z.infer<
 export const GetChainWeightsInputSchema = z
   .object({
     window: RouteQuery_chain_weights.shape.window,
-    limit: RouteQuery_chain_weights.shape.limit,
+    limit: RouteQuery_chain_weights.shape.limit.meta({
+      default: CHAIN_WEIGHTS_LIMIT_DEFAULT,
+    }),
   })
   .strict();
 export type GetChainWeightsInput = z.infer<typeof GetChainWeightsInputSchema>;
@@ -119,7 +137,9 @@ export type GetChainWeightsOutput = z.infer<typeof GetChainWeightsOutputSchema>;
 export const GetChainWeightSettersInputSchema = z
   .object({
     window: RouteQuery_chain_weights_setters.shape.window,
-    limit: RouteQuery_chain_weights_setters.shape.limit,
+    limit: RouteQuery_chain_weights_setters.shape.limit.meta({
+      default: CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT,
+    }),
   })
   .strict();
 export type GetChainWeightSettersInput = z.infer<
@@ -137,7 +157,9 @@ export type GetChainWeightSettersOutput = z.infer<
 export const GetChainStakeMovesInputSchema = z
   .object({
     window: RouteQuery_chain_stake_moves.shape.window,
-    limit: RouteQuery_chain_stake_moves.shape.limit,
+    limit: RouteQuery_chain_stake_moves.shape.limit.meta({
+      default: CHAIN_STAKE_MOVES_LIMIT_DEFAULT,
+    }),
   })
   .strict();
 export type GetChainStakeMovesInput = z.infer<
@@ -152,7 +174,9 @@ export type GetChainStakeMovesOutput = z.infer<
 export const GetChainStakeTransfersInputSchema = z
   .object({
     window: RouteQuery_chain_stake_transfers.shape.window,
-    limit: RouteQuery_chain_stake_transfers.shape.limit,
+    limit: RouteQuery_chain_stake_transfers.shape.limit.meta({
+      default: CHAIN_STAKE_TRANSFERS_LIMIT_DEFAULT,
+    }),
   })
   .strict();
 export type GetChainStakeTransfersInput = z.infer<
@@ -168,7 +192,9 @@ export type GetChainStakeTransfersOutput = z.infer<
 export const GetChainAxonRemovalsInputSchema = z
   .object({
     window: RouteQuery_chain_axon_removals.shape.window,
-    limit: RouteQuery_chain_axon_removals.shape.limit,
+    limit: RouteQuery_chain_axon_removals.shape.limit.meta({
+      default: CHAIN_AXON_REMOVALS_LIMIT_DEFAULT,
+    }),
   })
   .strict();
 export type GetChainAxonRemovalsInput = z.infer<
@@ -183,7 +209,9 @@ export type GetChainAxonRemovalsOutput = z.infer<
 export const GetChainServingInputSchema = z
   .object({
     window: RouteQuery_chain_serving.shape.window,
-    limit: RouteQuery_chain_serving.shape.limit,
+    limit: RouteQuery_chain_serving.shape.limit.meta({
+      default: CHAIN_SERVING_LIMIT_DEFAULT,
+    }),
   })
   .strict();
 export type GetChainServingInput = z.infer<typeof GetChainServingInputSchema>;
@@ -194,7 +222,9 @@ export type GetChainServingOutput = z.infer<typeof GetChainServingOutputSchema>;
 export const GetChainPrometheusInputSchema = z
   .object({
     window: RouteQuery_chain_prometheus.shape.window,
-    limit: RouteQuery_chain_prometheus.shape.limit,
+    limit: RouteQuery_chain_prometheus.shape.limit.meta({
+      default: CHAIN_PROMETHEUS_LIMIT_DEFAULT,
+    }),
   })
   .strict();
 export type GetChainPrometheusInput = z.infer<

--- a/schemas-src/mcp-tools/chain-registrations.ts
+++ b/schemas-src/mcp-tools/chain-registrations.ts
@@ -14,6 +14,8 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT } from "../../src/chain-deregistrations.ts";
+import { CHAIN_REGISTRATIONS_LIMIT_DEFAULT } from "../../src/chain-registrations.ts";
 import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import {
   ChainDeregistrationsArtifactSchema,
@@ -29,7 +31,9 @@ const RouteQuery_chain_deregistrations =
 export const GetChainRegistrationsInputSchema = z
   .object({
     window: RouteQuery_chain_registrations.shape.window,
-    limit: RouteQuery_chain_registrations.shape.limit,
+    limit: RouteQuery_chain_registrations.shape.limit.meta({
+      default: CHAIN_REGISTRATIONS_LIMIT_DEFAULT,
+    }),
   })
   .strict();
 export type GetChainRegistrationsInput = z.infer<
@@ -50,7 +54,9 @@ export type GetChainRegistrationsOutput = z.infer<
 export const GetChainDeregistrationsInputSchema = z
   .object({
     window: RouteQuery_chain_deregistrations.shape.window,
-    limit: RouteQuery_chain_deregistrations.shape.limit,
+    limit: RouteQuery_chain_deregistrations.shape.limit.meta({
+      default: CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT,
+    }),
   })
   .strict();
 export type GetChainDeregistrationsInput = z.infer<

--- a/schemas-src/mcp-tools/chain-transfers.ts
+++ b/schemas-src/mcp-tools/chain-transfers.ts
@@ -11,6 +11,8 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { CHAIN_TRANSFER_PAIR_LIMIT_DEFAULT } from "../../src/chain-transfer-pairs.ts";
+import { CHAIN_TRANSFER_LIMIT_DEFAULT } from "../../src/chain-transfers.ts";
 import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import {
   ChainTransferPairsArtifactSchema,
@@ -29,7 +31,9 @@ const RouteQuery_chain_transfer_pairs =
 export const GetChainTransfersInputSchema = z
   .object({
     window: RouteQuery_chain_transfers.shape.window,
-    limit: RouteQuery_chain_transfers.shape.limit,
+    limit: RouteQuery_chain_transfers.shape.limit.meta({
+      default: CHAIN_TRANSFER_LIMIT_DEFAULT,
+    }),
   })
   .strict();
 export type GetChainTransfersInput = z.infer<
@@ -45,7 +49,9 @@ export const GetChainTransferPairsInputSchema = z
   .object({
     window: RouteQuery_chain_transfer_pairs.shape.window,
     sort: RouteQuery_chain_transfer_pairs.shape.sort,
-    limit: RouteQuery_chain_transfer_pairs.shape.limit,
+    limit: RouteQuery_chain_transfer_pairs.shape.limit.meta({
+      default: CHAIN_TRANSFER_PAIR_LIMIT_DEFAULT,
+    }),
   })
   .strict();
 export type GetChainTransferPairsInput = z.infer<

--- a/schemas-src/mcp-tools/curation-and-gaps.ts
+++ b/schemas-src/mcp-tools/curation-and-gaps.ts
@@ -42,7 +42,7 @@ export const ListCurationInputSchema = z
     sort: sortSchema(API_QUERY_COLLECTIONS.curation.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();
@@ -70,7 +70,7 @@ export const ListGapsInputSchema = z
     sort: sortSchema(API_QUERY_COLLECTIONS.gaps.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/endpoint-pools-and-provider.ts
+++ b/schemas-src/mcp-tools/endpoint-pools-and-provider.ts
@@ -77,7 +77,7 @@ export const ListEndpointPoolsInputSchema = z
     ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();
@@ -124,7 +124,7 @@ export const ListEndpointIncidentsInputSchema = z
     ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/endpoints-catalog.ts
+++ b/schemas-src/mcp-tools/endpoints-catalog.ts
@@ -102,7 +102,7 @@ export const ListEndpointsInputSchema = z
     fields: fieldsSchema().optional(),
     // Ceiling is MAX_LIMIT (workers/request-params.ts:21); a literal here
     // because schemas-src/ imports from neither src/ nor workers/.
-    limit: limitSchema(1000).optional(),
+    limit: limitSchema(1000, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
+++ b/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
@@ -79,7 +79,7 @@ export const ListEnrichmentEvidenceInputSchema = z
     ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();
@@ -117,7 +117,7 @@ export const ListReviewGapsInputSchema = z
     sort: sortSchema(PRIORITY_SORT_FIELDS).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();
@@ -214,7 +214,7 @@ export const ListReviewEnrichmentTargetsInputSchema = z
     ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/enrichment-queue-and-candidates.ts
+++ b/schemas-src/mcp-tools/enrichment-queue-and-candidates.ts
@@ -98,7 +98,7 @@ export const ListEnrichmentQueueInputSchema = z
     ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();
@@ -151,7 +151,7 @@ export const ListAdapterCandidatesInputSchema = z
     ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/extrinsics.ts
+++ b/schemas-src/mcp-tools/extrinsics.ts
@@ -87,7 +87,7 @@ export const ListExtrinsicsInputSchema = z
         "Inclusive end of the range. A block height on chain tools, an ISO-8601 date on time-series ones; an EVM address on decode_evm_call.",
       )
       .meta({ examples: [8783000] }),
-    limit: RouteQuery_extrinsics.shape.limit,
+    limit: RouteQuery_extrinsics.shape.limit.meta({ default: 50 }),
     offset: RouteQuery_extrinsics.shape.offset,
     cursor: RouteQuery_extrinsics.shape.cursor,
   })

--- a/schemas-src/mcp-tools/find-subnets-by-capability.ts
+++ b/schemas-src/mcp-tools/find-subnets-by-capability.ts
@@ -15,7 +15,7 @@ export const FindSubnetsByCapabilityInputSchema = z
       )
       .meta({ examples: ["inference"] }),
     cursor: numericCursorSchema().optional(),
-    limit: limitSchema(50).optional(),
+    limit: limitSchema(50, 10).optional(),
   })
   .strict();
 export type FindSubnetsByCapabilityInput = z.infer<

--- a/schemas-src/mcp-tools/get-economics.ts
+++ b/schemas-src/mcp-tools/get-economics.ts
@@ -39,7 +39,7 @@ export const GetEconomicsInputSchema = z
     // format anywhere — comma-separated? a JSON array? — so the one parameter an agent
     // could not guess was the only one left undocumented.
     fields: fieldsSchema().optional(),
-    limit: limitSchema(1000).optional(),
+    limit: limitSchema(1000, 20).optional(),
     cursor: offsetSchema().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/get-global-incidents.ts
+++ b/schemas-src/mcp-tools/get-global-incidents.ts
@@ -34,7 +34,7 @@ export const GetGlobalIncidentsInputSchema = z
     netuid: API_QUERY_COLLECTIONS.incidents.filter_schemas.netuid.optional(),
     sort: sortSchema(API_QUERY_COLLECTIONS.incidents.sort_fields).optional(),
     order: orderSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/get-health-history.ts
+++ b/schemas-src/mcp-tools/get-health-history.ts
@@ -63,7 +63,7 @@ export const GetHealthHistoryInputSchema = z
     ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(1000).optional(),
+    limit: limitSchema(1000, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/get-registry-leaderboards.ts
+++ b/schemas-src/mcp-tools/get-registry-leaderboards.ts
@@ -40,7 +40,7 @@ export const GetRegistryLeaderboardsInputSchema = z
     board: RouteQuery_registry_leaderboards.shape.board
       .describe("Which leaderboard to return.")
       .meta({ examples: [LEADERBOARD_BOARDS[0]] }),
-    limit: RouteQuery_registry_leaderboards.shape.limit,
+    limit: RouteQuery_registry_leaderboards.shape.limit.meta({ default: 20 }),
   })
   .strict();
 export type GetRegistryLeaderboardsInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-events.ts
+++ b/schemas-src/mcp-tools/get-subnet-events.ts
@@ -24,7 +24,7 @@ export const GetSubnetEventsInputSchema = z
     kind: RouteQuery_subnets_netuid_events.shape.kind,
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    limit: RouteQuery_subnets_netuid_events.shape.limit,
+    limit: RouteQuery_subnets_netuid_events.shape.limit.meta({ default: 100 }),
     offset: RouteQuery_subnets_netuid_events.shape.offset,
     cursor: RouteQuery_subnets_netuid_events.shape.cursor,
   })

--- a/schemas-src/mcp-tools/get-subnet-hyperparams.ts
+++ b/schemas-src/mcp-tools/get-subnet-hyperparams.ts
@@ -43,7 +43,9 @@ export type GetSubnetHyperparamsOutput = z.infer<
 export const GetSubnetHyperparamsHistoryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    limit: RouteQuery_subnets_netuid_hyperparameters_history.shape.limit,
+    limit: RouteQuery_subnets_netuid_hyperparameters_history.shape.limit.meta({
+      default: 100,
+    }),
     offset: RouteQuery_subnets_netuid_hyperparameters_history.shape.offset,
     cursor: RouteQuery_subnets_netuid_hyperparameters_history.shape.cursor,
   })

--- a/schemas-src/mcp-tools/governance-feeds.ts
+++ b/schemas-src/mcp-tools/governance-feeds.ts
@@ -64,7 +64,7 @@ export const GetSudoInputSchema = z
     // Both feeds say "same filters as list_extrinsics" and were modelled on it,
     // but dropped its `.max(100)` — declaring unbounded while the tier they forward to
     // caps at 100. A copy-paste omission, not a wider ceiling.
-    limit: RouteQuery_sudo.shape.limit,
+    limit: RouteQuery_sudo.shape.limit.meta({ default: 50 }),
     offset: RouteQuery_sudo.shape.offset,
     cursor: RouteQuery_sudo.shape.cursor,
   })
@@ -128,7 +128,9 @@ export const GetGovernanceConfigChangesInputSchema = z
     // Both feeds say "same filters as list_extrinsics" and were modelled on it,
     // but dropped its `.max(100)` — declaring unbounded while the tier they forward to
     // caps at 100. A copy-paste omission, not a wider ceiling.
-    limit: RouteQuery_governance_config_changes.shape.limit,
+    limit: RouteQuery_governance_config_changes.shape.limit.meta({
+      default: 50,
+    }),
     offset: RouteQuery_governance_config_changes.shape.offset,
     cursor: RouteQuery_governance_config_changes.shape.cursor,
   })

--- a/schemas-src/mcp-tools/list-subnets.ts
+++ b/schemas-src/mcp-tools/list-subnets.ts
@@ -41,7 +41,7 @@ const LIST_SUBNETS_SORT_FIELDS = [
 export const ListSubnetsInputSchema = z
   .object({
     cursor: numericCursorSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 50).optional(),
     // A SUBNET status, not a health one. This described "rows with this health
     // status" and gave `ok` as the example -- a health verdict, on a parameter
     // whose route accepts active | inactive. The prose and the example both

--- a/schemas-src/mcp-tools/profiles.ts
+++ b/schemas-src/mcp-tools/profiles.ts
@@ -60,7 +60,7 @@ export const ListProfilesInputSchema = z
     sort: sortSchema(API_QUERY_COLLECTIONS.profiles.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(1000).optional(),
+    limit: limitSchema(1000, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/registry-catalogs-1.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-1.ts
@@ -61,7 +61,7 @@ export const ListProvidersInputSchema = z
     sort: sortSchema(API_QUERY_COLLECTIONS.providers.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();
@@ -123,7 +123,7 @@ export const ListSurfacesInputSchema = z
     ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();
@@ -152,7 +152,7 @@ export const ListCandidatesInputSchema = z
     sort: sortSchema(API_QUERY_COLLECTIONS.candidates.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(1000).optional(),
+    limit: limitSchema(1000, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/registry-catalogs-2.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-2.ts
@@ -58,7 +58,7 @@ export const ListEvidenceInputSchema = z
     sort: sortSchema(API_QUERY_COLLECTIONS.claims.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();
@@ -143,7 +143,7 @@ export const ListRpcEndpointsInputSchema = z
       .meta({ examples: ["netuid,name,slug"] }),
     // Ceiling is MAX_LIMIT (workers/request-params.ts:21); a literal here
     // because schemas-src/ imports from neither src/ nor workers/.
-    limit: limitSchema(1000).optional(),
+    limit: limitSchema(1000, 20).optional(),
     cursor: z
       .union([z.int().min(0), z.string()])
       .describe(
@@ -203,7 +203,7 @@ export const ListRpcPoolsInputSchema = z
     sort: sortSchema(API_QUERY_COLLECTIONS["rpc-pools"].sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();
@@ -229,7 +229,7 @@ export const ListSourceSnapshotsInputSchema = z
     sort: sortSchema(API_QUERY_COLLECTIONS.sources.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();
@@ -289,7 +289,7 @@ export const ListProfileCompletenessInputSchema = z
     ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/registry-summary-gaps.ts
+++ b/schemas-src/mcp-tools/registry-summary-gaps.ts
@@ -49,7 +49,7 @@ export type RegistrySummaryOutput = z.infer<typeof RegistrySummaryOutputSchema>;
 // against the actual runtime source at the time of writing.
 export const ListEnrichmentTargetsInputSchema = z
   .object({
-    limit: limitSchema(50).optional(),
+    limit: limitSchema(50, 10).optional(),
     tier: API_QUERY_COLLECTIONS["coverage-depth"].filter_schemas.tier
       .optional()
       .describe("How agent-ready the subnet is.")
@@ -214,7 +214,7 @@ export const ListSubnetGapsInputSchema = z
     ).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/rpc-tools.ts
+++ b/schemas-src/mcp-tools/rpc-tools.ts
@@ -48,7 +48,7 @@ export type GetRpcUsageOutput = z.infer<typeof GetRpcUsageOutputSchema>;
 
 export const GetBestRpcEndpointInputSchema = z
   .object({
-    limit: limitSchema(10).optional(),
+    limit: limitSchema(10, 3).optional(),
   })
   .strict();
 export type GetBestRpcEndpointInput = z.infer<

--- a/schemas-src/mcp-tools/search-documents.ts
+++ b/schemas-src/mcp-tools/search-documents.ts
@@ -39,7 +39,7 @@ export const ListSearchIndexInputSchema = z
     sort: sortSchema(API_QUERY_COLLECTIONS.documents.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();
@@ -65,7 +65,7 @@ export const ListSearchInputSchema = z
     sort: sortSchema(API_QUERY_COLLECTIONS.documents.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/search-subnets.ts
+++ b/schemas-src/mcp-tools/search-subnets.ts
@@ -37,7 +37,7 @@ export const SearchSubnetsInputSchema = z
       )
       .meta({ examples: ["inference"] }),
     cursor: numericCursorSchema().optional(),
-    limit: limitSchema(50).optional(),
+    limit: limitSchema(50, 10).optional(),
   })
   .strict();
 export type SearchSubnetsInput = z.infer<typeof SearchSubnetsInputSchema>;

--- a/schemas-src/mcp-tools/subnet-registry-lists.ts
+++ b/schemas-src/mcp-tools/subnet-registry-lists.ts
@@ -103,7 +103,7 @@ export const ListSubnetCandidatesInputSchema = z
     sort: sortSchema(API_QUERY_COLLECTIONS.candidates.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();
@@ -147,7 +147,7 @@ export const ListSubnetEvidenceInputSchema = z
     sort: sortSchema(API_QUERY_COLLECTIONS.claims.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/subnet-scoped-lists.ts
+++ b/schemas-src/mcp-tools/subnet-scoped-lists.ts
@@ -106,7 +106,7 @@ export const ListSubnetEndpointsInputSchema = z
     sort: sortSchema(API_QUERY_COLLECTIONS.endpoints.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();
@@ -181,7 +181,7 @@ export const ListSubnetHealthInputSchema = z
       API_QUERY_COLLECTIONS["health-surfaces"].sort_fields,
     ).optional(),
     order: orderSchema().optional(),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();

--- a/src/accounts-list.ts
+++ b/src/accounts-list.ts
@@ -28,6 +28,7 @@
 // a new gap this route introduces.
 
 import { loadD1AlphaPricesByNetuid } from "./metagraph-neurons.ts";
+import { clampRowLimit } from "../workers/request-params.ts";
 
 // Page-size ceiling, single-sourced in route-limits.ts so the contract's
 // published `maximum` and this route's enforcement cannot drift (#9127).
@@ -249,13 +250,13 @@ export function buildAccountsList(
   const normalizedSort = ACCOUNTS_LIST_SORTS.includes(sort)
     ? sort
     : DEFAULT_ACCOUNTS_LIST_SORT;
-  const flooredLimit = Math.floor(Number(limit));
-  // Floor at 0, not 1, so an explicit limit=0 returns an empty leaderboard
-  // rather than being silently bumped up to one account — mirrors
-  // buildGlobalValidators' own clamp.
-  const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(0, Math.min(flooredLimit, ACCOUNTS_LIST_LIMIT_MAX))
-    : ACCOUNTS_LIST_LIMIT_DEFAULT;
+  // Floor at 0, not 1: an explicit limit=0 returns an empty leaderboard
+  // rather than one row nobody asked for. clampRowLimit is that rule.
+  const normalizedLimit = clampRowLimit(
+    limit,
+    ACCOUNTS_LIST_LIMIT_DEFAULT,
+    ACCOUNTS_LIST_LIMIT_MAX,
+  );
 
   const accountsByHotkey = new Map<string, AccountAccumulator>();
   let latestCapturedAt: number | null = null;

--- a/src/chain-alpha-volume.ts
+++ b/src/chain-alpha-volume.ts
@@ -23,6 +23,7 @@ import {
   type AlphaVolumeSentiment,
 } from "./alpha-volume.ts";
 import { median, percentile } from "./lib/stats.ts";
+import { clampRowLimit } from "../workers/request-params.ts";
 
 export const CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT = 20;
 export const CHAIN_ALPHA_VOLUME_LIMIT_MAX = 100;
@@ -148,10 +149,11 @@ export function buildChainAlphaVolume(
   } = {},
 ): ChainAlphaVolumeResult {
   const list = Array.isArray(rows) ? rows : [];
-  const flooredLimit = Math.floor(Number(limit));
-  const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(0, Math.min(flooredLimit, CHAIN_ALPHA_VOLUME_LIMIT_MAX))
-    : CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT;
+  const normalizedLimit = clampRowLimit(
+    limit,
+    CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT,
+    CHAIN_ALPHA_VOLUME_LIMIT_MAX,
+  );
 
   const perNetuid = new Map<number, Array<Record<string, unknown>>>();
   let newestObserved: number | null = null;

--- a/src/chain-axon-removals.ts
+++ b/src/chain-axon-removals.ts
@@ -10,6 +10,7 @@
 // per-subnet /api/v1/subnets/{netuid}/axon-removals.
 
 import { median, percentile } from "./lib/stats.ts";
+import { clampRowLimit } from "../workers/request-params.ts";
 import {
   AXON_REMOVALS_DEGRADED_NEVER_EMITTED,
   type EventStreamDegraded,
@@ -163,10 +164,11 @@ export function buildChainAxonRemovals(
   } = {},
 ): ChainAxonRemovalsResult {
   const list = Array.isArray(subnetRows) ? subnetRows : [];
-  const flooredLimit = Math.floor(Number(limit));
-  const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(0, Math.min(flooredLimit, CHAIN_AXON_REMOVALS_LIMIT_MAX))
-    : CHAIN_AXON_REMOVALS_LIMIT_DEFAULT;
+  const normalizedLimit = clampRowLimit(
+    limit,
+    CHAIN_AXON_REMOVALS_LIMIT_DEFAULT,
+    CHAIN_AXON_REMOVALS_LIMIT_MAX,
+  );
   const observedAt = toIso(networkDistinct?.newest_observed);
 
   const empty: ChainAxonRemovalsResult = {

--- a/src/chain-deregistrations.ts
+++ b/src/chain-deregistrations.ts
@@ -13,6 +13,7 @@
 // schemas-src/routes/chain-network-rollups.ts (ChainDeregistrationsArtifact).
 
 import { median, percentile } from "./lib/stats.ts";
+import { clampRowLimit } from "../workers/request-params.ts";
 import type { DeregistrationDerivation } from "./deregistration-derivation.ts";
 import type { EventStreamDegraded } from "./uncurated-event-streams.ts";
 
@@ -178,10 +179,11 @@ export function buildChainDeregistrations(
   } = {},
 ): ChainDeregistrationsResult {
   const list = Array.isArray(subnetRows) ? subnetRows : [];
-  const flooredLimit = Math.floor(Number(limit));
-  const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(0, Math.min(flooredLimit, CHAIN_DEREGISTRATIONS_LIMIT_MAX))
-    : CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT;
+  const normalizedLimit = clampRowLimit(
+    limit,
+    CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT,
+    CHAIN_DEREGISTRATIONS_LIMIT_MAX,
+  );
   const observedAt = toIso(networkDistinct?.newest_observed);
 
   const empty: ChainDeregistrationsResult = {

--- a/src/chain-identity-history.ts
+++ b/src/chain-identity-history.ts
@@ -12,6 +12,7 @@
 // schema-stable empty feed and never throws.
 
 import { formatIdentityHistoryEntry } from "./subnet-identity-history.ts";
+import { clampToolLimit } from "../workers/request-params.ts";
 
 // Page-size ceiling, single-sourced in route-limits.ts so the contract's
 // published `maximum` and this route's enforcement cannot drift (#9127).
@@ -28,12 +29,14 @@ export {
 // non-finite. The Worker handler validates + REJECTS an out-of-range value with a
 // 400 (parseLimitParam); this keeps the pure loader's contract aligned when a
 // direct caller (e.g. the MCP tool) passes a plain number.
+// The shared tool page-size rule (workers/request-params.ts), coerced first
+// because this feed takes its limit straight off a raw argument.
 function clampFeedLimit(raw: unknown): number {
-  const n = typeof raw === "number" ? raw : Number(raw);
-  if (!Number.isFinite(n)) return CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT;
-  const floored = Math.floor(n);
-  if (floored < 1) return CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT;
-  return Math.min(floored, CHAIN_IDENTITY_HISTORY_LIMIT_MAX);
+  return clampToolLimit(
+    Number(raw),
+    CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
+    CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
+  );
 }
 
 // Coerce a raw D1 netuid cell to a valid subnet id or null. Guards the coercion the

--- a/src/chain-prometheus.ts
+++ b/src/chain-prometheus.ts
@@ -8,6 +8,7 @@
 // the same account_events [netuid, hotkey] tuple AxonServed uses.
 
 import { median, percentile } from "./lib/stats.ts";
+import { clampRowLimit } from "../workers/request-params.ts";
 import {
   PROMETHEUS_DEGRADED_NOT_CURATED,
   type EventStreamDegraded,
@@ -164,10 +165,11 @@ export function buildChainPrometheus(
   } = {},
 ): ChainPrometheusResult {
   const list = Array.isArray(subnetRows) ? subnetRows : [];
-  const flooredLimit = Math.floor(Number(limit));
-  const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(0, Math.min(flooredLimit, CHAIN_PROMETHEUS_LIMIT_MAX))
-    : CHAIN_PROMETHEUS_LIMIT_DEFAULT;
+  const normalizedLimit = clampRowLimit(
+    limit,
+    CHAIN_PROMETHEUS_LIMIT_DEFAULT,
+    CHAIN_PROMETHEUS_LIMIT_MAX,
+  );
   const observedAt = toIso(networkDistinct?.newest_observed);
 
   const empty: ChainPrometheusResult = {

--- a/src/chain-registrations.ts
+++ b/src/chain-registrations.ts
@@ -8,6 +8,7 @@
 // semantics live in schemas-src/routes/chain-network-rollups.ts (ChainRegistrationsArtifact).
 
 import { median, percentile } from "./lib/stats.ts";
+import { clampRowLimit } from "../workers/request-params.ts";
 
 // The account_events kind emitted when a neuron registers (or re-registers) on a subnet.
 export const REGISTRATION_EVENT_KIND = "NeuronRegistered";
@@ -157,10 +158,11 @@ export function buildChainRegistrations(
   } = {},
 ): ChainRegistrationsResult {
   const list = Array.isArray(subnetRows) ? subnetRows : [];
-  const flooredLimit = Math.floor(Number(limit));
-  const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(0, Math.min(flooredLimit, CHAIN_REGISTRATIONS_LIMIT_MAX))
-    : CHAIN_REGISTRATIONS_LIMIT_DEFAULT;
+  const normalizedLimit = clampRowLimit(
+    limit,
+    CHAIN_REGISTRATIONS_LIMIT_DEFAULT,
+    CHAIN_REGISTRATIONS_LIMIT_MAX,
+  );
   const observedAt = toIso(networkDistinct?.newest_observed);
 
   const empty: ChainRegistrationsResult = {

--- a/src/chain-serving.ts
+++ b/src/chain-serving.ts
@@ -5,6 +5,7 @@
 // The field semantics live in schemas-src/routes/chain-network-rollups.ts (ChainServingArtifact).
 
 import { median, percentile } from "./lib/stats.ts";
+import { clampRowLimit } from "../workers/request-params.ts";
 
 // The account_events kind emitted when a neuron announces its axon endpoint on a subnet.
 export const SERVING_EVENT_KIND = "AxonServed";
@@ -152,10 +153,11 @@ export function buildChainServing(
   } = {},
 ): ChainServingResult {
   const list = Array.isArray(subnetRows) ? subnetRows : [];
-  const flooredLimit = Math.floor(Number(limit));
-  const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(0, Math.min(flooredLimit, CHAIN_SERVING_LIMIT_MAX))
-    : CHAIN_SERVING_LIMIT_DEFAULT;
+  const normalizedLimit = clampRowLimit(
+    limit,
+    CHAIN_SERVING_LIMIT_DEFAULT,
+    CHAIN_SERVING_LIMIT_MAX,
+  );
   const observedAt = toIso(networkDistinct?.newest_observed);
 
   const empty: ChainServingResult = {

--- a/src/chain-stake-flow.ts
+++ b/src/chain-stake-flow.ts
@@ -8,6 +8,7 @@
 // (never throws), matching the sibling live tiers.
 
 import { median, percentile } from "./lib/stats.ts";
+import { clampRowLimit } from "../workers/request-params.ts";
 
 // The two account_events kinds that move stake: StakeAdded is capital entering a subnet,
 // StakeRemoved is capital leaving. Both carry a positive amount_tao, so net = staked - unstaked.
@@ -164,10 +165,11 @@ export function buildChainStakeFlow(
   }: { window?: string | null; limit?: number } = {},
 ): ChainStakeFlowResult {
   const list = Array.isArray(rows) ? rows : [];
-  const flooredLimit = Math.floor(Number(limit));
-  const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(0, Math.min(flooredLimit, CHAIN_STAKE_FLOW_LIMIT_MAX))
-    : CHAIN_STAKE_FLOW_LIMIT_DEFAULT;
+  const normalizedLimit = clampRowLimit(
+    limit,
+    CHAIN_STAKE_FLOW_LIMIT_DEFAULT,
+    CHAIN_STAKE_FLOW_LIMIT_MAX,
+  );
 
   const perNetuid = new Map<
     number,

--- a/src/chain-stake-moves.ts
+++ b/src/chain-stake-moves.ts
@@ -13,6 +13,7 @@
 // schema-stable empty stub, never D1.
 
 import { median, percentile } from "./lib/stats.ts";
+import { clampRowLimit } from "../workers/request-params.ts";
 
 // The account_events kind emitted when a coldkey moves stake between hotkeys/subnets (move_stake).
 export const STAKE_MOVED_EVENT_KIND = "StakeMoved";
@@ -157,10 +158,11 @@ export function buildChainStakeMoves(
   } = {},
 ): ChainStakeMovesResult {
   const list = Array.isArray(subnetRows) ? subnetRows : [];
-  const flooredLimit = Math.floor(Number(limit));
-  const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(0, Math.min(flooredLimit, CHAIN_STAKE_MOVES_LIMIT_MAX))
-    : CHAIN_STAKE_MOVES_LIMIT_DEFAULT;
+  const normalizedLimit = clampRowLimit(
+    limit,
+    CHAIN_STAKE_MOVES_LIMIT_DEFAULT,
+    CHAIN_STAKE_MOVES_LIMIT_MAX,
+  );
   const observedAt = toIso(networkDistinct?.newest_observed);
 
   const empty: ChainStakeMovesResult = {

--- a/src/chain-stake-transfers.ts
+++ b/src/chain-stake-transfers.ts
@@ -15,6 +15,7 @@
 // schema-stable empty stub, never D1.
 
 import { median, percentile } from "./lib/stats.ts";
+import { clampRowLimit } from "../workers/request-params.ts";
 
 // The account_events kind emitted when a coldkey transfers stake to another coldkey (transfer_stake).
 export const STAKE_TRANSFERRED_EVENT_KIND = "StakeTransferred";
@@ -159,10 +160,11 @@ export function buildChainStakeTransfers(
   } = {},
 ): ChainStakeTransfersResult {
   const list = Array.isArray(subnetRows) ? subnetRows : [];
-  const flooredLimit = Math.floor(Number(limit));
-  const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(0, Math.min(flooredLimit, CHAIN_STAKE_TRANSFERS_LIMIT_MAX))
-    : CHAIN_STAKE_TRANSFERS_LIMIT_DEFAULT;
+  const normalizedLimit = clampRowLimit(
+    limit,
+    CHAIN_STAKE_TRANSFERS_LIMIT_DEFAULT,
+    CHAIN_STAKE_TRANSFERS_LIMIT_MAX,
+  );
   const observedAt = toIso(networkDistinct?.newest_observed);
 
   const empty: ChainStakeTransfersResult = {

--- a/src/chain-turnover.ts
+++ b/src/chain-turnover.ts
@@ -7,6 +7,7 @@
 // so the two-snapshot read stays bounded (validators, not every neuron across the network).
 
 import { median, percentile } from "./lib/stats.ts";
+import { clampRowLimit } from "../workers/request-params.ts";
 
 // Page-size ceiling, single-sourced in route-limits.ts so the contract's
 // published `maximum` and this route's enforcement cannot drift (#9127).
@@ -224,10 +225,11 @@ export function buildChainTurnover(
   };
   // Clamp limit to a whole number in [0, MAX] so a direct caller cannot make slice() behave
   // oddly (the HTTP layer already validates 1..MAX; this keeps the pure builder aligned).
-  const flooredLimit = Math.floor(Number(limit));
-  const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(0, Math.min(flooredLimit, CHAIN_TURNOVER_LIMIT_MAX))
-    : CHAIN_TURNOVER_LIMIT_DEFAULT;
+  const normalizedLimit = clampRowLimit(
+    limit,
+    CHAIN_TURNOVER_LIMIT_DEFAULT,
+    CHAIN_TURNOVER_LIMIT_MAX,
+  );
 
   const empty: ChainTurnoverResult = {
     ...base,

--- a/src/chain-weight-setters.ts
+++ b/src/chain-weight-setters.ts
@@ -1,3 +1,4 @@
+import { clampRowLimit } from "../workers/request-params.ts";
 // Network-wide weight-setter leaderboard: across EVERY subnet over a 7d/30d window, the
 // individual validators driving consensus network-wide — each setter's total WeightsSet event
 // count (summed across every subnet it operates on), its share of the network total, and when it
@@ -110,10 +111,11 @@ export function buildChainWeightSetters(
   }: { window?: string | null; limit?: number } = {},
 ): ChainWeightSettersResult {
   const list = Array.isArray(rows) ? rows : [];
-  const flooredLimit = Math.floor(Number(limit));
-  const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(0, Math.min(flooredLimit, CHAIN_WEIGHT_SETTERS_LIMIT_MAX))
-    : CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT;
+  const normalizedLimit = clampRowLimit(
+    limit,
+    CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT,
+    CHAIN_WEIGHT_SETTERS_LIMIT_MAX,
+  );
   const totalSets = toCount(totals?.weight_sets);
   const setters: ChainWeightSetter[] = list
     .slice(0, normalizedLimit)

--- a/src/chain-weights.ts
+++ b/src/chain-weights.ts
@@ -4,6 +4,7 @@
 // Worker adds the envelope. See the schema/contracts for the full response contract.
 
 import { median, percentile } from "./lib/stats.ts";
+import { clampRowLimit } from "../workers/request-params.ts";
 
 // The account_events kind emitted when a validator sets weights on a subnet.
 export const WEIGHTS_EVENT_KIND = "WeightsSet";
@@ -149,10 +150,11 @@ export function buildChainWeights(
   } = {},
 ): ChainWeightsResult {
   const list = Array.isArray(subnetRows) ? subnetRows : [];
-  const flooredLimit = Math.floor(Number(limit));
-  const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(0, Math.min(flooredLimit, CHAIN_WEIGHTS_LIMIT_MAX))
-    : CHAIN_WEIGHTS_LIMIT_DEFAULT;
+  const normalizedLimit = clampRowLimit(
+    limit,
+    CHAIN_WEIGHTS_LIMIT_DEFAULT,
+    CHAIN_WEIGHTS_LIMIT_MAX,
+  );
   const observedAt = toIso(networkDistinct?.newest_observed);
 
   const empty: ChainWeightsResult = {

--- a/src/data-api-mcp.ts
+++ b/src/data-api-mcp.ts
@@ -12,6 +12,7 @@
 // the neurons families); that binding is alive, just not for chain events.
 
 import { chainDetailGapMessage } from "./chain-detail-hot-tier.ts";
+import { clampToolLimit } from "../workers/request-params.ts";
 import { hotTierBlockChainEvents } from "./chain-events-degraded.ts";
 import { CHAIN_EVENTS_LIMIT_DEFAULT } from "./route-limits.ts";
 import {
@@ -52,10 +53,12 @@ function throwToolError(code: string, message: string): never {
  */
 const MCP_CHAIN_EVENTS_LIMIT_MAX = 200;
 
+// The shared tool page-size rule (workers/request-params.ts). `Number(value)`
+// first because this surface receives the raw argument: Number(null) is 0 and
+// Number(undefined) is NaN, both of which the shared rule treats as "below 1"
+// and answers with the default -- the same outcome the private copy reached.
 function clampChainEventsLimit(value: unknown, max: number): number {
-  const n = Number(value);
-  if (!Number.isFinite(n) || n <= 0) return CHAIN_EVENTS_LIMIT_DEFAULT;
-  return Math.min(Math.max(Math.floor(n), 1), max);
+  return clampToolLimit(Number(value), CHAIN_EVENTS_LIMIT_DEFAULT, max);
 }
 
 // The data Worker returns `{ error: "..." }` on 400; some envelopes use

--- a/src/metagraph-neurons.ts
+++ b/src/metagraph-neurons.ts
@@ -11,6 +11,7 @@ import {
   loadIdentityByColdkeyMap,
 } from "./account-identity.ts";
 import { NeuronSchema } from "../schemas-src/routes/subnet-metagraph.ts";
+import { clampRowLimit } from "../workers/request-params.ts";
 import {
   parseFieldsParam,
   projectRow,
@@ -896,13 +897,13 @@ export function buildGlobalValidators(
   const normalizedSort = GLOBAL_VALIDATOR_SORTS.includes(sort)
     ? sort
     : DEFAULT_GLOBAL_VALIDATOR_SORT;
-  const flooredLimit = Math.floor(Number(limit));
-  // Floor the limit at 0, not 1, so an explicit limit=0 returns an empty
-  // leaderboard rather than being silently bumped up to a single validator.
-  // Mirrors the chain-turnover / chain-stake-flow / chain-weights (#2984) clamp.
-  const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(0, Math.min(flooredLimit, GLOBAL_VALIDATOR_LIMIT_MAX))
-    : GLOBAL_VALIDATOR_LIMIT_DEFAULT;
+  // Floor at 0, not 1: an explicit limit=0 returns an empty leaderboard
+  // rather than one row nobody asked for. clampRowLimit is that rule.
+  const normalizedLimit = clampRowLimit(
+    limit,
+    GLOBAL_VALIDATOR_LIMIT_DEFAULT,
+    GLOBAL_VALIDATOR_LIMIT_MAX,
+  );
   const validatorsByHotkey = new Map<string, ValidatorAccumEntry>();
   let latestCapturedAt: number | null = null;
   let latestBlockNumber: number | null = null;

--- a/src/movers.ts
+++ b/src/movers.ts
@@ -1,6 +1,7 @@
 // Page-size ceiling, single-sourced in route-limits.ts so the contract's
 // published `maximum` and this route's enforcement cannot drift (#9127).
 import { MOVERS_LIMIT_DEFAULT, MOVERS_LIMIT_MAX } from "./route-limits.ts";
+import { clampRowLimit } from "../workers/request-params.ts";
 export { MOVERS_LIMIT_DEFAULT, MOVERS_LIMIT_MAX };
 // Cross-subnet momentum ("movers"): rank every subnet by how much its stake, emission,
 // and validator set changed between a window's start and end neuron_daily snapshots.
@@ -311,10 +312,11 @@ export function buildMovers(
   // Clamp limit to a whole number in [0, MOVERS_LIMIT_MAX] so a direct caller cannot make
   // slice() behave oddly with a non-integer, negative, or over-max value (the HTTP layer
   // already validates 1..MOVERS_LIMIT_MAX; this keeps the pure builder's contract aligned).
-  const flooredLimit = Math.floor(Number(limit));
-  const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(0, Math.min(flooredLimit, MOVERS_LIMIT_MAX))
-    : MOVERS_LIMIT_DEFAULT;
+  const normalizedLimit = clampRowLimit(
+    limit,
+    MOVERS_LIMIT_DEFAULT,
+    MOVERS_LIMIT_MAX,
+  );
   const comparable =
     startDate != null && endDate != null && startDate !== endDate;
   const ranked = comparable

--- a/src/top-holders.ts
+++ b/src/top-holders.ts
@@ -1,3 +1,4 @@
+import { clampRowLimit } from "../workers/request-params.ts";
 // Page-size ceiling, single-sourced in route-limits.ts so the contract's
 // published `maximum` and this route's enforcement cannot drift (#9127).
 import {
@@ -173,10 +174,11 @@ export function buildTopHoldersList(
   const normalizedSort = TOP_HOLDERS_SORTS.includes(sort)
     ? sort
     : DEFAULT_TOP_HOLDERS_SORT;
-  const flooredLimit = Math.floor(Number(limit));
-  const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(0, Math.min(flooredLimit, TOP_HOLDERS_LIMIT_MAX))
-    : TOP_HOLDERS_LIMIT_DEFAULT;
+  const normalizedLimit = clampRowLimit(
+    limit,
+    TOP_HOLDERS_LIMIT_DEFAULT,
+    TOP_HOLDERS_LIMIT_MAX,
+  );
 
   let latestCapturedAt: number | null = null;
   const accounts = (Array.isArray(rows) ? rows : [])

--- a/src/validator-nominators.ts
+++ b/src/validator-nominators.ts
@@ -1,3 +1,4 @@
+import { clampRowLimit } from "../workers/request-params.ts";
 // Nominator list for one validator hotkey (#4334/7.2): who has staked to this
 // validator (across every subnet it operates in), derived from the same
 // StakeAdded/StakeRemoved account_events flow src/account-stake-flow.ts
@@ -203,10 +204,11 @@ export function buildValidatorNominators(
   const normalizedSort = NOMINATOR_SORTS.includes(sort)
     ? sort
     : DEFAULT_NOMINATOR_SORT;
-  const flooredLimit = Math.floor(Number(limit));
-  const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(0, Math.min(flooredLimit, NOMINATOR_LIMIT_MAX))
-    : NOMINATOR_LIMIT_DEFAULT;
+  const normalizedLimit = clampRowLimit(
+    limit,
+    NOMINATOR_LIMIT_DEFAULT,
+    NOMINATOR_LIMIT_MAX,
+  );
   const flooredOffset = Math.floor(Number(offset));
   const normalizedOffset =
     Number.isFinite(flooredOffset) && flooredOffset > 0 ? flooredOffset : 0;

--- a/workers/request-params.ts
+++ b/workers/request-params.ts
@@ -83,6 +83,35 @@ export function clampToolLimit(
   return Math.min(max, Math.floor(value));
 }
 
+/**
+ * The BUILDER page-size rule: clamp into [0, max], falling back to the default
+ * only when the value is not a finite number.
+ *
+ * The third of three, and the difference from `clampToolLimit` is the zero.
+ * These are pure row-shaping builders running BEHIND a handler that has
+ * already validated the request, so `limit: 0` reaching one is a caller who
+ * genuinely asked for no rows, not the unenforced `minimum` that made the tool
+ * rule fall back. Clamping 0 up would hand back a row nobody asked for.
+ *
+ * Exported because 17 modules had written the same four lines inline, each
+ * with its own pair of constants:
+ *
+ *   const flooredLimit = Math.floor(Number(limit));
+ *   const normalizedLimit = Number.isFinite(flooredLimit)
+ *     ? Math.max(0, Math.min(flooredLimit, X_LIMIT_MAX))
+ *     : X_LIMIT_DEFAULT;
+ */
+export function clampRowLimit(
+  value: unknown,
+  fallback: number,
+  max: number,
+): number {
+  const floored = Math.floor(Number(value));
+  return Number.isFinite(floored)
+    ? Math.max(0, Math.min(floored, max))
+    : fallback;
+}
+
 // Clamp a raw offset into [0, MAX_OFFSET], falling back to 0 when
 // absent/blank/non-finite.
 export function clampOffset(raw: string | number | null | undefined): number {


### PR DESCRIPTION
Two related fixes; the first is what made the second mechanical.

## 1. Three page-size rules, stated once each instead of 37 times (#10174)

`clampLimit` was consolidated in #10175. Sweeping for what else was hand-rolled found the same shape in **two more named functions and 19 inline copies**.

There are genuinely three rules, and the difference between them is the zero:

| rule | who | `limit: 0` becomes |
|---|---|---|
| `clampLimit` | REST/Worker | **1** — `clampInt` floors at `MIN_LIMIT` |
| `clampToolLimit` | MCP | **the default** — `tools/call` doesn't enforce the schema's `minimum`, and one row reads to an agent as *"this registry knows one subnet"* |
| `clampRowLimit` | builders | **0** — these run behind an already-validated handler, so 0 means "no rows" |

Only the first was exported, so the others were re-derived at every call site:

```ts
const flooredLimit = Math.floor(Number(limit));
const normalizedLimit = Number.isFinite(flooredLimit)
  ? Math.max(0, Math.min(flooredLimit, X_LIMIT_MAX))
  : X_LIMIT_DEFAULT;
```

each with its own constants. Two of the copies carry a comment explaining the zero — the rule was understood, just not shareable. All three now live in `workers/request-params.ts`, whose header already claimed these primitives exist so *"the shared D1 loaders + MCP tools clamp identically"*. No behaviour change.

## 2. 77 tools published a `limit` with no default (#10101)

83 of the 97 tools that publish a `limit` declared no `default`, so a caller could not tell how many rows an omitted `limit` returns. **91 of 97 now publish it**, measured rather than guessed:

- **48 read straight off production** — those responses echo the limit the server applied, which beats reading a handler. `list_subnets` 50, `get_account_events` 100, the 30 collection-backed tools 20.
- **The rest from the handler's own `clampToolLimit(args?.limit, DEFAULT, MAX)`** — only extractable *because* part 1 collapsed 37 spellings into one.

The thirty `20`s are one constant, `MCP_LIST_LIMIT_DEFAULT`, supplied once by `applyMcpQueryFilters`. It deliberately does **not** go in the route schema: REST's collection routes apply no default at all, because a browser can stream the full page and an agent cannot (#9730). Same parameter, two surfaces, two honest answers.

Attached with `.meta({ default })` on the inherited route schema, which merges — bound, description and examples still come from the route, so #10064's derivation is untouched.

**Six remain**, each needing its own answer rather than a guess: `get_subnet_metagraph`, `list_subnet_validators`, `get_subnet_identity_history`, `get_account_counterparties`, `list_provider_endpoints`, `get_feed`. Two apply no default at all; `get_account_counterparties`' description says 50 while production returned 20 rows — a question, not a default.

## 3. Untracked the `node_modules` symlink (also #10193)

#10183 committed `node_modules` as a symlink to another temporary worktree. Carried here too because this branch rebases onto main and the tracked symlink breaks `tsc` in any worktree that checks it out.

## Validation

```
npm run typecheck / lint / format:check    clean
npx vitest run                             767 files, 17,906 passed, 22 skipped
validate:mcp  validate:mcp-input-parity  validate:contract-drift  validate:openapi
validate:graphql-route-parity                                     all PASS
```

Refs #10174, #10101