### PR TITLE
feat(registry): the full resync the incremental lane relies on, as a Worker lane

### DIFF
--- a/src/registry-resync-lane.ts
+++ b/src/registry-resync-lane.ts
@@ -1,0 +1,333 @@
+// The full registry resync, as a Worker lane (#10236).
+//
+// ## What was missing
+//
+// src/registry-sync-lane.ts is INCREMENTAL by design. It keeps a head sha in
+// KV, compares it to main, and syncs the registry files that changed in
+// between. Its own comment names the thing it deliberately does not do:
+//
+//   FIRST RUN HAS NO BASE, and must not guess one. [...] recording the head
+//   and syncing from the NEXT commit costs one merge of latency once, and is
+//   the only option that cannot be wrong. The scheduled full resync is what
+//   closes any pre-existing gap.
+//
+// That reasoning is right and the second half did not exist. The "scheduled
+// full resync" was scripts/backfill-registry-postgres.ts, invoked from GitHub
+// Actions -- and no workflow calls it, which is the same discovery #9779 made
+// about the incremental half. So the cursor initialised on 2026-08-08 02:25,
+// the three registry merges from 08-07 fell before it, and `subnets`,
+// `providers` and `surfaces` sat 145-160h stale with `registry-sync` reporting
+// `ok: no registry files changed` on every tick. True for the window it looks
+// at; the gap was outside that window and nothing else was looking.
+//
+// ## Why this is a reconciler, not a backfill
+//
+// It reruns forever rather than once. The incremental lane cannot lose a
+// change while it works -- its cursor only advances on a successful POST -- so
+// a one-off would close today's gap and leave no cover for the next time the
+// lane is unbound, unscheduled, or replaced. A resync that runs on its own
+// schedule is the thing that makes those failures self-healing instead of
+// permanent.
+//
+// ## Paging, and why the pass is pinned to one commit
+//
+// ~265 files today, one GitHub request each. That is fine for subrequest
+// limits and slow for one invocation, so a pass spans several ticks with its
+// position in KV.
+//
+// The head sha is stored WITH the offset. A pass that re-resolved head each
+// tick would mix files from different commits, and a merge landing mid-pass
+// would be written half-old-half-new with no record of which. Pinning means a
+// pass always describes one commit; the incremental lane carries anything
+// newer, and the next pass picks it up.
+import {
+  buildRegistrySyncPayload,
+  isEmptyPayload,
+  isRegistryPath,
+  type ResolvedRegistryFile,
+  type Row,
+} from "./registry-sync-payload.ts";
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { laneHealthStore } from "./lane-health-store.ts";
+import { REPO, fileAt, ghJson } from "./registry-sync-lane.ts";
+
+export const REGISTRY_RESYNC_LANE = "registry-resync";
+const STATE_KEY = "registry-resync:state";
+const COMPLETED_KEY = "registry-resync:last-complete";
+
+/** Files resolved per tick. One GitHub request each; ~265 files is three
+ * ticks. Small enough that a tick stays well inside the invocation budget,
+ * large enough that a pass finishes the same day it starts. */
+export const RESYNC_PAGE_SIZE = 100;
+
+/**
+ * How long after a completed pass the next one may start.
+ *
+ * A reconciler over a git-backed registry has nothing to gain from running
+ * more often than the registry changes, and the incremental lane already
+ * carries every merge within a minute. 20h rather than 24 so the pass does not
+ * drift later each day and eventually skip one.
+ */
+export const RESYNC_MIN_INTERVAL_MS = 20 * 60 * 60 * 1000;
+
+/** The two directories the registry lives in, in the order a pass walks them. */
+const REGISTRY_DIRS = ["registry/subnets", "registry/providers"] as const;
+
+export interface RegistryResyncResult {
+  ok: boolean;
+  reason?: string;
+  detail?: string;
+  head?: string;
+  /** Files resolved this tick. */
+  files?: number;
+  /** Position after this tick, and the pass total. */
+  offset?: number;
+  total?: number;
+  /** True on the tick that finishes a pass. */
+  complete?: boolean;
+  written?: Record<string, unknown>;
+}
+
+interface KvLike {
+  get(key: string): Promise<string | null>;
+  put(key: string, value: string): Promise<void>;
+  delete?(key: string): Promise<void>;
+}
+
+interface ServiceLike {
+  fetch(request: Request): Promise<Response>;
+}
+
+interface PassState {
+  head: string;
+  paths: string[];
+  offset: number;
+}
+
+export interface RegistryResyncDeps {
+  kv?: KvLike | null;
+  registrySyncApi?: ServiceLike | null;
+  laneHealthDb?: LaneHealthDb | null;
+  now?: () => number;
+}
+
+/** Every registry file at `ref`, both directories, sorted for a stable pass. */
+async function listRegistryPaths(
+  env: Record<string, unknown>,
+  ref: string,
+): Promise<string[] | null> {
+  const paths: string[] = [];
+  for (const dir of REGISTRY_DIRS) {
+    const listing = await ghJson(
+      env,
+      `/repos/${REPO}/contents/${encodeURI(dir)}?ref=${ref}`,
+    );
+    // A directory that cannot be listed fails the PASS rather than being
+    // treated as empty. An empty listing and an unreachable one are the same
+    // shape here, and the second one would delete every row the first would
+    // have written.
+    if (!Array.isArray(listing)) return null;
+    for (const entry of listing as { path?: string; type?: string }[]) {
+      if (entry?.type !== "file") continue;
+      if (typeof entry.path === "string" && isRegistryPath(entry.path)) {
+        paths.push(entry.path);
+      }
+    }
+  }
+  return paths.sort();
+}
+
+/**
+ * One tick of the resync.
+ *
+ * Returns a summary rather than throwing, matching the rest of the cron
+ * family: a tick that cannot run is one missed report, not an outage.
+ */
+export async function runRegistryResyncLane(
+  env: unknown,
+  deps: RegistryResyncDeps = {},
+): Promise<RegistryResyncResult> {
+  const result = await runResyncTick(env, deps);
+  const bag = (env ?? {}) as Record<string, unknown>;
+  await recordLaneVerdict(laneHealthStore(bag, deps.laneHealthDb), {
+    lane: REGISTRY_RESYNC_LANE,
+    verdict: result.ok ? "ok" : "stale",
+    age_ms: null,
+    detail: resyncDetail(result),
+    checked_at: (deps.now ?? Date.now)(),
+  });
+  return result;
+}
+
+/**
+ * One line carrying COUNTS, not just an outcome.
+ *
+ * "resynced 0 of 3444 surfaces" must not read the same as a real pass, which
+ * is the failure #10236 asks this lane to make impossible for itself.
+ */
+export function resyncDetail(result: RegistryResyncResult): string {
+  if (!result.ok) {
+    return result.detail
+      ? `${result.reason}: ${result.detail}`
+      : `${result.reason}`;
+  }
+  if (result.reason && result.files === undefined) return result.reason;
+  const w = result.written ?? {};
+  const position = `${result.offset ?? 0}/${result.total ?? 0}`;
+  const counts =
+    `${result.files ?? 0} file(s): ${w.subnets_written ?? 0} subnet(s), ` +
+    `${w.surfaces_written ?? 0} surface(s), ${w.surfaces_deleted ?? 0} deleted`;
+  return result.complete
+    ? `pass complete at ${position} -- ${counts}`
+    : `${position} -- ${counts}`;
+}
+
+async function runResyncTick(
+  env: unknown,
+  deps: RegistryResyncDeps,
+): Promise<RegistryResyncResult> {
+  const bag = (env ?? {}) as Record<string, unknown>;
+  const kv = deps.kv ?? (bag.METAGRAPH_CONTROL as KvLike | undefined);
+  const api =
+    deps.registrySyncApi ?? (bag.REGISTRY_SYNC_API as ServiceLike | undefined);
+  const now = deps.now ?? Date.now;
+  if (!kv?.get) return { ok: false, reason: "kv unavailable" };
+  if (!api?.fetch)
+    return { ok: false, reason: "registry-sync binding unavailable" };
+  if (typeof bag.REGISTRY_SYNC_SECRET !== "string" || !bag.REGISTRY_SYNC_SECRET)
+    return { ok: false, reason: "registry sync secret not provisioned" };
+
+  let state = await readState(kv);
+  if (!state) {
+    // Between passes. Starting one is the only branch that consults the clock,
+    // so a pass ALREADY UNDER WAY always continues -- an interval check on
+    // every tick would strand a half-finished pass for a day.
+    // Read as a STRING first. `Number(null)` is 0, not NaN, so a
+    // Number()-then-isFinite check reads a never-run lane as "completed at the
+    // epoch" -- and with a real clock that is always more than the interval
+    // ago, which makes it due. It is only wrong under a fake clock, which is
+    // to say: it would have shipped green and only ever been wrong in
+    // production, on the very first tick, forever.
+    const raw = await kv.get(COMPLETED_KEY);
+    const last = raw === null || raw === "" ? null : Number(raw);
+    if (
+      last !== null &&
+      Number.isFinite(last) &&
+      now() - last < RESYNC_MIN_INTERVAL_MS
+    ) {
+      return { ok: true, reason: "not due" };
+    }
+    const headCommit = await ghJson(bag, `/repos/${REPO}/commits/main`);
+    const head = (headCommit as { sha?: string } | null)?.sha;
+    if (typeof head !== "string" || !head)
+      return { ok: false, reason: "could not resolve head" };
+    const paths = await listRegistryPaths(bag, head);
+    if (!paths) return { ok: false, reason: "could not list registry", head };
+    if (paths.length === 0)
+      return { ok: false, reason: "registry listed as empty", head };
+    state = { head, paths, offset: 0 };
+  }
+
+  const page = state.paths.slice(state.offset, state.offset + RESYNC_PAGE_SIZE);
+  const resolved: ResolvedRegistryFile[] = [];
+  for (const path of page) {
+    const overlay = await fileAt(bag, path, state.head);
+    // A file that will not resolve is SKIPPED, not emitted as a deletion. It
+    // is present in the listing, so it exists at this commit; treating a failed
+    // read as "gone" would delete the subnet and everything referencing it.
+    if (overlay) resolved.push({ path, overlay: overlay as Row });
+  }
+
+  const payload = buildRegistrySyncPayload(resolved, state.head);
+  if (!isEmptyPayload(payload)) {
+    const response = await api.fetch(
+      new Request("https://registry-sync.internal/sync", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-registry-sync-token": bag.REGISTRY_SYNC_SECRET,
+        },
+        body: JSON.stringify(payload),
+      }),
+    );
+    if (!response.ok) {
+      // The offset does NOT advance, so the next tick retries this page. Same
+      // discipline as the incremental lane's cursor, and for the same reason:
+      // advancing past a rejected write turns one failed request into a
+      // permanent hole.
+      await writeState(kv, state);
+      return {
+        ok: false,
+        reason: "sync rejected",
+        detail: `status ${response.status}`,
+        head: state.head,
+        files: resolved.length,
+        offset: state.offset,
+        total: state.paths.length,
+      };
+    }
+    const written = (await response.json().catch(() => null)) as Record<
+      string,
+      unknown
+    > | null;
+    return finishTick(kv, state, page.length, resolved.length, now, written);
+  }
+  return finishTick(kv, state, page.length, resolved.length, now, null);
+}
+
+async function finishTick(
+  kv: KvLike,
+  state: PassState,
+  pageSize: number,
+  files: number,
+  now: () => number,
+  written: Record<string, unknown> | null,
+): Promise<RegistryResyncResult> {
+  const offset = state.offset + pageSize;
+  const complete = offset >= state.paths.length;
+  if (complete) {
+    await kv.put(COMPLETED_KEY, String(now()));
+    // Cleared BEFORE the completion is reported, and by overwrite when the KV
+    // binding has no delete: a state left behind would restart the finished
+    // pass from its last page on the very next tick, forever.
+    if (kv.delete) await kv.delete(STATE_KEY);
+    else await kv.put(STATE_KEY, "");
+  } else {
+    await writeState(kv, { ...state, offset });
+  }
+  return {
+    ok: true,
+    head: state.head,
+    files,
+    offset: Math.min(offset, state.paths.length),
+    total: state.paths.length,
+    ...(complete ? { complete: true } : {}),
+    ...(written ? { written } : {}),
+  };
+}
+
+async function readState(kv: KvLike): Promise<PassState | null> {
+  const raw = await kv.get(STATE_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<PassState>;
+    if (
+      typeof parsed?.head === "string" &&
+      parsed.head !== "" &&
+      Array.isArray(parsed.paths) &&
+      parsed.paths.length > 0 &&
+      Number.isInteger(parsed.offset) &&
+      (parsed.offset as number) >= 0
+    ) {
+      return parsed as PassState;
+    }
+  } catch {
+    // A malformed state is discarded rather than throwing: the next tick
+    // starts a clean pass, which is the recovery either way.
+  }
+  return null;
+}
+
+async function writeState(kv: KvLike, state: PassState): Promise<void> {
+  await kv.put(STATE_KEY, JSON.stringify(state));
+}

--- a/src/registry-sync-lane.ts
+++ b/src/registry-sync-lane.ts
@@ -33,7 +33,7 @@ import { laneHealthStore } from "./lane-health-store.ts";
 
 /** Where the registry lives. Not configurable: this lane exists to mirror THIS
  * repo's registry, and a wrong value would silently sync someone else's. */
-const REPO = "JSONbored/metagraphed";
+export const REPO = "JSONbored/metagraphed";
 const KV_KEY = "registry-sync:last-synced-sha";
 export const REGISTRY_SYNC_LANE = "registry-sync";
 const API = "https://api.github.com";
@@ -75,7 +75,7 @@ function githubHeaders(env: Record<string, unknown>): Record<string, string> {
   return headers;
 }
 
-async function ghJson(
+export async function ghJson(
   env: Record<string, unknown>,
   path: string,
 ): Promise<unknown | null> {
@@ -92,7 +92,7 @@ async function ghJson(
 }
 
 /** One file's parsed overlay at a commit, or null when it is not there. */
-async function fileAt(
+export async function fileAt(
   env: Record<string, unknown>,
   path: string,
   ref: string,

--- a/tests/registry-resync-lane.test.ts
+++ b/tests/registry-resync-lane.test.ts
@@ -1,0 +1,440 @@
+// The registry reconciler's pass, which is the part that can lose or repeat work.
+//
+// #10236: the incremental lane (src/registry-sync-lane.ts) only ever syncs
+// forward from its cursor, and its own comment leans on a "scheduled full
+// resync" that was a GitHub Actions script nothing calls. So `subnets`,
+// `providers` and `surfaces` sat 145-160h stale while `registry-sync` reported
+// `ok: no registry files changed` every tick -- true for the window it looks
+// at, and the gap was outside it.
+//
+// The assertions below are about the four properties that make a paged
+// reconciler either self-healing or a new source of damage: the offset must
+// not advance past a rejected write, a pass must stay pinned to one commit, a
+// finished pass must not immediately restart, and the verdict must carry
+// counts so "0 of 3444" cannot read as success.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+import {
+  REGISTRY_RESYNC_LANE,
+  RESYNC_MIN_INTERVAL_MS,
+  RESYNC_PAGE_SIZE,
+  resyncDetail,
+  runRegistryResyncLane,
+} from "../src/registry-resync-lane.ts";
+
+/** A KV double that records every key, so state and completion are inspectable. */
+function kv(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    get: async (k: string) => store.get(k) ?? null,
+    put: async (k: string, v: string) => {
+      store.set(k, v);
+    },
+    delete: async (k: string) => {
+      store.delete(k);
+    },
+    read: (k: string) => store.get(k) ?? null,
+    has: (k: string) => store.has(k),
+  };
+}
+
+const OK_API = {
+  fetch: async () =>
+    new Response(JSON.stringify({ subnets_written: 2, surfaces_written: 9 }), {
+      status: 200,
+    }),
+};
+const REJECTING_API = {
+  fetch: async () => new Response("nope", { status: 500 }),
+};
+
+/**
+ * A `fetch` double for the GitHub calls the lane makes.
+ *
+ * `subnets`/`providers` are the file NAMES each directory listing returns; the
+ * contents call answers with a base64 overlay for any of them.
+ */
+function githubFetch({
+  head = "aaa",
+  subnets = ["one", "two"],
+  providers = ["p1"],
+  listingFails = false,
+}: {
+  head?: string;
+  subnets?: string[];
+  providers?: string[];
+  listingFails?: boolean;
+} = {}) {
+  const calls: string[] = [];
+  const overlay = (name: string, netuid: number) =>
+    btoa(
+      JSON.stringify({
+        content: undefined,
+        slug: name,
+        netuid,
+        name,
+        surfaces: [],
+      }),
+    );
+  const handler = async (url: string | URL) => {
+    const path = String(url);
+    calls.push(path);
+    if (path.includes("/commits/main")) {
+      return new Response(JSON.stringify({ sha: head }), { status: 200 });
+    }
+    if (path.includes("/contents/registry/subnets?")) {
+      if (listingFails) return new Response("no", { status: 404 });
+      return new Response(
+        JSON.stringify(
+          subnets.map((n) => ({
+            path: `registry/subnets/${n}.json`,
+            type: "file",
+          })),
+        ),
+        { status: 200 },
+      );
+    }
+    if (path.includes("/contents/registry/providers?")) {
+      if (listingFails) return new Response("no", { status: 404 });
+      return new Response(
+        JSON.stringify(
+          providers.map((n) => ({
+            path: `registry/providers/${n}.json`,
+            type: "file",
+          })),
+        ),
+        { status: 200 },
+      );
+    }
+    if (path.includes("/contents/registry/")) {
+      const name = path.split("/").pop()!.split(".json")[0]!;
+      return new Response(
+        JSON.stringify({ content: overlay(name, 1), encoding: "base64" }),
+        { status: 200 },
+      );
+    }
+    return new Response("?", { status: 404 });
+  };
+  return { handler, calls };
+}
+
+/** Installs the GitHub double for one call, restoring afterwards. */
+async function withGithub<T>(
+  gh: { handler: (url: string | URL) => Promise<Response> },
+  run: () => Promise<T>,
+): Promise<T> {
+  const real = globalThis.fetch;
+  globalThis.fetch = ((url: string | URL) => gh.handler(url)) as typeof fetch;
+  try {
+    return await run();
+  } finally {
+    globalThis.fetch = real;
+  }
+}
+
+const ENV = { REGISTRY_SYNC_SECRET: "s" };
+
+describe("the reconciler refuses to run without its dependencies", () => {
+  test("no KV means no pass state, so no tick", async () => {
+    const r = await runRegistryResyncLane(ENV, {
+      kv: null,
+      registrySyncApi: OK_API,
+    });
+    assert.equal(r.ok, false);
+    assert.match(r.reason!, /kv/i);
+  });
+
+  test("no service binding means the write has nowhere to go", async () => {
+    const r = await runRegistryResyncLane(ENV, {
+      kv: kv(),
+      registrySyncApi: null,
+    });
+    assert.equal(r.ok, false);
+    assert.match(r.reason!, /registry-sync binding/i);
+  });
+
+  test("an unprovisioned secret is reported, not sent as undefined", async () => {
+    const r = await runRegistryResyncLane(
+      {},
+      { kv: kv(), registrySyncApi: OK_API },
+    );
+    assert.equal(r.ok, false);
+    assert.match(r.reason!, /secret/i);
+  });
+});
+
+describe("a pass", () => {
+  test("walks every registry file and reports counts", async () => {
+    const gh = githubFetch({ subnets: ["a", "b"], providers: ["p"] });
+    const store = kv();
+    const r = await withGithub(gh, () =>
+      runRegistryResyncLane(ENV, {
+        kv: store,
+        registrySyncApi: OK_API,
+        now: () => 1000,
+      }),
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.total, 3, "two subnets and one provider");
+    assert.equal(r.files, 3);
+    assert.equal(r.complete, true, "3 files fit in one page");
+    assert.equal(r.head, "aaa");
+    // The completion timestamp is what gates the next pass.
+    assert.equal(store.read("registry-resync:last-complete"), "1000");
+  });
+
+  test("a lane that has never completed a pass is due", async () => {
+    // `Number(null)` is 0, so a naive interval check reads an absent
+    // completion marker as "completed at the epoch" and, under any clock a
+    // test controls, as NOT due. That is a first-tick-only bug in production.
+    const gh = githubFetch({ subnets: ["a"], providers: [] });
+    const r = await withGithub(gh, () =>
+      runRegistryResyncLane(ENV, {
+        kv: kv(),
+        registrySyncApi: OK_API,
+        now: () => 1000,
+      }),
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, undefined, "no reason means it ran");
+    assert.equal(r.complete, true);
+  });
+
+  test("a finished pass does not immediately restart", async () => {
+    const gh = githubFetch();
+    const store = kv({ "registry-resync:last-complete": "1000" });
+    const r = await withGithub(gh, () =>
+      runRegistryResyncLane(ENV, {
+        kv: store,
+        registrySyncApi: OK_API,
+        now: () => 1000 + RESYNC_MIN_INTERVAL_MS - 1,
+      }),
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, "not due");
+    // Nothing was fetched -- the interval check comes before any GitHub call.
+    assert.deepEqual(gh.calls, []);
+  });
+
+  test("starts again once the interval has elapsed", async () => {
+    const gh = githubFetch();
+    const store = kv({ "registry-resync:last-complete": "1000" });
+    const r = await withGithub(gh, () =>
+      runRegistryResyncLane(ENV, {
+        kv: store,
+        registrySyncApi: OK_API,
+        now: () => 1000 + RESYNC_MIN_INTERVAL_MS,
+      }),
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, undefined);
+    assert.equal(r.complete, true);
+  });
+
+  test("spans ticks, and each tick continues where the last stopped", async () => {
+    const many = Array.from(
+      { length: RESYNC_PAGE_SIZE + 5 },
+      (_, i) => `s${i}`,
+    );
+    const gh = githubFetch({ subnets: many, providers: [] });
+    const store = kv();
+
+    const first = await withGithub(gh, () =>
+      runRegistryResyncLane(ENV, { kv: store, registrySyncApi: OK_API }),
+    );
+    assert.equal(first.ok, true);
+    assert.equal(first.complete, undefined, "not finished after one page");
+    assert.equal(first.offset, RESYNC_PAGE_SIZE);
+    assert.equal(first.total, RESYNC_PAGE_SIZE + 5);
+
+    const second = await withGithub(gh, () =>
+      runRegistryResyncLane(ENV, { kv: store, registrySyncApi: OK_API }),
+    );
+    assert.equal(second.complete, true);
+    assert.equal(second.offset, RESYNC_PAGE_SIZE + 5);
+    assert.equal(
+      second.files,
+      5,
+      "the second tick resolved only the remainder",
+    );
+  });
+
+  test("stays pinned to the commit it started on", async () => {
+    // A pass that re-resolved head each tick would mix files from two commits
+    // and write them as though they were one.
+    const many = Array.from(
+      { length: RESYNC_PAGE_SIZE + 1 },
+      (_, i) => `s${i}`,
+    );
+    const store = kv();
+    await withGithub(
+      githubFetch({ head: "aaa", subnets: many, providers: [] }),
+      () => runRegistryResyncLane(ENV, { kv: store, registrySyncApi: OK_API }),
+    );
+    // main moves on between ticks.
+    const moved = githubFetch({ head: "bbb", subnets: many, providers: [] });
+    const second = await withGithub(moved, () =>
+      runRegistryResyncLane(ENV, { kv: store, registrySyncApi: OK_API }),
+    );
+    assert.equal(
+      second.head,
+      "aaa",
+      "the pass finishes on its original commit",
+    );
+    assert.ok(
+      !moved.calls.some((c) => c.includes("/commits/main")),
+      "a tick continuing a pass does not resolve head at all",
+    );
+  });
+
+  test("a state left behind by a finished pass cannot restart it", async () => {
+    const gh = githubFetch({ subnets: ["a"], providers: [] });
+    const store = kv();
+    await withGithub(gh, () =>
+      runRegistryResyncLane(ENV, {
+        kv: store,
+        registrySyncApi: OK_API,
+        now: () => 5000,
+      }),
+    );
+    assert.equal(
+      store.has("registry-resync:state") &&
+        store.read("registry-resync:state") !== "",
+      false,
+      "the pass state is cleared on completion",
+    );
+  });
+});
+
+describe("failures do not advance the pass", () => {
+  test("a rejected write leaves the offset where it was", async () => {
+    const many = Array.from(
+      { length: RESYNC_PAGE_SIZE + 5 },
+      (_, i) => `s${i}`,
+    );
+    const gh = githubFetch({ subnets: many, providers: [] });
+    const store = kv();
+    const r = await withGithub(gh, () =>
+      runRegistryResyncLane(ENV, { kv: store, registrySyncApi: REJECTING_API }),
+    );
+    assert.equal(r.ok, false);
+    assert.match(r.reason!, /sync rejected/);
+    assert.equal(r.offset, 0, "still at the page that failed");
+    const state = JSON.parse(store.read("registry-resync:state")!) as {
+      offset: number;
+    };
+    assert.equal(state.offset, 0);
+
+    // The retry covers the same page, and can then proceed.
+    const retry = await withGithub(gh, () =>
+      runRegistryResyncLane(ENV, { kv: store, registrySyncApi: OK_API }),
+    );
+    assert.equal(retry.ok, true);
+    assert.equal(retry.offset, RESYNC_PAGE_SIZE);
+  });
+
+  test("an unlistable directory fails the pass rather than reading as empty", async () => {
+    // An empty listing and an unreachable one are the same shape, and treating
+    // the second as the first would offer up a payload that deletes rows.
+    const gh = githubFetch({ listingFails: true });
+    const store = kv();
+    const r = await withGithub(gh, () =>
+      runRegistryResyncLane(ENV, { kv: store, registrySyncApi: OK_API }),
+    );
+    assert.equal(r.ok, false);
+    assert.match(r.reason!, /could not list/i);
+    assert.equal(store.read("registry-resync:last-complete"), null);
+  });
+
+  test("an empty registry is a failure, not a completed pass", async () => {
+    const gh = githubFetch({ subnets: [], providers: [] });
+    const r = await withGithub(gh, () =>
+      runRegistryResyncLane(ENV, { kv: kv(), registrySyncApi: OK_API }),
+    );
+    assert.equal(r.ok, false);
+    assert.match(r.reason!, /empty/i);
+  });
+});
+
+describe("the verdict carries counts", () => {
+  test("a pass that wrote nothing does not read like one that wrote everything", () => {
+    const wrote = resyncDetail({
+      ok: true,
+      files: 100,
+      offset: 100,
+      total: 265,
+      written: {
+        subnets_written: 12,
+        surfaces_written: 340,
+        surfaces_deleted: 2,
+      },
+    });
+    const nothing = resyncDetail({
+      ok: true,
+      files: 0,
+      offset: 100,
+      total: 265,
+      written: {},
+    });
+    assert.notEqual(wrote, nothing);
+    assert.match(wrote, /100\/265/);
+    assert.match(wrote, /340 surface/);
+    assert.match(nothing, /0 file\(s\)/);
+    assert.match(nothing, /0 surface/);
+  });
+
+  test("completion says so, and says where it finished", () => {
+    const detail = resyncDetail({
+      ok: true,
+      complete: true,
+      files: 65,
+      offset: 265,
+      total: 265,
+      written: { subnets_written: 3 },
+    });
+    assert.match(detail, /pass complete at 265\/265/);
+  });
+
+  test("a failure names the reason and the status", () => {
+    const detail = resyncDetail({
+      ok: false,
+      reason: "sync rejected",
+      detail: "status 500",
+    });
+    assert.equal(detail, "sync rejected: status 500");
+  });
+
+  test("the lane name is stable", () => {
+    assert.equal(REGISTRY_RESYNC_LANE, "registry-resync");
+  });
+});
+
+describe("the lane is actually scheduled", () => {
+  test("wrangler.jsonc declares the trigger", async () => {
+    // Without this, the code merges, the dispatcher branch exists, every test
+    // here passes -- and the lane never runs, which is precisely how the thing
+    // it replaces went unnoticed for six days.
+    const { REGISTRY_RESYNC_CRON } = await import("../workers/config.ts");
+    const { readFileSync } = await import("node:fs");
+    const raw = readFileSync(
+      new URL("../wrangler.jsonc", import.meta.url),
+      "utf8",
+    );
+    assert.ok(
+      raw.includes(`"${REGISTRY_RESYNC_CRON}"`),
+      `wrangler.jsonc has no trigger for ${REGISTRY_RESYNC_CRON}`,
+    );
+  });
+
+  test("it does not share a minute with the incremental lane", async () => {
+    // Both talk to the same GitHub rate-limit window and the same sync route.
+    const { REGISTRY_RESYNC_CRON, REGISTRY_SYNC_CRON } =
+      await import("../workers/config.ts");
+    const minutes = (cron: string) => new Set(cron.split(" ")[0]!.split(","));
+    const resync = minutes(REGISTRY_RESYNC_CRON);
+    for (const m of minutes(REGISTRY_SYNC_CRON)) {
+      assert.ok(!resync.has(m), `both lanes fire at minute ${m}`);
+    }
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -424,6 +424,7 @@ import {
   runChainDetailStalenessWatchdog,
 } from "../src/chain-detail-staleness-watchdog.ts";
 import { runRegistrySyncLane } from "../src/registry-sync-lane.ts";
+import { runRegistryResyncLane } from "../src/registry-resync-lane.ts";
 import { pruneChainDetail } from "../src/chain-detail-prune.ts";
 import { runRpcUsageStalenessWatchdog } from "../src/rpc-usage-staleness-watchdog.ts";
 import { runTopHoldersStalenessWatchdog } from "../src/top-holders-staleness-watchdog.ts";
@@ -501,6 +502,7 @@ import {
   PROJECTION_STALENESS_WATCHDOG_CRON,
   VALIDATOR_NOMINATOR_COUNTS_STALENESS_WATCHDOG_CRON,
   CHAIN_DETAIL_PRUNE_CRON,
+  REGISTRY_RESYNC_CRON,
   REGISTRY_SYNC_CRON,
   CHAIN_CONCENTRATION_ROLLUP_CRON,
   CHAIN_DETAIL_STALENESS_WATCHDOG_CRON,
@@ -2127,6 +2129,7 @@ function cronLabel(cron: string): string {
     return "validator-nominator-counts-staleness-watchdog";
   if (cron === CHAIN_DETAIL_PRUNE_CRON) return "chain-detail-prune";
   if (cron === REGISTRY_SYNC_CRON) return "registry-sync";
+  if (cron === REGISTRY_RESYNC_CRON) return "registry-resync";
   if (cron === CHAIN_CONCENTRATION_ROLLUP_CRON)
     return "chain-concentration-rollup";
   if (cron === CHAIN_DETAIL_STALENESS_WATCHDOG_CRON)
@@ -2532,6 +2535,15 @@ async function dispatchScheduled(
     // surface_history froze on 2026-08-02 as a result. Returns a summary
     // rather than throwing, like the rest of the cron family.
     return runRegistrySyncLane(env);
+  }
+  if (cron === REGISTRY_RESYNC_CRON) {
+    // #10236: the incremental lane above only ever syncs forward from its
+    // cursor, and the "scheduled full resync" its comment relies on to close
+    // any pre-existing gap was one of the same dead GitHub Actions scripts.
+    // The registry tables sat 145-160h stale while `registry-sync` reported
+    // `ok` on every tick, because "no registry files changed" was true for the
+    // window it looks at and the gap was outside it.
+    return runRegistryResyncLane(env);
   }
   if (cron === CHAIN_DETAIL_PRUNE_CRON) {
     // #9208 retention. Returns a summary rather than throwing so the #8998

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -238,6 +238,19 @@ export const CHAIN_DETAIL_STALENESS_WATCHDOG_CRON = "14,29,44,59 * * * *";
 // Minutes 10/25/40/55 tick on none of the hourly crons in this file and stay
 // off the */5 raw-capture and */15 probe grids.
 export const REGISTRY_SYNC_CRON = "10,25,40,55 * * * *";
+/**
+ * The full-registry reconciler (#10236), hourly.
+ *
+ * Hourly is the TICK, not the pass. A pass walks ~265 files 100 at a time and
+ * then refuses to start another for 20h, so this is roughly three consecutive
+ * ticks once a day. The lane's own interval gate does the pacing, because the
+ * cadence that matters is "how stale may the registry tables get", not "how
+ * often does the cron fire".
+ *
+ * Offset from REGISTRY_SYNC_CRON's minutes so the two never contend for the
+ * same GitHub rate-limit window or the same sync route.
+ */
+export const REGISTRY_RESYNC_CRON = "35 * * * *";
 // #9464: the top-holders leaderboard's alarm. That lane had NO watchdog and no
 // producer -- `account_balances` died with the box and is not in the poller
 // Container's job set -- so the route served a one-shot pre-decommission

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -998,6 +998,13 @@
       "12,27,42,57 * * * *",
       // #9779 registry writer -- see REGISTRY_SYNC_CRON in workers/config.ts.
       "10,25,40,55 * * * *",
+      // #10236 registry RECONCILER -- see REGISTRY_RESYNC_CRON. Hourly is the
+      // tick, not the pass: the lane walks the whole registry 100 files at a
+      // time and then declines to start again for 20h, so this is ~three
+      // consecutive ticks once a day. It exists because the lane above only
+      // syncs forward from its cursor, and the full resync its own comment
+      // relies on was a GitHub Actions script nothing calls.
+      "35 * * * *",
       // 14,29,44,59 = the chain-detail staleness watchdog (#9208): alarms when
       // the live-follow decode lane stops advancing. Its own trigger rather
       // than a step inside the prune, so a prune failure cannot swallow the


### PR DESCRIPTION
`subnets`, `providers` and `surfaces` in Neon have not been updated in almost a week, while `registry-sync` reports `ok` on every tick. Both of those are true at once, which is why it went unnoticed.

```
subnets    rows=129   newest updated_at 144.9h ago
providers  rows=136   newest updated_at 160.3h ago
surfaces   rows=3444  newest updated_at 160.2h ago

registry-sync | 08-08 19:55 | ok | no registry files changed
```

## The half that did not exist

`src/registry-sync-lane.ts` is **incremental** by design, and its own comment names what it deliberately does not do:

> FIRST RUN HAS NO BASE, and must not guess one. […] recording the head and syncing from the NEXT commit costs one merge of latency once, and is the only option that cannot be wrong. **The scheduled full resync is what closes any pre-existing gap.**

The reasoning is right. The scheduled resync was `scripts/backfill-registry-postgres.ts`, invoked from GitHub Actions — and no workflow calls it, which is the *same discovery #9779 made about the incremental half*.

```
$ grep -rl "backfill-registry-postgres" .github/workflows/   → nothing
$ grep -n "backfill-registry" package.json                   → nothing
```

So the cursor initialised at **08-08 02:25**, the three registry merges from 08-07 (#9777, #9761, #9741) fell before it, and nothing could ever pick them up. `no registry files changed` is true for the window the lane looks at; the gap was outside it and nothing else was looking.

## What this adds

A reconciler, on its own cron, as a **Worker lane** — not an Action, which would make a second writer.

A pass walks every registry file at **one pinned commit**, `RESYNC_PAGE_SIZE` (100) at a time, carrying its position in KV, then declines to start another for 20h. Hourly is the *tick*, not the pass: roughly three consecutive ticks once a day.

It reruns forever rather than closing today's gap once. The incremental lane cannot lose a change while it is working — its cursor only advances on a successful POST — so a one-off would leave no cover for the next time that lane is unbound, unscheduled, or replaced.

## The properties that make a paged reconciler safe, each pinned

| property | why it matters |
|---|---|
| the offset does not advance past a rejected write | a failed page is retried, not skipped — the same discipline as the incremental cursor |
| a pass stays on the commit it started on | a merge landing mid-pass would otherwise be written half-old-half-new, with no record of which |
| an unlistable directory **fails** the pass | an empty listing and an unreachable one are the same shape, and treating the second as the first offers a payload that **deletes rows** |
| a file that will not resolve is skipped, not emitted as a deletion | it is in the listing, so it exists at this commit |
| the verdict carries **counts** | `0 file(s)` must not read like a pass that wrote everything |
| `wrangler.jsonc` declares the trigger | without this the code merges, the dispatcher branch exists, every test passes — and the lane never runs |

That last one is the failure this whole issue is: a lane that exists in the tree and not in production.

## A bug the tests found

`Number(null)` is **0**, not `NaN`. The interval gate read a never-run lane as "completed at the epoch" — which under a real clock is always more than 20h ago, so it is *due*, and the check only misbehaves under a controlled clock. It would have shipped green and been wrong exactly once, on the first tick in production, silently deferring the first pass. Fixed by reading the marker as a string first, with its own test.

## Verification

- 19 new tests
- `registry-sync-lane`, `registry-sync-api`, `registry-sync-neon`, `registry-sync-proxy`, `registry-sync-client` — 75 tests, pass
- 15 cron/registry/config/worker-types suites — 165 tests, pass
- `npx tsc --noEmit`, `npm run lint`, `npx prettier --check .` clean

## After merge

Workers Builds deploys the code but **not** cron triggers, so this needs `npx wrangler triggers deploy --config wrangler.jsonc` and then a check that the lane actually wrote a `lane_health` verdict — not that its absence went quiet. I will do both and confirm the three tables advance.

Two follow-ups the issue notes and this does not do: `table-freshness`'s 48h threshold for these three tables should be sized to the resync cadence rather than to merge frequency, and the two Action-era scripts should be deleted or marked, since both currently read as live infrastructure.

Closes #10236