### PR TITLE
test(neon): the dual-write flag must NAME every lane, not merely agree

### DIFF
--- a/tests/neon-flag-config-parity.test.ts
+++ b/tests/neon-flag-config-parity.test.ts
@@ -26,6 +26,19 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 
+import {
+  BLOCKS_HEAD_NEON_LANE,
+  RAW_CAPTURE_STATE_NEON_LANE,
+} from "../src/capture-state-neon-write.ts";
+import { CHAIN_DETAIL_NEON_LANE } from "../src/chain-detail-neon-write.ts";
+import {
+  ACCOUNT_IDENTITY_NEON_LANE,
+  SUBNET_HYPERPARAMS_NEON_LANE,
+} from "../src/hyperparams-identity-neon-write.ts";
+import { LEDGER_MIRROR_PLANS } from "../src/ledger-neon-write.ts";
+import { NEURONS_NEON_LANE } from "../src/neurons-neon-write.ts";
+import { NOMINATOR_POSITIONS_NEON_LANE } from "../src/nominator-positions-neon-write.ts";
+
 /** Every config whose Worker reaches a Neon-flag gate. Hand-listed, because
  * "which Workers have gated paths" is the thing being asserted -- deriving it
  * from which files happen to contain the flags would make a config that
@@ -86,6 +99,63 @@ describe("the Neon migration flags", () => {
       }
     });
   }
+
+  test("NEON_DUAL_WRITE_LANES names every lane that has a writer", () => {
+    // AGREEMENT IS NOT COVERAGE, and this flag is the one where the difference
+    // costs the most. Since D1 was deleted (#10179) the six *-neon-write.ts
+    // modules are the ONLY writers for their tables, and each one early-returns
+    // `{ attempted: false }` when its lane is absent from this flag. So a lane
+    // dropped from the list is not a slower path or a fallback -- it is that
+    // table's writes stopping, silently, with every config still agreeing and
+    // every test above still passing.
+    //
+    // Derived from the lane constants the writers themselves export, so a new
+    // producer cannot be added without this list forcing the decision. Hard-
+    // coding the names here would assert the flag against a copy of itself.
+    const writers = new Set<string>([
+      BLOCKS_HEAD_NEON_LANE,
+      RAW_CAPTURE_STATE_NEON_LANE,
+      CHAIN_DETAIL_NEON_LANE,
+      SUBNET_HYPERPARAMS_NEON_LANE,
+      ACCOUNT_IDENTITY_NEON_LANE,
+      NEURONS_NEON_LANE,
+      NOMINATOR_POSITIONS_NEON_LANE,
+      ...Object.keys(LEDGER_MIRROR_PLANS),
+    ]);
+    assert.ok(
+      writers.size > 0,
+      "the writer set is not empty -- otherwise vacuous",
+    );
+
+    for (const config of GATED_CONFIGS) {
+      const value = declared(config, "NEON_DUAL_WRITE_LANES");
+      assert.notEqual(
+        value,
+        null,
+        `${config} declares no NEON_DUAL_WRITE_LANES`,
+      );
+      const enabled = new Set(
+        value!
+          .split(",")
+          .map((lane) => lane.trim())
+          .filter(Boolean),
+      );
+      const missing = [...writers].filter((lane) => !enabled.has(lane)).sort();
+      assert.deepEqual(
+        missing,
+        [],
+        `${config} omits these lanes, so their ONLY writer is off there`,
+      );
+      // The other direction catches a typo: a name in the flag matching no
+      // writer is a lane someone believes is enabled and that nothing reads.
+      const unknown = [...enabled].filter((lane) => !writers.has(lane)).sort();
+      assert.deepEqual(
+        unknown,
+        [],
+        `${config} names lanes no writer answers to -- a typo here reads as enabled`,
+      );
+    }
+  });
 
   test("the flag list itself has not outgrown this test", () => {
     // A fifth flag added to the data config and not to this list would go


### PR DESCRIPTION
`NEON_DUAL_WRITE_LANES` no longer controls a mirror. Since D1 was deleted (#10179), the six `src/*-neon-write.ts` modules are the **only** writers their tables have, and each early-returns before touching the store when its lane is absent from that flag.

So a lane dropped from the list is not a slower path or a fallback. It is **that table's writes stopping** — no error, no verdict, and a `{ attempted: false }` the caller treats as normal.

## The hole

`tests/neon-flag-config-parity.test.ts` (#10084) already checks the flag is **declared** in all three gated configs and that they **agree**. Both matter — `vars` are per-config with no inheritance, which has cost several live defects.

Neither is coverage, and I verified that by editing the tree. Removing `hotkey-alpha` from **all three** configs leaves them in perfect agreement:

```
✓ NEON_DUAL_WRITE_LANES is declared in every config with a gated path
✓ NEON_DUAL_WRITE_LANES says the same thing in all of them
× NEON_DUAL_WRITE_LANES names every lane that has a writer
      AssertionError: wrangler.jsonc omits these lanes, so their ONLY writer is off there
```

Only the new assertion fires. And a consistent removal is the *likely* edit — a tidy-up of a flag whose name says "dual write" for a migration that is over.

## What it asserts

Every lane a writer answers to must appear in the flag, in every gated config. The writer set is **derived from the lane constants the modules export** — `BLOCKS_HEAD_NEON_LANE`, `RAW_CAPTURE_STATE_NEON_LANE`, `CHAIN_DETAIL_NEON_LANE`, `SUBNET_HYPERPARAMS_NEON_LANE`, `ACCOUNT_IDENTITY_NEON_LANE`, `NEURONS_NEON_LANE`, `NOMINATOR_POSITIONS_NEON_LANE`, plus the `LEDGER_MIRROR_PLANS` keys — not hardcoded. Hardcoding would assert the flag against a copy of itself, and a new producer would slip past silently.

Both directions, because they fail differently:

| edit | caught by |
|---|---|
| lane removed from the flag | `omits these lanes, so their ONLY writer is off there` |
| lane misspelled in the flag (`hotkey-alfa`) | `names lanes no writer answers to — a typo here reads as enabled` |

Each verified against the real configs before this was committed, and the assertion is guarded with `writers.size > 0` so an empty derivation cannot make it pass vacuously.

## Deliberately not in this PR

**Retiring the flag entirely** is the better end state — the writes should be unconditional, and the precondition that survives ("does this deployment have a store") is already answered separately by `HYPERDRIVE`, which every one of these helpers checks anyway.

That is a change to six write paths and ~20 test files, on the most critical path in the system, where a mistake is exactly the failure this gate exists to prevent. It deserves its own PR and its own verification. #10051 covers the wider scaffolding teardown; #10239 records the reasoning.

Until then, this makes the drift loud instead of silent.

## Verification

- 8 tests pass; the three failure modes above each reproduced and reverted
- `npx tsc --noEmit`, `npm run lint`, `npx prettier --check .` clean
- no production behaviour change — this PR adds assertions only

Closes #10239