### PR TITLE
fix(sync): the internal-sync limit was sized for a traffic shape that changed

### DIFF
--- a/tests/neurons-sync-proxy.test.ts
+++ b/tests/neurons-sync-proxy.test.ts
@@ -5,7 +5,7 @@
 // downstream write logic itself is covered by tests/data-api.test.ts.
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import { handleRequest } from "../workers/api.ts";
+import { handleRequest, INTERNAL_SYNC_RATE_LIMIT } from "../workers/api.ts";
 
 function post(body: unknown, { method = "POST" }: { method?: string } = {}) {
   return new Request("https://api.metagraph.sh/api/v1/internal/neurons-sync", {
@@ -142,8 +142,18 @@ test("rate limiting: 429 with the rate-limit header family when the limiter reje
   assert.equal(res.status, 429);
   assert.equal((await res.json()).error.code, "internal_sync_rate_limited");
   assert.equal(res.headers.get("retry-after"), "60");
-  assert.equal(res.headers.get("x-ratelimit-limit"), "30");
-  assert.equal(res.headers.get("x-ratelimit-policy"), "30;w=60");
+  // The published headers must state the limit that is actually enforced --
+  // asked of the constant rather than restated, because a restated number is
+  // how the two drift and the header starts advertising a ceiling that is not
+  // the one being applied.
+  assert.equal(
+    res.headers.get("x-ratelimit-limit"),
+    String(INTERNAL_SYNC_RATE_LIMIT.limit),
+  );
+  assert.equal(
+    res.headers.get("x-ratelimit-policy"),
+    `${INTERNAL_SYNC_RATE_LIMIT.limit};w=${INTERNAL_SYNC_RATE_LIMIT.windowSeconds}`,
+  );
   assert.equal(res.headers.get("x-ratelimit-remaining"), "0");
   assert.equal(calls, 0);
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -3347,7 +3347,34 @@ async function handleRegistrySyncProxy(request: Request, env: Env) {
 // ratelimit namespaces are scoped to the Worker script that checks them, and
 // this check runs in api.ts, not data-api.ts. Optional-chained so it's a
 // no-op when the binding is absent (local dev/CI).
-const INTERNAL_SYNC_RATE_LIMIT = { limit: 30, windowSeconds: 60 };
+//
+// RESIZED 30 -> 300 (#10180), for the same reason and with the same arithmetic
+// #5027 used on CHAIN_FIREHOSE_INGEST_RATE_LIMIT forty lines below: a cap sized
+// for one traffic shape, never recalibrated when the producer's changed.
+//
+// THE MEASUREMENT. The validator-nominators job posts BOTH its tables in one
+// run -- validator_nominator_counts (112,250 rows) and nominator_positions
+// (123,511) -- and `lane_health` recorded "739565 scanned, 222343 written"
+// against 429s on 2026-08-07 18:22, 18:37 and 2026-08-08 08:51. At the per-route
+// row caps (50,000 and 25,000) a full pass would be ~8 requests and could never
+// trip 30, so the producer is chunking far smaller; at the alpha scan's
+// page_size of 1000 a pass is ~236 requests, which trips 30/60s about eight
+// seconds in. nominator_positions sat 28 HOURS stale as a result, and
+// hotkey_alpha's #9558 filter prices against whatever positions it can see.
+//
+// 300 lets one full pass through a single window with headroom. It is not a
+// number invented here: DATA_RATE_LIMITER_KEYED in this same file is 300/60s,
+// and the firehose precedent was a 10x lift for an identical diagnosis.
+//
+// WHAT IT DOES NOT WEAKEN. The abuse ceiling was never really the request count
+// -- each route independently caps ROWS per request, and each authenticates
+// downstream with its own secret. This bucket is keyed per IP, so it slows a
+// single leaked-secret script rather than stopping a distributed one; it is a
+// speed bump by construction, and 300 keeps it one.
+//
+// The better fix is upstream and is filed as such: a producer posting at the
+// row cap would put a pass at ~8 requests and need no limit here at all.
+export const INTERNAL_SYNC_RATE_LIMIT = { limit: 300, windowSeconds: 60 };
 
 async function internalSyncRateLimited(request: Request, env: Env) {
   if (!env.INTERNAL_SYNC_RATE_LIMITER?.limit) return null;


### PR DESCRIPTION
`INTERNAL_SYNC_RATE_LIMIT` goes **30 → 300** per 60s.

Same diagnosis and the same arithmetic #5027 applied to `CHAIN_FIREHOSE_INGEST_RATE_LIMIT` forty lines below in the same file, which was lifted **120 → 1200** for exactly this: a cap sized once and never recalibrated when the producer's shape moved under it.

## The measurement

The validator-nominators job posts **both** its tables in one run — `validator_nominator_counts` (112,250 rows) and `nominator_positions` (123,511) — and `lane_health` recorded `739565 scanned, 222343 written` against 429s on 2026-08-07 18:22, 18:37 and 2026-08-08 08:51.

At the per-route row caps (50,000 and 25,000) a full pass would be **~8 requests** and could never trip 30. It trips, so the producer is chunking far smaller; at the alpha scan's `page_size` of 1000 a pass is **~236 requests**, which exhausts 30/60s about eight seconds in.

The cost was not abstract. `nominator_positions` sat **28 hours** stale, and `hotkey_alpha`'s #9558 filter stores only pools a `nominator_positions` row references — so the staleness propagated into a second lane rather than staying contained.

## Why 300, and what it does not weaken

300 lets one full pass through a single window with headroom. It is not invented here: `DATA_RATE_LIMITER_KEYED` in this same file is already 300/60s.

The abuse ceiling was never really the request count. Each route independently caps **rows** per request and authenticates downstream with its own secret, and this bucket is keyed per **IP** — so it slows a single leaked-secret script rather than stopping a distributed one. It is a speed bump by construction, and 300 keeps it one.

The better fix is upstream: a producer posting at the row cap would put a pass at ~8 requests and need no limit here at all. #10180 says so, and stays open for it. This unblocks the lane meanwhile — and unblocks the last two lanes that have not cycled since the D1-free deploy, which is the remaining gate on dropping the database.

## Test

The proxy test now asks the constant for its expected headers instead of restating `"30"` — a restated number is how a published ceiling drifts from the enforced one.

Refs #10180
