### PR TITLE
feat(data): a historical write path for subnet_hyperparams_history (#10271)

### DIFF
--- a/src/subnet-hyperparams-backfill.ts
+++ b/src/subnet-hyperparams-backfill.ts
@@ -1,0 +1,151 @@
+// Writing HISTORICAL subnet_hyperparams_history rows (#5597).
+//
+// ## Why the live sync path cannot do this
+//
+// `handleSubnetHyperparamsSync` is a forward-only writer and correct as such,
+// but two of its properties make it unusable for a replay:
+//
+//   1. `const now = Date.now()` -- it stamps `observed_at` server-side. The
+//      payload carries `block_number` but not `observed_at`, so ~3,697
+//      historical rows would all land on one instant and collide on the
+//      `(netuid, observed_at)` conflict key.
+//   2. It diffs each incoming row against the LATEST recorded hash and appends
+//      only on change. Right for a lane reading the head; wrong for a replay,
+//      where a row must be diffed against its own predecessor in time, not
+//      against today.
+//
+// So this module takes `observed_at` from the caller (the BLOCK's timestamp)
+// and does not diff at all: the historical sequence IS the diff. The producer
+// already knows which blocks changed -- it read them out of the lakehouse's
+// AdminUtils extrinsics -- so re-deriving "did this change" here would be
+// asking a question that is already answered.
+//
+// ## Same rows as the live lane, deliberately
+//
+// The hash comes from `hyperparamsHash` and the column list from
+// `SUBNET_HYPERPARAMS_HISTORY_COLUMNS`, both shared with the live writer, so a
+// backfilled row is indistinguishable from one the hourly lane appended. That
+// is the whole requirement: `/subnets/{netuid}/hyperparameters/history` serves
+// both from one table and must not be able to tell them apart.
+//
+// ## Idempotency
+//
+// `ON CONFLICT (netuid, observed_at) DO NOTHING`. Migration 0003 records that
+// the natural key is unique and is "what the mirror and the backfill conflict
+// on" -- this is that backfill. Re-running is free, and the live lane can keep
+// writing while it runs.
+import { hyperparamsHash } from "./subnet-hyperparams-history.ts";
+import { formatSubnetHyperparams } from "./subnet-hyperparams.ts";
+import { SUBNET_HYPERPARAMS_HISTORY_COLUMNS } from "./hyperparams-identity-neon-write.ts";
+
+export const HYPERPARAMS_BACKFILL_LANE = "subnet-hyperparams-backfill";
+
+/**
+ * The epoch-milliseconds floor migration 0010 puts on every dated table.
+ *
+ * 1e12 is 2001-09-09; a seconds-valued stamp this decade is ~1.79e9, three
+ * digits short. #9782 is what this prevents -- a stamp missing those digits
+ * produced a row dated 1970 that no later pass could revise, in an append-only
+ * table exactly like this one. A backfill is the likeliest place to reintroduce
+ * it, because the producer is converting block timestamps rather than calling
+ * Date.now().
+ */
+export const EPOCH_MS_FLOOR = 1e12;
+
+export interface HistoricalHyperparamsRow {
+  netuid: number;
+  /** The block the change was observed at. Never null here: the producer found
+   * this row BY its block, so a null would mean it lost track of which. */
+  block_number: number;
+  /** The BLOCK's timestamp in epoch milliseconds -- not the time of the run. */
+  observed_at: number;
+  /** The decoded 33-field object, in the shape the live sync path posts. */
+  hyperparameters: Record<string, unknown>;
+}
+
+export interface BackfillWriteResult {
+  /** Rows the statement accepted. Not the same as rows INSERTED: a conflict is
+   * silently skipped, which is the point. */
+  attempted: number;
+  rejected: { netuid: number; reason: string }[];
+}
+
+/** Rows that cannot be written, with the reason -- never silently dropped. */
+export function rejectRow(row: HistoricalHyperparamsRow): string | null {
+  if (!Number.isInteger(row?.netuid) || row.netuid < 0) return "netuid";
+  if (!Number.isSafeInteger(row?.block_number) || row.block_number <= 0) {
+    return "block_number";
+  }
+  if (!Number.isSafeInteger(row?.observed_at)) return "observed_at";
+  // A seconds-valued stamp is the failure this floor exists for, and it is
+  // silent without the check: the row inserts fine and dates to 1970.
+  if (row.observed_at < EPOCH_MS_FLOOR) return "observed_at_not_millis";
+  if (!row.hyperparameters || typeof row.hyperparameters !== "object") {
+    return "hyperparameters";
+  }
+  return null;
+}
+
+interface SqlRunner {
+  unsafe(text: string, values?: unknown[]): Promise<unknown>;
+}
+
+/**
+ * Append a batch of historical revisions.
+ *
+ * Returns what it attempted and what it refused, rather than throwing on a bad
+ * row: one malformed entry in a 3,697-row replay should cost that entry, not
+ * the run -- but it must be REPORTED, because a backfill that silently drops
+ * rows is indistinguishable from one that worked.
+ */
+export async function writeHistoricalHyperparams(
+  sql: SqlRunner,
+  rows: readonly HistoricalHyperparamsRow[],
+): Promise<BackfillWriteResult> {
+  const rejected: { netuid: number; reason: string }[] = [];
+  let attempted = 0;
+
+  // The history columns minus the three keying ones, in the order the shared
+  // constant declares them -- so a column added to the family lands here
+  // without this module naming any of the 33 fields itself.
+  const fieldColumns = SUBNET_HYPERPARAMS_HISTORY_COLUMNS.filter(
+    (c) => c !== "netuid" && c !== "block_number" && c !== "observed_at",
+  );
+  const columns = ["netuid", "block_number", "observed_at", ...fieldColumns];
+  const placeholders = columns.map((_, i) => `$${i + 1}`).join(", ");
+  const statement =
+    `INSERT INTO subnet_hyperparams_history (${columns.join(", ")}) ` +
+    `VALUES (${placeholders}) ` +
+    `ON CONFLICT (netuid, observed_at) DO NOTHING`;
+
+  for (const row of rows) {
+    const reason = rejectRow(row);
+    if (reason) {
+      rejected.push({ netuid: row?.netuid, reason });
+      continue;
+    }
+    // The SAME formatter and hash the live path uses, so the two writers cannot
+    // produce different bytes for the same chain state.
+    const hyperparameters = formatSubnetHyperparams(row.hyperparameters) as
+      Record<string, unknown> | null | undefined;
+    if (!hyperparameters) {
+      rejected.push({ netuid: row.netuid, reason: "unformattable" });
+      continue;
+    }
+    const hash = await hyperparamsHash(hyperparameters);
+    const values = [
+      row.netuid,
+      row.block_number,
+      row.observed_at,
+      ...fieldColumns.map((column) =>
+        column === "hyperparams_hash"
+          ? hash
+          : ((hyperparameters as Record<string, unknown>)[column] ?? null),
+      ),
+    ];
+    await sql.unsafe(statement, values);
+    attempted += 1;
+  }
+
+  return { attempted, rejected };
+}

--- a/tests/subnet-hyperparams-backfill.test.ts
+++ b/tests/subnet-hyperparams-backfill.test.ts
@@ -1,0 +1,171 @@
+// The historical hyperparams writer (#5597).
+//
+// The assertions concentrate on the two properties that differ from the live
+// sync path, because those are exactly what a replay gets wrong:
+//
+//   1. `observed_at` comes from the CALLER (the block's timestamp). The live
+//      path stamps Date.now(); doing that here would collapse ~3,697 rows onto
+//      one instant and collide on the (netuid, observed_at) key.
+//   2. No latest-diff. The live path appends only when the hash differs from
+//      the newest recorded row; a replay must be diffed against its own
+//      predecessor in time, which the producer already did.
+//
+// Plus the epoch-millis floor, which is the silent one: a seconds-valued stamp
+// inserts perfectly and dates the row to 1970.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+import {
+  EPOCH_MS_FLOOR,
+  HYPERPARAMS_BACKFILL_LANE,
+  rejectRow,
+  writeHistoricalHyperparams,
+  type HistoricalHyperparamsRow,
+} from "../src/subnet-hyperparams-backfill.ts";
+import { hyperparamsHash } from "../src/subnet-hyperparams-history.ts";
+import { formatSubnetHyperparams } from "../src/subnet-hyperparams.ts";
+
+/** A SQL runner that records what it was asked to execute. */
+function recorder() {
+  const calls: { text: string; values: unknown[] }[] = [];
+  return {
+    calls,
+    sql: {
+      async unsafe(text: string, values: unknown[] = []) {
+        calls.push({ text, values });
+        return undefined;
+      },
+    },
+  };
+}
+
+const row = (
+  over: Partial<HistoricalHyperparamsRow> = {},
+): HistoricalHyperparamsRow => ({
+  netuid: 16,
+  block_number: 1_929_312,
+  observed_at: 1_700_000_000_000,
+  hyperparameters: { immunity_period: 8000, tempo: 360 },
+  ...over,
+});
+
+describe("writeHistoricalHyperparams", () => {
+  test("binds the CALLER's observed_at, never a wall-clock now", async () => {
+    // The whole reason this module exists rather than reusing the sync path.
+    const { sql, calls } = recorder();
+    const before = Date.now();
+    await writeHistoricalHyperparams(sql, [
+      row({ observed_at: 1_700_000_000_000 }),
+    ]);
+    const [call] = calls;
+    assert.equal(call!.values[2], 1_700_000_000_000);
+    assert.notEqual(call!.values[2], before);
+  });
+
+  test("binds netuid and block_number in the leading positions", async () => {
+    const { sql, calls } = recorder();
+    await writeHistoricalHyperparams(sql, [row()]);
+    assert.equal(calls[0]!.values[0], 16);
+    assert.equal(calls[0]!.values[1], 1_929_312);
+  });
+
+  test("the statement is idempotent on the natural key", async () => {
+    // Migration 0003 declares UNIQUE (netuid, observed_at) as "what the mirror
+    // and the backfill conflict on". Verified present in production.
+    const { sql, calls } = recorder();
+    await writeHistoricalHyperparams(sql, [row()]);
+    assert.match(
+      calls[0]!.text,
+      /ON CONFLICT \(netuid, observed_at\) DO NOTHING/,
+    );
+  });
+
+  test("does NOT read the latest row first -- the sequence is the diff", async () => {
+    // A SELECT here would mean this path re-derived "did it change", which the
+    // producer already answered by finding the block in the extrinsic stream.
+    const { sql, calls } = recorder();
+    await writeHistoricalHyperparams(sql, [
+      row(),
+      row({ observed_at: 1_700_000_001_000 }),
+    ]);
+    assert.equal(calls.length, 2);
+    for (const call of calls) assert.doesNotMatch(call.text, /SELECT/i);
+  });
+
+  test("writes the SAME hash the live writer would for the same input", async () => {
+    // Backfilled and live rows must be indistinguishable; a different hash for
+    // identical chain state would make them distinguishable in the worst way.
+    const { sql, calls } = recorder();
+    const hyperparameters = { immunity_period: 8000, tempo: 360 };
+    await writeHistoricalHyperparams(sql, [row({ hyperparameters })]);
+    const expected = await hyperparamsHash(
+      formatSubnetHyperparams(hyperparameters),
+    );
+    assert.ok(calls[0]!.values.includes(expected));
+  });
+
+  test("every column it binds comes from the shared history column list", async () => {
+    const { sql, calls } = recorder();
+    await writeHistoricalHyperparams(sql, [row()]);
+    const columns = /INSERT INTO subnet_hyperparams_history \(([^)]*)\)/
+      .exec(calls[0]!.text)![1]!
+      .split(",")
+      .map((c) => c.trim());
+    assert.equal(columns[0], "netuid");
+    assert.equal(columns[1], "block_number");
+    assert.equal(columns[2], "observed_at");
+    assert.ok(columns.includes("hyperparams_hash"));
+    // One placeholder per column, or the binds silently shift by one.
+    assert.equal(calls[0]!.values.length, columns.length);
+  });
+
+  test("a rejected row costs that row, not the run -- and is reported", async () => {
+    const { sql, calls } = recorder();
+    const result = await writeHistoricalHyperparams(sql, [
+      row({ netuid: -1 }),
+      row({ netuid: 7 }),
+    ]);
+    assert.equal(result.attempted, 1, "the good row still went");
+    assert.equal(calls.length, 1);
+    assert.deepEqual(result.rejected, [{ netuid: -1, reason: "netuid" }]);
+  });
+});
+
+describe("rejectRow", () => {
+  test("a SECONDS-valued observed_at is refused", () => {
+    // The silent one: it inserts fine and dates the row to 1970, in a table
+    // no later pass can revise. #9782 is this exact bug.
+    assert.equal(
+      rejectRow(row({ observed_at: 1_700_000_000 })),
+      "observed_at_not_millis",
+    );
+    assert.equal(rejectRow(row({ observed_at: EPOCH_MS_FLOOR })), null);
+  });
+
+  test("a missing block is refused -- the producer found the row BY its block", () => {
+    assert.equal(rejectRow(row({ block_number: 0 })), "block_number");
+    assert.equal(
+      rejectRow(row({ block_number: undefined as unknown as number })),
+      "block_number",
+    );
+  });
+
+  test("a non-integer netuid is refused", () => {
+    assert.equal(rejectRow(row({ netuid: 1.5 })), "netuid");
+  });
+
+  test("missing hyperparameters are refused", () => {
+    assert.equal(
+      rejectRow(row({ hyperparameters: undefined as unknown as never })),
+      "hyperparameters",
+    );
+  });
+
+  test("a well-formed row passes", () => {
+    assert.equal(rejectRow(row()), null);
+  });
+
+  test("the lane name is stable", () => {
+    assert.equal(HYPERPARAMS_BACKFILL_LANE, "subnet-hyperparams-backfill");
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -3634,6 +3634,23 @@ async function handleSubnetHyperparamsSyncProxy(request: Request, env: Env) {
   });
 }
 
+// Proxies POST /api/v1/internal/subnet-hyperparams-backfill -- the HISTORICAL
+// write path into subnet_hyperparams_history (#5597). Same DATA_API service
+// binding and same secret as the sync route above; what differs is that the
+// producer supplies the block's own observed_at and no diff is performed.
+async function handleSubnetHyperparamsBackfillProxy(
+  request: Request,
+  env: Env,
+) {
+  return proxyToDataApi(request, env, {
+    code: "subnet_hyperparams_backfill_unavailable",
+    notBoundMessage:
+      "The subnet-hyperparams backfill tier is not bound to this deployment.",
+    unreadableMessage:
+      "The subnet-hyperparams backfill tier returned an unreadable response.",
+  });
+}
+
 // Proxies POST /api/v1/internal/account-identity-sync -- the write path into
 // account_identity/account_identity_history (#4832 gap-closure). Same
 // DATA_API service binding as the other internal sync routes above.
@@ -4542,6 +4559,9 @@ export async function handleRequest(
   // The write path into account_identity/account_identity_history (#4832
   // gap-closure) -- refresh-account-identity.yml's sign-and-stage job calls
   // this the same way. Same DATA_API service binding.
+  if (url.pathname === "/api/v1/internal/subnet-hyperparams-backfill") {
+    return handleSubnetHyperparamsBackfillProxy(request, env);
+  }
   if (url.pathname === "/api/v1/internal/account-identity-sync") {
     return handleAccountIdentitySyncProxy(request, env);
   }

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -125,6 +125,10 @@ import {
   buildSubnetHyperparamsHistory,
 } from "../src/subnet-hyperparams-history.ts";
 import {
+  writeHistoricalHyperparams,
+  type HistoricalHyperparamsRow,
+} from "../src/subnet-hyperparams-backfill.ts";
+import {
   ACCOUNT_IDENTITY_INSERT_COLUMNS,
   IDENTITY_FIELDS,
   buildAccountIdentity,
@@ -1493,6 +1497,97 @@ async function handleSubnetHyperparamsSync(
     stores: ["neon"],
     neon: neon.results,
   });
+}
+
+// --- POST /api/v1/internal/subnet-hyperparams-backfill (#5597) ------------
+//
+// The HISTORICAL counterpart of subnet-hyperparams-sync above. That route is a
+// forward-only writer and correct as such, but two of its properties make it
+// unusable for a replay: it stamps `observed_at` with `Date.now()` (the payload
+// has no field for it), and it diffs each row against the LATEST recorded hash.
+// A replay needs the block's own timestamp, and needs no diff at all -- the
+// producer already established which blocks changed, by reading the AdminUtils
+// extrinsics out of the lakehouse.
+//
+// SAME SECRET as the sync route, deliberately. The producer is the same poller
+// with the same trust level writing the same family; a second secret would be a
+// second thing to provision and rotate for no boundary that differs.
+const SUBNET_HYPERPARAMS_BACKFILL_MAX_BODY_BYTES = 4_000_000;
+const SUBNET_HYPERPARAMS_BACKFILL_MAX_ROWS = 500;
+
+async function handleSubnetHyperparamsBackfill(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response> {
+  const provided =
+    request.headers.get(SUBNET_HYPERPARAMS_SYNC_TOKEN_HEADER) || "";
+  if (
+    !provided ||
+    !timingSafeEqual(provided, env.SUBNET_HYPERPARAMS_SYNC_SECRET)
+  ) {
+    return writeJson(
+      {
+        error: `provide a valid ${SUBNET_HYPERPARAMS_SYNC_TOKEN_HEADER} header`,
+      },
+      401,
+    );
+  }
+
+  const raw = await request.text();
+  if (utf8Bytes(raw).length > SUBNET_HYPERPARAMS_BACKFILL_MAX_BODY_BYTES) {
+    return writeJson(
+      {
+        error: `body exceeds ${SUBNET_HYPERPARAMS_BACKFILL_MAX_BODY_BYTES} bytes`,
+      },
+      413,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return writeJson({ error: "body must be JSON" }, 400);
+  }
+  const incoming = Array.isArray(parsed)
+    ? parsed
+    : ((parsed as { rows?: unknown })?.rows ?? null);
+  if (!Array.isArray(incoming)) {
+    return writeJson({ error: "expected an array of rows" }, 400);
+  }
+  if (incoming.length > SUBNET_HYPERPARAMS_BACKFILL_MAX_ROWS) {
+    return writeJson(
+      { error: `at most ${SUBNET_HYPERPARAMS_BACKFILL_MAX_ROWS} rows` },
+      413,
+    );
+  }
+
+  // The same family gate the sync route applies: the table and its history are
+  // one family, and writing history into a store that does not own it would put
+  // rows somewhere nothing reads.
+  if (!neonOwnsFamily(env, SUBNET_HYPERPARAMS_NEON_LANE)) {
+    return writeJson({ error: "no store bound for this route" }, 503);
+  }
+
+  const sql = createPgSql(env.HYPERDRIVE, ctx);
+  try {
+    const result = await writeHistoricalHyperparams(
+      sql,
+      incoming as HistoricalHyperparamsRow[],
+    );
+    // `rejected` is RETURNED, not logged and swallowed: a backfill that
+    // silently drops rows is indistinguishable from one that worked, and the
+    // producer is the only thing positioned to retry them.
+    return writeJson({
+      ok: true,
+      attempted: result.attempted,
+      rejected: result.rejected,
+    });
+  } catch (err) {
+    console.error("data-api subnet-hyperparams-backfill write failed:", err);
+    await captureDataApiError(err, "subnet-hyperparams-backfill", env);
+    return writeJson({ error: "write failed" }, 500);
+  }
 }
 
 // --- POST /api/v1/internal/account-identity-sync (#4832 gap-closure) ------
@@ -7400,6 +7495,12 @@ async function dispatchDataApiRequest(
       url.pathname === "/api/v1/internal/subnet-hyperparams-sync"
     ) {
       return handleSubnetHyperparamsSync(request, env, ctx);
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/internal/subnet-hyperparams-backfill"
+    ) {
+      return handleSubnetHyperparamsBackfill(request, env, ctx);
     }
     if (
       request.method === "POST" &&


### PR DESCRIPTION
Closes #10271 — part of #5597.

The metagraphed half of the hyperparams backfill: the write path a replay needs. The producer half (decoding historical state) belongs in metagraphed-infra, because the decode requires subxt — see below.

## The sync route cannot replay

`handleSubnetHyperparamsSync` is a forward-only writer and correct as such. Two properties make it unusable here:

```ts
const now = Date.now();
```

1. **`observed_at` is stamped server-side.** The payload carries `block_number` but has no field for `observed_at`, so ~3,697 historical rows would land on one instant and collide on the `(netuid, observed_at)` key.
2. **It diffs each row against the LATEST recorded hash.** Right for a lane reading the head; wrong for a replay, where a row must be compared with its predecessor *in time*. The producer already established which blocks changed — it read them from the lakehouse's `AdminUtils` extrinsics — so re-deriving it here answers a question already answered.

## What this adds

- `src/subnet-hyperparams-backfill.ts` — takes `observed_at` from the caller, performs no diff, inserts `ON CONFLICT (netuid, observed_at) DO NOTHING`.
- `POST /api/v1/internal/subnet-hyperparams-backfill` on data-api, proxied from api.ts.

**Same secret as the sync route**, deliberately: same producer, same trust level, same family. A second secret is a second thing to provision and rotate for no boundary that differs.

## Rows are indistinguishable from the live lane's, by construction

The hash comes from the shared `hyperparamsHash` and the columns from the shared `SUBNET_HYPERPARAMS_HISTORY_COLUMNS` — this module never names any of the 33 fields itself, so a column added to the family lands here automatically. Same chain state ⇒ same bytes from either writer. `/subnets/{netuid}/hyperparameters/history` serves both from one table and must not be able to tell them apart.

## The trap it guards

`observed_at` below `1e12` is refused. A seconds-valued stamp inserts perfectly and dates the row to **1970**, in an append-only table no later pass can revise — #9782 is that exact bug, and a backfill converting block timestamps is the likeliest place to reintroduce it.

Rejected rows are **returned**, not logged and swallowed: a backfill that silently drops rows is indistinguishable from one that worked, and the producer is the only thing positioned to retry them.

## Verification

- Emitted the statement this writer actually generates (37 columns, 37 placeholders) and **ran it against production inside a transaction**: `INSERT 0 1`, visible in-transaction, `ROLLBACK`, table unchanged. The conflict target is real — confirmed `subnet_hyperparams_history_netuid_observed_at_key UNIQUE (netuid, observed_at)` on the live schema.
- 13 new tests, weighted toward the two properties that differ from the live path plus the epoch-millis floor.
- `tsc --noEmit`, `lint`, `format:check` clean; `validate`, `validate:api`, `validate:contract-drift`, `validate:mcp-route-map`, `validate-docs` pass; 140 tests green across `data-api`, `data-api-hyperparams-identity`, `subnet-hyperparams-history`, `api-entry-handlers` and the new suite.

## Why the decode is not here

There is no SCALE decoder in TypeScript anywhere in this repo — the Worker only ever receives already-decoded JSON. The hyperparams payload's layout demonstrably shifts across the backfill range (59 / 75 / 92 / 82 bytes at blocks 2M / 3M / 4M / 6M, spec versions 101 → 443), and subxt already handles that correctly in the poller. So the producer decodes and POSTs here.