### PR TITLE
fix(repo): untrack the node_modules symlink and close the pattern that let it in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,13 @@ bower_components
 build/Release
 
 # Dependency directories
-node_modules/
+#
+# No trailing slash, deliberately. `node_modules/` is a directory-only pattern,
+# and git records a symlink as a blob (mode 120000) -- a file. So a symlinked
+# node_modules slips straight past it, which is how #10191 put an absolute path
+# to one maintainer's worktree on main. Without the slash the pattern covers
+# both shapes.
+node_modules
 jspm_packages/
 
 # Snowpack dependency directory (https://snowpack.dev/)

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/shadowbook/Documents/metagraphed/.claude/worktrees/metagraph-api-snapshot-bug-d897a4/node_modules


### PR DESCRIPTION
## Summary

`main` currently ships `node_modules` as a **committed symlink** to an absolute path on one maintainer's laptop, pointing into an unrelated worktree. This untracks it and closes the `.gitignore` gap that allowed it.

Introduced by 48cf17a17 (#10183) — the economics fix itself is fine, this is just the stray entry that rode along with it.

```
$ git ls-tree origin/main node_modules
120000 blob a08d3985f5994ce5c3190b83f414562a20db78d6	node_modules

$ git cat-file -p a08d3985f5994ce5c3190b83f414562a20db78d6
/Users/shadowbook/Documents/metagraphed/.claude/worktrees/metagraph-api-snapshot-bug-d897a4/node_modules
```

## Impact — a defect, not an outage

CI is **not** broken: `npm ci` removes and recreates the path, and `Validate` on `main` is green. Stating that plainly because it sets the urgency. What it does cause:

- Every clone materialises a dangling symlink to a path that exists on exactly one machine.
- It publishes a local filesystem layout, including an unrelated in-progress worktree's name, into a public repo.
- On the machine where the target *does* resolve, a local install can silently read another worktree's `node_modules` — the cross-contamination separate worktrees exist to prevent.

## Why `.gitignore` missed it, and why the fix is two lines

Line 47 was `node_modules/`. The **trailing slash makes the pattern directory-only**, and git records a symlink as a blob with mode `120000` — a file, not a directory — so the pattern never matched. Demonstrated in a scratch repo:

```
$ printf 'node_modules/\n' > .gitignore && ln -s /tmp/somewhere node_modules
$ git check-ignore -v node_modules    # no match; shows as untracked

$ printf 'node_modules\n' > .gitignore
$ git check-ignore -v node_modules    # .gitignore:1:node_modules	node_modules
```

So `git rm --cached` alone would leave the door open for the next `git add -A` from a sibling worktree. Dropping the slash closes it, and the comment records why the missing slash is deliberate so nobody "tidies" it back.

## Verification

```
git ls-files node_modules            # → empty (no longer tracked)
git check-ignore -v node_modules     # → .gitignore:53:node_modules
```

Sibling patterns (`dist/`, `coverage/`, `.wrangler/`) have the same shape and remain re-introducible as symlinks; left alone here to keep this change to one thing, and noted in the issue.

Closes #10191
