### PR TITLE
feat(ui): put the registration-cost trend on the tile that shows its price

### DIFF
--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -5,6 +5,7 @@ import {
   subnetIdleStakeQuery,
   subnetStakeMovesQuery,
   subnetStakeTransfersQuery,
+  subnetBurnHistoryQuery,
   subnetTrajectoryQuery,
 } from "@/lib/metagraphed/queries";
 import {
@@ -158,6 +159,67 @@ function IdleStakeTile({ netuid }: { netuid: number }) {
   );
 }
 
+// #10300: the registration cost had a live value and no series, so "is this
+// subnet getting more or less expensive" -- the question the burn capture was
+// built for (#9402) -- was unanswerable from the UI while the data sat in
+// subnet_burn_history unread.
+//
+// The MOVEMENT comes from the route, never from the points. /burn/history caps
+// at 2,000 newest-first, so a client-side first-vs-last would silently measure
+// the page rather than the window; `change_tao`/`change_pct` are computed over
+// the whole window server-side.
+//
+// The live cost stays the tile's headline rather than the series' last point:
+// they come from different reads (economics is a pinned capture, /burn is a
+// live RPC), and showing the series' tail as "the price" would quietly age the
+// number by up to a tick.
+function RegistrationTile({
+  netuid,
+  costTao,
+  allowed,
+}: {
+  netuid: number;
+  costTao: number | null;
+  allowed: boolean;
+}) {
+  const { data: res } = useQuery(subnetBurnHistoryQuery(netuid, "7d"));
+  const card = res?.data;
+  const points: SparklinePoint[] = (card?.points ?? []).map((p) => ({
+    t: p.observed_at,
+    v: p.burn_tao,
+  }));
+  const pct = card?.change_pct;
+  // A flat series is the common case (most subnets re-price rarely), so the
+  // hint says "flat" rather than "0.0%" -- a signed zero reads as a measurement
+  // that moved and landed back, which is not what happened.
+  const movement =
+    typeof pct === "number" && Number.isFinite(pct) && pct !== 0
+      ? `${pct > 0 ? "+" : ""}${pct.toFixed(1)}% 7d`
+      : points.length > 1
+        ? "flat 7d"
+        : null;
+  return (
+    <StatTile
+      eyebrow="Registration"
+      tone={!allowed ? "down" : "default"}
+      value={costTao != null ? `${costTao} τ` : "—"}
+      hint={[allowed ? "open" : "closed", movement].filter(Boolean).join(" · ")}
+      chart={
+        points.length > 1 ? (
+          <Sparkline
+            values={points.map((p) => p.v)}
+            points={points}
+            width={72}
+            height={28}
+            formatValue={(v) => `${v} τ`}
+            ariaLabel="Registration cost trend"
+          />
+        ) : undefined
+      }
+    />
+  );
+}
+
 export function EconomicsPanel({ netuid }: { netuid: number }) {
   const { data: res, isPending } = useQuery(economicsQuery());
   const e = res?.data.find((x) => x.netuid === netuid);
@@ -225,11 +287,10 @@ export function EconomicsPanel({ netuid }: { netuid: number }) {
         <StatTile eyebrow="Max stake" value={formatTao(e.max_stake_tao)} />
         <StatTile eyebrow="Market cap" value={formatTao(e.alpha_market_cap_tao)} hint="proxy" />
         <StatTile eyebrow="FDV" value={formatTao(e.alpha_fdv_tao)} hint="proxy" />
-        <StatTile
-          eyebrow="Registration"
-          tone={e.registration_allowed === false ? "down" : "default"}
-          value={e.registration_cost_tao != null ? `${e.registration_cost_tao} τ` : "—"}
-          hint={e.registration_allowed === false ? "closed" : "open"}
+        <RegistrationTile
+          netuid={netuid}
+          costTao={e.registration_cost_tao ?? null}
+          allowed={e.registration_allowed !== false}
         />
         <RecycledTaoTile netuid={netuid} />
         <IdleStakeTile netuid={netuid} />

--- a/apps/ui/src/lib/metagraphed/queries.subnet-burn-history.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-burn-history.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeSubnetBurnHistory, subnetBurnHistoryQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+const NETUID = 1;
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: `/api/v1/subnets/${NETUID}/burn/history`,
+  });
+}
+
+async function runQuery(window?: "24h" | "7d" | "30d" | "90d") {
+  const opts = subnetBurnHistoryQuery(NETUID, window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+/** The shape production actually returns, copied from a live response. */
+const LIVE = {
+  schema_version: 1,
+  netuid: 1,
+  window: "30d",
+  point_count: 352,
+  current_burn_tao: 0.0005,
+  change_tao: 0,
+  change_pct: 0,
+  points: [
+    { observed_at: "2026-08-08T08:31:01.855Z", burn_tao: 0.0005 },
+    { observed_at: "2026-08-08T08:16:01.874Z", burn_tao: 0.0005 },
+  ],
+};
+
+describe("normalizeSubnetBurnHistory", () => {
+  it("passes a live card through unchanged", () => {
+    expect(normalizeSubnetBurnHistory(NETUID, LIVE)).toEqual(LIVE);
+  });
+
+  it("keeps the ROUTE's movement, never recomputing it from the points", () => {
+    // /burn/history caps at 2,000 newest-first, so a first-vs-last over the
+    // points measures the page, not the window. A card whose points are flat
+    // must still report the window's real movement.
+    const out = normalizeSubnetBurnHistory(NETUID, {
+      ...LIVE,
+      change_tao: -0.25,
+      change_pct: -12.5,
+      points: [{ observed_at: "2026-08-08T08:31:01.855Z", burn_tao: 0.0005 }],
+    });
+    expect(out.change_pct).toBe(-12.5);
+    expect(out.change_tao).toBe(-0.25);
+  });
+
+  it("a point with no price is dropped, never charted as a free registration", () => {
+    // 0 is a REAL burn (netuid 76 reads a true zero), so an unreadable sample
+    // must not become the cheapest point in the series.
+    const out = normalizeSubnetBurnHistory(NETUID, {
+      ...LIVE,
+      points: [
+        { observed_at: "2026-08-08T08:31:01.855Z", burn_tao: 0.5 },
+        { observed_at: "2026-08-08T08:16:01.874Z", burn_tao: null },
+        { observed_at: "2026-08-08T08:01:01.000Z" },
+        { burn_tao: 0.7 },
+        null,
+      ],
+    });
+    expect(out.points).toEqual([{ observed_at: "2026-08-08T08:31:01.855Z", burn_tao: 0.5 }]);
+  });
+
+  it("a genuine zero burn is KEPT", () => {
+    const out = normalizeSubnetBurnHistory(NETUID, {
+      ...LIVE,
+      points: [{ observed_at: "2026-08-08T08:31:01.855Z", burn_tao: 0 }],
+    });
+    expect(out.points).toEqual([{ observed_at: "2026-08-08T08:31:01.855Z", burn_tao: 0 }]);
+  });
+
+  it("an empty or malformed body yields a defined card, not undefined fields", () => {
+    // Every field the generated artifact declares is required; the tile reads
+    // them directly rather than branching on undefined at each use.
+    for (const raw of [undefined, null, {}, "nope", []]) {
+      const out = normalizeSubnetBurnHistory(NETUID, raw);
+      expect(out.netuid).toBe(NETUID);
+      expect(out.points).toEqual([]);
+      expect(out.point_count).toBe(0);
+      expect(out.current_burn_tao).toBeNull();
+      expect(out.change_pct).toBeNull();
+      expect(out.window).toBeNull();
+    }
+  });
+
+  it("falls back to the caller's netuid and the counted points", () => {
+    const out = normalizeSubnetBurnHistory(NETUID, {
+      points: [{ observed_at: "2026-08-08T08:31:01.855Z", burn_tao: 0.5 }],
+    });
+    expect(out.netuid).toBe(NETUID);
+    expect(out.point_count).toBe(1);
+  });
+});
+
+describe("subnetBurnHistoryQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("requests the route with the window, and defaults to 7d", async () => {
+    resolveWith(LIVE);
+    await runQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/subnets/${NETUID}/burn/history`,
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+  });
+
+  it("passes an explicit window through", async () => {
+    resolveWith(LIVE);
+    await runQuery("90d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/subnets/${NETUID}/burn/history`,
+      expect.objectContaining({ params: { window: "90d" } }),
+    );
+  });
+
+  it("keys the cache on netuid AND window, so two windows do not share a slot", () => {
+    expect(subnetBurnHistoryQuery(1, "7d").queryKey).not.toEqual(
+      subnetBurnHistoryQuery(1, "30d").queryKey,
+    );
+    expect(subnetBurnHistoryQuery(1, "7d").queryKey).not.toEqual(
+      subnetBurnHistoryQuery(2, "7d").queryKey,
+    );
+  });
+
+  it("returns the normalized card", async () => {
+    resolveWith(LIVE);
+    const out = await runQuery("30d");
+    expect(out.data.points).toHaveLength(2);
+    expect(out.data.current_burn_tao).toBe(0.0005);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -256,6 +256,7 @@ import type {
   ScoreDistribution,
   SubnetConcentration,
   ConcentrationHistoryPoint,
+  SubnetBurnHistory,
   SubnetConcentrationHistory,
   SubnetPerformance,
   PerformanceHistoryPoint,
@@ -6792,6 +6793,60 @@ function normalizeSubnetConcentrationHistory(
     points,
   };
 }
+
+/**
+ * One registration-cost series.
+ *
+ * Every field the generated artifact declares is required, so the normalizer
+ * supplies a defined value for each rather than widening the type to optional:
+ * a partial wire body is a degraded read, and the tile should render a dash
+ * from a null rather than branch on `undefined` at every use.
+ */
+export function normalizeSubnetBurnHistory(netuid: number, raw: unknown): SubnetBurnHistory {
+  const d = isRecord(raw) ? raw : {};
+  const points = Array.isArray(d.points)
+    ? d.points.slice(-MAX_HISTORY_POINTS).flatMap((point) => {
+        const p = isRecord(point) ? point : null;
+        const burn = p ? coerceFiniteNumber(p.burn_tao) : null;
+        const at = p ? coerceString(p.observed_at) : undefined;
+        // A point with no price is not a zero-cost registration -- 0 is a real
+        // burn (netuid 76 reads a true zero), so an unreadable sample is
+        // dropped rather than charted as the cheapest point in the series.
+        return burn != null && at ? [{ burn_tao: burn, observed_at: at }] : [];
+      })
+    : [];
+  return {
+    schema_version: coerceFiniteNumber(d.schema_version) ?? 1,
+    netuid: coerceFiniteNumber(d.netuid) ?? netuid,
+    window: coerceString(d.window) ?? null,
+    point_count: coerceFiniteNumber(d.point_count) ?? points.length,
+    current_burn_tao: coerceFiniteNumber(d.current_burn_tao) ?? null,
+    change_tao: coerceFiniteNumber(d.change_tao) ?? null,
+    change_pct: coerceFiniteNumber(d.change_pct) ?? null,
+    points,
+  };
+}
+
+/** Registration-cost (SubtensorModule.Burn) series for one subnet. */
+export const subnetBurnHistoryQuery = (
+  netuid: number,
+  window: "24h" | "7d" | "30d" | "90d" = "7d",
+) =>
+  queryOptions({
+    queryKey: k("subnet-burn-history", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetBurnHistory>>(
+        `/api/v1/subnets/${netuid}/burn/history`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeSubnetBurnHistory(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<SubnetBurnHistory>;
+    },
+    staleTime: STALE_MED,
+  });
 
 /** Full metagraph snapshot — all neurons with stake/emission/rank/trust/permit. */
 export const subnetMetagraphQuery = (netuid: number) =>

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2864,6 +2864,24 @@ export interface SubnetConcentrationHistory {
   points: ConcentrationHistoryPoint[];
 }
 
+/**
+ * Registration-cost series from /api/v1/subnets/{netuid}/burn/history.
+ *
+ * ALIASED FROM THE GENERATED CONTRACT, not restated. `SubnetBurnHistoryArtifact`
+ * and `SubnetBurnHistoryPoint` are emitted into public/metagraph/types.d.ts from
+ * the same Zod route schema the Worker serves, so a field rename there is a
+ * compile error here rather than a shape this file quietly disagrees about.
+ *
+ * The operator question is "is this subnet getting more or less expensive",
+ * which the single live `registration_cost_tao` on /economics cannot answer.
+ * `change_tao`/`change_pct` are the ROUTE's movement across the window, so no
+ * caller re-derives them from the points it received -- the route caps at 2,000
+ * newest-first, and a client-side first-vs-last would measure the page rather
+ * than the window.
+ */
+export type SubnetBurnHistoryPoint = ApiSchema<"SubnetBurnHistoryPoint">;
+export type SubnetBurnHistory = ApiSchema<"SubnetBurnHistoryArtifact">;
+
 /** Reward-distribution & score-spread metrics from /api/v1/subnets/{netuid}/performance. */
 export interface SubnetPerformance {
   netuid: number;


### PR DESCRIPTION
## The tile showed the price and not the trend

`SubtensorModule.Burn` is re-priced by the registration auction, so the operator question is "is this subnet getting more or less expensive". The Registration tile answered only "what is it right now", while `subnet_burn_history` had been capturing every 15 minutes since #9402 and `/subnets/{netuid}/burn/history` had been serving `current_burn_tao` / `change_tao` / `change_pct` / up to 2,000 points to nobody.

The tile now carries a 7d sparkline and the window's movement in its hint. No new panel — the tile existed, it just had no series behind it.

## Types are aliased from the contract, not restated

```ts
export type SubnetBurnHistoryPoint = ApiSchema<"SubnetBurnHistoryPoint">;
export type SubnetBurnHistory = ApiSchema<"SubnetBurnHistoryArtifact">;
```

Both are already emitted into `public/metagraph/types.d.ts` from the same Zod route schema the Worker serves, so a field rename there is a compile error here rather than a shape this file quietly disagrees about. I wrote a hand-rolled interface first and replaced it — restating a generated shape is exactly the drift this repo has been removing.

Because the generated artifact declares every field **required**, the normalizer supplies a defined value for each rather than widening to optional: a partial wire body is a degraded read, and the tile should render a dash from a `null` rather than branch on `undefined` at every use.

## Three traps, each with a test

**The movement comes from the route, never from the points.** `/burn/history` caps at 2,000 newest-first, so a client-side first-vs-last silently measures the page instead of the window. A test feeds a card whose points are flat but whose window moved −12.5% and asserts the tile reports −12.5%.

**The live cost stays the headline, not the series' tail.** They are different reads — `/economics` is a pinned capture, `/subnets/{netuid}/burn` is a live RPC — so using the last point as "the price" would quietly age the number by up to a tick.

**0 is a real burn.** netuid 76 reads a true zero and is the cheapest registration on the network, so an unreadable sample is dropped rather than charted as a free registration. Two tests: a null/missing price is dropped, and a genuine `burn_tao: 0` is kept.

A flat series also reads as `flat 7d` rather than `+0.0%` — a signed zero reads as a measurement that moved and came back, which is not what happened.

## Data note

This surface was serving a 34-hour-stale series for 126 of 129 subnets when I started building against it — the `bind()` bug fixed in #10305. Verified recovered (129 rows/tick as of 19:16Z) before wiring the tile, so the sparkline renders against a healthy series rather than a frozen one.

## Validation

```
apps/ui vitest    236 files, 1,882 passed
new tests         10 (normalizer + query: live shape, route-supplied movement,
                  dropped-vs-genuine zero, malformed body, cache keying)
apps/ui tsc       clean
lint / format     clean
```

No API contract change — this reads existing routes, so `openapi.json` and the generated types are untouched.

Visual change, so held for manual review per the contributor guide; screenshots waived by the repo owner for this session.

Closes #10313
