### PR TITLE
feat(api): say whether a subnet is still registered on its hyperparameter card (#10259)

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -5509,6 +5509,8 @@ export type SubnetHyperparameters = {
   hyperparameters?: Maybe<Hyperparameters>;
   netuid: Scalars['Int']['output'];
   schema_version: Scalars['Int']['output'];
+  /** Whether this subnet is still registered: live | deregistered. The card is retained rather than pruned when a subnet leaves -- netuids are reused, so deleting it would let a re-registered subnet inherit a dead one's row. null means no lifecycle event has been recorded, which is not a claim either way. */
+  subnet_status?: Maybe<Scalars['String']['output']>;
 };
 
 export type SubnetHyperparamsHistory = {
@@ -10426,6 +10428,7 @@ export type SubnetHyperparametersResolvers<ContextType = GqlContext, ParentType 
   hyperparameters?: Resolver<Maybe<ResolversTypes['Hyperparameters']>, ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  subnet_status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type SubnetHyperparamsHistoryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetHyperparamsHistory'] = ResolversParentTypes['SubnetHyperparamsHistory']> = ResolversObject<{

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -10690,6 +10690,7 @@ export interface components {
             } | null;
             netuid: number;
             schema_version: number;
+            subnet_status?: ("live" | "deregistered") | null;
         } & {
             [key: string]: unknown;
         };
@@ -40998,7 +40999,8 @@ export interface operations {
                      *           "yuma_version": 1
                      *         },
                      *         "netuid": 7,
-                     *         "schema_version": 1
+                     *         "schema_version": 1,
+                     *         "subnet_status": "live"
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -9590,7 +9590,8 @@
               "yuma_version": 1
             },
             "netuid": 7,
-            "schema_version": 1
+            "schema_version": 1,
+            "subnet_status": "live"
           },
           "meta": {
             "artifact_path": "example",
@@ -46197,6 +46198,20 @@
             "maximum": 9007199254740991,
             "minimum": -9007199254740991,
             "type": "integer"
+          },
+          "subnet_status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "live",
+                  "deregistered"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -10690,6 +10690,7 @@ export interface components {
             } | null;
             netuid: number;
             schema_version: number;
+            subnet_status?: ("live" | "deregistered") | null;
         } & {
             [key: string]: unknown;
         };
@@ -40998,7 +40999,8 @@ export interface operations {
                      *           "yuma_version": 1
                      *         },
                      *         "netuid": 7,
-                     *         "schema_version": 1
+                     *         "schema_version": 1,
+                     *         "subnet_status": "live"
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/schemas-src/routes/subnet-hyperparameters.ts
+++ b/schemas-src/routes/subnet-hyperparameters.ts
@@ -65,6 +65,19 @@ export const SubnetHyperparametersArtifactSchema = z
     captured_at: z.string().nullable().optional(),
     block_number: z.int().nullable().optional(),
     hyperparameters: SubnetHyperparametersSchema.nullable(),
+    /**
+     * Whether this subnet is still registered (#10259).
+     *
+     * The card is NOT pruned when a subnet is deregistered: netuids are reused,
+     * so deleting the row would let a re-registered subnet silently inherit a
+     * dead one's card, and the last known configuration is a fact worth
+     * keeping. This says which it is, so one call answers "is it live" instead
+     * of requiring a second to /lifecycle.
+     *
+     * `null` means no lifecycle event has been recorded for this netuid --
+     * distinct from `deregistered`, and not a claim either way.
+     */
+    subnet_status: z.enum(["live", "deregistered"]).nullable().optional(),
   })
   .passthrough();
 export type SubnetHyperparametersArtifact = z.infer<

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -2822,6 +2822,8 @@ export const SDL = /* GraphQL */ `
     captured_at: String
     block_number: Int
     hyperparameters: Hyperparameters
+    "Whether this subnet is still registered: live | deregistered. The card is retained rather than pruned when a subnet leaves -- netuids are reused, so deleting it would let a re-registered subnet inherit a dead one's row. null means no lifecycle event has been recorded, which is not a claim either way."
+    subnet_status: String
   }
 
   "One subnet's on-chain hyperparameter block. Every field is nullable: a value absent from the captured row stays null rather than being coerced. *_ratio fields are 0..1 U16-derived ratios; *_tao fields are rao-exact (9dp); bonds_moving_avg_raw is the unscaled on-chain integer."

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -4599,7 +4599,14 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
       await handleSubnetHyperparams(req(path), env as unknown as Env, NETUID),
     );
     assert.equal(body.data.hyperparameters.tempo, 999);
-    assert.deepEqual(captures.sql, []);
+    // The hyperparameter DATA still comes entirely from the Postgres tier --
+    // the one statement here is #10259's subnet_status lookup, which reads
+    // subnet_lifecycle because the card is retained for deregistered subnets
+    // rather than pruned. Asserted by SHAPE rather than as an empty list, so
+    // this keeps saying "no tier query" instead of "no query at all".
+    assert.equal(captures.sql.length, 1);
+    assert.match(captures.sql[0], /FROM subnet_lifecycle/);
+    assert.doesNotMatch(captures.sql[0], /subnet_hyperparams/);
   });
 
   test("handleSubnetHyperparams: flag=postgres falls back to schema-stable null on failure (D1 retired)", async () => {

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -974,6 +974,19 @@ export async function handleSubnetHyperparams(
     // identical whichever tier answered.
     (await loadSubnetHyperparamsColdTier(env, netuid)) ??
     buildSubnetHyperparams(null, netuid);
+  // #10259: the card is retained for deregistered subnets rather than pruned,
+  // so it has to say which it is. Read-only and best-effort -- a lifecycle
+  // store that cannot be reached leaves the field null, which is "unknown"
+  // rather than a claim that the subnet is live.
+  const lifecycle = await loadSubnetLifecycle(env, netuid, {
+    limit: 1,
+    offset: 0,
+  }).catch(() => null);
+  (data as Record<string, unknown>).subnet_status = lifecycle?.[0]
+    ? lifecycle[0].event === "deregistered"
+      ? "deregistered"
+      : "live"
+    : null;
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
Closes #10259

The issue was written as *"restore the delete-on-absence prune D1 had, once a completeness signal exists."* Researching how this is modelled elsewhere showed the premise is wrong, so this does the opposite: **never prune, and mark the card instead.**

## Why deleting is wrong, not merely unnecessary

1. **Netuids are reused.** Deleting subnet 42's card on deregistration means a later re-registration of 42 silently inherits the dead subnet's row, with no boundary. `subnet_lifecycle` (#10262/#10263) deliberately records re-registration as a *second* event rather than mutating the first — the card has to honour the same distinction, and cannot if the row is gone.
2. **The last known configuration is a fact.** `/subnets/42/hyperparameters` going empty is a worse answer than the final values plus a marker saying the subnet is gone.
3. **Deregistration is routine.** Per taostats' docs on the chain mechanic: *"when a new subnet is registered, the subnet with the lowest EMA price is deregistered."* One leaves every time one joins — the normal lifecycle, not a cleanup. Their surface models it the same way, with `/subnet-deregistration-ranking` and a historical variant rather than deletion.

## It also dissolves the blocker

Deleting on **absence** needs a *"did we see every subnet"* guarantee this route structurally cannot provide — `hotkey-alpha` reported `scan ended at 48779 entries, under the 76257 floor` this month, so the failure mode is live. Keying on a **recorded** deregistration needs no such guarantee, because the neurons coverage floor already gates the event before it is written.

## What changed

`subnet_status: "live" | "deregistered" | null` on `SubnetHyperparametersArtifact`, populated from `subnet_lifecycle`, mirrored in the GraphQL type.

`null` means no lifecycle event has been recorded — deliberately distinct from `deregistered`, and not a claim either way. The lookup is best-effort: an unreachable lifecycle store leaves it null rather than defaulting to `live`, because "we could not check" and "it is live" are different answers.

## Verification

- `tsc --noEmit`, `lint`, `format:check` clean
- `validate`, `validate:api`, `validate:contract-drift`, `validate:single-schema-source`, `validate:graphql-component-parity`, `validate:graphql-types-drift`, `validate-docs` all pass
- 1,777 tests green across `request-handlers-entities`, `zod-schemas`, `graphql`, `subnet-lifecycle-read`
- Regenerated `openapi.json`, GraphQL types, contract artifacts and the apps/ui API reference

One existing assertion changed, listed deliberately: `handleSubnetHyperparams: flag=postgres` asserted `captures.sql` was empty. It now asserts the single statement is the `subnet_lifecycle` lookup and is *not* a `subnet_hyperparams` query — so it keeps meaning "no tier query" rather than "no query at all".

## Follow-up

#10285 — the predictive half we still lack: which subnet is *nearest* to being pruned. The inputs are already in Neon; it is a serving gap, not a data gap.