### PR TITLE
feat(graphql): execute every Query field against production, and fix the three the first run broke on (#10215)

### DIFF
--- a/.github/workflows/check-graphql-conformance.yml
+++ b/.github/workflows/check-graphql-conformance.yml
@@ -1,0 +1,69 @@
+name: Check GraphQL conformance
+
+# Does the GraphQL surface ANSWER? (#10215)
+#
+# MCP has check-mcp-conformance.yml, REST has check-response-conformance.yml.
+# GraphQL had neither: everything asserted about its 194 Query fields was
+# static -- the SDL compared to openapi.json offline -- and nothing had ever
+# executed a query against production and looked at the answer.
+#
+# A static gate cannot see a field that resolves to null, a field that answers a
+# confident zero, or a resolver that throws. All three are valid shapes.
+# DomainSummary.emission_concentration was the first: declared Float against a
+# 12-key object, so graphql-js coerced it to null on all 14 domains, and the
+# SDL's own comment defined that null as "the domain has no members". It was
+# found by reading, not by running. #10246 was the second: chain_transfers
+# reported 0 while its REST twin reported 2,859,197 in the same second.
+#
+# Out of band rather than in CI, for the same reason its two siblings are: it
+# needs production data, and a check that cannot run on a pull request should
+# not pretend to.
+on:
+  schedule:
+    # Daily, offset from check-mcp-conformance's 07:17 and
+    # check-response-conformance's 06:41 so the three are not sweeping the same
+    # Worker at once.
+    - cron: "53 7 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-graphql-conformance
+  cancel-in-progress: false
+
+jobs:
+  conformance:
+    name: Execute every Query field against production
+    runs-on: ubuntu-latest
+    # 192 fields at ~0.9s spacing plus a REST read for each of the ~184 that
+    # name the route they mirror is ~6 minutes; the ceiling leaves room for
+    # rate-limit backoff without letting a hung fetch hold a runner all day.
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.2
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Execute every Query field against production
+        run: |
+          node scripts/check-graphql-conformance.ts | tee graphql-conformance.log
+          {
+            echo '## GraphQL conformance'
+            echo '```'
+            cat graphql-conformance.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2248,12 +2248,24 @@ export type EndpointIncident = {
   user_reported?: Maybe<Scalars['Boolean']['output']>;
 };
 
+/**
+ * One reconstructed outage window.
+ *
+ * `started_at` and `ended_at` are epoch MILLISECONDS, which is why they are
+ * Float and not Int: GraphQL's Int is 32-bit and every real value overflows it
+ * (1786228205841 against a ceiling of 2147483647). Every incident window on
+ * `incidents`, `global_incidents` and `subnet_health_incidents` therefore
+ * errored, and because both fields are non-null the error propagated up and
+ * nulled the surrounding list -- on every request, since the surface shipped.
+ * Nothing had executed these fields (#10215). `duration_ms` is a span rather
+ * than an instant and stays an Int.
+ */
 export type EndpointIncidentWindow = {
   __typename?: 'EndpointIncidentWindow';
   duration_ms: Scalars['Int']['output'];
-  ended_at: Scalars['Int']['output'];
+  ended_at: Scalars['Float']['output'];
   failed_samples: Scalars['Int']['output'];
-  started_at: Scalars['Int']['output'];
+  started_at: Scalars['Float']['output'];
 };
 
 export type EndpointList = {
@@ -5006,11 +5018,26 @@ export type SelfHealthDay = {
   uptime_ratio: Scalars['Float']['output'];
 };
 
+/**
+ * One ingest lane's staleness verdict.
+ *
+ * Three of these five were declared non-null against a Zod schema that says
+ * otherwise, and production proved it: `self_health` returned
+ * `Cannot return null for non-nullable field SelfHealthLane.detail` and nulled
+ * the whole `lanes` list. `age_ms` and `checked_at` are null for the same
+ * reason -- the watchdog could not measure the lane, which is the "we did not
+ * measure" this type exists to distinguish from "the lane is fine" (#10215).
+ *
+ * `age_ms` is a Float because it is a duration in MILLISECONDS: a lane stale
+ * for more than 24.8 days exceeds GraphQL's 32-bit Int, and the answer to
+ * "how far behind is this lane" must not stop being representable exactly when
+ * it starts to matter.
+ */
 export type SelfHealthLane = {
   __typename?: 'SelfHealthLane';
-  age_ms: Scalars['Int']['output'];
-  checked_at: Scalars['String']['output'];
-  detail: Scalars['String']['output'];
+  age_ms?: Maybe<Scalars['Float']['output']>;
+  checked_at?: Maybe<Scalars['String']['output']>;
+  detail?: Maybe<Scalars['String']['output']>;
   lane: Scalars['String']['output'];
   verdict: Scalars['String']['output'];
 };
@@ -9038,9 +9065,9 @@ export type EndpointIncidentResolvers<ContextType = GqlContext, ParentType exten
 
 export type EndpointIncidentWindowResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['EndpointIncidentWindow'] = ResolversParentTypes['EndpointIncidentWindow']> = ResolversObject<{
   duration_ms?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  ended_at?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  ended_at?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   failed_samples?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  started_at?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  started_at?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
 }>;
 
 export type EndpointListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['EndpointList'] = ResolversParentTypes['EndpointList']> = ResolversObject<{
@@ -10004,9 +10031,9 @@ export type SelfHealthDayResolvers<ContextType = GqlContext, ParentType extends 
 }>;
 
 export type SelfHealthLaneResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SelfHealthLane'] = ResolversParentTypes['SelfHealthLane']> = ResolversObject<{
-  age_ms?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  checked_at?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  detail?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  age_ms?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  checked_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  detail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   lane?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   verdict?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
 }>;

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "deploy:wss-lb:preview": "scripts/deploy-worker-with-sourcemaps.sh wrangler.wss-lb.jsonc --preview",
     "smoke:live": "node scripts/smoke-live-api.ts",
     "smoke:mcp": "node scripts/mcp-smoke-sweep.ts",
+    "conformance:graphql": "node scripts/check-graphql-conformance.ts",
     "conformance:mcp": "node scripts/check-mcp-conformance.ts",
     "lint": "eslint .",
     "format:check": "prettier --check .",

--- a/schemas-src/graphql/emit.ts
+++ b/schemas-src/graphql/emit.ts
@@ -306,7 +306,24 @@ export function emitTypes(): EmittedTypes {
       return GraphQLString;
     }
 
-    if (node.type === "integer") return GraphQLInt;
+    // An INSTANT is a Float, not an Int. GraphQL's Int is 32-bit and every
+    // epoch-millisecond value overflows it -- 1786228205841 against a ceiling
+    // of 2147483647 -- so a non-null one nulls its whole parent list on every
+    // request. The hand-written SDL did exactly that on
+    // `EndpointIncidentWindow.started_at`/`ended_at`, unnoticed until #10215
+    // executed the fields; this is the rule that stops the generated SDL
+    // reintroducing it.
+    //
+    // Keyed on the NAME because the type cannot tell: `z.int()` stamps the JS
+    // safe-integer ceiling on every integer, count and instant alike, so
+    // "maximum exceeds Int32" is true of all of them. `_at` on an integer
+    // means an epoch value on this surface -- verified: the two that exist are
+    // the two that were broken. A DURATION (`duration_ms`, `age_ms`) is a span
+    // rather than an instant and stays an Int unless it is separately declared
+    // beyond the range.
+    if (node.type === "integer") {
+      return /_at$/.test(fallbackName) ? GraphQLFloat : GraphQLInt;
+    }
     if (node.type === "number") return GraphQLFloat;
     if (node.type === "boolean") return GraphQLBoolean;
     if (node.type === "string") return GraphQLString;

--- a/scripts/check-graphql-conformance.ts
+++ b/scripts/check-graphql-conformance.ts
@@ -1,0 +1,477 @@
+// Does the GraphQL surface ANSWER? (#10215)
+//
+// MCP has `conformance:mcp` -- 221 tools called against production, responses
+// validated against their own published schemas, scheduled daily. REST has
+// `check-response-conformance.ts`. GraphQL had neither: everything asserted
+// about it was static, the SDL compared to `openapi.json` offline, and nothing
+// had ever executed a query against production and looked at the answer.
+//
+// WHAT A STATIC GATE CANNOT SEE. Both shapes are valid and the schema is
+// satisfied in every one of these:
+//
+//   a field that resolves to null           DomainSummary.emission_concentration
+//                                           was declared Float against a 12-key
+//                                           object, so graphql-js coerced it to
+//                                           null on all 14 domains -- and the
+//                                           SDL's own comment defined that null
+//                                           as "the domain has no members"
+//   a field that answers a confident zero   chain_transfers reported 0 while
+//                                           its REST twin reported 2,859,197 in
+//                                           the same second (#10246)
+//   a resolver that throws                  nothing dispatched these fields
+//
+// THREE THINGS FAIL THIS CHECK, and they need no judgement to confirm:
+//
+//   1. `errors[]`            the field did not answer
+//   2. a null top-level      the SDL says the field resolves to a card, and
+//                            production returned nothing
+//   3. a numeric disagreement with the REST route the field says it MIRRORS
+//
+// (3) IS DELIBERATELY NARROW. ~25 of the SDL's types are resolver-built
+// pagination views rather than mirrors of an artifact, so diffing a GraphQL
+// answer against a REST body wholesale is a category error that manufactures
+// findings -- measured: an early sweep reported 161 "divergences", of which the
+// real count was 3. What is compared instead is only a key present on BOTH
+// sides whose value is a NUMBER on both sides. That is exactly the class
+// #10246 was: same question, same second, two different totals.
+//
+// Scheduled out of band like its MCP sibling, never in CI: it needs production.
+import { buildSchema } from "graphql";
+import type {
+  GraphQLArgument,
+  GraphQLField,
+  GraphQLNamedType,
+  GraphQLObjectType,
+  GraphQLOutputType,
+  GraphQLSchema,
+} from "graphql";
+import { SDL } from "../src/graphql-sdl.ts";
+
+// Live GraphQL payloads, read for reporting. Same `Row` precedent as
+// scripts/check-mcp-conformance.ts: an unexpected shape is what this exists to
+// surface, so typing each hop through `unknown` buys nothing.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+
+const ENDPOINT =
+  process.env.GRAPHQL_CONFORMANCE_ENDPOINT ||
+  "https://api.metagraph.sh/api/v1/graphql";
+const REST_ORIGIN =
+  process.env.GRAPHQL_CONFORMANCE_REST_ORIGIN || "https://api.metagraph.sh";
+// Serial and spaced, for the reason the MCP sweep records: the endpoint
+// rate-limits per CLIENT, so a parallel sweep turns healthy fields into
+// failures that read exactly like real defects.
+const CALL_SPACING_MS = Number(
+  process.env.GRAPHQL_CONFORMANCE_SPACING_MS ?? 900,
+);
+const REQUEST_TIMEOUT_MS = 30000;
+const RATE_LIMIT_RETRIES = 4;
+const RATE_LIMIT_BACKOFF_MS = 2000;
+
+/**
+ * How much of each field's answer to ask for.
+ *
+ * Not the whole tree: `src/graphql.ts` enforces a depth and a complexity
+ * budget, and a greedy selection is rejected by our own guard rather than by
+ * the data. Three levels and eight fields per level reaches the scalars that
+ * carry the counts -- which is what (2) and (3) above are about -- while
+ * staying well inside it.
+ */
+const MAX_DEPTH = 3;
+const MAX_FIELDS_PER_LEVEL = 8;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Concrete values for the arguments a field REQUIRES.
+ *
+ * The same subjects the parity gates use, so a field that declines here is
+ * declining for the same reason its REST twin would. Optional arguments are
+ * left out entirely: a field's default answer is the one a caller gets first,
+ * and it is the one nothing had ever checked.
+ */
+const ARGUMENT_FIXTURES: Record<string, unknown> = {
+  netuid: 64,
+  uid: 0,
+  ss58: "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
+  hotkey: "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
+  coldkey: "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
+  address: "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
+  ref: "4200000",
+  slug: "opentensor-foundation",
+  provider: "opentensor-foundation",
+  id: "sn-64-docs",
+  date: "2026-08-01",
+  tag: "inference",
+  q: "inference",
+  query: "inference",
+  hash: `0x${"a".repeat(64)}`,
+  h160: `0x${"a".repeat(40)}`,
+  surface_id: "sn-64-docs",
+  crowdloan_id: 0,
+  netuids: [1, 64],
+  hotkeys: "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
+  ids: "s64",
+};
+
+/**
+ * Where the argument's SUBJECT is the field's rather than the name's.
+ *
+ * `id` is a surface id nearly everywhere and a saved-query name on one field;
+ * `slug` is a provider on most and an adapter on one. A shared fixture there
+ * reports "unknown saved query" as though the field were broken, which is the
+ * one thing a conformance report must not do -- the same reason the MCP sweep
+ * reports an undocumented argument instead of guessing one.
+ */
+const FIELD_ARGUMENT_FIXTURES: Record<string, Record<string, unknown>> = {
+  saved_query: { id: "subnet-leaderboard" },
+  fixture: { surface_id: "allways-api-health" },
+  adapter: { slug: "allways" },
+  provider: { id: "academia" },
+  provider_endpoints: { slug: "opentensor" },
+  provider_detail: { slug: "opentensor" },
+};
+
+export interface FieldPlan {
+  field: string;
+  query: string;
+  /** The same field with a shallower selection, for a complexity refusal. */
+  narrowQuery: string;
+  /** The REST route the SDL says this field mirrors, if it names one. */
+  mirrors: string | null;
+}
+
+export interface Finding {
+  field: string;
+  kind: "error" | "null" | "divergence";
+  detail: string;
+}
+
+export interface ConformanceReport {
+  executed: number;
+  compared: number;
+  /** Fields re-asked with a shallower selection after a complexity refusal. */
+  narrowed: string[];
+  /** Disagreements that did not reproduce -- one side served a degraded read. */
+  transient: string[];
+  unfixtured: string[];
+  findings: Finding[];
+}
+
+function namedTypeOf(type: GraphQLOutputType): GraphQLNamedType {
+  let current = type as Row;
+  while (current.ofType) current = current.ofType;
+  return current as unknown as GraphQLNamedType;
+}
+
+function isLeaf(type: GraphQLNamedType): boolean {
+  const kind = (type as Row).constructor?.name ?? "";
+  return kind === "GraphQLScalarType" || kind === "GraphQLEnumType";
+}
+
+function objectFieldsOf(type: GraphQLNamedType): Row | null {
+  const getFields = (type as Row).getFields;
+  if (typeof getFields !== "function") return null;
+  // Unions and interfaces need inline fragments to select through; the fields
+  // this sweep is after are all on plain object types.
+  if ((type as Row).constructor?.name !== "GraphQLObjectType") return null;
+  return (type as GraphQLObjectType).getFields() as unknown as Row;
+}
+
+/**
+ * A selection set for one output type: its leaves first, then one bounded
+ * descent into the objects that carry the rest.
+ *
+ * Fields with REQUIRED arguments are skipped inside the tree -- a nested field
+ * that needs an argument is asking a different question, and guessing one here
+ * would report the guess's failure as the field's.
+ */
+function selectionFor(type: GraphQLNamedType, depth: number): string {
+  const fields = objectFieldsOf(type);
+  if (!fields) return "";
+  const leaves: string[] = [];
+  const branches: string[] = [];
+  for (const field of Object.values(fields) as GraphQLField<
+    unknown,
+    unknown
+  >[]) {
+    if (field.args.some((arg) => String(arg.type).endsWith("!"))) continue;
+    const named = namedTypeOf(field.type);
+    if (isLeaf(named)) {
+      if (leaves.length < MAX_FIELDS_PER_LEVEL) leaves.push(field.name);
+      continue;
+    }
+    if (depth >= MAX_DEPTH || branches.length >= 2) continue;
+    const nested = selectionFor(named, depth + 1);
+    if (nested) branches.push(`${field.name} ${nested}`);
+  }
+  const selected = [...leaves, ...branches];
+  return selected.length > 0 ? `{ ${selected.join(" ")} }` : "";
+}
+
+/** `Mirrors GET /api/v1/…` out of a field's own description. */
+export function mirroredRoute(
+  description: string | null | undefined,
+): string | null {
+  const match = /Mirrors GET (\/api\/v1\/[^\s.]+)/.exec(description ?? "");
+  return match ? match[1] : null;
+}
+
+function argumentLiteral(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(argumentLiteral).join(", ")}]`;
+  return typeof value === "number" ? String(value) : JSON.stringify(value);
+}
+
+/**
+ * The query to send for one Query field, or null when a required argument has
+ * no fixture -- reported rather than guessed, the same rule
+ * `buildToolArguments` follows on the MCP side.
+ */
+export function planFor(
+  field: GraphQLField<unknown, unknown>,
+): FieldPlan | null {
+  const required = field.args.filter((arg: GraphQLArgument) =>
+    String(arg.type).endsWith("!"),
+  );
+  const overrides = FIELD_ARGUMENT_FIXTURES[field.name] ?? {};
+  const supplied: string[] = [];
+  for (const arg of required) {
+    const value =
+      arg.name in overrides ? overrides[arg.name] : ARGUMENT_FIXTURES[arg.name];
+    if (value === undefined) return null;
+    supplied.push(`${arg.name}: ${argumentLiteral(value)}`);
+  }
+  const args = supplied.length > 0 ? `(${supplied.join(", ")})` : "";
+  const selection = selectionFor(namedTypeOf(field.type), 1);
+  return {
+    field: field.name,
+    query: `{ ${field.name}${args} ${selection} }`,
+    // The same field asked for less, for when the full selection trips the
+    // surface's own complexity budget. That refusal is this sweep's query
+    // being too big, not the field being broken, and reporting it as a
+    // finding would be reporting our own probe.
+    narrowQuery: `{ ${field.name}${args} ${selectionFor(namedTypeOf(field.type), MAX_DEPTH)} }`,
+    mirrors: mirroredRoute(field.description),
+  };
+}
+
+/** Every Query field the SDL declares, with the query that exercises it. */
+export function planAll(schema: GraphQLSchema): {
+  plans: FieldPlan[];
+  unfixtured: string[];
+} {
+  const query = schema.getQueryType();
+  /* v8 ignore next -- the SDL always declares a Query root. */
+  if (!query) return { plans: [], unfixtured: [] };
+  const plans: FieldPlan[] = [];
+  const unfixtured: string[] = [];
+  for (const field of Object.values(query.getFields())) {
+    const plan = planFor(field);
+    if (plan) plans.push(plan);
+    else unfixtured.push(field.name);
+  }
+  return { plans, unfixtured };
+}
+
+async function execute(query: string): Promise<Row> {
+  for (let attempt = 0; ; attempt += 1) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    let body: Row;
+    let status: number;
+    try {
+      const res = await fetch(ENDPOINT, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ query }),
+        signal: controller.signal,
+      });
+      status = res.status;
+      body = (await res.json()) as Row;
+    } finally {
+      clearTimeout(timer);
+    }
+    // A rate-limited call is not a result. Retrying rather than reporting it
+    // keeps "this field is broken" out of the same bucket as "we asked too
+    // fast" -- the one distinction a conformance report must not lose.
+    if (status === 429 && attempt < RATE_LIMIT_RETRIES) {
+      await sleep(RATE_LIMIT_BACKOFF_MS * (attempt + 1));
+      continue;
+    }
+    return body;
+  }
+}
+
+async function restBody(path: string): Promise<Row | null> {
+  let resolved = path;
+  for (const [name, value] of Object.entries(ARGUMENT_FIXTURES)) {
+    resolved = resolved.split(`{${name}}`).join(String(value));
+  }
+  if (/\{[a-z_0-9]+\}/.test(resolved)) return null;
+  const res = await fetch(`${REST_ORIGIN}${resolved}`, {
+    headers: { accept: "application/json" },
+  });
+  if (!res.ok) return null;
+  const body = (await res.json()) as Row;
+  return body?.data && typeof body.data === "object"
+    ? (body.data as Row)
+    : null;
+}
+
+/**
+ * Numbers the two surfaces both report for the same key, and disagree on.
+ *
+ * Exported for the unit test: the transport needs production, the comparison
+ * does not, and a comparison nobody can test offline is a comparison nobody
+ * checks.
+ */
+export function numericDivergences(
+  graphqlValue: unknown,
+  restData: Row,
+): string[] {
+  if (!graphqlValue || typeof graphqlValue !== "object") return [];
+  const divergences: string[] = [];
+  for (const [key, value] of Object.entries(graphqlValue as Row)) {
+    if (typeof value !== "number") continue;
+    // An AGE is computed at read time, so two calls a second apart disagree by
+    // construction. Comparing it reports the gap between the two requests as a
+    // defect -- measured on the first run: `head_age_ms` 39130 vs 40076, one
+    // second of elapsed time reported as a contract violation.
+    if (/_age_ms$|^age_ms$/.test(key)) continue;
+    const rest = restData[key];
+    if (typeof rest !== "number") continue;
+    if (value !== rest)
+      divergences.push(`${key}: graphql ${value}, rest ${rest}`);
+  }
+  return divergences;
+}
+
+export async function run(): Promise<ConformanceReport> {
+  const schema = buildSchema(SDL);
+  const { plans, unfixtured } = planAll(schema);
+  const report: ConformanceReport = {
+    executed: 0,
+    compared: 0,
+    narrowed: [],
+    transient: [],
+    unfixtured,
+    findings: [],
+  };
+
+  for (const plan of plans) {
+    let body = await execute(plan.query);
+    await sleep(CALL_SPACING_MS);
+    if (
+      /Query complexity \d+ exceeds/.test(String(body?.errors?.[0]?.message))
+    ) {
+      report.narrowed.push(plan.field);
+      body = await execute(plan.narrowQuery);
+      await sleep(CALL_SPACING_MS);
+    }
+    if (Array.isArray(body?.errors) && body.errors.length > 0) {
+      report.findings.push({
+        field: plan.field,
+        kind: "error",
+        detail: String(body.errors[0]?.message ?? "unknown error"),
+      });
+      continue;
+    }
+    report.executed += 1;
+    const value = body?.data?.[plan.field];
+    if (value === null || value === undefined) {
+      report.findings.push({
+        field: plan.field,
+        kind: "null",
+        detail: "resolved to null against production",
+      });
+      continue;
+    }
+    if (!plan.mirrors) continue;
+    const rest = await restBody(plan.mirrors);
+    if (!rest) continue;
+    report.compared += 1;
+    const divergences = numericDivergences(value, rest);
+    if (divergences.length === 0) continue;
+
+    // ASK BOTH SIDES AGAIN before reporting. A single disagreement cannot
+    // distinguish "these two surfaces answer differently" from "one of these
+    // two calls hit a degraded read" -- and the second really happens:
+    // /accounts/{ss58}/counterparties served `counterparty_count: 0` on 1 of 5
+    // consecutive requests for an account with 114, measured while this check
+    // was being written. Reporting that as a cross-surface divergence would
+    // name the wrong defect AND make the check flaky, which is how a scheduled
+    // check gets turned off.
+    //
+    // The transient is a real defect of its own -- it is just not this one.
+    await sleep(CALL_SPACING_MS);
+    const confirmValue = (await execute(plan.query))?.data?.[plan.field];
+    const confirmRest = await restBody(plan.mirrors);
+    const confirmed = confirmRest
+      ? new Set(numericDivergences(confirmValue, confirmRest))
+      : new Set<string>();
+    for (const divergence of divergences) {
+      if (!confirmed.has(divergence)) {
+        report.transient.push(`${plan.field} ${divergence}`);
+        continue;
+      }
+      report.findings.push({
+        field: plan.field,
+        kind: "divergence",
+        detail: `${plan.mirrors} ${divergence}`,
+      });
+    }
+  }
+  return report;
+}
+
+export function formatReport(report: ConformanceReport): string {
+  const lines = [
+    `Query fields executed against production: ${report.executed}`,
+    `of those, compared numerically against the REST route they mirror: ${report.compared}`,
+  ];
+  if (report.narrowed.length > 0) {
+    lines.push(
+      `re-asked with a shallower selection (complexity budget): ${report.narrowed.join(", ")}`,
+    );
+  }
+  if (report.transient.length > 0) {
+    lines.push(
+      `disagreed once and agreed on re-ask -- one side served a degraded read: ${report.transient.join(", ")}`,
+    );
+  }
+  if (report.unfixtured.length > 0) {
+    lines.push(
+      `not callable -- a required argument has no fixture: ${report.unfixtured.join(", ")}`,
+    );
+  }
+  if (report.findings.length === 0) {
+    lines.push("");
+    lines.push("Every field answered, and no answer contradicted its route.");
+    return lines.join("\n");
+  }
+  lines.push("");
+  lines.push(`${report.findings.length} FINDING(S):`);
+  for (const finding of report.findings) {
+    lines.push(`  [${finding.kind}] ${finding.field}: ${finding.detail}`);
+  }
+  return lines.join("\n");
+}
+
+// Guarded so the module can be imported by its test without sweeping
+// production, matching scripts/check-mcp-conformance.ts.
+if (
+  process.argv[1] &&
+  import.meta.url.endsWith(process.argv[1].split("/").pop() ?? "")
+) {
+  const report = await run();
+  console.log(formatReport(report));
+  if (report.findings.length > 0) process.exitCode = 1;
+  // Zero executed fields means the sweep did not run, not that everything
+  // passed -- without this the check reports a clean sheet after an outage.
+  if (report.executed === 0) {
+    console.error(
+      "No field was executed at all -- treating as a failure rather than a clean run.",
+    );
+    process.exitCode = 1;
+  }
+}

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -5298,12 +5298,27 @@ export const SDL = /* GraphQL */ `
     url: String!
   }
 
+  """
+  One ingest lane's staleness verdict.
+
+  Three of these five were declared non-null against a Zod schema that says
+  otherwise, and production proved it: \`self_health\` returned
+  \`Cannot return null for non-nullable field SelfHealthLane.detail\` and nulled
+  the whole \`lanes\` list. \`age_ms\` and \`checked_at\` are null for the same
+  reason -- the watchdog could not measure the lane, which is the "we did not
+  measure" this type exists to distinguish from "the lane is fine" (#10215).
+
+  \`age_ms\` is a Float because it is a duration in MILLISECONDS: a lane stale
+  for more than 24.8 days exceeds GraphQL's 32-bit Int, and the answer to
+  "how far behind is this lane" must not stop being representable exactly when
+  it starts to matter.
+  """
   type SelfHealthLane {
     lane: String!
     verdict: String!
-    age_ms: Int!
-    detail: String!
-    checked_at: String!
+    age_ms: Float
+    detail: String
+    checked_at: String
   }
 
   type RuntimeCoverageGap {
@@ -5337,9 +5352,21 @@ export const SDL = /* GraphQL */ `
     latest_stake_event_at: String!
   }
 
+  """
+  One reconstructed outage window.
+
+  \`started_at\` and \`ended_at\` are epoch MILLISECONDS, which is why they are
+  Float and not Int: GraphQL's Int is 32-bit and every real value overflows it
+  (1786228205841 against a ceiling of 2147483647). Every incident window on
+  \`incidents\`, \`global_incidents\` and \`subnet_health_incidents\` therefore
+  errored, and because both fields are non-null the error propagated up and
+  nulled the surrounding list -- on every request, since the surface shipped.
+  Nothing had executed these fields (#10215). \`duration_ms\` is a span rather
+  than an instant and stays an Int.
+  """
   type EndpointIncidentWindow {
-    started_at: Int!
-    ended_at: Int!
+    started_at: Float!
+    ended_at: Float!
     duration_ms: Int!
     failed_samples: Int!
   }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -268,6 +268,10 @@ import {
 import { loadGlobalIncidentsLedger } from "../workers/request-handlers/analytics.ts";
 import { validateRouteArgs } from "./route-query.ts";
 import {
+  CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
+  CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
+} from "./route-limits.ts";
+import {
   BLOCK_PAGINATION,
   DAY_PATTERN,
   FEED_PAGINATION,
@@ -2818,10 +2822,17 @@ const rootValue = {
     { limit }: QueryChain_Identity_HistoryArgs,
     context: GqlContext,
   ) {
-    // Same FEED_PAGINATION clamp REST applies. This chain-wide feed is
-    // limit-only (no offset/cursor) -- the network view returns the most-recent
-    // changes across every subnet in one pass.
-    const safeLimit = clampLimit(limit, FEED_PAGINATION);
+    // The ROUTE's page size, not the generic feed profile. This resolver
+    // clamped against FEED_PAGINATION -- default 100, cap 1000 -- while
+    // /api/v1/chain/identity-history publishes 50/200, so the two surfaces
+    // answered the same question with different pages: 100 changes across 88
+    // subnets over GraphQL against 50 across 45 over REST, in the same second
+    // (#10215). This feed is limit-only (no offset/cursor); the network view
+    // returns the most-recent changes across every subnet in one pass.
+    const safeLimit = clampLimit(limit, {
+      defaultLimit: CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
+      maxLimit: CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
+    });
     const params = new URLSearchParams();
     params.set("limit", String(safeLimit));
     // D1 retirement: subnet_identity_history's D1 write path is retired

--- a/tests/graphql-conformance.test.ts
+++ b/tests/graphql-conformance.test.ts
@@ -1,0 +1,122 @@
+// The parts of the production GraphQL sweep that do not need production.
+//
+// The transport is the half that needs the live surface; the query it builds
+// and the comparison it makes are not, and a comparison nobody can test
+// offline is a comparison nobody checks — the same split
+// tests/mcp-conformance.test.ts draws for its MCP sibling (#10215).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { buildSchema, parse } from "graphql";
+import { SDL } from "../src/graphql-sdl.ts";
+import {
+  mirroredRoute,
+  numericDivergences,
+  planAll,
+  planFor,
+} from "../scripts/check-graphql-conformance.ts";
+
+const schema = buildSchema(SDL);
+const queryFields = schema.getQueryType()!.getFields();
+
+describe("the GraphQL conformance sweep plans a real query per field", () => {
+  test("every Query field is planned, or named as unfixtured", () => {
+    const { plans, unfixtured } = planAll(schema);
+    const total = Object.keys(queryFields).length;
+    assert.equal(
+      plans.length + unfixtured.length,
+      total,
+      "a field must be planned or reported, never silently skipped",
+    );
+    // The sweep's whole claim is coverage, so a fixture regression that halved
+    // it must fail here rather than be reported as a clean run.
+    assert.ok(
+      plans.length > total * 0.95,
+      `only ${plans.length} of ${total} fields are callable: ${unfixtured.join(", ")}`,
+    );
+  });
+
+  test("every planned query parses", () => {
+    // A generated query that does not parse would come back as an `errors[]`
+    // finding and read exactly like a broken resolver.
+    const { plans } = planAll(schema);
+    for (const plan of plans) {
+      assert.doesNotThrow(
+        () => parse(plan.query),
+        `${plan.field}: ${plan.query}`,
+      );
+    }
+  });
+
+  test("a field's required arguments are supplied, and its optional ones are not", () => {
+    // The default answer is the one a caller gets first, and the one nothing
+    // had ever checked.
+    const plan = planFor(queryFields.subnet_registrations);
+    assert.ok(plan);
+    assert.match(plan.query, /^\{ subnet_registrations\(netuid: 64\) \{/);
+    assert.ok(!plan.query.includes("window:"), plan.query);
+  });
+
+  test("a field whose required argument has no fixture is reported, not guessed", () => {
+    const { unfixtured } = planAll(schema);
+    // Guessing an amount for a stake quote would report the guess's failure as
+    // the field's.
+    assert.ok(unfixtured.length >= 1);
+    for (const name of unfixtured) assert.ok(queryFields[name], name);
+  });
+});
+
+describe("the mirrored route comes from the field's own description", () => {
+  test("`Mirrors GET …` is read off the SDL", () => {
+    assert.equal(
+      mirroredRoute(
+        "One subnet's health. Mirrors GET /api/v1/subnets/{netuid}/health.",
+      ),
+      "/api/v1/subnets/{netuid}/health",
+    );
+  });
+
+  test("a field that names no route is compared against nothing", () => {
+    assert.equal(mirroredRoute("A paginated index."), null);
+    assert.equal(mirroredRoute(null), null);
+  });
+
+  test("most fields name one, or the comparison half is decorative", () => {
+    const { plans } = planAll(schema);
+    const mirrored = plans.filter((plan) => plan.mirrors).length;
+    assert.ok(
+      mirrored > 150,
+      `only ${mirrored} fields declare the route they mirror`,
+    );
+  });
+});
+
+describe("the cross-surface comparison is deliberately narrow", () => {
+  test("a number both surfaces report, and disagree on, is a finding", () => {
+    // The #10246 class: same question, same second, two different totals.
+    assert.deepEqual(
+      numericDivergences({ transfer_count: 0 }, { transfer_count: 2859197 }),
+      ["transfer_count: graphql 0, rest 2859197"],
+    );
+  });
+
+  test("agreement is not a finding", () => {
+    assert.deepEqual(numericDivergences({ total: 50 }, { total: 50 }), []);
+  });
+
+  test("a key only one surface reports is not compared", () => {
+    // ~25 SDL types are resolver-built pagination views rather than mirrors of
+    // an artifact. Diffing those wholesale is a category error that
+    // manufactures findings — measured once at 161 reported, 3 real.
+    assert.deepEqual(numericDivergences({ total: 50 }, { count: 40 }), []);
+  });
+
+  test("a key that is not a number on both sides is not compared", () => {
+    assert.deepEqual(numericDivergences({ window: "7d" }, { window: 7 }), []);
+    assert.deepEqual(numericDivergences({ limit: 50 }, { limit: "50" }), []);
+  });
+
+  test("a scalar answer has nothing to compare", () => {
+    assert.deepEqual(numericDivergences(42, { total: 1 }), []);
+    assert.deepEqual(numericDivergences(null, { total: 1 }), []);
+  });
+});

--- a/workers/list-query.ts
+++ b/workers/list-query.ts
@@ -322,7 +322,8 @@ function filterRows(
 // Inclusive numeric range filter: for each configured field F, `?min_F=` keeps
 // rows where row[F] >= n and `?max_F=` keeps rows where row[F] <= n. A row whose
 // F is absent / non-numeric can't satisfy a bound, so it is excluded once any
-// bound on F is set. Validation (validateListQuery) has already confirmed every
+// bound on F is set. Validation (the router's single parse, #10218) has
+// already confirmed every
 // present min_/max_ param is a finite number, so Number() here is safe.
 /**
  * `?min_F=9&max_F=2` -- a range that can match nothing, on purpose or by typo.

--- a/workers/request-params.ts
+++ b/workers/request-params.ts
@@ -4,11 +4,11 @@
 // `cursor` with its own inline `clampInt(...)` calls and literal bounds, so the
 // caps drifted between handlers (and a fix in one route never reached the others).
 // This module is the single place those rules live: the absolute bounds are named
-// constants, the per-route page-size pairs are named profiles, and `parsePagination`
-// returns the same `{ limit, offset, cursor }` shape for every handler -- or a
-// ParamError, since an out-of-range `limit` is rejected rather than clamped (#9916). The raw
-// `clampLimit`/`clampOffset` primitives let the shared D1 loaders + MCP tools clamp
-// identically off plain values (they never see a URL).
+// constants and the per-route page-size pairs are named profiles. The URL
+// parsers that used to live here went with #10218 -- see the note below the
+// profiles -- leaving the `clampLimit`/`clampOffset` primitives, which let the
+// shared D1 loaders and MCP tools clamp identically off plain values (they
+// never see a URL).
 //
 // Import-free apart from `clampInt`, so it stays a leaf the request handlers and
 // the src/* loaders can both depend on without a cycle.


### PR DESCRIPTION
Closes #10215.

MCP has `conformance:mcp` — 221 tools called against production daily, responses validated against their own published schemas. REST has `check-response-conformance`. **GraphQL had neither.** Everything asserted about its 194 Query fields was static: the SDL compared to `openapi.json`, offline. Nothing had ever executed a query against production and looked at the answer.

The first run found three declarations production cannot satisfy. Every shape involved is valid, which is exactly why a static gate could not see any of them.

## What was broken

**`EndpointIncidentWindow.started_at` / `ended_at` — epoch milliseconds declared `Int`.**

GraphQL's `Int` is signed 32-bit. Every real value overflows it:

```
Int cannot represent non 32-bit signed integer value: 1786228205841
                                          ceiling:       2147483647
```

Both fields are non-null, so the error propagates up and nulls the surrounding list. Every incident window on `incidents`, `global_incidents` and `subnet_health_incidents` has failed on **every request since the surface shipped**. REST serves the same numbers fine — it has no 32-bit integer.

**`SelfHealthLane` declared three nullable fields non-null.** `age_ms`, `detail` and `checked_at` are `.nullable()` in `SelfHealthLaneSchema`, and the SDL said `Int!`, `String!`, `String!`. Production returns `detail: null` for a lane the watchdog could not measure — which is the distinction the type exists to draw — so `self_health.lanes` resolves to null:

```
Cannot return null for non-nullable field SelfHealthLane.detail.
```

`age_ms` is now `Float` as well as nullable: a duration in milliseconds passes 32-bit at 24.8 days, so "how far behind is this lane" would stop being representable exactly when it starts to matter.

**`chain_identity_history` answered a different page than its route.** The resolver clamped against the generic feed profile (default 100, cap 1000) while `/api/v1/chain/identity-history` publishes 50/200. Same question, same second, two answers:

| | GraphQL | REST |
|---|---|---|
| `count` | 100 | 50 |
| `subnet_count` | 88 | 45 |

It now reads `CHAIN_IDENTITY_HISTORY_LIMIT_*`, the constants the route is built from.

## The check

`scripts/check-graphql-conformance.ts` builds a query per Query field from the SDL's own argument list, executes it against production serially, and fails on three things that need no judgement to confirm:

1. `errors[]` — the field did not answer
2. a null top-level — the SDL says a card, production returned nothing
3. a numeric disagreement with the REST route the field's own description says it **mirrors**

189 of 194 fields execute; 174 are compared against their route. The two that are not callable (`subnet_stake_quote`, `block_chain_events`) are **named** rather than skipped — guessing an amount for a stake quote would report the guess's failure as the field's, which is the one thing a conformance report must not do.

## Two restrictions, both measured

**Only a key both sides report as a NUMBER.** ~25 SDL types are resolver-built pagination views rather than mirrors of an artifact, so diffing a GraphQL answer against a REST body wholesale is a category error. Measured: an early wholesale sweep reported **161 divergences, of which 3 were real**.

**And only when a re-ask reproduces it.** A single disagreement cannot distinguish "these two surfaces answer differently" from "one of these two calls hit a degraded read", and the second really happens — `/accounts/{ss58}/counterparties` served `counterparty_count: 0` on **1 of 5 consecutive requests** for an account with 114, measured while this was being written. On this run the re-ask caught two: a `chain_events` count of 50-vs-0 and a `weight_sets` off-by-one from a counter advancing between calls. Both are reported as transients rather than as findings; the first is a real defect of its own, and a separate one.

Without that, the check would be red from day one for a reason it names wrongly, which is how a scheduled check gets turned off.

## Not reintroducible

`schemas-src/graphql/emit.ts` learns the first rule, so the generated SDL (#10214) cannot bring it back: an integer field naming an **instant** emits `Float`. Keyed on the name because the type cannot tell — `z.int()` stamps the JS safe-integer ceiling on every integer, count and instant alike, so "maximum exceeds Int32" is true of all of them. A *duration* (`duration_ms`) is a span and stays an `Int`.

Scheduled at 07:53 daily, offset from its two siblings so the three are not sweeping the same Worker at once. Out of band rather than in CI, for the reason they are: it needs production, and a check that cannot run on a pull request should not pretend to.

## Also here

Two comments #10218 left behind describing functions it deleted (`parsePagination` in `request-params.ts`'s header, `validateListQuery` in `list-query.ts`). Tombstones that name a live function are the drift the rest of that change removed.

## Validation

```
npm run build && npm run typecheck && npm run lint   # clean
24 CI validators                                     # all pass
npx vitest run                                       # 766 files, 18,014 passed
node scripts/check-graphql-conformance.ts            # run against production, twice
```

The remaining findings on the live run are the three fixed here — production still serves the old Worker until this deploys.
