### PR TITLE
fix(self-health): give the MCP and GraphQL chain REST's Neon tier

### DIFF
--- a/src/self-health-mcp.ts
+++ b/src/self-health-mcp.ts
@@ -43,19 +43,30 @@
 // the flag were flipped back. What remains is the cold tier, the artifact, and
 // the empty floor.
 //
-// KNOWN GAP, and it is NOT closed by that deletion: handleSelfHealth
-// (workers/request-handlers/entities.ts) grew a NEON tier in #9836 --
-// loadSelfHealthNeon, where the prober writes now -- and this chain never got
-// it. So REST answers from current readings while `get_self_health` and the
-// GraphQL `selfHealth` field fall to the cold rollup, which ends 2026-08-02.
-// That is the same divergence as #8633/#8987/#9153, for the same structural
-// reason: a resolution chain maintained in parallel with the route's instead
-// of shared with it. Closing it is a serving change, not a types change, so it
-// is deliberately not folded in here.
+// #10187 -- AND THE FOURTH REPEAT WAS THE NEON TIER. handleSelfHealth
+// (workers/request-handlers/entities.ts) grew one in #9836 --
+// loadSelfHealthNeon, where the prober writes now -- and this chain did not
+// get it, so REST answered from current readings while `get_self_health` and
+// the GraphQL `selfHealth` field fell to the cold rollup ending 2026-08-02.
+// Measured live on 2026-08-08, both surfaces the same minute: REST said
+// verdict "outage" with 3 measured components (api and publish both down),
+// while get_self_health said "degraded", observed_at null, 0 measured. Not
+// merely stale -- an agent asking during a real outage was told there was
+// nothing to measure, which is the reassuring direction to be wrong in.
+//
+// So the Neon tier is now FIRST here, exactly as it is in handleSelfHealth
+// once that route's own dead DATA_API step is skipped. Four repeats
+// (#8633 order, #8987 envelope, #9153 cold tier, #10187 Neon) all have the
+// same structural cause: a resolution chain maintained in parallel with the
+// route's instead of shared with it. Until the two genuinely share one
+// resolver, the tests below pin them tier-for-tier -- that pin is the only
+// thing standing between here and a fifth repeat.
 
 import { z } from "zod";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { loadSelfHealthColdTier } from "./self-health-cold-tier.ts";
+import { loadSelfHealthNeon } from "./self-health-neon.ts";
+import { createPgSql } from "./pg-sql.ts";
 import { loadLatestLaneHealth } from "./lane-health.ts";
 import { laneHealthStore } from "./lane-health-store.ts";
 import { withLaneHealth, type SelfHealth } from "./self-health.ts";
@@ -82,6 +93,36 @@ export function selfHealthToolError(
 }
 
 /**
+ * The ExecutionContext this loader needs to reach Neon, under either of the two
+ * names its callers give it.
+ *
+ * `createPgSql` hands its client back to Hyperdrive's pool through `waitUntil`
+ * rather than awaiting it, so a caller without one genuinely cannot read Neon --
+ * skipping the tier is correct there, not a degradation to paper over. The two
+ * entry points spell the field differently and both are real: the MCP context
+ * carries `executionCtx` (workers/api.ts hands the Worker's own ctx to every
+ * /mcp request -- it is `props`, not the context, that is OAuth-only), and
+ * GqlContext carries `ctx` (#10086, threaded for exactly this purpose).
+ * Accepting both beats renaming one and touching every other reader of it.
+ */
+type SelfHealthExecutionCtx = {
+  executionCtx?: { waitUntil?: (promise: Promise<unknown>) => void };
+  ctx?: { waitUntil?: (promise: Promise<unknown>) => void };
+};
+
+function selfHealthNeonSql(
+  ctx: { env: Env } & SelfHealthExecutionCtx,
+): ReturnType<typeof createPgSql> | null {
+  const waiter = ctx.executionCtx?.waitUntil
+    ? ctx.executionCtx
+    : ctx.ctx?.waitUntil
+      ? ctx.ctx
+      : null;
+  if (!ctx.env?.HYPERDRIVE || !waiter) return null;
+  return createPgSql(ctx.env.HYPERDRIVE, waiter as never);
+}
+
+/**
  * The card, from the first tier that can answer. Lane verdicts are attached by the
  * caller, not here, so that this stays a pure mirror of handleSelfHealth's tier chain
  * and the two can be compared line for line.
@@ -90,10 +131,19 @@ async function resolveSelfHealthCard(
   ctx: {
     env: Env;
     readArtifact: (env: Env, path: string) => Promise<StorageReadResult>;
-  },
+  } & SelfHealthExecutionCtx,
   readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>,
 ): Promise<unknown> {
-  // 1. Lakehouse cold tier — the same one REST falls through to.
+  // 1. Neon — where the self-health prober writes now (#9836), and the only
+  //    tier that can answer "are we up RIGHT NOW". Asked first for the same
+  //    reason handleSelfHealth asks it first: the cold tier below can only
+  //    ever report current_ok:null, so letting it answer while Neon has a
+  //    live reading is what produced #10187's "outage on REST, nothing
+  //    measurable on MCP" split.
+  const live = await loadSelfHealthNeon(selfHealthNeonSql(ctx));
+  if (live) return live;
+
+  // 2. Lakehouse cold tier — the same one REST falls through to.
   //
   // #9153 gave the REST route this step and did not give it to us, and when
   // METAGRAPH_SELF_HEALTH_SOURCE went to "retired" the DATA_API tier that used to
@@ -103,17 +153,12 @@ async function resolveSelfHealthCard(
   // component, `get_self_health` returned `days: []` and `uptime_90d: null` for all
   // three.
   //
-  // That is the THIRD time this module has served an empty card beside a working
-  // REST route (#8633 had the tiers in the wrong order, #8987 unwrapped an envelope
-  // the producer never sent). The recurring cause is a resolution chain maintained
-  // in parallel with the route's instead of shared with it, so the fix that matters
-  // is the ordering being identical here to handleSelfHealth's, tier for tier --
-  // which it is NOT today, because REST's #9836 Neon tier is still missing from
-  // this chain. See the KNOWN GAP note in the module header.
+  // Kept below Neon rather than removed: those 90 days are real history nothing
+  // else holds, and a deployment with no Hyperdrive binding still gets them.
   const cold = await loadSelfHealthColdTier(ctx.env);
   if (cold) return cold;
 
-  // 2. Baked artifact — dev/test/fixture environments, and any future bake.
+  // 3. Baked artifact — dev/test/fixture environments, and any future bake.
   const read = readArtifact ?? ctx.readArtifact;
   const result = await read(ctx.env, SELF_HEALTH_ARTIFACT);
   if (result?.ok) return result.data;
@@ -121,7 +166,7 @@ async function resolveSelfHealthCard(
   const code =
     (result as { code?: string } | undefined)?.code || "artifact_unavailable";
 
-  // 3. An ABSENT artifact is not an error: it is production's normal state,
+  // 4. An ABSENT artifact is not an error: it is production's normal state,
   //    and "we have no readings" is a real answer. Returning the schema-stable
   //    empty shape (three components, current_ok null, verdict "degraded") is
   //    precisely handleSelfHealth's own documented convention -- it never 404s
@@ -141,7 +186,7 @@ export async function loadSelfHealth(
   ctx: {
     env: Env;
     readArtifact: (env: Env, path: string) => Promise<StorageReadResult>;
-  },
+  } & SelfHealthExecutionCtx,
   {
     readArtifact,
   }: {

--- a/tests/self-health-mcp.test.ts
+++ b/tests/self-health-mcp.test.ts
@@ -141,6 +141,105 @@ describe("self-health-mcp", () => {
     code: "artifact_not_found",
   })) as unknown as ReadArtifact;
 
+  // #10187: the Neon tier, and the tier-for-tier pin that should have caught
+  // the previous three repeats. handleSelfHealth asks Neon before the
+  // lakehouse; this loader did not ask it at all, so REST reported a live
+  // outage while get_self_health reported nothing measurable in the same
+  // minute.
+  //
+  // The rows here are the two statements loadSelfHealthNeon actually issues,
+  // matched by substring: the daily rollup and the DISTINCT ON latest tick.
+  // Asserting the PRODUCER's shape (`{ rows }` from pg, snake_case columns),
+  // not a shape convenient to the test -- that inversion is what let #8987
+  // pass green for a month.
+  const neonCtx = (extra: Row = {}) => ({
+    env: { ...pgMockEnv(), ...extra } as unknown as Env,
+    executionCtx: { waitUntil: () => {} },
+    readArtifact: (async () => ({
+      ok: false,
+      code: "artifact_not_found",
+    })) as unknown as ReadArtifact,
+  });
+  const neonAnswers = () => [
+    {
+      match: "self_health_daily",
+      rows: [
+        { day: "2026-08-08", component: "api", checks: 100, ok_count: 90 },
+      ],
+    },
+    {
+      match: "self_health_checks",
+      rows: [
+        {
+          component: "api",
+          ok: false,
+          http_status: 503,
+          latency_ms: 12,
+          checked_at_ms: 1_786_000_000_000,
+        },
+      ],
+    },
+  ];
+
+  test("Neon answers FIRST, so a live outage reaches the MCP card (#10187)", async () => {
+    pg.control.answers = neonAnswers();
+    const out = (await loadSelfHealth(neonCtx())) as Row;
+    const api = (out.components as Row[]).find(
+      (c) => c.component === "api",
+    ) as Row;
+    // The exact split #10187 measured: REST said outage, this said nothing
+    // measurable. A current reading must now reach the card.
+    assert.equal(api.current_ok, false);
+    assert.equal(api.http_status, 503);
+    assert.equal(out.measured_component_count, 1);
+    assert.notEqual(out.observed_at, null);
+  });
+
+  test("Neon is asked BEFORE the lakehouse, matching handleSelfHealth's order", async () => {
+    pg.control.answers = neonAnswers();
+    await loadSelfHealth(neonCtx());
+    // The pin that matters: the cold tier can only ever answer current_ok
+    // null, so if it ever gets asked first the live reading is lost even
+    // though it existed. Proven by the query actually issued.
+    assert.ok(
+      pg.control.queries.some((q: Row) =>
+        /self_health_daily/.test(String(q.text)),
+      ),
+      "expected the Neon daily read to have been issued",
+    );
+  });
+
+  test("no waitUntil means skip Neon, not fail — the cold tier still answers", async () => {
+    // createPgSql returns its client through waitUntil, so a caller without
+    // one cannot read Neon. Skipping is correct; a throw would take the whole
+    // tool down for direct-call tests and any entry point without a ctx.
+    pg.control.answers = neonAnswers();
+    const out = (await loadSelfHealth({
+      env: pgMockEnv() as unknown as Env,
+      readArtifact: (async () => ({
+        ok: true,
+        data: SAMPLE_SELF_HEALTH,
+      })) as unknown as ReadArtifact,
+    })) as Row;
+    assert.equal(out.verdict, "operational"); // the artifact, not a throw
+  });
+
+  test("GraphQL's `ctx` field is accepted as well as MCP's `executionCtx`", async () => {
+    // GqlContext spells it `ctx` (#10086); McpCtx spells it `executionCtx`.
+    // Both are real callers, so both must reach Neon -- otherwise the GraphQL
+    // selfHealth field silently keeps the bug this change fixes.
+    pg.control.answers = neonAnswers();
+    const out = (await loadSelfHealth({
+      env: pgMockEnv() as unknown as Env,
+      ctx: { waitUntil: () => {} },
+      readArtifact: (async () => ({
+        ok: false,
+        code: "artifact_not_found",
+      })) as unknown as ReadArtifact,
+    } as never)) as Row;
+    assert.equal(out.measured_component_count, 1);
+  });
+
   test("falls back to the artifact when no tier is configured", async () => {
     // Dev/test and any fixture-backed environment: the artifact path is kept
     // deliberately, not deleted.


### PR DESCRIPTION
## Summary

`handleSelfHealth` grew a Neon tier in #9836 — `loadSelfHealthNeon`, where the self-health prober writes now. `resolveSelfHealthCard`, which backs **both** `get_self_health` and the GraphQL `selfHealth` field, never got it. This adds it, in REST's order.

## The bug, measured live on both surfaces the same minute (2026-08-08 ~17:05Z)

| | `GET /api/v1/self-health` | `get_self_health` (MCP) |
| --- | --- | --- |
| `verdict` | **`outage`** | `degraded` |
| `observed_at` | `2026-08-08T17:03:03.825Z` | **`null`** |
| `measured_component_count` | **3** | **0** |
| `api.current_ok` | **`false`** | `null` |
| `publish.current_ok` | **`false`** | `null` |
| last `days[]` | `2026-08-08` | **`2026-08-02`** |

Not staleness. REST was reporting a **real outage** — corroborated by the `self-health-probe` lane's own `"1/3 ok, down: api,publish"` at that same timestamp — while an agent asking the MCP tool was told there was nothing measurable at all. A health surface failing in the *reassuring* direction is the one failure mode it cannot have.

Neon had the data throughout: `self_health_checks` held a reading 2 minutes old, `self_health_daily` had that day's rows.

## The change

Neon goes **first**, matching `handleSelfHealth` once that route's own dead DATA_API step is skipped. The lakehouse stays below it rather than being removed — those 90 days are history nothing else holds, and a deployment with no Hyperdrive binding still gets them.

**Both ExecutionContext spellings are accepted, because both callers are real.** `McpCtx` carries `executionCtx` (`workers/api.ts:4400` hands the Worker's own ctx to every `/mcp` request — it is `props`, not the context, that is OAuth-only) and `GqlContext` carries `ctx` (#10086). Accepting both beats renaming one and touching every other reader of it. A caller with neither **skips** the tier rather than failing, because `createPgSql` returns its client through `waitUntil` and genuinely cannot run without one — so skipping is correct, not a degradation papered over.

## The tests are the point

This is the **fourth** repeat of one bug: #8633 (tier order), #8987 (envelope the producer never sent), #9153 (cold tier), and now #10187. Same structural cause every time — a resolution chain maintained *in parallel* with the route's instead of shared with it.

So the added tests pin the order tier-for-tier, and I verified they can actually fail: reverting the fix turns **three of the four red**, the fourth being the no-`waitUntil` fallback that must hold either way.

```
× Neon answers FIRST, so a live outage reaches the MCP card (#10187)
× Neon is asked BEFORE the lakehouse, matching handleSelfHealth's order
✓ no waitUntil means skip Neon, not fail — the cold tier still answers
× GraphQL's `ctx` field is accepted as well as MCP's `executionCtx`
```

They assert the **producer's** shape (`{ rows }` from `pg`, snake_case columns), not one convenient to the test — that inversion is exactly what let #8987 sit green for a month.

## Follow-up not folded in

The durable fix is for the two chains to share one resolver rather than being kept in step by hand; four repeats is enough evidence that hand-maintenance does not hold. That is a larger refactor than this bug warrants, and the tier-for-tier pin is what guards it meanwhile.

## Verification

`typecheck` · `lint` · `format:check` · `validate` (exit 0) · `contract-drift`/`schemas`/`api`/`openapi`/`mcp`/`no-hand-written-mjs`/`scan:public-safety` · 12 self-health-touching test files (3300 tests) · full suite **756 files / 17,897 tests, exit 0**.

Closes #10187
