### PR TITLE
fix(repo): untrack the node_modules symlink #10183 committed by accident

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/shadowbook/Documents/metagraphed/.claude/worktrees/metagraph-api-snapshot-bug-d897a4/node_modules


### PR DESCRIPTION
#10183 added `node_modules` to the index as a **symlink** (mode `120000`) whose target is an absolute path into a different, temporary worktree:

```
/Users/shadowbook/Documents/metagraphed/.claude/worktrees/metagraph-api-snapshot-bug-d897a4/node_modules
```

`.gitignore` has carried `node_modules/` since forever — but an ignore rule doesn't apply to a path already in the index, so the entry survived and shipped to main.

## What it costs

A fresh clone or CI checkout materialises a **dangling symlink** where the dependency tree belongs, pointing at a directory that exists on exactly one machine and disappears when that worktree is cleaned up. It also puts a local filesystem path in a public repo.

## How it surfaced

Rebasing onto main, `npm install` replaced the symlink with a real directory — and git reported it as the deletion of a tracked file.

```
$ git ls-files -s node_modules
120000 a08d3985f5994ce5c3190b83f414562a20db78d6 0	node_modules
```

Removed from the index only. Nothing on disk changes, and the ignore rule now does what it always claimed to.