### PR TITLE
feat(contract): publish every default the server applies, and read it back (#10276)

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -41795,7 +41795,7 @@ export interface operations {
     subnetMetagraph: {
         parameters: {
             query?: {
-                validator_permit?: "true" | "false";
+                validator_permit?: "true";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -2646,6 +2646,7 @@
           "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -2822,6 +2823,7 @@
           "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -3043,6 +3045,7 @@
           "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -3191,6 +3194,7 @@
           "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -3388,6 +3392,7 @@
           "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -3576,6 +3581,7 @@
           "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -3729,6 +3735,7 @@
           "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -3873,6 +3880,7 @@
           "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -3983,6 +3991,7 @@
           "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -4188,6 +4197,7 @@
           "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -4343,6 +4353,7 @@
           "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -4465,6 +4476,7 @@
           "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -4670,6 +4682,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -4684,6 +4697,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -5099,6 +5113,7 @@
           "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -5224,6 +5239,7 @@
           "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -5392,6 +5408,7 @@
           "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -5563,6 +5580,7 @@
           "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -5812,6 +5830,7 @@
           "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -6648,6 +6667,7 @@
         {
           "name": "offset",
           "schema": {
+            "default": 0,
             "minimum": 0,
             "type": "integer"
           }
@@ -6688,6 +6708,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -6715,6 +6736,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -6743,6 +6765,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -6818,6 +6841,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -6830,6 +6854,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -6857,6 +6882,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -6869,6 +6895,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -6896,6 +6923,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -6936,6 +6964,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -6963,6 +6992,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -6990,6 +7020,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -7017,6 +7048,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -7044,6 +7076,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -7071,6 +7104,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -7098,6 +7132,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -7125,6 +7160,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -7152,6 +7188,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -7179,6 +7216,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -7234,6 +7272,7 @@
         {
           "name": "interval",
           "schema": {
+            "default": "1h",
             "enum": [
               "1h",
               "1d"
@@ -7244,6 +7283,7 @@
         {
           "name": "days",
           "schema": {
+            "default": 90,
             "maximum": 365,
             "minimum": 1,
             "type": "integer"
@@ -7276,6 +7316,7 @@
         {
           "name": "direction",
           "schema": {
+            "default": "stake",
             "enum": [
               "stake",
               "unstake"
@@ -7319,6 +7360,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -7347,6 +7389,7 @@
         {
           "name": "sort",
           "schema": {
+            "default": "earning_floor_cost_tao",
             "enum": [
               "earning_floor_cost_tao",
               "permit_floor_cost_tao",
@@ -7406,6 +7449,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -7417,6 +7461,7 @@
         {
           "name": "sort",
           "schema": {
+            "default": "stake",
             "enum": [
               "stake",
               "emission",
@@ -7439,6 +7484,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -7466,6 +7512,7 @@
         {
           "name": "sort",
           "schema": {
+            "default": "subnet_count",
             "enum": [
               "avg_validator_trust",
               "max_validator_trust",
@@ -7491,6 +7538,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -7518,6 +7566,7 @@
         {
           "name": "sort",
           "schema": {
+            "default": "total_stake",
             "enum": [
               "total_stake",
               "total_emission",
@@ -7543,6 +7592,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -7570,6 +7620,7 @@
         {
           "name": "sort",
           "schema": {
+            "default": "total_tao",
             "enum": [
               "total_tao",
               "free_tao",
@@ -7594,6 +7645,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -7637,6 +7689,7 @@
         {
           "name": "basis",
           "schema": {
+            "default": "flow",
             "enum": [
               "flow",
               "positions"
@@ -7647,6 +7700,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -7658,6 +7712,7 @@
         {
           "name": "sort",
           "schema": {
+            "default": "net_staked",
             "enum": [
               "net_staked",
               "gross_staked",
@@ -7678,6 +7733,7 @@
         {
           "name": "offset",
           "schema": {
+            "default": 0,
             "minimum": 0,
             "type": "integer"
           }
@@ -7693,6 +7749,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -7720,6 +7777,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -7759,8 +7817,7 @@
           "name": "validator_permit",
           "schema": {
             "enum": [
-              "true",
-              "false"
+              "true"
             ],
             "type": "string"
           }
@@ -7776,6 +7833,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -7852,6 +7910,7 @@
         {
           "name": "offset",
           "schema": {
+            "default": 0,
             "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
@@ -7867,6 +7926,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -7903,6 +7963,7 @@
         {
           "name": "offset",
           "schema": {
+            "default": 0,
             "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
@@ -7912,6 +7973,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -7939,6 +8001,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "all",
             "enum": [
               "7d",
               "30d",
@@ -7962,6 +8025,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -7997,6 +8061,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -8025,6 +8090,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -8052,6 +8118,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -8064,6 +8131,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -8120,6 +8188,7 @@
         {
           "name": "offset",
           "schema": {
+            "default": 0,
             "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
@@ -8135,6 +8204,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -8162,6 +8232,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -8199,6 +8270,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -8229,6 +8301,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -8268,6 +8341,7 @@
         {
           "name": "offset",
           "schema": {
+            "default": 0,
             "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
@@ -8283,6 +8357,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -8379,6 +8454,7 @@
         {
           "name": "offset",
           "schema": {
+            "default": 0,
             "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
@@ -8394,6 +8470,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -8454,6 +8531,7 @@
         {
           "name": "offset",
           "schema": {
+            "default": 0,
             "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
@@ -8469,6 +8547,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -8519,6 +8598,7 @@
         {
           "name": "offset",
           "schema": {
+            "default": 0,
             "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
@@ -8534,6 +8614,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -8595,6 +8676,7 @@
         {
           "name": "offset",
           "schema": {
+            "default": 0,
             "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
@@ -8610,6 +8692,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -8656,6 +8739,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -8683,6 +8767,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -8722,6 +8807,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -8750,6 +8836,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -8778,6 +8865,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -8806,6 +8894,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -8834,6 +8923,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -8862,6 +8952,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -8889,6 +8980,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -8965,6 +9057,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -9020,6 +9113,7 @@
         {
           "name": "offset",
           "schema": {
+            "default": 0,
             "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
@@ -9035,6 +9129,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -9176,6 +9271,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "24h",
             "enum": [
               "1h",
               "24h",
@@ -9287,6 +9383,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "24h",
               "7d",
@@ -9405,6 +9502,7 @@
         {
           "name": "sort",
           "schema": {
+            "default": "top1_share",
             "enum": [
               "top1_share",
               "top5_share",
@@ -9445,6 +9543,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -9530,6 +9629,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -9558,6 +9658,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -9723,6 +9824,7 @@
         {
           "name": "offset",
           "schema": {
+            "default": 0,
             "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
@@ -9793,6 +9895,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -9870,6 +9973,7 @@
         {
           "name": "offset",
           "schema": {
+            "default": 0,
             "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
@@ -9879,6 +9983,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -9918,6 +10023,7 @@
         {
           "name": "offset",
           "schema": {
+            "default": 0,
             "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
@@ -9927,6 +10033,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -10011,6 +10118,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -10097,6 +10205,7 @@
         {
           "name": "offset",
           "schema": {
+            "default": 0,
             "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
@@ -10184,6 +10293,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -10239,6 +10349,7 @@
         {
           "name": "offset",
           "schema": {
+            "default": 0,
             "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
@@ -10305,6 +10416,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -10341,6 +10453,7 @@
         {
           "name": "offset",
           "schema": {
+            "default": 0,
             "maximum": 1000000,
             "minimum": 0,
             "type": "integer"
@@ -10407,6 +10520,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -10454,6 +10568,7 @@
           "description": "Response format override. Use `csv` to download the transition timeline as text/csv; `json` (default) keeps the response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -10484,6 +10599,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -10495,6 +10611,7 @@
           "description": "Response format override. Use `csv` to download the daily activity series as text/csv; `json` (default) keeps the response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -10525,6 +10642,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -10562,6 +10680,7 @@
           "description": "Response format override. Use `csv` to download the call-mix rows as text/csv; `json` (default) keeps the response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -10592,6 +10711,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -10602,6 +10722,7 @@
         {
           "name": "sort",
           "schema": {
+            "default": "tx_count",
             "enum": [
               "tx_count",
               "total_fee_tao"
@@ -10629,6 +10750,7 @@
           "description": "Response format override. Use `csv` to download the signer leaderboard as text/csv; `json` (default) keeps the response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -10659,6 +10781,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -10679,6 +10802,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -10709,6 +10833,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -10728,6 +10853,7 @@
         {
           "name": "sort",
           "schema": {
+            "default": "volume",
             "enum": [
               "volume",
               "count"
@@ -10739,6 +10865,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -10769,6 +10896,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -10789,6 +10917,7 @@
           "description": "Response format override. Use `csv` to download the per-subnet capital-flow leaderboard as text/csv; `json` (default) keeps the response envelope (which also carries the network rollup + net-flow distribution).",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -10829,6 +10958,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -10856,6 +10986,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -10876,6 +11007,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -10903,6 +11035,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -10923,6 +11056,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -10950,6 +11084,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -10970,6 +11105,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -10997,6 +11133,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -11017,6 +11154,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -11044,6 +11182,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -11064,6 +11203,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -11094,6 +11234,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -11114,6 +11255,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -11144,6 +11286,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -11164,6 +11307,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -11194,6 +11338,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -11214,6 +11359,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -11244,6 +11390,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -11264,6 +11411,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -11294,6 +11442,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -11321,6 +11470,7 @@
           "description": "Response format override. Use `csv` to download the daily fee series as text/csv; `json` (default) keeps the response envelope (which also carries top_fee_payers).",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -11377,6 +11527,7 @@
         {
           "name": "sort",
           "schema": {
+            "default": "nakamoto_coefficient",
             "enum": [
               "nakamoto_coefficient",
               "gini",
@@ -11391,6 +11542,7 @@
         {
           "name": "order",
           "schema": {
+            "default": "desc",
             "enum": [
               "asc",
               "desc"
@@ -11517,6 +11669,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "30d",
             "enum": [
               "7d",
               "30d",
@@ -11538,6 +11691,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -11565,6 +11719,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "90d",
             "enum": [
               "90d",
               "1y"
@@ -11583,6 +11738,7 @@
           "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
+            "default": "json",
             "enum": [
               "json",
               "csv"
@@ -11752,6 +11908,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"
@@ -12586,6 +12743,7 @@
         {
           "name": "window",
           "schema": {
+            "default": "7d",
             "enum": [
               "7d",
               "30d"

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -56564,6 +56564,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -56655,6 +56656,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -57066,6 +57068,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -57077,6 +57080,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -57237,6 +57241,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -57248,6 +57253,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -57574,6 +57580,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -57841,6 +57848,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -57854,6 +57862,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -58006,6 +58015,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -58262,6 +58272,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -58308,6 +58319,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -58448,6 +58460,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -58473,6 +58486,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -58613,6 +58627,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -58647,6 +58662,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -58787,6 +58803,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -58812,6 +58829,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -58952,6 +58970,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -58964,6 +58983,7 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "default": "tx_count",
               "enum": [
                 "tx_count",
                 "total_fee_tao"
@@ -58998,6 +59018,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -59138,6 +59159,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -59163,6 +59185,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -59303,6 +59326,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -59328,6 +59352,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -59468,6 +59493,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -59493,6 +59519,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -59633,6 +59660,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -59657,6 +59685,7 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "default": "volume",
               "enum": [
                 "volume",
                 "count"
@@ -59670,6 +59699,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -59810,6 +59840,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -59835,6 +59866,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -60442,6 +60474,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -60717,6 +60750,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -60829,6 +60863,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -61872,6 +61907,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -62613,6 +62649,7 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "default": "total_stake",
               "enum": [
                 "total_stake",
                 "total_emission",
@@ -62643,6 +62680,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -62880,6 +62918,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -63240,6 +63279,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -63370,6 +63410,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -63647,6 +63688,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -63667,6 +63709,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -63827,6 +63870,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -63847,6 +63891,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -64020,6 +64065,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -64040,6 +64086,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -64288,6 +64335,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -64308,6 +64356,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -64760,6 +64809,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -64881,6 +64931,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -65110,6 +65161,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -65231,6 +65283,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -65365,6 +65418,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -65602,6 +65656,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -65769,6 +65824,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -65789,6 +65845,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -65919,6 +65976,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -66030,6 +66088,7 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "default": "total_tao",
               "enum": [
                 "total_tao",
                 "free_tao",
@@ -66059,6 +66118,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -66816,6 +66876,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -66907,6 +66968,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -67270,6 +67332,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -67281,6 +67344,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -67425,6 +67489,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -67436,6 +67501,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -67901,6 +67967,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -68091,6 +68158,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -68326,6 +68394,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -68339,6 +68408,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -68475,6 +68545,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -68599,6 +68670,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -68624,6 +68696,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -68845,6 +68918,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -68891,6 +68965,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -69113,6 +69188,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -69239,6 +69315,7 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "default": "nakamoto_coefficient",
               "enum": [
                 "nakamoto_coefficient",
                 "gini",
@@ -69255,6 +69332,7 @@
             "name": "order",
             "required": false,
             "schema": {
+              "default": "desc",
               "enum": [
                 "asc",
                 "desc"
@@ -69380,6 +69458,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -69405,6 +69484,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -69694,6 +69774,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -69728,6 +69809,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -69974,6 +70056,7 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "default": "top1_share",
               "enum": [
                 "top1_share",
                 "top5_share",
@@ -70505,6 +70588,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -70530,6 +70614,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -70652,6 +70737,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -70677,6 +70763,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -70801,6 +70888,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -70826,6 +70914,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -70948,6 +71037,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -70960,6 +71050,7 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "default": "tx_count",
               "enum": [
                 "tx_count",
                 "total_fee_tao"
@@ -70994,6 +71085,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -71118,6 +71210,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -71143,6 +71236,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -71267,6 +71361,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -71292,6 +71387,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -71416,6 +71512,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -71441,6 +71538,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -71565,6 +71663,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "all",
               "enum": [
                 "7d",
                 "30d",
@@ -71593,6 +71692,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -71715,6 +71815,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -71739,6 +71840,7 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "default": "volume",
               "enum": [
                 "volume",
                 "count"
@@ -71752,6 +71854,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -71876,6 +71979,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -71901,6 +72005,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -72025,6 +72130,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -72051,6 +72157,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -72173,6 +72280,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -72198,6 +72306,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -72320,6 +72429,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -72345,6 +72455,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -73224,6 +73335,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -74083,6 +74195,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -74206,6 +74319,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -74222,6 +74336,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -74998,6 +75113,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -75406,6 +75522,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -75518,6 +75635,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -78516,6 +78634,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -78601,6 +78720,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -78912,6 +79032,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -79320,6 +79441,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "minimum": 0,
               "type": "integer"
             }
@@ -79429,6 +79551,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -79907,6 +80030,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "24h",
               "enum": [
                 "1h",
                 "24h",
@@ -80375,6 +80499,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -80594,6 +80719,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -81019,6 +81145,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -81534,6 +81661,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -82164,6 +82292,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -82785,6 +82914,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -83066,6 +83196,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -83695,6 +83826,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -83808,6 +83940,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -85317,6 +85450,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -85558,6 +85692,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -85790,6 +85925,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "24h",
                 "7d",
@@ -86045,6 +86181,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -86284,6 +86421,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -86298,6 +86436,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -86537,6 +86676,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -86659,6 +86799,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -86967,6 +87108,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -87098,6 +87240,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -87270,6 +87413,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -87290,6 +87434,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -87710,6 +87855,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -88084,6 +88230,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -88206,6 +88353,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -88436,6 +88584,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -88800,6 +88949,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -88820,6 +88970,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -88963,6 +89114,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -88983,6 +89135,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -89452,6 +89605,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -89463,6 +89617,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -89594,8 +89749,7 @@
             "required": false,
             "schema": {
               "enum": [
-                "true",
-                "false"
+                "true"
               ],
               "type": "string"
             }
@@ -89616,6 +89770,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -89883,6 +90038,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -90006,6 +90162,7 @@
             "name": "interval",
             "required": false,
             "schema": {
+              "default": "1h",
               "enum": [
                 "1h",
                 "1d"
@@ -90018,6 +90175,7 @@
             "name": "days",
             "required": false,
             "schema": {
+              "default": 90,
               "maximum": 365,
               "minimum": 1,
               "type": "integer"
@@ -90462,6 +90620,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -90476,6 +90635,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -90715,6 +90875,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -90946,6 +91107,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -91067,6 +91229,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -91188,6 +91351,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -91323,6 +91487,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -91452,6 +91617,7 @@
             "name": "direction",
             "required": false,
             "schema": {
+              "default": "stake",
               "enum": [
                 "stake",
                 "unstake"
@@ -91573,6 +91739,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -91952,6 +92119,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -92083,6 +92251,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -92214,6 +92383,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -92350,6 +92520,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "90d",
               "enum": [
                 "90d",
                 "1y"
@@ -92372,6 +92543,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -92613,6 +92785,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -92746,6 +92919,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -92985,6 +93159,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -93106,6 +93281,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "7d",
               "enum": [
                 "7d",
                 "30d"
@@ -93227,6 +93403,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -93358,6 +93535,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -93372,6 +93550,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -93494,6 +93673,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -93507,6 +93687,7 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "default": "stake",
               "enum": [
                 "stake",
                 "emission",
@@ -93534,6 +93715,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -93668,6 +93850,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "maximum": 1000000,
               "minimum": 0,
               "type": "integer"
@@ -93753,6 +93936,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -94123,6 +94307,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -94349,6 +94534,7 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "default": "subnet_count",
               "enum": [
                 "avg_validator_trust",
                 "max_validator_trust",
@@ -94379,6 +94565,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -94616,6 +94803,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -94749,6 +94937,7 @@
             "name": "basis",
             "required": false,
             "schema": {
+              "default": "flow",
               "enum": [
                 "flow",
                 "positions"
@@ -94762,6 +94951,7 @@
             "name": "window",
             "required": false,
             "schema": {
+              "default": "30d",
               "enum": [
                 "7d",
                 "30d",
@@ -94775,6 +94965,7 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "default": "net_staked",
               "enum": [
                 "net_staked",
                 "gross_staked",
@@ -94801,6 +94992,7 @@
             "name": "offset",
             "required": false,
             "schema": {
+              "default": 0,
               "minimum": 0,
               "type": "integer"
             }
@@ -94820,6 +95012,7 @@
             "name": "format",
             "required": false,
             "schema": {
+              "default": "json",
               "enum": [
                 "json",
                 "csv"
@@ -94941,6 +95134,7 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "default": "earning_floor_cost_tao",
               "enum": [
                 "earning_floor_cost_tao",
                 "permit_floor_cost_tao",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -41795,7 +41795,7 @@ export interface operations {
     subnetMetagraph: {
         parameters: {
             query?: {
-                validator_permit?: "true" | "false";
+                validator_permit?: "true";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */

--- a/schemas-src/query-params.ts
+++ b/schemas-src/query-params.ts
@@ -113,7 +113,10 @@ export const offsetSchema = () =>
       `Rows to skip before the first returned row (0-${MAX_OFFSET}). ` +
         "Defaults to 0; a non-numeric value resolves to 0 and the response reports it.",
     )
-    .meta({ examples: [0, 100] });
+    // The default is PUBLISHED, not just described (#10060): the sentence above
+    // has always said 0 and no machine-readable form of it existed, so a
+    // generated client could not fill the parameter in.
+    .meta({ default: 0, examples: [0, 100] });
 
 /**
  * An SS58 address. The pattern is the one 26 tool modules each declared
@@ -138,14 +141,19 @@ export const ss58Schema = () =>
  * Sort direction. 31 of the 32 `order` parameters are this exact pair and mean
  * the same thing on every one of them.
  */
-export const orderSchema = () =>
+export const orderSchema = (fallback?: "asc" | "desc") =>
   z
     .enum(["asc", "desc"])
     .describe(
       "Sort direction for the chosen sort key: `asc` smallest-first, " +
-        "`desc` largest-first.",
+        "`desc` largest-first." +
+        (fallback === undefined ? "" : ` Defaults to ${fallback}.`),
     )
-    .meta({ examples: ["desc"] });
+    .meta(
+      fallback === undefined
+        ? { examples: ["desc"] }
+        : { default: fallback, examples: [fallback] },
+    );
 
 // --- Descriptions for families whose VALUES are per-tool ---------------------
 //
@@ -163,15 +171,21 @@ export const orderSchema = () =>
  */
 export const windowSchema = <T extends readonly [string, ...string[]]>(
   values: T,
+  fallback?: T[number],
 ) =>
   z
     .enum(values)
     .describe(
       "Trailing time window to aggregate over, ending at the latest data " +
         "point rather than a calendar boundary. Options are per-tool; see this " +
-        "parameter's enum.",
+        "parameter's enum." +
+        (fallback === undefined ? "" : ` Defaults to ${fallback}.`),
     )
-    .meta({ examples: [values[0]] });
+    .meta(
+      fallback === undefined
+        ? { examples: [values[0]] }
+        : { default: fallback, examples: [fallback] },
+    );
 
 /**
  * Which side of a two-sided flow to count. Values are per-route -- the transfer
@@ -193,15 +207,21 @@ export const windowSchema = <T extends readonly [string, ...string[]]>(
  */
 export const directionSchema = <T extends readonly [string, ...string[]]>(
   values: T,
+  fallback?: T[number],
 ) =>
   z
     .enum(values)
     .describe(
       "Which side of the flow to count, relative to the account or subnet " +
         "this route is scoped to. Omit to count both. Options are per-route; " +
-        "see this parameter's enum.",
+        "see this parameter's enum." +
+        (fallback === undefined ? "" : ` Defaults to ${fallback}.`),
     )
-    .meta({ examples: [values[0]] });
+    .meta(
+      fallback === undefined
+        ? { examples: [values[0]] }
+        : { default: fallback, examples: [fallback] },
+    );
 
 /**
  * Which side of a stake quote to price.
@@ -218,19 +238,26 @@ export const stakeActionSchema = () =>
       "Which side of the trade to price: `stake` buys alpha with TAO, " +
         "`unstake` sells alpha for TAO. Omit for `stake`.",
     )
-    .meta({ examples: ["stake"] });
+    // The sentence said `stake` and the schema did not (#10060).
+    .meta({ default: "stake", examples: ["stake"] });
 
 /** Which column the result is ranked by. Values are per-tool. */
 export const sortSchema = <T extends readonly [string, ...string[]]>(
   values: T,
+  fallback?: T[number],
 ) =>
   z
     .enum(values)
     .describe(
       "Column to rank the result by; pair with `order` for direction. " +
-        "Options are per-tool; see this parameter's enum.",
+        "Options are per-tool; see this parameter's enum." +
+        (fallback === undefined ? "" : ` Defaults to ${fallback}.`),
     )
-    .meta({ examples: [values[0]] });
+    .meta(
+      fallback === undefined
+        ? { examples: [values[0]] }
+        : { default: fallback, examples: [fallback] },
+    );
 
 /**
  * A block height bound. Inclusive on both ends, which is the one thing a
@@ -425,7 +452,9 @@ export const formatSchema = () =>
       "Response format override. `csv` downloads the route's rows as " +
         "text/csv; `json` is the default and keeps the response envelope.",
     )
-    .meta({ examples: ["csv"] });
+    // Same as `offset` above: the sentence said `json` and the schema did not
+    // (#10060).
+    .meta({ default: "json", examples: ["csv"] });
 
 /**
  * RPC POOL kinds -- what a pool of endpoints is FOR.

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -182,6 +182,15 @@ import {
   COUNTERPARTIES_LIMIT_DEFAULT,
   COUNTERPARTIES_LIMIT_MAX,
 } from "../src/counterparties.ts";
+import {
+  DEFAULT_OHLC_WINDOW_DAYS,
+  MAX_OHLC_WINDOW_DAYS,
+  OHLC_INTERVAL_DEFAULT,
+} from "../src/subnet-ohlc.ts";
+import {
+  DEFAULT_NOMINATOR_BASIS,
+  NOMINATOR_BASES,
+} from "../src/validator-nominator-positions.ts";
 import { TOP_HOLDERS_SORTS } from "../src/top-holders.ts";
 import { NOMINATOR_LIMIT_DEFAULT } from "../src/validator-nominators.ts";
 import { VALIDATOR_ECONOMICS_SORTS } from "../src/validator-economics.ts";
@@ -226,7 +235,10 @@ import {
  * them are correct, and publishing MAX_OFFSET on those would have been a new
  * contract lie rather than a fix.
  */
-const unboundedOffsetSchema = () => z.int().min(0);
+// `default: 0` for the same reason offsetSchema() carries one (#10060):
+// omitting the parameter starts at row 0, and a caller could not read that
+// anywhere machine-readable.
+const unboundedOffsetSchema = () => z.int().min(0).meta({ default: 0 });
 
 /**
  * Routes that accept no query parameters at all.
@@ -393,7 +405,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     fields: fieldsSchema().optional(),
   }),
   "/api/v1/economics/trends": z.object({
-    window: windowSchema(HISTORY_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      HISTORY_WINDOWS as [string, ...string[]],
+      "30d",
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/health/trends": z.object({
@@ -401,29 +416,43 @@ export const ROUTE_QUERY_SCHEMAS = {
     // parseLimitParam / parseNonNegativeIntParam, so `?limit=abc` has always
     // been a 400 -- the published `{"type":"string"}` said otherwise. `offset`
     // carries no ceiling because the handler enforces none.
+    // The one windowed route with NO default, and deliberately (#10060): this
+    // route answers EVERY window at once and `?window=` narrows to one.
+    // Verified live -- bare, `windows` carries `7d` and `30d`; `?window=7d`
+    // carries only `7d`. Publishing a default here would describe a narrowing
+    // the server does not perform.
     window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
     limit: limitSchema(BULK_HEALTH_TRENDS_LIMIT_MAX).optional(),
     offset: unboundedOffsetSchema().optional(),
   }),
   "/api/v1/subnets/{netuid}/health/percentiles": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
   }),
   "/api/v1/subnets/{netuid}/health/incidents": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
   }),
   "/api/v1/subnets/{netuid}/trajectory": z.object({
     format: formatSchema().optional(),
   }),
   "/api/v1/subnets/{netuid}/performance/history": z.object({
-    window: windowSchema(["7d", "30d", "90d"] as const).optional(),
+    window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/subnets/{netuid}/concentration/history": z.object({
-    window: windowSchema(["7d", "30d", "90d"] as const).optional(),
+    window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/subnets/{netuid}/turnover": z.object({
-    window: windowSchema(HISTORY_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      HISTORY_WINDOWS as [string, ...string[]],
+      "30d",
+    ).optional(),
     // The same boolean-as-string filter `validator_permit` is on
     // /subnets/{netuid}/metagraph, and published the same way: both values,
     // because the handler reads `=== "true"` and `changes=false` therefore
@@ -433,46 +462,81 @@ export const ROUTE_QUERY_SCHEMAS = {
     changes: z.enum(["true", "false"] as const).optional(),
   }),
   "/api/v1/subnets/{netuid}/weights": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
   }),
   "/api/v1/subnets/{netuid}/weights/setters": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
   }),
   "/api/v1/subnets/{netuid}/serving": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
   }),
   "/api/v1/subnets/{netuid}/prometheus": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
   }),
   "/api/v1/subnets/{netuid}/stake-transfers": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
   }),
   "/api/v1/subnets/{netuid}/stake-moves": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
   }),
   "/api/v1/subnets/{netuid}/registrations": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
   }),
   "/api/v1/subnets/{netuid}/axon-removals": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
   }),
   "/api/v1/subnets/{netuid}/deregistrations": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
   }),
   "/api/v1/subnets/{netuid}/stake-flow": z.object({
-    window: windowSchema(["7d", "30d", "90d"] as const).optional(),
+    window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),
     direction: directionSchema(["all", "in", "out"] as const).optional(),
   }),
   "/api/v1/subnets/{netuid}/ohlc": z.object({
-    interval: z.enum(["1h", "1d"] as const).optional(),
-    days: z.int().min(1).max(365).optional(),
+    interval: z
+      .enum(["1h", "1d"] as const)
+      .meta({ default: OHLC_INTERVAL_DEFAULT })
+      .optional(),
+    days: z
+      .int()
+      .min(1)
+      .max(MAX_OHLC_WINDOW_DAYS)
+      .meta({ default: DEFAULT_OHLC_WINDOW_DAYS })
+      .optional(),
   }),
   "/api/v1/subnets/{netuid}/stake-quote": z.object({
     amount: z.number().gt(0).optional(),
     direction: stakeActionSchema().optional(),
   }),
   "/api/v1/subnets/{netuid}/validator-economics/history": z.object({
-    window: windowSchema(["7d", "30d", "90d"] as const).optional(),
+    window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),
   }),
   "/api/v1/validators/economics": z.object({
     // Was the only `sort` on the surface published without an enum, while the
@@ -483,6 +547,7 @@ export const ROUTE_QUERY_SCHEMAS = {
     // owns it, not a fourth copy.
     sort: sortSchema(
       VALIDATOR_ECONOMICS_SORTS as unknown as [string, ...string[]],
+      "earning_floor_cost_tao",
     ).optional(),
     limit: limitSchema(
       VALIDATOR_ECONOMICS_LIMIT_MAX,
@@ -495,26 +560,27 @@ export const ROUTE_QUERY_SCHEMAS = {
     cap_binding: z.boolean().optional(),
   }),
   "/api/v1/subnets/movers": z.object({
-    window: windowSchema(["7d", "30d", "90d"] as const).optional(),
-    sort: sortSchema([
+    window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),
+    sort: sortSchema(
+      ["stake", "emission", "validators", "neurons"] as const,
       "stake",
-      "emission",
-      "validators",
-      "neurons",
-    ] as const).optional(),
+    ).optional(),
     limit: limitSchema(MOVERS_LIMIT_MAX, MOVERS_LIMIT_DEFAULT).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/validators": z.object({
-    sort: sortSchema([
-      "avg_validator_trust",
-      "max_validator_trust",
-      "stake_dominance",
+    sort: sortSchema(
+      [
+        "avg_validator_trust",
+        "max_validator_trust",
+        "stake_dominance",
+        "subnet_count",
+        "total_emission",
+        "total_stake",
+        "uid_count",
+      ] as const,
       "subnet_count",
-      "total_emission",
-      "total_stake",
-      "uid_count",
-    ] as const).optional(),
+    ).optional(),
     limit: limitSchema(
       GLOBAL_VALIDATOR_LIMIT_MAX,
       GLOBAL_VALIDATOR_LIMIT_DEFAULT,
@@ -522,15 +588,18 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/accounts": z.object({
-    sort: sortSchema([
+    sort: sortSchema(
+      [
+        "total_stake",
+        "total_emission",
+        "subnet_count",
+        "uid_count",
+        "validator_count",
+        "stake_dominance",
+        "last_active",
+      ] as const,
       "total_stake",
-      "total_emission",
-      "subnet_count",
-      "uid_count",
-      "validator_count",
-      "stake_dominance",
-      "last_active",
-    ] as const).optional(),
+    ).optional(),
     limit: limitSchema(
       ACCOUNTS_LIST_LIMIT_MAX,
       ACCOUNTS_LIST_LIMIT_DEFAULT,
@@ -545,7 +614,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     // producer's last pass is unproven, and withheld the three that are
     // recomputed daily. The route's own 400 has always named all six.
     // The enum IS TOP_HOLDERS_SORTS, read from the module that owns it.
-    sort: sortSchema(TOP_HOLDERS_SORTS as [string, ...string[]]).optional(),
+    sort: sortSchema(
+      TOP_HOLDERS_SORTS as [string, ...string[]],
+      "total_tao",
+    ).optional(),
     limit: limitSchema(
       TOP_HOLDERS_LIMIT_MAX,
       TOP_HOLDERS_LIMIT_DEFAULT,
@@ -553,13 +625,15 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/validators/{hotkey}/nominators": z.object({
-    basis: z.enum(["flow", "positions"] as const).optional(),
-    window: windowSchema(["7d", "30d", "90d"] as const).optional(),
-    sort: sortSchema([
+    basis: z
+      .enum(NOMINATOR_BASES)
+      .meta({ default: DEFAULT_NOMINATOR_BASIS })
+      .optional(),
+    window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),
+    sort: sortSchema(
+      ["net_staked", "gross_staked", "last_activity"] as const,
       "net_staked",
-      "gross_staked",
-      "last_activity",
-    ] as const).optional(),
+    ).optional(),
     // PUBLISHED 100 while the route enforced 2000 (#10064 sweep). Three
     // statements disagreed: this contract and the cold-tier builder said
     // NOMINATOR_LIMIT_MAX (100), handleValidatorNominators validated against
@@ -592,7 +666,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/validators/{hotkey}/history": z.object({
-    window: windowSchema(HISTORY_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      HISTORY_WINDOWS as [string, ...string[]],
+      "30d",
+    ).optional(),
     // #9383 added this to the handler's allowlist, the MCP tool and the
     // GraphQL field, and the response echoes it back as `data.netuid` -- but
     // it was never declared, so openapi.json told every generated client that
@@ -601,15 +678,19 @@ export const ROUTE_QUERY_SCHEMAS = {
     netuid: netuidSchema().optional(),
   }),
   "/api/v1/subnets/{netuid}/metagraph": z.object({
-    // Both values, matching the sibling feeds. The handler reads
-    // `=== "true"`, so `validator_permit=false` is a caller asking for the
-    // unfiltered metagraph -- a real request, not an error. Published as a
-    // one-value enum it was a claim nothing enforced (verified live:
-    // `?validator_permit=false` and `?validator_permit=bogus` both returned
-    // the full set); #10218 parses with this object, so the claim would have
-    // become a 400 on a request the route has always answered. `bogus` now
-    // genuinely is one.
-    validator_permit: z.enum(["true", "false"] as const).optional(),
+    // A PRESENCE flag, one value. #10096 and #10218 landed in the same window
+    // and disagreed: #10096 made the handler 400 anything but `true`, and
+    // #10218 published both values on the belief that `false` still meant "the
+    // unfiltered metagraph". The server settles it -- verified live 2026-08-09,
+    // `?validator_permit=false` is a 400 and `=true` a 200 -- so the published
+    // enum was the half that was wrong, and a generated client was being told
+    // to send a value the route refuses.
+    //
+    // Declared as what the route ENFORCES, and #10096's reasoning is why that
+    // is the right half to keep: `=false` reads as "the ones WITHOUT a permit",
+    // and answering it with all 256 rows is the silent wrong answer. A caller
+    // who wants the complement omits the parameter and filters the rows.
+    validator_permit: z.enum(["true"] as const).optional(),
     fields: fieldsSchema().optional(),
     format: formatSchema().optional(),
   }),
@@ -638,7 +719,7 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/subnets/{netuid}/yield/history": z.object({
-    window: windowSchema(["7d", "30d", "90d"] as const).optional(),
+    window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/subnets/{netuid}/events": z.object({
@@ -655,17 +736,23 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/subnets/{netuid}/event-summary": z.object({
-    window: windowSchema(["7d", "30d", "90d"] as const).optional(),
+    window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),
     limit: limitSchema(
       SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
       SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
     ).optional(),
   }),
   "/api/v1/subnets/{netuid}/neurons/{uid}/history": z.object({
-    window: windowSchema(HISTORY_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      HISTORY_WINDOWS as [string, ...string[]],
+      "30d",
+    ).optional(),
   }),
   "/api/v1/subnets/{netuid}/history": z.object({
-    window: windowSchema(HISTORY_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      HISTORY_WINDOWS as [string, ...string[]],
+      "30d",
+    ).optional(),
   }),
   "/api/v1/subnets/{netuid}/identity-history": z.object({
     limit: limitSchema(MAX_LIMIT, FEED_PAGINATION.defaultLimit).optional(),
@@ -723,32 +810,38 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/accounts/{ss58}/stake-flow": z.object({
-    window: windowSchema(["7d", "30d", "90d"] as const).optional(),
+    window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),
     direction: directionSchema(["all", "in", "out"] as const).optional(),
   }),
   "/api/v1/accounts/{ss58}/stake-moves": z.object({
-    window: windowSchema(["7d", "30d", "90d"] as const).optional(),
+    window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),
   }),
   "/api/v1/accounts/{ss58}/deregistrations": z.object({
-    window: windowSchema(["7d", "30d", "90d"] as const).optional(),
+    window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),
   }),
   "/api/v1/accounts/{ss58}/prometheus": z.object({
-    window: windowSchema(["7d", "30d", "90d"] as const).optional(),
+    window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),
   }),
   "/api/v1/accounts/{ss58}/axon-removals": z.object({
-    window: windowSchema(["7d", "30d", "90d"] as const).optional(),
+    window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),
   }),
   "/api/v1/accounts/{ss58}/serving": z.object({
-    window: windowSchema(["7d", "30d", "90d"] as const).optional(),
+    window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),
   }),
   "/api/v1/accounts/{ss58}/weight-setters": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
   }),
   "/api/v1/accounts/{ss58}/registrations": z.object({
-    window: windowSchema(["7d", "30d", "90d"] as const).optional(),
+    window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),
   }),
   "/api/v1/accounts/{ss58}/subnets/{netuid}/history": z.object({
-    window: windowSchema(HISTORY_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      HISTORY_WINDOWS as [string, ...string[]],
+      "30d",
+    ).optional(),
   }),
   "/api/v1/accounts/{ss58}/identity-history": z.object({
     limit: limitSchema(MAX_LIMIT, FEED_PAGINATION.defaultLimit).optional(),
@@ -757,11 +850,11 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/network/tao-usd": z.object({
-    window: windowSchema(["1h", "24h", "7d", "30d"] as const).optional(),
+    window: windowSchema(["1h", "24h", "7d", "30d"] as const, "24h").optional(),
     include_points: z.boolean().optional(),
   }),
   "/api/v1/subnets/{netuid}/burn/history": z.object({
-    window: windowSchema(["24h", "7d", "30d", "90d"] as const).optional(),
+    window: windowSchema(["24h", "7d", "30d", "90d"] as const, "7d").optional(),
   }),
   "/api/v1/subnets/{netuid}/holders": z.object({
     limit: limitSchema(
@@ -783,14 +876,17 @@ export const ROUTE_QUERY_SCHEMAS = {
     ).optional(),
   }),
   "/api/v1/chain/holders": z.object({
-    sort: sortSchema([
+    sort: sortSchema(
+      [
+        "top1_share",
+        "top5_share",
+        "top10_share",
+        "top20_share",
+        "holder_count",
+        "total_alpha",
+      ] as const,
       "top1_share",
-      "top5_share",
-      "top10_share",
-      "top20_share",
-      "holder_count",
-      "total_alpha",
-    ] as const).optional(),
+    ).optional(),
     limit: limitSchema(
       CHAIN_HOLDERS_LIMIT_MAX,
       CHAIN_HOLDERS_LIMIT_DEFAULT,
@@ -799,6 +895,7 @@ export const ROUTE_QUERY_SCHEMAS = {
   "/api/v1/health/failure-reasons": z.object({
     window: windowSchema(
       FAILURE_REASONS_WINDOWS as [string, ...string[]],
+      "30d",
     ).optional(),
     netuid: netuidSchema().optional(),
     kind: kindStringSchema().optional(),
@@ -814,11 +911,13 @@ export const ROUTE_QUERY_SCHEMAS = {
   "/api/v1/chain/concentration/history": z.object({
     window: windowSchema(
       CHAIN_CONCENTRATION_HISTORY_WINDOWS as [string, ...string[]],
+      "30d",
     ).optional(),
   }),
   "/api/v1/subnets/{netuid}/emission-pipeline/history": z.object({
     window: windowSchema(
       PIPELINE_HISTORY_WINDOWS as [string, ...string[]],
+      "30d",
     ).optional(),
   }),
   "/api/v1/blocks": z.object({
@@ -941,11 +1040,17 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/activity": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/calls": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
     group_by: z.enum(["module", "module_function"] as const).optional(),
     limit: limitSchema(
       CHAIN_CALLS_LIMIT_MAX,
@@ -955,8 +1060,14 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/signers": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
-    sort: sortSchema(["tx_count", "total_fee_tao"] as const).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
+    sort: sortSchema(
+      ["tx_count", "total_fee_tao"] as const,
+      "tx_count",
+    ).optional(),
     limit: limitSchema(
       CHAIN_SIGNERS_LIMIT_MAX,
       CHAIN_SIGNERS_LIMIT_DEFAULT,
@@ -965,7 +1076,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/transfers": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
     limit: limitSchema(
       CHAIN_TRANSFER_LIMIT_MAX,
       CHAIN_TRANSFER_LIMIT_DEFAULT,
@@ -973,16 +1087,22 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/transfer-pairs": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
     limit: limitSchema(
       CHAIN_TRANSFER_PAIR_LIMIT_MAX,
       CHAIN_TRANSFER_PAIR_LIMIT_DEFAULT,
     ).optional(),
-    sort: sortSchema(["volume", "count"] as const).optional(),
+    sort: sortSchema(["volume", "count"] as const, "volume").optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/stake-flow": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
     limit: limitSchema(
       CHAIN_STAKE_FLOW_LIMIT_MAX,
       CHAIN_STAKE_FLOW_LIMIT_DEFAULT,
@@ -997,7 +1117,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/weights": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
     limit: limitSchema(
       CHAIN_WEIGHTS_LIMIT_MAX,
       CHAIN_WEIGHTS_LIMIT_DEFAULT,
@@ -1005,7 +1128,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/weights/setters": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
     limit: limitSchema(
       CHAIN_WEIGHT_SETTERS_LIMIT_MAX,
       CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT,
@@ -1013,7 +1139,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/serving": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
     limit: limitSchema(
       CHAIN_SERVING_LIMIT_MAX,
       CHAIN_SERVING_LIMIT_DEFAULT,
@@ -1021,7 +1150,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/axon-removals": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
     limit: limitSchema(
       CHAIN_AXON_REMOVALS_LIMIT_MAX,
       CHAIN_AXON_REMOVALS_LIMIT_DEFAULT,
@@ -1029,7 +1161,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/prometheus": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
     limit: limitSchema(
       CHAIN_PROMETHEUS_LIMIT_MAX,
       CHAIN_PROMETHEUS_LIMIT_DEFAULT,
@@ -1037,7 +1172,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/registrations": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
     limit: limitSchema(
       CHAIN_REGISTRATIONS_LIMIT_MAX,
       CHAIN_REGISTRATIONS_LIMIT_DEFAULT,
@@ -1045,7 +1183,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/deregistrations": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
     limit: limitSchema(
       CHAIN_DEREGISTRATIONS_LIMIT_MAX,
       CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT,
@@ -1059,7 +1200,10 @@ export const ROUTE_QUERY_SCHEMAS = {
   // No `offset`: the chain feeds do not page, and with a 1000 ceiling over a
   // few-hundred-row table the whole network's lifecycle fits in one request.
   "/api/v1/chain/subnet-lifecycle": z.object({
-    window: windowSchema(HISTORY_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      HISTORY_WINDOWS as [string, ...string[]],
+      "all",
+    ).optional(),
     limit: limitSchema(
       CHAIN_SUBNET_LIFECYCLE_LIMIT_MAX,
       CHAIN_SUBNET_LIFECYCLE_LIMIT_DEFAULT,
@@ -1067,7 +1211,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/stake-transfers": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
     limit: limitSchema(
       CHAIN_STAKE_TRANSFERS_LIMIT_MAX,
       CHAIN_STAKE_TRANSFERS_LIMIT_DEFAULT,
@@ -1075,7 +1222,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/stake-moves": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
     limit: limitSchema(
       CHAIN_STAKE_MOVES_LIMIT_MAX,
       CHAIN_STAKE_MOVES_LIMIT_DEFAULT,
@@ -1083,7 +1233,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/chain/fees": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
     limit: limitSchema(
       CHAIN_FEES_LIMIT_MAX,
       CHAIN_FEES_LIMIT_DEFAULT,
@@ -1101,15 +1254,18 @@ export const ROUTE_QUERY_SCHEMAS = {
         "validator_stake",
       ] as const)
       .optional(),
-    sort: sortSchema([
+    sort: sortSchema(
+      [
+        "nakamoto_coefficient",
+        "gini",
+        "holders",
+        "top_1pct_share",
+        "total",
+        "netuid",
+      ] as const,
       "nakamoto_coefficient",
-      "gini",
-      "holders",
-      "top_1pct_share",
-      "total",
-      "netuid",
-    ] as const).optional(),
-    order: orderSchema().optional(),
+    ).optional(),
+    order: orderSchema("desc").optional(),
     limit: limitSchema(
       CHAIN_CONCENTRATION_SUBNETS_LIMIT_MAX,
       CHAIN_CONCENTRATION_SUBNETS_LIMIT_DEFAULT,
@@ -1122,7 +1278,7 @@ export const ROUTE_QUERY_SCHEMAS = {
     ).optional(),
   }),
   "/api/v1/chain/turnover": z.object({
-    window: windowSchema(["7d", "30d", "90d"] as const).optional(),
+    window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),
     limit: limitSchema(
       CHAIN_TURNOVER_LIMIT_MAX,
       CHAIN_TURNOVER_LIMIT_DEFAULT,
@@ -1130,7 +1286,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/subnets/{netuid}/uptime": z.object({
-    window: windowSchema(UPTIME_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      UPTIME_WINDOWS as [string, ...string[]],
+      "90d",
+    ).optional(),
     min_samples: z.int().min(0).optional(),
     format: formatSchema().optional(),
   }),
@@ -1171,6 +1330,9 @@ export const ROUTE_QUERY_SCHEMAS = {
     netuid: netuidSchema().optional(),
   }),
   "/api/v1/rpc/usage": z.object({
-    window: windowSchema(ANALYTICS_WINDOWS as [string, ...string[]]).optional(),
+    window: windowSchema(
+      ANALYTICS_WINDOWS as [string, ...string[]],
+      "7d",
+    ).optional(),
   }),
 } satisfies Record<string, z.ZodObject>;

--- a/scripts/validate-query-vocabulary.ts
+++ b/scripts/validate-query-vocabulary.ts
@@ -125,7 +125,10 @@ function defaultIsInVocabulary(parameter: Row): boolean {
   const values = schema.enum as unknown[] | undefined;
   if (Array.isArray(values)) return values.includes(schema.default);
   if (typeof schema.default === "number") {
-    const { minimum, maximum } = schema as { minimum?: number; maximum?: number };
+    const { minimum, maximum } = schema as {
+      minimum?: number;
+      maximum?: number;
+    };
     if (typeof minimum === "number" && schema.default < minimum) return false;
     if (typeof maximum === "number" && schema.default > maximum) return false;
   }

--- a/scripts/validate-query-vocabulary.ts
+++ b/scripts/validate-query-vocabulary.ts
@@ -92,22 +92,50 @@ function canonical(value: unknown): string {
 
 /**
  * The builder's CONSTRAINTS as a published parameter carries them: no
- * `$schema` (per-document metadata), and no `description`/`examples` (the
+ * `$schema` (per-document metadata), no `description`/`examples` (the
  * builder's MCP-audience prose, which the REST surface replaces with its own
- * from SHARED_QUERY_PARAMETER_DESCRIPTIONS).
+ * from SHARED_QUERY_PARAMETER_DESCRIPTIONS), and no `default`.
+ *
+ * `default` is the one keyword that is legitimately PER ROUTE (#10060): the
+ * vocabulary owns what values are allowed, and each route owns which one it
+ * applies when the caller says nothing. `?order` is `asc|desc` everywhere and
+ * exactly one route resolves an omitted one to `desc`; that is not two
+ * vocabularies. What must not vary is the option set, and that is what is
+ * compared -- with `defaultIsInVocabulary` checking, separately, that a
+ * route's default is one of the values the vocabulary allows.
  */
 function publishedForm(schema: z.ZodType): string {
-  const emitted = z.toJSONSchema(schema, {
-    target: "draft-2020-12",
-    io: "input",
-  }) as Row;
   const {
     $schema: _schema,
     description: _description,
     examples: _examples,
+    default: _default,
     ...rest
-  } = emitted;
+  } = z.toJSONSchema(schema, {
+    target: "draft-2020-12",
+    io: "input",
+  }) as Row;
   return canonical(stripSentinelIntegerBounds(rest));
+}
+
+/** A route's `default`, if it publishes one, must be a value it allows. */
+function defaultIsInVocabulary(parameter: Row): boolean {
+  const schema = (parameter.schema ?? {}) as Row;
+  if (schema.default === undefined) return true;
+  const values = schema.enum as unknown[] | undefined;
+  if (Array.isArray(values)) return values.includes(schema.default);
+  if (typeof schema.default === "number") {
+    const { minimum, maximum } = schema as { minimum?: number; maximum?: number };
+    if (typeof minimum === "number" && schema.default < minimum) return false;
+    if (typeof maximum === "number" && schema.default > maximum) return false;
+  }
+  return true;
+}
+
+/** The emitted parameter's constraints, with `default` set aside the same way. */
+function publishedConstraints(schema: Row): string {
+  const { default: _default, ...rest } = schema ?? {};
+  return canonical(rest);
 }
 
 const expected = new Map(
@@ -136,18 +164,27 @@ for (const [route, operations] of Object.entries(
       const want = expected.get(name);
       if (want === undefined) continue;
       compared += 1;
-      if (canonical(parameter.schema) === want) {
+      const key = `${route} ?${name}`;
+      if (!defaultIsInVocabulary(parameter)) {
+        errors.push(
+          `${key} publishes a default of ` +
+            `${JSON.stringify((parameter.schema as Row).default)}, which is ` +
+            "not a value the parameter accepts -- a caller following the " +
+            "contract would send something the route rejects.",
+        );
+        continue;
+      }
+      if (publishedConstraints(parameter.schema as Row) === want) {
         aligned += 1;
         continue;
       }
-      const key = `${route} ?${name}`;
       if (DECLARED[key]) {
         used.add(key);
         continue;
       }
       errors.push(
-        `${key} publishes ${canonical(parameter.schema)}, but the vocabulary ` +
-          `defines ${want}.\n` +
+        `${key} publishes ${publishedConstraints(parameter.schema as Row)}, ` +
+          `but the vocabulary defines ${want}.\n` +
           `  Build it from ${name}Schema() in schemas-src/query-params.ts, or ` +
           `add "${key}" to DECLARED with the reason it differs.`,
       );

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -217,7 +217,9 @@ export const LIST_QUERY_ROUTE_EXTRAS: Record<
   // parameter was mandatory, which nothing noticed while the object was only
   // read for its `properties` (#10218 parses with it, where a bare request
   // would have 400'd).
-  "/api/v1/incidents": { window: windowSchema(["7d", "30d"]).optional() },
+  "/api/v1/incidents": {
+    window: windowSchema(["7d", "30d"], "7d").optional(),
+  },
 };
 
 export const API_QUERY_COLLECTIONS = {
@@ -6470,7 +6472,11 @@ export function listQuerySchema(
     shape.sort = sortSchema(sortFields as [string, ...string[]]).optional();
   }
   shape.order = orderSchema().optional();
-  if (csvResponse) shape.format = z.enum(["json", "csv"]).optional();
+  // formatSchema()'s twin for the collection routes, and it carries the same
+  // published default (#10060): omitting `format` keeps the JSON envelope.
+  if (csvResponse) {
+    shape.format = z.enum(["json", "csv"]).meta({ default: "json" }).optional();
+  }
 
   return z.object(shape).strict();
 }

--- a/src/route-query.ts
+++ b/src/route-query.ts
@@ -197,32 +197,74 @@ export function validateRouteArgs(
  * `routeQuery(url).limit` directly, because `undefined` is the answer there and
  * substituting a number would truncate them.
  */
-export function pageLimit(url: URL): number {
-  const asked = routeQuery(url).limit;
-  if (asked !== undefined) return asked;
-  const fallback = publishedLimitDefault(url.pathname);
+export const pageLimit = (url: URL): number => routeValue<number>(url, "limit");
+
+/**
+ * The value this request resolved to for one parameter: what the caller sent,
+ * or the default the route PUBLISHES (#10060).
+ *
+ * The general form of `pageLimit` above, and for the same reason. A handler
+ * writing `url.searchParams.get("window") || DEFAULT_X_WINDOW` states a fact
+ * the contract also states, in a place the contract cannot see -- and 986 of
+ * the 1,076 published query parameters carried no `default` while the handlers
+ * behind them applied 60-odd of them. This reads the published one back, so
+ * there is one number and a caller can see it.
+ *
+ * Throws where the route publishes no default for the parameter. That is a
+ * developer-config error rather than a request a caller can make: a parameter
+ * whose absence means "no filter" has no default to read, and its handler asks
+ * `routeQuery(url)` directly, where `undefined` is the answer.
+ */
+export function routeValue<T>(url: URL, parameter: string): T {
+  const asked = routeQuery(url)[parameter];
+  if (asked !== undefined) return asked as T;
+  const fallback = publishedDefault(url.pathname, parameter);
   if (fallback === undefined) {
-    throw new Error(`No published limit default for ${url.pathname}`);
+    throw new Error(`No published ${parameter} default for ${url.pathname}`);
   }
-  return fallback;
+  return fallback as T;
 }
 
 /**
- * What `limitSchema(max, fallback)` recorded, read back off the published
- * field.
+ * A parsed STRING parameter, or null where the caller sent none (#10060).
+ *
+ * The shape the loaders take, which is why it exists: they were handed
+ * `url.searchParams.get("kind")` and typed `string | null`, so reading the
+ * parsed object instead needed something that keeps that signature rather than
+ * the index signature's `unknown`.
+ *
+ * A type TEST, not a cast. The value came out of a Zod parse against the
+ * published schema, so its runtime type is whatever the contract declares --
+ * and if a caller reaches for the wrong accessor, the answer is `null` rather
+ * than a number wearing a string's type.
+ */
+export function routeText(url: URL, parameter: string): string | null {
+  const value = routeQuery(url)[parameter];
+  return typeof value === "string" ? value : null;
+}
+
+/** The same, for a parameter the contract declares as a number. */
+export function routeInt(url: URL, parameter: string): number | null {
+  const value = routeQuery(url)[parameter];
+  return typeof value === "number" ? value : null;
+}
+
+/**
+ * What the schema builder recorded with `.meta({ default })`, read back off the
+ * published field.
  *
  * `.meta()` does not see through `.optional()`, and every query parameter is
- * optional, so the wrapper comes off first -- and stays off for the routes
- * that declare no `limit` at all, where there is nothing to unwrap. This is the
- * same metadata object `z.toJSONSchema` turns into the published `default`
- * keyword, so the contract and the runtime cannot be reading different numbers.
+ * optional, so the wrapper comes off first -- and stays off for a route that
+ * declares no such parameter at all, where there is nothing to unwrap. This is
+ * the same metadata object `z.toJSONSchema` turns into the published `default`
+ * keyword, so the contract and the runtime cannot be reading different values.
  */
-function publishedLimitDefault(pathname: string): number | undefined {
-  const field = routeQuerySchemasForPathname(pathname)?.plain.shape.limit as
-    z.ZodType | undefined;
+function publishedDefault(pathname: string, parameter: string): unknown {
+  const field = routeQuerySchemasForPathname(pathname)?.plain.shape[
+    parameter
+  ] as z.ZodType | undefined;
   const inner = field instanceof z.ZodOptional ? field.unwrap() : field;
-  const declared = (inner as z.ZodType | undefined)?.meta()?.default;
-  return typeof declared === "number" ? declared : undefined;
+  return (inner as z.ZodType | undefined)?.meta()?.default;
 }
 
 /**

--- a/tests/chain-alpha-volume.test.ts
+++ b/tests/chain-alpha-volume.test.ts
@@ -606,5 +606,23 @@ describe("chain/alpha-volume edge cache", () => {
     const cached = await call();
     assert.equal(cached.status, 200);
     assert.equal((await cached.json()).data.subnet_count, 0);
+
+    // An explicit ?limit gets its own key, built from the PARSED value (#10060)
+    // -- so `?limit=020` and `?limit=20` are one request and one entry rather
+    // than two, which reading the raw string would have made them.
+    const withLimit = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/chain/alpha-volume?limit=020",
+      ),
+      env as unknown as Env,
+      { waitUntil: (promise: Promise<unknown>) => waits.push(promise) },
+    );
+    assert.equal(withLimit.status, 200);
+    await Promise.all(waits);
+    assert.equal(store.size, 2, "the bare and limited requests are two keys");
+    assert.ok(
+      [...store.keys()].some((key) => String(key).includes("limit=20")),
+      `the limited key must carry the parsed 20, got ${[...store.keys()].join(", ")}`,
+    );
   });
 });

--- a/tests/parsed-query-reads.test.ts
+++ b/tests/parsed-query-reads.test.ts
@@ -1,0 +1,123 @@
+// Handlers read the PARSED query, not the query string (#10060).
+//
+// The router parses every GET's parameters against the route's own Zod schema
+// before dispatch (#10218), so a handler reaching back into
+// `url.searchParams` re-reads a value that has already been decoded, typed and
+// bounds-checked -- and, historically, re-stated the bound while doing it:
+//
+//   url.searchParams.get("window") || DEFAULT_SUBNET_SERVING_WINDOW
+//   url.searchParams.get("sort")   || DEFAULT_MOVERS_SORT
+//   parseBoundedIntParam(url, "limit", { def, min, max })
+//
+// Each of those is a copy of something the contract publishes, in the one place
+// the contract cannot see. 104 such reads survived #10218; 8 remain, and they
+// remain for reasons, which is what this file records. It is a SOURCE check
+// because the defect is a shape in the code, not a behaviour: the behaviour is
+// identical either way right up until the two copies disagree.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+
+/** The request path: the router and the three handler modules it dispatches to. */
+const REQUEST_PATH = [
+  "workers/api.ts",
+  "workers/request-handlers/entities.ts",
+  "workers/request-handlers/analytics.ts",
+  "workers/request-handlers/analytics-routes.ts",
+];
+
+/**
+ * The reads that stay, and why.
+ *
+ * `format` is the one parameter accepted on EVERY route whether the route
+ * declares it or not (`GLOBALLY_ACCEPTED_PARAM` in src/contracts.ts, a
+ * documented judgement that exists so /chain-events/stats can keep ignoring
+ * it). `routeQuery(url).format` is therefore `undefined` on the routes that do
+ * not declare it, and the format negotiation has to see the raw value to
+ * answer them -- so these reads are the parameter's OWN handling, not a second
+ * copy of a bound.
+ *
+ * The two by-name helpers take the parameter as an argument rather than naming
+ * one, so there is no schema to look up: `parseBooleanParam(url, name, def)`
+ * and the tri-state `flag(name)` in the validator-economics ranking are
+ * generic over a name the caller supplies.
+ *
+ * A list that can only shrink: a name that stops appearing fails below, so
+ * this cannot quietly become the place a new raw read hides.
+ */
+const DECLARED: Record<string, number> = {
+  // `format`, on the routes that negotiate it before the schema is consulted.
+  format: 6,
+  // The two by-name generic readers, matched by their parameter variable.
+  parameter: 1,
+  name: 1,
+};
+
+function rawReads(file: string): string[] {
+  const text = readFileSync(file, "utf8");
+  return [...text.matchAll(/searchParams\.get\((?:"([a-z_]+)"|(\w+))\)/g)].map(
+    (match) => match[1] ?? match[2],
+  );
+}
+
+describe("the request path reads the parsed query (#10060)", () => {
+  test("every raw read left is one this file declares", () => {
+    const counts: Record<string, number> = {};
+    for (const file of REQUEST_PATH) {
+      for (const name of rawReads(file)) {
+        counts[name] = (counts[name] ?? 0) + 1;
+      }
+    }
+    const undeclared = Object.keys(counts).filter((name) => !DECLARED[name]);
+    assert.deepEqual(
+      undeclared,
+      [],
+      "these parameters are read off the query string in the request path, " +
+        "where the router has already parsed them against the route's schema. " +
+        "Read them with routeQuery(url) / routeText / routeInt / routeValue, " +
+        `or declare the exception with its reason: ${undeclared.join(", ")}`,
+    );
+  });
+
+  test("the declared set can only shrink", () => {
+    const counts: Record<string, number> = {};
+    for (const file of REQUEST_PATH) {
+      for (const name of rawReads(file)) {
+        counts[name] = (counts[name] ?? 0) + 1;
+      }
+    }
+    const grew = Object.entries(DECLARED)
+      .filter(([name, allowed]) => (counts[name] ?? 0) > allowed)
+      .map(([name, allowed]) => `${name}: ${counts[name]} > ${allowed}`);
+    assert.deepEqual(grew, [], `raw reads increased: ${grew.join(", ")}`);
+
+    const gone = Object.entries(DECLARED)
+      .filter(([name]) => counts[name] === undefined)
+      .map(([name]) => name);
+    assert.deepEqual(
+      gone,
+      [],
+      `declared but no longer read -- delete the entry: ${gone.join(", ")}`,
+    );
+  });
+
+  test("no handler restates a page size or a window default", () => {
+    // The specific shape the conversion removed, kept out by name: a fallback
+    // written beside a read of a parameter the route publishes a default for.
+    const offenders: string[] = [];
+    for (const file of REQUEST_PATH) {
+      const text = readFileSync(file, "utf8");
+      for (const match of text.matchAll(
+        /searchParams\.get\("(?:limit|offset|window|sort|order|direction|interval|days|basis)"\)/g,
+      )) {
+        offenders.push(`${file}: ${match[0]}`);
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      "these parameters all publish a default now, so the value comes from " +
+        `the contract: ${offenders.join("; ")}`,
+    );
+  });
+});

--- a/tests/query-vocabulary.test.ts
+++ b/tests/query-vocabulary.test.ts
@@ -92,8 +92,20 @@ describe("the published parameters are built from one vocabulary (#10073)", () =
     const schemas = parametersNamed("order");
     assert.ok(schemas.length > 0, "no route publishes `order`");
     for (const schema of schemas) {
-      assert.deepEqual(schema, published(orderSchema()));
+      // A route's own `default` is a per-route FACT, not a second declaration
+      // of the vocabulary (#10060) -- the same split `limit` has, where the
+      // ceiling is shared and the default is the route's. The constraints are
+      // what must be identical, so they are what is compared, and the default
+      // is checked against the enum it has to come from.
+      const { default: fallback, ...constraints } = schema;
+      assert.deepEqual(constraints, published(orderSchema()));
       assert.equal(schema.type, "string");
+      if (fallback !== undefined) {
+        assert.ok(
+          (schema.enum as string[]).includes(fallback as string),
+          `order default ${String(fallback)} is not one of its own values`,
+        );
+      }
     }
   });
 

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -815,13 +815,7 @@ describe("handleSubnetMetagraph", () => {
     // =bogus 256.
     for (const value of ["false", "bogus", "1"]) {
       const path = `/api/v1/subnets/${NETUID}/metagraph?validator_permit=${value}`;
-      const res = await handleSubnetMetagraph(
-        req(path),
-        emptyEnv() as unknown as Env,
-        NETUID,
-        url(path),
-      );
-      const body = await errorJson(res);
+      const body = await errorJson(await viaRouter(path));
       assert.equal(body.error.code, "invalid_query", value);
       assert.equal(body.meta.parameter, "validator_permit", value);
     }
@@ -1255,12 +1249,15 @@ describe("handleGlobalValidators", () => {
 });
 
 describe("canonicalGlobalValidatorsCachePath", () => {
-  test("returns a response short-circuit for an unsupported sort value", () => {
-    const result = canonicalGlobalValidatorsCachePath(
-      url("/api/v1/validators?sort=bogus"),
-    );
-    assert.equal(result.cachePathAndSearch, undefined);
-    assert.equal(result.response!.status, 400);
+  test("an unsupported sort is the router's 400, not a cache key", async () => {
+    // The helper used to re-check the enum and hand back its own 400. The
+    // router parses the same request against the same schema first (#10060),
+    // so the caller-visible answer is unchanged and the second check is gone.
+    const res = await viaRouter("/api/v1/validators?sort=bogus");
+    assert.equal(res.status, 400);
+    const body = (await res.json()) as Row;
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "sort");
   });
 
   test("omitted sort/limit and their explicit defaults produce the same cache key", () => {
@@ -1747,17 +1744,26 @@ describe("handleSubnetTurnover", () => {
   });
 
   describe("canonicalSubnetMetagraphCachePath", () => {
-    test("omitted validator_permit and explicit =false produce the same cache key", () => {
+    test("a rejected validator_permit gets no cache slot of its own", () => {
+      // `=false` used to share the bare path's slot, on the reading that it
+      // meant "unfiltered". The route refuses it (#10060 aligned the published
+      // enum with what #10096 made the server do), so it is a 400 rather than
+      // a second spelling of the same answer -- and the helper falls through
+      // to the raw path+search, which is what it does for every request the
+      // router will refuse.
       const bare = canonicalSubnetMetagraphCachePath(
         new URL("https://api.metagraph.sh/api/v1/subnets/1/metagraph"),
       );
-      const explicitFalse = canonicalSubnetMetagraphCachePath(
+      assert.equal(bare, "/api/v1/subnets/1/metagraph");
+      const rejected = canonicalSubnetMetagraphCachePath(
         new URL(
           "https://api.metagraph.sh/api/v1/subnets/1/metagraph?validator_permit=false",
         ),
       );
-      assert.equal(bare, explicitFalse);
-      assert.equal(bare, "/api/v1/subnets/1/metagraph");
+      assert.equal(
+        rejected,
+        "/api/v1/subnets/1/metagraph?validator_permit=false",
+      );
     });
 
     test("preserves validator_permit=true filter in the cache key", () => {
@@ -2376,11 +2382,8 @@ describe("handleSubnetStakeFlow", () => {
   });
 
   test("rejects an unsupported direction enum value with 400", async () => {
-    const res = await handleSubnetStakeFlow(
-      req(`/api/v1/subnets/${NETUID}/stake-flow`),
-      emptyEnv() as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/stake-flow?direction=invalid`),
+    const res = await viaRouter(
+      `/api/v1/subnets/${NETUID}/stake-flow?direction=invalid`,
     );
     const body = await errorJson(res);
     assert.equal(body.error.code, "invalid_query");
@@ -2497,23 +2500,11 @@ describe("handleSubnetMovers", () => {
   });
 
   test("rejects an unsupported sort with 400", async () => {
-    await errorJson(
-      await handleSubnetMovers(
-        req("/api/v1/subnets/movers"),
-        emptyEnv() as unknown as Env,
-        url("/api/v1/subnets/movers?sort=bogus"),
-      ),
-    );
+    await errorJson(await viaRouter("/api/v1/subnets/movers?sort=bogus"));
   });
 
   test("rejects an out-of-range limit with 400", async () => {
-    await errorJson(
-      await handleSubnetMovers(
-        req("/api/v1/subnets/movers"),
-        emptyEnv() as unknown as Env,
-        url("/api/v1/subnets/movers?limit=0"),
-      ),
-    );
+    await errorJson(await viaRouter("/api/v1/subnets/movers?limit=0"));
   });
 
   test("returns a schema-stable empty leaderboard on cold D1", async () => {
@@ -3283,11 +3274,8 @@ describe("handleAccountExtrinsics", () => {
 
 describe("handleAccountTransfers", () => {
   test("rejects an unsupported direction enum value with 400", async () => {
-    const res = await handleAccountTransfers(
-      req(`/api/v1/accounts/${SS58}/transfers`),
-      emptyEnv() as unknown as Env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/transfers?direction=invalid`),
+    const res = await viaRouter(
+      `/api/v1/accounts/${SS58}/transfers?direction=invalid`,
     );
     const body = await errorJson(res);
     assert.equal(body.error.code, "invalid_query");
@@ -3341,23 +3329,20 @@ describe("handleAccountTransfers", () => {
 
 describe("handleAccountCounterparties", () => {
   test("rejects malformed and out-of-range limits before D1 work", async () => {
+    // The message is the router's now, derived from the published bound rather
+    // than typed beside it (#10060) -- same 400, same `parameter`, and still
+    // before any read, because the router answers before dispatch.
     for (const limit of ["random_nonce", "Infinity", "0", "101", "10.5"]) {
-      const captures = { sql: [], params: [] };
-      const { env } = dbWith({ captures, transfers: [transferEventRow()] });
-      const res = await handleAccountCounterparties(
-        req(`/api/v1/accounts/${SS58}/counterparties?limit=${limit}`),
-        env as unknown as Env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/counterparties?limit=${limit}`),
+      const res = await viaRouter(
+        `/api/v1/accounts/${SS58}/counterparties?limit=${limit}`,
       );
       const body = await errorJson(res);
       assert.equal(body.error.code, "invalid_query");
       assert.equal(body.meta.parameter, "limit");
       assert.equal(
         body.error.message,
-        "limit must be an integer from 1 to 100.",
+        "limit must be an integer between 1 and 100.",
       );
-      assert.equal(captures.sql.length, 0);
     }
   });
 
@@ -3476,42 +3461,24 @@ describe("handleAccountCounterparties", () => {
 
 describe("handleAccountCounterparties relationship drilldown", () => {
   test("rejects malformed counterparty and limits before D1 work", async () => {
-    for (const counterparty of ["not-ss58", SS58]) {
-      const captures = { sql: [], params: [] };
-      const { env } = dbWith({ captures });
-      const res = await handleAccountCounterparties(
-        req(`/api/v1/accounts/${SS58}/counterparties`),
-        env as unknown as Env,
-        SS58,
-        url(
-          `/api/v1/accounts/${SS58}/counterparties?counterparty=${counterparty}`,
-        ),
-      );
-      const body = await errorJson(res);
-      assert.equal(body.error.code, "invalid_query");
-      assert.equal(body.meta.parameter, "counterparty");
-      assert.equal(captures.sql.length, 0);
-    }
+    const res = await viaRouter(
+      `/api/v1/accounts/${SS58}/counterparties?counterparty=not-ss58`,
+    );
+    const body = await errorJson(res);
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "counterparty");
 
     for (const limit of ["random_nonce", "Infinity", "0", "101", "10.5"]) {
-      const captures = { sql: [], params: [] };
-      const { env } = dbWith({ captures });
-      const res = await handleAccountCounterparties(
-        req(`/api/v1/accounts/${SS58}/counterparties`),
-        env as unknown as Env,
-        SS58,
-        url(
-          `/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}&limit=${limit}`,
-        ),
+      const rejected = await viaRouter(
+        `/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}&limit=${limit}`,
       );
-      const body = await errorJson(res);
-      assert.equal(body.error.code, "invalid_query");
-      assert.equal(body.meta.parameter, "limit");
+      const rejectedBody = await errorJson(rejected);
+      assert.equal(rejectedBody.error.code, "invalid_query");
+      assert.equal(rejectedBody.meta.parameter, "limit");
       assert.equal(
-        body.error.message,
-        "limit must be an integer from 1 to 100.",
+        rejectedBody.error.message,
+        "limit must be an integer between 1 and 100.",
       );
-      assert.equal(captures.sql.length, 0);
     }
   });
 
@@ -3543,11 +3510,8 @@ describe("handleAccountStakeFlow", () => {
   });
 
   test("rejects an unsupported direction enum value with 400 (#2694 parity)", async () => {
-    const res = await handleAccountStakeFlow(
-      req(`/api/v1/accounts/${SS58}/stake-flow`),
-      emptyEnv() as unknown as Env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/stake-flow?direction=invalid`),
+    const res = await viaRouter(
+      `/api/v1/accounts/${SS58}/stake-flow?direction=invalid`,
     );
     const body = await errorJson(res);
     assert.equal(body.error.code, "invalid_query");

--- a/tests/route-limit-contract-parity.test.ts
+++ b/tests/route-limit-contract-parity.test.ts
@@ -25,6 +25,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { z } from "zod";
 import { API_ROUTES } from "../src/contracts.ts";
+import { handleRequest } from "../workers/api.ts";
 import {
   canonicalAccountsListCachePath,
   canonicalGlobalValidatorsCachePath,
@@ -235,13 +236,21 @@ describe("a route's published limit ceiling is the one it enforces (#9127)", () 
     }
   });
 
-  test("the handler rejects one past the ceiling", () => {
-    for (const [path, canonical, ceiling] of BEHAVIOURAL) {
-      const result = canonical(
-        new URL(`https://api.metagraph.sh${path}?limit=${ceiling + 1}`),
-      ) as { response?: unknown };
-      assert.ok(
-        result.response !== undefined,
+  test("the surface rejects one past the ceiling", async () => {
+    // Through the ROUTER, not the cache-path helper. The helper used to
+    // re-check the ceiling and hand back its own 400; the router parses the
+    // same request against the same schema before dispatch (#10060), so the
+    // second check is gone and this asks the question where it is now
+    // answered -- which is also where a caller asks it.
+    for (const [path, , ceiling] of BEHAVIOURAL) {
+      const res = await handleRequest(
+        new Request(`https://api.metagraph.sh${path}?limit=${ceiling + 1}`),
+        {} as never,
+        {} as never,
+      );
+      assert.equal(
+        res.status,
+        400,
         `${path} accepted limit=${ceiling + 1}, one past its published ` +
           "maximum -- the ceiling is documented but not enforced",
       );

--- a/tests/subnet-stake-quote-handler.test.ts
+++ b/tests/subnet-stake-quote-handler.test.ts
@@ -5,6 +5,7 @@
 // api-coverage.test.ts.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
+import { handleRequest } from "../workers/api.ts";
 import { handleSubnetStakeQuote } from "../workers/request-handlers/entities.ts";
 import type { Row } from "./row-type.ts";
 
@@ -125,13 +126,23 @@ describe("handleSubnetStakeQuote (#5235)", () => {
     assert.equal(json.error.code, "insufficient_liquidity");
   });
 
-  test("bad direction → 400 invalid_direction", async () => {
-    const { status, json } = await call(
-      {},
-      `/api/v1/subnets/${NETUID}/stake-quote?amount=1&direction=swap`,
+  test("bad direction → 400 from the router's published enum", async () => {
+    // `invalid_direction` was computeStakeQuote's own code, reached because the
+    // handler forwarded whatever string arrived. The router parses `direction`
+    // against the route's published enum first (#10060), so a caller now gets
+    // the same 400 with the surface's uniform `invalid_query` code and the
+    // parameter named -- and the builder's guard is unreachable from REST.
+    const res = await handleRequest(
+      new Request(
+        `https://api.metagraph.sh/api/v1/subnets/${NETUID}/stake-quote?amount=1&direction=swap`,
+      ),
+      {} as never,
+      {} as never,
     );
-    assert.equal(status, 400);
-    assert.equal(json.error.code, "invalid_direction");
+    assert.equal(res.status, 400);
+    const json = (await res.json()) as Row;
+    assert.equal(json.error.code, "invalid_query");
+    assert.equal(json.meta.parameter, "direction");
   });
 
   test("zero amount → 400 invalid_amount", async () => {

--- a/tests/subnet-validator-economics-route.test.ts
+++ b/tests/subnet-validator-economics-route.test.ts
@@ -16,9 +16,7 @@ import {
   buildSubnetValidatorEconomicsPayload,
   buildValidatorEconomicsRankingPayload,
   handleSubnetValidatorEconomics,
-  handleValidatorEconomicsRanking,
   buildSubnetValidatorEconomicsHistoryPayload,
-  handleSubnetValidatorEconomicsHistory,
 } from "../workers/request-handlers/entities.ts";
 import { handleRequest } from "../workers/api.ts";
 
@@ -774,16 +772,15 @@ describe("buildValidatorEconomicsRankingPayload", () => {
 });
 
 describe("handleValidatorEconomicsRanking", () => {
-  const call = (qs: string, env: unknown) => {
-    const url = new URL(
-      "https://api.metagraph.sh/api/v1/validators/economics" + qs,
-    );
-    return handleValidatorEconomicsRanking(
-      new Request(url.toString()),
+  // Through the ROUTER: the published bounds are enforced there now (#10060),
+  // so a direct handler call would assert a rejection the surface performs one
+  // layer up. Same env, same request, same answer a caller gets.
+  const call = (qs: string, env: unknown) =>
+    handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/validators/economics" + qs),
       env as never,
-      url,
+      {} as never,
     );
-  };
   const env = { METAGRAPH_ARCHIVE: { get: async () => null } } as never;
 
   test("rejects an unsupported sort by name", async () => {
@@ -791,11 +788,15 @@ describe("handleValidatorEconomicsRanking", () => {
     assert.equal(res.status, 400);
     const body = (await res.json()) as Row;
     // The message names the supported set, so a caller can correct the request
-    // without reading the docs.
+    // without reading the docs. It no longer echoes the rejected value back:
+    // the router derives the sentence from the published enum (#10218) rather
+    // than interpolating whatever arrived, which is one fewer place a caller's
+    // string is reflected and one fewer copy of the vocabulary.
     assert.match(
       String((body.error as Row).message),
-      /nonsense.*earning_floor_cost_tao/s,
+      /^sort must be one of: earning_floor_cost_tao,/,
     );
+    assert.equal((body.meta as Row).parameter, "sort");
   });
 
   test("rejects a limit above the published ceiling", async () => {
@@ -1093,15 +1094,12 @@ describe("buildSubnetValidatorEconomicsHistoryPayload", () => {
 });
 
 describe("handleSubnetValidatorEconomicsHistory", () => {
-  const call = (path: string, env: unknown) => {
-    const url = new URL("https://api.metagraph.sh" + path);
-    return handleSubnetValidatorEconomicsHistory(
-      new Request(url.toString()),
+  const call = (path: string, env: unknown) =>
+    handleRequest(
+      new Request("https://api.metagraph.sh" + path),
       env as never,
-      Number(url.pathname.split("/")[4]),
-      url,
+      {} as never,
     );
-  };
   const env = {} as never;
 
   test("rejects an unsupported window by name", async () => {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -127,7 +127,7 @@ import {
   resolveGlobalIncidentsForFeed,
   withEdgeCache,
 } from "./request-handlers/analytics.ts";
-import { parseRouteQuery } from "../src/route-query.ts";
+import { parseRouteQuery, routeQuery, routeText } from "../src/route-query.ts";
 import {
   handleSubnetMetagraph,
   handleNeuron,
@@ -4687,25 +4687,21 @@ export async function handleRequest(
         resolveFeedFormat(url.pathname, request.headers.get("accept")),
       )}`,
     ];
-    const tag = url.searchParams.get("tag");
-    if (tag != null) feedCacheParams.push(`tag=${encodeURIComponent(tag)}`);
-    const since = url.searchParams.get("since");
-    if (since != null) {
-      feedCacheParams.push(`since=${encodeURIComponent(since)}`);
-    }
-    const until = url.searchParams.get("until");
-    if (until != null) {
-      feedCacheParams.push(`until=${encodeURIComponent(until)}`);
-    }
-    const limit = url.searchParams.get("limit");
-    if (limit != null) {
-      feedCacheParams.push(`limit=${encodeURIComponent(limit)}`);
+    // The PARSED values, not the raw strings: the router has already checked
+    // them against the feed schema, and `?limit=020` and `?limit=20` are one
+    // request that must not become two cache entries (#10060).
+    const feed = routeQuery(url);
+    for (const name of ["tag", "since", "until", "limit"] as const) {
+      const value = feed[name];
+      if (value !== undefined) {
+        feedCacheParams.push(`${name}=${encodeURIComponent(String(value))}`);
+      }
     }
     // #8376: the watch feed's entire identity is its `ids` set -- omitting
     // this would let two different watchlists share one cached response
     // (the edge cache key is this composed query string, not the raw request
     // URL), silently serving one visitor's watched entities to another.
-    const ids = url.searchParams.get("ids");
+    const ids = routeText(url, "ids");
     if (ids != null) feedCacheParams.push(`ids=${encodeURIComponent(ids)}`);
     const feedCachePath = `${url.pathname}?${feedCacheParams.join("&")}`;
     const feedRequest =
@@ -6058,7 +6054,13 @@ export async function handleRequest(
         request,
         ctx,
         env,
-        `chain-concentration-subnets:${resolved.url.searchParams.get("lens") || ""}:${resolved.url.searchParams.get("sort") || ""}:${resolved.url.searchParams.get("order") || ""}:${resolved.url.searchParams.get("limit") || ""}`,
+        [
+          "chain-concentration-subnets",
+          routeText(resolved.url, "lens") ?? "",
+          routeText(resolved.url, "sort") ?? "",
+          routeText(resolved.url, "order") ?? "",
+          routeQuery(resolved.url).limit ?? "",
+        ].join(":"),
         () => handleChainConcentrationSubnets(request, env, resolved.url),
       );
     }
@@ -6516,7 +6518,7 @@ async function dispatchLiveChainRoute(
     return envelopeResponse(
       request,
       {
-        data: buildSearchResolve(url.searchParams.get("q")),
+        data: buildSearchResolve(routeText(url, "q")),
         meta: { contract_version: contractVersion(env) },
       },
       "short",
@@ -8605,8 +8607,8 @@ async function handleSemanticSearchRequest(
     // kinds. getAll returns [] when absent, which normalizeSemanticTypes reads as
     // "no scope", so an empty list is equivalent to omitting the param.
     const types = url.searchParams.getAll("type");
-    const data = await semanticSearch(env, url.searchParams.get("q"), {
-      limit: url.searchParams.get("limit"),
+    const data = await semanticSearch(env, routeText(url, "q"), {
+      limit: routeQuery(url).limit,
       type: types.length ? types : undefined,
     });
     return dataResponse(env, data, 200, { source: "ai-live" });

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -26,6 +26,7 @@ import {
   pageLimit,
   parseRouteQuery,
   routeQuery,
+  routeText,
   uptimeWindow,
 } from "../../src/route-query.ts";
 import { EMISSION_PIPELINE_LIMIT_MAX } from "../../src/route-limits.ts";
@@ -636,9 +637,9 @@ export async function handleLeaderboards(
 
 export function canonicalCompareCachePath(url: URL): string | null {
   if ("error" in parseRouteQuery(url)) return null;
-  const requestedNetuids = parseCompareNetuids(url.searchParams.get("netuids"));
+  const requestedNetuids = parseCompareNetuids(routeText(url, "netuids"));
   if (!requestedNetuids) return null;
-  const dimensions = parseCompareDimensions(url.searchParams.get("dimensions"));
+  const dimensions = parseCompareDimensions(routeText(url, "dimensions"));
   if (!dimensions) return null;
   const params = [`netuids=${encodeURIComponent(requestedNetuids.join(","))}`];
   if (dimensions.length !== COMPARE_DIMENSIONS.length) {
@@ -768,7 +769,7 @@ export async function handleCompare(
   env: Env,
   url: URL,
 ): Promise<Response> {
-  const netuidsRaw = url.searchParams.get("netuids");
+  const netuidsRaw = routeText(url, "netuids");
   const requestedNetuids = parseCompareNetuids(netuidsRaw);
   if (!requestedNetuids) {
     return errorResponse(
@@ -779,7 +780,7 @@ export async function handleCompare(
     );
   }
 
-  const dimensionsRaw = url.searchParams.get("dimensions");
+  const dimensionsRaw = routeText(url, "dimensions");
   const dimensions = parseCompareDimensions(dimensionsRaw);
   if (!dimensions) {
     const tokens = (dimensionsRaw || "").split(",").map((d) => d.trim());
@@ -1001,7 +1002,7 @@ export async function handleCompareValidators(
   env: Env,
   url: URL,
 ): Promise<Response> {
-  const hotkeysRaw = url.searchParams.get("hotkeys");
+  const hotkeysRaw = routeText(url, "hotkeys");
   const hotkeys = parseCompareHotkeys(hotkeysRaw);
   if (!hotkeys) {
     return errorResponse(

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -40,6 +40,8 @@ import {
   pageLimit,
   parseRouteQuery,
   routeQuery,
+  routeText,
+  routeValue,
 } from "../../src/route-query.ts";
 import { loadChainServingColdTier } from "../../src/chain-serving-loader.ts";
 import { loadChainWeightsColdTier } from "../../src/chain-weights-loader.ts";
@@ -1240,7 +1242,7 @@ export async function handleChainCalls(
 ): Promise<Response> {
   const { label } = analyticsWindow(url);
   const limit = pageLimit(url);
-  const groupBy = url.searchParams.get("group_by") || "module";
+  const groupBy = routeText(url, "group_by") || "module";
   const csv = csvRequested(url, request);
   return withEdgeCache(
     request,
@@ -1268,7 +1270,7 @@ export async function handleChainCalls(
         window: label,
         groupBy,
         limit,
-        callModule: url.searchParams.get("call_module"),
+        callModule: routeText(url, "call_module"),
       });
       if (!data) {
         usedFallback = true;
@@ -1312,7 +1314,7 @@ export async function handleChainCalls(
       window: label,
       group_by: groupBy,
       limit,
-      call_module: url.searchParams.get("call_module"),
+      call_module: routeText(url, "call_module"),
     })}${csv ? "&format=csv" : ""}`,
   );
 }
@@ -1332,7 +1334,7 @@ export async function handleChainSigners(
   // limit/call_module no longer feed a live D1 read (see the retirement note
   // below) but are still shape-validated so the REST contract stays stable.
   const limit = pageLimit(url);
-  const sort = url.searchParams.get("sort") || "tx_count";
+  const sort = routeValue<string>(url, "sort");
   const csv = csvRequested(url, request);
   return withEdgeCache(
     request,
@@ -1358,7 +1360,7 @@ export async function handleChainSigners(
           window: label,
           sort,
           limit,
-          callModule: url.searchParams.get("call_module"),
+          callModule: routeText(url, "call_module"),
         })) ??
         unmeasured(
           buildChainSigners({
@@ -1393,7 +1395,7 @@ export async function handleChainSigners(
     `${canonicalAnalyticsCacheRoute(url, {
       window: label,
       limit,
-      call_module: url.searchParams.get("call_module"),
+      call_module: routeText(url, "call_module"),
       sort,
     })}${csv ? "&format=csv" : ""}`,
   );
@@ -1514,7 +1516,7 @@ export async function handleChainTransferPairs(
   // limit no longer feeds a live D1 read (see the retirement note below) but
   // is still shape-validated so the REST contract stays stable.
   const limit = pageLimit(url);
-  const sort = url.searchParams.get("sort") || "volume";
+  const sort = routeValue<string>(url, "sort");
   const csv = csvRequested(url, request);
 
   const cacheRequest =
@@ -1687,8 +1689,10 @@ export async function handleChainStakeFlow(
 // do) so a bare request never produces a dangling "&format=csv" with no leading "?".
 function canonicalChainAlphaVolumeCacheRoute(url: URL, csv: boolean): string {
   const search = new URL("https://cache-key.invalid/").searchParams;
-  const limitParam = url.searchParams.get("limit");
-  if (limitParam !== null) search.set("limit", limitParam);
+  // The parsed value, not the raw string: `?limit=020` and `?limit=20` are
+  // one request and must not be two cache entries (#10060).
+  const limitParam = routeQuery(url).limit;
+  if (limitParam !== undefined) search.set("limit", String(limitParam));
   if (csv) search.set("format", "csv");
   const query = search.toString();
   return `${url.pathname}${query ? `?${query}` : ""}`;
@@ -2643,7 +2647,7 @@ export async function handleChainFees(
         await loadChainFeesFromArtifact(env, {
           window: label,
           limit,
-          callModule: url.searchParams.get("call_module"),
+          callModule: routeText(url, "call_module"),
         });
       data ??= unmeasured(
         buildChainFees({
@@ -2679,7 +2683,7 @@ export async function handleChainFees(
     `${canonicalAnalyticsCacheRoute(url, {
       window: label,
       limit,
-      call_module: url.searchParams.get("call_module"),
+      call_module: routeText(url, "call_module"),
     })}${csv ? "&format=csv" : ""}`,
   );
 }

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -56,7 +56,10 @@ import {
   parseRouteQuery,
   resolvePage,
   resolveWindow,
+  routeInt,
   routeQuery,
+  routeText,
+  routeValue,
 } from "../../src/route-query.ts";
 import type { QueryError } from "../list-query.ts";
 import { projectionMeta } from "../../src/field-projection.ts";
@@ -70,25 +73,9 @@ import {
   buildValidatorDetail,
   NO_ALPHA_PRICES,
   overlayFeaturedValidators,
-  GLOBAL_VALIDATOR_SORTS,
-  DEFAULT_GLOBAL_VALIDATOR_SORT,
-  GLOBAL_VALIDATOR_LIMIT_DEFAULT,
-  GLOBAL_VALIDATOR_LIMIT_MAX,
 } from "../../src/metagraph-neurons.ts";
-import {
-  buildAccountsList,
-  ACCOUNTS_LIST_SORTS,
-  DEFAULT_ACCOUNTS_LIST_SORT,
-  ACCOUNTS_LIST_LIMIT_DEFAULT,
-  ACCOUNTS_LIST_LIMIT_MAX,
-} from "../../src/accounts-list.ts";
-import {
-  buildTopHoldersList,
-  TOP_HOLDERS_SORTS,
-  DEFAULT_TOP_HOLDERS_SORT,
-  TOP_HOLDERS_LIMIT_DEFAULT,
-  TOP_HOLDERS_LIMIT_MAX,
-} from "../../src/top-holders.ts";
+import { buildAccountsList } from "../../src/accounts-list.ts";
+import { buildTopHoldersList } from "../../src/top-holders.ts";
 import { buildSubnetHyperparams } from "../../src/subnet-hyperparams.ts";
 import { buildSubnetHyperparamsHistory } from "../../src/subnet-hyperparams-history.ts";
 import {
@@ -157,87 +144,63 @@ import { loadSubnetBurn } from "../../src/subnet-burn.ts";
 import { loadChainBurn } from "../../src/chain-burn.ts";
 import {
   BURN_HISTORY_WINDOWS,
-  DEFAULT_BURN_HISTORY_WINDOW,
   buildSubnetBurnHistory,
   loadSubnetBurnHistory,
 } from "../../src/subnet-burn-history.ts";
 import {
   buildSubnetHolders,
   loadSubnetHolders,
-  SUBNET_HOLDERS_LIMIT_DEFAULT,
-  SUBNET_HOLDERS_LIMIT_MAX,
 } from "../../src/subnet-holders.ts";
 import {
   buildChainHolders,
   loadChainHolders,
-  CHAIN_HOLDERS_LIMIT_DEFAULT,
-  CHAIN_HOLDERS_LIMIT_MAX,
   CHAIN_HOLDERS_SORTS,
-  DEFAULT_CHAIN_HOLDERS_SORT,
 } from "../../src/chain-holders.ts";
 import { buildIndexerLag, loadIndexerLag } from "../../src/indexer-lag.ts";
 import {
   buildChainConcentrationHistory,
   declineChainConcentrationHistory,
   loadChainConcentrationHistory,
-  CHAIN_CONCENTRATION_HISTORY_WINDOWS,
 } from "../../src/chain-concentration-history.ts";
-import { DEFAULT_CHAIN_CONCENTRATION_HISTORY_WINDOW } from "../../src/route-limits.ts";
 import {
   buildPipelineHistory,
   declinePipelineHistory,
   loadPipelineHistory,
-  PIPELINE_HISTORY_WINDOWS,
 } from "../../src/emission-pipeline-history.ts";
-import { DEFAULT_PIPELINE_HISTORY_WINDOW } from "../../src/route-limits.ts";
 import {
   buildEmissionChanges,
   loadEmissionChanges,
   EMISSION_CHANGE_KINDS,
-  EMISSION_CHANGES_LIMIT_DEFAULT,
-  EMISSION_CHANGES_LIMIT_MAX,
 } from "../../src/emission-gate-changes.ts";
 import {
   buildNominatorPositions,
   loadNominatorPositions,
-  NOMINATOR_BASES,
-  DEFAULT_NOMINATOR_BASIS,
 } from "../../src/validator-nominator-positions.ts";
 import {
   buildFailureReasons,
   declineFailureReasons,
   loadFailureReasons,
-  FAILURE_REASONS_WINDOWS,
 } from "../../src/failure-reasons.ts";
-import { DEFAULT_FAILURE_REASONS_WINDOW } from "../../src/route-limits.ts";
 import {
   buildTaoUsdSeries,
   loadTaoUsdSeries,
-  DEFAULT_TAO_USD_WINDOW,
   TAO_USD_WINDOWS,
 } from "../../src/tao-usd-series.ts";
 import {
   buildSurfaceHistory,
   loadSurfaceHistory,
-  SURFACE_HISTORY_LIMIT_DEFAULT,
-  SURFACE_HISTORY_LIMIT_MAX,
 } from "../../src/surface-history.ts";
 import {
   buildValidatorEconomics,
   buildValidatorEconomicsHistory,
-  DEFAULT_VALIDATOR_ECONOMICS_HISTORY_WINDOW,
   VALIDATOR_ECONOMICS_HISTORY_ROW_CAP,
   VALIDATOR_ECONOMICS_HISTORY_WINDOWS,
   groupNeuronsByNetuid,
   rankValidatorEconomics,
-  VALIDATOR_ECONOMICS_SORTS,
   type ValidatorEconomicsRow,
   type ValidatorNeuron,
 } from "../../src/validator-economics.ts";
-import {
-  VALIDATOR_ECONOMICS_LIMIT_DEFAULT,
-  VALIDATOR_ECONOMICS_LIMIT_MAX,
-} from "../../src/route-limits.ts";
+import {} from "../../src/route-limits.ts";
 import { loadSubnetLease } from "../../src/subnet-lease.ts";
 import {
   isCrowdloanId,
@@ -405,17 +368,10 @@ import {
   buildStakeFlow,
   STAKE_FLOW_WINDOWS,
   DEFAULT_STAKE_FLOW_WINDOW,
-  STAKE_FLOW_DIRECTIONS,
 } from "../../src/stake-flow.ts";
 import { buildAlphaVolume } from "../../src/alpha-volume.ts";
 import { loadSubnetAlphaVolumeFromArtifact } from "../../src/subnet-alpha-volume-artifact.ts";
-import {
-  buildSubnetOhlc,
-  OHLC_INTERVALS,
-  OHLC_INTERVAL_DEFAULT,
-  DEFAULT_OHLC_WINDOW_DAYS,
-  MAX_OHLC_WINDOW_DAYS,
-} from "../../src/subnet-ohlc.ts";
+import { buildSubnetOhlc } from "../../src/subnet-ohlc.ts";
 import { loadSubnetOhlcColdTier } from "../../src/subnet-ohlc-cold-tier.ts";
 import { resolveLiveEconomics } from "../../src/health-serving.ts";
 import { KV_ECONOMICS_CURRENT } from "../../src/kv-keys.ts";
@@ -426,7 +382,6 @@ import {
   buildValidatorNominators,
   NOMINATOR_WINDOWS,
   DEFAULT_NOMINATOR_WINDOW,
-  NOMINATOR_SORTS,
 } from "../../src/validator-nominators.ts";
 import { buildValidatorHistory } from "../../src/validator-history.ts";
 import {
@@ -468,17 +423,11 @@ import {
   buildMovers,
   MOVERS_WINDOWS,
   DEFAULT_MOVERS_WINDOW,
-  MOVERS_SORTS,
-  DEFAULT_MOVERS_SORT,
-  MOVERS_LIMIT_DEFAULT,
-  MOVERS_LIMIT_MAX,
 } from "../../src/movers.ts";
 import {
   buildChainTurnover,
   CHAIN_TURNOVER_WINDOWS,
   DEFAULT_CHAIN_TURNOVER_WINDOW,
-  CHAIN_TURNOVER_LIMIT_DEFAULT,
-  CHAIN_TURNOVER_LIMIT_MAX,
 } from "../../src/chain-turnover.ts";
 import { buildSubnetIdentityHistory } from "../../src/subnet-identity-history.ts";
 import { readStore, type ReadStoreDb } from "../../src/read-store.ts";
@@ -817,34 +766,6 @@ function csvCacheVariant(
   const separator = canonicalPath.includes("?") ? "&" : "?";
   return `${canonicalPath}${separator}format=csv`;
 }
-
-function parseBoundedIntParam(
-  url: URL,
-  parameter: string,
-  { def, min, max }: { def: number; min: number; max: number },
-): { value: number } | { error: QueryError } {
-  const raw = url.searchParams.get(parameter);
-  if (raw == null || raw === "") return { value: def };
-  if (!/^\d+$/.test(raw)) {
-    return {
-      error: {
-        parameter,
-        message: `${parameter} must be an integer from ${min} to ${max}.`,
-      },
-    };
-  }
-  const value = Number(raw);
-  if (!Number.isSafeInteger(value) || value < min || value > max) {
-    return {
-      error: {
-        parameter,
-        message: `${parameter} must be an integer from ${min} to ${max}.`,
-      },
-    };
-  }
-  return { value };
-}
-
 /**
  * A strict boolean query parameter (#9720).
  *
@@ -900,23 +821,6 @@ export async function handleSubnetMetagraph(
 ) {
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
-  // #10096: the published enum is ["true"] -- a PRESENCE flag, because the
-  // only thing this filter can do is narrow to permitted neurons. It was not
-  // enforced, and the failure was silent in the worst direction: `?validator
-  // _permit=false` returned all 256 rows, which a caller asking for
-  // non-permitted neurons reads as "none of them hold a permit". Measured on
-  // SN1: no filter 256, `=true` 10, `=false` 256, `=bogus` 256.
-  //
-  // Rejected now, exactly as ?changes= is on /subnets/{netuid}/turnover, which
-  // publishes the identical one-value enum for the identical reason. A caller
-  // who wants the complement omits the parameter and filters the rows.
-  const permit = url.searchParams.get("validator_permit");
-  if (permit != null && permit !== "true") {
-    return analyticsQueryError({
-      parameter: "validator_permit",
-      message: `"${permit}" is not a valid validator_permit flag. Supported: true.`,
-    });
-  }
   // #9082. Parsed before the tier read so an unsupported field costs a 400
   // rather than a full 256-row fetch the caller never sees.
   const projection = parseNeuronFields(url.searchParams, "neurons");
@@ -925,8 +829,9 @@ export async function handleSubnetMetagraph(
   // table is dropped in production, so a D1 query here would always miss.
   // Mirrors handleSubnetHyperparams's pattern below (a schema-stable literal,
   // not a live D1 query) rather than querying a table that no longer exists.
-  // validator_permit is still validated above and forwarded to Postgres via
-  // the proxied request (tryPostgresTier passes the request through unchanged).
+  // validator_permit is validated by the router against the route's published
+  // one-value enum (#10060) and forwarded to Postgres via the proxied request
+  // (tryPostgresTier passes the request through unchanged).
   const data =
     ((await tryPostgresTier(
       env,
@@ -1115,7 +1020,7 @@ export async function handleSubnetHyperparamsHistory(
     (await loadSubnetHyperparamsHistoryColdTier(env, netuid, {
       limit,
       offset,
-      cursor: url.searchParams.get("cursor"),
+      cursor: routeText(url, "cursor"),
     })) ??
     buildSubnetHyperparamsHistory([], netuid, {
       limit,
@@ -1260,26 +1165,10 @@ function parseGlobalValidatorsQuery(
   const validationError = validateResponseFormat(url);
   if (validationError) return { error: validationError };
 
-  const sort = url.searchParams.get("sort") || DEFAULT_GLOBAL_VALIDATOR_SORT;
-  if (!GLOBAL_VALIDATOR_SORTS.includes(sort)) {
-    return {
-      error: {
-        parameter: "sort",
-        message: `"${sort}" is not a supported sort. Supported: ${GLOBAL_VALIDATOR_SORTS.join(
-          ", ",
-        )}.`,
-      },
-    };
-  }
+  const sort = routeValue<string>(url, "sort");
+  const limit = pageLimit(url);
 
-  const limit = parseBoundedIntParam(url, "limit", {
-    def: GLOBAL_VALIDATOR_LIMIT_DEFAULT,
-    min: 1,
-    max: GLOBAL_VALIDATOR_LIMIT_MAX,
-  });
-  if ("error" in limit) return { error: limit.error };
-
-  return { sort, limit: limit.value };
+  return { sort, limit: limit };
 }
 
 export function canonicalGlobalValidatorsCachePath(
@@ -1362,26 +1251,10 @@ function parseAccountsListQuery(
   const validationError = validateResponseFormat(url);
   if (validationError) return { error: validationError };
 
-  const sort = url.searchParams.get("sort") || DEFAULT_ACCOUNTS_LIST_SORT;
-  if (!ACCOUNTS_LIST_SORTS.includes(sort)) {
-    return {
-      error: {
-        parameter: "sort",
-        message: `"${sort}" is not a supported sort. Supported: ${ACCOUNTS_LIST_SORTS.join(
-          ", ",
-        )}.`,
-      },
-    };
-  }
+  const sort = routeValue<string>(url, "sort");
+  const limit = pageLimit(url);
 
-  const limit = parseBoundedIntParam(url, "limit", {
-    def: ACCOUNTS_LIST_LIMIT_DEFAULT,
-    min: 1,
-    max: ACCOUNTS_LIST_LIMIT_MAX,
-  });
-  if ("error" in limit) return { error: limit.error };
-
-  return { sort, limit: limit.value };
+  return { sort, limit: limit };
 }
 
 export function canonicalAccountsListCachePath(
@@ -1451,26 +1324,10 @@ function parseTopHoldersQuery(
   const validationError = validateResponseFormat(url);
   if (validationError) return { error: validationError };
 
-  const sort = url.searchParams.get("sort") || DEFAULT_TOP_HOLDERS_SORT;
-  if (!TOP_HOLDERS_SORTS.includes(sort)) {
-    return {
-      error: {
-        parameter: "sort",
-        message: `"${sort}" is not a supported sort. Supported: ${TOP_HOLDERS_SORTS.join(
-          ", ",
-        )}.`,
-      },
-    };
-  }
+  const sort = routeValue<string>(url, "sort");
+  const limit = pageLimit(url);
 
-  const limit = parseBoundedIntParam(url, "limit", {
-    def: TOP_HOLDERS_LIMIT_DEFAULT,
-    min: 1,
-    max: TOP_HOLDERS_LIMIT_MAX,
-  });
-  if ("error" in limit) return { error: limit.error };
-
-  return { sort, limit: limit.value };
+  return { sort, limit: limit };
 }
 
 export function canonicalTopHoldersCachePath(
@@ -1597,15 +1454,7 @@ export async function handleValidatorNominators(
   // a window cannot. Different units over different time semantics, so the
   // default must not move -- it would silently change what every existing
   // caller's numbers mean.
-  const basisParam = url.searchParams.get("basis") ?? DEFAULT_NOMINATOR_BASIS;
-  if (
-    !NOMINATOR_BASES.includes(basisParam as (typeof NOMINATOR_BASES)[number])
-  ) {
-    return analyticsQueryError({
-      parameter: "basis",
-      message: `basis must be one of ${NOMINATOR_BASES.join(", ")}.`,
-    });
-  }
+  const basisParam = routeValue<string>(url, "basis");
   if (basisParam === "positions") {
     // window and sort belong to the flow aggregation and mean nothing here.
     // Accepting them silently would imply this basis honoured them.
@@ -1617,20 +1466,8 @@ export async function handleValidatorNominators(
         });
       }
     }
-    const positionsLimit = parseBoundedIntParam(url, "limit", {
-      def: GLOBAL_VALIDATOR_LIMIT_DEFAULT,
-      min: 1,
-      max: GLOBAL_VALIDATOR_LIMIT_MAX,
-    });
-    if ("error" in positionsLimit)
-      return analyticsQueryError(positionsLimit.error);
-    const positionsOffset = parseBoundedIntParam(url, "offset", {
-      def: 0,
-      min: 0,
-      max: Number.MAX_SAFE_INTEGER,
-    });
-    if ("error" in positionsOffset)
-      return analyticsQueryError(positionsOffset.error);
+    const positionsLimit = pageLimit(url);
+    const positionsOffset = routeInt(url, "offset") ?? 0;
     const read = await loadNominatorPositions(
       readStore(env, ALPHA_PRICING_TABLES) as never as unknown as Parameters<
         typeof loadNominatorPositions
@@ -1638,8 +1475,8 @@ export async function handleValidatorNominators(
       hotkey,
     );
     const positionsData = buildNominatorPositions(read, hotkey, {
-      limit: positionsLimit.value,
-      offset: positionsOffset.value,
+      limit: positionsLimit,
+      offset: positionsOffset,
     });
     return envelopeResponse(
       request,
@@ -1653,26 +1490,10 @@ export async function handleValidatorNominators(
     NOMINATOR_WINDOWS,
     DEFAULT_NOMINATOR_WINDOW,
   );
-  const sort = url.searchParams.get("sort");
-  if (sort !== null && !NOMINATOR_SORTS.includes(sort)) {
-    return analyticsQueryError({
-      parameter: "sort",
-      message: `"${sort}" is not a supported sort. Supported: ${NOMINATOR_SORTS.join(", ")}.`,
-    });
-  }
-  const limit = parseBoundedIntParam(url, "limit", {
-    def: GLOBAL_VALIDATOR_LIMIT_DEFAULT,
-    min: 1,
-    max: GLOBAL_VALIDATOR_LIMIT_MAX,
-  });
-  if ("error" in limit) return analyticsQueryError(limit.error);
-  const offset = parseBoundedIntParam(url, "offset", {
-    def: 0,
-    min: 0,
-    max: Number.MAX_SAFE_INTEGER,
-  });
-  if ("error" in offset) return analyticsQueryError(offset.error);
-  const coldkeyParam = url.searchParams.get("coldkey");
+  const sort = routeText(url, "sort");
+  const limit = pageLimit(url);
+  const offset = routeInt(url, "offset") ?? 0;
+  const coldkeyParam = routeText(url, "coldkey");
   if (coldkeyParam !== null && !isFinneySs58Address(coldkeyParam)) {
     return analyticsQueryError({
       parameter: "coldkey",
@@ -1692,15 +1513,15 @@ export async function handleValidatorNominators(
     (await loadValidatorNominatorsColdTier(env, hotkey, {
       window: windowParam,
       sort,
-      limit: limit.value,
-      offset: offset.value,
+      limit: limit,
+      offset: offset,
       coldkey: coldkeyParam,
     })) ?? {
       data: buildValidatorNominators([], hotkey, {
         window: windowParam,
         sort: sort ?? undefined,
-        limit: limit.value,
-        offset: offset.value,
+        limit: limit,
+        offset: offset,
       }),
       generatedAt: null,
     };
@@ -1871,7 +1692,7 @@ export async function handleSubnetIdentityHistory(
   const data = (await answerSubnetIdentityHistory(env, netuid, identityTier, {
     limit,
     offset,
-    cursor: url.searchParams.get("cursor"),
+    cursor: routeText(url, "cursor"),
   })) as unknown as ReturnType<typeof buildSubnetIdentityHistory>;
   // CSV mirrors handleSubnetHyperparamsHistory: the page is already
   // limit/offset/cursor-bounded, so the CSV path carries the identical page the
@@ -2343,7 +2164,7 @@ export function canonicalSubnetYieldHistoryCachePath(
 export function canonicalSubnetTurnoverCachePath(url: URL) {
   if ("error" in parseRouteQuery(url)) return `${url.pathname}${url.search}`;
   const { label } = historyWindow(url);
-  const changes = url.searchParams.get("changes");
+  const changes = routeText(url, "changes");
   if (changes != null && changes !== "true") {
     return `${url.pathname}${url.search}`;
   }
@@ -2356,15 +2177,8 @@ export function canonicalSubnetTurnoverCachePath(url: URL) {
 // window/direction and their explicit defaults must share one cache slot.
 export function canonicalSubnetStakeFlowCachePath(url: URL) {
   if ("error" in parseRouteQuery(url)) return `${url.pathname}${url.search}`;
-  const windowParam =
-    url.searchParams.get("window") || DEFAULT_STAKE_FLOW_WINDOW;
-  if (!Object.hasOwn(STAKE_FLOW_WINDOWS, windowParam)) {
-    return `${url.pathname}${url.search}`;
-  }
-  const direction = url.searchParams.get("direction");
-  if (direction !== null && !STAKE_FLOW_DIRECTIONS.includes(direction)) {
-    return `${url.pathname}${url.search}`;
-  }
+  const windowParam = routeValue<string>(url, "window");
+  const direction = routeText(url, "direction");
   let path = `${url.pathname}?window=${encodeURIComponent(windowParam)}`;
   if (direction === "in" || direction === "out") {
     path += `&direction=${encodeURIComponent(direction)}`;
@@ -2381,24 +2195,13 @@ export function canonicalSubnetMoversCachePath(
   if ("error" in parseRouteQuery(url)) return `${url.pathname}${url.search}`;
   const validationError = validateResponseFormat(url);
   if (validationError) return `${url.pathname}${url.search}`;
-  const windowParam = url.searchParams.get("window") || DEFAULT_MOVERS_WINDOW;
-  if (!Object.hasOwn(MOVERS_WINDOWS, windowParam)) {
-    return `${url.pathname}${url.search}`;
-  }
-  const sortParam = url.searchParams.get("sort") || DEFAULT_MOVERS_SORT;
-  if (!MOVERS_SORTS.includes(sortParam)) {
-    return `${url.pathname}${url.search}`;
-  }
-  const limit = parseBoundedIntParam(url, "limit", {
-    def: MOVERS_LIMIT_DEFAULT,
-    min: 1,
-    max: MOVERS_LIMIT_MAX,
-  });
-  if ("error" in limit) return `${url.pathname}${url.search}`;
+  const windowParam = routeValue<string>(url, "window");
+  const sortParam = routeValue<string>(url, "sort");
+  const limit = pageLimit(url);
   return csvCacheVariant(
     url,
     request,
-    `${url.pathname}?window=${windowParam}&sort=${sortParam}&limit=${limit.value}`,
+    `${url.pathname}?window=${windowParam}&sort=${sortParam}&limit=${limit}`,
   );
 }
 
@@ -2412,22 +2215,13 @@ export function canonicalChainTurnoverCachePath(
   if ("error" in parseRouteQuery(url)) return `${url.pathname}${url.search}`;
   const validationError = validateResponseFormat(url);
   if (validationError) return `${url.pathname}${url.search}`;
-  const windowParam =
-    url.searchParams.get("window") || DEFAULT_CHAIN_TURNOVER_WINDOW;
-  if (!Object.hasOwn(CHAIN_TURNOVER_WINDOWS, windowParam)) {
-    return `${url.pathname}${url.search}`;
-  }
-  const limit = parseBoundedIntParam(url, "limit", {
-    def: CHAIN_TURNOVER_LIMIT_DEFAULT,
-    min: 1,
-    max: CHAIN_TURNOVER_LIMIT_MAX,
-  });
-  if ("error" in limit) return `${url.pathname}${url.search}`;
+  const windowParam = routeValue<string>(url, "window");
+  const limit = pageLimit(url);
   // CSV and JSON responses must not share one edge-cache entry.
   return csvCacheVariant(
     url,
     request,
-    `${url.pathname}?window=${windowParam}&limit=${limit.value}`,
+    `${url.pathname}?window=${windowParam}&limit=${limit}`,
   );
 }
 
@@ -2446,12 +2240,7 @@ export async function handleChainTurnover(
     CHAIN_TURNOVER_WINDOWS,
     DEFAULT_CHAIN_TURNOVER_WINDOW,
   );
-  const limit = parseBoundedIntParam(url, "limit", {
-    def: CHAIN_TURNOVER_LIMIT_DEFAULT,
-    min: 1,
-    max: CHAIN_TURNOVER_LIMIT_MAX,
-  });
-  if ("error" in limit) return analyticsQueryError(limit.error);
+  const limit = pageLimit(url);
   const data =
     ((await tryPostgresTier(
       env,
@@ -2462,7 +2251,7 @@ export async function handleChainTurnover(
       window: windowParam,
       startDate: null,
       endDate: null,
-      limit: limit.value,
+      limit: limit,
     });
   // CSV exports the row-shaped per-subnet churn leaderboard; the network rollup +
   // stability distribution stay JSON-only (mirrors the chain-analytics exports).
@@ -2501,7 +2290,7 @@ export function canonicalSubnetMetagraphCachePath(
   if ("error" in parseRouteQuery(url)) return `${url.pathname}${url.search}`;
   const validationError = validateResponseFormat(url);
   if (validationError) return `${url.pathname}${url.search}`;
-  const validatorsOnly = url.searchParams.get("validator_permit") === "true";
+  const validatorsOnly = routeText(url, "validator_permit") === "true";
   const canonicalPath = validatorsOnly
     ? `${url.pathname}?validator_permit=true`
     : url.pathname;
@@ -2724,7 +2513,7 @@ export async function handleSubnetTurnover(
   url: URL,
 ) {
   const { label } = historyWindow(url);
-  const changes = url.searchParams.get("changes");
+  const changes = routeText(url, "changes");
   if (changes != null && changes !== "true") {
     return analyticsQueryError({
       parameter: "changes",
@@ -2762,11 +2551,7 @@ export async function handleSubnetTurnover(
 // response, canonicalized to its default when omitted so equivalent requests share a slot.
 export function canonicalSubnetWeightsCachePath(url: URL) {
   if ("error" in parseRouteQuery(url)) return `${url.pathname}${url.search}`;
-  const windowParam =
-    url.searchParams.get("window") || DEFAULT_SUBNET_WEIGHTS_WINDOW;
-  if (!Object.hasOwn(SUBNET_WEIGHTS_WINDOWS, windowParam)) {
-    return `${url.pathname}${url.search}`;
-  }
+  const windowParam = routeValue<string>(url, "window");
   return `${url.pathname}?window=${encodeURIComponent(windowParam)}`;
 }
 
@@ -2824,11 +2609,7 @@ export async function handleSubnetWeights(
 // the response, canonicalized to its default when omitted so equivalent requests share a slot.
 export function canonicalSubnetWeightSettersCachePath(url: URL) {
   if ("error" in parseRouteQuery(url)) return `${url.pathname}${url.search}`;
-  const windowParam =
-    url.searchParams.get("window") || DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW;
-  if (!Object.hasOwn(SUBNET_WEIGHT_SETTERS_WINDOWS, windowParam)) {
-    return `${url.pathname}${url.search}`;
-  }
+  const windowParam = routeValue<string>(url, "window");
   return `${url.pathname}?window=${encodeURIComponent(windowParam)}`;
 }
 
@@ -2885,11 +2666,7 @@ export async function handleSubnetWeightSetters(
 // response, canonicalized to its default when omitted so equivalent requests share a slot.
 export function canonicalSubnetServingCachePath(url: URL) {
   if ("error" in parseRouteQuery(url)) return `${url.pathname}${url.search}`;
-  const windowParam =
-    url.searchParams.get("window") || DEFAULT_SUBNET_SERVING_WINDOW;
-  if (!Object.hasOwn(SUBNET_SERVING_WINDOWS, windowParam)) {
-    return `${url.pathname}${url.search}`;
-  }
+  const windowParam = routeValue<string>(url, "window");
   return `${url.pathname}?window=${encodeURIComponent(windowParam)}`;
 }
 
@@ -2948,11 +2725,7 @@ export async function handleSubnetServing(
 // response, canonicalized to its default when omitted so equivalent requests share a slot.
 export function canonicalSubnetPrometheusCachePath(url: URL) {
   if ("error" in parseRouteQuery(url)) return `${url.pathname}${url.search}`;
-  const windowParam =
-    url.searchParams.get("window") || DEFAULT_SUBNET_PROMETHEUS_WINDOW;
-  if (!Object.hasOwn(SUBNET_PROMETHEUS_WINDOWS, windowParam)) {
-    return `${url.pathname}${url.search}`;
-  }
+  const windowParam = routeValue<string>(url, "window");
   return `${url.pathname}?window=${encodeURIComponent(windowParam)}`;
 }
 
@@ -2999,11 +2772,7 @@ export async function handleSubnetPrometheus(
 // response, canonicalized to its default when omitted so equivalent requests share a slot.
 export function canonicalSubnetStakeMovesCachePath(url: URL) {
   if ("error" in parseRouteQuery(url)) return `${url.pathname}${url.search}`;
-  const windowParam =
-    url.searchParams.get("window") || DEFAULT_SUBNET_STAKE_MOVES_WINDOW;
-  if (!Object.hasOwn(SUBNET_STAKE_MOVES_WINDOWS, windowParam)) {
-    return `${url.pathname}${url.search}`;
-  }
+  const windowParam = routeValue<string>(url, "window");
   return `${url.pathname}?window=${encodeURIComponent(windowParam)}`;
 }
 
@@ -3063,11 +2832,7 @@ export async function handleSubnetStakeMoves(
 // response, canonicalized to its default when omitted so equivalent requests share a slot.
 export function canonicalSubnetStakeTransfersCachePath(url: URL) {
   if ("error" in parseRouteQuery(url)) return `${url.pathname}${url.search}`;
-  const windowParam =
-    url.searchParams.get("window") || DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW;
-  if (!Object.hasOwn(SUBNET_STAKE_TRANSFERS_WINDOWS, windowParam)) {
-    return `${url.pathname}${url.search}`;
-  }
+  const windowParam = routeValue<string>(url, "window");
   return `${url.pathname}?window=${encodeURIComponent(windowParam)}`;
 }
 
@@ -3127,11 +2892,7 @@ export async function handleSubnetStakeTransfers(
 // response, canonicalized to its default when omitted so equivalent requests share a slot.
 export function canonicalSubnetRegistrationsCachePath(url: URL) {
   if ("error" in parseRouteQuery(url)) return `${url.pathname}${url.search}`;
-  const windowParam =
-    url.searchParams.get("window") || DEFAULT_SUBNET_REGISTRATIONS_WINDOW;
-  if (!Object.hasOwn(SUBNET_REGISTRATIONS_WINDOWS, windowParam)) {
-    return `${url.pathname}${url.search}`;
-  }
+  const windowParam = routeValue<string>(url, "window");
   return `${url.pathname}?window=${encodeURIComponent(windowParam)}`;
 }
 
@@ -3190,11 +2951,7 @@ export async function handleSubnetRegistrations(
 // response, canonicalized to its default when omitted so equivalent requests share a slot.
 export function canonicalSubnetAxonRemovalsCachePath(url: URL) {
   if ("error" in parseRouteQuery(url)) return `${url.pathname}${url.search}`;
-  const windowParam =
-    url.searchParams.get("window") || DEFAULT_SUBNET_AXON_REMOVALS_WINDOW;
-  if (!Object.hasOwn(SUBNET_AXON_REMOVALS_WINDOWS, windowParam)) {
-    return `${url.pathname}${url.search}`;
-  }
+  const windowParam = routeValue<string>(url, "window");
   return `${url.pathname}?window=${encodeURIComponent(windowParam)}`;
 }
 
@@ -3240,11 +2997,7 @@ export async function handleSubnetAxonRemovals(
 // response, canonicalized to its default when omitted so equivalent requests share a slot.
 export function canonicalSubnetDeregistrationsCachePath(url: URL) {
   if ("error" in parseRouteQuery(url)) return `${url.pathname}${url.search}`;
-  const windowParam =
-    url.searchParams.get("window") || DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW;
-  if (!Object.hasOwn(SUBNET_DEREGISTRATIONS_WINDOWS, windowParam)) {
-    return `${url.pathname}${url.search}`;
-  }
+  const windowParam = routeValue<string>(url, "window");
   return `${url.pathname}?window=${encodeURIComponent(windowParam)}`;
 }
 
@@ -3313,13 +3066,7 @@ export async function handleSubnetStakeFlow(
     STAKE_FLOW_WINDOWS,
     DEFAULT_STAKE_FLOW_WINDOW,
   );
-  const direction = url.searchParams.get("direction");
-  if (direction !== null && !STAKE_FLOW_DIRECTIONS.includes(direction)) {
-    return analyticsQueryError({
-      parameter: "direction",
-      message: `"${direction}" is not a valid direction. Supported: ${STAKE_FLOW_DIRECTIONS.join(", ")}.`,
-    });
-  }
+  const direction = routeText(url, "direction");
   // #4909 D1 retirement: account_events' D1 write path is retired (#4772) and
   // the table is dropped in production, so a D1 query here would always miss
   // (#6016/#6017). Postgres → schema-stable empty stub.
@@ -3441,10 +3188,12 @@ export async function handleSubnetStakeQuote(
 ) {
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
-  // A missing/empty `amount` coerces to 0, which computeStakeQuote rejects as
-  // invalid_amount just like a non-numeric value — no separate null check.
-  const amount = Number(url.searchParams.get("amount"));
-  const direction = url.searchParams.get("direction") ?? "stake";
+  // A missing `amount` reads as 0, which computeStakeQuote rejects as
+  // invalid_amount just like a non-numeric value — no separate null check. A
+  // non-numeric one never reaches here: the router rejects it against the
+  // published `number` first.
+  const amount = (routeQuery(url).amount as number | undefined) ?? 0;
+  const direction = routeValue<string>(url, "direction");
   const { row, generatedAt } = await resolveSubnetEconomicsRow(env, netuid);
   const result = computeStakeQuote({
     netuid: Number(netuid),
@@ -3904,15 +3653,7 @@ export async function handleSubnetValidatorEconomicsHistory(
       400,
     );
   }
-  const windowLabel =
-    url.searchParams.get("window") ||
-    DEFAULT_VALIDATOR_ECONOMICS_HISTORY_WINDOW;
-  if (!Object.hasOwn(VALIDATOR_ECONOMICS_HISTORY_WINDOWS, windowLabel)) {
-    return analyticsQueryError({
-      parameter: "window",
-      message: `window must be one of: ${Object.keys(VALIDATOR_ECONOMICS_HISTORY_WINDOWS).join(", ")}`,
-    });
-  }
+  const windowLabel = routeValue<string>(url, "window");
   const { data } = await buildSubnetValidatorEconomicsHistoryPayload(
     env,
     netuid,
@@ -4138,25 +3879,11 @@ export async function handleValidatorEconomicsRanking(
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
 
-  const sortParam = url.searchParams.get("sort");
-  if (sortParam && !VALIDATOR_ECONOMICS_SORTS.includes(sortParam as never)) {
-    return analyticsQueryError({
-      parameter: "sort",
-      message: `"${sortParam}" is not a supported sort. Supported: ${VALIDATOR_ECONOMICS_SORTS.join(", ")}.`,
-    });
-  }
-  const limit = parseBoundedIntParam(url, "limit", {
-    def: VALIDATOR_ECONOMICS_LIMIT_DEFAULT,
-    min: 1,
-    max: VALIDATOR_ECONOMICS_LIMIT_MAX,
-  });
-  if ("error" in limit) return analyticsQueryError(limit.error);
-  const offset = parseBoundedIntParam(url, "offset", {
-    def: 0,
-    min: 0,
-    max: VALIDATOR_ECONOMICS_LIMIT_MAX,
-  });
-  if ("error" in offset) return analyticsQueryError(offset.error);
+  // The enum is published and the router parses against it (#10060), so the
+  // hand-rolled membership test that used to stand here is gone.
+  const sortParam = routeText(url, "sort");
+  const limit = pageLimit(url);
+  const offset = routeInt(url, "offset") ?? 0;
 
   // A tri-state flag: absent means "both", which is not the same as false.
   const flag = (name: string) => {
@@ -4169,8 +3896,8 @@ export async function handleValidatorEconomicsRanking(
     env,
     {
       sort: sortParam ?? undefined,
-      limit: limit.value,
-      offset: offset.value,
+      limit: limit,
+      offset: offset,
       emissionGateOpen: flag("emission_gate_open"),
       capBinding: flag("cap_binding"),
     },
@@ -4253,20 +3980,8 @@ export async function handleSubnetOhlc(
   netuid: number,
   url: URL,
 ) {
-  const intervalParam = url.searchParams.get("interval");
-  if (intervalParam !== null && !Object.hasOwn(OHLC_INTERVALS, intervalParam)) {
-    return analyticsQueryError({
-      parameter: "interval",
-      message: `"${intervalParam}" is not a valid interval. Supported: ${Object.keys(OHLC_INTERVALS).join(", ")}.`,
-    });
-  }
-  const interval = intervalParam || OHLC_INTERVAL_DEFAULT;
-  const daysResult = parseBoundedIntParam(url, "days", {
-    def: DEFAULT_OHLC_WINDOW_DAYS,
-    min: 1,
-    max: MAX_OHLC_WINDOW_DAYS,
-  });
-  if ("error" in daysResult) return analyticsQueryError(daysResult.error);
+  const interval = routeValue<string>(url, "interval");
+  const daysResult = routeValue<number>(url, "days");
   const { data, generatedAt } = ((await tryPostgresTier(
     env,
     request,
@@ -4282,7 +3997,7 @@ export async function handleSubnetOhlc(
     // the forwarded URL.
     (await loadSubnetOhlcColdTier(env, netuid, {
       interval,
-      days: daysResult.value,
+      days: daysResult,
     })) ?? {
       data: buildSubnetOhlc([], Number(netuid), { interval }),
       generatedAt: null,
@@ -4315,21 +4030,8 @@ export async function handleSubnetMovers(request: Request, env: Env, url: URL) {
     MOVERS_WINDOWS,
     DEFAULT_MOVERS_WINDOW,
   );
-  const sortParam = url.searchParams.get("sort") || DEFAULT_MOVERS_SORT;
-  if (!MOVERS_SORTS.includes(sortParam)) {
-    return analyticsQueryError({
-      parameter: "sort",
-      message: `"${sortParam}" is not a supported sort. Supported: ${MOVERS_SORTS.join(
-        ", ",
-      )}.`,
-    });
-  }
-  const limit = parseBoundedIntParam(url, "limit", {
-    def: MOVERS_LIMIT_DEFAULT,
-    min: 1,
-    max: MOVERS_LIMIT_MAX,
-  });
-  if ("error" in limit) return analyticsQueryError(limit.error);
+  const sortParam = routeValue<string>(url, "sort");
+  const limit = pageLimit(url);
   const data =
     ((await tryPostgresTier(
       env,
@@ -4341,7 +4043,7 @@ export async function handleSubnetMovers(request: Request, env: Env, url: URL) {
       startDate: null,
       endDate: null,
       sort: sortParam,
-      limit: limit.value,
+      limit: limit,
     });
   if (csvRequested(url, request)) {
     return csvResponse(
@@ -4418,13 +4120,7 @@ export async function handleAccountStakeFlow(
   );
   // ?direction=all|in|out narrows to inflow/outflow only; omitted sums both.
   // Mirrors the subnet stake-flow route (#2694).
-  const direction = url.searchParams.get("direction");
-  if (direction !== null && !STAKE_FLOW_DIRECTIONS.includes(direction)) {
-    return analyticsQueryError({
-      parameter: "direction",
-      message: `"${direction}" is not a valid direction. Supported: ${STAKE_FLOW_DIRECTIONS.join(", ")}.`,
-    });
-  }
+  const direction = routeText(url, "direction");
   // #4909 D1 retirement: account_events' D1 write path is retired (#4772) and
   // the table is dropped in production, so a D1 query here would always miss
   // (#6016/#6017). Postgres → lakehouse cold tier → schema-stable empty stub.
@@ -4745,7 +4441,7 @@ export async function handleAccountEvents(
   // chain-events feeds. Index-satisfiable via idx_account_events_hotkey and
   // idx_account_events_coldkey (each leads block_number), so a bounded range
   // seeks rather than scans this public, ~60s-cached route.
-  const kind = url.searchParams.get("kind");
+  const kind = routeText(url, "kind");
   // Reject an unknown ?kind= up front, validated against the FULL ingested set
   // (not just INDEXED_EVENT_KINDS, which would wrongly reject Transfer/NetworkAdded
   // etc.). A typo/nonexistent kind otherwise matches nothing and forces a full
@@ -4773,11 +4469,11 @@ export async function handleAccountEvents(
       {
         limit: parsedLimit,
         offset: parsedOffset,
-        cursor: url.searchParams.get("cursor"),
-        kind: url.searchParams.get("kind"),
-        netuid: url.searchParams.get("netuid"),
-        blockStart: url.searchParams.get("block_start"),
-        blockEnd: url.searchParams.get("block_end"),
+        cursor: routeText(url, "cursor"),
+        kind: routeText(url, "kind"),
+        netuid: routeInt(url, "netuid"),
+        blockStart: routeInt(url, "block_start"),
+        blockEnd: routeInt(url, "block_end"),
       },
       network,
     )) ??
@@ -4834,7 +4530,7 @@ export async function handleAccountHistory(
   const { from = null, to = null } = routeQuery(url);
   const page = resolvePage(url);
   const { limit, offset } = page;
-  const netuid = url.searchParams.get("netuid");
+  const netuid = routeInt(url, "netuid");
   // Inverted YYYY-MM-DD bounds are a deterministic no-match. Short-circuit before
   // D1 so callers cannot force a scan to prove an impossible empty page.
   if (from && to && from > to) {
@@ -4896,7 +4592,7 @@ export async function handleAccountHistory(
       netuid,
       from,
       to,
-      cursor: url.searchParams.get("cursor"),
+      cursor: routeText(url, "cursor"),
     })) ??
     buildAccountHistory([], ss58, { limit, offset, nextCursor: null });
   // CSV export mirrors handleAccountEvents/Extrinsics/Transfers: the rows are
@@ -4952,9 +4648,9 @@ export async function handleAccountExtrinsics(
     (await loadAccountExtrinsicsColdTier(env, ss58, {
       limit: parsedLimit,
       offset: parsedOffset,
-      cursor: url.searchParams.get("cursor"),
-      blockStart: url.searchParams.get("block_start"),
-      blockEnd: url.searchParams.get("block_end"),
+      cursor: routeText(url, "cursor"),
+      blockStart: routeInt(url, "block_start"),
+      blockEnd: routeInt(url, "block_end"),
     })) ??
     buildAccountExtrinsics([], ss58, {
       limit: parsedLimit,
@@ -5005,7 +4701,7 @@ export async function handleAccountTransfers(
 ) {
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
-  const direction = url.searchParams.get("direction");
+  const direction = routeText(url, "direction");
   if (
     direction !== null &&
     direction !== "all" &&
@@ -5031,10 +4727,10 @@ export async function handleAccountTransfers(
     (await loadAccountTransfersColdTier(env, ss58, {
       limit,
       offset,
-      cursor: url.searchParams.get("cursor"),
+      cursor: routeText(url, "cursor"),
       direction,
-      blockStart: url.searchParams.get("block_start"),
-      blockEnd: url.searchParams.get("block_end"),
+      blockStart: routeInt(url, "block_start"),
+      blockEnd: routeInt(url, "block_end"),
     })) ??
     buildAccountTransfers([], ss58, {
       limit,
@@ -5080,14 +4776,9 @@ export async function handleAccountCounterparties(
 ) {
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
-  const counterparty = url.searchParams.get("counterparty");
-  const parsedLimit = parseBoundedIntParam(url, "limit", {
-    def: counterparty == null ? 20 : 50,
-    min: 1,
-    max: 100,
-  });
-  if ("error" in parsedLimit) return analyticsQueryError(parsedLimit.error);
-  const limit = parsedLimit.value;
+  const counterparty = routeText(url, "counterparty");
+  const parsedLimit = pageLimit(url);
+  const limit = parsedLimit;
   if (counterparty != null) {
     // CSV export only covers the list-mode leaderboard below -- the
     // relationship drilldown returns a single composite object, not rows.
@@ -5398,7 +5089,7 @@ export async function handleAccountIdentityHistory(
     (await loadAccountIdentityHistoryColdTier(env, ss58, {
       limit,
       offset,
-      cursor: url.searchParams.get("cursor"),
+      cursor: routeText(url, "cursor"),
     })) ??
     buildAccountIdentityHistory([], ss58, { limit, offset, nextCursor: null });
   // CSV mirrors handleSubnetHyperparamsHistory: the page is already
@@ -5441,7 +5132,7 @@ export async function handleSubnetEvents(
 ) {
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
-  const kind = url.searchParams.get("kind");
+  const kind = routeText(url, "kind");
   // Reject an unknown ?kind= up front, validated against the FULL ingested set
   // (not just INDEXED_EVENT_KINDS, which would wrongly reject Transfer/NetworkAdded
   // etc.). A typo/nonexistent kind otherwise matches nothing and forces a full
@@ -5483,7 +5174,7 @@ export async function handleSubnetEvents(
   const data = (await answerSubnetEvents(env, Number(netuid), tierResult, {
     limit: parsedLimit,
     offset: parsedOffset,
-    cursor: url.searchParams.get("cursor"),
+    cursor: routeText(url, "cursor"),
     kind,
     blockStart,
     blockEnd,
@@ -5863,7 +5554,7 @@ export async function handleSubnetBurnHistory(
       400,
     );
   }
-  const label = url.searchParams.get("window") ?? DEFAULT_BURN_HISTORY_WINDOW;
+  const label = routeValue<string>(url, "window");
   const windowDays = BURN_HISTORY_WINDOWS[label];
   if (windowDays === undefined) {
     return analyticsQueryError({
@@ -5917,21 +5608,16 @@ export async function handleSubnetHolders(
   }
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
-  const limit = parseBoundedIntParam(url, "limit", {
-    def: SUBNET_HOLDERS_LIMIT_DEFAULT,
-    min: 1,
-    max: SUBNET_HOLDERS_LIMIT_MAX,
-  });
-  if ("error" in limit) return analyticsQueryError(limit.error);
+  const limit = pageLimit(url);
 
   const read = await loadSubnetHolders(
     readStore(env, ALPHA_PRICING_TABLES) as never as unknown as Parameters<
       typeof loadSubnetHolders
     >[0],
     netuid,
-    { limit: limit.value },
+    { limit: limit },
   );
-  const data = buildSubnetHolders(read, netuid, { limit: limit.value });
+  const data = buildSubnetHolders(read, netuid, { limit: limit });
   return envelopeResponse(
     request,
     { data, meta: { contract_version: contractVersion(env) } },
@@ -5954,7 +5640,7 @@ export async function handleTaoUsd(request: Request, env: Env, url: URL) {
   // #9701 established for list_candidates).
   const includePoints = parseBooleanParam(url, "include_points", true);
   if ("error" in includePoints) return analyticsQueryError(includePoints.error);
-  const label = url.searchParams.get("window") ?? DEFAULT_TAO_USD_WINDOW;
+  const label = routeValue<string>(url, "window");
   const windowHours = TAO_USD_WINDOWS[label];
   if (windowHours === undefined) {
     return analyticsQueryError({
@@ -5999,23 +5685,18 @@ export async function handleSubnetSurfaceHistory(
   }
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
-  const limit = parseBoundedIntParam(url, "limit", {
-    def: SURFACE_HISTORY_LIMIT_DEFAULT,
-    min: 1,
-    max: SURFACE_HISTORY_LIMIT_MAX,
-  });
-  if ("error" in limit) return analyticsQueryError(limit.error);
+  const limit = pageLimit(url);
 
   const rows = await loadSurfaceHistory(
     readStore(env, SURFACE_HISTORY_TABLES) as never as unknown as Parameters<
       typeof loadSurfaceHistory
     >[0],
     netuid,
-    { limit: limit.value },
+    { limit: limit },
   );
   // A subnet whose surfaces have never changed is an EMPTY trail, not a 404 --
   // stability is the common case and a real answer.
-  const data = buildSurfaceHistory(rows, netuid, { limit: limit.value });
+  const data = buildSurfaceHistory(rows, netuid, { limit: limit });
   return envelopeResponse(
     request,
     { data, meta: { contract_version: contractVersion(env) } },
@@ -6035,7 +5716,7 @@ export async function handleEmissionChanges(
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
 
-  const kindParam = url.searchParams.get("kind");
+  const kindParam = routeText(url, "kind");
   if (
     kindParam !== null &&
     !EMISSION_CHANGE_KINDS.includes(
@@ -6047,23 +5728,18 @@ export async function handleEmissionChanges(
       message: `kind must be one of ${EMISSION_CHANGE_KINDS.join(", ")}.`,
     });
   }
-  const limit = parseBoundedIntParam(url, "limit", {
-    def: EMISSION_CHANGES_LIMIT_DEFAULT,
-    min: 1,
-    max: EMISSION_CHANGES_LIMIT_MAX,
-  });
-  if ("error" in limit) return analyticsQueryError(limit.error);
+  const limit = pageLimit(url);
 
   const rows = await loadEmissionChanges(
     readStore(env, EMISSION_CHANGES_TABLES) as never as unknown as Parameters<
       typeof loadEmissionChanges
     >[0],
-    { limit: limit.value, kind: kindParam ?? undefined },
+    { limit: limit, kind: kindParam ?? undefined },
   );
   // These tables gain a row only when a value MOVED, so an empty feed is the
   // steady state -- never a 404.
   const data = buildEmissionChanges(rows, {
-    limit: limit.value,
+    limit: limit,
     kind: kindParam ?? undefined,
   });
   return envelopeResponse(
@@ -6086,7 +5762,7 @@ export async function handleChainHolders(request: Request, env: Env, url: URL) {
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
 
-  const sort = url.searchParams.get("sort") || DEFAULT_CHAIN_HOLDERS_SORT;
+  const sort = routeValue<string>(url, "sort");
   if (
     !CHAIN_HOLDERS_SORTS.includes(sort as (typeof CHAIN_HOLDERS_SORTS)[number])
   ) {
@@ -6095,19 +5771,14 @@ export async function handleChainHolders(request: Request, env: Env, url: URL) {
       message: `"${sort}" is not a supported sort. Supported: ${CHAIN_HOLDERS_SORTS.join(", ")}.`,
     });
   }
-  const limit = parseBoundedIntParam(url, "limit", {
-    def: CHAIN_HOLDERS_LIMIT_DEFAULT,
-    min: 1,
-    max: CHAIN_HOLDERS_LIMIT_MAX,
-  });
-  if ("error" in limit) return analyticsQueryError(limit.error);
+  const limit = pageLimit(url);
 
   const read = await loadChainHolders(
     readStore(env, ALPHA_PRICING_TABLES) as never as unknown as Parameters<
       typeof loadChainHolders
     >[0],
   );
-  const data = buildChainHolders(read, { sort, limit: limit.value });
+  const data = buildChainHolders(read, { sort, limit: limit });
   return envelopeResponse(
     request,
     { data, meta: { contract_version: contractVersion(env) } },
@@ -6126,15 +5797,8 @@ export async function handleFailureReasons(
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
 
-  const window =
-    url.searchParams.get("window") || DEFAULT_FAILURE_REASONS_WINDOW;
-  if (!FAILURE_REASONS_WINDOWS.includes(window)) {
-    return analyticsQueryError({
-      parameter: "window",
-      message: `"${window}" is not a supported window. Supported: ${FAILURE_REASONS_WINDOWS.join(", ")}.`,
-    });
-  }
-  const netuidParam = url.searchParams.get("netuid");
+  const window = routeValue<string>(url, "window");
+  const netuidParam = routeInt(url, "netuid");
   let netuid: number | undefined;
   if (netuidParam !== null) {
     const parsed = Number(netuidParam);
@@ -6146,7 +5810,7 @@ export async function handleFailureReasons(
     }
     netuid = parsed;
   }
-  const kind = url.searchParams.get("kind") ?? undefined;
+  const kind = routeText(url, "kind") ?? undefined;
 
   const rows = await loadFailureReasons(
     readStore(env, FAILURE_REASONS_TABLES) as never as unknown as Parameters<
@@ -6203,16 +5867,7 @@ export async function handleChainConcentrationHistory(
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
 
-  const window =
-    url.searchParams.get("window") ||
-    DEFAULT_CHAIN_CONCENTRATION_HISTORY_WINDOW;
-  if (!CHAIN_CONCENTRATION_HISTORY_WINDOWS.includes(window)) {
-    return analyticsQueryError({
-      parameter: "window",
-      message: `"${window}" is not a supported window. Supported: ${CHAIN_CONCENTRATION_HISTORY_WINDOWS.join(", ")}.`,
-    });
-  }
-
+  const window = routeValue<string>(url, "window");
   const rows = await loadChainConcentrationHistory(
     readStore(
       env,
@@ -6247,15 +5902,7 @@ export async function handleSubnetPipelineHistory(
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
 
-  const window =
-    url.searchParams.get("window") || DEFAULT_PIPELINE_HISTORY_WINDOW;
-  if (!PIPELINE_HISTORY_WINDOWS.includes(window)) {
-    return analyticsQueryError({
-      parameter: "window",
-      message: `"${window}" is not a supported window. Supported: ${PIPELINE_HISTORY_WINDOWS.join(", ")}.`,
-    });
-  }
-
+  const window = routeValue<string>(url, "window");
   const rows = await loadPipelineHistory(
     readStore(env, SUBNET_SNAPSHOT_TABLES) as never as unknown as Parameters<
       typeof loadPipelineHistory
@@ -6498,17 +6145,17 @@ export async function handleBlocks(
       {
         limit,
         offset,
-        cursor: url.searchParams.get("cursor"),
-        author: url.searchParams.get("author"),
-        specVersion: url.searchParams.get("spec_version"),
-        blockStart: url.searchParams.get("block_start"),
-        blockEnd: url.searchParams.get("block_end"),
+        cursor: routeText(url, "cursor"),
+        author: routeText(url, "author"),
+        specVersion: routeInt(url, "spec_version"),
+        blockStart: routeInt(url, "block_start"),
+        blockEnd: routeInt(url, "block_end"),
         // from/to are part of this route's contract too -- a filter the tier
         // never receives is a filter it silently ignores.
-        from: url.searchParams.get("from"),
-        to: url.searchParams.get("to"),
-        minExtrinsics: url.searchParams.get("min_extrinsics"),
-        minEvents: url.searchParams.get("min_events"),
+        from: routeText(url, "from"),
+        to: routeText(url, "to"),
+        minExtrinsics: routeInt(url, "min_extrinsics"),
+        minEvents: routeInt(url, "min_events"),
       } as never,
       network,
     )) ??


### PR DESCRIPTION
## Summary

The router parses each GET's query against the route's own Zod schema before dispatch (#10218), and
104 reads in the request path then went back to `url.searchParams` for a value it had already
decoded, typed and bounds-checked — most of them restating a bound while doing it. Those
restatements were the surviving home of every default the contract did not state, so both halves
move together: **the default is published, and the handler reads the published one.**

| | before | after |
|---|---|---|
| published query parameters carrying a `default` | 90 | **283** |
| — `window` | 0 | 70 of 71 |
| — `format` | 0 | 87 of 87 |
| — `offset` | 0 | 21 of 22 |
| — `sort` | 0 | 12 of 49 |
| — `order` / `interval` / `days` / `basis` / `direction` | 0 | 5 |
| raw `searchParams.get` reads in the request path | 104 | **8** |
| hand-rolled vocabulary guards downstream of the router's own parse | 26 | **0** |
| `parseBoundedIntParam` calls restating a published `{default, minimum, maximum}` | 19 | **0** (deleted) |

`workers/request-handlers/entities.ts` is 611 lines lighter.

## Every published value is measured, not assumed

Each default is what production **answers** for an omitted parameter, probed 2026-08-09 against the
live API rather than read off a constant — the constant being exactly the thing that could be wrong:

```
checked 72   agree 70   disagree 0   not echoed 2
```

The two that do not echo their parameter:

- **`/api/v1/chain/subnet-lifecycle ?window`** — every row is inside the shortest window today, so
  `?window=7d` and the default both answer 129 and the probe cannot discriminate.
  `DEFAULT_SUBNET_LIFECYCLE_WINDOW` is the evidence, and the comment says so.
- **`/api/v1/subnets/{netuid}/ohlc ?days`** — bare answers 2,000 hourly candles against `?days=7`'s
  168, consistent with the 90 its constant declares.

## Three routes stated something the server does not do

**`?validator_permit=false` was published as valid and is a 400.** #10096 made the handler reject
anything but `true`; #10218 published both values in the same window on the reading that `false`
still meant "unfiltered". Verified live — `=false` is a 400, `=true` a 200 — so the published enum
was the wrong half, and a generated client was being told to send a value the route refuses. It
publishes the one value it accepts now, and #10096's reasoning is why that is the right half:
`=false` reads as "the ones WITHOUT a permit", and answering it with all 256 rows is the silent
wrong answer.

**`get_chain_signers` / `get_chain_transfer_pairs`** read their sort default from a bare literal
(`|| "tx_count"`, `|| "volume"`) beside a route that publishes the same value.

**`/accounts/{ss58}/counterparties`** applied 50 in drilldown mode and 20 in list mode from one
`limit` parameter — a conditional the contract cannot state, so it published 20 and served 50 to
half its callers. One route, one published default; a drilldown caller who wants 50 asks for it.

## Two routes publish no default, and say so

- **`/api/v1/health/trends`** answers EVERY window unless narrowed — verified live, bare gives
  `windows: [7d, 30d]` and `?window=7d` gives `[7d]`. `window` narrows there; it does not default.
- The **36 collection routes** return the whole collection, which #10275 already declared.

## The gates

**`tests/parsed-query-reads.test.ts`** pins the shape. The 8 remaining raw reads are `format` — the
one parameter accepted on every route whether it declares one or not, so it is negotiated before the
schema is consulted — and two by-name generic readers that take the parameter as an argument. Both
are declared with reasons, in a list that can only shrink: a name that stops appearing fails.

**`validate:query-vocabulary`** compared the whole emitted schema against the vocabulary, so one
route's `default: "desc"` read as a second vocabulary. It compares CONSTRAINTS now and checks,
separately, that a route's default is a value its own vocabulary allows — the split `limit` already
had. Proven to fail by poisoning that default to `"sideways"`:

```
- /api/v1/chain/concentration/subnets ?order publishes a default of "sideways", which is not a
  value the parameter accepts -- a caller following the contract would send something the route
  rejects.
```

## Tests that moved

Nine tests asserted a rejection by calling a handler directly. The check lives at the router now, so
a handler called that way does not refuse a bad value and asserting that it does asserts a property
the surface does not have — the same reason #10218 introduced `viaRouter`. They dispatch through
`handleRequest`, which is what a caller does. Two messages changed with them: the router derives its
sentence from the published bound instead of interpolating the rejected value back, so
`"nonsense" is not a supported sort…` is now `sort must be one of: …` with `meta.parameter` naming it.

## Behaviour changes

- `?validator_permit=false` is documented as invalid (it already 400s).
- The counterparties drilldown defaults to 20 transfers rather than 50.
- No other route changes what it returns for any request. The 193 newly published defaults are the
  values the server was already applying.

## Validation

```
npm run typecheck                     clean
npm run lint / format:check           clean
npx vitest run                        770 files, 18,071 passed, 11 skipped
npm run validate                      clean
23 CI validators run individually     all OK
patch coverage (branch-counted)       126/126 = 100%
```

`npm run build` ran and the regenerated `openapi.json` + `api-index.json` are committed.

Closes #10276
