### PR TITLE
refactor(ci): read wrangler configs with the shared JSONC helper, not a private copy

### DIFF
--- a/scripts/validate-worker-types-parity.ts
+++ b/scripts/validate-worker-types-parity.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { repoRoot } from "./lib.ts";
+import { repoRoot, stripJsonComments } from "./lib.ts";
 
 // Drift gate for the three generated Worker Env files (#10188).
 //
@@ -33,6 +33,14 @@ import { repoRoot } from "./lib.ts";
 // workerd build stamp moves with the pinned dependency rather than with repo
 // content. A Wrangler bump that leaves vars and bindings alone is not drift
 // this gate should fail on.
+//
+// JSONC parsing is scripts/lib.ts's stripJsonComments -- the same helper
+// scripts/cloudflare-verify.ts already reads wrangler.jsonc with. It is
+// string-aware for both comment forms AND trailing commas. The first cut of
+// this file carried its own copy that stripped trailing commas with a regex
+// over the whole document, which would have corrupted any var whose VALUE
+// contained `,}` (POSTHOG_USAGE_SAMPLE_RATES is an embedded JSON object, so
+// that was one config edit away from biting).
 //
 // The fix for any failure here is always the same: `npm run types:workers`,
 // then commit all three files.
@@ -75,49 +83,6 @@ const BINDING_KEYS = [
   "send_email",
   "version_metadata",
 ] as const;
-
-/**
- * JSONC -> JSON. Wrangler's configs carry `//` comments and trailing commas,
- * neither of which JSON.parse accepts. String-aware so a `//` inside a URL
- * (CHAIN_HEAD_RPC_URL is one) is not mistaken for a comment.
- */
-export function parseJsonc(source: string): Record<string, unknown> {
-  let out = "";
-  let inString = false;
-  let escaped = false;
-  for (let i = 0; i < source.length; i += 1) {
-    const ch = source[i]!;
-    if (inString) {
-      out += ch;
-      if (escaped) escaped = false;
-      else if (ch === "\\") escaped = true;
-      else if (ch === '"') inString = false;
-      continue;
-    }
-    if (ch === '"') {
-      inString = true;
-      out += ch;
-      continue;
-    }
-    if (ch === "/" && source[i + 1] === "/") {
-      while (i < source.length && source[i] !== "\n") i += 1;
-      out += "\n";
-      continue;
-    }
-    if (ch === "/" && source[i + 1] === "*") {
-      i += 2;
-      while (i < source.length && !(source[i] === "*" && source[i + 1] === "/"))
-        i += 1;
-      i += 1;
-      continue;
-    }
-    out += ch;
-  }
-  return JSON.parse(out.replace(/,(\s*[}\]])/g, "$1")) as Record<
-    string,
-    unknown
-  >;
-}
 
 /**
  * Every binding name a config declares, across all the binding blocks.
@@ -203,9 +168,11 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     let config: Record<string, unknown>;
     let types: string;
     try {
-      config = parseJsonc(
-        await fs.readFile(path.join(repoRoot, worker.config), "utf8"),
-      );
+      config = JSON.parse(
+        stripJsonComments(
+          await fs.readFile(path.join(repoRoot, worker.config), "utf8"),
+        ),
+      ) as Record<string, unknown>;
     } catch (error) {
       errors.push(`${worker.config}: could not parse (${String(error)})`);
       continue;

--- a/tests/validate-worker-types-parity.test.ts
+++ b/tests/validate-worker-types-parity.test.ts
@@ -14,13 +14,15 @@
 // validator silently skipped every durable-object and rate-limiter binding
 // (they key on `name`, not `binding`) until a deletion test caught it.
 
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   declaredBindings,
-  parseJsonc,
   workerTypesParityErrors,
   WORKERS,
 } from "../scripts/validate-worker-types-parity.ts";
+import { repoRoot, stripJsonComments } from "../scripts/lib.ts";
 
 const worker = { config: "wrangler.jsonc", types: "types.d.ts" };
 
@@ -137,23 +139,41 @@ describe("binding parity", () => {
   });
 });
 
-describe("parseJsonc", () => {
+describe("config parsing (scripts/lib.ts's shared stripJsonComments)", () => {
+  // Not this file's helper any more -- it reuses the one
+  // scripts/cloudflare-verify.ts already reads wrangler.jsonc with. These stay
+  // because the gate depends on all three behaviours, and a change to the
+  // shared helper should fail HERE rather than by silently reporting every
+  // var as missing.
+  const parse = (src: string) => JSON.parse(stripJsonComments(src)) as unknown;
+
   it("strips comments and trailing commas", () => {
-    expect(parseJsonc('{\n// c\n"a": 1,\n}')).toEqual({ a: 1 });
+    expect(parse('{\n// c\n"a": 1,\n}')).toEqual({ a: 1 });
   });
 
   it("does not treat a // inside a string as a comment", () => {
-    // CHAIN_HEAD_RPC_URL is an https:// URL; a naive comment stripper eats it
-    // and the whole config fails to parse.
-    expect(parseJsonc('{"url": "https://x.example/y"}')).toEqual({
+    // CHAIN_HEAD_RPC_URL is an https:// URL; a naive stripper eats it and the
+    // whole config fails to parse.
+    expect(parse('{"url": "https://x.example/y"}')).toEqual({
       url: "https://x.example/y",
     });
   });
 
   it("keeps an escaped quote inside a string", () => {
-    expect(parseJsonc('{"a": "he said \\"hi\\""}')).toEqual({
-      a: 'he said "hi"',
-    });
+    expect(parse('{"a": "he said \\"hi\\""}')).toEqual({ a: 'he said "hi"' });
+  });
+
+  it("does not strip a comma inside a string value", () => {
+    // The regex the first cut of this gate used would have eaten this one.
+    expect(parse('{"a": "{x:1,}"}')).toEqual({ a: "{x:1,}" });
+  });
+
+  it("parses all three real wrangler configs", () => {
+    for (const worker of WORKERS) {
+      expect(() =>
+        parse(readFileSync(path.join(repoRoot, worker.config), "utf8")),
+      ).not.toThrow();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

The worker-types gate (#10188, merged in #10199) shipped with its own JSONC parser. `scripts/lib.ts` already exports `stripJsonComments` — the helper `scripts/cloudflare-verify.ts` has read `wrangler.jsonc` with all along — so that was a second implementation of a solved problem, and the weaker of the two. Self-review of my own merged code.

## It carried a real latent bug

Comments were handled string-aware, but trailing commas were stripped with a regex over the **whole document**:

```js
out.replace(/,(\s*[}\]])/g, "$1")
```

That rewrites the inside of string values too:

```
shared helper -> {"vars":{"BLOB":"{a:1,}"}}
old regex     -> {"vars":{"BLOB":"{a:1}"}}
```

Nothing broke yet because no var value currently ends in `,}`. But `POSTHOG_USAGE_SAMPLE_RATES` already holds an embedded JSON object, so this was one config edit away from silently mis-parsing — and the failure mode is the worst kind for a drift gate: it would report a var as drifted when it wasn't, training people to ignore it.

## Tests

The parsing tests stay, pointed at the shared helper. The gate depends on all three behaviours (comments, trailing commas, string-awareness), and a change to `stripJsonComments` should fail loudly here rather than by quietly reporting every var as missing. Added two cases:

- the one the old regex would have failed (`"{x:1,}"` as a value)
- one that parses all three real wrangler configs, so the gate can't be broken by a config gaining a construct the helper doesn't handle

## Verification

`typecheck` · `lint` · `format:check` · `validate` (exit 0) · `validate:worker-types-parity` green · re-confirmed the gate still detects real drift (flipping a literal back to `"postgres"` still reports it) · full suite **758 files / 17,924 tests, exit 0**.
