### PR TITLE
fix(analytics): count the window's subnets, not the page's (#10249)

### DIFF
--- a/schemas-src/routes/chain-weight-setters.ts
+++ b/schemas-src/routes/chain-weight-setters.ts
@@ -26,8 +26,18 @@ export const ChainWeightSettersArtifactSchema = z
     schema_version: z.int(),
     window: z.enum(["7d", "30d"]).nullable(),
     observed_at: z.string().nullable(),
+    // The POPULATION: every distinct setter in the window, whatever the page
+    // carries.
     distinct_setters: z.int().min(0),
     weight_sets: z.int().min(0),
+    // The PAGE, not the population -- `setters.length`, which is what a
+    // caller gets back rather than what exists (#10249). Named here because
+    // the name alone reads as a population, and the two sit side by side:
+    // measured live, `?limit=20` published `setter_count: 20` beside
+    // `distinct_setters: 1247`, and `?limit=100` published 100 beside the
+    // same 1247. Unlike `subnet_count` on /chain/weights, this one has a
+    // true count beside it already, so making it a second copy of
+    // `distinct_setters` would cost the page size and add nothing.
     setter_count: z.int().min(0),
     setters: z.array(ChainWeightSetterSchema),
   })

--- a/schemas-src/routes/subnet-weights.ts
+++ b/schemas-src/routes/subnet-weights.ts
@@ -53,8 +53,16 @@ export const SubnetWeightSettersArtifactSchema = z
     netuid: z.int().min(0),
     window: z.enum(["7d", "30d"]).nullable(),
     observed_at: z.string().nullable(),
+    // The POPULATION: every distinct setter in the window, whatever the page
+    // carries.
     distinct_setters: z.int().min(0),
     weight_sets: z.int().min(0),
+    // The PAGE, not the population -- `setters.length`, which is what a
+    // caller gets back rather than what exists (#10249). Named here because
+    // the name alone reads as a population, and the two sit side by side.
+    // Unlike `subnet_count` on /chain/weights, this one has a true count
+    // beside it already, so making it a second copy of `distinct_setters`
+    // would cost the page size and add nothing.
     setter_count: z.int().min(0),
     // The cadence the verdicts were measured against, echoed so a null `overdue` is
     // explainable from the payload alone. Null when the subnet has no hyperparams row.

--- a/scripts/validate-tool-route-divergence.ts
+++ b/scripts/validate-tool-route-divergence.ts
@@ -17,11 +17,15 @@
 //   /api/v1/gaps AND /api/v1/review/gaps, and comparing it against the primary
 //   alone reports its correct match with the second as a divergence.
 //
-// What is left after both corrections is 81 differences, and every one of them
-// is an ENCODING (a boolean filter is `enum:["true","false"]` on a query string
-// and `boolean` in typed JSON) or a DECLARED NARROWING (a tool sized to a
-// context window, per #9701). This gate is what keeps that true: a NEW
+// What is left after both corrections is every difference being an ENCODING (a
+// boolean filter is `enum:["true","false"]` on a query string and `boolean` in
+// typed JSON) or a NARROWING (a tool sized to a context window, per #9701) or
+// one of the DECLARED entries below. This gate is what keeps that true: a NEW
 // difference in any other class fails.
+//
+// The count itself is deliberately not written down here -- it moves with every
+// tool and route added, and a number in a comment is a claim nothing checks.
+// Run the gate; it prints the current one.
 import { MCP_TOOL_ROUTES } from "../src/mcp-route-map.ts";
 import { listToolDefinitions } from "../src/mcp-server.ts";
 import { readJson, repoRoot } from "./lib.ts";

--- a/src/chain-event-rollup-cold-tier.ts
+++ b/src/chain-event-rollup-cold-tier.ts
@@ -133,22 +133,45 @@ export function safeColumnAlias(value: unknown): string | null {
     : null;
 }
 
+/**
+ * A count cell as a number, or null when the query could not answer.
+ *
+ * Null rather than 0: a failed count and a measured zero read identically once
+ * they are both `0`, and this one has a fallback the caller can take instead.
+ */
+function toRowCount(value: unknown): number | null {
+  const n = Math.trunc(Number(value));
+  return Number.isSafeInteger(n) && n >= 0 ? n : null;
+}
+
 export interface ChainEventRollup {
   /** One row per netuid, already grouped -- the shape the builders expect. */
   rows: Row[];
   /** The network block: distinct hotkeys across the whole window, and the
    * newest reading in it. */
   networkDistinct: Row;
+  /**
+   * How many subnets the WINDOW covers, not how many the page carries (#10249).
+   *
+   * `rows` is capped, so counting it answers a different question the moment
+   * the cap binds -- measured live before this existed:
+   * `/api/v1/chain/weights?limit=20` published `subnet_count: 20`, `?limit=100`
+   * published 99, and the truth was 129. A field named for a population,
+   * tracking a query parameter nobody set.
+   */
+  subnetCount: number | null;
 }
 
 /**
- * Both halves of one rollup, or null to leave the caller's empty payload
+ * Every part of one rollup, or null to leave the caller's empty payload
  * standing.
  *
- * Null on ANY miss rather than a partial answer: serving the per-subnet rows
- * without the network distinct would report a distinct-server count of zero
- * beside real per-subnet activity, which is a contradiction a caller cannot
- * detect.
+ * Null on a miss of EITHER PAYLOAD half rather than a partial answer: serving
+ * the per-subnet rows without the network distinct would report a
+ * distinct-server count of zero beside real per-subnet activity, which is a
+ * contradiction a caller cannot detect. `subnetCount` is not one of those
+ * halves -- it refines a number that already has an honest fallback -- so it
+ * degrades to null instead of blanking the card (#10249).
  */
 export async function loadChainEventRollup(
   env: Parameters<typeof r2SqlQuery>[0],
@@ -196,7 +219,7 @@ export async function loadChainEventRollup(
   const identity =
     distinctColumn === "uid" ? `netuid, ${distinctColumn}` : distinctColumn;
 
-  const [rows, networkRows] = await Promise.all([
+  const [rows, networkRows, subnetRows] = await Promise.all([
     // TWO LEVELS, NOT count(DISTINCT)+GROUP BY (#9227). The single-level form
     //
     //   SELECT netuid, count(*), count(DISTINCT hotkey) ... GROUP BY netuid
@@ -253,11 +276,43 @@ export async function loadChainEventRollup(
         ` FROM (SELECT ${identity}, max(observed_at) AS newest` +
         ` FROM chain.account_events ${where} GROUP BY ${identity})`,
     ),
+    // How many subnets the window covers (#10249). A THIRD query rather than a
+    // column on either of the two above, and both alternatives were measured
+    // before settling here:
+    //
+    //  * The first query cannot carry it: its outer level is `GROUP BY netuid
+    //    ... LIMIT cap`, so a window-wide aggregate cannot ride alongside a
+    //    capped page.
+    //  * Widening the network block's grouping to (identity, netuid) and taking
+    //    `count(DISTINCT identity)` / `count(DISTINCT netuid)` off the derived
+    //    table LOOKS free -- same source scan -- and it executes at 7d for the
+    //    uid identity. It is rejected everywhere else: `40015: scan budget
+    //    exceeded ... for count(DISTINCT) without GROUP BY` on AxonServed at
+    //    both 7d and 30d, and on WeightsSet at 30d. The engine prices the
+    //    DISTINCT against the SOURCE scan, not against the few thousand rows it
+    //    would actually run over, so nesting does not buy anything. That is the
+    //    same budget this module already routed around twice, which is why
+    //    there is no COUNT(DISTINCT) left in it -- and why this is not the
+    //    place to reintroduce the shape.
+    //
+    // So: the module's standard grouped form, in the SAME `Promise.all` as the
+    // other two. It costs one more source scan and no wall-clock latency.
+    // Measured against every window the routes offer, both event kinds:
+    // 1.2-3.6s, never the slowest of the three.
+    query(
+      env,
+      `SELECT count(*) AS subnet_count` +
+        ` FROM (SELECT netuid FROM chain.account_events ${where} GROUP BY netuid)`,
+    ),
   ]);
 
   if (!rows || !networkRows) return null;
   const networkDistinct = networkRows[0];
   if (!networkDistinct) return null;
+  // NOT a decline. The two above are the payload; this one only sharpens a
+  // count that has a usable fallback, so a miss here leaves the builder to fall
+  // back to the page length rather than blanking a card that is otherwise fine.
+  const subnetCount = toRowCount(subnetRows?.[0]?.subnet_count);
 
   // A window the frozen table no longer reaches. Declining keeps the caller's
   // empty payload rather than publishing zeros that read as measured silence:
@@ -265,7 +320,7 @@ export async function loadChainEventRollup(
   // will eventually cover none of them.
   if (rows.length === 0) return null;
 
-  return { rows, networkDistinct };
+  return { rows, networkDistinct, subnetCount };
 }
 
 /** The per-identity leaderboard, plus the ungrouped totals it is a share of. */

--- a/src/chain-serving-loader.ts
+++ b/src/chain-serving-loader.ts
@@ -81,5 +81,6 @@ export async function loadChainServingColdTier(
     window: label,
     limit: rowLimit,
     networkDistinct: rollup.networkDistinct,
+    subnetCount: rollup.subnetCount,
   });
 }

--- a/src/chain-serving.ts
+++ b/src/chain-serving.ts
@@ -140,16 +140,33 @@ export interface ChainServingResult {
 // distinct_servers) plus the newest observed_at. `limit` caps the leaderboard; subnet_count and
 // the distribution span every subnet with observed serving activity (subnets with no AxonServed
 // events in the window are absent). Null-safe: no rows yields the empty block.
+//
+// SUBNET_COUNT COMES FROM THE LOADER when the loader capped in SQL (#10249). This sentence used
+// to be false on exactly that path: the builder never sees the rows beyond the cap, so
+// `subnets.length` answered "how big was the page" under a field named for a population --
+// measured live, `?limit=20` published 20 where the window covered 38. The in-memory callers
+// still get the promise honestly from `subnets.length`, because they hand over every row.
 export function buildChainServing(
   subnetRows: Array<Record<string, unknown>> | null | undefined,
   {
     window,
     limit = CHAIN_SERVING_LIMIT_DEFAULT,
     networkDistinct,
+    subnetCount,
   }: {
     window?: string | null;
     limit?: number;
     networkDistinct?: { distinct_servers?: unknown; newest_observed?: unknown };
+    /**
+     * How many subnets the WINDOW covers, from the loader's own count.
+     *
+     * Optional because the in-memory callers hand this builder EVERY row and cap
+     * them here, where `subnets.length` is already the true answer. It is the
+     * SQL-capping path that needs telling: there the builder never sees the rows
+     * beyond the cap, so counting what arrived answers "how big was the page"
+     * under a field named for a population (#10249).
+     */
+    subnetCount?: number | null;
   } = {},
 ): ChainServingResult {
   const list = Array.isArray(subnetRows) ? subnetRows : [];
@@ -225,7 +242,7 @@ export function buildChainServing(
     schema_version: 1,
     window: window ?? null,
     observed_at: observedAt,
-    subnet_count: subnets.length,
+    subnet_count: subnetCount ?? subnets.length,
     network,
     // Distribution of per-subnet re-announcement intensity over EVERY subnet (not just the
     // returned page), so the spread is network-wide even when `limit` truncates the leaderboard.

--- a/src/chain-weight-setters.ts
+++ b/src/chain-weight-setters.ts
@@ -99,7 +99,10 @@ export interface ChainWeightSettersResult {
 // totals row. `rows` are already ordered by activity (newest-first tiebreak) from the loader;
 // `totals` carries weight_sets (COUNT(*)), distinct_setters (COUNT(DISTINCT identity)) and
 // newest_observed (MAX), all network-wide (no netuid filter). `limit` caps the returned page;
-// `distinct_setters` always reports the true network-wide total regardless of `limit`. Each
+// `distinct_setters` always reports the true network-wide total regardless of `limit`, and
+// `setter_count` is the PAGE -- `setters.length`, what the caller got back, which is a different
+// question from how many exist (#10249). Both are published because both are useful and neither
+// can be derived from the other once `limit` binds. Each
 // setter's share is its count over the network total, null when the total is zero (no rows).
 // Null-safe: null/absent inputs yield the schema-stable empty card.
 export function buildChainWeightSetters(

--- a/src/chain-weights-loader.ts
+++ b/src/chain-weights-loader.ts
@@ -51,9 +51,13 @@ export async function loadChainWeightsColdTier(
     query,
   });
   if (!rollup) return null;
+  // No cast. The sibling serving loader records why: `as unknown as
+  // Parameters<...>` is what let a window/limit mismatch typecheck there, and
+  // it would have hidden a mistyped `subnetCount` here just as well.
   return buildChainWeights(rollup.rows, {
     window,
     limit,
     networkDistinct: rollup.networkDistinct,
-  } as unknown as Parameters<typeof buildChainWeights>[1]);
+    subnetCount: rollup.subnetCount,
+  });
 }

--- a/src/chain-weights.ts
+++ b/src/chain-weights.ts
@@ -137,16 +137,33 @@ export interface ChainWeightsResult {
 // subnet_count and the distribution span every subnet with observed weight-setting activity
 // (subnets with no WeightsSet events in the window are absent). Null-safe: no rows yields the
 // empty block.
+//
+// SUBNET_COUNT COMES FROM THE LOADER when the loader capped in SQL (#10249). The sentence above
+// was false on that path in both directions: measured live, `?limit=20` published 20 and
+// `?limit=100` published 99, while the window covered 129. `subnets.length` is the page, and the
+// page is what the builder can see. The in-memory callers still get the promise honestly from it,
+// because they hand over every row.
 export function buildChainWeights(
   subnetRows: Array<Record<string, unknown>> | null | undefined,
   {
     window,
     limit = CHAIN_WEIGHTS_LIMIT_DEFAULT,
     networkDistinct,
+    subnetCount,
   }: {
     window?: string | null;
     limit?: number;
     networkDistinct?: { distinct_setters?: unknown; newest_observed?: unknown };
+    /**
+     * How many subnets the WINDOW covers, from the loader's own count.
+     *
+     * Optional because the in-memory callers hand this builder EVERY row and cap
+     * them here, where `subnets.length` is already the true answer. It is the
+     * SQL-capping path that needs telling: there the builder never sees the rows
+     * beyond the cap, so counting what arrived answers "how big was the page"
+     * under a field named for a population (#10249).
+     */
+    subnetCount?: number | null;
   } = {},
 ): ChainWeightsResult {
   const list = Array.isArray(subnetRows) ? subnetRows : [];
@@ -211,7 +228,7 @@ export function buildChainWeights(
     schema_version: 1,
     window: window ?? null,
     observed_at: observedAt,
-    subnet_count: subnets.length,
+    subnet_count: subnetCount ?? subnets.length,
     network,
     // Distribution of per-subnet update intensity over EVERY subnet (not just the returned page),
     // so the spread is network-wide even when `limit` truncates the leaderboard.

--- a/src/subnet-weight-setters.ts
+++ b/src/subnet-weight-setters.ts
@@ -174,6 +174,9 @@ function overdueView(
 // `rows` are already ordered by activity (newest-first tiebreak); `totals` carries weight_sets
 // (COUNT(*)), distinct_setters (COUNT(DISTINCT identity)) and newest_observed (MAX). Each
 // setter's share is its count over the subnet total, null when the total is zero (no rows).
+// `distinct_setters` is the POPULATION and `setter_count` is the PAGE -- `setters.length`, what
+// the caller got back (#10249). They agree on a subnet whose setters fit under the cap and part
+// company on one whose do not, which is exactly when the distinction matters.
 // Null-safe: null/absent inputs yield the schema-stable empty card.
 export function buildSubnetWeightSetters(
   rows: Row[] | null | undefined,

--- a/tests/chain-event-rollup-cold-tier.test.ts
+++ b/tests/chain-event-rollup-cold-tier.test.ts
@@ -35,6 +35,7 @@ function fakeEngine(
   answers: {
     rows?: Record<string, unknown>[] | null;
     network?: Record<string, unknown>[] | null;
+    subnets?: Record<string, unknown>[] | null;
   } = {},
 ) {
   const seen: string[] = [];
@@ -44,13 +45,19 @@ function fakeEngine(
     value === undefined ? fallback : value;
   const query = async (_env: unknown, sql: string) => {
     seen.push(sql);
-    return sql.includes("ORDER BY")
-      ? pick(answers.rows, [
-          { netuid: 1, announcements: 5, distinct_servers: 3 },
-        ])
-      : pick(answers.network, [
-          { distinct_servers: 3, newest_observed: NOW - 1000 },
-        ]);
+    // Three queries now (#10249). Routed by shape rather than by call order,
+    // because they run in one `Promise.all` and order is not a contract.
+    if (sql.includes("ORDER BY")) {
+      return pick(answers.rows, [
+        { netuid: 1, announcements: 5, distinct_servers: 3 },
+      ]);
+    }
+    if (sql.includes("AS subnet_count")) {
+      return pick(answers.subnets, [{ subnet_count: 12 }]);
+    }
+    return pick(answers.network, [
+      { distinct_servers: 3, newest_observed: NOW - 1000 },
+    ]);
   };
   return {
     query,
@@ -60,7 +67,11 @@ function fakeEngine(
      * on GROUP BY: the uid-keyed network total is itself a GROUP BY subquery,
      * so that would misroute it. */
     rowsSql: () => seen.find((sql) => sql.includes("ORDER BY")),
-    networkSql: () => seen.find((sql) => !sql.includes("ORDER BY")),
+    networkSql: () =>
+      seen.find(
+        (sql) => !sql.includes("ORDER BY") && !sql.includes("AS subnet_count"),
+      ),
+    subnetCountSql: () => seen.find((sql) => sql.includes("AS subnet_count")),
   };
 }
 
@@ -250,7 +261,7 @@ describe("the SQL it emits", () => {
     // network-wide AxonServed servers in 7d, well under the per-subnet sum.
     const { engine, result } = load();
     await result;
-    assert.equal(engine.seen.length, 2, "both halves must be queried");
+    assert.equal(engine.seen.length, 3, "every half must be queried");
     const rowsSql = engine.rowsSql()!;
     const networkSql = engine.networkSql()!;
     assert.match(rowsSql, /GROUP BY netuid/);
@@ -427,5 +438,53 @@ describe("what it hands back", () => {
     ]);
     assert.equal(rollup.networkDistinct.distinct_servers, 4);
     assert.equal(rollup.networkDistinct.newest_observed, NOW - 5);
+  });
+
+  test("the subnet count comes from its own query, not from the page", async () => {
+    // #10249. `rows` is capped, so counting it answers "how big was the page"
+    // the moment the cap binds -- measured live, /chain/weights published
+    // subnet_count 20 at ?limit=20 and 99 at ?limit=100 while the window
+    // covered 129. One row here against a count of 12 is the whole point: the
+    // two numbers must be allowed to disagree.
+    const { result } = load({
+      rows: [{ netuid: 7, announcements: 9, distinct_servers: 4 }],
+      subnets: [{ subnet_count: 12 }],
+    });
+    const rollup = await result;
+    assert.ok(rollup);
+    assert.equal(rollup.rows.length, 1);
+    assert.equal(rollup.subnetCount, 12);
+  });
+
+  test("the subnet count emits no COUNT(DISTINCT), at any window", async () => {
+    // The shape this module has routed around twice, and re-measured for
+    // #10249: `count(DISTINCT netuid)` over the network block's derived table
+    // LOOKS free -- same source scan -- and executes at 7d for the uid
+    // identity. R2 SQL refuses it everywhere else (`40015: scan budget
+    // exceeded ... for count(DISTINCT) without GROUP BY` on AxonServed at 7d
+    // and 30d, on WeightsSet at 30d), because the budget is priced against the
+    // SOURCE scan rather than the few thousand rows it would run over.
+    for (const windowDays of [1, 7, 30, 90]) {
+      const { engine, result } = load({}, { windowDays });
+      await result;
+      const sql = engine.subnetCountSql();
+      assert.ok(sql, `no subnet-count query at ${windowDays}d`);
+      assert.doesNotMatch(
+        sql,
+        /count\s*\(\s*distinct/i,
+        `${windowDays}d reintroduced the shape the budget refuses`,
+      );
+      assert.match(sql, /GROUP BY netuid/);
+    }
+  });
+
+  test("a missing subnet count degrades to null, it does not decline", async () => {
+    // The other two queries ARE the payload; this one refines a number that
+    // already has an honest fallback. Blanking the card over it would trade a
+    // slightly-wrong count for no card at all.
+    const { result } = load({ subnets: null });
+    const rollup = await result;
+    assert.ok(rollup, "the card still answers");
+    assert.equal(rollup.subnetCount, null);
   });
 });

--- a/tests/counts-before-the-cap.test.ts
+++ b/tests/counts-before-the-cap.test.ts
@@ -1,0 +1,108 @@
+// A published count must not move with `?limit=` (#10249).
+//
+// `subnet_count` reads as a population and was the page length on every route
+// whose loader caps in SQL, because the builder never sees the rows past the
+// cap. Measured live before the fix:
+//
+//   /api/v1/chain/serving ?limit=20    subnet_count 20     window covered 38
+//   /api/v1/chain/serving ?limit=100   subnet_count 38
+//   /api/v1/chain/weights ?limit=20    subnet_count 19     window covered 129
+//   /api/v1/chain/weights ?limit=100   subnet_count 99
+//
+// Wrong at BOTH limits on /chain/weights, which is what makes it a bug rather
+// than a truncation a caller could notice: nothing in the payload says the
+// number is a page, and it changes under a parameter nobody set.
+//
+// DERIVED OVER THE FAMILY, one entry per loader, so a sixth route added to the
+// rollup is covered the day it lands rather than the day someone remembers this
+// file. The check is the cheapest one that can tell the two apart: ask twice at
+// different limits and require the count to hold still.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { loadChainServingColdTier } from "../src/chain-serving-loader.ts";
+import { loadChainWeightsColdTier } from "../src/chain-weights-loader.ts";
+
+type Row = Record<string, unknown>;
+
+/** The window covers more subnets than any page below will ask for. */
+const SUBNETS_IN_WINDOW = 129;
+
+/**
+ * A lakehouse that answers the three rollup queries, capping the page in SQL
+ * exactly as the real engine does -- which is the condition the bug needs.
+ */
+function cappingEngine(distinctField: string, countField: string) {
+  const everySubnet = Array.from({ length: SUBNETS_IN_WINDOW }, (_, i) => ({
+    netuid: i,
+    [countField]: SUBNETS_IN_WINDOW - i,
+    [distinctField]: 3,
+  }));
+  return async (_env: unknown, sql: string): Promise<Row[]> => {
+    if (sql.includes("AS subnet_count")) {
+      return [{ subnet_count: SUBNETS_IN_WINDOW }];
+    }
+    if (sql.includes("ORDER BY")) {
+      const cap = Number(/LIMIT (\d+)/.exec(sql)?.[1] ?? SUBNETS_IN_WINDOW);
+      return everySubnet.slice(0, cap);
+    }
+    return [{ [distinctField]: 400, newest_observed: 1_785_000_000_000 }];
+  };
+}
+
+const FAMILY = [
+  {
+    route: "/api/v1/chain/serving",
+    load: (
+      limit: number,
+      query: Parameters<typeof loadChainServingColdTier>[1]["query"],
+    ) => loadChainServingColdTier({} as never, { window: "7d", limit, query }),
+    query: cappingEngine("distinct_servers", "announcements"),
+  },
+  {
+    route: "/api/v1/chain/weights",
+    load: (
+      limit: number,
+      query: Parameters<typeof loadChainWeightsColdTier>[1]["query"],
+    ) => loadChainWeightsColdTier({} as never, { window: "7d", limit, query }),
+    query: cappingEngine("distinct_setters", "weight_sets"),
+  },
+] as const;
+
+describe("a published count is the window's, not the page's (#10249)", () => {
+  for (const { route, load, query } of FAMILY) {
+    test(`${route} reports the same subnet_count at two limits`, async () => {
+      const small = await load(20, query);
+      const large = await load(100, query);
+      assert.ok(small && large, "the loader must answer");
+      assert.equal(
+        small.subnet_count,
+        SUBNETS_IN_WINDOW,
+        "the small page must still report the whole window",
+      );
+      assert.equal(small.subnet_count, large.subnet_count);
+      // And the page really is capped -- otherwise the assertion above passes
+      // for the uninteresting reason that nothing was truncated.
+      assert.equal(small.subnets.length, 20);
+      assert.equal(large.subnets.length, 100);
+    });
+  }
+
+  test("the count falls back to the page only when the loader cannot answer", async () => {
+    // The builders are also called in-memory with EVERY row, where the page IS
+    // the population. That path must keep working, and it is the reason
+    // `subnetCount` is optional rather than required.
+    const noSubnetCount = async (_env: unknown, sql: string): Promise<Row[]> =>
+      sql.includes("AS subnet_count")
+        ? []
+        : sql.includes("ORDER BY")
+          ? [{ netuid: 7, announcements: 9, distinct_servers: 4 }]
+          : [{ distinct_servers: 4, newest_observed: 1_785_000_000_000 }];
+    const data = await loadChainServingColdTier({} as never, {
+      window: "7d",
+      limit: 20,
+      query: noSubnetCount,
+    });
+    assert.ok(data);
+    assert.equal(data.subnet_count, 1, "the page length, honestly");
+  });
+});


### PR DESCRIPTION
## Summary

`subnet_count` reads as a population and was `subnets.length` — the page. On the routes whose
loader caps in SQL the builder never sees the rows past the cap, so a field named for how many
subnets exist tracked a query parameter nobody set.

Measured live before the fix, and against R2 SQL for the truth:

| | `?limit=20` | `?limit=100` | window covers |
|---|---|---|---|
| `/api/v1/chain/serving` | **20** | 38 | 38 |
| `/api/v1/chain/weights` | **19** | **99** | 129 |

`/chain/weights` is not in the issue and is the worse case: **wrong at both limits**, so no page
size a caller picks makes it right. Both builders' own comments promise "subnet_count and the
distribution span every subnet with observed activity" — this is the change that makes that
sentence true.

## The scan it costs, and the two cheaper shapes that do not work

A third query in the **same `Promise.all`**, so no wall-clock latency; one more source scan. Both
alternatives were measured before settling:

**The first query cannot carry it.** Its outer level is `GROUP BY netuid … LIMIT cap`, so a
window-wide aggregate cannot ride alongside a capped page.

**Widening the network block looks free and is refused.** Grouping it by `(identity, netuid)` and
taking `count(DISTINCT identity)` / `count(DISTINCT netuid)` off the derived table scans the same
source, and it *executes at 7d for the uid identity* — which is exactly the sample that would have
made me generalise wrongly. Everywhere else:

```
AxonServed  7d   40015: scan budget exceeded ... for count(DISTINCT) without GROUP BY
AxonServed 30d   40015
WeightsSet  7d   ok    {distinct_x: 1247, subnet_count: 128}
WeightsSet 30d   40015
```

The budget is priced against the **source** scan, not the few thousand rows the DISTINCT would run
over, so nesting buys nothing. That is the same budget this module already routed around twice
(#9227), which is why there is no `COUNT(DISTINCT)` left in it — and why this was not the place to
put one back.

So: the module's standard grouped form, `SELECT count(*) FROM (SELECT netuid … GROUP BY netuid)`.
Measured across every window both routes offer:

```
AxonServed   7d 1163ms   30d 2415ms   90d 3633ms
WeightsSet   7d 3563ms   30d 2901ms   90d 3335ms
```

Never the slowest of the three, so the added latency is zero. A miss degrades to `null` and the
builder falls back to the page length rather than blanking a card that is otherwise fine — the
other two queries are the payload, this one only sharpens a number that already has an honest
fallback.

## `setter_count` is the page, and now says so

`/chain/weights/setters` and `/subnets/{netuid}/weights/setters` publish `distinct_setters` — the
population, already correct — beside `setter_count` (`setters.length`). Measured: `?limit=20` gives
`setter_count: 20` and `?limit=100` gives 100, both beside `distinct_setters: 1247`.

Making the second a copy of the first would cost the page size and add nothing, so the fix there is
the **contract**: both fields are named for what they are, in the schema a caller reads and in the
builders' own comments. That is the "make the doc true" option the issue offers as the interim, and
here it is the better answer rather than the cheaper one — the population is already published.

## The gates

`tests/counts-before-the-cap.test.ts` asks each loader twice at different limits and requires the
count to hold still, **derived over the family** so a sixth route on this rollup is covered the day
it lands. It also pins the fallback path, since the in-memory callers hand the builder every row
and `subnets.length` is the honest answer there.

Three more in the rollup's own tests: the count comes from its own query (1 row against a count of
12 — the two must be *allowed* to disagree), it emits no `COUNT(DISTINCT)` at any window, and a
missing count degrades rather than declines.

Proven to fail: restoring `subnets.length` fails the family test; making `subnetCount` read
`rows.length` fails two of the rollup tests.

## Also in this diff

- The `as unknown as Parameters<…>` cast in `chain-weights-loader.ts` is gone. Its sibling's comment
  records that exact cast letting a window/limit mismatch typecheck; it would have hidden a mistyped
  `subnetCount` just as well.
- A number I left in `validate-tool-route-divergence.ts`'s header last week said "81 differences",
  from an intermediate measurement, while the gate itself reports 666 reconciled. Removed rather
  than updated — it moves with every tool and route added, and a number in a comment is a claim
  nothing checks.

## Validation

```
npm run typecheck / lint / format:check   clean
npx vitest run                            771 files, 18,077 passed, 11 skipped
npm run validate                          clean
14 CI validators run individually         all OK
patch coverage (branch-counted)           9/9 = 100%
```

`npm run build` ran; regenerated artifacts committed.

Closes #10249
