### PR TITLE
fix(neon): weights_version is a u64 on chain, not an int32

### DIFF
--- a/migrations/neon/0014_weights_version_bigint.sql
+++ b/migrations/neon/0014_weights_version_bigint.sql
@@ -1,0 +1,37 @@
+-- weights_version is a u64 on chain and was an int32 here (#10298).
+--
+-- SubtensorModule.WeightsVersionKey is a u64. Both columns storing it were
+-- declared INTEGER -- migrations/neon/0001_side_tables.sql and
+-- migrations/neon/0003_append_only_histories.sql -- which caps at 2,147,483,647.
+--
+-- THIS IS NOT A THEORETICAL RANGE. Measured 2026-08-09, the live maximum across
+-- all 129 subnets was 1,778,428,951: working, and 83% of the way to the ceiling.
+-- But three subnets have historically carried a value above it --
+--
+--   netuid 16  3,000,000,030
+--   netuid 18  9,223,372,036,854,775,807
+--   netuid 28  9,223,372,036,854,775,807
+--
+-- -- and that second value is i64::MAX, the sentinel a subnet sets to disable
+-- version gating outright. Two subnets have used it. Found when 15 rows of the
+-- #5597 historical replay failed with "value 3000000030 is out of range for
+-- type integer".
+--
+-- The live hourly lane writes this column through the same shared column list,
+-- one statement per row, so a subnet setting the key above 2^31-1 fails that
+-- row -- and nothing in the write path clamps or reports it. This is one sudo
+-- call away from being a live fault rather than a backfill one.
+--
+-- BIGINT is int64 and the chain type is u64, so the top half of the chain's
+-- range is still not representable. That is deliberate rather than overlooked:
+-- i64::MAX is the value actually used as the "never" sentinel and it fits,
+-- while NUMERIC would cost every reader an arbitrary-precision decode for a
+-- range the chain does not use.
+--
+-- Widening only -- every existing value is valid unchanged, and both tables are
+-- small (129 and ~2,000 rows), so the rewrite is negligible.
+ALTER TABLE subnet_hyperparams
+  ALTER COLUMN weights_version TYPE BIGINT;
+
+ALTER TABLE subnet_hyperparams_history
+  ALTER COLUMN weights_version TYPE BIGINT;


### PR DESCRIPTION
## The column could not hold the value the chain publishes

`SubtensorModule.WeightsVersionKey` is a **u64**. Both columns storing it were `INTEGER` — int32, ceiling 2,147,483,647.

## Not theoretical — already exceeded, twice

Found flushing the #5597 historical backfill: 15 replayed rows failed with

```
error: value "3000000030" is out of range for type integer
  where: "unnamed portal parameter $9 = '...'"      ($9 = weights_version)
```

| netuid | weights_version |
|---|---|
| 16 | 3,000,000,030 |
| 18 | 9,223,372,036,854,775,807 |
| 28 | 9,223,372,036,854,775,807 |

That second value is `i64::MAX`, the sentinel a subnet sets to disable version gating outright. **Two subnets have used it on mainnet.**

## It works today by luck, and the margin is 17%

Live maximum across all 129 subnets, measured 2026-08-09: **1,778,428,951** — 83% of the way to the ceiling, no nulls. Every current write succeeds.

The live hourly lane writes this column through the same shared column list and the same one-statement-per-row insert, and nothing in the write path clamps, range-checks or reports it — `rejectRow` guards `netuid`, `block_number` and the epoch-millis floor, not field ranges. So a subnet raising its key past 2^31−1 fails that row as a Postgres error, not as a counted rejection. This is one sudo call from being a live fault instead of a backfill one.

## Why BIGINT and not NUMERIC

`BIGINT` is int64 and the chain type is u64, so the top half of the chain's range is still unrepresentable. That is deliberate: `i64::MAX` is the value actually used as the "never" sentinel and it fits, while `NUMERIC` would cost every reader an arbitrary-precision decode for a range the chain does not use. The migration says so, so the next person does not rediscover it.

## Applied

Both columns are `bigint` in production as of this change — verified against `information_schema`. Widening only; every existing value is valid unchanged, and the tables are small (129 and ~3,150 rows), so the rewrite was negligible.

The remaining backfill then flushed clean: **2,329 rows attempted, 0 rejected**, `subnet_hyperparams_history` 2,066 → 3,150.

`0001_side_tables.sql` and `0003_append_only_histories.sql` are left alone deliberately — an applied migration is a record of what was applied, and 0014 is the record of this change. Nothing in the repo derives column types from those files.

Closes #10298
