### PR TITLE
fix(economics): SQLite date arithmetic reached Postgres and froze economics:current

### DIFF
--- a/scripts/lib/load-alpha-price-history.ts
+++ b/scripts/lib/load-alpha-price-history.ts
@@ -43,12 +43,41 @@ interface D1HttpResult {
 }
 
 /**
- * SQLite date arithmetic, not Postgres': `date('now','-40 days')` is the
- * D1 spelling of `CURRENT_DATE - 40 * INTERVAL '1 day'`. Inlined rather than
- * bound because the lookback is a module constant, never caller input.
+ * The cutoff as a DATE LITERAL, computed here rather than by the database.
+ *
+ * THIS QUERY HAS TWO ENGINES BEHIND IT, which is the whole reason the cutoff
+ * moved out of the SQL. `loadAlphaPriceHistoryByNetuid` below sends it to D1
+ * over HTTP at build time; `src/live-economics-refresh.ts` sends the same text
+ * through `readStore`, which is Postgres. It used to read
+ * `date('now','-40 days')` -- SQLite's spelling, and `function date(unknown,
+ * unknown) does not exist` on Postgres, verified against the live database.
+ *
+ * The failure was total rather than partial: the read sits inside
+ * refreshLiveEconomics's own try, so the throw took the WHOLE tick and KV
+ * `economics:current` simply stopped advancing -- with the last good blob still
+ * being served, which is what made it look like nothing was wrong.
+ *
+ * Computing the date in JS is the same move #9798 made for the neuron_daily
+ * window, and for the same reason: it removes the dialect from the question
+ * instead of translating it. A quoted `YYYY-MM-DD` literal compares correctly
+ * against `snapshot_date` on both engines, and there is no date function left
+ * for two dialects to disagree about.
+ *
+ * Inlined rather than bound because one of the two callers is an HTTP door with
+ * no bind slot, and the value is generated from a number rather than accepted
+ * from one.
  */
+export function alphaPriceHistoryCutoff(
+  lookbackDays: number = ALPHA_PRICE_HISTORY_LOOKBACK_DAYS,
+  now: () => number = Date.now,
+): string {
+  const cutoff = now() - Math.trunc(lookbackDays) * 86_400_000;
+  return new Date(cutoff).toISOString().slice(0, 10);
+}
+
 export function alphaPriceHistoryQuery(
   lookbackDays: number = ALPHA_PRICE_HISTORY_LOOKBACK_DAYS,
+  now: () => number = Date.now,
 ): string {
   return (
     // captured_at is load-bearing, not decoration (#9449): a snapshot row is
@@ -57,7 +86,7 @@ export function alphaPriceHistoryQuery(
     // actually are. Two consecutive dates were measured one hour apart.
     "SELECT netuid, snapshot_date, alpha_price_tao, captured_at " +
     "FROM subnet_snapshots " +
-    `WHERE snapshot_date >= date('now','-${Math.trunc(lookbackDays)} days') ` +
+    `WHERE snapshot_date >= '${alphaPriceHistoryCutoff(lookbackDays, now)}' ` +
     "ORDER BY netuid ASC, snapshot_date ASC"
   );
 }

--- a/tests/live-economics-refresh.test.ts
+++ b/tests/live-economics-refresh.test.ts
@@ -14,6 +14,7 @@
 // against what /api/v1/economics served that day (owner_coldkey
 // 5FRYKhbm..., owner_hotkey 5CS3g6nV..., registration_cost_tao 0.0005).
 import assert from "node:assert/strict";
+import { alphaPriceHistoryQuery } from "../scripts/lib/load-alpha-price-history.ts";
 import { describe, test } from "vitest";
 import emissionFixture from "./fixtures/emission-pipeline.json" with { type: "json" };
 import {
@@ -623,10 +624,14 @@ describe("refreshLiveEconomics", () => {
       NEURON_AGGREGATE_QUERY,
       // #9449: captured_at is selected because the %-change windows are
       // measured in elapsed time, not by subtracting snapshot dates.
-      "SELECT netuid, snapshot_date, alpha_price_tao, captured_at " +
-        "FROM subnet_snapshots " +
-        "WHERE snapshot_date >= date('now','-40 days') " +
-        "ORDER BY netuid ASC, snapshot_date ASC",
+      //
+      // Asked of the builder rather than restated, because the cutoff moves
+      // with the clock now: it is a YYYY-MM-DD literal computed in JS, not
+      // `date('now','-40 days')`. That spelling is SQLite's, and this read goes
+      // to Postgres through readStore -- "function date(unknown, unknown) does
+      // not exist" took the whole tick, so KV economics:current stopped
+      // advancing while the last good blob kept being served.
+      alphaPriceHistoryQuery(),
     ]);
   });
 

--- a/tests/load-alpha-price-history.test.ts
+++ b/tests/load-alpha-price-history.test.ts
@@ -42,22 +42,38 @@ function okBody(rows: Record<string, unknown>[]) {
 }
 
 describe("alphaPriceHistoryQuery", () => {
-  test("uses SQLite date arithmetic, not Postgres INTERVAL", () => {
+  // THE INCIDENT THIS PINS. This query has TWO engines behind it -- the D1 HTTP
+  // door at build time, and Postgres through readStore in
+  // src/live-economics-refresh.ts. It used to carry `date('now','-40 days')`,
+  // which is SQLite's spelling and `function date(unknown, unknown) does not
+  // exist` on Postgres. The read sits inside refreshLiveEconomics's own try, so
+  // the throw took the WHOLE tick: KV `economics:current` stopped advancing
+  // while the last good blob kept being served.
+  //
+  // So what is asserted is the ABSENCE of a dialect, not the presence of one.
+  test("carries no date function at all, in either dialect", () => {
     const sql = alphaPriceHistoryQuery();
-    // date('now','-40 days') is the D1 spelling; CURRENT_DATE - INTERVAL is
-    // the Postgres one and would be a syntax error here.
-    assert.match(
-      sql,
-      new RegExp(
-        `date\\('now','-${ALPHA_PRICE_HISTORY_LOOKBACK_DAYS} days'\\)`,
-      ),
-    );
+    assert.ok(!/date\s*\(/i.test(sql), `a date function survived: ${sql}`);
     assert.ok(!sql.includes("INTERVAL"));
+    assert.ok(!sql.includes("CURRENT_DATE"));
     assert.match(sql, /ORDER BY netuid ASC, snapshot_date ASC/);
   });
 
+  test("compares against a plain YYYY-MM-DD literal, which both engines parse", () => {
+    const sql = alphaPriceHistoryQuery(ALPHA_PRICE_HISTORY_LOOKBACK_DAYS, () =>
+      Date.parse("2026-08-08T00:00:00Z"),
+    );
+    // 40 days before 2026-08-08.
+    assert.match(sql, /WHERE snapshot_date >= '2026-06-29'/);
+  });
+
   test("truncates a fractional lookback rather than emitting a broken literal", () => {
-    assert.match(alphaPriceHistoryQuery(7.9), /-7 days/);
+    const sql = alphaPriceHistoryQuery(7.9, () =>
+      Date.parse("2026-08-08T00:00:00Z"),
+    );
+    // 7 days, not 7.9 -- a fractional day would land mid-day and shift the
+    // boundary by the time of day the build happened to run.
+    assert.match(sql, /WHERE snapshot_date >= '2026-08-01'/);
   });
 });
 


### PR DESCRIPTION
`alphaPriceHistoryQuery()` emitted `date('now','-40 days')` — SQLite's spelling. `src/live-economics-refresh.ts` runs that query through `readStore`, and both of its tables (`neurons`, `subnet_snapshots`) are sole-store on Neon, so it goes to Postgres:

```
function date(unknown, unknown) does not exist
```

Verified directly against the production database.

## The failure is total, not partial

The read sits inside `refreshLiveEconomics`'s own `try`, so the throw takes the **whole tick** rather than just the price-history leg. KV `economics:current` is never written.

Nothing surfaces it. The last good blob keeps being served, so every reader still gets a well-formed payload — just a progressively older one. There is no `lane_health` verdict for this lane, so no watchdog notices either.

**Observed:** `generated_at` pinned at `2026-08-08T12:26:35Z` against a 3-hourly cron (`26 */3 * * *`), with the 15:26 tick already missed at 15:40.

## The fix

The cutoff is computed in JS and inlined as a `YYYY-MM-DD` literal. Both engines behind this query compare that correctly — the D1 HTTP door at build time, Postgres at runtime. Same move #9798 made for the `neuron_daily` window, and for the same reason: it removes the dialect from the question instead of translating it.

The clock is injectable, so the emitted literal is assertable without freezing time globally. `tests/live-economics-refresh.test.ts` now asks the builder for the expected text rather than restating it — a restated literal is what let the two drift apart in the first place.

## Scope

Deliberately minimal, so it can deploy on its own. Two related things are **not** here:

- `tests/no-sqlite-only-sql.test.ts` has `datetime('now')` and stops there, and it walks `src/`/`workers/` only — while this statement is *built* in `scripts/lib/` and *executed* in `src/`. Both gaps are being closed in the D1-elimination branch, where the same scan also catches `json_extract`.
- `loadAlphaPriceHistoryByNetuid` still talks to D1 over HTTP with a hard-coded database id. That is a build-time path and is handled with the rest of the D1 teardown.

Closes #10176