### PR TITLE
perf(neon): index the query shapes that were costing ~2,700s of database time

### DIFF
--- a/migrations/neon/0011_index_hygiene.sql
+++ b/migrations/neon/0011_index_hygiene.sql
@@ -1,0 +1,72 @@
+-- Index hygiene: one index that cannot serve its query, two that serve none.
+--
+-- Measured on production Neon 2026-08-08. `pg_stat_user_indexes.stats_reset` is
+-- NULL, so `idx_scan = 0` means never used in the database's lifetime, not
+-- "not used lately" -- which is what makes these safe to act on.
+--
+-- 21 non-unique indexes had never been scanned, totalling 148 MB against a
+-- 1,866 MB database. Three of them are essentially all of it; the other
+-- eighteen are 16-48 kB each and not worth the churn.
+--
+-- ## 1. chain_detail_extrinsics: the index does not match the query
+--
+-- THIS ONE IS NOT DEAD WEIGHT, IT IS A MISS. src/chain-detail-hot-tier.ts
+-- looks an extrinsic up case-insensitively:
+--
+--     SELECT ... FROM chain_detail_extrinsics WHERE lower(extrinsic_hash) = ?
+--
+-- and the index is on the RAW column. A btree on `extrinsic_hash` cannot serve
+-- `lower(extrinsic_hash) = ?`, so the planner ignores it and scans the table:
+--
+--     Seq Scan on chain_detail_extrinsics (actual time=24.634..24.634)
+--       Filter: (lower(extrinsic_hash) = '0xabc'::text)
+--       Rows Removed by Filter: 36980
+--       Buffers: shared hit=6724
+--
+-- 24.6 ms and 6,724 buffers for a single-row lookup. Replaced with an
+-- expression index on `lower(extrinsic_hash)`, which is what the query asks
+-- for. The zero scan count was the symptom; the cost was paid on every
+-- extrinsic-by-hash request.
+--
+-- Swept for the same shape elsewhere -- `(lower|upper)(col) = ?` across src/
+-- and workers/ -- and this is the only one.
+--
+-- ## 2. surface_checks(surface_key, checked_at DESC): 119 MB, no reader
+--
+-- The table's other two indexes are used (`_netuid_time` 637 scans,
+-- `_time` 543) and its primary key 1.45M. Nothing filters or orders by
+-- `surface_key`: the analytics loaders partition and GROUP BY it, which needs
+-- no index, and their WHERE clauses are on `netuid`/`checked_at`.
+--
+-- Worth stating because it was nearly a wrong call: those loaders were THROWING
+-- until 2026-08-08 (#10200), so "no scans" could have meant "its query never
+-- ran". It does not -- the fixed queries filter on netuid and time, so this
+-- index would still be unused. Checked after the fix, not before.
+--
+-- ## 3. account_balances(free_tao DESC): 20 MB, and the predicate is total
+--
+-- src/top-holders-holdings.ts filters `WHERE free_tao > 0`. Every row in the
+-- table satisfies it -- 365,482 of 365,482 -- so a sequential scan is the
+-- correct plan and always will be. An index that can only ever return the whole
+-- table is not selective enough to be chosen.
+--
+-- ## CONCURRENTLY, and why this file is not idempotent-by-transaction
+--
+-- Every statement is CONCURRENTLY so a live table is never locked against
+-- writes. That means none of them may run inside a transaction block -- apply
+-- this file statement by statement (psql does this by default), NOT wrapped in
+-- BEGIN/COMMIT. A CONCURRENTLY build that fails leaves an INVALID index behind
+-- that must be dropped before retrying; check with
+--   SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid;
+
+-- 1. The miss: replace the raw-column index with the expression the query uses.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chain_detail_extrinsics_hash_lower
+  ON chain_detail_extrinsics (lower(extrinsic_hash));
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_chain_detail_extrinsics_hash;
+
+-- 2. No reader.
+DROP INDEX CONCURRENTLY IF EXISTS idx_surface_checks_key_time;
+
+-- 3. Predicate matches every row.
+DROP INDEX CONCURRENTLY IF EXISTS idx_account_balances_free;

--- a/migrations/neon/0012_hot_query_indexes.sql
+++ b/migrations/neon/0012_hot_query_indexes.sql
@@ -1,0 +1,72 @@
+-- The three shapes `pg_stat_statements` says cost the most, 2026-08-08.
+--
+-- Read off production by total execution time, excluding catalog queries:
+--
+--   857s  39,671 calls  21.6ms  SELECT ... FROM chain_detail_extrinsics ...
+--   515s     875 calls 589.0ms  WITH daily AS (SELECT nd.hotkey, nd.snapshot_date, SUM(...
+--   496s   1,000 calls 496.1ms  (the same aggregate, second shape)
+--   491s  39,452 calls  12.4ms  SELECT b.block_number ... FROM blocks_head b LEFT JOIN ...
+--   152s     439 calls 345.2ms  SELECT ... FROM neuron_daily WHERE validator_permit ...
+--   114s     420 calls 272.0ms  SELECT MIN(snapshot_date) FROM neuron_daily WHERE snapshot_date >= $1
+--   107s     367 calls 290.3ms  SELECT MAX(snapshot_date) FROM neuron_daily
+--
+-- The first is already fixed (0011). This file is the rest.
+--
+-- ## 1. blocks_head: the same expression miss as chain_detail_extrinsics
+--
+-- src/blocks-cold-tier.ts:428 resolves a block by hash case-insensitively:
+--
+--     ... FROM blocks_head b LEFT JOIN chain_detail_blocks c ... WHERE lower(b.block_hash) = ?
+--
+-- and `blocks_head` is indexed on `block_number` and `observed_at`. Nothing can
+-- serve `lower(block_hash)`, so every block-by-hash request scans the table:
+--
+--     Seq Scan on blocks_head b  (actual time=12.624..12.624)  Buffers: shared hit=1322
+--
+-- 39,452 calls at 12.4ms = 491 seconds of database time.
+--
+-- WORTH RECORDING HOW THIS WAS NEARLY MISSED. Fixing the identical bug in 0011
+-- I swept for `(lower|upper)(col) = ?` and concluded it was "the only one". The
+-- regex was `[a-z_]+` inside the parentheses, which does not match a
+-- table-qualified `b.block_hash` -- so the sweep reported one hit when there
+-- were two, and the second was the fourth-largest consumer of database time in
+-- the whole system. Re-run allowing qualified names, the answer is exactly
+-- these two and no more.
+--
+-- ## 2 & 3. neuron_daily has no index leading with snapshot_date
+--
+-- Its two indexes are `(netuid, uid, snapshot_date)` and `(hotkey,
+-- snapshot_date)`. In both, snapshot_date TRAILS, so neither can serve a
+-- predicate or an aggregate on it alone. `SELECT MAX(snapshot_date)` -- which
+-- should be a single index descent -- is a parallel sequential scan of a 387 MB
+-- table:
+--
+--     Finalize Aggregate  (actual time=335.875..341.693)
+--       Buffers: shared hit=2608 read=32770
+--
+-- `(snapshot_date)` alone fixes the MIN/MAX pair and gives the range scans
+-- somewhere to start. `(validator_permit, snapshot_date)` is added for the
+-- aggregate, which is equality-then-range -- the textbook composite -- and is
+-- the single most expensive statement in the system at 1,011 seconds across
+-- 1,875 calls.
+--
+-- Two indexes rather than one because they answer different questions: a bare
+-- MAX cannot use a composite whose leading column it does not constrain.
+--
+-- ## CONCURRENTLY: not in a transaction
+--
+-- As 0011. Apply statement by statement; a failed build leaves an INVALID index
+-- to drop before retrying (`SELECT indexrelid::regclass FROM pg_index WHERE NOT
+-- indisvalid`).
+
+-- 1. Block-by-hash, case-insensitively.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_head_hash_lower
+  ON blocks_head (lower(block_hash));
+
+-- 2. MIN/MAX and bare range scans over the day axis.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_neuron_daily_snapshot_date
+  ON neuron_daily (snapshot_date);
+
+-- 3. The validator-history aggregate: equality on the flag, range on the day.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_neuron_daily_permit_date
+  ON neuron_daily (validator_permit, snapshot_date);


### PR DESCRIPTION
Two migrations, both already applied to production `CONCURRENTLY` (no table locked, no invalid indexes left behind). Everything below is measured on production, not estimated.

Closes #10256, closes #10258.

---

## Where the time was going

`pg_stat_statements`, by total execution time, catalog queries excluded:

```
857s  39,671 calls  21.6ms   chain_detail_extrinsics ... WHERE lower(extrinsic_hash) = ?
515s     875 calls 589.0ms   WITH daily AS (... neuron_daily ...)
496s   1,000 calls 496.1ms   the same aggregate, second shape
491s  39,452 calls  12.4ms   blocks_head ... WHERE lower(b.block_hash) = ?
152s     439 calls 345.2ms   neuron_daily WHERE validator_permit ...
114s     420 calls 272.0ms   SELECT MIN(snapshot_date) FROM neuron_daily
107s     367 calls 290.3ms   SELECT MAX(snapshot_date) FROM neuron_daily
```

## The pattern behind two of them: an index that cannot serve its query

Both hash lookups are case-insensitive and both tables were indexed on the **raw** column. A btree on `extrinsic_hash` cannot serve `lower(extrinsic_hash)`, so the planner ignored it and scanned:

| | before | after |
|---|---|---|
| `chain_detail_extrinsics` by hash | Seq Scan **24.634 ms**, 6,724 buffers, 36,980 rows filtered | Index Scan **0.013 ms**, 3 buffers |
| `blocks_head` by hash | Seq Scan **12.629 ms**, 1,322 buffers | Index Scan **0.010 ms**, 3 buffers |

**And I got the sweep wrong the first time, which is worth recording.** Fixing `chain_detail_extrinsics` I searched for `(lower|upper)(col) = ?` and concluded it was the only instance. The regex matched `lower(col)` but not a table-qualified `lower(b.block_hash)` — so it reported one hit where there were two, and the miss was the fourth-largest consumer of database time in the system. Re-run allowing qualified names: exactly these two, no more.

## `neuron_daily` had no index leading with `snapshot_date`

Its indexes are `(netuid, uid, snapshot_date)` and `(hotkey, snapshot_date)` — `snapshot_date` **trails** in both, so nothing could serve a predicate or aggregate on it alone. `SELECT MAX(snapshot_date)` was a parallel sequential scan of 387 MB.

Two indexes rather than one, because **a bare `MAX` cannot use a composite whose leading column it does not constrain**:

| | before | after |
|---|---|---|
| `MAX(snapshot_date)` | **341.693 ms**, 35,378 buffers | **0.069 ms** |
| `validator_permit` + date range | **234.523 ms**, parallel seq | Index Only Scan **4.411 ms** |

## And 148 MB that served nothing

`stats_reset` is NULL on this database, so `idx_scan = 0` means *never used in its lifetime*. 21 non-unique indexes qualified; three were essentially all of the 148 MB:

- `surface_checks(surface_key, checked_at DESC)` — 119 MB. Nothing filters or orders by `surface_key`; the loaders `GROUP BY` it, which needs no index.
- `account_balances(free_tao DESC)` — 20 MB. The only predicate is `free_tao > 0` and **365,482 of 365,482** rows satisfy it, so a seq scan is correct and always will be.
- the raw-column `extrinsic_hash` index, replaced above.

**`surface_checks` was nearly a wrong call**, and the migration says so: its loaders were *throwing* until earlier today (#10200), so "no scans" could have meant "its query never ran" — the exact trap of drawing conclusions from a broken system. Re-checked after that fix; the working queries filter on `netuid`/`checked_at`, so it was genuinely dead.

The other 18 are 16–48 kB each and deliberately left alone: churn against no measurable gain.

## Net

**1,867 MB → 1,719 MB.** Six statements totalling ~2,700 s of measured database time now have indexes that can serve them.

Both files are `CONCURRENTLY` throughout, which means **they must not be wrapped in a transaction** — each header says so, and says how to find and drop an INVALID index if a build fails partway. `npm run validate:migrations` → 12 files, prefixes unique and sequential.

## Follow-up, not in this PR

Cache hit ratio was **85.65%** before this — low for OLTP. 148 MB freed plus far fewer buffer reads on the hot paths should move it, but if it stays low after a day of traffic the answer is compute size, not indexes. Worth re-measuring before concluding.