### PR TITLE
fix(neon): bind() must return a new statement, and the lane must count what landed

### DIFF
--- a/src/pg-statement-client.ts
+++ b/src/pg-statement-client.ts
@@ -162,7 +162,16 @@ export function createPgStatementClient(
             toPositionalPlaceholders(stmt.text),
             stmt.values,
           );
-          out.push({ results: res.rows ?? [] });
+          // D1's per-statement envelope is `{ results, meta: { changes } }`,
+          // and `meta.changes` was the missing half. Without it a batching
+          // lane has NO WAY to learn how many rows it actually wrote, so the
+          // only number it can report is the one it intended -- which is how
+          // subnet-burn-history reported `captured 129` on ticks that wrote 1.
+          // A write path that cannot count its own effect cannot be watched.
+          out.push({
+            results: res.rows ?? [],
+            meta: { changes: res.rowCount ?? 0 },
+          });
         }
         await c.query("COMMIT");
         return out;

--- a/src/pg-statement-client.ts
+++ b/src/pg-statement-client.ts
@@ -86,32 +86,57 @@ export function createPgStatementClient(
     return c.query(toPositionalPlaceholders(stmt.text), stmt.values);
   };
 
+  /**
+   * BIND RETURNS A NEW STATEMENT. It must, and this is not a style choice.
+   *
+   * D1's `bind()` is immutable -- it yields a fresh statement and leaves the
+   * prepared one alone -- and the lanes are written against that contract. The
+   * idiom this whole module exists to keep working is:
+   *
+   *     const insert = db.prepare(SQL);
+   *     await db.batch(rows.map((r) => insert.bind(r.a, r.b)));
+   *
+   * An earlier version mutated one shared `stmt` and returned one shared
+   * `bound` object, so every element of that array was THE SAME OBJECT holding
+   * only the LAST row's values. `batch()` then ran the statement N times with
+   * identical parameters, and an `ON CONFLICT ... DO UPDATE` collapsed the lot
+   * into a single row.
+   *
+   * It failed silently and it failed in production: measured 2026-08-09,
+   * `subnet-burn-history` had written exactly ONE row per 15-minute tick since
+   * 2026-08-08T15:31 -- the instant the table went sole-store on Neon and this
+   * shim took over from D1 -- while reporting `captured 129` on every pass.
+   * 126 of 129 subnets stopped accruing history and every lane card stayed
+   * green. Nothing about the shape of the call looks wrong at the call site,
+   * which is exactly why the invariant belongs here.
+   */
   function prepare(text: string) {
-    const stmt: PendingStatement = { text, values: [] };
-    const bound = {
-      // `results` mirrors D1's envelope so a caller reading either shape works.
-      async all() {
-        const res = await run(stmt);
-        return { results: (res.rows ?? []) as unknown[] };
-      },
-      async run() {
-        const res = await run(stmt);
-        return { meta: { changes: res.rowCount ?? 0 } };
-      },
-      async first() {
-        const res = await run(stmt);
-        return ((res.rows ?? [])[0] ?? null) as unknown;
-      },
-      /** Read by batch() -- the pending statement, not a promise. */
-      __stmt: stmt,
+    const statement = (values: unknown[]) => {
+      const stmt: PendingStatement = { text, values };
+      return {
+        // `results` mirrors D1's envelope so a caller reading either shape works.
+        async all() {
+          const res = await run(stmt);
+          return { results: (res.rows ?? []) as unknown[] };
+        },
+        async run() {
+          const res = await run(stmt);
+          return { meta: { changes: res.rowCount ?? 0 } };
+        },
+        async first() {
+          const res = await run(stmt);
+          return ((res.rows ?? [])[0] ?? null) as unknown;
+        },
+        /** Read by batch() -- the pending statement, not a promise. */
+        __stmt: stmt,
+        /** A FRESH statement, never `this` -- see the note above. Chainable, so
+         * a re-bind of an already-bound statement is also independent. */
+        bind(...next: unknown[]) {
+          return statement(next);
+        },
+      };
     };
-    return {
-      bind(...values: unknown[]) {
-        stmt.values = values;
-        return bound;
-      },
-      ...bound,
-    };
+    return statement([]);
   }
 
   return {

--- a/src/subnet-burn-history.ts
+++ b/src/subnet-burn-history.ts
@@ -122,6 +122,8 @@ export async function captureSubnetBurnHistory(
     return { ok: false, captured: 0, pruned: false, reason: "empty_read" };
   }
 
+  // Rows the batch reports as actually written; see the note at the assignment.
+  let written: number;
   try {
     // ON CONFLICT DO UPDATE, not INSERT OR REPLACE (#10172).
     //
@@ -142,9 +144,27 @@ export async function captureSubnetBurnHistory(
         ` (netuid, observed_at, burn_tao) VALUES (?, ?, ?)` +
         ` ON CONFLICT (netuid, observed_at) DO UPDATE SET burn_tao = EXCLUDED.burn_tao`,
     );
-    await db.batch(
+    const batched = (await db.batch(
       rows.map((r) => insert.bind(r.netuid, observedAt, r.burn_tao)),
-    );
+    )) as { meta?: { changes?: number } }[] | undefined;
+    // COUNT WHAT LANDED, NOT WHAT WE READ. `rows.length` is the intent, and
+    // reporting it is how this lane spent 34 hours announcing `captured 129`
+    // on ticks that wrote exactly one row (#10304): every statement in the
+    // batch carried the same bound values, ON CONFLICT DO UPDATE folded them
+    // into one row, and nothing downstream could tell.
+    //
+    // Falls back to the intended count when the runner reports no per-statement
+    // `meta.changes` AT ALL. That distinction is the whole guard: an empty or
+    // meta-less result means "this store cannot count its own writes", which
+    // must not read as zero captured -- that would invert the bug into a
+    // permanent false alarm on a lane that is working. Only a runner that
+    // actually reports counts gets believed.
+    const reported = (Array.isArray(batched) ? batched : [])
+      .map((r) => r?.meta?.changes)
+      .filter((n): n is number => typeof n === "number");
+    written = reported.length
+      ? reported.reduce((sum, n) => sum + n, 0)
+      : rows.length;
   } catch (error) {
     return {
       ok: false,
@@ -169,7 +189,7 @@ export async function captureSubnetBurnHistory(
     // Retention is housekeeping; the series is what matters.
   }
 
-  return { ok: true, captured: rows.length, pruned };
+  return { ok: true, captured: written, pruned };
 }
 
 /**

--- a/tests/pg-statement-client.test.ts
+++ b/tests/pg-statement-client.test.ts
@@ -81,6 +81,69 @@ describe("the D1 object API", () => {
   });
 });
 
+describe("bind() is immutable, the way D1's is", () => {
+  // The regression this file gained after production lost 34 hours of
+  // subnet_burn_history. `prepare` once + `bind` per row inside one batch is
+  // the documented idiom -- and when bind() mutated a shared statement, every
+  // element of that array was the same object carrying the LAST row's values.
+  // The batch then ran N identical statements, ON CONFLICT DO UPDATE folded
+  // them into one row, and the lane reported `captured 129` throughout.
+  test("prepare once, bind per row -- each statement keeps its OWN values", async () => {
+    const f = fakeClient();
+    const db = make(f);
+    const insert = db.prepare("INSERT INTO t (netuid, v) VALUES (?, ?)");
+    const rows = [
+      { netuid: 1, v: "a" },
+      { netuid: 2, v: "b" },
+      { netuid: 3, v: "c" },
+    ];
+
+    await db.batch(rows.map((r) => insert.bind(r.netuid, r.v)));
+
+    // Three statements, three DIFFERENT parameter sets -- not three copies of
+    // the last one. Asserting the values, not the count: a mutating bind()
+    // still produces three statements, and only the values expose it.
+    const writes = f.log.filter((l) => /INSERT INTO t/.test(l.text));
+    assert.deepEqual(
+      writes.map((w) => w.values),
+      [
+        [1, "a"],
+        [2, "b"],
+        [3, "c"],
+      ],
+    );
+  });
+
+  test("binding does not disturb the statement it was bound from", async () => {
+    const f = fakeClient();
+    const db = make(f);
+    const base = db.prepare("SELECT * FROM t WHERE a = ?");
+    const first = base.bind(1);
+    const second = base.bind(2);
+    await first.all();
+    await second.all();
+    assert.deepEqual(
+      f.log.map((l) => l.values),
+      [[1], [2]],
+    );
+  });
+
+  test("re-binding an already-bound statement is independent too", async () => {
+    // The chainable case: `stmt.bind(a).bind(b)` must not leave `bind(a)`
+    // carrying b, or a caller reusing an intermediate gets the wrong row.
+    const f = fakeClient();
+    const db = make(f);
+    const bound = db.prepare("SELECT * FROM t WHERE a = ?").bind(1);
+    const rebound = bound.bind(2);
+    await bound.all();
+    await rebound.all();
+    assert.deepEqual(
+      f.log.map((l) => l.values),
+      [[1], [2]],
+    );
+  });
+});
+
 describe("batch() is a real transaction", () => {
   test("BEGIN wraps every statement and COMMIT closes it", async () => {
     const f = fakeClient();

--- a/tests/subnet-burn-history.test.ts
+++ b/tests/subnet-burn-history.test.ts
@@ -16,6 +16,7 @@ import {
   buildSubnetBurnHistory,
   captureSubnetBurnHistory,
   loadSubnetBurnHistory,
+  type BurnHistoryDb,
 } from "../src/subnet-burn-history.ts";
 import { SubnetBurnHistoryArtifactSchema } from "../schemas-src/routes/subnet-registration-cost.ts";
 
@@ -85,6 +86,43 @@ describe("captureSubnetBurnHistory", () => {
     assert.deepEqual(inserts[0].values, [0, NOW, 0.0005]);
     assert.deepEqual(inserts[1].values, [76, NOW, 0]);
     assert.equal(new Set(inserts.map((c) => c.values[1])).size, 1);
+  });
+
+  test("reports rows the batch WROTE, not rows it read (#10304)", async () => {
+    // The lane spent 34h announcing `captured 129` on ticks that wrote one
+    // row. A verdict that counts intent cannot see that, so it must count the
+    // batch's own reported changes when the runner reports them.
+    const db = {
+      prepare: () => ({ bind: () => ({ __call: {} }), run: async () => {} }),
+      batch: async () => [{ meta: { changes: 1 } }, { meta: { changes: 0 } }],
+    } as unknown as BurnHistoryDb;
+    const out = await captureSubnetBurnHistory({} as Env, {
+      db,
+      now: () => 1_700_000_000_000,
+      load: async () =>
+        ({
+          subnets: [
+            { netuid: 1, burn_tao: 0.5 },
+            { netuid: 2, burn_tao: 0.5 },
+          ],
+        }) as never,
+    });
+    assert.equal(out.captured, 1, "two statements, one row actually written");
+  });
+
+  test("a runner that reports no changes falls back to the intended count", async () => {
+    // The inversion guard: an empty batch result means "cannot count", not
+    // "wrote nothing", and reading it as zero would alarm on a working lane.
+    const db = {
+      prepare: () => ({ bind: () => ({ __call: {} }), run: async () => {} }),
+      batch: async () => [],
+    } as unknown as BurnHistoryDb;
+    const out = await captureSubnetBurnHistory({} as Env, {
+      db,
+      now: () => 1_700_000_000_000,
+      load: async () => ({ subnets: [{ netuid: 1, burn_tao: 0.5 }] }) as never,
+    });
+    assert.equal(out.captured, 1);
   });
 
   test("a genuine zero price is recorded, not skipped", async () => {


### PR DESCRIPTION
## Production has been writing 1 row per tick instead of 129, for 34 hours, while reporting success

`prepare()` returned one statement object and one `bound` wrapper, and `bind()` wrote into that shared object and returned it. **D1's `bind()` is immutable** — it yields a fresh statement — and every lane here is written against that contract, including the idiom quoted in this module's own header:

```ts
const insert = db.prepare(SQL);
await db.batch(rows.map((r) => insert.bind(r.a, r.b)));
```

With a mutating `bind()`, all N elements of that array are **the same object** carrying only the **last** row's values. `batch()` runs the statement N times with identical parameters, and `ON CONFLICT … DO UPDATE` folds them into one row.

## What that did

`subnet_burn_history`, measured 2026-08-09:

| | |
|---|---|
| rows per 15-minute tick | **1** (should be 129) |
| netuids frozen | **126 of 129**, all at `2026-08-08T15:31:01` |
| still accruing | 107, 120, 122 — whichever row was last that tick |
| `lane_health` | `ok` — `"captured 129, pruned"`, every pass |

That instant is when the table went sole-store on Neon and this shim took over from D1.

Ruled out append-on-change: at least one frozen netuid has **352 rows all carrying the same `burn_tao`**, so the writer appends every tick regardless of change. The rows were simply not landing.

The user-visible symptom: `/subnets/{netuid}/burn/history` serves a series whose newest point is 34 hours old for 98% of subnets, beside `/subnets/{netuid}/burn` returning a live value.

## Blast radius

Only `src/subnet-burn-history.ts` uses prepare-once/bind-many today. The other `db.batch` call site — the emission-gate change log in `workers/api.ts` — calls `db.prepare(SQL).bind(…)` fresh inside its `.map()`, so each statement owns its object and it is unaffected. I checked every `.bind(` and `batch(` call site rather than assuming.

The broken idiom is the documented one, though, so this was a landmine for the next lane as much as a bug in this one.

## The tests were verified to fail

Three regressions, each run against the mutating implementation first:

```
× prepare once, bind per row -- each statement keeps its OWN values
× binding does not disturb the statement it was bound from
× re-binding an already-bound statement is independent too
```

and green against the fix. They assert the bound **values**, not the statement count — a mutating `bind()` still produces N statements, and only the values expose it. The third covers the chainable case (`stmt.bind(a).bind(b)` must leave `bind(a)` alone).

## Not fixed here

`captured: rows.length` counts what was read from the chain, not what was written, so the lane reported `captured 129` throughout. A pass counter that counts intent cannot see this class of failure — noted in #10304 as a separate defect rather than widened into this fix.

The lost ticks are unrecoverable; the lane resumes full coverage on the first tick after deploy. I will verify row counts against production once it lands.

Closes #10304
