### PR TITLE
fix(registry): report every count the sync route returns, not three of five

### DIFF
--- a/src/registry-resync-lane.ts
+++ b/src/registry-resync-lane.ts
@@ -46,6 +46,7 @@ import {
   isRegistryPath,
   type ResolvedRegistryFile,
   type Row,
+  summaryCounts,
 } from "./registry-sync-payload.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { laneHealthStore } from "./lane-health-store.ts";
@@ -172,11 +173,8 @@ export function resyncDetail(result: RegistryResyncResult): string {
       : `${result.reason}`;
   }
   if (result.reason && result.files === undefined) return result.reason;
-  const w = result.written ?? {};
   const position = `${result.offset ?? 0}/${result.total ?? 0}`;
-  const counts =
-    `${result.files ?? 0} file(s): ${w.subnets_written ?? 0} subnet(s), ` +
-    `${w.surfaces_written ?? 0} surface(s), ${w.surfaces_deleted ?? 0} deleted`;
+  const counts = `${result.files ?? 0} file(s): ${summaryCounts(result.written)}`;
   return result.complete
     ? `pass complete at ${position} -- ${counts}`
     : `${position} -- ${counts}`;

--- a/src/registry-sync-lane.ts
+++ b/src/registry-sync-lane.ts
@@ -26,6 +26,7 @@ import {
   buildRegistrySyncPayload,
   isEmptyPayload,
   isRegistryPath,
+  summaryCounts,
   type ResolvedRegistryFile,
   type Row,
 } from "./registry-sync-payload.ts";
@@ -162,11 +163,12 @@ function laneDetail(result: RegistrySyncLaneResult): string {
       : `${result.reason}`;
   }
   if (result.reason) return result.reason;
-  const w = result.written ?? {};
-  return (
-    `${result.files ?? 0} file(s): ${w.subnets_written ?? 0} subnet(s), ` +
-    `${w.surfaces_written ?? 0} surface(s), ${w.surfaces_deleted ?? 0} deleted`
-  );
+  // Every count the route returned. The hand-picked three this replaced named
+  // `subnets_written`, `surfaces_written` and `surfaces_deleted` and omitted
+  // `providers_written`, so a merge touching only registry/providers/* reported
+  // "0 subnet(s), 0 surface(s)" over a pass that had written all of them
+  // (caught on the resync lane's first real pass, #10236).
+  return `${result.files ?? 0} file(s): ${summaryCounts(result.written)}`;
 }
 
 async function runRegistrySyncTick(

--- a/src/registry-sync-payload.ts
+++ b/src/registry-sync-payload.ts
@@ -192,3 +192,32 @@ export function isEmptyPayload(payload: RegistrySyncPayload): boolean {
     payload.delete_subnets.length === 0
   );
 }
+
+/**
+ * Every count the sync route returned, not a chosen subset.
+ *
+ * THE FIRST REAL PASS CAUGHT THIS. Paths sort alphabetically, so page one is
+ * 100 of the 136 `registry/providers/*` files -- and the verdict read
+ *
+ *   ok :: 100/266 -- 100 file(s): 0 subnet(s), 0 surface(s), 0 deleted
+ *
+ * while `providers.updated_at` moved from 160.7h stale to 3.5 minutes. The
+ * lane had done exactly its job and its own report said it had written
+ * nothing, because the detail named three of `RegistrySyncSummary`'s five
+ * fields and `providers_written` was not one of them.
+ *
+ * That is the failure this verdict exists to prevent, one level up: a page
+ * that wrote everything reading like a page that wrote nothing. Enumerating
+ * the RESPONSE rather than a hand-picked list is the only version that cannot
+ * drift -- a count added to the route appears here without anyone remembering
+ * to add it, which is precisely what did not happen the first time.
+ */
+export function summaryCounts(
+  written: Record<string, unknown> | undefined,
+): string {
+  const entries = Object.entries(written ?? {})
+    .filter(([, value]) => typeof value === "number")
+    .sort(([a], [b]) => a.localeCompare(b));
+  if (entries.length === 0) return "no counts returned";
+  return entries.map(([key, value]) => `${key}=${value as number}`).join(", ");
+}

--- a/tests/registry-resync-lane.test.ts
+++ b/tests/registry-resync-lane.test.ts
@@ -358,6 +358,66 @@ describe("failures do not advance the pass", () => {
 });
 
 describe("the verdict carries counts", () => {
+  test("a providers-only page reports the providers it wrote", () => {
+    // THE FIRST REAL PASS. Paths sort alphabetically, so page one is 100 of the
+    // 136 registry/providers/* files. The verdict read
+    //   ok :: 100/266 -- 100 file(s): 0 subnet(s), 0 surface(s), 0 deleted
+    // while providers.updated_at moved from 160.7h stale to 3.5 minutes. The
+    // lane had done its job and its own report said it had written nothing,
+    // because the detail named three of RegistrySyncSummary's five fields.
+    //
+    // The earlier version of the test below could not catch that: it compared a
+    // "wrote something" case against a "wrote nothing" case using the SAME
+    // hand-picked field list the code used, so an omitted field was invisible
+    // to both.
+    const detail = resyncDetail({
+      ok: true,
+      files: 100,
+      offset: 100,
+      total: 266,
+      written: {
+        providers_written: 100,
+        subnets_written: 0,
+        surfaces_written: 0,
+        surfaces_deleted: 0,
+        subnets_deleted: 0,
+      },
+    });
+    assert.match(detail, /providers_written=100/);
+    assert.doesNotMatch(
+      detail,
+      /^(?!.*providers_written).*$/,
+      "the count that moved must appear",
+    );
+  });
+
+  test("every numeric count the route returns is reported", () => {
+    // Enumerated from the RESPONSE, so a count added to the sync route shows up
+    // without anyone remembering to add it here.
+    const detail = resyncDetail({
+      ok: true,
+      files: 1,
+      offset: 1,
+      total: 1,
+      written: { a_written: 1, b_written: 2, c_deleted: 3, note: "ignored" },
+    });
+    for (const key of ["a_written=1", "b_written=2", "c_deleted=3"]) {
+      assert.match(detail, new RegExp(key));
+    }
+    assert.doesNotMatch(detail, /note/, "non-numeric fields are not counts");
+  });
+
+  test("a response with no counts says so rather than implying zero", () => {
+    const detail = resyncDetail({
+      ok: true,
+      files: 40,
+      offset: 40,
+      total: 266,
+      written: {},
+    });
+    assert.match(detail, /no counts returned/);
+  });
+
   test("a pass that wrote nothing does not read like one that wrote everything", () => {
     const wrote = resyncDetail({
       ok: true,
@@ -375,13 +435,13 @@ describe("the verdict carries counts", () => {
       files: 0,
       offset: 100,
       total: 265,
-      written: {},
+      written: { subnets_written: 0, surfaces_written: 0, surfaces_deleted: 0 },
     });
     assert.notEqual(wrote, nothing);
     assert.match(wrote, /100\/265/);
-    assert.match(wrote, /340 surface/);
+    assert.match(wrote, /surfaces_written=340/);
     assert.match(nothing, /0 file\(s\)/);
-    assert.match(nothing, /0 surface/);
+    assert.match(nothing, /surfaces_written=0/);
   });
 
   test("completion says so, and says where it finished", () => {


### PR DESCRIPTION
The `registry-resync` lane (#10237) fired for the first time at 20:36Z and wrote:

```
registry-resync | ok | 100/266 -- 100 file(s): 0 subnet(s), 0 surface(s), 0 deleted
```

It had worked. `providers.updated_at` moved from **160.7h stale to 3.5 minutes** in that same tick.

Paths sort alphabetically, so page one of a pass is 100 of the 136 `registry/providers/*` files — an entirely providers-only page. `RegistrySyncSummary` carries five counts:

```
providers_written   subnets_written   surfaces_written   surfaces_deleted   subnets_deleted
```

Both lanes named three. `providers_written` was not one of them, so the only count that moved was the only one not reported.

`src/registry-sync-lane.ts` has had the same omission since #9779 — a merge touching only `registry/providers/*` has always reported `0 subnet(s), 0 surface(s)` there too. It just never had a pass that was *entirely* providers to make it obvious.

## The test asserted this exact property and passed

`tests/registry-resync-lane.test.ts` says, in as many words:

> a pass that wrote nothing does not read like one that wrote everything

It passed, because it compared a wrote-something case against a wrote-nothing case **using the same hand-picked field list the code used**. A field absent from both sides is invisible to a comparison between them.

That is the part worth carrying forward: a test that shares the implementation's *choice of fields* cannot detect a wrong choice of fields. It can only check the fields it was told about.

## Fix

`summaryCounts(written)` enumerates every **numeric key in the response**, sorted, in `src/registry-sync-payload.ts` — shared, so the two lanes do not have to import each other (the first version created a cycle between them).

```
100 file(s): providers_written=100, subnets_deleted=0, subnets_written=0, surfaces_deleted=0, surfaces_written=0
```

A count added to the sync route now appears in both lanes' verdicts without anyone remembering to add it — which is precisely what did not happen the first time.

`no counts returned` is emitted when the response carries none. That is a different statement from "wrote zero" and now reads differently; previously both rendered as a row of zeros.

## Tests

- a providers-only page must show `providers_written` — the actual production case, pinned
- every numeric key in a response appears; non-numeric fields do not
- an empty response says `no counts returned`
- the original wrote-something-vs-wrote-nothing comparison, retargeted at the new format

9 registry suites, 115 tests, all pass. `npx tsc --noEmit`, `npm run lint`, `npx prettier --check .` clean.

## Note on the lane itself

This is a reporting fix, not a data fix — the lane is working. As of this PR the pass is partway through: providers are current, and the remaining ~166 subnet files land over the next two hourly ticks.

Closes #10241