### PR TITLE
ci(neon): identify a SQL runner by its type, not by whether it is called `sql`

### DIFF
--- a/scripts/validate-pg-json-binds.ts
+++ b/scripts/validate-pg-json-binds.ts
@@ -100,6 +100,28 @@ export function findRiskyBinds(
     );
   }
 
+  /**
+   * Whether a tagged template's tag is a SQL runner.
+   *
+   * TYPE FIRST, NAME SECOND. Matching the name `sql` alone is a hole: the
+   * runner is a value, so it can be bound to any identifier, and
+   * workers/data-api.ts already has two `historySql` templates that a `/^sql$/`
+   * matcher walks straight past. They happen to carry no interpolations today,
+   * which is exactly how a gate goes quietly green while its blind spot grows.
+   *
+   * The structural test is what the runner IS: `createPgSql` returns something
+   * callable that also has `.unsafe` (PgSql/D1Sql are defined that way, so the
+   * two stay interchangeable). That holds for any variable name. The name check
+   * remains as a fallback for a tag whose type does not resolve.
+   */
+  function isSqlRunnerTag(tag: ts.Expression): boolean {
+    const type = checker.getTypeAtLocation(tag);
+    if (type.getCallSignatures().length > 0 && type.getProperty("unsafe")) {
+      return true;
+    }
+    return /(^|\.)[A-Za-z0-9_$]*sql$/i.test(tag.getText());
+  }
+
   const found: RiskyBind[] = [];
 
   const consider = (
@@ -130,7 +152,7 @@ export function findRiskyBinds(
       // sql`INSERT ... ${value}`
       if (
         ts.isTaggedTemplateExpression(node) &&
-        /(^|\.)sql$/i.test(node.tag.getText()) &&
+        isSqlRunnerTag(node.tag) &&
         ts.isTemplateExpression(node.template)
       ) {
         const text = node.template.getText();

--- a/tests/validate-pg-json-binds.test.ts
+++ b/tests/validate-pg-json-binds.test.ts
@@ -17,10 +17,17 @@ import { afterEach, describe, test } from "vitest";
 import { findRiskyBinds } from "../scripts/validate-pg-json-binds.ts";
 
 const PRELUDE = `
-declare const sql: {
+type Runner = {
   (strings: TemplateStringsArray, ...values: unknown[]): Promise<unknown>;
   unsafe(text: string, values?: unknown[]): Promise<unknown>;
 };
+declare const sql: Runner;
+// workers/data-api.ts binds the same runner to this name twice.
+declare const historySql: Runner;
+// ...and nothing stops it being bound to a name with no "sql" in it at all.
+declare const store: Runner;
+// A tagged template that is NOT a SQL runner must be ignored entirely.
+declare function html(strings: TemplateStringsArray, ...values: unknown[]): string;
 interface Condition { metric: string; operator: string; threshold: number }
 declare const tableFilter: string[] | null;
 declare const condition: Condition | null;
@@ -78,6 +85,28 @@ describe("findRiskyBinds — catches the reinterpreted binds", () => {
     assert.equal(hits[0].expression, "tableFilter");
   });
 
+  // A runner is a VALUE, so it can be bound to any identifier. Matching the
+  // name `sql` alone walked straight past workers/data-api.ts's two
+  // `historySql` templates -- which carry no interpolations today, which is
+  // precisely how a gate stays green while its blind spot grows.
+  test("a runner bound to a name ending in Sql", () => {
+    const hits = scan("await historySql`UPDATE t SET f = ${tableFilter}`;");
+    assert.deepEqual(
+      hits.map((h) => h.expression),
+      ["tableFilter"],
+    );
+  });
+
+  // The structural test earns its keep here: no name-based rule would catch
+  // this one, and nothing stops someone writing it.
+  test("a runner bound to a name with no `sql` in it", () => {
+    const hits = scan("await store`UPDATE t SET f = ${tableFilter}`;");
+    assert.deepEqual(
+      hits.map((h) => h.expression),
+      ["tableFilter"],
+    );
+  });
+
   test("every risky bind in one statement, not just the first", () => {
     const hits = scan(
       "await sql`INSERT INTO t (a, b, c) VALUES (${tableFilter}, ${label}, ${condition})`;",
@@ -95,6 +124,12 @@ describe("findRiskyBinds — leaves the correct binds alone", () => {
       scan("await sql`UPDATE t SET f = ${JSON.stringify(tableFilter)}`;"),
       [],
     );
+  });
+
+  // Widening from `sql` to "any runner" must not widen to "any tagged
+  // template" -- an array in an html`` tag is not a SQL bind.
+  test("a tagged template that is not a SQL runner", () => {
+    assert.deepEqual(scan("html`<p>${tableFilter}</p>`;"), []);
   });
 
   test("scalars and Date", () => {


### PR DESCRIPTION
## Summary

- #10204's gate decided whether a tagged template was SQL by matching the tag **name**. A runner is a value, so it can be bound to anything — and already is: `workers/data-api.ts` assigns `createPgSql(...)` to `historySql` twice, and those two templates were invisible to the check.
- The runner is now identified by what it **is** — callable, with an `.unsafe` member — which holds regardless of the variable's name.
- Latent, not live: both `historySql` templates are static `SELECT`s with no interpolations, so nothing risky was being missed.

## What Changed

- `scripts/validate-pg-json-binds.ts`: `isSqlRunnerTag()` tests the tag's **type** (call signature + `unsafe` property — the shape `PgSql`/`D1Sql` were deliberately given so they stay interchangeable), falling back to the name check when the type doesn't resolve.
- `tests/validate-pg-json-binds.test.ts`: 3 new cases (12 total).

### Why this was worth fixing at all

An AST sweep of every tagged template under `src/`/`workers/` returns exactly two distinct tags: `sql` (86) and `historySql` (2). Neither `historySql` template interpolates anything, so no bind is being missed today.

That's precisely what makes it worth fixing rather than noting: **the gate was green, the hole was invisible, and the first `historySql`​`...${array}`​ would have walked straight through the check built to stop it.** It's the same shape as the bug the gate exists for — a guard that looks correct, reports success, and isn't watching what it claims to watch.

### The widening is bounded

Going from "tags named `sql`" to "any runner" must not become "any tagged template" — an array interpolated into an `html`​`` tag is not a SQL bind. That boundary has its own test.

Proven in both directions:
- Both new runner cases **fail** against the old name-only matcher.
- The `html`​`` case **passes under both**, which is what shows the widening didn't overshoot.
- The gate still exits 1 when #10179's four binds are reverted on current `main`.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #10207`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. *(none in this diff)*
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. *(none — CI-only)*

## Validation

- [x] `npm run lint` · `npm run format:check` · `npm run typecheck`
- [x] `npm run validate:pg-json-binds` — green on current `main`; exit 1 with #10179's binds reverted
- [x] `tests/validate-pg-json-binds.test.ts` — 12 tests
- [x] `git diff --check`
- [ ] `npm run check` / `npm run test:coverage` — left to CI. No `src/**`/`workers/**` runtime lines change, and `scripts/**` sits outside codecov's `include` globs, so there is no patch-coverage surface.
- [ ] `validate:schemas` / `api` / `openapi` / `types` / `artifact-budgets` / `docs` / `intake` / `worker:test` — not applicable; no schema, contract, artifact, or Worker-runtime change.

Closes #10207
