### PR TITLE
fix(neon): restore the prune and the guards the D1 writer had

### DIFF
--- a/src/neurons-neon-write.ts
+++ b/src/neurons-neon-write.ts
@@ -209,15 +209,30 @@ export const NEURON_MIRROR_PLANS: Readonly<Record<string, MirrorPlan>> = {
     // rows with older ones -- silently, since both writes succeed.
     guard: "neurons.captured_at < EXCLUDED.captured_at",
   },
+  // THE DAILY TABLES CARRY THE GUARD TOO (#10184), and the reasoning that said
+  // they did not need one was half right.
+  //
+  // It went: these are keyed by snapshot_date, so a late arrival lands on its
+  // own day and cannot collide with a fresher row. That holds ACROSS days and
+  // fails WITHIN one -- handleNeuronDailyBackfill replays past snapshot_dates,
+  // and a replay whose range overlaps TODAY shares today's snapshot_date while
+  // carrying an older captured_at. Without the guard it wins, and the route's
+  // own header promises the opposite: "a backfill re-POST can never clobber a
+  // fresher row".
+  //
+  // D1's buildJsonUpsert appended `captured_at <= excluded.captured_at` to
+  // every one of the three unconditionally. This restores that.
   neuron_daily: {
     table: "neuron_daily",
     columns: NEURON_DAILY_COLUMNS,
     conflict: ["netuid", "uid", "snapshot_date"],
+    guard: "neuron_daily.captured_at < EXCLUDED.captured_at",
   },
   account_position_daily: {
     table: "account_position_daily",
     columns: ACCOUNT_POSITION_DAILY_COLUMNS,
     conflict: ["account", "netuid", "snapshot_date"],
+    guard: "account_position_daily.captured_at < EXCLUDED.captured_at",
   },
 };
 
@@ -234,6 +249,61 @@ export interface NeuronMirrorInput {
    * enforced below instead, by writing the tally ONLY after every table
    * succeeded. */
   pass?: PassTallyInput | null;
+  /**
+   * Per-netuid max `captured_at`, which the prune below deletes beneath.
+   *
+   * Optional because the backfill route legitimately has none: it walks PAST
+   * snapshot_dates and must never touch `neurons`, so it passes `rows: []` and
+   * omits this. Absent means "do not prune", never "prune everything".
+   */
+  netuidMaxCapturedAt?: Map<number, number> | null;
+}
+
+/**
+ * Delete each netuid's rows older than that netuid's newest capture.
+ *
+ * ONE STATEMENT for the whole map rather than one per netuid: a full pass
+ * covers ~129 subnets, and 129 round trips on a Hyperdrive connection is the
+ * kind of cost that turns a prune into a timeout. The pairs travel as two
+ * parallel arrays and are joined with `unnest`, so nothing is interpolated into
+ * the text and the parameter count is 2 regardless of how many netuids there
+ * are.
+ *
+ * Never throws -- it reports like every other write here, because a failed
+ * prune must not fail a pass whose rows landed.
+ */
+export async function pruneNeuronsToCapture(
+  sql: { unsafe(text: string, values?: unknown[]): Promise<unknown> },
+  cutoffs: ReadonlyMap<number, number>,
+): Promise<NeonWriteResult> {
+  const netuids: number[] = [];
+  const capturedAt: number[] = [];
+  for (const [netuid, at] of cutoffs) {
+    // Re-checked here rather than trusted: a NaN cutoff would delete every row
+    // for that netuid, which is the one outcome this function must not have.
+    if (!Number.isFinite(netuid) || !Number.isFinite(at)) continue;
+    netuids.push(netuid);
+    capturedAt.push(at);
+  }
+  if (netuids.length === 0) {
+    return { ok: true, rows: 0, statements: 0 };
+  }
+  try {
+    await sql.unsafe(
+      "DELETE FROM neurons n USING unnest($1::int[], $2::bigint[])" +
+        " AS cutoff(netuid, captured_at)" +
+        " WHERE n.netuid = cutoff.netuid AND n.captured_at < cutoff.captured_at",
+      [netuids, capturedAt],
+    );
+    return { ok: true, rows: 0, statements: 1 };
+  } catch (error) {
+    return {
+      ok: false,
+      rows: 0,
+      statements: 1,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
 export interface NeuronMirrorOutcome {
@@ -241,6 +311,10 @@ export interface NeuronMirrorOutcome {
    * from a failed attempt: "we did not try" is not "we tried and it broke". */
   attempted: boolean;
   results: Record<string, NeonWriteResult>;
+  /** The deregistration prune, kept OUT of `results` on purpose -- see the
+   * write path. Absent when there were no cutoffs to prune on, or when a table
+   * failed and the prune was withheld. */
+  prune?: NeonWriteResult;
 }
 
 export interface NeuronMirrorDeps {
@@ -308,6 +382,47 @@ export async function mirrorNeuronSnapshotToNeon(
     await recordNeonWriteVerdict(laneDb, name, result, now());
   }
 
+  // THE DEREGISTRATION PRUNE (#10184). D1's writer ran this and the Neon mirror
+  // never did, so a UID that leaves a subnet stayed in `neurons` forever.
+  //
+  // PER NETUID, never one batch-wide cutoff. A global max would let one
+  // netuid's later capture delete rows this same write just upserted for a
+  // different, earlier-captured netuid -- its own fresh rows would satisfy
+  // `captured_at < max`. netuidMaxCapturedAt is computed from the posted rows
+  // for exactly this reason, and computed ONCE so the writer and the prune
+  // cannot disagree about the cutoff.
+  //
+  // AFTER the upserts, never before: the rows this pass carries have to be in
+  // before anything is deleted beneath them, or a failure between the two
+  // leaves the netuid short.
+  //
+  // ONLY when every table landed. A prune on top of a failed upsert deletes the
+  // old rows without the new ones replacing them, which turns a retryable write
+  // failure into missing data. Skipping costs one tick of stale UIDs; the next
+  // pass prunes them.
+  //
+  // Benign today and permanent tomorrow, which is why it is worth restoring
+  // now: every pass currently rewrites every UID under one shared captured_at,
+  // so Neon holds 0 stale rows (verified 2026-08-08). It stops being benign the
+  // first time a subnet shrinks its UID count or is deregistered.
+  //
+  // REPORTED BESIDE `results`, NEVER INSIDE IT. The callers fold over
+  // `results` to decide whether the request failed, so putting the prune there
+  // would 502 a pass whose rows all landed -- and the producer would re-send a
+  // snapshot that is already stored. The rows are the valuable half; stale UIDs
+  // cost one tick. Its own lane verdict is how it stays visible.
+  const cutoffs = input.netuidMaxCapturedAt;
+  let prune: NeonWriteResult | undefined;
+  if (cutoffs?.size && Object.values(results).every((r) => r.ok)) {
+    prune = await pruneNeuronsToCapture(sql, cutoffs);
+    await recordNeonWriteVerdict(
+      laneDb,
+      `${NEURONS_NEON_LANE}-prune`,
+      prune,
+      now(),
+    );
+  }
+
   // THE TALLY GOES LAST, AND ONLY IF EVERY TABLE LANDED (#10056).
   //
   // This is the Postgres form of the ordering src/neurons-d1-write.ts gets for
@@ -338,5 +453,5 @@ export async function mirrorNeuronSnapshotToNeon(
     );
     results[`${NEURONS_NEON_LANE}_passes`] = verdict;
   }
-  return { attempted: true, results };
+  return { attempted: true, results, ...(prune ? { prune } : {}) };
 }

--- a/tests/neurons-neon-write.test.ts
+++ b/tests/neurons-neon-write.test.ts
@@ -28,6 +28,7 @@ import {
   mirrorNeuronSnapshotToNeon,
   NEURON_MIRROR_PLANS,
   NEURONS_NEON_LANE,
+  pruneNeuronsToCapture,
 } from "../src/neurons-neon-write.ts";
 import { pgMockEnv } from "./helpers/pg-mock.ts";
 
@@ -101,16 +102,25 @@ describe("NEURON_MIRROR_PLANS", () => {
     ]);
   });
 
-  test("only `neurons` carries the out-of-order guard", () => {
-    // It is the one table a retried chunk can regress: the daily tables are
-    // keyed by snapshot_date, so a late arrival lands on its own day rather
-    // than overwriting a newer one.
-    assert.match(
-      String(NEURON_MIRROR_PLANS.neurons.guard),
-      /captured_at < EXCLUDED\.captured_at/,
-    );
-    assert.equal(NEURON_MIRROR_PLANS.neuron_daily.guard, undefined);
-    assert.equal(NEURON_MIRROR_PLANS.account_position_daily.guard, undefined);
+  test("all three carry the out-of-order guard", () => {
+    // THE REASONING THAT EXEMPTED THE DAILY TABLES WAS HALF RIGHT (#10184).
+    //
+    // It went: they are keyed by snapshot_date, so a late arrival lands on its
+    // own day rather than overwriting a newer one. True ACROSS days, false
+    // WITHIN one -- handleNeuronDailyBackfill replays past snapshot_dates, and
+    // a replay overlapping TODAY shares today's snapshot_date while carrying an
+    // older captured_at. Without the guard it wins, and that route's own header
+    // promises "a backfill re-POST can never clobber a fresher row".
+    //
+    // D1's buildJsonUpsert appended the guard to all three unconditionally, so
+    // this is a restoration rather than a new rule.
+    for (const plan of Object.values(NEURON_MIRROR_PLANS)) {
+      assert.match(
+        String(plan.guard),
+        new RegExp(`^${plan.table}\\.captured_at < EXCLUDED\\.captured_at$`),
+        `${plan.table} has no out-of-order guard`,
+      );
+    }
   });
 });
 
@@ -294,5 +304,209 @@ describe("mirrorNeuronSnapshotToNeon", () => {
     );
     assert.equal(out.attempted, true);
     assert.equal(out.results.neurons.ok, true);
+  });
+});
+
+// THE DEREGISTRATION PRUNE (#10184). D1's writer deleted each netuid's rows
+// beneath that netuid's newest capture, and the Neon mirror never did -- so a
+// UID that leaves a subnet stayed in `neurons` forever.
+//
+// Benign at the time it was restored: every pass rewrites every UID under one
+// shared captured_at, so Neon held 0 stale rows (verified against production
+// 2026-08-08). It stops being benign the first time a subnet shrinks its UID
+// count or is deregistered, and by then D1 is gone and there is no second copy
+// to notice against.
+describe("pruneNeuronsToCapture", () => {
+  test("one statement for the whole map, with the pairs as parallel arrays", async () => {
+    // NOT one statement per netuid: a full pass covers ~129 subnets, and 129
+    // round trips on a Hyperdrive connection is how a prune becomes a timeout.
+    // The parameter count stays 2 no matter how many netuids there are, and
+    // nothing is interpolated into the text.
+    const sql = fakeSql();
+    const result = await pruneNeuronsToCapture(
+      sql,
+      new Map([
+        [1, 1_786_000_000_000],
+        [64, 1_786_000_000_500],
+      ]),
+    );
+    assert.deepEqual(result, { ok: true, rows: 0, statements: 1 });
+    assert.equal(sql.calls.length, 1);
+    assert.match(sql.calls[0]!.text, /DELETE FROM neurons n USING unnest/);
+    assert.match(sql.calls[0]!.text, /n\.captured_at < cutoff\.captured_at/);
+    assert.deepEqual(sql.calls[0]!.values, [
+      [1, 64],
+      [1_786_000_000_000, 1_786_000_000_500],
+    ]);
+  });
+
+  test("PER NETUID, so one subnet's later capture cannot delete another's fresh rows", async () => {
+    // The failure a single batch-wide cutoff produces: netuid 64's newer
+    // capture would satisfy `captured_at < max` for netuid 1's rows, which this
+    // same write just landed. The pairing is what prevents it, so the pairing
+    // is what is asserted.
+    const sql = fakeSql();
+    await pruneNeuronsToCapture(
+      sql,
+      new Map([
+        [1, 1_000],
+        [64, 9_999],
+      ]),
+    );
+    const [netuids, cutoffs] = sql.calls[0]!.values as [number[], number[]];
+    assert.equal(netuids.indexOf(1), cutoffs.indexOf(1_000));
+    assert.equal(netuids.indexOf(64), cutoffs.indexOf(9_999));
+  });
+
+  test("an unusable netuid or cutoff is SKIPPED, never widened to everything", async () => {
+    // A NaN cutoff in the statement would delete every row for that netuid --
+    // the one outcome this function must not have. Skipping the pair leaves
+    // that subnet unpruned for a tick, which the next pass fixes.
+    const sql = fakeSql();
+    await pruneNeuronsToCapture(
+      sql,
+      new Map([
+        [1, Number.NaN],
+        [Number.NaN, 1_000],
+        [64, 1_786_000_000_500],
+      ]),
+    );
+    assert.deepEqual(sql.calls[0]!.values, [[64], [1_786_000_000_500]]);
+  });
+
+  test("an empty map issues no statement at all", async () => {
+    const sql = fakeSql();
+    const result = await pruneNeuronsToCapture(sql, new Map());
+    assert.deepEqual(result, { ok: true, rows: 0, statements: 0 });
+    assert.equal(sql.calls.length, 0);
+  });
+
+  test("a failure is reported, never thrown", async () => {
+    // A failed prune must not fail a pass whose rows landed: the rows are the
+    // valuable half, and stale UIDs cost one tick.
+    const sql = {
+      async unsafe() {
+        throw new Error("deadlock detected");
+      },
+    };
+    const result = await pruneNeuronsToCapture(sql, new Map([[1, 1_000]]));
+    assert.equal(result.ok, false);
+    assert.match(String(result.reason), /deadlock detected/);
+  });
+});
+
+describe("the mirror's prune ordering", () => {
+  test("prunes AFTER the upserts, and only when every table landed", async () => {
+    const sql = fakeSql();
+    const spy = laneSpy();
+    await mirrorNeuronSnapshotToNeon(
+      { ...pgMockEnv() },
+      { waitUntil: () => undefined },
+      {
+        rows: [{ netuid: 1, uid: 0, captured_at: 1_000 }],
+        dailyRows: [],
+        positionRows: [],
+        netuidMaxCapturedAt: new Map([[1, 1_000]]),
+      },
+      { sql, laneHealthDb: spy.db, now: () => NOW },
+    );
+    const texts = sql.calls.map((c) => c.text);
+    const upsert = texts.findIndex((t) => t.includes("INTO neurons "));
+    const prune = texts.findIndex((t) => t.includes("DELETE FROM neurons"));
+    assert.ok(upsert >= 0, "no upsert was issued");
+    assert.ok(prune > upsert, "the prune ran before the rows it deletes under");
+  });
+
+  test("a failed upsert withholds the prune", async () => {
+    // A prune on top of a failed upsert deletes the old rows without the new
+    // ones replacing them -- it turns a retryable write failure into missing
+    // data.
+    const sql = fakeSql("neurons");
+    const spy = laneSpy();
+    await mirrorNeuronSnapshotToNeon(
+      { ...pgMockEnv() },
+      { waitUntil: () => undefined },
+      {
+        rows: [{ netuid: 1, uid: 0, captured_at: 1_000 }],
+        dailyRows: [],
+        positionRows: [],
+        netuidMaxCapturedAt: new Map([[1, 1_000]]),
+      },
+      { sql, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.equal(
+      sql.calls.some((c) => c.text.includes("DELETE FROM neurons")),
+      false,
+      "pruned on top of a failed upsert",
+    );
+  });
+
+  test("a failed prune does NOT fail the pass", async () => {
+    // THE BUG THIS PINS, caught by tests/data-api-neurons-d1 rather than by
+    // review: the prune result was first reported INSIDE `results`, and every
+    // caller folds over `results` to decide whether the request failed. A
+    // transient prune failure would therefore 502 a pass whose rows all landed,
+    // and the producer would re-send a snapshot that is already stored.
+    //
+    // The rows are the valuable half. Stale UIDs cost one tick; a rejected pass
+    // costs the pass.
+    const sql = {
+      calls: [] as { text: string }[],
+      async unsafe(text: string) {
+        sql.calls.push({ text });
+        if (text.startsWith("DELETE")) throw new Error("deadlock detected");
+        return [];
+      },
+    };
+    const spy = laneSpy();
+    const outcome = await mirrorNeuronSnapshotToNeon(
+      { ...pgMockEnv() },
+      { waitUntil: () => undefined },
+      {
+        rows: [{ netuid: 1, uid: 0, captured_at: 1_000 }],
+        dailyRows: [],
+        positionRows: [],
+        netuidMaxCapturedAt: new Map([[1, 1_000]]),
+      },
+      { sql, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.equal(
+      Object.values(outcome.results).every((r) => r.ok),
+      true,
+      "the failed prune leaked into results and would fail the request",
+    );
+    // Still visible, on its own: reported beside results and recorded as its
+    // own lane verdict, so it cannot fail silently either.
+    assert.equal(outcome.prune?.ok, false);
+    assert.ok(
+      spy.rows.some(
+        (r) =>
+          r.lane === `neon:${NEURONS_NEON_LANE}-prune` && r.verdict !== "ok",
+      ),
+      "no lane verdict recorded for the failed prune",
+    );
+  });
+
+  test("no cutoffs means no prune -- the backfill route passes none", async () => {
+    // handleNeuronDailyBackfill walks PAST snapshot_dates and must never touch
+    // `neurons`. Absent cutoffs must read as "do not prune", never as "prune
+    // everything".
+    const sql = fakeSql();
+    const spy = laneSpy();
+    await mirrorNeuronSnapshotToNeon(
+      { ...pgMockEnv() },
+      { waitUntil: () => undefined },
+      {
+        rows: [],
+        dailyRows: [{ netuid: 1, uid: 0, snapshot_date: "2026-01-01" }],
+        positionRows: [],
+      },
+      { sql, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.equal(
+      sql.calls.some((c) => c.text.includes("DELETE FROM neurons")),
+      false,
+      "a backfill pruned the latest-only table",
+    );
   });
 });

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -772,6 +772,10 @@ async function handleNeuronsSync(
       positionRows,
       // The tally follows the rows into the store that holds them (#10056).
       pass,
+      // The deregistration prune's cutoffs (#10184). Derived by the SAME
+      // function that produced dailyRows/positionRows above, so the writer and
+      // the prune cannot disagree about where the floor is.
+      netuidMaxCapturedAt,
     },
   );
 


### PR DESCRIPTION
Three of the four properties #10184 lists. The fourth is deliberately not here.

## The deregistration prune

D1's writer deleted, per netuid, every row beneath that netuid's newest capture. The Neon mirror upserted three tables and deleted from none, so a UID that leaves a subnet stayed in `neurons` forever.

Benign today for a reason that is luck rather than design: every pass rewrites every UID under one shared `captured_at`, so Neon holds **0** stale rows — verified against production, 30,127 rows across 129 netuids at a single stamp. It stops being benign the first time a subnet shrinks its UID count or is deregistered, and by then there is no second copy to notice against.

**Per netuid, never one batch-wide cutoff.** A global max lets one netuid's later capture delete rows the same write just landed for a different, earlier-captured netuid — its own fresh rows would satisfy `captured_at < max`.

**One statement for the whole map**, via `unnest` over two parallel arrays. A full pass covers ~129 subnets, and 129 round trips on a Hyperdrive connection is how a prune becomes a timeout; the parameter count stays 2 regardless and nothing is interpolated into the text. Verified against the live database as a `SELECT` first — 0 deletions at each netuid's true cutoff, 256 with an artificially future one.

**Ordering:** after the upserts, and only when every table landed. A prune on top of a failed upsert deletes the old rows without the new ones replacing them, which turns a retryable write failure into missing data.

## The bug my first version introduced

I put the prune result inside `results`. Every caller folds over `results` to decide whether the request failed — so a transient prune failure would have **502'd a pass whose rows all landed**, and the producer would re-send a snapshot that is already stored.

`tests/data-api-neurons-d1` caught it; review did not. It is now reported beside `results` with its own lane verdict, so it cannot fail the pass and cannot fail silently either. There is a test pinning exactly that, because the mistake was easy to make and invisible from the diff.

## The daily-table guards

The reasoning that exempted `neuron_daily` and `account_position_daily` was half right: they are keyed by `snapshot_date`, so a late arrival lands on its own day. True *across* days, false *within* one — `handleNeuronDailyBackfill` replays past snapshot_dates, and a replay overlapping today shares today's `snapshot_date` while carrying an older `captured_at`. It then wins, against that route's own header promising "a backfill re-POST can never clobber a fresher row".

D1's `buildJsonUpsert` appended the guard to all three unconditionally. This restores that.

## Deliberately not restored

`subnet_hyperparams`' `netuid NOT IN (<this batch>)` prune.

It deletes on **absence** rather than on staleness, so unlike the neurons prune it is unbounded: a partial batch deletes live subnets. Its premise — "every successful upstream fetch covers ALL active subnets" — is a claim about the producer that the handler never verifies, and there is no `pass_total` or `key_complete` on that route to bound it.

The present cost is a deregistered subnet keeping a stale card with an ageing `captured_at`, which readers can see. Deleting live subnets is not recoverable. Restoring it needs the completeness guarantee established first, and that is its own change.

## Verification

`npm run lint`, `tsc --noEmit`, `prettier --check` clean; **757 files / 17,933 tests passing**.

Refs #10184