### PR TITLE
fix(api): a declined lakehouse read must say so (#10270)

### DIFF
--- a/tests/degraded-answer-is-labelled.test.ts
+++ b/tests/degraded-answer-is-labelled.test.ts
@@ -1,0 +1,264 @@
+// A tier that declined must not answer `ok: true` with zeros and no header
+// (#10270).
+//
+// `/api/v1/accounts/{ss58}/counterparties` answered `counterparty_count: 0,
+// transfers_scanned: 0` for an account with 114, on roughly one request in
+// five. `transfers_scanned: 0` is the tell: the route reported that it scanned
+// nothing and concluded there was nothing. Its Postgres rung is `"retired"` in
+// wrangler.jsonc, so the lakehouse read IS its tier -- and `src/r2-sql.ts`'s
+// failure counter, declared with "same contract as the Postgres tier's
+// fallback generation: a caller can snapshot this before a read and compare
+// after", had no reader outside its own test file.
+//
+// TWO TESTS, because the route was never the interesting part. The first pins
+// the reported case end to end, in both directions. The second asks the same
+// question of the whole route table and answers it by DRIVING the router, so
+// it covers a route added tomorrow without anyone editing this file: for every
+// registered path, if the lakehouse declined while the request was served and
+// the answer was still a 200, that 200 must say so.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleRequest } from "../workers/api.ts";
+import {
+  degradedSnapshot,
+  labelDegradedResponse,
+} from "../workers/request-handlers/analytics.ts";
+import { currentR2SqlFailureGeneration } from "../src/r2-sql.ts";
+import { API_ROUTES, FEED_ROUTES } from "../src/contracts.ts";
+import { concretePath } from "./concrete-path.ts";
+
+/** The account from the issue -- 114 counterparties, 196 transfers scanned. */
+const SS58 = "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3";
+const COUNTERPARTY = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+/**
+ * Enough env for `isR2SqlConfigured` to say yes, and nothing else.
+ *
+ * That gate is the reason this has to be set: an UNCONFIGURED lakehouse
+ * returns null without touching the counter, on the stated grounds that a
+ * self-hoster with no lakehouse is not a fault. A test that left the token out
+ * would therefore drive the same empty payload while proving nothing about the
+ * case that matters -- the configured lakehouse that declined.
+ */
+const LAKEHOUSE_ENV = { R2_SQL_TOKEN: "test-token" } as unknown as Env;
+
+const DEGRADED_HEADER = "x-metagraph-degraded";
+
+async function withFetch<T>(
+  stub: typeof fetch,
+  run: () => Promise<T>,
+): Promise<T> {
+  const real = globalThis.fetch;
+  globalThis.fetch = stub;
+  try {
+    return await run();
+  } finally {
+    globalThis.fetch = real;
+  }
+}
+
+/** The lakehouse unreachable: a transport throw, the shape a dropped socket
+ * or an aborted query takes by the time `r2SqlQuery` sees it. */
+const refusingLakehouse = (() => {
+  throw new Error("r2 sql unreachable");
+}) as unknown as typeof fetch;
+
+/** The lakehouse answering, in R2 SQL's own envelope. */
+function answeringLakehouse(rows: Record<string, unknown>[]): typeof fetch {
+  return (async () =>
+    new Response(JSON.stringify({ success: true, result: { rows } }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+}
+
+function apiRequest(path: string): Request {
+  return new Request(`https://api.metagraph.sh${path}`);
+}
+
+describe("the counterparties zero says it is a zero (#10270)", () => {
+  test("a declining lakehouse produces a LABELLED empty card", async () => {
+    const res = (await withFetch(refusingLakehouse, () =>
+      handleRequest(
+        apiRequest(`/api/v1/accounts/${SS58}/counterparties`),
+        LAKEHOUSE_ENV,
+        {},
+      ),
+    )) as Response;
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: { counterparty_count: number; transfers_scanned: number };
+    };
+    // Still a 200 and still schema-stable: #9146 settled that a public READ
+    // degrades to a parseable empty rather than erroring. What changes is that
+    // the caller can now tell which it got.
+    assert.equal(res.status, 200);
+    assert.equal(body.ok, true);
+    assert.equal(body.data.counterparty_count, 0);
+    assert.equal(body.data.transfers_scanned, 0);
+    assert.equal(res.headers.get(DEGRADED_HEADER), "tier_unavailable");
+  });
+
+  test("a measured answer carries NO label", async () => {
+    // Without this the test above passes for the uninteresting reason that
+    // every response is labelled, which would be a worse bug than the one
+    // being fixed -- a marker on everything marks nothing.
+    const res = (await withFetch(
+      answeringLakehouse([
+        {
+          hotkey: SS58,
+          coldkey: COUNTERPARTY,
+          amount_tao: 1.5,
+          block_number: 5_870_000,
+          event_index: 0,
+          observed_at: 1_785_000_000_000,
+        },
+      ]),
+      () =>
+        handleRequest(
+          apiRequest(`/api/v1/accounts/${SS58}/counterparties`),
+          LAKEHOUSE_ENV,
+          {},
+        ),
+    )) as Response;
+    const body = (await res.json()) as {
+      data: { counterparty_count: number; transfers_scanned: number };
+    };
+    assert.equal(res.status, 200);
+    assert.equal(body.data.counterparty_count, 1);
+    assert.equal(body.data.transfers_scanned, 1);
+    assert.equal(res.headers.get(DEGRADED_HEADER), null);
+  });
+});
+
+describe("no registered route serves an unlabelled decline (#10270)", () => {
+  /**
+   * Both route tables, because they are two registries and a sweep of one
+   * misses the other: `FEED_ROUTES` is separate from `API_ROUTES` by design
+   * (#8703), and a family-wide invariant that only asked the bigger table
+   * would be silently partial.
+   */
+  const EVERY_ROUTE = [...API_ROUTES, ...FEED_ROUTES];
+
+  /**
+   * The two anchors this sweep must reach, one per response path.
+   *
+   * `counterparties` goes through `envelopeResponse` with no edge cache -- the
+   * 71-handler family #9110's fix never covered. `chain/weights` goes through
+   * `withEdgeCache`, which had the labelling but not the r2-sql signal. If a
+   * refactor stopped either from reaching the lakehouse, the sweep would go
+   * quietly green on a smaller surface, so name them rather than trust a count.
+   */
+  const ANCHORS = [
+    "/api/v1/accounts/{ss58}/counterparties",
+    "/api/v1/chain/weights",
+  ];
+
+  test("every route that saw the lakehouse decline says so", async () => {
+    const exercised: string[] = [];
+    const unlabelled: string[] = [];
+    const threw: string[] = [];
+
+    await withFetch(refusingLakehouse, async () => {
+      for (const route of EVERY_ROUTE) {
+        const before = currentR2SqlFailureGeneration();
+        let res: Response;
+        try {
+          res = (await handleRequest(
+            apiRequest(concretePath(route.path)),
+            LAKEHOUSE_ENV,
+            {},
+          )) as Response;
+        } catch (error) {
+          threw.push(`${route.path}: ${(error as Error).message}`);
+          continue;
+        }
+        // The counter is the whole discriminator: a route that never asked the
+        // lakehouse has nothing to declare, and needs no exemption entry here.
+        if (currentR2SqlFailureGeneration() === before) continue;
+        exercised.push(route.path);
+        if (res.status === 200 && !res.headers.get(DEGRADED_HEADER)) {
+          unlabelled.push(route.path);
+        }
+      }
+    });
+
+    assert.deepEqual(
+      threw,
+      [],
+      "handleRequest has no top-level try/catch, so a throw here is a 500 in production",
+    );
+    assert.deepEqual(
+      unlabelled,
+      [],
+      "these answered 200 after the lakehouse declined, with nothing to say so",
+    );
+    for (const anchor of ANCHORS) {
+      assert.ok(
+        exercised.includes(anchor),
+        `${anchor} no longer reaches the lakehouse -- this sweep is measuring less than it thinks`,
+      );
+    }
+  });
+});
+
+describe("what the router label refuses to touch", () => {
+  // The four early returns, each stated once. Driving them through a route
+  // would need a route that happens to be in each state, which is how a
+  // condition ends up asserted by coincidence rather than on purpose.
+  const stale = () => ({ ...degradedSnapshot(), r2Sql: -1 });
+
+  test("a non-200 is left alone", () => {
+    const res = new Response("{}", { status: 503 });
+    labelDegradedResponse(res, stale());
+    assert.equal(res.headers.get(DEGRADED_HEADER), null);
+  });
+
+  test("a handler's own wording survives", () => {
+    // #9273: get_account_positions and its siblings can say WHY a zero is
+    // untrustworthy. A generic `tier_unavailable` written over that would make
+    // the specific reason unrecoverable.
+    const res = new Response("{}", {
+      status: 200,
+      headers: { [DEGRADED_HEADER]: "position_ledger_incomplete" },
+    });
+    labelDegradedResponse(res, stale());
+    assert.equal(
+      res.headers.get(DEGRADED_HEADER),
+      "position_ledger_incomplete",
+    );
+  });
+
+  test("a measured answer is left alone", () => {
+    const res = new Response("{}", { status: 200 });
+    labelDegradedResponse(res, degradedSnapshot());
+    assert.equal(res.headers.get(DEGRADED_HEADER), null);
+  });
+
+  test("a stable decline is labelled too, not only a tier failure", () => {
+    const res = new Response("{}", { status: 200 });
+    labelDegradedResponse(res, { ...degradedSnapshot(), unmeasured: -1 });
+    assert.equal(res.headers.get(DEGRADED_HEADER), "tier_unavailable");
+  });
+
+  test("immutable headers are swallowed, not thrown", () => {
+    // A body read back out of the edge cache. `withEdgeCache` only ever stored
+    // a measured answer there, so the throw means a CONCURRENT request
+    // degraded -- relabelling a known-good cached body on that evidence would
+    // be the false positive, and a throw here would be a 500 on a request that
+    // had a perfectly good answer in hand.
+    let attempted = false;
+    const frozen = {
+      status: 200,
+      headers: {
+        has: () => false,
+        set: () => {
+          attempted = true;
+          throw new TypeError("Can't modify immutable headers.");
+        },
+      },
+    } as unknown as Response;
+    labelDegradedResponse(frozen, stale());
+    assert.equal(attempted, true, "the label must have been attempted");
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -394,7 +394,11 @@ import {
   degradedChainEventsPayload,
   hotTierBlockChainEvents,
 } from "../src/chain-events-degraded.ts";
-import { markPostgresTierFallbackResponse } from "./request-handlers/analytics.ts";
+import {
+  degradedSnapshot,
+  labelDegradedResponse,
+  markPostgresTierFallbackResponse,
+} from "./request-handlers/analytics.ts";
 import { loadGlobalOperationalHealth } from "../src/global-operational-health.ts";
 import {
   CHAIN_FIREHOSE_INGEST_TOKEN_HEADER,
@@ -4259,7 +4263,42 @@ async function handleChainFirehoseIngest(request: Request, env: Env) {
   });
 }
 
+/**
+ * THE ROUTER, plus the one thing every route must not be able to forget
+ * (#10270).
+ *
+ * A data tier that declines mid-request leaves the handler holding a
+ * schema-stable empty payload, and 71 of the tier-reading handlers in
+ * `request-handlers/entities.ts` returned it with `ok: true` and no header --
+ * `/accounts/{ss58}/counterparties` answering `counterparty_count: 0,
+ * transfers_scanned: 0` for an account with 114, on roughly one request in
+ * five, while the lakehouse was rate-limited. `transfers_scanned: 0` is the
+ * tell: the route reported that it scanned nothing and concluded there was
+ * nothing.
+ *
+ * #9110 solved this for the analytics family by labelling inside
+ * `withEdgeCache` rather than in each handler, on the argument that a
+ * per-handler flag is exactly what the next handler forgets. Not one of the 71
+ * uses `withEdgeCache`, so none of them was ever covered. This is the same
+ * argument at the only point that covers all of them: a handler cannot opt out
+ * of being routed.
+ *
+ * The dispatch itself is `dispatchRequest` below, unchanged -- it has ~40
+ * early returns, and wrapping it from outside is what makes the label
+ * unforgettable rather than 40 more places to remember.
+ */
 export async function handleRequest(
+  request: Request,
+  env: Env = {} as unknown as Env,
+  ctx: Ctx = {},
+) {
+  const before = degradedSnapshot();
+  const response = await dispatchRequest(request, env, ctx);
+  labelDegradedResponse(response, before);
+  return response;
+}
+
+async function dispatchRequest(
   request: Request,
   env: Env = {} as unknown as Env,
   ctx: Ctx = {},

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -58,6 +58,7 @@ import {
   currentPostgresTierFallbackGeneration,
   tryPostgresTier,
 } from "../postgres-tier.ts";
+import { currentR2SqlFailureGeneration } from "../../src/r2-sql.ts";
 import { loadBulkHealthTrends } from "../../src/bulk-health-trends.ts";
 import {} from "../../src/route-limits.ts";
 import { formatGlobalIncidents } from "../../src/health-serving.ts";
@@ -338,6 +339,111 @@ function markPostgresTierFallbackResponse(response: Response): Response {
   return marked;
 }
 
+/**
+ * Every "this answer was not measured" counter, read as one value (#10270).
+ *
+ * There are three of them and they lived in three modules, so each place that
+ * wanted to know whether an answer was real had to remember the full list.
+ * `withEdgeCache` remembered two; the r2-sql one it never knew about at all,
+ * even though `src/r2-sql.ts` declares its counter with "same contract as the
+ * Postgres tier's fallback generation: a caller can snapshot this before a
+ * read and compare after". Nothing outside its own test file ever did --
+ * measured repo-wide, `currentR2SqlFailureGeneration` had zero production
+ * readers -- which is why `/accounts/{ss58}/counterparties` could answer
+ * `counterparty_count: 0, transfers_scanned: 0` with `ok: true` and no header
+ * while the lakehouse was rate-limited. That route's Postgres rung is
+ * `"retired"` in wrangler.jsonc, so the r2-sql read IS the tier; a signal
+ * nobody reads is the same as no signal.
+ */
+export interface DegradedSnapshot {
+  postgresTier: number;
+  r2Sql: number;
+  unmeasured: number;
+}
+
+export function degradedSnapshot(): DegradedSnapshot {
+  return {
+    postgresTier: currentPostgresTierFallbackGeneration(),
+    r2Sql: currentR2SqlFailureGeneration(),
+    unmeasured: unmeasuredGeneration,
+  };
+}
+
+/**
+ * What moved since `before`, split by how long it will stay true.
+ *
+ * TRANSIENT is a tier that failed or backed off -- a DATA_API subrequest that
+ * did not land, an r2-sql timeout, the account rate-limit breaker declining to
+ * ask. It will likely succeed on the next request, so the answer is labelled
+ * AND barred from the edge cache; persisting it would prolong the outage
+ * (#1760).
+ *
+ * UNMEASURED is a stable decline: a projection this route never precomputes,
+ * an artifact that is absent. Still labelled -- a caller must not read those
+ * zeros as measured -- but cacheable for the whole TTL, because it will answer
+ * the same way for the whole TTL (#10189).
+ */
+export function degradedSince(before: DegradedSnapshot): {
+  transient: boolean;
+  unmeasured: boolean;
+} {
+  const now = degradedSnapshot();
+  return {
+    transient:
+      now.postgresTier !== before.postgresTier || now.r2Sql !== before.r2Sql,
+    unmeasured: now.unmeasured !== before.unmeasured,
+  };
+}
+
+/**
+ * Label a response whose data tier declined while it was being served.
+ *
+ * Called from the router (`workers/api.ts`), which is the ONE point every
+ * route passes -- the same argument #9110 made for labelling inside
+ * `withEdgeCache` rather than in each handler, applied to the 71 tier-reading
+ * handlers in `workers/request-handlers/entities.ts` that #9110 never covered
+ * because not one of them uses `withEdgeCache`.
+ *
+ * HEADER ONLY, no cache-control rewrite. These routes have no server-side
+ * cache to poison -- measured live 2026-08-09, an api.metagraph.sh response
+ * carries no `cf-cache-status` at all, so the Workers Cache API inside
+ * `withEdgeCache` is the only cache in play and it makes its own decision from
+ * the same snapshot. Rewriting `cache-control` here would instead make every
+ * response in an isolate uncacheable for the length of an r2-sql cooldown,
+ * which is load amplification aimed at the exact condition the breaker exists
+ * to relieve.
+ *
+ * A 304 is skipped: the caller already holds the body its ETag names, and
+ * there is nothing in a 304 to mislabel. A response that already carries the
+ * header is left alone rather than re-set, so a handler that classified its
+ * own degradation keeps its own wording.
+ *
+ * IN PLACE, returning nothing, which is a deliberate difference from
+ * `withDegradedHeader`'s copy-on-immutable fallback. The one response class
+ * with immutable headers is a body read back out of the edge cache, and
+ * `withEdgeCache` only ever stored a MEASURED answer there -- so a throw here
+ * means a concurrent request degraded while this one was served from cache,
+ * and relabelling a known-good cached body on that evidence would be the false
+ * positive rather than the catch. Swallowing it is the correct answer, not the
+ * convenient one. Mutating also keeps the router's return type exactly what
+ * the dispatch inferred, so the label costs no signature change at ~40 return
+ * sites.
+ */
+export function labelDegradedResponse(
+  response: Response,
+  before: DegradedSnapshot,
+): void {
+  if (response.status !== 200) return;
+  if (response.headers.has(DEGRADED_HEADER)) return;
+  const moved = degradedSince(before);
+  if (!moved.transient && !moved.unmeasured) return;
+  try {
+    response.headers.set(DEGRADED_HEADER, DEGRADED_TIER_UNAVAILABLE);
+  } catch {
+    // An immutable-headers response: see above.
+  }
+}
+
 async function analyticsMeta(
   env: Env,
   artifactPath: string,
@@ -468,8 +574,7 @@ export async function withEdgeCache(
         : hit;
     }
   }
-  const pgFallbackGeneration = currentPostgresTierFallbackGeneration();
-  const unmeasuredBefore = unmeasuredGeneration;
+  const before = degradedSnapshot();
   const built = await buildResponse(cacheRequest);
   // #9110: the generation counter already told us the tier degraded while this
   // request was being served -- it is what suppresses caching two lines down.
@@ -486,19 +591,24 @@ export async function withEdgeCache(
   // this one too. That is the same trade the cache-suppression below already
   // makes, and it errs the safe way: a false "degraded" makes good data look
   // suspect, where the bug it replaces made missing data look measured.
+  //
+  // #10270: the r2-sql counter joined the two this used to read by name. It
+  // was declared for exactly this comparison and had no reader -- see
+  // `degradedSnapshot`. The suppression below is what it was declared FOR: an
+  // r2-sql decline is a 60s account-wide breaker, and caching its empty answer
+  // for the full TTL outlives the condition that produced it.
+  const moved = degradedSince(before);
   const degraded =
-    POSTGRES_TIER_FALLBACK_RESPONSES.has(built) ||
-    currentPostgresTierFallbackGeneration() !== pgFallbackGeneration;
+    POSTGRES_TIER_FALLBACK_RESPONSES.has(built) || moved.transient;
   // #10189: an unmeasured answer is labelled but NOT made uncacheable. See
   // `unmeasured` above for why the two signals have to be separate -- a
   // projection decline is stable for the whole TTL, where a tier failure is
   // transient and caching it would prolong the outage.
-  const unmeasuredAnswer = unmeasuredGeneration !== unmeasuredBefore;
   const labelled = built.status === 200 && !built.headers.has(DEGRADED_HEADER);
   let response = built;
   if (labelled && degraded) {
     response = markPostgresTierFallbackResponse(built);
-  } else if (labelled && unmeasuredAnswer) {
+  } else if (labelled && moved.unmeasured) {
     response = withDegradedHeader(built);
   }
   // Never cache errors / non-200s (a cold Postgres tier still returns a 200
@@ -508,7 +618,7 @@ export async function withEdgeCache(
     cacheKey &&
     response.status === 200 &&
     !POSTGRES_TIER_FALLBACK_RESPONSES.has(response) &&
-    currentPostgresTierFallbackGeneration() === pgFallbackGeneration
+    !moved.transient
   ) {
     ctx?.waitUntil?.(cache.put(cacheKey, response.clone()));
   }


### PR DESCRIPTION
## Which rung served the zero

`METAGRAPH_ACCOUNT_EVENTS_SOURCE` is `"retired"` in `wrangler.jsonc`, so `tryPostgresTier` returns
`null` without forwarding and without touching its counter. The **lakehouse read is this route's
tier** — and `src/r2-sql.ts` has carried a failure counter for it since #9465, declared in its own
words:

> Same contract as the Postgres tier's fallback generation: a caller can snapshot this before a read
> and compare after, so a degraded (empty) answer is never written into the edge cache as though it
> were real.

Measured repo-wide, **`currentR2SqlFailureGeneration` had zero production readers** — only its own
test file. The signal was written and never asked. 80014 is an *account-wide* limit with a 60s
breaker, which is the shape "one request in five" has.

So this is the issue's question 1 (does the reader distinguish declined from empty?) answered *no*,
and question 2 (`scan_capped`) ruled out — the zero path never reaches the builder's cap logic at
all. Question 3, the colo: 25 live requests today, each with a distinct `?limit=` so each is its own
cache key, all returned 114/196 — and the responses carry **no `cf-cache-status` at all**, so the
zero was never a cached one.

## Labelled at the router, not at 71 handlers

#9110 made exactly this argument for the analytics family and put the label in `withEdgeCache`
rather than in each handler, "because a per-handler flag is exactly the thing the 22nd handler will
forget". **Not one of the 71 tier-reading handlers in `request-handlers/entities.ts` uses
`withEdgeCache`**, so none of them was ever covered. This is the same argument at the only point that
covers all of them.

Measured by driving every registered route with the lakehouse refusing:

| | routes |
|---|---|
| registered (`API_ROUTES` 205 + `FEED_ROUTES` 6) | 211 |
| that reach the lakehouse | 47 |
| **that answered 200 with no marker** | **38** |

Two deliberate limits on the mechanism:

- **Header only, no `cache-control` rewrite.** Measured live: an `api.metagraph.sh` response carries
  no `cf-cache-status`, so the Workers Cache API inside `withEdgeCache` is the only cache in play and
  it makes its own decision from the same snapshot. Rewriting `cache-control` here would instead make
  every response in an isolate uncacheable for the length of an r2-sql cooldown — load amplification
  aimed at the exact condition the breaker exists to relieve.
- **In place, returning nothing.** The one response class with immutable headers is a body read back
  out of the edge cache, and `withEdgeCache` only ever stored a *measured* answer there — so a throw
  means a concurrent request degraded, and relabelling a known-good cached body on that evidence is
  the false positive rather than the catch. Mutating also leaves the router's return type exactly as
  inferred, so the label costs no signature change at ~40 return sites.

## One definition of "not measured"

Three counters lived in three modules and every reader had to remember the full list; `withEdgeCache`
remembered two. `degradedSnapshot` / `degradedSince` state it once, split by how long it stays true:

| | labelled | edge-cacheable |
|---|---|---|
| **transient** — a tier failed or backed off | yes | **no** |
| **unmeasured** — a projection this route never precomputes | yes | yes |

That is #10189's split unchanged, now with r2-sql on the transient side — where its own comment
always put it, and which is the suppression the counter was declared for.

## Gates

`tests/degraded-answer-is-labelled.test.ts` drives `handleRequest` for every entry in **both** route
tables with the lakehouse refusing, and requires that any route which saw a decline and still
answered 200 says so. **Derived, with no exemption list**: a route that never asked the lakehouse
never moves the counter and is skipped, so a route added tomorrow is covered without editing the
file. Both tables, because `FEED_ROUTES` is a separate registry (#8703) and a sweep of one is
silently partial. Two anchors are named — `counterparties` for the `envelopeResponse` path,
`chain/weights` for the `withEdgeCache` one — so a refactor cannot shrink the sweep quietly.

Proven to fail:

```
router label disabled          27 routes unlabelled
r2-sql dropped from snapshot   38 routes unlabelled
label made unconditional       "a measured answer carries NO label" fails
```

That last one matters as much as the first two: a marker on everything marks nothing.

## Validation

```
npm run typecheck / lint / format:check   clean
npx vitest run                            772 files, 18,080 passed, 11 skipped
npm run validate                          clean
contract-drift / api / openapi / schemas  all pass
patch coverage (branch-counted)           17/17 = 100%
```

## Noted, not fixed here

`handleRequest` infers `Promise<any>`. Giving it an honest `Response` return type surfaces **1,246**
latent type errors across `tests/` and `scripts/` — every `await res.json()` in the suite is
currently typed `any`. That is the same class as #10261 (the DB boundary) and wants its own change;
this PR keeps the signature untouched precisely so the label is not entangled with it.

Closes #10270
