### PR TITLE
feat(schemas): the SDL's prose moves to the schema it describes (#10288)

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4964,7 +4964,7 @@ export interface components {
             total_deregistrations: number;
             window: ("7d" | "30d" | "90d") | null;
         };
-        /** @description One coldkey's community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities. */
+        /** @description One `coldkey`'s community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities. */
         AccountEntitiesArtifact: {
             labels: ({
                 category?: ("exchange" | "bridge" | "foundation" | "pool" | "infra" | "project" | "operator" | "other") | null;
@@ -5476,7 +5476,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** @description One account's (validator hotkey's) WeightsSet weight-setting footprint across subnets over a 7d/30d window. Mirrors GET /api/v1/accounts/{ss58}/weight-setters. */
+        /** @description One account's (validator's hotkey's) WeightsSet weight-setting footprint across subnets over a 7d/30d window. Mirrors GET /api/v1/accounts/{ss58}/weight-setters. */
         AccountWeightSettersArtifact: {
             address: string;
             /** @description Herfindahl-Hirschman index of weight-sets across subnets: 1 = all on one subnet, -> 1/n as it spreads evenly; null when the account has no weight-sets. */
@@ -6843,7 +6843,7 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
-            /** @description Network-wide stake-move rollup: every subnet with StakeMoved events in the window, combined. distinct_movers counts a coldkey once even when it moves on several subnets. */
+            /** @description Network-wide stake-move rollup: every subnet with StakeMoved events in the window, combined. distinct_movers counts a `coldkey` once even when it moves on several subnets. */
             network: {
                 distinct_movers: number;
                 movements: number;
@@ -6873,7 +6873,7 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
-            /** @description Network-wide stake-transfer rollup: every subnet with StakeTransferred events in the window, combined. distinct_senders counts an origin coldkey once even when it transfers out of several subnets. */
+            /** @description Network-wide stake-transfer rollup: every subnet with StakeTransferred events in the window, combined. distinct_senders counts an origin `coldkey` once even when it transfers out of several subnets. */
             network: {
                 distinct_senders: number;
                 transfers: number;
@@ -7198,7 +7198,7 @@ export interface components {
                 apy_estimate_eligible_subnet_count: number;
                 avg_validator_trust: number | null;
                 coldkey: string | null;
-                /** @description The coldkey's self-declared on-chain identity; opaque JSON, matching the REST/MCP shape. */
+                /** @description The `coldkey`'s self-declared on-chain identity; opaque JSON, matching the REST/MCP shape. */
                 coldkey_identity: {
                     additional: string | null;
                     captured_at: string | null;
@@ -11014,12 +11014,12 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** @description One coldkey's holding of a subnet's alpha, including alpha staked to hotkeys that hold no UID on that subnet. */
+        /** @description One `coldkey`'s holding of a subnet's alpha, including alpha staked to hotkeys that hold no UID on that subnet. */
         SubnetHolder: {
             /** @description ALPHA, not TAO. Within one subnet alpha is already a common unit, so there is no price conversion and none of its staleness -- multiply by the subnet's alpha_price_tao for TAO. */
             alpha: number;
             coldkey: string;
-            /** @description Distinct hotkeys this coldkey holds the subnet's alpha through -- registered on it or not, which is the part a neurons-sourced view misses. */
+            /** @description Distinct hotkeys this `coldkey` holds the subnet's alpha through -- registered on it or not, which is the part a neurons-sourced view misses. */
             hotkey_count: number | null;
             /** @description This holder's alpha over the subnet's FULL measured total, so it means the same thing at limit 5 and limit 100. Null when the total is zero. */
             share_of_total: number | null;
@@ -12668,7 +12668,7 @@ export interface components {
                 event_count: number;
                 /** @description staked_tao + unstaked_tao (total churn, regardless of direction). */
                 gross_staked_tao: number;
-                /** @description Most recent StakeAdded/StakeRemoved time for this coldkey; null when unstamped. */
+                /** @description Most recent StakeAdded/StakeRemoved time for this `coldkey`; null when unstamped. */
                 last_observed_at: string | null;
                 /** @description staked_tao - unstaked_tao. */
                 net_staked_tao: number;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4816,6 +4816,7 @@ export interface components {
         AccountAxonRemovalsArtifact: {
             address: string;
             concentration: number | null;
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
@@ -4832,6 +4833,7 @@ export interface components {
             total_removals: number;
             window: ("7d" | "30d" | "90d") | null;
         };
+        /** @description Live free+reserved balance in TAO for one Finney ss58 account, read directly from chain via RPC (KV-cached). balance_tao is null on RPC failure (schema-stable, never a GraphQL error). Mirrors GET /api/v1/accounts/{ss58}/balance. */
         AccountBalanceArtifact: {
             balance_tao?: number | null;
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
@@ -4850,6 +4852,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Live child-hotkey delegation graph (#6723) for one Finney ss58 account, read directly from chain via RPC (KV-cached). subnets is null on RPC failure, distinct from a confirmed-empty [] (schema-stable, never a GraphQL error). Mirrors GET /api/v1/accounts/{ss58}/children. */
         AccountChildrenArtifact: {
             account: string;
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
@@ -4885,8 +4888,10 @@ export interface components {
                 transfer_count: number;
             }[];
             counterparty_count: number;
+            /** @description Present only in relationship (counterparty) mode; null in list mode. */
             relationship?: {
                 counterparty: string;
+                /** @description Oldest block/timestamp are null when the newest-first scan was truncated (scan_capped). */
                 first_block: number | null;
                 first_seen_at: string | null;
                 last_block: number | null;
@@ -4902,7 +4907,10 @@ export interface components {
                 transfers: {
                     amount_tao: number;
                     block_number: number | null;
-                    /** @enum {string} */
+                    /**
+                     * @description sent (account = from) or received (account = to).
+                     * @enum {string}
+                     */
                     direction: "sent" | "received";
                     event_index: number | null;
                     from: string;
@@ -4924,19 +4932,24 @@ export interface components {
         AccountDeregistrationsArtifact: {
             address: string;
             concentration: number | null;
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
             };
+            /** @description How a deregistration feed was derived (#9307). NeuronDeregistered has never been emitted, so deregistrations are derived from UID reuse: a NeuronRegistered on a (netuid, uid) slot already held by a different hotkey IS the deregistration of the previous occupant. unattributed_registrations is the honest part -- the published totals are a LOWER BOUND by that many events, because those registrations displaced a holder the derivation's lookback cannot name. */
             derivation?: {
                 /**
                  * @description True when the count is a floor rather than a measurement: some registrations in the window displaced a holder the derivation's lookback cannot name, so the real figure is higher by at least `unattributed_registrations`. Treat the value as 'at least this many', never as a total.
                  * @example true
                  */
                 is_lower_bound: boolean;
+                /** @description Days of NeuronRegistered history the derivation had available. */
                 lookback_days: number;
                 method: string;
+                /** @description Of those, the ones with no observed previous holder. */
                 unattributed_registrations: number;
+                /** @description Registrations observed inside the reported window. */
                 window_registrations: number;
             };
             dominant_netuid: number | null;
@@ -4951,6 +4964,7 @@ export interface components {
             total_deregistrations: number;
             window: ("7d" | "30d" | "90d") | null;
         };
+        /** @description One coldkey's community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities. */
         AccountEntitiesArtifact: {
             labels: ({
                 category?: ("exchange" | "bridge" | "foundation" | "pool" | "infra" | "project" | "operator" | "other") | null;
@@ -4991,6 +5005,7 @@ export interface components {
             price_basis?: ("trade_exact" | "root_no_pool") | null;
             uid?: number | null;
         };
+        /** @description One account's first-party chain-event feed (matched by the hotkey OR coldkey union, newest first), keyset-paginated. event_count is the page count, not a grand total. Mirrors GET /api/v1/accounts/{ss58}/events' data envelope. Each item is an AccountEvent. */
         AccountEventsArtifact: {
             event_count: number;
             events: components["schemas"]["AccountEvent"][];
@@ -5002,10 +5017,12 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One account's signed-extrinsic feed (newest first), backing account_extrinsics. Matched by the extrinsic signer only. extrinsic_count is the page count, matching the REST feed convention. Each item is a full Extrinsic (block/index/hash/call/success/fee/tip). */
         AccountExtrinsicsArtifact: {
             extrinsic_count: number;
             extrinsics: {
                 block_number: number | null;
+                /** @description JSON-encoded decoded call arguments. */
                 call_args?: unknown | null;
                 call_function?: string | null;
                 call_module?: string | null;
@@ -5015,6 +5032,7 @@ export interface components {
                 observed_at?: string | null;
                 signer?: string | null;
                 success?: boolean | null;
+                /** @description Deterministic human-readable action sentence for this extrinsic's call, or null when no template matches call_module.call_function (#8525). */
                 summary?: string | null;
                 tip_tao?: number | null;
             }[];
@@ -5026,6 +5044,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One account's durable per-day activity series (hotkey-keyed, newest day first), keyset-paginated. day_count is the page count, not a grand total. Mirrors GET /api/v1/accounts/{ss58}/history' data envelope. Each item is an AccountDay. */
         AccountHistoryArtifact: {
             day_count: number;
             days: ({
@@ -5066,6 +5085,7 @@ export interface components {
                 description?: string | null;
                 discord?: string | null;
                 github?: string | null;
+                /** @description Stable hash of this entry's tracked identity fields -- unchanged across entries where nothing actually differs. */
                 identity_hash: string;
                 image?: string | null;
                 name?: string | null;
@@ -5080,6 +5100,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Live parent-hotkey delegation graph (#6723) for one Finney ss58 account, read directly from chain via RPC (KV-cached). subnets is null on RPC failure, distinct from a confirmed-empty [] (schema-stable, never a GraphQL error). Mirrors GET /api/v1/accounts/{ss58}/parents. */
         AccountParentsArtifact: {
             account: string;
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
@@ -5105,6 +5126,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One wallet's cross-subnet neuron portfolio (#5702): every subnet where the hotkey is a registered neuron, plus wallet-level aggregates. Mirrors GET /api/v1/accounts/{ss58}/portfolio. */
         AccountPortfolioArtifact: {
             captured_at: string | null;
             miner_count: number;
@@ -5125,10 +5147,12 @@ export interface components {
                 stake_tao: number;
                 trust: number | null;
                 uid: number | null;
+                /** @description Emission over stake for this position; null when stake is 0. */
                 yield: number | null;
             }[];
             schema_version: number;
             ss58: string;
+            /** @description How concentrated the wallet's stake is across its subnets (Gini/HHI/etc); null with no positions. */
             stake_concentration: components["schemas"]["ConcentrationMetrics"];
             subnet_count: number;
             /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest SPOT price -- tao_in_pool_tao / alpha_in_pool from that subnet's newest snapshot, root at 1:1 -- before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Marked at SPOT, not at alpha_price_tao: that field is the chain's MOVING price (#9408), and a lagging average is the wrong mark for what a position is worth -- measured -1.29% against spot on netuid 64 for 2026-08-03. Prices still come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier; the lag is the rollup's, no longer the average's. */
@@ -5139,6 +5163,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One account's per-subnet position history over a lookback window, one point per neuron_daily snapshot. Mirrors GET /api/v1/accounts/{ss58}/subnets/{netuid}/history. */
         AccountPositionHistoryArtifact: {
             netuid: number;
             point_count: number;
@@ -5166,6 +5191,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description This account's reconstructed nominator-side positions: what it holds delegated across every hotkey/subnet, distinct from AccountPortfolio's hotkey-scoped view. Mirrors GET /api/v1/accounts/{ss58}/positions. */
         AccountPositionsArtifact: {
             captured_at: string | null;
             degraded?: {
@@ -5183,6 +5209,7 @@ export interface components {
             positions: {
                 hotkey: string;
                 netuid: number;
+                /** @description This account's share of the hotkey's total alpha-pool shares on this subnet (0..1), not a TAO amount. */
                 share_fraction: number;
                 /** @description This position's stake in the subnet named by the sibling `netuid`. ALPHA, not TAO: nominator_positions holds only netuid != 0 rows, so this is always that subnet's alpha token (#2550). It is the per-row counterpart of `total_stake_alpha` above -- same denomination, kept under the on-chain column name deliberately (#8945). */
                 stake_tao: number;
@@ -5194,9 +5221,12 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One account's Prometheus telemetry-serving footprint (#5703) across subnets over a 7d/30d/90d window. Mirrors GET /api/v1/accounts/{ss58}/prometheus. */
         AccountPrometheusArtifact: {
             address: string;
+            /** @description Herfindahl-Hirschman index of announcements across subnets: 1 = all on one subnet, -> 1/n as it spreads evenly; null when the account has no announcements. */
             concentration: number | null;
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
@@ -5228,6 +5258,7 @@ export interface components {
             total_registrations: number;
             window: ("7d" | "30d" | "90d") | null;
         };
+        /** @description Live root-claim current state for one Finney ss58 account (#7229), read directly from chain via RPC (KV-cached). claim_type/hotkeys are null on RPC failure (schema-stable, never a GraphQL error). Read-only; never submits claim_root. Mirrors GET /api/v1/accounts/{ss58}/root-claim. */
         AccountRootClaimArtifact: {
             claim_type?: {
                 /** @enum {string} */
@@ -5309,12 +5340,18 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One account's StakeAdded/StakeRemoved staking-behavior scorecard (#5706) across subnets over a 7d/30d/90d window. Mirrors GET /api/v1/accounts/{ss58}/stake-flow. */
         AccountStakeFlowArtifact: {
             address: string;
+            /** @description Herfindahl-Hirschman index of gross flow across subnets: 1 = all flow in one subnet, -> 1/n as it spreads evenly; null when there is no flow to concentrate. */
             concentration: number | null;
-            /** @enum {string} */
+            /**
+             * @description accumulating / exiting / churning / idle, derived from flow_ratio.
+             * @enum {string}
+             */
             direction: "accumulating" | "exiting" | "churning" | "idle";
             dominant_netuid: number | null;
+            /** @description net_flow_tao / gross_flow_tao, [-1, 1]; null when gross_flow_tao is 0 (no flow to rate). */
             flow_ratio: number | null;
             gross_flow_tao: number;
             net_flow_tao: number;
@@ -5349,15 +5386,18 @@ export interface components {
                 last_moved_at: string | null;
                 movements: number;
                 netuid: number;
+                /** @description Alpha price (TAO) on the UTC day of this subnet's most recent move; null when that day has no snapshot yet or there was no move. */
                 price_tao_at_last_move: number | null;
             }[];
             total_movements: number;
             window: ("7d" | "30d" | "90d") | null;
         };
+        /** @description One account's live cross-subnet registration footprint (the neurons snapshot), backing account_subnets. The lightweight sibling of AccountPortfolio -- registration facts only, no economics rollup. */
         AccountSubnetsArtifact: {
             schema_version: number;
             ss58: string;
             subnet_count: number;
+            /** @description Where this hotkey is currently registered, ordered by netuid -- each an AccountRegistration (netuid/uid/stake/validator_permit/active). */
             subnets: {
                 active: boolean;
                 netuid: number;
@@ -5369,6 +5409,7 @@ export interface components {
             [key: string]: unknown;
         };
         AccountSummaryArtifact: {
+            /** @description Signing-activity aggregate from the extrinsics tier, matched by signer only. tx_count / total_fee_tao / last_tx_* are all-time over every extrinsic this address has signed; modules_called is the pallet mix over the newest 1000 only, with modules_called_capped true when that window is incomplete. An account queried by a key that did not sign returns tx_count 0, modules_called_capped false, other fields null/empty. */
             activity?: {
                 last_tx_at: string | null;
                 last_tx_block: number | null;
@@ -5385,6 +5426,7 @@ export interface components {
                 count: number;
                 kind: string;
             }[];
+            /** @description True when this account has more events than the summary's scan window -- event_count/subnet_count/event_kinds are then a lower bound and first_block/first_seen_at are null. */
             event_scan_capped?: boolean;
             first_block?: number | null;
             first_seen_at?: string | null;
@@ -5400,6 +5442,7 @@ export interface components {
             last_block?: number | null;
             last_seen_at?: string | null;
             recent_events?: components["schemas"]["AccountEvent"][];
+            /** @description Where this hotkey is currently registered + staked (the live cross-subnet footprint). */
             registrations: {
                 active: boolean;
                 netuid: number;
@@ -5413,6 +5456,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One account's native-TAO transfer feed, keyset-paginated newest-first. Mirrors GET /api/v1/accounts/{ss58}/transfers' data envelope. */
         AccountTransfersArtifact: {
             limit: number | null;
             next_cursor?: string | null;
@@ -5432,8 +5476,10 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One account's (validator hotkey's) WeightsSet weight-setting footprint across subnets over a 7d/30d window. Mirrors GET /api/v1/accounts/{ss58}/weight-setters. */
         AccountWeightSettersArtifact: {
             address: string;
+            /** @description Herfindahl-Hirschman index of weight-sets across subnets: 1 = all on one subnet, -> 1/n as it spreads evenly; null when the account has no weight-sets. */
             concentration: number | null;
             dominant_netuid: number | null;
             schema_version: number;
@@ -5447,8 +5493,10 @@ export interface components {
             total_weight_sets: number;
             window: ("7d" | "30d") | null;
         };
+        /** @description One adapter-backed public metrics snapshot. snapshot and extensions are opaque JSON -- their shape is adapter-specific. Mirrors GET /api/v1/adapters/{slug}'s data envelope. */
         AdapterArtifact: {
             contract_version?: string;
+            /** @description Per-adapter extension metadata keyed by provider id; each value's shape is adapter-specific. */
             extensions: {
                 [key: string]: {
                     [key: string]: unknown;
@@ -5456,10 +5504,12 @@ export interface components {
             };
             generated_at: string;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
             slug: string;
+            /** @description Captured adapter metrics payload; shape is adapter-specific. */
             snapshot?: ({
                 adapter_kind?: string | null;
                 contract_version?: string;
@@ -5525,6 +5575,7 @@ export interface components {
             callable_service_count?: number;
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -5573,6 +5624,7 @@ export interface components {
             integration_readiness?: number;
             name?: string;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             previously_known_as?: string[];
             readiness?: components["schemas"]["IntegrationReadiness"];
@@ -5722,6 +5774,7 @@ export interface components {
             } & {
                 [key: string]: unknown;
             };
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             published_at?: string | null;
             resources: ({
@@ -5782,6 +5835,7 @@ export interface components {
             base_path: "/api/v1";
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             openapi_url: "/metagraph/openapi.json";
@@ -5829,6 +5883,7 @@ export interface components {
         ArtifactBase: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -5872,6 +5927,7 @@ export interface components {
                 observed_at?: number | null;
                 pallet: string | null;
                 phase?: string | null;
+                /** @description Deterministic human-readable action sentence for this event's pallet.method, or null when no template matches (#8525). */
                 summary?: string | null;
             }[];
         } & {
@@ -5888,13 +5944,16 @@ export interface components {
                 parent_hash: string | null;
                 spec_version: number | null;
             } | null;
+            /** @description Nearest STORED higher block height for chain-walk nav (detail only); null at the head of the retained window or when the ref didn't resolve. */
             next_block_number: number | null;
+            /** @description Nearest STORED lower block height for chain-walk nav (detail only); null at the start of the retained window or when the ref didn't resolve. */
             prev_block_number: number | null;
             ref: string | null;
             schema_version: number;
         } & {
             [key: string]: unknown;
         };
+        /** @description One block's decoded, account-attributed events list (#6977). Rows are opaque JSON; block_number is null for an unknown ref. */
         BlockEventsArtifact: {
             block_number: number | null;
             event_count: number;
@@ -5906,6 +5965,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One block's extrinsics list (#6977). Rows are the opaque JSON extrinsic shape the extrinsics feed uses; block_number is null for an unknown ref. */
         BlockExtrinsicsArtifact: {
             block_number: number | null;
             extrinsic_count: number;
@@ -5951,6 +6011,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Block-production summary (#5664) over the recent-block window. Every aggregate is null on a cold retired-D1 store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/summary. */
         BlocksSummaryArtifact: {
             author_concentration: components["schemas"]["ConcentrationMetrics"] | null;
             block_count: number;
@@ -6014,6 +6075,7 @@ export interface components {
             full_artifact_count?: number;
             full_artifact_size_bytes?: number;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             profile_count?: number;
             provider_count?: number;
@@ -6037,10 +6099,12 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description All-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history. Mirrors GET /api/v1/health/trends' data envelope. */
         BulkHealthTrendsArtifact: {
             observed_at?: string | null;
             schema_version: number;
             source: string;
+            /** @description The 7d/30d windows keyed by window label (7d, 30d), each holding days/granularity/subnet_count and the per-subnet daily point series. Opaque JSON: dynamic-keyed by window label, matching the get_health_trends MCP/REST shape. */
             windows: {
                 [key: string]: {
                     days: number;
@@ -6070,6 +6134,7 @@ export interface components {
             candidates: components["schemas"]["CandidateSurface"][];
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -6128,6 +6193,7 @@ export interface components {
             url: string;
             verification?: components["schemas"]["VerificationResult"] | null;
         };
+        /** @description Per-UTC-day network activity series (blocks, extrinsics, events, signers) over the window, newest day first. Mirrors GET /api/v1/chain/activity's data envelope. */
         ChainActivityArtifact: {
             day_count: number;
             days: {
@@ -6145,7 +6211,9 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Network-wide rolling 24h buy/sell alpha-volume leaderboard, summed live from the account_events StakeAdded/StakeRemoved stream. Mirrors GET /api/v1/chain/alpha-volume's data envelope. */
         ChainAlphaVolumeArtifact: {
+            /** @description Network-wide buy/sell volume rollup across every subnet with volume in the window. */
             network: {
                 buy_count: number;
                 buy_volume_alpha: number;
@@ -6154,16 +6222,22 @@ export interface components {
                 sell_count: number;
                 sell_volume_alpha: number;
                 sell_volume_tao: number;
-                /** @enum {string} */
+                /**
+                 * @description Coarse sentiment label (bullish/bearish/neutral); neutral both for balanced volume and an empty window.
+                 * @enum {string}
+                 */
                 sentiment: "bullish" | "bearish" | "neutral";
+                /** @description net/gross alpha lean in [-1, 1]; null when there was no volume in the window. */
                 sentiment_ratio: number | null;
                 total_volume_alpha: number;
                 total_volume_tao: number;
             };
+            /** @description Newest event observed_at across the window; null on a cold store. */
             observed_at: string | null;
             schema_version: number;
             subnet_count: number;
             subnets: components["schemas"]["SubnetAlphaVolumeArtifact"][];
+            /** @description Spread of per-subnet total_volume_tao across every subnet with volume; null when no subnet had volume. */
             volume_distribution: {
                 count: number;
                 max: number;
@@ -6174,10 +6248,14 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
-            /** @enum {string} */
+            /**
+             * @description Fixed rolling window label (always 24h).
+             * @enum {string}
+             */
             window: "24h";
         };
         ChainAxonRemovalsArtifact: {
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
@@ -6192,9 +6270,11 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Network-wide axon-removal rollup: every subnet with AxonInfoRemoved events in the window, combined. distinct_removers counts a hotkey once even when it tears endpoints down on several subnets, so it is NOT the sum of the per-subnet counts. */
             network: {
                 distinct_removers: number;
                 removals: number;
+                /** @description Null when distinct_removers is 0 (no defined intensity without removers). */
                 removals_per_remover: number | null;
             };
             observed_at: string | null;
@@ -6234,6 +6314,7 @@ export interface components {
             burn_tao: number;
             netuid: number;
         };
+        /** @description Extrinsic call-mix breakdown over the window. Mirrors GET /api/v1/chain/calls's data envelope. */
         ChainCallsArtifact: {
             call_count: number;
             calls: {
@@ -6250,29 +6331,41 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Network-wide stake & emission decentralization card (#5872). Metric blocks are null on a cold/empty store. Mirrors GET /api/v1/chain/concentration. */
         ChainConcentrationArtifact: {
             captured_at: string | null;
+            /** @description Raw emission concentration across every neuron network-wide. */
             emission: components["schemas"]["ConcentrationMetrics"];
+            /** @description Distinct controlling entities (coldkeys) network-wide, collapsed across subnets. */
             entity_count: number;
+            /** @description Emission concentration per controlling entity -- hotkeys collapsed across subnets. */
             entity_emission: components["schemas"]["ConcentrationMetrics"];
+            /** @description Stake concentration per controlling entity -- hotkeys collapsed across subnets, so one operator counts once. */
             entity_stake: components["schemas"]["ConcentrationMetrics"];
             neuron_count: number;
             schema_version: number;
+            /** @description Raw stake concentration across every neuron network-wide. */
             stake: components["schemas"]["ConcentrationMetrics"];
+            /** @description Distinct subnets the snapshot spans. */
             subnet_count: number;
+            /** @description UIDs per controlling entity network-wide -- a consolidation signal (1.0 = every UID a distinct owner; higher = fewer operators each running many). Null when no entities. */
             uids_per_entity: number | null;
+            /** @description Stake concentration across permitted validators network-wide only. */
             validator_stake: components["schemas"]["ConcentrationMetrics"];
         } & {
             [key: string]: unknown;
         };
         ChainConcentrationHistoryArtifact: {
+            /** @description Every distinct builder version in the series. More than one means it changes DEFINITION partway along. */
             builder_versions: number[];
+            /** @description Present ONLY on a decline. An empty window is a measurement. */
             degraded?: {
                 /** @enum {string} */
                 reason: "unavailable";
             };
             newest_day: string | null;
             oldest_day: string | null;
+            /** @description From the ROWS. A day the capture did not run is absent, never a zero-concentration point. */
             point_count: number | null;
             points: components["schemas"]["ChainConcentrationHistoryPoint"][];
             schema_version: number;
@@ -6281,14 +6374,18 @@ export interface components {
             [key: string]: unknown;
         };
         ChainConcentrationHistoryPoint: {
+            /** @description Which definition of the metrics produced this point. */
             builder_version: number | null;
             day: string;
             emission: components["schemas"]["ChainConcentrationScorecard"] | null;
             entity_count: number | null;
             entity_emission: components["schemas"]["ChainConcentrationScorecard"] | null;
             entity_stake: components["schemas"]["ChainConcentrationScorecard"] | null;
+            /** @description The shape of the day the card was computed over -- a point across half the network is not comparable to one across all of it. */
             neuron_count: number | null;
+            /** @description WHEN the network looked like this, as distinct from when it was computed. */
             source_captured_at: string | null;
+            /** @description NULL means no measurable distribution, NOT missing. */
             stake: components["schemas"]["ChainConcentrationScorecard"] | null;
             subnet_count: number | null;
             uids_per_entity: number | null;
@@ -6349,19 +6446,24 @@ export interface components {
             [key: string]: unknown;
         };
         ChainDeregistrationsArtifact: {
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
             };
+            /** @description How a deregistration feed was derived (#9307). NeuronDeregistered has never been emitted, so deregistrations are derived from UID reuse: a NeuronRegistered on a (netuid, uid) slot already held by a different hotkey IS the deregistration of the previous occupant. unattributed_registrations is the honest part -- the published totals are a LOWER BOUND by that many events, because those registrations displaced a holder the derivation's lookback cannot name. */
             derivation?: {
                 /**
                  * @description True when the count is a floor rather than a measurement: some registrations in the window displaced a holder the derivation's lookback cannot name, so the real figure is higher by at least `unattributed_registrations`. Treat the value as 'at least this many', never as a total.
                  * @example true
                  */
                 is_lower_bound: boolean;
+                /** @description Days of NeuronRegistered history the derivation had available. */
                 lookback_days: number;
                 method: string;
+                /** @description Of those, the ones with no observed previous holder. */
                 unattributed_registrations: number;
+                /** @description Registrations observed inside the reported window. */
                 window_registrations: number;
             };
             intensity_distribution: {
@@ -6374,8 +6476,10 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Network-wide deregistration rollup: every subnet with a derived deregistration in the window, combined. distinct_deregistered_hotkeys counts a hotkey once even when it is deregistered from several subnets, so it is NOT the sum of the per-subnet counts. */
             network: {
                 deregistrations: number;
+                /** @description Null when distinct_deregistered_hotkeys is 0 (no defined intensity without hotkeys). */
                 deregistrations_per_hotkey: number | null;
                 distinct_deregistered_hotkeys: number;
                 tenure?: {
@@ -6408,6 +6512,7 @@ export interface components {
             }[];
             window: ("7d" | "30d") | null;
         };
+        /** @description Paginated all-events feed from the chain_events lakehouse table. Mirrors GET /api/v1/chain-events (and MCP list_chain_events). Distinct from Subscription.chainEvents. */
         ChainEventsFeedArtifact: {
             count: number;
             events: {
@@ -6428,6 +6533,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Chain-activity aggregate (pallet.method event distribution) over the most recent N blocks from the chain_events lakehouse table. The aggregate sibling of ChainEventsFeed. Mirrors GET /api/v1/chain-events/stats (and MCP get_chain_activity). */
         ChainEventsStatsArtifact: {
             activity: {
                 count: number;
@@ -6439,6 +6545,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Per-UTC-day network fee/tip series plus the top fee payers over the window. Mirrors GET /api/v1/chain/fees's data envelope. */
         ChainFeesArtifact: {
             daily: {
                 avg_fee_tao: number | null;
@@ -6466,6 +6573,7 @@ export interface components {
         };
         ChainHoldersArtifact: {
             captured_at: string | null;
+            /** @description Present ONLY on a decline. An empty subnets list WITHOUT this block is a measurement. */
             degraded?: {
                 /** @enum {string} */
                 reason: "pool_totals_unproven" | "unavailable";
@@ -6475,25 +6583,32 @@ export interface components {
             positions_captured_at: string | null;
             schema_version: number;
             sort: string;
+            /** @description Subnets measured -- NOT the length of the subnets list when limit bites. */
             subnet_count: number | null;
             subnets: components["schemas"]["ChainHoldersSubnet"][];
         } & {
             [key: string]: unknown;
         };
+        /** @description Dimension-free network facts. There is deliberately no cross-subnet alpha total: summing different subnets' alpha has no unit. */
         ChainHoldersNetwork: {
             median_top1_share: number | null;
             subnets_measured: number | null;
+            /** @description Subnets where ONE account holds a majority of the measured alpha. */
             subnets_with_majority_holder: number | null;
+            /** @description Subnets whose entire measured alpha sits in a single wallet. */
             subnets_with_single_holder: number | null;
         };
+        /** @description One subnet's alpha-ownership concentration. */
         ChainHoldersSubnet: {
             holder_count: number | null;
             netuid: number;
+            /** @description The largest holder's coldkey (an ss58 address). */
             top_holder: string | null;
             top1_share: number | null;
             top10_share: number | null;
             top20_share: number | null;
             top5_share: number | null;
+            /** @description ALPHA, comparable only WITHIN this subnet -- each subnet's alpha is a different token. */
             total_alpha: number | null;
         };
         ChainIdentityHistoryArtifact: {
@@ -6518,6 +6633,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Network-wide idle-stake rollup: every subnet's stake on currently-zero-dividends hotkeys, ranked by idle_stake_alpha. Mirrors GET /api/v1/chain/idle-stake's data envelope. */
         ChainIdleStakeArtifact: {
             captured_at?: string | null;
             schema_version: number;
@@ -6534,22 +6650,30 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Network-wide reward-distribution & score-spread card (#5688) -- the network analog of SubnetPerformance, spanning every subnet's neurons in one snapshot. Metric blocks are null on a cold/empty store. Mirrors GET /api/v1/chain/performance. */
         ChainPerformanceArtifact: {
             active_count?: number;
             captured_at?: string | null;
+            /** @description Consensus score spread across all neurons network-wide. */
             consensus: components["schemas"]["ScoreDistribution"];
+            /** @description Dividends concentration across permitted validators network-wide only. */
             dividends: components["schemas"]["ConcentrationMetrics"];
+            /** @description Incentive concentration across all neurons network-wide with positive incentive. */
             incentive: components["schemas"]["ConcentrationMetrics"];
             neuron_count: number;
             schema_version: number;
+            /** @description Distinct subnets the snapshot spans. */
             subnet_count: number;
+            /** @description Trust score spread across all neurons network-wide. */
             trust: components["schemas"]["ScoreDistribution"];
             validator_count?: number;
+            /** @description Validator-trust score spread across permitted validators network-wide only. */
             validator_trust?: components["schemas"]["ScoreDistribution"];
         } & {
             [key: string]: unknown;
         };
         ChainPrometheusArtifact: {
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
@@ -6564,8 +6688,10 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Network-wide Prometheus-serving rollup: every subnet with PrometheusServed announcements in the window, combined. distinct_exporters counts a hotkey once even when it announces on several subnets, so it is NOT the sum of the per-subnet counts. */
             network: {
                 announcements: number;
+                /** @description Null when distinct_exporters is 0 (no defined intensity without exporters). */
                 announcements_per_exporter: number | null;
                 distinct_exporters: number;
             };
@@ -6591,9 +6717,11 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Network-wide registration rollup: every subnet with NeuronRegistered events in the window, combined. distinct_registrants counts a hotkey once even when it registers on several subnets, so it is NOT the sum of the per-subnet counts. */
             network: {
                 distinct_registrants: number;
                 registrations: number;
+                /** @description Null when distinct_registrants is 0 (no defined intensity without hotkeys). */
                 registrations_per_registrant: number | null;
             };
             observed_at: string | null;
@@ -6607,6 +6735,7 @@ export interface components {
             }[];
             window: ("7d" | "30d") | null;
         };
+        /** @description Network-wide axon-serving announcement leaderboard (#5873). The network-wide counterpart of subnet_serving. Mirrors GET /api/v1/chain/serving's data envelope. */
         ChainServingArtifact: {
             intensity_distribution: {
                 count: number;
@@ -6618,8 +6747,10 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Network-wide axon-serving rollup: every subnet with AxonServed announcements in the window, combined. */
             network: {
                 announcements: number;
+                /** @description Null when distinct_servers is 0 (no defined intensity without servers). */
                 announcements_per_server: number | null;
                 distinct_servers: number;
             };
@@ -6634,6 +6765,7 @@ export interface components {
             }[];
             window: ("7d" | "30d") | null;
         };
+        /** @description Network-wide weight-setter leaderboard over a lookback window, summed live from the account_events WeightsSet stream. The setter-level drill-in behind ChainWeights. Mirrors GET /api/v1/chain/weights/setters. */
         ChainSignersArtifact: {
             observed_at?: string | null;
             schema_version: number;
@@ -6641,17 +6773,23 @@ export interface components {
             signers: {
                 last_tx_block: number | null;
                 signer: string;
+                /** @description Total fees paid across the window's extrinsics; null when the tier has no fee data. */
                 total_fee_tao: number;
                 total_tip_tao: number;
                 tx_count: number;
             }[];
-            /** @enum {string} */
+            /**
+             * @description The rank order actually applied: tx_count or total_fee_tao.
+             * @enum {string}
+             */
             sort: "tx_count" | "total_fee_tao";
             window: string;
         } & {
             [key: string]: unknown;
         };
+        /** @description Network-wide cross-subnet capital-flow leaderboard over a lookback window, summed live from the account_events StakeAdded/StakeRemoved stream. Mirrors GET /api/v1/chain/stake-flow's data envelope. */
         ChainStakeFlowArtifact: {
+            /** @description Spread of per-subnet net_flow_tao across EVERY subnet with stake events; null when no subnet moved stake. */
             net_flow_distribution: {
                 count: number;
                 max: number;
@@ -6662,6 +6800,7 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Network rollup over every subnet that moved stake in the window. */
             network: {
                 flat: number;
                 gaining: number;
@@ -6677,7 +6816,10 @@ export interface components {
             schema_version: number;
             subnet_count: number;
             subnets: {
-                /** @enum {string} */
+                /**
+                 * @description inflow | outflow | balanced
+                 * @enum {string}
+                 */
                 direction: "inflow" | "outflow" | "balanced";
                 gross_flow_tao: number;
                 net_flow_tao: number;
@@ -6689,6 +6831,7 @@ export interface components {
             }[];
             window: ("7d" | "30d") | null;
         };
+        /** @description Network-wide stake-movement (re-delegation) leaderboard over a lookback window, summed live from the account_events StakeMoved stream. Mirrors GET /api/v1/chain/stake-moves's data envelope. */
         ChainStakeMovesArtifact: {
             intensity_distribution: {
                 count: number;
@@ -6700,9 +6843,11 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Network-wide stake-move rollup: every subnet with StakeMoved events in the window, combined. distinct_movers counts a coldkey once even when it moves on several subnets. */
             network: {
                 distinct_movers: number;
                 movements: number;
+                /** @description Null when distinct_movers is 0. */
                 movements_per_mover: number | null;
             };
             observed_at: string | null;
@@ -6716,6 +6861,7 @@ export interface components {
             }[];
             window: ("7d" | "30d") | null;
         };
+        /** @description Network-wide stake-transfer (between-coldkeys) leaderboard over a lookback window, summed live from the account_events StakeTransferred stream. Mirrors GET /api/v1/chain/stake-transfers's data envelope. */
         ChainStakeTransfersArtifact: {
             intensity_distribution: {
                 count: number;
@@ -6727,9 +6873,11 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Network-wide stake-transfer rollup: every subnet with StakeTransferred events in the window, combined. distinct_senders counts an origin coldkey once even when it transfers out of several subnets. */
             network: {
                 distinct_senders: number;
                 transfers: number;
+                /** @description Null when distinct_senders is 0. */
                 transfers_per_sender: number | null;
             };
             observed_at: string | null;
@@ -6759,10 +6907,12 @@ export interface components {
             next_cursor?: string | null;
             offset?: number | null;
             schema_version: number;
+            /** @description Distinct subnets appearing in this page -- context for entry_count. */
             subnet_count: number;
         } & {
             [key: string]: unknown;
         };
+        /** @description Network-wide directed native-TAO transfer-corridor leaderboard over a lookback window. Mirrors GET /api/v1/chain/transfer-pairs's data envelope. */
         ChainTransferPairsArtifact: {
             observed_at: string | null;
             pair_count: number;
@@ -6775,14 +6925,19 @@ export interface components {
                 volume_tao: number;
             }[];
             schema_version: number;
-            /** @enum {string} */
+            /**
+             * @description The rank order actually applied: volume or count.
+             * @enum {string}
+             */
             sort: "volume" | "count";
+            /** @description Highest-volume corridor's share of total pairable volume; null when the window has no pairable volume. */
             top_pair_share: number | null;
             total_volume_tao: number;
             transfer_count: number;
             unique_pairs: number;
             window: string | null;
         };
+        /** @description Network-wide native-TAO transfer analytics over a lookback window. Mirrors GET /api/v1/chain/transfers's data envelope. */
         ChainTransfersArtifact: {
             observed_at: string | null;
             schema_version: number;
@@ -6791,6 +6946,7 @@ export interface components {
                 transfer_count: number;
                 volume_tao: number;
             }[];
+            /** @description Top senders' combined share of total volume; null when total volume is 0. */
             top_sender_share: number | null;
             top_senders: {
                 address: string;
@@ -6803,11 +6959,17 @@ export interface components {
             unique_senders: number;
             window: string | null;
         };
+        /** @description Network-wide validator-set churn across all subnets (#5686). Mirrors GET /api/v1/chain/turnover's data envelope. */
         ChainTurnoverArtifact: {
+            /** @description False when the window resolved to fewer than two distinct snapshots, so start/end churn is not measurable. */
             comparable: boolean;
+            /** @description End snapshot date; null on a cold store. */
             end_date: string | null;
+            /** @description Network-wide validator-set rollup: every subnet's validators combined, deduplicated across the network. */
             network: {
+                /** @description 0-100 stability score; null on a cold/non-comparable window. */
                 stability_score: number | null;
+                /** @description Jaccard retention of the start set into the end set; null on a cold/non-comparable window. */
                 validator_retention: number | null;
                 validators_end: number;
                 validators_entered: number;
@@ -6815,6 +6977,7 @@ export interface components {
                 validators_start: number;
             };
             schema_version: number;
+            /** @description Null when no subnet had a stability score in the window (nothing to distribute). */
             stability_distribution: {
                 count: number;
                 max: number;
@@ -6825,6 +6988,7 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Start snapshot date; null on a cold store. */
             start_date: string | null;
             subnet_count: number;
             subnets: {
@@ -6838,6 +7002,7 @@ export interface components {
             }[];
             window: ("7d" | "30d" | "90d") | null;
         };
+        /** @description Network-wide validator weight-setting activity over a lookback window, summed live from the account_events WeightsSet stream. Mirrors GET /api/v1/chain/weights. */
         ChainWeightsArtifact: {
             intensity_distribution: {
                 count: number;
@@ -6849,8 +7014,10 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Network-wide weight-setting rollup: every subnet that set weights in the window, combined. */
             network: {
                 distinct_setters: number;
+                /** @description Null when distinct_setters is 0 (no defined intensity without setters). */
                 sets_per_setter: number | null;
                 weight_sets: number;
             };
@@ -6875,6 +7042,7 @@ export interface components {
                 hotkey: string | null;
                 last_set_at: string | null;
                 netuid: number | null;
+                /** @description This setter's share of the network total weight_sets; null when the network total is 0. */
                 share: number | null;
                 uid: number | null;
                 weight_sets: number;
@@ -6882,6 +7050,7 @@ export interface components {
             weight_sets: number;
             window: ("7d" | "30d") | null;
         };
+        /** @description Network-wide emission-yield (return rate) card across every subnet's neurons. Aggregates are null on a cold store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/chain/yield. */
         ChainYieldArtifact: {
             captured_at?: string | null;
             distribution: ({
@@ -6933,6 +7102,7 @@ export interface components {
             };
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -7017,7 +7187,9 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Several validators placed side by side (#6989). Mirrors GET /api/v1/compare/validators. */
         CompareValidatorsArtifact: {
+            /** @description The optional subnet context the comparison was scoped to. */
             netuid: number | null;
             schema_version: number;
             validator_count: number;
@@ -7026,6 +7198,7 @@ export interface components {
                 apy_estimate_eligible_subnet_count: number;
                 avg_validator_trust: number | null;
                 coldkey: string | null;
+                /** @description The coldkey's self-declared on-chain identity; opaque JSON, matching the REST/MCP shape. */
                 coldkey_identity: {
                     additional: string | null;
                     captured_at: string | null;
@@ -7040,6 +7213,7 @@ export interface components {
                 hotkey: string;
                 max_validator_trust: number | null;
                 nominator_count: number | null;
+                /** @description This validator's membership row in the requested netuid; null when netuid was omitted or it has no permit there. Opaque JSON, matching the REST/MCP shape. */
                 subnet_context: {
                     active: boolean;
                     axon: string | null;
@@ -7108,6 +7282,7 @@ export interface components {
             contract_version?: string;
             generated_at: string;
             name: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             openapi_url: "/metagraph/openapi.json";
@@ -7161,6 +7336,7 @@ export interface components {
             native_only_without_candidates: number;
             native_snapshot_captured_at: string;
             network: components["schemas"]["BittensorNetwork"];
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             probed_count: number;
             probed_surface_count: number;
@@ -7189,6 +7365,7 @@ export interface components {
             contract_version?: string;
             coverage_depth_version: number;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             ranked_queue: {
                 name: string;
@@ -7339,6 +7516,7 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
@@ -7359,6 +7537,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Network-wide public evidence ledger page. Mirrors GET /api/v1/evidence (and MCP list_evidence). */
         CurationArtifact: {
             contract_version?: string;
             curation: {
@@ -7377,6 +7556,7 @@ export interface components {
                 surface_count: number;
             }[];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -7393,13 +7573,16 @@ export interface components {
             source_count?: number;
             verified_at?: string | null;
         };
+        /** @description The per-domain rollup overview across the fixed capability taxonomy (#6989). Mirrors GET /api/v1/domains. */
         DomainsArtifact: {
             domain_count: number;
             domains: components["schemas"]["DomainSummaryArtifact"][];
             schema_version: number;
         };
+        /** @description One domain/capability tag's rollup (#6989). Mirrors GET /api/v1/domains/{tag}/summary. */
         DomainSummaryArtifact: {
             domain: string;
+            /** @description Within-domain emission concentration scorecard; null when the domain has no members. Declared Float until #9889 — the route has served the full 12-key scorecard for long enough that the scalar coerced to null on every domain, which this type's own comment then read as 'no members'. */
             emission_concentration: {
                 entropy: number | null;
                 entropy_normalized: number | null;
@@ -7423,11 +7606,15 @@ export interface components {
         };
         EconomicsArtifact: {
             captured_at: string | null;
+            /** @description The chain state the decomposition's inputs were pinned to. theta/q/h are read AS STORED at this block -- the runtime gates with the stored bar between its 360-block recomputes, so a live read is the wrong number for 359 blocks out of 360. */
             chain_state?: {
                 block: number;
+                /** @description The block hash, so the pinning is exact -- a height alone is ambiguous across a reorg. */
                 block_hash: string;
                 emission_bar_quantile: number | null;
+                /** @description theta. Null when the bar is unset, which disables the gate outright. */
                 emission_gate_bar: number | null;
+                /** @description h. Null means the runtime default 3, NOT zero -- h = 0 makes the Hill gate a constant 0.5 for every subnet. */
                 emission_gate_exponent: number | null;
                 total_issuance_tao: number;
             };
@@ -7444,6 +7631,7 @@ export interface components {
             };
             generated_at: string;
             network: string | null;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -7454,9 +7642,13 @@ export interface components {
                 alpha_market_cap_tao: number | null;
                 alpha_out_emission?: number | null;
                 alpha_out_pool: number | null;
+                /** @description Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227). */
                 alpha_price_change_1d?: number | null;
+                /** @description Signed %-change in alpha_price_tao over ~1h. Always null from daily snapshots (#7227). */
                 alpha_price_change_1h?: number | null;
+                /** @description Signed %-change in alpha_price_tao over ~30 days from subnet_snapshots (#7227). */
                 alpha_price_change_1m?: number | null;
+                /** @description Signed %-change in alpha_price_tao over ~7 days from subnet_snapshots (#7227). */
                 alpha_price_change_7d?: number | null;
                 /** @description The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that. */
                 alpha_price_tao: number | null;
@@ -7493,9 +7685,12 @@ export interface components {
             summary: {
                 registration_open_count: number;
                 subnet_count: number;
+                /** @description Sum of every non-root subnet's alpha_market_cap_tao -- rao-precision decimal string (#6641). */
                 total_alpha_value_tao: string;
                 total_miners: number;
+                /** @description total_root_value_tao + total_alpha_value_tao -- Backprop's Total Network Value (#6641). */
                 total_network_value_tao: string;
+                /** @description Root (netuid 0) TAO-denominated stake -- rao-precision decimal string (#6641). */
                 total_root_value_tao: string;
                 total_stake_alpha: string;
                 total_validators: number;
@@ -7513,6 +7708,7 @@ export interface components {
                 miner_count?: number | null;
                 snapshot_date: string;
                 subnet_count: number;
+                /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet reporting that day -- exceeds the exact-double ceiling as a JSON number, so it is served as a string rather than Float. */
                 total_stake_alpha?: string | null;
                 validator_count?: number | null;
             }[];
@@ -7538,6 +7734,7 @@ export interface components {
             kind: string | null;
             latest_change_at: string | null;
             limit: number | null;
+            /** @description How many returned entries are first observations rather than changes. */
             predates_capture_count: number;
             schema_version: number;
         } & {
@@ -7555,23 +7752,32 @@ export interface components {
             source: ("governance" | "runtime_recomputed") | null;
             value: number | null;
         };
+        /** @description The v440 emission pipeline replayed over one pinned block (#8744) -- the per-subnet share decomposition, the network aggregate, and the identity checks evaluated on the rows being served. */
         EmissionPipelineArtifact: {
+            /** @description Network-wide totals across every row in the capture -- unchanged by the netuid argument, which narrows the per-subnet rows only. */
             aggregate: {
                 disabled_count: number;
                 eligible_count: number;
                 excess_tao: number;
+                /** @description The network split nobody else publishes: pool injection vs chain buys. */
                 liquidity_fraction: number | null;
                 tao_in_emission: number;
                 tao_total: number;
+                /** @description Sum of final_share. 1.0 to float precision, or the surface is broken. */
                 total_final_share: number;
             };
             block_emission_halvings: number | null;
+            /** @description Block emission derived from TotalIssuance at that block, never read from the stale BlockEmission storage item. */
             block_emission_tao: number | null;
+            /** @description The block every input below was pinned to. Required: without it nothing here can be verified. */
             chain_state: {
                 block: number;
+                /** @description The block hash, so the pinning is exact -- a height alone is ambiguous across a reorg. */
                 block_hash: string;
                 emission_bar_quantile: number | null;
+                /** @description theta. Null when the bar is unset, which disables the gate outright. */
                 emission_gate_bar: number | null;
+                /** @description h. Null means the runtime default 3, NOT zero -- h = 0 makes the Hill gate a constant 0.5 for every subnet. */
                 emission_gate_exponent: number | null;
                 total_issuance_tao: number;
             };
@@ -7591,22 +7797,34 @@ export interface components {
             subnets: {
                 alpha_in_emission: number | null;
                 alpha_out_emission: number | null;
+                /** @description weighted_share / theta. Null when the bar is unset. */
                 distance_to_bar: number | null;
+                /** @description PUBLISHED, NOT INFERRED. A subnet far enough below the bar has its gated share underflow to exactly 0, so an enabled-but-deeply-gated subnet and a disabled one both read final_share: 0 -- this flag is the only thing that separates them. */
                 emission_enabled: boolean;
+                /** @description Stage 1, the published emission_share (ADR 0023 decision 1) -- the PRICE share, not the share of TAO received. */
                 emission_share: number | null;
+                /** @description Stage 7, measured: the TAO that reached the subnet by chain buys instead. */
                 excess_tao: number | null;
                 final_share: number | null;
+                /** @description gated_share - weighted_share. Sums to ~0 across the network: the gate redistributes, it never withholds. */
                 gate_delta: number | null;
                 gated_share: number | null;
+                /** @description Non-null (root, never_emitted, subtoken_disabled, registration_closed) means the subnet took no part in stage 1, and every downstream share is null rather than 0 -- 'not in the distribution' is not 'in it with nothing'. */
                 ineligible_reason: ("root" | "never_emitted" | "subtoken_disabled" | "registration_closed") | null;
+                /** @description tao_in_emission / tao_total, the headline per-subnet number. Null rather than NaN for a zero-intake subnet: 0/0 is not a fraction, and zero intake is a real state. */
                 liquidity_fraction: number | null;
+                /** @description Stage 2 input. A FRACTION in [0,1], never an amount. */
                 miner_burned: number;
                 netuid: number;
+                /** @description Stage 8, measured: the TAO injected into the subnet's pool this block. */
                 tao_in_emission: number | null;
+                /** @description Their sum -- the subnet's whole TAO intake this block. Null unless both channels were actually read. */
                 tao_total: number | null;
                 weighted_share: number | null;
             }[];
+            /** @description The four identities, evaluated on the rows being served rather than read from a stored flag -- a stored flag can be green while THIS response is broken, and it can go stale. ADR 0023 decision 3. */
             verification: {
+                /** @description A rao count as a string -- the tolerance is a bigint, and a JSON number is the wrong type for one. */
                 aggregate_tolerance_rao: string;
                 checks: {
                     detail: string;
@@ -7614,6 +7832,7 @@ export interface components {
                     ok: boolean;
                 }[];
                 subnet_share_tolerance: number;
+                /** @description False means at least one identity did not hold on these rows: the response is not defensible and must not be used. */
                 verified: boolean;
             };
         } & {
@@ -7665,6 +7884,7 @@ export interface components {
             contract_version?: string;
             generated_at: string;
             incidents: components["schemas"]["EndpointIncident"][];
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -7691,6 +7911,7 @@ export interface components {
             source: string;
             timeout_ms?: number | null;
         };
+        /** @description Endpoint pool scores (#6570): same pools[] row shape, filter/sort/page surface, and pagination metadata as PoolList. Split from it in #9892 for the one field that differs -- operational_observed_at, which GET /api/v1/endpoint-pools does not serve at all, because endpoint pools carry no live cron eligibility overlay and so have no observation stamp to report. The shared type declared it anyway and GraphQL answered null, which reads as not-observed-yet rather than never-observed-here. */
         EndpointPoolsArtifact: {
             contract_version?: string;
             disabled_proxy_contract?: {
@@ -7715,6 +7936,7 @@ export interface components {
                 [key: string]: unknown;
             };
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             pools: components["schemas"]["RpcPool"][];
             provider_scores?: {
@@ -7791,6 +8013,7 @@ export interface components {
             endpoints: components["schemas"]["EndpointResource"][];
             generated_at: string;
             health_source?: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             operational_observed_at?: string | null;
             /** @constant */
@@ -7852,6 +8075,7 @@ export interface components {
             claims: components["schemas"]["EvidenceClaim"][];
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -7864,6 +8088,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Live EVM (H160) -> Substrate (SS58) account-address mapping read from chain via RPC. ss58 is null when the mapping cannot be resolved (schema-stable, never a GraphQL error). Mirrors GET /api/v1/evm/address/{h160}. */
         EvmAddressMappingArtifact: {
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
             field_sources: {
@@ -7933,12 +8158,17 @@ export interface components {
         FailureReason: {
             checks: number;
             classification: string;
+            /** @description Of the FAILING probes only; null on a succeeding classification, where the question does not apply. */
             failure_share: number | null;
+            /** @description redirected is NOT a failure -- a surface answering from a new location is serving. */
             is_failure: boolean;
+            /** @description Of every probe in the window. */
             share: number | null;
         };
         FailureReasonsArtifact: {
+            /** @description Counted from the ROWS, not the requested window -- a day the prober did not run is absent rather than a zero. */
             days_covered: number | null;
+            /** @description Present ONLY on a decline. An empty window is a measurement, not a decline. */
             degraded?: {
                 /** @enum {string} */
                 reason: "unavailable";
@@ -7951,6 +8181,7 @@ export interface components {
             oldest_day: string | null;
             reasons: components["schemas"]["FailureReason"][];
             schema_version: number;
+            /** @description Oldest day first. */
             series: components["schemas"]["FailureReasonsDay"][];
             total_checks: number | null;
             window: string | null;
@@ -7958,6 +8189,7 @@ export interface components {
             [key: string]: unknown;
         };
         FailureReasonsDay: {
+            /** @description Checks per classification on this day, as a JSON object. */
             by_classification: {
                 [key: string]: number;
             };
@@ -7972,6 +8204,7 @@ export interface components {
             generated_at: string;
             kind: components["schemas"]["SurfaceKind"];
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             request: {
                 /** @constant */
@@ -8026,6 +8259,7 @@ export interface components {
             })[];
             generated_at: string;
             missing_count?: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             published_at?: string | null;
             /** @constant */
@@ -8039,6 +8273,7 @@ export interface components {
         FreshnessArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -8088,6 +8323,7 @@ export interface components {
             moving_target_surfaces?: string[];
             supported_kinds: components["schemas"]["SurfaceKind"][];
         };
+        /** @description Registry-wide interface gap report page. Mirrors GET /api/v1/gaps (and MCP list_gaps). */
         GapsArtifact: {
             contract_version?: string;
             gaps: {
@@ -8103,6 +8339,7 @@ export interface components {
                 slug: string;
             }[];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -8114,11 +8351,13 @@ export interface components {
             generated_at?: "1970-01-01T00:00:00.000Z";
         };
         GenericArtifact: components["schemas"]["ArtifactBase"];
+        /** @description Global endpoint-incident ledger (#5660). Mirrors GET /api/v1/incidents' data envelope. */
         GlobalIncidentsArtifact: {
             min_incident_samples: number;
             observed_at?: string | null;
             schema_version: number;
             source: string;
+            /** @description Aggregate counts -- incident_count, active_count, and by_kind/by_layer/by_provider/by_severity/by_status maps. Opaque JSON: the by_* maps are dynamic-keyed, matching the MCP get_global_incidents summary shape. */
             summary: {
                 affected_surface_count: number;
                 incident_count: number;
@@ -8223,6 +8462,7 @@ export interface components {
             /** @description Badge right-hand text. Currently the same value as `status`, kept separate because the badge's wording is a display concern and the verdict is not. */
             message: string;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             ok_count?: number;
             /** @constant */
@@ -8237,6 +8477,7 @@ export interface components {
             contract_version?: string;
             date: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             probe_finished_at: string | null;
             probe_started_at: string | null;
@@ -8267,12 +8508,14 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One subnet's per-surface SLA + reconstructed downtime incidents over the window. Mirrors GET /api/v1/subnets/{netuid}/health/incidents's data envelope. */
         HealthIncidentsArtifact: {
             min_incident_samples: number;
             netuid: number;
             observed_at?: string | null;
             schema_version: number;
             source: string;
+            /** @description Per operational surface: its sample count, uptime_ratio, incident_count, total downtime_ms, and gap-island incident list (started_at/ended_at/duration_ms/failed_samples, epoch-ms). Opaque JSON passed through verbatim, matching the get_subnet_health_incidents MCP/REST shape (like SubnetHealthTrends.windows). */
             surfaces: ({
                 downtime_ms: number;
                 incident_count: number;
@@ -8299,6 +8542,7 @@ export interface components {
         HealthLatestArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @description When the probe run that produced this rollup finished -- `probe_finished_at || observed_at || null`, not the build's `generated_at`. */
             observed_at: string | null;
@@ -8319,11 +8563,13 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One subnet's per-surface success-only latency percentiles (#6980). Mirrors GET /api/v1/subnets/{netuid}/health/percentiles' data envelope. */
         HealthPercentilesArtifact: {
             netuid: number;
             observed_at?: string | null;
             schema_version: number;
             source: string;
+            /** @description Per operational surface: its success-only latency sample count and p50/p90/p95/p99 latency percentiles in ms. Opaque JSON passed through verbatim, matching the get_subnet_health_percentiles MCP/REST shape (like SubnetHealthIncidents.surfaces). */
             surfaces: ({
                 latency_ms: {
                     avg: number | null;
@@ -8458,11 +8704,13 @@ export interface components {
             url: string;
             verified_at?: string | null;
         };
+        /** @description One subnet's uptime + latency trend windows. Mirrors GET /api/v1/subnets/{netuid}/health/trends's data envelope. */
         HealthTrendsArtifact: {
             netuid: number;
             observed_at?: string | null;
             schema_version: number;
             source: string;
+            /** @description The 7d/30d windows keyed by window label, each holding this subnet's samples, uptime_ratio, latency_sample_count and the per-surface uptime/latency series. Opaque JSON: dynamic-keyed by window label, matching the get_subnet_health_trends MCP/REST shape. */
             windows: {
                 [key: string]: {
                     latency_sample_count: number;
@@ -8492,21 +8740,26 @@ export interface components {
             [key: string]: unknown;
         };
         IndexerLagArtifact: {
+            /** @description Blocks the distribution was computed over. Null only on a decline. */
             block_count: number | null;
+            /** @description Present ONLY on a decline; its absence says the measurement is real. */
             degraded?: {
                 detail?: string;
                 /** @enum {string} */
                 reason: "no_retained_blocks" | "unavailable";
             };
+            /** @description now - the newest observed_at. The number that moves when the lane stalls. */
             head_age_ms: number | null;
             /** Format: date-time */
             measured_at: string;
             schema_version: number;
+            /** @description What was actually measured -- the table is pruned, so a distribution without its bounds would read as a lifetime one. */
             window: components["schemas"]["IndexerLagWindow"] | null;
             write_latency_ms: components["schemas"]["IndexerLagLatency"] | null;
         } & {
             [key: string]: unknown;
         };
+        /** @description Milliseconds from a block's own timestamp to the moment it became queryable here. Unbounded below: a negative value is block-author clock skew, served as measured. */
         IndexerLagLatency: {
             max: number | null;
             mean: number | null;
@@ -8569,6 +8822,7 @@ export interface components {
             matched_by_counts?: {
                 [key: string]: number;
             };
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             published_at?: string | null;
             /** @constant */
@@ -8609,6 +8863,7 @@ export interface components {
             /** @constant */
             schema_version: 1;
         };
+        /** @description Live global Subtensor protocol/governance parameters, read live from chain via RPC. Each field is independently null on its own RPC failure (schema-stable). Mirrors GET /api/v1/network/parameters's data envelope. */
         NetworkParametersArtifact: {
             block_emission_halvings?: number | null;
             block_emission_tao?: number | null;
@@ -8635,10 +8890,12 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One neuron's live metagraph detail card (#5900). Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}: neuron is null when that UID is absent from the latest snapshot. */
         NeuronDetailArtifact: {
             block_number?: number | null;
             captured_at?: string | null;
             netuid: number;
+            /** @description The UID's live metagraph row; null when absent from the latest snapshot. */
             neuron: {
                 active: boolean;
                 /** @description The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541). */
@@ -8650,7 +8907,9 @@ export interface components {
                 emission_tao?: number | null;
                 featured?: boolean;
                 hotkey: string | null;
+                /** @description Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block/timestamp at ~12s/block; null if that anchor is unavailable (#6640). */
                 immunity_expires_at?: string | null;
+                /** @description The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640). */
                 immunity_expires_at_block?: number;
                 incentive?: number | null;
                 is_immunity_period?: boolean;
@@ -8659,6 +8918,7 @@ export interface components {
                 registered_at_block?: number | null;
                 /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao?: number | null;
+                /** @description Validator take/commission (0..1) from SubtensorModule::Delegates; null when no Delegates entry at capture. */
                 take?: number | null;
                 trust?: number | null;
                 uid: number;
@@ -8669,6 +8929,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One neuron's per-day metagraph history. Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}/history. */
         NeuronHistoryArtifact: {
             netuid: number;
             point_count: number;
@@ -8685,7 +8946,9 @@ export interface components {
                 emission_tao?: number | null;
                 featured?: boolean;
                 hotkey: string | null;
+                /** @description Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block/timestamp at ~12s/block; null if that anchor is unavailable (#6640). */
                 immunity_expires_at?: string | null;
+                /** @description The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640). */
                 immunity_expires_at_block?: number;
                 incentive?: number | null;
                 is_immunity_period?: boolean;
@@ -8695,6 +8958,7 @@ export interface components {
                 snapshot_date: string;
                 /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao?: number | null;
+                /** @description Validator take/commission (0..1) from SubtensorModule::Delegates; null when no Delegates entry at capture. */
                 take?: number | null;
                 trust?: number | null;
                 uid: number;
@@ -8735,6 +8999,7 @@ export interface components {
             generated_at: string;
             /** @description The operational surface kinds this list is filtered to (OPERATIONAL_SURFACE_KINDS), sorted. */
             kinds: string[];
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -8806,15 +9071,19 @@ export interface components {
          */
         PartnershipTier: "pilot";
         PipelineHistoryArtifact: {
+            /** @description Present ONLY on a decline. An empty series is a measurement. */
             degraded?: {
                 /** @enum {string} */
                 reason: "unavailable";
             };
+            /** @description Independent samples -- the honest denominator for any claim about how a value moved. */
             distinct_observations: number | null;
+            /** @description The first day the pipeline columns were ever written, so a short series reads as a start rather than a gap. */
             first_captured_day: string;
             netuid: number;
             newest_day: string | null;
             oldest_day: string | null;
+            /** @description Rows returned. NOT the number of times the pipeline was read. */
             point_count: number | null;
             points: components["schemas"]["PipelineHistoryPoint"][];
             schema_version: number;
@@ -8830,12 +9099,16 @@ export interface components {
             day: string;
             emission_enabled: boolean | null;
             emission_share: number | null;
+            /** @description Chain buys. */
             excess_tao: number | null;
             first_emission_block: number | null;
             miner_burned_fraction: number | null;
+            /** @description The chain state this point describes. A point that cannot say which block it came from is not served. */
             pipeline_block: number;
             pipeline_block_hash: string | null;
+            /** @description True when the snapshot writer carried the previous capture forward: this point is NOT an independent sample. */
             repeats_previous_observation: boolean;
+            /** @description Pool liquidity injection. */
             tao_in_emission_tao: number | null;
             tao_in_pool_tao: number | null;
         };
@@ -8878,6 +9151,7 @@ export interface components {
             contract_version?: string;
             endpoint_summary?: components["schemas"]["EndpointSummary"];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             provider: components["schemas"]["Provider"];
             /** @constant */
@@ -8889,6 +9163,7 @@ export interface components {
             contract_version?: string;
             endpoints: components["schemas"]["EndpointResource"][];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             provider: {
                 authority?: string;
@@ -8909,6 +9184,7 @@ export interface components {
         ProvidersArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             providers: components["schemas"]["Provider"][];
             /** @constant */
@@ -8945,6 +9221,7 @@ export interface components {
              * @enum {string}
              */
             manifest_kind?: "compact" | "full";
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @description Artifact paths the publish step must find in the archive even though the compact manifest omits them. */
             required_artifact_paths?: string[];
@@ -8969,6 +9246,7 @@ export interface components {
             /** @enum {string} */
             storage_tier: "dual" | "git" | "r2";
         };
+        /** @description Live drand randomness-beacon status read from chain via RPC. Each field is independently null on its own RPC failure (schema-stable). Mirrors GET /api/v1/network/randomness's data envelope. */
         RandomnessArtifact: {
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
             field_sources: {
@@ -8988,8 +9266,11 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Registry leaderboards over the operational + economic-opportunity boards. Mirrors GET /api/v1/registry/leaderboards. */
         RegistryLeaderboardsArtifact: {
+            /** @description The board filter that was applied, or null when every board is returned. */
             board?: string | null;
+            /** @description Every board keyed by board name, each an array of ranked subnet entries capped at limit. Opaque JSON like HealthTrends.windows: the keys are dynamic AND hyphenated (fastest-rpc, most-complete, open-slots, …) so they are not expressible as GraphQL field names, and each board carries its own metric columns (healthiest has uptime_ratio/surfaces_ok, fastest-rpc has latency_ms, fastest-growing has completeness_delta, …). Passing it through verbatim keeps the REST/MCP get_registry_leaderboards shape byte-for-byte. */
             boards: {
                 [key: string]: ({
                     alpha_price_change_1d?: number | null;
@@ -9067,6 +9348,7 @@ export interface components {
             }) | null;
             curation_level_counts?: components["schemas"]["CountMap"];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             profile_level_counts?: components["schemas"]["CountMap"];
             recent_changes?: {
@@ -9153,6 +9435,7 @@ export interface components {
             candidates: components["schemas"]["ReviewAdapterCandidate"][];
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -9175,6 +9458,7 @@ export interface components {
             contract_version?: string;
             gap_priorities: components["schemas"]["ReviewGapPriority"][];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             review_decisions: components["schemas"]["ReviewDecision"][];
             /** @constant */
@@ -9205,6 +9489,7 @@ export interface components {
             contract_version?: string;
             decisions: components["schemas"]["ReviewDecision"][];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -9426,6 +9711,7 @@ export interface components {
         ReviewGapPrioritiesArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             priorities: components["schemas"]["ReviewGapPriority"][];
             /** @constant */
@@ -9449,6 +9735,7 @@ export interface components {
         ReviewProfileCompletenessArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             profiles: {
                 candidate_count: number;
@@ -9548,6 +9835,7 @@ export interface components {
                 url: string;
             }[];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -9603,6 +9891,7 @@ export interface components {
             id: string;
             kind: string;
         };
+        /** @description RPC pool scores (#6570): same pools[] row shape, filter/sort/page surface, and pagination metadata as EndpointPoolList, plus operational_observed_at -- real here and only here, since the RPC pools are the ones carrying a live 15-minute cron eligibility overlay. */
         RpcPoolsArtifact: {
             contract_version?: string;
             disabled_proxy_contract?: {
@@ -9627,6 +9916,7 @@ export interface components {
                 [key: string]: unknown;
             };
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             pools: components["schemas"]["RpcPool"][];
             provider_scores?: {
@@ -9647,8 +9937,11 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description RPC reverse-proxy usage analytics over a 7d/30d window. Mirrors GET /api/v1/rpc/usage's data envelope. */
         RpcUsageArtifact: {
+            /** @description Time-bucket granularity for buckets: 1h for the 7d window, 6h for 30d. Null on a cold store. */
             bucket_granularity?: string | null;
+            /** @description Bounded time buckets over the window for heatmaps, oldest-first. */
             buckets: ({
                 avg_latency_ms: number | null;
                 errors: number;
@@ -9657,28 +9950,38 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
+            /** @description What the answer is actually about, as opposed to what window was asked for. */
             coverage: {
+                /** @description Epoch ms of the newest measured event across every contributing store, or null when nothing was measured. */
                 end: number | null;
+                /** @description The sub-range summary.latency_ms p50/p95 describe, or null when nothing measured them. Counts are additive across disjoint ranges; percentiles are not, so they stay scoped to the one store that has a percentile function. */
                 latency_percentiles: ({
                     end: number | null;
                     start: number | null;
                 } & {
                     [key: string]: unknown;
                 }) | null;
+                /** @description One entry per contributing store, oldest first. Two non-adjacent entries mean the window has a hole between them that no store covers. */
                 segments: ({
+                    /** @description Epoch ms of this store's newest measured event in the window. */
                     end: number | null;
+                    /** @description Which store measured it: analytics-engine (live capture) or lakehouse (frozen history). */
                     source: string;
+                    /** @description Epoch ms of this store's oldest measured event in the window. */
                     start: number | null;
                 } & {
                     [key: string]: unknown;
                 })[];
+                /** @description Epoch ms of the oldest measured event across every contributing store, or null when nothing was measured. */
                 start: number | null;
             } & {
                 [key: string]: unknown;
             };
+            /** @description Per-endpoint request distribution, ranked by request volume (top 50). */
             endpoints: ({
                 avg_latency_ms?: number | null;
                 endpoint_id: string | null;
+                /** @description Null when the endpoint had no requests in the window. */
                 error_rate?: number | null;
                 ok_requests: number;
                 provider?: string | null;
@@ -9687,7 +9990,9 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
+            /** @description Per-network request breakdown, ordered by request volume. */
             networks: ({
+                /** @description Null when the network had no requests in the window. */
                 error_rate?: number | null;
                 network: string;
                 ok_requests: number;
@@ -9702,13 +10007,18 @@ export interface components {
             observed_at?: number | null;
             schema_version: number;
             source: string;
+            /** @description Window-total rollup for RPC reverse-proxy traffic. */
             summary: {
+                /** @description Null when there are no requests in the window. */
                 cache_hit_rate?: number | null;
                 cache_hits?: number;
+                /** @description Null when there are no requests in the window (no defined rate). */
                 error_rate?: number | null;
                 error_requests: number;
+                /** @description Null when there are no requests in the window. */
                 failover_rate?: number | null;
                 failover_requests?: number;
+                /** @description Window latency percentiles + average for RPC reverse-proxy traffic; each is null on a cold store. */
                 latency_ms?: {
                     avg?: number | null;
                     p50?: number | null;
@@ -9725,6 +10035,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Site-wide runtime spec-version transition timeline. Mirrors GET /api/v1/runtime. */
         RuntimeVersionsArtifact: {
             coverage_complete: boolean;
             coverage_from_at: string | null;
@@ -9750,6 +10061,7 @@ export interface components {
         SchemaDriftArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @description When the snapshot run observed these surfaces -- NOT the build's `generated_at`. A rebuild republishes an old capture unchanged, so this is the only field that says how old the drift verdict is. Absent on the build-time placeholder, which observed nothing. */
             observed_at?: string | null;
@@ -9798,6 +10110,7 @@ export interface components {
         SchemaIndexArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             observed_at?: string;
             /** @constant */
@@ -9884,6 +10197,7 @@ export interface components {
         SearchArtifact: {
             contract_version?: string;
             document_count?: number;
+            /** @description Heterogeneous per-type documents (subnet/surface/provider/doc), passed through verbatim as opaque JSON. */
             documents: {
                 artifact_path: string;
                 categories?: string[];
@@ -9899,12 +10213,14 @@ export interface components {
                 url?: string;
             }[];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
         } & {
             [key: string]: unknown;
         };
+        /** @description Filtered and paginated search-index documents with full REST list-query pagination metadata (#7877). Mirrors GET /api/v1/search-index (and MCP list_search_index). */
         SearchIndexArtifact: {
             contract_version?: string;
             document_count?: number;
@@ -9922,6 +10238,7 @@ export interface components {
                 url?: string;
             }[];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -9938,38 +10255,65 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description metagraphed's own uptime verdict (#8422). Mirrors GET /api/v1/self-health. */
         SelfHealthArtifact: {
             components: components["schemas"]["SelfHealthComponent"][];
             lanes: components["schemas"]["SelfHealthLane"][];
+            /** @description Components with data. Zero means the poller hasn't written anything yet. */
             measured_component_count: number;
             observed_at: string | null;
             schema_version: number;
             stale_lane_count: number;
-            /** @enum {string} */
+            /**
+             * @description operational | degraded | outage.
+             * @enum {string}
+             */
             verdict: "operational" | "degraded" | "outage";
         } & {
             [key: string]: unknown;
         };
+        /** @description One self-health component (api / site / publish): its latest probe state and trailing-90-day daily ratios. */
         SelfHealthComponent: {
             checked_at: string | null;
             component: string;
+            /** @description Null when the component has never been probed -- NOT false. */
             current_ok: boolean | null;
+            /** @description Trailing-90d daily ratios, oldest first; gaps are absent, never zero-filled. */
             days: components["schemas"]["SelfHealthDay"][];
             http_status: number | null;
             latency_ms: number | null;
+            /** @description Qualifies a false current_ok with why, for non-HTTP failure modes. Null when there's nothing to add. */
             note: string | null;
+            /** @description Mean uptime across the days we actually have. Null when there are none. */
             uptime_90d: number | null;
         } & {
             [key: string]: unknown;
         };
+        /** @description One UTC day's uptime ratio for a self-health component. Days with no probe rows are ABSENT, never zero-filled. */
         SelfHealthDay: {
             checks: number;
             day: string;
             ok_count: number;
+            /** @description ok_count / checks, 0..1. */
             uptime_ratio: number;
         } & {
             [key: string]: unknown;
         };
+        /**
+         * @description One ingest lane's staleness verdict.
+         *
+         *     Three of these five were declared non-null against a Zod schema that says
+         *     otherwise, and production proved it: \`self_health\` returned
+         *     \`Cannot return null for non-nullable field SelfHealthLane.detail\` and nulled
+         *     the whole \`lanes\` list. \`age_ms\` and \`checked_at\` are null for the same
+         *     reason -- the watchdog could not measure the lane, which is the "we did not
+         *     measure" this type exists to distinguish from "the lane is fine" (#10215).
+         *
+         *     \`age_ms\` is a Float because it is a duration in MILLISECONDS: a lane stale
+         *     for more than 24.8 days exceeds GraphQL's 32-bit Int, and the answer to
+         *     "how far behind is this lane" must not stop being representable exactly when
+         *     it starts to matter.
+         */
         SelfHealthLane: {
             age_ms: number | null;
             checked_at: string | null;
@@ -10003,6 +10347,7 @@ export interface components {
         SourceHealthArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             providers: {
                 authority: components["schemas"]["Authority"];
@@ -10038,6 +10383,7 @@ export interface components {
         SourceSnapshotsArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -10063,6 +10409,7 @@ export interface components {
         };
         /** @enum {string} */
         SourceTier: "native-chain" | "provider-claimed" | "third-party-index" | "community-docs";
+        /** @description One subnet's rolling 24h alpha trading volume (#6979). Mirrors GET /api/v1/subnets/{netuid}/volume' data envelope. */
         SubnetAlphaVolumeArtifact: {
             buy_count: number;
             buy_volume_alpha: number;
@@ -10073,16 +10420,25 @@ export interface components {
             sell_count: number;
             sell_volume_alpha: number;
             sell_volume_tao: number;
-            /** @enum {string} */
+            /**
+             * @description Bucketed reading of sentiment_ratio (buying/selling/neutral).
+             * @enum {string}
+             */
             sentiment: "bullish" | "bearish" | "neutral";
+            /** @description Buy share of total volume (0-1); null when there was no volume. */
             sentiment_ratio: number | null;
             total_volume_alpha: number;
             total_volume_tao: number;
+            /** @description Total TAO volume over alpha market cap; null when market cap is unknown. */
             vol_mcap_ratio: number | null;
-            /** @enum {string} */
+            /**
+             * @description The rolling window label this card covers (24h).
+             * @enum {string}
+             */
             window: "24h";
         };
         SubnetAxonRemovalsArtifact: {
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
@@ -10095,6 +10451,7 @@ export interface components {
             schema_version: number;
             window: ("7d" | "30d") | null;
         };
+        /** @description Live current registration/burn cost for one subnet, read directly from chain via RPC. burn_tao is null on RPC failure (schema-stable, never a GraphQL error). Mirrors GET /api/v1/subnets/{netuid}/burn. */
         SubnetBurnArtifact: {
             burn_tao?: number | null;
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
@@ -10136,6 +10493,7 @@ export interface components {
             generated_at: string;
             name?: string;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -10143,8 +10501,10 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Per-subnet stake & emission concentration card (#5901) over the current neurons snapshot. Metric blocks are null on a cold/empty subnet. Mirrors GET /api/v1/subnets/{netuid}/concentration. */
         SubnetConcentrationArtifact: {
             captured_at?: string | null;
+            /** @description Emission concentration across all UIDs. */
             emission: ({
                 entropy?: number | null;
                 entropy_normalized?: number | null;
@@ -10161,7 +10521,9 @@ export interface components {
             } & {
                 [key: string]: unknown;
             }) | null;
+            /** @description Distinct controlling entities (coldkeys) behind the subnet's UIDs. */
             entity_count: number;
+            /** @description Emission concentration collapsed to one holder per controlling entity. */
             entity_emission?: ({
                 entropy?: number | null;
                 entropy_normalized?: number | null;
@@ -10178,6 +10540,7 @@ export interface components {
             } & {
                 [key: string]: unknown;
             }) | null;
+            /** @description Stake concentration collapsed to one holder per controlling entity. */
             entity_stake?: ({
                 entropy?: number | null;
                 entropy_normalized?: number | null;
@@ -10197,6 +10560,7 @@ export interface components {
             netuid: number;
             neuron_count: number;
             schema_version: number;
+            /** @description Stake concentration across all UIDs. */
             stake: ({
                 entropy?: number | null;
                 entropy_normalized?: number | null;
@@ -10213,7 +10577,9 @@ export interface components {
             } & {
                 [key: string]: unknown;
             }) | null;
+            /** @description UIDs per controlling entity -- a Sybil/consolidation signal (1.0 = every UID a distinct owner; higher = fewer operators each running many hotkeys). Null on an empty subnet. */
             uids_per_entity?: number | null;
+            /** @description Stake concentration across permitted validators only. */
             validator_stake?: ({
                 entropy?: number | null;
                 entropy_normalized?: number | null;
@@ -10233,6 +10599,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Per-subnet per-day concentration trend (#5901) from the neuron_daily rollup, newest first. An empty series (point_count 0) on a cold store, never a GraphQL error. Mirrors GET /api/v1/subnets/{netuid}/concentration/history. */
         SubnetConcentrationHistoryArtifact: {
             netuid: number;
             point_count: number;
@@ -10249,10 +10616,12 @@ export interface components {
                 [key: string]: unknown;
             })[];
             schema_version: number;
+            /** @description The resolved window label (7d/30d/90d). */
             window?: string | null;
         } & {
             [key: string]: unknown;
         };
+        /** @description Live per-subnet conviction leaderboard -- who currently holds the most rolled conviction, rolled forward from a periodically-captured snapshot using the current live-queried unlock_rate/maturity_rate. Mirrors GET /api/v1/subnets/{netuid}/conviction. */
         SubnetConvictionArtifact: {
             count: number;
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
@@ -10280,22 +10649,28 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Per-subnet neuron-deregistration activity over a window (#5719). Zeroed card (0 counts) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/deregistrations. */
         SubnetDeregistrationsArtifact: {
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
             };
             deregistrations: number;
             deregistrations_per_hotkey: number | null;
+            /** @description How a deregistration feed was derived (#9307). NeuronDeregistered has never been emitted, so deregistrations are derived from UID reuse: a NeuronRegistered on a (netuid, uid) slot already held by a different hotkey IS the deregistration of the previous occupant. unattributed_registrations is the honest part -- the published totals are a LOWER BOUND by that many events, because those registrations displaced a holder the derivation's lookback cannot name. */
             derivation?: {
                 /**
                  * @description True when the count is a floor rather than a measurement: some registrations in the window displaced a holder the derivation's lookback cannot name, so the real figure is higher by at least `unattributed_registrations`. Treat the value as 'at least this many', never as a total.
                  * @example true
                  */
                 is_lower_bound: boolean;
+                /** @description Days of NeuronRegistered history the derivation had available. */
                 lookback_days: number;
                 method: string;
+                /** @description Of those, the ones with no observed previous holder. */
                 unattributed_registrations: number;
+                /** @description Registrations observed inside the reported window. */
                 window_registrations: number;
             };
             distinct_deregistered_hotkeys: number;
@@ -10416,9 +10791,13 @@ export interface components {
                 alpha_market_cap_tao: number | null;
                 alpha_out_emission?: number | null;
                 alpha_out_pool: number | null;
+                /** @description Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227). */
                 alpha_price_change_1d?: number | null;
+                /** @description Signed %-change in alpha_price_tao over ~1h. Always null from daily snapshots (#7227). */
                 alpha_price_change_1h?: number | null;
+                /** @description Signed %-change in alpha_price_tao over ~30 days from subnet_snapshots (#7227). */
                 alpha_price_change_1m?: number | null;
+                /** @description Signed %-change in alpha_price_tao over ~7 days from subnet_snapshots (#7227). */
                 alpha_price_change_7d?: number | null;
                 /** @description The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that. */
                 alpha_price_tao: number | null;
@@ -10455,6 +10834,7 @@ export interface components {
             endpoints?: components["schemas"]["EndpointResource"][];
             gaps: components["schemas"]["Gaps"];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -10471,6 +10851,7 @@ export interface components {
             health_source?: string;
             name?: string;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             operational_observed_at?: string | null;
             /** @constant */
@@ -10480,6 +10861,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One subnet's paginated first-party chain-event feed (#7172), newest first, offset-paginated. event_count is the page count, not a grand total. Each item is an AccountEvent. Empty feed on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/events' data envelope. */
         SubnetEventsArtifact: {
             event_count: number;
             events: components["schemas"]["AccountEvent"][];
@@ -10491,7 +10873,9 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One subnet's chain-event activity summary over a window (#6980). Mirrors GET /api/v1/subnets/{netuid}/event-summary' data envelope. */
         SubnetEventSummaryArtifact: {
+            /** @description Per event category: its kind list and rolled-up counts. Opaque JSON passed through verbatim, matching the get_subnet_event_summary MCP/REST shape. */
             categories: {
                 alpha_amount: number;
                 amount_tao: number;
@@ -10505,6 +10889,7 @@ export interface components {
                 last_observed_at: string | null;
             }[];
             category_count: number;
+            /** @description Per event kind: event_count, hotkey/coldkey participation counts, TAO/alpha amounts, and first/last block + observed_at. Opaque JSON passed through verbatim. */
             event_kinds: {
                 alpha_amount: number;
                 amount_tao: number;
@@ -10520,14 +10905,19 @@ export interface components {
                 last_observed_at: string | null;
             }[];
             kind_count: number;
+            /** @description The resolved recent-event cap actually applied (1-50, default 10). */
             limit: number;
             netuid: number;
             observed_at: string | null;
             recent_event_count: number;
+            /** @description The bounded newest-first recent-event list. Opaque JSON passed through verbatim. */
             recent_events: components["schemas"]["AccountEvent"][];
             schema_version: number;
             total_events: number;
-            /** @enum {string} */
+            /**
+             * @description The resolved window label (7d/30d/90d).
+             * @enum {string}
+             */
             window: "7d" | "30d" | "90d";
         } & {
             [key: string]: unknown;
@@ -10538,6 +10928,7 @@ export interface components {
             generated_at: string;
             name?: string;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -10598,6 +10989,7 @@ export interface components {
             generated_at: string;
             name?: string;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             priorities: components["schemas"]["ReviewGapPriority"][];
             /** @constant */
@@ -10606,6 +10998,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One subnet's daily history series (#7172) from the neuron_daily rollup, newest first. Empty series (point_count 0) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/history' data envelope. */
         SubnetHistoryArtifact: {
             netuid: number;
             point_count: number;
@@ -10621,35 +11014,46 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One coldkey's holding of a subnet's alpha, including alpha staked to hotkeys that hold no UID on that subnet. */
         SubnetHolder: {
+            /** @description ALPHA, not TAO. Within one subnet alpha is already a common unit, so there is no price conversion and none of its staleness -- multiply by the subnet's alpha_price_tao for TAO. */
             alpha: number;
             coldkey: string;
+            /** @description Distinct hotkeys this coldkey holds the subnet's alpha through -- registered on it or not, which is the part a neurons-sourced view misses. */
             hotkey_count: number | null;
+            /** @description This holder's alpha over the subnet's FULL measured total, so it means the same thing at limit 5 and limit 100. Null when the total is zero. */
             share_of_total: number | null;
         };
         SubnetHoldersArtifact: {
+            /** @description The pool pass every row was valued against. */
             captured_at: string | null;
             concentration: components["schemas"]["SubnetHoldersConcentration"];
+            /** @description Present ONLY on a decline. Its absence is what says the ranking is real -- an empty holders list with no degraded block means the subnet genuinely has no measured holders. */
             degraded?: components["schemas"]["SubnetHoldersDegraded"];
+            /** @description Distinct coldkeys holding this subnet's alpha -- the whole set, never the returned page's length. */
             holder_count: number | null;
             holders: components["schemas"]["SubnetHolder"][];
             limit: number | null;
             netuid: number;
+            /** @description When the positions ledger itself was last written, which advances on a different cadence than the pool totals. */
             positions_captured_at: string | null;
             schema_version: number;
             total_alpha: number | null;
         } & {
             [key: string]: unknown;
         };
+        /** @description Concentration of a subnet's alpha, each rank summed over the top N of the FULL holder set rather than the returned page. */
         SubnetHoldersConcentration: {
             top10_share: number | null;
             top20_share: number | null;
             top5_share: number | null;
         };
+        /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
         SubnetHoldersDegraded: {
             /** @enum {string} */
             reason: "pool_totals_unproven" | "root_not_in_alpha_map" | "unavailable";
         };
+        /** @description Per-subnet neuron-registration activity over a window (#5720). Zeroed card (0 counts) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/registrations. */
         SubnetHyperparametersArtifact: {
             block_number?: number | null;
             captured_at?: string | null;
@@ -10743,6 +11147,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Append-only on-chain subnet identity timeline (#1647 / #5721). Empty entries on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/identity-history. */
         SubnetIdentityHistoryArtifact: {
             entries: {
                 block_number?: number | null;
@@ -10765,6 +11170,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Per-subnet idle-stake scorecard (#7172). Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/idle-stake. */
         SubnetIdleStakeArtifact: {
             captured_at?: string | null;
             idle_neuron_count: number;
@@ -10845,6 +11251,7 @@ export interface components {
             updated_at?: string | null;
             website_url?: string | null;
         };
+        /** @description Live subnet-lease state -- whether a subnet is currently under a lease and, if so, its terms (beneficiary, coldkey, hotkey, emissions_share_percent, end_block, cost_tao) and accumulated-but-undistributed alpha dividends. leased is null (not false) on RPC failure, distinct from a confirmed no-lease (leased:false). Mirrors GET /api/v1/subnets/{netuid}/lease. */
         SubnetLeaseArtifact: {
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
             field_sources: {
@@ -10876,6 +11283,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Every SubnetLeaseCreated/SubnetLeaseTerminated event one subnet has had, decoded from the account_events stream. Mirrors GET /api/v1/subnets/{netuid}/lease/history. */
         SubnetLeaseHistoryArtifact: {
             count: number;
             event_kinds: string[];
@@ -10927,7 +11335,9 @@ export interface components {
                 emission_tao?: number | null;
                 featured?: boolean;
                 hotkey: string | null;
+                /** @description Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block/timestamp at ~12s/block; null if that anchor is unavailable (#6640). */
                 immunity_expires_at?: string | null;
+                /** @description The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640). */
                 immunity_expires_at_block?: number;
                 incentive?: number | null;
                 is_immunity_period?: boolean;
@@ -10936,6 +11346,7 @@ export interface components {
                 registered_at_block?: number | null;
                 /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao?: number | null;
+                /** @description Validator take/commission (0..1) from SubtensorModule::Delegates; null when no Delegates entry at capture. */
                 take?: number | null;
                 trust?: number | null;
                 uid: number;
@@ -10960,13 +11371,16 @@ export interface components {
                 neurons_start: number;
                 stake_delta_alpha: number;
                 stake_end_alpha: number;
+                /** @description Null when the start snapshot's stake was 0 (growth from nothing is undefined). */
                 stake_pct_change: number | null;
+                /** @description This subnet's share of network stake at the end snapshot; null when the network total is 0. */
                 stake_share_pct: number | null;
                 stake_start_alpha: number;
                 validators_delta: number;
                 validators_end: number;
                 validators_start: number;
             }[];
+            /** @description Network-wide boundary totals for the movers window, summed across every ranked subnet (not just the returned page). */
             network: {
                 gainers: number;
                 losers: number;
@@ -10975,6 +11389,7 @@ export interface components {
                 total_emission_start_alpha: string;
                 total_stake_delta_alpha: string;
                 total_stake_end_alpha: string;
+                /** @description Lossless fixed 9-decimal (rao-precision) TAO string -- exceeds the exact-double ceiling as a JSON number, so it is served as a string rather than Float. */
                 total_stake_start_alpha: string;
                 total_validators_delta: number;
                 total_validators_end: number;
@@ -10988,8 +11403,10 @@ export interface components {
             subnet_count: number;
             window: ("7d" | "30d" | "90d") | null;
         };
+        /** @description One subnet's alpha-price OHLC candles (#6979). Mirrors GET /api/v1/subnets/{netuid}/ohlc' data envelope. */
         SubnetOhlcArtifact: {
             candles: {
+                /** @description Bucket start as epoch milliseconds -- a Float, since epoch-ms exceeds GraphQL's 32-bit Int. */
                 bucket_start: number;
                 /** Format: date-time */
                 bucket_start_iso: string;
@@ -11001,9 +11418,13 @@ export interface components {
                 volume_alpha: number;
                 volume_tao: number;
             }[];
-            /** @enum {string} */
+            /**
+             * @description The resolved bucket interval (1h/1d).
+             * @enum {string}
+             */
             interval: "1h" | "1d";
             netuid: number;
+            /** @description True for root (netuid 0), whose 1:1 price makes candles meaningless, so none are emitted. */
             root_excluded: boolean;
             schema_version: number;
         };
@@ -11038,6 +11459,7 @@ export interface components {
             health_source?: string | null;
             name?: string;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             operational_observed_at?: string | null;
             profile: components["schemas"]["SubnetProfile"] | null;
@@ -11048,12 +11470,17 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Every automatic ownership transfer one subnet has undergone, decoded from the chain_events SubnetOwnerChanged stream. Mirrors GET /api/v1/subnets/{netuid}/ownership-history. */
         SubnetOwnershipHistoryArtifact: {
             count: number;
+            /** @description The chain_events method the authoritative records are decoded from. */
             event_method: string;
+            /** @description The chain_events pallet the authoritative records are decoded from. */
             event_pallet: string;
             netuid: number;
+            /** @description The newest owner observation for this subnet, ISO-8601 -- how far the observation source covers it at all, so watched-but-never-changed-hands is distinguishable from not-watched-since. Null when no observations were read. */
             observed_through?: string | null;
+            /** @description Each record carries a source: chain-event (announced on chain, block-stamped) or owner-observation (inferred from two consecutive owner captures, so observed_at is when the change was NOTICED and block_number is null). */
             ownership_changes: {
                 block_number?: number | null;
                 netuid?: number | null;
@@ -11066,21 +11493,28 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Per-subnet reward-distribution & score-spread card (#5714). Metric blocks are null on a cold/empty subnet. Mirrors GET /api/v1/subnets/{netuid}/performance. */
         SubnetPerformanceArtifact: {
             active_count?: number;
             captured_at?: string | null;
+            /** @description Consensus score spread across all neurons. */
             consensus: components["schemas"]["ScoreDistribution"];
+            /** @description Dividends concentration across permitted validators only. */
             dividends: components["schemas"]["ConcentrationMetrics"];
+            /** @description Incentive concentration across all neurons with positive incentive. */
             incentive: components["schemas"]["ConcentrationMetrics"];
             netuid: number;
             neuron_count: number;
             schema_version: number;
+            /** @description Trust score spread across all neurons. */
             trust: components["schemas"]["ScoreDistribution"];
             validator_count?: number;
+            /** @description Validator-trust score spread across permitted validators only. */
             validator_trust?: components["schemas"]["ScoreDistribution"];
         } & {
             [key: string]: unknown;
         };
+        /** @description Per-subnet per-day reward-distribution trend (#6981) from the neuron_daily rollup, newest first. An empty series (point_count 0) on a cold store, never a GraphQL error. The history twin of subnet_performance, mirroring GET /api/v1/subnets/{netuid}/performance/history. */
         SubnetPerformanceHistoryArtifact: {
             netuid: number;
             point_count: number;
@@ -11105,6 +11539,7 @@ export interface components {
                 [key: string]: unknown;
             })[];
             schema_version: number;
+            /** @description The resolved window label (7d/30d/90d). */
             window?: string | null;
         } & {
             [key: string]: unknown;
@@ -11242,6 +11677,7 @@ export interface components {
             endpoints: components["schemas"]["EndpointResource"][];
             gaps: components["schemas"]["Gaps"];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             profile: components["schemas"]["SubnetProfile"];
             /** @constant */
@@ -11267,6 +11703,7 @@ export interface components {
         SubnetProfilesArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             profiles: components["schemas"]["SubnetProfile"][];
             /** @constant */
@@ -11290,9 +11727,11 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Per-subnet Prometheus-endpoint serving activity (#7172) over a 7d/30d window. Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/prometheus. */
         SubnetPrometheusArtifact: {
             announcements: number;
             announcements_per_exporter: number | null;
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
@@ -11303,6 +11742,7 @@ export interface components {
             schema_version: number;
             window: ("7d" | "30d") | null;
         };
+        /** @description Live cumulative TAO recycled for registration on one subnet, read directly from chain via RPC. recycled_tao is null on RPC failure (schema-stable, never a GraphQL error). Mirrors GET /api/v1/subnets/{netuid}/recycled. */
         SubnetRecycledArtifact: {
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
             field_sources: {
@@ -11334,6 +11774,7 @@ export interface components {
             contract_version?: string;
             generated_at: string;
             network: components["schemas"]["BittensorNetwork"];
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -11360,6 +11801,7 @@ export interface components {
             schema_version: number;
             window: ("7d" | "30d") | null;
         };
+        /** @description Per-subnet net stake flow (#7172) over a 7d/30d/90d window. Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/stake-flow' data envelope. */
         SubnetStakeFlowArtifact: {
             net_flow_tao: number;
             netuid: number;
@@ -11379,15 +11821,20 @@ export interface components {
             schema_version: number;
             window: ("7d" | "30d") | null;
         };
+        /** @description A read-only hypothetical stake/unstake quote against one subnet's live AMM pool (#6979). Mirrors GET /api/v1/subnets/{netuid}/stake-quote. */
         SubnetStakeQuoteArtifact: {
             alpha_in_pool: number | null;
             amount: number;
-            /** @enum {string} */
+            /**
+             * @description stake (spends TAO for alpha) or unstake (spends alpha for TAO).
+             * @enum {string}
+             */
             direction: "stake" | "unstake";
             effective_price_tao: number;
             expected_out: number;
             /** @enum {string} */
             expected_out_unit: "alpha" | "tao";
+            /** @description True for root (netuid 0), which quotes 1:1 with no price impact. */
             is_root: boolean;
             netuid: number;
             price_impact_pct: number;
@@ -11395,6 +11842,7 @@ export interface components {
             spot_price_tao: number;
             tao_in_pool_tao: number | null;
         };
+        /** @description Per-subnet stake-transfer activity (#5717) over a 7d/30d window. Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/stake-transfers. */
         SubnetStakeTransfersArtifact: {
             distinct_senders: number;
             netuid: number;
@@ -11413,6 +11861,7 @@ export interface components {
             limit: number | null;
             netuid: number;
             schema_version: number;
+            /** @description Distinct surfaces with a recorded mutation -- NOT the subnet's current surface count. A deleted surface is counted here and absent there. */
             surface_count: number;
         } & {
             [key: string]: unknown;
@@ -11422,6 +11871,7 @@ export interface components {
             generated_at: string;
             name?: string;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -11430,7 +11880,9 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One subnet's weekly structural + economics trajectory from the daily snapshots (#5887). Mirrors GET /api/v1/subnets/{netuid}/trajectory's data envelope. The REST envelope's window-keyed deltas map (7d/30d) is exposed here as a list carrying each window label, since those keys are not valid GraphQL field names. */
         SubnetTrajectoryArtifact: {
+            /** @description Latest-vs-window-ago deltas -- one entry per window (7d, 30d) that has a prior point to compare against; empty when the series is too short. */
             deltas: {
                 [key: string]: ({
                     alpha_in_pool?: number | null;
@@ -11468,7 +11920,9 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One subnet's validator/neuron-set turnover between a window's boundary snapshots. The churn metrics are zeroed and the retentions/stability null on a single-snapshot or cold store (schema-stable). Mirrors GET /api/v1/subnets/{netuid}/turnover's default scorecard. */
         SubnetTurnoverArtifact: {
+            /** @description Per-neuron churn detail behind the counts above, populated only when the field's changes toggle is set (mirroring REST's ?changes=true). Null otherwise, and on a cold store. */
             changes?: {
                 uid_reassignment_count?: number;
                 uid_reassignments: {
@@ -11478,11 +11932,13 @@ export interface components {
                 }[];
                 validators_entered: {
                     hotkey: string;
+                    /** @description The UID it held at the boundary snapshot, null when the row carried no usable uid. */
                     uid: number | null;
                 }[];
                 validators_entered_count?: number;
                 validators_exited: {
                     hotkey: string;
+                    /** @description The UID it held at the boundary snapshot, null when the row carried no usable uid. */
                     uid: number | null;
                 }[];
                 validators_exited_count?: number;
@@ -11511,10 +11967,13 @@ export interface components {
         SubnetValidatorEconomicsArtifact: {
             cap_binding: boolean | null;
             composition: components["schemas"]["ValidatorSetComposition"] | null;
+            /** @description Names the missing input whenever a field above was withheld, so a caller can tell 'unknown' from 'zero'. */
             degraded_reason: string | null;
             earning_entry_cost_tao: number | null;
             earning_floor_cost_tao: number | null;
+            /** @description The smallest stake that actually EARNS dividends here, excluding the subnet owner -- its permit is unconditional, so an owner earning on ~0 stake would report a floor of 0. Null when NO non-owner has earned on this subnet, which is a real answer (the owner is taking the dividends), not a missing one. */
             earning_floor_units: number | null;
+            /** @description Reported, never scored. Gate-closed subnets still emit alpha at a comparable rate and are less contested, so per unit of stake they pay MORE -- the gate is an exit-liquidity question, not an eligibility one. */
             emission_gate_open: boolean | null;
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
             field_sources: {
@@ -11530,13 +11989,18 @@ export interface components {
             min_childkey_take_ratio: number | null;
             model_agreement: components["schemas"]["ValidatorPermitModelAgreement"] | null;
             netuid: number;
+            /** @description Floor cost plus the registration burn. Entry is two spends; publishing one understates it. */
             permit_entry_cost_tao: number | null;
             permit_floor_cost_tao: number | null;
+            /** @description Floors are in total_stake UNITS (alpha + tao_weight * root), the quantity the chain threshold actually tests -- not alpha alone. */
             permit_floor_units: number | null;
+            /** @description How much more it takes to EARN than merely to hold a permit. */
             permit_to_earning_multiple: number | null;
             registration_cost_tao: number | null;
+            /** @description Root is not split: this much root clears the threshold on EVERY subnet the hotkey is registered on at once. */
             root_tao_to_clear_threshold: number | null;
             schema_version: number;
+            /** @description Echoed so a caller never has to guess what the floor was computed against. Both are sudo-settable, so a cached copy would silently rot. */
             stake_threshold_units: number | null;
             takes: components["schemas"]["ValidatorTakeDistribution"] | null;
             tao_inflow_per_day: number | null;
@@ -11556,16 +12020,19 @@ export interface components {
                 };
             };
             netuid: number;
+            /** @description Newest first. */
             points: components["schemas"]["ValidatorEconomicsHistoryPoint"][];
             schema_version: number;
             window: string;
         };
+        /** @description One subnet's current validator set (#6979). Mirrors GET /api/v1/subnets/{netuid}/validators' data envelope. */
         SubnetValidatorsArtifact: {
             block_number?: number | null;
             captured_at?: string | null;
             netuid: number;
             schema_version: number;
             validator_count: number;
+            /** @description Each permitted validator's live metagraph row -- the same NeuronState shape the neuron field returns. */
             validators: {
                 active: boolean;
                 /** @description The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541). */
@@ -11577,7 +12044,9 @@ export interface components {
                 emission_tao?: number | null;
                 featured?: boolean;
                 hotkey: string | null;
+                /** @description Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block/timestamp at ~12s/block; null if that anchor is unavailable (#6640). */
                 immunity_expires_at?: string | null;
+                /** @description The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640). */
                 immunity_expires_at_block?: number;
                 incentive?: number | null;
                 is_immunity_period?: boolean;
@@ -11586,6 +12055,7 @@ export interface components {
                 registered_at_block?: number | null;
                 /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao?: number | null;
+                /** @description Validator take/commission (0..1) from SubtensorModule::Delegates; null when no Delegates entry at capture. */
                 take?: number | null;
                 trust?: number | null;
                 uid: number;
@@ -11601,6 +12071,7 @@ export interface components {
             generated_at: string;
             name: string | null;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             results: components["schemas"]["VerificationResult"][];
             /** @constant */
@@ -11625,6 +12096,7 @@ export interface components {
             weight_sets: number;
             window: ("7d" | "30d") | null;
         };
+        /** @description Per-subnet weight-setter leaderboard (#5712). Empty setters on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/weights/setters. */
         SubnetWeightSettersArtifact: {
             distinct_setters: number;
             netuid: number;
@@ -11640,6 +12112,7 @@ export interface components {
                 /** @description Whether this setter is more than overdue_tempo_multiple tempos past its last weight set. NULL means not evaluated -- the subnet's tempo or this setter's last_set_at was unavailable -- which is deliberately distinct from false ('evaluated, on time'). */
                 overdue: boolean | null;
                 seconds_since_last_set: number | null;
+                /** @description This setter's share of the subnet total weight_sets; null when the subnet total is 0. */
                 share: number | null;
                 tempos_since_last_set: number | null;
                 uid: number | null;
@@ -11697,6 +12170,7 @@ export interface components {
                 [key: string]: unknown;
             })[];
             schema_version: number;
+            /** @description The resolved window label (7d/30d/90d). */
             window?: string | null;
         } & {
             [key: string]: unknown;
@@ -11711,6 +12185,7 @@ export interface components {
             /** @constant */
             schema_version: 1;
         };
+        /** @description The network's on-chain sudo (superuser) key, read live from chain via RPC. hotkey is null on RPC failure or a renounced sudo (schema-stable). Mirrors GET /api/v1/sudo/key's data envelope. */
         SudoKeyArtifact: {
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
             field_sources: {
@@ -11830,6 +12305,7 @@ export interface components {
             }[];
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -11847,13 +12323,17 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One recorded mutation of a subnet's public surface. */
         SurfaceHistoryChange: {
+            /** @description insert, update or delete. A delete is the only evidence a surface ever existed. */
             action: ("insert" | "update" | "delete") | null;
             kind: string | null;
             name: string | null;
             /** Format: date-time */
             recorded_at: string;
+            /** @description The registry commit that produced the change. */
             source_commit: string | null;
+            /** @description Coalesced column then overlay id, so it is present on every row including those written before the column was recorded. */
             surface_id: string | null;
             url: string | null;
         };
@@ -11862,6 +12342,7 @@ export interface components {
         SurfacesArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -11893,28 +12374,36 @@ export interface components {
             change_pct: number | null;
             change_usd: number | null;
             latest: components["schemas"]["TaoUsdLatest"] | null;
+            /** @description How far back the answer actually reaches -- the series began 2026-08-02. */
             oldest_observed_at: string | null;
             point_count: number;
             points: components["schemas"]["TaoUsdPoint"][];
+            /** @description How many points carried a price. A gap from point_count is how a window with unpriceable blocks announces itself. */
             priced_point_count: number;
             schema_version: number;
             window: string | null;
         } & {
             [key: string]: unknown;
         };
+        /** @description The newest reading with the derivation that produced it, kept together so both describe the same block. */
         TaoUsdLatest: {
             block_number: number | null;
+            /** @description The ETH/USDC anchor leg the composition multiplied through. */
             eth_usd: number | null;
             observed_at: string | null;
             pool_count: number | null;
+            /** @description Per-pool provenance as the producer stored it. */
             pools: unknown[];
+            /** @description Stated even when the price is null -- it is what says why. */
             price_basis: string | null;
             usd_per_tao: number | null;
         };
+        /** @description One TAO/USD reading. */
         TaoUsdPoint: {
             block_number: number | null;
             /** Format: date-time */
             observed_at: string;
+            /** @description Null means the block was not priceable (insufficient pool quorum), NOT a zero price. */
             usd_per_tao: number | null;
         };
         TopHoldersArtifact: {
@@ -11943,8 +12432,10 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One subnet's long-term daily uptime history (#5885). Mirrors GET /api/v1/subnets/{netuid}/uptime's data envelope. */
         UptimeArtifact: {
             netuid: number;
+            /** @description Window-wide reliability score (0-100) with letter grade. Surface-level scores omit window/surface_count/day_count/computed_at. */
             reliability: ({
                 avg_latency_ms: number | null;
                 computed_at?: string | null;
@@ -11962,11 +12453,13 @@ export interface components {
             }) | null;
             schema_version: number;
             source: string;
+            /** @description Per-surface day series with window-wide uptime ratios and per-surface reliability scores. */
             surfaces: ({
                 day_count: number;
                 days: ({
                     avg_latency_ms?: number | null;
                     day: string;
+                    /** @description Percentile latency summary for one uptime day. */
                     latency_ms?: {
                         p50?: number | null;
                         p95?: number | null;
@@ -11981,6 +12474,7 @@ export interface components {
                 } & {
                     [key: string]: unknown;
                 })[];
+                /** @description Window-wide reliability score (0-100) with letter grade. Surface-level scores omit window/surface_count/day_count/computed_at. */
                 reliability?: ({
                     avg_latency_ms: number | null;
                     computed_at?: string | null;
@@ -12046,6 +12540,7 @@ export interface components {
             root_stake_tao: number;
             schema_version: number;
             subnet_count: number;
+            /** @description Per-subnet membership rows for this validator. The global leaderboard entry caps this at the top 10 by stake; the single-validator lookup carries every subnet. */
             subnets: {
                 active: boolean;
                 axon: string | null;
@@ -12074,16 +12569,21 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One subnet the ranking dropped, and why, so that a caller can tell an omitted subnet from an absent one without re-deriving the ranking. */
         ValidatorEconomicsExclusion: {
             netuid: number;
             reason: string;
         };
+        /** @description One day's observed economics. The floors are read off the snapshot, not re-derived: StakeThreshold is sudo-settable, so re-running today's threshold against an old day would show a flat line across a governance change that actually moved the floor. */
         ValidatorEconomicsHistoryPoint: {
             earning_floor_alpha: number | null;
             emission_gate_open: boolean | null;
+            /** @description The validator cap in force on this day. permit_floor_alpha is the observed floor REGARDLESS of cap state, so it cannot be read without this -- and joining today's cap onto an old point is wrong for any subnet whose cap moved. */
             max_validators: number | null;
+            /** @description Where max_validators came from: observed = the hyperparameter change-log recorded it at or before this day; current = the change-log does not reach this far back, so the LIVE cap is reported. */
             max_validators_source: ("observed" | "current") | null;
             permit_floor_alpha: number | null;
+            /** @description Whether the permit set was full on this day (validators_permitted >= max_validators). NOT the same measure as the current record's cap_binding, which counts UIDs clearing the threshold against slots -- only the permitted set survives in a daily snapshot. */
             permit_set_full: boolean | null;
             snapshot_date: string;
             tao_inflow_per_day: number | null;
@@ -12109,12 +12609,16 @@ export interface components {
             rows: components["schemas"]["SubnetValidatorEconomicsArtifact"][];
             schema_version: number;
             sort: string;
+            /** @description Echoed once for the whole ranking: every row's floors were derived against exactly these values, and both are sudo-settable. */
             stake_threshold_units: number | null;
             tao_weight: number | null;
+            /** @description Rows matching the filters, BEFORE limit/offset -- so a caller can page without re-counting. */
             total: number;
         };
+        /** @description One validator's cross-subnet staked-over-time history. Mirrors GET /api/v1/validators/{hotkey}/history. */
         ValidatorHistoryArtifact: {
             hotkey: string;
+            /** @description The subnet this series was scoped to, or null for the cross-subnet rollup. */
             netuid: number | null;
             /** @description take_last_changed_date + TxDelegateTakeRateLimit (216,000 blocks / 30.00 days, read from the chain's runtime metadata default). NULL when no change is resolvable in the retained window, which is SHORTER than the rate limit — so 'no change seen' cannot be resolved to 'eligible now'. */
             next_take_change_eligible_date: string | null;
@@ -12124,6 +12628,7 @@ export interface components {
                 dividend_efficiency?: number | null;
                 dividends?: number | null;
                 emission_alpha?: number | null;
+                /** @description The scoped subnet. Null on the unscoped cross-subnet series. */
                 netuid?: number | null;
                 rewards_per_1000_alpha?: number | null;
                 rewards_per_1000_tao: number | null;
@@ -12139,6 +12644,7 @@ export interface components {
                 uid?: number | null;
                 /** @description Whether the permit was held that day. The scoped series reports a lost permit rather than dropping the day, so 'lost the permit' stays distinguishable from 'no data'. */
                 validator_permit?: boolean | null;
+                /** @description Per-subnet facts, null unless the query scoped a netuid: a cross-subnet average of these is a number the chain never computes. */
                 validator_trust?: number | null;
             }[];
             schema_version: number;
@@ -12149,6 +12655,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One validator's nominator leaderboard (#5692). Mirrors GET /api/v1/validators/{hotkey}/nominators' data envelope. */
         ValidatorNominatorsArtifact: {
             concentration_complete: boolean;
             hotkey: string;
@@ -12159,22 +12666,30 @@ export interface components {
             nominators: {
                 coldkey: string;
                 event_count: number;
+                /** @description staked_tao + unstaked_tao (total churn, regardless of direction). */
                 gross_staked_tao: number;
+                /** @description Most recent StakeAdded/StakeRemoved time for this coldkey; null when unstamped. */
                 last_observed_at: string | null;
+                /** @description staked_tao - unstaked_tao. */
                 net_staked_tao: number;
                 staked_tao: number;
                 unstaked_tao: number;
             }[];
             offset: number;
             schema_version: number;
-            /** @enum {string} */
+            /**
+             * @description The resolved sort actually applied (an omitted sort resolves to net_staked).
+             * @enum {string}
+             */
             sort: "net_staked" | "gross_staked" | "last_activity";
             top_nominator_share: number | null;
             top5_nominator_share: number | null;
+            /** @description The resolved window label; null only if the builder was handed no window. */
             window: string | null;
         } & {
             [key: string]: unknown;
         };
+        /** @description How well the derived permit rule still reproduces the permits the chain actually granted. Published so a caller can see when the model has drifted rather than trusting a floor it no longer supports. */
         ValidatorPermitModelAgreement: {
             agreement: number | null;
             matched: number;
@@ -12183,15 +12698,18 @@ export interface components {
             publishable: boolean;
             under_predicted: number;
         };
+        /** @description Permitted, active and earning are three DIFFERENT sets. Network-wide 2026-08-03: 1,523 / 1,137 / 1,117; SN83 is 64 / 8 / 7. Published separately rather than collapsed, because 'how many validators does this subnet have' has three defensible answers. */
         ValidatorSetComposition: {
             active: number;
             earning: number;
             permitted: number;
         };
+        /** @description The commission picture across permit-holders. The sorted vector is published because the shape is the information: it is genuinely bimodal, with a cohort competing at or near zero against a median at the effective ceiling, and validators earning at both ends. */
         ValidatorTakeDistribution: {
             distribution: number[];
             max: number | null;
             median: number | null;
+            /** @description Median restricted to permit-holders that actually earn -- takes among validators nobody delegates to are noise. */
             median_earning: number | null;
             min: number | null;
             sample_size: number;
@@ -12201,6 +12719,7 @@ export interface components {
             candidate_count: number;
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             observed_at?: string | null;
             results: components["schemas"]["VerificationResult"][];

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -10091,7 +10091,7 @@ export interface components {
              * @description How this capture compares with the previous one. Absent only where a producer omits it.
              * @enum {string}
              */
-            drift_status?: "changed" | "missing-after-previous-capture" | "new" | "not-captured" | "unchanged";
+            drift_status?: "new" | "changed" | "unchanged" | "not-captured" | "missing-after-previous-capture";
             error?: string | null;
             hash?: string | null;
             netuid: number;
@@ -10118,7 +10118,7 @@ export interface components {
             schemas: {
                 content_type?: string | null;
                 /** @enum {string} */
-                drift_status: "changed" | "missing-after-previous-capture" | "new" | "not-captured" | "unchanged";
+                drift_status: "new" | "changed" | "unchanged" | "not-captured" | "missing-after-previous-capture";
                 error?: string | null;
                 hash?: string | null;
                 netuid?: number;
@@ -37263,7 +37263,7 @@ export interface operations {
                      *         "schema_version": 1,
                      *         "schemas": [
                      *           {
-                     *             "drift_status": "changed",
+                     *             "drift_status": "new",
                      *             "schema_url": "https://api.metagraph.sh/example",
                      *             "status": "captured",
                      *             "surface_id": "example"

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -7964,7 +7964,7 @@
             "schema_version": 1,
             "schemas": [
               {
-                "drift_status": "changed",
+                "drift_status": "new",
                 "schema_url": "https://api.metagraph.sh/example",
                 "status": "captured",
                 "surface_id": "example"
@@ -41073,11 +41073,11 @@
           "drift_status": {
             "description": "How this capture compares with the previous one. Absent only where a producer omits it.",
             "enum": [
-              "changed",
-              "missing-after-previous-capture",
               "new",
+              "changed",
+              "unchanged",
               "not-captured",
-              "unchanged"
+              "missing-after-previous-capture"
             ],
             "type": "string"
           },
@@ -41207,11 +41207,11 @@
                 },
                 "drift_status": {
                   "enum": [
-                    "changed",
-                    "missing-after-previous-capture",
                     "new",
+                    "changed",
+                    "unchanged",
                     "not-captured",
-                    "unchanged"
+                    "missing-after-previous-capture"
                   ],
                   "type": "string"
                 },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -13404,7 +13404,7 @@
       },
       "AccountEntitiesArtifact": {
         "additionalProperties": {},
-        "description": "One coldkey's community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities.",
+        "description": "One `coldkey`'s community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities.",
         "properties": {
           "labels": {
             "items": {
@@ -13480,7 +13480,7 @@
           "ownership_ties": {
             "items": {
               "additionalProperties": {},
-              "description": "One SubnetOwnerChanged transfer tying this coldkey to a subnet, either as the gaining or losing side, newest first.",
+              "description": "One SubnetOwnerChanged transfer tying this `coldkey` to a subnet, either as the gaining or losing side, newest first.",
               "properties": {
                 "block_number": {
                   "anyOf": [
@@ -16563,7 +16563,7 @@
       },
       "AccountWeightSettersArtifact": {
         "additionalProperties": false,
-        "description": "One account's (validator hotkey's) WeightsSet weight-setting footprint across subnets over a 7d/30d window. Mirrors GET /api/v1/accounts/{ss58}/weight-setters.",
+        "description": "One account's (validator's hotkey's) WeightsSet weight-setting footprint across subnets over a 7d/30d window. Mirrors GET /api/v1/accounts/{ss58}/weight-setters.",
         "properties": {
           "address": {
             "type": "string"
@@ -24009,7 +24009,7 @@
           },
           "network": {
             "additionalProperties": false,
-            "description": "Network-wide stake-move rollup: every subnet with StakeMoved events in the window, combined. distinct_movers counts a coldkey once even when it moves on several subnets.",
+            "description": "Network-wide stake-move rollup: every subnet with StakeMoved events in the window, combined. distinct_movers counts a `coldkey` once even when it moves on several subnets.",
             "properties": {
               "distinct_movers": {
                 "maximum": 9007199254740991,
@@ -24192,7 +24192,7 @@
           },
           "network": {
             "additionalProperties": false,
-            "description": "Network-wide stake-transfer rollup: every subnet with StakeTransferred events in the window, combined. distinct_senders counts an origin coldkey once even when it transfers out of several subnets.",
+            "description": "Network-wide stake-transfer rollup: every subnet with StakeTransferred events in the window, combined. distinct_senders counts an origin `coldkey` once even when it transfers out of several subnets.",
             "properties": {
               "distinct_senders": {
                 "maximum": 9007199254740991,
@@ -26107,7 +26107,7 @@
                   "anyOf": [
                     {
                       "additionalProperties": false,
-                      "description": "Self-reported on-chain identity (SubtensorModule::set_identity) for a coldkey.",
+                      "description": "Self-reported on-chain identity (SubtensorModule::set_identity) for a `coldkey`.",
                       "properties": {
                         "additional": {
                           "anyOf": [
@@ -26214,7 +26214,7 @@
                       "type": "null"
                     }
                   ],
-                  "description": "The coldkey's self-declared on-chain identity; opaque JSON, matching the REST/MCP shape."
+                  "description": "The `coldkey`'s self-declared on-chain identity; opaque JSON, matching the REST/MCP shape."
                 },
                 "hotkey": {
                   "type": "string"
@@ -32725,7 +32725,7 @@
                   "anyOf": [
                     {
                       "additionalProperties": false,
-                      "description": "Self-reported on-chain identity (SubtensorModule::set_identity) for a coldkey.",
+                      "description": "Self-reported on-chain identity (SubtensorModule::set_identity) for a `coldkey`.",
                       "properties": {
                         "additional": {
                           "anyOf": [
@@ -46081,7 +46081,7 @@
       },
       "SubnetHolder": {
         "additionalProperties": false,
-        "description": "One coldkey's holding of a subnet's alpha, including alpha staked to hotkeys that hold no UID on that subnet.",
+        "description": "One `coldkey`'s holding of a subnet's alpha, including alpha staked to hotkeys that hold no UID on that subnet.",
         "properties": {
           "alpha": {
             "description": "ALPHA, not TAO. Within one subnet alpha is already a common unit, so there is no price conversion and none of its staleness -- multiply by the subnet's alpha_price_tao for TAO.",
@@ -46102,7 +46102,7 @@
                 "type": "null"
               }
             ],
-            "description": "Distinct hotkeys this coldkey holds the subnet's alpha through -- registered on it or not, which is the part a neurons-sourced view misses."
+            "description": "Distinct hotkeys this `coldkey` holds the subnet's alpha through -- registered on it or not, which is the part a neurons-sourced view misses."
           },
           "share_of_total": {
             "anyOf": [
@@ -54752,7 +54752,7 @@
             "anyOf": [
               {
                 "additionalProperties": false,
-                "description": "Self-reported on-chain identity (SubtensorModule::set_identity) for a coldkey.",
+                "description": "Self-reported on-chain identity (SubtensorModule::set_identity) for a `coldkey`.",
                 "properties": {
                   "additional": {
                     "anyOf": [
@@ -55495,7 +55495,7 @@
           "points": {
             "items": {
               "additionalProperties": false,
-              "description": "One day's rollup for a validator hotkey. Cross-subnet (summed across every subnet it validates in) unless the query scoped a netuid, in which case the per-subnet fields below are populated too.",
+              "description": "One day's rollup for a validator's hotkey. Cross-subnet (summed across every subnet it validates in) unless the query scoped a netuid, in which case the per-subnet fields below are populated too.",
               "properties": {
                 "consensus": {
                   "anyOf": [
@@ -55783,7 +55783,7 @@
           "nominators": {
             "items": {
               "additionalProperties": false,
-              "description": "One nominating coldkey's staking activity toward a validator within the window.",
+              "description": "One nominating `coldkey`'s staking activity toward a validator within the window.",
               "properties": {
                 "coldkey": {
                   "type": "string"
@@ -55807,7 +55807,7 @@
                       "type": "null"
                     }
                   ],
-                  "description": "Most recent StakeAdded/StakeRemoved time for this coldkey; null when unstamped."
+                  "description": "Most recent StakeAdded/StakeRemoved time for this `coldkey`; null when unstamped."
                 },
                 "net_staked_tao": {
                   "description": "staked_tao - unstaked_tao.",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -12623,6 +12623,7 @@
           },
           "degraded": {
             "additionalProperties": false,
+            "description": "A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer.",
             "properties": {
               "detail": {
                 "type": "string"
@@ -12661,6 +12662,7 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's slice of an account's axon-removal footprint over the window.",
               "properties": {
                 "first_removed_at": {
                   "anyOf": [
@@ -12738,6 +12740,7 @@
       },
       "AccountBalanceArtifact": {
         "additionalProperties": {},
+        "description": "Live free+reserved balance in TAO for one Finney ss58 account, read directly from chain via RPC (KV-cached). balance_tao is null on RPC failure (schema-stable, never a GraphQL error). Mirrors GET /api/v1/accounts/{ss58}/balance.",
         "properties": {
           "balance_tao": {
             "anyOf": [
@@ -12818,6 +12821,7 @@
       },
       "AccountChildrenArtifact": {
         "additionalProperties": {},
+        "description": "Live child-hotkey delegation graph (#6723) for one Finney ss58 account, read directly from chain via RPC (KV-cached). subnets is null on RPC failure, distinct from a confirmed-empty [] (schema-stable, never a GraphQL error). Mirrors GET /api/v1/accounts/{ss58}/children.",
         "properties": {
           "account": {
             "type": "string"
@@ -12883,10 +12887,12 @@
               {
                 "items": {
                   "additionalProperties": false,
+                  "description": "One subnet's child-hotkey delegation entries in an account's live children graph.",
                   "properties": {
                     "entries": {
                       "items": {
                         "additionalProperties": false,
+                        "description": "One child hotkey's delegated-stake proportion on a subnet. proportion is the raw stringified u64 (0..u64::MAX represents 0..100%); proportion_fraction is the same value pre-divided to a 0..1 float.",
                         "properties": {
                           "child": {
                             "anyOf": [
@@ -12947,6 +12953,7 @@
           "counterparties": {
             "items": {
               "additionalProperties": false,
+              "description": "One counterparty the account transacts native TAO with, aggregated over the scanned Transfer set.",
               "properties": {
                 "address": {
                   "type": "string"
@@ -12997,6 +13004,7 @@
           },
           "relationship": {
             "additionalProperties": false,
+            "description": "Present only in relationship (counterparty) mode; null in list mode.",
             "properties": {
               "counterparty": {
                 "type": "string"
@@ -13011,7 +13019,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Oldest block/timestamp are null when the newest-first scan was truncated (scan_capped)."
               },
               "first_seen_at": {
                 "anyOf": [
@@ -13078,6 +13087,7 @@
               "transfers": {
                 "items": {
                   "additionalProperties": false,
+                  "description": "One direction-aware transfer between the account and the drilled-into counterparty.",
                   "properties": {
                     "amount_tao": {
                       "type": "number"
@@ -13095,6 +13105,7 @@
                       ]
                     },
                     "direction": {
+                      "description": "sent (account = from) or received (account = to).",
                       "enum": [
                         "sent",
                         "received"
@@ -13234,6 +13245,7 @@
           },
           "degraded": {
             "additionalProperties": false,
+            "description": "A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer.",
             "properties": {
               "detail": {
                 "type": "string"
@@ -13249,6 +13261,7 @@
           },
           "derivation": {
             "additionalProperties": false,
+            "description": "How a deregistration feed was derived (#9307). NeuronDeregistered has never been emitted, so deregistrations are derived from UID reuse: a NeuronRegistered on a (netuid, uid) slot already held by a different hotkey IS the deregistration of the previous occupant. unattributed_registrations is the honest part -- the published totals are a LOWER BOUND by that many events, because those registrations displaced a holder the derivation's lookback cannot name.",
             "properties": {
               "is_lower_bound": {
                 "description": "True when the count is a floor rather than a measurement: some registrations in the window displaced a holder the derivation's lookback cannot name, so the real figure is higher by at least `unattributed_registrations`. Treat the value as 'at least this many', never as a total.",
@@ -13258,6 +13271,7 @@
                 "type": "boolean"
               },
               "lookback_days": {
+                "description": "Days of NeuronRegistered history the derivation had available.",
                 "maximum": 9007199254740991,
                 "minimum": 0,
                 "type": "integer"
@@ -13266,11 +13280,13 @@
                 "type": "string"
               },
               "unattributed_registrations": {
+                "description": "Of those, the ones with no observed previous holder.",
                 "maximum": 9007199254740991,
                 "minimum": 0,
                 "type": "integer"
               },
               "window_registrations": {
+                "description": "Registrations observed inside the reported window.",
                 "maximum": 9007199254740991,
                 "minimum": 0,
                 "type": "integer"
@@ -13310,6 +13326,7 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's slice of an account's deregistration footprint over the window.",
               "properties": {
                 "deregistrations": {
                   "maximum": 9007199254740991,
@@ -13387,10 +13404,12 @@
       },
       "AccountEntitiesArtifact": {
         "additionalProperties": {},
+        "description": "One coldkey's community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities.",
         "properties": {
           "labels": {
             "items": {
               "additionalProperties": {},
+              "description": "A community-contributed entity label for an address (exchange/foundation/operator/other).",
               "properties": {
                 "category": {
                   "anyOf": [
@@ -13461,6 +13480,7 @@
           "ownership_ties": {
             "items": {
               "additionalProperties": {},
+              "description": "One SubnetOwnerChanged transfer tying this coldkey to a subnet, either as the gaining or losing side, newest first.",
               "properties": {
                 "block_number": {
                   "anyOf": [
@@ -13688,6 +13708,7 @@
       },
       "AccountEventsArtifact": {
         "additionalProperties": {},
+        "description": "One account's first-party chain-event feed (matched by the hotkey OR coldkey union, newest first), keyset-paginated. event_count is the page count, not a grand total. Mirrors GET /api/v1/accounts/{ss58}/events' data envelope. Each item is an AccountEvent.",
         "properties": {
           "event_count": {
             "maximum": 9007199254740991,
@@ -13755,6 +13776,7 @@
       },
       "AccountExtrinsicsArtifact": {
         "additionalProperties": {},
+        "description": "One account's signed-extrinsic feed (newest first), backing account_extrinsics. Matched by the extrinsic signer only. extrinsic_count is the page count, matching the REST feed convention. Each item is a full Extrinsic (block/index/hash/call/success/fee/tip).",
         "properties": {
           "extrinsic_count": {
             "maximum": 9007199254740991,
@@ -13783,7 +13805,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "JSON-encoded decoded call arguments."
                 },
                 "call_function": {
                   "anyOf": [
@@ -13875,7 +13898,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Deterministic human-readable action sentence for this extrinsic's call, or null when no template matches call_module.call_function (#8525)."
                 },
                 "tip_tao": {
                   "anyOf": [
@@ -13951,6 +13975,7 @@
       },
       "AccountHistoryArtifact": {
         "additionalProperties": {},
+        "description": "One account's durable per-day activity series (hotkey-keyed, newest day first), keyset-paginated. day_count is the page count, not a grand total. Mirrors GET /api/v1/accounts/{ss58}/history' data envelope. Each item is an AccountDay.",
         "properties": {
           "day_count": {
             "maximum": 9007199254740991,
@@ -13960,6 +13985,7 @@
           "days": {
             "items": {
               "additionalProperties": {},
+              "description": "One day's rolled-up activity for an account on one subnet, from the account_events_daily tier. event_kinds is the distinct set of event ids seen that day.",
               "properties": {
                 "day": {
                   "anyOf": [
@@ -14198,6 +14224,7 @@
           "entries": {
             "items": {
               "additionalProperties": false,
+              "description": "One diff-tracked snapshot of an account's on-chain identity, taken when any tracked field changed since the previous entry.",
               "properties": {
                 "additional": {
                   "anyOf": [
@@ -14241,6 +14268,7 @@
                   ]
                 },
                 "identity_hash": {
+                  "description": "Stable hash of this entry's tracked identity fields -- unchanged across entries where nothing actually differs.",
                   "type": "string"
                 },
                 "image": {
@@ -14347,6 +14375,7 @@
       },
       "AccountParentsArtifact": {
         "additionalProperties": {},
+        "description": "Live parent-hotkey delegation graph (#6723) for one Finney ss58 account, read directly from chain via RPC (KV-cached). subnets is null on RPC failure, distinct from a confirmed-empty [] (schema-stable, never a GraphQL error). Mirrors GET /api/v1/accounts/{ss58}/parents.",
         "properties": {
           "account": {
             "type": "string"
@@ -14412,10 +14441,12 @@
               {
                 "items": {
                   "additionalProperties": false,
+                  "description": "One subnet's parent-hotkey delegation entries in an account's live parents graph.",
                   "properties": {
                     "entries": {
                       "items": {
                         "additionalProperties": false,
+                        "description": "One parent hotkey's delegated-stake proportion on a subnet. proportion is the raw stringified u64 (0..u64::MAX represents 0..100%); proportion_fraction is the same value pre-divided to a 0..1 float.",
                         "properties": {
                           "parent": {
                             "anyOf": [
@@ -14472,6 +14503,7 @@
       },
       "AccountPortfolioArtifact": {
         "additionalProperties": {},
+        "description": "One wallet's cross-subnet neuron portfolio (#5702): every subnet where the hotkey is a registered neuron, plus wallet-level aggregates. Mirrors GET /api/v1/accounts/{ss58}/portfolio.",
         "properties": {
           "captured_at": {
             "anyOf": [
@@ -14507,6 +14539,7 @@
           "positions": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet position in a wallet's portfolio, ranked biggest-stake-first.",
               "properties": {
                 "active": {
                   "type": "boolean"
@@ -14591,7 +14624,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Emission over stake for this position; null when stake is 0."
                 }
               },
               "required": [
@@ -14620,7 +14654,8 @@
             "type": "string"
           },
           "stake_concentration": {
-            "$ref": "#/components/schemas/ConcentrationMetrics"
+            "$ref": "#/components/schemas/ConcentrationMetrics",
+            "description": "How concentrated the wallet's stake is across its subnets (Gini/HHI/etc); null with no positions."
           },
           "subnet_count": {
             "maximum": 9007199254740991,
@@ -14659,6 +14694,7 @@
       },
       "AccountPositionHistoryArtifact": {
         "additionalProperties": {},
+        "description": "One account's per-subnet position history over a lookback window, one point per neuron_daily snapshot. Mirrors GET /api/v1/accounts/{ss58}/subnets/{netuid}/history.",
         "properties": {
           "netuid": {
             "maximum": 9007199254740991,
@@ -14673,6 +14709,7 @@
           "points": {
             "items": {
               "additionalProperties": false,
+              "description": "One day's position for an account in one subnet: the neuron's uid/role/active plus stake/emission and its rank/trust/incentive/dividends scores and emission-per-stake yield.",
               "properties": {
                 "active": {
                   "type": "boolean"
@@ -14827,6 +14864,7 @@
       },
       "AccountPositionsArtifact": {
         "additionalProperties": {},
+        "description": "This account's reconstructed nominator-side positions: what it holds delegated across every hotkey/subnet, distinct from AccountPortfolio's hotkey-scoped view. Mirrors GET /api/v1/accounts/{ss58}/positions.",
         "properties": {
           "captured_at": {
             "anyOf": [
@@ -14888,6 +14926,7 @@
           "positions": {
             "items": {
               "additionalProperties": false,
+              "description": "One (hotkey, netuid) delegation this account holds, reconstructed from the nominator-positions ledger joined against the hotkey's live stake_tao for that netuid.",
               "properties": {
                 "hotkey": {
                   "type": "string"
@@ -14898,6 +14937,7 @@
                   "type": "integer"
                 },
                 "share_fraction": {
+                  "description": "This account's share of the hotkey's total alpha-pool shares on this subnet (0..1), not a TAO amount.",
                   "maximum": 1,
                   "minimum": 0,
                   "type": "number"
@@ -14944,6 +14984,7 @@
       },
       "AccountPrometheusArtifact": {
         "additionalProperties": false,
+        "description": "One account's Prometheus telemetry-serving footprint (#5703) across subnets over a 7d/30d/90d window. Mirrors GET /api/v1/accounts/{ss58}/prometheus.",
         "properties": {
           "address": {
             "type": "string"
@@ -14956,10 +14997,12 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Herfindahl-Hirschman index of announcements across subnets: 1 = all on one subnet, -> 1/n as it spreads evenly; null when the account has no announcements."
           },
           "degraded": {
             "additionalProperties": false,
+            "description": "A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer.",
             "properties": {
               "detail": {
                 "type": "string"
@@ -14998,6 +15041,7 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's Prometheus-announcement activity in an account's footprint, ranked most-active-first.",
               "properties": {
                 "announcements": {
                   "maximum": 9007199254740991,
@@ -15114,6 +15158,7 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's slice of an account's registration footprint over the window.",
               "properties": {
                 "first_registered_at": {
                   "anyOf": [
@@ -15191,11 +15236,13 @@
       },
       "AccountRootClaimArtifact": {
         "additionalProperties": {},
+        "description": "Live root-claim current state for one Finney ss58 account (#7229), read directly from chain via RPC (KV-cached). claim_type/hotkeys are null on RPC failure (schema-stable, never a GraphQL error). Read-only; never submits claim_root. Mirrors GET /api/v1/accounts/{ss58}/root-claim.",
         "properties": {
           "claim_type": {
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "Per-account RootClaimTypeEnum (#7229): Swap / Keep / KeepSubnets.",
                 "properties": {
                   "kind": {
                     "enum": [
@@ -15270,10 +15317,12 @@
               {
                 "items": {
                   "additionalProperties": false,
+                  "description": "Root-claim rows for one staking/owned hotkey of the queried account (#7229).",
                   "properties": {
                     "entries": {
                       "items": {
                         "additionalProperties": false,
+                        "description": "One netuid's root-claim accounting for a (hotkey, account) pair (#7229).",
                         "properties": {
                           "claimable_rate": {
                             "type": "number"
@@ -15384,6 +15433,7 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's slice of an account's axon-serving footprint over the window.",
               "properties": {
                 "announcements": {
                   "maximum": 9007199254740991,
@@ -15665,6 +15715,7 @@
       },
       "AccountStakeFlowArtifact": {
         "additionalProperties": false,
+        "description": "One account's StakeAdded/StakeRemoved staking-behavior scorecard (#5706) across subnets over a 7d/30d/90d window. Mirrors GET /api/v1/accounts/{ss58}/stake-flow.",
         "properties": {
           "address": {
             "type": "string"
@@ -15677,9 +15728,11 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Herfindahl-Hirschman index of gross flow across subnets: 1 = all flow in one subnet, -> 1/n as it spreads evenly; null when there is no flow to concentrate."
           },
           "direction": {
+            "description": "accumulating / exiting / churning / idle, derived from flow_ratio.",
             "enum": [
               "accumulating",
               "exiting",
@@ -15708,7 +15761,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "net_flow_tao / gross_flow_tao, [-1, 1]; null when gross_flow_tao is 0 (no flow to rate)."
           },
           "gross_flow_tao": {
             "type": "number"
@@ -15734,6 +15788,7 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's stake flow in an account's footprint, ranked most-active-first (highest gross flow).",
               "properties": {
                 "direction": {
                   "enum": [
@@ -15884,6 +15939,7 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's slice of an account's stake-movement footprint over the window.",
               "properties": {
                 "first_moved_at": {
                   "anyOf": [
@@ -15923,7 +15979,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Alpha price (TAO) on the UTC day of this subnet's most recent move; null when that day has no snapshot yet or there was no move."
                 }
               },
               "required": [
@@ -15972,6 +16029,7 @@
       },
       "AccountSubnetsArtifact": {
         "additionalProperties": {},
+        "description": "One account's live cross-subnet registration footprint (the neurons snapshot), backing account_subnets. The lightweight sibling of AccountPortfolio -- registration facts only, no economics rollup.",
         "properties": {
           "schema_version": {
             "maximum": 9007199254740991,
@@ -15987,6 +16045,7 @@
             "type": "integer"
           },
           "subnets": {
+            "description": "Where this hotkey is currently registered, ordered by netuid -- each an AccountRegistration (netuid/uid/stake/validator_permit/active).",
             "items": {
               "additionalProperties": false,
               "properties": {
@@ -16049,6 +16108,7 @@
         "properties": {
           "activity": {
             "additionalProperties": false,
+            "description": "Signing-activity aggregate from the extrinsics tier, matched by signer only. tx_count / total_fee_tao / last_tx_* are all-time over every extrinsic this address has signed; modules_called is the pallet mix over the newest 1000 only, with modules_called_capped true when that window is incomplete. An account queried by a key that did not sign returns tx_count 0, modules_called_capped false, other fields null/empty.",
             "properties": {
               "last_tx_at": {
                 "anyOf": [
@@ -16156,6 +16216,7 @@
             "type": "array"
           },
           "event_scan_capped": {
+            "description": "True when this account has more events than the summary's scan window -- event_count/subnet_count/event_kinds are then a lower bound and first_block/first_seen_at are null.",
             "type": "boolean"
           },
           "first_block": {
@@ -16274,6 +16335,7 @@
             "type": "array"
           },
           "registrations": {
+            "description": "Where this hotkey is currently registered + staked (the live cross-subnet footprint).",
             "items": {
               "additionalProperties": false,
               "properties": {
@@ -16346,6 +16408,7 @@
       },
       "AccountTransfersArtifact": {
         "additionalProperties": {},
+        "description": "One account's native-TAO transfer feed, keyset-paginated newest-first. Mirrors GET /api/v1/accounts/{ss58}/transfers' data envelope.",
         "properties": {
           "limit": {
             "anyOf": [
@@ -16397,6 +16460,7 @@
           "transfers": {
             "items": {
               "additionalProperties": false,
+              "description": "One native-TAO Balances.Transfer event on an account's feed. direction is relative to the queried address (sent = it paid, received = it was paid).",
               "properties": {
                 "amount_tao": {
                   "anyOf": [
@@ -16499,6 +16563,7 @@
       },
       "AccountWeightSettersArtifact": {
         "additionalProperties": false,
+        "description": "One account's (validator hotkey's) WeightsSet weight-setting footprint across subnets over a 7d/30d window. Mirrors GET /api/v1/accounts/{ss58}/weight-setters.",
         "properties": {
           "address": {
             "type": "string"
@@ -16511,7 +16576,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Herfindahl-Hirschman index of weight-sets across subnets: 1 = all on one subnet, -> 1/n as it spreads evenly; null when the account has no weight-sets."
           },
           "dominant_netuid": {
             "anyOf": [
@@ -16538,6 +16604,7 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's WeightsSet activity in an account's weight-setting footprint, ranked most-active-first.",
               "properties": {
                 "first_set_at": {
                   "anyOf": [
@@ -16614,6 +16681,7 @@
       },
       "AdapterArtifact": {
         "additionalProperties": {},
+        "description": "One adapter-backed public metrics snapshot. snapshot and extensions are opaque JSON -- their shape is adapter-specific. Mirrors GET /api/v1/adapters/{slug}'s data envelope.",
         "properties": {
           "contract_version": {
             "type": "string"
@@ -16624,6 +16692,7 @@
               "properties": {},
               "type": "object"
             },
+            "description": "Per-adapter extension metadata keyed by provider id; each value's shape is adapter-specific.",
             "propertyNames": {
               "type": "string"
             },
@@ -16648,7 +16717,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -16796,7 +16866,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Captured adapter metrics payload; shape is adapter-specific."
           },
           "subnet": {
             "type": "string"
@@ -16963,7 +17034,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -17184,7 +17256,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "previously_known_as": {
             "items": {
@@ -17872,7 +17945,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "published_at": {
             "anyOf": [
@@ -18176,7 +18250,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "openapi_url": {
             "const": "/metagraph/openapi.json",
@@ -18366,7 +18441,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -18505,6 +18581,7 @@
           "events": {
             "items": {
               "additionalProperties": false,
+              "description": "One raw pallet-level chain event from the all-events tier (distinct from the curated AccountEvent and from Subscription's ChainEvent firehose payload).",
               "properties": {
                 "args": {
                   "anyOf": [
@@ -18614,7 +18691,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Deterministic human-readable action sentence for this event's pallet.method, or null when no template matches (#8525)."
                 }
               },
               "required": [
@@ -18758,7 +18836,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Nearest STORED higher block height for chain-walk nav (detail only); null at the head of the retained window or when the ref didn't resolve."
           },
           "prev_block_number": {
             "anyOf": [
@@ -18770,7 +18849,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Nearest STORED lower block height for chain-walk nav (detail only); null at the start of the retained window or when the ref didn't resolve."
           },
           "ref": {
             "anyOf": [
@@ -18799,6 +18879,7 @@
       },
       "BlockEventsArtifact": {
         "additionalProperties": {},
+        "description": "One block's decoded, account-attributed events list (#6977). Rows are opaque JSON; block_number is null for an unknown ref.",
         "properties": {
           "block_number": {
             "anyOf": [
@@ -18876,6 +18957,7 @@
       },
       "BlockExtrinsicsArtifact": {
         "additionalProperties": {},
+        "description": "One block's extrinsics list (#6977). Rows are the opaque JSON extrinsic shape the extrinsics feed uses; block_number is null for an unknown ref.",
         "properties": {
           "block_number": {
             "anyOf": [
@@ -19271,6 +19353,7 @@
       },
       "BlocksSummaryArtifact": {
         "additionalProperties": {},
+        "description": "Block-production summary (#5664) over the recent-block window. Every aggregate is null on a cold retired-D1 store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/summary.",
         "properties": {
           "author_concentration": {
             "anyOf": [
@@ -19291,6 +19374,7 @@
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "Inter-block interval distribution in milliseconds, over genuinely consecutive in-window blocks.",
                 "properties": {
                   "count": {
                     "maximum": 9007199254740991,
@@ -19413,6 +19497,7 @@
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "Extrinsic/event throughput across the summarized block window.",
                 "properties": {
                   "max_extrinsics_in_block": {
                     "maximum": 9007199254740991,
@@ -19635,7 +19720,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "profile_count": {
             "maximum": 9007199254740991,
@@ -19722,6 +19808,7 @@
       },
       "BulkHealthTrendsArtifact": {
         "additionalProperties": false,
+        "description": "All-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history. Mirrors GET /api/v1/health/trends' data envelope.",
         "properties": {
           "observed_at": {
             "anyOf": [
@@ -19878,6 +19965,7 @@
               ],
               "type": "object"
             },
+            "description": "The 7d/30d windows keyed by window label (7d, 30d), each holding days/granularity/subnet_count and the per-subnet daily point series. Opaque JSON: dynamic-keyed by window label, matching the get_health_trends MCP/REST shape.",
             "propertyNames": {
               "type": "string"
             },
@@ -19925,7 +20013,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -20183,6 +20272,7 @@
       },
       "ChainActivityArtifact": {
         "additionalProperties": {},
+        "description": "Per-UTC-day network activity series (blocks, extrinsics, events, signers) over the window, newest day first. Mirrors GET /api/v1/chain/activity's data envelope.",
         "properties": {
           "day_count": {
             "maximum": 9007199254740991,
@@ -20192,6 +20282,7 @@
           "days": {
             "items": {
               "additionalProperties": false,
+              "description": "One UTC day's network activity: block/extrinsic/event counts, the successful-extrinsic count and its success rate (null on a zero-extrinsic day), and the distinct signer count.",
               "properties": {
                 "block_count": {
                   "maximum": 9007199254740991,
@@ -20276,9 +20367,11 @@
       },
       "ChainAlphaVolumeArtifact": {
         "additionalProperties": false,
+        "description": "Network-wide rolling 24h buy/sell alpha-volume leaderboard, summed live from the account_events StakeAdded/StakeRemoved stream. Mirrors GET /api/v1/chain/alpha-volume's data envelope.",
         "properties": {
           "network": {
             "additionalProperties": false,
+            "description": "Network-wide buy/sell volume rollup across every subnet with volume in the window.",
             "properties": {
               "buy_count": {
                 "maximum": 9007199254740991,
@@ -20310,6 +20403,7 @@
                 "type": "number"
               },
               "sentiment": {
+                "description": "Coarse sentiment label (bullish/bearish/neutral); neutral both for balanced volume and an empty window.",
                 "enum": [
                   "bullish",
                   "bearish",
@@ -20325,7 +20419,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "net/gross alpha lean in [-1, 1]; null when there was no volume in the window."
               },
               "total_volume_alpha": {
                 "minimum": 0,
@@ -20359,7 +20454,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Newest event observed_at across the window; null on a cold store."
           },
           "schema_version": {
             "maximum": 9007199254740991,
@@ -20381,6 +20477,7 @@
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "Spread of per-subnet total_volume_tao across EVERY subnet with volume (not just the returned page, so the spread stays network-wide when limit truncates the leaderboard).",
                 "properties": {
                   "count": {
                     "maximum": 9007199254740991,
@@ -20431,9 +20528,11 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Spread of per-subnet total_volume_tao across every subnet with volume; null when no subnet had volume."
           },
           "window": {
+            "description": "Fixed rolling window label (always 24h).",
             "enum": [
               "24h"
             ],
@@ -20456,6 +20555,7 @@
         "properties": {
           "degraded": {
             "additionalProperties": false,
+            "description": "A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer.",
             "properties": {
               "detail": {
                 "type": "string"
@@ -20473,6 +20573,7 @@
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "Spread of per-subnet transfers-per-sender intensity across EVERY subnet with transfers in the window.",
                 "properties": {
                   "count": {
                     "maximum": 9007199254740991,
@@ -20527,6 +20628,7 @@
           },
           "network": {
             "additionalProperties": false,
+            "description": "Network-wide axon-removal rollup: every subnet with AxonInfoRemoved events in the window, combined. distinct_removers counts a hotkey once even when it tears endpoints down on several subnets, so it is NOT the sum of the per-subnet counts.",
             "properties": {
               "distinct_removers": {
                 "maximum": 9007199254740991,
@@ -20547,7 +20649,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Null when distinct_removers is 0 (no defined intensity without removers)."
               }
             },
             "required": [
@@ -20580,6 +20683,7 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's axon-removal activity in the window, ranked by removals.",
               "properties": {
                 "distinct_removers": {
                   "maximum": 9007199254740991,
@@ -20796,6 +20900,7 @@
       },
       "ChainCallsArtifact": {
         "additionalProperties": {},
+        "description": "Extrinsic call-mix breakdown over the window. Mirrors GET /api/v1/chain/calls's data envelope.",
         "properties": {
           "call_count": {
             "maximum": 9007199254740991,
@@ -20805,6 +20910,7 @@
           "calls": {
             "items": {
               "additionalProperties": false,
+              "description": "One row of the extrinsic call-mix breakdown -- a call_module (plus call_function when group_by=module_function), its extrinsic count over the window, and its share of the window total (null when the window has no extrinsics).",
               "properties": {
                 "call_function": {
                   "anyOf": [
@@ -20886,6 +20992,7 @@
       },
       "ChainConcentrationArtifact": {
         "additionalProperties": {},
+        "description": "Network-wide stake & emission decentralization card (#5872). Metric blocks are null on a cold/empty store. Mirrors GET /api/v1/chain/concentration.",
         "properties": {
           "captured_at": {
             "anyOf": [
@@ -20898,18 +21005,22 @@
             ]
           },
           "emission": {
-            "$ref": "#/components/schemas/ConcentrationMetrics"
+            "$ref": "#/components/schemas/ConcentrationMetrics",
+            "description": "Raw emission concentration across every neuron network-wide."
           },
           "entity_count": {
+            "description": "Distinct controlling entities (coldkeys) network-wide, collapsed across subnets.",
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
           },
           "entity_emission": {
-            "$ref": "#/components/schemas/ConcentrationMetrics"
+            "$ref": "#/components/schemas/ConcentrationMetrics",
+            "description": "Emission concentration per controlling entity -- hotkeys collapsed across subnets."
           },
           "entity_stake": {
-            "$ref": "#/components/schemas/ConcentrationMetrics"
+            "$ref": "#/components/schemas/ConcentrationMetrics",
+            "description": "Stake concentration per controlling entity -- hotkeys collapsed across subnets, so one operator counts once."
           },
           "neuron_count": {
             "maximum": 9007199254740991,
@@ -20922,9 +21033,11 @@
             "type": "integer"
           },
           "stake": {
-            "$ref": "#/components/schemas/ConcentrationMetrics"
+            "$ref": "#/components/schemas/ConcentrationMetrics",
+            "description": "Raw stake concentration across every neuron network-wide."
           },
           "subnet_count": {
+            "description": "Distinct subnets the snapshot spans.",
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
@@ -20937,10 +21050,12 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "UIDs per controlling entity network-wide -- a consolidation signal (1.0 = every UID a distinct owner; higher = fewer operators each running many). Null when no entities."
           },
           "validator_stake": {
-            "$ref": "#/components/schemas/ConcentrationMetrics"
+            "$ref": "#/components/schemas/ConcentrationMetrics",
+            "description": "Stake concentration across permitted validators network-wide only."
           }
         },
         "required": [
@@ -20962,6 +21077,7 @@
         "additionalProperties": {},
         "properties": {
           "builder_versions": {
+            "description": "Every distinct builder version in the series. More than one means it changes DEFINITION partway along.",
             "items": {
               "maximum": 9007199254740991,
               "minimum": -9007199254740991,
@@ -20971,6 +21087,7 @@
           },
           "degraded": {
             "additionalProperties": false,
+            "description": "Present ONLY on a decline. An empty window is a measurement.",
             "properties": {
               "reason": {
                 "enum": [
@@ -21014,7 +21131,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "From the ROWS. A day the capture did not run is absent, never a zero-concentration point."
           },
           "points": {
             "items": {
@@ -21062,7 +21180,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Which definition of the metrics produced this point."
           },
           "day": {
             "type": "string"
@@ -21119,7 +21238,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The shape of the day the card was computed over -- a point across half the network is not comparable to one across all of it."
           },
           "source_captured_at": {
             "anyOf": [
@@ -21131,7 +21251,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "WHEN the network looked like this, as distinct from when it was computed."
           },
           "stake": {
             "anyOf": [
@@ -21141,7 +21262,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "NULL means no measurable distribution, NOT missing."
           },
           "subnet_count": {
             "anyOf": [
@@ -21598,6 +21720,7 @@
         "properties": {
           "degraded": {
             "additionalProperties": false,
+            "description": "A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer.",
             "properties": {
               "detail": {
                 "type": "string"
@@ -21613,6 +21736,7 @@
           },
           "derivation": {
             "additionalProperties": false,
+            "description": "How a deregistration feed was derived (#9307). NeuronDeregistered has never been emitted, so deregistrations are derived from UID reuse: a NeuronRegistered on a (netuid, uid) slot already held by a different hotkey IS the deregistration of the previous occupant. unattributed_registrations is the honest part -- the published totals are a LOWER BOUND by that many events, because those registrations displaced a holder the derivation's lookback cannot name.",
             "properties": {
               "is_lower_bound": {
                 "description": "True when the count is a floor rather than a measurement: some registrations in the window displaced a holder the derivation's lookback cannot name, so the real figure is higher by at least `unattributed_registrations`. Treat the value as 'at least this many', never as a total.",
@@ -21622,6 +21746,7 @@
                 "type": "boolean"
               },
               "lookback_days": {
+                "description": "Days of NeuronRegistered history the derivation had available.",
                 "maximum": 9007199254740991,
                 "minimum": 0,
                 "type": "integer"
@@ -21630,11 +21755,13 @@
                 "type": "string"
               },
               "unattributed_registrations": {
+                "description": "Of those, the ones with no observed previous holder.",
                 "maximum": 9007199254740991,
                 "minimum": 0,
                 "type": "integer"
               },
               "window_registrations": {
+                "description": "Registrations observed inside the reported window.",
                 "maximum": 9007199254740991,
                 "minimum": 0,
                 "type": "integer"
@@ -21653,6 +21780,7 @@
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "Spread of per-subnet transfers-per-sender intensity across EVERY subnet with transfers in the window.",
                 "properties": {
                   "count": {
                     "maximum": 9007199254740991,
@@ -21707,6 +21835,7 @@
           },
           "network": {
             "additionalProperties": false,
+            "description": "Network-wide deregistration rollup: every subnet with a derived deregistration in the window, combined. distinct_deregistered_hotkeys counts a hotkey once even when it is deregistered from several subnets, so it is NOT the sum of the per-subnet counts.",
             "properties": {
               "deregistrations": {
                 "maximum": 9007199254740991,
@@ -21722,7 +21851,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Null when distinct_deregistered_hotkeys is 0 (no defined intensity without hotkeys)."
               },
               "distinct_deregistered_hotkeys": {
                 "maximum": 9007199254740991,
@@ -21843,6 +21973,7 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's neuron-deregistration activity in the window, ranked by deregistrations.",
               "properties": {
                 "deregistrations": {
                   "maximum": 9007199254740991,
@@ -21992,6 +22123,7 @@
       },
       "ChainEventsFeedArtifact": {
         "additionalProperties": {},
+        "description": "Paginated all-events feed from the chain_events lakehouse table. Mirrors GET /api/v1/chain-events (and MCP list_chain_events). Distinct from Subscription.chainEvents.",
         "properties": {
           "count": {
             "maximum": 9007199254740991,
@@ -22156,10 +22288,12 @@
       },
       "ChainEventsStatsArtifact": {
         "additionalProperties": {},
+        "description": "Chain-activity aggregate (pallet.method event distribution) over the most recent N blocks from the chain_events lakehouse table. The aggregate sibling of ChainEventsFeed. Mirrors GET /api/v1/chain-events/stats (and MCP get_chain_activity).",
         "properties": {
           "activity": {
             "items": {
               "additionalProperties": false,
+              "description": "One pallet.method group in the chain-activity aggregate, with its event count over the window.",
               "properties": {
                 "count": {
                   "maximum": 9007199254740991,
@@ -22216,10 +22350,12 @@
       },
       "ChainFeesArtifact": {
         "additionalProperties": {},
+        "description": "Per-UTC-day network fee/tip series plus the top fee payers over the window. Mirrors GET /api/v1/chain/fees's data envelope.",
         "properties": {
           "daily": {
             "items": {
               "additionalProperties": false,
+              "description": "One UTC day's fee/tip aggregate: extrinsic count, total/avg/median fee and tip in TAO. avg/median are computed over signed extrinsics only and are null on a day with no signed extrinsics; extrinsic_count counts every extrinsic including unsigned inherents.",
               "properties": {
                 "avg_fee_tao": {
                   "anyOf": [
@@ -22325,6 +22461,7 @@
           "top_fee_payers": {
             "items": {
               "additionalProperties": false,
+              "description": "One top fee-paying signer over the window, with its total fee/tip and extrinsic count.",
               "properties": {
                 "extrinsic_count": {
                   "maximum": 9007199254740991,
@@ -22383,6 +22520,7 @@
           },
           "degraded": {
             "additionalProperties": false,
+            "description": "Present ONLY on a decline. An empty subnets list WITHOUT this block is a measurement.",
             "properties": {
               "reason": {
                 "enum": [
@@ -22442,7 +22580,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Subnets measured -- NOT the length of the subnets list when limit bites."
           },
           "subnets": {
             "items": {
@@ -22465,6 +22604,7 @@
       },
       "ChainHoldersNetwork": {
         "additionalProperties": false,
+        "description": "Dimension-free network facts. There is deliberately no cross-subnet alpha total: summing different subnets' alpha has no unit.",
         "properties": {
           "median_top1_share": {
             "anyOf": [
@@ -22500,7 +22640,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Subnets where ONE account holds a majority of the measured alpha."
           },
           "subnets_with_single_holder": {
             "anyOf": [
@@ -22512,7 +22653,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Subnets whose entire measured alpha sits in a single wallet."
           }
         },
         "required": [
@@ -22525,6 +22667,7 @@
       },
       "ChainHoldersSubnet": {
         "additionalProperties": false,
+        "description": "One subnet's alpha-ownership concentration.",
         "properties": {
           "holder_count": {
             "anyOf": [
@@ -22551,7 +22694,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The largest holder's coldkey (an ss58 address)."
           },
           "top1_share": {
             "anyOf": [
@@ -22610,7 +22754,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "ALPHA, comparable only WITHIN this subnet -- each subnet's alpha is a different token."
           }
         },
         "required": [
@@ -22631,6 +22776,7 @@
           "changes": {
             "items": {
               "additionalProperties": {},
+              "description": "One cross-subnet identity change in the network-wide feed (carries its netuid).",
               "properties": {
                 "block_number": {
                   "anyOf": [
@@ -22786,6 +22932,7 @@
       },
       "ChainIdleStakeArtifact": {
         "additionalProperties": {},
+        "description": "Network-wide idle-stake rollup: every subnet's stake on currently-zero-dividends hotkeys, ranked by idle_stake_alpha. Mirrors GET /api/v1/chain/idle-stake's data envelope.",
         "properties": {
           "captured_at": {
             "anyOf": [
@@ -22810,6 +22957,7 @@
           "subnets": {
             "items": {
               "additionalProperties": {},
+              "description": "One subnet's idle-stake scorecard in the network ranking.",
               "properties": {
                 "idle_neuron_count": {
                   "maximum": 9007199254740991,
@@ -22856,6 +23004,7 @@
       },
       "ChainPerformanceArtifact": {
         "additionalProperties": {},
+        "description": "Network-wide reward-distribution & score-spread card (#5688) -- the network analog of SubnetPerformance, spanning every subnet's neurons in one snapshot. Metric blocks are null on a cold/empty store. Mirrors GET /api/v1/chain/performance.",
         "properties": {
           "active_count": {
             "maximum": 9007199254740991,
@@ -22873,13 +23022,16 @@
             ]
           },
           "consensus": {
-            "$ref": "#/components/schemas/ScoreDistribution"
+            "$ref": "#/components/schemas/ScoreDistribution",
+            "description": "Consensus score spread across all neurons network-wide."
           },
           "dividends": {
-            "$ref": "#/components/schemas/ConcentrationMetrics"
+            "$ref": "#/components/schemas/ConcentrationMetrics",
+            "description": "Dividends concentration across permitted validators network-wide only."
           },
           "incentive": {
-            "$ref": "#/components/schemas/ConcentrationMetrics"
+            "$ref": "#/components/schemas/ConcentrationMetrics",
+            "description": "Incentive concentration across all neurons network-wide with positive incentive."
           },
           "neuron_count": {
             "maximum": 9007199254740991,
@@ -22892,12 +23044,14 @@
             "type": "integer"
           },
           "subnet_count": {
+            "description": "Distinct subnets the snapshot spans.",
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
           },
           "trust": {
-            "$ref": "#/components/schemas/ScoreDistribution"
+            "$ref": "#/components/schemas/ScoreDistribution",
+            "description": "Trust score spread across all neurons network-wide."
           },
           "validator_count": {
             "maximum": 9007199254740991,
@@ -22905,7 +23059,8 @@
             "type": "integer"
           },
           "validator_trust": {
-            "$ref": "#/components/schemas/ScoreDistribution"
+            "$ref": "#/components/schemas/ScoreDistribution",
+            "description": "Validator-trust score spread across permitted validators network-wide only."
           }
         },
         "required": [
@@ -22924,6 +23079,7 @@
         "properties": {
           "degraded": {
             "additionalProperties": false,
+            "description": "A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer.",
             "properties": {
               "detail": {
                 "type": "string"
@@ -22941,6 +23097,7 @@
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "Spread of per-subnet transfers-per-sender intensity across EVERY subnet with transfers in the window.",
                 "properties": {
                   "count": {
                     "maximum": 9007199254740991,
@@ -22995,6 +23152,7 @@
           },
           "network": {
             "additionalProperties": false,
+            "description": "Network-wide Prometheus-serving rollup: every subnet with PrometheusServed announcements in the window, combined. distinct_exporters counts a hotkey once even when it announces on several subnets, so it is NOT the sum of the per-subnet counts.",
             "properties": {
               "announcements": {
                 "maximum": 9007199254740991,
@@ -23010,7 +23168,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Null when distinct_exporters is 0 (no defined intensity without exporters)."
               },
               "distinct_exporters": {
                 "maximum": 9007199254740991,
@@ -23048,6 +23207,7 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's Prometheus telemetry-serving activity in the window, ranked by announcements.",
               "properties": {
                 "announcements": {
                   "maximum": 9007199254740991,
@@ -23119,6 +23279,7 @@
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "Spread of per-subnet transfers-per-sender intensity across EVERY subnet with transfers in the window.",
                 "properties": {
                   "count": {
                     "maximum": 9007199254740991,
@@ -23173,6 +23334,7 @@
           },
           "network": {
             "additionalProperties": false,
+            "description": "Network-wide registration rollup: every subnet with NeuronRegistered events in the window, combined. distinct_registrants counts a hotkey once even when it registers on several subnets, so it is NOT the sum of the per-subnet counts.",
             "properties": {
               "distinct_registrants": {
                 "maximum": 9007199254740991,
@@ -23193,7 +23355,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Null when distinct_registrants is 0 (no defined intensity without hotkeys)."
               }
             },
             "required": [
@@ -23226,6 +23389,7 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's neuron-registration activity in the window, ranked by registrations.",
               "properties": {
                 "distinct_registrants": {
                   "maximum": 9007199254740991,
@@ -23292,11 +23456,13 @@
       },
       "ChainServingArtifact": {
         "additionalProperties": false,
+        "description": "Network-wide axon-serving announcement leaderboard (#5873). The network-wide counterpart of subnet_serving. Mirrors GET /api/v1/chain/serving's data envelope.",
         "properties": {
           "intensity_distribution": {
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "Spread of per-subnet transfers-per-sender intensity across EVERY subnet with transfers in the window.",
                 "properties": {
                   "count": {
                     "maximum": 9007199254740991,
@@ -23351,6 +23517,7 @@
           },
           "network": {
             "additionalProperties": false,
+            "description": "Network-wide axon-serving rollup: every subnet with AxonServed announcements in the window, combined.",
             "properties": {
               "announcements": {
                 "maximum": 9007199254740991,
@@ -23366,7 +23533,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Null when distinct_servers is 0 (no defined intensity without servers)."
               },
               "distinct_servers": {
                 "maximum": 9007199254740991,
@@ -23404,6 +23572,7 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's axon-serving activity in the window, ranked by announcements.",
               "properties": {
                 "announcements": {
                   "maximum": 9007199254740991,
@@ -23470,6 +23639,7 @@
       },
       "ChainSignersArtifact": {
         "additionalProperties": {},
+        "description": "Network-wide weight-setter leaderboard over a lookback window, summed live from the account_events WeightsSet stream. The setter-level drill-in behind ChainWeights. Mirrors GET /api/v1/chain/weights/setters.",
         "properties": {
           "observed_at": {
             "anyOf": [
@@ -23494,6 +23664,7 @@
           "signers": {
             "items": {
               "additionalProperties": false,
+              "description": "One account's extrinsic-submission activity in the window, ranked by the requested sort.",
               "properties": {
                 "last_tx_block": {
                   "anyOf": [
@@ -23511,6 +23682,7 @@
                   "type": "string"
                 },
                 "total_fee_tao": {
+                  "description": "Total fees paid across the window's extrinsics; null when the tier has no fee data.",
                   "minimum": 0,
                   "type": "number"
                 },
@@ -23536,6 +23708,7 @@
             "type": "array"
           },
           "sort": {
+            "description": "The rank order actually applied: tx_count or total_fee_tao.",
             "enum": [
               "tx_count",
               "total_fee_tao"
@@ -23557,11 +23730,13 @@
       },
       "ChainStakeFlowArtifact": {
         "additionalProperties": false,
+        "description": "Network-wide cross-subnet capital-flow leaderboard over a lookback window, summed live from the account_events StakeAdded/StakeRemoved stream. Mirrors GET /api/v1/chain/stake-flow's data envelope.",
         "properties": {
           "net_flow_distribution": {
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "Spread of per-subnet net_flow_tao (can be negative) across EVERY subnet with stake events (not just the returned page).",
                 "properties": {
                   "count": {
                     "maximum": 9007199254740991,
@@ -23605,10 +23780,12 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Spread of per-subnet net_flow_tao across EVERY subnet with stake events; null when no subnet moved stake."
           },
           "network": {
             "additionalProperties": false,
+            "description": "Network rollup over every subnet that moved stake in the window.",
             "properties": {
               "flat": {
                 "maximum": 9007199254740991,
@@ -23687,8 +23864,10 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's capital-flow scorecard in the window, ranked by net_flow_tao.",
               "properties": {
                 "direction": {
+                  "description": "inflow | outflow | balanced",
                   "enum": [
                     "inflow",
                     "outflow",
@@ -23769,11 +23948,13 @@
       },
       "ChainStakeMovesArtifact": {
         "additionalProperties": false,
+        "description": "Network-wide stake-movement (re-delegation) leaderboard over a lookback window, summed live from the account_events StakeMoved stream. Mirrors GET /api/v1/chain/stake-moves's data envelope.",
         "properties": {
           "intensity_distribution": {
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "Spread of per-subnet transfers-per-sender intensity across EVERY subnet with transfers in the window.",
                 "properties": {
                   "count": {
                     "maximum": 9007199254740991,
@@ -23828,6 +24009,7 @@
           },
           "network": {
             "additionalProperties": false,
+            "description": "Network-wide stake-move rollup: every subnet with StakeMoved events in the window, combined. distinct_movers counts a coldkey once even when it moves on several subnets.",
             "properties": {
               "distinct_movers": {
                 "maximum": 9007199254740991,
@@ -23848,7 +24030,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Null when distinct_movers is 0."
               }
             },
             "required": [
@@ -23881,6 +24064,7 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's stake-movement activity in the window, ranked by movements.",
               "properties": {
                 "distinct_movers": {
                   "maximum": 9007199254740991,
@@ -23947,11 +24131,13 @@
       },
       "ChainStakeTransfersArtifact": {
         "additionalProperties": false,
+        "description": "Network-wide stake-transfer (between-coldkeys) leaderboard over a lookback window, summed live from the account_events StakeTransferred stream. Mirrors GET /api/v1/chain/stake-transfers's data envelope.",
         "properties": {
           "intensity_distribution": {
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "Spread of per-subnet transfers-per-sender intensity across EVERY subnet with transfers in the window.",
                 "properties": {
                   "count": {
                     "maximum": 9007199254740991,
@@ -24006,6 +24192,7 @@
           },
           "network": {
             "additionalProperties": false,
+            "description": "Network-wide stake-transfer rollup: every subnet with StakeTransferred events in the window, combined. distinct_senders counts an origin coldkey once even when it transfers out of several subnets.",
             "properties": {
               "distinct_senders": {
                 "maximum": 9007199254740991,
@@ -24026,7 +24213,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Null when distinct_senders is 0."
               }
             },
             "required": [
@@ -24059,6 +24247,7 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's stake-transfer activity in the window, ranked by transfers.",
               "properties": {
                 "distinct_senders": {
                   "maximum": 9007199254740991,
@@ -24129,6 +24318,7 @@
           "entries": {
             "items": {
               "additionalProperties": {},
+              "description": "One observed subnet transition. block_number is null when the event predates capture or the detecting pass could not attribute one; that is a fact, not a gap.",
               "properties": {
                 "block_number": {
                   "anyOf": [
@@ -24217,6 +24407,7 @@
             "type": "integer"
           },
           "subnet_count": {
+            "description": "Distinct subnets appearing in this page -- context for entry_count.",
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
@@ -24232,6 +24423,7 @@
       },
       "ChainTransferPairsArtifact": {
         "additionalProperties": false,
+        "description": "Network-wide directed native-TAO transfer-corridor leaderboard over a lookback window. Mirrors GET /api/v1/chain/transfer-pairs's data envelope.",
         "properties": {
           "observed_at": {
             "anyOf": [
@@ -24251,6 +24443,7 @@
           "pairs": {
             "items": {
               "additionalProperties": false,
+              "description": "One directed sender -> receiver corridor on the transfer-pairs leaderboard.",
               "properties": {
                 "from": {
                   "type": "string"
@@ -24308,6 +24501,7 @@
             "type": "integer"
           },
           "sort": {
+            "description": "The rank order actually applied: volume or count.",
             "enum": [
               "volume",
               "count"
@@ -24322,7 +24516,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Highest-volume corridor's share of total pairable volume; null when the window has no pairable volume."
           },
           "total_volume_tao": {
             "minimum": 0,
@@ -24365,6 +24560,7 @@
       },
       "ChainTransfersArtifact": {
         "additionalProperties": false,
+        "description": "Network-wide native-TAO transfer analytics over a lookback window. Mirrors GET /api/v1/chain/transfers's data envelope.",
         "properties": {
           "observed_at": {
             "anyOf": [
@@ -24384,6 +24580,7 @@
           "top_receivers": {
             "items": {
               "additionalProperties": false,
+              "description": "One account on a chain-transfers sender/receiver leaderboard.",
               "properties": {
                 "address": {
                   "type": "string"
@@ -24414,11 +24611,13 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Top senders' combined share of total volume; null when total volume is 0."
           },
           "top_senders": {
             "items": {
               "additionalProperties": false,
+              "description": "One account on a chain-transfers sender/receiver leaderboard.",
               "properties": {
                 "address": {
                   "type": "string"
@@ -24486,8 +24685,10 @@
       },
       "ChainTurnoverArtifact": {
         "additionalProperties": false,
+        "description": "Network-wide validator-set churn across all subnets (#5686). Mirrors GET /api/v1/chain/turnover's data envelope.",
         "properties": {
           "comparable": {
+            "description": "False when the window resolved to fewer than two distinct snapshots, so start/end churn is not measurable.",
             "type": "boolean"
           },
           "end_date": {
@@ -24499,10 +24700,12 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "End snapshot date; null on a cold store."
           },
           "network": {
             "additionalProperties": false,
+            "description": "Network-wide validator-set rollup: every subnet's validators combined, deduplicated across the network.",
             "properties": {
               "stability_score": {
                 "anyOf": [
@@ -24514,7 +24717,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "0-100 stability score; null on a cold/non-comparable window."
               },
               "validator_retention": {
                 "anyOf": [
@@ -24526,7 +24730,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Jaccard retention of the start set into the end set; null on a cold/non-comparable window."
               },
               "validators_end": {
                 "maximum": 9007199254740991,
@@ -24568,6 +24773,7 @@
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "Spread of per-subnet stability score across EVERY subnet in the window (not just the returned page, so the spread stays network-wide when limit truncates the leaderboard).",
                 "properties": {
                   "count": {
                     "maximum": 9007199254740991,
@@ -24625,7 +24831,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Null when no subnet had a stability score in the window (nothing to distribute)."
           },
           "start_date": {
             "anyOf": [
@@ -24636,7 +24843,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Start snapshot date; null on a cold store."
           },
           "subnet_count": {
             "maximum": 9007199254740991,
@@ -24646,6 +24854,7 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's validator-set churn, ranked by gross churn (entered + exited) then netuid.",
               "properties": {
                 "netuid": {
                   "maximum": 9007199254740991,
@@ -24741,11 +24950,13 @@
       },
       "ChainWeightsArtifact": {
         "additionalProperties": false,
+        "description": "Network-wide validator weight-setting activity over a lookback window, summed live from the account_events WeightsSet stream. Mirrors GET /api/v1/chain/weights.",
         "properties": {
           "intensity_distribution": {
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "Spread of per-subnet transfers-per-sender intensity across EVERY subnet with transfers in the window.",
                 "properties": {
                   "count": {
                     "maximum": 9007199254740991,
@@ -24800,6 +25011,7 @@
           },
           "network": {
             "additionalProperties": false,
+            "description": "Network-wide weight-setting rollup: every subnet that set weights in the window, combined.",
             "properties": {
               "distinct_setters": {
                 "maximum": 9007199254740991,
@@ -24815,7 +25027,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Null when distinct_setters is 0 (no defined intensity without setters)."
               },
               "weight_sets": {
                 "maximum": 9007199254740991,
@@ -24853,6 +25066,7 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's weight-setting activity in the window, ranked by weight_sets.",
               "properties": {
                 "distinct_setters": {
                   "maximum": 9007199254740991,
@@ -24948,6 +25162,7 @@
           "setters": {
             "items": {
               "additionalProperties": false,
+              "description": "One validator's network-wide weight-setting activity in the window. netuid is set only when hotkey is null (a uid-only identity has no meaning outside its own subnet).",
               "properties": {
                 "first_set_at": {
                   "anyOf": [
@@ -25000,7 +25215,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "This setter's share of the network total weight_sets; null when the network total is 0."
                 },
                 "uid": {
                   "anyOf": [
@@ -25066,6 +25282,7 @@
       },
       "ChainYieldArtifact": {
         "additionalProperties": {},
+        "description": "Network-wide emission-yield (return rate) card across every subnet's neurons. Aggregates are null on a cold store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/chain/yield.",
         "properties": {
           "captured_at": {
             "anyOf": [
@@ -25081,6 +25298,7 @@
             "anyOf": [
               {
                 "additionalProperties": {},
+                "description": "Distribution of the per-neuron emission/stake return rate across the network.",
                 "properties": {
                   "count": {
                     "maximum": 9007199254740991,
@@ -25340,7 +25558,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -25819,6 +26038,7 @@
       },
       "CompareValidatorsArtifact": {
         "additionalProperties": {},
+        "description": "Several validators placed side by side (#6989). Mirrors GET /api/v1/compare/validators.",
         "properties": {
           "netuid": {
             "anyOf": [
@@ -25830,7 +26050,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The optional subnet context the comparison was scoped to."
           },
           "schema_version": {
             "maximum": 9007199254740991,
@@ -25886,6 +26107,7 @@
                   "anyOf": [
                     {
                       "additionalProperties": false,
+                      "description": "Self-reported on-chain identity (SubtensorModule::set_identity) for a coldkey.",
                       "properties": {
                         "additional": {
                           "anyOf": [
@@ -25991,7 +26213,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "The coldkey's self-declared on-chain identity; opaque JSON, matching the REST/MCP shape."
                 },
                 "hotkey": {
                   "type": "string"
@@ -26200,7 +26423,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "This validator's membership row in the requested netuid; null when netuid was omitted or it has no permit there. Opaque JSON, matching the REST/MCP shape."
                 },
                 "subnet_count": {
                   "maximum": 9007199254740991,
@@ -26500,7 +26724,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "openapi_url": {
             "const": "/metagraph/openapi.json",
@@ -26692,7 +26917,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "probed_count": {
             "maximum": 9007199254740991,
@@ -26857,7 +27083,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "ranked_queue": {
             "items": {
@@ -27609,6 +27836,7 @@
           },
           "degraded": {
             "additionalProperties": false,
+            "description": "A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer.",
             "properties": {
               "detail": {
                 "type": "string"
@@ -27704,6 +27932,7 @@
       },
       "CurationArtifact": {
         "additionalProperties": {},
+        "description": "Network-wide public evidence ledger page. Mirrors GET /api/v1/evidence (and MCP list_evidence).",
         "properties": {
           "contract_version": {
             "type": "string"
@@ -27798,7 +28027,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -27872,6 +28102,7 @@
       },
       "DomainsArtifact": {
         "additionalProperties": false,
+        "description": "The per-domain rollup overview across the fixed capability taxonomy (#6989). Mirrors GET /api/v1/domains.",
         "properties": {
           "domain_count": {
             "maximum": 9007199254740991,
@@ -27899,6 +28130,7 @@
       },
       "DomainSummaryArtifact": {
         "additionalProperties": false,
+        "description": "One domain/capability tag's rollup (#6989). Mirrors GET /api/v1/domains/{tag}/summary.",
         "properties": {
           "domain": {
             "type": "string"
@@ -27907,6 +28139,7 @@
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "Concentration metrics over a value distribution -- Gini, HHI (raw + holder-count-normalized), Nakamoto coefficient, top-percentile shares, and Shannon entropy.",
                 "properties": {
                   "entropy": {
                     "anyOf": [
@@ -28038,7 +28271,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Within-domain emission concentration scorecard; null when the domain has no members. Declared Float until #9889 — the route has served the full 12-key scorecard for long enough that the scalar coerced to null on every domain, which this type's own comment then read as 'no members'."
           },
           "netuids": {
             "items": {
@@ -28106,6 +28340,7 @@
           },
           "chain_state": {
             "additionalProperties": false,
+            "description": "The chain state the decomposition's inputs were pinned to. theta/q/h are read AS STORED at this block -- the runtime gates with the stored bar between its 360-block recomputes, so a live read is the wrong number for 359 blocks out of 360.",
             "properties": {
               "block": {
                 "maximum": 9007199254740991,
@@ -28113,6 +28348,7 @@
                 "type": "integer"
               },
               "block_hash": {
+                "description": "The block hash, so the pinning is exact -- a height alone is ambiguous across a reorg.",
                 "pattern": "^0x[0-9a-fA-F]{64}$",
                 "type": "string"
               },
@@ -28134,7 +28370,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "theta. Null when the bar is unset, which disables the gate outright."
               },
               "emission_gate_exponent": {
                 "anyOf": [
@@ -28146,7 +28383,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "h. Null means the runtime default 3, NOT zero -- h = 0 makes the Hill gate a constant 0.5 for every subnet."
               },
               "total_issuance_tao": {
                 "minimum": 0,
@@ -28231,7 +28469,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -28309,7 +28548,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227)."
                 },
                 "alpha_price_change_1h": {
                   "anyOf": [
@@ -28319,7 +28559,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Signed %-change in alpha_price_tao over ~1h. Always null from daily snapshots (#7227)."
                 },
                 "alpha_price_change_1m": {
                   "anyOf": [
@@ -28329,7 +28570,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Signed %-change in alpha_price_tao over ~30 days from subnet_snapshots (#7227)."
                 },
                 "alpha_price_change_7d": {
                   "anyOf": [
@@ -28339,7 +28581,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Signed %-change in alpha_price_tao over ~7 days from subnet_snapshots (#7227)."
                 },
                 "alpha_price_tao": {
                   "anyOf": [
@@ -28641,6 +28884,7 @@
                 "type": "integer"
               },
               "total_alpha_value_tao": {
+                "description": "Sum of every non-root subnet's alpha_market_cap_tao -- rao-precision decimal string (#6641).",
                 "pattern": "^\\d+\\.\\d{9}$",
                 "type": "string"
               },
@@ -28650,10 +28894,12 @@
                 "type": "integer"
               },
               "total_network_value_tao": {
+                "description": "total_root_value_tao + total_alpha_value_tao -- Backprop's Total Network Value (#6641).",
                 "pattern": "^\\d+\\.\\d{9}$",
                 "type": "string"
               },
               "total_root_value_tao": {
+                "description": "Root (netuid 0) TAO-denominated stake -- rao-precision decimal string (#6641).",
                 "pattern": "^\\d+\\.\\d{9}$",
                 "type": "string"
               },
@@ -28707,6 +28953,7 @@
           "days": {
             "items": {
               "additionalProperties": false,
+              "description": "One UTC day of network-wide economics aggregated across every subnet with a snapshot that day. Sums are null only when no subnet reported a value that day.",
               "properties": {
                 "alpha_price_tao_median": {
                   "anyOf": [
@@ -28767,7 +29014,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet reporting that day -- exceeds the exact-double ceiling as a JSON number, so it is served as a string rather than Float."
                 },
                 "validator_count": {
                   "anyOf": [
@@ -28948,6 +29196,7 @@
             ]
           },
           "predates_capture_count": {
+            "description": "How many returned entries are first observations rather than changes.",
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
@@ -29059,9 +29308,11 @@
       },
       "EmissionPipelineArtifact": {
         "additionalProperties": {},
+        "description": "The v440 emission pipeline replayed over one pinned block (#8744) -- the per-subnet share decomposition, the network aggregate, and the identity checks evaluated on the rows being served.",
         "properties": {
           "aggregate": {
             "additionalProperties": false,
+            "description": "Network-wide totals across every row in the capture -- unchanged by the netuid argument, which narrows the per-subnet rows only.",
             "properties": {
               "disabled_count": {
                 "maximum": 9007199254740991,
@@ -29086,7 +29337,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "The network split nobody else publishes: pool injection vs chain buys."
               },
               "tao_in_emission": {
                 "type": "number"
@@ -29095,6 +29347,7 @@
                 "type": "number"
               },
               "total_final_share": {
+                "description": "Sum of final_share. 1.0 to float precision, or the surface is broken.",
                 "type": "number"
               }
             },
@@ -29129,10 +29382,12 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Block emission derived from TotalIssuance at that block, never read from the stale BlockEmission storage item."
           },
           "chain_state": {
             "additionalProperties": false,
+            "description": "The block every input below was pinned to. Required: without it nothing here can be verified.",
             "properties": {
               "block": {
                 "maximum": 9007199254740991,
@@ -29140,6 +29395,7 @@
                 "type": "integer"
               },
               "block_hash": {
+                "description": "The block hash, so the pinning is exact -- a height alone is ambiguous across a reorg.",
                 "pattern": "^0x[0-9a-fA-F]{64}$",
                 "type": "string"
               },
@@ -29161,7 +29417,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "theta. Null when the bar is unset, which disables the gate outright."
               },
               "emission_gate_exponent": {
                 "anyOf": [
@@ -29173,7 +29430,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "h. Null means the runtime default 3, NOT zero -- h = 0 makes the Hill gate a constant 0.5 for every subnet."
               },
               "total_issuance_tao": {
                 "minimum": 0,
@@ -29249,6 +29507,7 @@
           "subnets": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's path through stages 0-8. Every share is a fraction of block emission, null where stage 0 excluded the subnet from the distribution entirely.",
               "properties": {
                 "alpha_in_emission": {
                   "anyOf": [
@@ -29278,9 +29537,11 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "weighted_share / theta. Null when the bar is unset."
                 },
                 "emission_enabled": {
+                  "description": "PUBLISHED, NOT INFERRED. A subnet far enough below the bar has its gated share underflow to exactly 0, so an enabled-but-deeply-gated subnet and a disabled one both read final_share: 0 -- this flag is the only thing that separates them.",
                   "type": "boolean"
                 },
                 "emission_share": {
@@ -29291,7 +29552,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Stage 1, the published emission_share (ADR 0023 decision 1) -- the PRICE share, not the share of TAO received."
                 },
                 "excess_tao": {
                   "anyOf": [
@@ -29301,7 +29563,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Stage 7, measured: the TAO that reached the subnet by chain buys instead."
                 },
                 "final_share": {
                   "anyOf": [
@@ -29321,7 +29584,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "gated_share - weighted_share. Sums to ~0 across the network: the gate redistributes, it never withholds."
                 },
                 "gated_share": {
                   "anyOf": [
@@ -29347,7 +29611,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Non-null (root, never_emitted, subtoken_disabled, registration_closed) means the subnet took no part in stage 1, and every downstream share is null rather than 0 -- 'not in the distribution' is not 'in it with nothing'."
                 },
                 "liquidity_fraction": {
                   "anyOf": [
@@ -29359,9 +29624,11 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "tao_in_emission / tao_total, the headline per-subnet number. Null rather than NaN for a zero-intake subnet: 0/0 is not a fraction, and zero intake is a real state."
                 },
                 "miner_burned": {
+                  "description": "Stage 2 input. A FRACTION in [0,1], never an amount.",
                   "maximum": 1,
                   "minimum": 0,
                   "type": "number"
@@ -29379,7 +29646,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Stage 8, measured: the TAO injected into the subnet's pool this block."
                 },
                 "tao_total": {
                   "anyOf": [
@@ -29389,7 +29657,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Their sum -- the subnet's whole TAO intake this block. Null unless both channels were actually read."
                 },
                 "weighted_share": {
                   "anyOf": [
@@ -29426,14 +29695,17 @@
           },
           "verification": {
             "additionalProperties": false,
+            "description": "The four identities, evaluated on the rows being served rather than read from a stored flag -- a stored flag can be green while THIS response is broken, and it can go stale. ADR 0023 decision 3.",
             "properties": {
               "aggregate_tolerance_rao": {
+                "description": "A rao count as a string -- the tolerance is a bigint, and a JSON number is the wrong type for one.",
                 "pattern": "^\\d+$",
                 "type": "string"
               },
               "checks": {
                 "items": {
                   "additionalProperties": false,
+                  "description": "One identity, reported whether it passed or failed.",
                   "properties": {
                     "detail": {
                       "type": "string"
@@ -29458,6 +29730,7 @@
                 "type": "number"
               },
               "verified": {
+                "description": "False means at least one identity did not hold on these rows: the response is not defensible and must not be used.",
                 "type": "boolean"
               }
             },
@@ -29727,7 +30000,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -29848,6 +30122,7 @@
       },
       "EndpointPoolsArtifact": {
         "additionalProperties": {},
+        "description": "Endpoint pool scores (#6570): same pools[] row shape, filter/sort/page surface, and pagination metadata as PoolList. Split from it in #9892 for the one field that differs -- operational_observed_at, which GET /api/v1/endpoint-pools does not serve at all, because endpoint pools carry no live cron eligibility overlay and so have no observation stamp to report. The shared type declared it anyway and GraphQL answered null, which reads as not-observed-yet rather than never-observed-here.",
         "properties": {
           "contract_version": {
             "type": "string"
@@ -29926,7 +30201,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "pools": {
             "items": {
@@ -30347,7 +30623,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "operational_observed_at": {
             "anyOf": [
@@ -30602,7 +30879,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -30651,6 +30929,7 @@
       },
       "EvmAddressMappingArtifact": {
         "additionalProperties": {},
+        "description": "Live EVM (H160) -> Substrate (SS58) account-address mapping read from chain via RPC. ss58 is null when the mapping cannot be resolved (schema-stable, never a GraphQL error). Mirrors GET /api/v1/evm/address/{h160}.",
         "properties": {
           "field_sources": {
             "additionalProperties": {
@@ -31163,9 +31442,11 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Of the FAILING probes only; null on a succeeding classification, where the question does not apply."
           },
           "is_failure": {
+            "description": "redirected is NOT a failure -- a surface answering from a new location is serving.",
             "type": "boolean"
           },
           "share": {
@@ -31178,7 +31459,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Of every probe in the window."
           }
         },
         "required": [
@@ -31203,10 +31485,12 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Counted from the ROWS, not the requested window -- a day the prober did not run is absent rather than a zero."
           },
           "degraded": {
             "additionalProperties": false,
+            "description": "Present ONLY on a decline. An empty window is a measurement, not a decline.",
             "properties": {
               "reason": {
                 "enum": [
@@ -31298,6 +31582,7 @@
             "type": "integer"
           },
           "series": {
+            "description": "Oldest day first.",
             "items": {
               "$ref": "#/components/schemas/FailureReasonsDay"
             },
@@ -31351,6 +31636,7 @@
               "minimum": 0,
               "type": "integer"
             },
+            "description": "Checks per classification on this day, as a JSON object.",
             "propertyNames": {
               "type": "string"
             },
@@ -31431,7 +31717,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "request": {
             "additionalProperties": {},
@@ -31715,7 +32002,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "published_at": {
             "anyOf": [
@@ -31771,7 +32059,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -32079,6 +32368,7 @@
       },
       "GapsArtifact": {
         "additionalProperties": {},
+        "description": "Registry-wide interface gap report page. Mirrors GET /api/v1/gaps (and MCP list_gaps).",
         "properties": {
           "contract_version": {
             "type": "string"
@@ -32152,7 +32442,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -32179,6 +32470,7 @@
       },
       "GlobalIncidentsArtifact": {
         "additionalProperties": {},
+        "description": "Global endpoint-incident ledger (#5660). Mirrors GET /api/v1/incidents' data envelope.",
         "properties": {
           "min_incident_samples": {
             "maximum": 9007199254740991,
@@ -32205,6 +32497,7 @@
           },
           "summary": {
             "additionalProperties": {},
+            "description": "Aggregate counts -- incident_count, active_count, and by_kind/by_layer/by_provider/by_severity/by_status maps. Opaque JSON: the by_* maps are dynamic-keyed, matching the MCP get_global_incidents summary shape.",
             "properties": {
               "affected_surface_count": {
                 "maximum": 9007199254740991,
@@ -32226,6 +32519,7 @@
           "surfaces": {
             "items": {
               "additionalProperties": {},
+              "description": "One endpoint incident in the global ledger. Mirrors the REST EndpointIncident shape (enum-valued fields carried as their string values).",
               "properties": {
                 "downtime_ms": {
                   "maximum": 9007199254740991,
@@ -32240,6 +32534,7 @@
                 "incidents": {
                   "items": {
                     "additionalProperties": {},
+                    "description": "One reconstructed outage window.\n\n\\`started_at\\` and \\`ended_at\\` are epoch MILLISECONDS, which is why they are\nFloat and not Int: GraphQL's Int is 32-bit and every real value overflows it\n(1786228205841 against a ceiling of 2147483647). Every incident window on\n\\`incidents\\`, \\`global_incidents\\` and \\`subnet_health_incidents\\` therefore\nerrored, and because both fields are non-null the error propagated up and\nnulled the surrounding list -- on every request, since the surface shipped.\nNothing had executed these fields (#10215). \\`duration_ms\\` is a span rather\nthan an instant and stays an Int.",
                     "properties": {
                       "duration_ms": {
                         "maximum": 9007199254740991,
@@ -32430,6 +32725,7 @@
                   "anyOf": [
                     {
                       "additionalProperties": false,
+                      "description": "Self-reported on-chain identity (SubtensorModule::set_identity) for a coldkey.",
                       "properties": {
                         "additional": {
                           "anyOf": [
@@ -32832,7 +33128,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "ok_count": {
             "maximum": 9007199254740991,
@@ -32893,7 +33190,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "probe_finished_at": {
             "anyOf": [
@@ -33066,6 +33364,7 @@
       },
       "HealthIncidentsArtifact": {
         "additionalProperties": {},
+        "description": "One subnet's per-surface SLA + reconstructed downtime incidents over the window. Mirrors GET /api/v1/subnets/{netuid}/health/incidents's data envelope.",
         "properties": {
           "min_incident_samples": {
             "maximum": 9007199254740991,
@@ -33096,6 +33395,7 @@
             "type": "string"
           },
           "surfaces": {
+            "description": "Per operational surface: its sample count, uptime_ratio, incident_count, total downtime_ms, and gap-island incident list (started_at/ended_at/duration_ms/failed_samples, epoch-ms). Opaque JSON passed through verbatim, matching the get_subnet_health_incidents MCP/REST shape (like SubnetHealthTrends.windows).",
             "items": {
               "additionalProperties": {},
               "properties": {
@@ -33227,7 +33527,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "observed_at": {
             "anyOf": [
@@ -33309,6 +33610,7 @@
       },
       "HealthPercentilesArtifact": {
         "additionalProperties": {},
+        "description": "One subnet's per-surface success-only latency percentiles (#6980). Mirrors GET /api/v1/subnets/{netuid}/health/percentiles' data envelope.",
         "properties": {
           "netuid": {
             "maximum": 9007199254740991,
@@ -33334,6 +33636,7 @@
             "type": "string"
           },
           "surfaces": {
+            "description": "Per operational surface: its success-only latency sample count and p50/p90/p95/p99 latency percentiles in ms. Opaque JSON passed through verbatim, matching the get_subnet_health_percentiles MCP/REST shape (like SubnetHealthIncidents.surfaces).",
             "items": {
               "additionalProperties": {},
               "properties": {
@@ -34056,6 +34359,7 @@
       },
       "HealthTrendsArtifact": {
         "additionalProperties": {},
+        "description": "One subnet's uptime + latency trend windows. Mirrors GET /api/v1/subnets/{netuid}/health/trends's data envelope.",
         "properties": {
           "netuid": {
             "maximum": 9007199254740991,
@@ -34212,6 +34516,7 @@
               ],
               "type": "object"
             },
+            "description": "The 7d/30d windows keyed by window label, each holding this subnet's samples, uptime_ratio, latency_sample_count and the per-surface uptime/latency series. Opaque JSON: dynamic-keyed by window label, matching the get_subnet_health_trends MCP/REST shape.",
             "propertyNames": {
               "type": "string"
             },
@@ -34239,10 +34544,12 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Blocks the distribution was computed over. Null only on a decline."
           },
           "degraded": {
             "additionalProperties": false,
+            "description": "Present ONLY on a decline; its absence says the measurement is real.",
             "properties": {
               "detail": {
                 "type": "string"
@@ -34268,7 +34575,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "now - the newest observed_at. The number that moves when the lane stalls."
           },
           "measured_at": {
             "format": "date-time",
@@ -34288,7 +34596,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "What was actually measured -- the table is pruned, so a distribution without its bounds would read as a lifetime one."
           },
           "write_latency_ms": {
             "anyOf": [
@@ -34313,6 +34622,7 @@
       },
       "IndexerLagLatency": {
         "additionalProperties": false,
+        "description": "Milliseconds from a block's own timestamp to the moment it became queryable here. Unbounded below: a negative value is block-author clock skew, served as measured.",
         "properties": {
           "max": {
             "anyOf": [
@@ -34685,7 +34995,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "published_at": {
             "anyOf": [
@@ -34876,6 +35187,7 @@
       },
       "NetworkParametersArtifact": {
         "additionalProperties": {},
+        "description": "Live global Subtensor protocol/governance parameters, read live from chain via RPC. Each field is independently null on its own RPC failure (schema-stable). Mirrors GET /api/v1/network/parameters's data envelope.",
         "properties": {
           "block_emission_halvings": {
             "anyOf": [
@@ -35046,6 +35358,7 @@
       },
       "NeuronDetailArtifact": {
         "additionalProperties": {},
+        "description": "One neuron's live metagraph detail card (#5900). Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}: neuron is null when that UID is absent from the latest snapshot.",
         "properties": {
           "block_number": {
             "anyOf": [
@@ -35078,6 +35391,7 @@
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "One UID's live metagraph state within a subnet (hot/cold keys, scores, stake/emission, axon, take).",
                 "properties": {
                   "active": {
                     "type": "boolean"
@@ -35155,9 +35469,11 @@
                       {
                         "type": "null"
                       }
-                    ]
+                    ],
+                    "description": "Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block/timestamp at ~12s/block; null if that anchor is unavailable (#6640)."
                   },
                   "immunity_expires_at_block": {
+                    "description": "The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640).",
                     "maximum": 9007199254740991,
                     "minimum": -9007199254740991,
                     "type": "integer"
@@ -35217,7 +35533,8 @@
                       {
                         "type": "null"
                       }
-                    ]
+                    ],
+                    "description": "Validator take/commission (0..1) from SubtensorModule::Delegates; null when no Delegates entry at capture."
                   },
                   "trust": {
                     "anyOf": [
@@ -35260,7 +35577,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The UID's live metagraph row; null when absent from the latest snapshot."
           },
           "schema_version": {
             "maximum": 9007199254740991,
@@ -35277,6 +35595,7 @@
       },
       "NeuronHistoryArtifact": {
         "additionalProperties": {},
+        "description": "One neuron's per-day metagraph history. Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}/history.",
         "properties": {
           "netuid": {
             "maximum": 9007199254740991,
@@ -35291,6 +35610,7 @@
           "points": {
             "items": {
               "additionalProperties": {},
+              "description": "One day's metagraph state for a single UID (NeuronState fields plus snapshot_date/captured_at/block_number).",
               "properties": {
                 "active": {
                   "type": "boolean"
@@ -35390,9 +35710,11 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block/timestamp at ~12s/block; null if that anchor is unavailable (#6640)."
                 },
                 "immunity_expires_at_block": {
+                  "description": "The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640).",
                   "maximum": 9007199254740991,
                   "minimum": -9007199254740991,
                   "type": "integer"
@@ -35455,7 +35777,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Validator take/commission (0..1) from SubtensorModule::Delegates; null when no Delegates entry at capture."
                 },
                 "trust": {
                   "anyOf": [
@@ -35609,7 +35932,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -35869,6 +36193,7 @@
         "properties": {
           "degraded": {
             "additionalProperties": false,
+            "description": "Present ONLY on a decline. An empty series is a measurement.",
             "properties": {
               "reason": {
                 "enum": [
@@ -35892,9 +36217,11 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Independent samples -- the honest denominator for any claim about how a value moved."
           },
           "first_captured_day": {
+            "description": "The first day the pipeline columns were ever written, so a short series reads as a start rather than a gap.",
             "type": "string"
           },
           "netuid": {
@@ -35932,7 +36259,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Rows returned. NOT the number of times the pipeline was read."
           },
           "points": {
             "items": {
@@ -36045,7 +36373,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Chain buys."
           },
           "first_emission_block": {
             "anyOf": [
@@ -36070,6 +36399,7 @@
             ]
           },
           "pipeline_block": {
+            "description": "The chain state this point describes. A point that cannot say which block it came from is not served.",
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
@@ -36085,6 +36415,7 @@
             ]
           },
           "repeats_previous_observation": {
+            "description": "True when the snapshot writer carried the previous capture forward: this point is NOT an independent sample.",
             "type": "boolean"
           },
           "tao_in_emission_tao": {
@@ -36095,7 +36426,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Pool liquidity injection."
           },
           "tao_in_pool_tao": {
             "anyOf": [
@@ -36297,7 +36629,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "provider": {
             "$ref": "#/components/schemas/Provider"
@@ -36340,7 +36673,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "provider": {
             "additionalProperties": {},
@@ -36407,7 +36741,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "providers": {
             "items": {
@@ -36526,7 +36861,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "required_artifact_paths": {
             "description": "Artifact paths the publish step must find in the archive even though the compact manifest omits them.",
@@ -36612,6 +36948,7 @@
       },
       "RandomnessArtifact": {
         "additionalProperties": {},
+        "description": "Live drand randomness-beacon status read from chain via RPC. Each field is independently null on its own RPC failure (schema-stable). Mirrors GET /api/v1/network/randomness's data envelope.",
         "properties": {
           "field_sources": {
             "additionalProperties": {
@@ -36714,6 +37051,7 @@
       },
       "RegistryLeaderboardsArtifact": {
         "additionalProperties": {},
+        "description": "Registry leaderboards over the operational + economic-opportunity boards. Mirrors GET /api/v1/registry/leaderboards.",
         "properties": {
           "board": {
             "anyOf": [
@@ -36723,7 +37061,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The board filter that was applied, or null when every board is returned."
           },
           "boards": {
             "additionalProperties": {
@@ -37024,6 +37363,7 @@
               },
               "type": "array"
             },
+            "description": "Every board keyed by board name, each an array of ranked subnet entries capped at limit. Opaque JSON like HealthTrends.windows: the keys are dynamic AND hyphenated (fastest-rpc, most-complete, open-slots, …) so they are not expressible as GraphQL field names, and each board carries its own metric columns (healthiest has uptime_ratio/surfaces_ok, fastest-rpc has latency_ms, fastest-growing has completeness_delta, …). Passing it through verbatim keeps the REST/MCP get_registry_leaderboards shape byte-for-byte.",
             "propertyNames": {
               "type": "string"
             },
@@ -37189,7 +37529,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "profile_level_counts": {
             "$ref": "#/components/schemas/CountMap"
@@ -37525,7 +37866,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -37626,7 +37968,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "review_decisions": {
             "items": {
@@ -37765,7 +38108,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -38934,7 +39278,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "priorities": {
             "items": {
@@ -39039,7 +39384,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "profiles": {
             "items": {
@@ -39572,7 +39918,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -39840,6 +40187,7 @@
       },
       "RpcPoolsArtifact": {
         "additionalProperties": {},
+        "description": "RPC pool scores (#6570): same pools[] row shape, filter/sort/page surface, and pagination metadata as EndpointPoolList, plus operational_observed_at -- real here and only here, since the RPC pools are the ones carrying a live 15-minute cron eligibility overlay.",
         "properties": {
           "contract_version": {
             "type": "string"
@@ -39918,7 +40266,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "pools": {
             "items": {
@@ -40011,6 +40360,7 @@
       },
       "RpcUsageArtifact": {
         "additionalProperties": {},
+        "description": "RPC reverse-proxy usage analytics over a 7d/30d window. Mirrors GET /api/v1/rpc/usage's data envelope.",
         "properties": {
           "bucket_granularity": {
             "anyOf": [
@@ -40020,11 +40370,14 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Time-bucket granularity for buckets: 1h for the 7d window, 6h for 30d. Null on a cold store."
           },
           "buckets": {
+            "description": "Bounded time buckets over the window for heatmaps, oldest-first.",
             "items": {
               "additionalProperties": {},
+              "description": "One bounded time bucket of RPC reverse-proxy traffic (bucket_granularity wide).",
               "properties": {
                 "avg_latency_ms": {
                   "anyOf": [
@@ -40066,6 +40419,7 @@
           },
           "coverage": {
             "additionalProperties": {},
+            "description": "What the answer is actually about, as opposed to what window was asked for.",
             "properties": {
               "end": {
                 "anyOf": [
@@ -40077,12 +40431,14 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Epoch ms of the newest measured event across every contributing store, or null when nothing was measured."
               },
               "latency_percentiles": {
                 "anyOf": [
                   {
                     "additionalProperties": {},
+                    "description": "An epoch-ms span.",
                     "properties": {
                       "end": {
                         "anyOf": [
@@ -40118,11 +40474,14 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "The sub-range summary.latency_ms p50/p95 describe, or null when nothing measured them. Counts are additive across disjoint ranges; percentiles are not, so they stay scoped to the one store that has a percentile function."
               },
               "segments": {
+                "description": "One entry per contributing store, oldest first. Two non-adjacent entries mean the window has a hole between them that no store covers.",
                 "items": {
                   "additionalProperties": {},
+                  "description": "One store's contribution to an rpc_usage answer.",
                   "properties": {
                     "end": {
                       "anyOf": [
@@ -40134,9 +40493,11 @@
                         {
                           "type": "null"
                         }
-                      ]
+                      ],
+                      "description": "Epoch ms of this store's newest measured event in the window."
                     },
                     "source": {
+                      "description": "Which store measured it: analytics-engine (live capture) or lakehouse (frozen history).",
                       "type": "string"
                     },
                     "start": {
@@ -40149,7 +40510,8 @@
                         {
                           "type": "null"
                         }
-                      ]
+                      ],
+                      "description": "Epoch ms of this store's oldest measured event in the window."
                     }
                   },
                   "required": [
@@ -40171,7 +40533,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Epoch ms of the oldest measured event across every contributing store, or null when nothing was measured."
               }
             },
             "required": [
@@ -40183,8 +40546,10 @@
             "type": "object"
           },
           "endpoints": {
+            "description": "Per-endpoint request distribution, ranked by request volume (top 50).",
             "items": {
               "additionalProperties": {},
+              "description": "One endpoint's share of RPC reverse-proxy traffic in the window.",
               "properties": {
                 "avg_latency_ms": {
                   "anyOf": [
@@ -40216,7 +40581,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Null when the endpoint had no requests in the window."
                 },
                 "ok_requests": {
                   "maximum": 9007199254740991,
@@ -40254,8 +40620,10 @@
             "type": "array"
           },
           "networks": {
+            "description": "Per-network request breakdown, ordered by request volume.",
             "items": {
               "additionalProperties": {},
+              "description": "One network's share of RPC reverse-proxy traffic in the window.",
               "properties": {
                 "error_rate": {
                   "anyOf": [
@@ -40265,7 +40633,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Null when the network had no requests in the window."
                 },
                 "network": {
                   "type": "string"
@@ -40316,6 +40685,7 @@
           },
           "summary": {
             "additionalProperties": {},
+            "description": "Window-total rollup for RPC reverse-proxy traffic.",
             "properties": {
               "cache_hit_rate": {
                 "anyOf": [
@@ -40325,7 +40695,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Null when there are no requests in the window."
               },
               "cache_hits": {
                 "maximum": 9007199254740991,
@@ -40340,7 +40711,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Null when there are no requests in the window (no defined rate)."
               },
               "error_requests": {
                 "maximum": 9007199254740991,
@@ -40355,7 +40727,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Null when there are no requests in the window."
               },
               "failover_requests": {
                 "maximum": 9007199254740991,
@@ -40364,6 +40737,7 @@
               },
               "latency_ms": {
                 "additionalProperties": {},
+                "description": "Window latency percentiles + average for RPC reverse-proxy traffic; each is null on a cold store.",
                 "properties": {
                   "avg": {
                     "anyOf": [
@@ -40446,6 +40820,7 @@
       },
       "RuntimeVersionsArtifact": {
         "additionalProperties": {},
+        "description": "Site-wide runtime spec-version transition timeline. Mirrors GET /api/v1/runtime.",
         "properties": {
           "coverage_complete": {
             "type": "boolean"
@@ -40538,6 +40913,7 @@
           "transitions": {
             "items": {
               "additionalProperties": false,
+              "description": "One runtime spec-version's first-seen block in the transition timeline.",
               "properties": {
                 "block_number": {
                   "maximum": 9007199254740991,
@@ -40602,7 +40978,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "observed_at": {
             "anyOf": [
@@ -40804,7 +41181,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "observed_at": {
             "type": "string"
@@ -41337,6 +41715,7 @@
             "type": "integer"
           },
           "documents": {
+            "description": "Heterogeneous per-type documents (subnet/surface/provider/doc), passed through verbatim as opaque JSON.",
             "items": {
               "additionalProperties": false,
               "properties": {
@@ -41415,7 +41794,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -41431,6 +41811,7 @@
       },
       "SearchIndexArtifact": {
         "additionalProperties": {},
+        "description": "Filtered and paginated search-index documents with full REST list-query pagination metadata (#7877). Mirrors GET /api/v1/search-index (and MCP list_search_index).",
         "properties": {
           "contract_version": {
             "type": "string"
@@ -41512,7 +41893,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -41562,6 +41944,7 @@
       },
       "SelfHealthArtifact": {
         "additionalProperties": {},
+        "description": "metagraphed's own uptime verdict (#8422). Mirrors GET /api/v1/self-health.",
         "properties": {
           "components": {
             "items": {
@@ -41576,6 +41959,7 @@
             "type": "array"
           },
           "measured_component_count": {
+            "description": "Components with data. Zero means the poller hasn't written anything yet.",
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
@@ -41601,6 +41985,7 @@
             "type": "integer"
           },
           "verdict": {
+            "description": "operational | degraded | outage.",
             "enum": [
               "operational",
               "degraded",
@@ -41622,6 +42007,7 @@
       },
       "SelfHealthComponent": {
         "additionalProperties": {},
+        "description": "One self-health component (api / site / publish): its latest probe state and trailing-90-day daily ratios.",
         "properties": {
           "checked_at": {
             "anyOf": [
@@ -41644,9 +42030,11 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Null when the component has never been probed -- NOT false."
           },
           "days": {
+            "description": "Trailing-90d daily ratios, oldest first; gaps are absent, never zero-filled.",
             "items": {
               "$ref": "#/components/schemas/SelfHealthDay"
             },
@@ -41684,7 +42072,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Qualifies a false current_ok with why, for non-HTTP failure modes. Null when there's nothing to add."
           },
           "uptime_90d": {
             "anyOf": [
@@ -41696,7 +42085,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Mean uptime across the days we actually have. Null when there are none."
           }
         },
         "required": [
@@ -41713,6 +42103,7 @@
       },
       "SelfHealthDay": {
         "additionalProperties": {},
+        "description": "One UTC day's uptime ratio for a self-health component. Days with no probe rows are ABSENT, never zero-filled.",
         "properties": {
           "checks": {
             "maximum": 9007199254740991,
@@ -41728,6 +42119,7 @@
             "type": "integer"
           },
           "uptime_ratio": {
+            "description": "ok_count / checks, 0..1.",
             "maximum": 1,
             "minimum": 0,
             "type": "number"
@@ -41743,6 +42135,7 @@
       },
       "SelfHealthLane": {
         "additionalProperties": {},
+        "description": "One ingest lane's staleness verdict.\n\nThree of these five were declared non-null against a Zod schema that says\notherwise, and production proved it: \\`self_health\\` returned\n\\`Cannot return null for non-nullable field SelfHealthLane.detail\\` and nulled\nthe whole \\`lanes\\` list. \\`age_ms\\` and \\`checked_at\\` are null for the same\nreason -- the watchdog could not measure the lane, which is the \"we did not\nmeasure\" this type exists to distinguish from \"the lane is fine\" (#10215).\n\n\\`age_ms\\` is a Float because it is a duration in MILLISECONDS: a lane stale\nfor more than 24.8 days exceeds GraphQL's 32-bit Int, and the answer to\n\"how far behind is this lane\" must not stop being representable exactly when\nit starts to matter.",
         "properties": {
           "age_ms": {
             "anyOf": [
@@ -41921,7 +42314,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "providers": {
             "items": {
@@ -42078,7 +42472,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -42194,6 +42589,7 @@
       },
       "SubnetAlphaVolumeArtifact": {
         "additionalProperties": false,
+        "description": "One subnet's rolling 24h alpha trading volume (#6979). Mirrors GET /api/v1/subnets/{netuid}/volume' data envelope.",
         "properties": {
           "buy_count": {
             "maximum": 9007199254740991,
@@ -42231,6 +42627,7 @@
             "type": "number"
           },
           "sentiment": {
+            "description": "Bucketed reading of sentiment_ratio (buying/selling/neutral).",
             "enum": [
               "bullish",
               "bearish",
@@ -42246,7 +42643,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Buy share of total volume (0-1); null when there was no volume."
           },
           "total_volume_alpha": {
             "type": "number"
@@ -42262,9 +42660,11 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Total TAO volume over alpha market cap; null when market cap is unknown."
           },
           "window": {
+            "description": "The rolling window label this card covers (24h).",
             "enum": [
               "24h"
             ],
@@ -42295,6 +42695,7 @@
         "properties": {
           "degraded": {
             "additionalProperties": false,
+            "description": "A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer.",
             "properties": {
               "detail": {
                 "type": "string"
@@ -42379,6 +42780,7 @@
       },
       "SubnetBurnArtifact": {
         "additionalProperties": {},
+        "description": "Live current registration/burn cost for one subnet, read directly from chain via RPC. burn_tao is null on RPC failure (schema-stable, never a GraphQL error). Mirrors GET /api/v1/subnets/{netuid}/burn.",
         "properties": {
           "burn_tao": {
             "anyOf": [
@@ -42592,7 +42994,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -42612,6 +43015,7 @@
       },
       "SubnetConcentrationArtifact": {
         "additionalProperties": {},
+        "description": "Per-subnet stake & emission concentration card (#5901) over the current neurons snapshot. Metric blocks are null on a cold/empty subnet. Mirrors GET /api/v1/subnets/{netuid}/concentration.",
         "properties": {
           "captured_at": {
             "anyOf": [
@@ -42627,6 +43031,7 @@
             "anyOf": [
               {
                 "additionalProperties": {},
+                "description": "Concentration metrics over a value distribution -- Gini, HHI (raw + holder-count-normalized), Nakamoto coefficient, top-percentile shares, and Shannon entropy.",
                 "properties": {
                   "entropy": {
                     "anyOf": [
@@ -42751,9 +43156,11 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Emission concentration across all UIDs."
           },
           "entity_count": {
+            "description": "Distinct controlling entities (coldkeys) behind the subnet's UIDs.",
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
@@ -42762,6 +43169,7 @@
             "anyOf": [
               {
                 "additionalProperties": {},
+                "description": "Concentration metrics over a value distribution -- Gini, HHI (raw + holder-count-normalized), Nakamoto coefficient, top-percentile shares, and Shannon entropy.",
                 "properties": {
                   "entropy": {
                     "anyOf": [
@@ -42886,12 +43294,14 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Emission concentration collapsed to one holder per controlling entity."
           },
           "entity_stake": {
             "anyOf": [
               {
                 "additionalProperties": {},
+                "description": "Concentration metrics over a value distribution -- Gini, HHI (raw + holder-count-normalized), Nakamoto coefficient, top-percentile shares, and Shannon entropy.",
                 "properties": {
                   "entropy": {
                     "anyOf": [
@@ -43016,7 +43426,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Stake concentration collapsed to one holder per controlling entity."
           },
           "netuid": {
             "maximum": 9007199254740991,
@@ -43037,6 +43448,7 @@
             "anyOf": [
               {
                 "additionalProperties": {},
+                "description": "Concentration metrics over a value distribution -- Gini, HHI (raw + holder-count-normalized), Nakamoto coefficient, top-percentile shares, and Shannon entropy.",
                 "properties": {
                   "entropy": {
                     "anyOf": [
@@ -43161,7 +43573,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Stake concentration across all UIDs."
           },
           "uids_per_entity": {
             "anyOf": [
@@ -43171,12 +43584,14 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "UIDs per controlling entity -- a Sybil/consolidation signal (1.0 = every UID a distinct owner; higher = fewer operators each running many hotkeys). Null on an empty subnet."
           },
           "validator_stake": {
             "anyOf": [
               {
                 "additionalProperties": {},
+                "description": "Concentration metrics over a value distribution -- Gini, HHI (raw + holder-count-normalized), Nakamoto coefficient, top-percentile shares, and Shannon entropy.",
                 "properties": {
                   "entropy": {
                     "anyOf": [
@@ -43301,7 +43716,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Stake concentration across permitted validators only."
           }
         },
         "required": [
@@ -43316,6 +43732,7 @@
       },
       "SubnetConcentrationHistoryArtifact": {
         "additionalProperties": {},
+        "description": "Per-subnet per-day concentration trend (#5901) from the neuron_daily rollup, newest first. An empty series (point_count 0) on a cold store, never a GraphQL error. Mirrors GET /api/v1/subnets/{netuid}/concentration/history.",
         "properties": {
           "netuid": {
             "maximum": 9007199254740991,
@@ -43424,7 +43841,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The resolved window label (7d/30d/90d)."
           }
         },
         "required": [
@@ -43437,6 +43855,7 @@
       },
       "SubnetConvictionArtifact": {
         "additionalProperties": {},
+        "description": "Live per-subnet conviction leaderboard -- who currently holds the most rolled conviction, rolled forward from a periodically-captured snapshot using the current live-queried unlock_rate/maturity_rate. Mirrors GET /api/v1/subnets/{netuid}/conviction.",
         "properties": {
           "count": {
             "maximum": 9007199254740991,
@@ -43573,9 +43992,11 @@
       },
       "SubnetDeregistrationsArtifact": {
         "additionalProperties": false,
+        "description": "Per-subnet neuron-deregistration activity over a window (#5719). Zeroed card (0 counts) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/deregistrations.",
         "properties": {
           "degraded": {
             "additionalProperties": false,
+            "description": "A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer.",
             "properties": {
               "detail": {
                 "type": "string"
@@ -43607,6 +44028,7 @@
           },
           "derivation": {
             "additionalProperties": false,
+            "description": "How a deregistration feed was derived (#9307). NeuronDeregistered has never been emitted, so deregistrations are derived from UID reuse: a NeuronRegistered on a (netuid, uid) slot already held by a different hotkey IS the deregistration of the previous occupant. unattributed_registrations is the honest part -- the published totals are a LOWER BOUND by that many events, because those registrations displaced a holder the derivation's lookback cannot name.",
             "properties": {
               "is_lower_bound": {
                 "description": "True when the count is a floor rather than a measurement: some registrations in the window displaced a holder the derivation's lookback cannot name, so the real figure is higher by at least `unattributed_registrations`. Treat the value as 'at least this many', never as a total.",
@@ -43616,6 +44038,7 @@
                 "type": "boolean"
               },
               "lookback_days": {
+                "description": "Days of NeuronRegistered history the derivation had available.",
                 "maximum": 9007199254740991,
                 "minimum": 0,
                 "type": "integer"
@@ -43624,11 +44047,13 @@
                 "type": "string"
               },
               "unattributed_registrations": {
+                "description": "Of those, the ones with no observed previous holder.",
                 "maximum": 9007199254740991,
                 "minimum": 0,
                 "type": "integer"
               },
               "window_registrations": {
+                "description": "Registrations observed inside the reported window.",
                 "maximum": 9007199254740991,
                 "minimum": 0,
                 "type": "integer"
@@ -44372,7 +44797,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227)."
               },
               "alpha_price_change_1h": {
                 "anyOf": [
@@ -44382,7 +44808,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Signed %-change in alpha_price_tao over ~1h. Always null from daily snapshots (#7227)."
               },
               "alpha_price_change_1m": {
                 "anyOf": [
@@ -44392,7 +44819,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Signed %-change in alpha_price_tao over ~30 days from subnet_snapshots (#7227)."
               },
               "alpha_price_change_7d": {
                 "anyOf": [
@@ -44402,7 +44830,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "Signed %-change in alpha_price_tao over ~7 days from subnet_snapshots (#7227)."
               },
               "alpha_price_tao": {
                 "anyOf": [
@@ -44711,7 +45140,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -44780,7 +45210,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "operational_observed_at": {
             "anyOf": [
@@ -44814,6 +45245,7 @@
       },
       "SubnetEventsArtifact": {
         "additionalProperties": {},
+        "description": "One subnet's paginated first-party chain-event feed (#7172), newest first, offset-paginated. event_count is the page count, not a grand total. Each item is an AccountEvent. Empty feed on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/events' data envelope.",
         "properties": {
           "event_count": {
             "maximum": 9007199254740991,
@@ -44867,8 +45299,10 @@
       },
       "SubnetEventSummaryArtifact": {
         "additionalProperties": {},
+        "description": "One subnet's chain-event activity summary over a window (#6980). Mirrors GET /api/v1/subnets/{netuid}/event-summary' data envelope.",
         "properties": {
           "categories": {
+            "description": "Per event category: its kind list and rolled-up counts. Opaque JSON passed through verbatim, matching the get_subnet_event_summary MCP/REST shape.",
             "items": {
               "additionalProperties": false,
               "properties": {
@@ -44974,6 +45408,7 @@
             "type": "integer"
           },
           "event_kinds": {
+            "description": "Per event kind: event_count, hotkey/coldkey participation counts, TAO/alpha amounts, and first/last block + observed_at. Opaque JSON passed through verbatim.",
             "items": {
               "additionalProperties": false,
               "properties": {
@@ -45089,6 +45524,7 @@
             "type": "integer"
           },
           "limit": {
+            "description": "The resolved recent-event cap actually applied (1-50, default 10).",
             "maximum": 50,
             "minimum": 1,
             "type": "integer"
@@ -45116,6 +45552,7 @@
             "type": "integer"
           },
           "recent_events": {
+            "description": "The bounded newest-first recent-event list. Opaque JSON passed through verbatim.",
             "items": {
               "$ref": "#/components/schemas/AccountEvent"
             },
@@ -45132,6 +45569,7 @@
             "type": "integer"
           },
           "window": {
+            "description": "The resolved window label (7d/30d/90d).",
             "enum": [
               "7d",
               "30d",
@@ -45190,7 +45628,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -45516,7 +45955,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "priorities": {
             "items": {
@@ -45543,6 +45983,7 @@
       },
       "SubnetHistoryArtifact": {
         "additionalProperties": {},
+        "description": "One subnet's daily history series (#7172) from the neuron_daily rollup, newest first. Empty series (point_count 0) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/history' data envelope.",
         "properties": {
           "netuid": {
             "maximum": 9007199254740991,
@@ -45557,6 +45998,7 @@
           "points": {
             "items": {
               "additionalProperties": false,
+              "description": "One daily-rollup point on a subnet's history (#7172). Economics fields are null on days captured before those columns existed / when unavailable.",
               "properties": {
                 "neuron_count": {
                   "anyOf": [
@@ -45639,8 +46081,10 @@
       },
       "SubnetHolder": {
         "additionalProperties": false,
+        "description": "One coldkey's holding of a subnet's alpha, including alpha staked to hotkeys that hold no UID on that subnet.",
         "properties": {
           "alpha": {
+            "description": "ALPHA, not TAO. Within one subnet alpha is already a common unit, so there is no price conversion and none of its staleness -- multiply by the subnet's alpha_price_tao for TAO.",
             "minimum": 0,
             "type": "number"
           },
@@ -45657,7 +46101,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Distinct hotkeys this coldkey holds the subnet's alpha through -- registered on it or not, which is the part a neurons-sourced view misses."
           },
           "share_of_total": {
             "anyOf": [
@@ -45669,7 +46114,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "This holder's alpha over the subnet's FULL measured total, so it means the same thing at limit 5 and limit 100. Null when the total is zero."
           }
         },
         "required": [
@@ -45693,13 +46139,15 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The pool pass every row was valued against."
           },
           "concentration": {
             "$ref": "#/components/schemas/SubnetHoldersConcentration"
           },
           "degraded": {
-            "$ref": "#/components/schemas/SubnetHoldersDegraded"
+            "$ref": "#/components/schemas/SubnetHoldersDegraded",
+            "description": "Present ONLY on a decline. Its absence is what says the ranking is real -- an empty holders list with no degraded block means the subnet genuinely has no measured holders."
           },
           "holder_count": {
             "anyOf": [
@@ -45711,7 +46159,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Distinct coldkeys holding this subnet's alpha -- the whole set, never the returned page's length."
           },
           "holders": {
             "items": {
@@ -45746,7 +46195,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "When the positions ledger itself was last written, which advances on a different cadence than the pool totals."
           },
           "schema_version": {
             "maximum": 9007199254740991,
@@ -45780,6 +46230,7 @@
       },
       "SubnetHoldersConcentration": {
         "additionalProperties": false,
+        "description": "Concentration of a subnet's alpha, each rank summed over the top N of the FULL holder set rather than the returned page.",
         "properties": {
           "top10_share": {
             "anyOf": [
@@ -45827,6 +46278,7 @@
       },
       "SubnetHoldersDegraded": {
         "additionalProperties": false,
+        "description": "A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer.",
         "properties": {
           "reason": {
             "enum": [
@@ -45844,6 +46296,7 @@
       },
       "SubnetHyperparametersArtifact": {
         "additionalProperties": {},
+        "description": "Per-subnet neuron-registration activity over a window (#5720). Zeroed card (0 counts) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/registrations.",
         "properties": {
           "block_number": {
             "anyOf": [
@@ -45871,6 +46324,7 @@
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "One subnet's on-chain hyperparameter block. Every field is nullable: a value absent from the captured row stays null rather than being coerced. *_ratio fields are 0..1 U16-derived ratios; *_tao fields are rao-exact (9dp); bonds_moving_avg_raw is the unscaled on-chain integer.",
                 "properties": {
                   "activity_cutoff": {
                     "anyOf": [
@@ -46212,6 +46666,7 @@
           "entries": {
             "items": {
               "additionalProperties": false,
+              "description": "One observed hyperparameter change: the full block as of that block_number, plus the hash the diff-on-change writer keyed it by.",
               "properties": {
                 "block_number": {
                   "anyOf": [
@@ -46229,6 +46684,7 @@
                   "anyOf": [
                     {
                       "additionalProperties": false,
+                      "description": "One subnet's on-chain hyperparameter block. Every field is nullable: a value absent from the captured row stays null rather than being coerced. *_ratio fields are 0..1 U16-derived ratios; *_tao fields are rao-exact (9dp); bonds_moving_avg_raw is the unscaled on-chain integer.",
                       "properties": {
                         "activity_cutoff": {
                           "anyOf": [
@@ -46628,10 +47084,12 @@
       },
       "SubnetIdentityHistoryArtifact": {
         "additionalProperties": {},
+        "description": "Append-only on-chain subnet identity timeline (#1647 / #5721). Empty entries on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/identity-history.",
         "properties": {
           "entries": {
             "items": {
               "additionalProperties": false,
+              "description": "One SubnetIdentitiesV3 snapshot recorded when a tracked identity field changed.",
               "properties": {
                 "block_number": {
                   "anyOf": [
@@ -46810,6 +47268,7 @@
       },
       "SubnetIdleStakeArtifact": {
         "additionalProperties": {},
+        "description": "Per-subnet idle-stake scorecard (#7172). Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/idle-stake.",
         "properties": {
           "captured_at": {
             "anyOf": [
@@ -47306,6 +47765,7 @@
       },
       "SubnetLeaseArtifact": {
         "additionalProperties": {},
+        "description": "Live subnet-lease state -- whether a subnet is currently under a lease and, if so, its terms (beneficiary, coldkey, hotkey, emissions_share_percent, end_block, cost_tao) and accumulated-but-undistributed alpha dividends. leased is null (not false) on RPC failure, distinct from a confirmed no-lease (leased:false). Mirrors GET /api/v1/subnets/{netuid}/lease.",
         "properties": {
           "field_sources": {
             "additionalProperties": {
@@ -47460,6 +47920,7 @@
       },
       "SubnetLeaseHistoryArtifact": {
         "additionalProperties": {},
+        "description": "Every SubnetLeaseCreated/SubnetLeaseTerminated event one subnet has had, decoded from the account_events stream. Mirrors GET /api/v1/subnets/{netuid}/lease/history.",
         "properties": {
           "count": {
             "maximum": 9007199254740991,
@@ -47548,6 +48009,7 @@
           "entries": {
             "items": {
               "additionalProperties": {},
+              "description": "One observed subnet transition. block_number is null when the event predates capture or the detecting pass could not attribute one; that is a fact, not a gap.",
               "properties": {
                 "block_number": {
                   "anyOf": [
@@ -47687,6 +48149,7 @@
           "neurons": {
             "items": {
               "additionalProperties": false,
+              "description": "One UID's live metagraph state within a subnet (hot/cold keys, scores, stake/emission, axon, take).",
               "properties": {
                 "active": {
                   "type": "boolean"
@@ -47764,9 +48227,11 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block/timestamp at ~12s/block; null if that anchor is unavailable (#6640)."
                 },
                 "immunity_expires_at_block": {
+                  "description": "The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640).",
                   "maximum": 9007199254740991,
                   "minimum": -9007199254740991,
                   "type": "integer"
@@ -47826,7 +48291,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Validator take/commission (0..1) from SubtensorModule::Delegates; null when no Delegates entry at capture."
                 },
                 "trust": {
                   "anyOf": [
@@ -47899,6 +48365,7 @@
           "movers": {
             "items": {
               "additionalProperties": false,
+              "description": "One subnet's stake/emission/validator/neuron movement between the window's start and end snapshots.",
               "properties": {
                 "emission_delta_alpha": {
                   "type": "number"
@@ -47965,7 +48432,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Null when the start snapshot's stake was 0 (growth from nothing is undefined)."
                 },
                 "stake_share_pct": {
                   "anyOf": [
@@ -47977,7 +48445,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "This subnet's share of network stake at the end snapshot; null when the network total is 0."
                 },
                 "stake_start_alpha": {
                   "type": "number"
@@ -48023,6 +48492,7 @@
           },
           "network": {
             "additionalProperties": false,
+            "description": "Network-wide boundary totals for the movers window, summed across every ranked subnet (not just the returned page).",
             "properties": {
               "gainers": {
                 "maximum": 9007199254740991,
@@ -48055,6 +48525,7 @@
                 "type": "string"
               },
               "total_stake_start_alpha": {
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string -- exceeds the exact-double ceiling as a JSON number, so it is served as a string rather than Float.",
                 "pattern": "^\\d+\\.\\d{9}$",
                 "type": "string"
               },
@@ -48155,12 +48626,14 @@
       },
       "SubnetOhlcArtifact": {
         "additionalProperties": false,
+        "description": "One subnet's alpha-price OHLC candles (#6979). Mirrors GET /api/v1/subnets/{netuid}/ohlc' data envelope.",
         "properties": {
           "candles": {
             "items": {
               "additionalProperties": false,
               "properties": {
                 "bucket_start": {
+                  "description": "Bucket start as epoch milliseconds -- a Float, since epoch-ms exceeds GraphQL's 32-bit Int.",
                   "maximum": 9007199254740991,
                   "minimum": -9007199254740991,
                   "type": "integer"
@@ -48211,6 +48684,7 @@
             "type": "array"
           },
           "interval": {
+            "description": "The resolved bucket interval (1h/1d).",
             "enum": [
               "1h",
               "1d"
@@ -48223,6 +48697,7 @@
             "type": "integer"
           },
           "root_excluded": {
+            "description": "True for root (netuid 0), whose 1:1 price makes candles meaningless, so none are emitted.",
             "type": "boolean"
           },
           "schema_version": {
@@ -48407,7 +48882,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "operational_observed_at": {
             "anyOf": [
@@ -48452,6 +48928,7 @@
       },
       "SubnetOwnershipHistoryArtifact": {
         "additionalProperties": {},
+        "description": "Every automatic ownership transfer one subnet has undergone, decoded from the chain_events SubnetOwnerChanged stream. Mirrors GET /api/v1/subnets/{netuid}/ownership-history.",
         "properties": {
           "count": {
             "maximum": 9007199254740991,
@@ -48459,9 +48936,11 @@
             "type": "integer"
           },
           "event_method": {
+            "description": "The chain_events method the authoritative records are decoded from.",
             "type": "string"
           },
           "event_pallet": {
+            "description": "The chain_events pallet the authoritative records are decoded from.",
             "type": "string"
           },
           "netuid": {
@@ -48479,9 +48958,11 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The newest owner observation for this subnet, ISO-8601 -- how far the observation source covers it at all, so watched-but-never-changed-hands is distinguishable from not-watched-since. Null when no observations were read."
           },
           "ownership_changes": {
+            "description": "Each record carries a source: chain-event (announced on chain, block-stamped) or owner-observation (inferred from two consecutive owner captures, so observed_at is when the change was NOTICED and block_number is null).",
             "items": {
               "additionalProperties": false,
               "properties": {
@@ -48578,6 +49059,7 @@
       },
       "SubnetPerformanceArtifact": {
         "additionalProperties": {},
+        "description": "Per-subnet reward-distribution & score-spread card (#5714). Metric blocks are null on a cold/empty subnet. Mirrors GET /api/v1/subnets/{netuid}/performance.",
         "properties": {
           "active_count": {
             "maximum": 9007199254740991,
@@ -48595,13 +49077,16 @@
             ]
           },
           "consensus": {
-            "$ref": "#/components/schemas/ScoreDistribution"
+            "$ref": "#/components/schemas/ScoreDistribution",
+            "description": "Consensus score spread across all neurons."
           },
           "dividends": {
-            "$ref": "#/components/schemas/ConcentrationMetrics"
+            "$ref": "#/components/schemas/ConcentrationMetrics",
+            "description": "Dividends concentration across permitted validators only."
           },
           "incentive": {
-            "$ref": "#/components/schemas/ConcentrationMetrics"
+            "$ref": "#/components/schemas/ConcentrationMetrics",
+            "description": "Incentive concentration across all neurons with positive incentive."
           },
           "netuid": {
             "maximum": 9007199254740991,
@@ -48619,7 +49104,8 @@
             "type": "integer"
           },
           "trust": {
-            "$ref": "#/components/schemas/ScoreDistribution"
+            "$ref": "#/components/schemas/ScoreDistribution",
+            "description": "Trust score spread across all neurons."
           },
           "validator_count": {
             "maximum": 9007199254740991,
@@ -48627,7 +49113,8 @@
             "type": "integer"
           },
           "validator_trust": {
-            "$ref": "#/components/schemas/ScoreDistribution"
+            "$ref": "#/components/schemas/ScoreDistribution",
+            "description": "Validator-trust score spread across permitted validators only."
           }
         },
         "required": [
@@ -48643,6 +49130,7 @@
       },
       "SubnetPerformanceHistoryArtifact": {
         "additionalProperties": {},
+        "description": "Per-subnet per-day reward-distribution trend (#6981) from the neuron_daily rollup, newest first. An empty series (point_count 0) on a cold store, never a GraphQL error. The history twin of subnet_performance, mirroring GET /api/v1/subnets/{netuid}/performance/history.",
         "properties": {
           "netuid": {
             "maximum": 9007199254740991,
@@ -48657,6 +49145,7 @@
           "points": {
             "items": {
               "additionalProperties": {},
+              "description": "One day's point in a subnet's concentration trend (#5901). Flattened (not nested) stake/emission metrics keep the series trivial to plot; each is null on a cold/empty day.",
               "properties": {
                 "active_count": {
                   "maximum": 9007199254740991,
@@ -48821,7 +49310,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The resolved window label (7d/30d/90d)."
           }
         },
         "required": [
@@ -49635,7 +50125,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "profile": {
             "$ref": "#/components/schemas/SubnetProfile"
@@ -49762,7 +50253,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "profiles": {
             "items": {
@@ -49859,6 +50351,7 @@
       },
       "SubnetPrometheusArtifact": {
         "additionalProperties": false,
+        "description": "Per-subnet Prometheus-endpoint serving activity (#7172) over a 7d/30d window. Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/prometheus.",
         "properties": {
           "announcements": {
             "maximum": 9007199254740991,
@@ -49878,6 +50371,7 @@
           },
           "degraded": {
             "additionalProperties": false,
+            "description": "A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer.",
             "properties": {
               "detail": {
                 "type": "string"
@@ -49944,6 +50438,7 @@
       },
       "SubnetRecycledArtifact": {
         "additionalProperties": {},
+        "description": "Live cumulative TAO recycled for registration on one subnet, read directly from chain via RPC. recycled_tao is null on RPC failure (schema-stable, never a GraphQL error). Mirrors GET /api/v1/subnets/{netuid}/recycled.",
         "properties": {
           "field_sources": {
             "additionalProperties": {
@@ -50121,7 +50616,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -50241,6 +50737,7 @@
       },
       "SubnetStakeFlowArtifact": {
         "additionalProperties": false,
+        "description": "Per-subnet net stake flow (#7172) over a 7d/30d/90d window. Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/stake-flow' data envelope.",
         "properties": {
           "net_flow_tao": {
             "type": "number"
@@ -50373,6 +50870,7 @@
       },
       "SubnetStakeQuoteArtifact": {
         "additionalProperties": false,
+        "description": "A read-only hypothetical stake/unstake quote against one subnet's live AMM pool (#6979). Mirrors GET /api/v1/subnets/{netuid}/stake-quote.",
         "properties": {
           "alpha_in_pool": {
             "anyOf": [
@@ -50389,6 +50887,7 @@
             "type": "number"
           },
           "direction": {
+            "description": "stake (spends TAO for alpha) or unstake (spends alpha for TAO).",
             "enum": [
               "stake",
               "unstake"
@@ -50411,6 +50910,7 @@
             "type": "string"
           },
           "is_root": {
+            "description": "True for root (netuid 0), which quotes 1:1 with no price impact.",
             "type": "boolean"
           },
           "netuid": {
@@ -50460,6 +50960,7 @@
       },
       "SubnetStakeTransfersArtifact": {
         "additionalProperties": false,
+        "description": "Per-subnet stake-transfer activity (#5717) over a 7d/30d window. Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/stake-transfers.",
         "properties": {
           "distinct_senders": {
             "maximum": 9007199254740991,
@@ -50587,6 +51088,7 @@
             "type": "integer"
           },
           "surface_count": {
+            "description": "Distinct surfaces with a recorded mutation -- NOT the subnet's current surface count. A deleted surface is counted here and absent there.",
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
@@ -50631,7 +51133,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -50657,6 +51160,7 @@
       },
       "SubnetTrajectoryArtifact": {
         "additionalProperties": {},
+        "description": "One subnet's weekly structural + economics trajectory from the daily snapshots (#5887). Mirrors GET /api/v1/subnets/{netuid}/trajectory's data envelope. The REST envelope's window-keyed deltas map (7d/30d) is exposed here as a list carrying each window label, since those keys are not valid GraphQL field names.",
         "properties": {
           "deltas": {
             "additionalProperties": {
@@ -50742,6 +51246,7 @@
                 }
               ]
             },
+            "description": "Latest-vs-window-ago deltas -- one entry per window (7d, 30d) that has a prior point to compare against; empty when the series is too short.",
             "propertyNames": {
               "type": "string"
             },
@@ -50760,6 +51265,7 @@
           "points": {
             "items": {
               "additionalProperties": {},
+              "description": "One daily-snapshot point on a subnet's trajectory (chronological). Economics fields are null on rows captured before those columns existed / when economics was unavailable that day.",
               "properties": {
                 "alpha_in_pool": {
                   "anyOf": [
@@ -50919,11 +51425,13 @@
       },
       "SubnetTurnoverArtifact": {
         "additionalProperties": {},
+        "description": "One subnet's validator/neuron-set turnover between a window's boundary snapshots. The churn metrics are zeroed and the retentions/stability null on a single-snapshot or cold store (schema-stable). Mirrors GET /api/v1/subnets/{netuid}/turnover's default scorecard.",
         "properties": {
           "changes": {
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "The per-neuron churn behind a subnet's turnover scorecard: which validators entered and exited, and which UIDs were reassigned. Mirrors the changes block of GET /api/v1/subnets/{netuid}/turnover?changes=true.",
                 "properties": {
                   "uid_reassignment_count": {
                     "maximum": 9007199254740991,
@@ -50933,6 +51441,7 @@
                   "uid_reassignments": {
                     "items": {
                       "additionalProperties": false,
+                      "description": "One UID that changed hands between the window's boundary snapshots.",
                       "properties": {
                         "from_hotkey": {
                           "type": "string"
@@ -50958,6 +51467,7 @@
                   "validators_entered": {
                     "items": {
                       "additionalProperties": false,
+                      "description": "One validator that entered or left a subnet's validator set between the window's boundary snapshots.",
                       "properties": {
                         "hotkey": {
                           "type": "string"
@@ -50972,7 +51482,8 @@
                             {
                               "type": "null"
                             }
-                          ]
+                          ],
+                          "description": "The UID it held at the boundary snapshot, null when the row carried no usable uid."
                         }
                       },
                       "required": [
@@ -50991,6 +51502,7 @@
                   "validators_exited": {
                     "items": {
                       "additionalProperties": false,
+                      "description": "One validator that entered or left a subnet's validator set between the window's boundary snapshots.",
                       "properties": {
                         "hotkey": {
                           "type": "string"
@@ -51005,7 +51517,8 @@
                             {
                               "type": "null"
                             }
-                          ]
+                          ],
+                          "description": "The UID it held at the boundary snapshot, null when the row carried no usable uid."
                         }
                       },
                       "required": [
@@ -51032,7 +51545,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Per-neuron churn detail behind the counts above, populated only when the field's changes toggle is set (mirroring REST's ?changes=true). Null otherwise, and on a cold store."
           },
           "comparable": {
             "type": "boolean"
@@ -51190,7 +51704,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Names the missing input whenever a field above was withheld, so a caller can tell 'unknown' from 'zero'."
           },
           "earning_entry_cost_tao": {
             "anyOf": [
@@ -51220,7 +51735,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The smallest stake that actually EARNS dividends here, excluding the subnet owner -- its permit is unconditional, so an owner earning on ~0 stake would report a floor of 0. Null when NO non-owner has earned on this subnet, which is a real answer (the owner is taking the dividends), not a missing one."
           },
           "emission_gate_open": {
             "anyOf": [
@@ -51230,7 +51746,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Reported, never scored. Gate-closed subnets still emit alpha at a comparable rate and are less contested, so per unit of stake they pay MORE -- the gate is an exit-liquidity question, not an eligibility one."
           },
           "field_sources": {
             "additionalProperties": {
@@ -51318,7 +51835,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Floor cost plus the registration burn. Entry is two spends; publishing one understates it."
           },
           "permit_floor_cost_tao": {
             "anyOf": [
@@ -51338,7 +51856,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Floors are in total_stake UNITS (alpha + tao_weight * root), the quantity the chain threshold actually tests -- not alpha alone."
           },
           "permit_to_earning_multiple": {
             "anyOf": [
@@ -51348,7 +51867,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "How much more it takes to EARN than merely to hold a permit."
           },
           "registration_cost_tao": {
             "anyOf": [
@@ -51368,7 +51888,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Root is not split: this much root clears the threshold on EVERY subnet the hotkey is registered on at once."
           },
           "schema_version": {
             "maximum": 9007199254740991,
@@ -51383,7 +51904,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Echoed so a caller never has to guess what the floor was computed against. Both are sudo-settable, so a cached copy would silently rot."
           },
           "takes": {
             "anyOf": [
@@ -51519,6 +52041,7 @@
             "type": "integer"
           },
           "points": {
+            "description": "Newest first.",
             "items": {
               "$ref": "#/components/schemas/ValidatorEconomicsHistoryPoint"
             },
@@ -51544,6 +52067,7 @@
       },
       "SubnetValidatorsArtifact": {
         "additionalProperties": {},
+        "description": "One subnet's current validator set (#6979). Mirrors GET /api/v1/subnets/{netuid}/validators' data envelope.",
         "properties": {
           "block_number": {
             "anyOf": [
@@ -51583,8 +52107,10 @@
             "type": "integer"
           },
           "validators": {
+            "description": "Each permitted validator's live metagraph row -- the same NeuronState shape the neuron field returns.",
             "items": {
               "additionalProperties": false,
+              "description": "One UID's live metagraph state within a subnet (hot/cold keys, scores, stake/emission, axon, take).",
               "properties": {
                 "active": {
                   "type": "boolean"
@@ -51662,9 +52188,11 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block/timestamp at ~12s/block; null if that anchor is unavailable (#6640)."
                 },
                 "immunity_expires_at_block": {
+                  "description": "The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640).",
                   "maximum": 9007199254740991,
                   "minimum": -9007199254740991,
                   "type": "integer"
@@ -51724,7 +52252,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Validator take/commission (0..1) from SubtensorModule::Delegates; null when no Delegates entry at capture."
                 },
                 "trust": {
                   "anyOf": [
@@ -51815,7 +52344,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "results": {
             "items": {
@@ -51935,6 +52465,7 @@
       },
       "SubnetWeightSettersArtifact": {
         "additionalProperties": false,
+        "description": "Per-subnet weight-setter leaderboard (#5712). Empty setters on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/weights/setters.",
         "properties": {
           "distinct_setters": {
             "maximum": 9007199254740991,
@@ -51979,6 +52510,7 @@
           "setters": {
             "items": {
               "additionalProperties": false,
+              "description": "One validator's weight-setting activity within one subnet over the lookback window.",
               "properties": {
                 "first_set_at": {
                   "anyOf": [
@@ -52042,7 +52574,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "This setter's share of the subnet total weight_sets; null when the subnet total is 0."
                 },
                 "tempos_since_last_set": {
                   "anyOf": [
@@ -52200,6 +52733,7 @@
           "neurons": {
             "items": {
               "additionalProperties": false,
+              "description": "One UID's emission-per-stake yield within a subnet's current metagraph snapshot.",
               "properties": {
                 "emission_tao": {
                   "anyOf": [
@@ -52471,7 +53005,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The resolved window label (7d/30d/90d)."
           }
         },
         "required": [
@@ -52512,6 +53047,7 @@
       },
       "SudoKeyArtifact": {
         "additionalProperties": {},
+        "description": "The network's on-chain sudo (superuser) key, read live from chain via RPC. hotkey is null on RPC failure or a renounced sudo (schema-stable). Mirrors GET /api/v1/sudo/key's data envelope.",
         "properties": {
           "field_sources": {
             "additionalProperties": {
@@ -53076,7 +53612,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -53138,6 +53675,7 @@
       },
       "SurfaceHistoryChange": {
         "additionalProperties": false,
+        "description": "One recorded mutation of a subnet's public surface.",
         "properties": {
           "action": {
             "anyOf": [
@@ -53152,7 +53690,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "insert, update or delete. A delete is the only evidence a surface ever existed."
           },
           "kind": {
             "anyOf": [
@@ -53187,7 +53726,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The registry commit that produced the change."
           },
           "surface_id": {
             "anyOf": [
@@ -53197,7 +53737,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Coalesced column then overlay id, so it is present on every row including those written before the column was recorded."
           },
           "url": {
             "anyOf": [
@@ -53260,7 +53801,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "schema_version": {
             "const": 1,
@@ -53431,7 +53973,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "How far back the answer actually reaches -- the series began 2026-08-02."
           },
           "point_count": {
             "maximum": 9007199254740991,
@@ -53445,6 +53988,7 @@
             "type": "array"
           },
           "priced_point_count": {
+            "description": "How many points carried a price. A gap from point_count is how a window with unpriceable blocks announces itself.",
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
@@ -53480,6 +54024,7 @@
       },
       "TaoUsdLatest": {
         "additionalProperties": false,
+        "description": "The newest reading with the derivation that produced it, kept together so both describe the same block.",
         "properties": {
           "block_number": {
             "anyOf": [
@@ -53502,7 +54047,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The ETH/USDC anchor leg the composition multiplied through."
           },
           "observed_at": {
             "anyOf": [
@@ -53529,6 +54075,7 @@
             ]
           },
           "pools": {
+            "description": "Per-pool provenance as the producer stored it.",
             "items": {},
             "type": "array"
           },
@@ -53540,7 +54087,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Stated even when the price is null -- it is what says why."
           },
           "usd_per_tao": {
             "anyOf": [
@@ -53567,6 +54115,7 @@
       },
       "TaoUsdPoint": {
         "additionalProperties": false,
+        "description": "One TAO/USD reading.",
         "properties": {
           "block_number": {
             "anyOf": [
@@ -53594,7 +54143,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Null means the block was not priceable (insufficient pool quorum), NOT a zero price."
           }
         },
         "required": [
@@ -53756,6 +54306,7 @@
       },
       "UptimeArtifact": {
         "additionalProperties": {},
+        "description": "One subnet's long-term daily uptime history (#5885). Mirrors GET /api/v1/subnets/{netuid}/uptime's data envelope.",
         "properties": {
           "netuid": {
             "maximum": 9007199254740991,
@@ -53858,7 +54409,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Window-wide reliability score (0-100) with letter grade. Surface-level scores omit window/surface_count/day_count/computed_at."
           },
           "schema_version": {
             "maximum": 9007199254740991,
@@ -53869,8 +54421,10 @@
             "type": "string"
           },
           "surfaces": {
+            "description": "Per-surface day series with window-wide uptime ratios and per-surface reliability scores.",
             "items": {
               "additionalProperties": {},
+              "description": "One operational surface's uptime history over the requested window.",
               "properties": {
                 "day_count": {
                   "maximum": 9007199254740991,
@@ -53880,6 +54434,7 @@
                 "days": {
                   "items": {
                     "additionalProperties": {},
+                    "description": "One daily uptime point for a surface.",
                     "properties": {
                       "avg_latency_ms": {
                         "anyOf": [
@@ -53898,6 +54453,7 @@
                       },
                       "latency_ms": {
                         "additionalProperties": {},
+                        "description": "Percentile latency summary for one uptime day.",
                         "properties": {
                           "p50": {
                             "anyOf": [
@@ -54068,7 +54624,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Window-wide reliability score (0-100) with letter grade. Surface-level scores omit window/surface_count/day_count/computed_at."
                 },
                 "samples": {
                   "maximum": 9007199254740991,
@@ -54195,6 +54752,7 @@
             "anyOf": [
               {
                 "additionalProperties": false,
+                "description": "Self-reported on-chain identity (SubtensorModule::set_identity) for a coldkey.",
                 "properties": {
                   "additional": {
                     "anyOf": [
@@ -54409,6 +54967,7 @@
             "type": "integer"
           },
           "subnets": {
+            "description": "Per-subnet membership rows for this validator. The global leaderboard entry caps this at the top 10 by stake; the single-validator lookup carries every subnet.",
             "items": {
               "additionalProperties": false,
               "properties": {
@@ -54640,6 +55199,7 @@
       },
       "ValidatorEconomicsExclusion": {
         "additionalProperties": false,
+        "description": "One subnet the ranking dropped, and why, so that a caller can tell an omitted subnet from an absent one without re-deriving the ranking.",
         "properties": {
           "netuid": {
             "maximum": 9007199254740991,
@@ -54658,6 +55218,7 @@
       },
       "ValidatorEconomicsHistoryPoint": {
         "additionalProperties": false,
+        "description": "One day's observed economics. The floors are read off the snapshot, not re-derived: StakeThreshold is sudo-settable, so re-running today's threshold against an old day would show a flat line across a governance change that actually moved the floor.",
         "properties": {
           "earning_floor_alpha": {
             "anyOf": [
@@ -54689,7 +55250,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The validator cap in force on this day. permit_floor_alpha is the observed floor REGARDLESS of cap state, so it cannot be read without this -- and joining today's cap onto an old point is wrong for any subnet whose cap moved."
           },
           "max_validators_source": {
             "anyOf": [
@@ -54703,7 +55265,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Where max_validators came from: observed = the hyperparameter change-log recorded it at or before this day; current = the change-log does not reach this far back, so the LIVE cap is reported."
           },
           "permit_floor_alpha": {
             "anyOf": [
@@ -54723,7 +55286,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Whether the permit set was full on this day (validators_permitted >= max_validators). NOT the same measure as the current record's cap_binding, which counts UIDs clearing the threshold against slots -- only the permitted set survives in a daily snapshot."
           },
           "snapshot_date": {
             "type": "string"
@@ -54858,7 +55422,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Echoed once for the whole ranking: every row's floors were derived against exactly these values, and both are sudo-settable."
           },
           "tao_weight": {
             "anyOf": [
@@ -54871,6 +55436,7 @@
             ]
           },
           "total": {
+            "description": "Rows matching the filters, BEFORE limit/offset -- so a caller can page without re-counting.",
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
@@ -54892,6 +55458,7 @@
       },
       "ValidatorHistoryArtifact": {
         "additionalProperties": {},
+        "description": "One validator's cross-subnet staked-over-time history. Mirrors GET /api/v1/validators/{hotkey}/history.",
         "properties": {
           "hotkey": {
             "type": "string"
@@ -54906,7 +55473,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The subnet this series was scoped to, or null for the cross-subnet rollup."
           },
           "next_take_change_eligible_date": {
             "anyOf": [
@@ -54927,6 +55495,7 @@
           "points": {
             "items": {
               "additionalProperties": false,
+              "description": "One day's rollup for a validator hotkey. Cross-subnet (summed across every subnet it validates in) unless the query scoped a netuid, in which case the per-subnet fields below are populated too.",
               "properties": {
                 "consensus": {
                   "anyOf": [
@@ -54979,7 +55548,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "The scoped subnet. Null on the unscoped cross-subnet series."
                 },
                 "rewards_per_1000_alpha": {
                   "anyOf": [
@@ -55100,7 +55670,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Per-subnet facts, null unless the query scoped a netuid: a cross-subnet average of these is a number the chain never computes."
                 }
               },
               "required": [
@@ -55171,6 +55742,7 @@
       },
       "ValidatorNominatorsArtifact": {
         "additionalProperties": {},
+        "description": "One validator's nominator leaderboard (#5692). Mirrors GET /api/v1/validators/{hotkey}/nominators' data envelope.",
         "properties": {
           "concentration_complete": {
             "type": "boolean"
@@ -55211,6 +55783,7 @@
           "nominators": {
             "items": {
               "additionalProperties": false,
+              "description": "One nominating coldkey's staking activity toward a validator within the window.",
               "properties": {
                 "coldkey": {
                   "type": "string"
@@ -55221,6 +55794,7 @@
                   "type": "integer"
                 },
                 "gross_staked_tao": {
+                  "description": "staked_tao + unstaked_tao (total churn, regardless of direction).",
                   "minimum": 0,
                   "type": "number"
                 },
@@ -55232,9 +55806,11 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Most recent StakeAdded/StakeRemoved time for this coldkey; null when unstamped."
                 },
                 "net_staked_tao": {
+                  "description": "staked_tao - unstaked_tao.",
                   "type": "number"
                 },
                 "staked_tao": {
@@ -55270,6 +55846,7 @@
             "type": "integer"
           },
           "sort": {
+            "description": "The resolved sort actually applied (an omitted sort resolves to net_staked).",
             "enum": [
               "net_staked",
               "gross_staked",
@@ -55309,7 +55886,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The resolved window label; null only if the builder was handed no window."
           }
         },
         "required": [
@@ -55330,6 +55908,7 @@
       },
       "ValidatorPermitModelAgreement": {
         "additionalProperties": false,
+        "description": "How well the derived permit rule still reproduces the permits the chain actually granted. Published so a caller can see when the model has drifted rather than trusting a floor it no longer supports.",
         "properties": {
           "agreement": {
             "anyOf": [
@@ -55379,6 +55958,7 @@
       },
       "ValidatorSetComposition": {
         "additionalProperties": false,
+        "description": "Permitted, active and earning are three DIFFERENT sets. Network-wide 2026-08-03: 1,523 / 1,137 / 1,117; SN83 is 64 / 8 / 7. Published separately rather than collapsed, because 'how many validators does this subnet have' has three defensible answers.",
         "properties": {
           "active": {
             "maximum": 9007199254740991,
@@ -55405,6 +55985,7 @@
       },
       "ValidatorTakeDistribution": {
         "additionalProperties": false,
+        "description": "The commission picture across permit-holders. The sorted vector is published because the shape is the information: it is genuinely bimodal, with a cohort competing at or near zero against a median at the effective ceiling, and validators earning at both ends.",
         "properties": {
           "distribution": {
             "items": {
@@ -55440,7 +56021,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Median restricted to permit-holders that actually earn -- takes among validators nobody delegates to are noise."
           },
           "min": {
             "anyOf": [
@@ -55494,7 +56076,8 @@
                 },
                 "type": "array"
               }
-            ]
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "observed_at": {
             "anyOf": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4964,7 +4964,7 @@ export interface components {
             total_deregistrations: number;
             window: ("7d" | "30d" | "90d") | null;
         };
-        /** @description One coldkey's community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities. */
+        /** @description One `coldkey`'s community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities. */
         AccountEntitiesArtifact: {
             labels: ({
                 category?: ("exchange" | "bridge" | "foundation" | "pool" | "infra" | "project" | "operator" | "other") | null;
@@ -5476,7 +5476,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** @description One account's (validator hotkey's) WeightsSet weight-setting footprint across subnets over a 7d/30d window. Mirrors GET /api/v1/accounts/{ss58}/weight-setters. */
+        /** @description One account's (validator's hotkey's) WeightsSet weight-setting footprint across subnets over a 7d/30d window. Mirrors GET /api/v1/accounts/{ss58}/weight-setters. */
         AccountWeightSettersArtifact: {
             address: string;
             /** @description Herfindahl-Hirschman index of weight-sets across subnets: 1 = all on one subnet, -> 1/n as it spreads evenly; null when the account has no weight-sets. */
@@ -6843,7 +6843,7 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
-            /** @description Network-wide stake-move rollup: every subnet with StakeMoved events in the window, combined. distinct_movers counts a coldkey once even when it moves on several subnets. */
+            /** @description Network-wide stake-move rollup: every subnet with StakeMoved events in the window, combined. distinct_movers counts a `coldkey` once even when it moves on several subnets. */
             network: {
                 distinct_movers: number;
                 movements: number;
@@ -6873,7 +6873,7 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
-            /** @description Network-wide stake-transfer rollup: every subnet with StakeTransferred events in the window, combined. distinct_senders counts an origin coldkey once even when it transfers out of several subnets. */
+            /** @description Network-wide stake-transfer rollup: every subnet with StakeTransferred events in the window, combined. distinct_senders counts an origin `coldkey` once even when it transfers out of several subnets. */
             network: {
                 distinct_senders: number;
                 transfers: number;
@@ -7198,7 +7198,7 @@ export interface components {
                 apy_estimate_eligible_subnet_count: number;
                 avg_validator_trust: number | null;
                 coldkey: string | null;
-                /** @description The coldkey's self-declared on-chain identity; opaque JSON, matching the REST/MCP shape. */
+                /** @description The `coldkey`'s self-declared on-chain identity; opaque JSON, matching the REST/MCP shape. */
                 coldkey_identity: {
                     additional: string | null;
                     captured_at: string | null;
@@ -11014,12 +11014,12 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** @description One coldkey's holding of a subnet's alpha, including alpha staked to hotkeys that hold no UID on that subnet. */
+        /** @description One `coldkey`'s holding of a subnet's alpha, including alpha staked to hotkeys that hold no UID on that subnet. */
         SubnetHolder: {
             /** @description ALPHA, not TAO. Within one subnet alpha is already a common unit, so there is no price conversion and none of its staleness -- multiply by the subnet's alpha_price_tao for TAO. */
             alpha: number;
             coldkey: string;
-            /** @description Distinct hotkeys this coldkey holds the subnet's alpha through -- registered on it or not, which is the part a neurons-sourced view misses. */
+            /** @description Distinct hotkeys this `coldkey` holds the subnet's alpha through -- registered on it or not, which is the part a neurons-sourced view misses. */
             hotkey_count: number | null;
             /** @description This holder's alpha over the subnet's FULL measured total, so it means the same thing at limit 5 and limit 100. Null when the total is zero. */
             share_of_total: number | null;
@@ -12668,7 +12668,7 @@ export interface components {
                 event_count: number;
                 /** @description staked_tao + unstaked_tao (total churn, regardless of direction). */
                 gross_staked_tao: number;
-                /** @description Most recent StakeAdded/StakeRemoved time for this coldkey; null when unstamped. */
+                /** @description Most recent StakeAdded/StakeRemoved time for this `coldkey`; null when unstamped. */
                 last_observed_at: string | null;
                 /** @description staked_tao - unstaked_tao. */
                 net_staked_tao: number;

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4816,6 +4816,7 @@ export interface components {
         AccountAxonRemovalsArtifact: {
             address: string;
             concentration: number | null;
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
@@ -4832,6 +4833,7 @@ export interface components {
             total_removals: number;
             window: ("7d" | "30d" | "90d") | null;
         };
+        /** @description Live free+reserved balance in TAO for one Finney ss58 account, read directly from chain via RPC (KV-cached). balance_tao is null on RPC failure (schema-stable, never a GraphQL error). Mirrors GET /api/v1/accounts/{ss58}/balance. */
         AccountBalanceArtifact: {
             balance_tao?: number | null;
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
@@ -4850,6 +4852,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Live child-hotkey delegation graph (#6723) for one Finney ss58 account, read directly from chain via RPC (KV-cached). subnets is null on RPC failure, distinct from a confirmed-empty [] (schema-stable, never a GraphQL error). Mirrors GET /api/v1/accounts/{ss58}/children. */
         AccountChildrenArtifact: {
             account: string;
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
@@ -4885,8 +4888,10 @@ export interface components {
                 transfer_count: number;
             }[];
             counterparty_count: number;
+            /** @description Present only in relationship (counterparty) mode; null in list mode. */
             relationship?: {
                 counterparty: string;
+                /** @description Oldest block/timestamp are null when the newest-first scan was truncated (scan_capped). */
                 first_block: number | null;
                 first_seen_at: string | null;
                 last_block: number | null;
@@ -4902,7 +4907,10 @@ export interface components {
                 transfers: {
                     amount_tao: number;
                     block_number: number | null;
-                    /** @enum {string} */
+                    /**
+                     * @description sent (account = from) or received (account = to).
+                     * @enum {string}
+                     */
                     direction: "sent" | "received";
                     event_index: number | null;
                     from: string;
@@ -4924,19 +4932,24 @@ export interface components {
         AccountDeregistrationsArtifact: {
             address: string;
             concentration: number | null;
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
             };
+            /** @description How a deregistration feed was derived (#9307). NeuronDeregistered has never been emitted, so deregistrations are derived from UID reuse: a NeuronRegistered on a (netuid, uid) slot already held by a different hotkey IS the deregistration of the previous occupant. unattributed_registrations is the honest part -- the published totals are a LOWER BOUND by that many events, because those registrations displaced a holder the derivation's lookback cannot name. */
             derivation?: {
                 /**
                  * @description True when the count is a floor rather than a measurement: some registrations in the window displaced a holder the derivation's lookback cannot name, so the real figure is higher by at least `unattributed_registrations`. Treat the value as 'at least this many', never as a total.
                  * @example true
                  */
                 is_lower_bound: boolean;
+                /** @description Days of NeuronRegistered history the derivation had available. */
                 lookback_days: number;
                 method: string;
+                /** @description Of those, the ones with no observed previous holder. */
                 unattributed_registrations: number;
+                /** @description Registrations observed inside the reported window. */
                 window_registrations: number;
             };
             dominant_netuid: number | null;
@@ -4951,6 +4964,7 @@ export interface components {
             total_deregistrations: number;
             window: ("7d" | "30d" | "90d") | null;
         };
+        /** @description One coldkey's community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities. */
         AccountEntitiesArtifact: {
             labels: ({
                 category?: ("exchange" | "bridge" | "foundation" | "pool" | "infra" | "project" | "operator" | "other") | null;
@@ -4991,6 +5005,7 @@ export interface components {
             price_basis?: ("trade_exact" | "root_no_pool") | null;
             uid?: number | null;
         };
+        /** @description One account's first-party chain-event feed (matched by the hotkey OR coldkey union, newest first), keyset-paginated. event_count is the page count, not a grand total. Mirrors GET /api/v1/accounts/{ss58}/events' data envelope. Each item is an AccountEvent. */
         AccountEventsArtifact: {
             event_count: number;
             events: components["schemas"]["AccountEvent"][];
@@ -5002,10 +5017,12 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One account's signed-extrinsic feed (newest first), backing account_extrinsics. Matched by the extrinsic signer only. extrinsic_count is the page count, matching the REST feed convention. Each item is a full Extrinsic (block/index/hash/call/success/fee/tip). */
         AccountExtrinsicsArtifact: {
             extrinsic_count: number;
             extrinsics: {
                 block_number: number | null;
+                /** @description JSON-encoded decoded call arguments. */
                 call_args?: unknown | null;
                 call_function?: string | null;
                 call_module?: string | null;
@@ -5015,6 +5032,7 @@ export interface components {
                 observed_at?: string | null;
                 signer?: string | null;
                 success?: boolean | null;
+                /** @description Deterministic human-readable action sentence for this extrinsic's call, or null when no template matches call_module.call_function (#8525). */
                 summary?: string | null;
                 tip_tao?: number | null;
             }[];
@@ -5026,6 +5044,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One account's durable per-day activity series (hotkey-keyed, newest day first), keyset-paginated. day_count is the page count, not a grand total. Mirrors GET /api/v1/accounts/{ss58}/history' data envelope. Each item is an AccountDay. */
         AccountHistoryArtifact: {
             day_count: number;
             days: ({
@@ -5066,6 +5085,7 @@ export interface components {
                 description?: string | null;
                 discord?: string | null;
                 github?: string | null;
+                /** @description Stable hash of this entry's tracked identity fields -- unchanged across entries where nothing actually differs. */
                 identity_hash: string;
                 image?: string | null;
                 name?: string | null;
@@ -5080,6 +5100,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Live parent-hotkey delegation graph (#6723) for one Finney ss58 account, read directly from chain via RPC (KV-cached). subnets is null on RPC failure, distinct from a confirmed-empty [] (schema-stable, never a GraphQL error). Mirrors GET /api/v1/accounts/{ss58}/parents. */
         AccountParentsArtifact: {
             account: string;
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
@@ -5105,6 +5126,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One wallet's cross-subnet neuron portfolio (#5702): every subnet where the hotkey is a registered neuron, plus wallet-level aggregates. Mirrors GET /api/v1/accounts/{ss58}/portfolio. */
         AccountPortfolioArtifact: {
             captured_at: string | null;
             miner_count: number;
@@ -5125,10 +5147,12 @@ export interface components {
                 stake_tao: number;
                 trust: number | null;
                 uid: number | null;
+                /** @description Emission over stake for this position; null when stake is 0. */
                 yield: number | null;
             }[];
             schema_version: number;
             ss58: string;
+            /** @description How concentrated the wallet's stake is across its subnets (Gini/HHI/etc); null with no positions. */
             stake_concentration: components["schemas"]["ConcentrationMetrics"];
             subnet_count: number;
             /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest SPOT price -- tao_in_pool_tao / alpha_in_pool from that subnet's newest snapshot, root at 1:1 -- before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Marked at SPOT, not at alpha_price_tao: that field is the chain's MOVING price (#9408), and a lagging average is the wrong mark for what a position is worth -- measured -1.29% against spot on netuid 64 for 2026-08-03. Prices still come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier; the lag is the rollup's, no longer the average's. */
@@ -5139,6 +5163,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One account's per-subnet position history over a lookback window, one point per neuron_daily snapshot. Mirrors GET /api/v1/accounts/{ss58}/subnets/{netuid}/history. */
         AccountPositionHistoryArtifact: {
             netuid: number;
             point_count: number;
@@ -5166,6 +5191,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description This account's reconstructed nominator-side positions: what it holds delegated across every hotkey/subnet, distinct from AccountPortfolio's hotkey-scoped view. Mirrors GET /api/v1/accounts/{ss58}/positions. */
         AccountPositionsArtifact: {
             captured_at: string | null;
             degraded?: {
@@ -5183,6 +5209,7 @@ export interface components {
             positions: {
                 hotkey: string;
                 netuid: number;
+                /** @description This account's share of the hotkey's total alpha-pool shares on this subnet (0..1), not a TAO amount. */
                 share_fraction: number;
                 /** @description This position's stake in the subnet named by the sibling `netuid`. ALPHA, not TAO: nominator_positions holds only netuid != 0 rows, so this is always that subnet's alpha token (#2550). It is the per-row counterpart of `total_stake_alpha` above -- same denomination, kept under the on-chain column name deliberately (#8945). */
                 stake_tao: number;
@@ -5194,9 +5221,12 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One account's Prometheus telemetry-serving footprint (#5703) across subnets over a 7d/30d/90d window. Mirrors GET /api/v1/accounts/{ss58}/prometheus. */
         AccountPrometheusArtifact: {
             address: string;
+            /** @description Herfindahl-Hirschman index of announcements across subnets: 1 = all on one subnet, -> 1/n as it spreads evenly; null when the account has no announcements. */
             concentration: number | null;
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
@@ -5228,6 +5258,7 @@ export interface components {
             total_registrations: number;
             window: ("7d" | "30d" | "90d") | null;
         };
+        /** @description Live root-claim current state for one Finney ss58 account (#7229), read directly from chain via RPC (KV-cached). claim_type/hotkeys are null on RPC failure (schema-stable, never a GraphQL error). Read-only; never submits claim_root. Mirrors GET /api/v1/accounts/{ss58}/root-claim. */
         AccountRootClaimArtifact: {
             claim_type?: {
                 /** @enum {string} */
@@ -5309,12 +5340,18 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One account's StakeAdded/StakeRemoved staking-behavior scorecard (#5706) across subnets over a 7d/30d/90d window. Mirrors GET /api/v1/accounts/{ss58}/stake-flow. */
         AccountStakeFlowArtifact: {
             address: string;
+            /** @description Herfindahl-Hirschman index of gross flow across subnets: 1 = all flow in one subnet, -> 1/n as it spreads evenly; null when there is no flow to concentrate. */
             concentration: number | null;
-            /** @enum {string} */
+            /**
+             * @description accumulating / exiting / churning / idle, derived from flow_ratio.
+             * @enum {string}
+             */
             direction: "accumulating" | "exiting" | "churning" | "idle";
             dominant_netuid: number | null;
+            /** @description net_flow_tao / gross_flow_tao, [-1, 1]; null when gross_flow_tao is 0 (no flow to rate). */
             flow_ratio: number | null;
             gross_flow_tao: number;
             net_flow_tao: number;
@@ -5349,15 +5386,18 @@ export interface components {
                 last_moved_at: string | null;
                 movements: number;
                 netuid: number;
+                /** @description Alpha price (TAO) on the UTC day of this subnet's most recent move; null when that day has no snapshot yet or there was no move. */
                 price_tao_at_last_move: number | null;
             }[];
             total_movements: number;
             window: ("7d" | "30d" | "90d") | null;
         };
+        /** @description One account's live cross-subnet registration footprint (the neurons snapshot), backing account_subnets. The lightweight sibling of AccountPortfolio -- registration facts only, no economics rollup. */
         AccountSubnetsArtifact: {
             schema_version: number;
             ss58: string;
             subnet_count: number;
+            /** @description Where this hotkey is currently registered, ordered by netuid -- each an AccountRegistration (netuid/uid/stake/validator_permit/active). */
             subnets: {
                 active: boolean;
                 netuid: number;
@@ -5369,6 +5409,7 @@ export interface components {
             [key: string]: unknown;
         };
         AccountSummaryArtifact: {
+            /** @description Signing-activity aggregate from the extrinsics tier, matched by signer only. tx_count / total_fee_tao / last_tx_* are all-time over every extrinsic this address has signed; modules_called is the pallet mix over the newest 1000 only, with modules_called_capped true when that window is incomplete. An account queried by a key that did not sign returns tx_count 0, modules_called_capped false, other fields null/empty. */
             activity?: {
                 last_tx_at: string | null;
                 last_tx_block: number | null;
@@ -5385,6 +5426,7 @@ export interface components {
                 count: number;
                 kind: string;
             }[];
+            /** @description True when this account has more events than the summary's scan window -- event_count/subnet_count/event_kinds are then a lower bound and first_block/first_seen_at are null. */
             event_scan_capped?: boolean;
             first_block?: number | null;
             first_seen_at?: string | null;
@@ -5400,6 +5442,7 @@ export interface components {
             last_block?: number | null;
             last_seen_at?: string | null;
             recent_events?: components["schemas"]["AccountEvent"][];
+            /** @description Where this hotkey is currently registered + staked (the live cross-subnet footprint). */
             registrations: {
                 active: boolean;
                 netuid: number;
@@ -5413,6 +5456,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One account's native-TAO transfer feed, keyset-paginated newest-first. Mirrors GET /api/v1/accounts/{ss58}/transfers' data envelope. */
         AccountTransfersArtifact: {
             limit: number | null;
             next_cursor?: string | null;
@@ -5432,8 +5476,10 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One account's (validator hotkey's) WeightsSet weight-setting footprint across subnets over a 7d/30d window. Mirrors GET /api/v1/accounts/{ss58}/weight-setters. */
         AccountWeightSettersArtifact: {
             address: string;
+            /** @description Herfindahl-Hirschman index of weight-sets across subnets: 1 = all on one subnet, -> 1/n as it spreads evenly; null when the account has no weight-sets. */
             concentration: number | null;
             dominant_netuid: number | null;
             schema_version: number;
@@ -5447,8 +5493,10 @@ export interface components {
             total_weight_sets: number;
             window: ("7d" | "30d") | null;
         };
+        /** @description One adapter-backed public metrics snapshot. snapshot and extensions are opaque JSON -- their shape is adapter-specific. Mirrors GET /api/v1/adapters/{slug}'s data envelope. */
         AdapterArtifact: {
             contract_version?: string;
+            /** @description Per-adapter extension metadata keyed by provider id; each value's shape is adapter-specific. */
             extensions: {
                 [key: string]: {
                     [key: string]: unknown;
@@ -5456,10 +5504,12 @@ export interface components {
             };
             generated_at: string;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
             slug: string;
+            /** @description Captured adapter metrics payload; shape is adapter-specific. */
             snapshot?: ({
                 adapter_kind?: string | null;
                 contract_version?: string;
@@ -5525,6 +5575,7 @@ export interface components {
             callable_service_count?: number;
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -5573,6 +5624,7 @@ export interface components {
             integration_readiness?: number;
             name?: string;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             previously_known_as?: string[];
             readiness?: components["schemas"]["IntegrationReadiness"];
@@ -5722,6 +5774,7 @@ export interface components {
             } & {
                 [key: string]: unknown;
             };
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             published_at?: string | null;
             resources: ({
@@ -5782,6 +5835,7 @@ export interface components {
             base_path: "/api/v1";
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             openapi_url: "/metagraph/openapi.json";
@@ -5829,6 +5883,7 @@ export interface components {
         ArtifactBase: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -5872,6 +5927,7 @@ export interface components {
                 observed_at?: number | null;
                 pallet: string | null;
                 phase?: string | null;
+                /** @description Deterministic human-readable action sentence for this event's pallet.method, or null when no template matches (#8525). */
                 summary?: string | null;
             }[];
         } & {
@@ -5888,13 +5944,16 @@ export interface components {
                 parent_hash: string | null;
                 spec_version: number | null;
             } | null;
+            /** @description Nearest STORED higher block height for chain-walk nav (detail only); null at the head of the retained window or when the ref didn't resolve. */
             next_block_number: number | null;
+            /** @description Nearest STORED lower block height for chain-walk nav (detail only); null at the start of the retained window or when the ref didn't resolve. */
             prev_block_number: number | null;
             ref: string | null;
             schema_version: number;
         } & {
             [key: string]: unknown;
         };
+        /** @description One block's decoded, account-attributed events list (#6977). Rows are opaque JSON; block_number is null for an unknown ref. */
         BlockEventsArtifact: {
             block_number: number | null;
             event_count: number;
@@ -5906,6 +5965,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One block's extrinsics list (#6977). Rows are the opaque JSON extrinsic shape the extrinsics feed uses; block_number is null for an unknown ref. */
         BlockExtrinsicsArtifact: {
             block_number: number | null;
             extrinsic_count: number;
@@ -5951,6 +6011,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Block-production summary (#5664) over the recent-block window. Every aggregate is null on a cold retired-D1 store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/summary. */
         BlocksSummaryArtifact: {
             author_concentration: components["schemas"]["ConcentrationMetrics"] | null;
             block_count: number;
@@ -6014,6 +6075,7 @@ export interface components {
             full_artifact_count?: number;
             full_artifact_size_bytes?: number;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             profile_count?: number;
             provider_count?: number;
@@ -6037,10 +6099,12 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description All-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history. Mirrors GET /api/v1/health/trends' data envelope. */
         BulkHealthTrendsArtifact: {
             observed_at?: string | null;
             schema_version: number;
             source: string;
+            /** @description The 7d/30d windows keyed by window label (7d, 30d), each holding days/granularity/subnet_count and the per-subnet daily point series. Opaque JSON: dynamic-keyed by window label, matching the get_health_trends MCP/REST shape. */
             windows: {
                 [key: string]: {
                     days: number;
@@ -6070,6 +6134,7 @@ export interface components {
             candidates: components["schemas"]["CandidateSurface"][];
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -6128,6 +6193,7 @@ export interface components {
             url: string;
             verification?: components["schemas"]["VerificationResult"] | null;
         };
+        /** @description Per-UTC-day network activity series (blocks, extrinsics, events, signers) over the window, newest day first. Mirrors GET /api/v1/chain/activity's data envelope. */
         ChainActivityArtifact: {
             day_count: number;
             days: {
@@ -6145,7 +6211,9 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Network-wide rolling 24h buy/sell alpha-volume leaderboard, summed live from the account_events StakeAdded/StakeRemoved stream. Mirrors GET /api/v1/chain/alpha-volume's data envelope. */
         ChainAlphaVolumeArtifact: {
+            /** @description Network-wide buy/sell volume rollup across every subnet with volume in the window. */
             network: {
                 buy_count: number;
                 buy_volume_alpha: number;
@@ -6154,16 +6222,22 @@ export interface components {
                 sell_count: number;
                 sell_volume_alpha: number;
                 sell_volume_tao: number;
-                /** @enum {string} */
+                /**
+                 * @description Coarse sentiment label (bullish/bearish/neutral); neutral both for balanced volume and an empty window.
+                 * @enum {string}
+                 */
                 sentiment: "bullish" | "bearish" | "neutral";
+                /** @description net/gross alpha lean in [-1, 1]; null when there was no volume in the window. */
                 sentiment_ratio: number | null;
                 total_volume_alpha: number;
                 total_volume_tao: number;
             };
+            /** @description Newest event observed_at across the window; null on a cold store. */
             observed_at: string | null;
             schema_version: number;
             subnet_count: number;
             subnets: components["schemas"]["SubnetAlphaVolumeArtifact"][];
+            /** @description Spread of per-subnet total_volume_tao across every subnet with volume; null when no subnet had volume. */
             volume_distribution: {
                 count: number;
                 max: number;
@@ -6174,10 +6248,14 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
-            /** @enum {string} */
+            /**
+             * @description Fixed rolling window label (always 24h).
+             * @enum {string}
+             */
             window: "24h";
         };
         ChainAxonRemovalsArtifact: {
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
@@ -6192,9 +6270,11 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Network-wide axon-removal rollup: every subnet with AxonInfoRemoved events in the window, combined. distinct_removers counts a hotkey once even when it tears endpoints down on several subnets, so it is NOT the sum of the per-subnet counts. */
             network: {
                 distinct_removers: number;
                 removals: number;
+                /** @description Null when distinct_removers is 0 (no defined intensity without removers). */
                 removals_per_remover: number | null;
             };
             observed_at: string | null;
@@ -6234,6 +6314,7 @@ export interface components {
             burn_tao: number;
             netuid: number;
         };
+        /** @description Extrinsic call-mix breakdown over the window. Mirrors GET /api/v1/chain/calls's data envelope. */
         ChainCallsArtifact: {
             call_count: number;
             calls: {
@@ -6250,29 +6331,41 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Network-wide stake & emission decentralization card (#5872). Metric blocks are null on a cold/empty store. Mirrors GET /api/v1/chain/concentration. */
         ChainConcentrationArtifact: {
             captured_at: string | null;
+            /** @description Raw emission concentration across every neuron network-wide. */
             emission: components["schemas"]["ConcentrationMetrics"];
+            /** @description Distinct controlling entities (coldkeys) network-wide, collapsed across subnets. */
             entity_count: number;
+            /** @description Emission concentration per controlling entity -- hotkeys collapsed across subnets. */
             entity_emission: components["schemas"]["ConcentrationMetrics"];
+            /** @description Stake concentration per controlling entity -- hotkeys collapsed across subnets, so one operator counts once. */
             entity_stake: components["schemas"]["ConcentrationMetrics"];
             neuron_count: number;
             schema_version: number;
+            /** @description Raw stake concentration across every neuron network-wide. */
             stake: components["schemas"]["ConcentrationMetrics"];
+            /** @description Distinct subnets the snapshot spans. */
             subnet_count: number;
+            /** @description UIDs per controlling entity network-wide -- a consolidation signal (1.0 = every UID a distinct owner; higher = fewer operators each running many). Null when no entities. */
             uids_per_entity: number | null;
+            /** @description Stake concentration across permitted validators network-wide only. */
             validator_stake: components["schemas"]["ConcentrationMetrics"];
         } & {
             [key: string]: unknown;
         };
         ChainConcentrationHistoryArtifact: {
+            /** @description Every distinct builder version in the series. More than one means it changes DEFINITION partway along. */
             builder_versions: number[];
+            /** @description Present ONLY on a decline. An empty window is a measurement. */
             degraded?: {
                 /** @enum {string} */
                 reason: "unavailable";
             };
             newest_day: string | null;
             oldest_day: string | null;
+            /** @description From the ROWS. A day the capture did not run is absent, never a zero-concentration point. */
             point_count: number | null;
             points: components["schemas"]["ChainConcentrationHistoryPoint"][];
             schema_version: number;
@@ -6281,14 +6374,18 @@ export interface components {
             [key: string]: unknown;
         };
         ChainConcentrationHistoryPoint: {
+            /** @description Which definition of the metrics produced this point. */
             builder_version: number | null;
             day: string;
             emission: components["schemas"]["ChainConcentrationScorecard"] | null;
             entity_count: number | null;
             entity_emission: components["schemas"]["ChainConcentrationScorecard"] | null;
             entity_stake: components["schemas"]["ChainConcentrationScorecard"] | null;
+            /** @description The shape of the day the card was computed over -- a point across half the network is not comparable to one across all of it. */
             neuron_count: number | null;
+            /** @description WHEN the network looked like this, as distinct from when it was computed. */
             source_captured_at: string | null;
+            /** @description NULL means no measurable distribution, NOT missing. */
             stake: components["schemas"]["ChainConcentrationScorecard"] | null;
             subnet_count: number | null;
             uids_per_entity: number | null;
@@ -6349,19 +6446,24 @@ export interface components {
             [key: string]: unknown;
         };
         ChainDeregistrationsArtifact: {
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
             };
+            /** @description How a deregistration feed was derived (#9307). NeuronDeregistered has never been emitted, so deregistrations are derived from UID reuse: a NeuronRegistered on a (netuid, uid) slot already held by a different hotkey IS the deregistration of the previous occupant. unattributed_registrations is the honest part -- the published totals are a LOWER BOUND by that many events, because those registrations displaced a holder the derivation's lookback cannot name. */
             derivation?: {
                 /**
                  * @description True when the count is a floor rather than a measurement: some registrations in the window displaced a holder the derivation's lookback cannot name, so the real figure is higher by at least `unattributed_registrations`. Treat the value as 'at least this many', never as a total.
                  * @example true
                  */
                 is_lower_bound: boolean;
+                /** @description Days of NeuronRegistered history the derivation had available. */
                 lookback_days: number;
                 method: string;
+                /** @description Of those, the ones with no observed previous holder. */
                 unattributed_registrations: number;
+                /** @description Registrations observed inside the reported window. */
                 window_registrations: number;
             };
             intensity_distribution: {
@@ -6374,8 +6476,10 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Network-wide deregistration rollup: every subnet with a derived deregistration in the window, combined. distinct_deregistered_hotkeys counts a hotkey once even when it is deregistered from several subnets, so it is NOT the sum of the per-subnet counts. */
             network: {
                 deregistrations: number;
+                /** @description Null when distinct_deregistered_hotkeys is 0 (no defined intensity without hotkeys). */
                 deregistrations_per_hotkey: number | null;
                 distinct_deregistered_hotkeys: number;
                 tenure?: {
@@ -6408,6 +6512,7 @@ export interface components {
             }[];
             window: ("7d" | "30d") | null;
         };
+        /** @description Paginated all-events feed from the chain_events lakehouse table. Mirrors GET /api/v1/chain-events (and MCP list_chain_events). Distinct from Subscription.chainEvents. */
         ChainEventsFeedArtifact: {
             count: number;
             events: {
@@ -6428,6 +6533,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Chain-activity aggregate (pallet.method event distribution) over the most recent N blocks from the chain_events lakehouse table. The aggregate sibling of ChainEventsFeed. Mirrors GET /api/v1/chain-events/stats (and MCP get_chain_activity). */
         ChainEventsStatsArtifact: {
             activity: {
                 count: number;
@@ -6439,6 +6545,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Per-UTC-day network fee/tip series plus the top fee payers over the window. Mirrors GET /api/v1/chain/fees's data envelope. */
         ChainFeesArtifact: {
             daily: {
                 avg_fee_tao: number | null;
@@ -6466,6 +6573,7 @@ export interface components {
         };
         ChainHoldersArtifact: {
             captured_at: string | null;
+            /** @description Present ONLY on a decline. An empty subnets list WITHOUT this block is a measurement. */
             degraded?: {
                 /** @enum {string} */
                 reason: "pool_totals_unproven" | "unavailable";
@@ -6475,25 +6583,32 @@ export interface components {
             positions_captured_at: string | null;
             schema_version: number;
             sort: string;
+            /** @description Subnets measured -- NOT the length of the subnets list when limit bites. */
             subnet_count: number | null;
             subnets: components["schemas"]["ChainHoldersSubnet"][];
         } & {
             [key: string]: unknown;
         };
+        /** @description Dimension-free network facts. There is deliberately no cross-subnet alpha total: summing different subnets' alpha has no unit. */
         ChainHoldersNetwork: {
             median_top1_share: number | null;
             subnets_measured: number | null;
+            /** @description Subnets where ONE account holds a majority of the measured alpha. */
             subnets_with_majority_holder: number | null;
+            /** @description Subnets whose entire measured alpha sits in a single wallet. */
             subnets_with_single_holder: number | null;
         };
+        /** @description One subnet's alpha-ownership concentration. */
         ChainHoldersSubnet: {
             holder_count: number | null;
             netuid: number;
+            /** @description The largest holder's coldkey (an ss58 address). */
             top_holder: string | null;
             top1_share: number | null;
             top10_share: number | null;
             top20_share: number | null;
             top5_share: number | null;
+            /** @description ALPHA, comparable only WITHIN this subnet -- each subnet's alpha is a different token. */
             total_alpha: number | null;
         };
         ChainIdentityHistoryArtifact: {
@@ -6518,6 +6633,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Network-wide idle-stake rollup: every subnet's stake on currently-zero-dividends hotkeys, ranked by idle_stake_alpha. Mirrors GET /api/v1/chain/idle-stake's data envelope. */
         ChainIdleStakeArtifact: {
             captured_at?: string | null;
             schema_version: number;
@@ -6534,22 +6650,30 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Network-wide reward-distribution & score-spread card (#5688) -- the network analog of SubnetPerformance, spanning every subnet's neurons in one snapshot. Metric blocks are null on a cold/empty store. Mirrors GET /api/v1/chain/performance. */
         ChainPerformanceArtifact: {
             active_count?: number;
             captured_at?: string | null;
+            /** @description Consensus score spread across all neurons network-wide. */
             consensus: components["schemas"]["ScoreDistribution"];
+            /** @description Dividends concentration across permitted validators network-wide only. */
             dividends: components["schemas"]["ConcentrationMetrics"];
+            /** @description Incentive concentration across all neurons network-wide with positive incentive. */
             incentive: components["schemas"]["ConcentrationMetrics"];
             neuron_count: number;
             schema_version: number;
+            /** @description Distinct subnets the snapshot spans. */
             subnet_count: number;
+            /** @description Trust score spread across all neurons network-wide. */
             trust: components["schemas"]["ScoreDistribution"];
             validator_count?: number;
+            /** @description Validator-trust score spread across permitted validators network-wide only. */
             validator_trust?: components["schemas"]["ScoreDistribution"];
         } & {
             [key: string]: unknown;
         };
         ChainPrometheusArtifact: {
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
@@ -6564,8 +6688,10 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Network-wide Prometheus-serving rollup: every subnet with PrometheusServed announcements in the window, combined. distinct_exporters counts a hotkey once even when it announces on several subnets, so it is NOT the sum of the per-subnet counts. */
             network: {
                 announcements: number;
+                /** @description Null when distinct_exporters is 0 (no defined intensity without exporters). */
                 announcements_per_exporter: number | null;
                 distinct_exporters: number;
             };
@@ -6591,9 +6717,11 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Network-wide registration rollup: every subnet with NeuronRegistered events in the window, combined. distinct_registrants counts a hotkey once even when it registers on several subnets, so it is NOT the sum of the per-subnet counts. */
             network: {
                 distinct_registrants: number;
                 registrations: number;
+                /** @description Null when distinct_registrants is 0 (no defined intensity without hotkeys). */
                 registrations_per_registrant: number | null;
             };
             observed_at: string | null;
@@ -6607,6 +6735,7 @@ export interface components {
             }[];
             window: ("7d" | "30d") | null;
         };
+        /** @description Network-wide axon-serving announcement leaderboard (#5873). The network-wide counterpart of subnet_serving. Mirrors GET /api/v1/chain/serving's data envelope. */
         ChainServingArtifact: {
             intensity_distribution: {
                 count: number;
@@ -6618,8 +6747,10 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Network-wide axon-serving rollup: every subnet with AxonServed announcements in the window, combined. */
             network: {
                 announcements: number;
+                /** @description Null when distinct_servers is 0 (no defined intensity without servers). */
                 announcements_per_server: number | null;
                 distinct_servers: number;
             };
@@ -6634,6 +6765,7 @@ export interface components {
             }[];
             window: ("7d" | "30d") | null;
         };
+        /** @description Network-wide weight-setter leaderboard over a lookback window, summed live from the account_events WeightsSet stream. The setter-level drill-in behind ChainWeights. Mirrors GET /api/v1/chain/weights/setters. */
         ChainSignersArtifact: {
             observed_at?: string | null;
             schema_version: number;
@@ -6641,17 +6773,23 @@ export interface components {
             signers: {
                 last_tx_block: number | null;
                 signer: string;
+                /** @description Total fees paid across the window's extrinsics; null when the tier has no fee data. */
                 total_fee_tao: number;
                 total_tip_tao: number;
                 tx_count: number;
             }[];
-            /** @enum {string} */
+            /**
+             * @description The rank order actually applied: tx_count or total_fee_tao.
+             * @enum {string}
+             */
             sort: "tx_count" | "total_fee_tao";
             window: string;
         } & {
             [key: string]: unknown;
         };
+        /** @description Network-wide cross-subnet capital-flow leaderboard over a lookback window, summed live from the account_events StakeAdded/StakeRemoved stream. Mirrors GET /api/v1/chain/stake-flow's data envelope. */
         ChainStakeFlowArtifact: {
+            /** @description Spread of per-subnet net_flow_tao across EVERY subnet with stake events; null when no subnet moved stake. */
             net_flow_distribution: {
                 count: number;
                 max: number;
@@ -6662,6 +6800,7 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Network rollup over every subnet that moved stake in the window. */
             network: {
                 flat: number;
                 gaining: number;
@@ -6677,7 +6816,10 @@ export interface components {
             schema_version: number;
             subnet_count: number;
             subnets: {
-                /** @enum {string} */
+                /**
+                 * @description inflow | outflow | balanced
+                 * @enum {string}
+                 */
                 direction: "inflow" | "outflow" | "balanced";
                 gross_flow_tao: number;
                 net_flow_tao: number;
@@ -6689,6 +6831,7 @@ export interface components {
             }[];
             window: ("7d" | "30d") | null;
         };
+        /** @description Network-wide stake-movement (re-delegation) leaderboard over a lookback window, summed live from the account_events StakeMoved stream. Mirrors GET /api/v1/chain/stake-moves's data envelope. */
         ChainStakeMovesArtifact: {
             intensity_distribution: {
                 count: number;
@@ -6700,9 +6843,11 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Network-wide stake-move rollup: every subnet with StakeMoved events in the window, combined. distinct_movers counts a coldkey once even when it moves on several subnets. */
             network: {
                 distinct_movers: number;
                 movements: number;
+                /** @description Null when distinct_movers is 0. */
                 movements_per_mover: number | null;
             };
             observed_at: string | null;
@@ -6716,6 +6861,7 @@ export interface components {
             }[];
             window: ("7d" | "30d") | null;
         };
+        /** @description Network-wide stake-transfer (between-coldkeys) leaderboard over a lookback window, summed live from the account_events StakeTransferred stream. Mirrors GET /api/v1/chain/stake-transfers's data envelope. */
         ChainStakeTransfersArtifact: {
             intensity_distribution: {
                 count: number;
@@ -6727,9 +6873,11 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Network-wide stake-transfer rollup: every subnet with StakeTransferred events in the window, combined. distinct_senders counts an origin coldkey once even when it transfers out of several subnets. */
             network: {
                 distinct_senders: number;
                 transfers: number;
+                /** @description Null when distinct_senders is 0. */
                 transfers_per_sender: number | null;
             };
             observed_at: string | null;
@@ -6759,10 +6907,12 @@ export interface components {
             next_cursor?: string | null;
             offset?: number | null;
             schema_version: number;
+            /** @description Distinct subnets appearing in this page -- context for entry_count. */
             subnet_count: number;
         } & {
             [key: string]: unknown;
         };
+        /** @description Network-wide directed native-TAO transfer-corridor leaderboard over a lookback window. Mirrors GET /api/v1/chain/transfer-pairs's data envelope. */
         ChainTransferPairsArtifact: {
             observed_at: string | null;
             pair_count: number;
@@ -6775,14 +6925,19 @@ export interface components {
                 volume_tao: number;
             }[];
             schema_version: number;
-            /** @enum {string} */
+            /**
+             * @description The rank order actually applied: volume or count.
+             * @enum {string}
+             */
             sort: "volume" | "count";
+            /** @description Highest-volume corridor's share of total pairable volume; null when the window has no pairable volume. */
             top_pair_share: number | null;
             total_volume_tao: number;
             transfer_count: number;
             unique_pairs: number;
             window: string | null;
         };
+        /** @description Network-wide native-TAO transfer analytics over a lookback window. Mirrors GET /api/v1/chain/transfers's data envelope. */
         ChainTransfersArtifact: {
             observed_at: string | null;
             schema_version: number;
@@ -6791,6 +6946,7 @@ export interface components {
                 transfer_count: number;
                 volume_tao: number;
             }[];
+            /** @description Top senders' combined share of total volume; null when total volume is 0. */
             top_sender_share: number | null;
             top_senders: {
                 address: string;
@@ -6803,11 +6959,17 @@ export interface components {
             unique_senders: number;
             window: string | null;
         };
+        /** @description Network-wide validator-set churn across all subnets (#5686). Mirrors GET /api/v1/chain/turnover's data envelope. */
         ChainTurnoverArtifact: {
+            /** @description False when the window resolved to fewer than two distinct snapshots, so start/end churn is not measurable. */
             comparable: boolean;
+            /** @description End snapshot date; null on a cold store. */
             end_date: string | null;
+            /** @description Network-wide validator-set rollup: every subnet's validators combined, deduplicated across the network. */
             network: {
+                /** @description 0-100 stability score; null on a cold/non-comparable window. */
                 stability_score: number | null;
+                /** @description Jaccard retention of the start set into the end set; null on a cold/non-comparable window. */
                 validator_retention: number | null;
                 validators_end: number;
                 validators_entered: number;
@@ -6815,6 +6977,7 @@ export interface components {
                 validators_start: number;
             };
             schema_version: number;
+            /** @description Null when no subnet had a stability score in the window (nothing to distribute). */
             stability_distribution: {
                 count: number;
                 max: number;
@@ -6825,6 +6988,7 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Start snapshot date; null on a cold store. */
             start_date: string | null;
             subnet_count: number;
             subnets: {
@@ -6838,6 +7002,7 @@ export interface components {
             }[];
             window: ("7d" | "30d" | "90d") | null;
         };
+        /** @description Network-wide validator weight-setting activity over a lookback window, summed live from the account_events WeightsSet stream. Mirrors GET /api/v1/chain/weights. */
         ChainWeightsArtifact: {
             intensity_distribution: {
                 count: number;
@@ -6849,8 +7014,10 @@ export interface components {
                 p75: number;
                 p90: number;
             } | null;
+            /** @description Network-wide weight-setting rollup: every subnet that set weights in the window, combined. */
             network: {
                 distinct_setters: number;
+                /** @description Null when distinct_setters is 0 (no defined intensity without setters). */
                 sets_per_setter: number | null;
                 weight_sets: number;
             };
@@ -6875,6 +7042,7 @@ export interface components {
                 hotkey: string | null;
                 last_set_at: string | null;
                 netuid: number | null;
+                /** @description This setter's share of the network total weight_sets; null when the network total is 0. */
                 share: number | null;
                 uid: number | null;
                 weight_sets: number;
@@ -6882,6 +7050,7 @@ export interface components {
             weight_sets: number;
             window: ("7d" | "30d") | null;
         };
+        /** @description Network-wide emission-yield (return rate) card across every subnet's neurons. Aggregates are null on a cold store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/chain/yield. */
         ChainYieldArtifact: {
             captured_at?: string | null;
             distribution: ({
@@ -6933,6 +7102,7 @@ export interface components {
             };
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -7017,7 +7187,9 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Several validators placed side by side (#6989). Mirrors GET /api/v1/compare/validators. */
         CompareValidatorsArtifact: {
+            /** @description The optional subnet context the comparison was scoped to. */
             netuid: number | null;
             schema_version: number;
             validator_count: number;
@@ -7026,6 +7198,7 @@ export interface components {
                 apy_estimate_eligible_subnet_count: number;
                 avg_validator_trust: number | null;
                 coldkey: string | null;
+                /** @description The coldkey's self-declared on-chain identity; opaque JSON, matching the REST/MCP shape. */
                 coldkey_identity: {
                     additional: string | null;
                     captured_at: string | null;
@@ -7040,6 +7213,7 @@ export interface components {
                 hotkey: string;
                 max_validator_trust: number | null;
                 nominator_count: number | null;
+                /** @description This validator's membership row in the requested netuid; null when netuid was omitted or it has no permit there. Opaque JSON, matching the REST/MCP shape. */
                 subnet_context: {
                     active: boolean;
                     axon: string | null;
@@ -7108,6 +7282,7 @@ export interface components {
             contract_version?: string;
             generated_at: string;
             name: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             openapi_url: "/metagraph/openapi.json";
@@ -7161,6 +7336,7 @@ export interface components {
             native_only_without_candidates: number;
             native_snapshot_captured_at: string;
             network: components["schemas"]["BittensorNetwork"];
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             probed_count: number;
             probed_surface_count: number;
@@ -7189,6 +7365,7 @@ export interface components {
             contract_version?: string;
             coverage_depth_version: number;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             ranked_queue: {
                 name: string;
@@ -7339,6 +7516,7 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
@@ -7359,6 +7537,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Network-wide public evidence ledger page. Mirrors GET /api/v1/evidence (and MCP list_evidence). */
         CurationArtifact: {
             contract_version?: string;
             curation: {
@@ -7377,6 +7556,7 @@ export interface components {
                 surface_count: number;
             }[];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -7393,13 +7573,16 @@ export interface components {
             source_count?: number;
             verified_at?: string | null;
         };
+        /** @description The per-domain rollup overview across the fixed capability taxonomy (#6989). Mirrors GET /api/v1/domains. */
         DomainsArtifact: {
             domain_count: number;
             domains: components["schemas"]["DomainSummaryArtifact"][];
             schema_version: number;
         };
+        /** @description One domain/capability tag's rollup (#6989). Mirrors GET /api/v1/domains/{tag}/summary. */
         DomainSummaryArtifact: {
             domain: string;
+            /** @description Within-domain emission concentration scorecard; null when the domain has no members. Declared Float until #9889 — the route has served the full 12-key scorecard for long enough that the scalar coerced to null on every domain, which this type's own comment then read as 'no members'. */
             emission_concentration: {
                 entropy: number | null;
                 entropy_normalized: number | null;
@@ -7423,11 +7606,15 @@ export interface components {
         };
         EconomicsArtifact: {
             captured_at: string | null;
+            /** @description The chain state the decomposition's inputs were pinned to. theta/q/h are read AS STORED at this block -- the runtime gates with the stored bar between its 360-block recomputes, so a live read is the wrong number for 359 blocks out of 360. */
             chain_state?: {
                 block: number;
+                /** @description The block hash, so the pinning is exact -- a height alone is ambiguous across a reorg. */
                 block_hash: string;
                 emission_bar_quantile: number | null;
+                /** @description theta. Null when the bar is unset, which disables the gate outright. */
                 emission_gate_bar: number | null;
+                /** @description h. Null means the runtime default 3, NOT zero -- h = 0 makes the Hill gate a constant 0.5 for every subnet. */
                 emission_gate_exponent: number | null;
                 total_issuance_tao: number;
             };
@@ -7444,6 +7631,7 @@ export interface components {
             };
             generated_at: string;
             network: string | null;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -7454,9 +7642,13 @@ export interface components {
                 alpha_market_cap_tao: number | null;
                 alpha_out_emission?: number | null;
                 alpha_out_pool: number | null;
+                /** @description Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227). */
                 alpha_price_change_1d?: number | null;
+                /** @description Signed %-change in alpha_price_tao over ~1h. Always null from daily snapshots (#7227). */
                 alpha_price_change_1h?: number | null;
+                /** @description Signed %-change in alpha_price_tao over ~30 days from subnet_snapshots (#7227). */
                 alpha_price_change_1m?: number | null;
+                /** @description Signed %-change in alpha_price_tao over ~7 days from subnet_snapshots (#7227). */
                 alpha_price_change_7d?: number | null;
                 /** @description The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that. */
                 alpha_price_tao: number | null;
@@ -7493,9 +7685,12 @@ export interface components {
             summary: {
                 registration_open_count: number;
                 subnet_count: number;
+                /** @description Sum of every non-root subnet's alpha_market_cap_tao -- rao-precision decimal string (#6641). */
                 total_alpha_value_tao: string;
                 total_miners: number;
+                /** @description total_root_value_tao + total_alpha_value_tao -- Backprop's Total Network Value (#6641). */
                 total_network_value_tao: string;
+                /** @description Root (netuid 0) TAO-denominated stake -- rao-precision decimal string (#6641). */
                 total_root_value_tao: string;
                 total_stake_alpha: string;
                 total_validators: number;
@@ -7513,6 +7708,7 @@ export interface components {
                 miner_count?: number | null;
                 snapshot_date: string;
                 subnet_count: number;
+                /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet reporting that day -- exceeds the exact-double ceiling as a JSON number, so it is served as a string rather than Float. */
                 total_stake_alpha?: string | null;
                 validator_count?: number | null;
             }[];
@@ -7538,6 +7734,7 @@ export interface components {
             kind: string | null;
             latest_change_at: string | null;
             limit: number | null;
+            /** @description How many returned entries are first observations rather than changes. */
             predates_capture_count: number;
             schema_version: number;
         } & {
@@ -7555,23 +7752,32 @@ export interface components {
             source: ("governance" | "runtime_recomputed") | null;
             value: number | null;
         };
+        /** @description The v440 emission pipeline replayed over one pinned block (#8744) -- the per-subnet share decomposition, the network aggregate, and the identity checks evaluated on the rows being served. */
         EmissionPipelineArtifact: {
+            /** @description Network-wide totals across every row in the capture -- unchanged by the netuid argument, which narrows the per-subnet rows only. */
             aggregate: {
                 disabled_count: number;
                 eligible_count: number;
                 excess_tao: number;
+                /** @description The network split nobody else publishes: pool injection vs chain buys. */
                 liquidity_fraction: number | null;
                 tao_in_emission: number;
                 tao_total: number;
+                /** @description Sum of final_share. 1.0 to float precision, or the surface is broken. */
                 total_final_share: number;
             };
             block_emission_halvings: number | null;
+            /** @description Block emission derived from TotalIssuance at that block, never read from the stale BlockEmission storage item. */
             block_emission_tao: number | null;
+            /** @description The block every input below was pinned to. Required: without it nothing here can be verified. */
             chain_state: {
                 block: number;
+                /** @description The block hash, so the pinning is exact -- a height alone is ambiguous across a reorg. */
                 block_hash: string;
                 emission_bar_quantile: number | null;
+                /** @description theta. Null when the bar is unset, which disables the gate outright. */
                 emission_gate_bar: number | null;
+                /** @description h. Null means the runtime default 3, NOT zero -- h = 0 makes the Hill gate a constant 0.5 for every subnet. */
                 emission_gate_exponent: number | null;
                 total_issuance_tao: number;
             };
@@ -7591,22 +7797,34 @@ export interface components {
             subnets: {
                 alpha_in_emission: number | null;
                 alpha_out_emission: number | null;
+                /** @description weighted_share / theta. Null when the bar is unset. */
                 distance_to_bar: number | null;
+                /** @description PUBLISHED, NOT INFERRED. A subnet far enough below the bar has its gated share underflow to exactly 0, so an enabled-but-deeply-gated subnet and a disabled one both read final_share: 0 -- this flag is the only thing that separates them. */
                 emission_enabled: boolean;
+                /** @description Stage 1, the published emission_share (ADR 0023 decision 1) -- the PRICE share, not the share of TAO received. */
                 emission_share: number | null;
+                /** @description Stage 7, measured: the TAO that reached the subnet by chain buys instead. */
                 excess_tao: number | null;
                 final_share: number | null;
+                /** @description gated_share - weighted_share. Sums to ~0 across the network: the gate redistributes, it never withholds. */
                 gate_delta: number | null;
                 gated_share: number | null;
+                /** @description Non-null (root, never_emitted, subtoken_disabled, registration_closed) means the subnet took no part in stage 1, and every downstream share is null rather than 0 -- 'not in the distribution' is not 'in it with nothing'. */
                 ineligible_reason: ("root" | "never_emitted" | "subtoken_disabled" | "registration_closed") | null;
+                /** @description tao_in_emission / tao_total, the headline per-subnet number. Null rather than NaN for a zero-intake subnet: 0/0 is not a fraction, and zero intake is a real state. */
                 liquidity_fraction: number | null;
+                /** @description Stage 2 input. A FRACTION in [0,1], never an amount. */
                 miner_burned: number;
                 netuid: number;
+                /** @description Stage 8, measured: the TAO injected into the subnet's pool this block. */
                 tao_in_emission: number | null;
+                /** @description Their sum -- the subnet's whole TAO intake this block. Null unless both channels were actually read. */
                 tao_total: number | null;
                 weighted_share: number | null;
             }[];
+            /** @description The four identities, evaluated on the rows being served rather than read from a stored flag -- a stored flag can be green while THIS response is broken, and it can go stale. ADR 0023 decision 3. */
             verification: {
+                /** @description A rao count as a string -- the tolerance is a bigint, and a JSON number is the wrong type for one. */
                 aggregate_tolerance_rao: string;
                 checks: {
                     detail: string;
@@ -7614,6 +7832,7 @@ export interface components {
                     ok: boolean;
                 }[];
                 subnet_share_tolerance: number;
+                /** @description False means at least one identity did not hold on these rows: the response is not defensible and must not be used. */
                 verified: boolean;
             };
         } & {
@@ -7665,6 +7884,7 @@ export interface components {
             contract_version?: string;
             generated_at: string;
             incidents: components["schemas"]["EndpointIncident"][];
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -7691,6 +7911,7 @@ export interface components {
             source: string;
             timeout_ms?: number | null;
         };
+        /** @description Endpoint pool scores (#6570): same pools[] row shape, filter/sort/page surface, and pagination metadata as PoolList. Split from it in #9892 for the one field that differs -- operational_observed_at, which GET /api/v1/endpoint-pools does not serve at all, because endpoint pools carry no live cron eligibility overlay and so have no observation stamp to report. The shared type declared it anyway and GraphQL answered null, which reads as not-observed-yet rather than never-observed-here. */
         EndpointPoolsArtifact: {
             contract_version?: string;
             disabled_proxy_contract?: {
@@ -7715,6 +7936,7 @@ export interface components {
                 [key: string]: unknown;
             };
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             pools: components["schemas"]["RpcPool"][];
             provider_scores?: {
@@ -7791,6 +8013,7 @@ export interface components {
             endpoints: components["schemas"]["EndpointResource"][];
             generated_at: string;
             health_source?: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             operational_observed_at?: string | null;
             /** @constant */
@@ -7852,6 +8075,7 @@ export interface components {
             claims: components["schemas"]["EvidenceClaim"][];
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -7864,6 +8088,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Live EVM (H160) -> Substrate (SS58) account-address mapping read from chain via RPC. ss58 is null when the mapping cannot be resolved (schema-stable, never a GraphQL error). Mirrors GET /api/v1/evm/address/{h160}. */
         EvmAddressMappingArtifact: {
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
             field_sources: {
@@ -7933,12 +8158,17 @@ export interface components {
         FailureReason: {
             checks: number;
             classification: string;
+            /** @description Of the FAILING probes only; null on a succeeding classification, where the question does not apply. */
             failure_share: number | null;
+            /** @description redirected is NOT a failure -- a surface answering from a new location is serving. */
             is_failure: boolean;
+            /** @description Of every probe in the window. */
             share: number | null;
         };
         FailureReasonsArtifact: {
+            /** @description Counted from the ROWS, not the requested window -- a day the prober did not run is absent rather than a zero. */
             days_covered: number | null;
+            /** @description Present ONLY on a decline. An empty window is a measurement, not a decline. */
             degraded?: {
                 /** @enum {string} */
                 reason: "unavailable";
@@ -7951,6 +8181,7 @@ export interface components {
             oldest_day: string | null;
             reasons: components["schemas"]["FailureReason"][];
             schema_version: number;
+            /** @description Oldest day first. */
             series: components["schemas"]["FailureReasonsDay"][];
             total_checks: number | null;
             window: string | null;
@@ -7958,6 +8189,7 @@ export interface components {
             [key: string]: unknown;
         };
         FailureReasonsDay: {
+            /** @description Checks per classification on this day, as a JSON object. */
             by_classification: {
                 [key: string]: number;
             };
@@ -7972,6 +8204,7 @@ export interface components {
             generated_at: string;
             kind: components["schemas"]["SurfaceKind"];
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             request: {
                 /** @constant */
@@ -8026,6 +8259,7 @@ export interface components {
             })[];
             generated_at: string;
             missing_count?: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             published_at?: string | null;
             /** @constant */
@@ -8039,6 +8273,7 @@ export interface components {
         FreshnessArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -8088,6 +8323,7 @@ export interface components {
             moving_target_surfaces?: string[];
             supported_kinds: components["schemas"]["SurfaceKind"][];
         };
+        /** @description Registry-wide interface gap report page. Mirrors GET /api/v1/gaps (and MCP list_gaps). */
         GapsArtifact: {
             contract_version?: string;
             gaps: {
@@ -8103,6 +8339,7 @@ export interface components {
                 slug: string;
             }[];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -8114,11 +8351,13 @@ export interface components {
             generated_at?: "1970-01-01T00:00:00.000Z";
         };
         GenericArtifact: components["schemas"]["ArtifactBase"];
+        /** @description Global endpoint-incident ledger (#5660). Mirrors GET /api/v1/incidents' data envelope. */
         GlobalIncidentsArtifact: {
             min_incident_samples: number;
             observed_at?: string | null;
             schema_version: number;
             source: string;
+            /** @description Aggregate counts -- incident_count, active_count, and by_kind/by_layer/by_provider/by_severity/by_status maps. Opaque JSON: the by_* maps are dynamic-keyed, matching the MCP get_global_incidents summary shape. */
             summary: {
                 affected_surface_count: number;
                 incident_count: number;
@@ -8223,6 +8462,7 @@ export interface components {
             /** @description Badge right-hand text. Currently the same value as `status`, kept separate because the badge's wording is a display concern and the verdict is not. */
             message: string;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             ok_count?: number;
             /** @constant */
@@ -8237,6 +8477,7 @@ export interface components {
             contract_version?: string;
             date: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             probe_finished_at: string | null;
             probe_started_at: string | null;
@@ -8267,12 +8508,14 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One subnet's per-surface SLA + reconstructed downtime incidents over the window. Mirrors GET /api/v1/subnets/{netuid}/health/incidents's data envelope. */
         HealthIncidentsArtifact: {
             min_incident_samples: number;
             netuid: number;
             observed_at?: string | null;
             schema_version: number;
             source: string;
+            /** @description Per operational surface: its sample count, uptime_ratio, incident_count, total downtime_ms, and gap-island incident list (started_at/ended_at/duration_ms/failed_samples, epoch-ms). Opaque JSON passed through verbatim, matching the get_subnet_health_incidents MCP/REST shape (like SubnetHealthTrends.windows). */
             surfaces: ({
                 downtime_ms: number;
                 incident_count: number;
@@ -8299,6 +8542,7 @@ export interface components {
         HealthLatestArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @description When the probe run that produced this rollup finished -- `probe_finished_at || observed_at || null`, not the build's `generated_at`. */
             observed_at: string | null;
@@ -8319,11 +8563,13 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One subnet's per-surface success-only latency percentiles (#6980). Mirrors GET /api/v1/subnets/{netuid}/health/percentiles' data envelope. */
         HealthPercentilesArtifact: {
             netuid: number;
             observed_at?: string | null;
             schema_version: number;
             source: string;
+            /** @description Per operational surface: its success-only latency sample count and p50/p90/p95/p99 latency percentiles in ms. Opaque JSON passed through verbatim, matching the get_subnet_health_percentiles MCP/REST shape (like SubnetHealthIncidents.surfaces). */
             surfaces: ({
                 latency_ms: {
                     avg: number | null;
@@ -8458,11 +8704,13 @@ export interface components {
             url: string;
             verified_at?: string | null;
         };
+        /** @description One subnet's uptime + latency trend windows. Mirrors GET /api/v1/subnets/{netuid}/health/trends's data envelope. */
         HealthTrendsArtifact: {
             netuid: number;
             observed_at?: string | null;
             schema_version: number;
             source: string;
+            /** @description The 7d/30d windows keyed by window label, each holding this subnet's samples, uptime_ratio, latency_sample_count and the per-surface uptime/latency series. Opaque JSON: dynamic-keyed by window label, matching the get_subnet_health_trends MCP/REST shape. */
             windows: {
                 [key: string]: {
                     latency_sample_count: number;
@@ -8492,21 +8740,26 @@ export interface components {
             [key: string]: unknown;
         };
         IndexerLagArtifact: {
+            /** @description Blocks the distribution was computed over. Null only on a decline. */
             block_count: number | null;
+            /** @description Present ONLY on a decline; its absence says the measurement is real. */
             degraded?: {
                 detail?: string;
                 /** @enum {string} */
                 reason: "no_retained_blocks" | "unavailable";
             };
+            /** @description now - the newest observed_at. The number that moves when the lane stalls. */
             head_age_ms: number | null;
             /** Format: date-time */
             measured_at: string;
             schema_version: number;
+            /** @description What was actually measured -- the table is pruned, so a distribution without its bounds would read as a lifetime one. */
             window: components["schemas"]["IndexerLagWindow"] | null;
             write_latency_ms: components["schemas"]["IndexerLagLatency"] | null;
         } & {
             [key: string]: unknown;
         };
+        /** @description Milliseconds from a block's own timestamp to the moment it became queryable here. Unbounded below: a negative value is block-author clock skew, served as measured. */
         IndexerLagLatency: {
             max: number | null;
             mean: number | null;
@@ -8569,6 +8822,7 @@ export interface components {
             matched_by_counts?: {
                 [key: string]: number;
             };
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             published_at?: string | null;
             /** @constant */
@@ -8609,6 +8863,7 @@ export interface components {
             /** @constant */
             schema_version: 1;
         };
+        /** @description Live global Subtensor protocol/governance parameters, read live from chain via RPC. Each field is independently null on its own RPC failure (schema-stable). Mirrors GET /api/v1/network/parameters's data envelope. */
         NetworkParametersArtifact: {
             block_emission_halvings?: number | null;
             block_emission_tao?: number | null;
@@ -8635,10 +8890,12 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One neuron's live metagraph detail card (#5900). Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}: neuron is null when that UID is absent from the latest snapshot. */
         NeuronDetailArtifact: {
             block_number?: number | null;
             captured_at?: string | null;
             netuid: number;
+            /** @description The UID's live metagraph row; null when absent from the latest snapshot. */
             neuron: {
                 active: boolean;
                 /** @description The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541). */
@@ -8650,7 +8907,9 @@ export interface components {
                 emission_tao?: number | null;
                 featured?: boolean;
                 hotkey: string | null;
+                /** @description Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block/timestamp at ~12s/block; null if that anchor is unavailable (#6640). */
                 immunity_expires_at?: string | null;
+                /** @description The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640). */
                 immunity_expires_at_block?: number;
                 incentive?: number | null;
                 is_immunity_period?: boolean;
@@ -8659,6 +8918,7 @@ export interface components {
                 registered_at_block?: number | null;
                 /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao?: number | null;
+                /** @description Validator take/commission (0..1) from SubtensorModule::Delegates; null when no Delegates entry at capture. */
                 take?: number | null;
                 trust?: number | null;
                 uid: number;
@@ -8669,6 +8929,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One neuron's per-day metagraph history. Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}/history. */
         NeuronHistoryArtifact: {
             netuid: number;
             point_count: number;
@@ -8685,7 +8946,9 @@ export interface components {
                 emission_tao?: number | null;
                 featured?: boolean;
                 hotkey: string | null;
+                /** @description Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block/timestamp at ~12s/block; null if that anchor is unavailable (#6640). */
                 immunity_expires_at?: string | null;
+                /** @description The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640). */
                 immunity_expires_at_block?: number;
                 incentive?: number | null;
                 is_immunity_period?: boolean;
@@ -8695,6 +8958,7 @@ export interface components {
                 snapshot_date: string;
                 /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao?: number | null;
+                /** @description Validator take/commission (0..1) from SubtensorModule::Delegates; null when no Delegates entry at capture. */
                 take?: number | null;
                 trust?: number | null;
                 uid: number;
@@ -8735,6 +8999,7 @@ export interface components {
             generated_at: string;
             /** @description The operational surface kinds this list is filtered to (OPERATIONAL_SURFACE_KINDS), sorted. */
             kinds: string[];
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -8806,15 +9071,19 @@ export interface components {
          */
         PartnershipTier: "pilot";
         PipelineHistoryArtifact: {
+            /** @description Present ONLY on a decline. An empty series is a measurement. */
             degraded?: {
                 /** @enum {string} */
                 reason: "unavailable";
             };
+            /** @description Independent samples -- the honest denominator for any claim about how a value moved. */
             distinct_observations: number | null;
+            /** @description The first day the pipeline columns were ever written, so a short series reads as a start rather than a gap. */
             first_captured_day: string;
             netuid: number;
             newest_day: string | null;
             oldest_day: string | null;
+            /** @description Rows returned. NOT the number of times the pipeline was read. */
             point_count: number | null;
             points: components["schemas"]["PipelineHistoryPoint"][];
             schema_version: number;
@@ -8830,12 +9099,16 @@ export interface components {
             day: string;
             emission_enabled: boolean | null;
             emission_share: number | null;
+            /** @description Chain buys. */
             excess_tao: number | null;
             first_emission_block: number | null;
             miner_burned_fraction: number | null;
+            /** @description The chain state this point describes. A point that cannot say which block it came from is not served. */
             pipeline_block: number;
             pipeline_block_hash: string | null;
+            /** @description True when the snapshot writer carried the previous capture forward: this point is NOT an independent sample. */
             repeats_previous_observation: boolean;
+            /** @description Pool liquidity injection. */
             tao_in_emission_tao: number | null;
             tao_in_pool_tao: number | null;
         };
@@ -8878,6 +9151,7 @@ export interface components {
             contract_version?: string;
             endpoint_summary?: components["schemas"]["EndpointSummary"];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             provider: components["schemas"]["Provider"];
             /** @constant */
@@ -8889,6 +9163,7 @@ export interface components {
             contract_version?: string;
             endpoints: components["schemas"]["EndpointResource"][];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             provider: {
                 authority?: string;
@@ -8909,6 +9184,7 @@ export interface components {
         ProvidersArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             providers: components["schemas"]["Provider"][];
             /** @constant */
@@ -8945,6 +9221,7 @@ export interface components {
              * @enum {string}
              */
             manifest_kind?: "compact" | "full";
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @description Artifact paths the publish step must find in the archive even though the compact manifest omits them. */
             required_artifact_paths?: string[];
@@ -8969,6 +9246,7 @@ export interface components {
             /** @enum {string} */
             storage_tier: "dual" | "git" | "r2";
         };
+        /** @description Live drand randomness-beacon status read from chain via RPC. Each field is independently null on its own RPC failure (schema-stable). Mirrors GET /api/v1/network/randomness's data envelope. */
         RandomnessArtifact: {
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
             field_sources: {
@@ -8988,8 +9266,11 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Registry leaderboards over the operational + economic-opportunity boards. Mirrors GET /api/v1/registry/leaderboards. */
         RegistryLeaderboardsArtifact: {
+            /** @description The board filter that was applied, or null when every board is returned. */
             board?: string | null;
+            /** @description Every board keyed by board name, each an array of ranked subnet entries capped at limit. Opaque JSON like HealthTrends.windows: the keys are dynamic AND hyphenated (fastest-rpc, most-complete, open-slots, …) so they are not expressible as GraphQL field names, and each board carries its own metric columns (healthiest has uptime_ratio/surfaces_ok, fastest-rpc has latency_ms, fastest-growing has completeness_delta, …). Passing it through verbatim keeps the REST/MCP get_registry_leaderboards shape byte-for-byte. */
             boards: {
                 [key: string]: ({
                     alpha_price_change_1d?: number | null;
@@ -9067,6 +9348,7 @@ export interface components {
             }) | null;
             curation_level_counts?: components["schemas"]["CountMap"];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             profile_level_counts?: components["schemas"]["CountMap"];
             recent_changes?: {
@@ -9153,6 +9435,7 @@ export interface components {
             candidates: components["schemas"]["ReviewAdapterCandidate"][];
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -9175,6 +9458,7 @@ export interface components {
             contract_version?: string;
             gap_priorities: components["schemas"]["ReviewGapPriority"][];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             review_decisions: components["schemas"]["ReviewDecision"][];
             /** @constant */
@@ -9205,6 +9489,7 @@ export interface components {
             contract_version?: string;
             decisions: components["schemas"]["ReviewDecision"][];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -9426,6 +9711,7 @@ export interface components {
         ReviewGapPrioritiesArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             priorities: components["schemas"]["ReviewGapPriority"][];
             /** @constant */
@@ -9449,6 +9735,7 @@ export interface components {
         ReviewProfileCompletenessArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             profiles: {
                 candidate_count: number;
@@ -9548,6 +9835,7 @@ export interface components {
                 url: string;
             }[];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -9603,6 +9891,7 @@ export interface components {
             id: string;
             kind: string;
         };
+        /** @description RPC pool scores (#6570): same pools[] row shape, filter/sort/page surface, and pagination metadata as EndpointPoolList, plus operational_observed_at -- real here and only here, since the RPC pools are the ones carrying a live 15-minute cron eligibility overlay. */
         RpcPoolsArtifact: {
             contract_version?: string;
             disabled_proxy_contract?: {
@@ -9627,6 +9916,7 @@ export interface components {
                 [key: string]: unknown;
             };
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             pools: components["schemas"]["RpcPool"][];
             provider_scores?: {
@@ -9647,8 +9937,11 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description RPC reverse-proxy usage analytics over a 7d/30d window. Mirrors GET /api/v1/rpc/usage's data envelope. */
         RpcUsageArtifact: {
+            /** @description Time-bucket granularity for buckets: 1h for the 7d window, 6h for 30d. Null on a cold store. */
             bucket_granularity?: string | null;
+            /** @description Bounded time buckets over the window for heatmaps, oldest-first. */
             buckets: ({
                 avg_latency_ms: number | null;
                 errors: number;
@@ -9657,28 +9950,38 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
+            /** @description What the answer is actually about, as opposed to what window was asked for. */
             coverage: {
+                /** @description Epoch ms of the newest measured event across every contributing store, or null when nothing was measured. */
                 end: number | null;
+                /** @description The sub-range summary.latency_ms p50/p95 describe, or null when nothing measured them. Counts are additive across disjoint ranges; percentiles are not, so they stay scoped to the one store that has a percentile function. */
                 latency_percentiles: ({
                     end: number | null;
                     start: number | null;
                 } & {
                     [key: string]: unknown;
                 }) | null;
+                /** @description One entry per contributing store, oldest first. Two non-adjacent entries mean the window has a hole between them that no store covers. */
                 segments: ({
+                    /** @description Epoch ms of this store's newest measured event in the window. */
                     end: number | null;
+                    /** @description Which store measured it: analytics-engine (live capture) or lakehouse (frozen history). */
                     source: string;
+                    /** @description Epoch ms of this store's oldest measured event in the window. */
                     start: number | null;
                 } & {
                     [key: string]: unknown;
                 })[];
+                /** @description Epoch ms of the oldest measured event across every contributing store, or null when nothing was measured. */
                 start: number | null;
             } & {
                 [key: string]: unknown;
             };
+            /** @description Per-endpoint request distribution, ranked by request volume (top 50). */
             endpoints: ({
                 avg_latency_ms?: number | null;
                 endpoint_id: string | null;
+                /** @description Null when the endpoint had no requests in the window. */
                 error_rate?: number | null;
                 ok_requests: number;
                 provider?: string | null;
@@ -9687,7 +9990,9 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
+            /** @description Per-network request breakdown, ordered by request volume. */
             networks: ({
+                /** @description Null when the network had no requests in the window. */
                 error_rate?: number | null;
                 network: string;
                 ok_requests: number;
@@ -9702,13 +10007,18 @@ export interface components {
             observed_at?: number | null;
             schema_version: number;
             source: string;
+            /** @description Window-total rollup for RPC reverse-proxy traffic. */
             summary: {
+                /** @description Null when there are no requests in the window. */
                 cache_hit_rate?: number | null;
                 cache_hits?: number;
+                /** @description Null when there are no requests in the window (no defined rate). */
                 error_rate?: number | null;
                 error_requests: number;
+                /** @description Null when there are no requests in the window. */
                 failover_rate?: number | null;
                 failover_requests?: number;
+                /** @description Window latency percentiles + average for RPC reverse-proxy traffic; each is null on a cold store. */
                 latency_ms?: {
                     avg?: number | null;
                     p50?: number | null;
@@ -9725,6 +10035,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Site-wide runtime spec-version transition timeline. Mirrors GET /api/v1/runtime. */
         RuntimeVersionsArtifact: {
             coverage_complete: boolean;
             coverage_from_at: string | null;
@@ -9750,6 +10061,7 @@ export interface components {
         SchemaDriftArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @description When the snapshot run observed these surfaces -- NOT the build's `generated_at`. A rebuild republishes an old capture unchanged, so this is the only field that says how old the drift verdict is. Absent on the build-time placeholder, which observed nothing. */
             observed_at?: string | null;
@@ -9798,6 +10110,7 @@ export interface components {
         SchemaIndexArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             observed_at?: string;
             /** @constant */
@@ -9884,6 +10197,7 @@ export interface components {
         SearchArtifact: {
             contract_version?: string;
             document_count?: number;
+            /** @description Heterogeneous per-type documents (subnet/surface/provider/doc), passed through verbatim as opaque JSON. */
             documents: {
                 artifact_path: string;
                 categories?: string[];
@@ -9899,12 +10213,14 @@ export interface components {
                 url?: string;
             }[];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
         } & {
             [key: string]: unknown;
         };
+        /** @description Filtered and paginated search-index documents with full REST list-query pagination metadata (#7877). Mirrors GET /api/v1/search-index (and MCP list_search_index). */
         SearchIndexArtifact: {
             contract_version?: string;
             document_count?: number;
@@ -9922,6 +10238,7 @@ export interface components {
                 url?: string;
             }[];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -9938,38 +10255,65 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description metagraphed's own uptime verdict (#8422). Mirrors GET /api/v1/self-health. */
         SelfHealthArtifact: {
             components: components["schemas"]["SelfHealthComponent"][];
             lanes: components["schemas"]["SelfHealthLane"][];
+            /** @description Components with data. Zero means the poller hasn't written anything yet. */
             measured_component_count: number;
             observed_at: string | null;
             schema_version: number;
             stale_lane_count: number;
-            /** @enum {string} */
+            /**
+             * @description operational | degraded | outage.
+             * @enum {string}
+             */
             verdict: "operational" | "degraded" | "outage";
         } & {
             [key: string]: unknown;
         };
+        /** @description One self-health component (api / site / publish): its latest probe state and trailing-90-day daily ratios. */
         SelfHealthComponent: {
             checked_at: string | null;
             component: string;
+            /** @description Null when the component has never been probed -- NOT false. */
             current_ok: boolean | null;
+            /** @description Trailing-90d daily ratios, oldest first; gaps are absent, never zero-filled. */
             days: components["schemas"]["SelfHealthDay"][];
             http_status: number | null;
             latency_ms: number | null;
+            /** @description Qualifies a false current_ok with why, for non-HTTP failure modes. Null when there's nothing to add. */
             note: string | null;
+            /** @description Mean uptime across the days we actually have. Null when there are none. */
             uptime_90d: number | null;
         } & {
             [key: string]: unknown;
         };
+        /** @description One UTC day's uptime ratio for a self-health component. Days with no probe rows are ABSENT, never zero-filled. */
         SelfHealthDay: {
             checks: number;
             day: string;
             ok_count: number;
+            /** @description ok_count / checks, 0..1. */
             uptime_ratio: number;
         } & {
             [key: string]: unknown;
         };
+        /**
+         * @description One ingest lane's staleness verdict.
+         *
+         *     Three of these five were declared non-null against a Zod schema that says
+         *     otherwise, and production proved it: \`self_health\` returned
+         *     \`Cannot return null for non-nullable field SelfHealthLane.detail\` and nulled
+         *     the whole \`lanes\` list. \`age_ms\` and \`checked_at\` are null for the same
+         *     reason -- the watchdog could not measure the lane, which is the "we did not
+         *     measure" this type exists to distinguish from "the lane is fine" (#10215).
+         *
+         *     \`age_ms\` is a Float because it is a duration in MILLISECONDS: a lane stale
+         *     for more than 24.8 days exceeds GraphQL's 32-bit Int, and the answer to
+         *     "how far behind is this lane" must not stop being representable exactly when
+         *     it starts to matter.
+         */
         SelfHealthLane: {
             age_ms: number | null;
             checked_at: string | null;
@@ -10003,6 +10347,7 @@ export interface components {
         SourceHealthArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             providers: {
                 authority: components["schemas"]["Authority"];
@@ -10038,6 +10383,7 @@ export interface components {
         SourceSnapshotsArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -10063,6 +10409,7 @@ export interface components {
         };
         /** @enum {string} */
         SourceTier: "native-chain" | "provider-claimed" | "third-party-index" | "community-docs";
+        /** @description One subnet's rolling 24h alpha trading volume (#6979). Mirrors GET /api/v1/subnets/{netuid}/volume' data envelope. */
         SubnetAlphaVolumeArtifact: {
             buy_count: number;
             buy_volume_alpha: number;
@@ -10073,16 +10420,25 @@ export interface components {
             sell_count: number;
             sell_volume_alpha: number;
             sell_volume_tao: number;
-            /** @enum {string} */
+            /**
+             * @description Bucketed reading of sentiment_ratio (buying/selling/neutral).
+             * @enum {string}
+             */
             sentiment: "bullish" | "bearish" | "neutral";
+            /** @description Buy share of total volume (0-1); null when there was no volume. */
             sentiment_ratio: number | null;
             total_volume_alpha: number;
             total_volume_tao: number;
+            /** @description Total TAO volume over alpha market cap; null when market cap is unknown. */
             vol_mcap_ratio: number | null;
-            /** @enum {string} */
+            /**
+             * @description The rolling window label this card covers (24h).
+             * @enum {string}
+             */
             window: "24h";
         };
         SubnetAxonRemovalsArtifact: {
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
@@ -10095,6 +10451,7 @@ export interface components {
             schema_version: number;
             window: ("7d" | "30d") | null;
         };
+        /** @description Live current registration/burn cost for one subnet, read directly from chain via RPC. burn_tao is null on RPC failure (schema-stable, never a GraphQL error). Mirrors GET /api/v1/subnets/{netuid}/burn. */
         SubnetBurnArtifact: {
             burn_tao?: number | null;
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
@@ -10136,6 +10493,7 @@ export interface components {
             generated_at: string;
             name?: string;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -10143,8 +10501,10 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Per-subnet stake & emission concentration card (#5901) over the current neurons snapshot. Metric blocks are null on a cold/empty subnet. Mirrors GET /api/v1/subnets/{netuid}/concentration. */
         SubnetConcentrationArtifact: {
             captured_at?: string | null;
+            /** @description Emission concentration across all UIDs. */
             emission: ({
                 entropy?: number | null;
                 entropy_normalized?: number | null;
@@ -10161,7 +10521,9 @@ export interface components {
             } & {
                 [key: string]: unknown;
             }) | null;
+            /** @description Distinct controlling entities (coldkeys) behind the subnet's UIDs. */
             entity_count: number;
+            /** @description Emission concentration collapsed to one holder per controlling entity. */
             entity_emission?: ({
                 entropy?: number | null;
                 entropy_normalized?: number | null;
@@ -10178,6 +10540,7 @@ export interface components {
             } & {
                 [key: string]: unknown;
             }) | null;
+            /** @description Stake concentration collapsed to one holder per controlling entity. */
             entity_stake?: ({
                 entropy?: number | null;
                 entropy_normalized?: number | null;
@@ -10197,6 +10560,7 @@ export interface components {
             netuid: number;
             neuron_count: number;
             schema_version: number;
+            /** @description Stake concentration across all UIDs. */
             stake: ({
                 entropy?: number | null;
                 entropy_normalized?: number | null;
@@ -10213,7 +10577,9 @@ export interface components {
             } & {
                 [key: string]: unknown;
             }) | null;
+            /** @description UIDs per controlling entity -- a Sybil/consolidation signal (1.0 = every UID a distinct owner; higher = fewer operators each running many hotkeys). Null on an empty subnet. */
             uids_per_entity?: number | null;
+            /** @description Stake concentration across permitted validators only. */
             validator_stake?: ({
                 entropy?: number | null;
                 entropy_normalized?: number | null;
@@ -10233,6 +10599,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Per-subnet per-day concentration trend (#5901) from the neuron_daily rollup, newest first. An empty series (point_count 0) on a cold store, never a GraphQL error. Mirrors GET /api/v1/subnets/{netuid}/concentration/history. */
         SubnetConcentrationHistoryArtifact: {
             netuid: number;
             point_count: number;
@@ -10249,10 +10616,12 @@ export interface components {
                 [key: string]: unknown;
             })[];
             schema_version: number;
+            /** @description The resolved window label (7d/30d/90d). */
             window?: string | null;
         } & {
             [key: string]: unknown;
         };
+        /** @description Live per-subnet conviction leaderboard -- who currently holds the most rolled conviction, rolled forward from a periodically-captured snapshot using the current live-queried unlock_rate/maturity_rate. Mirrors GET /api/v1/subnets/{netuid}/conviction. */
         SubnetConvictionArtifact: {
             count: number;
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
@@ -10280,22 +10649,28 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Per-subnet neuron-deregistration activity over a window (#5719). Zeroed card (0 counts) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/deregistrations. */
         SubnetDeregistrationsArtifact: {
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
             };
             deregistrations: number;
             deregistrations_per_hotkey: number | null;
+            /** @description How a deregistration feed was derived (#9307). NeuronDeregistered has never been emitted, so deregistrations are derived from UID reuse: a NeuronRegistered on a (netuid, uid) slot already held by a different hotkey IS the deregistration of the previous occupant. unattributed_registrations is the honest part -- the published totals are a LOWER BOUND by that many events, because those registrations displaced a holder the derivation's lookback cannot name. */
             derivation?: {
                 /**
                  * @description True when the count is a floor rather than a measurement: some registrations in the window displaced a holder the derivation's lookback cannot name, so the real figure is higher by at least `unattributed_registrations`. Treat the value as 'at least this many', never as a total.
                  * @example true
                  */
                 is_lower_bound: boolean;
+                /** @description Days of NeuronRegistered history the derivation had available. */
                 lookback_days: number;
                 method: string;
+                /** @description Of those, the ones with no observed previous holder. */
                 unattributed_registrations: number;
+                /** @description Registrations observed inside the reported window. */
                 window_registrations: number;
             };
             distinct_deregistered_hotkeys: number;
@@ -10416,9 +10791,13 @@ export interface components {
                 alpha_market_cap_tao: number | null;
                 alpha_out_emission?: number | null;
                 alpha_out_pool: number | null;
+                /** @description Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227). */
                 alpha_price_change_1d?: number | null;
+                /** @description Signed %-change in alpha_price_tao over ~1h. Always null from daily snapshots (#7227). */
                 alpha_price_change_1h?: number | null;
+                /** @description Signed %-change in alpha_price_tao over ~30 days from subnet_snapshots (#7227). */
                 alpha_price_change_1m?: number | null;
+                /** @description Signed %-change in alpha_price_tao over ~7 days from subnet_snapshots (#7227). */
                 alpha_price_change_7d?: number | null;
                 /** @description The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that. */
                 alpha_price_tao: number | null;
@@ -10455,6 +10834,7 @@ export interface components {
             endpoints?: components["schemas"]["EndpointResource"][];
             gaps: components["schemas"]["Gaps"];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -10471,6 +10851,7 @@ export interface components {
             health_source?: string;
             name?: string;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             operational_observed_at?: string | null;
             /** @constant */
@@ -10480,6 +10861,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One subnet's paginated first-party chain-event feed (#7172), newest first, offset-paginated. event_count is the page count, not a grand total. Each item is an AccountEvent. Empty feed on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/events' data envelope. */
         SubnetEventsArtifact: {
             event_count: number;
             events: components["schemas"]["AccountEvent"][];
@@ -10491,7 +10873,9 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One subnet's chain-event activity summary over a window (#6980). Mirrors GET /api/v1/subnets/{netuid}/event-summary' data envelope. */
         SubnetEventSummaryArtifact: {
+            /** @description Per event category: its kind list and rolled-up counts. Opaque JSON passed through verbatim, matching the get_subnet_event_summary MCP/REST shape. */
             categories: {
                 alpha_amount: number;
                 amount_tao: number;
@@ -10505,6 +10889,7 @@ export interface components {
                 last_observed_at: string | null;
             }[];
             category_count: number;
+            /** @description Per event kind: event_count, hotkey/coldkey participation counts, TAO/alpha amounts, and first/last block + observed_at. Opaque JSON passed through verbatim. */
             event_kinds: {
                 alpha_amount: number;
                 amount_tao: number;
@@ -10520,14 +10905,19 @@ export interface components {
                 last_observed_at: string | null;
             }[];
             kind_count: number;
+            /** @description The resolved recent-event cap actually applied (1-50, default 10). */
             limit: number;
             netuid: number;
             observed_at: string | null;
             recent_event_count: number;
+            /** @description The bounded newest-first recent-event list. Opaque JSON passed through verbatim. */
             recent_events: components["schemas"]["AccountEvent"][];
             schema_version: number;
             total_events: number;
-            /** @enum {string} */
+            /**
+             * @description The resolved window label (7d/30d/90d).
+             * @enum {string}
+             */
             window: "7d" | "30d" | "90d";
         } & {
             [key: string]: unknown;
@@ -10538,6 +10928,7 @@ export interface components {
             generated_at: string;
             name?: string;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -10598,6 +10989,7 @@ export interface components {
             generated_at: string;
             name?: string;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             priorities: components["schemas"]["ReviewGapPriority"][];
             /** @constant */
@@ -10606,6 +10998,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One subnet's daily history series (#7172) from the neuron_daily rollup, newest first. Empty series (point_count 0) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/history' data envelope. */
         SubnetHistoryArtifact: {
             netuid: number;
             point_count: number;
@@ -10621,35 +11014,46 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One coldkey's holding of a subnet's alpha, including alpha staked to hotkeys that hold no UID on that subnet. */
         SubnetHolder: {
+            /** @description ALPHA, not TAO. Within one subnet alpha is already a common unit, so there is no price conversion and none of its staleness -- multiply by the subnet's alpha_price_tao for TAO. */
             alpha: number;
             coldkey: string;
+            /** @description Distinct hotkeys this coldkey holds the subnet's alpha through -- registered on it or not, which is the part a neurons-sourced view misses. */
             hotkey_count: number | null;
+            /** @description This holder's alpha over the subnet's FULL measured total, so it means the same thing at limit 5 and limit 100. Null when the total is zero. */
             share_of_total: number | null;
         };
         SubnetHoldersArtifact: {
+            /** @description The pool pass every row was valued against. */
             captured_at: string | null;
             concentration: components["schemas"]["SubnetHoldersConcentration"];
+            /** @description Present ONLY on a decline. Its absence is what says the ranking is real -- an empty holders list with no degraded block means the subnet genuinely has no measured holders. */
             degraded?: components["schemas"]["SubnetHoldersDegraded"];
+            /** @description Distinct coldkeys holding this subnet's alpha -- the whole set, never the returned page's length. */
             holder_count: number | null;
             holders: components["schemas"]["SubnetHolder"][];
             limit: number | null;
             netuid: number;
+            /** @description When the positions ledger itself was last written, which advances on a different cadence than the pool totals. */
             positions_captured_at: string | null;
             schema_version: number;
             total_alpha: number | null;
         } & {
             [key: string]: unknown;
         };
+        /** @description Concentration of a subnet's alpha, each rank summed over the top N of the FULL holder set rather than the returned page. */
         SubnetHoldersConcentration: {
             top10_share: number | null;
             top20_share: number | null;
             top5_share: number | null;
         };
+        /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
         SubnetHoldersDegraded: {
             /** @enum {string} */
             reason: "pool_totals_unproven" | "root_not_in_alpha_map" | "unavailable";
         };
+        /** @description Per-subnet neuron-registration activity over a window (#5720). Zeroed card (0 counts) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/registrations. */
         SubnetHyperparametersArtifact: {
             block_number?: number | null;
             captured_at?: string | null;
@@ -10743,6 +11147,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Append-only on-chain subnet identity timeline (#1647 / #5721). Empty entries on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/identity-history. */
         SubnetIdentityHistoryArtifact: {
             entries: {
                 block_number?: number | null;
@@ -10765,6 +11170,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Per-subnet idle-stake scorecard (#7172). Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/idle-stake. */
         SubnetIdleStakeArtifact: {
             captured_at?: string | null;
             idle_neuron_count: number;
@@ -10845,6 +11251,7 @@ export interface components {
             updated_at?: string | null;
             website_url?: string | null;
         };
+        /** @description Live subnet-lease state -- whether a subnet is currently under a lease and, if so, its terms (beneficiary, coldkey, hotkey, emissions_share_percent, end_block, cost_tao) and accumulated-but-undistributed alpha dividends. leased is null (not false) on RPC failure, distinct from a confirmed no-lease (leased:false). Mirrors GET /api/v1/subnets/{netuid}/lease. */
         SubnetLeaseArtifact: {
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
             field_sources: {
@@ -10876,6 +11283,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Every SubnetLeaseCreated/SubnetLeaseTerminated event one subnet has had, decoded from the account_events stream. Mirrors GET /api/v1/subnets/{netuid}/lease/history. */
         SubnetLeaseHistoryArtifact: {
             count: number;
             event_kinds: string[];
@@ -10927,7 +11335,9 @@ export interface components {
                 emission_tao?: number | null;
                 featured?: boolean;
                 hotkey: string | null;
+                /** @description Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block/timestamp at ~12s/block; null if that anchor is unavailable (#6640). */
                 immunity_expires_at?: string | null;
+                /** @description The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640). */
                 immunity_expires_at_block?: number;
                 incentive?: number | null;
                 is_immunity_period?: boolean;
@@ -10936,6 +11346,7 @@ export interface components {
                 registered_at_block?: number | null;
                 /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao?: number | null;
+                /** @description Validator take/commission (0..1) from SubtensorModule::Delegates; null when no Delegates entry at capture. */
                 take?: number | null;
                 trust?: number | null;
                 uid: number;
@@ -10960,13 +11371,16 @@ export interface components {
                 neurons_start: number;
                 stake_delta_alpha: number;
                 stake_end_alpha: number;
+                /** @description Null when the start snapshot's stake was 0 (growth from nothing is undefined). */
                 stake_pct_change: number | null;
+                /** @description This subnet's share of network stake at the end snapshot; null when the network total is 0. */
                 stake_share_pct: number | null;
                 stake_start_alpha: number;
                 validators_delta: number;
                 validators_end: number;
                 validators_start: number;
             }[];
+            /** @description Network-wide boundary totals for the movers window, summed across every ranked subnet (not just the returned page). */
             network: {
                 gainers: number;
                 losers: number;
@@ -10975,6 +11389,7 @@ export interface components {
                 total_emission_start_alpha: string;
                 total_stake_delta_alpha: string;
                 total_stake_end_alpha: string;
+                /** @description Lossless fixed 9-decimal (rao-precision) TAO string -- exceeds the exact-double ceiling as a JSON number, so it is served as a string rather than Float. */
                 total_stake_start_alpha: string;
                 total_validators_delta: number;
                 total_validators_end: number;
@@ -10988,8 +11403,10 @@ export interface components {
             subnet_count: number;
             window: ("7d" | "30d" | "90d") | null;
         };
+        /** @description One subnet's alpha-price OHLC candles (#6979). Mirrors GET /api/v1/subnets/{netuid}/ohlc' data envelope. */
         SubnetOhlcArtifact: {
             candles: {
+                /** @description Bucket start as epoch milliseconds -- a Float, since epoch-ms exceeds GraphQL's 32-bit Int. */
                 bucket_start: number;
                 /** Format: date-time */
                 bucket_start_iso: string;
@@ -11001,9 +11418,13 @@ export interface components {
                 volume_alpha: number;
                 volume_tao: number;
             }[];
-            /** @enum {string} */
+            /**
+             * @description The resolved bucket interval (1h/1d).
+             * @enum {string}
+             */
             interval: "1h" | "1d";
             netuid: number;
+            /** @description True for root (netuid 0), whose 1:1 price makes candles meaningless, so none are emitted. */
             root_excluded: boolean;
             schema_version: number;
         };
@@ -11038,6 +11459,7 @@ export interface components {
             health_source?: string | null;
             name?: string;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             operational_observed_at?: string | null;
             profile: components["schemas"]["SubnetProfile"] | null;
@@ -11048,12 +11470,17 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Every automatic ownership transfer one subnet has undergone, decoded from the chain_events SubnetOwnerChanged stream. Mirrors GET /api/v1/subnets/{netuid}/ownership-history. */
         SubnetOwnershipHistoryArtifact: {
             count: number;
+            /** @description The chain_events method the authoritative records are decoded from. */
             event_method: string;
+            /** @description The chain_events pallet the authoritative records are decoded from. */
             event_pallet: string;
             netuid: number;
+            /** @description The newest owner observation for this subnet, ISO-8601 -- how far the observation source covers it at all, so watched-but-never-changed-hands is distinguishable from not-watched-since. Null when no observations were read. */
             observed_through?: string | null;
+            /** @description Each record carries a source: chain-event (announced on chain, block-stamped) or owner-observation (inferred from two consecutive owner captures, so observed_at is when the change was NOTICED and block_number is null). */
             ownership_changes: {
                 block_number?: number | null;
                 netuid?: number | null;
@@ -11066,21 +11493,28 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Per-subnet reward-distribution & score-spread card (#5714). Metric blocks are null on a cold/empty subnet. Mirrors GET /api/v1/subnets/{netuid}/performance. */
         SubnetPerformanceArtifact: {
             active_count?: number;
             captured_at?: string | null;
+            /** @description Consensus score spread across all neurons. */
             consensus: components["schemas"]["ScoreDistribution"];
+            /** @description Dividends concentration across permitted validators only. */
             dividends: components["schemas"]["ConcentrationMetrics"];
+            /** @description Incentive concentration across all neurons with positive incentive. */
             incentive: components["schemas"]["ConcentrationMetrics"];
             netuid: number;
             neuron_count: number;
             schema_version: number;
+            /** @description Trust score spread across all neurons. */
             trust: components["schemas"]["ScoreDistribution"];
             validator_count?: number;
+            /** @description Validator-trust score spread across permitted validators only. */
             validator_trust?: components["schemas"]["ScoreDistribution"];
         } & {
             [key: string]: unknown;
         };
+        /** @description Per-subnet per-day reward-distribution trend (#6981) from the neuron_daily rollup, newest first. An empty series (point_count 0) on a cold store, never a GraphQL error. The history twin of subnet_performance, mirroring GET /api/v1/subnets/{netuid}/performance/history. */
         SubnetPerformanceHistoryArtifact: {
             netuid: number;
             point_count: number;
@@ -11105,6 +11539,7 @@ export interface components {
                 [key: string]: unknown;
             })[];
             schema_version: number;
+            /** @description The resolved window label (7d/30d/90d). */
             window?: string | null;
         } & {
             [key: string]: unknown;
@@ -11242,6 +11677,7 @@ export interface components {
             endpoints: components["schemas"]["EndpointResource"][];
             gaps: components["schemas"]["Gaps"];
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             profile: components["schemas"]["SubnetProfile"];
             /** @constant */
@@ -11267,6 +11703,7 @@ export interface components {
         SubnetProfilesArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             profiles: components["schemas"]["SubnetProfile"][];
             /** @constant */
@@ -11290,9 +11727,11 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Per-subnet Prometheus-endpoint serving activity (#7172) over a 7d/30d window. Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/prometheus. */
         SubnetPrometheusArtifact: {
             announcements: number;
             announcements_per_exporter: number | null;
+            /** @description A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
             degraded?: {
                 detail?: string;
                 reason: string;
@@ -11303,6 +11742,7 @@ export interface components {
             schema_version: number;
             window: ("7d" | "30d") | null;
         };
+        /** @description Live cumulative TAO recycled for registration on one subnet, read directly from chain via RPC. recycled_tao is null on RPC failure (schema-stable, never a GraphQL error). Mirrors GET /api/v1/subnets/{netuid}/recycled. */
         SubnetRecycledArtifact: {
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
             field_sources: {
@@ -11334,6 +11774,7 @@ export interface components {
             contract_version?: string;
             generated_at: string;
             network: components["schemas"]["BittensorNetwork"];
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -11360,6 +11801,7 @@ export interface components {
             schema_version: number;
             window: ("7d" | "30d") | null;
         };
+        /** @description Per-subnet net stake flow (#7172) over a 7d/30d/90d window. Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/stake-flow' data envelope. */
         SubnetStakeFlowArtifact: {
             net_flow_tao: number;
             netuid: number;
@@ -11379,15 +11821,20 @@ export interface components {
             schema_version: number;
             window: ("7d" | "30d") | null;
         };
+        /** @description A read-only hypothetical stake/unstake quote against one subnet's live AMM pool (#6979). Mirrors GET /api/v1/subnets/{netuid}/stake-quote. */
         SubnetStakeQuoteArtifact: {
             alpha_in_pool: number | null;
             amount: number;
-            /** @enum {string} */
+            /**
+             * @description stake (spends TAO for alpha) or unstake (spends alpha for TAO).
+             * @enum {string}
+             */
             direction: "stake" | "unstake";
             effective_price_tao: number;
             expected_out: number;
             /** @enum {string} */
             expected_out_unit: "alpha" | "tao";
+            /** @description True for root (netuid 0), which quotes 1:1 with no price impact. */
             is_root: boolean;
             netuid: number;
             price_impact_pct: number;
@@ -11395,6 +11842,7 @@ export interface components {
             spot_price_tao: number;
             tao_in_pool_tao: number | null;
         };
+        /** @description Per-subnet stake-transfer activity (#5717) over a 7d/30d window. Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/stake-transfers. */
         SubnetStakeTransfersArtifact: {
             distinct_senders: number;
             netuid: number;
@@ -11413,6 +11861,7 @@ export interface components {
             limit: number | null;
             netuid: number;
             schema_version: number;
+            /** @description Distinct surfaces with a recorded mutation -- NOT the subnet's current surface count. A deleted surface is counted here and absent there. */
             surface_count: number;
         } & {
             [key: string]: unknown;
@@ -11422,6 +11871,7 @@ export interface components {
             generated_at: string;
             name?: string;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -11430,7 +11880,9 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One subnet's weekly structural + economics trajectory from the daily snapshots (#5887). Mirrors GET /api/v1/subnets/{netuid}/trajectory's data envelope. The REST envelope's window-keyed deltas map (7d/30d) is exposed here as a list carrying each window label, since those keys are not valid GraphQL field names. */
         SubnetTrajectoryArtifact: {
+            /** @description Latest-vs-window-ago deltas -- one entry per window (7d, 30d) that has a prior point to compare against; empty when the series is too short. */
             deltas: {
                 [key: string]: ({
                     alpha_in_pool?: number | null;
@@ -11468,7 +11920,9 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One subnet's validator/neuron-set turnover between a window's boundary snapshots. The churn metrics are zeroed and the retentions/stability null on a single-snapshot or cold store (schema-stable). Mirrors GET /api/v1/subnets/{netuid}/turnover's default scorecard. */
         SubnetTurnoverArtifact: {
+            /** @description Per-neuron churn detail behind the counts above, populated only when the field's changes toggle is set (mirroring REST's ?changes=true). Null otherwise, and on a cold store. */
             changes?: {
                 uid_reassignment_count?: number;
                 uid_reassignments: {
@@ -11478,11 +11932,13 @@ export interface components {
                 }[];
                 validators_entered: {
                     hotkey: string;
+                    /** @description The UID it held at the boundary snapshot, null when the row carried no usable uid. */
                     uid: number | null;
                 }[];
                 validators_entered_count?: number;
                 validators_exited: {
                     hotkey: string;
+                    /** @description The UID it held at the boundary snapshot, null when the row carried no usable uid. */
                     uid: number | null;
                 }[];
                 validators_exited_count?: number;
@@ -11511,10 +11967,13 @@ export interface components {
         SubnetValidatorEconomicsArtifact: {
             cap_binding: boolean | null;
             composition: components["schemas"]["ValidatorSetComposition"] | null;
+            /** @description Names the missing input whenever a field above was withheld, so a caller can tell 'unknown' from 'zero'. */
             degraded_reason: string | null;
             earning_entry_cost_tao: number | null;
             earning_floor_cost_tao: number | null;
+            /** @description The smallest stake that actually EARNS dividends here, excluding the subnet owner -- its permit is unconditional, so an owner earning on ~0 stake would report a floor of 0. Null when NO non-owner has earned on this subnet, which is a real answer (the owner is taking the dividends), not a missing one. */
             earning_floor_units: number | null;
+            /** @description Reported, never scored. Gate-closed subnets still emit alpha at a comparable rate and are less contested, so per unit of stake they pay MORE -- the gate is an exit-liquidity question, not an eligibility one. */
             emission_gate_open: boolean | null;
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
             field_sources: {
@@ -11530,13 +11989,18 @@ export interface components {
             min_childkey_take_ratio: number | null;
             model_agreement: components["schemas"]["ValidatorPermitModelAgreement"] | null;
             netuid: number;
+            /** @description Floor cost plus the registration burn. Entry is two spends; publishing one understates it. */
             permit_entry_cost_tao: number | null;
             permit_floor_cost_tao: number | null;
+            /** @description Floors are in total_stake UNITS (alpha + tao_weight * root), the quantity the chain threshold actually tests -- not alpha alone. */
             permit_floor_units: number | null;
+            /** @description How much more it takes to EARN than merely to hold a permit. */
             permit_to_earning_multiple: number | null;
             registration_cost_tao: number | null;
+            /** @description Root is not split: this much root clears the threshold on EVERY subnet the hotkey is registered on at once. */
             root_tao_to_clear_threshold: number | null;
             schema_version: number;
+            /** @description Echoed so a caller never has to guess what the floor was computed against. Both are sudo-settable, so a cached copy would silently rot. */
             stake_threshold_units: number | null;
             takes: components["schemas"]["ValidatorTakeDistribution"] | null;
             tao_inflow_per_day: number | null;
@@ -11556,16 +12020,19 @@ export interface components {
                 };
             };
             netuid: number;
+            /** @description Newest first. */
             points: components["schemas"]["ValidatorEconomicsHistoryPoint"][];
             schema_version: number;
             window: string;
         };
+        /** @description One subnet's current validator set (#6979). Mirrors GET /api/v1/subnets/{netuid}/validators' data envelope. */
         SubnetValidatorsArtifact: {
             block_number?: number | null;
             captured_at?: string | null;
             netuid: number;
             schema_version: number;
             validator_count: number;
+            /** @description Each permitted validator's live metagraph row -- the same NeuronState shape the neuron field returns. */
             validators: {
                 active: boolean;
                 /** @description The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541). */
@@ -11577,7 +12044,9 @@ export interface components {
                 emission_tao?: number | null;
                 featured?: boolean;
                 hotkey: string | null;
+                /** @description Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block/timestamp at ~12s/block; null if that anchor is unavailable (#6640). */
                 immunity_expires_at?: string | null;
+                /** @description The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640). */
                 immunity_expires_at_block?: number;
                 incentive?: number | null;
                 is_immunity_period?: boolean;
@@ -11586,6 +12055,7 @@ export interface components {
                 registered_at_block?: number | null;
                 /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao?: number | null;
+                /** @description Validator take/commission (0..1) from SubtensorModule::Delegates; null when no Delegates entry at capture. */
                 take?: number | null;
                 trust?: number | null;
                 uid: number;
@@ -11601,6 +12071,7 @@ export interface components {
             generated_at: string;
             name: string | null;
             netuid: number;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             results: components["schemas"]["VerificationResult"][];
             /** @constant */
@@ -11625,6 +12096,7 @@ export interface components {
             weight_sets: number;
             window: ("7d" | "30d") | null;
         };
+        /** @description Per-subnet weight-setter leaderboard (#5712). Empty setters on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/weights/setters. */
         SubnetWeightSettersArtifact: {
             distinct_setters: number;
             netuid: number;
@@ -11640,6 +12112,7 @@ export interface components {
                 /** @description Whether this setter is more than overdue_tempo_multiple tempos past its last weight set. NULL means not evaluated -- the subnet's tempo or this setter's last_set_at was unavailable -- which is deliberately distinct from false ('evaluated, on time'). */
                 overdue: boolean | null;
                 seconds_since_last_set: number | null;
+                /** @description This setter's share of the subnet total weight_sets; null when the subnet total is 0. */
                 share: number | null;
                 tempos_since_last_set: number | null;
                 uid: number | null;
@@ -11697,6 +12170,7 @@ export interface components {
                 [key: string]: unknown;
             })[];
             schema_version: number;
+            /** @description The resolved window label (7d/30d/90d). */
             window?: string | null;
         } & {
             [key: string]: unknown;
@@ -11711,6 +12185,7 @@ export interface components {
             /** @constant */
             schema_version: 1;
         };
+        /** @description The network's on-chain sudo (superuser) key, read live from chain via RPC. hotkey is null on RPC failure or a renounced sudo (schema-stable). Mirrors GET /api/v1/sudo/key's data envelope. */
         SudoKeyArtifact: {
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
             field_sources: {
@@ -11830,6 +12305,7 @@ export interface components {
             }[];
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -11847,13 +12323,17 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One recorded mutation of a subnet's public surface. */
         SurfaceHistoryChange: {
+            /** @description insert, update or delete. A delete is the only evidence a surface ever existed. */
             action: ("insert" | "update" | "delete") | null;
             kind: string | null;
             name: string | null;
             /** Format: date-time */
             recorded_at: string;
+            /** @description The registry commit that produced the change. */
             source_commit: string | null;
+            /** @description Coalesced column then overlay id, so it is present on every row including those written before the column was recorded. */
             surface_id: string | null;
             url: string | null;
         };
@@ -11862,6 +12342,7 @@ export interface components {
         SurfacesArtifact: {
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
@@ -11893,28 +12374,36 @@ export interface components {
             change_pct: number | null;
             change_usd: number | null;
             latest: components["schemas"]["TaoUsdLatest"] | null;
+            /** @description How far back the answer actually reaches -- the series began 2026-08-02. */
             oldest_observed_at: string | null;
             point_count: number;
             points: components["schemas"]["TaoUsdPoint"][];
+            /** @description How many points carried a price. A gap from point_count is how a window with unpriceable blocks announces itself. */
             priced_point_count: number;
             schema_version: number;
             window: string | null;
         } & {
             [key: string]: unknown;
         };
+        /** @description The newest reading with the derivation that produced it, kept together so both describe the same block. */
         TaoUsdLatest: {
             block_number: number | null;
+            /** @description The ETH/USDC anchor leg the composition multiplied through. */
             eth_usd: number | null;
             observed_at: string | null;
             pool_count: number | null;
+            /** @description Per-pool provenance as the producer stored it. */
             pools: unknown[];
+            /** @description Stated even when the price is null -- it is what says why. */
             price_basis: string | null;
             usd_per_tao: number | null;
         };
+        /** @description One TAO/USD reading. */
         TaoUsdPoint: {
             block_number: number | null;
             /** Format: date-time */
             observed_at: string;
+            /** @description Null means the block was not priceable (insufficient pool quorum), NOT a zero price. */
             usd_per_tao: number | null;
         };
         TopHoldersArtifact: {
@@ -11943,8 +12432,10 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One subnet's long-term daily uptime history (#5885). Mirrors GET /api/v1/subnets/{netuid}/uptime's data envelope. */
         UptimeArtifact: {
             netuid: number;
+            /** @description Window-wide reliability score (0-100) with letter grade. Surface-level scores omit window/surface_count/day_count/computed_at. */
             reliability: ({
                 avg_latency_ms: number | null;
                 computed_at?: string | null;
@@ -11962,11 +12453,13 @@ export interface components {
             }) | null;
             schema_version: number;
             source: string;
+            /** @description Per-surface day series with window-wide uptime ratios and per-surface reliability scores. */
             surfaces: ({
                 day_count: number;
                 days: ({
                     avg_latency_ms?: number | null;
                     day: string;
+                    /** @description Percentile latency summary for one uptime day. */
                     latency_ms?: {
                         p50?: number | null;
                         p95?: number | null;
@@ -11981,6 +12474,7 @@ export interface components {
                 } & {
                     [key: string]: unknown;
                 })[];
+                /** @description Window-wide reliability score (0-100) with letter grade. Surface-level scores omit window/surface_count/day_count/computed_at. */
                 reliability?: ({
                     avg_latency_ms: number | null;
                     computed_at?: string | null;
@@ -12046,6 +12540,7 @@ export interface components {
             root_stake_tao: number;
             schema_version: number;
             subnet_count: number;
+            /** @description Per-subnet membership rows for this validator. The global leaderboard entry caps this at the top 10 by stake; the single-validator lookup carries every subnet. */
             subnets: {
                 active: boolean;
                 axon: string | null;
@@ -12074,16 +12569,21 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One subnet the ranking dropped, and why, so that a caller can tell an omitted subnet from an absent one without re-deriving the ranking. */
         ValidatorEconomicsExclusion: {
             netuid: number;
             reason: string;
         };
+        /** @description One day's observed economics. The floors are read off the snapshot, not re-derived: StakeThreshold is sudo-settable, so re-running today's threshold against an old day would show a flat line across a governance change that actually moved the floor. */
         ValidatorEconomicsHistoryPoint: {
             earning_floor_alpha: number | null;
             emission_gate_open: boolean | null;
+            /** @description The validator cap in force on this day. permit_floor_alpha is the observed floor REGARDLESS of cap state, so it cannot be read without this -- and joining today's cap onto an old point is wrong for any subnet whose cap moved. */
             max_validators: number | null;
+            /** @description Where max_validators came from: observed = the hyperparameter change-log recorded it at or before this day; current = the change-log does not reach this far back, so the LIVE cap is reported. */
             max_validators_source: ("observed" | "current") | null;
             permit_floor_alpha: number | null;
+            /** @description Whether the permit set was full on this day (validators_permitted >= max_validators). NOT the same measure as the current record's cap_binding, which counts UIDs clearing the threshold against slots -- only the permitted set survives in a daily snapshot. */
             permit_set_full: boolean | null;
             snapshot_date: string;
             tao_inflow_per_day: number | null;
@@ -12109,12 +12609,16 @@ export interface components {
             rows: components["schemas"]["SubnetValidatorEconomicsArtifact"][];
             schema_version: number;
             sort: string;
+            /** @description Echoed once for the whole ranking: every row's floors were derived against exactly these values, and both are sudo-settable. */
             stake_threshold_units: number | null;
             tao_weight: number | null;
+            /** @description Rows matching the filters, BEFORE limit/offset -- so a caller can page without re-counting. */
             total: number;
         };
+        /** @description One validator's cross-subnet staked-over-time history. Mirrors GET /api/v1/validators/{hotkey}/history. */
         ValidatorHistoryArtifact: {
             hotkey: string;
+            /** @description The subnet this series was scoped to, or null for the cross-subnet rollup. */
             netuid: number | null;
             /** @description take_last_changed_date + TxDelegateTakeRateLimit (216,000 blocks / 30.00 days, read from the chain's runtime metadata default). NULL when no change is resolvable in the retained window, which is SHORTER than the rate limit — so 'no change seen' cannot be resolved to 'eligible now'. */
             next_take_change_eligible_date: string | null;
@@ -12124,6 +12628,7 @@ export interface components {
                 dividend_efficiency?: number | null;
                 dividends?: number | null;
                 emission_alpha?: number | null;
+                /** @description The scoped subnet. Null on the unscoped cross-subnet series. */
                 netuid?: number | null;
                 rewards_per_1000_alpha?: number | null;
                 rewards_per_1000_tao: number | null;
@@ -12139,6 +12644,7 @@ export interface components {
                 uid?: number | null;
                 /** @description Whether the permit was held that day. The scoped series reports a lost permit rather than dropping the day, so 'lost the permit' stays distinguishable from 'no data'. */
                 validator_permit?: boolean | null;
+                /** @description Per-subnet facts, null unless the query scoped a netuid: a cross-subnet average of these is a number the chain never computes. */
                 validator_trust?: number | null;
             }[];
             schema_version: number;
@@ -12149,6 +12655,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One validator's nominator leaderboard (#5692). Mirrors GET /api/v1/validators/{hotkey}/nominators' data envelope. */
         ValidatorNominatorsArtifact: {
             concentration_complete: boolean;
             hotkey: string;
@@ -12159,22 +12666,30 @@ export interface components {
             nominators: {
                 coldkey: string;
                 event_count: number;
+                /** @description staked_tao + unstaked_tao (total churn, regardless of direction). */
                 gross_staked_tao: number;
+                /** @description Most recent StakeAdded/StakeRemoved time for this coldkey; null when unstamped. */
                 last_observed_at: string | null;
+                /** @description staked_tao - unstaked_tao. */
                 net_staked_tao: number;
                 staked_tao: number;
                 unstaked_tao: number;
             }[];
             offset: number;
             schema_version: number;
-            /** @enum {string} */
+            /**
+             * @description The resolved sort actually applied (an omitted sort resolves to net_staked).
+             * @enum {string}
+             */
             sort: "net_staked" | "gross_staked" | "last_activity";
             top_nominator_share: number | null;
             top5_nominator_share: number | null;
+            /** @description The resolved window label; null only if the builder was handed no window. */
             window: string | null;
         } & {
             [key: string]: unknown;
         };
+        /** @description How well the derived permit rule still reproduces the permits the chain actually granted. Published so a caller can see when the model has drifted rather than trusting a floor it no longer supports. */
         ValidatorPermitModelAgreement: {
             agreement: number | null;
             matched: number;
@@ -12183,15 +12698,18 @@ export interface components {
             publishable: boolean;
             under_predicted: number;
         };
+        /** @description Permitted, active and earning are three DIFFERENT sets. Network-wide 2026-08-03: 1,523 / 1,137 / 1,117; SN83 is 64 / 8 / 7. Published separately rather than collapsed, because 'how many validators does this subnet have' has three defensible answers. */
         ValidatorSetComposition: {
             active: number;
             earning: number;
             permitted: number;
         };
+        /** @description The commission picture across permit-holders. The sorted vector is published because the shape is the information: it is genuinely bimodal, with a cohort competing at or near zero against a median at the effective ceiling, and validators earning at both ends. */
         ValidatorTakeDistribution: {
             distribution: number[];
             max: number | null;
             median: number | null;
+            /** @description Median restricted to permit-holders that actually earn -- takes among validators nobody delegates to are noise. */
             median_earning: number | null;
             min: number | null;
             sample_size: number;
@@ -12201,6 +12719,7 @@ export interface components {
             candidate_count: number;
             contract_version?: string;
             generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             observed_at?: string | null;
             results: components["schemas"]["VerificationResult"][];

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -10091,7 +10091,7 @@ export interface components {
              * @description How this capture compares with the previous one. Absent only where a producer omits it.
              * @enum {string}
              */
-            drift_status?: "changed" | "missing-after-previous-capture" | "new" | "not-captured" | "unchanged";
+            drift_status?: "new" | "changed" | "unchanged" | "not-captured" | "missing-after-previous-capture";
             error?: string | null;
             hash?: string | null;
             netuid: number;
@@ -10118,7 +10118,7 @@ export interface components {
             schemas: {
                 content_type?: string | null;
                 /** @enum {string} */
-                drift_status: "changed" | "missing-after-previous-capture" | "new" | "not-captured" | "unchanged";
+                drift_status: "new" | "changed" | "unchanged" | "not-captured" | "missing-after-previous-capture";
                 error?: string | null;
                 hash?: string | null;
                 netuid?: number;
@@ -37263,7 +37263,7 @@ export interface operations {
                      *         "schema_version": 1,
                      *         "schemas": [
                      *           {
-                     *             "drift_status": "changed",
+                     *             "drift_status": "new",
                      *             "schema_url": "https://api.metagraph.sh/example",
                      *             "status": "captured",
                      *             "surface_id": "example"

--- a/schemas-src/artifacts/schema-drift.ts
+++ b/schemas-src/artifacts/schema-drift.ts
@@ -17,6 +17,7 @@
 // snapshot producer.
 import { z } from "zod";
 import { ArtifactBaseSchema, CountMapSchema } from "../envelope.ts";
+import { SchemaDriftStatusSchema } from "../shared.ts";
 
 export const SchemaDriftSurfaceSchema = z
   .object({
@@ -35,18 +36,9 @@ export const SchemaDriftSurfaceSchema = z
       .describe(
         "What the capture attempt found. `ui-only-or-undiscovered` means the surface declares no schema_url at all, which is a gap rather than a failure.",
       ),
-    drift_status: z
-      .enum([
-        "changed",
-        "missing-after-previous-capture",
-        "new",
-        "not-captured",
-        "unchanged",
-      ])
-      .optional()
-      .describe(
-        "How this capture compares with the previous one. Absent only where a producer omits it.",
-      ),
+    drift_status: SchemaDriftStatusSchema.optional().describe(
+      "How this capture compares with the previous one. Absent only where a producer omits it.",
+    ),
     subnet_slug: z.string(),
     surface_id: z.string(),
     url: z.url(),

--- a/schemas-src/envelope.ts
+++ b/schemas-src/envelope.ts
@@ -51,7 +51,12 @@ export const ArtifactBaseSchema = z
   .object({
     contract_version: z.string().optional(),
     generated_at: z.string(),
-    notes: z.union([z.string(), z.array(z.string())]).optional(),
+    notes: z
+      .union([z.string(), z.array(z.string())])
+      .optional()
+      .describe(
+        "Public-safe notes; may be a string or a string list depending on the adapter.",
+      ),
     schema_version: z.literal(1),
   })
   .passthrough();

--- a/schemas-src/routes/account-activity-registrations.ts
+++ b/schemas-src/routes/account-activity-registrations.ts
@@ -148,7 +148,7 @@ export const AccountWeightSettersArtifactSchema = z
   })
   .strict()
   .describe(
-    "One account's (validator hotkey's) WeightsSet weight-setting footprint across subnets over a 7d/30d window. Mirrors GET /api/v1/accounts/{ss58}/weight-setters.",
+    "One account's (validator's hotkey's) WeightsSet weight-setting footprint across subnets over a 7d/30d window. Mirrors GET /api/v1/accounts/{ss58}/weight-setters.",
   );
 export type AccountWeightSettersArtifact = z.infer<
   typeof AccountWeightSettersArtifactSchema

--- a/schemas-src/routes/account-activity-registrations.ts
+++ b/schemas-src/routes/account-activity-registrations.ts
@@ -35,7 +35,10 @@ export const AccountAxonRemovalsArtifactSchema = z
           first_removed_at: z.string().nullable(),
           last_removed_at: z.string().nullable(),
         })
-        .strict(),
+        .strict()
+        .describe(
+          "One subnet's slice of an account's axon-removal footprint over the window.",
+        ),
     ),
     // #9307: AxonInfoRemoved has never been emitted, so this footprint's zero
     // has never measured this account.
@@ -66,7 +69,10 @@ export const AccountDeregistrationsArtifactSchema = z
           first_deregistered_at: z.string().nullable(),
           last_deregistered_at: z.string().nullable(),
         })
-        .strict(),
+        .strict()
+        .describe(
+          "One subnet's slice of an account's deregistration footprint over the window.",
+        ),
     ),
     // #9307: the slots where this account was the PREVIOUS holder, derived
     // from UID reuse; `degraded` when nothing derived it.
@@ -98,7 +104,10 @@ export const AccountRegistrationsArtifactSchema = z
           first_registered_at: z.string().nullable(),
           last_registered_at: z.string().nullable(),
         })
-        .strict(),
+        .strict()
+        .describe(
+          "One subnet's slice of an account's registration footprint over the window.",
+        ),
     ),
   })
   .strict();
@@ -116,7 +125,12 @@ export const AccountWeightSettersArtifactSchema = z
     window: z.enum(WINDOW_ENUM_7_30D).nullable(),
     total_weight_sets: z.int().min(0),
     subnet_count: z.int().min(0),
-    concentration: z.number().nullable(),
+    concentration: z
+      .number()
+      .nullable()
+      .describe(
+        "Herfindahl-Hirschman index of weight-sets across subnets: 1 = all on one subnet, -> 1/n as it spreads evenly; null when the account has no weight-sets.",
+      ),
     dominant_netuid: z.int().min(0).nullable(),
     subnets: z.array(
       z
@@ -126,10 +140,16 @@ export const AccountWeightSettersArtifactSchema = z
           first_set_at: z.string().nullable(),
           last_set_at: z.string().nullable(),
         })
-        .strict(),
+        .strict()
+        .describe(
+          "One subnet's WeightsSet activity in an account's weight-setting footprint, ranked most-active-first.",
+        ),
     ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One account's (validator hotkey's) WeightsSet weight-setting footprint across subnets over a 7d/30d window. Mirrors GET /api/v1/accounts/{ss58}/weight-setters.",
+  );
 export type AccountWeightSettersArtifact = z.infer<
   typeof AccountWeightSettersArtifactSchema
 >;

--- a/schemas-src/routes/account-activity.ts
+++ b/schemas-src/routes/account-activity.ts
@@ -46,7 +46,10 @@ export const AccountServingArtifactSchema = z
           first_served_at: z.string().nullable(),
           last_served_at: z.string().nullable(),
         })
-        .strict(),
+        .strict()
+        .describe(
+          "One subnet's slice of an account's axon-serving footprint over the window.",
+        ),
     ),
   })
   .strict();
@@ -64,7 +67,12 @@ export const AccountPrometheusArtifactSchema = z
     window: z.enum(WINDOW_ENUM).nullable(),
     total_announcements: z.int().min(0),
     subnet_count: z.int().min(0),
-    concentration: z.number().nullable(),
+    concentration: z
+      .number()
+      .nullable()
+      .describe(
+        "Herfindahl-Hirschman index of announcements across subnets: 1 = all on one subnet, -> 1/n as it spreads evenly; null when the account has no announcements.",
+      ),
     dominant_netuid: z.int().min(0).nullable(),
     subnets: z.array(
       z
@@ -74,14 +82,20 @@ export const AccountPrometheusArtifactSchema = z
           first_announced_at: z.string().nullable(),
           last_announced_at: z.string().nullable(),
         })
-        .strict(),
+        .strict()
+        .describe(
+          "One subnet's Prometheus-announcement activity in an account's footprint, ranked most-active-first.",
+        ),
     ),
     // #9307: the chain emits PrometheusServed and our account_events curation
     // drops all 18,041 of them, so this footprint's zero is "we could not
     // look".
     degraded: EventStreamDegradedSchema.optional(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One account's Prometheus telemetry-serving footprint (#5703) across subnets over a 7d/30d/90d window. Mirrors GET /api/v1/accounts/{ss58}/prometheus.",
+  );
 export type AccountPrometheusArtifact = z.infer<
   typeof AccountPrometheusArtifactSchema
 >;
@@ -105,9 +119,17 @@ export const AccountStakeMovesArtifactSchema = z
           movements: z.int().min(0),
           first_moved_at: z.string().nullable(),
           last_moved_at: z.string().nullable(),
-          price_tao_at_last_move: z.number().nullable(),
+          price_tao_at_last_move: z
+            .number()
+            .nullable()
+            .describe(
+              "Alpha price (TAO) on the UTC day of this subnet's most recent move; null when that day has no snapshot yet or there was no move.",
+            ),
         })
-        .strict(),
+        .strict()
+        .describe(
+          "One subnet's slice of an account's stake-movement footprint over the window.",
+        ),
     ),
   })
   .strict();
@@ -134,12 +156,26 @@ export const AccountStakeFlowArtifactSchema = z
     total_unstaked_tao: z.number(),
     net_flow_tao: z.number(),
     gross_flow_tao: z.number(),
-    flow_ratio: z.number().nullable(),
-    direction: z.enum(FLOW_DIRECTION_ENUM),
+    flow_ratio: z
+      .number()
+      .nullable()
+      .describe(
+        "net_flow_tao / gross_flow_tao, [-1, 1]; null when gross_flow_tao is 0 (no flow to rate).",
+      ),
+    direction: z
+      .enum(FLOW_DIRECTION_ENUM)
+      .describe(
+        "accumulating / exiting / churning / idle, derived from flow_ratio.",
+      ),
     stake_events: z.int().min(0),
     unstake_events: z.int().min(0),
     subnet_count: z.int().min(0),
-    concentration: z.number().nullable(),
+    concentration: z
+      .number()
+      .nullable()
+      .describe(
+        "Herfindahl-Hirschman index of gross flow across subnets: 1 = all flow in one subnet, -> 1/n as it spreads evenly; null when there is no flow to concentrate.",
+      ),
     dominant_netuid: z.int().min(0).nullable(),
     subnets: z.array(
       z
@@ -154,10 +190,16 @@ export const AccountStakeFlowArtifactSchema = z
           stake_events: z.int().min(0),
           unstake_events: z.int().min(0),
         })
-        .strict(),
+        .strict()
+        .describe(
+          "One subnet's stake flow in an account's footprint, ranked most-active-first (highest gross flow).",
+        ),
     ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One account's StakeAdded/StakeRemoved staking-behavior scorecard (#5706) across subnets over a 7d/30d/90d window. Mirrors GET /api/v1/accounts/{ss58}/stake-flow.",
+  );
 export type AccountStakeFlowArtifact = z.infer<
   typeof AccountStakeFlowArtifactSchema
 >;

--- a/schemas-src/routes/account-balance.ts
+++ b/schemas-src/routes/account-balance.ts
@@ -22,7 +22,10 @@ export const AccountBalanceArtifactSchema = z
     // response shape legitimately lacks it.
     field_sources: FieldSourcesSchema,
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Live free+reserved balance in TAO for one Finney ss58 account, read directly from chain via RPC (KV-cached). balance_tao is null on RPC failure (schema-stable, never a GraphQL error). Mirrors GET /api/v1/accounts/{ss58}/balance.",
+  );
 export type AccountBalanceArtifact = z.infer<
   typeof AccountBalanceArtifactSchema
 >;

--- a/schemas-src/routes/account-child-delegation.ts
+++ b/schemas-src/routes/account-child-delegation.ts
@@ -21,14 +21,20 @@ const ChildDelegationEntrySchema = z
     proportion: z.string(),
     proportion_fraction: z.number(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One child hotkey's delegated-stake proportion on a subnet. proportion is the raw stringified u64 (0..u64::MAX represents 0..100%); proportion_fraction is the same value pre-divided to a 0..1 float.",
+  );
 
 const ChildDelegationSubnetSchema = z
   .object({
     netuid: z.int().min(0).max(65535),
     entries: z.array(ChildDelegationEntrySchema),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One subnet's child-hotkey delegation entries in an account's live children graph.",
+  );
 
 export const AccountChildrenArtifactSchema = z
   .object({
@@ -40,7 +46,10 @@ export const AccountChildrenArtifactSchema = z
     // response shape legitimately lacks it.
     field_sources: FieldSourcesSchema,
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Live child-hotkey delegation graph (#6723) for one Finney ss58 account, read directly from chain via RPC (KV-cached). subnets is null on RPC failure, distinct from a confirmed-empty [] (schema-stable, never a GraphQL error). Mirrors GET /api/v1/accounts/{ss58}/children.",
+  );
 export type AccountChildrenArtifact = z.infer<
   typeof AccountChildrenArtifactSchema
 >;
@@ -54,14 +63,20 @@ const ParentDelegationEntrySchema = z
     proportion: z.string(),
     proportion_fraction: z.number(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One parent hotkey's delegated-stake proportion on a subnet. proportion is the raw stringified u64 (0..u64::MAX represents 0..100%); proportion_fraction is the same value pre-divided to a 0..1 float.",
+  );
 
 const ParentDelegationSubnetSchema = z
   .object({
     netuid: z.int().min(0).max(65535),
     entries: z.array(ParentDelegationEntrySchema),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One subnet's parent-hotkey delegation entries in an account's live parents graph.",
+  );
 
 export const AccountParentsArtifactSchema = z
   .object({
@@ -73,7 +88,10 @@ export const AccountParentsArtifactSchema = z
     // response shape legitimately lacks it.
     field_sources: FieldSourcesSchema,
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Live parent-hotkey delegation graph (#6723) for one Finney ss58 account, read directly from chain via RPC (KV-cached). subnets is null on RPC failure, distinct from a confirmed-empty [] (schema-stable, never a GraphQL error). Mirrors GET /api/v1/accounts/{ss58}/parents.",
+  );
 export type AccountParentsArtifact = z.infer<
   typeof AccountParentsArtifactSchema
 >;

--- a/schemas-src/routes/account-counterparties.ts
+++ b/schemas-src/routes/account-counterparties.ts
@@ -40,7 +40,10 @@ const CounterpartySchema = z
     transfer_count: z.int().min(0),
     last_block: z.int().nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One counterparty the account transacts native TAO with, aggregated over the scanned Transfer set.",
+  );
 
 const CounterpartyTransferSchema = z
   .object({
@@ -50,10 +53,15 @@ const CounterpartyTransferSchema = z
     from: z.string(),
     to: z.string(),
     amount_tao: z.number(),
-    direction: z.enum(["sent", "received"]),
+    direction: z
+      .enum(["sent", "received"])
+      .describe("sent (account = from) or received (account = to)."),
     observed_at: z.string().nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One direction-aware transfer between the account and the drilled-into counterparty.",
+  );
 
 export const CounterpartyRelationshipSchema = z
   .object({
@@ -66,14 +74,22 @@ export const CounterpartyRelationshipSchema = z
     total_sent_tao: z.number(),
     total_received_tao: z.number(),
     net_tao: z.number(),
-    first_block: z.int().nullable(),
+    first_block: z
+      .int()
+      .nullable()
+      .describe(
+        "Oldest block/timestamp are null when the newest-first scan was truncated (scan_capped).",
+      ),
     last_block: z.int().nullable(),
     first_seen_at: z.string().nullable(),
     last_seen_at: z.string().nullable(),
     limit: z.int().min(1).max(100),
     transfers: z.array(CounterpartyTransferSchema),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Focused fund-flow summary for one account/counterparty relationship, with the bounded transfer evidence; only present when counterparty was supplied.",
+  );
 
 export const AccountCounterpartiesArtifactSchema = z
   .object({
@@ -85,7 +101,9 @@ export const AccountCounterpartiesArtifactSchema = z
     total_sent_tao: z.number(),
     total_received_tao: z.number(),
     counterparties: z.array(CounterpartySchema),
-    relationship: CounterpartyRelationshipSchema.optional(),
+    relationship: CounterpartyRelationshipSchema.optional().describe(
+      "Present only in relationship (counterparty) mode; null in list mode.",
+    ),
   })
   .passthrough();
 export type AccountCounterpartiesArtifact = z.infer<

--- a/schemas-src/routes/account-entities.ts
+++ b/schemas-src/routes/account-entities.ts
@@ -23,25 +23,14 @@
 // identical field).
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
+import { EntityCategorySchema } from "../shared.ts";
 
 const EntityLabelSchema = z
   .object({
     name: z.string().nullable().optional(),
     // #8372: widened to match schemas/entity.schema.json's category enum
     // and account-summary.ts's own copy -- keep all three in sync.
-    category: z
-      .enum([
-        "exchange",
-        "bridge",
-        "foundation",
-        "pool",
-        "infra",
-        "project",
-        "operator",
-        "other",
-      ])
-      .nullable()
-      .optional(),
+    category: EntityCategorySchema.nullable().optional(),
     notes: z.string().nullable().optional(),
     url: z.string().nullable().optional(),
     source_urls: z.array(z.string()).optional(),

--- a/schemas-src/routes/account-entities.ts
+++ b/schemas-src/routes/account-entities.ts
@@ -46,7 +46,10 @@ const EntityLabelSchema = z
     url: z.string().nullable().optional(),
     source_urls: z.array(z.string()).optional(),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "A community-contributed entity label for an address (exchange/foundation/operator/other).",
+  );
 
 export const AccountEntitiesArtifactSchema = z
   .object({
@@ -62,10 +65,16 @@ export const AccountEntitiesArtifactSchema = z
           block_number: z.int().nullable().optional(),
           observed_at: z.string().nullable().optional(),
         })
-        .passthrough(),
+        .passthrough()
+        .describe(
+          "One SubnetOwnerChanged transfer tying this coldkey to a subnet, either as the gaining or losing side, newest first.",
+        ),
     ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One coldkey's community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities.",
+  );
 export type AccountEntitiesArtifact = z.infer<
   typeof AccountEntitiesArtifactSchema
 >;

--- a/schemas-src/routes/account-entities.ts
+++ b/schemas-src/routes/account-entities.ts
@@ -56,13 +56,13 @@ export const AccountEntitiesArtifactSchema = z
         })
         .passthrough()
         .describe(
-          "One SubnetOwnerChanged transfer tying this coldkey to a subnet, either as the gaining or losing side, newest first.",
+          "One SubnetOwnerChanged transfer tying this `coldkey` to a subnet, either as the gaining or losing side, newest first.",
         ),
     ),
   })
   .passthrough()
   .describe(
-    "One coldkey's community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities.",
+    "One `coldkey`'s community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities.",
   );
 export type AccountEntitiesArtifact = z.infer<
   typeof AccountEntitiesArtifactSchema

--- a/schemas-src/routes/account-events-feed.ts
+++ b/schemas-src/routes/account-events-feed.ts
@@ -43,7 +43,10 @@ export const AccountEventsArtifactSchema = z
     next_cursor: z.string().nullable().optional(),
     events: z.array(AccountEventSchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One account's first-party chain-event feed (matched by the hotkey OR coldkey union, newest first), keyset-paginated. event_count is the page count, not a grand total. Mirrors GET /api/v1/accounts/{ss58}/events' data envelope. Each item is an AccountEvent.",
+  );
 export type AccountEventsArtifact = z.infer<typeof AccountEventsArtifactSchema>;
 export const AccountEventsResponseSchema = successEnvelopeSchema(
   AccountEventsArtifactSchema,
@@ -58,7 +61,10 @@ const AccountDaySchema = z
     first_block: z.int().nullable().optional(),
     last_block: z.int().nullable().optional(),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One day's rolled-up activity for an account on one subnet, from the account_events_daily tier. event_kinds is the distinct set of event ids seen that day.",
+  );
 
 export const AccountHistoryArtifactSchema = z
   .object({
@@ -70,7 +76,10 @@ export const AccountHistoryArtifactSchema = z
     next_cursor: z.string().nullable().optional(),
     days: z.array(AccountDaySchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One account's durable per-day activity series (hotkey-keyed, newest day first), keyset-paginated. day_count is the page count, not a grand total. Mirrors GET /api/v1/accounts/{ss58}/history' data envelope. Each item is an AccountDay.",
+  );
 export type AccountHistoryArtifact = z.infer<
   typeof AccountHistoryArtifactSchema
 >;
@@ -88,7 +97,10 @@ const AccountTransferEntrySchema = z
     direction: z.enum(["sent", "received"]).nullable().optional(),
     observed_at: z.string().nullable().optional(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One native-TAO Balances.Transfer event on an account's feed. direction is relative to the queried address (sent = it paid, received = it was paid).",
+  );
 
 export const AccountTransfersArtifactSchema = z
   .object({
@@ -100,7 +112,10 @@ export const AccountTransfersArtifactSchema = z
     next_cursor: z.string().nullable().optional(),
     transfers: z.array(AccountTransferEntrySchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One account's native-TAO transfer feed, keyset-paginated newest-first. Mirrors GET /api/v1/accounts/{ss58}/transfers' data envelope.",
+  );
 export type AccountTransfersArtifact = z.infer<
   typeof AccountTransfersArtifactSchema
 >;

--- a/schemas-src/routes/account-extrinsics.ts
+++ b/schemas-src/routes/account-extrinsics.ts
@@ -32,7 +32,11 @@ const ExtrinsicSchema = z
     signer: z.string().nullable().optional(),
     call_module: z.string().nullable().optional(),
     call_function: z.string().nullable().optional(),
-    call_args: z.unknown().nullable().optional(),
+    call_args: z
+      .unknown()
+      .nullable()
+      .optional()
+      .describe("JSON-encoded decoded call arguments."),
     fee_tao: z.number().nullable().optional(),
     tip_tao: z.number().nullable().optional(),
     success: z.boolean().nullable().optional(),
@@ -40,7 +44,13 @@ const ExtrinsicSchema = z
     // #8525: deterministic human-readable action sentence for this
     // extrinsic's call, or null when no template matches
     // call_module.call_function -- never a guessed/partial sentence.
-    summary: z.string().nullable().optional(),
+    summary: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "Deterministic human-readable action sentence for this extrinsic's call, or null when no template matches call_module.call_function (#8525).",
+      ),
   })
   .strict();
 
@@ -61,7 +71,10 @@ export const AccountExtrinsicsArtifactSchema = z
     next_cursor: z.string().nullable().optional(),
     extrinsics: z.array(ExtrinsicSchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One account's signed-extrinsic feed (newest first), backing account_extrinsics. Matched by the extrinsic signer only. extrinsic_count is the page count, matching the REST feed convention. Each item is a full Extrinsic (block/index/hash/call/success/fee/tip).",
+  );
 export type AccountExtrinsicsArtifact = z.infer<
   typeof AccountExtrinsicsArtifactSchema
 >;

--- a/schemas-src/routes/account-identity.ts
+++ b/schemas-src/routes/account-identity.ts
@@ -54,9 +54,16 @@ const AccountIdentityHistoryEntrySchema = z
     discord: z.string().max(200).nullable().optional(),
     description: z.string().nullable().optional(),
     additional: z.string().nullable().optional(),
-    identity_hash: z.string(),
+    identity_hash: z
+      .string()
+      .describe(
+        "Stable hash of this entry's tracked identity fields -- unchanged across entries where nothing actually differs.",
+      ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One diff-tracked snapshot of an account's on-chain identity, taken when any tracked field changed since the previous entry.",
+  );
 
 export const AccountIdentityHistoryArtifactSchema = z
   .object({

--- a/schemas-src/routes/account-portfolio.ts
+++ b/schemas-src/routes/account-portfolio.ts
@@ -44,9 +44,15 @@ const PortfolioPositionSchema = z
     trust: z.number().nullable(),
     incentive: z.number().nullable(),
     dividends: z.number().nullable(),
-    yield: z.number().nullable(),
+    yield: z
+      .number()
+      .nullable()
+      .describe("Emission over stake for this position; null when stake is 0."),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One subnet position in a wallet's portfolio, ranked biggest-stake-first.",
+  );
 
 export const AccountPortfolioArtifactSchema = z
   .object({
@@ -73,10 +79,15 @@ export const AccountPortfolioArtifactSchema = z
       .describe(
         "Priced emission per priced stake -- both sides in TAO (#9051), so the ratio is dimensionally coherent. Null with no priceable stake.",
       ),
-    stake_concentration: ConcentrationMetricsSchema,
+    stake_concentration: ConcentrationMetricsSchema.describe(
+      "How concentrated the wallet's stake is across its subnets (Gini/HHI/etc); null with no positions.",
+    ),
     positions: z.array(PortfolioPositionSchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One wallet's cross-subnet neuron portfolio (#5702): every subnet where the hotkey is a registered neuron, plus wallet-level aggregates. Mirrors GET /api/v1/accounts/{ss58}/portfolio.",
+  );
 export type AccountPortfolioArtifact = z.infer<
   typeof AccountPortfolioArtifactSchema
 >;

--- a/schemas-src/routes/account-positions.ts
+++ b/schemas-src/routes/account-positions.ts
@@ -33,7 +33,13 @@ const NominatorPositionSchema = z
   .object({
     hotkey: z.string(),
     netuid: z.int().min(0),
-    share_fraction: z.number().min(0).max(1),
+    share_fraction: z
+      .number()
+      .min(0)
+      .max(1)
+      .describe(
+        "This account's share of the hotkey's total alpha-pool shares on this subnet (0..1), not a TAO amount.",
+      ),
     stake_tao: z
       .number()
       .min(0)
@@ -41,7 +47,10 @@ const NominatorPositionSchema = z
         "This position's stake in the subnet named by the sibling `netuid`. ALPHA, not TAO: nominator_positions holds only netuid != 0 rows, so this is always that subnet's alpha token (#2550). It is the per-row counterpart of `total_stake_alpha` above -- same denomination, kept under the on-chain column name deliberately (#8945).",
       ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One (hotkey, netuid) delegation this account holds, reconstructed from the nominator-positions ledger joined against the hotkey's live stake_tao for that netuid.",
+  );
 
 // #9273. Present ONLY when this payload's zero is not a measurement, so a
 // consumer that ignores it reads exactly what it read before. Optional rather
@@ -89,7 +98,10 @@ export const AccountPositionsArtifactSchema = z
     positions: z.array(NominatorPositionSchema),
     degraded: AccountPositionsDegradedSchema.optional(),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "This account's reconstructed nominator-side positions: what it holds delegated across every hotkey/subnet, distinct from AccountPortfolio's hotkey-scoped view. Mirrors GET /api/v1/accounts/{ss58}/positions.",
+  );
 export type AccountPositionsArtifact = z.infer<
   typeof AccountPositionsArtifactSchema
 >;
@@ -121,7 +133,10 @@ const AccountPositionHistoryPointSchema = z
     dividends: z.number().nullable(),
     yield: z.number().nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One day's position for an account in one subnet: the neuron's uid/role/active plus stake/emission and its rank/trust/incentive/dividends scores and emission-per-stake yield.",
+  );
 
 export const AccountPositionHistoryArtifactSchema = z
   .object({
@@ -132,7 +147,10 @@ export const AccountPositionHistoryArtifactSchema = z
     point_count: z.int().min(0),
     points: z.array(AccountPositionHistoryPointSchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One account's per-subnet position history over a lookback window, one point per neuron_daily snapshot. Mirrors GET /api/v1/accounts/{ss58}/subnets/{netuid}/history.",
+  );
 export type AccountPositionHistoryArtifact = z.infer<
   typeof AccountPositionHistoryArtifactSchema
 >;

--- a/schemas-src/routes/account-root-claim.ts
+++ b/schemas-src/routes/account-root-claim.ts
@@ -26,7 +26,10 @@ const RootClaimTypeSchema = z
     kind: z.enum(["Swap", "Keep", "KeepSubnets"]),
     subnets: z.array(z.int().min(0).max(65535)).optional(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Per-account RootClaimTypeEnum (#7229): Swap / Keep / KeepSubnets.",
+  );
 
 const RootClaimEntrySchema = z
   .object({
@@ -35,14 +38,20 @@ const RootClaimEntrySchema = z
     claimed: z.string(),
     threshold: z.number(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One netuid's root-claim accounting for a (hotkey, account) pair (#7229).",
+  );
 
 const RootClaimHotkeySchema = z
   .object({
     hotkey: z.string(),
     entries: z.array(RootClaimEntrySchema),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Root-claim rows for one staking/owned hotkey of the queried account (#7229).",
+  );
 
 export const AccountRootClaimArtifactSchema = z
   .object({
@@ -55,7 +64,10 @@ export const AccountRootClaimArtifactSchema = z
     // response shape legitimately lacks it.
     field_sources: FieldSourcesSchema,
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Live root-claim current state for one Finney ss58 account (#7229), read directly from chain via RPC (KV-cached). claim_type/hotkeys are null on RPC failure (schema-stable, never a GraphQL error). Read-only; never submits claim_root. Mirrors GET /api/v1/accounts/{ss58}/root-claim.",
+  );
 export type AccountRootClaimArtifact = z.infer<
   typeof AccountRootClaimArtifactSchema
 >;

--- a/schemas-src/routes/account-summary.ts
+++ b/schemas-src/routes/account-summary.ts
@@ -40,6 +40,7 @@
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
 import { AccountEventSchema } from "./subnet-events.ts";
+import { EntityCategorySchema } from "../shared.ts";
 
 const AccountRegistrationSchema = z
   .object({
@@ -90,19 +91,7 @@ const EntityLabelSchema = z
     // #8372: widened to match schemas/entity.schema.json's category enum
     // (bridge/pool/infra/project added; exchange/foundation/operator/other
     // retained so an existing entry stays valid). Keep both in sync.
-    category: z
-      .enum([
-        "exchange",
-        "bridge",
-        "foundation",
-        "pool",
-        "infra",
-        "project",
-        "operator",
-        "other",
-      ])
-      .nullable()
-      .optional(),
+    category: EntityCategorySchema.nullable().optional(),
     notes: z.string().nullable().optional(),
     url: z.string().nullable().optional(),
     source_urls: z.array(z.string()).optional(),

--- a/schemas-src/routes/account-summary.ts
+++ b/schemas-src/routes/account-summary.ts
@@ -74,7 +74,10 @@ export const AccountActivitySchema = z
     ),
     modules_called_capped: z.boolean(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Signing-activity aggregate from the extrinsics tier, matched by signer only. tx_count / total_fee_tao / last_tx_* are all-time over every extrinsic this address has signed; modules_called is the pallet mix over the newest 1000 only, with modules_called_capped true when that window is incomplete. An account queried by a key that did not sign returns tx_count 0, modules_called_capped false, other fields null/empty.",
+  );
 
 // EntityLabel is reused inline (not imported) -- it's still a shared component
 // referenced by the not-yet-converted AccountEntitiesArtifact (GET /api/v1/
@@ -116,9 +119,18 @@ export const AccountSummaryArtifactSchema = z
     last_block: z.int().nullable().optional(),
     first_seen_at: z.string().nullable().optional(),
     last_seen_at: z.string().nullable().optional(),
-    event_scan_capped: z.boolean().optional(),
+    event_scan_capped: z
+      .boolean()
+      .optional()
+      .describe(
+        "True when this account has more events than the summary's scan window -- event_count/subnet_count/event_kinds are then a lower bound and first_block/first_seen_at are null.",
+      ),
     event_kinds: z.array(AccountEventKindCountSchema).optional(),
-    registrations: z.array(AccountRegistrationSchema),
+    registrations: z
+      .array(AccountRegistrationSchema)
+      .describe(
+        "Where this hotkey is currently registered + staked (the live cross-subnet footprint).",
+      ),
     recent_events: z.array(AccountEventSchema).optional(),
     activity: AccountActivitySchema.optional(),
     labels: z.array(EntityLabelSchema).optional(),
@@ -136,9 +148,16 @@ export const AccountSubnetsArtifactSchema = z
     schema_version: z.int(),
     ss58: z.string(),
     subnet_count: z.int().min(0),
-    subnets: z.array(AccountRegistrationSchema),
+    subnets: z
+      .array(AccountRegistrationSchema)
+      .describe(
+        "Where this hotkey is currently registered, ordered by netuid -- each an AccountRegistration (netuid/uid/stake/validator_permit/active).",
+      ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One account's live cross-subnet registration footprint (the neurons snapshot), backing account_subnets. The lightweight sibling of AccountPortfolio -- registration facts only, no economics rollup.",
+  );
 export type AccountSubnetsArtifact = z.infer<
   typeof AccountSubnetsArtifactSchema
 >;

--- a/schemas-src/routes/adapter.ts
+++ b/schemas-src/routes/adapter.ts
@@ -61,9 +61,19 @@ export const AdapterArtifactSchema = ArtifactBaseSchema.extend({
   // dimension lists, the generic OpenAPI adapter ships something else
   // entirely. There is no shape to declare, so the contract says so instead
   // of pretending. Listed in scripts/validate-schema-opacity.ts.
-  extensions: z.record(z.string(), z.object({}).passthrough()),
-  snapshot: AdapterSnapshotSchema.nullable().optional(),
-}).passthrough();
+  extensions: z
+    .record(z.string(), z.object({}).passthrough())
+    .describe(
+      "Per-adapter extension metadata keyed by provider id; each value's shape is adapter-specific.",
+    ),
+  snapshot: AdapterSnapshotSchema.nullable()
+    .optional()
+    .describe("Captured adapter metrics payload; shape is adapter-specific."),
+})
+  .passthrough()
+  .describe(
+    "One adapter-backed public metrics snapshot. snapshot and extensions are opaque JSON -- their shape is adapter-specific. Mirrors GET /api/v1/adapters/{slug}'s data envelope.",
+  );
 export type AdapterArtifact = z.infer<typeof AdapterArtifactSchema>;
 export const AdapterResponseSchema = successEnvelopeSchema(
   AdapterArtifactSchema,

--- a/schemas-src/routes/agent-catalog.ts
+++ b/schemas-src/routes/agent-catalog.ts
@@ -32,6 +32,8 @@ import { z } from "zod";
 import { ArtifactBaseSchema } from "../envelope.ts";
 import { IntegrationReadinessSchema } from "./subnet-profile.ts";
 import { AgentReadinessBlockerSchema } from "./coverage.ts";
+import { SurfaceAuthLocationSchema } from "../shared.ts";
+import { SurfaceAuthSchemeSchema } from "../shared.ts";
 
 export const AgentReadinessStatusSchema = z
   .object({
@@ -211,25 +213,12 @@ export const AgentCatalogServiceSchema = z
     // declarations is #9799.
     auth: z
       .object({
-        scheme: z
-          .enum([
-            "none",
-            "bearer",
-            "api-key",
-            "basic",
-            "oauth2",
-            "signature",
-            "custom",
-          ])
-          .describe(
-            "`signature` means the request is signed per-call (a hotkey/nonce/signature header set, see `names`), not a static token.",
-          ),
-        location: z
-          .enum(["header", "query", "cookie", "body"])
-          .optional()
-          .describe(
-            "Where the credential is sent. `body` only applies to scheme:signature, whose values are merged into the outgoing JSON request body.",
-          ),
+        scheme: SurfaceAuthSchemeSchema.describe(
+          "`signature` means the request is signed per-call (a hotkey/nonce/signature header set, see `names`), not a static token.",
+        ),
+        location: SurfaceAuthLocationSchema.optional().describe(
+          "Where the credential is sent. `body` only applies to scheme:signature, whose values are merged into the outgoing JSON request body.",
+        ),
         name: z
           .string()
           .optional()

--- a/schemas-src/routes/block-chain-events.ts
+++ b/schemas-src/routes/block-chain-events.ts
@@ -40,9 +40,18 @@ const ChainEventSchema = z
     // #8525: deterministic human-readable action sentence for this event's
     // pallet.method, or null when no template matches -- never a
     // guessed/partial sentence.
-    summary: z.string().nullable().optional(),
+    summary: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "Deterministic human-readable action sentence for this event's pallet.method, or null when no template matches (#8525).",
+      ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One raw pallet-level chain event from the all-events tier (distinct from the curated AccountEvent and from Subscription's ChainEvent firehose payload).",
+  );
 
 export const BlockChainEventsArtifactSchema = z
   .object({

--- a/schemas-src/routes/block-events.ts
+++ b/schemas-src/routes/block-events.ts
@@ -26,7 +26,10 @@ export const BlockEventsArtifactSchema = z
     offset: z.int().nullable(),
     events: z.array(AccountEventSchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One block's decoded, account-attributed events list (#6977). Rows are opaque JSON; block_number is null for an unknown ref.",
+  );
 export type BlockEventsArtifact = z.infer<typeof BlockEventsArtifactSchema>;
 export const BlockEventsResponseSchema = successEnvelopeSchema(
   BlockEventsArtifactSchema,

--- a/schemas-src/routes/block-extrinsics.ts
+++ b/schemas-src/routes/block-extrinsics.ts
@@ -24,7 +24,10 @@ export const BlockExtrinsicsArtifactSchema = z
     offset: z.int().nullable(),
     extrinsics: z.array(ExtrinsicSchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One block's extrinsics list (#6977). Rows are the opaque JSON extrinsic shape the extrinsics feed uses; block_number is null for an unknown ref.",
+  );
 export type BlockExtrinsicsArtifact = z.infer<
   typeof BlockExtrinsicsArtifactSchema
 >;

--- a/schemas-src/routes/blocks-summary.ts
+++ b/schemas-src/routes/blocks-summary.ts
@@ -21,6 +21,9 @@ const BlockTimeDistributionSchema = z
     p90_ms: z.int(),
   })
   .strict()
+  .describe(
+    "Inter-block interval distribution in milliseconds, over genuinely consecutive in-window blocks.",
+  )
   .nullable();
 
 export const BlocksSummaryArtifactSchema = z
@@ -41,13 +44,19 @@ export const BlocksSummaryArtifactSchema = z
         max_extrinsics_in_block: z.int().min(0),
       })
       .strict()
+      .describe(
+        "Extrinsic/event throughput across the summarized block window.",
+      )
       .nullable(),
     distinct_authors: z.int().min(0),
     author_concentration: ConcentrationMetricsSchema.nullable(),
     distinct_spec_versions: z.int().min(0),
     latest_spec_version: z.int().min(0).nullable(),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Block-production summary (#5664) over the recent-block window. Every aggregate is null on a cold retired-D1 store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/summary.",
+  );
 export type BlocksSummaryArtifact = z.infer<typeof BlocksSummaryArtifactSchema>;
 export const BlocksSummaryResponseSchema = successEnvelopeSchema(
   BlocksSummaryArtifactSchema,

--- a/schemas-src/routes/blocks.ts
+++ b/schemas-src/routes/blocks.ts
@@ -50,8 +50,20 @@ export const BlockDetailArtifactSchema = z
     schema_version: z.int(),
     ref: z.string().nullable(),
     block: BlockSchema.nullable(),
-    prev_block_number: z.int().min(0).nullable(),
-    next_block_number: z.int().min(0).nullable(),
+    prev_block_number: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe(
+        "Nearest STORED lower block height for chain-walk nav (detail only); null at the start of the retained window or when the ref didn't resolve.",
+      ),
+    next_block_number: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe(
+        "Nearest STORED higher block height for chain-walk nav (detail only); null at the head of the retained window or when the ref didn't resolve.",
+      ),
   })
   .passthrough();
 export type BlockDetailArtifact = z.infer<typeof BlockDetailArtifactSchema>;

--- a/schemas-src/routes/chain-alpha-volume.ts
+++ b/schemas-src/routes/chain-alpha-volume.ts
@@ -28,13 +28,23 @@ const VolumeDistributionSchema = z
     p90: z.number().min(0),
     max: z.number().min(0),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Spread of per-subnet total_volume_tao across EVERY subnet with volume (not just the returned page, so the spread stays network-wide when limit truncates the leaderboard).",
+  );
 
 export const ChainAlphaVolumeArtifactSchema = z
   .object({
     schema_version: z.int(),
-    window: z.enum(["24h"]),
-    observed_at: z.string().nullable(),
+    window: z
+      .enum(["24h"])
+      .describe("Fixed rolling window label (always 24h)."),
+    observed_at: z
+      .string()
+      .nullable()
+      .describe(
+        "Newest event observed_at across the window; null on a cold store.",
+      ),
     subnet_count: z.int().min(0),
     network: z
       .object({
@@ -47,14 +57,31 @@ export const ChainAlphaVolumeArtifactSchema = z
         buy_count: z.int().min(0),
         sell_count: z.int().min(0),
         net_volume_alpha: z.number(),
-        sentiment_ratio: z.number().nullable(),
-        sentiment: z.enum(["bullish", "bearish", "neutral"]),
+        sentiment_ratio: z
+          .number()
+          .nullable()
+          .describe(
+            "net/gross alpha lean in [-1, 1]; null when there was no volume in the window.",
+          ),
+        sentiment: z
+          .enum(["bullish", "bearish", "neutral"])
+          .describe(
+            "Coarse sentiment label (bullish/bearish/neutral); neutral both for balanced volume and an empty window.",
+          ),
       })
-      .strict(),
-    volume_distribution: VolumeDistributionSchema.nullable(),
+      .strict()
+      .describe(
+        "Network-wide buy/sell volume rollup across every subnet with volume in the window.",
+      ),
+    volume_distribution: VolumeDistributionSchema.nullable().describe(
+      "Spread of per-subnet total_volume_tao across every subnet with volume; null when no subnet had volume.",
+    ),
     subnets: z.array(SubnetAlphaVolumeArtifactSchema),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Network-wide rolling 24h buy/sell alpha-volume leaderboard, summed live from the account_events StakeAdded/StakeRemoved stream. Mirrors GET /api/v1/chain/alpha-volume's data envelope.",
+  );
 export type ChainAlphaVolumeArtifact = z.infer<
   typeof ChainAlphaVolumeArtifactSchema
 >;

--- a/schemas-src/routes/chain-analytics.ts
+++ b/schemas-src/routes/chain-analytics.ts
@@ -23,7 +23,10 @@ const ChainActivityDaySchema = z
     success_rate: z.number().min(0).max(1).nullable(),
     unique_signers: z.int().min(0),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One UTC day's network activity: block/extrinsic/event counts, the successful-extrinsic count and its success rate (null on a zero-extrinsic day), and the distinct signer count.",
+  );
 
 export const ChainActivityArtifactSchema = z
   .object({
@@ -33,7 +36,10 @@ export const ChainActivityArtifactSchema = z
     day_count: z.int().min(0),
     days: z.array(ChainActivityDaySchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Per-UTC-day network activity series (blocks, extrinsics, events, signers) over the window, newest day first. Mirrors GET /api/v1/chain/activity's data envelope.",
+  );
 export type ChainActivityArtifact = z.infer<typeof ChainActivityArtifactSchema>;
 export const ChainActivityResponseSchema = successEnvelopeSchema(
   ChainActivityArtifactSchema,
@@ -46,7 +52,10 @@ const ChainCallEntrySchema = z
     count: z.int().min(0),
     share: z.number().min(0).max(1).nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One row of the extrinsic call-mix breakdown -- a call_module (plus call_function when group_by=module_function), its extrinsic count over the window, and its share of the window total (null when the window has no extrinsics).",
+  );
 
 export const ChainCallsArtifactSchema = z
   .object({
@@ -58,7 +67,10 @@ export const ChainCallsArtifactSchema = z
     call_count: z.int().min(0),
     calls: z.array(ChainCallEntrySchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Extrinsic call-mix breakdown over the window. Mirrors GET /api/v1/chain/calls's data envelope.",
+  );
 export type ChainCallsArtifact = z.infer<typeof ChainCallsArtifactSchema>;
 export const ChainCallsResponseSchema = successEnvelopeSchema(
   ChainCallsArtifactSchema,
@@ -68,22 +80,35 @@ const ChainSignerEntrySchema = z
   .object({
     signer: z.string(),
     tx_count: z.int().min(0),
-    total_fee_tao: z.number().min(0),
+    total_fee_tao: z
+      .number()
+      .min(0)
+      .describe(
+        "Total fees paid across the window's extrinsics; null when the tier has no fee data.",
+      ),
     total_tip_tao: z.number().min(0),
     last_tx_block: z.int().nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One account's extrinsic-submission activity in the window, ranked by the requested sort.",
+  );
 
 export const ChainSignersArtifactSchema = z
   .object({
     schema_version: z.int(),
     window: z.string(),
-    sort: z.enum(["tx_count", "total_fee_tao"]),
+    sort: z
+      .enum(["tx_count", "total_fee_tao"])
+      .describe("The rank order actually applied: tx_count or total_fee_tao."),
     observed_at: z.string().nullable().optional(),
     signer_count: z.int().min(0),
     signers: z.array(ChainSignerEntrySchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Network-wide weight-setter leaderboard over a lookback window, summed live from the account_events WeightsSet stream. The setter-level drill-in behind ChainWeights. Mirrors GET /api/v1/chain/weights/setters.",
+  );
 export type ChainSignersArtifact = z.infer<typeof ChainSignersArtifactSchema>;
 export const ChainSignersResponseSchema = successEnvelopeSchema(
   ChainSignersArtifactSchema,
@@ -101,7 +126,10 @@ const ChainFeeDaySchema = z
     avg_tip_tao: z.number().min(0).nullable(),
     median_tip_tao: z.number().min(0).nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One UTC day's fee/tip aggregate: extrinsic count, total/avg/median fee and tip in TAO. avg/median are computed over signed extrinsics only and are null on a day with no signed extrinsics; extrinsic_count counts every extrinsic including unsigned inherents.",
+  );
 
 const ChainFeePayerSchema = z
   .object({
@@ -110,7 +138,10 @@ const ChainFeePayerSchema = z
     total_tip_tao: z.number().min(0),
     extrinsic_count: z.int().min(0),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One top fee-paying signer over the window, with its total fee/tip and extrinsic count.",
+  );
 
 export const ChainFeesArtifactSchema = z
   .object({
@@ -121,7 +152,10 @@ export const ChainFeesArtifactSchema = z
     daily: z.array(ChainFeeDaySchema),
     top_fee_payers: z.array(ChainFeePayerSchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Per-UTC-day network fee/tip series plus the top fee payers over the window. Mirrors GET /api/v1/chain/fees's data envelope.",
+  );
 export type ChainFeesArtifact = z.infer<typeof ChainFeesArtifactSchema>;
 export const ChainFeesResponseSchema = successEnvelopeSchema(
   ChainFeesArtifactSchema,

--- a/schemas-src/routes/chain-concentration-history.ts
+++ b/schemas-src/routes/chain-concentration-history.ts
@@ -25,19 +25,35 @@ export const ChainConcentrationHistoryPointSchema = z
     day: z.string(),
     /** The shape of the day the card was computed over -- a point across half
      * the network is not comparable to one across all of it. */
-    neuron_count: z.int().min(0).nullable(),
+    neuron_count: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe(
+        "The shape of the day the card was computed over -- a point across half the network is not comparable to one across all of it.",
+      ),
     subnet_count: z.int().min(0).nullable(),
     entity_count: z.int().min(0).nullable(),
     /** WHEN the network looked like this, as distinct from when it was
      * computed. */
-    source_captured_at: z.iso.datetime().nullable(),
+    source_captured_at: z.iso
+      .datetime()
+      .nullable()
+      .describe(
+        "WHEN the network looked like this, as distinct from when it was computed.",
+      ),
     /** Which definition of the metrics produced this point. Comparing across a
      * change here compares two definitions, not two networks. */
-    builder_version: z.int().nullable(),
+    builder_version: z
+      .int()
+      .nullable()
+      .describe("Which definition of the metrics produced this point."),
     uids_per_entity: z.number().nullable(),
     /** NULL means no measurable distribution, NOT missing -- substituting zeros
      * would invent a perfectly equal one. */
-    stake: ChainConcentrationScorecardSchema.nullable(),
+    stake: ChainConcentrationScorecardSchema.nullable().describe(
+      "NULL means no measurable distribution, NOT missing.",
+    ),
     emission: ChainConcentrationScorecardSchema.nullable(),
     entity_stake: ChainConcentrationScorecardSchema.nullable(),
     entity_emission: ChainConcentrationScorecardSchema.nullable(),
@@ -51,18 +67,29 @@ export const ChainConcentrationHistoryArtifactSchema = z
     window: z.string().nullable(),
     /** From the ROWS. A day the capture did not run is absent, never a
      * zero-concentration point. */
-    point_count: z.int().min(0).nullable(),
+    point_count: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe(
+        "From the ROWS. A day the capture did not run is absent, never a zero-concentration point.",
+      ),
     oldest_day: z.string().nullable(),
     newest_day: z.string().nullable(),
     /** More than one means the series changes DEFINITION partway along, and a
      * trend drawn across the boundary is not a trend. */
-    builder_versions: z.array(z.int()),
+    builder_versions: z
+      .array(z.int())
+      .describe(
+        "Every distinct builder version in the series. More than one means it changes DEFINITION partway along.",
+      ),
     points: z.array(ChainConcentrationHistoryPointSchema),
     /** Present ONLY on a decline. An empty window is a measurement. */
     degraded: z
       .object({ reason: z.enum(["unavailable"]) })
       .strict()
-      .optional(),
+      .optional()
+      .describe("Present ONLY on a decline. An empty window is a measurement."),
   })
   .passthrough();
 export type ChainConcentrationHistoryArtifact = z.infer<

--- a/schemas-src/routes/chain-concentration.ts
+++ b/schemas-src/routes/chain-concentration.ts
@@ -11,18 +11,44 @@ import { ConcentrationMetricsSchema } from "../shared.ts";
 export const ChainConcentrationArtifactSchema = z
   .object({
     schema_version: z.int(),
-    subnet_count: z.int().min(0),
+    subnet_count: z
+      .int()
+      .min(0)
+      .describe("Distinct subnets the snapshot spans."),
     neuron_count: z.int().min(0),
-    entity_count: z.int().min(0),
-    uids_per_entity: z.number().nullable(),
+    entity_count: z
+      .int()
+      .min(0)
+      .describe(
+        "Distinct controlling entities (coldkeys) network-wide, collapsed across subnets.",
+      ),
+    uids_per_entity: z
+      .number()
+      .nullable()
+      .describe(
+        "UIDs per controlling entity network-wide -- a consolidation signal (1.0 = every UID a distinct owner; higher = fewer operators each running many). Null when no entities.",
+      ),
     captured_at: z.string().nullable(),
-    stake: ConcentrationMetricsSchema,
-    emission: ConcentrationMetricsSchema,
-    entity_stake: ConcentrationMetricsSchema,
-    entity_emission: ConcentrationMetricsSchema,
-    validator_stake: ConcentrationMetricsSchema,
+    stake: ConcentrationMetricsSchema.describe(
+      "Raw stake concentration across every neuron network-wide.",
+    ),
+    emission: ConcentrationMetricsSchema.describe(
+      "Raw emission concentration across every neuron network-wide.",
+    ),
+    entity_stake: ConcentrationMetricsSchema.describe(
+      "Stake concentration per controlling entity -- hotkeys collapsed across subnets, so one operator counts once.",
+    ),
+    entity_emission: ConcentrationMetricsSchema.describe(
+      "Emission concentration per controlling entity -- hotkeys collapsed across subnets.",
+    ),
+    validator_stake: ConcentrationMetricsSchema.describe(
+      "Stake concentration across permitted validators network-wide only.",
+    ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Network-wide stake & emission decentralization card (#5872). Metric blocks are null on a cold/empty store. Mirrors GET /api/v1/chain/concentration.",
+  );
 export type ChainConcentrationArtifact = z.infer<
   typeof ChainConcentrationArtifactSchema
 >;

--- a/schemas-src/routes/chain-events.ts
+++ b/schemas-src/routes/chain-events.ts
@@ -55,7 +55,10 @@ export const ChainEventsFeedArtifactSchema = z
       .optional(),
     events: z.array(ChainEventSchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Paginated all-events feed from the chain_events lakehouse table. Mirrors GET /api/v1/chain-events (and MCP list_chain_events). Distinct from Subscription.chainEvents.",
+  );
 export type ChainEventsFeedArtifact = z.infer<
   typeof ChainEventsFeedArtifactSchema
 >;
@@ -69,7 +72,10 @@ const ChainEventEntrySchema = z
     method: z.string().nullable(),
     count: z.int().min(0),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One pallet.method group in the chain-activity aggregate, with its event count over the window.",
+  );
 
 export const ChainEventsStatsArtifactSchema = z
   .object({
@@ -77,7 +83,10 @@ export const ChainEventsStatsArtifactSchema = z
     groups: z.int().min(0),
     activity: z.array(ChainEventEntrySchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Chain-activity aggregate (pallet.method event distribution) over the most recent N blocks from the chain_events lakehouse table. The aggregate sibling of ChainEventsFeed. Mirrors GET /api/v1/chain-events/stats (and MCP get_chain_activity).",
+  );
 export type ChainEventsStatsArtifact = z.infer<
   typeof ChainEventsStatsArtifactSchema
 >;

--- a/schemas-src/routes/chain-holders.ts
+++ b/schemas-src/routes/chain-holders.ts
@@ -14,26 +14,49 @@ export const ChainHoldersSubnetSchema = z
     netuid: z.int().min(0).max(65535),
     holder_count: z.int().min(0).nullable(),
     /** ALPHA, and only comparable WITHIN this subnet. */
-    total_alpha: z.number().min(0).nullable(),
+    total_alpha: z
+      .number()
+      .min(0)
+      .nullable()
+      .describe(
+        "ALPHA, comparable only WITHIN this subnet -- each subnet's alpha is a different token.",
+      ),
     top1_share: z.number().min(0).max(1).nullable(),
     top5_share: z.number().min(0).max(1).nullable(),
     top10_share: z.number().min(0).max(1).nullable(),
     top20_share: z.number().min(0).max(1).nullable(),
     /** The largest holder's coldkey (an ss58 address) -- public on-chain data. */
-    top_holder: z.string().nullable(),
+    top_holder: z
+      .string()
+      .nullable()
+      .describe("The largest holder's coldkey (an ss58 address)."),
   })
-  .strict();
+  .strict()
+  .describe("One subnet's alpha-ownership concentration.");
 
 export const ChainHoldersNetworkSchema = z
   .object({
     subnets_measured: z.int().min(0).nullable(),
     /** Subnets where ONE account holds a majority of the measured alpha. */
-    subnets_with_majority_holder: z.int().min(0).nullable(),
+    subnets_with_majority_holder: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe(
+        "Subnets where ONE account holds a majority of the measured alpha.",
+      ),
     /** Subnets whose entire measured alpha sits in a single wallet. */
-    subnets_with_single_holder: z.int().min(0).nullable(),
+    subnets_with_single_holder: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe("Subnets whose entire measured alpha sits in a single wallet."),
     median_top1_share: z.number().min(0).max(1).nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Dimension-free network facts. There is deliberately no cross-subnet alpha total: summing different subnets' alpha has no unit.",
+  );
 
 export const ChainHoldersArtifactSchema = z
   .object({
@@ -41,7 +64,13 @@ export const ChainHoldersArtifactSchema = z
     sort: z.string(),
     limit: z.int().min(1).nullable(),
     /** Subnets measured, which is NOT the length of `subnets` when limit bites. */
-    subnet_count: z.int().min(0).nullable(),
+    subnet_count: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe(
+        "Subnets measured -- NOT the length of the subnets list when limit bites.",
+      ),
     network: ChainHoldersNetworkSchema,
     captured_at: z.iso.datetime().nullable(),
     positions_captured_at: z.iso.datetime().nullable(),
@@ -50,7 +79,13 @@ export const ChainHoldersArtifactSchema = z
     degraded: z
       .object({ reason: z.enum(["pool_totals_unproven", "unavailable"]) })
       .strict()
-      .optional(),
+      .describe(
+        "A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer.",
+      )
+      .optional()
+      .describe(
+        "Present ONLY on a decline. An empty subnets list WITHOUT this block is a measurement.",
+      ),
   })
   .passthrough();
 export type ChainHoldersArtifact = z.infer<typeof ChainHoldersArtifactSchema>;

--- a/schemas-src/routes/chain-identity-history.ts
+++ b/schemas-src/routes/chain-identity-history.ts
@@ -34,7 +34,10 @@ const ChainIdentityHistoryChangeSchema = z
     logo_url: z.url().nullable().optional(),
     identity_hash: z.string().nullable(),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One cross-subnet identity change in the network-wide feed (carries its netuid).",
+  );
 
 export const ChainIdentityHistoryArtifactSchema = z
   .object({

--- a/schemas-src/routes/chain-idle-stake.ts
+++ b/schemas-src/routes/chain-idle-stake.ts
@@ -19,10 +19,14 @@ export const ChainIdleStakeArtifactSchema = z
           idle_neuron_count: z.int().min(0),
           idle_stake_alpha: z.number().min(0),
         })
-        .passthrough(),
+        .passthrough()
+        .describe("One subnet's idle-stake scorecard in the network ranking."),
     ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Network-wide idle-stake rollup: every subnet's stake on currently-zero-dividends hotkeys, ranked by idle_stake_alpha. Mirrors GET /api/v1/chain/idle-stake's data envelope.",
+  );
 export type ChainIdleStakeArtifact = z.infer<
   typeof ChainIdleStakeArtifactSchema
 >;

--- a/schemas-src/routes/chain-network-rollups.ts
+++ b/schemas-src/routes/chain-network-rollups.ts
@@ -32,7 +32,10 @@ const IntensityDistributionSchema = z
     p90: z.number().min(0),
     max: z.number().min(0),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Spread of per-subnet transfers-per-sender intensity across EVERY subnet with transfers in the window.",
+  );
 
 export const ChainAxonRemovalsArtifactSchema = z
   .object({
@@ -44,9 +47,18 @@ export const ChainAxonRemovalsArtifactSchema = z
       .object({
         distinct_removers: z.int().min(0),
         removals: z.int().min(0),
-        removals_per_remover: z.number().min(0).nullable(),
+        removals_per_remover: z
+          .number()
+          .min(0)
+          .nullable()
+          .describe(
+            "Null when distinct_removers is 0 (no defined intensity without removers).",
+          ),
       })
-      .strict(),
+      .strict()
+      .describe(
+        "Network-wide axon-removal rollup: every subnet with AxonInfoRemoved events in the window, combined. distinct_removers counts a hotkey once even when it tears endpoints down on several subnets, so it is NOT the sum of the per-subnet counts.",
+      ),
     intensity_distribution: IntensityDistributionSchema.nullable(),
     subnets: z.array(
       z
@@ -56,7 +68,10 @@ export const ChainAxonRemovalsArtifactSchema = z
           removals: z.int().min(0),
           removals_per_remover: z.number().min(0).nullable(),
         })
-        .strict(),
+        .strict()
+        .describe(
+          "One subnet's axon-removal activity in the window, ranked by removals.",
+        ),
     ),
     // #9307: AxonInfoRemoved has never been emitted, so the empty answer this
     // route can only ever give is not a measurement.
@@ -97,10 +112,19 @@ export const ChainDeregistrationsArtifactSchema = z
       .object({
         distinct_deregistered_hotkeys: z.int().min(0),
         deregistrations: z.int().min(0),
-        deregistrations_per_hotkey: z.number().min(0).nullable(),
+        deregistrations_per_hotkey: z
+          .number()
+          .min(0)
+          .nullable()
+          .describe(
+            "Null when distinct_deregistered_hotkeys is 0 (no defined intensity without hotkeys).",
+          ),
         tenure: SlotTenureSchema.optional(),
       })
-      .strict(),
+      .strict()
+      .describe(
+        "Network-wide deregistration rollup: every subnet with a derived deregistration in the window, combined. distinct_deregistered_hotkeys counts a hotkey once even when it is deregistered from several subnets, so it is NOT the sum of the per-subnet counts.",
+      ),
     intensity_distribution: IntensityDistributionSchema.nullable(),
     subnets: z.array(
       z
@@ -111,7 +135,10 @@ export const ChainDeregistrationsArtifactSchema = z
           deregistrations_per_hotkey: z.number().min(0).nullable(),
           tenure: SlotTenureSchema.optional(),
         })
-        .strict(),
+        .strict()
+        .describe(
+          "One subnet's neuron-deregistration activity in the window, ranked by deregistrations.",
+        ),
     ),
     // #9307: derived from UID reuse, with the derivation's own lower-bound
     // statement; `degraded` when nothing derived it.
@@ -136,9 +163,18 @@ export const ChainPrometheusArtifactSchema = z
       .object({
         distinct_exporters: z.int().min(0),
         announcements: z.int().min(0),
-        announcements_per_exporter: z.number().min(0).nullable(),
+        announcements_per_exporter: z
+          .number()
+          .min(0)
+          .nullable()
+          .describe(
+            "Null when distinct_exporters is 0 (no defined intensity without exporters).",
+          ),
       })
-      .strict(),
+      .strict()
+      .describe(
+        "Network-wide Prometheus-serving rollup: every subnet with PrometheusServed announcements in the window, combined. distinct_exporters counts a hotkey once even when it announces on several subnets, so it is NOT the sum of the per-subnet counts.",
+      ),
     intensity_distribution: IntensityDistributionSchema.nullable(),
     subnets: z.array(
       z
@@ -148,7 +184,10 @@ export const ChainPrometheusArtifactSchema = z
           announcements: z.int().min(0),
           announcements_per_exporter: z.number().min(0).nullable(),
         })
-        .strict(),
+        .strict()
+        .describe(
+          "One subnet's Prometheus telemetry-serving activity in the window, ranked by announcements.",
+        ),
     ),
     // #9307: the chain emits PrometheusServed and our account_events curation
     // drops it, so the empty answer is not a measurement.
@@ -172,9 +211,18 @@ export const ChainRegistrationsArtifactSchema = z
       .object({
         distinct_registrants: z.int().min(0),
         registrations: z.int().min(0),
-        registrations_per_registrant: z.number().min(0).nullable(),
+        registrations_per_registrant: z
+          .number()
+          .min(0)
+          .nullable()
+          .describe(
+            "Null when distinct_registrants is 0 (no defined intensity without hotkeys).",
+          ),
       })
-      .strict(),
+      .strict()
+      .describe(
+        "Network-wide registration rollup: every subnet with NeuronRegistered events in the window, combined. distinct_registrants counts a hotkey once even when it registers on several subnets, so it is NOT the sum of the per-subnet counts.",
+      ),
     intensity_distribution: IntensityDistributionSchema.nullable(),
     subnets: z.array(
       z
@@ -184,7 +232,10 @@ export const ChainRegistrationsArtifactSchema = z
           registrations: z.int().min(0),
           registrations_per_registrant: z.number().min(0).nullable(),
         })
-        .strict(),
+        .strict()
+        .describe(
+          "One subnet's neuron-registration activity in the window, ranked by registrations.",
+        ),
     ),
   })
   .strict();
@@ -205,9 +256,18 @@ export const ChainServingArtifactSchema = z
       .object({
         distinct_servers: z.int().min(0),
         announcements: z.int().min(0),
-        announcements_per_server: z.number().min(0).nullable(),
+        announcements_per_server: z
+          .number()
+          .min(0)
+          .nullable()
+          .describe(
+            "Null when distinct_servers is 0 (no defined intensity without servers).",
+          ),
       })
-      .strict(),
+      .strict()
+      .describe(
+        "Network-wide axon-serving rollup: every subnet with AxonServed announcements in the window, combined.",
+      ),
     intensity_distribution: IntensityDistributionSchema.nullable(),
     subnets: z.array(
       z
@@ -217,10 +277,16 @@ export const ChainServingArtifactSchema = z
           announcements: z.int().min(0),
           announcements_per_server: z.number().min(0).nullable(),
         })
-        .strict(),
+        .strict()
+        .describe(
+          "One subnet's axon-serving activity in the window, ranked by announcements.",
+        ),
     ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Network-wide axon-serving announcement leaderboard (#5873). The network-wide counterpart of subnet_serving. Mirrors GET /api/v1/chain/serving's data envelope.",
+  );
 export type ChainServingArtifact = z.infer<typeof ChainServingArtifactSchema>;
 export const ChainServingResponseSchema = successEnvelopeSchema(
   ChainServingArtifactSchema,
@@ -236,9 +302,16 @@ export const ChainStakeMovesArtifactSchema = z
       .object({
         distinct_movers: z.int().min(0),
         movements: z.int().min(0),
-        movements_per_mover: z.number().min(0).nullable(),
+        movements_per_mover: z
+          .number()
+          .min(0)
+          .nullable()
+          .describe("Null when distinct_movers is 0."),
       })
-      .strict(),
+      .strict()
+      .describe(
+        "Network-wide stake-move rollup: every subnet with StakeMoved events in the window, combined. distinct_movers counts a coldkey once even when it moves on several subnets.",
+      ),
     intensity_distribution: IntensityDistributionSchema.nullable(),
     subnets: z.array(
       z
@@ -248,10 +321,16 @@ export const ChainStakeMovesArtifactSchema = z
           movements: z.int().min(0),
           movements_per_mover: z.number().min(0).nullable(),
         })
-        .strict(),
+        .strict()
+        .describe(
+          "One subnet's stake-movement activity in the window, ranked by movements.",
+        ),
     ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Network-wide stake-movement (re-delegation) leaderboard over a lookback window, summed live from the account_events StakeMoved stream. Mirrors GET /api/v1/chain/stake-moves's data envelope.",
+  );
 export type ChainStakeMovesArtifact = z.infer<
   typeof ChainStakeMovesArtifactSchema
 >;
@@ -269,9 +348,16 @@ export const ChainStakeTransfersArtifactSchema = z
       .object({
         distinct_senders: z.int().min(0),
         transfers: z.int().min(0),
-        transfers_per_sender: z.number().min(0).nullable(),
+        transfers_per_sender: z
+          .number()
+          .min(0)
+          .nullable()
+          .describe("Null when distinct_senders is 0."),
       })
-      .strict(),
+      .strict()
+      .describe(
+        "Network-wide stake-transfer rollup: every subnet with StakeTransferred events in the window, combined. distinct_senders counts an origin coldkey once even when it transfers out of several subnets.",
+      ),
     intensity_distribution: IntensityDistributionSchema.nullable(),
     subnets: z.array(
       z
@@ -281,10 +367,16 @@ export const ChainStakeTransfersArtifactSchema = z
           transfers: z.int().min(0),
           transfers_per_sender: z.number().min(0).nullable(),
         })
-        .strict(),
+        .strict()
+        .describe(
+          "One subnet's stake-transfer activity in the window, ranked by transfers.",
+        ),
     ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Network-wide stake-transfer (between-coldkeys) leaderboard over a lookback window, summed live from the account_events StakeTransferred stream. Mirrors GET /api/v1/chain/stake-transfers's data envelope.",
+  );
 export type ChainStakeTransfersArtifact = z.infer<
   typeof ChainStakeTransfersArtifactSchema
 >;
@@ -302,9 +394,18 @@ export const ChainWeightsArtifactSchema = z
       .object({
         distinct_setters: z.int().min(0),
         weight_sets: z.int().min(0),
-        sets_per_setter: z.number().min(0).nullable(),
+        sets_per_setter: z
+          .number()
+          .min(0)
+          .nullable()
+          .describe(
+            "Null when distinct_setters is 0 (no defined intensity without setters).",
+          ),
       })
-      .strict(),
+      .strict()
+      .describe(
+        "Network-wide weight-setting rollup: every subnet that set weights in the window, combined.",
+      ),
     intensity_distribution: IntensityDistributionSchema.nullable(),
     subnets: z.array(
       z
@@ -314,10 +415,16 @@ export const ChainWeightsArtifactSchema = z
           weight_sets: z.int().min(0),
           sets_per_setter: z.number().min(0).nullable(),
         })
-        .strict(),
+        .strict()
+        .describe(
+          "One subnet's weight-setting activity in the window, ranked by weight_sets.",
+        ),
     ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Network-wide validator weight-setting activity over a lookback window, summed live from the account_events WeightsSet stream. Mirrors GET /api/v1/chain/weights.",
+  );
 export type ChainWeightsArtifact = z.infer<typeof ChainWeightsArtifactSchema>;
 export const ChainWeightsResponseSchema = successEnvelopeSchema(
   ChainWeightsArtifactSchema,

--- a/schemas-src/routes/chain-network-rollups.ts
+++ b/schemas-src/routes/chain-network-rollups.ts
@@ -310,7 +310,7 @@ export const ChainStakeMovesArtifactSchema = z
       })
       .strict()
       .describe(
-        "Network-wide stake-move rollup: every subnet with StakeMoved events in the window, combined. distinct_movers counts a coldkey once even when it moves on several subnets.",
+        "Network-wide stake-move rollup: every subnet with StakeMoved events in the window, combined. distinct_movers counts a `coldkey` once even when it moves on several subnets.",
       ),
     intensity_distribution: IntensityDistributionSchema.nullable(),
     subnets: z.array(
@@ -356,7 +356,7 @@ export const ChainStakeTransfersArtifactSchema = z
       })
       .strict()
       .describe(
-        "Network-wide stake-transfer rollup: every subnet with StakeTransferred events in the window, combined. distinct_senders counts an origin coldkey once even when it transfers out of several subnets.",
+        "Network-wide stake-transfer rollup: every subnet with StakeTransferred events in the window, combined. distinct_senders counts an origin `coldkey` once even when it transfers out of several subnets.",
       ),
     intensity_distribution: IntensityDistributionSchema.nullable(),
     subnets: z.array(

--- a/schemas-src/routes/chain-performance.ts
+++ b/schemas-src/routes/chain-performance.ts
@@ -16,18 +16,34 @@ import {
 export const ChainPerformanceArtifactSchema = z
   .object({
     schema_version: z.int(),
-    subnet_count: z.int().min(0),
+    subnet_count: z
+      .int()
+      .min(0)
+      .describe("Distinct subnets the snapshot spans."),
     neuron_count: z.int().min(0),
     validator_count: z.int().min(0).optional(),
     active_count: z.int().min(0).optional(),
     captured_at: z.string().nullable().optional(),
-    incentive: ConcentrationMetricsSchema,
-    dividends: ConcentrationMetricsSchema,
-    trust: ScoreDistributionSchema,
-    consensus: ScoreDistributionSchema,
-    validator_trust: ScoreDistributionSchema.optional(),
+    incentive: ConcentrationMetricsSchema.describe(
+      "Incentive concentration across all neurons network-wide with positive incentive.",
+    ),
+    dividends: ConcentrationMetricsSchema.describe(
+      "Dividends concentration across permitted validators network-wide only.",
+    ),
+    trust: ScoreDistributionSchema.describe(
+      "Trust score spread across all neurons network-wide.",
+    ),
+    consensus: ScoreDistributionSchema.describe(
+      "Consensus score spread across all neurons network-wide.",
+    ),
+    validator_trust: ScoreDistributionSchema.optional().describe(
+      "Validator-trust score spread across permitted validators network-wide only.",
+    ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Network-wide reward-distribution & score-spread card (#5688) -- the network analog of SubnetPerformance, spanning every subnet's neurons in one snapshot. Metric blocks are null on a cold/empty store. Mirrors GET /api/v1/chain/performance.",
+  );
 export type ChainPerformanceArtifact = z.infer<
   typeof ChainPerformanceArtifactSchema
 >;

--- a/schemas-src/routes/chain-stake-flow.ts
+++ b/schemas-src/routes/chain-stake-flow.ts
@@ -16,7 +16,10 @@ const NetFlowDistributionSchema = z
     p90: z.number(),
     max: z.number(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Spread of per-subnet net_flow_tao (can be negative) across EVERY subnet with stake events (not just the returned page).",
+  );
 
 export const ChainStakeFlowArtifactSchema = z
   .object({
@@ -36,8 +39,13 @@ export const ChainStakeFlowArtifactSchema = z
         losing: z.int().min(0),
         flat: z.int().min(0),
       })
-      .strict(),
-    net_flow_distribution: NetFlowDistributionSchema.nullable(),
+      .strict()
+      .describe(
+        "Network rollup over every subnet that moved stake in the window.",
+      ),
+    net_flow_distribution: NetFlowDistributionSchema.nullable().describe(
+      "Spread of per-subnet net_flow_tao across EVERY subnet with stake events; null when no subnet moved stake.",
+    ),
     subnets: z.array(
       z
         .object({
@@ -48,12 +56,20 @@ export const ChainStakeFlowArtifactSchema = z
           gross_flow_tao: z.number().min(0),
           stake_events: z.int().min(0),
           unstake_events: z.int().min(0),
-          direction: z.enum(["inflow", "outflow", "balanced"]),
+          direction: z
+            .enum(["inflow", "outflow", "balanced"])
+            .describe("inflow | outflow | balanced"),
         })
-        .strict(),
+        .strict()
+        .describe(
+          "One subnet's capital-flow scorecard in the window, ranked by net_flow_tao.",
+        ),
     ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Network-wide cross-subnet capital-flow leaderboard over a lookback window, summed live from the account_events StakeAdded/StakeRemoved stream. Mirrors GET /api/v1/chain/stake-flow's data envelope.",
+  );
 export type ChainStakeFlowArtifact = z.infer<
   typeof ChainStakeFlowArtifactSchema
 >;

--- a/schemas-src/routes/chain-transfers.ts
+++ b/schemas-src/routes/chain-transfers.ts
@@ -24,22 +24,35 @@ const ChainTransferPairSchema = z
     last_block: z.int().min(0).nullable(),
     last_observed_at: z.string().nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One directed sender -> receiver corridor on the transfer-pairs leaderboard.",
+  );
 
 export const ChainTransferPairsArtifactSchema = z
   .object({
     schema_version: z.int(),
     window: z.string().nullable(),
-    sort: z.enum(["volume", "count"]),
+    sort: z
+      .enum(["volume", "count"])
+      .describe("The rank order actually applied: volume or count."),
     observed_at: z.string().nullable(),
     total_volume_tao: z.number().min(0),
     transfer_count: z.int().min(0),
     unique_pairs: z.int().min(0),
     pair_count: z.int().min(0),
-    top_pair_share: z.number().nullable(),
+    top_pair_share: z
+      .number()
+      .nullable()
+      .describe(
+        "Highest-volume corridor's share of total pairable volume; null when the window has no pairable volume.",
+      ),
     pairs: z.array(ChainTransferPairSchema),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Network-wide directed native-TAO transfer-corridor leaderboard over a lookback window. Mirrors GET /api/v1/chain/transfer-pairs's data envelope.",
+  );
 export type ChainTransferPairsArtifact = z.infer<
   typeof ChainTransferPairsArtifactSchema
 >;
@@ -53,7 +66,8 @@ const ChainTransferPartySchema = z
     volume_tao: z.number(),
     transfer_count: z.int().min(0),
   })
-  .strict();
+  .strict()
+  .describe("One account on a chain-transfers sender/receiver leaderboard.");
 
 export const ChainTransfersArtifactSchema = z
   .object({
@@ -64,11 +78,19 @@ export const ChainTransfersArtifactSchema = z
     transfer_count: z.int().min(0),
     unique_senders: z.int().min(0),
     unique_receivers: z.int().min(0),
-    top_sender_share: z.number().nullable(),
+    top_sender_share: z
+      .number()
+      .nullable()
+      .describe(
+        "Top senders' combined share of total volume; null when total volume is 0.",
+      ),
     top_senders: z.array(ChainTransferPartySchema),
     top_receivers: z.array(ChainTransferPartySchema),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Network-wide native-TAO transfer analytics over a lookback window. Mirrors GET /api/v1/chain/transfers's data envelope.",
+  );
 export type ChainTransfersArtifact = z.infer<
   typeof ChainTransfersArtifactSchema
 >;

--- a/schemas-src/routes/chain-turnover.ts
+++ b/schemas-src/routes/chain-turnover.ts
@@ -19,7 +19,10 @@ const StabilityDistributionSchema = z
     p90: z.int().min(0).max(100),
     max: z.int().min(0).max(100),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Spread of per-subnet stability score across EVERY subnet in the window (not just the returned page, so the spread stays network-wide when limit truncates the leaderboard).",
+  );
 
 export const ChainTurnoverArtifactSchema = z
   .object({
@@ -28,12 +31,18 @@ export const ChainTurnoverArtifactSchema = z
     start_date: z
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}$/)
-      .nullable(),
+      .nullable()
+      .describe("Start snapshot date; null on a cold store."),
     end_date: z
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}$/)
-      .nullable(),
-    comparable: z.boolean(),
+      .nullable()
+      .describe("End snapshot date; null on a cold store."),
+    comparable: z
+      .boolean()
+      .describe(
+        "False when the window resolved to fewer than two distinct snapshots, so start/end churn is not measurable.",
+      ),
     subnet_count: z.int().min(0),
     network: z
       .object({
@@ -41,11 +50,30 @@ export const ChainTurnoverArtifactSchema = z
         validators_end: z.int().min(0),
         validators_entered: z.int().min(0),
         validators_exited: z.int().min(0),
-        validator_retention: z.number().min(0).max(1).nullable(),
-        stability_score: z.int().min(0).max(100).nullable(),
+        validator_retention: z
+          .number()
+          .min(0)
+          .max(1)
+          .nullable()
+          .describe(
+            "Jaccard retention of the start set into the end set; null on a cold/non-comparable window.",
+          ),
+        stability_score: z
+          .int()
+          .min(0)
+          .max(100)
+          .nullable()
+          .describe(
+            "0-100 stability score; null on a cold/non-comparable window.",
+          ),
       })
-      .strict(),
-    stability_distribution: StabilityDistributionSchema.nullable(),
+      .strict()
+      .describe(
+        "Network-wide validator-set rollup: every subnet's validators combined, deduplicated across the network.",
+      ),
+    stability_distribution: StabilityDistributionSchema.nullable().describe(
+      "Null when no subnet had a stability score in the window (nothing to distribute).",
+    ),
     subnets: z.array(
       z
         .object({
@@ -57,10 +85,16 @@ export const ChainTurnoverArtifactSchema = z
           validator_retention: z.number().min(0).max(1).nullable(),
           stability_score: z.int().min(0).max(100).nullable(),
         })
-        .strict(),
+        .strict()
+        .describe(
+          "One subnet's validator-set churn, ranked by gross churn (entered + exited) then netuid.",
+        ),
     ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Network-wide validator-set churn across all subnets (#5686). Mirrors GET /api/v1/chain/turnover's data envelope.",
+  );
 export type ChainTurnoverArtifact = z.infer<typeof ChainTurnoverArtifactSchema>;
 export const ChainTurnoverResponseSchema = successEnvelopeSchema(
   ChainTurnoverArtifactSchema,

--- a/schemas-src/routes/chain-weight-setters.ts
+++ b/schemas-src/routes/chain-weight-setters.ts
@@ -15,11 +15,20 @@ const ChainWeightSetterSchema = z
     netuid: z.int().min(0).nullable(),
     uid: z.int().min(0).nullable(),
     weight_sets: z.int().min(0),
-    share: z.number().min(0).nullable(),
+    share: z
+      .number()
+      .min(0)
+      .nullable()
+      .describe(
+        "This setter's share of the network total weight_sets; null when the network total is 0.",
+      ),
     first_set_at: z.string().nullable(),
     last_set_at: z.string().nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One validator's network-wide weight-setting activity in the window. netuid is set only when hotkey is null (a uid-only identity has no meaning outside its own subnet).",
+  );
 
 export const ChainWeightSettersArtifactSchema = z
   .object({

--- a/schemas-src/routes/chain-yield.ts
+++ b/schemas-src/routes/chain-yield.ts
@@ -22,6 +22,9 @@ const YieldDistributionSchema = z
     p90: z.number(),
   })
   .passthrough()
+  .describe(
+    "Distribution of the per-neuron emission/stake return rate across the network.",
+  )
   .nullable();
 
 export const ChainYieldArtifactSchema = z
@@ -54,7 +57,10 @@ export const ChainYieldArtifactSchema = z
     miner_yield: z.number().nullable().optional(),
     distribution: YieldDistributionSchema,
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Network-wide emission-yield (return rate) card across every subnet's neurons. Aggregates are null on a cold store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/chain/yield.",
+  );
 export type ChainYieldArtifact = z.infer<typeof ChainYieldArtifactSchema>;
 export const ChainYieldResponseSchema = successEnvelopeSchema(
   ChainYieldArtifactSchema,

--- a/schemas-src/routes/compare-validators.ts
+++ b/schemas-src/routes/compare-validators.ts
@@ -15,7 +15,7 @@ export const CompareValidatorEntrySchema = z
     hotkey: z.string(),
     coldkey: z.string().nullable(),
     coldkey_identity: ColdkeyIdentitySchema.nullable().describe(
-      "The coldkey's self-declared on-chain identity; opaque JSON, matching the REST/MCP shape.",
+      "The `coldkey`'s self-declared on-chain identity; opaque JSON, matching the REST/MCP shape.",
     ),
     take: z.number().nullable(),
     apy_estimate: z.number().min(0).nullable(),

--- a/schemas-src/routes/compare-validators.ts
+++ b/schemas-src/routes/compare-validators.ts
@@ -14,7 +14,9 @@ export const CompareValidatorEntrySchema = z
   .object({
     hotkey: z.string(),
     coldkey: z.string().nullable(),
-    coldkey_identity: ColdkeyIdentitySchema.nullable(),
+    coldkey_identity: ColdkeyIdentitySchema.nullable().describe(
+      "The coldkey's self-declared on-chain identity; opaque JSON, matching the REST/MCP shape.",
+    ),
     take: z.number().nullable(),
     apy_estimate: z.number().min(0).nullable(),
     apy_estimate_eligible_subnet_count: z.int().min(0),
@@ -24,18 +26,27 @@ export const CompareValidatorEntrySchema = z
     avg_validator_trust: z.number().nullable(),
     max_validator_trust: z.number().nullable(),
     subnet_count: z.int().min(0),
-    subnet_context: ValidatorDetailSubnetSchema.nullable(),
+    subnet_context: ValidatorDetailSubnetSchema.nullable().describe(
+      "This validator's membership row in the requested netuid; null when netuid was omitted or it has no permit there. Opaque JSON, matching the REST/MCP shape.",
+    ),
   })
   .strict();
 
 export const CompareValidatorsArtifactSchema = z
   .object({
     schema_version: z.int(),
-    netuid: z.int().min(0).nullable(),
+    netuid: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe("The optional subnet context the comparison was scoped to."),
     validator_count: z.int().min(0),
     validators: z.array(CompareValidatorEntrySchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Several validators placed side by side (#6989). Mirrors GET /api/v1/compare/validators.",
+  );
 export type CompareValidatorsArtifact = z.infer<
   typeof CompareValidatorsArtifactSchema
 >;

--- a/schemas-src/routes/curation-gaps.ts
+++ b/schemas-src/routes/curation-gaps.ts
@@ -42,7 +42,11 @@ export const CurationEntrySchema = z
 
 export const CurationArtifactSchema = ArtifactBaseSchema.extend({
   curation: z.array(CurationEntrySchema),
-}).passthrough();
+})
+  .passthrough()
+  .describe(
+    "Network-wide public evidence ledger page. Mirrors GET /api/v1/evidence (and MCP list_evidence).",
+  );
 export type CurationArtifact = z.infer<typeof CurationArtifactSchema>;
 export const CurationResponseSchema = successEnvelopeSchema(
   CurationArtifactSchema,
@@ -75,6 +79,10 @@ export const GapsEntrySchema = z
 
 export const GapsArtifactSchema = ArtifactBaseSchema.extend({
   gaps: z.array(GapsEntrySchema),
-}).passthrough();
+})
+  .passthrough()
+  .describe(
+    "Registry-wide interface gap report page. Mirrors GET /api/v1/gaps (and MCP list_gaps).",
+  );
 export type GapsArtifact = z.infer<typeof GapsArtifactSchema>;
 export const GapsResponseSchema = successEnvelopeSchema(GapsArtifactSchema);

--- a/schemas-src/routes/domains.ts
+++ b/schemas-src/routes/domains.ts
@@ -26,7 +26,10 @@ export const ConcentrationScorecardSchema = z
     entropy: z.number().nullable(),
     entropy_normalized: z.number().nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Concentration metrics over a value distribution -- Gini, HHI (raw + holder-count-normalized), Nakamoto coefficient, top-percentile shares, and Shannon entropy.",
+  );
 export type ConcentrationScorecard = z.infer<
   typeof ConcentrationScorecardSchema
 >;
@@ -44,9 +47,14 @@ export const DomainSummaryArtifactSchema = z
         "This domain's member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051), rather than a sum of incomparable per-subnet alpha tokens. The economics tier carries a price for every subnet, so a member without one is a data defect and is excluded from the total.",
       ),
     total_emission_share: z.number().nullable(),
-    emission_concentration: ConcentrationScorecardSchema.nullable(),
+    emission_concentration: ConcentrationScorecardSchema.nullable().describe(
+      "Within-domain emission concentration scorecard; null when the domain has no members. Declared Float until #9889 — the route has served the full 12-key scorecard for long enough that the scalar coerced to null on every domain, which this type's own comment then read as 'no members'.",
+    ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One domain/capability tag's rollup (#6989). Mirrors GET /api/v1/domains/{tag}/summary.",
+  );
 export type DomainSummaryArtifact = z.infer<typeof DomainSummaryArtifactSchema>;
 export const DomainSummaryResponseSchema = successEnvelopeSchema(
   DomainSummaryArtifactSchema,
@@ -58,7 +66,10 @@ export const DomainsArtifactSchema = z
     domain_count: z.int().min(0),
     domains: z.array(DomainSummaryArtifactSchema),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The per-domain rollup overview across the fixed capability taxonomy (#6989). Mirrors GET /api/v1/domains.",
+  );
 export type DomainsArtifact = z.infer<typeof DomainsArtifactSchema>;
 export const DomainsResponseSchema = successEnvelopeSchema(
   DomainsArtifactSchema,

--- a/schemas-src/routes/economics-trends.ts
+++ b/schemas-src/routes/economics-trends.ts
@@ -21,14 +21,21 @@ const EconomicsTrendsDaySchema = z
   .object({
     snapshot_date: z.string(),
     subnet_count: z.int().min(0),
-    total_stake_alpha: RaoPrecisionTaoStringSchema.nullable().optional(),
+    total_stake_alpha: RaoPrecisionTaoStringSchema.nullable()
+      .optional()
+      .describe(
+        "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet reporting that day -- exceeds the exact-double ceiling as a JSON number, so it is served as a string rather than Float.",
+      ),
     alpha_price_tao_weighted: z.number().nullable().optional(),
     alpha_price_tao_median: z.number().nullable().optional(),
     validator_count: z.int().nullable().optional(),
     miner_count: z.int().nullable().optional(),
     mean_emission_share: z.number().nullable().optional(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One UTC day of network-wide economics aggregated across every subnet with a snapshot that day. Sums are null only when no subnet reported a value that day.",
+  );
 
 export const EconomicsTrendsArtifactSchema = z
   .object({

--- a/schemas-src/routes/economics.ts
+++ b/schemas-src/routes/economics.ts
@@ -37,10 +37,16 @@ export const EconomicsSummarySchema = z
   .object({
     registration_open_count: z.int().min(0),
     subnet_count: z.int().min(0),
-    total_alpha_value_tao: RaoPrecisionTaoStringSchema,
+    total_alpha_value_tao: RaoPrecisionTaoStringSchema.describe(
+      "Sum of every non-root subnet's alpha_market_cap_tao -- rao-precision decimal string (#6641).",
+    ),
     total_miners: z.int().min(0),
-    total_network_value_tao: RaoPrecisionTaoStringSchema,
-    total_root_value_tao: RaoPrecisionTaoStringSchema,
+    total_network_value_tao: RaoPrecisionTaoStringSchema.describe(
+      "total_root_value_tao + total_alpha_value_tao -- Backprop's Total Network Value (#6641).",
+    ),
+    total_root_value_tao: RaoPrecisionTaoStringSchema.describe(
+      "Root (netuid 0) TAO-denominated stake -- rao-precision decimal string (#6641).",
+    ),
     total_stake_alpha: RaoPrecisionTaoStringSchema,
     total_validators: z.int().min(0),
     with_economics_count: z.int().min(0),

--- a/schemas-src/routes/emission-gate-changes.ts
+++ b/schemas-src/routes/emission-gate-changes.ts
@@ -58,7 +58,12 @@ export const EmissionGateChangesArtifactSchema = z
     change_count: z.int().min(0),
     /** Entries that are a first observation rather than a change. A reader
      * counting governance events must subtract these. */
-    predates_capture_count: z.int().min(0),
+    predates_capture_count: z
+      .int()
+      .min(0)
+      .describe(
+        "How many returned entries are first observations rather than changes.",
+      ),
     latest_change_at: z.iso.datetime().nullable(),
     changes: z.array(
       z.union([

--- a/schemas-src/routes/emission-pipeline-history.ts
+++ b/schemas-src/routes/emission-pipeline-history.ts
@@ -9,20 +9,32 @@ export const PipelineHistoryPointSchema = z
     day: z.string(),
     /** The chain state this point describes. Required -- a point that cannot
      * say which block it came from cannot be placed in a series. */
-    pipeline_block: z.int().min(0),
+    pipeline_block: z
+      .int()
+      .min(0)
+      .describe(
+        "The chain state this point describes. A point that cannot say which block it came from is not served.",
+      ),
     pipeline_block_hash: z.string().nullable(),
     /** True when the snapshot writer carried the previous capture forward
      * because a fresh one had not landed: this point is NOT an independent
      * sample, and reading it as flatness is a finding the data cannot support. */
-    repeats_previous_observation: z.boolean(),
+    repeats_previous_observation: z
+      .boolean()
+      .describe(
+        "True when the snapshot writer carried the previous capture forward: this point is NOT an independent sample.",
+      ),
     captured_at: z.iso.datetime().nullable(),
     emission_share: z.number().nullable(),
     alpha_price_tao: z.number().nullable(),
     tao_in_pool_tao: z.number().nullable(),
     /** Pool liquidity injection. */
-    tao_in_emission_tao: z.number().nullable(),
+    tao_in_emission_tao: z
+      .number()
+      .nullable()
+      .describe("Pool liquidity injection."),
     /** Chain buys. */
-    excess_tao: z.number().nullable(),
+    excess_tao: z.number().nullable().describe("Chain buys."),
     alpha_in_emission: z.number().nullable(),
     alpha_out_emission: z.number().nullable(),
     miner_burned_fraction: z.number().nullable(),
@@ -37,22 +49,39 @@ export const PipelineHistoryArtifactSchema = z
     netuid: z.int().min(0).max(65535),
     window: z.string().nullable(),
     /** Rows returned. NOT the number of times the pipeline was read. */
-    point_count: z.int().min(0).nullable(),
+    point_count: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe(
+        "Rows returned. NOT the number of times the pipeline was read.",
+      ),
     /** Independent samples -- the honest denominator for any claim about how a
      * value moved. */
-    distinct_observations: z.int().min(0).nullable(),
+    distinct_observations: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe(
+        "Independent samples -- the honest denominator for any claim about how a value moved.",
+      ),
     oldest_day: z.string().nullable(),
     newest_day: z.string().nullable(),
     /** The first day the pipeline columns were ever written, on every response,
      * so 5 points for a 90d window reads as "the series begins here" rather
      * than "85 days were dropped". */
-    first_captured_day: z.string(),
+    first_captured_day: z
+      .string()
+      .describe(
+        "The first day the pipeline columns were ever written, so a short series reads as a start rather than a gap.",
+      ),
     points: z.array(PipelineHistoryPointSchema),
     /** Present ONLY on a decline. An empty series is a measurement. */
     degraded: z
       .object({ reason: z.enum(["unavailable"]) })
       .strict()
-      .optional(),
+      .optional()
+      .describe("Present ONLY on a decline. An empty series is a measurement."),
   })
   .passthrough();
 export type PipelineHistoryArtifact = z.infer<

--- a/schemas-src/routes/emission-pipeline.ts
+++ b/schemas-src/routes/emission-pipeline.ts
@@ -22,33 +22,75 @@ export const SubnetEmissionDecompositionSchema = z
         "subtoken_disabled",
         "registration_closed",
       ])
-      .nullable(),
+      .nullable()
+      .describe(
+        "Non-null (root, never_emitted, subtoken_disabled, registration_closed) means the subnet took no part in stage 1, and every downstream share is null rather than 0 -- 'not in the distribution' is not 'in it with nothing'.",
+      ),
     /** Stage 1, the published `emission_share` (ADR 0023 decision 1). */
-    emission_share: ShareSchema,
+    emission_share: ShareSchema.describe(
+      "Stage 1, the published emission_share (ADR 0023 decision 1) -- the PRICE share, not the share of TAO received.",
+    ),
     /** Stage 2 input. A FRACTION in [0,1] (U96F32), never an amount. */
-    miner_burned: z.number().min(0).max(1),
+    miner_burned: z
+      .number()
+      .min(0)
+      .max(1)
+      .describe("Stage 2 input. A FRACTION in [0,1], never an amount."),
     weighted_share: ShareSchema,
     gated_share: ShareSchema,
     // PUBLISHED, NOT INFERRED. A subnet far enough below the bar has its gated
     // share underflow to exactly 0, so an enabled-but-deeply-gated subnet and
     // a disabled one both read final_share: 0. The flag is the only thing that
     // separates them.
-    emission_enabled: z.boolean(),
+    emission_enabled: z
+      .boolean()
+      .describe(
+        "PUBLISHED, NOT INFERRED. A subnet far enough below the bar has its gated share underflow to exactly 0, so an enabled-but-deeply-gated subnet and a disabled one both read final_share: 0 -- this flag is the only thing that separates them.",
+      ),
     final_share: ShareSchema,
     /** `gated_share - weighted_share`. Sums to ~0: the gate never withholds. */
-    gate_delta: ShareSchema,
+    gate_delta: ShareSchema.describe(
+      "gated_share - weighted_share. Sums to ~0 across the network: the gate redistributes, it never withholds.",
+    ),
     /** `weighted_share / theta`. Null when the bar is unset (gate disabled). */
-    distance_to_bar: ShareSchema,
-    tao_in_emission: z.number().nullable(),
-    excess_tao: z.number().nullable(),
-    tao_total: z.number().nullable(),
+    distance_to_bar: ShareSchema.describe(
+      "weighted_share / theta. Null when the bar is unset.",
+    ),
+    tao_in_emission: z
+      .number()
+      .nullable()
+      .describe(
+        "Stage 8, measured: the TAO injected into the subnet's pool this block.",
+      ),
+    excess_tao: z
+      .number()
+      .nullable()
+      .describe(
+        "Stage 7, measured: the TAO that reached the subnet by chain buys instead.",
+      ),
+    tao_total: z
+      .number()
+      .nullable()
+      .describe(
+        "Their sum -- the subnet's whole TAO intake this block. Null unless both channels were actually read.",
+      ),
     // Null rather than NaN for a zero-intake subnet: 0/0 is not a fraction,
     // and zero intake is a real state.
-    liquidity_fraction: z.number().min(0).max(1).nullable(),
+    liquidity_fraction: z
+      .number()
+      .min(0)
+      .max(1)
+      .nullable()
+      .describe(
+        "tao_in_emission / tao_total, the headline per-subnet number. Null rather than NaN for a zero-intake subnet: 0/0 is not a fraction, and zero intake is a real state.",
+      ),
     alpha_in_emission: z.number().nullable(),
     alpha_out_emission: z.number().nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One subnet's path through stages 0-8. Every share is a fraction of block emission, null where stage 0 excluded the subnet from the distribution entirely.",
+  );
 
 /** One identity, reported whether it passed or failed. */
 export const EmissionIdentityCheckSchema = z
@@ -57,7 +99,8 @@ export const EmissionIdentityCheckSchema = z
     ok: z.boolean(),
     detail: z.string(),
   })
-  .strict();
+  .strict()
+  .describe("One identity, reported whether it passed or failed.");
 
 // The decomposition's own fields, split out from the artifact schema so the
 // get_emission_pipeline MCP tool can mirror the REST contract field for field
@@ -71,8 +114,15 @@ export const EMISSION_PIPELINE_BODY = {
   // has no `generated_at` to give -- same shape EconomicsTrendsArtifact and
   // CompareArtifact take for the same reason.
   schema_version: z.int(),
-  chain_state: ChainStateSchema,
-  block_emission_tao: z.number().nullable(),
+  chain_state: ChainStateSchema.describe(
+    "The block every input below was pinned to. Required: without it nothing here can be verified.",
+  ),
+  block_emission_tao: z
+    .number()
+    .nullable()
+    .describe(
+      "Block emission derived from TotalIssuance at that block, never read from the stale BlockEmission storage item.",
+    ),
   block_emission_halvings: z.int().min(0).nullable(),
   subnets: z.array(SubnetEmissionDecompositionSchema),
   // Present only when the caller narrowed the list with `limit`/`fields`
@@ -93,23 +143,49 @@ export const EMISSION_PIPELINE_BODY = {
       tao_in_emission: z.number(),
       excess_tao: z.number(),
       tao_total: z.number(),
-      liquidity_fraction: z.number().min(0).max(1).nullable(),
-      total_final_share: z.number(),
+      liquidity_fraction: z
+        .number()
+        .min(0)
+        .max(1)
+        .nullable()
+        .describe(
+          "The network split nobody else publishes: pool injection vs chain buys.",
+        ),
+      total_final_share: z
+        .number()
+        .describe(
+          "Sum of final_share. 1.0 to float precision, or the surface is broken.",
+        ),
     })
-    .strict(),
+    .strict()
+    .describe(
+      "Network-wide totals across every row in the capture -- unchanged by the netuid argument, which narrows the per-subnet rows only.",
+    ),
   // ADR 0023 decision 3, in band. `verified: false` means the identities did
   // not hold on THESE rows -- the response is not defensible and must not be
   // used, rather than being quietly served as if it were.
   verification: z
     .object({
-      verified: z.boolean(),
+      verified: z
+        .boolean()
+        .describe(
+          "False means at least one identity did not hold on these rows: the response is not defensible and must not be used.",
+        ),
       checks: z.array(EmissionIdentityCheckSchema),
       subnet_share_tolerance: z.number(),
       // A rao count, as a string: the tolerance is a bigint and a JSON number
       // is the wrong type for one.
-      aggregate_tolerance_rao: z.string().regex(/^\d+$/),
+      aggregate_tolerance_rao: z
+        .string()
+        .regex(/^\d+$/)
+        .describe(
+          "A rao count as a string -- the tolerance is a bigint, and a JSON number is the wrong type for one.",
+        ),
     })
-    .strict(),
+    .strict()
+    .describe(
+      "The four identities, evaluated on the rows being served rather than read from a stored flag -- a stored flag can be green while THIS response is broken, and it can go stale. ADR 0023 decision 3.",
+    ),
   // Per-field kind + storage item, so a consumer cannot mistake OUR arithmetic
   // for something the chain published. The shape moved to ../shared.ts when
   // the network singletons started publishing the same map (#9078) -- same
@@ -119,7 +195,10 @@ export const EMISSION_PIPELINE_BODY = {
 
 export const EmissionPipelineArtifactSchema = z
   .object(EMISSION_PIPELINE_BODY)
-  .passthrough();
+  .passthrough()
+  .describe(
+    "The v440 emission pipeline replayed over one pinned block (#8744) -- the per-subnet share decomposition, the network aggregate, and the identity checks evaluated on the rows being served.",
+  );
 export type EmissionPipelineArtifact = z.infer<
   typeof EmissionPipelineArtifactSchema
 >;

--- a/schemas-src/routes/endpoints-pools.ts
+++ b/schemas-src/routes/endpoints-pools.ts
@@ -221,5 +221,7 @@ export const EndpointPoolsArtifactSchema = ArtifactBaseSchema.extend({
     .optional(),
   provider_scores: z.array(EndpointProviderScoreSchema).optional(),
   pools: z.array(RpcPoolSchema),
-});
+}).describe(
+  "Endpoint pool scores (#6570): same pools[] row shape, filter/sort/page surface, and pagination metadata as PoolList. Split from it in #9892 for the one field that differs -- operational_observed_at, which GET /api/v1/endpoint-pools does not serve at all, because endpoint pools carry no live cron eligibility overlay and so have no observation stamp to report. The shared type declared it anyway and GraphQL answered null, which reads as not-observed-yet rather than never-observed-here.",
+);
 export type EndpointPoolsArtifact = z.infer<typeof EndpointPoolsArtifactSchema>;

--- a/schemas-src/routes/event-stream-honesty.ts
+++ b/schemas-src/routes/event-stream-honesty.ts
@@ -19,7 +19,10 @@ export const EventStreamDegradedSchema = z
     reason: z.string(),
     detail: z.string().optional(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer.",
+  );
 
 /**
  * How a deregistration feed was derived.
@@ -31,9 +34,20 @@ export const EventStreamDegradedSchema = z
 export const DeregistrationDerivationSchema = z
   .object({
     method: z.string(),
-    lookback_days: z.int().min(0),
-    window_registrations: z.int().min(0),
-    unattributed_registrations: z.int().min(0),
+    lookback_days: z
+      .int()
+      .min(0)
+      .describe(
+        "Days of NeuronRegistered history the derivation had available.",
+      ),
+    window_registrations: z
+      .int()
+      .min(0)
+      .describe("Registrations observed inside the reported window."),
+    unattributed_registrations: z
+      .int()
+      .min(0)
+      .describe("Of those, the ones with no observed previous holder."),
     // #9708: the same fact, machine-readable. The prose above and
     // `unattributed_registrations` have said "lower bound" since #9307, but
     // only to a human reading docs -- the payload published a bare count, and
@@ -54,4 +68,7 @@ export const DeregistrationDerivationSchema = z
       )
       .meta({ examples: [true] }),
   })
-  .strict();
+  .strict()
+  .describe(
+    "How a deregistration feed was derived (#9307). NeuronDeregistered has never been emitted, so deregistrations are derived from UID reuse: a NeuronRegistered on a (netuid, uid) slot already held by a different hotkey IS the deregistration of the previous occupant. unattributed_registrations is the honest part -- the published totals are a LOWER BOUND by that many events, because those registrations displaced a holder the derivation's lookback cannot name.",
+  );

--- a/schemas-src/routes/evidence-search.ts
+++ b/schemas-src/routes/evidence-search.ts
@@ -178,7 +178,11 @@ const SearchDocumentSchema = z
 
 export const SearchArtifactSchema = ArtifactBaseSchema.extend({
   document_count: z.int().min(0).optional(),
-  documents: z.array(SearchDocumentSchema),
+  documents: z
+    .array(SearchDocumentSchema)
+    .describe(
+      "Heterogeneous per-type documents (subnet/surface/provider/doc), passed through verbatim as opaque JSON.",
+    ),
 });
 export type SearchArtifact = z.infer<typeof SearchArtifactSchema>;
 
@@ -202,5 +206,7 @@ const SearchIndexDocumentSchema = z
 export const SearchIndexArtifactSchema = ArtifactBaseSchema.extend({
   document_count: z.int().min(0).optional(),
   documents: z.array(SearchIndexDocumentSchema),
-});
+}).describe(
+  "Filtered and paginated search-index documents with full REST list-query pagination metadata (#7877). Mirrors GET /api/v1/search-index (and MCP list_search_index).",
+);
 export type SearchIndexArtifact = z.infer<typeof SearchIndexArtifactSchema>;

--- a/schemas-src/routes/failure-reasons.ts
+++ b/schemas-src/routes/failure-reasons.ts
@@ -9,13 +9,29 @@ export const FailureReasonSchema = z
     classification: z.string(),
     /** `redirected` is NOT a failure -- a surface answering from a new location
      * is serving, and the probe's own status says so. */
-    is_failure: z.boolean(),
+    is_failure: z
+      .boolean()
+      .describe(
+        "redirected is NOT a failure -- a surface answering from a new location is serving.",
+      ),
     checks: z.int().min(0),
     /** Of every probe in the window. */
-    share: z.number().min(0).max(1).nullable(),
+    share: z
+      .number()
+      .min(0)
+      .max(1)
+      .nullable()
+      .describe("Of every probe in the window."),
     /** Of the FAILING probes only; null on a succeeding classification, where
      * the question does not apply. */
-    failure_share: z.number().min(0).max(1).nullable(),
+    failure_share: z
+      .number()
+      .min(0)
+      .max(1)
+      .nullable()
+      .describe(
+        "Of the FAILING probes only; null on a succeeding classification, where the question does not apply.",
+      ),
   })
   .strict();
 
@@ -25,7 +41,9 @@ export const FailureReasonsDaySchema = z
     total_checks: z.int().min(0),
     failing_checks: z.int().min(0),
     failure_rate: z.number().min(0).max(1).nullable(),
-    by_classification: z.record(z.string(), z.int().min(0)),
+    by_classification: z
+      .record(z.string(), z.int().min(0))
+      .describe("Checks per classification on this day, as a JSON object."),
   })
   .strict();
 
@@ -37,7 +55,13 @@ export const FailureReasonsArtifactSchema = z
     kind: z.string().nullable(),
     /** Counted from the ROWS, not the requested window -- a day the prober did
      * not run is absent rather than a zero. */
-    days_covered: z.int().min(0).nullable(),
+    days_covered: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe(
+        "Counted from the ROWS, not the requested window -- a day the prober did not run is absent rather than a zero.",
+      ),
     oldest_day: z.string().nullable(),
     newest_day: z.string().nullable(),
     total_checks: z.int().min(0).nullable(),
@@ -45,13 +69,16 @@ export const FailureReasonsArtifactSchema = z
     failure_rate: z.number().min(0).max(1).nullable(),
     reasons: z.array(FailureReasonSchema),
     /** Oldest day first, so a caller plotting the series need not reverse it. */
-    series: z.array(FailureReasonsDaySchema),
+    series: z.array(FailureReasonsDaySchema).describe("Oldest day first."),
     /** Present ONLY on a decline. An empty window is NOT a decline: it means
      * the prober recorded nothing in that range, which is a measurement. */
     degraded: z
       .object({ reason: z.enum(["unavailable"]) })
       .strict()
-      .optional(),
+      .optional()
+      .describe(
+        "Present ONLY on a decline. An empty window is a measurement, not a decline.",
+      ),
   })
   .passthrough();
 export type FailureReasonsArtifact = z.infer<

--- a/schemas-src/routes/global-validators.ts
+++ b/schemas-src/routes/global-validators.ts
@@ -39,7 +39,7 @@ export const ColdkeyIdentitySchema = z
   })
   .strict()
   .describe(
-    "Self-reported on-chain identity (SubtensorModule::set_identity) for a coldkey.",
+    "Self-reported on-chain identity (SubtensorModule::set_identity) for a `coldkey`.",
   );
 
 const GlobalValidatorSubnetSchema = z

--- a/schemas-src/routes/global-validators.ts
+++ b/schemas-src/routes/global-validators.ts
@@ -37,7 +37,10 @@ export const ColdkeyIdentitySchema = z
     additional: z.string().nullable(),
     captured_at: z.string().nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Self-reported on-chain identity (SubtensorModule::set_identity) for a coldkey.",
+  );
 
 const GlobalValidatorSubnetSchema = z
   .object({

--- a/schemas-src/routes/health-surfaces.ts
+++ b/schemas-src/routes/health-surfaces.ts
@@ -126,19 +126,26 @@ export const BulkHealthTrendsArtifactSchema = z
     schema_version: z.int(),
     observed_at: z.string().nullable().optional(),
     source: z.string(),
-    windows: z.record(
-      z.string(),
-      z
-        .object({
-          days: z.int().min(0),
-          granularity: z.literal("1d"),
-          subnet_count: z.int().min(0),
-          subnets: z.array(BulkHealthTrendSubnetSchema),
-        })
-        .strict(),
-    ),
+    windows: z
+      .record(
+        z.string(),
+        z
+          .object({
+            days: z.int().min(0),
+            granularity: z.literal("1d"),
+            subnet_count: z.int().min(0),
+            subnets: z.array(BulkHealthTrendSubnetSchema),
+          })
+          .strict(),
+      )
+      .describe(
+        "The 7d/30d windows keyed by window label (7d, 30d), each holding days/granularity/subnet_count and the per-subnet daily point series. Opaque JSON: dynamic-keyed by window label, matching the get_health_trends MCP/REST shape.",
+      ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "All-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history. Mirrors GET /api/v1/health/trends' data envelope.",
+  );
 export type BulkHealthTrendsArtifact = z.infer<
   typeof BulkHealthTrendsArtifactSchema
 >;
@@ -184,7 +191,10 @@ const GlobalIncidentEntrySchema = z
     // tightened from optional to required.
     failed_samples: z.int().min(0),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One reconstructed outage window.\n\n\\`started_at\\` and \\`ended_at\\` are epoch MILLISECONDS, which is why they are\nFloat and not Int: GraphQL's Int is 32-bit and every real value overflows it\n(1786228205841 against a ceiling of 2147483647). Every incident window on\n\\`incidents\\`, \\`global_incidents\\` and \\`subnet_health_incidents\\` therefore\nerrored, and because both fields are non-null the error propagated up and\nnulled the surrounding list -- on every request, since the surface shipped.\nNothing had executed these fields (#10215). \\`duration_ms\\` is a span rather\nthan an instant and stays an Int.",
+  );
 
 const GlobalIncidentSurfaceSchema = z
   .object({
@@ -202,7 +212,10 @@ const GlobalIncidentSurfaceSchema = z
     transient_failed_samples: z.int().min(0),
     incidents: z.array(GlobalIncidentEntrySchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One endpoint incident in the global ledger. Mirrors the REST EndpointIncident shape (enum-valued fields carried as their string values).",
+  );
 
 export const GlobalIncidentsArtifactSchema = z
   .object({
@@ -215,13 +228,19 @@ export const GlobalIncidentsArtifactSchema = z
         incident_count: z.int().min(0),
         affected_surface_count: z.int().min(0),
       })
-      .passthrough(),
+      .passthrough()
+      .describe(
+        "Aggregate counts -- incident_count, active_count, and by_kind/by_layer/by_provider/by_severity/by_status maps. Opaque JSON: the by_* maps are dynamic-keyed, matching the MCP get_global_incidents summary shape.",
+      ),
     // #8824: the incident-qualifying threshold (MIN_INCIDENT_SAMPLES),
     // published once so a surface's transient_failure_count is self-describing.
     min_incident_samples: z.int().min(1),
     surfaces: z.array(GlobalIncidentSurfaceSchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Global endpoint-incident ledger (#5660). Mirrors GET /api/v1/incidents' data envelope.",
+  );
 export type GlobalIncidentsArtifact = z.infer<
   typeof GlobalIncidentsArtifactSchema
 >;
@@ -370,9 +389,16 @@ export const HealthIncidentsArtifactSchema = z
     // #8824: the incident-qualifying threshold (MIN_INCIDENT_SAMPLES),
     // published once so a surface's transient_failure_count is self-describing.
     min_incident_samples: z.int().min(1),
-    surfaces: z.array(HealthIncidentSurfaceSchema),
+    surfaces: z
+      .array(HealthIncidentSurfaceSchema)
+      .describe(
+        "Per operational surface: its sample count, uptime_ratio, incident_count, total downtime_ms, and gap-island incident list (started_at/ended_at/duration_ms/failed_samples, epoch-ms). Opaque JSON passed through verbatim, matching the get_subnet_health_incidents MCP/REST shape (like SubnetHealthTrends.windows).",
+      ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One subnet's per-surface SLA + reconstructed downtime incidents over the window. Mirrors GET /api/v1/subnets/{netuid}/health/incidents's data envelope.",
+  );
 export type HealthIncidentsArtifact = z.infer<
   typeof HealthIncidentsArtifactSchema
 >;
@@ -406,9 +432,16 @@ export const HealthPercentilesArtifactSchema = z
     window: z.string().nullable().optional(),
     observed_at: z.string().nullable().optional(),
     source: z.string(),
-    surfaces: z.array(HealthPercentilesSurfaceSchema),
+    surfaces: z
+      .array(HealthPercentilesSurfaceSchema)
+      .describe(
+        "Per operational surface: its success-only latency sample count and p50/p90/p95/p99 latency percentiles in ms. Opaque JSON passed through verbatim, matching the get_subnet_health_percentiles MCP/REST shape (like SubnetHealthIncidents.surfaces).",
+      ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One subnet's per-surface success-only latency percentiles (#6980). Mirrors GET /api/v1/subnets/{netuid}/health/percentiles' data envelope.",
+  );
 export type HealthPercentilesArtifact = z.infer<
   typeof HealthPercentilesArtifactSchema
 >;
@@ -450,9 +483,16 @@ export const HealthTrendsArtifactSchema = z
     netuid: z.int().min(0),
     observed_at: z.string().nullable().optional(),
     source: z.string(),
-    windows: z.record(z.string(), HealthTrendWindowSchema),
+    windows: z
+      .record(z.string(), HealthTrendWindowSchema)
+      .describe(
+        "The 7d/30d windows keyed by window label, each holding this subnet's samples, uptime_ratio, latency_sample_count and the per-surface uptime/latency series. Opaque JSON: dynamic-keyed by window label, matching the get_subnet_health_trends MCP/REST shape.",
+      ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One subnet's uptime + latency trend windows. Mirrors GET /api/v1/subnets/{netuid}/health/trends's data envelope.",
+  );
 export type HealthTrendsArtifact = z.infer<typeof HealthTrendsArtifactSchema>;
 
 // ---- GET /api/v1/subnets/{netuid}/uptime -> UptimeArtifact ----
@@ -492,10 +532,12 @@ const UptimeDaySchema = z
         p99: z.int().nullable().optional(),
       })
       .passthrough()
+      .describe("Percentile latency summary for one uptime day.")
       .optional(),
     status: z.string(),
   })
-  .passthrough();
+  .passthrough()
+  .describe("One daily uptime point for a surface.");
 
 const UptimeSurfaceSchema = z
   .object({
@@ -503,10 +545,18 @@ const UptimeSurfaceSchema = z
     day_count: z.int().min(0),
     samples: z.int().min(0),
     uptime_ratio: z.number().nullable(),
-    reliability: z.union([ReliabilityScoreSchema, z.null()]).optional(),
+    reliability: z
+      .union([ReliabilityScoreSchema, z.null()])
+      .describe(
+        "Window-wide reliability score (0-100) with letter grade. Surface-level scores omit window/surface_count/day_count/computed_at.",
+      )
+      .optional(),
     days: z.array(UptimeDaySchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One operational surface's uptime history over the requested window.",
+  );
 
 export const UptimeArtifactSchema = z
   .object({
@@ -517,8 +567,19 @@ export const UptimeArtifactSchema = z
     // Always-present key in formatUptime()'s real return (its value is the
     // JS null when there are no samples, never an omitted key) -- required,
     // unlike the per-surface `reliability` above (no comparable guarantee).
-    reliability: z.union([ReliabilityScoreSchema, z.null()]),
-    surfaces: z.array(UptimeSurfaceSchema),
+    reliability: z
+      .union([ReliabilityScoreSchema, z.null()])
+      .describe(
+        "Window-wide reliability score (0-100) with letter grade. Surface-level scores omit window/surface_count/day_count/computed_at.",
+      ),
+    surfaces: z
+      .array(UptimeSurfaceSchema)
+      .describe(
+        "Per-surface day series with window-wide uptime ratios and per-surface reliability scores.",
+      ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One subnet's long-term daily uptime history (#5885). Mirrors GET /api/v1/subnets/{netuid}/uptime's data envelope.",
+  );
 export type UptimeArtifact = z.infer<typeof UptimeArtifactSchema>;

--- a/schemas-src/routes/indexer-lag.ts
+++ b/schemas-src/routes/indexer-lag.ts
@@ -30,14 +30,25 @@ export const IndexerLagLatencySchema = z
     max: z.number().nullable(),
     mean: z.number().nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Milliseconds from a block's own timestamp to the moment it became queryable here. Unbounded below: a negative value is block-author clock skew, served as measured.",
+  );
 
 export const IndexerLagArtifactSchema = z
   .object({
     schema_version: z.int(),
     /** Blocks the distribution was computed over. Null only on a decline. */
-    block_count: z.int().min(0).nullable(),
-    window: IndexerLagWindowSchema.nullable(),
+    block_count: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe(
+        "Blocks the distribution was computed over. Null only on a decline.",
+      ),
+    window: IndexerLagWindowSchema.nullable().describe(
+      "What was actually measured -- the table is pruned, so a distribution without its bounds would read as a lifetime one.",
+    ),
     write_latency_ms: IndexerLagLatencySchema.nullable(),
     /**
      * now - the newest observed_at: how far behind the lane is RIGHT NOW.
@@ -46,7 +57,12 @@ export const IndexerLagArtifactSchema = z
      * lane stalls -- a stalled lane keeps a perfect latency distribution while
      * this climbs without bound.
      */
-    head_age_ms: z.number().nullable(),
+    head_age_ms: z
+      .number()
+      .nullable()
+      .describe(
+        "now - the newest observed_at. The number that moves when the lane stalls.",
+      ),
     measured_at: z.iso.datetime(),
     /** Present ONLY on a decline; its absence says the measurement is real. */
     degraded: z
@@ -55,7 +71,10 @@ export const IndexerLagArtifactSchema = z
         detail: z.string().optional(),
       })
       .strict()
-      .optional(),
+      .optional()
+      .describe(
+        "Present ONLY on a decline; its absence says the measurement is real.",
+      ),
   })
   .passthrough();
 export type IndexerLagArtifact = z.infer<typeof IndexerLagArtifactSchema>;

--- a/schemas-src/routes/network-singletons.ts
+++ b/schemas-src/routes/network-singletons.ts
@@ -21,7 +21,10 @@ export const EvmAddressMappingArtifactSchema = z
     // response shape legitimately lacks it.
     field_sources: FieldSourcesSchema,
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Live EVM (H160) -> Substrate (SS58) account-address mapping read from chain via RPC. ss58 is null when the mapping cannot be resolved (schema-stable, never a GraphQL error). Mirrors GET /api/v1/evm/address/{h160}.",
+  );
 export type EvmAddressMappingArtifact = z.infer<
   typeof EvmAddressMappingArtifactSchema
 >;
@@ -59,7 +62,10 @@ export const NetworkParametersArtifactSchema = z
     // values we supply, and nothing else in the body says so.
     field_sources: FieldSourcesSchema,
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Live global Subtensor protocol/governance parameters, read live from chain via RPC. Each field is independently null on its own RPC failure (schema-stable). Mirrors GET /api/v1/network/parameters's data envelope.",
+  );
 export type NetworkParametersArtifact = z.infer<
   typeof NetworkParametersArtifactSchema
 >;
@@ -78,7 +84,10 @@ export const RandomnessArtifactSchema = z
     // not a retention window the beacon publishes.
     field_sources: FieldSourcesSchema,
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Live drand randomness-beacon status read from chain via RPC. Each field is independently null on its own RPC failure (schema-stable). Mirrors GET /api/v1/network/randomness's data envelope.",
+  );
 export type RandomnessArtifact = z.infer<typeof RandomnessArtifactSchema>;
 export const RandomnessResponseSchema = successEnvelopeSchema(
   RandomnessArtifactSchema,
@@ -94,7 +103,10 @@ export const SudoKeyArtifactSchema = z
     // assume from the absence of a map.
     field_sources: FieldSourcesSchema,
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "The network's on-chain sudo (superuser) key, read live from chain via RPC. hotkey is null on RPC failure or a renounced sudo (schema-stable). Mirrors GET /api/v1/sudo/key's data envelope.",
+  );
 export type SudoKeyArtifact = z.infer<typeof SudoKeyArtifactSchema>;
 export const SudoKeyResponseSchema = successEnvelopeSchema(
   SudoKeyArtifactSchema,

--- a/schemas-src/routes/providers-rpc.ts
+++ b/schemas-src/routes/providers-rpc.ts
@@ -318,7 +318,9 @@ export const RpcPoolsArtifactSchema = ArtifactBaseSchema.extend({
     .optional(),
   provider_scores: z.array(EndpointProviderScoreSchema).optional(),
   pools: z.array(RpcPoolSchema),
-});
+}).describe(
+  "RPC pool scores (#6570): same pools[] row shape, filter/sort/page surface, and pagination metadata as EndpointPoolList, plus operational_observed_at -- real here and only here, since the RPC pools are the ones carrying a live 15-minute cron eligibility overlay.",
+);
 export type RpcPoolsArtifact = z.infer<typeof RpcPoolsArtifactSchema>;
 
 // Fully live (rpc_proxy_events telemetry), no static file, no ArtifactBase --
@@ -330,19 +332,29 @@ const RpcUsageEndpointRowSchema = z
     provider: z.string().nullable().optional(),
     requests: z.int().min(0),
     ok_requests: z.int().min(0),
-    error_rate: z.number().nullable().optional(),
+    error_rate: z
+      .number()
+      .nullable()
+      .optional()
+      .describe("Null when the endpoint had no requests in the window."),
     avg_latency_ms: z.int().nullable().optional(),
   })
-  .passthrough();
+  .passthrough()
+  .describe("One endpoint's share of RPC reverse-proxy traffic in the window.");
 
 const RpcUsageNetworkRowSchema = z
   .object({
     network: z.string(),
     requests: z.int().min(0),
     ok_requests: z.int().min(0),
-    error_rate: z.number().nullable().optional(),
+    error_rate: z
+      .number()
+      .nullable()
+      .optional()
+      .describe("Null when the network had no requests in the window."),
   })
-  .passthrough();
+  .passthrough()
+  .describe("One network's share of RPC reverse-proxy traffic in the window.");
 
 const RpcUsageBucketSchema = z
   .object({
@@ -351,7 +363,10 @@ const RpcUsageBucketSchema = z
     errors: z.int().min(0),
     avg_latency_ms: z.int().nullable(),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One bounded time bucket of RPC reverse-proxy traffic (bucket_granularity wide).",
+  );
 
 // `window` is what the caller asked for; `coverage` is what the two stores
 // (Analytics Engine live, R2 lakehouse frozen) could actually answer. They
@@ -362,30 +377,71 @@ const RpcUsageCoverageRangeSchema = z
     start: z.int().nullable(),
     end: z.int().nullable(),
   })
-  .passthrough();
+  .passthrough()
+  .describe("An epoch-ms span.");
 
 const RpcUsageCoverageSegmentSchema = z
   .object({
-    source: z.string(),
-    start: z.int().nullable(),
-    end: z.int().nullable(),
+    source: z
+      .string()
+      .describe(
+        "Which store measured it: analytics-engine (live capture) or lakehouse (frozen history).",
+      ),
+    start: z
+      .int()
+      .nullable()
+      .describe(
+        "Epoch ms of this store's oldest measured event in the window.",
+      ),
+    end: z
+      .int()
+      .nullable()
+      .describe(
+        "Epoch ms of this store's newest measured event in the window.",
+      ),
   })
-  .passthrough();
+  .passthrough()
+  .describe("One store's contribution to an rpc_usage answer.");
 
 const RpcUsageCoverageSchema = z
   .object({
-    start: z.int().nullable(),
-    end: z.int().nullable(),
-    segments: z.array(RpcUsageCoverageSegmentSchema),
-    latency_percentiles: RpcUsageCoverageRangeSchema.nullable(),
+    start: z
+      .int()
+      .nullable()
+      .describe(
+        "Epoch ms of the oldest measured event across every contributing store, or null when nothing was measured.",
+      ),
+    end: z
+      .int()
+      .nullable()
+      .describe(
+        "Epoch ms of the newest measured event across every contributing store, or null when nothing was measured.",
+      ),
+    segments: z
+      .array(RpcUsageCoverageSegmentSchema)
+      .describe(
+        "One entry per contributing store, oldest first. Two non-adjacent entries mean the window has a hole between them that no store covers.",
+      ),
+    latency_percentiles: RpcUsageCoverageRangeSchema.nullable().describe(
+      "The sub-range summary.latency_ms p50/p95 describe, or null when nothing measured them. Counts are additive across disjoint ranges; percentiles are not, so they stay scoped to the one store that has a percentile function.",
+    ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "The measured span behind an rpc_usage answer. window is what the caller asked for; this is what the stores could answer, and they are not the same whenever a store's retention does not span the window.",
+  );
 
 export const RpcUsageArtifactSchema = z
   .object({
     schema_version: z.int(),
     window: z.string().nullable().optional(),
-    bucket_granularity: z.string().nullable().optional(),
+    bucket_granularity: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "Time-bucket granularity for buckets: 1h for the 7d window, 6h for 30d. Null on a cold store.",
+      ),
     // EPOCH MILLISECONDS, not an ISO string (#9794). Both GET /api/v1/rpc/usage
     // and the get_rpc_usage MCP tool serve a number here -- 1786099339000 --
     // so this route contract has been wrong since it was written, and the
@@ -404,17 +460,33 @@ export const RpcUsageArtifactSchema = z
       )
       .meta({ examples: [1786099339000] }),
     source: z.string(),
-    coverage: RpcUsageCoverageSchema,
+    coverage: RpcUsageCoverageSchema.describe(
+      "What the answer is actually about, as opposed to what window was asked for.",
+    ),
     summary: z
       .object({
         total_requests: z.int().min(0),
         ok_requests: z.int().min(0),
         error_requests: z.int().min(0),
-        error_rate: z.number().nullable().optional(),
+        error_rate: z
+          .number()
+          .nullable()
+          .optional()
+          .describe(
+            "Null when there are no requests in the window (no defined rate).",
+          ),
         failover_requests: z.int().min(0).optional(),
-        failover_rate: z.number().nullable().optional(),
+        failover_rate: z
+          .number()
+          .nullable()
+          .optional()
+          .describe("Null when there are no requests in the window."),
         cache_hits: z.int().min(0).optional(),
-        cache_hit_rate: z.number().nullable().optional(),
+        cache_hit_rate: z
+          .number()
+          .nullable()
+          .optional()
+          .describe("Null when there are no requests in the window."),
         latency_ms: z
           .object({
             p50: z.int().nullable().optional(),
@@ -422,12 +494,29 @@ export const RpcUsageArtifactSchema = z
             avg: z.int().nullable().optional(),
           })
           .passthrough()
+          .describe(
+            "Window latency percentiles + average for RPC reverse-proxy traffic; each is null on a cold store.",
+          )
           .optional(),
       })
-      .passthrough(),
-    endpoints: z.array(RpcUsageEndpointRowSchema),
-    networks: z.array(RpcUsageNetworkRowSchema),
-    buckets: z.array(RpcUsageBucketSchema),
+      .passthrough()
+      .describe("Window-total rollup for RPC reverse-proxy traffic."),
+    endpoints: z
+      .array(RpcUsageEndpointRowSchema)
+      .describe(
+        "Per-endpoint request distribution, ranked by request volume (top 50).",
+      ),
+    networks: z
+      .array(RpcUsageNetworkRowSchema)
+      .describe("Per-network request breakdown, ordered by request volume."),
+    buckets: z
+      .array(RpcUsageBucketSchema)
+      .describe(
+        "Bounded time buckets over the window for heatmaps, oldest-first.",
+      ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "RPC reverse-proxy usage analytics over a 7d/30d window. Mirrors GET /api/v1/rpc/usage's data envelope.",
+  );
 export type RpcUsageArtifact = z.infer<typeof RpcUsageArtifactSchema>;

--- a/schemas-src/routes/registry-summary-leaderboards.ts
+++ b/schemas-src/routes/registry-summary-leaderboards.ts
@@ -138,7 +138,13 @@ const LeaderboardEntrySchema = z
 export const RegistryLeaderboardsArtifactSchema = z
   .object({
     schema_version: z.int(),
-    board: z.string().nullable().optional(),
+    board: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "The board filter that was applied, or null when every board is returned.",
+      ),
     observed_at: z.string().nullable().optional(),
     source: z.string(),
     // Keyed by board name (LEADERBOARD_BOARDS), which is a typed record. The
@@ -146,9 +152,16 @@ export const RegistryLeaderboardsArtifactSchema = z
     // same three identity fields and then carry the metric that board ranks
     // by, so the union below is a real description rather than a shrug.
     // Modeled from all twelve boards' live rows.
-    boards: z.record(z.string(), z.array(LeaderboardEntrySchema)),
+    boards: z
+      .record(z.string(), z.array(LeaderboardEntrySchema))
+      .describe(
+        "Every board keyed by board name, each an array of ranked subnet entries capped at limit. Opaque JSON like HealthTrends.windows: the keys are dynamic AND hyphenated (fastest-rpc, most-complete, open-slots, …) so they are not expressible as GraphQL field names, and each board carries its own metric columns (healthiest has uptime_ratio/surfaces_ok, fastest-rpc has latency_ms, fastest-growing has completeness_delta, …). Passing it through verbatim keeps the REST/MCP get_registry_leaderboards shape byte-for-byte.",
+      ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Registry leaderboards over the operational + economic-opportunity boards. Mirrors GET /api/v1/registry/leaderboards.",
+  );
 export type RegistryLeaderboardsArtifact = z.infer<
   typeof RegistryLeaderboardsArtifactSchema
 >;

--- a/schemas-src/routes/runtime-versions.ts
+++ b/schemas-src/routes/runtime-versions.ts
@@ -16,7 +16,10 @@ const RuntimeVersionTransitionSchema = z
     block_number: z.int().min(0),
     observed_at: z.string().nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One runtime spec-version's first-seen block in the transition timeline.",
+  );
 
 // An interior hole in the timeline: two consecutive recorded transitions too
 // far apart in block distance for any real upgrade cadence to explain, so
@@ -43,7 +46,10 @@ export const RuntimeVersionsArtifactSchema = z
     coverage_complete: z.boolean(),
     coverage_gaps: z.array(RuntimeCoverageGapSchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Site-wide runtime spec-version transition timeline. Mirrors GET /api/v1/runtime.",
+  );
 export type RuntimeVersionsArtifact = z.infer<
   typeof RuntimeVersionsArtifactSchema
 >;

--- a/schemas-src/routes/self-health.ts
+++ b/schemas-src/routes/self-health.ts
@@ -15,9 +15,12 @@ export const SelfHealthDaySchema = z
     day: z.string(),
     checks: z.int().min(0),
     ok_count: z.int().min(0),
-    uptime_ratio: z.number().min(0).max(1),
+    uptime_ratio: z.number().min(0).max(1).describe("ok_count / checks, 0..1."),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One UTC day's uptime ratio for a self-health component. Days with no probe rows are ABSENT, never zero-filled.",
+  );
 export type SelfHealthDay = z.infer<typeof SelfHealthDaySchema>;
 
 export const SelfHealthComponentSchema = z
@@ -25,7 +28,10 @@ export const SelfHealthComponentSchema = z
     component: z.string(),
     // Null, not false, when the component has never been probed: "not
     // measured" and "down" are different claims.
-    current_ok: z.boolean().nullable(),
+    current_ok: z
+      .boolean()
+      .nullable()
+      .describe("Null when the component has never been probed -- NOT false."),
     http_status: z.int().nullable(),
     latency_ms: z.int().nullable(),
     checked_at: z.string().nullable(),
@@ -34,13 +40,32 @@ export const SelfHealthComponentSchema = z
     // an HTTP-level outage -- null whenever there's nothing to qualify (the
     // component is healthy, or its failure IS the plain "down" the label
     // already says).
-    note: z.string().nullable(),
+    note: z
+      .string()
+      .nullable()
+      .describe(
+        "Qualifies a false current_ok with why, for non-HTTP failure modes. Null when there's nothing to add.",
+      ),
     // Days with no rows are absent, never zero-filled -- a gap means "we
     // weren't measuring", and 0% would invent an outage.
-    days: z.array(SelfHealthDaySchema),
-    uptime_90d: z.number().min(0).max(1).nullable(),
+    days: z
+      .array(SelfHealthDaySchema)
+      .describe(
+        "Trailing-90d daily ratios, oldest first; gaps are absent, never zero-filled.",
+      ),
+    uptime_90d: z
+      .number()
+      .min(0)
+      .max(1)
+      .nullable()
+      .describe(
+        "Mean uptime across the days we actually have. Null when there are none.",
+      ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One self-health component (api / site / publish): its latest probe state and trailing-90-day daily ratios.",
+  );
 export type SelfHealthComponent = z.infer<typeof SelfHealthComponentSchema>;
 
 // #9330/#9340: the per-lane watchdog verdicts, from the D1 `lane_health` table.
@@ -65,7 +90,10 @@ export const SelfHealthLaneSchema = z
     detail: z.string().nullable(),
     checked_at: z.string().nullable(),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    'One ingest lane\'s staleness verdict.\n\nThree of these five were declared non-null against a Zod schema that says\notherwise, and production proved it: \\`self_health\\` returned\n\\`Cannot return null for non-nullable field SelfHealthLane.detail\\` and nulled\nthe whole \\`lanes\\` list. \\`age_ms\\` and \\`checked_at\\` are null for the same\nreason -- the watchdog could not measure the lane, which is the "we did not\nmeasure" this type exists to distinguish from "the lane is fine" (#10215).\n\n\\`age_ms\\` is a Float because it is a duration in MILLISECONDS: a lane stale\nfor more than 24.8 days exceeds GraphQL\'s 32-bit Int, and the answer to\n"how far behind is this lane" must not stop being representable exactly when\nit starts to matter.',
+  );
 export type SelfHealthLane = z.infer<typeof SelfHealthLaneSchema>;
 
 export const SelfHealthArtifactSchema = z
@@ -73,15 +101,25 @@ export const SelfHealthArtifactSchema = z
     schema_version: z.int(),
     // Scoped to our OWN components only -- never mixed with third-party
     // subnet-surface health.
-    verdict: z.enum(["operational", "degraded", "outage"]),
+    verdict: z
+      .enum(["operational", "degraded", "outage"])
+      .describe("operational | degraded | outage."),
     components: z.array(SelfHealthComponentSchema),
-    measured_component_count: z.int().min(0),
+    measured_component_count: z
+      .int()
+      .min(0)
+      .describe(
+        "Components with data. Zero means the poller hasn't written anything yet.",
+      ),
     // Stale lanes lead, then alphabetical -- the rows an operator acts on first.
     lanes: z.array(SelfHealthLaneSchema),
     stale_lane_count: z.int().min(0),
     observed_at: z.string().nullable(),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "metagraphed's own uptime verdict (#8422). Mirrors GET /api/v1/self-health.",
+  );
 export type SelfHealthArtifact = z.infer<typeof SelfHealthArtifactSchema>;
 
 export const SelfHealthResponseSchema = successEnvelopeSchema(

--- a/schemas-src/routes/stake-quote.ts
+++ b/schemas-src/routes/stake-quote.ts
@@ -14,18 +14,29 @@ export const SubnetStakeQuoteArtifactSchema = z
   .object({
     alpha_in_pool: z.number().nullable(),
     amount: z.number().gt(0),
-    direction: z.enum(["stake", "unstake"]),
+    direction: z
+      .enum(["stake", "unstake"])
+      .describe(
+        "stake (spends TAO for alpha) or unstake (spends alpha for TAO).",
+      ),
     effective_price_tao: z.number().min(0),
     expected_out: z.number().min(0),
     expected_out_unit: z.enum(["alpha", "tao"]),
-    is_root: z.boolean(),
+    is_root: z
+      .boolean()
+      .describe(
+        "True for root (netuid 0), which quotes 1:1 with no price impact.",
+      ),
     netuid: z.int().min(0),
     price_impact_pct: z.number().min(0),
     schema_version: z.int(),
     spot_price_tao: z.number().min(0),
     tao_in_pool_tao: z.number().nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "A read-only hypothetical stake/unstake quote against one subnet's live AMM pool (#6979). Mirrors GET /api/v1/subnets/{netuid}/stake-quote.",
+  );
 export type SubnetStakeQuoteArtifact = z.infer<
   typeof SubnetStakeQuoteArtifactSchema
 >;

--- a/schemas-src/routes/subnet-activity.ts
+++ b/schemas-src/routes/subnet-activity.ts
@@ -94,7 +94,10 @@ export const SubnetDeregistrationsArtifactSchema = z
     derivation: DeregistrationDerivationSchema.optional(),
     degraded: EventStreamDegradedSchema.optional(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Per-subnet neuron-deregistration activity over a window (#5719). Zeroed card (0 counts) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/deregistrations.",
+  );
 export type SubnetDeregistrationsArtifact = z.infer<
   typeof SubnetDeregistrationsArtifactSchema
 >;

--- a/schemas-src/routes/subnet-alpha-volume.ts
+++ b/schemas-src/routes/subnet-alpha-volume.ts
@@ -10,7 +10,9 @@ export const SubnetAlphaVolumeArtifactSchema = z
   .object({
     schema_version: z.int(),
     netuid: z.int().min(0),
-    window: z.enum(["24h"]),
+    window: z
+      .enum(["24h"])
+      .describe("The rolling window label this card covers (24h)."),
     buy_volume_alpha: z.number(),
     sell_volume_alpha: z.number(),
     total_volume_alpha: z.number(),
@@ -20,11 +22,28 @@ export const SubnetAlphaVolumeArtifactSchema = z
     buy_count: z.int().min(0),
     sell_count: z.int().min(0),
     net_volume_alpha: z.number(),
-    sentiment_ratio: z.number().nullable(),
-    sentiment: z.enum(["bullish", "bearish", "neutral"]),
-    vol_mcap_ratio: z.number().nullable(),
+    sentiment_ratio: z
+      .number()
+      .nullable()
+      .describe(
+        "Buy share of total volume (0-1); null when there was no volume.",
+      ),
+    sentiment: z
+      .enum(["bullish", "bearish", "neutral"])
+      .describe(
+        "Bucketed reading of sentiment_ratio (buying/selling/neutral).",
+      ),
+    vol_mcap_ratio: z
+      .number()
+      .nullable()
+      .describe(
+        "Total TAO volume over alpha market cap; null when market cap is unknown.",
+      ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One subnet's rolling 24h alpha trading volume (#6979). Mirrors GET /api/v1/subnets/{netuid}/volume' data envelope.",
+  );
 export type SubnetAlphaVolumeArtifact = z.infer<
   typeof SubnetAlphaVolumeArtifactSchema
 >;

--- a/schemas-src/routes/subnet-concentration.ts
+++ b/schemas-src/routes/subnet-concentration.ts
@@ -31,23 +31,54 @@ const ConcentrationLensSchema = z
     entropy: z.number().nullable().optional(),
     entropy_normalized: z.number().nullable().optional(),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Concentration metrics over a value distribution -- Gini, HHI (raw + holder-count-normalized), Nakamoto coefficient, top-percentile shares, and Shannon entropy.",
+  );
 
 export const SubnetConcentrationArtifactSchema = z
   .object({
     schema_version: z.int(),
     netuid: z.int().min(0),
     neuron_count: z.int().min(0),
-    entity_count: z.int().min(0),
-    uids_per_entity: z.number().nullable().optional(),
+    entity_count: z
+      .int()
+      .min(0)
+      .describe(
+        "Distinct controlling entities (coldkeys) behind the subnet's UIDs.",
+      ),
+    uids_per_entity: z
+      .number()
+      .nullable()
+      .optional()
+      .describe(
+        "UIDs per controlling entity -- a Sybil/consolidation signal (1.0 = every UID a distinct owner; higher = fewer operators each running many hotkeys). Null on an empty subnet.",
+      ),
     captured_at: z.string().nullable().optional(),
-    stake: ConcentrationLensSchema.nullable(),
-    emission: ConcentrationLensSchema.nullable(),
-    entity_stake: ConcentrationLensSchema.nullable().optional(),
-    entity_emission: ConcentrationLensSchema.nullable().optional(),
-    validator_stake: ConcentrationLensSchema.nullable().optional(),
+    stake: ConcentrationLensSchema.nullable().describe(
+      "Stake concentration across all UIDs.",
+    ),
+    emission: ConcentrationLensSchema.nullable().describe(
+      "Emission concentration across all UIDs.",
+    ),
+    entity_stake: ConcentrationLensSchema.nullable()
+      .optional()
+      .describe(
+        "Stake concentration collapsed to one holder per controlling entity.",
+      ),
+    entity_emission: ConcentrationLensSchema.nullable()
+      .optional()
+      .describe(
+        "Emission concentration collapsed to one holder per controlling entity.",
+      ),
+    validator_stake: ConcentrationLensSchema.nullable()
+      .optional()
+      .describe("Stake concentration across permitted validators only."),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Per-subnet stake & emission concentration card (#5901) over the current neurons snapshot. Metric blocks are null on a cold/empty subnet. Mirrors GET /api/v1/subnets/{netuid}/concentration.",
+  );
 export type SubnetConcentrationArtifact = z.infer<
   typeof SubnetConcentrationArtifactSchema
 >;
@@ -72,11 +103,18 @@ export const SubnetConcentrationHistoryArtifactSchema = z
   .object({
     schema_version: z.int(),
     netuid: z.int().min(0),
-    window: z.string().nullable().optional(),
+    window: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("The resolved window label (7d/30d/90d)."),
     point_count: z.int().min(0),
     points: z.array(SubnetConcentrationHistoryPointSchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Per-subnet per-day concentration trend (#5901) from the neuron_daily rollup, newest first. An empty series (point_count 0) on a cold store, never a GraphQL error. Mirrors GET /api/v1/subnets/{netuid}/concentration/history.",
+  );
 export type SubnetConcentrationHistoryArtifact = z.infer<
   typeof SubnetConcentrationHistoryArtifactSchema
 >;

--- a/schemas-src/routes/subnet-conviction.ts
+++ b/schemas-src/routes/subnet-conviction.ts
@@ -31,7 +31,10 @@ export const SubnetConvictionArtifactSchema = z
     // not a reading at it -- this is where the response says so.
     field_sources: FieldSourcesSchema,
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Live per-subnet conviction leaderboard -- who currently holds the most rolled conviction, rolled forward from a periodically-captured snapshot using the current live-queried unlock_rate/maturity_rate. Mirrors GET /api/v1/subnets/{netuid}/conviction.",
+  );
 export type SubnetConvictionArtifact = z.infer<
   typeof SubnetConvictionArtifactSchema
 >;

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -31,6 +31,8 @@ import {
   CONFIDENCE_LEVEL_VALUES,
   NATIVE_NAME_QUALITY_VALUES,
 } from "../shared.ts";
+import { SurfaceAuthLocationSchema } from "../shared.ts";
+import { SurfaceAuthSchemeSchema } from "../shared.ts";
 
 const HttpUrlSchema = z.string().regex(/^[Hh][Tt][Tt][Pp][Ss]?:\/\//);
 const HttpOrWssUrlSchema = z
@@ -149,20 +151,12 @@ const AuthSchema = z
       })
       .strict()
       .optional(),
-    location: z.enum(["header", "query", "cookie", "body"]).optional(),
+    location: SurfaceAuthLocationSchema.optional(),
     name: z.string().optional(),
     // minItems:1 in the hand-edited contract -- verified against real
     // registry/subnets/*.json auth.names values (#7860's diff audit).
     names: z.array(z.string()).min(1).optional(),
-    scheme: z.enum([
-      "none",
-      "bearer",
-      "api-key",
-      "basic",
-      "oauth2",
-      "signature",
-      "custom",
-    ]),
+    scheme: SurfaceAuthSchemeSchema,
     scopes_note: z.string().optional(),
     token_url: HttpUrlSchema.optional(),
     value_format: z.string().optional(),

--- a/schemas-src/routes/subnet-event-summary.ts
+++ b/schemas-src/routes/subnet-event-summary.ts
@@ -65,18 +65,41 @@ export const SubnetEventSummaryArtifactSchema = z
   .object({
     schema_version: z.int(),
     netuid: z.int(),
-    window: z.enum(SUBNET_EVENT_SUMMARY_WINDOW_VALUES),
+    window: z
+      .enum(SUBNET_EVENT_SUMMARY_WINDOW_VALUES)
+      .describe("The resolved window label (7d/30d/90d)."),
     observed_at: z.iso.datetime().nullable(),
     total_events: z.int().min(0),
     kind_count: z.int().min(0),
     category_count: z.int().min(0),
     recent_event_count: z.int().min(0),
-    limit: z.int().min(1).max(50),
-    categories: z.array(SubnetEventCategorySummarySchema),
-    event_kinds: z.array(SubnetEventKindSummarySchema),
-    recent_events: z.array(AccountEventSchema),
+    limit: z
+      .int()
+      .min(1)
+      .max(50)
+      .describe(
+        "The resolved recent-event cap actually applied (1-50, default 10).",
+      ),
+    categories: z
+      .array(SubnetEventCategorySummarySchema)
+      .describe(
+        "Per event category: its kind list and rolled-up counts. Opaque JSON passed through verbatim, matching the get_subnet_event_summary MCP/REST shape.",
+      ),
+    event_kinds: z
+      .array(SubnetEventKindSummarySchema)
+      .describe(
+        "Per event kind: event_count, hotkey/coldkey participation counts, TAO/alpha amounts, and first/last block + observed_at. Opaque JSON passed through verbatim.",
+      ),
+    recent_events: z
+      .array(AccountEventSchema)
+      .describe(
+        "The bounded newest-first recent-event list. Opaque JSON passed through verbatim.",
+      ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One subnet's chain-event activity summary over a window (#6980). Mirrors GET /api/v1/subnets/{netuid}/event-summary' data envelope.",
+  );
 export type SubnetEventSummaryArtifact = z.infer<
   typeof SubnetEventSummaryArtifactSchema
 >;

--- a/schemas-src/routes/subnet-events.ts
+++ b/schemas-src/routes/subnet-events.ts
@@ -54,7 +54,10 @@ export const SubnetEventsArtifactSchema = z
     next_cursor: z.string().nullable().optional(),
     events: z.array(AccountEventSchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One subnet's paginated first-party chain-event feed (#7172), newest first, offset-paginated. event_count is the page count, not a grand total. Each item is an AccountEvent. Empty feed on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/events' data envelope.",
+  );
 export type SubnetEventsArtifact = z.infer<typeof SubnetEventsArtifactSchema>;
 export const SubnetEventsResponseSchema = successEnvelopeSchema(
   SubnetEventsArtifactSchema,

--- a/schemas-src/routes/subnet-history.ts
+++ b/schemas-src/routes/subnet-history.ts
@@ -27,7 +27,10 @@ const SubnetHistoryPointSchema = z
     total_stake_alpha: z.number().nullable().optional(),
     total_emission_alpha: z.number().nullable().optional(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One daily-rollup point on a subnet's history (#7172). Economics fields are null on days captured before those columns existed / when unavailable.",
+  );
 
 export const SubnetHistoryArtifactSchema = z
   .object({
@@ -37,7 +40,10 @@ export const SubnetHistoryArtifactSchema = z
     point_count: z.int().min(0),
     points: z.array(SubnetHistoryPointSchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One subnet's daily history series (#7172) from the neuron_daily rollup, newest first. Empty series (point_count 0) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/history' data envelope.",
+  );
 export type SubnetHistoryArtifact = z.infer<typeof SubnetHistoryArtifactSchema>;
 export const SubnetHistoryResponseSchema = successEnvelopeSchema(
   SubnetHistoryArtifactSchema,

--- a/schemas-src/routes/subnet-holders.ts
+++ b/schemas-src/routes/subnet-holders.ts
@@ -40,12 +40,12 @@ export const SubnetHolderSchema = z
       .min(0)
       .nullable()
       .describe(
-        "Distinct hotkeys this coldkey holds the subnet's alpha through -- registered on it or not, which is the part a neurons-sourced view misses.",
+        "Distinct hotkeys this `coldkey` holds the subnet's alpha through -- registered on it or not, which is the part a neurons-sourced view misses.",
       ),
   })
   .strict()
   .describe(
-    "One coldkey's holding of a subnet's alpha, including alpha staked to hotkeys that hold no UID on that subnet.",
+    "One `coldkey`'s holding of a subnet's alpha, including alpha staked to hotkeys that hold no UID on that subnet.",
   );
 
 export const SubnetHoldersConcentrationSchema = z

--- a/schemas-src/routes/subnet-holders.ts
+++ b/schemas-src/routes/subnet-holders.ts
@@ -16,16 +16,37 @@ export const SubnetHolderSchema = z
     // Alpha, not TAO. Within one subnet alpha is already a common unit, so the
     // ranking needs no price join -- and carries none of the price-staleness
     // caveats the chain-wide holdings columns must.
-    alpha: z.number().min(0),
+    alpha: z
+      .number()
+      .min(0)
+      .describe(
+        "ALPHA, not TAO. Within one subnet alpha is already a common unit, so there is no price conversion and none of its staleness -- multiply by the subnet's alpha_price_tao for TAO.",
+      ),
     // This holder's alpha over the subnet's FULL measured total, so it means the
     // same thing at ?limit=5 and ?limit=100. Null when the total is zero: with
     // nothing measured there is no share to state.
-    share_of_total: z.number().min(0).max(1).nullable(),
+    share_of_total: z
+      .number()
+      .min(0)
+      .max(1)
+      .nullable()
+      .describe(
+        "This holder's alpha over the subnet's FULL measured total, so it means the same thing at limit 5 and limit 100. Null when the total is zero.",
+      ),
     // Distinct hotkeys this coldkey holds the subnet's alpha through --
     // registered on it or not, which is the part reading off `neurons` misses.
-    hotkey_count: z.int().min(0).nullable(),
+    hotkey_count: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe(
+        "Distinct hotkeys this coldkey holds the subnet's alpha through -- registered on it or not, which is the part a neurons-sourced view misses.",
+      ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One coldkey's holding of a subnet's alpha, including alpha staked to hotkeys that hold no UID on that subnet.",
+  );
 
 export const SubnetHoldersConcentrationSchema = z
   .object({
@@ -35,7 +56,10 @@ export const SubnetHoldersConcentrationSchema = z
     top10_share: z.number().min(0).max(1).nullable(),
     top20_share: z.number().min(0).max(1).nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Concentration of a subnet's alpha, each rank summed over the top N of the FULL holder set rather than the returned page.",
+  );
 
 export const SubnetHoldersDegradedSchema = z
   .object({
@@ -51,7 +75,10 @@ export const SubnetHoldersDegradedSchema = z
       "unavailable",
     ]),
   })
-  .strict();
+  .strict()
+  .describe(
+    "A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer.",
+  );
 
 export const SubnetHoldersArtifactSchema = z
   .object({
@@ -60,19 +87,35 @@ export const SubnetHoldersArtifactSchema = z
     limit: z.int().min(1).nullable(),
     // Distinct coldkeys holding this subnet's alpha -- the whole set, not the
     // returned page's length.
-    holder_count: z.int().min(0).nullable(),
+    holder_count: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe(
+        "Distinct coldkeys holding this subnet's alpha -- the whole set, never the returned page's length.",
+      ),
     total_alpha: z.number().min(0).nullable(),
     concentration: SubnetHoldersConcentrationSchema,
     // The pool pass every row was valued against. Rows are scoped to ONE
     // captured_at: mixing stamps values a coldkey's positions against totals
     // read at different blocks, which is a silently inconsistent sum.
-    captured_at: z.iso.datetime().nullable(),
+    captured_at: z.iso
+      .datetime()
+      .nullable()
+      .describe("The pool pass every row was valued against."),
     // When the positions ledger itself was last written, which advances on a
     // different cadence than the pool totals above.
-    positions_captured_at: z.iso.datetime().nullable(),
+    positions_captured_at: z.iso
+      .datetime()
+      .nullable()
+      .describe(
+        "When the positions ledger itself was last written, which advances on a different cadence than the pool totals.",
+      ),
     holders: z.array(SubnetHolderSchema),
     // Present ONLY on a decline. Its absence is what says the ranking is real.
-    degraded: SubnetHoldersDegradedSchema.optional(),
+    degraded: SubnetHoldersDegradedSchema.optional().describe(
+      "Present ONLY on a decline. Its absence is what says the ranking is real -- an empty holders list with no degraded block means the subnet genuinely has no measured holders.",
+    ),
   })
   .passthrough();
 export type SubnetHoldersArtifact = z.infer<typeof SubnetHoldersArtifactSchema>;

--- a/schemas-src/routes/subnet-hyperparameters.ts
+++ b/schemas-src/routes/subnet-hyperparameters.ts
@@ -56,7 +56,10 @@ const SubnetHyperparametersSchema = z
     owner_cut_auto_lock_enabled: z.boolean(),
     min_childkey_take_ratio: z.number().nullable().optional(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One subnet's on-chain hyperparameter block. Every field is nullable: a value absent from the captured row stays null rather than being coerced. *_ratio fields are 0..1 U16-derived ratios; *_tao fields are rao-exact (9dp); bonds_moving_avg_raw is the unscaled on-chain integer.",
+  );
 
 export const SubnetHyperparametersArtifactSchema = z
   .object({
@@ -66,7 +69,10 @@ export const SubnetHyperparametersArtifactSchema = z
     block_number: z.int().nullable().optional(),
     hyperparameters: SubnetHyperparametersSchema.nullable(),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Per-subnet neuron-registration activity over a window (#5720). Zeroed card (0 counts) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/registrations.",
+  );
 export type SubnetHyperparametersArtifact = z.infer<
   typeof SubnetHyperparametersArtifactSchema
 >;
@@ -81,7 +87,10 @@ const SubnetHyperparamsHistoryEntrySchema = z
     hyperparameters: SubnetHyperparametersSchema.nullable().optional(),
     hyperparams_hash: z.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One observed hyperparameter change: the full block as of that block_number, plus the hash the diff-on-change writer keyed it by.",
+  );
 
 export const SubnetHyperparamsHistoryArtifactSchema = z
   .object({

--- a/schemas-src/routes/subnet-identity-history.ts
+++ b/schemas-src/routes/subnet-identity-history.ts
@@ -27,7 +27,10 @@ export const SubnetIdentityHistoryEntrySchema = z
     logo_url: z.url().nullable().optional(),
     identity_hash: z.string().nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One SubnetIdentitiesV3 snapshot recorded when a tracked identity field changed.",
+  );
 export type SubnetIdentityHistoryEntry = z.infer<
   typeof SubnetIdentityHistoryEntrySchema
 >;
@@ -42,7 +45,10 @@ export const SubnetIdentityHistoryArtifactSchema = z
     next_cursor: z.string().nullable().optional(),
     entries: z.array(SubnetIdentityHistoryEntrySchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Append-only on-chain subnet identity timeline (#1647 / #5721). Empty entries on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/identity-history.",
+  );
 export type SubnetIdentityHistoryArtifact = z.infer<
   typeof SubnetIdentityHistoryArtifactSchema
 >;

--- a/schemas-src/routes/subnet-idle-stake.ts
+++ b/schemas-src/routes/subnet-idle-stake.ts
@@ -15,7 +15,10 @@ export const SubnetIdleStakeArtifactSchema = z
     idle_neuron_count: z.int().min(0),
     idle_stake_alpha: z.number().min(0),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Per-subnet idle-stake scorecard (#7172). Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/idle-stake.",
+  );
 export type SubnetIdleStakeArtifact = z.infer<
   typeof SubnetIdleStakeArtifactSchema
 >;

--- a/schemas-src/routes/subnet-lease.ts
+++ b/schemas-src/routes/subnet-lease.ts
@@ -36,7 +36,10 @@ export const SubnetLeaseArtifactSchema = z
     // response shape legitimately lacks it.
     field_sources: FieldSourcesSchema,
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Live subnet-lease state -- whether a subnet is currently under a lease and, if so, its terms (beneficiary, coldkey, hotkey, emissions_share_percent, end_block, cost_tao) and accumulated-but-undistributed alpha dividends. leased is null (not false) on RPC failure, distinct from a confirmed no-lease (leased:false). Mirrors GET /api/v1/subnets/{netuid}/lease.",
+  );
 export type SubnetLeaseArtifact = z.infer<typeof SubnetLeaseArtifactSchema>;
 export const SubnetLeaseResponseSchema = successEnvelopeSchema(
   SubnetLeaseArtifactSchema,
@@ -68,7 +71,10 @@ export const SubnetLeaseHistoryArtifactSchema = z
     count: z.int().min(0),
     lease_events: z.array(SubnetLeaseEventSchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Every SubnetLeaseCreated/SubnetLeaseTerminated event one subnet has had, decoded from the account_events stream. Mirrors GET /api/v1/subnets/{netuid}/lease/history.",
+  );
 export type SubnetLeaseHistoryArtifact = z.infer<
   typeof SubnetLeaseHistoryArtifactSchema
 >;

--- a/schemas-src/routes/subnet-lifecycle.ts
+++ b/schemas-src/routes/subnet-lifecycle.ts
@@ -46,7 +46,10 @@ export const SubnetLifecycleEntrySchema = z
      */
     predates_capture: z.boolean(),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One observed subnet transition. block_number is null when the event predates capture or the detecting pass could not attribute one; that is a fact, not a gap.",
+  );
 export type SubnetLifecycleEntry = z.infer<typeof SubnetLifecycleEntrySchema>;
 
 export const SubnetLifecycleArtifactSchema = z
@@ -80,7 +83,12 @@ export const ChainSubnetLifecycleArtifactSchema = z
     schema_version: z.int(),
     entry_count: z.int().min(0),
     /** Distinct subnets appearing in this page. Context for the count above. */
-    subnet_count: z.int().min(0),
+    subnet_count: z
+      .int()
+      .min(0)
+      .describe(
+        "Distinct subnets appearing in this page -- context for entry_count.",
+      ),
     limit: z.int().min(1).max(1000).nullable().optional(),
     offset: z.int().min(0).nullable().optional(),
     next_cursor: z.string().nullable().optional(),

--- a/schemas-src/routes/subnet-metagraph.ts
+++ b/schemas-src/routes/subnet-metagraph.ts
@@ -68,10 +68,21 @@ export const NeuronSchema = z
     is_immunity_period: z.boolean().optional(),
     // registered_at_block+immunity_period; present only while is_immunity_period
     // is true and both inputs are known (#6640) -- omitted, not null, otherwise.
-    immunity_expires_at_block: z.int().optional(),
+    immunity_expires_at_block: z
+      .int()
+      .optional()
+      .describe(
+        "The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640).",
+      ),
     // Wall-clock ETA for immunity_expires_at_block, extrapolated at ~12s/block;
     // only present alongside immunity_expires_at_block.
-    immunity_expires_at: z.string().nullable().optional(),
+    immunity_expires_at: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block/timestamp at ~12s/block; null if that anchor is unavailable (#6640).",
+      ),
     axon: z
       .string()
       .nullable()
@@ -88,9 +99,18 @@ export const NeuronSchema = z
     featured: z.boolean().optional(),
     // Validator take/commission (#2548), global per-hotkey. Null if the
     // hotkey had no Delegates entry at capture time.
-    take: z.number().nullable().optional(),
+    take: z
+      .number()
+      .nullable()
+      .optional()
+      .describe(
+        "Validator take/commission (0..1) from SubtensorModule::Delegates; null when no Delegates entry at capture.",
+      ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One UID's live metagraph state within a subnet (hot/cold keys, scores, stake/emission, axon, take).",
+  );
 
 export const SubnetMetagraphArtifactSchema = z
   .object({
@@ -115,9 +135,14 @@ export const NeuronDetailArtifactSchema = z
     netuid: z.int().min(0),
     captured_at: z.string().nullable().optional(),
     block_number: z.int().nullable().optional(),
-    neuron: NeuronSchema.nullable(),
+    neuron: NeuronSchema.nullable().describe(
+      "The UID's live metagraph row; null when absent from the latest snapshot.",
+    ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One neuron's live metagraph detail card (#5900). Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}: neuron is null when that UID is absent from the latest snapshot.",
+  );
 export type NeuronDetailArtifact = z.infer<typeof NeuronDetailArtifactSchema>;
 export const NeuronDetailResponseSchema = successEnvelopeSchema(
   NeuronDetailArtifactSchema,
@@ -130,9 +155,16 @@ export const SubnetValidatorsArtifactSchema = z
     validator_count: z.int().min(0),
     captured_at: z.string().nullable().optional(),
     block_number: z.int().nullable().optional(),
-    validators: z.array(NeuronSchema),
+    validators: z
+      .array(NeuronSchema)
+      .describe(
+        "Each permitted validator's live metagraph row -- the same NeuronState shape the neuron field returns.",
+      ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One subnet's current validator set (#6979). Mirrors GET /api/v1/subnets/{netuid}/validators' data envelope.",
+  );
 export type SubnetValidatorsArtifact = z.infer<
   typeof SubnetValidatorsArtifactSchema
 >;
@@ -150,7 +182,10 @@ const NeuronHistoryPointSchema = z
     block_number: z.int().nullable().optional(),
   })
   .extend(NeuronSchema.shape)
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One day's metagraph state for a single UID (NeuronState fields plus snapshot_date/captured_at/block_number).",
+  );
 
 export const NeuronHistoryArtifactSchema = z
   .object({
@@ -161,7 +196,10 @@ export const NeuronHistoryArtifactSchema = z
     point_count: z.int().min(0),
     points: z.array(NeuronHistoryPointSchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One neuron's per-day metagraph history. Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}/history.",
+  );
 export type NeuronHistoryArtifact = z.infer<typeof NeuronHistoryArtifactSchema>;
 export const NeuronHistoryResponseSchema = successEnvelopeSchema(
   NeuronHistoryArtifactSchema,

--- a/schemas-src/routes/subnet-movers.ts
+++ b/schemas-src/routes/subnet-movers.ts
@@ -25,7 +25,9 @@ const SignedRaoPrecisionTaoStringSchema = z.string().regex(/^-?\d+\.\d{9}$/);
 
 const MoversNetworkSummarySchema = z
   .object({
-    total_stake_start_alpha: RaoPrecisionTaoStringSchema,
+    total_stake_start_alpha: RaoPrecisionTaoStringSchema.describe(
+      "Lossless fixed 9-decimal (rao-precision) TAO string -- exceeds the exact-double ceiling as a JSON number, so it is served as a string rather than Float.",
+    ),
     total_stake_end_alpha: RaoPrecisionTaoStringSchema,
     total_stake_delta_alpha: SignedRaoPrecisionTaoStringSchema,
     total_emission_start_alpha: RaoPrecisionTaoStringSchema,
@@ -38,7 +40,10 @@ const MoversNetworkSummarySchema = z
     losers: z.int().min(0),
     unchanged: z.int().min(0),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Network-wide boundary totals for the movers window, summed across every ranked subnet (not just the returned page).",
+  );
 
 const MoverEntrySchema = z
   .object({
@@ -46,8 +51,20 @@ const MoverEntrySchema = z
     stake_start_alpha: z.number(),
     stake_end_alpha: z.number(),
     stake_delta_alpha: z.number(),
-    stake_pct_change: z.number().nullable(),
-    stake_share_pct: z.number().min(0).max(100).nullable(),
+    stake_pct_change: z
+      .number()
+      .nullable()
+      .describe(
+        "Null when the start snapshot's stake was 0 (growth from nothing is undefined).",
+      ),
+    stake_share_pct: z
+      .number()
+      .min(0)
+      .max(100)
+      .nullable()
+      .describe(
+        "This subnet's share of network stake at the end snapshot; null when the network total is 0.",
+      ),
     emission_start_alpha: z.number(),
     emission_end_alpha: z.number(),
     emission_delta_alpha: z.number(),
@@ -60,7 +77,10 @@ const MoverEntrySchema = z
     neurons_end: z.int().min(0),
     neurons_delta: z.int(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One subnet's stake/emission/validator/neuron movement between the window's start and end snapshots.",
+  );
 
 export const SubnetMoversArtifactSchema = z
   .object({

--- a/schemas-src/routes/subnet-ohlc.ts
+++ b/schemas-src/routes/subnet-ohlc.ts
@@ -7,7 +7,11 @@ import { successEnvelopeSchema } from "../envelope.ts";
 
 const SubnetOhlcCandleSchema = z
   .object({
-    bucket_start: z.int(),
+    bucket_start: z
+      .int()
+      .describe(
+        "Bucket start as epoch milliseconds -- a Float, since epoch-ms exceeds GraphQL's 32-bit Int.",
+      ),
     bucket_start_iso: z.iso.datetime(),
     open: z.number(),
     high: z.number(),
@@ -23,11 +27,20 @@ export const SubnetOhlcArtifactSchema = z
   .object({
     schema_version: z.int(),
     netuid: z.int().min(0),
-    interval: z.enum(["1h", "1d"]),
+    interval: z
+      .enum(["1h", "1d"])
+      .describe("The resolved bucket interval (1h/1d)."),
     candles: z.array(SubnetOhlcCandleSchema),
-    root_excluded: z.boolean(),
+    root_excluded: z
+      .boolean()
+      .describe(
+        "True for root (netuid 0), whose 1:1 price makes candles meaningless, so none are emitted.",
+      ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One subnet's alpha-price OHLC candles (#6979). Mirrors GET /api/v1/subnets/{netuid}/ohlc' data envelope.",
+  );
 export type SubnetOhlcArtifact = z.infer<typeof SubnetOhlcArtifactSchema>;
 export const SubnetOhlcResponseSchema = successEnvelopeSchema(
   SubnetOhlcArtifactSchema,

--- a/schemas-src/routes/subnet-ownership-history.ts
+++ b/schemas-src/routes/subnet-ownership-history.ts
@@ -36,18 +36,39 @@ export const SubnetOwnershipHistoryArtifactSchema = z
   .object({
     schema_version: z.int(),
     netuid: z.int().min(0).max(65535),
-    event_pallet: z.string(),
-    event_method: z.string(),
+    event_pallet: z
+      .string()
+      .describe(
+        "The chain_events pallet the authoritative records are decoded from.",
+      ),
+    event_method: z
+      .string()
+      .describe(
+        "The chain_events method the authoritative records are decoded from.",
+      ),
     count: z.int().min(0),
-    ownership_changes: z.array(SubnetOwnershipChangeSchema),
+    ownership_changes: z
+      .array(SubnetOwnershipChangeSchema)
+      .describe(
+        "Each record carries a source: chain-event (announced on chain, block-stamped) or owner-observation (inferred from two consecutive owner captures, so observed_at is when the change was NOTICED and block_number is null).",
+      ),
     // How far the owner-observation source covers this subnet at all (#9312),
     // ISO-8601. Optional because the DATA_API tier does not read that source;
     // null when it was read and holds nothing for this netuid. It is what makes
     // "watched, never changed hands" distinguishable from "not watched since",
     // which an empty ownership_changes array on its own cannot say.
-    observed_through: z.iso.datetime().nullable().optional(),
+    observed_through: z.iso
+      .datetime()
+      .nullable()
+      .optional()
+      .describe(
+        "The newest owner observation for this subnet, ISO-8601 -- how far the observation source covers it at all, so watched-but-never-changed-hands is distinguishable from not-watched-since. Null when no observations were read.",
+      ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Every automatic ownership transfer one subnet has undergone, decoded from the chain_events SubnetOwnerChanged stream. Mirrors GET /api/v1/subnets/{netuid}/ownership-history.",
+  );
 export type SubnetOwnershipHistoryArtifact = z.infer<
   typeof SubnetOwnershipHistoryArtifactSchema
 >;

--- a/schemas-src/routes/subnet-performance.ts
+++ b/schemas-src/routes/subnet-performance.ts
@@ -25,13 +25,26 @@ export const SubnetPerformanceArtifactSchema = z
     validator_count: z.int().min(0).optional(),
     active_count: z.int().min(0).optional(),
     captured_at: z.string().nullable().optional(),
-    incentive: ConcentrationMetricsSchema,
-    dividends: ConcentrationMetricsSchema,
-    trust: ScoreDistributionSchema,
-    consensus: ScoreDistributionSchema,
-    validator_trust: ScoreDistributionSchema.optional(),
+    incentive: ConcentrationMetricsSchema.describe(
+      "Incentive concentration across all neurons with positive incentive.",
+    ),
+    dividends: ConcentrationMetricsSchema.describe(
+      "Dividends concentration across permitted validators only.",
+    ),
+    trust: ScoreDistributionSchema.describe(
+      "Trust score spread across all neurons.",
+    ),
+    consensus: ScoreDistributionSchema.describe(
+      "Consensus score spread across all neurons.",
+    ),
+    validator_trust: ScoreDistributionSchema.optional().describe(
+      "Validator-trust score spread across permitted validators only.",
+    ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Per-subnet reward-distribution & score-spread card (#5714). Metric blocks are null on a cold/empty subnet. Mirrors GET /api/v1/subnets/{netuid}/performance.",
+  );
 export type SubnetPerformanceArtifact = z.infer<
   typeof SubnetPerformanceArtifactSchema
 >;
@@ -58,17 +71,27 @@ const SubnetPerformanceHistoryPointSchema = z
     validator_trust_mean: z.number().nullable().optional(),
     validator_trust_median: z.number().nullable().optional(),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One day's point in a subnet's concentration trend (#5901). Flattened (not nested) stake/emission metrics keep the series trivial to plot; each is null on a cold/empty day.",
+  );
 
 export const SubnetPerformanceHistoryArtifactSchema = z
   .object({
     schema_version: z.int(),
     netuid: z.int().min(0),
-    window: z.string().nullable().optional(),
+    window: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("The resolved window label (7d/30d/90d)."),
     point_count: z.int().min(0),
     points: z.array(SubnetPerformanceHistoryPointSchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Per-subnet per-day reward-distribution trend (#6981) from the neuron_daily rollup, newest first. An empty series (point_count 0) on a cold store, never a GraphQL error. The history twin of subnet_performance, mirroring GET /api/v1/subnets/{netuid}/performance/history.",
+  );
 export type SubnetPerformanceHistoryArtifact = z.infer<
   typeof SubnetPerformanceHistoryArtifactSchema
 >;

--- a/schemas-src/routes/subnet-profiles.ts
+++ b/schemas-src/routes/subnet-profiles.ts
@@ -27,6 +27,7 @@ import {
   SubnetDetailSchema,
   SurfaceSchema,
 } from "./subnet-detail.ts";
+import { SchemaDriftStatusSchema } from "../shared.ts";
 
 export const SubnetProfilesArtifactSchema = ArtifactBaseSchema.extend({
   profiles: z.array(SubnetProfileSchema),
@@ -60,13 +61,7 @@ export type SubnetProfileArtifact = z.infer<typeof SubnetProfileArtifactSchema>;
 const SchemaIndexEntrySchema = z
   .object({
     content_type: z.string().nullable().optional(),
-    drift_status: z.enum([
-      "changed",
-      "missing-after-previous-capture",
-      "new",
-      "not-captured",
-      "unchanged",
-    ]),
+    drift_status: SchemaDriftStatusSchema,
     error: z.string().nullable().optional(),
     hash: z.string().nullable().optional(),
     netuid: z.int().min(0).optional(),

--- a/schemas-src/routes/subnet-prometheus.ts
+++ b/schemas-src/routes/subnet-prometheus.ts
@@ -22,7 +22,10 @@ export const SubnetPrometheusArtifactSchema = z
     // drops all 18,041 of them, so this card's zero is "we could not look".
     degraded: EventStreamDegradedSchema.optional(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Per-subnet Prometheus-endpoint serving activity (#7172) over a 7d/30d window. Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/prometheus.",
+  );
 export type SubnetPrometheusArtifact = z.infer<
   typeof SubnetPrometheusArtifactSchema
 >;

--- a/schemas-src/routes/subnet-registration-cost.ts
+++ b/schemas-src/routes/subnet-registration-cost.ts
@@ -19,7 +19,10 @@ export const SubnetBurnArtifactSchema = z
     // response shape legitimately lacks it.
     field_sources: FieldSourcesSchema,
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Live current registration/burn cost for one subnet, read directly from chain via RPC. burn_tao is null on RPC failure (schema-stable, never a GraphQL error). Mirrors GET /api/v1/subnets/{netuid}/burn.",
+  );
 export type SubnetBurnArtifact = z.infer<typeof SubnetBurnArtifactSchema>;
 export const SubnetBurnResponseSchema = successEnvelopeSchema(
   SubnetBurnArtifactSchema,
@@ -35,7 +38,10 @@ export const SubnetRecycledArtifactSchema = z
     // response shape legitimately lacks it.
     field_sources: FieldSourcesSchema,
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "Live cumulative TAO recycled for registration on one subnet, read directly from chain via RPC. recycled_tao is null on RPC failure (schema-stable, never a GraphQL error). Mirrors GET /api/v1/subnets/{netuid}/recycled.",
+  );
 export type SubnetRecycledArtifact = z.infer<
   typeof SubnetRecycledArtifactSchema
 >;

--- a/schemas-src/routes/subnet-stake-flow.ts
+++ b/schemas-src/routes/subnet-stake-flow.ts
@@ -26,7 +26,10 @@ export const SubnetStakeFlowArtifactSchema = z
     stake_events: z.int().min(0),
     unstake_events: z.int().min(0),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Per-subnet net stake flow (#7172) over a 7d/30d/90d window. Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/stake-flow' data envelope.",
+  );
 export type SubnetStakeFlowArtifact = z.infer<
   typeof SubnetStakeFlowArtifactSchema
 >;

--- a/schemas-src/routes/subnet-stake-transfers.ts
+++ b/schemas-src/routes/subnet-stake-transfers.ts
@@ -16,7 +16,10 @@ export const SubnetStakeTransfersArtifactSchema = z
     transfers: z.int().min(0),
     transfers_per_sender: z.number().min(0).nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Per-subnet stake-transfer activity (#5717) over a 7d/30d window. Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/stake-transfers.",
+  );
 export type SubnetStakeTransfersArtifact = z.infer<
   typeof SubnetStakeTransfersArtifactSchema
 >;

--- a/schemas-src/routes/subnet-surface-history.ts
+++ b/schemas-src/routes/subnet-surface-history.ts
@@ -7,17 +7,31 @@ export const SurfaceHistoryChangeSchema = z
   .object({
     /** Coalesced column -> overlay id, so it is present on every row including
      * the 8,831 written before the writer recorded the column. */
-    surface_id: z.string().nullable(),
+    surface_id: z
+      .string()
+      .nullable()
+      .describe(
+        "Coalesced column then overlay id, so it is present on every row including those written before the column was recorded.",
+      ),
     /** A DELETE entry is the only evidence a surface ever existed. */
-    action: z.enum(["insert", "update", "delete"]).nullable(),
+    action: z
+      .enum(["insert", "update", "delete"])
+      .nullable()
+      .describe(
+        "insert, update or delete. A delete is the only evidence a surface ever existed.",
+      ),
     kind: z.string().nullable(),
     url: z.string().nullable(),
     name: z.string().nullable(),
     /** The registry commit that produced the change. */
-    source_commit: z.string().nullable(),
+    source_commit: z
+      .string()
+      .nullable()
+      .describe("The registry commit that produced the change."),
     recorded_at: z.iso.datetime(),
   })
-  .strict();
+  .strict()
+  .describe("One recorded mutation of a subnet's public surface.");
 
 export const SubnetSurfaceHistoryArtifactSchema = z
   .object({
@@ -27,7 +41,12 @@ export const SubnetSurfaceHistoryArtifactSchema = z
     change_count: z.int().min(0),
     /** Distinct surfaces with a recorded mutation -- NOT the subnet's current
      * surface count. A deleted surface is counted here and absent there. */
-    surface_count: z.int().min(0),
+    surface_count: z
+      .int()
+      .min(0)
+      .describe(
+        "Distinct surfaces with a recorded mutation -- NOT the subnet's current surface count. A deleted surface is counted here and absent there.",
+      ),
     latest_change_at: z.iso.datetime().nullable(),
     changes: z.array(SurfaceHistoryChangeSchema),
   })

--- a/schemas-src/routes/subnet-trajectory.ts
+++ b/schemas-src/routes/subnet-trajectory.ts
@@ -41,7 +41,10 @@ const SubnetTrajectoryPointSchema = z
     alpha_out_pool: z.number().nullable().optional(),
     subnet_volume_tao: z.number().nullable().optional(),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One daily-snapshot point on a subnet's trajectory (chronological). Economics fields are null on rows captured before those columns existed / when economics was unavailable that day.",
+  );
 
 export const SubnetTrajectoryArtifactSchema = z
   .object({
@@ -56,9 +59,16 @@ export const SubnetTrajectoryArtifactSchema = z
     // there, so the deltas this route exists to serve had no declared shape
     // at all. Modeled from formatTrajectory() and verified against the live
     // response for both windows.
-    deltas: z.record(z.string(), SubnetTrajectoryDeltaSchema.nullable()),
+    deltas: z
+      .record(z.string(), SubnetTrajectoryDeltaSchema.nullable())
+      .describe(
+        "Latest-vs-window-ago deltas -- one entry per window (7d, 30d) that has a prior point to compare against; empty when the series is too short.",
+      ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One subnet's weekly structural + economics trajectory from the daily snapshots (#5887). Mirrors GET /api/v1/subnets/{netuid}/trajectory's data envelope. The REST envelope's window-keyed deltas map (7d/30d) is exposed here as a list carrying each window label, since those keys are not valid GraphQL field names.",
+  );
 export type SubnetTrajectoryArtifact = z.infer<
   typeof SubnetTrajectoryArtifactSchema
 >;

--- a/schemas-src/routes/subnet-turnover.ts
+++ b/schemas-src/routes/subnet-turnover.ts
@@ -17,9 +17,17 @@ export const SUBNET_TURNOVER_WINDOW_VALUES = [
 const ValidatorDetailSchema = z
   .object({
     hotkey: z.string(),
-    uid: z.int().nullable(),
+    uid: z
+      .int()
+      .nullable()
+      .describe(
+        "The UID it held at the boundary snapshot, null when the row carried no usable uid.",
+      ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One validator that entered or left a subnet's validator set between the window's boundary snapshots.",
+  );
 
 const UidReassignmentSchema = z
   .object({
@@ -27,7 +35,10 @@ const UidReassignmentSchema = z
     from_hotkey: z.string(),
     to_hotkey: z.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One UID that changed hands between the window's boundary snapshots.",
+  );
 
 const TurnoverChangesSchema = z
   .object({
@@ -38,7 +49,10 @@ const TurnoverChangesSchema = z
     validators_exited: z.array(ValidatorDetailSchema),
     uid_reassignments: z.array(UidReassignmentSchema),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The per-neuron churn behind a subnet's turnover scorecard: which validators entered and exited, and which UIDs were reassigned. Mirrors the changes block of GET /api/v1/subnets/{netuid}/turnover?changes=true.",
+  );
 
 export const SubnetTurnoverArtifactSchema = z
   .object({
@@ -58,9 +72,16 @@ export const SubnetTurnoverArtifactSchema = z
     uids_deregistered: z.int().min(0).optional(),
     neuron_retention: z.number().nullable().optional(),
     stability_score: z.int().nullable().optional(),
-    changes: TurnoverChangesSchema.nullable().optional(),
+    changes: TurnoverChangesSchema.nullable()
+      .optional()
+      .describe(
+        "Per-neuron churn detail behind the counts above, populated only when the field's changes toggle is set (mirroring REST's ?changes=true). Null otherwise, and on a cold store.",
+      ),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One subnet's validator/neuron-set turnover between a window's boundary snapshots. The churn metrics are zeroed and the retentions/stability null on a single-snapshot or cold store (schema-stable). Mirrors GET /api/v1/subnets/{netuid}/turnover's default scorecard.",
+  );
 export type SubnetTurnoverArtifact = z.infer<
   typeof SubnetTurnoverArtifactSchema
 >;

--- a/schemas-src/routes/subnet-weights.ts
+++ b/schemas-src/routes/subnet-weights.ts
@@ -30,7 +30,13 @@ const SubnetWeightSetterSchema = z
     hotkey: z.string().nullable(),
     uid: z.int().min(0).nullable(),
     weight_sets: z.int().min(0),
-    share: z.number().min(0).nullable(),
+    share: z
+      .number()
+      .min(0)
+      .nullable()
+      .describe(
+        "This setter's share of the subnet total weight_sets; null when the subnet total is 0.",
+      ),
     first_set_at: z.string().nullable(),
     last_set_at: z.string().nullable(),
     // #9389. Measured against the window's newest event rather than wall-clock now, so
@@ -45,7 +51,10 @@ const SubnetWeightSetterSchema = z
         "Whether this setter is more than overdue_tempo_multiple tempos past its last weight set. NULL means not evaluated -- the subnet's tempo or this setter's last_set_at was unavailable -- which is deliberately distinct from false ('evaluated, on time').",
       ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One validator's weight-setting activity within one subnet over the lookback window.",
+  );
 
 export const SubnetWeightSettersArtifactSchema = z
   .object({
@@ -71,7 +80,10 @@ export const SubnetWeightSettersArtifactSchema = z
     overdue_setter_count: z.int().min(0),
     setters: z.array(SubnetWeightSetterSchema),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Per-subnet weight-setter leaderboard (#5712). Empty setters on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/weights/setters.",
+  );
 export type SubnetWeightSettersArtifact = z.infer<
   typeof SubnetWeightSettersArtifactSchema
 >;

--- a/schemas-src/routes/subnet-yield.ts
+++ b/schemas-src/routes/subnet-yield.ts
@@ -28,7 +28,10 @@ const SubnetYieldNeuronSchema = z
     yield: z.number().nullable(),
     vs_median: z.enum(["above", "below", "at"]).nullable(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One UID's emission-per-stake yield within a subnet's current metagraph snapshot.",
+  );
 
 export const SubnetYieldArtifactSchema = z
   .object({
@@ -74,7 +77,11 @@ export const SubnetYieldHistoryArtifactSchema = z
   .object({
     schema_version: z.int(),
     netuid: z.int().min(0),
-    window: z.string().nullable().optional(),
+    window: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("The resolved window label (7d/30d/90d)."),
     point_count: z.int().min(0),
     points: z.array(SubnetYieldHistoryPointSchema),
   })

--- a/schemas-src/routes/tao-usd.ts
+++ b/schemas-src/routes/tao-usd.ts
@@ -13,24 +13,43 @@ export const TaoUsdPointSchema = z
   .object({
     observed_at: z.iso.datetime(),
     block_number: z.int().nullable(),
-    usd_per_tao: z.number().positive().nullable(),
+    usd_per_tao: z
+      .number()
+      .positive()
+      .nullable()
+      .describe(
+        "Null means the block was not priceable (insufficient pool quorum), NOT a zero price.",
+      ),
   })
-  .strict();
+  .strict()
+  .describe("One TAO/USD reading.");
 
 export const TaoUsdLatestSchema = z
   .object({
     usd_per_tao: z.number().positive().nullable(),
     /** Stated even when the price is null -- it is what says WHY. */
-    price_basis: z.string().nullable(),
+    price_basis: z
+      .string()
+      .nullable()
+      .describe("Stated even when the price is null -- it is what says why."),
     /** The ETH/USDC anchor leg the composition multiplied through. */
-    eth_usd: z.number().positive().nullable(),
+    eth_usd: z
+      .number()
+      .positive()
+      .nullable()
+      .describe("The ETH/USDC anchor leg the composition multiplied through."),
     block_number: z.int().nullable(),
     observed_at: z.iso.datetime().nullable(),
     pool_count: z.int().min(0).nullable(),
     /** Per-pool provenance as the producer stored it. */
-    pools: z.array(z.unknown()),
+    pools: z
+      .array(z.unknown())
+      .describe("Per-pool provenance as the producer stored it."),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The newest reading with the derivation that produced it, kept together so both describe the same block.",
+  );
 
 export const TaoUsdArtifactSchema = z
   .object({
@@ -39,11 +58,21 @@ export const TaoUsdArtifactSchema = z
     point_count: z.int().min(0),
     /** How many points carried a price. A gap from point_count is how a window
      * with unpriceable blocks announces itself. */
-    priced_point_count: z.int().min(0),
+    priced_point_count: z
+      .int()
+      .min(0)
+      .describe(
+        "How many points carried a price. A gap from point_count is how a window with unpriceable blocks announces itself.",
+      ),
     latest: TaoUsdLatestSchema.nullable(),
     /** How far back the answer actually reaches -- the series began 2026-08-02,
      * so a wide window returns everything rather than the window's span. */
-    oldest_observed_at: z.iso.datetime().nullable(),
+    oldest_observed_at: z.iso
+      .datetime()
+      .nullable()
+      .describe(
+        "How far back the answer actually reaches -- the series began 2026-08-02.",
+      ),
     change_usd: z.number().nullable(),
     change_pct: z.number().nullable(),
     points: z.array(TaoUsdPointSchema),

--- a/schemas-src/routes/validator-detail.ts
+++ b/schemas-src/routes/validator-detail.ts
@@ -116,7 +116,11 @@ export const ValidatorDetailArtifactSchema = z
     max_validator_trust: z.number().nullable(),
     captured_at: z.string().nullable(),
     block_number: z.int().min(0).nullable(),
-    subnets: z.array(ValidatorDetailSubnetSchema),
+    subnets: z
+      .array(ValidatorDetailSubnetSchema)
+      .describe(
+        "Per-subnet membership rows for this validator. The global leaderboard entry caps this at the top 10 by stake; the single-validator lookup carries every subnet.",
+      ),
   })
   .passthrough();
 export type ValidatorDetailArtifact = z.infer<

--- a/schemas-src/routes/validator-economics.ts
+++ b/schemas-src/routes/validator-economics.ts
@@ -21,7 +21,10 @@ export const ValidatorSetCompositionSchema = z
     active: z.int().min(0),
     earning: z.int().min(0),
   })
-  .strict();
+  .strict()
+  .describe(
+    "Permitted, active and earning are three DIFFERENT sets. Network-wide 2026-08-03: 1,523 / 1,137 / 1,117; SN83 is 64 / 8 / 7. Published separately rather than collapsed, because 'how many validators does this subnet have' has three defensible answers.",
+  );
 
 // The derived floor is only publishable while the rule still reproduces the permits the
 // chain actually granted. This is the route telling a caller when its own model has
@@ -35,7 +38,10 @@ export const ValidatorPermitModelAgreementSchema = z
     agreement: z.number().min(0).max(1).nullable(),
     publishable: z.boolean(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "How well the derived permit rule still reproduces the permits the chain actually granted. Published so a caller can see when the model has drifted rather than trusting a floor it no longer supports.",
+  );
 
 // The shape is the information (#9327): SN64's permit-holders sat at
 // `0, 0, 0.001, 0.01, 0.0135, 0.06, 0.09, 0.18 x9` — a median of 0.18 against a cohort
@@ -47,10 +53,18 @@ export const ValidatorTakeDistributionSchema = z
     min: z.number().nullable(),
     max: z.number().nullable(),
     distribution: z.array(z.number()),
-    median_earning: z.number().nullable(),
+    median_earning: z
+      .number()
+      .nullable()
+      .describe(
+        "Median restricted to permit-holders that actually earn -- takes among validators nobody delegates to are noise.",
+      ),
     sample_size: z.int().min(0),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The commission picture across permit-holders. The sorted vector is published because the shape is the information: it is genuinely bimodal, with a cohort competing at or near zero against a median at the effective ceiling, and validators earning at both ends.",
+  );
 
 export const SubnetValidatorEconomicsArtifactSchema = z
   .object({
@@ -59,23 +73,46 @@ export const SubnetValidatorEconomicsArtifactSchema = z
 
     // Floors are in total_stake UNITS (alpha + tao_weight * root), not alpha alone —
     // the quantity the chain threshold actually tests.
-    permit_floor_units: z.number().nullable(),
+    permit_floor_units: z
+      .number()
+      .nullable()
+      .describe(
+        "Floors are in total_stake UNITS (alpha + tao_weight * root), the quantity the chain threshold actually tests -- not alpha alone.",
+      ),
     permit_floor_cost_tao: z.number().nullable(),
-    permit_entry_cost_tao: z.number().nullable(),
+    permit_entry_cost_tao: z
+      .number()
+      .nullable()
+      .describe(
+        "Floor cost plus the registration burn. Entry is two spends; publishing one understates it.",
+      ),
     // The EARNING floors exclude the subnet owner: its permit is unconditional,
     // so an owner earning on ~0 stake reported a floor of 0 -- "free to earn here" -- and
     // a 0-alpha buy cannot be priced, which then dropped the subnet out of the
     // cross-subnet ranking as unpriceable. Null means no NON-OWNER has earned here,
     // which is a real answer about the subnet rather than a missing reading.
-    earning_floor_units: z.number().nullable(),
+    earning_floor_units: z
+      .number()
+      .nullable()
+      .describe(
+        "The smallest stake that actually EARNS dividends here, excluding the subnet owner -- its permit is unconditional, so an owner earning on ~0 stake would report a floor of 0. Null when NO non-owner has earned on this subnet, which is a real answer (the owner is taking the dividends), not a missing one.",
+      ),
     earning_floor_cost_tao: z.number().nullable(),
     earning_entry_cost_tao: z.number().nullable(),
-    permit_to_earning_multiple: z.number().nullable(),
+    permit_to_earning_multiple: z
+      .number()
+      .nullable()
+      .describe("How much more it takes to EARN than merely to hold a permit."),
 
     // Root is not split: this one figure clears the threshold on EVERY subnet the
     // hotkey is registered on at once, which is the cross-subnet alternative to the
     // per-subnet alpha costs above.
-    root_tao_to_clear_threshold: z.number().nullable(),
+    root_tao_to_clear_threshold: z
+      .number()
+      .nullable()
+      .describe(
+        "Root is not split: this much root clears the threshold on EVERY subnet the hotkey is registered on at once.",
+      ),
 
     max_validators: z.int().min(0).nullable(),
     validator_slots_open: z.int().min(0).nullable(),
@@ -89,17 +126,32 @@ export const SubnetValidatorEconomicsArtifactSchema = z
     // Reported, never scored. Gate-closed subnets still emit alpha at a comparable rate
     // and are less contested, so per unit of stake they pay MORE — the gate is an
     // exit-liquidity question, not an eligibility one.
-    emission_gate_open: z.boolean().nullable(),
+    emission_gate_open: z
+      .boolean()
+      .nullable()
+      .describe(
+        "Reported, never scored. Gate-closed subnets still emit alpha at a comparable rate and are less contested, so per unit of stake they pay MORE -- the gate is an exit-liquidity question, not an eligibility one.",
+      ),
     tao_inflow_per_day: z.number().nullable(),
     registration_cost_tao: z.number().nullable(),
 
     // Echoed so a caller never has to guess what the floor was computed against. Both
     // are sudo-settable, so a cached copy on the caller's side would silently rot.
-    stake_threshold_units: z.number().nullable(),
+    stake_threshold_units: z
+      .number()
+      .nullable()
+      .describe(
+        "Echoed so a caller never has to guess what the floor was computed against. Both are sudo-settable, so a cached copy would silently rot.",
+      ),
     tao_weight: z.number().nullable(),
 
     model_agreement: ValidatorPermitModelAgreementSchema.nullable(),
-    degraded_reason: z.string().nullable(),
+    degraded_reason: z
+      .string()
+      .nullable()
+      .describe(
+        "Names the missing input whenever a field above was withheld, so a caller can tell 'unknown' from 'zero'.",
+      ),
     // Required by the chain-read route convention. Nearly every field here is
     // DERIVED — there is no storage item behind `permit_floor_units` — so those
     // carry `kind: "reconstructed", storage: null`, and `measured` is reserved for
@@ -128,20 +180,33 @@ export const ValidatorEconomicsExclusionSchema = z
     netuid: z.int().min(0),
     reason: z.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One subnet the ranking dropped, and why, so that a caller can tell an omitted subnet from an absent one without re-deriving the ranking.",
+  );
 
 export const ValidatorEconomicsRankingArtifactSchema = z
   .object({
     schema_version: z.int(),
     sort: z.string(),
     order: z.enum(["asc", "desc"]),
-    total: z.int().min(0),
+    total: z
+      .int()
+      .min(0)
+      .describe(
+        "Rows matching the filters, BEFORE limit/offset -- so a caller can page without re-counting.",
+      ),
     rows: z.array(SubnetValidatorEconomicsArtifactSchema),
     excluded: z.array(ValidatorEconomicsExclusionSchema),
     // Echoed once for the whole ranking rather than repeated per row: both are
     // network-wide and sudo-settable, and the floors in every row were derived
     // against exactly these values.
-    stake_threshold_units: z.number().nullable(),
+    stake_threshold_units: z
+      .number()
+      .nullable()
+      .describe(
+        "Echoed once for the whole ranking: every row's floors were derived against exactly these values, and both are sudo-settable.",
+      ),
     tao_weight: z.number().nullable(),
     root_tao_to_clear_threshold: z.number().nullable(),
     field_sources: FieldSourcesSchema,
@@ -190,18 +255,39 @@ export const ValidatorEconomicsHistoryPointSchema = z
     validators_earning: z.int().min(0),
     emission_gate_open: z.boolean().nullable(),
     tao_inflow_per_day: z.number().nullable(),
-    max_validators: z.int().min(1).nullable(),
-    max_validators_source: z.enum(["observed", "current"]).nullable(),
-    permit_set_full: z.boolean().nullable(),
+    max_validators: z
+      .int()
+      .min(1)
+      .nullable()
+      .describe(
+        "The validator cap in force on this day. permit_floor_alpha is the observed floor REGARDLESS of cap state, so it cannot be read without this -- and joining today's cap onto an old point is wrong for any subnet whose cap moved.",
+      ),
+    max_validators_source: z
+      .enum(["observed", "current"])
+      .nullable()
+      .describe(
+        "Where max_validators came from: observed = the hyperparameter change-log recorded it at or before this day; current = the change-log does not reach this far back, so the LIVE cap is reported.",
+      ),
+    permit_set_full: z
+      .boolean()
+      .nullable()
+      .describe(
+        "Whether the permit set was full on this day (validators_permitted >= max_validators). NOT the same measure as the current record's cap_binding, which counts UIDs clearing the threshold against slots -- only the permitted set survives in a daily snapshot.",
+      ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One day's observed economics. The floors are read off the snapshot, not re-derived: StakeThreshold is sudo-settable, so re-running today's threshold against an old day would show a flat line across a governance change that actually moved the floor.",
+  );
 
 export const SubnetValidatorEconomicsHistoryArtifactSchema = z
   .object({
     schema_version: z.int(),
     netuid: z.int().min(0),
     window: z.string(),
-    points: z.array(ValidatorEconomicsHistoryPointSchema),
+    points: z
+      .array(ValidatorEconomicsHistoryPointSchema)
+      .describe("Newest first."),
     field_sources: FieldSourcesSchema,
   })
   .strict();

--- a/schemas-src/routes/validator-history.ts
+++ b/schemas-src/routes/validator-history.ts
@@ -65,7 +65,7 @@ const ValidatorHistoryPointSchema = z
   })
   .strict()
   .describe(
-    "One day's rollup for a validator hotkey. Cross-subnet (summed across every subnet it validates in) unless the query scoped a netuid, in which case the per-subnet fields below are populated too.",
+    "One day's rollup for a validator's hotkey. Cross-subnet (summed across every subnet it validates in) unless the query scoped a netuid, in which case the per-subnet fields below are populated too.",
   );
 
 export const ValidatorHistoryArtifactSchema = z

--- a/schemas-src/routes/validator-history.ts
+++ b/schemas-src/routes/validator-history.ts
@@ -22,7 +22,12 @@ const ValidatorHistoryPointSchema = z
     // take are per-(hotkey, netuid) facts and averaging them across subnets would
     // publish a number the chain never computes. The point schema is .strict(), so
     // they have to be declared here or a scoped response fails its own contract.
-    netuid: z.int().min(0).nullable().optional(),
+    netuid: z
+      .int()
+      .min(0)
+      .nullable()
+      .optional()
+      .describe("The scoped subnet. Null on the unscoped cross-subnet series."),
     uid: z.int().min(0).nullable().optional(),
     stake_alpha: z
       .number()
@@ -32,7 +37,13 @@ const ValidatorHistoryPointSchema = z
         "Native alpha, NOT converted to TAO — the unit the subnet actually emits in, and what an operator compares day over day. The TAO-priced equivalents remain total_stake_tao/total_emission_tao on the same point.",
       ),
     emission_alpha: z.number().nullable().optional(),
-    validator_trust: z.number().nullable().optional(),
+    validator_trust: z
+      .number()
+      .nullable()
+      .optional()
+      .describe(
+        "Per-subnet facts, null unless the query scoped a netuid: a cross-subnet average of these is a number the chain never computes.",
+      ),
     consensus: z.number().nullable().optional(),
     dividends: z.number().nullable().optional(),
     take: z.number().nullable().optional(),
@@ -52,7 +63,10 @@ const ValidatorHistoryPointSchema = z
     stake_share: z.number().min(0).nullable().optional(),
     dividend_efficiency: z.number().min(0).nullable().optional(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One day's rollup for a validator hotkey. Cross-subnet (summed across every subnet it validates in) unless the query scoped a netuid, in which case the per-subnet fields below are populated too.",
+  );
 
 export const ValidatorHistoryArtifactSchema = z
   .object({
@@ -61,7 +75,13 @@ export const ValidatorHistoryArtifactSchema = z
     window: z.string().nullable(),
     // The subnet this series was scoped to; null for the cross-subnet rollup, so a
     // consumer never has to probe a point to learn which shape it received.
-    netuid: z.int().min(0).nullable(),
+    netuid: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe(
+        "The subnet this series was scoped to, or null for the cross-subnet rollup.",
+      ),
     // #9390: take is a delegate-level fact, reported once for the series rather than
     // per point, and compared as the u16 the chain stores it in — the float rendering
     // is not stable and diffing it manufactures changes that never happened.
@@ -77,7 +97,10 @@ export const ValidatorHistoryArtifactSchema = z
     point_count: z.int().min(0),
     points: z.array(ValidatorHistoryPointSchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One validator's cross-subnet staked-over-time history. Mirrors GET /api/v1/validators/{hotkey}/history.",
+  );
 export type ValidatorHistoryArtifact = z.infer<
   typeof ValidatorHistoryArtifactSchema
 >;

--- a/schemas-src/routes/validator-nominators.ts
+++ b/schemas-src/routes/validator-nominators.ts
@@ -38,12 +38,12 @@ const ValidatorNominatorEntrySchema = z
       .string()
       .nullable()
       .describe(
-        "Most recent StakeAdded/StakeRemoved time for this coldkey; null when unstamped.",
+        "Most recent StakeAdded/StakeRemoved time for this `coldkey`; null when unstamped.",
       ),
   })
   .strict()
   .describe(
-    "One nominating coldkey's staking activity toward a validator within the window.",
+    "One nominating `coldkey`'s staking activity toward a validator within the window.",
   );
 
 export const ValidatorNominatorsArtifactSchema = z

--- a/schemas-src/routes/validator-nominators.ts
+++ b/schemas-src/routes/validator-nominators.ts
@@ -26,19 +26,41 @@ const ValidatorNominatorEntrySchema = z
     coldkey: z.string(),
     staked_tao: z.number().min(0),
     unstaked_tao: z.number().min(0),
-    net_staked_tao: z.number(),
-    gross_staked_tao: z.number().min(0),
+    net_staked_tao: z.number().describe("staked_tao - unstaked_tao."),
+    gross_staked_tao: z
+      .number()
+      .min(0)
+      .describe(
+        "staked_tao + unstaked_tao (total churn, regardless of direction).",
+      ),
     event_count: z.int().min(0),
-    last_observed_at: z.string().nullable(),
+    last_observed_at: z
+      .string()
+      .nullable()
+      .describe(
+        "Most recent StakeAdded/StakeRemoved time for this coldkey; null when unstamped.",
+      ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "One nominating coldkey's staking activity toward a validator within the window.",
+  );
 
 export const ValidatorNominatorsArtifactSchema = z
   .object({
     schema_version: z.int(),
     hotkey: z.string(),
-    window: z.string().nullable(),
-    sort: z.enum(VALIDATOR_NOMINATORS_NOMINATOR_SORTS_VALUES),
+    window: z
+      .string()
+      .nullable()
+      .describe(
+        "The resolved window label; null only if the builder was handed no window.",
+      ),
+    sort: z
+      .enum(VALIDATOR_NOMINATORS_NOMINATOR_SORTS_VALUES)
+      .describe(
+        "The resolved sort actually applied (an omitted sort resolves to net_staked).",
+      ),
     limit: z.int().min(0).max(100),
     offset: z.int().min(0),
     nominator_count: z
@@ -56,7 +78,10 @@ export const ValidatorNominatorsArtifactSchema = z
     nominator_gini: z.number().min(0).max(1).nullable(),
     nominators: z.array(ValidatorNominatorEntrySchema),
   })
-  .passthrough();
+  .passthrough()
+  .describe(
+    "One validator's nominator leaderboard (#5692). Mirrors GET /api/v1/validators/{hotkey}/nominators' data envelope.",
+  );
 export type ValidatorNominatorsArtifact = z.infer<
   typeof ValidatorNominatorsArtifactSchema
 >;

--- a/schemas-src/shared.ts
+++ b/schemas-src/shared.ts
@@ -79,6 +79,72 @@ export const BITTENSOR_NETWORK_VALUES = ["finney", "test", "local"] as const;
 export const BittensorNetworkSchema = z.enum(BITTENSOR_NETWORK_VALUES);
 export type BittensorNetwork = z.infer<typeof BittensorNetworkSchema>;
 
+/**
+ * What an address-labelling entity IS (#8372).
+ *
+ * Both copies carried an instruction rather than an import -- "keep all three
+ * in sync" on one and "Keep both in sync" on the other -- which is the shape
+ * of a vocabulary with no owner. `validate:schema-vocabularies` could not see
+ * either: prettier had wrapped both as `z` then `.enum([...])` on the next
+ * line, and the gate's matcher was anchored on `z.enum(`.
+ */
+export const ENTITY_CATEGORY_VALUES = [
+  "exchange",
+  "bridge",
+  "foundation",
+  "pool",
+  "infra",
+  "project",
+  "operator",
+  "other",
+] as const;
+export const EntityCategorySchema = z.enum(ENTITY_CATEGORY_VALUES);
+export type EntityCategory = z.infer<typeof EntityCategorySchema>;
+
+/**
+ * How a callable surface authenticates.
+ *
+ * Restated by the agent catalogue and the subnet detail card, which describe
+ * the same surfaces -- and the catalogue's own comment already said so:
+ * "Single-sourcing the two declarations is #9799". `signature` means the
+ * request is signed per call (a hotkey/nonce/signature header set) rather than
+ * carrying a static token.
+ */
+export const SURFACE_AUTH_SCHEME_VALUES = [
+  "none",
+  "bearer",
+  "api-key",
+  "basic",
+  "oauth2",
+  "signature",
+  "custom",
+] as const;
+export const SurfaceAuthSchemeSchema = z.enum(SURFACE_AUTH_SCHEME_VALUES);
+export type SurfaceAuthScheme = z.infer<typeof SurfaceAuthSchemeSchema>;
+
+/** Where an auth credential travels. Same two restating modules as the kind
+ * above -- one vocabulary split across two files describing one surface. */
+export const SURFACE_AUTH_LOCATION_VALUES = [
+  "header",
+  "query",
+  "cookie",
+  "body",
+] as const;
+export const SurfaceAuthLocationSchema = z.enum(SURFACE_AUTH_LOCATION_VALUES);
+export type SurfaceAuthLocation = z.infer<typeof SurfaceAuthLocationSchema>;
+
+/** What a capture pass concluded about one surface's schema since the last
+ * one. The drift artifact declares it and the profile card republishes it. */
+export const SCHEMA_DRIFT_STATUS_VALUES = [
+  "new",
+  "changed",
+  "unchanged",
+  "not-captured",
+  "missing-after-previous-capture",
+] as const;
+export const SchemaDriftStatusSchema = z.enum(SCHEMA_DRIFT_STATUS_VALUES);
+export type SchemaDriftStatus = z.infer<typeof SchemaDriftStatusSchema>;
+
 /** The vocabulary, exported as a tuple so every other schema that needs
  * these values imports them instead of restating them (#9799). */
 export const HEALTH_STATUS_VALUES = QUERY_ENUMS.healthStatus;

--- a/schemas-src/shared.ts
+++ b/schemas-src/shared.ts
@@ -125,10 +125,34 @@ export const SubnetEconomicsSchema = z
     alpha_in_pool: z.number().nullable(),
     alpha_market_cap_tao: z.number().nullable(),
     alpha_out_pool: z.number().nullable(),
-    alpha_price_change_1d: z.number().nullable().optional(),
-    alpha_price_change_1h: z.number().nullable().optional(),
-    alpha_price_change_1m: z.number().nullable().optional(),
-    alpha_price_change_7d: z.number().nullable().optional(),
+    alpha_price_change_1d: z
+      .number()
+      .nullable()
+      .optional()
+      .describe(
+        "Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227).",
+      ),
+    alpha_price_change_1h: z
+      .number()
+      .nullable()
+      .optional()
+      .describe(
+        "Signed %-change in alpha_price_tao over ~1h. Always null from daily snapshots (#7227).",
+      ),
+    alpha_price_change_1m: z
+      .number()
+      .nullable()
+      .optional()
+      .describe(
+        "Signed %-change in alpha_price_tao over ~30 days from subnet_snapshots (#7227).",
+      ),
+    alpha_price_change_7d: z
+      .number()
+      .nullable()
+      .optional()
+      .describe(
+        "Signed %-change in alpha_price_tao over ~7 days from subnet_snapshots (#7227).",
+      ),
     alpha_price_tao: z
       .number()
       .nullable()
@@ -224,7 +248,12 @@ export type SubnetEconomics = z.infer<typeof SubnetEconomicsSchema>;
 export const ChainStateSchema = z
   .object({
     block: z.int().min(0),
-    block_hash: z.string().regex(/^0x[0-9a-fA-F]{64}$/),
+    block_hash: z
+      .string()
+      .regex(/^0x[0-9a-fA-F]{64}$/)
+      .describe(
+        "The block hash, so the pinning is exact -- a height alone is ambiguous across a reorg.",
+      ),
     // Block emission is derived from issuance (#8747), never read from the
     // stale `BlockEmission` storage item. Kept at the height so a historical
     // row stays interpretable against the emission in force when captured.
@@ -236,15 +265,28 @@ export const ChainStateSchema = z
     //
     // theta is null when the bar is unset, which disables the gate outright
     // (apply_emission_gate's own `if theta <= zero { return; }`).
-    emission_gate_bar: z.number().nullable(),
+    emission_gate_bar: z
+      .number()
+      .nullable()
+      .describe(
+        "theta. Null when the bar is unset, which disables the gate outright.",
+      ),
     emission_bar_quantile: z.number().nullable(),
     // NULL MEANS THE RUNTIME DEFAULT h = 3, NOT ZERO. h = 0 would make the
     // Hill gate return exactly 0.5 for every subnet, so coercing absent to 0
     // silently replaces the gate with a constant. Left null here and resolved
     // by the consumer against DEFAULT_EMISSION_GATE_EXPONENT.
-    emission_gate_exponent: z.int().nullable(),
+    emission_gate_exponent: z
+      .int()
+      .nullable()
+      .describe(
+        "h. Null means the runtime default 3, NOT zero -- h = 0 makes the Hill gate a constant 0.5 for every subnet.",
+      ),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The chain state the decomposition's inputs were pinned to. theta/q/h are read AS STORED at this block -- the runtime gates with the stored bar between its 360-block recomputes, so a live read is the wrong number for 359 blocks out of 360.",
+  );
 export type ChainState = z.infer<typeof ChainStateSchema>;
 
 // Per-field provenance (#9078): every published value labelled `measured` --

--- a/scripts/validate-schema-vocabularies.ts
+++ b/scripts/validate-schema-vocabularies.ts
@@ -87,7 +87,14 @@ for (const dir of SCHEMA_DIRS) {
       if (values.every((value) => JSON_SCHEMA_TYPES.has(value))) return;
       sites.push({ file, values });
     };
-    for (const match of source.matchAll(/z\.enum\(\s*\[([^\]]*)\]\s*\)/g))
+    // `z\s*\.enum`, not `z\.enum`: prettier breaks a chain across lines once it
+    // grows past the print width, so `z.enum([...])` becomes `z` then
+    // `.enum([...])` on the next line the moment a `.describe()` is added. The
+    // anchored form stopped matching `chain-alpha-volume.ts` for exactly that
+    // reason and the gate reported the bullish/bearish/neutral allowlist entry
+    // as STALE -- a formatting change had made it blind, and the fix it asked
+    // for was to delete the entry guarding a live duplicate (#10288).
+    for (const match of source.matchAll(/z\s*\.enum\(\s*\[([^\]]*)\]\s*\)/g))
       push(match[1]);
     for (const match of source.matchAll(
       /(?:export )?const \w+\s*=\s*\[([^\]]*)\]\s*as const;/g,

--- a/tests/degraded-answer-is-labelled.test.ts
+++ b/tests/degraded-answer-is-labelled.test.ts
@@ -1,0 +1,264 @@
+// A tier that declined must not answer `ok: true` with zeros and no header
+// (#10270).
+//
+// `/api/v1/accounts/{ss58}/counterparties` answered `counterparty_count: 0,
+// transfers_scanned: 0` for an account with 114, on roughly one request in
+// five. `transfers_scanned: 0` is the tell: the route reported that it scanned
+// nothing and concluded there was nothing. Its Postgres rung is `"retired"` in
+// wrangler.jsonc, so the lakehouse read IS its tier -- and `src/r2-sql.ts`'s
+// failure counter, declared with "same contract as the Postgres tier's
+// fallback generation: a caller can snapshot this before a read and compare
+// after", had no reader outside its own test file.
+//
+// TWO TESTS, because the route was never the interesting part. The first pins
+// the reported case end to end, in both directions. The second asks the same
+// question of the whole route table and answers it by DRIVING the router, so
+// it covers a route added tomorrow without anyone editing this file: for every
+// registered path, if the lakehouse declined while the request was served and
+// the answer was still a 200, that 200 must say so.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleRequest } from "../workers/api.ts";
+import {
+  degradedSnapshot,
+  labelDegradedResponse,
+} from "../workers/request-handlers/analytics.ts";
+import { currentR2SqlFailureGeneration } from "../src/r2-sql.ts";
+import { API_ROUTES, FEED_ROUTES } from "../src/contracts.ts";
+import { concretePath } from "./concrete-path.ts";
+
+/** The account from the issue -- 114 counterparties, 196 transfers scanned. */
+const SS58 = "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3";
+const COUNTERPARTY = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+/**
+ * Enough env for `isR2SqlConfigured` to say yes, and nothing else.
+ *
+ * That gate is the reason this has to be set: an UNCONFIGURED lakehouse
+ * returns null without touching the counter, on the stated grounds that a
+ * self-hoster with no lakehouse is not a fault. A test that left the token out
+ * would therefore drive the same empty payload while proving nothing about the
+ * case that matters -- the configured lakehouse that declined.
+ */
+const LAKEHOUSE_ENV = { R2_SQL_TOKEN: "test-token" } as unknown as Env;
+
+const DEGRADED_HEADER = "x-metagraph-degraded";
+
+async function withFetch<T>(
+  stub: typeof fetch,
+  run: () => Promise<T>,
+): Promise<T> {
+  const real = globalThis.fetch;
+  globalThis.fetch = stub;
+  try {
+    return await run();
+  } finally {
+    globalThis.fetch = real;
+  }
+}
+
+/** The lakehouse unreachable: a transport throw, the shape a dropped socket
+ * or an aborted query takes by the time `r2SqlQuery` sees it. */
+const refusingLakehouse = (() => {
+  throw new Error("r2 sql unreachable");
+}) as unknown as typeof fetch;
+
+/** The lakehouse answering, in R2 SQL's own envelope. */
+function answeringLakehouse(rows: Record<string, unknown>[]): typeof fetch {
+  return (async () =>
+    new Response(JSON.stringify({ success: true, result: { rows } }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+}
+
+function apiRequest(path: string): Request {
+  return new Request(`https://api.metagraph.sh${path}`);
+}
+
+describe("the counterparties zero says it is a zero (#10270)", () => {
+  test("a declining lakehouse produces a LABELLED empty card", async () => {
+    const res = (await withFetch(refusingLakehouse, () =>
+      handleRequest(
+        apiRequest(`/api/v1/accounts/${SS58}/counterparties`),
+        LAKEHOUSE_ENV,
+        {},
+      ),
+    )) as Response;
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: { counterparty_count: number; transfers_scanned: number };
+    };
+    // Still a 200 and still schema-stable: #9146 settled that a public READ
+    // degrades to a parseable empty rather than erroring. What changes is that
+    // the caller can now tell which it got.
+    assert.equal(res.status, 200);
+    assert.equal(body.ok, true);
+    assert.equal(body.data.counterparty_count, 0);
+    assert.equal(body.data.transfers_scanned, 0);
+    assert.equal(res.headers.get(DEGRADED_HEADER), "tier_unavailable");
+  });
+
+  test("a measured answer carries NO label", async () => {
+    // Without this the test above passes for the uninteresting reason that
+    // every response is labelled, which would be a worse bug than the one
+    // being fixed -- a marker on everything marks nothing.
+    const res = (await withFetch(
+      answeringLakehouse([
+        {
+          hotkey: SS58,
+          coldkey: COUNTERPARTY,
+          amount_tao: 1.5,
+          block_number: 5_870_000,
+          event_index: 0,
+          observed_at: 1_785_000_000_000,
+        },
+      ]),
+      () =>
+        handleRequest(
+          apiRequest(`/api/v1/accounts/${SS58}/counterparties`),
+          LAKEHOUSE_ENV,
+          {},
+        ),
+    )) as Response;
+    const body = (await res.json()) as {
+      data: { counterparty_count: number; transfers_scanned: number };
+    };
+    assert.equal(res.status, 200);
+    assert.equal(body.data.counterparty_count, 1);
+    assert.equal(body.data.transfers_scanned, 1);
+    assert.equal(res.headers.get(DEGRADED_HEADER), null);
+  });
+});
+
+describe("no registered route serves an unlabelled decline (#10270)", () => {
+  /**
+   * Both route tables, because they are two registries and a sweep of one
+   * misses the other: `FEED_ROUTES` is separate from `API_ROUTES` by design
+   * (#8703), and a family-wide invariant that only asked the bigger table
+   * would be silently partial.
+   */
+  const EVERY_ROUTE = [...API_ROUTES, ...FEED_ROUTES];
+
+  /**
+   * The two anchors this sweep must reach, one per response path.
+   *
+   * `counterparties` goes through `envelopeResponse` with no edge cache -- the
+   * 71-handler family #9110's fix never covered. `chain/weights` goes through
+   * `withEdgeCache`, which had the labelling but not the r2-sql signal. If a
+   * refactor stopped either from reaching the lakehouse, the sweep would go
+   * quietly green on a smaller surface, so name them rather than trust a count.
+   */
+  const ANCHORS = [
+    "/api/v1/accounts/{ss58}/counterparties",
+    "/api/v1/chain/weights",
+  ];
+
+  test("every route that saw the lakehouse decline says so", async () => {
+    const exercised: string[] = [];
+    const unlabelled: string[] = [];
+    const threw: string[] = [];
+
+    await withFetch(refusingLakehouse, async () => {
+      for (const route of EVERY_ROUTE) {
+        const before = currentR2SqlFailureGeneration();
+        let res: Response;
+        try {
+          res = (await handleRequest(
+            apiRequest(concretePath(route.path)),
+            LAKEHOUSE_ENV,
+            {},
+          )) as Response;
+        } catch (error) {
+          threw.push(`${route.path}: ${(error as Error).message}`);
+          continue;
+        }
+        // The counter is the whole discriminator: a route that never asked the
+        // lakehouse has nothing to declare, and needs no exemption entry here.
+        if (currentR2SqlFailureGeneration() === before) continue;
+        exercised.push(route.path);
+        if (res.status === 200 && !res.headers.get(DEGRADED_HEADER)) {
+          unlabelled.push(route.path);
+        }
+      }
+    });
+
+    assert.deepEqual(
+      threw,
+      [],
+      "handleRequest has no top-level try/catch, so a throw here is a 500 in production",
+    );
+    assert.deepEqual(
+      unlabelled,
+      [],
+      "these answered 200 after the lakehouse declined, with nothing to say so",
+    );
+    for (const anchor of ANCHORS) {
+      assert.ok(
+        exercised.includes(anchor),
+        `${anchor} no longer reaches the lakehouse -- this sweep is measuring less than it thinks`,
+      );
+    }
+  });
+});
+
+describe("what the router label refuses to touch", () => {
+  // The four early returns, each stated once. Driving them through a route
+  // would need a route that happens to be in each state, which is how a
+  // condition ends up asserted by coincidence rather than on purpose.
+  const stale = () => ({ ...degradedSnapshot(), r2Sql: -1 });
+
+  test("a non-200 is left alone", () => {
+    const res = new Response("{}", { status: 503 });
+    labelDegradedResponse(res, stale());
+    assert.equal(res.headers.get(DEGRADED_HEADER), null);
+  });
+
+  test("a handler's own wording survives", () => {
+    // #9273: get_account_positions and its siblings can say WHY a zero is
+    // untrustworthy. A generic `tier_unavailable` written over that would make
+    // the specific reason unrecoverable.
+    const res = new Response("{}", {
+      status: 200,
+      headers: { [DEGRADED_HEADER]: "position_ledger_incomplete" },
+    });
+    labelDegradedResponse(res, stale());
+    assert.equal(
+      res.headers.get(DEGRADED_HEADER),
+      "position_ledger_incomplete",
+    );
+  });
+
+  test("a measured answer is left alone", () => {
+    const res = new Response("{}", { status: 200 });
+    labelDegradedResponse(res, degradedSnapshot());
+    assert.equal(res.headers.get(DEGRADED_HEADER), null);
+  });
+
+  test("a stable decline is labelled too, not only a tier failure", () => {
+    const res = new Response("{}", { status: 200 });
+    labelDegradedResponse(res, { ...degradedSnapshot(), unmeasured: -1 });
+    assert.equal(res.headers.get(DEGRADED_HEADER), "tier_unavailable");
+  });
+
+  test("immutable headers are swallowed, not thrown", () => {
+    // A body read back out of the edge cache. `withEdgeCache` only ever stored
+    // a measured answer there, so the throw means a CONCURRENT request
+    // degraded -- relabelling a known-good cached body on that evidence would
+    // be the false positive, and a throw here would be a 500 on a request that
+    // had a perfectly good answer in hand.
+    let attempted = false;
+    const frozen = {
+      status: 200,
+      headers: {
+        has: () => false,
+        set: () => {
+          attempted = true;
+          throw new TypeError("Can't modify immutable headers.");
+        },
+      },
+    } as unknown as Response;
+    labelDegradedResponse(frozen, stale());
+    assert.equal(attempted, true, "the label must have been attempted");
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -394,7 +394,11 @@ import {
   degradedChainEventsPayload,
   hotTierBlockChainEvents,
 } from "../src/chain-events-degraded.ts";
-import { markPostgresTierFallbackResponse } from "./request-handlers/analytics.ts";
+import {
+  degradedSnapshot,
+  labelDegradedResponse,
+  markPostgresTierFallbackResponse,
+} from "./request-handlers/analytics.ts";
 import { loadGlobalOperationalHealth } from "../src/global-operational-health.ts";
 import {
   CHAIN_FIREHOSE_INGEST_TOKEN_HEADER,
@@ -4259,7 +4263,42 @@ async function handleChainFirehoseIngest(request: Request, env: Env) {
   });
 }
 
+/**
+ * THE ROUTER, plus the one thing every route must not be able to forget
+ * (#10270).
+ *
+ * A data tier that declines mid-request leaves the handler holding a
+ * schema-stable empty payload, and 71 of the tier-reading handlers in
+ * `request-handlers/entities.ts` returned it with `ok: true` and no header --
+ * `/accounts/{ss58}/counterparties` answering `counterparty_count: 0,
+ * transfers_scanned: 0` for an account with 114, on roughly one request in
+ * five, while the lakehouse was rate-limited. `transfers_scanned: 0` is the
+ * tell: the route reported that it scanned nothing and concluded there was
+ * nothing.
+ *
+ * #9110 solved this for the analytics family by labelling inside
+ * `withEdgeCache` rather than in each handler, on the argument that a
+ * per-handler flag is exactly what the next handler forgets. Not one of the 71
+ * uses `withEdgeCache`, so none of them was ever covered. This is the same
+ * argument at the only point that covers all of them: a handler cannot opt out
+ * of being routed.
+ *
+ * The dispatch itself is `dispatchRequest` below, unchanged -- it has ~40
+ * early returns, and wrapping it from outside is what makes the label
+ * unforgettable rather than 40 more places to remember.
+ */
 export async function handleRequest(
+  request: Request,
+  env: Env = {} as unknown as Env,
+  ctx: Ctx = {},
+) {
+  const before = degradedSnapshot();
+  const response = await dispatchRequest(request, env, ctx);
+  labelDegradedResponse(response, before);
+  return response;
+}
+
+async function dispatchRequest(
   request: Request,
   env: Env = {} as unknown as Env,
   ctx: Ctx = {},

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -58,6 +58,7 @@ import {
   currentPostgresTierFallbackGeneration,
   tryPostgresTier,
 } from "../postgres-tier.ts";
+import { currentR2SqlFailureGeneration } from "../../src/r2-sql.ts";
 import { loadBulkHealthTrends } from "../../src/bulk-health-trends.ts";
 import {} from "../../src/route-limits.ts";
 import { formatGlobalIncidents } from "../../src/health-serving.ts";
@@ -338,6 +339,111 @@ function markPostgresTierFallbackResponse(response: Response): Response {
   return marked;
 }
 
+/**
+ * Every "this answer was not measured" counter, read as one value (#10270).
+ *
+ * There are three of them and they lived in three modules, so each place that
+ * wanted to know whether an answer was real had to remember the full list.
+ * `withEdgeCache` remembered two; the r2-sql one it never knew about at all,
+ * even though `src/r2-sql.ts` declares its counter with "same contract as the
+ * Postgres tier's fallback generation: a caller can snapshot this before a
+ * read and compare after". Nothing outside its own test file ever did --
+ * measured repo-wide, `currentR2SqlFailureGeneration` had zero production
+ * readers -- which is why `/accounts/{ss58}/counterparties` could answer
+ * `counterparty_count: 0, transfers_scanned: 0` with `ok: true` and no header
+ * while the lakehouse was rate-limited. That route's Postgres rung is
+ * `"retired"` in wrangler.jsonc, so the r2-sql read IS the tier; a signal
+ * nobody reads is the same as no signal.
+ */
+export interface DegradedSnapshot {
+  postgresTier: number;
+  r2Sql: number;
+  unmeasured: number;
+}
+
+export function degradedSnapshot(): DegradedSnapshot {
+  return {
+    postgresTier: currentPostgresTierFallbackGeneration(),
+    r2Sql: currentR2SqlFailureGeneration(),
+    unmeasured: unmeasuredGeneration,
+  };
+}
+
+/**
+ * What moved since `before`, split by how long it will stay true.
+ *
+ * TRANSIENT is a tier that failed or backed off -- a DATA_API subrequest that
+ * did not land, an r2-sql timeout, the account rate-limit breaker declining to
+ * ask. It will likely succeed on the next request, so the answer is labelled
+ * AND barred from the edge cache; persisting it would prolong the outage
+ * (#1760).
+ *
+ * UNMEASURED is a stable decline: a projection this route never precomputes,
+ * an artifact that is absent. Still labelled -- a caller must not read those
+ * zeros as measured -- but cacheable for the whole TTL, because it will answer
+ * the same way for the whole TTL (#10189).
+ */
+export function degradedSince(before: DegradedSnapshot): {
+  transient: boolean;
+  unmeasured: boolean;
+} {
+  const now = degradedSnapshot();
+  return {
+    transient:
+      now.postgresTier !== before.postgresTier || now.r2Sql !== before.r2Sql,
+    unmeasured: now.unmeasured !== before.unmeasured,
+  };
+}
+
+/**
+ * Label a response whose data tier declined while it was being served.
+ *
+ * Called from the router (`workers/api.ts`), which is the ONE point every
+ * route passes -- the same argument #9110 made for labelling inside
+ * `withEdgeCache` rather than in each handler, applied to the 71 tier-reading
+ * handlers in `workers/request-handlers/entities.ts` that #9110 never covered
+ * because not one of them uses `withEdgeCache`.
+ *
+ * HEADER ONLY, no cache-control rewrite. These routes have no server-side
+ * cache to poison -- measured live 2026-08-09, an api.metagraph.sh response
+ * carries no `cf-cache-status` at all, so the Workers Cache API inside
+ * `withEdgeCache` is the only cache in play and it makes its own decision from
+ * the same snapshot. Rewriting `cache-control` here would instead make every
+ * response in an isolate uncacheable for the length of an r2-sql cooldown,
+ * which is load amplification aimed at the exact condition the breaker exists
+ * to relieve.
+ *
+ * A 304 is skipped: the caller already holds the body its ETag names, and
+ * there is nothing in a 304 to mislabel. A response that already carries the
+ * header is left alone rather than re-set, so a handler that classified its
+ * own degradation keeps its own wording.
+ *
+ * IN PLACE, returning nothing, which is a deliberate difference from
+ * `withDegradedHeader`'s copy-on-immutable fallback. The one response class
+ * with immutable headers is a body read back out of the edge cache, and
+ * `withEdgeCache` only ever stored a MEASURED answer there -- so a throw here
+ * means a concurrent request degraded while this one was served from cache,
+ * and relabelling a known-good cached body on that evidence would be the false
+ * positive rather than the catch. Swallowing it is the correct answer, not the
+ * convenient one. Mutating also keeps the router's return type exactly what
+ * the dispatch inferred, so the label costs no signature change at ~40 return
+ * sites.
+ */
+export function labelDegradedResponse(
+  response: Response,
+  before: DegradedSnapshot,
+): void {
+  if (response.status !== 200) return;
+  if (response.headers.has(DEGRADED_HEADER)) return;
+  const moved = degradedSince(before);
+  if (!moved.transient && !moved.unmeasured) return;
+  try {
+    response.headers.set(DEGRADED_HEADER, DEGRADED_TIER_UNAVAILABLE);
+  } catch {
+    // An immutable-headers response: see above.
+  }
+}
+
 async function analyticsMeta(
   env: Env,
   artifactPath: string,
@@ -468,8 +574,7 @@ export async function withEdgeCache(
         : hit;
     }
   }
-  const pgFallbackGeneration = currentPostgresTierFallbackGeneration();
-  const unmeasuredBefore = unmeasuredGeneration;
+  const before = degradedSnapshot();
   const built = await buildResponse(cacheRequest);
   // #9110: the generation counter already told us the tier degraded while this
   // request was being served -- it is what suppresses caching two lines down.
@@ -486,19 +591,24 @@ export async function withEdgeCache(
   // this one too. That is the same trade the cache-suppression below already
   // makes, and it errs the safe way: a false "degraded" makes good data look
   // suspect, where the bug it replaces made missing data look measured.
+  //
+  // #10270: the r2-sql counter joined the two this used to read by name. It
+  // was declared for exactly this comparison and had no reader -- see
+  // `degradedSnapshot`. The suppression below is what it was declared FOR: an
+  // r2-sql decline is a 60s account-wide breaker, and caching its empty answer
+  // for the full TTL outlives the condition that produced it.
+  const moved = degradedSince(before);
   const degraded =
-    POSTGRES_TIER_FALLBACK_RESPONSES.has(built) ||
-    currentPostgresTierFallbackGeneration() !== pgFallbackGeneration;
+    POSTGRES_TIER_FALLBACK_RESPONSES.has(built) || moved.transient;
   // #10189: an unmeasured answer is labelled but NOT made uncacheable. See
   // `unmeasured` above for why the two signals have to be separate -- a
   // projection decline is stable for the whole TTL, where a tier failure is
   // transient and caching it would prolong the outage.
-  const unmeasuredAnswer = unmeasuredGeneration !== unmeasuredBefore;
   const labelled = built.status === 200 && !built.headers.has(DEGRADED_HEADER);
   let response = built;
   if (labelled && degraded) {
     response = markPostgresTierFallbackResponse(built);
-  } else if (labelled && unmeasuredAnswer) {
+  } else if (labelled && moved.unmeasured) {
     response = withDegradedHeader(built);
   }
   // Never cache errors / non-200s (a cold Postgres tier still returns a 200
@@ -508,7 +618,7 @@ export async function withEdgeCache(
     cacheKey &&
     response.status === 200 &&
     !POSTGRES_TIER_FALLBACK_RESPONSES.has(response) &&
-    currentPostgresTierFallbackGeneration() === pgFallbackGeneration
+    !moved.transient
   ) {
     ctx?.waitUntil?.(cache.put(cacheKey, response.clone()));
   }


### PR DESCRIPTION
## What moved

475 descriptions the published GraphQL SDL carried and nothing else in the repo did.

| | before | after |
|---|---|---|
| type descriptions on the Zod component | **0** of 219 | 218 |
| field descriptions on the Zod component | **15** of 289 | 288 |
| `openapi.json` | 3,024,277 B | 3,111,501 B |
| `$ref` count in `openapi.json` | 2,969 | **2,969** |

The `$ref` count is the check that matters on the size line: wrapping a registered component in
`.describe()` would have unregistered it and inlined the whole shape. Nothing was inlined — the 87 KB
is prose.

## They were never GraphQL's

They describe the shape the *route* returns. So `openapi.json` published those same components with
no description at all, the MCP output schemas that derive from the route `ArtifactSchema`s were
undocumented for the same reason, and the generated client's types carried no doc comments. One edit
now serves all four surfaces — which is the whole argument of #10060, applied to the last part of the
contract that was still single-surface.

## The one thing that does not survive

For an **inlined** nested object the property node and the object node are the same JSON Schema node,
so a single `.describe()` sets both, while GraphQL keeps a field description and its type's apart.

`.nullable()` turns out to cover most of it: it emits an `anyOf` the emitter unwraps before building
the object type, so prose on the wrapper reaches the field and never the type. That is why the
codemod puts a **type** description on the inner schema (following an identifier to its const, so a
shared shape is described once) and a **field** description on the wrapper.

Where the collision is real — 23 measured, 11 after the `.nullable()` split — the **type** prose
wins. Those are shared shapes whose field prose is parent-specific navigation help rather than schema
truth:

> `SubnetValidatorList.validators` → `NeuronState`
> field: *"Each permitted validator's live metagraph row — the same NeuronState shape the neuron field returns."*
> type: *"One UID's live metagraph state within a subnet (hot/cold keys, scores, stake/emission, axon, take."*

The first sentence is about the caller's path through the graph, not about the type. It should not
have been on a shared type.

Keeping both would mean registering the 355 inlined objects as components so a `{$ref, description}`
node holds each separately. That adds ~355 named interfaces to every generated client, and it is the
same mechanism #9685 needs to de-duplicate the 1.09 MB `tools/list` — so it belongs with that work,
not in a prose move.

## Where the two already disagreed

**42** descriptions exist on both sides and differ. The schema's wins, being the single source — and
it is generally the more current of the two:

| | SDL says | schema says |
|---|---|---|
| `Validator.total_stake_tao` | "its own subnet's latest `alpha_price_tao`" | "latest **SPOT** price" |
| `SubnetYieldHistory` | the subnet-wide return | the return **plus the per-UID median/p25/p75/p90** |

Those 42 become the published GraphQL wording when #10214 generates the SDL. Listing them here is the
point: they are the change a reader of the published schema will actually see.

**11** published types are shared by several components (`DegradedInfo` mirrors 11 `…Degraded`
sub-shapes). Each component gets the shared prose — they have to agree, or the generator cannot
collapse them into one published type at all.

**4** remain unmoved, all shared nodes a field description reached first
(`UptimeArtifactReliability` under two paths, `ChainEventsFeedArtifactEvents`). They publish no type
description today either, so nothing regresses.

## How it was done

A TypeScript-AST codemod, not hand edits: resolve each component (registered id, or the dotted path
the emitter derived its name from) to the expression that produces it, peel the field's own wrappers,
follow identifiers to their const, and append one `.describe(...)`. Three shapes in `schemas-src`
needed teaching — `z.object(BODY_CONST)`, a `.extend({...})` behind `.passthrough()`, and a body
declared `as const` — each of which had silently produced an unresolved target until it was handled.
Final run: **456 targets resolved, 0 unresolved**, plus 19 for the shared types.

## Validation

```
npm run typecheck / lint / format:check   clean
npx vitest run                            18,065 passed, 31 skipped
npm run validate                          clean
validate:graphql-component-parity         324 mirror types, 2,374 fields, OK
```

`npm run build` ran; regenerated `openapi.json`, `types.d.ts` and the contract types are committed.

No `src/**` or `workers/**` lines change, so `codecov/patch` has nothing to measure.

Closes #10288
