### PR TITLE
fix(health): a deleted lane's last verdict is served forever

### DIFF
--- a/src/lane-health.ts
+++ b/src/lane-health.ts
@@ -50,6 +50,64 @@ import {
  */
 export const LANE_HEALTH_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
 
+/**
+ * Lanes whose PRODUCER was deleted, so no future tick can ever revise them.
+ *
+ * A verdict is a statement about a lane as of `checked_at`, and the serving read
+ * takes the newest row per lane with no liveness bound. That is right while a
+ * producer exists -- the newest thing it said is the current truth. It stops being
+ * right the moment the producer goes: the last thing a deleted lane ever said is
+ * served forever, and if that was `stale` it is a permanent alarm nothing can clear.
+ *
+ * Live case this fixes (#10222). #10167 deleted the reconciler, the parity sweep and
+ * the mirror-lag watchdog, correctly, because Neon is the sole store now. Their rows
+ * stayed:
+ *
+ *   neon-parity  stale  "chain_detail_chain_events -169126, chain_detail_account_events -126582"
+ *
+ * `neon-parity` counted Neon against D1. D1 was deleted on 2026-08-08, so those
+ * deficits are the size of the store, they only grow, and no pass will ever revise
+ * them. `stale_lane_count` could not return to zero, on either
+ * `GET /api/v1/self-health` or `get_self_health`.
+ *
+ * THIS IS NOT SUPPRESSION, and the distinction is the whole design. Suppressing a
+ * watchdog means muting a lane that still runs. These lanes do not run. Serving their
+ * last verdict is not vigilance, it is reporting a fact about the past as though it
+ * were current -- and a stale count that can never reach zero teaches everyone to
+ * ignore the number, which costs more than the one row.
+ *
+ * The entries are tied to deleted FILES, and tests/lane-health-retired.test.ts asserts
+ * those files are still absent. So a lane cannot be quietly retired while its producer
+ * lives, and resurrecting a producer fails the test until its name is removed here.
+ */
+export const RETIRED_LANES: readonly string[] = [
+  // src/neon-parity.ts -- compared row counts against D1 (#10167).
+  "neon-parity",
+  // src/neon-mirror-lag.ts -- measured how far a mirror trailed its D1 source
+  // (#10167). Reports `ok`, so it alarms nothing; it is equally a lie.
+  "neon-mirror-lag",
+];
+
+/**
+ * Retired lane FAMILIES, by prefix.
+ *
+ * `neon:backfill:<table>` was one lane per table reconciled, named at runtime from
+ * NEON_BACKFILL_LANES. Both the flag and src/neon-backfill.ts are gone, and 24 of
+ * these rows remain -- including `neon:backfill:tao_usd_index`, whose verdict says
+ * `stale` while its own detail says "0 date(s) / 0 row(s) still behind". A prefix
+ * rather than 24 names because the family is defined by its producer, not its members:
+ * a table nobody ever named cannot come back.
+ */
+export const RETIRED_LANE_PREFIXES: readonly string[] = ["neon:backfill:"];
+
+/** Whether `lane`'s producer has been deleted. */
+export function isRetiredLane(lane: string): boolean {
+  return (
+    RETIRED_LANES.includes(lane) ||
+    RETIRED_LANE_PREFIXES.some((prefix) => lane.startsWith(prefix))
+  );
+}
+
 /** The minimal D1 surface these helpers use, so callers can inject a fake. */
 export interface LaneHealthDb {
   prepare(sql: string): {
@@ -145,6 +203,10 @@ export async function loadLatestLaneHealth(
     for (const row of rows) {
       const lane = row.lane == null ? "" : String(row.lane);
       if (!lane) continue;
+      // Filtered HERE rather than in the SQL so the rule is one testable
+      // predicate shared by every caller, and so a row that outlives its
+      // deletion is still visible to anyone querying the table directly.
+      if (isRetiredLane(lane)) continue;
       out[lane] = {
         lane,
         verdict: normalizeVerdict(row.verdict),

--- a/tests/lane-health-retired.test.ts
+++ b/tests/lane-health-retired.test.ts
@@ -1,0 +1,108 @@
+// A deleted lane's last verdict was served forever (#10222).
+//
+// THE BUG. `loadLatestLaneHealth` takes the newest row per lane with no liveness
+// bound. That is correct while a producer exists -- the newest thing it said IS the
+// current truth. It inverts the moment the producer is deleted, because no future
+// tick can revise the row. #10167 removed the reconciler, the parity sweep and the
+// mirror-lag watchdog; `neon-parity` went on reporting `stale` with deficits measured
+// against a D1 that was itself deleted the next day, so `stale_lane_count` could
+// never return to zero on `/api/v1/self-health` or `get_self_health`.
+//
+// WHY THE LIST IS TIED TO FILES. A hand-maintained "ignore these" list is exactly the
+// shape that rots into suppression: someone adds a noisy lane, the producer keeps
+// running, and the alarm is gone. Pinning each entry to a file that must NOT exist
+// makes the claim checkable -- a lane can only be retired if the thing that wrote it
+// is genuinely gone, and resurrecting a producer fails here until its name is removed.
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  RETIRED_LANES,
+  RETIRED_LANE_PREFIXES,
+  isRetiredLane,
+  loadLatestLaneHealth,
+} from "../src/lane-health.ts";
+
+/** Each retired lane, and the producer whose deletion justifies retiring it. */
+const PRODUCERS: Record<string, string> = {
+  "neon-parity": "src/neon-parity.ts",
+  "neon-mirror-lag": "src/neon-mirror-lag.ts",
+  "neon:backfill:": "src/neon-backfill.ts",
+};
+
+function fakeDb(rows: Record<string, unknown>[]) {
+  return {
+    prepare: () => ({
+      bind: () => ({ run: async () => ({}) }),
+      all: async () => ({ results: rows }),
+    }),
+  };
+}
+
+const row = (lane: string, verdict = "stale", checked_at = 1) => ({
+  lane,
+  verdict,
+  age_ms: 1,
+  detail: "d",
+  checked_at,
+});
+
+describe("retired lanes (#10222)", () => {
+  test("every retired name is justified by a producer that no longer exists", () => {
+    const names = [...RETIRED_LANES, ...RETIRED_LANE_PREFIXES];
+    assert.ok(names.length > 0, "the list is not empty -- otherwise vacuous");
+    for (const name of names) {
+      const producer = PRODUCERS[name];
+      assert.ok(producer, `${name} names the producer it retires`);
+      assert.equal(
+        existsSync(new URL(`../${producer}`, import.meta.url)),
+        false,
+        `${producer} is gone -- ${name} may only be retired because nothing writes it`,
+      );
+    }
+  });
+
+  test("isRetiredLane matches the families and nothing else", () => {
+    assert.equal(isRetiredLane("neon-parity"), true);
+    assert.equal(isRetiredLane("neon-mirror-lag"), true);
+    assert.equal(isRetiredLane("neon:backfill:tao_usd_index"), true);
+    assert.equal(isRetiredLane("neon:backfill:surface_checks"), true);
+    // The live `neon:<lane>` mirrors share a prefix with the retired backfills and
+    // must NOT be caught: src/neon-write.ts builds them as `neon:${lane}`, and they
+    // are the only writers left for those tables.
+    assert.equal(isRetiredLane("neon:hotkey-alpha"), false);
+    assert.equal(isRetiredLane("neon:neurons-prune"), false);
+    assert.equal(isRetiredLane("neon:backfill"), false);
+    assert.equal(isRetiredLane("neon-parity-2"), false);
+    assert.equal(isRetiredLane("table-freshness"), false);
+  });
+
+  test("the serving read drops retired lanes and keeps live ones", async () => {
+    const lanes = await loadLatestLaneHealth(
+      fakeDb([
+        row("neon-parity"),
+        row("neon-mirror-lag", "ok"),
+        row("neon:backfill:tao_usd_index"),
+        row("neon:hotkey-alpha"),
+        row("table-freshness", "ok"),
+      ]) as unknown as Parameters<typeof loadLatestLaneHealth>[0],
+    );
+    assert.deepEqual(Object.keys(lanes).sort(), [
+      "neon:hotkey-alpha",
+      "table-freshness",
+    ]);
+    // Not a blanket mute: a live lane's `stale` still arrives, which is what makes
+    // dropping the retired ones something other than suppression.
+    assert.equal(lanes["neon:hotkey-alpha"]?.verdict, "stale");
+  });
+
+  test("a retired lane cannot make stale_lane_count non-zero on its own", async () => {
+    const lanes = await loadLatestLaneHealth(
+      fakeDb([
+        row("neon-parity"),
+        row("neon:backfill:surface_checks"),
+      ]) as unknown as Parameters<typeof loadLatestLaneHealth>[0],
+    );
+    assert.deepEqual(lanes, {});
+  });
+});


### PR DESCRIPTION
`loadLatestLaneHealth` takes the newest row per lane with **no liveness bound**. That is correct while a producer exists — the newest thing a lane said *is* the current truth. It inverts the moment the producer is deleted, because no future tick can revise the row.

#10167 removed the reconciler, the parity sweep and the mirror-lag watchdog. Correctly — Neon is the sole store. Their rows stayed:

```
neon-parity | stale | 5.9h | chain_detail_chain_events -169126, chain_detail_account_events -126582, …
```

`neon-parity` counted Neon against **D1, which was deleted the next day**. Those deficits are the size of the store, they only grow, and no pass will ever revise them. `GET /api/v1/self-health` and `get_self_health` both report it, so `stale_lane_count` could not return to zero. A count that can never reach zero teaches everyone to ignore the number — the same failure as an unlabelled empty payload, one level up.

## What is retired

| lane | producer, deleted in #10167 |
|---|---|
| `neon-parity` | `src/neon-parity.ts` |
| `neon-mirror-lag` | `src/neon-mirror-lag.ts` |
| `neon:backfill:<table>` (24 rows) | `src/neon-backfill.ts` |

The backfill family is matched by **prefix**, not by listing 24 names: it was one lane per table named at runtime from `NEON_BACKFILL_LANES`, and both the flag and the module are gone, so a table nobody ever named cannot come back. One of those rows is `neon:backfill:tao_usd_index`, `verdict: stale` with detail `"0 date(s) / 0 row(s) still behind"` — a verdict contradicting its own detail, which is what a frozen last word looks like.

## This is not suppression, and the design says so structurally

An "ignore these lanes" list is exactly the shape that rots into suppression: someone adds a noisy lane, its producer keeps running, and a real alarm is gone.

So every entry **names the file whose deletion justifies it**, and `tests/lane-health-retired.test.ts` asserts that file is still absent:

```
AssertionError: src/neon-parity.ts is gone -- neon-parity may only be retired
because nothing writes it
```

(verified by restoring `src/neon-parity.ts` and watching the test fail). A lane cannot be quietly retired while its producer lives, and resurrecting a producer fails CI until the name is removed.

The tests also pin the two edges that would make this dangerous:

- **A live lane's `stale` still arrives** — `neon:hotkey-alpha` with `verdict: "stale"` survives the filter. Without this the change would be a blanket mute.
- **The live `neon:<lane>` mirrors are not caught by the backfill prefix.** They share four characters with it and `src/neon-write.ts` builds them as `` `neon:${lane}` ``. They are the only writers left for those tables, so catching them would blind the estate to its own producers.
- `isRetiredLane("neon:backfill")` and `isRetiredLane("neon-parity-2")` are both false — the prefix does not overshoot.

Filtering happens in the reader rather than in the SQL so the rule is one testable predicate shared by every caller, and so a row that outlives its deletion is still visible to anyone querying `lane_health` directly.

## Not in this PR

The issue's option 1 — a **per-lane liveness bound** derived from each lane's own observed cadence — is the general fix and is genuinely harder: cadences here differ by more than 100x (`chain-detail` writes every ~30s, `neon:hotkey-alpha` bursts roughly every 14h), so a single global cutoff would either mute real alarms or fail to catch this one. `src/lane-alarm.ts` already has the machinery (`laneCadenceMs`, `laneSilenceThresholdMs`) on the alarm path; wiring the same idea into the serving read deserves its own change and its own thought about what verdict a silent-but-live lane should carry. Filed as #10232 rather than bolted on here.

The orphan rows themselves are deleted separately, after this merges — the filter is what makes the fix hold regardless.

## Verification

- 4 new tests; the producer-absence gate proven to fail
- `lane-alarm`, `lane-health`, `lane-health-store`, `poller-lane-health`, `self-health`, `self-health-cold-tier`, `self-health-mcp`, `self-health-prober` — 9 files, 153 tests, all pass
- `npx tsc --noEmit`, `npm run lint`, `npx prettier --check .` clean

Closes #10222