### PR TITLE
feat(api): publish SubnetMovingPrice on the emission pipeline

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -5348,6 +5348,8 @@ export type SubnetEmissionDecomposition = {
   liquidity_fraction?: Maybe<Scalars['Float']['output']>;
   /** Stage 2 input. A FRACTION in [0,1], never an amount. */
   miner_burned: Scalars['Float']['output'];
+  /** SubnetMovingPrice (I64F64) in TAO -- the EMA of the subnet's alpha price and stage 1's raw input. Published because it is the quantity the runtime compares when deciding which subnet to deregister, and emission_share normalizes it away. Null for subnets with no positive moving price (root, never-emitted). */
+  moving_price?: Maybe<Scalars['Float']['output']>;
   netuid: Scalars['Int']['output'];
   /** Stage 8, measured: the TAO injected into the subnet's pool this block. */
   tao_in_emission?: Maybe<Scalars['Float']['output']>;
@@ -10306,6 +10308,7 @@ export type SubnetEmissionDecompositionResolvers<ContextType = GqlContext, Paren
   ineligible_reason?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   liquidity_fraction?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   miner_burned?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  moving_price?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   tao_in_emission?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   tao_total?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7815,6 +7815,8 @@ export interface components {
                 liquidity_fraction: number | null;
                 /** @description Stage 2 input. A FRACTION in [0,1], never an amount. */
                 miner_burned: number;
+                /** @description SubtensorModule.SubnetMovingPrice in TAO -- the EMA of the subnet's alpha price and stage 1's raw input. Published unnormalized because it is the quantity the runtime compares when deciding which subnet to deregister; emission_share divides it by the sum across subnets, so a caller cannot recover it from anything else here. Null for a subnet with no positive moving price (root, and the never-emitted set). */
+                moving_price?: number | null;
                 netuid: number;
                 /** @description Stage 8, measured: the TAO injected into the subnet's pool this block. */
                 tao_in_emission: number | null;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -29634,6 +29634,17 @@
                   "minimum": 0,
                   "type": "number"
                 },
+                "moving_price": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "SubtensorModule.SubnetMovingPrice in TAO -- the EMA of the subnet's alpha price and stage 1's raw input. Published unnormalized because it is the quantity the runtime compares when deciding which subnet to deregister; emission_share divides it by the sum across subnets, so a caller cannot recover it from anything else here. Null for a subnet with no positive moving price (root, and the never-emitted set)."
+                },
                 "netuid": {
                   "maximum": 9007199254740991,
                   "minimum": 0,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7815,6 +7815,8 @@ export interface components {
                 liquidity_fraction: number | null;
                 /** @description Stage 2 input. A FRACTION in [0,1], never an amount. */
                 miner_burned: number;
+                /** @description SubtensorModule.SubnetMovingPrice in TAO -- the EMA of the subnet's alpha price and stage 1's raw input. Published unnormalized because it is the quantity the runtime compares when deciding which subnet to deregister; emission_share divides it by the sum across subnets, so a caller cannot recover it from anything else here. Null for a subnet with no positive moving price (root, and the never-emitted set). */
+                moving_price?: number | null;
                 netuid: number;
                 /** @description Stage 8, measured: the TAO injected into the subnet's pool this block. */
                 tao_in_emission: number | null;

--- a/schemas-src/routes/emission-pipeline.ts
+++ b/schemas-src/routes/emission-pipeline.ts
@@ -26,6 +26,25 @@ export const SubnetEmissionDecompositionSchema = z
       .describe(
         "Non-null (root, never_emitted, subtoken_disabled, registration_closed) means the subnet took no part in stage 1, and every downstream share is null rather than 0 -- 'not in the distribution' is not 'in it with nothing'.",
       ),
+    /**
+     * `SubnetMovingPrice` (I96F32) -- the EMA of the subnet's alpha price and
+     * stage 1's raw input, in TAO.
+     *
+     * Published because it is the quantity the runtime compares when deciding
+     * which subnet to deregister, and one subnet leaves every time a new one
+     * registers (#10285). `emission_share` normalizes it away, so a caller
+     * cannot recover it from anything else served here.
+     *
+     * Null for a subnet with no positive moving price -- root and the
+     * never-emitted set.
+     */
+    moving_price: z
+      .number()
+      .nullable()
+      .optional()
+      .describe(
+        "SubtensorModule.SubnetMovingPrice in TAO -- the EMA of the subnet's alpha price and stage 1's raw input. Published unnormalized because it is the quantity the runtime compares when deciding which subnet to deregister; emission_share divides it by the sum across subnets, so a caller cannot recover it from anything else here. Null for a subnet with no positive moving price (root, and the never-emitted set).",
+      ),
     /** Stage 1, the published `emission_share` (ADR 0023 decision 1). */
     emission_share: ShareSchema.describe(
       "Stage 1, the published emission_share (ADR 0023 decision 1) -- the PRICE share, not the share of TAO received.",

--- a/src/emission-decomposition.ts
+++ b/src/emission-decomposition.ts
@@ -95,6 +95,15 @@ export const EMISSION_FIELD_SOURCES = {
     kind: "measured",
     storage: "SubtensorModule.SubnetMovingPrice",
   },
+  // The same storage item `emission_share` names, published unnormalized
+  // (#10285). Two entries citing one read is not a duplication: the pallet
+  // compares the RAW price when it decides which subnet to prune, and
+  // `emission_share` is that price divided by the sum across subnets — a
+  // caller cannot recover one from the other without every row.
+  moving_price: {
+    kind: "measured",
+    storage: "SubtensorModule.SubnetMovingPrice",
+  },
   miner_burned: { kind: "measured", storage: "SubtensorModule.MinerBurned" },
   emission_enabled: {
     kind: "measured",

--- a/src/emission-pipeline.ts
+++ b/src/emission-pipeline.ts
@@ -64,6 +64,16 @@ export interface SubnetPipelineStages {
   netuid: number;
   /** Null when ineligible — a subnet outside stage 0 has no share at all. */
   ineligible_reason: IneligibleReason | null;
+  /**
+   * `SubnetMovingPrice` itself (I64F64), the EMA of the subnet's alpha price
+   * and stage 1's raw input.
+   *
+   * Published rather than kept internal (#10285) because it is the quantity
+   * the runtime compares when it decides which subnet to deregister -- one
+   * leaves every time a new one registers -- and nothing else we serve exposes
+   * it. `price_share` normalizes it away, so a caller cannot recover it.
+   */
+  moving_price: number | null;
   /** Stage 1: `SubnetMovingPrice_i / Σ SubnetMovingPrice`. */
   price_share: number | null;
   miner_burned: number;
@@ -191,6 +201,7 @@ export function reconstructEmissionPipeline(input: {
     const row: SubnetPipelineStages = {
       netuid: subnet.netuid,
       ineligible_reason: reason,
+      moving_price: positive(subnet.moving_price) ? subnet.moving_price : null,
       price_share: null,
       // Capped at 1 the way the runtime caps it: a value above 1 would make
       // (1 - burned) negative and hand the subnet a negative weight.

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -1255,6 +1255,8 @@ export const SDL = /* GraphQL */ `
     netuid: Int!
     "Non-null (root, never_emitted, subtoken_disabled, registration_closed) means the subnet took no part in stage 1, and every downstream share is null rather than 0 -- 'not in the distribution' is not 'in it with nothing'."
     ineligible_reason: String
+    "SubnetMovingPrice (I64F64) in TAO -- the EMA of the subnet's alpha price and stage 1's raw input. Published because it is the quantity the runtime compares when deciding which subnet to deregister, and emission_share normalizes it away. Null for subnets with no positive moving price (root, never-emitted)."
+    moving_price: Float
     "Stage 1, the published emission_share (ADR 0023 decision 1) -- the PRICE share, not the share of TAO received."
     emission_share: Float
     "Stage 2 input. A FRACTION in [0,1], never an amount."


### PR DESCRIPTION
Refs #10285

## The gap

The runtime deregisters the subnet with the **lowest moving price**, and one subnet leaves every time a new one registers — so *"how close am I to being pruned"* is a question every subnet owner has, and nothing we serve could answer it.

We already read `SubtensorModule.SubnetMovingPrice` — it is stage 1's input in `emission-decomposition.ts`. But the pipeline only published `emission_share`, which is the price share **after** normalizing by the sum. The raw quantity the runtime compares was computed and then thrown away, and no caller could recover it from anything else on the route.

Confirmed against production before changing anything: `/api/v1/chain/emission-pipeline?limit=200` returns 129 subnets and **0** with a moving price — the field simply was not there.

## What changed

`moving_price` on each pipeline subnet row, mirrored in the GraphQL type.

Null — not 0 — where there is no positive moving price (root, never-emitted). "Outside the distribution" is not "in it at zero", the same distinction `ineligible_reason` already draws for the downstream shares.

## Deliberately not a ranking

Ordering subnets by this is *probably* the pruning order. "Probably" is not good enough to publish as one: a rank that disagrees with the chain's own would be worse than publishing none, because it would be believed. #10285 tracks the ranking and now has its input; whoever builds it should confirm the comparison against the pallet first.

## Verification

`tsc --noEmit`, `lint`, `format:check` clean. `validate`, `validate:api`, `validate:contract-drift`, `validate:single-schema-source`, `validate:graphql-component-parity`, `validate:graphql-types-drift`, `validate-docs` all pass — the component-parity gate caught the missing SDL mirror before CI did. 1,459 tests green across `emission-pipeline`, `graphql`, `zod-schemas`. Regenerated contract, GraphQL types and the apps/ui API reference.