### PR TITLE
fix(api): three serving loaders throw on Postgres and publish an empty card

### DIFF
--- a/src/analytics-live.ts
+++ b/src/analytics-live.ts
@@ -334,7 +334,7 @@ export async function loadSubnetUptime(
             SUM(samples) AS samples,
             SUM(ok_count) AS ok_count,
             CASE
-              WHEN SUM(samples) > 0 THEN ROUND(CAST(SUM(ok_count) AS REAL) / SUM(samples), 4)
+              WHEN SUM(samples) > 0 THEN ROUND(CAST(CAST(SUM(ok_count) AS REAL) / SUM(samples) AS NUMERIC), 4)
               ELSE NULL
             END AS uptime_ratio,
             ${dailyLatencyColumns({ roundedAvg: true })},

--- a/src/health-sql.ts
+++ b/src/health-sql.ts
@@ -90,8 +90,27 @@ export function latencyStatColumns({
   // one whenever q*N was an integer (e.g. N=100 → p50/p95/p99 picked ranks
   // 51/96/100 instead of 50/95/99).
   const pick = (q: number, name: string): string => {
-    const pos = `${q} * lat_cnt`;
-    return `MAX(CASE WHEN rn = CAST(${pos} AS INTEGER) + (${pos} > CAST(${pos} AS INTEGER)) THEN latency_ms END) AS ${name}`;
+    // CEIL, not trunc-plus-carry. The carry form was written for SQLite, which
+    // had no ceil, and it does not survive Postgres -- twice over. `CAST(x AS
+    // INTEGER)` TRUNCATES in SQLite and ROUNDS in Postgres, and `(a > b)` is a
+    // boolean Postgres will not add to an integer.
+    //
+    // The second half errors, which is how this was found: every serving read
+    // of surface_checks threw `operator does not exist: integer + boolean`,
+    // d1All degraded the failure to zero rows, and /uptime, /health/percentiles
+    // and the per-subnet /health/trends each published an empty card over a
+    // table with rows in it (#10200).
+    //
+    // The FIRST half would not have errored. On its own the rounding CAST
+    // returns a confidently wrong percentile -- which is the more dangerous
+    // half, and the reason this is one expression rather than a patch to the
+    // comparison.
+    //
+    // Both engines have had ceil since SQLite 3.35, and it is what the carry
+    // form was always spelling. src/observations-neon.ts made the same move for
+    // the rollup path and verified the two agree at lat_cnt = 1, 3, 7, 20 and
+    // 100 for all three quantiles.
+    return `MAX(CASE WHEN rn = CAST(CEIL(${q} * lat_cnt) AS INTEGER) THEN latency_ms END) AS ${name}`;
   };
   const columns = [
     `MAX(lat_cnt) AS latency_samples`,

--- a/tests/health-sql.test.ts
+++ b/tests/health-sql.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
 import { describe, test } from "vitest";
 import {
   OK_COUNT,
@@ -88,24 +89,67 @@ describe("health-sql latency builders", () => {
     assert.ok(!cols.includes("CAST(ROUND("));
   });
 
-  test("latencyStatColumns picks percentiles by nearest rank (ceil), not floor+1", () => {
+  test("latencyStatColumns picks percentiles by nearest rank, EXECUTED", () => {
+    // ASSERTED BY RUNNING IT, not by matching the spelling. The previous
+    // version of this test pinned the exact string
+    // `CAST(q*lat_cnt AS INTEGER) + (q*lat_cnt > CAST(...))`, which is a
+    // restatement of the implementation: it passed for a SQLite-only
+    // expression that threw `operator does not exist: integer + boolean` on
+    // every Postgres read, and it would have blocked the fix (#10200).
+    //
+    // What matters is the rank each quantile selects. node:sqlite evaluates it
+    // here; tests/analytics-live-sqlite.test.ts runs the whole loader.
     const cols = latencyStatColumns();
-    // ceil(q*N): truncate toward zero, then add 1 only on a fractional part.
-    // The old floor(q*N)+1 overshot by one whenever q*N was an integer (the
-    // common case, e.g. N=100 → p50/p95/p99 hit ranks 51/96/100, not 50/95/99).
-    for (const q of ["0.5", "0.95", "0.99"]) {
-      assert.ok(
-        cols.includes(
-          `CAST(${q} * lat_cnt AS INTEGER) + (${q} * lat_cnt > CAST(${q} * lat_cnt AS INTEGER))`,
-        ),
-        `percentile ${q} must select the nearest-rank (ceil) position`,
+    for (const p of ["AS p50", "AS p95", "AS p99"]) {
+      assert.ok(cols.includes(p), p);
+    }
+    const db = new DatabaseSync(":memory:");
+    const rank = (q: number, n: number): number => {
+      const expr = cols
+        .split("\n")
+        .map((line) => line.trim())
+        .find(
+          (line) =>
+            line.startsWith(`MAX(CASE WHEN rn = `) &&
+            line.includes(`${q} * lat_cnt`),
+        );
+      assert.ok(expr, `an expression exists for q=${q}`);
+      const position = expr
+        .replace("MAX(CASE WHEN rn = ", "")
+        .replace(/ THEN latency_ms END\) AS \w+,?$/, "")
+        .replaceAll("lat_cnt", String(n));
+      const row = db.prepare(`SELECT ${position} AS pos`).get() as {
+        pos: number;
+      };
+      return row.pos;
+    };
+    // ceil(q * N). The floor(q*N)+1 form this replaced overshot by one whenever
+    // q*N was an integer -- N=100 picked ranks 51/96/100 instead of 50/95/99.
+    const cases: [number, number, number][] = [
+      [0.5, 1, 1],
+      [0.95, 1, 1],
+      [0.99, 1, 1],
+      [0.5, 3, 2],
+      [0.95, 3, 3],
+      [0.99, 3, 3],
+      [0.5, 7, 4],
+      [0.95, 7, 7],
+      [0.99, 7, 7],
+      [0.5, 20, 10],
+      [0.95, 20, 19],
+      [0.99, 20, 20],
+      [0.5, 100, 50],
+      [0.95, 100, 95],
+      [0.99, 100, 99],
+    ];
+    for (const [q, n, expected] of cases) {
+      assert.equal(
+        rank(q, n),
+        expected,
+        `p${q * 100} of ${n} rows is rank ${expected}`,
       );
     }
-    // The off-by-one `floor(q*N) + 1` form must be gone.
-    assert.ok(
-      !/CAST\([0-9.]+ \* lat_cnt AS INTEGER\) \+ 1\b/.test(cols),
-      "must not use the floor+1 rank that overshoots at integer boundaries",
-    );
+    db.close();
   });
 
   test("latencyStatColumns honours roundedAvg and includeMinMax options", () => {

--- a/tests/no-sqlite-only-sql.test.ts
+++ b/tests/no-sqlite-only-sql.test.ts
@@ -72,6 +72,33 @@ const SQLITE_ONLY: [RegExp, string][] = [
     "json_extract() — Postgres uses ->> / jsonb_extract_path_text",
   ],
   [/\bjson_each\s*\(/i, "json_each() — Postgres uses jsonb_array_elements"],
+  // BOOLEAN ARITHMETIC. SQLite has no boolean type, so `n + (a > b)` adds 1 or
+  // 0; Postgres answers `operator does not exist: integer + boolean`.
+  //
+  // This is how src/health-sql.ts's percentile picker shipped a SQLite-only
+  // expression into every serving read of surface_checks (#10200):
+  // `CAST(q*n AS INTEGER) + (q*n > CAST(q*n AS INTEGER))` -- SQLite's ceil,
+  // written as trunc-plus-carry because SQLite had no ceil. `d1All` degrades a
+  // read failure to zero rows, so /uptime, /health/percentiles and the
+  // per-subnet /health/trends each published an empty card over a table that
+  // had rows in it. Both engines have ceil(); use it.
+  [
+    // Spaces around the operator, and never a shift: `(high >>> 0)` is a JS
+    // expression that lives in a string literal in this tree, and an
+    // unanchored `[<>]` matched it.
+    /[)\w ]\+ \((?:[^()\n]|\([^()\n]*\))*?\s(?<![<>])(?:<=|>=|<>|!=|<|>)(?![<>=])\s(?:[^()\n]|\([^()\n]*\))*?\)/,
+    "arithmetic on a comparison — SQLite treats a boolean as 0/1, Postgres does not; use CASE WHEN ... THEN 1 ELSE 0 END, or ceil()/floor() where that is what it spells",
+  ],
+  // TWO-ARGUMENT ROUND over a float. Postgres has round(numeric, int) and
+  // round(double precision), but NOT round(double precision, int). The same
+  // #10200 sweep found `ROUND(CAST(SUM(ok_count) AS REAL) / SUM(samples), 4)`
+  // in src/analytics-live.ts, one line from the boolean above and failing the
+  // same silent way. Cast the value to NUMERIC first; SQLite is happy either
+  // way. Anything already naming NUMERIC is exempt.
+  [
+    /\bROUND\s*\((?!(?:[^()\n]|\((?:[^()\n]|\([^()\n]*\))*\))*?(?:NUMERIC|::numeric))(?:[^()\n]|\((?:[^()\n]|\([^()\n]*\))*\))*?,\s*\d+\s*\)/i,
+    "ROUND(x, n) on a non-numeric — Postgres has no round(double precision, integer); CAST the value AS NUMERIC first",
+  ],
 ];
 
 /** SQL lives in string literals; the prose around it does not. Scanning raw


### PR DESCRIPTION
`GET /api/v1/subnets/1/uptime` and `/health/percentiles` return `surfaces: []` for every subnet, while `/api/v1/health/trends` returns **123 subnets** from the same tables. Probed on production just now — still live.

It is not a missing prober and not missing rows. `surface_uptime_daily` has **69 rows for netuid 1** inside the window.

## The queries throw

I captured every statement the `src/analytics-live.ts` loaders issue and ran each against production Neon:

```
FAIL  loadSubnetUptime        function round(double precision, integer) does not exist
FAIL  loadSubnetPercentiles   operator does not exist: integer + boolean
FAIL  loadSubnetHealthTrends  operator does not exist: integer + boolean
OK    loadSubnetTrajectory
OK    loadSubnetIncidents
OK    loadGlobalIncidents
OK    loadGlobalIncidentRows
OK    loadRegistryLeaderboards
OK    loadCompareSubnets

3 failing statement(s) of 11
```

`d1All` degrades a read failure to zero rows, so each route publishes a **schema-valid empty card over a table with data in it** — the failure mode this repo already names for the tier cascade, one level down.

Blast radius is wider than REST: these loaders are also reached from `src/graphql.ts` and `src/mcp-server.ts`.

## Both spellings are SQLite idioms

| expression | why Postgres refuses |
|---|---|
| `ROUND(x, 4)` | Postgres has `round(numeric, int)` and `round(double precision)` — but no `round(double precision, int)` |
| `CAST(q*n AS INTEGER) + (q*n > CAST(q*n AS INTEGER))` | SQLite's ceil, written as trunc-plus-carry because SQLite had no `ceil`. Postgres will not add a boolean to an integer |

`src/observations-neon.ts` documents **both of these, precisely, in its header** — and fixed them for the rollup path. `src/health-sql.ts` and `src/analytics-live.ts` feed the *serving* path and were never updated. The knowledge was in the tree; it just never reached the second copy.

### Which half errors is the interesting part

The carry expression breaks **twice** on Postgres: the `CAST` rounds instead of truncating, *and* the boolean will not add. Only the second one throws.

The first would have returned a **confidently wrong percentile** — no error, no empty card, just a p95 off by one rank. That is why this replaces the whole expression with `ceil()` rather than patching the addition.

`ceil(q * lat_cnt)` is verified equivalent to the carry form at `lat_cnt` = 1, 3, 7, 20 and 100 for all three quantiles, on Postgres **and** in `node:sqlite` — 15 of 15 agree.

## The test that let it through

`tests/health-sql.test.ts` asserted the **SQL string**:

```ts
assert.ok(cols.includes(`CAST(${q} * lat_cnt AS INTEGER) + (${q} * lat_cnt > CAST(...))`))
```

That is a restatement of the implementation. It passed for an expression that threw on every Postgres read, and it would have *blocked* this fix. It now builds the expression, executes it in `node:sqlite`, and checks the rank each quantile selects across all 15 cases.

## The gate

`tests/no-sqlite-only-sql.test.ts` gains two rules — arithmetic on a comparison, and two-argument `ROUND` over a non-numeric. **Each verified to fail on the real line before it was fixed:**

```
src/health-sql.ts: + (${pos} > CAST(${pos} AS INTEGER)) — arithmetic on a comparison …
src/analytics-live.ts: ROUND(CAST(SUM(ok_count) AS REAL) / SUM(samples), 4) — ROUND(x, n) on a non-numeric …
```

Both are constrained to a single line and tolerate two levels of paren nesting: earlier drafts false-positived on `(high >>> 0)` (a JS shift in a string literal) and on prose spanning two template lines. The clean tree passes.

## Verification

- 11 captured statements re-run against Neon after the fix: **0 failing**
- the uptime query now returns rows for netuid 1 (`77 samples, ratio 1.0000`, 2026-08-08)
- 185 health/analytics/surface/observation/incident/trend suites — **2,389 tests, all pass**
- `npx tsc --noEmit`, `npm run lint`, `npx prettier --check .` clean

This is the concrete case #10227 was filed for: these loaders are execution-tested on SQLite, where both expressions work, and served from Postgres, where both fail.

Closes #10200