### PR TITLE
fix(ui): take the TAO market figures from our own API, not coinpaprika

### DIFF
--- a/apps/ui/src/components/metagraphed/registry-ticker.tsx
+++ b/apps/ui/src/components/metagraphed/registry-ticker.tsx
@@ -156,14 +156,24 @@ export function RegistryTicker() {
 
         {/* Right cluster — market aggregates */}
         <div className="hidden min-[1120px]:flex items-center gap-4 shrink-0">
-          <span className="inline-flex items-baseline gap-1.5">
+          <span
+            className="inline-flex items-baseline gap-1.5"
+            title="The chain's own TotalIssuance x our TAO/USD price. Venues quoting a circulating-supply estimate report a smaller number against a smaller denominator."
+          >
             <span className="text-ink-muted">mkt cap</span>
             <span className="text-ink-strong tabular-nums">
               {formatUsdCompact(market?.market_cap)}
             </span>
           </span>
-          <span className="inline-flex items-baseline gap-1.5">
-            <span className="text-ink-muted">24h vol</span>
+          {/* "on-chain" is load-bearing, not decoration: this is subnet-AMM
+              volume from the account_events stream, not global exchange volume,
+              and it is roughly a third of what a ticker site reports. Dropping
+              the qualifier would make an honest number read as a wrong one. */}
+          <span
+            className="inline-flex items-baseline gap-1.5"
+            title="Subnet-AMM volume over 24h, priced in USD. Not global exchange volume — most TAO trades on centralized venues this does not index."
+          >
+            <span className="text-ink-muted">24h on-chain vol</span>
             <span className="text-ink-strong tabular-nums">
               {formatUsdCompact(market?.volume_24h)}
             </span>

--- a/apps/ui/src/hooks/use-tao-price.ts
+++ b/apps/ui/src/hooks/use-tao-price.ts
@@ -12,8 +12,9 @@ export function resolveTaoPrice(data: TaoMarketData | undefined): number | null 
 }
 
 /**
- * Shared TAO/USD price hook. Backed by the same coinpaprika query used on
- * /subnets so the browser cache dedupes across the app.
+ * Shared TAO/USD price hook. Backed by the same `tao-market` query the header
+ * ticker uses, so the browser cache dedupes across the app -- one composed
+ * read of OUR OWN API rather than a per-component fetch.
  *
  * Returns `null` price when the request is pending or has failed — callers
  * must render a "USD unavailable" fallback rather than invent a number.

--- a/apps/ui/src/lib/metagraphed/market.functions.test.ts
+++ b/apps/ui/src/lib/metagraphed/market.functions.test.ts
@@ -1,63 +1,141 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { fetchTaoMarket } from "./market.functions";
+import { DEFAULT_API_BASE } from "./config";
 
-const COINPAPRIKA_URL = "https://api.coinpaprika.com/v1/tickers/tao-bittensor";
+const PRICE_URL = `${DEFAULT_API_BASE}/api/v1/network/tao-usd?include_points=false`;
+const PARAMS_URL = `${DEFAULT_API_BASE}/api/v1/network/parameters`;
+const VOLUME_URL = `${DEFAULT_API_BASE}/api/v1/chain/alpha-volume?limit=1`;
+
+const PRICE = 207.03;
+const ISSUANCE = 11_215_598.62;
+const VOLUME_TAO = 163_936.26;
+
+/** An envelope in the shape every route returns, so a test failure means the
+ * composition is wrong rather than that the fixture is. */
+const envelope = (data: unknown) => ({
+  ok: true,
+  json: async () => ({ ok: true, schema_version: 1, data }),
+});
+
+/** Route each URL to its own payload; anything unstubbed rejects, so a leg the
+ * code adds without a test is a failure and not a silent pass. */
+function stubApi(over: Partial<Record<"price" | "params" | "volume", unknown>> = {}) {
+  const bodies: Record<string, unknown> = {
+    [PRICE_URL]: over.price ?? { latest: { usd_per_tao: PRICE } },
+    [PARAMS_URL]: over.params ?? { total_issuance_tao: ISSUANCE },
+    [VOLUME_URL]: over.volume ?? { network: { total_volume_tao: VOLUME_TAO } },
+  };
+  const fetchMock = vi.fn(async (url: string) => {
+    if (!(url in bodies)) throw new Error(`unexpected fetch: ${url}`);
+    const body = bodies[url];
+    if (body === "http_error") return { ok: false, json: async () => ({}) };
+    if (body === "throws") throw new Error("network down");
+    return envelope(body);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
 
 describe("fetchTaoMarket", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it("returns the parsed USD quote on a successful fetch with a positive price", async () => {
-    const usd = { price: 412.5, market_cap: 1_000_000_000, volume_24h: 20_000_000 };
+  it("composes all three figures from OUR API, never a third party", async () => {
+    // The whole point of the change: no request leaves for coinpaprika.
+    const fetchMock = stubApi();
+    const result = await fetchTaoMarket();
+
+    expect(result.price).toBe(PRICE);
+    expect(result.market_cap).toBeCloseTo(PRICE * ISSUANCE, 2);
+    expect(result.volume_24h).toBeCloseTo(PRICE * VOLUME_TAO, 2);
+
+    const called = fetchMock.mock.calls.map((c) => c[0] as string);
+    expect(called.sort()).toEqual([PRICE_URL, VOLUME_URL, PARAMS_URL].sort());
+    expect(called.some((u) => u.includes("coinpaprika"))).toBe(false);
+  });
+
+  it("states the basis of both derived figures", async () => {
+    // Without these, a market cap 17% above the venues' and a volume a third
+    // of theirs read as errors rather than as different denominators.
+    stubApi();
+    const result = await fetchTaoMarket();
+    expect(result.supply_basis).toBe("total_issuance");
+    expect(result.volume_basis).toBe("subnet_amm_onchain");
+  });
+
+  it("narrows both heavy reads -- the ticker needs neither the series nor 128 rows", async () => {
+    const fetchMock = stubApi();
+    await fetchTaoMarket();
+    const called = fetchMock.mock.calls.map((c) => c[0] as string);
+    expect(called).toContain(PRICE_URL);
+    expect(PRICE_URL).toContain("include_points=false");
+    expect(VOLUME_URL).toContain("limit=1");
+  });
+
+  it("a null usd_per_tao yields NO price -- and no derived figure either", async () => {
+    // `price_basis: insufficient_pools` is a stated outcome on that surface.
+    // A market cap computed from a missing price would be a confident zero.
+    stubApi({ price: { latest: { usd_per_tao: null } } });
+    const result = await fetchTaoMarket();
+    expect(result.price).toBeUndefined();
+    expect(result.market_cap).toBeUndefined();
+    expect(result.volume_24h).toBeUndefined();
+  });
+
+  it("a zero price is rejected, not passed through", async () => {
+    stubApi({ price: { latest: { usd_per_tao: 0 } } });
+    await expect(fetchTaoMarket()).resolves.toMatchObject({
+      price: undefined,
+      market_cap: undefined,
+    });
+  });
+
+  it("one failed leg costs its own figure, not the others", async () => {
+    // A cold parameters read must not blank the price tile beside it.
+    stubApi({ params: "http_error" });
+    const result = await fetchTaoMarket();
+    expect(result.price).toBe(PRICE);
+    expect(result.market_cap).toBeUndefined();
+    expect(result.volume_24h).toBeCloseTo(PRICE * VOLUME_TAO, 2);
+  });
+
+  it("a thrown leg is caught -- the ticker never takes the page down", async () => {
+    stubApi({ volume: "throws" });
+    const result = await fetchTaoMarket();
+    expect(result.price).toBe(PRICE);
+    expect(result.volume_24h).toBeUndefined();
+  });
+
+  it("an ok:false envelope is a failed read, not a body", async () => {
+    // The envelope's own `ok` is the contract; an error envelope still parses
+    // as JSON and would otherwise be read as an empty success.
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ quotes: { USD: usd } }) }),
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ ok: false, error: { code: "unavailable" } }),
+      })),
     );
-
-    await expect(fetchTaoMarket()).resolves.toEqual(usd);
-    expect(fetch).toHaveBeenCalledWith(COINPAPRIKA_URL);
+    const result = await fetchTaoMarket();
+    expect(result.price).toBeUndefined();
+    expect(result.market_cap).toBeUndefined();
+    expect(result.volume_24h).toBeUndefined();
   });
 
-  it("passes a zero/negative price through unchanged (the >0 guard lives in the hook)", async () => {
+  it("every leg failing yields a payload of absences, never zeros", async () => {
     vi.stubGlobal(
       "fetch",
-      vi
-        .fn()
-        .mockResolvedValue({ ok: true, json: async () => ({ quotes: { USD: { price: 0 } } }) }),
+      vi.fn(async () => {
+        throw new Error("offline");
+      }),
     );
-
-    await expect(fetchTaoMarket()).resolves.toEqual({ price: 0 });
-  });
-
-  it("resolves an empty object when the payload has a quotes block but no USD quote", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ quotes: {} }) }),
-    );
-
-    await expect(fetchTaoMarket()).resolves.toEqual({});
-  });
-
-  it("resolves an empty object when the payload has no quotes block at all", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
-
-    await expect(fetchTaoMarket()).resolves.toEqual({});
-  });
-
-  it("throws with the status code on a non-ok response", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({ ok: false, status: 503, json: async () => ({}) }),
-    );
-
-    await expect(fetchTaoMarket()).rejects.toThrow("TAO market data returned 503");
-  });
-
-  it("propagates a network-level fetch error", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
-
-    await expect(fetchTaoMarket()).rejects.toThrow("network down");
+    const result = await fetchTaoMarket();
+    expect(result).toMatchObject({
+      price: undefined,
+      market_cap: undefined,
+      volume_24h: undefined,
+    });
   });
 });

--- a/apps/ui/src/lib/metagraphed/market.functions.ts
+++ b/apps/ui/src/lib/metagraphed/market.functions.ts
@@ -1,20 +1,116 @@
 import { createServerFn } from "@tanstack/react-start";
 
+import { DEFAULT_API_BASE } from "./config";
+
+/**
+ * The TAO market figures the header ticker shows, composed from OUR OWN API.
+ *
+ * ## Why this stopped calling coinpaprika
+ *
+ * It used to fetch `api.coinpaprika.com/v1/tickers/tao-bittensor` and read
+ * `quotes.USD`. We publish a TAO/USD price ourselves -- and ours is the one we
+ * can explain: `/api/v1/network/tao-usd` is a liquidity-weighted median across
+ * qualifying wTAO/WETH pools with outlier rejection and a two-pool quorum,
+ * multiplied through an ETH/USDC anchor (ADR 0025), pinned to an Ethereum
+ * block, with the pool addresses and their liquidity published beside it.
+ * Measured 2026-08-09 the two agreed to 0.05% ($207.03 vs $207.14), so this is
+ * not a correction -- it is removing a third-party dependency for a number we
+ * already serve, and keeping one source of truth instead of two.
+ *
+ * ## The other two figures are NOT the same quantities coinpaprika reported
+ *
+ * That matters more than the price, and both are relabelled in the ticker
+ * rather than silently swapped:
+ *
+ *   - MARKET CAP is `TotalIssuance x usd_per_tao` -- the chain's own issuance,
+ *     not a circulating-supply estimate. Coinpaprika reported
+ *     `circulating_supply: 0` and a market cap implying ~9.61M TAO against the
+ *     chain's 11.22M, so ours reads ~17% higher. Neither is wrong; they are
+ *     different denominators, which is exactly why `supply_basis` rides along.
+ *
+ *   - VOLUME is on-chain subnet-AMM volume over 24h, from the same
+ *     account_events stream `/chain/alpha-volume` serves. It is NOT global
+ *     exchange volume: measured 2026-08-09 it was ~$34M against coinpaprika's
+ *     ~$115M, because most TAO trades on centralized venues we do not index.
+ *     Calling it "24h volume" unqualified would be a confident wrong answer,
+ *     so the tile says "24h on-chain vol" and `volume_basis` states it.
+ *
+ * ## Cost
+ *
+ * Three requests instead of one, but all three are ours, edge-cached, and tiny
+ * -- 743 B + 1,285 B + 1,297 B measured against production, ~3.3 KB total. The
+ * volume read is narrowed with `limit=1` because the ticker needs the network
+ * aggregate and not the 128 per-subnet rows, and the price read drops its 1,428
+ * series points with `include_points=false` for the same reason.
+ *
+ * A failed leg yields `undefined` for that figure rather than failing the
+ * whole payload: the price tile going blank should not take the market cap
+ * with it, and `formatUsdCompact` already renders an em-dash for undefined.
+ */
 export interface TaoMarketData {
   price?: number;
   market_cap?: number;
   volume_24h?: number;
+  /** What denominator `market_cap` used. Published so the gap with venues
+   * quoting a circulating-supply estimate is explicable, not surprising. */
+  supply_basis?: "total_issuance";
+  /** What `volume_24h` measures. NOT global exchange volume. */
+  volume_basis?: "subnet_amm_onchain";
 }
 
-// Extracted from the createServerFn handler so the fetch/parse/error path is
+/** One JSON leg. Resolves to null on any failure -- never throws, so one cold
+ * surface cannot blank the other two tiles. */
+async function leg(path: string): Promise<Record<string, unknown> | null> {
+  try {
+    const response = await fetch(`${DEFAULT_API_BASE}${path}`);
+    if (!response.ok) return null;
+    const body = (await response.json()) as { ok?: boolean; data?: unknown };
+    if (body?.ok !== true || typeof body.data !== "object" || body.data === null) {
+      return null;
+    }
+    return body.data as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/** A finite, strictly-positive number, or undefined. Zero is rejected for the
+ * same reason `resolveTaoPrice` rejects it: a zero price or a zero cap is a
+ * failed read wearing a plausible value. */
+function positive(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+// Extracted from the createServerFn handler so the fetch/compose path is
 // unit-testable directly, without TanStack Start's AsyncLocalStorage request
 // context (see market.functions.test.ts). getTaoMarket delegates to it, so
 // runtime behavior is unchanged.
 export async function fetchTaoMarket(): Promise<TaoMarketData> {
-  const response = await fetch("https://api.coinpaprika.com/v1/tickers/tao-bittensor");
-  if (!response.ok) throw new Error(`TAO market data returned ${response.status}`);
-  const payload = (await response.json()) as { quotes?: { USD?: TaoMarketData } };
-  return payload.quotes?.USD ?? {};
+  const [priceData, params, volume] = await Promise.all([
+    leg("/api/v1/network/tao-usd?include_points=false"),
+    leg("/api/v1/network/parameters"),
+    leg("/api/v1/chain/alpha-volume?limit=1"),
+  ]);
+
+  const latest = (priceData?.latest ?? null) as Record<string, unknown> | null;
+  // A null usd_per_tao is a STATED OUTCOME on that surface (price_basis
+  // "insufficient_pools"), not a gap -- so it must read as "no price", which
+  // positive() already does, rather than as zero.
+  const price = positive(latest?.usd_per_tao);
+  const issuance = positive(params?.total_issuance_tao);
+  const volumeTao = positive(
+    (volume?.network as Record<string, unknown> | undefined)?.total_volume_tao,
+  );
+
+  // Both derived figures need the price, so both are absent without it. A
+  // market cap in TAO would be a different number wearing a dollar sign.
+  return {
+    price,
+    market_cap: price !== undefined && issuance !== undefined ? price * issuance : undefined,
+    volume_24h: price !== undefined && volumeTao !== undefined ? price * volumeTao : undefined,
+    supply_basis: "total_issuance",
+    volume_basis: "subnet_amm_onchain",
+  };
 }
 
 export const getTaoMarket = createServerFn({ method: "GET" }).handler(fetchTaoMarket);


### PR DESCRIPTION
## We were fetching a TAO price from coinpaprika while publishing our own

`market.functions.ts` fetched `api.coinpaprika.com/v1/tickers/tao-bittensor` for the header ticker's three figures, while `/api/v1/network/tao-usd` — referenced nowhere in the UI — publishes a price we can actually explain: a liquidity-weighted median across qualifying wTAO/WETH pools with outlier rejection and a two-pool quorum, through an ETH/USDC anchor (ADR 0025), pinned to an Ethereum block, with the pool addresses and liquidity beside it.

The two agree to **0.05%** ($207.03 vs $207.14), so the price is not a correction. It is one source of truth instead of two.

## The other two tiles are different quantities, and are relabelled rather than swapped

This is the part that mattered more than the price.

| | ours | coinpaprika | why |
|---|---|---|---|
| market cap | **$2.32B** | $1.99B | `TotalIssuance` 11.22M vs their implied ~9.61M — they report `circulating_supply: 0` and use an estimate. Different denominators, not a disagreement. |
| 24h volume | **$34M** | $115M | ours is on-chain subnet-AMM volume from `/chain/alpha-volume`; theirs includes centralized venues we do not index. |

So the volume tile now reads **"24h on-chain vol"**, and both tiles carry a `title` explaining their basis. Calling $34M "24h volume" unqualified would have been a confident wrong answer of exactly the kind this repo keeps finding — an honest number reading as a broken one.

The payload also carries `supply_basis: "total_issuance"` and `volume_basis: "subnet_amm_onchain"` so the basis travels with the number rather than living only in a tooltip.

## Cost

Three requests instead of one, all ours, all edge-cached, all small — measured against production: 743 B + 1,285 B + 1,297 B, **~3.3 KB total**. The price read drops its 1,428 series points (`include_points=false`) and the volume read takes `limit=1`, because the ticker wants the network aggregate, not 128 per-subnet rows.

## Failure is per-tile

Each leg resolves to `null` on any failure and never throws, so a cold `/network/parameters` costs the market cap and leaves the price beside it intact. Both derived figures are absent without a price — a market cap computed from a missing price would be a confident zero, and a market cap in TAO would be a different number wearing a dollar sign.

`usd_per_tao: null` is a **stated outcome** on that surface (`price_basis: insufficient_pools`), not a gap, so it reads as "no price" rather than as zero — the same rule `resolveTaoPrice` already applied.

## Verified against production, not only against stubs

```
price        : 207.0322969548063
issuance TAO : 11215612.119621303
volume TAO   : 163936.264199547
market_cap   : $2,321,993,939
volume_24h   : $33,940,101
all three present: true
```

## Validation

```
apps/ui vitest       235 files, 1,872 passed
market.functions     9 tests (composition, both bases, narrowing, null/zero price,
                     per-leg failure, thrown leg, ok:false envelope, total outage)
apps/ui tsc          clean
apps/ui lint/format  clean
root build           clean
```

The test stubs route each URL to its own payload and **throw on any unstubbed URL**, so a leg added later without a test fails rather than silently passing — and one test asserts explicitly that no request goes to coinpaprika.

No API contract change: this composes existing routes, so `openapi.json` and the generated types are untouched.

Closes #10302
