### PR TITLE
feat(health): alarm on a hole in the MIDDLE of a daily series

### DIFF
--- a/src/daily-series-coverage-watchdog.ts
+++ b/src/daily-series-coverage-watchdog.ts
@@ -1,0 +1,304 @@
+// The alarm for a hole in the MIDDLE of a daily series (#9781).
+//
+// ## The gap freshness cannot see
+//
+// Every existing watchdog here asks how old the newest row is. That question is
+// structurally blind to a missing day: a rollup that skips 08-06 and runs
+// normally on 08-07 has a newest row minutes old, a full width, and a hole in
+// its history that no freshness check can express.
+//
+// It happened, and it went unnoticed until someone queried by hand:
+//
+//   neuron_daily                          account_position_daily
+//   2026-08-07  30118 rows, 129 netuids   2026-08-07  30946 rows
+//               <-- 08-06 absent -->                  <-- 08-06 absent -->
+//   2026-08-05  30104 rows, 129 netuids   2026-08-05  31091 rows
+//
+// Both tables, the same single day, every other day back to 07-29 present at
+// full width. `neuron_daily` is the history source and it is only ~26 days
+// deep, so a missed day ages out of any recomputable window and becomes
+// permanent. The cost of not noticing is not "a late alert", it is the data.
+//
+// ## Two faults, deliberately distinguished
+//
+// MISSING is a date with no rows between the oldest and newest the table holds.
+// THIN is a date present at a small fraction of the median width -- a pass that
+// started and died partway, which reads as a normal day to anything counting
+// dates rather than rows. They send whoever reads the alert to different
+// places, so they are separate reasons rather than one "incomplete".
+//
+// ## Why the boundary dates are excluded
+//
+// The newest date is almost always in progress -- a rollup writing right now is
+// thin by definition and will be full within the hour. Alarming on it would
+// fire every single day, and an alarm that fires on a working lane stops being
+// read (#9301). The oldest is excluded for the mirror reason: retention prunes
+// from that end, so the oldest day is legitimately a partial remnant.
+//
+// The cost is honest and bounded: a hole on the newest day is caught one day
+// late. Freshness already covers that end, which is the half this is not.
+import { laneHealthStore } from "./lane-health-store.ts";
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { readStore } from "./read-store.ts";
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+
+export const DAILY_COVERAGE_LANE = "daily-series-coverage";
+
+/**
+ * The series this covers, and the column each dates its rows by.
+ *
+ * Hand-listed rather than discovered from the schema. Ten tables carry a daily
+ * date column and only these are SERIES -- a continuous record where a missing
+ * day is a hole. `api_key_usage_daily` and `api_quota_daily` have rows only on
+ * days with traffic, so a gap there is a quiet Tuesday, and alarming on it
+ * would be the #9301 failure by construction.
+ */
+export const DAILY_SERIES: readonly { table: string; column: string }[] = [
+  { table: "neuron_daily", column: "snapshot_date" },
+  { table: "account_position_daily", column: "snapshot_date" },
+];
+
+/**
+ * How far below the median a present day may fall before it is THIN.
+ *
+ * A third. Wide enough that ordinary day-to-day variation -- subnets
+ * registering, UIDs churning -- never trips it, narrow enough to catch the
+ * failure this pairs with: a pass that died partway leaves a fraction of a
+ * normal day, not 70% of one. Measured against the MEDIAN rather than the mean
+ * so the thin day cannot drag its own threshold down.
+ */
+export const DAILY_THIN_RATIO = 1 / 3;
+
+/**
+ * How far back from the NEWEST date the walk goes.
+ *
+ * ~26 days of history today; 90 covers any retention change without asking the
+ * store for the whole table.
+ *
+ * ANCHORED TO THE NEWEST DATE, NOT TO THE OLDEST ROW, and that is not a
+ * micro-optimisation. Run against production this found `neuron_daily: missing
+ * 2026-08-06` -- correct -- and then `account_position_daily` missing every day
+ * from 1970-01-22 onward, because one row there carries a `captured_at` written
+ * in SECONDS and is stranded in 1970 (#9782). Walking oldest-to-newest made the
+ * interior 56 years wide and produced a 221 KB verdict naming 20,000 dates.
+ *
+ * A single corrupt row must not be able to do that. Anchoring to the newest
+ * date bounds the walk at 90 entries whatever the oldest row claims, and leaves
+ * the stranded row to the issue that is actually about it.
+ */
+export const DAILY_COVERAGE_LOOKBACK_DAYS = 90;
+
+/**
+ * How many dates a verdict names before it summarises.
+ *
+ * `lane_health.detail` is read by a human deciding where to look, and thirty
+ * dates is already past the point where one more helps. The count is always
+ * exact even when the list is truncated -- "and 4 more" is information, a
+ * silently shortened list is not.
+ */
+export const DAILY_COVERAGE_MAX_LISTED = 12;
+
+export interface DailySeriesDay {
+  date: string;
+  rows: number;
+}
+
+export interface DailySeriesVerdict {
+  table: string;
+  /** Dates with no rows at all, between the oldest and newest held. */
+  missing: string[];
+  /** Dates present but far below the median width. */
+  thin: string[];
+  /** Days examined, excluding the two boundaries. */
+  examined: number;
+  median_rows: number;
+}
+
+/** UTC date arithmetic on YYYY-MM-DD, with no timezone anywhere near it. */
+function addDays(date: string, days: number): string {
+  const ms = Date.parse(`${date}T00:00:00Z`);
+  return new Date(ms + days * 86_400_000).toISOString().slice(0, 10);
+}
+
+function nextDate(date: string): string {
+  return addDays(date, 1);
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? Math.round((sorted[mid - 1]! + sorted[mid]!) / 2)
+    : sorted[mid]!;
+}
+
+/**
+ * The rule alone, testable without a database or a clock.
+ *
+ * Takes the days a table actually holds and returns the holes. Walking the
+ * calendar between the observed ends rather than from "today" is what makes
+ * this independent of when it runs -- and of whether today's rollup has
+ * happened yet, which is the freshness question this is deliberately not
+ * asking.
+ */
+export function evaluateDailyCoverage(
+  table: string,
+  days: readonly DailySeriesDay[],
+  thinRatio = DAILY_THIN_RATIO,
+  lookbackDays = DAILY_COVERAGE_LOOKBACK_DAYS,
+): DailySeriesVerdict {
+  const empty = { table, missing: [], thin: [], examined: 0, median_rows: 0 };
+  if (days.length < 3) {
+    // Two days cannot have a hole between them, and one cannot have a median.
+    // Reporting "no gaps" over a table too short to have one would be a green
+    // light that means nothing.
+    return empty;
+  }
+  const byDate = new Map(days.map((d) => [d.date, d.rows]));
+  const dates = [...byDate.keys()].sort();
+  const newest = dates[dates.length - 1]!;
+  // The floor is the LATER of the oldest row and the lookback, so one row with
+  // a corrupt date cannot widen the walk (see the constant's note on #9782).
+  const horizon = addDays(newest, -lookbackDays);
+  const oldest = dates.find((date) => date >= horizon) ?? newest;
+
+  const interior: string[] = [];
+  for (let date = nextDate(oldest); date < newest; date = nextDate(date)) {
+    interior.push(date);
+  }
+  // The median is taken over PRESENT interior days, so a run of missing dates
+  // cannot pull the width threshold toward zero and hide the thin ones.
+  const widths = interior
+    .map((date) => byDate.get(date))
+    .filter((rows): rows is number => typeof rows === "number" && rows > 0);
+  const med = median(widths);
+  const floor = Math.floor(med * thinRatio);
+
+  const missing: string[] = [];
+  const thin: string[] = [];
+  for (const date of interior) {
+    const rows = byDate.get(date);
+    if (rows === undefined || rows === 0) missing.push(date);
+    else if (med > 0 && rows < floor) thin.push(date);
+  }
+  return {
+    table,
+    missing,
+    thin,
+    examined: interior.length,
+    median_rows: med,
+  };
+}
+
+/** The dates, capped -- but the COUNT is always exact, because a silently
+ * shortened list is worse than a long one. */
+function listDates(dates: readonly string[]): string {
+  if (dates.length <= DAILY_COVERAGE_MAX_LISTED) return dates.join(",");
+  const shown = dates.slice(0, DAILY_COVERAGE_MAX_LISTED).join(",");
+  return `${shown} and ${dates.length - DAILY_COVERAGE_MAX_LISTED} more (${dates.length} total)`;
+}
+
+/** One line naming the dates, because "3 gaps" sends nobody anywhere. */
+export function coverageDetail(
+  verdicts: readonly DailySeriesVerdict[],
+): string {
+  const faults = verdicts.filter(
+    (v) => v.missing.length > 0 || v.thin.length > 0,
+  );
+  if (faults.length === 0) {
+    const examined = verdicts.reduce((sum, v) => sum + v.examined, 0);
+    return `${verdicts.length} series, ${examined} interior day(s), no gaps`;
+  }
+  return faults
+    .map((v) => {
+      const parts: string[] = [];
+      if (v.missing.length > 0) parts.push(`missing ${listDates(v.missing)}`);
+      if (v.thin.length > 0) {
+        parts.push(`thin ${listDates(v.thin)} (median ${v.median_rows})`);
+      }
+      return `${v.table}: ${parts.join("; ")}`;
+    })
+    .join(" | ");
+}
+
+interface D1Like {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      all(): Promise<{ results?: unknown[] } | null>;
+    };
+  };
+}
+
+export interface DailyCoverageDeps {
+  laneHealthDb?: LaneHealthDb | null;
+  now?: () => number;
+  recordException?: typeof recordExceptionEvent;
+}
+
+/**
+ * One tick.
+ *
+ * Returns a summary rather than throwing, matching the rest of the cron family.
+ */
+export async function runDailySeriesCoverageWatchdog(
+  env: Record<string, unknown> | null | undefined,
+  deps: DailyCoverageDeps = {},
+): Promise<Record<string, unknown>> {
+  const now = deps.now ?? Date.now;
+  const record = deps.recordException ?? recordExceptionEvent;
+  const db = readStore(
+    env,
+    DAILY_SERIES.map((s) => s.table),
+  ) as unknown as D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "no store bound" };
+
+  const verdicts: DailySeriesVerdict[] = [];
+  try {
+    for (const { table, column } of DAILY_SERIES) {
+      // Grouped in the store rather than pulled row by row: these tables hold
+      // ~30k rows a day and the answer is one integer per date.
+      const result = await db
+        .prepare(
+          `SELECT ${column} AS date, COUNT(*) AS rows FROM ${table} ` +
+            `GROUP BY ${column} ORDER BY ${column} DESC LIMIT ?`,
+        )
+        .bind(DAILY_COVERAGE_LOOKBACK_DAYS)
+        .all();
+      const days = ((result?.results ?? []) as Record<string, unknown>[])
+        .map((row) => ({
+          date: String(row.date ?? ""),
+          rows: Number(row.rows ?? 0),
+        }))
+        .filter((d) => d.date !== "" && Number.isFinite(d.rows));
+      verdicts.push(evaluateDailyCoverage(table, days));
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "query_failed",
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const holed = verdicts.some((v) => v.missing.length > 0 || v.thin.length > 0);
+  const detail = coverageDetail(verdicts);
+  if (holed) {
+    await record(env as never, {
+      error: new Error(
+        `daily series has a hole: ${detail} -- a missing day is invisible to every freshness check, ` +
+          `and neuron_daily is only ~26 days deep, so it ages out of any recomputable window`,
+      ),
+      route: `watchdog:${DAILY_COVERAGE_LANE}`,
+      errorCode: "daily_series_gap",
+    }).catch(() => false);
+  }
+  await recordLaneVerdict(laneHealthStore(env, deps.laneHealthDb), {
+    lane: DAILY_COVERAGE_LANE,
+    verdict: holed ? "stale" : "ok",
+    age_ms: null,
+    detail,
+    checked_at: now(),
+  });
+  return { ok: true, alerted: holed, verdicts };
+}

--- a/tests/daily-series-coverage-watchdog.test.ts
+++ b/tests/daily-series-coverage-watchdog.test.ts
@@ -1,0 +1,370 @@
+// The alarm for a hole in the MIDDLE of a daily series (#9781).
+//
+// THE BUG THIS EXISTS FOR. 2026-08-06 is missing entirely from `neuron_daily`
+// and `account_position_daily`, and nothing noticed for two days. Every other
+// watchdog in this repo asks how old the newest row is, and that question is
+// structurally blind to a missing day: the rollup ran normally on 08-07, so the
+// newest row was minutes old and the width was full.
+//
+// The assertions below are about the four things that decide whether a gap
+// check is useful or just noisy: it must find a hole between two healthy days,
+// it must NOT fire on the newest day (in progress) or the oldest (being pruned),
+// it must distinguish missing from thin, and it must name the dates.
+import assert from "node:assert/strict";
+import { beforeEach, describe, test, vi } from "vitest";
+
+const { pg } = await vi.hoisted(async () => ({
+  pg: (await import("./helpers/pg-mock.ts")).createPgMock(),
+}));
+vi.mock("pg", () => pg.module);
+
+import { pgMockEnv } from "./helpers/pg-mock.ts";
+import {
+  DAILY_SERIES,
+  DAILY_THIN_RATIO,
+  coverageDetail,
+  evaluateDailyCoverage,
+  runDailySeriesCoverageWatchdog,
+} from "../src/daily-series-coverage-watchdog.ts";
+
+/** A run of consecutive days at a uniform width. */
+function series(start: string, count: number, rows = 30_000) {
+  const out: { date: string; rows: number }[] = [];
+  let ms = Date.parse(`${start}T00:00:00Z`);
+  for (let i = 0; i < count; i++) {
+    out.push({ date: new Date(ms).toISOString().slice(0, 10), rows });
+    ms += 86_400_000;
+  }
+  return out;
+}
+
+describe("evaluateDailyCoverage", () => {
+  test("finds the real 2026-08-06 hole", () => {
+    // The production shape, transcribed: 07-29..08-08 at full width with 08-06
+    // absent. Both tables had exactly this.
+    const days = series("2026-07-29", 11, 30_100).filter(
+      (d) => d.date !== "2026-08-06",
+    );
+    const v = evaluateDailyCoverage("neuron_daily", days);
+    assert.deepEqual(v.missing, ["2026-08-06"]);
+    assert.deepEqual(v.thin, []);
+  });
+
+  test("a clean series reports nothing", () => {
+    const v = evaluateDailyCoverage("neuron_daily", series("2026-07-29", 11));
+    assert.deepEqual(v.missing, []);
+    assert.deepEqual(v.thin, []);
+    assert.equal(v.examined, 9, "the two boundary days are excluded");
+  });
+
+  test("the NEWEST day is never a fault, however thin", () => {
+    // A rollup writing right now is thin by definition. Alarming on it would
+    // fire every day, and an alarm that fires on a working lane stops being
+    // read (#9301).
+    const days = [...series("2026-07-29", 10), { date: "2026-08-07", rows: 3 }];
+    const v = evaluateDailyCoverage("neuron_daily", days);
+    assert.deepEqual(v.thin, [], "today is in progress, not thin");
+    assert.deepEqual(v.missing, []);
+  });
+
+  test("the OLDEST day is never a fault, because retention prunes from that end", () => {
+    const days = [
+      { date: "2026-07-28", rows: 12 },
+      ...series("2026-07-29", 10),
+    ];
+    const v = evaluateDailyCoverage("neuron_daily", days);
+    assert.deepEqual(v.thin, []);
+    assert.deepEqual(v.missing, []);
+  });
+
+  test("a present-but-truncated day is THIN, not missing", () => {
+    // A pass that started and died. Counting dates alone reads this as a
+    // normal day, which is the second way a series loses data.
+    const days = series("2026-07-29", 11).map((d) =>
+      d.date === "2026-08-03" ? { ...d, rows: 900 } : d,
+    );
+    const v = evaluateDailyCoverage("neuron_daily", days);
+    assert.deepEqual(v.thin, ["2026-08-03"]);
+    assert.deepEqual(v.missing, [], "it has rows -- a different fault");
+  });
+
+  test("ordinary day-to-day variation is not thin", () => {
+    const days = series("2026-07-29", 11).map((d, i) => ({
+      ...d,
+      rows: 30_000 + i * 400,
+    }));
+    const v = evaluateDailyCoverage("neuron_daily", days);
+    assert.deepEqual(v.thin, []);
+  });
+
+  test("a run of missing days cannot drag the width floor to zero", () => {
+    // The median is taken over PRESENT interior days. Were zeros included, a
+    // long outage would pull the threshold down and hide every thin day with it.
+    const days = series("2026-07-29", 14)
+      .filter(
+        (d) => !["2026-08-02", "2026-08-03", "2026-08-04"].includes(d.date),
+      )
+      .map((d) => (d.date === "2026-08-06" ? { ...d, rows: 500 } : d));
+    const v = evaluateDailyCoverage("neuron_daily", days);
+    assert.deepEqual(v.missing, ["2026-08-02", "2026-08-03", "2026-08-04"]);
+    assert.deepEqual(v.thin, ["2026-08-06"], "still caught alongside the run");
+    assert.ok(v.median_rows > 0);
+  });
+
+  test("a table too short to have a hole reports nothing rather than a green light", () => {
+    for (const days of [[], series("2026-08-01", 1), series("2026-08-01", 2)]) {
+      const v = evaluateDailyCoverage("neuron_daily", days);
+      assert.deepEqual(v.missing, []);
+      assert.equal(v.examined, 0);
+    }
+  });
+
+  test("the thin ratio is applied against the median, not the mean", () => {
+    // One enormous day would drag a mean upward and make ordinary days read as
+    // thin -- the false-alarm direction.
+    const days = series("2026-07-29", 11).map((d) =>
+      d.date === "2026-08-02" ? { ...d, rows: 3_000_000 } : d,
+    );
+    const v = evaluateDailyCoverage("neuron_daily", days, DAILY_THIN_RATIO);
+    assert.deepEqual(v.thin, []);
+  });
+
+  test("one row stranded in 1970 cannot widen the walk to 56 years", () => {
+    // FOUND BY RUNNING THIS AGAINST PRODUCTION. account_position_daily holds a
+    // row whose captured_at was written in SECONDS (#9782), dating it to
+    // 1970-01-21. Walking oldest-to-newest made the interior 20,000 days wide
+    // and produced a 221 KB verdict naming every one of them.
+    const days = [
+      { date: "1970-01-21", rows: 1 },
+      ...series("2026-07-29", 11).filter((d) => d.date !== "2026-08-06"),
+    ];
+    const v = evaluateDailyCoverage("account_position_daily", days);
+    assert.deepEqual(
+      v.missing,
+      ["2026-08-06"],
+      "the real hole, and nothing from 1970",
+    );
+    assert.ok(v.examined < 90, `walked ${v.examined} days, not 20,000`);
+  });
+
+  test("the lookback bounds the walk even with a long clean history", () => {
+    const v = evaluateDailyCoverage(
+      "neuron_daily",
+      series("2026-01-01", 200),
+      DAILY_THIN_RATIO,
+      30,
+    );
+    assert.ok(v.examined <= 30, `examined ${v.examined}`);
+  });
+
+  test("dates roll over a month boundary correctly", () => {
+    const days = series("2026-07-28", 8).filter((d) => d.date !== "2026-08-01");
+    const v = evaluateDailyCoverage("neuron_daily", days);
+    assert.deepEqual(v.missing, ["2026-08-01"]);
+  });
+});
+
+describe("coverageDetail", () => {
+  test("names the dates, because a count sends nobody anywhere", () => {
+    const detail = coverageDetail([
+      {
+        table: "neuron_daily",
+        missing: ["2026-08-06"],
+        thin: [],
+        examined: 9,
+        median_rows: 30100,
+      },
+      {
+        table: "account_position_daily",
+        missing: ["2026-08-06"],
+        thin: ["2026-08-02"],
+        examined: 9,
+        median_rows: 31000,
+      },
+    ]);
+    assert.match(detail, /neuron_daily: missing 2026-08-06/);
+    assert.match(
+      detail,
+      /account_position_daily: missing 2026-08-06; thin 2026-08-02/,
+    );
+  });
+
+  test("a long gap list is capped but its COUNT stays exact", () => {
+    // A silently shortened list is worse than a long one: it reads as though
+    // the gap were small.
+    const missing = Array.from({ length: 40 }, (_, i) =>
+      new Date(Date.UTC(2026, 0, i + 1)).toISOString().slice(0, 10),
+    );
+    const detail = coverageDetail([
+      {
+        table: "neuron_daily",
+        missing,
+        thin: [],
+        examined: 60,
+        median_rows: 30000,
+      },
+    ]);
+    assert.match(detail, /and 28 more \(40 total\)/);
+    assert.ok(detail.length < 500, `detail is ${detail.length} chars`);
+  });
+
+  test("a clean check says what it examined, not just 'ok'", () => {
+    const detail = coverageDetail([
+      {
+        table: "neuron_daily",
+        missing: [],
+        thin: [],
+        examined: 9,
+        median_rows: 1,
+      },
+    ]);
+    assert.match(detail, /9 interior day\(s\), no gaps/);
+  });
+});
+
+describe("the watchdog tick", () => {
+  beforeEach(() => {
+    pg.control.queries.length = 0;
+    pg.control.answers.length = 0;
+    pg.control.rows = null;
+    pg.control.failNext = null;
+  });
+
+  /** Answer each series' GROUP BY with the days given. */
+  function answerWith(
+    byTable: Record<string, { date: string; rows: number }[]>,
+  ) {
+    for (const [table, days] of Object.entries(byTable)) {
+      pg.control.answers.push({
+        match: new RegExp(`FROM ${table}\\b`),
+        rows: days.map((d) => ({ date: d.date, rows: d.rows })),
+      });
+    }
+    // Everything else (the lane_health insert and its prune) answers empty.
+    pg.control.answers.push({ match: /.*/, rows: [] });
+  }
+
+  /** The verdict the tick durably recorded, read off the recorded statements. */
+  function recordedVerdict() {
+    const insert = pg.control.queries.find((q) =>
+      q.text.includes("INSERT INTO lane_health"),
+    );
+    assert.ok(insert, "the tick recorded a verdict");
+    return {
+      lane: insert.values[0],
+      verdict: insert.values[1],
+      detail: insert.values[3],
+    };
+  }
+
+  test("records `stale` NAMING the missing date when a series has a hole", async () => {
+    answerWith({
+      neuron_daily: series("2026-07-29", 11, 30_100).filter(
+        (d) => d.date !== "2026-08-06",
+      ),
+      account_position_daily: series("2026-07-29", 11, 31_000),
+    });
+    const result = (await runDailySeriesCoverageWatchdog(pgMockEnv(), {
+      now: () => 1000,
+      recordException: (async () => true) as never,
+    })) as { ok: boolean; alerted: boolean };
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, true);
+    const v = recordedVerdict();
+    assert.equal(v.lane, "daily-series-coverage");
+    assert.equal(v.verdict, "stale");
+    assert.match(String(v.detail), /neuron_daily: missing 2026-08-06/);
+  });
+
+  test("records `ok` with what it examined when every series is whole", async () => {
+    answerWith({
+      neuron_daily: series("2026-07-29", 11),
+      account_position_daily: series("2026-07-29", 11, 31_000),
+    });
+    const result = (await runDailySeriesCoverageWatchdog(pgMockEnv(), {
+      now: () => 1000,
+      recordException: (async () => true) as never,
+    })) as { ok: boolean; alerted: boolean };
+    assert.equal(result.alerted, false);
+    const v = recordedVerdict();
+    assert.equal(v.verdict, "ok");
+    assert.match(String(v.detail), /no gaps/);
+    assert.match(
+      String(v.detail),
+      /interior day\(s\)/,
+      "says what it examined",
+    );
+  });
+
+  test("it reads EVERY series, not just the first", async () => {
+    // A loop that stopped at the first table would have found 08-06 and
+    // reported it, looking entirely correct while never checking the second.
+    answerWith({
+      neuron_daily: series("2026-07-29", 11),
+      account_position_daily: series("2026-07-29", 11, 31_000).filter(
+        (d) => d.date !== "2026-08-04",
+      ),
+    });
+    const result = (await runDailySeriesCoverageWatchdog(pgMockEnv(), {
+      now: () => 1000,
+      recordException: (async () => true) as never,
+    })) as { alerted: boolean };
+    assert.equal(result.alerted, true);
+    assert.match(
+      String(recordedVerdict().detail),
+      /account_position_daily: missing 2026-08-04/,
+    );
+    for (const { table } of DAILY_SERIES) {
+      assert.ok(
+        pg.control.queries.some((q) => q.text.includes(`FROM ${table}`)),
+        `${table} was queried`,
+      );
+    }
+  });
+
+  test("a failing read is reported, not rendered as a clean series", async () => {
+    // The direction that matters: a query error must never read as "no gaps".
+    pg.control.failNext = new Error("connection reset");
+    const result = (await runDailySeriesCoverageWatchdog(pgMockEnv(), {
+      now: () => 1000,
+      recordException: (async () => true) as never,
+    })) as { ok: boolean; reason?: string };
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "query_failed");
+  });
+
+  test("declines rather than reporting a clean series with no store", async () => {
+    const result = (await runDailySeriesCoverageWatchdog({}, {})) as {
+      ok: boolean;
+      reason?: string;
+    };
+    assert.equal(result.ok, false);
+    assert.match(result.reason!, /no store/i);
+  });
+});
+
+describe("the lane is actually scheduled", () => {
+  test("wrangler.jsonc declares the trigger", async () => {
+    // Without this the code merges, the dispatcher branch exists, every test
+    // above passes -- and the check never runs, which is the same shape as the
+    // gap it exists to find.
+    const { DAILY_SERIES_COVERAGE_CRON } = await import("../workers/config.ts");
+    const { readFileSync } = await import("node:fs");
+    const raw = readFileSync(
+      new URL("../wrangler.jsonc", import.meta.url),
+      "utf8",
+    );
+    assert.ok(
+      raw.includes(`"${DAILY_SERIES_COVERAGE_CRON}"`),
+      `wrangler.jsonc has no trigger for ${DAILY_SERIES_COVERAGE_CRON}`,
+    );
+  });
+
+  test("it runs after both daily rollup windows, not during one", async () => {
+    // Reading a series mid-rollup would report the day being written as thin.
+    const { DAILY_SERIES_COVERAGE_CRON } = await import("../workers/config.ts");
+    const [minute, hours] = DAILY_SERIES_COVERAGE_CRON.split(" ");
+    assert.equal(minute, "35");
+    assert.deepEqual(hours!.split(",").sort(), ["19", "7"]);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -425,6 +425,7 @@ import {
 } from "../src/chain-detail-staleness-watchdog.ts";
 import { runRegistrySyncLane } from "../src/registry-sync-lane.ts";
 import { runRegistryResyncLane } from "../src/registry-resync-lane.ts";
+import { runDailySeriesCoverageWatchdog } from "../src/daily-series-coverage-watchdog.ts";
 import { pruneChainDetail } from "../src/chain-detail-prune.ts";
 import { runRpcUsageStalenessWatchdog } from "../src/rpc-usage-staleness-watchdog.ts";
 import { runTopHoldersStalenessWatchdog } from "../src/top-holders-staleness-watchdog.ts";
@@ -502,6 +503,7 @@ import {
   PROJECTION_STALENESS_WATCHDOG_CRON,
   VALIDATOR_NOMINATOR_COUNTS_STALENESS_WATCHDOG_CRON,
   CHAIN_DETAIL_PRUNE_CRON,
+  DAILY_SERIES_COVERAGE_CRON,
   REGISTRY_RESYNC_CRON,
   REGISTRY_SYNC_CRON,
   CHAIN_CONCENTRATION_ROLLUP_CRON,
@@ -2130,6 +2132,7 @@ function cronLabel(cron: string): string {
   if (cron === CHAIN_DETAIL_PRUNE_CRON) return "chain-detail-prune";
   if (cron === REGISTRY_SYNC_CRON) return "registry-sync";
   if (cron === REGISTRY_RESYNC_CRON) return "registry-resync";
+  if (cron === DAILY_SERIES_COVERAGE_CRON) return "daily-series-coverage";
   if (cron === CHAIN_CONCENTRATION_ROLLUP_CRON)
     return "chain-concentration-rollup";
   if (cron === CHAIN_DETAIL_STALENESS_WATCHDOG_CRON)
@@ -2544,6 +2547,16 @@ async function dispatchScheduled(
     // `ok` on every tick, because "no registry files changed" was true for the
     // window it looks at and the gap was outside it.
     return runRegistryResyncLane(env);
+  }
+  if (cron === DAILY_SERIES_COVERAGE_CRON) {
+    // #9781: 2026-08-06 is missing entirely from neuron_daily and
+    // account_position_daily, and nothing noticed, because every watchdog here
+    // asks how old the NEWEST row is -- a question structurally blind to a hole
+    // in the middle. neuron_daily is the history source and only ~26 days deep,
+    // so a missed day ages out of any recomputable window and becomes permanent.
+    return runDailySeriesCoverageWatchdog(
+      env as unknown as Record<string, unknown>,
+    );
   }
   if (cron === CHAIN_DETAIL_PRUNE_CRON) {
     // #9208 retention. Returns a summary rather than throwing so the #8998

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -251,6 +251,18 @@ export const REGISTRY_SYNC_CRON = "10,25,40,55 * * * *";
  * same GitHub rate-limit window or the same sync route.
  */
 export const REGISTRY_RESYNC_CRON = "35 * * * *";
+/**
+ * The daily-series gap check (#9781), twice a day.
+ *
+ * A HOLE DOES NOT HEAL, so there is nothing to gain from asking often -- unlike
+ * a staleness watchdog, where the whole value is noticing quickly. Twice a day
+ * bounds how long a missed rollup sits unreported while keeping the cost at two
+ * grouped scans rather than ninety-six.
+ *
+ * 07:35 and 19:35 UTC: after both daily rollup windows, so a day being written
+ * right now is already complete rather than being read mid-pass.
+ */
+export const DAILY_SERIES_COVERAGE_CRON = "35 7,19 * * *";
 // #9464: the top-holders leaderboard's alarm. That lane had NO watchdog and no
 // producer -- `account_balances` died with the box and is not in the poller
 // Container's job set -- so the route served a one-shot pre-decommission

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -998,6 +998,12 @@
       "12,27,42,57 * * * *",
       // #9779 registry writer -- see REGISTRY_SYNC_CRON in workers/config.ts.
       "10,25,40,55 * * * *",
+      // #9781 daily-series gap check -- see DAILY_SERIES_COVERAGE_CRON in
+      // workers/config.ts. Twice a day rather than often: a hole does not heal,
+      // so the value is noticing at all, not noticing fast. Every other
+      // watchdog here asks how old the newest row is, which cannot see a
+      // missing day in the middle.
+      "35 7,19 * * *",
       // #10236 registry RECONCILER -- see REGISTRY_RESYNC_CRON. Hourly is the
       // tick, not the pass: the lane walks the whole registry 100 files at a
       // time and then declines to start again for 20h, so this is ~three


### PR DESCRIPTION
2026-08-06 is missing entirely from `neuron_daily` and `account_position_daily`, and nothing noticed for two days. It was found by querying by hand.

```
neuron_daily                          account_position_daily
2026-08-07  30118 rows, 129 netuids   2026-08-07  30946 rows
            <-- 08-06 absent -->                  <-- 08-06 absent -->
2026-08-05  30104 rows, 129 netuids   2026-08-05  31091 rows
```

Every watchdog in this repo asks **how old the newest row is**, and that question is structurally blind to this. The rollup ran normally on 08-07, so the newest row was minutes old and the width was full. Freshness was perfect and a day was gone.

`neuron_daily` is the history source and only ~26 days deep, so a missed day ages out of any recomputable window. The cost of not noticing is not a late alert — it is the data.

## Two faults, kept separate

| | what it means | where it sends you |
|---|---|---|
| **missing** | a date with no rows | the rollup did not run |
| **thin** | a date at a fraction of the median width | the rollup started and died partway |

A pass that dies halfway leaves a date that *exists*, so anything counting dates reads it as a normal day. That is the second way a series loses data and it needs its own name.

Both boundary dates are excluded: the newest is in progress by definition (alarming on it would fire every day — #9301), the oldest is being pruned. The cost is a hole on the newest day caught one day late, which is exactly the half freshness already covers.

## The design was fixed by running it against production before it shipped

The first version walked oldest-to-newest:

```
neuron_daily: missing 2026-08-06 | account_position_daily: missing
1970-01-22,1970-01-23,1970-01-24, … — 221 KB naming 20,000 dates
```

Correct on the first table, useless on the second — because `account_position_daily` holds one row whose `captured_at` was written in **seconds**, stranding it in 1970 (**#9782**, still live). Walking from the oldest row made the interior 56 years wide.

A single corrupt row must not be able to do that. The walk is now anchored to the **newest** date and bounded by the lookback, and a long list is capped with its count kept exact (`and 28 more (40 total)`) — because a silently shortened list reads as though the gap were small. Same query, same data, after the fix:

```
VERDICT (77 chars): neuron_daily: missing 2026-08-06 | account_position_daily: missing 2026-08-06
```

Both are the real hole, and nothing from 1970.

## Cadence

Twice a day (`35 7,19 * * *`), after both rollup windows. A hole does not heal, so the value is noticing **at all**, not noticing fast — unlike a staleness watchdog, where speed is the whole point. Two grouped scans instead of ninety-six.

## Tests — 22

The rule is a pure function, so most of it needs no database or clock:

- the real 08-06 shape, transcribed from production, is found
- the newest day is never a fault however thin; the oldest never is either
- a truncated day is **thin**, not missing
- a run of missing days cannot drag the width floor to zero and hide the thin ones
- the ratio is applied against the **median**, not the mean — one enormous day must not make ordinary days read as thin
- one row stranded in 1970 cannot widen the walk (the production case, pinned)
- a table too short to have a hole reports nothing rather than a green light
- month boundaries roll correctly

and against the `pg` module double: a hole is recorded as `stale` **naming the date**; a clean run records `ok` saying what it examined; **every** series is queried, not just the first; a failing read is `query_failed` rather than a clean series; no store declines rather than reporting no gaps.

Plus the house assertion that `wrangler.jsonc` actually declares the trigger — without it the code merges, the dispatcher branch exists, every test passes, and the check never runs, which is the same shape as the gap it looks for.

25 cron/config/lane-health/watchdog suites, 431 tests, all pass. `tsc`, `lint`, `prettier` clean.

## What this does not do

**It does not backfill 08-06.** That day is still gone from both tables and needs re-deriving from the archive RPC — tracked on #9781's discussion rather than here, because detection and recovery are separate jobs and only one of them can be done from this repo.

Closes #9781