### PR TITLE
feat(contract): publish what a caller gets for omitting `limit` (#10274)

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -12943,7 +12943,7 @@ export interface operations {
     blocksFeedByNetwork: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -13310,7 +13310,7 @@ export interface operations {
     blockEventsByNetwork: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -13436,7 +13436,7 @@ export interface operations {
     blockExtrinsicsByNetwork: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -13718,7 +13718,7 @@ export interface operations {
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: string;
                 before?: number;
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -14078,7 +14078,7 @@ export interface operations {
     chainAlphaVolumeByNetwork: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -14358,7 +14358,7 @@ export interface operations {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
                 group_by?: "module" | "module_function";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 call_module?: string;
                 /** @description Response format override. Use `csv` to download the call-mix rows as text/csv; `json` (default) keeps the response envelope. */
@@ -14486,7 +14486,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -14643,7 +14643,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25. */
                 limit?: number;
                 call_module?: string;
                 /** @description Response format override. Use `csv` to download the daily fee series as text/csv; `json` (default) keeps the response envelope (which also carries top_fee_payers). */
@@ -14782,7 +14782,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -14929,7 +14929,7 @@ export interface operations {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
                 sort?: "tx_count" | "total_fee_tao";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 call_module?: string;
                 /** @description Response format override. Use `csv` to download the signer leaderboard as text/csv; `json` (default) keeps the response envelope. */
@@ -15057,7 +15057,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the per-subnet capital-flow leaderboard as text/csv; `json` (default) keeps the response envelope (which also carries the network rollup + net-flow distribution). */
                 format?: "json" | "csv";
@@ -15207,7 +15207,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -15353,7 +15353,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -15499,7 +15499,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25. */
                 limit?: number;
                 sort?: "volume" | "count";
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
@@ -15632,7 +15632,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -16179,7 +16179,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -16464,7 +16464,7 @@ export interface operations {
     extrinsicsFeedByNetwork: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -17249,7 +17249,7 @@ export interface operations {
                 max_tempo?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -18180,7 +18180,7 @@ export interface operations {
         parameters: {
             query?: {
                 sort?: "total_stake" | "total_emission" | "subnet_count" | "uid_count" | "validator_count" | "stake_dominance" | "last_active";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -18818,7 +18818,7 @@ export interface operations {
         parameters: {
             query?: {
                 counterparty?: string;
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -19219,7 +19219,7 @@ export interface operations {
                 netuid?: number;
                 block_start?: number;
                 block_end?: number;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -19347,7 +19347,7 @@ export interface operations {
             query?: {
                 block_start?: number;
                 block_end?: number;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -19477,7 +19477,7 @@ export interface operations {
                 netuid?: number;
                 from?: string;
                 to?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -19713,7 +19713,7 @@ export interface operations {
     accountIdentityHistory: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -21194,7 +21194,7 @@ export interface operations {
                 direction?: "all" | "sent" | "received";
                 block_start?: number;
                 block_end?: number;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -21440,7 +21440,7 @@ export interface operations {
         parameters: {
             query?: {
                 sort?: "total_tao" | "free_tao" | "delegated_tao" | "net_flow_7d" | "net_flow_30d" | "net_flow_90d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -22345,7 +22345,7 @@ export interface operations {
     blocksFeed: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -22705,7 +22705,7 @@ export interface operations {
     blockEvents: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -22829,7 +22829,7 @@ export interface operations {
     blockExtrinsics: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -23279,7 +23279,7 @@ export interface operations {
                 confidence?: "low" | "medium" | "high";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -23419,7 +23419,7 @@ export interface operations {
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: string;
                 before?: number;
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -23770,7 +23770,7 @@ export interface operations {
     chainAlphaVolume: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -23926,7 +23926,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -24191,7 +24191,7 @@ export interface operations {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
                 group_by?: "module" | "module_function";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 call_module?: string;
                 /** @description Response format override. Use `csv` to download the call-mix rows as text/csv; `json` (default) keeps the response envelope. */
@@ -24664,7 +24664,7 @@ export interface operations {
                 lens?: "emission" | "stake" | "entity_emission" | "entity_stake" | "validator_stake";
                 sort?: "nakamoto_coefficient" | "gini" | "holders" | "top_1pct_share" | "total" | "netuid";
                 order?: "asc" | "desc";
-                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
             };
             header?: never;
@@ -24804,7 +24804,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -24960,7 +24960,7 @@ export interface operations {
                 netuid?: number;
                 sort?: "final_share" | "emission_share" | "weighted_share" | "gated_share" | "gate_delta" | "distance_to_bar" | "tao_in_emission" | "excess_tao" | "tao_total" | "liquidity_fraction" | "miner_burned" | "netuid";
                 order?: "asc" | "desc";
-                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
@@ -25125,7 +25125,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25. */
                 limit?: number;
                 call_module?: string;
                 /** @description Response format override. Use `csv` to download the daily fee series as text/csv; `json` (default) keeps the response envelope (which also carries top_fee_payers). */
@@ -25260,7 +25260,7 @@ export interface operations {
         parameters: {
             query?: {
                 kind?: "param" | "subnet" | "flow";
-                /** @description Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
             };
             header?: never;
@@ -25380,7 +25380,7 @@ export interface operations {
         parameters: {
             query?: {
                 sort?: "top1_share" | "top5_share" | "top10_share" | "top20_share" | "holder_count" | "total_alpha";
-                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
             };
             header?: never;
@@ -25508,7 +25508,7 @@ export interface operations {
     chainIdentityHistory: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
             };
             header?: never;
@@ -26016,7 +26016,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -26163,7 +26163,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -26306,7 +26306,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -26450,7 +26450,7 @@ export interface operations {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
                 sort?: "tx_count" | "total_fee_tao";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 call_module?: string;
                 /** @description Response format override. Use `csv` to download the signer leaderboard as text/csv; `json` (default) keeps the response envelope. */
@@ -26575,7 +26575,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the per-subnet capital-flow leaderboard as text/csv; `json` (default) keeps the response envelope (which also carries the network rollup + net-flow distribution). */
                 format?: "json" | "csv";
@@ -26722,7 +26722,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -26865,7 +26865,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -27008,7 +27008,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`, `1y`, `all`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d" | "1y" | "all";
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -27133,7 +27133,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25. */
                 limit?: number;
                 sort?: "volume" | "count";
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
@@ -27263,7 +27263,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -27405,7 +27405,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -27550,7 +27550,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -27693,7 +27693,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -28618,7 +28618,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -29078,7 +29078,7 @@ export interface operations {
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -29469,7 +29469,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -29765,7 +29765,7 @@ export interface operations {
                 state?: "active" | "resolved";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -29921,7 +29921,7 @@ export interface operations {
                 max_endpoint_count?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -30105,7 +30105,7 @@ export interface operations {
                 max_score?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -30270,7 +30270,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -30509,7 +30509,7 @@ export interface operations {
     extrinsicsFeed: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -32331,7 +32331,7 @@ export interface operations {
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -32462,7 +32462,7 @@ export interface operations {
     governanceConfigChanges: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -32607,7 +32607,7 @@ export interface operations {
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -32878,7 +32878,7 @@ export interface operations {
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -33018,7 +33018,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -33155,7 +33155,7 @@ export interface operations {
                 netuid?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -34027,7 +34027,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -34290,7 +34290,7 @@ export interface operations {
                 authority?: "community" | "official" | "provider-claimed" | "registry-observed";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -34568,7 +34568,7 @@ export interface operations {
                 max_score?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -34735,7 +34735,7 @@ export interface operations {
         parameters: {
             query?: {
                 board?: "healthiest" | "fastest-rpc" | "most-complete" | "most-enriched" | "fastest-growing" | "most-reliable" | "open-slots" | "cheapest-registration" | "highest-emission" | "validator-headroom" | "biggest-alpha-gain-1d" | "biggest-alpha-gain-7d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
             };
             header?: never;
@@ -34994,7 +34994,7 @@ export interface operations {
                 recommended_adapter_kind?: "custom-adapter" | "data-artifact-adapter" | "generic-openapi-or-custom" | "stream-adapter";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -35161,7 +35161,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -35331,7 +35331,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -35553,7 +35553,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -35768,7 +35768,7 @@ export interface operations {
                 review_state?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -35912,7 +35912,7 @@ export interface operations {
                 native_name_quality?: "chain" | "placeholder" | "empty";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -36125,7 +36125,7 @@ export interface operations {
                 max_score?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -36267,7 +36267,7 @@ export interface operations {
                 max_endpoint_count?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -36844,7 +36844,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -36974,7 +36974,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -37210,7 +37210,7 @@ export interface operations {
             query?: {
                 /** @description Free-text search query, matched case-insensitively against the collection's indexed text fields. Whitespace-separated terms narrow the result (AND), and an empty or whitespace-only value is treated as no filter rather than as a search matching nothing. */
                 q?: string;
-                /** @description Maximum number of rows to return in one page (at most 20). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 20). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 10. */
                 limit?: number;
                 type?: "subnet" | "surface" | "provider";
             };
@@ -37590,7 +37590,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -37747,7 +37747,7 @@ export interface operations {
                 max_tempo?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -38562,7 +38562,7 @@ export interface operations {
                 confidence?: "low" | "medium" | "high";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -39387,7 +39387,7 @@ export interface operations {
                 max_score?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -39554,7 +39554,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d";
-                /** @description Maximum number of rows to return in one page (at most 50). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 50). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 10. */
                 limit?: number;
             };
             header?: never;
@@ -39703,7 +39703,7 @@ export interface operations {
                 kind?: string;
                 block_start?: number;
                 block_end?: number;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -39833,7 +39833,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -39966,7 +39966,7 @@ export interface operations {
                 review_state?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -40184,7 +40184,7 @@ export interface operations {
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -40814,7 +40814,7 @@ export interface operations {
     subnetHolders: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
             };
             header?: never;
@@ -41079,7 +41079,7 @@ export interface operations {
     subnetHyperparametersHistory: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -41205,7 +41205,7 @@ export interface operations {
     subnetIdentityHistory: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -41668,7 +41668,7 @@ export interface operations {
     subnetLifecycle: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -44315,7 +44315,7 @@ export interface operations {
     subnetSurfaceHistory: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
             };
             header?: never;
@@ -44443,7 +44443,7 @@ export interface operations {
                 rate_limited?: "true" | "false";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -46004,7 +46004,7 @@ export interface operations {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d";
                 sort?: "stake" | "emission" | "validators" | "neurons";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -46153,7 +46153,7 @@ export interface operations {
     sudoCalls: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -46410,7 +46410,7 @@ export interface operations {
                 rate_limited?: "true" | "false";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -46657,7 +46657,7 @@ export interface operations {
         parameters: {
             query?: {
                 sort?: "avg_validator_trust" | "max_validator_trust" | "stake_dominance" | "subnet_count" | "total_emission" | "total_stake" | "uid_count";
-                /** @description Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -47103,7 +47103,7 @@ export interface operations {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d";
                 sort?: "net_staked" | "gross_staked" | "last_activity";
-                /** @description Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -47239,7 +47239,7 @@ export interface operations {
         parameters: {
             query?: {
                 sort?: "earning_floor_cost_tao" | "permit_floor_cost_tao" | "permit_to_earning_multiple" | "tao_inflow_per_day" | "validator_headroom";
-                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -7360,6 +7360,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 50,
             "maximum": 512,
             "minimum": 1,
             "type": "integer"
@@ -7428,6 +7429,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -7479,6 +7481,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 2000,
             "minimum": 1,
             "type": "integer"
@@ -7530,6 +7533,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -7580,6 +7584,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -7664,6 +7669,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 2000,
             "minimum": 1,
             "type": "integer"
@@ -7837,6 +7843,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 100,
             "maximum": 1000,
             "minimum": 1,
             "type": "integer"
@@ -7887,6 +7894,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 100,
             "maximum": 1000,
             "minimum": 1,
             "type": "integer"
@@ -7944,6 +7952,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 50,
             "maximum": 1000,
             "minimum": 1,
             "type": "integer"
@@ -8102,6 +8111,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 100,
             "maximum": 1000,
             "minimum": 1,
             "type": "integer"
@@ -8163,6 +8173,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 10,
             "maximum": 50,
             "minimum": 1,
             "type": "integer"
@@ -8248,6 +8259,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 100,
             "maximum": 1000,
             "minimum": 1,
             "type": "integer"
@@ -8358,6 +8370,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 100,
             "maximum": 1000,
             "minimum": 1,
             "type": "integer"
@@ -8432,6 +8445,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 100,
             "maximum": 1000,
             "minimum": 1,
             "type": "integer"
@@ -8496,6 +8510,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 100,
             "maximum": 1000,
             "minimum": 1,
             "type": "integer"
@@ -8571,6 +8586,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 100,
             "maximum": 1000,
             "minimum": 1,
             "type": "integer"
@@ -8629,6 +8645,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "description": "Max counterparties to return in list mode (default 20), or max transfer evidence rows in relationship drilldown mode when ?counterparty is present (default 50).",
             "maximum": 100,
             "minimum": 1,
@@ -8994,6 +9011,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 100,
             "maximum": 1000,
             "minimum": 1,
             "type": "integer"
@@ -9298,6 +9316,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -9323,6 +9342,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 50,
             "maximum": 200,
             "minimum": 1,
             "type": "integer"
@@ -9359,6 +9379,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 50,
             "maximum": 200,
             "minimum": 1,
             "type": "integer"
@@ -9398,6 +9419,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 512,
             "minimum": 1,
             "type": "integer"
@@ -9692,6 +9714,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 50,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -9838,6 +9861,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 50,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -9885,6 +9909,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 100,
             "maximum": 1000,
             "minimum": 1,
             "type": "integer"
@@ -9976,6 +10001,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 50,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -10062,6 +10088,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 50,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -10203,6 +10230,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 50,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -10304,6 +10332,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 50,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -10516,6 +10545,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 50,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -10582,6 +10612,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 50,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -10638,6 +10669,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 25,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -10687,6 +10719,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 25,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -10746,6 +10779,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -10785,6 +10819,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -10831,6 +10866,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -10877,6 +10913,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -10923,6 +10960,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -10969,6 +11007,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -11015,6 +11054,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -11064,6 +11104,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -11113,6 +11154,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -11162,6 +11204,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -11211,6 +11254,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -11260,6 +11304,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 25,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -11356,6 +11401,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 512,
             "minimum": 1,
             "type": "integer"
@@ -11413,6 +11459,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 50,
             "maximum": 200,
             "minimum": 1,
             "type": "integer"
@@ -11481,6 +11528,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
@@ -11582,6 +11630,7 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
             "maximum": 100,
             "minimum": 1,
             "type": "integer"

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -56547,11 +56547,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -57048,11 +57049,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 100,
               "maximum": 1000,
               "minimum": 1,
               "type": "integer"
@@ -57218,11 +57220,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -57554,11 +57557,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -57985,11 +57989,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -58277,11 +58282,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -58450,11 +58456,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -58614,11 +58621,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 25,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -58787,11 +58795,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -58963,11 +58972,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -59136,11 +59146,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -59300,11 +59311,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -59464,11 +59476,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -59628,11 +59641,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 25,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -59804,11 +59818,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 25,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -60356,7 +60371,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -60685,11 +60700,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -61792,7 +61808,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -62610,11 +62626,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -63205,11 +63222,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "description": "Max counterparties to return in list mode (default 20), or max transfer evidence rows in relationship drilldown mode when ?counterparty is present (default 50).",
               "maximum": 100,
               "minimum": 1,
@@ -63612,11 +63630,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 100,
               "maximum": 1000,
               "minimum": 1,
               "type": "integer"
@@ -63791,11 +63810,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 100,
               "maximum": 1000,
               "minimum": 1,
               "type": "integer"
@@ -63983,11 +64003,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 100,
               "maximum": 1000,
               "minimum": 1,
               "type": "integer"
@@ -64250,11 +64271,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 100,
               "maximum": 1000,
               "minimum": 1,
               "type": "integer"
@@ -65730,11 +65752,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 100,
               "maximum": 1000,
               "minimum": 1,
               "type": "integer"
@@ -66019,11 +66042,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -66775,11 +66799,12 @@
         "operationId": "blocksFeed",
         "parameters": [
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -67228,11 +67253,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 100,
               "maximum": 1000,
               "minimum": 1,
               "type": "integer"
@@ -67382,11 +67408,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -67817,7 +67844,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -68047,11 +68074,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -68430,11 +68458,12 @@
         "operationId": "chainAlphaVolume",
         "parameters": [
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -68578,11 +68607,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -68835,11 +68865,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -69232,11 +69263,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 512,
               "minimum": 1,
               "type": "integer"
@@ -69356,11 +69388,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -69536,7 +69569,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -69669,11 +69702,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 25,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -69826,11 +69860,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 200,
               "minimum": 1,
               "type": "integer"
@@ -69951,11 +69986,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 512,
               "minimum": 1,
               "type": "integer"
@@ -70060,11 +70096,12 @@
         "operationId": "chainIdentityHistory",
         "parameters": [
           {
-            "description": "Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 200,
               "minimum": 1,
               "type": "integer"
@@ -70476,11 +70513,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -70622,11 +70660,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -70770,11 +70809,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -70928,11 +70968,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -71085,11 +71126,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -71233,11 +71275,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -71381,11 +71424,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -71532,11 +71576,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 1000,
               "minimum": 1,
               "type": "integer"
@@ -71678,11 +71723,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 25,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -71838,11 +71884,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 25,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -71987,11 +72034,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -72133,11 +72181,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -72279,11 +72328,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -73117,7 +73167,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -73551,7 +73601,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -73962,7 +74012,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -74382,7 +74432,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -74599,7 +74649,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -74888,7 +74938,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -75084,7 +75134,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -75339,11 +75389,12 @@
         "operationId": "extrinsicsFeed",
         "parameters": [
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -78300,7 +78351,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -78448,11 +78499,12 @@
         "operationId": "governanceConfigChanges",
         "parameters": [
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -78701,7 +78753,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -79085,7 +79137,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -79252,7 +79304,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -79406,7 +79458,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -80263,7 +80315,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -80488,7 +80540,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -80907,7 +80959,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -81106,11 +81158,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -81422,7 +81475,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -81708,7 +81761,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -82043,7 +82096,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -82446,7 +82499,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -82674,7 +82727,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -82949,7 +83002,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -83273,7 +83326,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -83490,7 +83543,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -84013,7 +84066,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -84204,7 +84257,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -84470,7 +84523,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 20). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 20). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 10.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -84807,7 +84860,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -85200,7 +85253,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -85935,7 +85988,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -86854,7 +86907,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -87054,11 +87107,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 50). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 50). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 10.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 10,
               "maximum": 50,
               "minimum": 1,
               "type": "integer"
@@ -87199,11 +87253,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 100,
               "maximum": 1000,
               "minimum": 1,
               "type": "integer"
@@ -87381,7 +87436,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -87597,7 +87652,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -87860,7 +87915,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -88501,11 +88556,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -88727,11 +88783,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 100,
               "maximum": 1000,
               "minimum": 1,
               "type": "integer"
@@ -88889,11 +88946,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 100,
               "maximum": 1000,
               "minimum": 1,
               "type": "integer"
@@ -89377,11 +89435,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 100,
               "maximum": 1000,
               "minimum": 1,
               "type": "integer"
@@ -91631,11 +91690,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 200,
               "minimum": 1,
               "type": "integer"
@@ -91837,7 +91897,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -93457,11 +93517,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -93590,11 +93651,12 @@
         "operationId": "sudoCalls",
         "parameters": [
           {
-            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -94006,7 +94068,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -94300,11 +94362,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 2000,
               "minimum": 1,
               "type": "integer"
@@ -94721,11 +94784,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
               "maximum": 2000,
               "minimum": 1,
               "type": "integer"
@@ -94888,11 +94952,12 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916).",
+            "description": "Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 50,
               "maximum": 512,
               "minimum": 1,
               "type": "integer"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -12943,7 +12943,7 @@ export interface operations {
     blocksFeedByNetwork: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -13310,7 +13310,7 @@ export interface operations {
     blockEventsByNetwork: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -13436,7 +13436,7 @@ export interface operations {
     blockExtrinsicsByNetwork: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -13718,7 +13718,7 @@ export interface operations {
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: string;
                 before?: number;
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -14078,7 +14078,7 @@ export interface operations {
     chainAlphaVolumeByNetwork: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -14358,7 +14358,7 @@ export interface operations {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
                 group_by?: "module" | "module_function";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 call_module?: string;
                 /** @description Response format override. Use `csv` to download the call-mix rows as text/csv; `json` (default) keeps the response envelope. */
@@ -14486,7 +14486,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -14643,7 +14643,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25. */
                 limit?: number;
                 call_module?: string;
                 /** @description Response format override. Use `csv` to download the daily fee series as text/csv; `json` (default) keeps the response envelope (which also carries top_fee_payers). */
@@ -14782,7 +14782,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -14929,7 +14929,7 @@ export interface operations {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
                 sort?: "tx_count" | "total_fee_tao";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 call_module?: string;
                 /** @description Response format override. Use `csv` to download the signer leaderboard as text/csv; `json` (default) keeps the response envelope. */
@@ -15057,7 +15057,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the per-subnet capital-flow leaderboard as text/csv; `json` (default) keeps the response envelope (which also carries the network rollup + net-flow distribution). */
                 format?: "json" | "csv";
@@ -15207,7 +15207,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -15353,7 +15353,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -15499,7 +15499,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25. */
                 limit?: number;
                 sort?: "volume" | "count";
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
@@ -15632,7 +15632,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -16179,7 +16179,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -16464,7 +16464,7 @@ export interface operations {
     extrinsicsFeedByNetwork: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -17249,7 +17249,7 @@ export interface operations {
                 max_tempo?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -18180,7 +18180,7 @@ export interface operations {
         parameters: {
             query?: {
                 sort?: "total_stake" | "total_emission" | "subnet_count" | "uid_count" | "validator_count" | "stake_dominance" | "last_active";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -18818,7 +18818,7 @@ export interface operations {
         parameters: {
             query?: {
                 counterparty?: string;
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -19219,7 +19219,7 @@ export interface operations {
                 netuid?: number;
                 block_start?: number;
                 block_end?: number;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -19347,7 +19347,7 @@ export interface operations {
             query?: {
                 block_start?: number;
                 block_end?: number;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -19477,7 +19477,7 @@ export interface operations {
                 netuid?: number;
                 from?: string;
                 to?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -19713,7 +19713,7 @@ export interface operations {
     accountIdentityHistory: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -21194,7 +21194,7 @@ export interface operations {
                 direction?: "all" | "sent" | "received";
                 block_start?: number;
                 block_end?: number;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -21440,7 +21440,7 @@ export interface operations {
         parameters: {
             query?: {
                 sort?: "total_tao" | "free_tao" | "delegated_tao" | "net_flow_7d" | "net_flow_30d" | "net_flow_90d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -22345,7 +22345,7 @@ export interface operations {
     blocksFeed: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -22705,7 +22705,7 @@ export interface operations {
     blockEvents: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -22829,7 +22829,7 @@ export interface operations {
     blockExtrinsics: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -23279,7 +23279,7 @@ export interface operations {
                 confidence?: "low" | "medium" | "high";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -23419,7 +23419,7 @@ export interface operations {
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: string;
                 before?: number;
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -23770,7 +23770,7 @@ export interface operations {
     chainAlphaVolume: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -23926,7 +23926,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -24191,7 +24191,7 @@ export interface operations {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
                 group_by?: "module" | "module_function";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 call_module?: string;
                 /** @description Response format override. Use `csv` to download the call-mix rows as text/csv; `json` (default) keeps the response envelope. */
@@ -24664,7 +24664,7 @@ export interface operations {
                 lens?: "emission" | "stake" | "entity_emission" | "entity_stake" | "validator_stake";
                 sort?: "nakamoto_coefficient" | "gini" | "holders" | "top_1pct_share" | "total" | "netuid";
                 order?: "asc" | "desc";
-                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
             };
             header?: never;
@@ -24804,7 +24804,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -24960,7 +24960,7 @@ export interface operations {
                 netuid?: number;
                 sort?: "final_share" | "emission_share" | "weighted_share" | "gated_share" | "gate_delta" | "distance_to_bar" | "tao_in_emission" | "excess_tao" | "tao_total" | "liquidity_fraction" | "miner_burned" | "netuid";
                 order?: "asc" | "desc";
-                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
@@ -25125,7 +25125,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25. */
                 limit?: number;
                 call_module?: string;
                 /** @description Response format override. Use `csv` to download the daily fee series as text/csv; `json` (default) keeps the response envelope (which also carries top_fee_payers). */
@@ -25260,7 +25260,7 @@ export interface operations {
         parameters: {
             query?: {
                 kind?: "param" | "subnet" | "flow";
-                /** @description Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
             };
             header?: never;
@@ -25380,7 +25380,7 @@ export interface operations {
         parameters: {
             query?: {
                 sort?: "top1_share" | "top5_share" | "top10_share" | "top20_share" | "holder_count" | "total_alpha";
-                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
             };
             header?: never;
@@ -25508,7 +25508,7 @@ export interface operations {
     chainIdentityHistory: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
             };
             header?: never;
@@ -26016,7 +26016,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -26163,7 +26163,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -26306,7 +26306,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -26450,7 +26450,7 @@ export interface operations {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
                 sort?: "tx_count" | "total_fee_tao";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 call_module?: string;
                 /** @description Response format override. Use `csv` to download the signer leaderboard as text/csv; `json` (default) keeps the response envelope. */
@@ -26575,7 +26575,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the per-subnet capital-flow leaderboard as text/csv; `json` (default) keeps the response envelope (which also carries the network rollup + net-flow distribution). */
                 format?: "json" | "csv";
@@ -26722,7 +26722,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -26865,7 +26865,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -27008,7 +27008,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`, `1y`, `all`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d" | "1y" | "all";
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -27133,7 +27133,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25. */
                 limit?: number;
                 sort?: "volume" | "count";
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
@@ -27263,7 +27263,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -27405,7 +27405,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -27550,7 +27550,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -27693,7 +27693,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -28618,7 +28618,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -29078,7 +29078,7 @@ export interface operations {
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -29469,7 +29469,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -29765,7 +29765,7 @@ export interface operations {
                 state?: "active" | "resolved";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -29921,7 +29921,7 @@ export interface operations {
                 max_endpoint_count?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -30105,7 +30105,7 @@ export interface operations {
                 max_score?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -30270,7 +30270,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -30509,7 +30509,7 @@ export interface operations {
     extrinsicsFeed: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -32331,7 +32331,7 @@ export interface operations {
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -32462,7 +32462,7 @@ export interface operations {
     governanceConfigChanges: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -32607,7 +32607,7 @@ export interface operations {
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -32878,7 +32878,7 @@ export interface operations {
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -33018,7 +33018,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
-                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -33155,7 +33155,7 @@ export interface operations {
                 netuid?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -34027,7 +34027,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -34290,7 +34290,7 @@ export interface operations {
                 authority?: "community" | "official" | "provider-claimed" | "registry-observed";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -34568,7 +34568,7 @@ export interface operations {
                 max_score?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -34735,7 +34735,7 @@ export interface operations {
         parameters: {
             query?: {
                 board?: "healthiest" | "fastest-rpc" | "most-complete" | "most-enriched" | "fastest-growing" | "most-reliable" | "open-slots" | "cheapest-registration" | "highest-emission" | "validator-headroom" | "biggest-alpha-gain-1d" | "biggest-alpha-gain-7d";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
             };
             header?: never;
@@ -34994,7 +34994,7 @@ export interface operations {
                 recommended_adapter_kind?: "custom-adapter" | "data-artifact-adapter" | "generic-openapi-or-custom" | "stream-adapter";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -35161,7 +35161,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -35331,7 +35331,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -35553,7 +35553,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -35768,7 +35768,7 @@ export interface operations {
                 review_state?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -35912,7 +35912,7 @@ export interface operations {
                 native_name_quality?: "chain" | "placeholder" | "empty";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -36125,7 +36125,7 @@ export interface operations {
                 max_score?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -36267,7 +36267,7 @@ export interface operations {
                 max_endpoint_count?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -36844,7 +36844,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -36974,7 +36974,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -37210,7 +37210,7 @@ export interface operations {
             query?: {
                 /** @description Free-text search query, matched case-insensitively against the collection's indexed text fields. Whitespace-separated terms narrow the result (AND), and an empty or whitespace-only value is treated as no filter rather than as a search matching nothing. */
                 q?: string;
-                /** @description Maximum number of rows to return in one page (at most 20). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 20). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 10. */
                 limit?: number;
                 type?: "subnet" | "surface" | "provider";
             };
@@ -37590,7 +37590,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -37747,7 +37747,7 @@ export interface operations {
                 max_tempo?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -38562,7 +38562,7 @@ export interface operations {
                 confidence?: "low" | "medium" | "high";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -39387,7 +39387,7 @@ export interface operations {
                 max_score?: number;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -39554,7 +39554,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d";
-                /** @description Maximum number of rows to return in one page (at most 50). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 50). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 10. */
                 limit?: number;
             };
             header?: never;
@@ -39703,7 +39703,7 @@ export interface operations {
                 kind?: string;
                 block_start?: number;
                 block_end?: number;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -39833,7 +39833,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -39966,7 +39966,7 @@ export interface operations {
                 review_state?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -40184,7 +40184,7 @@ export interface operations {
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -40814,7 +40814,7 @@ export interface operations {
     subnetHolders: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
             };
             header?: never;
@@ -41079,7 +41079,7 @@ export interface operations {
     subnetHyperparametersHistory: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -41205,7 +41205,7 @@ export interface operations {
     subnetIdentityHistory: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -41668,7 +41668,7 @@ export interface operations {
     subnetLifecycle: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -44315,7 +44315,7 @@ export interface operations {
     subnetSurfaceHistory: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
             };
             header?: never;
@@ -44443,7 +44443,7 @@ export interface operations {
                 rate_limited?: "true" | "false";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -46004,7 +46004,7 @@ export interface operations {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d";
                 sort?: "stake" | "emission" | "validators" | "neurons";
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -46153,7 +46153,7 @@ export interface operations {
     sudoCalls: {
         parameters: {
             query?: {
-                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -46410,7 +46410,7 @@ export interface operations {
                 rate_limited?: "true" | "false";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
-                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
                 /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
                 cursor?: number;
@@ -46657,7 +46657,7 @@ export interface operations {
         parameters: {
             query?: {
                 sort?: "avg_validator_trust" | "max_validator_trust" | "stake_dominance" | "subnet_count" | "total_emission" | "total_stake" | "uid_count";
-                /** @description Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -47103,7 +47103,7 @@ export interface operations {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d";
                 sort?: "net_staked" | "gross_staked" | "last_activity";
-                /** @description Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
@@ -47239,7 +47239,7 @@ export interface operations {
         parameters: {
             query?: {
                 sort?: "earning_floor_cost_tao" | "permit_floor_cost_tao" | "permit_to_earning_multiple" | "tao_inflow_per_day" | "validator_headroom";
-                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). */
+                /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;

--- a/schemas-src/mcp-tools/account-extrinsics.ts
+++ b/schemas-src/mcp-tools/account-extrinsics.ts
@@ -23,9 +23,7 @@ export const GetAccountExtrinsicsInputSchema = z
     ss58: ss58Schema(),
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    limit: RouteQuery_accounts_ss58_extrinsics.shape.limit.meta({
-      default: 100,
-    }),
+    limit: RouteQuery_accounts_ss58_extrinsics.shape.limit,
     offset: RouteQuery_accounts_ss58_extrinsics.shape.offset,
     cursor: RouteQuery_accounts_ss58_extrinsics.shape.cursor,
   })

--- a/schemas-src/mcp-tools/account-history.ts
+++ b/schemas-src/mcp-tools/account-history.ts
@@ -22,7 +22,7 @@ export const GetAccountHistoryInputSchema = z
     // example was rejected (#10115).
     from: RouteQuery_accounts_ss58_history.shape.from,
     to: RouteQuery_accounts_ss58_history.shape.to,
-    limit: RouteQuery_accounts_ss58_history.shape.limit.meta({ default: 100 }),
+    limit: RouteQuery_accounts_ss58_history.shape.limit,
     offset: RouteQuery_accounts_ss58_history.shape.offset,
     cursor: RouteQuery_accounts_ss58_history.shape.cursor,
   })

--- a/schemas-src/mcp-tools/account-identity.ts
+++ b/schemas-src/mcp-tools/account-identity.ts
@@ -39,9 +39,7 @@ export type GetAccountIdentityOutput = z.infer<
 export const GetAccountIdentityHistoryInputSchema = z
   .object({
     ss58: ss58Schema(),
-    limit: RouteQuery_accounts_ss58_identity_history.shape.limit.meta({
-      default: 100,
-    }),
+    limit: RouteQuery_accounts_ss58_identity_history.shape.limit,
     offset: RouteQuery_accounts_ss58_identity_history.shape.offset,
     cursor: RouteQuery_accounts_ss58_identity_history.shape.cursor,
   })

--- a/schemas-src/mcp-tools/account-summary.ts
+++ b/schemas-src/mcp-tools/account-summary.ts
@@ -116,7 +116,7 @@ export const GetAccountEventsInputSchema = z
     netuid: RouteQuery_accounts_ss58_events.shape.netuid,
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    limit: RouteQuery_accounts_ss58_events.shape.limit.meta({ default: 100 }),
+    limit: RouteQuery_accounts_ss58_events.shape.limit,
     offset: RouteQuery_accounts_ss58_events.shape.offset,
     cursor: RouteQuery_accounts_ss58_events.shape.cursor,
   })

--- a/schemas-src/mcp-tools/account-transfers.ts
+++ b/schemas-src/mcp-tools/account-transfers.ts
@@ -11,9 +11,8 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { COUNTERPARTIES_LIMIT_DEFAULT } from "../../src/counterparties.ts";
 import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
-import { blockBoundSchema, limitSchema, ss58Schema } from "./shared.ts";
+import { blockBoundSchema, ss58Schema } from "./shared.ts";
 import { AccountTransfersArtifactSchema } from "../routes/account-events-feed.ts";
 import { CounterpartyRelationshipSchema } from "../routes/account-counterparties.ts";
 
@@ -33,9 +32,7 @@ export const GetAccountTransfersInputSchema = z
       .meta({ examples: ["all"] }),
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    limit: RouteQuery_accounts_ss58_transfers.shape.limit.meta({
-      default: 100,
-    }),
+    limit: RouteQuery_accounts_ss58_transfers.shape.limit,
     offset: RouteQuery_accounts_ss58_transfers.shape.offset,
     cursor: RouteQuery_accounts_ss58_transfers.shape.cursor,
   })
@@ -59,7 +56,11 @@ export const GetAccountCounterpartiesInputSchema = z
         "The other SS58 account in the transfer pair — results are restricted to flows between the subject account and this one.",
       )
       .meta({ examples: ["5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F"] }),
-    limit: limitSchema(100, COUNTERPARTIES_LIMIT_DEFAULT).optional(),
+    // Inherited rather than restated: the route publishes the same ceiling and
+    // the same default now that both are named in src/counterparties.ts, so a
+    // local `limitSchema(100, …)` would be a second copy of a bound the route
+    // already declares.
+    limit: RouteQuery_accounts_ss58_counterparties.shape.limit,
   })
   .strict();
 export type GetAccountCounterpartiesInput = z.infer<

--- a/schemas-src/mcp-tools/accounts-leaderboards.ts
+++ b/schemas-src/mcp-tools/accounts-leaderboards.ts
@@ -11,10 +11,7 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import {
-  ACCOUNTS_LIST_LIMIT_DEFAULT,
-  TOP_HOLDERS_LIMIT_DEFAULT,
-} from "../../src/route-limits.ts";
+import {} from "../../src/route-limits.ts";
 import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { AccountsListArtifactSchema } from "../routes/accounts-list.ts";
 import { TopHoldersArtifactSchema } from "../routes/top-holders.ts";
@@ -31,9 +28,7 @@ const RouteQuery_accounts_top_holders =
 export const ListAccountsInputSchema = z
   .object({
     sort: RouteQuery_accounts.shape.sort,
-    limit: RouteQuery_accounts.shape.limit.meta({
-      default: ACCOUNTS_LIST_LIMIT_DEFAULT,
-    }),
+    limit: RouteQuery_accounts.shape.limit,
   })
   .strict();
 export type ListAccountsInput = z.infer<typeof ListAccountsInputSchema>;
@@ -46,9 +41,7 @@ export type ListAccountsOutput = z.infer<typeof ListAccountsOutputSchema>;
 export const GetTopHoldersInputSchema = z
   .object({
     sort: RouteQuery_accounts_top_holders.shape.sort,
-    limit: RouteQuery_accounts_top_holders.shape.limit.meta({
-      default: TOP_HOLDERS_LIMIT_DEFAULT,
-    }),
+    limit: RouteQuery_accounts_top_holders.shape.limit,
   })
   .strict();
 export type GetTopHoldersInput = z.infer<typeof GetTopHoldersInputSchema>;

--- a/schemas-src/mcp-tools/blocks.ts
+++ b/schemas-src/mcp-tools/blocks.ts
@@ -77,7 +77,7 @@ export const ListBlocksInputSchema = z
         "Inclusive lower bound on a block's event count; quieter blocks are excluded.",
       )
       .meta({ examples: [20] }),
-    limit: RouteQuery_blocks.shape.limit.meta({ default: 50 }),
+    limit: RouteQuery_blocks.shape.limit,
     offset: RouteQuery_blocks.shape.offset,
     cursor: RouteQuery_blocks.shape.cursor,
   })
@@ -133,7 +133,7 @@ export const ListBlockExtrinsicsInputSchema = z
           "0x9f1e2d3c4b5a69788796a5b4c3d2e1f009182736455463728190abcdef012345",
         ],
       }),
-    limit: RouteQuery_blocks_ref_extrinsics.shape.limit.meta({ default: 50 }),
+    limit: RouteQuery_blocks_ref_extrinsics.shape.limit,
     offset: RouteQuery_blocks_ref_extrinsics.shape.offset,
   })
   .strict();
@@ -159,7 +159,7 @@ export const GetBlockEventsInputSchema = z
           "0x9f1e2d3c4b5a69788796a5b4c3d2e1f009182736455463728190abcdef012345",
         ],
       }),
-    limit: RouteQuery_blocks_ref_events.shape.limit.meta({ default: 100 }),
+    limit: RouteQuery_blocks_ref_events.shape.limit,
     offset: RouteQuery_blocks_ref_events.shape.offset,
   })
   .strict();

--- a/schemas-src/mcp-tools/chain-calls-fees.ts
+++ b/schemas-src/mcp-tools/chain-calls-fees.ts
@@ -34,7 +34,7 @@ export const GetChainCallsInputSchema = z
         "How to bucket the counts: by pallet, or by pallet and call together.",
       )
       .meta({ examples: ["module"] }),
-    limit: RouteQuery_chain_calls.shape.limit.meta({ default: 50 }),
+    limit: RouteQuery_chain_calls.shape.limit,
     call_module: RouteQuery_chain_calls.shape.call_module
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
@@ -53,7 +53,7 @@ export const GetChainSignersInputSchema = z
   .object({
     window: RouteQuery_chain_signers.shape.window,
     sort: RouteQuery_chain_signers.shape.sort,
-    limit: RouteQuery_chain_signers.shape.limit.meta({ default: 50 }),
+    limit: RouteQuery_chain_signers.shape.limit,
     call_module: RouteQuery_chain_signers.shape.call_module
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",
@@ -70,7 +70,7 @@ export type GetChainSignersOutput = z.infer<typeof GetChainSignersOutputSchema>;
 export const GetChainFeesInputSchema = z
   .object({
     window: RouteQuery_chain_fees.shape.window,
-    limit: RouteQuery_chain_fees.shape.limit.meta({ default: 25 }),
+    limit: RouteQuery_chain_fees.shape.limit,
     call_module: RouteQuery_chain_fees.shape.call_module
       .describe(
         "Restrict to one pallet, by its runtime name (`SubtensorModule`). Case-sensitive.",

--- a/schemas-src/mcp-tools/chain-leaderboards.ts
+++ b/schemas-src/mcp-tools/chain-leaderboards.ts
@@ -18,16 +18,6 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { CHAIN_SERVING_LIMIT_DEFAULT } from "../../src/chain-serving.ts";
-import { CHAIN_TURNOVER_LIMIT_DEFAULT } from "../../src/route-limits.ts";
-import { CHAIN_WEIGHTS_LIMIT_DEFAULT } from "../../src/chain-weights.ts";
-import { CHAIN_PROMETHEUS_LIMIT_DEFAULT } from "../../src/chain-prometheus.ts";
-import { CHAIN_STAKE_TRANSFERS_LIMIT_DEFAULT } from "../../src/chain-stake-transfers.ts";
-import { CHAIN_STAKE_FLOW_LIMIT_DEFAULT } from "../../src/chain-stake-flow.ts";
-import { CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT } from "../../src/chain-weight-setters.ts";
-import { CHAIN_AXON_REMOVALS_LIMIT_DEFAULT } from "../../src/chain-axon-removals.ts";
-import { CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT } from "../../src/chain-alpha-volume.ts";
-import { CHAIN_STAKE_MOVES_LIMIT_DEFAULT } from "../../src/chain-stake-moves.ts";
 import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { ChainAlphaVolumeArtifactSchema } from "../routes/chain-alpha-volume.ts";
 import {
@@ -72,9 +62,7 @@ const RouteQuery_chain_alpha_volume =
 export const GetChainTurnoverInputSchema = z
   .object({
     window: RouteQuery_chain_turnover.shape.window,
-    limit: RouteQuery_chain_turnover.shape.limit.meta({
-      default: CHAIN_TURNOVER_LIMIT_DEFAULT,
-    }),
+    limit: RouteQuery_chain_turnover.shape.limit,
   })
   .strict();
 export type GetChainTurnoverInput = z.infer<typeof GetChainTurnoverInputSchema>;
@@ -87,9 +75,7 @@ export type GetChainTurnoverOutput = z.infer<
 export const GetChainStakeFlowInputSchema = z
   .object({
     window: RouteQuery_chain_stake_flow.shape.window,
-    limit: RouteQuery_chain_stake_flow.shape.limit.meta({
-      default: CHAIN_STAKE_FLOW_LIMIT_DEFAULT,
-    }),
+    limit: RouteQuery_chain_stake_flow.shape.limit,
   })
   .strict();
 export type GetChainStakeFlowInput = z.infer<
@@ -103,9 +89,7 @@ export type GetChainStakeFlowOutput = z.infer<
 
 export const GetChainAlphaVolumeInputSchema = z
   .object({
-    limit: RouteQuery_chain_alpha_volume.shape.limit.meta({
-      default: CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT,
-    }),
+    limit: RouteQuery_chain_alpha_volume.shape.limit,
   })
   .strict();
 export type GetChainAlphaVolumeInput = z.infer<
@@ -124,9 +108,7 @@ export type GetChainAlphaVolumeOutput = z.infer<
 export const GetChainWeightsInputSchema = z
   .object({
     window: RouteQuery_chain_weights.shape.window,
-    limit: RouteQuery_chain_weights.shape.limit.meta({
-      default: CHAIN_WEIGHTS_LIMIT_DEFAULT,
-    }),
+    limit: RouteQuery_chain_weights.shape.limit,
   })
   .strict();
 export type GetChainWeightsInput = z.infer<typeof GetChainWeightsInputSchema>;
@@ -137,9 +119,7 @@ export type GetChainWeightsOutput = z.infer<typeof GetChainWeightsOutputSchema>;
 export const GetChainWeightSettersInputSchema = z
   .object({
     window: RouteQuery_chain_weights_setters.shape.window,
-    limit: RouteQuery_chain_weights_setters.shape.limit.meta({
-      default: CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT,
-    }),
+    limit: RouteQuery_chain_weights_setters.shape.limit,
   })
   .strict();
 export type GetChainWeightSettersInput = z.infer<
@@ -157,9 +137,7 @@ export type GetChainWeightSettersOutput = z.infer<
 export const GetChainStakeMovesInputSchema = z
   .object({
     window: RouteQuery_chain_stake_moves.shape.window,
-    limit: RouteQuery_chain_stake_moves.shape.limit.meta({
-      default: CHAIN_STAKE_MOVES_LIMIT_DEFAULT,
-    }),
+    limit: RouteQuery_chain_stake_moves.shape.limit,
   })
   .strict();
 export type GetChainStakeMovesInput = z.infer<
@@ -174,9 +152,7 @@ export type GetChainStakeMovesOutput = z.infer<
 export const GetChainStakeTransfersInputSchema = z
   .object({
     window: RouteQuery_chain_stake_transfers.shape.window,
-    limit: RouteQuery_chain_stake_transfers.shape.limit.meta({
-      default: CHAIN_STAKE_TRANSFERS_LIMIT_DEFAULT,
-    }),
+    limit: RouteQuery_chain_stake_transfers.shape.limit,
   })
   .strict();
 export type GetChainStakeTransfersInput = z.infer<
@@ -192,9 +168,7 @@ export type GetChainStakeTransfersOutput = z.infer<
 export const GetChainAxonRemovalsInputSchema = z
   .object({
     window: RouteQuery_chain_axon_removals.shape.window,
-    limit: RouteQuery_chain_axon_removals.shape.limit.meta({
-      default: CHAIN_AXON_REMOVALS_LIMIT_DEFAULT,
-    }),
+    limit: RouteQuery_chain_axon_removals.shape.limit,
   })
   .strict();
 export type GetChainAxonRemovalsInput = z.infer<
@@ -209,9 +183,7 @@ export type GetChainAxonRemovalsOutput = z.infer<
 export const GetChainServingInputSchema = z
   .object({
     window: RouteQuery_chain_serving.shape.window,
-    limit: RouteQuery_chain_serving.shape.limit.meta({
-      default: CHAIN_SERVING_LIMIT_DEFAULT,
-    }),
+    limit: RouteQuery_chain_serving.shape.limit,
   })
   .strict();
 export type GetChainServingInput = z.infer<typeof GetChainServingInputSchema>;
@@ -222,9 +194,7 @@ export type GetChainServingOutput = z.infer<typeof GetChainServingOutputSchema>;
 export const GetChainPrometheusInputSchema = z
   .object({
     window: RouteQuery_chain_prometheus.shape.window,
-    limit: RouteQuery_chain_prometheus.shape.limit.meta({
-      default: CHAIN_PROMETHEUS_LIMIT_DEFAULT,
-    }),
+    limit: RouteQuery_chain_prometheus.shape.limit,
   })
   .strict();
 export type GetChainPrometheusInput = z.infer<

--- a/schemas-src/mcp-tools/chain-registrations.ts
+++ b/schemas-src/mcp-tools/chain-registrations.ts
@@ -14,8 +14,6 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT } from "../../src/chain-deregistrations.ts";
-import { CHAIN_REGISTRATIONS_LIMIT_DEFAULT } from "../../src/chain-registrations.ts";
 import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import {
   ChainDeregistrationsArtifactSchema,
@@ -31,9 +29,7 @@ const RouteQuery_chain_deregistrations =
 export const GetChainRegistrationsInputSchema = z
   .object({
     window: RouteQuery_chain_registrations.shape.window,
-    limit: RouteQuery_chain_registrations.shape.limit.meta({
-      default: CHAIN_REGISTRATIONS_LIMIT_DEFAULT,
-    }),
+    limit: RouteQuery_chain_registrations.shape.limit,
   })
   .strict();
 export type GetChainRegistrationsInput = z.infer<
@@ -54,9 +50,7 @@ export type GetChainRegistrationsOutput = z.infer<
 export const GetChainDeregistrationsInputSchema = z
   .object({
     window: RouteQuery_chain_deregistrations.shape.window,
-    limit: RouteQuery_chain_deregistrations.shape.limit.meta({
-      default: CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT,
-    }),
+    limit: RouteQuery_chain_deregistrations.shape.limit,
   })
   .strict();
 export type GetChainDeregistrationsInput = z.infer<

--- a/schemas-src/mcp-tools/chain-transfers.ts
+++ b/schemas-src/mcp-tools/chain-transfers.ts
@@ -11,8 +11,6 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { CHAIN_TRANSFER_PAIR_LIMIT_DEFAULT } from "../../src/chain-transfer-pairs.ts";
-import { CHAIN_TRANSFER_LIMIT_DEFAULT } from "../../src/chain-transfers.ts";
 import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import {
   ChainTransferPairsArtifactSchema,
@@ -31,9 +29,7 @@ const RouteQuery_chain_transfer_pairs =
 export const GetChainTransfersInputSchema = z
   .object({
     window: RouteQuery_chain_transfers.shape.window,
-    limit: RouteQuery_chain_transfers.shape.limit.meta({
-      default: CHAIN_TRANSFER_LIMIT_DEFAULT,
-    }),
+    limit: RouteQuery_chain_transfers.shape.limit,
   })
   .strict();
 export type GetChainTransfersInput = z.infer<
@@ -49,9 +45,7 @@ export const GetChainTransferPairsInputSchema = z
   .object({
     window: RouteQuery_chain_transfer_pairs.shape.window,
     sort: RouteQuery_chain_transfer_pairs.shape.sort,
-    limit: RouteQuery_chain_transfer_pairs.shape.limit.meta({
-      default: CHAIN_TRANSFER_PAIR_LIMIT_DEFAULT,
-    }),
+    limit: RouteQuery_chain_transfer_pairs.shape.limit,
   })
   .strict();
 export type GetChainTransferPairsInput = z.infer<

--- a/schemas-src/mcp-tools/extrinsics.ts
+++ b/schemas-src/mcp-tools/extrinsics.ts
@@ -87,7 +87,7 @@ export const ListExtrinsicsInputSchema = z
         "Inclusive end of the range. A block height on chain tools, an ISO-8601 date on time-series ones; an EVM address on decode_evm_call.",
       )
       .meta({ examples: [8783000] }),
-    limit: RouteQuery_extrinsics.shape.limit.meta({ default: 50 }),
+    limit: RouteQuery_extrinsics.shape.limit,
     offset: RouteQuery_extrinsics.shape.offset,
     cursor: RouteQuery_extrinsics.shape.cursor,
   })

--- a/schemas-src/mcp-tools/get-registry-leaderboards.ts
+++ b/schemas-src/mcp-tools/get-registry-leaderboards.ts
@@ -40,7 +40,7 @@ export const GetRegistryLeaderboardsInputSchema = z
     board: RouteQuery_registry_leaderboards.shape.board
       .describe("Which leaderboard to return.")
       .meta({ examples: [LEADERBOARD_BOARDS[0]] }),
-    limit: RouteQuery_registry_leaderboards.shape.limit.meta({ default: 20 }),
+    limit: RouteQuery_registry_leaderboards.shape.limit,
   })
   .strict();
 export type GetRegistryLeaderboardsInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-events.ts
+++ b/schemas-src/mcp-tools/get-subnet-events.ts
@@ -24,7 +24,7 @@ export const GetSubnetEventsInputSchema = z
     kind: RouteQuery_subnets_netuid_events.shape.kind,
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    limit: RouteQuery_subnets_netuid_events.shape.limit.meta({ default: 100 }),
+    limit: RouteQuery_subnets_netuid_events.shape.limit,
     offset: RouteQuery_subnets_netuid_events.shape.offset,
     cursor: RouteQuery_subnets_netuid_events.shape.cursor,
   })

--- a/schemas-src/mcp-tools/get-subnet-hyperparams.ts
+++ b/schemas-src/mcp-tools/get-subnet-hyperparams.ts
@@ -43,9 +43,7 @@ export type GetSubnetHyperparamsOutput = z.infer<
 export const GetSubnetHyperparamsHistoryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    limit: RouteQuery_subnets_netuid_hyperparameters_history.shape.limit.meta({
-      default: 100,
-    }),
+    limit: RouteQuery_subnets_netuid_hyperparameters_history.shape.limit,
     offset: RouteQuery_subnets_netuid_hyperparameters_history.shape.offset,
     cursor: RouteQuery_subnets_netuid_hyperparameters_history.shape.cursor,
   })

--- a/schemas-src/mcp-tools/get-subnet-identity-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-identity-history.ts
@@ -11,7 +11,6 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { DEFAULT_LIMIT } from "../../workers/request-params.ts";
 import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { netuidSchema } from "./shared.ts";
 import { SubnetIdentityHistoryArtifactSchema } from "../routes/subnet-identity-history.ts";
@@ -22,12 +21,7 @@ const RouteQuery_subnets_netuid_identity_history =
 export const GetSubnetIdentityHistoryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    // The route defaults this through FEED_PAGINATION and the tool's own
-    // description already says "default 100" -- it just was not in the
-    // schema, so only prose carried it (#10101).
-    limit: RouteQuery_subnets_netuid_identity_history.shape.limit.meta({
-      default: DEFAULT_LIMIT,
-    }),
+    limit: RouteQuery_subnets_netuid_identity_history.shape.limit,
     offset: RouteQuery_subnets_netuid_identity_history.shape.offset,
     cursor: RouteQuery_subnets_netuid_identity_history.shape.cursor,
   })

--- a/schemas-src/mcp-tools/get-subnet-lifecycle.ts
+++ b/schemas-src/mcp-tools/get-subnet-lifecycle.ts
@@ -22,12 +22,7 @@ const RouteQuery_chain_subnet_lifecycle =
 export const GetSubnetLifecycleInputSchema = z
   .object({
     netuid: netuidSchema(),
-    // The MCP narrowing of the route's ceiling, declared rather than silently
-    // different: an agent paying per token wants a page it can read, and this
-    // table is small enough that 100 is almost always the whole history.
-    limit: RouteQuery_subnets_netuid_lifecycle.shape.limit.meta({
-      default: 100,
-    }),
+    limit: RouteQuery_subnets_netuid_lifecycle.shape.limit,
     offset: RouteQuery_subnets_netuid_lifecycle.shape.offset,
   })
   .strict();
@@ -43,7 +38,12 @@ export type GetSubnetLifecycleOutput = z.infer<
 export const GetChainSubnetLifecycleInputSchema = z
   .object({
     window: RouteQuery_chain_subnet_lifecycle.shape.window,
-    limit: RouteQuery_chain_subnet_lifecycle.shape.limit.meta({ default: 100 }),
+    // Was a local `default: 100` against a route that serves 50 -- verified
+    // live, `GET /api/v1/chain/subnet-lifecycle` with no `limit` answers
+    // `limit: 50`. Not a declared narrowing but the opposite: the tool
+    // advertised a WIDER page than its own route, which #9701's asymmetry says
+    // never happens. Inherited now, so there is one number.
+    limit: RouteQuery_chain_subnet_lifecycle.shape.limit,
   })
   .strict();
 export type GetChainSubnetLifecycleInput = z.infer<

--- a/schemas-src/mcp-tools/governance-feeds.ts
+++ b/schemas-src/mcp-tools/governance-feeds.ts
@@ -64,7 +64,7 @@ export const GetSudoInputSchema = z
     // Both feeds say "same filters as list_extrinsics" and were modelled on it,
     // but dropped its `.max(100)` — declaring unbounded while the tier they forward to
     // caps at 100. A copy-paste omission, not a wider ceiling.
-    limit: RouteQuery_sudo.shape.limit.meta({ default: 50 }),
+    limit: RouteQuery_sudo.shape.limit,
     offset: RouteQuery_sudo.shape.offset,
     cursor: RouteQuery_sudo.shape.cursor,
   })
@@ -128,9 +128,7 @@ export const GetGovernanceConfigChangesInputSchema = z
     // Both feeds say "same filters as list_extrinsics" and were modelled on it,
     // but dropped its `.max(100)` — declaring unbounded while the tier they forward to
     // caps at 100. A copy-paste omission, not a wider ceiling.
-    limit: RouteQuery_governance_config_changes.shape.limit.meta({
-      default: 50,
-    }),
+    limit: RouteQuery_governance_config_changes.shape.limit,
     offset: RouteQuery_governance_config_changes.shape.offset,
     cursor: RouteQuery_governance_config_changes.shape.cursor,
   })

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -57,58 +57,133 @@
 // what 3/5 publishes either way.
 import { z } from "zod";
 import {
+  ACCOUNTS_LIST_LIMIT_DEFAULT,
   ACCOUNTS_LIST_LIMIT_MAX,
   ANALYTICS_WINDOWS,
   BULK_HEALTH_TRENDS_LIMIT_MAX,
   CHAIN_CONCENTRATION_HISTORY_WINDOWS,
   CHAIN_CALL_MODULE_MAX_LENGTH,
+  CHAIN_CONCENTRATION_SUBNETS_LIMIT_DEFAULT,
   CHAIN_CONCENTRATION_SUBNETS_LIMIT_MAX,
+  CHAIN_EVENTS_LIMIT_DEFAULT,
   CHAIN_EVENTS_LIMIT_MAX,
   CHAIN_EVENT_NAME_MAX_LENGTH,
+  CHAIN_HOLDERS_LIMIT_DEFAULT,
   CHAIN_HOLDERS_LIMIT_MAX,
+  CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
   CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
+  CHAIN_TURNOVER_LIMIT_DEFAULT,
   CHAIN_TURNOVER_LIMIT_MAX,
+  EMISSION_CHANGES_LIMIT_DEFAULT,
   EMISSION_CHANGES_LIMIT_MAX,
   EMISSION_PIPELINE_LIMIT_MAX,
   FAILURE_REASONS_WINDOWS,
   FEED_LIMIT_MAX,
   FEED_WATCH_IDS_MAX_LENGTH,
+  GLOBAL_VALIDATOR_LIMIT_DEFAULT,
   GLOBAL_VALIDATOR_LIMIT_MAX,
   HISTORY_WINDOWS,
+  LEADERBOARDS_LIMIT_DEFAULT,
   LEADERBOARDS_LIMIT_MAX,
+  MOVERS_LIMIT_DEFAULT,
   MOVERS_LIMIT_MAX,
   PIPELINE_HISTORY_WINDOWS,
   SEMANTIC_LIMIT_DEFAULT,
   SEMANTIC_LIMIT_MAX,
   SEMANTIC_QUERY_MAX_LENGTH,
   SEMANTIC_TYPES,
+  SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
   SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
   UPTIME_WINDOWS,
+  SUBNET_HOLDERS_LIMIT_DEFAULT,
   SUBNET_HOLDERS_LIMIT_MAX,
+  SURFACE_HISTORY_LIMIT_DEFAULT,
   SURFACE_HISTORY_LIMIT_MAX,
+  TOP_HOLDERS_LIMIT_DEFAULT,
   TOP_HOLDERS_LIMIT_MAX,
+  VALIDATOR_ECONOMICS_LIMIT_DEFAULT,
   VALIDATOR_ECONOMICS_LIMIT_MAX,
 } from "../src/route-limits.ts";
-import { BLOCK_PAGINATION, MAX_LIMIT } from "../workers/request-params.ts";
-import { CHAIN_ALPHA_VOLUME_LIMIT_MAX } from "../src/chain-alpha-volume.ts";
-import { CHAIN_AXON_REMOVALS_LIMIT_MAX } from "../src/chain-axon-removals.ts";
-import { CHAIN_CALLS_LIMIT_MAX } from "../src/chain-calls-artifact.ts";
-import { CHAIN_DEREGISTRATIONS_LIMIT_MAX } from "../src/chain-deregistrations.ts";
-import { CHAIN_SUBNET_LIFECYCLE_LIMIT_MAX } from "../src/subnet-lifecycle-read.ts";
+import {
+  BLOCK_PAGINATION,
+  FEED_PAGINATION,
+  MAX_LIMIT,
+} from "../workers/request-params.ts";
+import {
+  CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT,
+  CHAIN_ALPHA_VOLUME_LIMIT_MAX,
+} from "../src/chain-alpha-volume.ts";
+import {
+  CHAIN_AXON_REMOVALS_LIMIT_DEFAULT,
+  CHAIN_AXON_REMOVALS_LIMIT_MAX,
+} from "../src/chain-axon-removals.ts";
+import {
+  CHAIN_CALLS_LIMIT_DEFAULT,
+  CHAIN_CALLS_LIMIT_MAX,
+} from "../src/chain-calls-artifact.ts";
+import {
+  CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT,
+  CHAIN_DEREGISTRATIONS_LIMIT_MAX,
+} from "../src/chain-deregistrations.ts";
+import {
+  CHAIN_SUBNET_LIFECYCLE_LIMIT_DEFAULT,
+  CHAIN_SUBNET_LIFECYCLE_LIMIT_MAX,
+} from "../src/subnet-lifecycle-read.ts";
 import { CHAIN_EVENTS_STATS_BLOCKS_MAX } from "../src/chain-events-cold-tier.ts";
-import { CHAIN_FEES_LIMIT_MAX } from "../src/chain-fees-artifact.ts";
-import { CHAIN_PROMETHEUS_LIMIT_MAX } from "../src/chain-prometheus.ts";
-import { CHAIN_REGISTRATIONS_LIMIT_MAX } from "../src/chain-registrations.ts";
-import { CHAIN_SERVING_LIMIT_MAX } from "../src/chain-serving.ts";
-import { CHAIN_SIGNERS_LIMIT_MAX } from "../src/chain-signers-artifact.ts";
-import { CHAIN_STAKE_FLOW_LIMIT_MAX } from "../src/chain-stake-flow.ts";
-import { CHAIN_STAKE_MOVES_LIMIT_MAX } from "../src/chain-stake-moves.ts";
-import { CHAIN_STAKE_TRANSFERS_LIMIT_MAX } from "../src/chain-stake-transfers.ts";
-import { CHAIN_TRANSFER_PAIR_LIMIT_MAX } from "../src/chain-transfer-pairs.ts";
-import { CHAIN_TRANSFER_LIMIT_MAX } from "../src/chain-transfers.ts";
-import { CHAIN_WEIGHT_SETTERS_LIMIT_MAX } from "../src/chain-weight-setters.ts";
-import { CHAIN_WEIGHTS_LIMIT_MAX } from "../src/chain-weights.ts";
+import {
+  CHAIN_FEES_LIMIT_DEFAULT,
+  CHAIN_FEES_LIMIT_MAX,
+} from "../src/chain-fees-artifact.ts";
+import {
+  CHAIN_PROMETHEUS_LIMIT_DEFAULT,
+  CHAIN_PROMETHEUS_LIMIT_MAX,
+} from "../src/chain-prometheus.ts";
+import {
+  CHAIN_REGISTRATIONS_LIMIT_DEFAULT,
+  CHAIN_REGISTRATIONS_LIMIT_MAX,
+} from "../src/chain-registrations.ts";
+import {
+  CHAIN_SERVING_LIMIT_DEFAULT,
+  CHAIN_SERVING_LIMIT_MAX,
+} from "../src/chain-serving.ts";
+import {
+  CHAIN_SIGNERS_LIMIT_DEFAULT,
+  CHAIN_SIGNERS_LIMIT_MAX,
+} from "../src/chain-signers-artifact.ts";
+import {
+  CHAIN_STAKE_FLOW_LIMIT_DEFAULT,
+  CHAIN_STAKE_FLOW_LIMIT_MAX,
+} from "../src/chain-stake-flow.ts";
+import {
+  CHAIN_STAKE_MOVES_LIMIT_DEFAULT,
+  CHAIN_STAKE_MOVES_LIMIT_MAX,
+} from "../src/chain-stake-moves.ts";
+import {
+  CHAIN_STAKE_TRANSFERS_LIMIT_DEFAULT,
+  CHAIN_STAKE_TRANSFERS_LIMIT_MAX,
+} from "../src/chain-stake-transfers.ts";
+import {
+  CHAIN_TRANSFER_PAIR_LIMIT_DEFAULT,
+  CHAIN_TRANSFER_PAIR_LIMIT_MAX,
+} from "../src/chain-transfer-pairs.ts";
+import {
+  CHAIN_TRANSFER_LIMIT_DEFAULT,
+  CHAIN_TRANSFER_LIMIT_MAX,
+} from "../src/chain-transfers.ts";
+import {
+  CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT,
+  CHAIN_WEIGHT_SETTERS_LIMIT_MAX,
+} from "../src/chain-weight-setters.ts";
+import {
+  CHAIN_WEIGHTS_LIMIT_DEFAULT,
+  CHAIN_WEIGHTS_LIMIT_MAX,
+} from "../src/chain-weights.ts";
+import {
+  COUNTERPARTIES_LIMIT_DEFAULT,
+  COUNTERPARTIES_LIMIT_MAX,
+} from "../src/counterparties.ts";
 import { TOP_HOLDERS_SORTS } from "../src/top-holders.ts";
+import { NOMINATOR_LIMIT_DEFAULT } from "../src/validator-nominators.ts";
 import { VALIDATOR_ECONOMICS_SORTS } from "../src/validator-economics.ts";
 import {
   blockBoundSchema,
@@ -409,7 +484,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     sort: sortSchema(
       VALIDATOR_ECONOMICS_SORTS as unknown as [string, ...string[]],
     ).optional(),
-    limit: limitSchema(VALIDATOR_ECONOMICS_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      VALIDATOR_ECONOMICS_LIMIT_MAX,
+      VALIDATOR_ECONOMICS_LIMIT_DEFAULT,
+    ).optional(),
     // Bounded by the ranking's own ceiling, not the generic deep-paging one:
     // one row per subnet, so seeking past the limit seeks nothing.
     offset: z.int().min(0).max(VALIDATOR_ECONOMICS_LIMIT_MAX).optional(),
@@ -424,7 +502,7 @@ export const ROUTE_QUERY_SCHEMAS = {
       "validators",
       "neurons",
     ] as const).optional(),
-    limit: limitSchema(MOVERS_LIMIT_MAX).optional(),
+    limit: limitSchema(MOVERS_LIMIT_MAX, MOVERS_LIMIT_DEFAULT).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/validators": z.object({
@@ -437,7 +515,10 @@ export const ROUTE_QUERY_SCHEMAS = {
       "total_stake",
       "uid_count",
     ] as const).optional(),
-    limit: limitSchema(GLOBAL_VALIDATOR_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      GLOBAL_VALIDATOR_LIMIT_MAX,
+      GLOBAL_VALIDATOR_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/accounts": z.object({
@@ -450,7 +531,10 @@ export const ROUTE_QUERY_SCHEMAS = {
       "stake_dominance",
       "last_active",
     ] as const).optional(),
-    limit: limitSchema(ACCOUNTS_LIST_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      ACCOUNTS_LIST_LIMIT_MAX,
+      ACCOUNTS_LIST_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/accounts/top-holders": z.object({
@@ -462,7 +546,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     // recomputed daily. The route's own 400 has always named all six.
     // The enum IS TOP_HOLDERS_SORTS, read from the module that owns it.
     sort: sortSchema(TOP_HOLDERS_SORTS as [string, ...string[]]).optional(),
-    limit: limitSchema(TOP_HOLDERS_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      TOP_HOLDERS_LIMIT_MAX,
+      TOP_HOLDERS_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/validators/{hotkey}/nominators": z.object({
@@ -485,7 +572,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     // cold-tier builder still clamps at NOMINATOR_LIMIT_MAX, so a fallback
     // page is shorter than this ceiling; that is a tier difference, not a
     // second contract.
-    limit: limitSchema(GLOBAL_VALIDATOR_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      GLOBAL_VALIDATOR_LIMIT_MAX,
+      NOMINATOR_LIMIT_DEFAULT,
+    ).optional(),
     offset: unboundedOffsetSchema().optional(),
     // The handler DOES validate this -- `?coldkey=notanaddress` is a 400,
     // verified live -- and the contract simply did not say so, while
@@ -527,7 +617,7 @@ export const ROUTE_QUERY_SCHEMAS = {
     fields: fieldsSchema().optional(),
   }),
   "/api/v1/subnets/{netuid}/hyperparameters/history": z.object({
-    limit: limitSchema(MAX_LIMIT).optional(),
+    limit: limitSchema(MAX_LIMIT, FEED_PAGINATION.defaultLimit).optional(),
     offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     format: formatSchema().optional(),
@@ -536,7 +626,7 @@ export const ROUTE_QUERY_SCHEMAS = {
   // change, this one a table that grows per subnet per LIFETIME. Publishing a
   // keyset token here would advertise resumability the loader does not provide.
   "/api/v1/subnets/{netuid}/lifecycle": z.object({
-    limit: limitSchema(MAX_LIMIT).optional(),
+    limit: limitSchema(MAX_LIMIT, FEED_PAGINATION.defaultLimit).optional(),
     offset: offsetSchema().optional(),
     format: formatSchema().optional(),
   }),
@@ -555,7 +645,7 @@ export const ROUTE_QUERY_SCHEMAS = {
     kind: kindStringSchema().optional(),
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    limit: limitSchema(MAX_LIMIT).optional(),
+    limit: limitSchema(MAX_LIMIT, FEED_PAGINATION.defaultLimit).optional(),
     offset: offsetSchema().optional(),
     // The handler has always accepted and forwarded this, and the sibling
     // /accounts/{ss58}/events feed publishes it -- but this route did not, so
@@ -566,7 +656,10 @@ export const ROUTE_QUERY_SCHEMAS = {
   }),
   "/api/v1/subnets/{netuid}/event-summary": z.object({
     window: windowSchema(["7d", "30d", "90d"] as const).optional(),
-    limit: limitSchema(SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
+      SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
+    ).optional(),
   }),
   "/api/v1/subnets/{netuid}/neurons/{uid}/history": z.object({
     window: windowSchema(HISTORY_WINDOWS as [string, ...string[]]).optional(),
@@ -575,7 +668,7 @@ export const ROUTE_QUERY_SCHEMAS = {
     window: windowSchema(HISTORY_WINDOWS as [string, ...string[]]).optional(),
   }),
   "/api/v1/subnets/{netuid}/identity-history": z.object({
-    limit: limitSchema(MAX_LIMIT).optional(),
+    limit: limitSchema(MAX_LIMIT, FEED_PAGINATION.defaultLimit).optional(),
     offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     format: formatSchema().optional(),
@@ -585,7 +678,7 @@ export const ROUTE_QUERY_SCHEMAS = {
     netuid: netuidSchema().optional(),
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    limit: limitSchema(MAX_LIMIT).optional(),
+    limit: limitSchema(MAX_LIMIT, FEED_PAGINATION.defaultLimit).optional(),
     offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     format: formatSchema().optional(),
@@ -594,7 +687,7 @@ export const ROUTE_QUERY_SCHEMAS = {
     netuid: netuidSchema().optional(),
     from: daySchema("first").optional(),
     to: daySchema("last").optional(),
-    limit: limitSchema(MAX_LIMIT).optional(),
+    limit: limitSchema(MAX_LIMIT, FEED_PAGINATION.defaultLimit).optional(),
     offset: offsetSchema().optional(),
     // handleAccountHistory forwards this to loadAccountHistoryColdTier and has
     // since #9315; only the contract left it out (#10065).
@@ -604,7 +697,7 @@ export const ROUTE_QUERY_SCHEMAS = {
   "/api/v1/accounts/{ss58}/extrinsics": z.object({
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    limit: limitSchema(MAX_LIMIT).optional(),
+    limit: limitSchema(MAX_LIMIT, FEED_PAGINATION.defaultLimit).optional(),
     offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     format: formatSchema().optional(),
@@ -613,7 +706,7 @@ export const ROUTE_QUERY_SCHEMAS = {
     direction: directionSchema(["all", "sent", "received"] as const).optional(),
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    limit: limitSchema(MAX_LIMIT).optional(),
+    limit: limitSchema(MAX_LIMIT, FEED_PAGINATION.defaultLimit).optional(),
     offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     format: formatSchema().optional(),
@@ -623,7 +716,10 @@ export const ROUTE_QUERY_SCHEMAS = {
       .string()
       .regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/)
       .optional(),
-    limit: z.int().min(1).max(100).optional(),
+    limit: limitSchema(
+      COUNTERPARTIES_LIMIT_MAX,
+      COUNTERPARTIES_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/accounts/{ss58}/stake-flow": z.object({
@@ -655,7 +751,7 @@ export const ROUTE_QUERY_SCHEMAS = {
     window: windowSchema(HISTORY_WINDOWS as [string, ...string[]]).optional(),
   }),
   "/api/v1/accounts/{ss58}/identity-history": z.object({
-    limit: limitSchema(MAX_LIMIT).optional(),
+    limit: limitSchema(MAX_LIMIT, FEED_PAGINATION.defaultLimit).optional(),
     offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     format: formatSchema().optional(),
@@ -668,14 +764,23 @@ export const ROUTE_QUERY_SCHEMAS = {
     window: windowSchema(["24h", "7d", "30d", "90d"] as const).optional(),
   }),
   "/api/v1/subnets/{netuid}/holders": z.object({
-    limit: limitSchema(SUBNET_HOLDERS_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      SUBNET_HOLDERS_LIMIT_MAX,
+      SUBNET_HOLDERS_LIMIT_DEFAULT,
+    ).optional(),
   }),
   "/api/v1/subnets/{netuid}/surface-history": z.object({
-    limit: limitSchema(SURFACE_HISTORY_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      SURFACE_HISTORY_LIMIT_MAX,
+      SURFACE_HISTORY_LIMIT_DEFAULT,
+    ).optional(),
   }),
   "/api/v1/chain/governance/emission-changes": z.object({
     kind: kindSchema(["param", "subnet", "flow"] as const).optional(),
-    limit: limitSchema(EMISSION_CHANGES_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      EMISSION_CHANGES_LIMIT_MAX,
+      EMISSION_CHANGES_LIMIT_DEFAULT,
+    ).optional(),
   }),
   "/api/v1/chain/holders": z.object({
     sort: sortSchema([
@@ -686,7 +791,10 @@ export const ROUTE_QUERY_SCHEMAS = {
       "holder_count",
       "total_alpha",
     ] as const).optional(),
-    limit: limitSchema(CHAIN_HOLDERS_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_HOLDERS_LIMIT_MAX,
+      CHAIN_HOLDERS_LIMIT_DEFAULT,
+    ).optional(),
   }),
   "/api/v1/health/failure-reasons": z.object({
     window: windowSchema(
@@ -714,7 +822,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     ).optional(),
   }),
   "/api/v1/blocks": z.object({
-    limit: limitSchema(BLOCK_PAGINATION.maxLimit).optional(),
+    limit: limitSchema(
+      BLOCK_PAGINATION.maxLimit,
+      BLOCK_PAGINATION.defaultLimit,
+    ).optional(),
     offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     // DIVERGENCE: the block author is an SS58 and publishes no pattern.
@@ -729,12 +840,15 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/blocks/{ref}/extrinsics": z.object({
-    limit: limitSchema(BLOCK_PAGINATION.maxLimit).optional(),
+    limit: limitSchema(
+      BLOCK_PAGINATION.maxLimit,
+      BLOCK_PAGINATION.defaultLimit,
+    ).optional(),
     offset: offsetSchema().optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/blocks/{ref}/events": z.object({
-    limit: limitSchema(MAX_LIMIT).optional(),
+    limit: limitSchema(MAX_LIMIT, FEED_PAGINATION.defaultLimit).optional(),
     offset: offsetSchema().optional(),
     format: formatSchema().optional(),
   }),
@@ -754,14 +868,20 @@ export const ROUTE_QUERY_SCHEMAS = {
     // different values and the contract was written from the one the request
     // path does not use. One constant now, in src/route-limits.ts, and it is
     // the number the route enforces.
-    limit: limitSchema(CHAIN_EVENTS_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_EVENTS_LIMIT_MAX,
+      CHAIN_EVENTS_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain-events/stats": z.object({
     blocks: z.int().min(1).max(CHAIN_EVENTS_STATS_BLOCKS_MAX).optional(),
   }),
   "/api/v1/extrinsics": z.object({
-    limit: limitSchema(BLOCK_PAGINATION.maxLimit).optional(),
+    limit: limitSchema(
+      BLOCK_PAGINATION.maxLimit,
+      BLOCK_PAGINATION.defaultLimit,
+    ).optional(),
     offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     block: blockBoundSchema("first").optional(),
@@ -786,7 +906,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/sudo": z.object({
-    limit: limitSchema(BLOCK_PAGINATION.maxLimit).optional(),
+    limit: limitSchema(
+      BLOCK_PAGINATION.maxLimit,
+      BLOCK_PAGINATION.defaultLimit,
+    ).optional(),
     offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     block: blockBoundSchema("first").optional(),
@@ -799,7 +922,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/governance/config-changes": z.object({
-    limit: limitSchema(BLOCK_PAGINATION.maxLimit).optional(),
+    limit: limitSchema(
+      BLOCK_PAGINATION.maxLimit,
+      BLOCK_PAGINATION.defaultLimit,
+    ).optional(),
     offset: offsetSchema().optional(),
     cursor: keysetCursorSchema().optional(),
     block: blockBoundSchema("first").optional(),
@@ -821,70 +947,109 @@ export const ROUTE_QUERY_SCHEMAS = {
   "/api/v1/chain/calls": z.object({
     window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
     group_by: z.enum(["module", "module_function"] as const).optional(),
-    limit: limitSchema(CHAIN_CALLS_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_CALLS_LIMIT_MAX,
+      CHAIN_CALLS_LIMIT_DEFAULT,
+    ).optional(),
     call_module: z.string().max(CHAIN_CALL_MODULE_MAX_LENGTH).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/signers": z.object({
     window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
     sort: sortSchema(["tx_count", "total_fee_tao"] as const).optional(),
-    limit: limitSchema(CHAIN_SIGNERS_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_SIGNERS_LIMIT_MAX,
+      CHAIN_SIGNERS_LIMIT_DEFAULT,
+    ).optional(),
     call_module: z.string().max(CHAIN_CALL_MODULE_MAX_LENGTH).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/transfers": z.object({
     window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
-    limit: limitSchema(CHAIN_TRANSFER_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_TRANSFER_LIMIT_MAX,
+      CHAIN_TRANSFER_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/transfer-pairs": z.object({
     window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
-    limit: limitSchema(CHAIN_TRANSFER_PAIR_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_TRANSFER_PAIR_LIMIT_MAX,
+      CHAIN_TRANSFER_PAIR_LIMIT_DEFAULT,
+    ).optional(),
     sort: sortSchema(["volume", "count"] as const).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/stake-flow": z.object({
     window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
-    limit: limitSchema(CHAIN_STAKE_FLOW_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_STAKE_FLOW_LIMIT_MAX,
+      CHAIN_STAKE_FLOW_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/alpha-volume": z.object({
-    limit: limitSchema(CHAIN_ALPHA_VOLUME_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_ALPHA_VOLUME_LIMIT_MAX,
+      CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/weights": z.object({
     window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
-    limit: limitSchema(CHAIN_WEIGHTS_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_WEIGHTS_LIMIT_MAX,
+      CHAIN_WEIGHTS_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/weights/setters": z.object({
     window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
-    limit: limitSchema(CHAIN_WEIGHT_SETTERS_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_WEIGHT_SETTERS_LIMIT_MAX,
+      CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/serving": z.object({
     window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
-    limit: limitSchema(CHAIN_SERVING_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_SERVING_LIMIT_MAX,
+      CHAIN_SERVING_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/axon-removals": z.object({
     window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
-    limit: limitSchema(CHAIN_AXON_REMOVALS_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_AXON_REMOVALS_LIMIT_MAX,
+      CHAIN_AXON_REMOVALS_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/prometheus": z.object({
     window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
-    limit: limitSchema(CHAIN_PROMETHEUS_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_PROMETHEUS_LIMIT_MAX,
+      CHAIN_PROMETHEUS_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/registrations": z.object({
     window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
-    limit: limitSchema(CHAIN_REGISTRATIONS_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_REGISTRATIONS_LIMIT_MAX,
+      CHAIN_REGISTRATIONS_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/deregistrations": z.object({
     window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
-    limit: limitSchema(CHAIN_DEREGISTRATIONS_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_DEREGISTRATIONS_LIMIT_MAX,
+      CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   // The five-value window, not the 7d/30d the per-UID feed above takes: a
@@ -895,22 +1060,34 @@ export const ROUTE_QUERY_SCHEMAS = {
   // few-hundred-row table the whole network's lifecycle fits in one request.
   "/api/v1/chain/subnet-lifecycle": z.object({
     window: windowSchema(HISTORY_WINDOWS as [string, ...string[]]).optional(),
-    limit: limitSchema(CHAIN_SUBNET_LIFECYCLE_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_SUBNET_LIFECYCLE_LIMIT_MAX,
+      CHAIN_SUBNET_LIFECYCLE_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/stake-transfers": z.object({
     window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
-    limit: limitSchema(CHAIN_STAKE_TRANSFERS_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_STAKE_TRANSFERS_LIMIT_MAX,
+      CHAIN_STAKE_TRANSFERS_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/stake-moves": z.object({
     window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
-    limit: limitSchema(CHAIN_STAKE_MOVES_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_STAKE_MOVES_LIMIT_MAX,
+      CHAIN_STAKE_MOVES_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/fees": z.object({
     window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
-    limit: limitSchema(CHAIN_FEES_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_FEES_LIMIT_MAX,
+      CHAIN_FEES_LIMIT_DEFAULT,
+    ).optional(),
     call_module: z.string().max(CHAIN_CALL_MODULE_MAX_LENGTH).optional(),
     format: formatSchema().optional(),
   }),
@@ -933,14 +1110,23 @@ export const ROUTE_QUERY_SCHEMAS = {
       "netuid",
     ] as const).optional(),
     order: orderSchema().optional(),
-    limit: limitSchema(CHAIN_CONCENTRATION_SUBNETS_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_CONCENTRATION_SUBNETS_LIMIT_MAX,
+      CHAIN_CONCENTRATION_SUBNETS_LIMIT_DEFAULT,
+    ).optional(),
   }),
   "/api/v1/chain/identity-history": z.object({
-    limit: limitSchema(CHAIN_IDENTITY_HISTORY_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
+      CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
+    ).optional(),
   }),
   "/api/v1/chain/turnover": z.object({
     window: windowSchema(["7d", "30d", "90d"] as const).optional(),
-    limit: limitSchema(CHAIN_TURNOVER_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      CHAIN_TURNOVER_LIMIT_MAX,
+      CHAIN_TURNOVER_LIMIT_DEFAULT,
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/subnets/{netuid}/uptime": z.object({
@@ -965,7 +1151,10 @@ export const ROUTE_QUERY_SCHEMAS = {
         "biggest-alpha-gain-7d",
       ] as const)
       .optional(),
-    limit: limitSchema(LEADERBOARDS_LIMIT_MAX).optional(),
+    limit: limitSchema(
+      LEADERBOARDS_LIMIT_MAX,
+      LEADERBOARDS_LIMIT_DEFAULT,
+    ).optional(),
   }),
   "/api/v1/compare": z.object({
     netuids: netuidListSchema().optional(),

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -5549,7 +5549,12 @@ function openApiOperationId(routeId: string) {
 export const SHARED_QUERY_PARAMETER_DESCRIPTIONS: Record<
   string,
   (parameter: {
-    schema?: { maximum?: number; minimum?: number; enum?: unknown[] };
+    schema?: {
+      maximum?: number;
+      minimum?: number;
+      enum?: unknown[];
+      default?: unknown;
+    };
   }) => string
 > = {
   // ── Why this map exists ALONGSIDE limitSchema's own .describe() ───────────
@@ -5580,14 +5585,21 @@ export const SHARED_QUERY_PARAMETER_DESCRIPTIONS: Record<
   // exemption.
   limit: (parameter) => {
     const maximum = parameter.schema?.maximum;
-    // The ceiling is read off the parameter's own schema rather than restated,
-    // so it follows route-limits.ts wherever a route sets a different one.
+    // The ceiling AND the omitted-value behaviour are read off the parameter's
+    // own schema rather than restated, so both follow the route wherever it
+    // sets its own (#10060). A route that publishes no `default` does not do so
+    // by omission: it returns every matching row when `limit` is absent, which
+    // is what the second sentence says instead of leaving a caller to guess.
+    const fallback = parameter.schema?.default;
     return (
       "Maximum number of rows to return in one page" +
       (typeof maximum === "number" ? ` (at most ${maximum})` : "") +
       ". A larger value, or a non-positive one, is rejected with 400 " +
       "`invalid_query` -- so a short page means the result set is exhausted, " +
-      "not that the server quietly capped you (#9916)."
+      "not that the server quietly capped you (#9916). " +
+      (typeof fallback === "number"
+        ? `Omitted, the server applies ${fallback}.`
+        : "Omitted, every matching row is returned.")
     );
   },
   offset: () =>
@@ -5644,7 +5656,12 @@ function withSharedParameterDescription<T extends object>(parameter: T): T {
   const spec = parameter as {
     name?: unknown;
     description?: unknown;
-    schema?: { maximum?: number; minimum?: number; enum?: unknown[] };
+    schema?: {
+      maximum?: number;
+      minimum?: number;
+      enum?: unknown[];
+      default?: unknown;
+    };
   };
   if (typeof spec.name !== "string" || spec.description) return parameter;
   const shared = SHARED_QUERY_PARAMETER_DESCRIPTIONS[spec.name];

--- a/src/counterparties.ts
+++ b/src/counterparties.ts
@@ -7,6 +7,15 @@
  * default by counting rows.
  */
 export const COUNTERPARTIES_LIMIT_DEFAULT = 20;
+/**
+ * The ceiling the route rejects above.
+ *
+ * The number existed as a bare `100` in three places -- the route's query
+ * schema, the MCP tool's, and nowhere the handler could cite -- which is the
+ * same shape the default above was in before #10101 named it. Named here, with
+ * the default, so the two halves of one bound have one owner.
+ */
+export const COUNTERPARTIES_LIMIT_MAX = 100;
 // Account counterparty / fund-flow analytics: who one account transacts with,
 // aggregated from the account_events Transfer tier (hotkey = from, coldkey = to,
 // amount_tao). Pure + exported for unit tests; workers/data-api.ts does the

--- a/src/route-query.ts
+++ b/src/route-query.ts
@@ -175,27 +175,78 @@ export function validateRouteArgs(
 }
 
 /**
+ * The page size this request resolved to: what the caller asked for, or the
+ * default the route PUBLISHES (#10060).
+ *
+ * The number is not restated here and no longer restated by the handler. It is
+ * declared once, beside the ceiling, in the module that owns the route's bounds
+ * -- `schemas-src/route-queries.ts` passes it to `limitSchema(max, fallback)`,
+ * which puts it in `openapi.json` as the parameter's `default`, and this reads
+ * it back out of the same object. A caller and the server now get the page size
+ * from one place.
+ *
+ * Before this, 103 of the 128 published `limit` parameters carried no `default`
+ * while their handler applied one -- so the contract could not say what a
+ * caller got for omitting it, and the MCP tool mirroring the same route DID
+ * declare one, leaving the two published surfaces disagreeing about a route
+ * neither was wrong about.
+ *
+ * Throws for a route that publishes no default. That is a developer-config
+ * error, not a request the caller can make: the 36 collection routes and the
+ * three others that return every matching row when `limit` is absent read
+ * `routeQuery(url).limit` directly, because `undefined` is the answer there and
+ * substituting a number would truncate them.
+ */
+export function pageLimit(url: URL): number {
+  const asked = routeQuery(url).limit;
+  if (asked !== undefined) return asked;
+  const fallback = publishedLimitDefault(url.pathname);
+  if (fallback === undefined) {
+    throw new Error(`No published limit default for ${url.pathname}`);
+  }
+  return fallback;
+}
+
+/**
+ * What `limitSchema(max, fallback)` recorded, read back off the published
+ * field.
+ *
+ * `.meta()` does not see through `.optional()`, and every query parameter is
+ * optional, so the wrapper comes off first -- and stays off for the routes
+ * that declare no `limit` at all, where there is nothing to unwrap. This is the
+ * same metadata object `z.toJSONSchema` turns into the published `default`
+ * keyword, so the contract and the runtime cannot be reading different numbers.
+ */
+function publishedLimitDefault(pathname: string): number | undefined {
+  const field = routeQuerySchemasForPathname(pathname)?.plain.shape.limit as
+    z.ZodType | undefined;
+  const inner = field instanceof z.ZodOptional ? field.unwrap() : field;
+  const declared = (inner as z.ZodType | undefined)?.meta()?.default;
+  return typeof declared === "number" ? declared : undefined;
+}
+
+/**
  * The pagination triplet from the already-validated query.
  *
  * `parsePagination` used to do this AND enforce it, restating `limit`'s bound
  * (#9916's reject-don't-clamp rule) next to a hand-rolled `offset` clamp that
  * did the opposite -- so one request could have its page size rejected and its
  * offset silently moved. Both bounds are published; the router enforces both
- * from the schema, and what is left here is the page-size default, which the
- * contract does not state.
+ * from the schema, and the page size now comes from the schema too.
  *
- * `defaultLimit` therefore stays a caller-supplied profile (FEED_PAGINATION /
- * BLOCK_PAGINATION) rather than being read off the schema: 83 of the 84 routes
- * that publish a `limit` publish no `default` alongside it. Publishing them is
- * a contract change and its own issue -- this is the read, not the decision.
+ * `defaultLimit` used to be a caller-supplied profile (FEED_PAGINATION /
+ * BLOCK_PAGINATION) because the contract did not state the default. It does
+ * now, on every route that has one, so the argument is gone rather than kept
+ * as a second way to say the same thing.
  */
-export function resolvePage(
-  url: URL,
-  { defaultLimit }: { defaultLimit: number },
-): { limit: number; offset: number; cursor: string | null } {
-  const { limit, offset, cursor } = routeQuery(url);
+export function resolvePage(url: URL): {
+  limit: number;
+  offset: number;
+  cursor: string | null;
+} {
+  const { offset, cursor } = routeQuery(url);
   return {
-    limit: limit ?? defaultLimit,
+    limit: pageLimit(url),
     offset: offset ?? 0,
     cursor: cursor ?? null,
   };

--- a/src/validator-nominators.ts
+++ b/src/validator-nominators.ts
@@ -204,11 +204,16 @@ export function buildValidatorNominators(
   const normalizedSort = NOMINATOR_SORTS.includes(sort)
     ? sort
     : DEFAULT_NOMINATOR_SORT;
-  const normalizedLimit = clampRowLimit(
-    limit,
-    NOMINATOR_LIMIT_DEFAULT,
-    NOMINATOR_LIMIT_MAX,
-  );
+  // NOMINATOR_LIMIT_MAX bounds the IN-MEMORY slice below, and only that. When
+  // the caller already applied its page in SQL, clamping again would report a
+  // page size that is not the one served: verified live before the fix,
+  // `/api/v1/validators/{hotkey}/nominators?limit=2000` returned 2000 rows and
+  // echoed `limit: 100`, on a route whose published ceiling is 2000 and whose
+  // `limit` parameter promises the response reports the limit actually applied
+  // (#10060). The ceiling itself is enforced by the router, from the schema.
+  const normalizedLimit = alreadyPaged
+    ? clampRowLimit(limit, NOMINATOR_LIMIT_DEFAULT, Number.MAX_SAFE_INTEGER)
+    : clampRowLimit(limit, NOMINATOR_LIMIT_DEFAULT, NOMINATOR_LIMIT_MAX);
   const flooredOffset = Math.floor(Number(offset));
   const normalizedOffset =
     Number.isFinite(flooredOffset) && flooredOffset > 0 ? flooredOffset : 0;

--- a/tests/blocks.test.ts
+++ b/tests/blocks.test.ts
@@ -475,6 +475,15 @@ const BAD_BLOCK_REFS = [
   "99999999999999999999", // all-digits but overflows MAX_SAFE_INTEGER → 1e20
 ];
 
+// The ref under test is the ARGUMENT, not the pathname: the router 404s a
+// malformed ref before dispatch (verified live -- `/api/v1/blocks/0x1/extrinsics`,
+// `/1e3/`, `/12-3/` and `/%205/` are all 404 `No API route matched this path`),
+// so a URL carrying one describes a request that cannot happen. Since #10060 the
+// handlers read their page size off the route the pathname resolves to, and an
+// unroutable pathname resolves to nothing -- so these pass a dispatchable URL and
+// keep the malformed ref where the handler actually reads it.
+const DISPATCHABLE_REF = "1";
+
 for (const badRef of BAD_BLOCK_REFS) {
   test(`handleBlock("${badRef}") is a clean miss, not a coerced row (#2063)`, async () => {
     const env = dbWith({
@@ -500,10 +509,12 @@ for (const badRef of BAD_BLOCK_REFS) {
       feed: [{ block_number: 1, extrinsic_index: 0, observed_at: 5 }],
     });
     const res = await handleBlockExtrinsics(
-      req(`/api/v1/blocks/${badRef}/extrinsics`),
+      req(`/api/v1/blocks/${DISPATCHABLE_REF}/extrinsics`),
       env as unknown as Env,
       badRef,
-      new URL(`https://api.metagraph.sh/api/v1/blocks/${badRef}/extrinsics`),
+      new URL(
+        `https://api.metagraph.sh/api/v1/blocks/${DISPATCHABLE_REF}/extrinsics`,
+      ),
     );
     const body = (await res.json()) as Row;
     assert.equal(body.data.block_number, null);
@@ -516,10 +527,12 @@ for (const badRef of BAD_BLOCK_REFS) {
       feed: [{ block_number: 1, event_index: 0, observed_at: 5 }],
     });
     const res = await handleBlockEvents(
-      req(`/api/v1/blocks/${badRef}/events`),
+      req(`/api/v1/blocks/${DISPATCHABLE_REF}/events`),
       env as unknown as Env,
       badRef,
-      new URL(`https://api.metagraph.sh/api/v1/blocks/${badRef}/events`),
+      new URL(
+        `https://api.metagraph.sh/api/v1/blocks/${DISPATCHABLE_REF}/events`,
+      ),
     );
     const body = (await res.json()) as Row;
     assert.equal(body.data.block_number, null);

--- a/tests/page-size-default.test.ts
+++ b/tests/page-size-default.test.ts
@@ -1,0 +1,298 @@
+// What a caller gets for OMITTING `limit` is part of the contract (#10060).
+//
+// 103 of the 128 published `limit` parameters carried no `default` while their
+// handler applied one, so `openapi.json` could not answer "how many rows do I
+// get if I say nothing" -- and the MCP tool mirroring the same route DID
+// declare one, leaving the two published surfaces disagreeing about a route
+// neither was wrong about. Measured before this landed:
+//
+//   GET /api/v1/chain/serving              serves 20, published no default
+//   get_chain_serving (MCP)                declared 20
+//   GET /api/v1/chain/subnet-lifecycle     serves 50, published no default
+//   get_chain_subnet_lifecycle (MCP)       declared 100  <- and served it
+//
+// The number now lives once, next to the ceiling, in the module that owns the
+// route's bounds. `limitSchema(max, fallback)` publishes it and `pageLimit()`
+// reads it back, so a handler no longer holds a second copy.
+//
+// ── What this pins ─────────────────────────────────────────────────────────
+//
+// Three things, each of which failed differently before:
+//
+//   1. COVERAGE -- every published `limit` says what omitting it does. A route
+//      with no default is not silence: it returns the whole collection, and
+//      the description says so.
+//   2. THE READ -- `pageLimit()` resolves the same number on every route that
+//      publishes one, INCLUDING the /{network}/ twins, whose pathname the
+//      schema resolver has to map back to the contract path. A resolution miss
+//      there is a 500 on a live route, not a lint.
+//   3. NO SECOND COPY -- no handler restates a page size. This is the
+//      regression that already happened: CHAIN_CALLS_LIMIT_DEFAULT existed and
+//      handleChainCalls wrote `limit = 50` anyway.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { pageLimit } from "../src/route-query.ts";
+
+interface Parameter {
+  name: string;
+  description?: string;
+  schema?: { default?: unknown; maximum?: number };
+}
+const SPEC = JSON.parse(
+  readFileSync("public/metagraph/openapi.json", "utf8"),
+) as { paths: Record<string, Record<string, { parameters?: Parameter[] }>> };
+
+/**
+ * The routes that answer with the WHOLE collection when `limit` is absent, so
+ * a published `default` would be a number the server never applies.
+ *
+ * Declared rather than derived, because "returns everything" is a property of
+ * the handler and not of the schema -- but declared as a list that can only
+ * shrink: an entry whose route starts publishing a default fails below, so
+ * this cannot quietly become the place a missing default hides.
+ *
+ * 36 of the 38 are the collection routes, where `paginateRows` pages only once
+ * the caller has opted in (#9730) -- correct for REST, which is why the MCP
+ * side carries `MCP_LIST_LIMIT_DEFAULT` instead. Verified against production
+ * 2026-08-09: all 38 returned the full set, `next_cursor: null`, `rows ===
+ * total`.
+ */
+const FULL_COLLECTION = new Set([
+  "/api/v1/{network}/economics",
+  "/api/v1/{network}/subnets",
+  "/api/v1/candidates",
+  // Not a collection route: a CEILING with no default by an explicit decision
+  // (see EMISSION_PIPELINE_LIMIT_MAX) -- one row per subnet, and the REST route
+  // has always served all of them.
+  "/api/v1/chain/emission-pipeline",
+  "/api/v1/coverage-depth",
+  "/api/v1/curation",
+  "/api/v1/economics",
+  "/api/v1/endpoint-incidents",
+  "/api/v1/endpoint-pools",
+  "/api/v1/endpoints",
+  "/api/v1/evidence",
+  "/api/v1/gaps",
+  "/api/v1/health",
+  "/api/v1/health/history/{date}",
+  // Not a collection route either: handleBulkHealthTrends passes `limit ?? null`
+  // to the loader, and null means every subnet. Verified live -- no `limit`
+  // answers 123 subnets with subnet_count 123, `?limit=3` answers 3 of 123.
+  "/api/v1/health/trends",
+  "/api/v1/incidents",
+  "/api/v1/profiles",
+  "/api/v1/providers",
+  "/api/v1/providers/{slug}/endpoints",
+  "/api/v1/review/adapter-candidates",
+  "/api/v1/review/enrichment-evidence",
+  "/api/v1/review/enrichment-queue",
+  "/api/v1/review/enrichment-targets",
+  "/api/v1/review/gaps",
+  "/api/v1/review/profile-completeness",
+  "/api/v1/rpc/endpoints",
+  "/api/v1/rpc/pools",
+  "/api/v1/search",
+  "/api/v1/search-index",
+  "/api/v1/source-snapshots",
+  "/api/v1/subnets",
+  "/api/v1/subnets/{netuid}/candidates",
+  "/api/v1/subnets/{netuid}/endpoints",
+  "/api/v1/subnets/{netuid}/evidence",
+  "/api/v1/subnets/{netuid}/gaps",
+  "/api/v1/subnets/{netuid}/health",
+  "/api/v1/subnets/{netuid}/surfaces",
+  "/api/v1/surfaces",
+]);
+
+/** Enough of a path to make a URL the schema resolver can classify. */
+const SUBSTITUTIONS: Record<string, string> = {
+  "{netuid}": "64",
+  "{network}": "finney",
+  "{ss58}": "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F",
+  "{hotkey}": "5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u",
+  "{ref}": "6500000",
+  "{slug}": "opentensor",
+  "{date}": "2026-08-01",
+};
+
+function concrete(path: string): string {
+  let out = path;
+  for (const [token, value] of Object.entries(SUBSTITUTIONS)) {
+    out = out.split(token).join(value);
+  }
+  return out;
+}
+
+function publishedLimits(): { path: string; parameter: Parameter }[] {
+  const found: { path: string; parameter: Parameter }[] = [];
+  for (const [path, operations] of Object.entries(SPEC.paths)) {
+    const get = operations.get;
+    if (!get) continue;
+    const parameter = (get.parameters ?? []).find((p) => p.name === "limit");
+    if (parameter) found.push({ path, parameter });
+  }
+  return found;
+}
+
+describe("every published limit says what omitting it does (#10060)", () => {
+  test("a route either publishes a default or is declared full-collection", () => {
+    const silent = publishedLimits()
+      .filter(({ path, parameter }) => {
+        return (
+          typeof parameter.schema?.default !== "number" &&
+          !FULL_COLLECTION.has(path)
+        );
+      })
+      .map(({ path }) => path);
+    assert.deepEqual(
+      silent,
+      [],
+      "these routes publish a `limit` without saying what a caller gets for " +
+        "omitting it. Pass the handler's default to limitSchema(max, fallback), " +
+        "or -- if the route really returns every matching row -- add it to " +
+        `FULL_COLLECTION with the evidence: ${silent.join(", ")}`,
+    );
+  });
+
+  test("the full-collection list can only shrink", () => {
+    const published = new Map(
+      publishedLimits().map(({ path, parameter }) => [
+        path,
+        parameter.schema?.default,
+      ]),
+    );
+    const stale = [...FULL_COLLECTION].filter(
+      (path) => !published.has(path) || typeof published.get(path) === "number",
+    );
+    assert.deepEqual(
+      stale,
+      [],
+      "these are listed as returning the whole collection but no longer " +
+        "publish a bare `limit` -- either the route gained a default (drop " +
+        "the entry) or it stopped publishing `limit` at all: " +
+        stale.join(", "),
+    );
+  });
+
+  test("a full-collection route SAYS so in its published description", () => {
+    // The point of the list is that a missing default is a statement, not an
+    // omission. If the sentence a caller reads does not carry it, the list is
+    // only reassuring us.
+    const unstated = publishedLimits()
+      .filter(({ path }) => FULL_COLLECTION.has(path))
+      .filter(
+        ({ parameter }) =>
+          !(parameter.description ?? "").includes(
+            "every matching row is returned",
+          ),
+      )
+      .map(({ path }) => path);
+    assert.deepEqual(unstated, [], `undocumented full-collection: ${unstated}`);
+  });
+
+  test("a route with a default SAYS which one", () => {
+    const unstated = publishedLimits()
+      .filter(({ parameter }) => typeof parameter.schema?.default === "number")
+      .filter(
+        ({ parameter }) =>
+          !(parameter.description ?? "").includes(
+            `${parameter.schema?.default}`,
+          ),
+      )
+      .map(({ path }) => path);
+    assert.deepEqual(unstated, [], `default not in the prose: ${unstated}`);
+  });
+});
+
+describe("the runtime reads the page size off the contract (#10060)", () => {
+  test("pageLimit resolves every published default, twins included", () => {
+    const wrong: string[] = [];
+    for (const { path, parameter } of publishedLimits()) {
+      const declared = parameter.schema?.default;
+      if (typeof declared !== "number") continue;
+      const url = new URL(`https://api.metagraph.sh${concrete(path)}`);
+      let resolved: number | string;
+      try {
+        resolved = pageLimit(url);
+      } catch (error) {
+        resolved = `threw: ${(error as Error).message}`;
+      }
+      if (resolved !== declared) {
+        wrong.push(`${path}: published ${declared}, pageLimit ${resolved}`);
+      }
+    }
+    assert.deepEqual(
+      wrong,
+      [],
+      "pageLimit() could not read back what the route publishes -- on a live " +
+        `request that is a wrong page size or a 500: ${wrong.join("; ")}`,
+    );
+  });
+
+  test("an explicit limit still wins over the published default", () => {
+    const url = new URL(
+      "https://api.metagraph.sh/api/v1/chain/serving?limit=7",
+    );
+    assert.equal(pageLimit(url), 7);
+  });
+
+  test("pageLimit refuses a route that publishes no default", () => {
+    // Not a fallback: substituting a number on a route that returns everything
+    // would truncate it, which is the failure this whole issue is about.
+    const url = new URL("https://api.metagraph.sh/api/v1/subnets");
+    assert.throws(() => pageLimit(url), /No published limit default/);
+  });
+
+  test("pageLimit refuses a route that declares no limit at all", () => {
+    // A different absence from the one above -- there is no field to unwrap,
+    // not a field with no default -- and it must not resolve to a number
+    // either. /api/v1/coverage publishes no query parameters.
+    const url = new URL("https://api.metagraph.sh/api/v1/coverage");
+    assert.throws(() => pageLimit(url), /No published limit default/);
+  });
+});
+
+describe("no handler keeps a second copy of a page size (#10060)", () => {
+  const SOURCES = [
+    "workers/request-handlers/analytics.ts",
+    "workers/request-handlers/analytics-routes.ts",
+    "workers/request-handlers/entities.ts",
+    "workers/api.ts",
+    "workers/data-api.ts",
+  ];
+
+  test("no routeQuery destructure supplies its own limit fallback", () => {
+    const offenders: string[] = [];
+    for (const file of SOURCES) {
+      const text = readFileSync(file, "utf8");
+      for (const match of text.matchAll(
+        /const \{[^}]*\blimit\s*=\s*[^,}]+[^}]*\}\s*=\s*(?:routeQuery\(url\)|parsed\.query)/g,
+      )) {
+        offenders.push(`${file}: ${match[0].split("\n")[0]}`);
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      "the page size is published now -- read it with pageLimit(url) rather " +
+        `than restating it here: ${offenders.join("; ")}`,
+    );
+  });
+
+  test("resolvePage takes no pagination profile", () => {
+    const offenders: string[] = [];
+    for (const file of SOURCES) {
+      const text = readFileSync(file, "utf8");
+      for (const match of text.matchAll(/resolvePage\(url,/g)) {
+        offenders.push(`${file}: ${match[0]}`);
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      "resolvePage reads the route's published default; passing a profile is " +
+        `the second copy this removed: ${offenders.join("; ")}`,
+    );
+  });
+});

--- a/tests/request-handlers-analytics-routes.test.ts
+++ b/tests/request-handlers-analytics-routes.test.ts
@@ -792,7 +792,11 @@ describe("handleLeaderboards", () => {
   test("health/rpc/growth/reliability boards are always empty; most-complete is not", async () => {
     const env = createLocalArtifactEnv();
     const body = await json(
-      await handleLeaderboards(req("/"), mockEnv(env), url("/")),
+      await handleLeaderboards(
+        req("/api/v1/registry/leaderboards"),
+        mockEnv(env),
+        url("/api/v1/registry/leaderboards"),
+      ),
     );
     assert.deepEqual(body.data.boards["healthiest"], []);
     assert.deepEqual(body.data.boards["fastest-rpc"], []);

--- a/tests/validator-nominators.test.ts
+++ b/tests/validator-nominators.test.ts
@@ -526,4 +526,33 @@ describe("buildValidatorNominators — count and concentration", () => {
     assert.equal((d.nominators as Row[]).length, 2, "still paged here");
     assert.equal(d.concentration_complete, true);
   });
+
+  test("an already-paged read reports the page size it was actually served", () => {
+    // #10060. NOMINATOR_LIMIT_MAX bounds the IN-MEMORY slice, and clamping an
+    // already-paged read to it published a page size that was not the one
+    // served: verified live before the fix, `?limit=2000` on a validator with
+    // 3,020 nominators returned 2000 rows and echoed `limit: 100`, on a route
+    // whose published ceiling is 2000. A caller paging on the echoed number
+    // would have re-read the same 1,900 rows on every page.
+    const served = 300;
+    const page = nominators(...Array.from({ length: served }, (_, i) => i + 1));
+    const d = buildValidatorNominators(page, HOTKEY, {
+      limit: served,
+      totalCount: 3020,
+      alreadyPaged: true,
+    }) as Row;
+    assert.equal(d.limit, served);
+    assert.equal((d.nominators as Row[]).length, served);
+  });
+
+  test("the in-memory slice is still capped at NOMINATOR_LIMIT_MAX", () => {
+    // The other half: without alreadyPaged the builder IS the pager, and an
+    // unbounded slice is what the cap exists to stop.
+    const all = nominators(...Array.from({ length: 300 }, (_, i) => i + 1));
+    const d = buildValidatorNominators(all, HOTKEY, {
+      limit: 300,
+    }) as Row;
+    assert.equal(d.limit, NOMINATOR_LIMIT_MAX);
+    assert.equal((d.nominators as Row[]).length, NOMINATOR_LIMIT_MAX);
+  });
 });

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -23,14 +23,12 @@ import {
 } from "./analytics.ts";
 import {
   historyWindow,
+  pageLimit,
   parseRouteQuery,
   routeQuery,
   uptimeWindow,
 } from "../../src/route-query.ts";
-import {
-  EMISSION_PIPELINE_LIMIT_MAX,
-  LEADERBOARDS_LIMIT_DEFAULT,
-} from "../../src/route-limits.ts";
+import { EMISSION_PIPELINE_LIMIT_MAX } from "../../src/route-limits.ts";
 import { loadEconomicsTrends } from "../../src/economics-trends.ts";
 import {
   EMISSION_PIPELINE_UNAVAILABLE_CODE,
@@ -473,8 +471,8 @@ export function canonicalTrajectoryCachePath(
 export function canonicalLeaderboardsCachePath(url: URL): string {
   const parsed = parseRouteQuery(url);
   if ("error" in parsed) return `${url.pathname}${url.search}`;
-  const { limit = LEADERBOARDS_LIMIT_DEFAULT, board } = parsed.query;
-  const params = [`limit=${limit}`];
+  const { board } = parsed.query;
+  const params = [`limit=${pageLimit(url)}`];
   if (board) params.unshift(`board=${encodeURIComponent(String(board))}`);
   return `${url.pathname}?${params.join("&")}`;
 }
@@ -610,7 +608,8 @@ export async function handleLeaderboards(
   env: Env,
   url: URL,
 ): Promise<Response> {
-  const { board, limit = LEADERBOARDS_LIMIT_DEFAULT } = routeQuery(url);
+  const { board } = routeQuery(url);
+  const limit = pageLimit(url);
   const { data, isFallback } = await composeLeaderboardsData(env, {
     board: (board as string | undefined) ?? null,
     limit,

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -37,6 +37,7 @@ import {
 } from "../../src/chain-network.ts";
 import {
   analyticsWindow,
+  pageLimit,
   parseRouteQuery,
   routeQuery,
 } from "../../src/route-query.ts";
@@ -81,54 +82,23 @@ import {
 } from "../../src/chain-analytics.ts";
 import { buildChainTransferPairs } from "../../src/chain-transfer-pairs.ts";
 import { buildChainTransfers } from "../../src/chain-transfers.ts";
-import {
-  buildChainServing,
-  CHAIN_SERVING_LIMIT_DEFAULT,
-} from "../../src/chain-serving.ts";
-import {
-  buildChainPrometheus,
-  CHAIN_PROMETHEUS_LIMIT_DEFAULT,
-} from "../../src/chain-prometheus.ts";
-import {
-  buildChainAxonRemovals,
-  CHAIN_AXON_REMOVALS_LIMIT_DEFAULT,
-} from "../../src/chain-axon-removals.ts";
-import {
-  buildChainRegistrations,
-  CHAIN_REGISTRATIONS_LIMIT_DEFAULT,
-} from "../../src/chain-registrations.ts";
-import {
-  buildChainDeregistrations,
-  CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT,
-} from "../../src/chain-deregistrations.ts";
+import { buildChainServing } from "../../src/chain-serving.ts";
+import { buildChainPrometheus } from "../../src/chain-prometheus.ts";
+import { buildChainAxonRemovals } from "../../src/chain-axon-removals.ts";
+import { buildChainRegistrations } from "../../src/chain-registrations.ts";
+import { buildChainDeregistrations } from "../../src/chain-deregistrations.ts";
 import {
   buildChainSubnetLifecycle,
-  CHAIN_SUBNET_LIFECYCLE_LIMIT_DEFAULT,
   DEFAULT_SUBNET_LIFECYCLE_WINDOW,
   loadChainSubnetLifecycle,
 } from "../../src/subnet-lifecycle-read.ts";
 // The shared window parser, rather than a restated map -- see the handler.
 import { parseHistoryWindow } from "../../src/neuron-history.ts";
-import {
-  buildChainStakeMoves,
-  CHAIN_STAKE_MOVES_LIMIT_DEFAULT,
-} from "../../src/chain-stake-moves.ts";
-import {
-  buildChainStakeTransfers,
-  CHAIN_STAKE_TRANSFERS_LIMIT_DEFAULT,
-} from "../../src/chain-stake-transfers.ts";
-import {
-  buildChainWeights,
-  CHAIN_WEIGHTS_LIMIT_DEFAULT,
-} from "../../src/chain-weights.ts";
-import {
-  buildChainWeightSetters,
-  CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT,
-} from "../../src/chain-weight-setters.ts";
-import {
-  buildChainStakeFlow,
-  CHAIN_STAKE_FLOW_LIMIT_DEFAULT,
-} from "../../src/chain-stake-flow.ts";
+import { buildChainStakeMoves } from "../../src/chain-stake-moves.ts";
+import { buildChainStakeTransfers } from "../../src/chain-stake-transfers.ts";
+import { buildChainWeights } from "../../src/chain-weights.ts";
+import { buildChainWeightSetters } from "../../src/chain-weight-setters.ts";
+import { buildChainStakeFlow } from "../../src/chain-stake-flow.ts";
 import { loadChainTransfersFromArtifact } from "../../src/chain-transfers-artifact.ts";
 import { loadChainStakeFlowFromArtifact } from "../../src/chain-stake-flow-artifact.ts";
 import { loadChainRegistrationsFromArtifact } from "../../src/chain-registrations-artifact.ts";
@@ -145,10 +115,7 @@ import { resolveMarketCapIndex } from "../../src/market-cap-index.ts";
 import { loadChainStakeTransfersFromArtifact } from "../../src/chain-stake-transfers-artifact.ts";
 import { loadChainTransferPairsFromArtifact } from "../../src/chain-transfer-pairs-artifact.ts";
 import { loadChainStakeMovesFromArtifact } from "../../src/chain-stake-moves-artifact.ts";
-import {
-  buildChainAlphaVolume,
-  CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT,
-} from "../../src/chain-alpha-volume.ts";
+import { buildChainAlphaVolume } from "../../src/chain-alpha-volume.ts";
 
 // The shape of the api.ts-local in-isolate memoized KV read (see
 // configureAnalytics below) -- loose on the return value beyond `last_run_at`
@@ -1272,7 +1239,7 @@ export async function handleChainCalls(
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
   const { label } = analyticsWindow(url);
-  const { limit = 50 } = routeQuery(url);
+  const limit = pageLimit(url);
   const groupBy = url.searchParams.get("group_by") || "module";
   const csv = csvRequested(url, request);
   return withEdgeCache(
@@ -1364,7 +1331,7 @@ export async function handleChainSigners(
   const { label } = analyticsWindow(url);
   // limit/call_module no longer feed a live D1 read (see the retirement note
   // below) but are still shape-validated so the REST contract stays stable.
-  const { limit = 50 } = routeQuery(url);
+  const limit = pageLimit(url);
   const sort = url.searchParams.get("sort") || "tx_count";
   const csv = csvRequested(url, request);
   return withEdgeCache(
@@ -1447,7 +1414,7 @@ export async function handleChainTransfers(
   const { label } = analyticsWindow(url);
   // limit no longer feeds a live D1 read (see the retirement note below) but
   // is still shape-validated so the REST contract stays stable.
-  const { limit = 25 } = routeQuery(url);
+  const limit = pageLimit(url);
   const csv = csvRequested(url, request);
 
   // HEAD probes are globally allowed for read-only API routes. Normalize them
@@ -1546,7 +1513,7 @@ export async function handleChainTransferPairs(
   const { label } = analyticsWindow(url);
   // limit no longer feeds a live D1 read (see the retirement note below) but
   // is still shape-validated so the REST contract stays stable.
-  const { limit = 25 } = routeQuery(url);
+  const limit = pageLimit(url);
   const sort = url.searchParams.get("sort") || "volume";
   const csv = csvRequested(url, request);
 
@@ -1639,7 +1606,7 @@ export async function handleChainStakeFlow(
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
   const { label } = analyticsWindow(url);
-  const { limit = CHAIN_STAKE_FLOW_LIMIT_DEFAULT } = routeQuery(url);
+  const limit = pageLimit(url);
   const csv = csvRequested(url, request);
 
   // Normalize HEAD probes through the GET cache key so they cannot bypass the edge cache and
@@ -1742,7 +1709,7 @@ export async function handleChainAlphaVolume(
   /** Which chain's projection to serve (#9412). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
-  const { limit = CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT } = routeQuery(url);
+  const limit = pageLimit(url);
   const csv = csvRequested(url, request);
 
   // Normalize HEAD probes through the GET cache key so they cannot bypass the edge cache and
@@ -1827,7 +1794,7 @@ export async function handleChainWeights(
   ctx: EdgeCacheCtx = {},
 ): Promise<Response> {
   const { label } = analyticsWindow(url);
-  const { limit = CHAIN_WEIGHTS_LIMIT_DEFAULT } = routeQuery(url);
+  const limit = pageLimit(url);
   const csv = csvRequested(url, request);
 
   const cacheRequest =
@@ -1908,7 +1875,7 @@ export async function handleChainWeightSetters(
   ctx: EdgeCacheCtx = {},
 ): Promise<Response> {
   const { label } = analyticsWindow(url);
-  const { limit = CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT } = routeQuery(url);
+  const limit = pageLimit(url);
   const csv = csvRequested(url, request);
 
   const cacheRequest =
@@ -1981,7 +1948,7 @@ export async function handleChainServing(
   ctx: EdgeCacheCtx = {},
 ): Promise<Response> {
   const { label } = analyticsWindow(url);
-  const { limit = CHAIN_SERVING_LIMIT_DEFAULT } = routeQuery(url);
+  const limit = pageLimit(url);
   const csv = csvRequested(url, request);
 
   const cacheRequest =
@@ -2062,7 +2029,7 @@ export async function handleChainPrometheus(
   ctx: EdgeCacheCtx = {},
 ): Promise<Response> {
   const { label } = analyticsWindow(url);
-  const { limit = CHAIN_PROMETHEUS_LIMIT_DEFAULT } = routeQuery(url);
+  const limit = pageLimit(url);
   const csv = csvRequested(url, request);
 
   const cacheRequest =
@@ -2133,7 +2100,7 @@ export async function handleChainAxonRemovals(
   ctx: EdgeCacheCtx = {},
 ): Promise<Response> {
   const { label } = analyticsWindow(url);
-  const { limit = CHAIN_AXON_REMOVALS_LIMIT_DEFAULT } = routeQuery(url);
+  const limit = pageLimit(url);
   const csv = csvRequested(url, request);
 
   const cacheRequest =
@@ -2205,7 +2172,7 @@ export async function handleChainRegistrations(
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
   const { label } = analyticsWindow(url);
-  const { limit = CHAIN_REGISTRATIONS_LIMIT_DEFAULT } = routeQuery(url);
+  const limit = pageLimit(url);
   const csv = csvRequested(url, request);
 
   const cacheRequest =
@@ -2309,10 +2276,8 @@ export async function handleChainSubnetLifecycle(
   // the handler ran -- including the `window` enum and the `limit` ceiling --
   // so this reads the result rather than re-checking it. The ceiling still
   // REJECTS rather than clamps; that is the schema's doing, not the handler's.
-  const {
-    window = DEFAULT_SUBNET_LIFECYCLE_WINDOW,
-    limit = CHAIN_SUBNET_LIFECYCLE_LIMIT_DEFAULT,
-  } = routeQuery(url);
+  const { window = DEFAULT_SUBNET_LIFECYCLE_WINDOW } = routeQuery(url);
+  const limit = pageLimit(url);
   // `days === null` means `all` (no lower bound) -- a real answer, so this must
   // not become a truthiness test. The label is already schema-valid here.
   const parsed = parseHistoryWindow(window);
@@ -2370,7 +2335,7 @@ export async function handleChainDeregistrations(
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
   const { label } = analyticsWindow(url);
-  const { limit = CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT } = routeQuery(url);
+  const limit = pageLimit(url);
   const csv = csvRequested(url, request);
 
   const cacheRequest =
@@ -2468,7 +2433,7 @@ export async function handleChainStakeMoves(
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
   const { label } = analyticsWindow(url);
-  const { limit = CHAIN_STAKE_MOVES_LIMIT_DEFAULT } = routeQuery(url);
+  const limit = pageLimit(url);
   const csv = csvRequested(url, request);
 
   const cacheRequest =
@@ -2554,7 +2519,7 @@ export async function handleChainStakeTransfers(
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
   const { label } = analyticsWindow(url);
-  const { limit = CHAIN_STAKE_TRANSFERS_LIMIT_DEFAULT } = routeQuery(url);
+  const limit = pageLimit(url);
   const csv = csvRequested(url, request);
 
   const cacheRequest =
@@ -2637,7 +2602,7 @@ export async function handleChainFees(
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<Response> {
   const { label, days: windowDays } = analyticsWindow(url);
-  const { limit = 25 } = routeQuery(url);
+  const limit = pageLimit(url);
   // Optional pallet scope (applies to both the daily series and the payer list),
   // backed by idx_extrinsics_module_block.
   const csv = csvRequested(url, request);

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -32,7 +32,6 @@ import {
   type ChainNetworkId,
 } from "../../src/chain-network.ts";
 import { resolveClientIp } from "../config.ts";
-import { BLOCK_PAGINATION, FEED_PAGINATION } from "../request-params.ts";
 
 import {
   errorResponse,
@@ -53,6 +52,7 @@ import {
 } from "./analytics.ts";
 import {
   historyWindow,
+  pageLimit,
   parseRouteQuery,
   resolvePage,
   resolveWindow,
@@ -334,10 +334,7 @@ import {
   buildChainIdleStake,
   buildSubnetIdleStake,
 } from "../../src/subnet-idle-stake.ts";
-import {
-  buildChainIdentityHistory,
-  CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
-} from "../../src/chain-identity-history.ts";
+import { buildChainIdentityHistory } from "../../src/chain-identity-history.ts";
 import {
   buildSubnetPerformance,
   buildSubnetPerformanceHistory,
@@ -1105,7 +1102,7 @@ export async function handleSubnetHyperparamsHistory(
 ) {
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
-  const page = resolvePage(url, FEED_PAGINATION);
+  const page = resolvePage(url);
   const { limit, offset } = page;
   const data =
     ((await tryPostgresTier(
@@ -1176,7 +1173,7 @@ export async function handleSubnetLifecycle(
   if (validationError) return analyticsQueryError(validationError);
   // #10218: the router already parsed and rejected against the route's schema,
   // so this reads the result rather than re-checking it by hand.
-  const { limit, offset } = resolvePage(url, FEED_PAGINATION);
+  const { limit, offset } = resolvePage(url);
   const rows = await loadSubnetLifecycle(env, netuid, { limit, offset });
   const data = buildSubnetLifecycle(rows, netuid, { limit, offset });
   if (csvRequested(url, request)) {
@@ -1860,7 +1857,7 @@ export async function handleSubnetIdentityHistory(
 ) {
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
-  const page = resolvePage(url, FEED_PAGINATION);
+  const page = resolvePage(url);
   const { limit, offset } = page;
   const identityTier =
     ((await tryPostgresTier(
@@ -2139,7 +2136,7 @@ export async function handleChainIdentityHistory(
   env: Env,
   url: URL,
 ) {
-  const { limit = CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT } = routeQuery(url);
+  const limit = pageLimit(url);
   // D1 retirement: subnet_identity_history's D1 write path is retired
   // (2026-07-16, syncSubnetIdentityToPostgres is the sole writer now), so a
   // Postgres miss/outage degrades to a schema-stable empty feed, never a
@@ -2274,8 +2271,7 @@ export async function handleChainYield(request: Request, env: Env) {
 export function canonicalChainIdentityHistoryCachePath(url: URL) {
   const parsed = parseRouteQuery(url);
   if ("error" in parsed) return `${url.pathname}${url.search}`;
-  const { limit = CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT } = parsed.query;
-  return `${url.pathname}?limit=${limit}`;
+  return `${url.pathname}?limit=${pageLimit(url)}`;
 }
 
 // Shared helper: build a canonical edge-cache key for a windowed route, so an
@@ -4763,7 +4759,7 @@ export async function handleAccountEvents(
   }
   // #4909 D1 retirement: account_events' D1 write path is retired (#4772) and
   // the table is dropped in production, so a D1 query here would always miss.
-  const page = resolvePage(url, FEED_PAGINATION);
+  const page = resolvePage(url);
   const { limit: parsedLimit, offset: parsedOffset } = page;
   const data =
     ((await tryPostgresTier(
@@ -4836,7 +4832,7 @@ export async function handleAccountHistory(
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
   const { from = null, to = null } = routeQuery(url);
-  const page = resolvePage(url, FEED_PAGINATION);
+  const page = resolvePage(url);
   const { limit, offset } = page;
   const netuid = url.searchParams.get("netuid");
   // Inverted YYYY-MM-DD bounds are a deterministic no-match. Short-circuit before
@@ -4945,7 +4941,7 @@ export async function handleAccountExtrinsics(
   if (validationError) return analyticsQueryError(validationError);
   // #4909 D1 retirement: extrinsics' D1 write path is retired (#4772) and the
   // table is dropped in production, so a D1 query here would always miss.
-  const page = resolvePage(url, FEED_PAGINATION);
+  const page = resolvePage(url);
   const { limit: parsedLimit, offset: parsedOffset } = page;
   const data =
     ((await tryPostgresTier(
@@ -5021,7 +5017,7 @@ export async function handleAccountTransfers(
       message: `"${direction}" is not a valid direction. Supported: all, sent, received.`,
     });
   }
-  const page = resolvePage(url, FEED_PAGINATION);
+  const page = resolvePage(url);
   const { limit, offset } = page;
   // #4909 D1 retirement: account_events' D1 write path is retired (#4772) and
   // the table is dropped in production, so a D1 query here would always miss.
@@ -5389,7 +5385,7 @@ export async function handleAccountIdentityHistory(
 ) {
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
-  const page = resolvePage(url, FEED_PAGINATION);
+  const page = resolvePage(url);
   const { limit, offset } = page;
   const data =
     ((await tryPostgresTier(
@@ -5461,7 +5457,7 @@ export async function handleSubnetEvents(
   // seeks rather than scans this public, ~60s-cached route.
   // #4909 D1 retirement: account_events' D1 write path is retired (#4772) and
   // the table is dropped in production, so a D1 query here would always miss.
-  const page = resolvePage(url, FEED_PAGINATION);
+  const page = resolvePage(url);
   const { limit: parsedLimit, offset: parsedOffset } = page;
   const { block_start: blockStart, block_end: blockEnd } = routeQuery(url);
   // #9146: this feed has always read empty -- data-api never registered
@@ -6483,7 +6479,7 @@ export async function handleBlocks(
 ) {
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
-  const page = resolvePage(url, BLOCK_PAGINATION);
+  const page = resolvePage(url);
   const { limit, offset } = page;
   // When the Postgres tier misses (the self-hosted box is gone), the cold tier
   // answers from the two sources that outlive it: the R2 lakehouse for
@@ -6664,7 +6660,7 @@ export async function handleBlockExtrinsics(
 ) {
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
-  const page = resolvePage(url, BLOCK_PAGINATION);
+  const page = resolvePage(url);
   const { limit, offset } = page;
   // #4909 D1 retirement: extrinsics' D1 write path is retired (#4772) and the
   // table is dropped in production, so a D1 query here would always miss.
@@ -6738,7 +6734,7 @@ export async function handleBlockEvents(
 ) {
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
-  const page = resolvePage(url, FEED_PAGINATION);
+  const page = resolvePage(url);
   const { limit, offset } = page;
   // #4909 D1 retirement: account_events' D1 write path is retired (#4772) and
   // the table is dropped in production, so a D1 query here would always miss.
@@ -6815,7 +6811,7 @@ export async function handleExtrinsics(
   // The same cap the three chain-analytics feeds apply to `call_module`
   // (#10096). This route took the identical filter with no bound at all, so a
   // 150-character value was a 400 on /chain/calls and a 200 here.
-  const page = resolvePage(url, BLOCK_PAGINATION);
+  const page = resolvePage(url);
   const { limit, offset } = page;
   const query = routeQuery(url);
   const successRaw = (query.success as string | undefined) ?? null;
@@ -6904,7 +6900,7 @@ export async function handleExtrinsics(
 export async function handleSudo(request: Request, env: Env, url: URL) {
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
-  const page = resolvePage(url, BLOCK_PAGINATION);
+  const page = resolvePage(url);
   const { limit, offset } = page;
   const query = routeQuery(url);
   const successRaw = (query.success as string | undefined) ?? null;
@@ -6972,7 +6968,7 @@ export async function handleGovernanceConfigChanges(
 ) {
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
-  const page = resolvePage(url, BLOCK_PAGINATION);
+  const page = resolvePage(url);
   const { limit, offset } = page;
   const query = routeQuery(url);
   const successRaw = (query.success as string | undefined) ?? null;


### PR DESCRIPTION
## Summary

103 of the 128 published `limit` parameters carried no `default`, so `openapi.json` could not say
what a caller gets for omitting one. The number existed — in the handler — and the MCP tool
mirroring the same route published it, so the two published surfaces disagreed about a route
neither was wrong about.

The number now lives once, beside the ceiling, in the module that owns the route's bounds.
`limitSchema(max, fallback)` writes it into the published `default`; `pageLimit(url)` reads it back.

| | before | after |
|---|---|---|
| published `limit` parameters | 128 | 128 |
| …carrying a `default` | 25 | **90** |
| …declared full-collection, and saying so | 0 | **38** |
| page-size literals in the request path | 50 | **0** |
| `.meta({ default })` overrides in MCP tools re-declaring their route's number | 34 | **0** |

38 routes genuinely return the whole collection when `limit` is absent — the 36 collection routes
(`paginateRows` pages only once the caller opts in, #9730) plus `/chain/emission-pipeline` and
`/health/trends`. Those publish no `default` and the description now says
`Omitted, every matching row is returned.`, so a missing one reads as a statement rather than an
oversight.

## Verified against production, 2026-08-09

Every route this PR gives a default was asked, with no `limit`, whether it applies that number:

```
routes with a published default        65   (49 base + 16 /{network}/ twins)
agree with what the server applies     65
disagree                                0
```

And the other half of the claim:

```
routes publishing no default           38
returned the whole set                 38   (next_cursor: null, rows === total)
```

`/health/trends` was checked by hand — no `limit` answers 123 subnets with `subnet_count: 123`;
`?limit=3` answers 3 of 123.

## Two divergences the audit turned up

**`get_chain_subnet_lifecycle` declared and served a wider page than its own route.** Its input
schema carried a local `default: 100` and its handler `clampToolLimit(args?.limit, 100, …)`, while
`GET /api/v1/chain/subnet-lifecycle` applies `CHAIN_SUBNET_LIFECYCLE_LIMIT_DEFAULT` (50) — verified
live, no `limit` answers `limit: 50, entry_count: 50`. Not a declared narrowing but its inverse,
which #9701's asymmetry says never happens. It inherits the route's number now.

**`/api/v1/validators/{hotkey}/nominators` reported a page size it did not serve.** The cold-tier
builder re-clamped a page SQL had already applied, so:

```
?limit=2000  ->  2000 rows returned, "limit": 100 echoed   (3,020 nominators)
?limit=300   ->   315 rows returned, "limit": 100 echoed
```

A caller paging on the echoed number re-read the same 1,900 rows every page. `NOMINATOR_LIMIT_MAX`
still bounds the **in-memory** slice, which is the only thing it was ever for; the route's ceiling
is enforced by the router from the schema, as everywhere else.

## The gate

`tests/page-size-default.test.ts` pins three things, each of which failed differently before:

1. **Coverage** — every published `limit` either carries a `default` or is in a declared
   full-collection list whose description says so. The list can only shrink: an entry whose route
   starts publishing a default fails.
2. **The read** — `pageLimit()` resolves the same number on every route that publishes one,
   including the 16 `/{network}/` twins whose pathname the schema resolver has to map back to the
   contract path. A miss there is a 500 on a live route, not a lint.
3. **No second copy** — no handler restates a page size and `resolvePage` takes no pagination
   profile. This is the regression that already happened: `CHAIN_CALLS_LIMIT_DEFAULT` existed and
   `handleChainCalls` wrote `limit = 50` anyway.

Check 3 failed twice while it was being written, on the two copies left in
`handleChainSubnetLifecycle` and `canonicalChainIdentityHistoryCachePath` — that is the gate
demonstrating it can fail.

## Behaviour changes

- **`get_chain_subnet_lifecycle` now defaults to 50 rather than 100.** Narrower, matching its
  route; a caller wanting more passes `limit`.
- **The nominators route echoes the page size it served**, not 100.
- No REST route changes what it returns for any request. The 65 defaults now published are the
  numbers the server was already applying.

## Validation

```
npm run typecheck                     clean
npm run lint / format:check           clean
npx vitest run                        769 files, 18,067 passed, 11 skipped
npm run validate                      clean
34 CI validators run individually     all OK
   (incl. mcp, mcp-input-parity, mcp-route-map, route-query-parity, query-vocabulary,
    contract-drift, openapi, types, graphql-route-parity, graphql-component-parity,
    contract-doc-sync, single-schema-source, schema-vocabularies, module-state-resets)
patch coverage (branch-counted)       64/64 = 100%
```

`npm run build` ran and the regenerated `openapi.json`, `api-index.json`, `types.d.ts` and
`packages/contract/index.d.ts` are committed.

Closes #10274
