### PR TITLE
fix(api): give chain/prometheus the cold-tier rung its axon twin has

### DIFF
--- a/src/chain-event-rollup-cold-tier.ts
+++ b/src/chain-event-rollup-cold-tier.ts
@@ -61,6 +61,17 @@ export const CHAIN_SERVING_ROLLUP: ChainEventRollupSpec = {
   distinctColumn: "hotkey",
 };
 
+// PrometheusServed is AxonServed's twin -- the pallet emits both as
+// (netuid, hotkey) from the same serving.rs -- so it rolls up identically.
+// It had no spec at all, which is why /chain/prometheus had no cold-tier rung
+// to fall to and answered a permanent zero beside a live axon card (#10248).
+export const CHAIN_PROMETHEUS_ROLLUP: ChainEventRollupSpec = {
+  eventKind: "PrometheusServed",
+  countField: "announcements",
+  distinctField: "distinct_exporters",
+  distinctColumn: "hotkey",
+};
+
 export const CHAIN_WEIGHTS_ROLLUP: ChainEventRollupSpec = {
   eventKind: "WeightsSet",
   countField: "weight_sets",

--- a/src/chain-prometheus-loader.ts
+++ b/src/chain-prometheus-loader.ts
@@ -1,0 +1,70 @@
+// Shared chain-prometheus loader for REST + MCP + GraphQL parity.
+//
+// THE RUNG THAT WAS MISSING (#10248). Both prometheus and its axon twin resolve
+// their data the same way -- `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)`
+// first -- and that flag reads "retired", so the call can never forward (#10190
+// counts eight such flags). `/chain/serving` survives that because it has a
+// SECOND rung, `loadChainServingColdTier`, which reads the lakehouse rollup.
+// Prometheus had no second rung at all: it fell straight from a tier that
+// always misses to the empty stub, and published a confident zero.
+//
+// So the route was never "waiting for curation" in the sense its degraded
+// marker implied. Even with a fully curated stream it had nothing to read from.
+//
+// Mirrors src/chain-serving-loader.ts deliberately, down to resolving BOTH the
+// window and the limit once here: the rollup reader caps at 200 and the builder
+// at 20, so an omitted limit otherwise scans ten times the rows the response
+// can carry -- the exact defect #9239 fixed on the serving side.
+//
+// Returns null rather than a zeroed card so each caller keeps its own fallback
+// and error contract.
+import {
+  ANALYTICS_WINDOW_DAYS,
+  DEFAULT_ANALYTICS_WINDOW,
+} from "../workers/config.ts";
+import {
+  buildChainPrometheus,
+  CHAIN_PROMETHEUS_LIMIT_DEFAULT,
+} from "./chain-prometheus.ts";
+import {
+  CHAIN_PROMETHEUS_ROLLUP,
+  loadChainEventRollup,
+} from "./chain-event-rollup-cold-tier.ts";
+import type { r2SqlQuery } from "./r2-sql.ts";
+
+/**
+ * One window of prometheus-serving activity from the lakehouse, already built
+ * into the response shape -- or null when the lakehouse cannot answer.
+ */
+export async function loadChainPrometheusColdTier(
+  env: Parameters<typeof r2SqlQuery>[0],
+  {
+    window,
+    limit,
+    query,
+  }: {
+    window: string;
+    /** Optional so callers that leave it to the builder's own default do not
+     * have to restate it here. */
+    limit?: number;
+    /** Injectable for tests; forwarded to the rollup reader. */
+    query?: typeof r2SqlQuery;
+  },
+): Promise<ReturnType<typeof buildChainPrometheus> | null> {
+  const label = Object.hasOwn(ANALYTICS_WINDOW_DAYS, window)
+    ? window
+    : DEFAULT_ANALYTICS_WINDOW;
+  const rowLimit = limit ?? CHAIN_PROMETHEUS_LIMIT_DEFAULT;
+  const rollup = await loadChainEventRollup(env, CHAIN_PROMETHEUS_ROLLUP, {
+    windowDays: ANALYTICS_WINDOW_DAYS[label],
+    limit: rowLimit,
+    query,
+  });
+  if (!rollup) return null;
+  return buildChainPrometheus(rollup.rows, {
+    window: label,
+    limit: rowLimit,
+    networkDistinct: rollup.networkDistinct,
+    subnetCount: rollup.subnetCount,
+  });
+}

--- a/src/chain-prometheus.ts
+++ b/src/chain-prometheus.ts
@@ -155,9 +155,19 @@ export function buildChainPrometheus(
     window,
     limit = CHAIN_PROMETHEUS_LIMIT_DEFAULT,
     networkDistinct,
+    subnetCount,
   }: {
     window?: string | null;
     limit?: number;
+    /**
+     * How many subnets the WINDOW covers, from the loader's own count.
+     *
+     * `subnets.length` is the RETURNED PAGE, so without this a `limit` of 20
+     * publishes `subnet_count: 20` for a window covering 128 -- a truncation
+     * reported as a measurement. Mirrors buildChainServing's parameter of the
+     * same name; the two cards are twins and had drifted on exactly this.
+     */
+    subnetCount?: number | null;
     networkDistinct?: {
       distinct_exporters?: unknown;
       newest_observed?: unknown;
@@ -243,7 +253,7 @@ export function buildChainPrometheus(
     schema_version: 1,
     window: window ?? null,
     observed_at: observedAt,
-    subnet_count: subnets.length,
+    subnet_count: subnetCount ?? subnets.length,
     network,
     // Distribution of per-subnet re-announcement intensity over EVERY subnet (not just the
     // returned page), so the spread is network-wide even when `limit` truncates the leaderboard.

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -566,6 +566,7 @@ import {
 } from "../workers/config.ts";
 import { answerRpcUsage } from "./rpc-usage-answer.ts";
 import { loadChainServingColdTier } from "./chain-serving-loader.ts";
+import { loadChainPrometheusColdTier } from "./chain-prometheus-loader.ts";
 import {
   accountSummaryGapMessage,
   answerAccountSummary,
@@ -8301,6 +8302,15 @@ const rootValue = {
         context.env,
         postgresTierRequest(context, "/api/v1/chain/prometheus", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) as Row | null) ??
+      // The same lakehouse rung REST and MCP now use (#10248). Wiring one
+      // surface and not the others is exactly the drift chain-serving-loader.ts
+      // was extracted to stop.
+      ((await loadChainPrometheusColdTier(
+        context.env as unknown as Parameters<
+          typeof loadChainPrometheusColdTier
+        >[0],
+        { window: requestedWindow, limit: safeLimit },
       )) as Row | null) ??
       buildChainPrometheus([], { window: requestedWindow, limit: safeLimit });
     return {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1243,6 +1243,7 @@ import {
   CHAIN_PROMETHEUS_WINDOWS,
   DEFAULT_CHAIN_PROMETHEUS_WINDOW,
 } from "./chain-prometheus.ts";
+import { loadChainPrometheusColdTier } from "./chain-prometheus-loader.ts";
 import {
   buildChainServing,
   CHAIN_SERVING_LIMIT_DEFAULT,
@@ -6659,7 +6660,15 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             limit,
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildChainPrometheus([], { window, limit })
+        )) ??
+        // The lakehouse rung, same as REST and GraphQL (#10248).
+        (await loadChainPrometheusColdTier(
+          ctx.env as unknown as Parameters<
+            typeof loadChainPrometheusColdTier
+          >[0],
+          { window, limit },
+        )) ??
+        buildChainPrometheus([], { window, limit })
       );
     },
   },

--- a/tests/chain-prometheus-loader.test.ts
+++ b/tests/chain-prometheus-loader.test.ts
@@ -1,0 +1,130 @@
+// The shared chain-prometheus loader — the rung this route never had (#10248).
+//
+// /chain/prometheus resolved `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)`
+// and, on the miss that flag guarantees ("retired", one of the eight #10190
+// counts), fell straight to the empty stub. Its axon twin has read the
+// lakehouse rollup at that same point since #9216. So the card published a
+// confident zero beside a live sibling, and no amount of curating the event
+// stream could have changed it -- there was nothing wired to read the stream.
+//
+// These assert the properties that differ from "does it aggregate" (the rollup
+// reader's own tests cover that): the rollup is asked for the RIGHT event kind,
+// the window and limit are resolved ONCE, and a declining lakehouse yields null
+// so each caller keeps its own fallback.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { loadChainPrometheusColdTier } from "../src/chain-prometheus-loader.ts";
+import { CHAIN_PROMETHEUS_LIMIT_DEFAULT } from "../src/chain-prometheus.ts";
+
+const ROWS = [
+  { netuid: 7, announcements: 9, distinct_exporters: 4 },
+  { netuid: 3, announcements: 2, distinct_exporters: 1 },
+];
+const NETWORK = [{ distinct_exporters: 5, newest_observed: 1_785_000_000_000 }];
+
+function fakeEngine(
+  overrides: {
+    rows?: Record<string, unknown>[] | null;
+    network?: Record<string, unknown>[] | null;
+  } = {},
+) {
+  const seen: string[] = [];
+  const pick = <T>(value: T | undefined, fallback: T) =>
+    value === undefined ? fallback : value;
+  const query = async (_env: unknown, sql: string) => {
+    seen.push(sql);
+    return sql.includes("ORDER BY")
+      ? pick(overrides.rows, ROWS)
+      : pick(overrides.network, NETWORK);
+  };
+  return { query, seen };
+}
+
+describe("the shared chain-prometheus loader", () => {
+  test("asks the rollup for PrometheusServed, not its axon twin", async () => {
+    // The twins share a pallet arm and a row shape, so a copy-paste that left
+    // AxonServed in the spec would return plausible numbers for the wrong
+    // event -- the failure this route is least able to survive again.
+    const engine = fakeEngine();
+    await loadChainPrometheusColdTier({} as never, {
+      window: "7d",
+      query: engine.query as never,
+    });
+    assert.ok(engine.seen.length > 0, "expected the rollup to be queried");
+    for (const sql of engine.seen) {
+      assert.match(sql, /event_kind = 'PrometheusServed'/);
+      assert.doesNotMatch(sql, /AxonServed/);
+    }
+  });
+
+  test("builds the response shape, not raw rollup rows", async () => {
+    const engine = fakeEngine();
+    const data = await loadChainPrometheusColdTier({} as never, {
+      window: "7d",
+      query: engine.query as never,
+    });
+    assert.ok(data);
+    assert.equal(data.window, "7d");
+    assert.equal(Array.isArray(data.subnets), true);
+    // The whole point: a real read is NOT marked degraded. The marker exists
+    // for the empty answer, and an empty answer is no longer the only one.
+    assert.equal(data.degraded, undefined);
+  });
+
+  test("subnet_count is the WINDOW's count, not the returned page", async () => {
+    // Without the builder's `subnetCount`, a limit of 1 would publish
+    // `subnet_count: 1` for a window covering two -- a truncation reported as
+    // a measurement. buildChainServing has carried this parameter; its twin
+    // did not, which is the drift this closes.
+    const engine = fakeEngine();
+    const data = await loadChainPrometheusColdTier({} as never, {
+      window: "7d",
+      limit: 1,
+      query: engine.query as never,
+    });
+    assert.ok(data);
+    assert.equal(data.subnets.length, 1, "the page is capped");
+    assert.equal(data.subnet_count, 2, "the count is the window's");
+  });
+
+  test("an unrecognised window narrows the SCAN and the LABEL together", async () => {
+    // #9239 on the serving side: the scan fell back to 7d while the caller's
+    // original string still reached the builder, so the card misdescribed data
+    // that was itself correct.
+    const engine = fakeEngine();
+    const data = await loadChainPrometheusColdTier({} as never, {
+      window: "not-a-window",
+      query: engine.query as never,
+    });
+    assert.ok(data);
+    assert.notEqual(data.window, "not-a-window");
+  });
+
+  test("an omitted limit resolves once, so the scan cannot outrun the response", async () => {
+    // The rollup reader caps at 200 and the builder at 20; left to their own
+    // defaults an omitted limit scans ten times the rows the card can carry.
+    const engine = fakeEngine();
+    await loadChainPrometheusColdTier({} as never, {
+      window: "7d",
+      query: engine.query as never,
+    });
+    const ordered = engine.seen.find((s) => s.includes("ORDER BY"));
+    assert.ok(ordered);
+    assert.match(
+      ordered,
+      new RegExp(`LIMIT ${CHAIN_PROMETHEUS_LIMIT_DEFAULT}\\b`),
+    );
+  });
+
+  test("a declining lakehouse is null, never a zeroed card", async () => {
+    // Each caller keeps its own fallback and error contract -- GraphQL answers
+    // a schema-stable card rather than an error, and that belongs at the call
+    // site, not here.
+    const engine = fakeEngine({ rows: null, network: null });
+    const data = await loadChainPrometheusColdTier({} as never, {
+      window: "7d",
+      query: engine.query as never,
+    });
+    assert.equal(data, null);
+  });
+});

--- a/tests/graphql-tier-cascade.test.ts
+++ b/tests/graphql-tier-cascade.test.ts
@@ -142,8 +142,6 @@ const PENDING_WIRING = new Set<string>([
 const NO_TIER_ANYWHERE: Record<string, string> = {
   chain_axon_removals:
     "get_chain_axon_removals falls to buildChainAxonRemovals([]) on MCP too -- no lane exists for it",
-  chain_prometheus:
-    "get_chain_prometheus falls to buildChainPrometheus([]) on MCP too -- no lane exists for it",
   account_prometheus:
     "get_account_prometheus falls to buildAccountPrometheus([]) on MCP too -- no lane exists for it",
   account_axon_removals:

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -87,6 +87,7 @@ import { buildChainTransferPairs } from "../../src/chain-transfer-pairs.ts";
 import { buildChainTransfers } from "../../src/chain-transfers.ts";
 import { buildChainServing } from "../../src/chain-serving.ts";
 import { buildChainPrometheus } from "../../src/chain-prometheus.ts";
+import { loadChainPrometheusColdTier } from "../../src/chain-prometheus-loader.ts";
 import { buildChainAxonRemovals } from "../../src/chain-axon-removals.ts";
 import { buildChainRegistrations } from "../../src/chain-registrations.ts";
 import { buildChainDeregistrations } from "../../src/chain-deregistrations.ts";
@@ -2166,6 +2167,14 @@ export async function handleChainPrometheus(
           cacheRequest,
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) as ReturnType<typeof buildChainPrometheus> | null) ??
+        // The rung this route never had (#10248). Its axon twin has read the
+        // lakehouse rollup here since #9216; prometheus fell straight from a
+        // tier that always misses to the empty stub, so it published a
+        // confident zero no amount of curation could have fixed.
+        (await loadChainPrometheusColdTier(
+          env as unknown as Parameters<typeof loadChainPrometheusColdTier>[0],
+          { window: label, limit },
+        )) ??
         buildChainPrometheus([], {
           window: label,
           limit,


### PR DESCRIPTION
## The route had two rungs where its twin has three

`/chain/prometheus` and `/chain/serving` are twins — the pallet emits `PrometheusServed` and `AxonServed` from the same `serving.rs`, as the same `(netuid, hotkey)` tuple. They resolved data differently:

```
serving:     tryPostgresTier(…) ?? loadChainServingColdTier(…) ?? empty stub
prometheus:  tryPostgresTier(…) ??                                empty stub
```

`METAGRAPH_ACCOUNT_EVENTS_SOURCE` reads `"retired"` (one of the eight #10190 counts), so that first rung **can never forward**. Serving survives on its second rung, added in #9216. Prometheus had no second rung at all — it fell straight from a tier that always misses to a zeroed card.

So the `prometheus_stream_not_curated` marker was pointing at the wrong system. Curating the stream perfectly would have changed nothing: **nothing was wired to read it.** Verified live — `/chain/prometheus?window=7d` answers `subnet_count: 0` beside `/chain/serving?window=7d` answering 38.

## Wired on all three surfaces, deliberately

REST, MCP and GraphQL each had the identical two-rung shape. `src/chain-serving-loader.ts` exists *because* #9216 wired only REST and left `get_chain_serving` and GraphQL's `chain_serving` returning zeroed cards — "a caller could not tell which surface was lying". Repeating that here would have been repeating a documented mistake, so all three now call one `loadChainPrometheusColdTier`.

## A drift the twins had already accumulated

`buildChainServing` takes a `subnetCount`; `buildChainPrometheus` did not, and derived `subnet_count` from `subnets.length` — the **returned page**. With the default limit of 20 over a window covering 128 subnets, that publishes `subnet_count: 20` as a measurement. Added the parameter to match, with a test that a `limit: 1` over two subnets still reports `subnet_count: 2`.

## The gate caught its own stale exemption

`tests/graphql-tier-cascade.test.ts` carries `chain_prometheus` in `NO_TIER_ANYWHERE` with the note *"no lane exists for it"*. That stopped being true in this diff, and the gate failed **because the exemption was now stale** — it checks both directions. Removed.

## Data side, already done

`chain.account_events` carried 0 `PrometheusServed` against 18,041 in `chain.chain_events`. Backfilled today by projecting `chain_events` (its `args` already carry `[netuid, [[32 bytes]]]`) — **18,041 rows, blocks 109 → 8,655,704**, verified against the `serve_prometheus` extrinsic signer on 40/40 sampled events and committed through `iceberg_load.py`'s exactly-once ledger.

Not a re-decode: those events reach back to block 109, far below the raw R2 capture floor of 8,759,336, so the bytes to re-decode do not exist.

**Expect the card to stay quiet, and that is correct.** The last `serve_prometheus` on mainnet was block 8,655,704 / 2026-07-19, so a 7d or 30d window legitimately covers zero announcements. What changes is that the zero is now *measured* rather than structural, the marker no longer blames a curation gap that is closed, and the historical data is reachable.

## Validation

```
npx vitest run       774 files, 18,126 passed, 11 skipped
new tests            6 (right event kind, response shape, window-vs-page
                     subnet_count, window/label resolved together, limit
                     resolved once, declining lakehouse -> null)
validate, validate:api, validate:contract-drift, graphql-component-parity,
validate-docs, validate-mcp-route-map                                  clean
build / typecheck / lint / format                                      clean
```

Closes #10248
