### PR TITLE
fix(api): unify the limit ceiling per surface — REST rejects, MCP clamps (#10174)

### DIFF
--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -633,7 +633,50 @@ export async function latestArtifactDate(
   );
 }
 
+/**
+ * Directories only `npm run build` produces, used to tell an UNBUILT tree from
+ * a genuinely empty artifact.
+ *
+ * `public/metagraph/` is not empty in a fresh checkout -- openapi.json,
+ * contracts.json and a few other publish-owned files are committed -- so the
+ * root existing proves nothing. These per-entity directories are build output.
+ */
+const BUILT_ARTIFACT_MARKERS = ["subnets", "health"];
+
+/**
+ * Fail loudly when the artifact tree has not been built (#10174).
+ *
+ * METAGRAPH_ARCHIVE.get() returns `null` for a missing file, and `null` is the
+ * CORRECT signal for "this artifact carries no data" -- every reader degrades
+ * on it to a schema-stable empty card. So an unbuilt tree was indistinguishable
+ * from an empty one: the reader degraded, the assertion read
+ * `service_count >= 1` as `false !== true`, and nothing anywhere said "run the
+ * build". Same shape as the confident zeros this repo keeps finding -- a
+ * correct-looking decline standing in for a missing producer.
+ *
+ * Checked once per env rather than per read, and only for the absence of the
+ * whole tree: a single missing artifact stays a `null`, because that is a real
+ * condition the readers are supposed to handle.
+ */
+function assertArtifactsBuilt(): void {
+  const built = BUILT_ARTIFACT_MARKERS.some(
+    (marker) =>
+      existsSync(path.join(r2StagingRoot, marker)) ||
+      existsSync(path.join(publicMetagraphRoot, marker)),
+  );
+  if (built) return;
+  throw new Error(
+    "createLocalArtifactEnv(): the artifact tree is not built, so every read " +
+      "would return null and every reader would degrade to an empty card -- " +
+      "which is indistinguishable from a real empty result.\n" +
+      `Looked for ${BUILT_ARTIFACT_MARKERS.map((m) => `${m}/`).join(" or ")} ` +
+      `under ${publicMetagraphRoot} and ${r2StagingRoot}.\n` +
+      "Run `npm run build` first (CI does this before the suite).",
+  );
+}
+
 export function createLocalArtifactEnv(overrides: Row = {}): Row {
+  assertArtifactsBuilt();
   return {
     ASSETS: {
       async fetch(request: Request) {

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -5508,11 +5508,17 @@ export const SHARED_QUERY_PARAMETER_DESCRIPTIONS: Record<
   // change for agent callers. One shared sentence would make one of the two
   // contracts a lie.
   //
+  // Both sentences are now true of their WHOLE surface (#10174). They were not
+  // when this map was written: /api/v1/chain-events clamped like MCP, so the
+  // "on every route" clause below was false, and 15 MCP tools rejected, so the
+  // clamp promise was false for them. Both are fixed rather than hedged --
+  // chain-events runs the same parseLimitParam as the other 81 routes, and the
+  // MCP dispatch clamps to the ceiling each tool's own inputSchema publishes.
+  //
   // `tests/pagination-bound-parity.test.ts` holds both halves to that, derived
-  // over every route and every tool -- so if either surface changes, the gate
-  // fails and these sentences have to change with it. It is what caught the
-  // "on every route" clause below being false on /api/v1/chain-events, which
-  // clamps like MCP does.
+  // over every route and every tool, with both DECLARED lists now EMPTY -- so
+  // a single route or tool drifting back fails the gate rather than earning an
+  // exemption.
   limit: (parameter) => {
     const maximum = parameter.schema?.maximum;
     // The ceiling is read off the parameter's own schema rather than restated,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -3658,7 +3658,46 @@ function validateToolArguments(tool: Row, args: Row) {
   // merely a courtesy: several handlers forward their whole argument object
   // into a query builder or an upstream call, where an unexpected key becomes
   // a filter, a cache-key difference, or a 400 from someone else's API.
-  return splitMcpIntent(args).rest;
+  return clampPublishedLimit(tool, splitMcpIntent(args).rest);
+}
+
+/**
+ * Clamp `limit` to the ceiling the tool itself publishes (#10174).
+ *
+ * Over-ceiling `limit` used to do two different things depending on which
+ * handler an agent happened to reach: 25 tools rejected it -- 15 through the
+ * shared list-query engine, the rest through a synthetic request whose REST
+ * handler calls parseBoundedIntParam -- and the rest clamped. Clamp-vs-reject
+ * was a property of the HANDLER, invisible from anything published, so an
+ * agent could not predict which it would get.
+ *
+ * Clamping here makes it a property of the SURFACE: MCP always clamps, REST
+ * always rejects, one predictable sentence each. This is the forgiving
+ * direction, so no agent caller that works today stops working -- an agent
+ * that miscounts a page size gets an answer instead of an error, and the
+ * response already reports the limit actually applied.
+ *
+ * The ceiling is read from the tool's OWN inputSchema rather than a list kept
+ * alongside it, so a tool cannot be added with a bound this does not honour.
+ *
+ * Deliberately `limit` only. A published `maximum` on an identifier is a
+ * validity bound, not a page size: clamping `netuid: 99999` to 65535 would
+ * answer a question the caller did not ask, where rejecting it is correct.
+ *
+ * And deliberately only ABOVE the ceiling. `limit: 0`, a negative, and `1.5`
+ * are malformed rather than over-ambitious, and each still reaches the handler
+ * that rejects it -- `0` in particular means different things to the three
+ * page-size rules (REST floors it to 1, MCP falls back to the tool's default,
+ * the row builders honour it as zero), so rewriting it here would flatten a
+ * distinction tests/pagination-bound-parity.test.ts exists to keep.
+ */
+function clampPublishedLimit(tool: Row, args: Row): Row {
+  const schema = tool.inputSchema?.properties?.limit as Row | undefined;
+  const max = schema?.maximum;
+  const value = args?.limit;
+  if (typeof max !== "number" || typeof value !== "number") return args;
+  if (!Number.isInteger(value) || value <= max) return args;
+  return { ...args, limit: max };
 }
 
 /**

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -12464,7 +12464,10 @@ describe("MCP economics + metagraph data tools", () => {
   // #8832: out-of-range limit must hard-error before tryPostgresTier, not
   // degrade into a success-shaped empty feed.
   describe("get_chain_identity_history limit validation", () => {
-    for (const limit of [0, -1, 1.5, 201, 500, "abc"]) {
+    // Malformed rather than over-ambitious: 0, a negative, a fraction and a
+    // string are still rejected. Only a value ABOVE the published ceiling
+    // clamps (#10174) -- see the over-ceiling test below.
+    for (const limit of [0, -1, 1.5, "abc"]) {
       test(`rejects limit=${JSON.stringify(limit)} as invalid_params`, async () => {
         let fetched = false;
         const env = {
@@ -12501,6 +12504,36 @@ describe("MCP economics + metagraph data tools", () => {
           subnet_count: 0,
           changes: [],
         });
+      });
+    }
+
+    // #10174: MCP clamps an over-ceiling limit to the maximum this tool's own
+    // inputSchema publishes, instead of rejecting it. The tier IS reached --
+    // the caller gets an answer, capped, rather than an error.
+    for (const limit of [201, 500]) {
+      test(`clamps limit=${limit} to the published 200`, async () => {
+        let seenLimit: string | null = null;
+        const env = {
+          METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+          DATA_API: {
+            fetch: async (request: Request) => {
+              seenLimit = new URL(request.url).searchParams.get("limit");
+              return Response.json({
+                schema_version: 1,
+                count: 0,
+                subnet_count: 0,
+                changes: [],
+              });
+            },
+          },
+        };
+        const res = await callTool(
+          "get_chain_identity_history",
+          { limit },
+          { env },
+        );
+        assert.equal(res.body.result.isError, false);
+        assert.equal(seenLimit, "200");
       });
     }
 
@@ -20115,7 +20148,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
   // contract and must behave identically at the ceiling -- both bound at
   // maximum 1000 in the published schema and both REJECT (not clamp) an
   // out-of-range value with the same invalid_params message.
-  test("list_endpoints and list_rpc_endpoints both publish limit maximum 1000 and reject an out-of-range limit identically", async () => {
+  test("list_endpoints and list_rpc_endpoints both publish limit maximum 1000 and clamp an out-of-range limit identically", async () => {
     const defs = listToolDefinitions();
     for (const name of ["list_endpoints", "list_rpc_endpoints"]) {
       const def = defs.find((t) => t.name === name);
@@ -20139,16 +20172,20 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
       ["list_endpoints", endpointsDeps()],
       ["list_rpc_endpoints", endpointsDepsFixture],
     ] as const) {
-      const rejected = await callTool(name, { limit: 1001 }, { deps });
-      assert.equal(
-        rejected.body.result.isError,
+      // #10174: MCP clamps an over-ceiling limit to the published maximum
+      // rather than rejecting it -- the dispatch reads the bound off this
+      // tool's own inputSchema, so the two tools cannot diverge. REST still
+      // rejects; the split is now per surface rather than per handler.
+      const clamped = await callTool(name, { limit: 1001 }, { deps });
+      assert.notEqual(
+        clamped.body.result.isError,
         true,
-        `${name} rejects limit 1001`,
+        `${name} clamps limit 1001 instead of rejecting it`,
       );
-      assert.match(rejected.body.result.content[0].text, /invalid_params/);
-      assert.match(
-        rejected.body.result.content[0].text,
-        /limit must be an integer between 1 and 1000\./,
+      assert.equal(
+        clamped.body.result.structuredContent.limit,
+        1000,
+        `${name} applies its published ceiling`,
       );
       // The ceiling itself is accepted (not rejected as out-of-range).
       const okAtMax = await callTool(name, { limit: 1000 }, { deps });

--- a/tests/pagination-bound-parity.test.ts
+++ b/tests/pagination-bound-parity.test.ts
@@ -20,18 +20,31 @@
 //     than rejected" was false for a quarter of the tools that publish a
 //     ceiling.
 //
-// Clamp-vs-reject is a property of the HANDLER, not of the surface. Both
-// sentences have been corrected to stop promising a behaviour their surface
-// does not uniformly have.
+// Clamp-vs-reject was a property of the HANDLER, not of the surface, so a
+// caller could not predict it from anything published.
 //
-// ── Why DECLARED lists rather than one green rule ───────────────────────────
+// ── Both DECLARED lists are now EMPTY (#10174) ──────────────────────────────
 //
-// Every way of unifying this is a behaviour change for callers being served
-// today -- making chain-events reject 400s them, making the 25 clamp silently
-// shortens their pages. That should be one deliberate decision (#10174), not
-// 26 taken by a refactor. So the current partition is pinned, with the reason,
-// and a STALE entry FAILS: the same idiom the MCP-parity and GraphQL-parity
-// gates use, so the lists can only shrink.
+// The split was pinned rather than fixed because unifying it is a behaviour
+// change either way, and that is one deliberate decision rather than 26 taken
+// by a refactor. The decision: REST rejects, MCP clamps -- per SURFACE, one
+// predictable sentence each, and the MCP half is the forgiving direction so no
+// agent caller that works today stops working.
+//
+//   * /api/v1/chain-events now runs the same parseLimitParam as the other 81
+//     routes, so its 400 body is byte-identical rather than merely similar.
+//   * The MCP dispatch clamps `limit` to the ceiling each tool's OWN
+//     inputSchema publishes (validateToolArguments -> clampPublishedLimit), so
+//     a tool cannot ship with a bound the dispatch does not honour.
+//
+// Ten of the 25 tools this file once declared were never rejecting on `limit`
+// at all: the probe filled every required string with "1", so `ss58: "1"` and
+// `date: "1"` answered invalid_params about the SUBJECT and were read as a
+// rejected limit. ARG_FIXTURES supplies real values, and the clamp assertion
+// below checks the applied limit rather than merely the absence of an error --
+// not erroring is not the same as honouring the bound.
+//
+// A STALE entry in either list still FAILS, so neither can grow back quietly.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { z } from "zod";
@@ -45,60 +58,16 @@ import type { Row } from "./row-type.ts";
  * REST routes that CLAMP an over-large `limit` instead of rejecting it, and
  * why each is allowed to. A stale entry fails.
  */
-const DECLARED_CLAMPING_ROUTES: Record<string, string> = {
-  "/api/v1/chain-events":
-    "clamps to the published maximum instead of 400ing, unlike the other 81 " +
-    "routes that publish a ceiling. Verified live: ?limit=99999 answers 200 " +
-    "with 100 events. Left as-is because tightening it would 400 callers " +
-    "being served today; the shared `limit` description no longer claims " +
-    "every route rejects.",
-};
+const DECLARED_CLAMPING_ROUTES: Record<string, string> = {};
 
 /**
  * MCP tools that REJECT an over-ceiling `limit` instead of clamping it.
  *
- * The clamp is not a property of the surface, it is a property of the handler:
- * 15 of these are collection-backed and reject through `validateListQuery`,
- * and the rest reject through `parseBoundedIntParam`. Measured by dispatching
- * `limit: maximum + 1` at every tool that publishes a ceiling -- which is why
- * `limitSchema`'s description no longer promises clamping to all of them.
- *
- * Declared rather than "fixed": making them clamp, or making the others
- * reject, is a behaviour change for live agent callers either way, and it
- * should be one decision taken deliberately rather than 25 taken by a
- * refactor. A stale entry FAILS, so the list can only shrink.
+ * EMPTY (#10174): the dispatch clamps to the ceiling each tool publishes, so
+ * there is nothing left to declare. A stale entry FAILS, so this cannot grow
+ * back without someone noticing.
  */
-const REJECTS_BY_SHARED_ENGINE =
-  "rejects an over-ceiling limit rather than clamping, through the shared " +
-  "list-query engine or parseBoundedIntParam. See #10174.";
-
-const DECLARED_REJECTING_TOOLS: Record<string, string> = {
-  get_account_counterparties: REJECTS_BY_SHARED_ENGINE,
-  get_account_events: REJECTS_BY_SHARED_ENGINE,
-  get_account_extrinsics: REJECTS_BY_SHARED_ENGINE,
-  get_account_history: REJECTS_BY_SHARED_ENGINE,
-  get_account_identity_history: REJECTS_BY_SHARED_ENGINE,
-  get_account_transfers: REJECTS_BY_SHARED_ENGINE,
-  get_chain_concentration_subnets: REJECTS_BY_SHARED_ENGINE,
-  get_chain_identity_history: REJECTS_BY_SHARED_ENGINE,
-  get_extrinsic_chain_events: REJECTS_BY_SHARED_ENGINE,
-  get_global_incidents: REJECTS_BY_SHARED_ENGINE,
-  get_health_history: REJECTS_BY_SHARED_ENGINE,
-  get_validator_nominators: REJECTS_BY_SHARED_ENGINE,
-  list_candidates: REJECTS_BY_SHARED_ENGINE,
-  list_curation: REJECTS_BY_SHARED_ENGINE,
-  list_endpoint_incidents: REJECTS_BY_SHARED_ENGINE,
-  list_endpoint_pools: REJECTS_BY_SHARED_ENGINE,
-  list_evidence: REJECTS_BY_SHARED_ENGINE,
-  list_gaps: REJECTS_BY_SHARED_ENGINE,
-  list_providers: REJECTS_BY_SHARED_ENGINE,
-  list_rpc_endpoints: REJECTS_BY_SHARED_ENGINE,
-  list_rpc_pools: REJECTS_BY_SHARED_ENGINE,
-  list_search_index: REJECTS_BY_SHARED_ENGINE,
-  list_source_snapshots: REJECTS_BY_SHARED_ENGINE,
-  list_surfaces: REJECTS_BY_SHARED_ENGINE,
-  search_subnets: REJECTS_BY_SHARED_ENGINE,
-};
+const DECLARED_REJECTING_TOOLS: Record<string, string> = {};
 
 const PATH_FIXTURES: Record<string, string> = {
   "{netuid}": "1",
@@ -114,6 +83,39 @@ const PATH_FIXTURES: Record<string, string> = {
   "{h160}": `0x${"0".repeat(40)}`,
   "{id}": "00000000-0000-0000-0000-000000000000",
   "{crowdloan_id}": "0",
+};
+
+/**
+ * Realistic values for an MCP tool's REQUIRED arguments, so the dispatch
+ * reaches the `limit` handling this test exists to measure.
+ *
+ * Filling every required string with `"1"` made ten tools answer
+ * `invalid_params` for reasons that had nothing to do with `limit` --
+ * `ss58: "1"` is not an address and `date: "1"` is not a day -- and the test
+ * read those as "this tool rejects an over-ceiling limit". Ten entries sat in
+ * DECLARED_REJECTING_TOOLS describing a fixture, not a contract (#10174).
+ *
+ * Keyed by argument name and shared with PATH_FIXTURES' values, so the two
+ * halves of this file agree on what a valid subject looks like.
+ */
+const ARG_FIXTURES: Record<string, unknown> = {
+  ss58: PATH_FIXTURES["{ss58}"],
+  hotkey: PATH_FIXTURES["{hotkey}"],
+  coldkey: PATH_FIXTURES["{ss58}"],
+  address: PATH_FIXTURES["{ss58}"],
+  date: PATH_FIXTURES["{date}"],
+  slug: PATH_FIXTURES["{slug}"],
+  surface_id: PATH_FIXTURES["{surface_id}"],
+  // Not PATH_FIXTURES["{ref}"]: the REST path accepts a bare block number,
+  // but get_extrinsic_chain_events requires the composite
+  // `block_number-extrinsic_index` and rejects anything else as invalid_params.
+  ref: "4200000-3",
+  netuid: 1,
+  uid: 0,
+  q: "subnet",
+  query: "subnet",
+  task: "inference",
+  capability: PATH_FIXTURES["{tag}"],
 };
 
 function publishedLimitMaximum(entry: Row): number | null {
@@ -191,6 +193,7 @@ describe("a published `limit` ceiling means what its surface says (#10064)", () 
     >[1];
     const rejecting: string[] = [];
     const suppressed = new Set<string>();
+    const unclamped: string[] = [];
     let checked = 0;
 
     for (const tool of listToolDefinitions() as Row[]) {
@@ -209,11 +212,21 @@ describe("a published `limit` ceiling means what its surface says (#10064)", () 
         const values = property?.enum as unknown[] | undefined;
         args[key] = values?.length
           ? values[0]
-          : type === "string"
-            ? "1"
-            : type === "array"
-              ? [1]
-              : 1;
+          : (ARG_FIXTURES[key] ??
+            (type === "string" ? "1" : type === "array" ? [1] : 1));
+      }
+      // A tool can state its requirement as `anyOf: [{required:["q"]}, ...]`
+      // rather than in `required` -- search_subnets takes either `q` or its
+      // `query` alias. Filling only `required` left it with neither, so it
+      // answered invalid_params about the missing query and this test read
+      // that as a rejected `limit`.
+      for (const branch of ((tool.inputSchema as Row)?.anyOf ?? []) as Row[]) {
+        const names = (branch?.required ?? []) as string[];
+        if (!names.length || names.some((name) => name in args)) continue;
+        for (const name of names) {
+          args[name] = ARG_FIXTURES[name] ?? "1";
+        }
+        break;
       }
       const response = await handleMcpRequest(
         new Request("https://api.metagraph.sh/mcp", {
@@ -230,13 +243,24 @@ describe("a published `limit` ceiling means what its surface says (#10064)", () 
         {},
       );
       const body = (await response.json()) as Row;
-      const code = ((body?.result?.structuredContent as Row)?.error as Row)
-        ?.code;
+      const structured = (body?.result?.structuredContent ?? {}) as Row;
+      const code = (structured.error as Row)?.code;
       // Only `invalid_params` is the failure being guarded against. A tool
       // that cannot reach its tier under this env answers something else, and
       // that says nothing about how it treats `limit`.
       if (code === undefined || code === null) {
         checked += 1;
+        // Absence of an error is not proof of a clamp -- a tool could ignore
+        // `limit` entirely and pass. Where the answer reports the limit it
+        // applied, hold it to the published ceiling.
+        if (
+          typeof structured.limit === "number" &&
+          structured.limit > maximum
+        ) {
+          unclamped.push(
+            `${tool.name} applied limit=${structured.limit} above its published ${maximum}`,
+          );
+        }
         continue;
       }
       if (code !== "invalid_params") continue;
@@ -263,6 +287,14 @@ describe("a published `limit` ceiling means what its surface says (#10064)", () 
         "and limitSchema's published description promises they do. If this is " +
         "a deliberate contract change, that sentence has to change with it: " +
         rejecting.join(", "),
+    );
+    assert.deepEqual(
+      unclamped,
+      [],
+      "these answered without error but applied a limit ABOVE their published " +
+        "ceiling, so the clamp did not happen -- passing this test by not " +
+        "erroring is not the same as honouring the bound: " +
+        unclamped.join(", "),
     );
     assert.ok(checked > 40, `only ${checked} tools were reachable`);
   }, 300_000);

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -387,12 +387,15 @@ import {
 import { tryPostgresTier } from "./postgres-tier.ts";
 import { chainEventsQueryError } from "../src/chain-events-cold-tier.ts";
 import {
+  CHAIN_EVENTS_LIMIT_DEFAULT,
+  CHAIN_EVENTS_LIMIT_MAX,
   type ColdTierAnswer,
   chainEventsQueryFromUrl,
   coldTierChainEventsPayload,
   degradedChainEventsPayload,
   hotTierBlockChainEvents,
 } from "../src/chain-events-degraded.ts";
+import { parseLimitParam } from "./request-params.ts";
 import { markPostgresTierFallbackResponse } from "./request-handlers/analytics.ts";
 import { loadGlobalOperationalHealth } from "../src/global-operational-health.ts";
 import {
@@ -2896,6 +2899,20 @@ export async function handleChainEventsFamily(
   // raises the same condition as `invalid_params` and GraphQL as
   // BAD_USER_INPUT, off this one shared check.
   if (url.pathname === "/api/v1/chain-events") {
+    // #10174: `limit` is checked with the SAME parser the other 81 routes
+    // publishing a ceiling use, so the 400 body is byte-identical rather than
+    // merely similar. This feed used to be the one REST route that silently
+    // clamped -- `?limit=99999` answered 200 with 100 events, and
+    // `?limit=notanumber` answered 200 with the default -- while the shared
+    // `limit` description told callers REST never clamps. A caller who asked
+    // for 5,000 rows and got 100 had no signal they had been capped, which is
+    // exactly the "a short page means the feed is exhausted" property the
+    // rejecting routes buy.
+    const limitResult = parseLimitParam(url, {
+      defaultLimit: CHAIN_EVENTS_LIMIT_DEFAULT,
+      maxLimit: CHAIN_EVENTS_LIMIT_MAX,
+    });
+    if ("error" in limitResult) return analyticsQueryError(limitResult.error);
     const badValue = chainEventsQueryError(chainEventsQueryFromUrl(url));
     if (badValue) {
       return analyticsQueryError({


### PR DESCRIPTION
Closes #10174.

`limit` is the most-used parameter on the API and it did two different things depending on which handler you reached. Clamp-vs-reject was a property of the **handler**, invisible from anything published, so a caller could not predict it. #10174 asked for one deliberate decision instead of 26 taken by a refactor.

**The decision: REST rejects, MCP clamps** — per *surface*, one predictable sentence each. The MCP half is the forgiving direction, so no agent caller that works today stops working.

Both `DECLARED_CLAMPING_ROUTES` and `DECLARED_REJECTING_TOOLS` in `tests/pagination-bound-parity.test.ts` are now **empty**, which is what the issue set as done.

## REST — one route out of 82

`/api/v1/chain-events` was the only route that clamped. It now runs the **same `parseLimitParam`** as the other 81, so the 400 body is byte-identical rather than merely similar. It had also silently defaulted a malformed value — `?limit=notanumber` answered `200` with the default page — which is the dropped-filter harm the query allowlist exists to prevent, and one of the 15 hits from a malformed-value sweep I ran across 239 parameters in production.

## MCP — the bound comes from the schema

The dispatch clamps `limit` to the ceiling each tool's **own `inputSchema`** publishes:

```ts
const schema = tool.inputSchema?.properties?.limit;   // Zod-derived
const max = schema?.maximum;
```

One site (`validateToolArguments` → `clampPublishedLimit`), not 25 — so the bound is read from the published schema rather than restated per tool, and a new tool cannot ship with a ceiling the dispatch does not honour.

Only **above** the ceiling. `0`, negatives and fractions are malformed rather than over-ambitious and still reach the handler that rejects them. `limit: 0` in particular means three different things to the three page-size rules (`clampLimit` → 1, `clampToolLimit` → default, `clampRowLimit` → 0), and flattening that is exactly what this test file exists to prevent.

## Ten of the 25 declared tools were never rejecting on `limit`

Worth stating plainly, because it means that list was partly describing the probe rather than the API:

- the builder filled every required string with `"1"`, so `ss58: "1"` and `date: "1"` answered `invalid_params` about the **subject** and were recorded as a rejected limit;
- `get_extrinsic_chain_events` needs the composite `block_number-extrinsic_index`, not a bare block number;
- `search_subnets` states its requirement in `anyOf`, not `required`, so it was being called with no query at all.

`ARG_FIXTURES` supplies real values and the builder now satisfies `anyOf`. Fixing fixtures could just as easily hide a real defect, so the test no longer accepts "didn't error" as proof: it asserts the limit **actually applied** equals the published ceiling.

```
these answered without error but applied a limit ABOVE their published ceiling,
so the clamp did not happen -- passing this test by not erroring is not the
same as honouring the bound
```

## A harness bug found on the way

`createLocalArtifactEnv()` returned `null` for every read when the artifact tree was unbuilt — and `null` is the **correct** signal for "this artifact carries no data", which every reader degrades on. So "you never ran the build" and "this artifact is empty" were indistinguishable: readers degraded to empty cards and the suite failed with `false !== true` and no hint. It now fails with the reason and the command to run. Same confident-zero shape this repo keeps finding, this time in the test harness.

## Validation

```
npm run lint && npm run format:check     # clean
npm run typecheck                        # clean
npm run validate:mcp                     # 227 tools, lifecycle + all tools/call
npx vitest run tests/mcp-server.test.ts tests/mcp-schema-enforcement.test.ts \
              tests/pagination-bound-parity.test.ts tests/graphql.test.ts \
              tests/chain-events-degraded.test.ts tests/chain-events-cold-tier.test.ts \
              tests/api-query-validation.test.ts
                                         # 2,579 passed
```

Three tests that asserted the old rejecting behaviour are updated to assert the clamp — that behaviour change is the point of the issue, not collateral. A stale entry in either declared list still fails, so neither can grow back quietly.
