### PR TITLE
fix(scripts): unblock main — the built-artifact precondition broke validate:committed-seed

### DIFF
--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -648,17 +648,21 @@ const BUILT_ARTIFACT_MARKERS = ["subnets", "health"];
  *
  * METAGRAPH_ARCHIVE.get() returns `null` for a missing file, and `null` is the
  * CORRECT signal for "this artifact carries no data" -- every reader degrades
- * on it to a schema-stable empty card. So an unbuilt tree was indistinguishable
- * from an empty one: the reader degraded, the assertion read
- * `service_count >= 1` as `false !== true`, and nothing anywhere said "run the
+ * on it to a schema-stable empty card. So an unbuilt tree is indistinguishable
+ * from an empty one: the reader degrades, an assertion reads
+ * `service_count >= 1` as `false !== true`, and nothing anywhere says "run the
  * build". Same shape as the confident zeros this repo keeps finding -- a
  * correct-looking decline standing in for a missing producer.
  *
- * Checked once per env rather than per read, and only for the absence of the
- * whole tree: a single missing artifact stays a `null`, because that is a real
- * condition the readers are supposed to handle.
+ * CALLED BY THE CALLER, not by createLocalArtifactEnv. Wiring it into the
+ * factory broke `validate:committed-seed`, which builds that env deliberately
+ * against the COMMITTED tree -- an unbuilt tree is its subject, not its bug.
+ * Only a caller that needs real per-entity artifacts should assert this.
+ *
+ * Checks only for the absence of the whole tree: a single missing artifact
+ * stays a `null`, because that is a real condition readers must handle.
  */
-function assertArtifactsBuilt(): void {
+export function assertArtifactsBuilt(): void {
   const built = BUILT_ARTIFACT_MARKERS.some(
     (marker) =>
       existsSync(path.join(r2StagingRoot, marker)) ||
@@ -676,7 +680,6 @@ function assertArtifactsBuilt(): void {
 }
 
 export function createLocalArtifactEnv(overrides: Row = {}): Row {
-  assertArtifactsBuilt();
   return {
     ASSETS: {
       async fetch(request: Request) {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -41,7 +41,11 @@ import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
 import * as profilesMcp from "../src/profiles-mcp.ts";
 import * as healthHistoryMcp from "../src/health-history-mcp.ts";
 import { KV_HEALTH_RPC_POOL } from "../src/health-prober.ts";
-import { createLocalArtifactEnv, latestArtifactDate } from "../scripts/lib.ts";
+import {
+  assertArtifactsBuilt,
+  createLocalArtifactEnv,
+  latestArtifactDate,
+} from "../scripts/lib.ts";
 import { handleRequest } from "../workers/api.ts";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.ts";
 import { MCP_CHAIN_STREAM_RESOURCE_URI } from "../workers/mcp-session-hub.ts";
@@ -8742,6 +8746,10 @@ describe("MCP edge cases", () => {
 
 describe("MCP end-to-end through the Worker dispatch", () => {
   test("POST /mcp tools/call resolves real artifacts from the local env", async () => {
+    // Needs the per-entity artifacts, not just the committed seed. Without
+    // the assert every read returns null, the reader degrades to an empty
+    // card, and this fails as `false !== true` with no mention of the build.
+    assertArtifactsBuilt();
     const env = createLocalArtifactEnv();
     const request = new Request(MCP_URL, {
       method: "POST",

--- a/tests/pagination-bound-parity.test.ts
+++ b/tests/pagination-bound-parity.test.ts
@@ -49,7 +49,10 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { z } from "zod";
 import { API_ROUTES, querySchemaForRoute } from "../src/contracts.ts";
-import { createLocalArtifactEnv } from "../scripts/lib.ts";
+import {
+  assertArtifactsBuilt,
+  createLocalArtifactEnv,
+} from "../scripts/lib.ts";
 import { handleRequest } from "../workers/api.ts";
 import { handleMcpRequest, listToolDefinitions } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
@@ -131,6 +134,9 @@ function publishedLimitMaximum(entry: Row): number | null {
 
 describe("a published `limit` ceiling means what its surface says (#10064)", () => {
   test("every REST route publishing a ceiling rejects one over it", async () => {
+    // Routes answer 503 without their artifacts, and a 503 is skipped here --
+    // so an unbuilt tree would silently check almost nothing rather than fail.
+    assertArtifactsBuilt();
     const env = await createLocalArtifactEnv();
     const ctx = { waitUntil() {}, passThroughOnException() {} };
     const clamping: string[] = [];


### PR DESCRIPTION
Refs #10174. **main is red** — this unblocks it.

#10254 added an `assertArtifactsBuilt()` precondition so an unbuilt artifact tree fails with the reason instead of `false !== true`. I wired it into `createLocalArtifactEnv()` itself, which was wrong: `validate:committed-seed` builds that same env **deliberately against the committed tree**, and runs before any build. An unbuilt tree is that gate's subject, not its bug — so it threw, and `Validate committed contract (drift)` went red.

The precondition is real; the placement was not. `assertArtifactsBuilt` is now exported and called by the two callers that genuinely need per-entity artifacts:

- the MCP end-to-end test, which asserts `service_count >= 1`;
- the REST half of `pagination-bound-parity`, where an unbuilt tree is *worse* than a failure — every route answers 503, every 503 is skipped, and the sweep silently checks almost nothing while passing.

`createLocalArtifactEnv()` goes back to returning `null` for a missing file, which is the correct signal every reader degrades on.

## Validation

```
npm run validate:committed-seed
  ✓ Committed cold-start seed valid — 4 DUAL-tier route(s) checked (pre-build, no R2/D1)

npm run validate:contract-drift          # passes
npm run lint && npm run format:check     # clean
npm run typecheck                        # clean
npx vitest run tests/mcp-server.test.ts tests/pagination-bound-parity.test.ts
  1,401 passed
```

The committed-seed gate is verified against an unbuilt tree specifically, which is the case that broke.

My error: I ran the full local suite *after* building, so the pre-build ordering never came up locally. The gate that caught it is the one that runs before the build — which is exactly why it exists.
