### PR TITLE
feat(data): record when a subnet is registered or deregistered

### DIFF
--- a/migrations/neon/0013_subnet_lifecycle.sql
+++ b/migrations/neon/0013_subnet_lifecycle.sql
@@ -1,0 +1,62 @@
+-- When a subnet was registered or deregistered (#10262).
+--
+-- Nothing records this today. Per-UID registration is well covered --
+-- `neurons.registered_at_block`, `is_immunity_period`, a daily history in
+-- `neuron_daily`, and three deregistration routes -- but per-SUBNET there is
+-- no record at all. `subnets` holds registry metadata (slug, name, overlay)
+-- with no lifecycle, and `subnet_emission_enabled_history` tracks emission
+-- being switched on and off, which is a different event: a subnet can have
+-- emission disabled and still exist.
+--
+-- The consequences are all silent. A deregistered subnet's `subnet_hyperparams`
+-- row lingers forever (#10259), every count derived from it keeps counting a
+-- subnet that is gone, and "how many subnets existed on 2026-06-01" is
+-- unanswerable.
+--
+-- ## Modelled on subnet_emission_enabled_history
+--
+-- Same shape as the existing append-only chain-event history (77 rows, 72
+-- netuids): one row per observed transition, never updated, with a
+-- `predates_capture` flag. That flag is load-bearing rather than decorative --
+-- the 129 subnets alive today were all registered before capture began, so
+-- their `registered` rows carry a NULL block, and a consumer must be able to
+-- tell "registered before we were watching" from "registered at block 0".
+--
+-- ## `event` is TEXT with a CHECK, not an enum
+--
+-- A Postgres enum needs ALTER TYPE to gain a member, which is a migration on a
+-- live table for what is otherwise a one-line change; the repo already spells
+-- closed sets this way (see `lane_health.verdict`). Re-registration is a second
+-- `registered` row rather than a mutation of the first, which is what makes the
+-- table answer "when, historically" rather than only "what now".
+
+CREATE TABLE IF NOT EXISTS subnet_lifecycle (
+  id               BIGSERIAL PRIMARY KEY,
+  netuid           INTEGER NOT NULL,
+  -- 'registered' | 'deregistered'
+  event            TEXT    NOT NULL,
+  -- NULL when the transition predates capture, or when the detecting pass
+  -- could not attribute a block. A lifecycle event with no block is still a
+  -- fact worth keeping; a fabricated block is not.
+  block_number     BIGINT,
+  observed_at      BIGINT  NOT NULL,
+  -- TRUE for the seed rows: this subnet already existed when the lane first
+  -- ran, so its registration is older than anything we can see.
+  predates_capture BOOLEAN NOT NULL DEFAULT FALSE,
+  CONSTRAINT subnet_lifecycle_event_known
+    CHECK (event IN ('registered', 'deregistered')),
+  -- The same epoch-milliseconds floor 0010 put on the daily tables: 1e12 is
+  -- 2001-09-09, and a seconds-valued stamp this decade is ~1.79e9. #9782 is
+  -- what this prevents -- a stamp missing three digits produced a row dated
+  -- 1970 that no later pass could revise, in a table exactly like this one.
+  CONSTRAINT subnet_lifecycle_observed_at_is_millis
+    CHECK (observed_at >= 1000000000000)
+);
+
+-- One subnet's own history, newest first: the /subnets/{netuid}/lifecycle read.
+CREATE INDEX IF NOT EXISTS idx_subnet_lifecycle_netuid_time
+  ON subnet_lifecycle (netuid, observed_at DESC);
+
+-- The network-wide feed, windowed: "what changed lately".
+CREATE INDEX IF NOT EXISTS idx_subnet_lifecycle_time
+  ON subnet_lifecycle (observed_at DESC);

--- a/src/subnet-lifecycle.ts
+++ b/src/subnet-lifecycle.ts
@@ -1,0 +1,288 @@
+// When a subnet was registered or deregistered (#10262).
+//
+// ## Where the signal comes from, and why it needs no producer change
+//
+// The obvious source would be `subnet_hyperparams` -- one row per live subnet.
+// It cannot work: nothing prunes that table (#10259 is exactly that gap), so a
+// deregistered subnet's row stays forever and its disappearance is never
+// observable. Using it would be circular.
+//
+// `neurons` is the source. The metagraph lane rewrites EVERY netuid on every
+// pass under one shared `captured_at` -- measured on production: 30,129 rows,
+// 129 netuids, and `COUNT(DISTINCT captured_at) = 1`. So the netuid set at the
+// newest stamp is the live subnet set, observed directly, and diffing two
+// consecutive observations is the lifecycle event.
+//
+// ## The gate that makes this safe
+//
+// A netuid missing because the scan DIED is not a deregistration, and this
+// table is append-only, so a false `deregistered` row is permanent. The scan
+// does die: `lane_health` recorded `scan Delegates: Encountered an error
+// iterating over storage` twice within one hour on 2026-08-08.
+//
+// So detection runs only when the pass cleared the same coverage floor
+// `neurons-staleness` uses -- 80% of the expected netuids, the ratio already
+// sized and justified there. Below it, this lane records `partial` and writes
+// NOTHING. Writing nothing is always recoverable: the next complete pass sees
+// the same difference and emits the same event. Writing a false deregistration
+// is not.
+//
+// This is the same distinction #10236's registry resync had to make between an
+// empty listing and an unreachable one -- absence is only meaningful when you
+// know you looked properly.
+import {
+  createPgSql,
+  type HyperdriveLike,
+  type WaitUntilLike,
+} from "./pg-sql.ts";
+import { laneHealthStore } from "./lane-health-store.ts";
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { readStore } from "./read-store.ts";
+import {
+  NEURONS_COVERAGE_FLOOR_NETUIDS,
+  NEURONS_PASS_WINDOW_MS,
+} from "./neurons-staleness-watchdog.ts";
+
+export const SUBNET_LIFECYCLE_LANE = "subnet-lifecycle";
+
+export type SubnetLifecycleEventName = "registered" | "deregistered";
+
+export interface SubnetLifecycleEvent {
+  netuid: number;
+  event: SubnetLifecycleEventName;
+  block_number: number | null;
+  predates_capture: boolean;
+}
+
+export interface SubnetLifecycleDiff {
+  events: SubnetLifecycleEvent[];
+  /** True when this is the first run and the table is being seeded. */
+  seeded: boolean;
+}
+
+/**
+ * The rule alone: two netuid sets in, the events between them out.
+ *
+ * `known` is the set the table currently believes is live -- netuids whose
+ * newest event is `registered`. `observed` is what the latest complete pass
+ * actually saw.
+ *
+ * FIRST RUN SEEDS RATHER THAN REGISTERS. With an empty table every live subnet
+ * would otherwise be reported as newly registered at the moment the lane was
+ * deployed, which is false and, in an append-only table, permanently so. The
+ * seed rows carry `predates_capture: true` and no block, which is the honest
+ * statement: these existed before anything was watching.
+ */
+export function diffSubnetSets(
+  known: ReadonlySet<number>,
+  observed: ReadonlySet<number>,
+  blockNumber: number | null = null,
+): SubnetLifecycleDiff {
+  const seeded = known.size === 0;
+  const events: SubnetLifecycleEvent[] = [];
+  for (const netuid of [...observed].sort((a, b) => a - b)) {
+    if (known.has(netuid)) continue;
+    events.push({
+      netuid,
+      event: "registered",
+      // A seeded row cannot claim a block: the registration happened before
+      // this lane existed, and the current head is not when it happened.
+      block_number: seeded ? null : blockNumber,
+      predates_capture: seeded,
+    });
+  }
+  if (!seeded) {
+    // Deregistrations are never emitted on the seeding run: an empty `known`
+    // set means nothing is known to have left, not that everything did.
+    for (const netuid of [...known].sort((a, b) => a - b)) {
+      if (observed.has(netuid)) continue;
+      events.push({
+        netuid,
+        event: "deregistered",
+        block_number: blockNumber,
+        predates_capture: false,
+      });
+    }
+  }
+  return { events, seeded };
+}
+
+/** One line naming the netuids, because a count sends nobody anywhere. */
+export function lifecycleDetail(
+  diff: SubnetLifecycleDiff,
+  observedCount: number,
+): string {
+  if (diff.seeded) {
+    return `seeded ${diff.events.length} subnet(s) as predating capture`;
+  }
+  if (diff.events.length === 0) return `no change, ${observedCount} subnet(s)`;
+  const by = (name: SubnetLifecycleEventName) =>
+    diff.events.filter((e) => e.event === name).map((e) => e.netuid);
+  const parts: string[] = [];
+  const reg = by("registered");
+  const dereg = by("deregistered");
+  if (reg.length > 0) parts.push(`registered ${reg.join(",")}`);
+  if (dereg.length > 0) parts.push(`deregistered ${dereg.join(",")}`);
+  return `${parts.join("; ")} (${observedCount} subnet(s) observed)`;
+}
+
+interface D1Like {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      all(): Promise<{ results?: unknown[] } | null>;
+      run(): Promise<unknown>;
+    };
+    all(): Promise<{ results?: unknown[] } | null>;
+  };
+}
+
+export interface SubnetLifecycleDeps {
+  laneHealthDb?: LaneHealthDb | null;
+  now?: () => number;
+  coverageFloor?: number;
+  /** The write runner. `readStore`'s handle exposes all()/first() and no run()
+   * -- it is a READ store, deliberately -- so the append needs its own. */
+  sql?: { unsafe(text: string, values?: unknown[]): Promise<unknown> } | null;
+  ctx?: WaitUntilLike | null;
+}
+
+/**
+ * One tick. Returns a summary rather than throwing, like the rest of the family.
+ */
+export async function runSubnetLifecycleLane(
+  env: Record<string, unknown> | null | undefined,
+  deps: SubnetLifecycleDeps = {},
+): Promise<Record<string, unknown>> {
+  const now = deps.now ?? Date.now;
+  const floor = deps.coverageFloor ?? NEURONS_COVERAGE_FLOOR_NETUIDS;
+  const db = readStore(env, ["neurons", "subnet_lifecycle"]) as unknown as
+    D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "no store bound" };
+
+  const record = async (
+    verdict: "ok" | "stale",
+    detail: string,
+  ): Promise<void> => {
+    await recordLaneVerdict(laneHealthStore(env, deps.laneHealthDb), {
+      lane: SUBNET_LIFECYCLE_LANE,
+      verdict,
+      age_ms: null,
+      detail,
+      checked_at: now(),
+    });
+  };
+
+  try {
+    // The netuid set at the newest stamp, plus that pass's block for
+    // attribution. One statement: the window is the same 5 minutes
+    // neurons-staleness uses to mean "the newest pass".
+    const observedRows = ((
+      await db
+        .prepare(
+          "SELECT DISTINCT netuid, MAX(block_number) AS block_number FROM neurons " +
+            "WHERE captured_at >= (SELECT MAX(captured_at) FROM neurons) - ? " +
+            "GROUP BY netuid",
+        )
+        .bind(NEURONS_PASS_WINDOW_MS)
+        .all()
+    )?.results ?? []) as Record<string, unknown>[];
+
+    const observed = new Set<number>();
+    let blockNumber: number | null = null;
+    for (const row of observedRows) {
+      const netuid = Number(row.netuid);
+      if (!Number.isInteger(netuid)) continue;
+      observed.add(netuid);
+      const block = Number(row.block_number);
+      if (
+        Number.isFinite(block) &&
+        (blockNumber === null || block > blockNumber)
+      ) {
+        blockNumber = block;
+      }
+    }
+
+    if (observed.size < floor) {
+      // The gate. A short pass says nothing about what left.
+      const detail = `partial: ${observed.size} netuid(s) under the ${floor} floor -- no events written`;
+      await record("stale", detail);
+      return {
+        ok: true,
+        alerted: true,
+        reason: "partial",
+        observed: observed.size,
+      };
+    }
+
+    // What the table currently believes: netuids whose NEWEST event is a
+    // registration. DISTINCT ON is the same shape loadLatestLaneHealth uses.
+    const knownRows = ((
+      await db
+        .prepare(
+          "SELECT DISTINCT ON (netuid) netuid, event FROM subnet_lifecycle " +
+            "ORDER BY netuid, observed_at DESC, id DESC",
+        )
+        .all()
+    )?.results ?? []) as Record<string, unknown>[];
+    const known = new Set<number>();
+    for (const row of knownRows) {
+      if (String(row.event) !== "registered") continue;
+      const netuid = Number(row.netuid);
+      if (Number.isInteger(netuid)) known.add(netuid);
+    }
+
+    const diff = diffSubnetSets(known, observed, blockNumber);
+    if (diff.events.length > 0) {
+      const hyperdrive = env?.HYPERDRIVE as HyperdriveLike | undefined;
+      const sql =
+        deps.sql ??
+        (hyperdrive?.connectionString && deps.ctx
+          ? createPgSql(hyperdrive, deps.ctx)
+          : hyperdrive?.connectionString
+            ? createPgSql(hyperdrive, { waitUntil: () => {} })
+            : null);
+      if (!sql) {
+        // Events to write and nowhere to write them is a FAILURE, not a quiet
+        // pass: reporting `ok` here would claim the diff had been recorded.
+        await record(
+          "stale",
+          `${diff.events.length} event(s) unwritten: no write runner`,
+        );
+        return {
+          ok: false,
+          reason: "no write runner",
+          events: diff.events.length,
+        };
+      }
+      for (const event of diff.events) {
+        await sql.unsafe(
+          "INSERT INTO subnet_lifecycle (netuid, event, block_number, observed_at, predates_capture)" +
+            " VALUES ($1, $2, $3, $4, $5)",
+          [
+            event.netuid,
+            event.event,
+            event.block_number,
+            now(),
+            event.predates_capture,
+          ],
+        );
+      }
+    }
+
+    const detail = lifecycleDetail(diff, observed.size);
+    await record("ok", detail);
+    return {
+      ok: true,
+      alerted: false,
+      seeded: diff.seeded,
+      events: diff.events.length,
+      observed: observed.size,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "query_failed",
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/tests/subnet-lifecycle.test.ts
+++ b/tests/subnet-lifecycle.test.ts
@@ -1,0 +1,308 @@
+// Subnet registration/deregistration detection (#10262).
+//
+// THE TABLE IS APPEND-ONLY, which is what makes the gate the important part. A
+// netuid missing because the scan died is not a deregistration, and a false
+// `deregistered` row can never be revised by a later pass. The scan does die --
+// `lane_health` recorded `scan Delegates: Encountered an error iterating over
+// storage` twice within one hour on 2026-08-08.
+//
+// So the assertions below are weighted toward what must NOT be written: a short
+// pass writes nothing, a first run does not claim 129 registrations, and a
+// seeded row does not claim a block it cannot know.
+import assert from "node:assert/strict";
+import { beforeEach, describe, test, vi } from "vitest";
+
+const { pg } = await vi.hoisted(async () => ({
+  pg: (await import("./helpers/pg-mock.ts")).createPgMock(),
+}));
+vi.mock("pg", () => pg.module);
+
+import { pgMockEnv } from "./helpers/pg-mock.ts";
+import {
+  SUBNET_LIFECYCLE_LANE,
+  diffSubnetSets,
+  lifecycleDetail,
+  runSubnetLifecycleLane,
+} from "../src/subnet-lifecycle.ts";
+
+const set = (...n: number[]) => new Set(n);
+
+describe("diffSubnetSets", () => {
+  test("a new netuid is a registration, carrying the pass's block", () => {
+    const d = diffSubnetSets(set(1, 2), set(1, 2, 3), 8_800_000);
+    assert.equal(d.seeded, false);
+    assert.deepEqual(d.events, [
+      {
+        netuid: 3,
+        event: "registered",
+        block_number: 8_800_000,
+        predates_capture: false,
+      },
+    ]);
+  });
+
+  test("a vanished netuid is a deregistration", () => {
+    const d = diffSubnetSets(set(1, 2, 3), set(1, 3), 8_800_000);
+    assert.deepEqual(d.events, [
+      {
+        netuid: 2,
+        event: "deregistered",
+        block_number: 8_800_000,
+        predates_capture: false,
+      },
+    ]);
+  });
+
+  test("no change emits nothing", () => {
+    assert.deepEqual(diffSubnetSets(set(1, 2, 3), set(1, 2, 3), 1).events, []);
+  });
+
+  test("the FIRST run seeds rather than claiming 129 registrations today", () => {
+    // With an empty table every live subnet would otherwise be recorded as
+    // newly registered at the moment this lane was deployed -- false, and
+    // permanently so in an append-only table.
+    const d = diffSubnetSets(set(), set(0, 1, 2), 8_800_000);
+    assert.equal(d.seeded, true);
+    assert.equal(d.events.length, 3);
+    for (const e of d.events) {
+      assert.equal(e.event, "registered");
+      assert.equal(e.predates_capture, true, "these predate capture");
+      assert.equal(
+        e.block_number,
+        null,
+        "a seeded row cannot claim a block: the head is not when it happened",
+      );
+    }
+  });
+
+  test("the seeding run emits NO deregistrations", () => {
+    // An empty `known` set means nothing is known to have left -- not that
+    // everything did.
+    const d = diffSubnetSets(set(), set(1), 1);
+    assert.equal(d.events.filter((e) => e.event === "deregistered").length, 0);
+  });
+
+  test("re-registration is a second event, not a mutation", () => {
+    // known={1} means 1's newest event was `registered`; it vanishes, then
+    // returns. Two separate diffs, two separate rows.
+    const gone = diffSubnetSets(set(1), set(), 100);
+    assert.equal(gone.events[0]!.event, "deregistered");
+    const back = diffSubnetSets(set(), set(1), 200);
+    assert.equal(back.events[0]!.event, "registered");
+  });
+
+  test("events come out in netuid order, registrations before deregistrations", () => {
+    const d = diffSubnetSets(set(5, 6), set(1, 5), 1);
+    assert.deepEqual(
+      d.events.map((e) => [e.netuid, e.event]),
+      [
+        [1, "registered"],
+        [6, "deregistered"],
+      ],
+    );
+  });
+});
+
+describe("lifecycleDetail", () => {
+  test("names the netuids, because a count sends nobody anywhere", () => {
+    const d = diffSubnetSets(set(1, 2), set(1, 3), 9);
+    assert.match(lifecycleDetail(d, 2), /registered 3/);
+    assert.match(lifecycleDetail(d, 2), /deregistered 2/);
+  });
+
+  test("a quiet tick says how many it saw, not just 'ok'", () => {
+    const d = diffSubnetSets(set(1), set(1), 9);
+    assert.match(lifecycleDetail(d, 129), /no change, 129 subnet\(s\)/);
+  });
+
+  test("a seeding run says it seeded", () => {
+    const d = diffSubnetSets(set(), set(1, 2), 9);
+    assert.match(lifecycleDetail(d, 2), /seeded 2 subnet\(s\) as predating/);
+  });
+});
+
+describe("the lane tick", () => {
+  beforeEach(() => {
+    pg.control.queries.length = 0;
+    pg.control.answers.length = 0;
+    pg.control.failNext = null;
+  });
+
+  /** `observed` = netuids in neurons' newest pass; `known` = rows already in
+   *  subnet_lifecycle. */
+  function answer(observed: number[], known: [number, string][] = []) {
+    pg.control.answers.push({
+      match: /FROM neurons/,
+      rows: observed.map((netuid) => ({ netuid, block_number: 8_800_000 })),
+    });
+    pg.control.answers.push({
+      match: /FROM subnet_lifecycle/,
+      rows: known.map(([netuid, event]) => ({ netuid, event })),
+    });
+    pg.control.answers.push({ match: /.*/, rows: [] });
+  }
+
+  const inserts = () =>
+    pg.control.queries.filter((q) =>
+      q.text.includes("INSERT INTO subnet_lifecycle"),
+    );
+
+  const verdict = () => {
+    const q = pg.control.queries.find((x) =>
+      x.text.includes("INSERT INTO lane_health"),
+    );
+    assert.ok(q, "a verdict was recorded");
+    return { lane: q.values[0], verdict: q.values[1], detail: q.values[3] };
+  };
+
+  const env = () =>
+    pgMockEnv([...["neurons", "subnet_lifecycle"], "lane_health"]);
+
+  test("A SHORT PASS WRITES NOTHING — the assertion that matters", async () => {
+    // 40 of 129 is what a scan dying partway looks like. In an append-only
+    // table a false deregistration is permanent; writing nothing is always
+    // recoverable, because the next complete pass sees the same difference.
+    answer(
+      Array.from({ length: 40 }, (_, i) => i),
+      [[0, "registered"]],
+    );
+    const r = (await runSubnetLifecycleLane(env(), {
+      now: () => 1_800_000_000_000,
+    })) as { ok: boolean; reason?: string };
+    assert.equal(r.reason, "partial");
+    assert.equal(inserts().length, 0, "no lifecycle rows written");
+    const v = verdict();
+    assert.equal(v.verdict, "stale");
+    assert.match(String(v.detail), /under the \d+ floor -- no events written/);
+  });
+
+  test("a complete pass with a new netuid writes one registration", async () => {
+    const live = Array.from({ length: 130 }, (_, i) => i);
+    const known: [number, string][] = live
+      .slice(0, 129)
+      .map((n) => [n, "registered"]);
+    answer(live, known);
+    await runSubnetLifecycleLane(env(), { now: () => 1_800_000_000_000 });
+    const rows = inserts();
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]!.values[0], 129, "the new netuid");
+    assert.equal(rows[0]!.values[1], "registered");
+    assert.equal(verdict().verdict, "ok");
+  });
+
+  test("a complete pass with a vanished netuid writes one deregistration", async () => {
+    const known: [number, string][] = Array.from({ length: 130 }, (_, i) => [
+      i,
+      "registered",
+    ]);
+    answer(
+      Array.from({ length: 130 }, (_, i) => i).filter((n) => n !== 42),
+      known,
+    );
+    await runSubnetLifecycleLane(env(), { now: () => 1_800_000_000_000 });
+    const rows = inserts();
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]!.values[0], 42);
+    assert.equal(rows[0]!.values[1], "deregistered");
+  });
+
+  test("a netuid whose newest event is `deregistered` is not counted as live", async () => {
+    // The known set is built from the NEWEST event per netuid. A subnet that
+    // left and came back must register again rather than be silently present.
+    const live = Array.from({ length: 129 }, (_, i) => i);
+    const known: [number, string][] = live.map((n) => [
+      n,
+      n === 7 ? "deregistered" : "registered",
+    ]);
+    answer(live, known);
+    await runSubnetLifecycleLane(env(), { now: () => 1_800_000_000_000 });
+    const rows = inserts();
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]!.values[0], 7);
+    assert.equal(rows[0]!.values[1], "registered", "re-registered");
+  });
+
+  test("a failing read is reported, not rendered as 'no change'", async () => {
+    pg.control.failNext = new Error("connection reset");
+    const r = (await runSubnetLifecycleLane(env(), {
+      now: () => 1_800_000_000_000,
+    })) as { ok: boolean; reason?: string };
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "query_failed");
+    assert.equal(inserts().length, 0);
+  });
+
+  test("no store declines rather than reporting an empty network", async () => {
+    const r = (await runSubnetLifecycleLane({}, {})) as {
+      ok: boolean;
+      reason?: string;
+    };
+    assert.equal(r.ok, false);
+    assert.match(r.reason!, /no store/i);
+  });
+
+  test("the lane name is stable", () => {
+    assert.equal(SUBNET_LIFECYCLE_LANE, "subnet-lifecycle");
+  });
+});
+
+describe("the lane runs on an existing tick, not a new cron", () => {
+  test("it is invoked from the neurons-staleness branch", async () => {
+    // #10262 needs exactly what that watchdog already reads -- the netuid set
+    // at neurons' newest stamp, and whether the pass cleared the coverage
+    // floor. A trigger of its own would re-read the same pass on a different
+    // schedule and add a 35th cron expression to the 34 #10226 exists to
+    // collapse. This asserts it stayed folded in.
+    const { readFileSync } = await import("node:fs");
+    const api = readFileSync(
+      new URL("../workers/api.ts", import.meta.url),
+      "utf8",
+    );
+    const branch = api.slice(
+      api.indexOf("NEURONS_STALENESS_WATCHDOG_CRON) {"),
+      api.indexOf("NEURONS_STALENESS_WATCHDOG_CRON) {") + 1400,
+    );
+    assert.match(branch, /runSubnetLifecycleLane\(/);
+    assert.doesNotMatch(
+      api,
+      /SUBNET_LIFECYCLE_CRON/,
+      "it must not gain a cron expression of its own",
+    );
+  });
+
+  test("its failure cannot cost the estate the staleness verdict", async () => {
+    // The alarm is the load-bearing half. The lifecycle write is deliberately
+    // after it, detached, and its rejection swallowed.
+    const { readFileSync } = await import("node:fs");
+    const api = readFileSync(
+      new URL("../workers/api.ts", import.meta.url),
+      "utf8",
+    );
+    const i = api.indexOf("NEURONS_STALENESS_WATCHDOG_CRON) {");
+    const branch = api.slice(i, i + 1400);
+    assert.ok(
+      branch.indexOf("runNeuronsStalenessWatchdog") <
+        branch.indexOf("runSubnetLifecycleLane"),
+      "the watchdog runs first",
+    );
+    assert.match(branch, /runSubnetLifecycleLane[\s\S]*?\.catch\(/);
+  });
+
+  test("a ctx with no waitUntil is awaited, not thrown on", async () => {
+    // A bare `{}` ctx reaches the scheduled dispatcher from callers that have
+    // none to give, and `ctx.waitUntil(...)` on it throws -- which would take
+    // the staleness alarm down with it, the exact outcome the guard exists to
+    // prevent. Awaiting is the fallback rather than dropping the promise,
+    // because a floating promise in an isolate about to end is work silently
+    // not done.
+    const { readFileSync } = await import("node:fs");
+    const api = readFileSync(
+      new URL("../workers/api.ts", import.meta.url),
+      "utf8",
+    );
+    const i = api.indexOf("NEURONS_STALENESS_WATCHDOG_CRON) {");
+    const branch = api.slice(i, i + 2000);
+    assert.match(branch, /typeof ctx\?\.waitUntil === "function"/);
+    assert.match(branch, /else await lifecycle/);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -429,6 +429,7 @@ import {
 import { runRegistrySyncLane } from "../src/registry-sync-lane.ts";
 import { runRegistryResyncLane } from "../src/registry-resync-lane.ts";
 import { runDailySeriesCoverageWatchdog } from "../src/daily-series-coverage-watchdog.ts";
+import { runSubnetLifecycleLane } from "../src/subnet-lifecycle.ts";
 import { pruneChainDetail } from "../src/chain-detail-prune.ts";
 import { runRpcUsageStalenessWatchdog } from "../src/rpc-usage-staleness-watchdog.ts";
 import { runTopHoldersStalenessWatchdog } from "../src/top-holders-staleness-watchdog.ts";
@@ -2499,9 +2500,32 @@ async function dispatchScheduled(
     // The neurons live lane's alarm. Zero alerts is the correct steady state;
     // a stale verdict records one exception under
     // watchdog:neurons-staleness, which is the project's alert channel.
-    return runNeuronsStalenessWatchdog(
+    // #10262 rides this tick rather than taking a cron of its own. It needs
+    // exactly what this watchdog already reads -- the netuid set at `neurons`'
+    // newest stamp, and whether that pass cleared the coverage floor -- so a
+    // separate trigger would re-read the same pass on a different schedule and
+    // add a 35th cron expression to the 34 that #10226 exists to collapse.
+    //
+    // Guarded, and deliberately AFTER the watchdog: the alarm is the load-
+    // bearing half. A lifecycle write that throws must not cost the estate its
+    // neurons staleness verdict, so its failure is swallowed here and recorded
+    // in its own lane_health row.
+    const staleness = await runNeuronsStalenessWatchdog(
       env as unknown as Record<string, unknown>,
     );
+    const lifecycle = runSubnetLifecycleLane(
+      env as unknown as Record<string, unknown>,
+      { ctx },
+    ).catch(() => undefined);
+    // waitUntil where there is one, AWAIT where there is not. A bare `{}` ctx
+    // reaches here from callers that have none to give, and calling
+    // `ctx.waitUntil` on it throws -- which would take the staleness alarm down
+    // with it, the precise outcome the guard above exists to prevent. Awaiting
+    // is the safe fallback rather than dropping the promise, because a floating
+    // promise in an isolate that is about to end is work silently not done.
+    if (typeof ctx?.waitUntil === "function") ctx.waitUntil(lifecycle);
+    else await lifecycle;
+    return staleness;
   }
   if (cron === PROJECTION_STALENESS_WATCHDOG_CRON) {
     // The projection lanes' alarm (#9423). Zero alerts is the correct steady


### PR DESCRIPTION
Closes #10262. First slice of #10260 — the record itself, no serving surface (that is #10263).

## The gap

Per-**UID** registration is well covered: `neurons.registered_at_block`, `is_immunity_period`, a daily history in `neuron_daily`, three deregistration routes. Per-**subnet** there was no record at all.

So a deregistered subnet's `subnet_hyperparams` row lingers forever (#10259), every count derived from it keeps counting a subnet that is gone, and "how many subnets existed on 2026-06-01" is unanswerable.

## The signal needs no producer change

`subnet_hyperparams` cannot be the source — nothing prunes it, so a dead subnet's row never disappears and its absence is never observable. Using it would be circular with #10259.

`neurons` can. The metagraph lane rewrites **every** netuid on every pass under one shared `captured_at` — measured on production: 30,129 rows, 129 netuids, `COUNT(DISTINCT captured_at) = 1`. So the netuid set at the newest stamp *is* the live subnet set, and diffing two observations is the event.

## The gate is the important part

A netuid missing because the scan **died** is not a deregistration, and this table is append-only, so a false `deregistered` row is permanent. The scan does die — `lane_health`, twice within one hour on 2026-08-08:

```
22:35  stale  scan Delegates: Encountered an error iterating over storage
22:34  stale  scan Delegates: Encountered an error iterating over storage
```

Detection therefore runs **only** above the same 80% coverage floor `neurons-staleness` already uses, and below it writes **nothing**. Writing nothing is always recoverable — the next complete pass sees the same difference and emits the same event. Writing a false deregistration is not.

Same distinction #10236's registry resync had to make between an empty listing and an unreachable one: absence only means something when you know you looked properly.

## The first run seeds rather than registering

With an empty table, every live subnet would otherwise be recorded as newly registered *at the moment this lane was deployed* — false, and permanently so. Seed rows carry `predates_capture: true` and **no block**, because the current head is not when they happened.

## No new cron

It rides the `neurons-staleness` tick, which already reads exactly what this needs — the netuid set at the newest stamp and whether the pass cleared the floor. A trigger of its own would re-read the same pass on a different schedule and add a **35th** cron expression to the 34 that #10226 exists to collapse.

Deliberately **after** the watchdog and detached: the alarm is the load-bearing half, so a lifecycle write that throws must not cost the estate its staleness verdict. Both the ordering and the `.catch` are asserted.

`ctx.waitUntil` is guarded — a bare `{}` ctx reaches the scheduled dispatcher from callers that have none, and calling `waitUntil` on it throws, which would have taken the alarm down with it. That was a real failure in `tests/neurons-staleness-watchdog.test.ts` before the guard, not a hypothetical. Where there is no `waitUntil` the promise is **awaited** rather than dropped, because a floating promise in an isolate about to end is work silently not done.

## Tests — 19, weighted toward what must NOT be written

- **a short pass writes nothing** — 40 of 129, zero rows, `stale` verdict naming the floor
- the first run seeds, and a seeded row **cannot claim a block**
- the seeding run emits **no** deregistrations — an empty known set means nothing is known to have left
- a netuid whose newest event is `deregistered` is not counted as live, so a return re-registers
- re-registration is a second row, not a mutation
- a failing read is `query_failed`, not "no change"
- events to write with no write runner is a **failure**, not a quiet pass

Plus the two scheduling assertions above.

26 neuron/cron/config/lane suites, 572 tests, pass. `tsc`, `lint`, `prettier` clean. `validate:migrations` → 13 files.

`migrations/neon/0013_subnet_lifecycle.sql` is applied (table + two indexes, 0 rows — it seeds on its first tick). It carries the same epoch-ms CHECK 0010 added, because #9782 is exactly what happens to an append-only table when a stamp loses three digits.