### PR TITLE
fix(mcp): the last six tools that published a `limit` without saying what omitting it does (#10101)

### DIFF
--- a/schemas-src/mcp-tools/account-transfers.ts
+++ b/schemas-src/mcp-tools/account-transfers.ts
@@ -11,6 +11,7 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { COUNTERPARTIES_LIMIT_DEFAULT } from "../../src/counterparties.ts";
 import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { blockBoundSchema, limitSchema, ss58Schema } from "./shared.ts";
 import { AccountTransfersArtifactSchema } from "../routes/account-events-feed.ts";
@@ -58,7 +59,7 @@ export const GetAccountCounterpartiesInputSchema = z
         "The other SS58 account in the transfer pair — results are restricted to flows between the subject account and this one.",
       )
       .meta({ examples: ["5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F"] }),
-    limit: limitSchema(100).optional(),
+    limit: limitSchema(100, COUNTERPARTIES_LIMIT_DEFAULT).optional(),
   })
   .strict();
 export type GetAccountCounterpartiesInput = z.infer<

--- a/schemas-src/mcp-tools/endpoint-pools-and-provider.ts
+++ b/schemas-src/mcp-tools/endpoint-pools-and-provider.ts
@@ -11,6 +11,7 @@
 // REQUIRED (a path param, not a filter), unlike every other filter in this
 // file.
 import { z } from "zod";
+import { PROVIDER_ENDPOINTS_LIMIT_DEFAULT } from "../../src/route-limits.ts";
 import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   McpListArtifactStamp,
@@ -211,7 +212,9 @@ export const ListProviderEndpointsInputSchema = z
     sort: sortSchema(API_QUERY_COLLECTIONS.endpoints.sort_fields).optional(),
     order: orderSchema().optional(),
     fields: fieldsSchema().optional(),
-    limit: limitSchema(100).optional(),
+    // 50, not the 20 its two siblings above use: src/provider-endpoints-mcp.ts
+    // clamps with clampToolLimit(args.limit, 50, 100) (#10101).
+    limit: limitSchema(100, PROVIDER_ENDPOINTS_LIMIT_DEFAULT).optional(),
     cursor: numericCursorSchema().optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/feed.ts
+++ b/schemas-src/mcp-tools/feed.ts
@@ -60,7 +60,10 @@ export const GetFeedInputSchema = z
           "means the END of that UTC day, so the whole day is kept.",
       )
       .meta({ examples: ["2026-08-06T23:59:59Z", "2026-08-06"] }),
-    limit: limitSchema(FEED_MAX_ITEMS).optional(),
+    // resolveLimit() in src/feed-mcp.ts returns FEED_MAX_ITEMS when the
+    // caller names none, so the ceiling IS the default here -- unusual, and
+    // worth publishing precisely because it is (#10101).
+    limit: limitSchema(FEED_MAX_ITEMS, FEED_MAX_ITEMS).optional(),
   })
   .strict();
 export type GetFeedInput = z.infer<typeof GetFeedInputSchema>;

--- a/schemas-src/mcp-tools/get-subnet-identity-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-identity-history.ts
@@ -11,6 +11,7 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { DEFAULT_LIMIT } from "../../workers/request-params.ts";
 import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { netuidSchema } from "./shared.ts";
 import { SubnetIdentityHistoryArtifactSchema } from "../routes/subnet-identity-history.ts";
@@ -21,7 +22,12 @@ const RouteQuery_subnets_netuid_identity_history =
 export const GetSubnetIdentityHistoryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    limit: RouteQuery_subnets_netuid_identity_history.shape.limit,
+    // The route defaults this through FEED_PAGINATION and the tool's own
+    // description already says "default 100" -- it just was not in the
+    // schema, so only prose carried it (#10101).
+    limit: RouteQuery_subnets_netuid_identity_history.shape.limit.meta({
+      default: DEFAULT_LIMIT,
+    }),
     offset: RouteQuery_subnets_netuid_identity_history.shape.offset,
     cursor: RouteQuery_subnets_netuid_identity_history.shape.cursor,
   })

--- a/src/counterparties.ts
+++ b/src/counterparties.ts
@@ -1,3 +1,12 @@
+/**
+ * Rows `buildCounterparties` returns when the caller names no limit.
+ *
+ * Named so the MCP tool can PUBLISH it (#10101). It was a bare `20` in the
+ * parameter default, which meant the number existed but no schema could cite
+ * it -- the tool advertised a `limit` and left a caller to discover the
+ * default by counting rows.
+ */
+export const COUNTERPARTIES_LIMIT_DEFAULT = 20;
 // Account counterparty / fund-flow analytics: who one account transacts with,
 // aggregated from the account_events Transfer tier (hotkey = from, coldkey = to,
 // amount_tao). Pure + exported for unit tests; workers/data-api.ts does the
@@ -105,7 +114,7 @@ interface PartyEntry {
 export function buildCounterparties(
   rows: Array<Record<string, unknown>> | null | undefined,
   ss58: string,
-  { limit = 20 }: { limit?: number } = {},
+  { limit = COUNTERPARTIES_LIMIT_DEFAULT }: { limit?: number } = {},
 ): CounterpartiesResult {
   const list = Array.isArray(rows) ? rows : [];
   const byParty = new Map<string, PartyEntry>();

--- a/src/provider-endpoints-mcp.ts
+++ b/src/provider-endpoints-mcp.ts
@@ -5,6 +5,7 @@
 
 import { z } from "zod";
 import { clampToolLimit } from "../workers/request-params.ts";
+import { PROVIDER_ENDPOINTS_LIMIT_DEFAULT } from "./route-limits.ts";
 import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
@@ -162,7 +163,10 @@ export function providerEndpointsQueryUrl(
   const maxScore = optionalRangeBound(args, "max_score");
   if (maxScore !== null) url.searchParams.set("max_score", String(maxScore));
   if (args?.limit !== undefined) {
-    url.searchParams.set("limit", String(clampToolLimit(args.limit, 50, 100)));
+    url.searchParams.set(
+      "limit",
+      String(clampToolLimit(args.limit, PROVIDER_ENDPOINTS_LIMIT_DEFAULT, 100)),
+    );
   }
   if (args?.cursor !== undefined) {
     const cursor = args.cursor;

--- a/src/route-limits.ts
+++ b/src/route-limits.ts
@@ -220,6 +220,9 @@ export const CHAIN_CONCENTRATION_SUBNETS_LIMIT_MAX = 512;
 export const EMISSION_PIPELINE_LIMIT_MAX = 512;
 export const EMISSION_PIPELINE_MCP_LIMIT_DEFAULT = 20;
 
+/** Rows list_provider_endpoints returns when the caller names no limit. */
+export const PROVIDER_ENDPOINTS_LIMIT_DEFAULT = 50;
+
 /**
  * Every MCP list tool that pages through `applyQueryFilters` (#9730).
  *

--- a/tests/mcp-schema-enforcement.test.ts
+++ b/tests/mcp-schema-enforcement.test.ts
@@ -339,3 +339,59 @@ describe("published string constraints are enforced at runtime (#10065)", () => 
     );
   }, 180_000);
 });
+
+describe("a published `limit` says what omitting it does (#10101)", () => {
+  // 83 of the 97 tools that publish a `limit` declared no `default`, so a
+  // caller could read the schema and still not know how many rows an omitted
+  // `limit` returns. The server always applied one; it just never said which.
+  //
+  // The two exceptions are real: `get_subnet_metagraph` and
+  // `list_subnet_validators` read their limit with `optionalPositiveInt` and
+  // apply NO default -- omitting it returns everything. Publishing an invented
+  // number there would be the same lie in the other direction, so they are
+  // named rather than defaulted, and a stale entry FAILS.
+  const NO_DEFAULT_APPLIED: Record<string, string> = {
+    get_subnet_metagraph:
+      "optionalPositiveInt with no fallback -- an omitted limit returns the " +
+      "whole metagraph, so there is no default to publish",
+    list_subnet_validators:
+      "optionalPositiveInt with no fallback -- the limit is an MCP-side " +
+      "post-filter, absent means unfiltered",
+  };
+
+  test("every tool publishing a limit publishes the default it applies", () => {
+    const missing: string[] = [];
+    const suppressed = new Set<string>();
+    let checked = 0;
+
+    for (const tool of listToolDefinitions() as Row[]) {
+      const limit = ((tool.inputSchema as Row)?.properties as Row)?.limit as
+        Row | undefined;
+      if (!limit) continue;
+      checked += 1;
+      if (limit.default !== undefined) continue;
+      if ((tool.name as string) in NO_DEFAULT_APPLIED) {
+        suppressed.add(tool.name as string);
+        continue;
+      }
+      missing.push(tool.name as string);
+    }
+
+    const stale = Object.keys(NO_DEFAULT_APPLIED).filter(
+      (name) => !suppressed.has(name),
+    );
+    assert.deepEqual(
+      stale,
+      [],
+      `these now publish a default, so remove them from NO_DEFAULT_APPLIED: ${stale.join(", ")}`,
+    );
+    assert.deepEqual(
+      missing,
+      [],
+      "these publish a `limit` without saying what omitting it does — pass the " +
+        "fallback the handler applies to limitSchema(max, fallback), or attach " +
+        `it with .meta({ default }): ${missing.join(", ")}`,
+    );
+    assert.ok(checked > 90, `only ${checked} tools publish a limit`);
+  });
+});


### PR DESCRIPTION
Finishes #10101. **95 of 97** tools now publish the default they apply, and the two that don't are named with the reason.

Each of these six needed its own answer rather than a guess, which is why the first pass left them:

| tool | default | where it comes from |
|---|---|---|
| `get_account_counterparties` | **20** | `buildCounterparties`' own parameter default — a bare literal until now. Named `COUNTERPARTIES_LIMIT_DEFAULT` so the schema cites the number the builder uses instead of restating it. |
| `get_subnet_identity_history` | **100** | `FEED_PAGINATION.defaultLimit`. The tool's own description already *said* "default 100" — only the schema didn't. |
| `list_provider_endpoints` | **50** | `clampToolLimit(args.limit, 50, 100)` — **not** the 20 its two siblings in the same file use. Named `PROVIDER_ENDPOINTS_LIMIT_DEFAULT`, read by both the clamp and the schema. |
| `get_feed` | **`FEED_MAX_ITEMS`** | `resolveLimit()` returns the *ceiling* when the caller names none, so here the max **is** the default. Unusual, and worth publishing precisely because it is. |

## Two correctly have none

`get_subnet_metagraph` and `list_subnet_validators` read their limit with `optionalPositiveInt` and **no fallback** — omitting it returns everything. Publishing an invented number there would be the same lie in the other direction.

## Gated

Every tool publishing a `limit` must publish the default it applies. Those two are named in `NO_DEFAULT_APPLIED` with their reason, and **a stale entry fails**. Derived from `listToolDefinitions()`, so a tool added tomorrow is covered tonight.

## Validation

```
npm run typecheck / lint / format:check    clean
npx vitest run                             767 files, 17,912 passed, 22 skipped
```

Closes #10101