### PR TITLE
fix(reads): the Postgres read adapter answered a different shape than readStore

### DIFF
--- a/src/observations-read-runner.ts
+++ b/src/observations-read-runner.ts
@@ -46,26 +46,54 @@ export interface ReadRunnerSql {
 }
 
 /**
- * Present a Postgres runner as the D1 read surface the loaders expect.
+ * Present a Postgres runner as the D1-shaped read surface the loaders expect.
  *
- * `d1All` accepts either a bare array or `{ results }`, and `unsafe` resolves
- * to the array, so no row-shape translation is needed on the way back either.
+ * SHAPE-IDENTICAL TO `readStore`'s handle (src/read-store.ts), deliberately.
+ * Two adapters in this tree present Postgres as a D1-shaped reader, and they
+ * disagreed about what a prepared statement offers. This one answered
+ * `prepare(text) -> { bind, all }` with the rows as a BARE ARRAY; readStore
+ * answers `{ bind, all, first }` with `{ results }`, which is the shape D1
+ * itself had and therefore the shape the call sites were written against.
+ *
+ * Neither difference is caught by a type -- every consumer reaches these
+ * through a structural interface or a cast -- and both fail SILENTLY:
+ *
+ *   A caller doing `.first()` gets "not a function". That lands in the
+ *   try/catch these readers wrap their query in, so it is reported as a
+ *   decline rather than as a broken read: see the note in
+ *   src/validator-nominator-counts-staleness-watchdog.ts, which hit exactly
+ *   this and had to move to readStore.
+ *
+ *   A caller guarding on `Array.isArray(res?.results)` reads `undefined` off
+ *   an array and takes its own failure branch on a read that SUCCEEDED --
+ *   the guard src/top-holders-holdings.ts and src/chain-holders.ts both use.
+ *
+ * `d1All` accepts a bare array or `{ results }`, so the loaders that go through
+ * it never saw the difference; it is the readers that unwrap the result
+ * themselves that it reaches. With D1 gone (#10181) there is no second store to
+ * absorb the mismatch, so the two adapters agreeing is the whole safety margin.
  */
 export function pgObservationsReadDb(sql: ReadRunnerSql): ObservationsReadDb {
+  const rows = async (text: string, values: unknown[]) =>
+    ((await sql.unsafe(text, values)) ?? []) as unknown[];
+  const ops = (text: string, values: unknown[]) => ({
+    async all() {
+      return { results: await rows(text, values) };
+    },
+    async first() {
+      return (await rows(text, values))[0] ?? null;
+    },
+  });
   return {
     prepare(text: string) {
       return {
-        bind(...values: unknown[]) {
-          return {
-            all: () => sql.unsafe(text, values),
-          };
-        },
-        // BOTH SHAPES, because D1 has both and this codebase uses both.
+        bind: (...values: unknown[]) => ops(text, values),
+        // BOTH SHAPES, because D1 had both and this codebase uses both.
         // src/top-holders-holdings.ts calls `prepare(sql).all?.()` with no
         // bind at all -- its statement carries no parameters -- and an adapter
         // offering only the bind path would throw there rather than fall back,
         // turning a store swap into a route outage.
-        all: () => sql.unsafe(text, []),
+        ...ops(text, []),
       };
     },
   };

--- a/tests/observations-read-runner.test.ts
+++ b/tests/observations-read-runner.test.ts
@@ -65,8 +65,43 @@ describe("pgObservationsReadDb", () => {
       all?: () => Promise<unknown>;
     };
     assert.equal(typeof prepared.all, "function");
-    assert.deepEqual(await prepared.all!(), [{ netuid: 1 }]);
+    // `{ results }` -- the envelope readStore's handle answers with, and the
+    // one D1 itself had. NOT the bare array this adapter used to return: the
+    // readers that unwrap the result themselves guard on
+    // `Array.isArray(res?.results)`, and `.results` on an array is undefined,
+    // so a read that SUCCEEDED took the failure branch.
+    assert.deepEqual(await prepared.all!(), { results: [{ netuid: 1 }] });
     assert.deepEqual(seen, [[]]);
+  });
+
+  test("first() returns one row, and null when there are none", async () => {
+    // The other half of the same divergence: this adapter had no `first()` at
+    // all, so a caller that used one got "not a function" -- caught by the
+    // try/catch these readers wrap their query in and reported as a decline
+    // rather than as a broken read. That is what sent
+    // src/validator-nominator-counts-staleness-watchdog.ts to readStore.
+    const db = pgObservationsReadDb({
+      unsafe: async () => [{ captured_at: 7 }, { captured_at: 6 }],
+    }) as unknown as {
+      prepare(sql: string): {
+        first(): Promise<unknown>;
+        bind(...values: unknown[]): { first(): Promise<unknown> };
+      };
+    };
+    // Both call shapes, because D1 had both and this codebase uses both.
+    assert.deepEqual(await db.prepare("SELECT 1").first(), { captured_at: 7 });
+    assert.deepEqual(await db.prepare("SELECT 1").bind(1).first(), {
+      captured_at: 7,
+    });
+
+    const empty = pgObservationsReadDb({
+      unsafe: async () => [],
+    }) as unknown as { prepare(sql: string): { first(): Promise<unknown> } };
+    assert.equal(
+      await empty.prepare("SELECT 1").first(),
+      null,
+      "no rows is null, not undefined -- D1's own contract",
+    );
   });
 
   test("a rejected read degrades to zero rows rather than throwing", async () => {


### PR DESCRIPTION
Closes #10203

`pgObservationsReadDb` returned `prepare(text) -> { bind, all }` with the rows as a **bare array**. `readStore`'s handle returns `{ bind, all, first }` with `{ results }` — the shape D1 itself had, and therefore the shape the call sites were written against.

## Why it was silent

Neither difference is caught by a type. Every consumer reaches these through the structural `ObservationsReadDb` or a cast, so both failures land as a wrong answer rather than an error:

- `.first()` gets `not a function`. These readers wrap their query in a try/catch, so it surfaces as a **decline**, not a broken read.
- A caller guarding on `Array.isArray(res?.results)` reads `undefined` off an array and takes its own **failure branch on a read that succeeded** — the guard in `src/top-holders-holdings.ts` and `src/chain-holders.ts`.

This has already cost us once: `src/validator-nominator-counts-staleness-watchdog.ts` carries a comment recording that it hit exactly this and had to move to `readStore`.

## Why now

Before #10181 the D1 fallback answered `{ results }` and had `first()`, so holding the divergent handle was the exception. With D1 gone there is no second store to absorb the mismatch — the two adapters agreeing **is** the safety margin.

## Blast radius

`d1All` accepts a bare array or `{ results }`, so the loaders that go through it never saw the difference and are unaffected either way. I verified every `observationsReadDb` call site: all nine consuming loaders (`loadSubnetTrajectory`, `loadEconomicsTrends`, `loadSubnetUptime`, `loadBulkHealthTrends`, `loadSubnetHealthTrends`, `loadSubnetPercentiles`, `loadSubnetIncidents`, `loadGlobalIncidentRows`, `loadEndpointReliability`) funnel through `d1All`.

## Verification

- `tsc --noEmit` clean, eslint and prettier clean.
- 698 tests green across the adapter and its consumers, including `observations-read-runner`, `top-holders-holdings`, `chain-holders`, `analytics-live`, `health-prober`, `subnet-validator-economics-route`, `request-handlers-entities`, `analytics-edge-cache`, `observations-flip-readiness`, `read-store` and `neon-sole-store`.
- Two tests added: `all()` now asserts the `{ results }` envelope, and a new case covers `first()` on both the bound and unbound paths plus the empty-result `null`.