### PR TITLE
fix(ratelimit): the internal-sync ceiling is advertised at 300 and enforced at 30

### DIFF
--- a/tests/api-tiers.test.ts
+++ b/tests/api-tiers.test.ts
@@ -24,9 +24,12 @@ import { MCP_TIERED_RATE_LIMIT } from "../src/mcp-server.ts";
 import { AI_TIERED_RATE_LIMIT } from "../src/ai-search.ts";
 import { STATE_QUERY_TIERED_RATE_LIMIT } from "../workers/request-handlers/rpc-proxy.ts";
 import {
+  CHAIN_FIREHOSE_INGEST_RATE_LIMIT,
   DATA_TIERED_RATE_LIMIT,
+  INTERNAL_SYNC_RATE_LIMIT,
   WEBHOOK_SUBSCRIPTION_TIERED_RATE_LIMIT,
 } from "../workers/api.ts";
+import { FULLNODE_RPC_TIER_RATE_LIMITS } from "../workers/request-handlers/fullnode-rpc-proxy.ts";
 
 /** wrangler.jsonc's `ratelimits`, by binding name. */
 function limiterBindings(): Map<string, { limit: number; period: number }> {
@@ -153,5 +156,106 @@ describe("buildTierPolicies", () => {
     for (const tier of API_TIERS) {
       assert.equal(policies[tier].windowSeconds, 10);
     }
+  });
+});
+
+// THE SAME BUG, ON THE BINDINGS THIS FILE'S TIERED LOOP NEVER LOOKED AT
+// (#10180). `SURFACES` covers the five tiered configs, which is 20 of the 27
+// bindings. The rest are flat -- one constant, one binding -- and nothing
+// checked them, so `INTERNAL_SYNC_RATE_LIMIT` sat at 300 in workers/api.ts
+// while INTERNAL_SYNC_RATE_LIMITER enforced 30 in wrangler.jsonc.
+//
+// That constant feeds ONLY the 429 response headers. Raising it advertised
+// headroom that did not exist, and the producer kept being refused: the
+// validator-nominators lane 429'd from 2026-08-07 18:22, freezing
+// nominator_positions, validator_nominator_counts and hotkey_alpha together,
+// because all three land through the same proxy.
+
+/** Flat limiters: one advertised constant, one binding, no tiers. */
+const FLAT_LIMITERS: [
+  string,
+  { limit: number; windowSeconds: number },
+  string,
+][] = [
+  ["internal-sync", INTERNAL_SYNC_RATE_LIMIT, "INTERNAL_SYNC_RATE_LIMITER"],
+  [
+    "chain-firehose-ingest",
+    CHAIN_FIREHOSE_INGEST_RATE_LIMIT,
+    "CHAIN_FIREHOSE_INGEST_RATE_LIMITER",
+  ],
+];
+
+/**
+ * Bindings that enforce a limit but advertise no number to compare against.
+ *
+ * Listed rather than skipped by pattern: the coverage test below fails on any
+ * binding that appears in neither this list nor a config, so a new limiter
+ * cannot be added without someone deciding which kind it is. That decision is
+ * the point -- an advertised limit needs pinning, an unadvertised one does not.
+ */
+const UNADVERTISED_BINDINGS = new Set([
+  // src/mcp-server.ts's call_rpc guard returns a bare `rate_limited` with no
+  // x-ratelimit headers, so there is no second number that could disagree.
+  "RPC_RATE_LIMITER",
+  // fullnode-rpc-proxy's pre-auth guess guard; its 429 carries the TIER's
+  // numbers, checked below, not this binding's.
+  "FULLNODE_RPC_GUESS_RATE_LIMITER",
+]);
+
+describe("untiered ceilings are backed by real bindings (#10180)", () => {
+  const bindings = limiterBindings();
+
+  for (const [name, policy, envVar] of FLAT_LIMITERS) {
+    test(`${name}: enforces the ${policy.limit}/${policy.windowSeconds}s it advertises`, () => {
+      const binding = bindings.get(envVar);
+      assert.ok(binding, `${envVar} exists in wrangler.jsonc`);
+      assert.equal(
+        binding.limit,
+        policy.limit,
+        `${envVar} enforces the limit ${name}'s 429 headers advertise`,
+      );
+      assert.equal(binding.period, policy.windowSeconds);
+    });
+  }
+
+  for (const [tier, policy] of Object.entries(FULLNODE_RPC_TIER_RATE_LIMITS)) {
+    test(`fullnode-rpc ${tier}: enforces the ${policy.limit}/min it advertises`, () => {
+      const binding = bindings.get(policy.envVar);
+      assert.ok(binding, `${policy.envVar} exists in wrangler.jsonc`);
+      assert.equal(binding.limit, policy.limit);
+      assert.equal(binding.period, policy.windowSeconds);
+    });
+  }
+
+  test("every binding in wrangler.jsonc is claimed by some config", () => {
+    // The hole this closes is the one that produced #10180: a binding nothing
+    // compares against drifts silently, and drift is invisible in the
+    // direction that matters -- the enforced number is the low one.
+    // Not vacuous: an empty parse would make `orphans` empty and pass.
+    assert.ok(
+      bindings.size >= 20,
+      `limiterBindings() parsed ${bindings.size} bindings -- it reads wrangler.jsonc`,
+    );
+    const claimed = new Set<string>(UNADVERTISED_BINDINGS);
+    for (const [, config] of SURFACES) {
+      for (const policy of [config.anonymous, config.keyed]) {
+        claimed.add(policy.envVar);
+      }
+      for (const tier of API_TIERS) {
+        const policy = config.tiers?.[tier];
+        if (policy) claimed.add(policy.envVar);
+      }
+    }
+    for (const [, , envVar] of FLAT_LIMITERS) claimed.add(envVar);
+    for (const policy of Object.values(FULLNODE_RPC_TIER_RATE_LIMITS)) {
+      claimed.add(policy.envVar);
+    }
+    const orphans = [...bindings.keys()].filter((name) => !claimed.has(name));
+    assert.deepEqual(
+      orphans,
+      [],
+      "each of these enforces a limit no config declares -- add it to a tier " +
+        "config, to FLAT_LIMITERS, or to UNADVERTISED_BINDINGS",
+    );
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -3423,7 +3423,10 @@ async function internalSyncRateLimited(request: Request, env: Env) {
 // forwardWithRetry now also properly respects retry-after and pauses its
 // whole poll loop on a 429 (the since-retired relay), so a real
 // spike still degrades gracefully instead of repeating this failure mode.
-const CHAIN_FIREHOSE_INGEST_RATE_LIMIT = { limit: 1200, windowSeconds: 60 };
+export const CHAIN_FIREHOSE_INGEST_RATE_LIMIT = {
+  limit: 1200,
+  windowSeconds: 60,
+};
 
 async function chainFirehoseIngestRateLimited(request: Request, env: Env) {
   if (!env.CHAIN_FIREHOSE_INGEST_RATE_LIMITER?.limit) return null;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1289,11 +1289,25 @@
     // tolerate legitimate chunked historical-backfill scripts (see
     // proxyToDataApi's own comment in workers/api.ts). Skipped when the
     // binding is absent (local dev/CI).
+    //
+    // 300/60s SINCE #10180, AND THIS NUMBER IS THE ENFORCED ONE. The limit
+    // lived here at 30 while workers/api.ts's INTERNAL_SYNC_RATE_LIMIT --
+    // which feeds only the 429 response HEADERS -- was raised to 300. Nothing
+    // read the constant to enforce anything, so the raise advertised headroom
+    // that did not exist and the producer kept being refused: the
+    // validator-nominators lane 429'd from 2026-08-07 18:22 onward, freezing
+    // nominator_positions (30.9h stale), validator_nominator_counts and
+    // hotkey_alpha together, because all three land through this proxy.
+    //
+    // tests/api-tiers.test.ts now pins the two together. That file already
+    // existed to stop exactly this -- an advertised ceiling that no binding
+    // enforces (#8608) -- and this binding was simply outside the tiered loop
+    // it checks.
     {
       "name": "INTERNAL_SYNC_RATE_LIMITER",
       "namespace_id": "1007",
       "simple": {
-        "limit": 30,
+        "limit": 300,
         "period": 60,
       },
     },


### PR DESCRIPTION
Three Neon tables are frozen right now, and they share one cause.

```
nominator_positions         123,511 rows, newest 30.9h
validator_nominator_counts  112,250 rows, newest 10.7h
hotkey_alpha                 17,867 rows, newest 10.5h
```

`lane_health` says why:

```
validator-nominators | stale | post nominator_positions: sync POST failed:
                               curl: (22) The requested URL returned error: 429
```

All three land through the same six `proxyToDataApi` internal-sync routes, so one 429 freezes all three.

## The 429 is ours, and the limit that produces it is not the one we publish

`INTERNAL_SYNC_RATE_LIMIT` in `workers/api.ts` feeds the **429 response headers** — `x-ratelimit-limit`, `x-ratelimit-policy`, `retry-after`. Nothing reads it to enforce anything. Enforcement is `env.INTERNAL_SYNC_RATE_LIMITER.limit()`, a Cloudflare binding whose real numbers live in `wrangler.jsonc`:

| | value |
|---|---|
| `INTERNAL_SYNC_RATE_LIMIT` (headers) | 300 / 60s |
| `INTERNAL_SYNC_RATE_LIMITER` (enforced) | **30 / 60s** |

So the constant had been raised to 300 and the producer was still being refused at 30, while the 429 it received advertised 300. This PR raises the binding, which is the number that matters.

## The gate that should have caught it, and why it did not

`tests/api-tiers.test.ts` exists for precisely this bug — #8608, where three tiers advertised three ceilings and shared one binding. Its header says so. But its loop walks `SURFACES`, the five **tiered** configs, which is 20 of the 27 bindings. The flat ones — one constant, one binding, no tiers — were never in scope.

Now checked:

- `INTERNAL_SYNC_RATE_LIMIT` → `INTERNAL_SYNC_RATE_LIMITER`
- `CHAIN_FIREHOSE_INGEST_RATE_LIMIT` → `CHAIN_FIREHOSE_INGEST_RATE_LIMITER` (already agreed at 1200)
- the three `FULLNODE_RPC_TIER_RATE_LIMITS` tiers → their bindings (already agreed)

and a **coverage assertion**: every binding in `wrangler.jsonc` must be claimed by a tier config, by `FLAT_LIMITERS`, or by a documented `UNADVERTISED_BINDINGS` list. A new limiter cannot be added without someone deciding which kind it is — that decision being forced is the point, since drift is invisible in the direction that matters (the enforced number is the low one).

`RPC_RATE_LIMITER` and `FULLNODE_RPC_GUESS_RATE_LIMITER` are on the unadvertised list with the reason inline: their 429s carry no number that could disagree.

## Verification

- **The gate fails on the real bug.** With the binding put back at 30: `AssertionError: INTERNAL_SYNC_RATE_LIMITER enforces the limit internal-sync's 429 headers advertise / 30 !== 300`.
- The coverage test asserts `bindings.size >= 20` first, so an empty parse cannot make it pass vacuously.
- `npx tsc --noEmit`, `npm run lint`, `npx prettier --check .` clean.
- `api-tiers`, `neurons-sync-proxy`, `validate-worker-types-parity`, `fullnode-rpc-proxy` pass. (`batch-ratelimit` fails in a worktree with no `npm run build` — 404 vs 200 on artifact reads — and passes once built; it was in the same set that cleared after building on #10229.)

## After merge

Workers Builds deploys the config, so the binding takes effect with the code. I will confirm the producer's next pass lands rather than 429s, and that the three tables advance.

Note for #10180's own framing: the issue and my earlier comment both need the correction that the constant is header-only — that is the whole bug, and it is why the earlier raise appeared to change nothing.

Closes #10180