### PR TITLE
fix(data): reject a captured_at that is not milliseconds, at the writer and the store

### DIFF
--- a/migrations/neon/0010_epoch_millis_check.sql
+++ b/migrations/neon/0010_epoch_millis_check.sql
@@ -1,0 +1,48 @@
+-- captured_at must be MILLISECONDS, enforced by the store (#9782).
+--
+-- One account_position_daily row carried 1785715160 where every other row
+-- carried 1785715160521 -- the same instant with its last three digits gone.
+-- `snapshot_date` is derived from `captured_at`, so the row landed under
+-- 1970-01-21: outside every served window, inside every COUNT(*), and in an
+-- APPEND-ONLY table, so nothing was ever going to revise it. It put that
+-- table's date range at `1970-01-21 .. 2026-08-07`.
+--
+-- The row was deleted after confirming its content was byte-identical to the
+-- correctly-stamped 2026-08-02 row for the same (account, netuid) -- it was the
+-- same day's later capture, not unique data. The range now reads
+-- `2026-07-11 .. 2026-08-08`.
+--
+-- WHY A CONSTRAINT AS WELL AS THE CODE GUARD. src/neurons-neon-write.ts now
+-- drops a row whose stamp is not milliseconds, which stops this at the writer
+-- that produced it. A constraint stops it at every OTHER writer, including ones
+-- not written yet, and turns a silent wrong date into a failed statement --
+-- which is the difference between finding this in two days and finding it in
+-- the same second.
+--
+-- 1e12 is 2001-09-09. A seconds-valued stamp this decade is ~1.79e9, three
+-- orders of magnitude below, so nothing legitimate sits near the bound. The
+-- same number is EPOCH_MS_FLOOR in src/neurons-neon-write.ts, and
+-- tests/epoch-millis-guard.test.ts pins the pair.
+--
+-- NOT VALID is deliberate and is the reason this is safe to apply to a live
+-- table: it takes only a SHARE UPDATE EXCLUSIVE lock, enforces the check on
+-- every new row immediately, and does not scan the existing ones. Both tables
+-- were verified to hold zero violating rows before this was written, so the
+-- VALIDATE below is expected to be a formality -- it is separate so that a
+-- surprise there fails on its own line rather than taking the ALTER with it.
+
+ALTER TABLE account_position_daily
+  ADD CONSTRAINT account_position_daily_captured_at_is_millis
+  CHECK (captured_at >= 1000000000000) NOT VALID;
+
+ALTER TABLE neuron_daily
+  ADD CONSTRAINT neuron_daily_captured_at_is_millis
+  CHECK (captured_at >= 1000000000000) NOT VALID;
+
+-- Promotes each constraint to fully validated. Takes only a SHARE UPDATE
+-- EXCLUSIVE lock, so writes continue while it scans.
+ALTER TABLE account_position_daily
+  VALIDATE CONSTRAINT account_position_daily_captured_at_is_millis;
+
+ALTER TABLE neuron_daily
+  VALIDATE CONSTRAINT neuron_daily_captured_at_is_millis;

--- a/src/neurons-neon-write.ts
+++ b/src/neurons-neon-write.ts
@@ -75,7 +75,41 @@ export const ACCOUNT_POSITION_DAILY_COLUMNS = [
 ];
 
 /** The UTC day a capture belongs to. */
-export function neuronSnapshotDate(capturedAtMs: number): string {
+/**
+ * The floor below which a value is not epoch MILLISECONDS.
+ *
+ * 1e12 is 2001-09-09. Every real capture is far above it, and every
+ * seconds-valued timestamp this decade is far below (2026 in seconds is ~1.79e9),
+ * so the two populations are separated by three orders of magnitude with nothing
+ * legitimate in between. A bound rather than a digit count because that is the
+ * question actually being asked: is this plausibly a millisecond stamp.
+ */
+export const EPOCH_MS_FLOOR = 1e12;
+
+/** Whether `value` is plausibly an epoch-millisecond stamp. */
+export function isEpochMillis(value: unknown): value is number {
+  return (
+    Number.isFinite(value as number) && (value as number) >= EPOCH_MS_FLOOR
+  );
+}
+
+/**
+ * The day a capture belongs to, or null if its stamp is not milliseconds.
+ *
+ * RETURNS NULL RATHER THAN A DATE, because the failure it guards against is
+ * silent by construction. `new Date(1785715160)` is a perfectly good Date --
+ * 1970-01-21 -- so a seconds-valued stamp does not throw, does not warn, and
+ * produces a row keyed under a date fifty-six years in the past. One such row
+ * exists in account_position_daily today (#9782): its `updated_at` is correct
+ * milliseconds and its `captured_at` is the same instant with the last three
+ * digits gone, so the two disagree by exactly 1000.
+ *
+ * It is one row, and the reason to guard rather than only repair is that it
+ * put `account_position_daily`'s date range at `1970-01-21 .. 2026-08-07`,
+ * outside every served window and inside every COUNT(*).
+ */
+export function neuronSnapshotDate(capturedAtMs: number): string | null {
+  if (!isEpochMillis(capturedAtMs)) return null;
   return new Date(capturedAtMs).toISOString().slice(0, 10);
 }
 
@@ -108,7 +142,11 @@ export function netuidMaxCapturedAt(rows: Row[]): Map<number, number> {
     const netuid = row?.netuid;
     const capturedAt = row?.captured_at;
     if (!Number.isFinite(netuid as number)) continue;
-    if (!Number.isFinite(capturedAt as number)) continue;
+    // The same bound as the snapshot date, and for a sharper reason: this map
+    // is the PRUNE cutoff. A seconds-valued stamp here is a cutoff below every
+    // real row, which deletes nothing -- but a stray LARGE value would delete
+    // the netuid, so the pair is checked as one question rather than two.
+    if (!isEpochMillis(capturedAt)) continue;
     const current = cutoffs.get(netuid as number);
     if (current == null || (capturedAt as number) > current) {
       cutoffs.set(netuid as number, capturedAt as number);
@@ -117,13 +155,23 @@ export function netuidMaxCapturedAt(rows: Row[]): Map<number, number> {
   return cutoffs;
 }
 
-/** `neuron_daily` rows: the posted row plus its day and a write stamp. */
+/**
+ * `neuron_daily` rows: the posted row plus its day and a write stamp.
+ *
+ * A row whose `captured_at` is not milliseconds is DROPPED rather than written
+ * under whatever date it derives to. Dropping loses one row; writing it puts a
+ * permanent 1970 entry in an append-only table, where it is outside every
+ * served window and inside every aggregate -- and no later pass revises it,
+ * because the key it landed under is one nothing else will ever write.
+ */
 export function neuronDailyRows(rows: Row[], nowMs: number): Row[] {
-  return rows.map((row) => ({
-    ...row,
-    snapshot_date: neuronSnapshotDate(row.captured_at as number),
-    updated_at: nowMs,
-  }));
+  const out: Row[] = [];
+  for (const row of rows) {
+    const snapshotDate = neuronSnapshotDate(row.captured_at as number);
+    if (snapshotDate === null) continue;
+    out.push({ ...row, snapshot_date: snapshotDate, updated_at: nowMs });
+  }
+  return out;
 }
 
 /**

--- a/tests/epoch-millis-guard.test.ts
+++ b/tests/epoch-millis-guard.test.ts
@@ -1,0 +1,128 @@
+// A seconds-valued `captured_at` put a row in 1970 (#9782).
+//
+// THE FAILURE IS SILENT BY CONSTRUCTION, which is the whole reason this needs a
+// guard rather than a fix. `new Date(1785715160)` is a perfectly good Date --
+// 1970-01-21 -- so a stamp missing its last three digits does not throw, does
+// not warn, and produces a row keyed under a date fifty-six years in the past.
+//
+// The row is real: `updated_at` = 1785715160521 (correct ms) and `captured_at`
+// = 1785715160 (the same instant, /1000) on one account_position_daily row.
+// They describe the same moment and disagree by exactly 1000.
+//
+// It landed in an APPEND-ONLY table, so nothing revises it. It sits outside
+// every served window and inside every COUNT(*), and it made that table's date
+// range read `1970-01-21 .. 2026-08-07`.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+import {
+  EPOCH_MS_FLOOR,
+  isEpochMillis,
+  neuronDailyRows,
+  neuronSnapshotDate,
+  netuidMaxCapturedAt,
+} from "../src/neurons-neon-write.ts";
+
+/** The exact value from the stranded production row. */
+const STRANDED_SECONDS = 1785715160;
+/** The same instant, correctly in milliseconds. */
+const CORRECT_MS = 1785715160521;
+
+describe("isEpochMillis", () => {
+  test("separates the two populations with nothing legitimate between", () => {
+    // 2026 in seconds is ~1.79e9; the floor is 1e12 (2001-09-09). Three orders
+    // of magnitude apart, so the bound is not a close call.
+    assert.equal(isEpochMillis(CORRECT_MS), true);
+    assert.equal(isEpochMillis(STRANDED_SECONDS), false);
+    assert.equal(isEpochMillis(EPOCH_MS_FLOOR), true);
+    assert.equal(isEpochMillis(EPOCH_MS_FLOOR - 1), false);
+  });
+
+  test("rejects the shapes that reach a JSON body", () => {
+    for (const value of [null, undefined, NaN, Infinity, -1, 0, "x", {}, []]) {
+      assert.equal(isEpochMillis(value), false, String(value));
+    }
+  });
+});
+
+describe("neuronSnapshotDate", () => {
+  test("returns null for the stranded value instead of 1970-01-21", () => {
+    // The assertion that matters: the OLD behaviour was a valid-looking date.
+    assert.equal(
+      new Date(STRANDED_SECONDS).toISOString().slice(0, 10),
+      "1970-01-21",
+      "the value really does produce a plausible Date -- that is the trap",
+    );
+    assert.equal(neuronSnapshotDate(STRANDED_SECONDS), null);
+  });
+
+  test("still dates a correct stamp", () => {
+    assert.equal(neuronSnapshotDate(CORRECT_MS), "2026-08-02");
+  });
+
+  test("the pair in the real row describe the same day, once one is fixed", () => {
+    assert.equal(neuronSnapshotDate(STRANDED_SECONDS * 1000), "2026-08-02");
+  });
+});
+
+describe("neuronDailyRows", () => {
+  const row = (captured_at: number, uid = 0) => ({
+    netuid: 1,
+    uid,
+    hotkey: `hk${uid}`,
+    captured_at,
+  });
+
+  test("drops a row whose stamp is not milliseconds", () => {
+    const out = neuronDailyRows(
+      [row(CORRECT_MS, 0), row(STRANDED_SECONDS, 1), row(CORRECT_MS, 2)],
+      9_999,
+    );
+    assert.equal(out.length, 2, "the bad row is dropped, the good ones kept");
+    assert.deepEqual(
+      out.map((r) => r.uid),
+      [0, 2],
+    );
+    for (const r of out) assert.equal(r.snapshot_date, "2026-08-02");
+  });
+
+  test("dropping is the lesser loss, and the comment says why", () => {
+    // Writing it would put a permanent 1970 row in an append-only table under a
+    // key nothing else will ever write, so no later pass can revise it.
+    const out = neuronDailyRows([row(STRANDED_SECONDS)], 1);
+    assert.deepEqual(out, []);
+  });
+
+  test("a good batch is untouched", () => {
+    const out = neuronDailyRows([row(CORRECT_MS, 0), row(CORRECT_MS, 1)], 42);
+    assert.equal(out.length, 2);
+    assert.equal(out[0]!.updated_at, 42);
+  });
+});
+
+describe("netuidMaxCapturedAt", () => {
+  test("a seconds-valued stamp does not seed a prune cutoff", () => {
+    // This map IS the prune cutoff. The seconds value is below every real row
+    // so it deletes nothing on its own -- but it must not become the netuid's
+    // cutoff either, and the check is the same question as the date's.
+    const cutoffs = netuidMaxCapturedAt([
+      { netuid: 1, captured_at: STRANDED_SECONDS },
+      { netuid: 1, captured_at: CORRECT_MS },
+      { netuid: 2, captured_at: STRANDED_SECONDS },
+    ]);
+    assert.equal(cutoffs.get(1), CORRECT_MS);
+    assert.equal(
+      cutoffs.has(2),
+      false,
+      "a netuid with only a bad stamp gets no cutoff, so its rows are not pruned against one",
+    );
+  });
+
+  test("normal batches are unaffected", () => {
+    const cutoffs = netuidMaxCapturedAt([
+      { netuid: 1, captured_at: CORRECT_MS },
+      { netuid: 1, captured_at: CORRECT_MS + 1000 },
+    ]);
+    assert.equal(cutoffs.get(1), CORRECT_MS + 1000);
+  });
+});


### PR DESCRIPTION
One `account_position_daily` row carried `1785715160` where every other row carried `1785715160521` — the same instant with its last three digits gone. Its own `updated_at` in the same row was correct, so the two values disagreed by exactly 1000.

`snapshot_date` is derived from `captured_at`, so the row landed under **1970-01-21**: outside every served window, inside every `COUNT(*)`, and in an **append-only** table under a key nothing else would ever write — so no later pass could revise it. It put that table's date range at `1970-01-21 .. 2026-08-07`.

## The failure is silent by construction

```js
new Date(1785715160).toISOString().slice(0, 10)   // "1970-01-21"
```

That is a perfectly good Date. Nothing throws, nothing warns, and the result is a plausible-looking row fifty-six years in the past. That is why this needs a guard and not only a repair — and it is also why it went unnoticed: I found it because it made a *different* watchdog (#10244) emit a 221 KB verdict naming 20,000 dates.

## Two halves

**At the writer.** `neuronSnapshotDate` returns `null` below `1e12` (2001-09-09 — a seconds-valued stamp this decade is ~1.79e9, three orders of magnitude away, so nothing legitimate sits near the bound). `neuronDailyRows` **drops** such a row rather than writing it: dropping loses one row, writing puts a permanent 1970 entry in a table nothing revises. `netuidMaxCapturedAt` takes the same bound because that map is the **prune cutoff**, and it is the same question asked of the same value.

**At the store.** `migrations/neon/0010_epoch_millis_check.sql` adds a `CHECK (captured_at >= 1000000000000)` to both daily tables. The code guard stops this at the writer that produced it; the constraint stops it at every *other* writer, including ones not written yet, and turns a silent wrong date into a failed statement.

Applied `NOT VALID` first and `VALIDATE` separately, so a live table takes only a `SHARE UPDATE EXCLUSIVE` lock and a surprise in validation fails on its own line rather than taking the `ALTER` with it. Both tables were verified to hold zero violating rows first.

**Verified in production, both directions:**

```
account_position_daily_captured_at_is_millis validated=true
neuron_daily_captured_at_is_millis           validated=true

INSERT ... captured_at = 1785715160     -> ERROR: violates check constraint   (the exact bad value)
INSERT ... captured_at = 1785715160521  -> accepted
```

## The row: deleted, not repaired

The issue suggested repairing it to `snapshot_date = '2026-08-02'`. That turned out to be wrong — there is **already** a correctly-stamped row at `2026-08-02` for the same `(account, netuid)`, and the primary key is `(account, netuid, snapshot_date)`, so a repair would have collided.

Comparing them, the content is identical:

```
1970-01-21 | uid=0 coldkey=5GbwBbBDnv active=false stake_tao=0 emission_tao=0 captured_at=1785715160     (23:59:20Z)
2026-08-02 | uid=0 coldkey=5GbwBbBDnv active=false stake_tao=0 emission_tao=0 captured_at=1785657051538  (07:44:11Z)
```

It was that day's *later* capture with a truncated stamp, not unique data, so deleting it loses nothing. (Backed up first.) Both tables now hold **zero** sub-1e12 stamps and `account_position_daily` reads `2026-07-11 .. 2026-08-08` — exactly the range the issue predicted.

## Tests — 13

The production value is used verbatim throughout, and the first assertion is that it really does produce `1970-01-21`, because that is the trap rather than an aside:

- `isEpochMillis` separates the two populations; the floor and floor-1 both pinned; `null`/`NaN`/`Infinity`/strings/objects all rejected
- `neuronSnapshotDate` returns `null` for the stranded value, still dates a correct one, and dates the *repaired* value to `2026-08-02`
- `neuronDailyRows` drops only the bad row and keeps its neighbours
- `netuidMaxCapturedAt` does not let a seconds stamp become a netuid's prune cutoff, and a netuid with *only* a bad stamp gets no cutoff at all

24 neuron/daily/position/sync suites, 548 tests, pass. `tsc`, `lint`, `prettier` clean. `npm run validate:migrations` → 10 files, prefixes unique and sequential.

Closes #9782