### PR TITLE
feat(api): let a caller ask for fewer candles (#10318)

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -4441,6 +4441,7 @@ export type QuerySubnet_MoversArgs = {
 export type QuerySubnet_OhlcArgs = {
   days?: InputMaybe<Scalars['Int']['input']>;
   interval?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
   netuid: Scalars['Int']['input'];
 };
 
@@ -5678,6 +5679,8 @@ export type SubnetMoversNetwork = {
 /** One subnet's alpha-price OHLC candles (#6979). Mirrors GET /api/v1/subnets/{netuid}/ohlc' data envelope. */
 export type SubnetOhlc = {
   __typename?: 'SubnetOhlc';
+  /** How many candles the WINDOW holds, not how many this page carries. A limit narrows the candle list from the recent end; this stays the denominator, the same convention /chain/deregistrations uses for its own page. */
+  candle_count: Scalars['Int']['output'];
   candles: Array<SubnetOhlcCandle>;
   /** The resolved bucket interval (1h/1d). */
   interval?: Maybe<Scalars['String']['output']>;
@@ -10574,6 +10577,7 @@ export type SubnetMoversNetworkResolvers<ContextType = GqlContext, ParentType ex
 }>;
 
 export type SubnetOhlcResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetOhlc'] = ResolversParentTypes['SubnetOhlc']> = ResolversObject<{
+  candle_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   candles?: Resolver<Array<ResolversTypes['SubnetOhlcCandle']>, ParentType, ContextType>;
   interval?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -11492,6 +11492,8 @@ export interface components {
         };
         /** @description One subnet's alpha-price OHLC candles (#6979). Mirrors GET /api/v1/subnets/{netuid}/ohlc' data envelope. */
         SubnetOhlcArtifact: {
+            /** @description How many candles the WINDOW holds, not how many this page carries. A `limit` narrows `candles` from the recent end; this stays the denominator, the same convention /chain/deregistrations uses for its own page. */
+            candle_count: number;
             candles: {
                 /** @description Bucket start as epoch milliseconds -- a Float, since epoch-ms exceeds GraphQL's 32-bit Int. */
                 bucket_start: number;
@@ -42929,6 +42931,8 @@ export interface operations {
             query?: {
                 interval?: "1h" | "1d";
                 days?: number;
+                /** @description Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 2000. */
+                limit?: number;
             };
             header?: never;
             path: {
@@ -42950,6 +42954,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "candle_count": 1,
                      *         "candles": [
                      *           {
                      *             "bucket_start": 1,

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -7313,6 +7313,15 @@
             "minimum": 1,
             "type": "integer"
           }
+        },
+        {
+          "name": "limit",
+          "schema": {
+            "default": 2000,
+            "maximum": 2000,
+            "minimum": 1,
+            "type": "integer"
+          }
         }
       ]
     },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -10085,6 +10085,7 @@
       "SubnetOhlcArtifactResponse": {
         "value": {
           "data": {
+            "candle_count": 1,
             "candles": [
               {
                 "bucket_start": 1,
@@ -49138,6 +49139,12 @@
         "additionalProperties": false,
         "description": "One subnet's alpha-price OHLC candles (#6979). Mirrors GET /api/v1/subnets/{netuid}/ohlc' data envelope.",
         "properties": {
+          "candle_count": {
+            "description": "How many candles the WINDOW holds, not how many this page carries. A `limit` narrows `candles` from the recent end; this stays the denominator, the same convention /chain/deregistrations uses for its own page.",
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
           "candles": {
             "items": {
               "additionalProperties": false,
@@ -49221,6 +49228,7 @@
           "netuid",
           "interval",
           "candles",
+          "candle_count",
           "root_excluded"
         ],
         "type": "object"
@@ -91368,6 +91376,18 @@
             "schema": {
               "default": 90,
               "maximum": 365,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 2000.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 2000,
+              "maximum": 2000,
               "minimum": 1,
               "type": "integer"
             }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -11492,6 +11492,8 @@ export interface components {
         };
         /** @description One subnet's alpha-price OHLC candles (#6979). Mirrors GET /api/v1/subnets/{netuid}/ohlc' data envelope. */
         SubnetOhlcArtifact: {
+            /** @description How many candles the WINDOW holds, not how many this page carries. A `limit` narrows `candles` from the recent end; this stays the denominator, the same convention /chain/deregistrations uses for its own page. */
+            candle_count: number;
             candles: {
                 /** @description Bucket start as epoch milliseconds -- a Float, since epoch-ms exceeds GraphQL's 32-bit Int. */
                 bucket_start: number;
@@ -42929,6 +42931,8 @@ export interface operations {
             query?: {
                 interval?: "1h" | "1d";
                 days?: number;
+                /** @description Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 2000. */
+                limit?: number;
             };
             header?: never;
             path: {
@@ -42950,6 +42954,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "candle_count": 1,
                      *         "candles": [
                      *           {
                      *             "bucket_start": 1,

--- a/schemas-src/mcp-tools/get-subnet-volume-ohlc.ts
+++ b/schemas-src/mcp-tools/get-subnet-volume-ohlc.ts
@@ -16,6 +16,18 @@ import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { netuidSchema } from "./shared.ts";
 import { SubnetAlphaVolumeArtifactSchema } from "../routes/subnet-alpha-volume.ts";
 import { SubnetOhlcArtifactSchema } from "../routes/subnet-ohlc.ts";
+import { limitSchema } from "../query-params.ts";
+import { MAX_CANDLES } from "../../src/subnet-ohlc.ts";
+
+/**
+ * Candles this tool serves when the caller names no `limit`.
+ *
+ * A week of hourly candles -- the question an agent actually asks about a
+ * subnet's price. PUBLISHED here and read by the dispatcher rather than
+ * restated there (#10096): the schema's `.meta({ default })` is the single
+ * source, and a second literal in the handler is how the two come to disagree.
+ */
+export const GET_SUBNET_OHLC_CANDLE_DEFAULT = 168;
 
 const RouteQuery_subnets_netuid_ohlc =
   ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/ohlc"];
@@ -41,6 +53,20 @@ export const GetSubnetOhlcInputSchema = z
     days: RouteQuery_subnets_netuid_ohlc.shape.days
       .describe("How many trailing days to cover, ending today (UTC).")
       .meta({ examples: [7, 30] }),
+    // Defaults to a PAGE of candles, not the route's cap (#10318). Measured
+    // live: the uncapped answer is 486 KB and 13.5 s, the largest and slowest
+    // response this server produces, and 1h over the default 90 days is
+    // 2,000 candles nobody asked for. 168 is a week of hourly candles -- the
+    // question an agent actually asks -- and `candle_count` still reports what
+    // the window holds, so narrowing costs no context. Same split #10027 made
+    // for get_health_trends: the route keeps its default, the tool serves a
+    // page.
+    limit: limitSchema(MAX_CANDLES, GET_SUBNET_OHLC_CANDLE_DEFAULT)
+      .describe(
+        "How many candles to return, newest first. The window is unchanged -- `candle_count` reports what it holds.",
+      )
+      .meta({ examples: [168, 24] })
+      .optional(),
   })
   .strict();
 export type GetSubnetOhlcInput = z.infer<typeof GetSubnetOhlcInputSchema>;

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -184,6 +184,7 @@ import {
 } from "../src/counterparties.ts";
 import {
   DEFAULT_OHLC_WINDOW_DAYS,
+  MAX_CANDLES,
   MAX_OHLC_WINDOW_DAYS,
   OHLC_INTERVAL_DEFAULT,
 } from "../src/subnet-ohlc.ts";
@@ -535,6 +536,13 @@ export const ROUTE_QUERY_SCHEMAS = {
       .max(MAX_OHLC_WINDOW_DAYS)
       .meta({ default: DEFAULT_OHLC_WINDOW_DAYS })
       .optional(),
+    // The candle ceiling, published (#9981/#10318). MAX_CANDLES has capped
+    // this response at 2,000 since it shipped, and a caller had no way to ask
+    // for fewer and no way to learn the cap existed -- 1h over the default 90
+    // days is 486 KB and 13.5 s, the largest and slowest thing this API
+    // serves. The DEFAULT is the cap, so today's answer is unchanged for
+    // every existing consumer; what is new is the lever.
+    limit: limitSchema(MAX_CANDLES, MAX_CANDLES).optional(),
   }),
   "/api/v1/subnets/{netuid}/stake-quote": z.object({
     amount: z.number().gt(0).optional(),

--- a/schemas-src/routes/subnet-ohlc.ts
+++ b/schemas-src/routes/subnet-ohlc.ts
@@ -31,6 +31,12 @@ export const SubnetOhlcArtifactSchema = z
       .enum(["1h", "1d"])
       .describe("The resolved bucket interval (1h/1d)."),
     candles: z.array(SubnetOhlcCandleSchema),
+    candle_count: z
+      .int()
+      .min(0)
+      .describe(
+        "How many candles the WINDOW holds, not how many this page carries. A `limit` narrows `candles` from the recent end; this stays the denominator, the same convention /chain/deregistrations uses for its own page.",
+      ),
     root_excluded: z
       .boolean()
       .describe(

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -194,7 +194,12 @@ export const SDL = /* GraphQL */ `
       cursor: Int
     ): JSON
     "One subnet's alpha-price OHLC candles bucketed by interval (1h or 1d, default 1h) over the trailing days window (default 90, max 365), from the same executed-trade stream subnet_volume reads. A subnet with no trades resolves to a schema-stable empty candle list, never null. Mirrors GET /api/v1/subnets/{netuid}/ohlc."
-    subnet_ohlc(netuid: Int!, interval: String, days: Int): SubnetOhlc!
+    subnet_ohlc(
+      netuid: Int!
+      interval: String
+      days: Int
+      limit: Int
+    ): SubnetOhlc!
     "A read-only quote for a hypothetical stake/unstake against one subnet's live AMM pool: expected amount out, spot vs effective price, and estimated price impact. Computes nothing on-chain and signs nothing. Mirrors GET /api/v1/subnets/{netuid}/stake-quote."
     subnet_stake_quote(
       netuid: Int!
@@ -3833,6 +3838,8 @@ export const SDL = /* GraphQL */ `
     "The resolved bucket interval (1h/1d)."
     interval: String
     candles: [SubnetOhlcCandle!]!
+    "How many candles the WINDOW holds, not how many this page carries. A limit narrows the candle list from the recent end; this stays the denominator, the same convention /chain/deregistrations uses for its own page."
+    candle_count: Int!
     "True for root (netuid 0), whose 1:1 price makes candles meaningless, so none are emitted."
     root_excluded: Boolean!
   }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -274,7 +274,7 @@ import {
   DEFAULT_CONCENTRATION_HISTORY_WINDOW,
 } from "./concentration.ts";
 import { loadGlobalIncidentsLedger } from "../workers/request-handlers/analytics.ts";
-import { validateRouteArgs } from "./route-query.ts";
+import { parseRouteArgs, validateRouteArgs } from "./route-query.ts";
 import {
   CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
   CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
@@ -467,6 +467,7 @@ import {
   OHLC_INTERVALS,
   OHLC_INTERVAL_DEFAULT,
   DEFAULT_OHLC_WINDOW_DAYS,
+  MAX_CANDLES,
   MAX_OHLC_WINDOW_DAYS,
 } from "./subnet-ohlc.ts";
 import { loadSubnetOhlcColdTier } from "./subnet-ohlc-cold-tier.ts";
@@ -4766,7 +4767,7 @@ const rootValue = {
   },
 
   async subnet_ohlc(
-    { netuid, interval, days }: QuerySubnet_OhlcArgs,
+    { netuid, interval, days, limit }: QuerySubnet_OhlcArgs,
     context: GqlContext,
   ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
@@ -4795,9 +4796,27 @@ const rootValue = {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
+    // #10318: the candle ceiling is published now, so this surface has to
+    // forward it -- otherwise a GraphQL caller asking for 24 candles gets the
+    // route's 2,000 and the three surfaces disagree about the page.
+    //
+    // PARSED BY THE ROUTE'S OWN SCHEMA, not by a bound restated here.
+    // `assertRouteArgs` safeParses against the same Zod object `openapi.json`
+    // is emitted from, so the ceiling lives in one place and this resolver
+    // cannot disagree with it. Only 8 of the 165 resolvers in this file do
+    // that today and the other 250 checks are hand-written (#10313) -- adding
+    // a 251st would have been the easy thing and the wrong one.
+    assertRouteArgs("/api/v1/subnets/{netuid}/ohlc", { limit });
+    // The published default, read back rather than restated -- the same rule
+    // `pageLimit` follows for a URL, applied to a resolver's arguments.
+    const limitParam =
+      parseRouteArgs<{ limit?: number }>("/api/v1/subnets/{netuid}/ohlc", {
+        limit,
+      })?.limit ?? MAX_CANDLES;
     const params = new URLSearchParams();
     params.set("interval", intervalParam);
     params.set("days", String(daysParam));
+    params.set("limit", String(limitParam));
     // The tier serves this route inside a { data, generatedAt } envelope (same
     // as subnet_volume above, unlike the flat cards), so unwrap it before
     // falling back. Reading the envelope as the payload made `candles` always
@@ -4817,14 +4836,19 @@ const rootValue = {
         await loadSubnetOhlcColdTier(context.env, netuid, {
           interval: intervalParam,
           days: daysParam,
+          limit: limitParam,
         })
       )?.data ??
-      buildSubnetOhlc([], netuid, { interval: intervalParam });
+      buildSubnetOhlc([], netuid, {
+        interval: intervalParam,
+        limit: limitParam,
+      });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
       interval: data.interval ?? intervalParam,
       candles: data.candles ?? [],
+      candle_count: data.candle_count ?? 0,
       root_excluded: data.root_excluded ?? false,
     };
   },

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1576,10 +1576,12 @@ import {
   buildSubnetOhlc,
   OHLC_INTERVALS,
   OHLC_INTERVAL_DEFAULT,
+  MAX_CANDLES,
   DEFAULT_OHLC_WINDOW_DAYS,
   MAX_OHLC_WINDOW_DAYS,
 } from "./subnet-ohlc.ts";
 import { loadSubnetOhlcColdTier } from "./subnet-ohlc-cold-tier.ts";
+import { GET_SUBNET_OHLC_CANDLE_DEFAULT } from "../schemas-src/mcp-tools/get-subnet-volume-ohlc.ts";
 import { computeStakeQuote } from "./stake-quote.ts";
 import { buildAccountPositionHistory } from "./account-position-history.ts";
 import { buildAccountIdentity } from "./account-identity.ts";
@@ -8511,6 +8513,20 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           `days must be at most ${MAX_OHLC_WINDOW_DAYS}.`,
         );
       }
+      // The tool's own page size (#10318), smaller than the route's cap: the
+      // uncapped answer is 486 KB and 13.5 s, and an agent asking about a
+      // subnet's price wants recent candles, not 83 days of hourly ones.
+      // `candle_count` still reports the window, so the narrowing costs no
+      // context. Forwarded to the Postgres tier too, or the two surfaces would
+      // disagree about the page.
+      const limit =
+        optionalPositiveInt(args, "limit") ?? GET_SUBNET_OHLC_CANDLE_DEFAULT;
+      if (limit > MAX_CANDLES) {
+        throw toolError(
+          "invalid_params",
+          `limit must be at most ${MAX_CANDLES}.`,
+        );
+      }
       return (
         (
           await tryPostgresTier(
@@ -8518,15 +8534,21 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/ohlc`, {
               interval,
               days,
+              limit,
             }),
             "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
           )
         )?.data ??
         // The SAME lakehouse reader REST's handleSubnetOhlc falls to, so the
         // two surfaces cannot disagree about a subnet's candles.
-        (await loadSubnetOhlcColdTier(ctx.env, netuid, { interval, days }))
-          ?.data ??
-        buildSubnetOhlc([], netuid, { interval })
+        (
+          await loadSubnetOhlcColdTier(ctx.env, netuid, {
+            interval,
+            days,
+            limit,
+          })
+        )?.data ??
+        buildSubnetOhlc([], netuid, { interval, limit })
       );
     },
   },

--- a/src/route-query.ts
+++ b/src/route-query.ts
@@ -175,6 +175,49 @@ export function validateRouteArgs(
 }
 
 /**
+ * The route's own parse of a non-URL argument set, defaults applied (#10313).
+ *
+ * `validateRouteArgs` answers "is this allowed"; this answers "what is it".
+ * The difference matters for GraphQL, whose resolvers receive arguments rather
+ * than a URL and therefore cannot use `routeValue`: without this they restate
+ * the route's default -- `limit ?? MAX_CANDLES` -- which is a second copy of a
+ * number the schema already publishes, and the copy is what drifts.
+ *
+ * Returns null when the path has no query schema, so a caller can tell "this
+ * route declares nothing" from "this route declares nothing about that
+ * argument".
+ */
+export function parseRouteArgs<T = Record<string, unknown>>(
+  routePath: string,
+  args: Record<string, unknown>,
+): T | null {
+  const schemas = routeQuerySchemasForPathname(routePath);
+  if (!schemas) return null;
+  const supplied: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(args)) {
+    if (value !== null && value !== undefined && name in schemas.plain.shape) {
+      supplied[name] = value;
+    }
+  }
+  const parsed = schemas.plain.safeParse(supplied);
+  if (!parsed.success) return null;
+  // `.meta({ default })` is published, not applied by parse -- the same reason
+  // `pageLimit` reads it back rather than trusting the parsed object.
+  const withDefaults = { ...(parsed.data as Record<string, unknown>) };
+  for (const [name, field] of Object.entries(schemas.plain.shape)) {
+    if (withDefaults[name] !== undefined) continue;
+    const declared = field as z.ZodType;
+    const inner =
+      declared instanceof z.ZodOptional
+        ? (declared.unwrap() as z.ZodType)
+        : declared;
+    const fallback = inner.meta()?.default;
+    if (fallback !== undefined) withDefaults[name] = fallback;
+  }
+  return withDefaults as T;
+}
+
+/**
  * The page size this request resolved to: what the caller asked for, or the
  * default the route PUBLISHES (#10060).
  *

--- a/src/subnet-ohlc-cold-tier.ts
+++ b/src/subnet-ohlc-cold-tier.ts
@@ -78,6 +78,10 @@ export interface SubnetOhlcQuery {
   interval?: unknown;
   /** 1..MAX_OHLC_WINDOW_DAYS. Same reasoning. */
   days?: unknown;
+  /** How many candles to return, newest-first, up to MAX_CANDLES (#10318).
+   * The window is unchanged -- `candle_count` still reports what the window
+   * holds, so a narrowed page keeps its denominator. */
+  limit?: number;
 }
 
 /**
@@ -197,7 +201,10 @@ export async function loadSubnetOhlcColdTier(
   }
 
   return {
-    data: buildSubnetOhlcFromBuckets(buckets, subnet, { interval }),
+    data: buildSubnetOhlcFromBuckets(buckets, subnet, {
+      interval,
+      limit: query.limit,
+    }),
     // data-api derives generatedAt from the newest observed_at it read; the
     // capped window is the same set of rows the candles came from, so the
     // two tiers report the same instant for the same data.

--- a/src/subnet-ohlc.ts
+++ b/src/subnet-ohlc.ts
@@ -147,7 +147,10 @@ export interface OhlcBucket {
 export function buildSubnetOhlcFromBuckets(
   buckets: Map<number, OhlcBucket>,
   netuid: number,
-  { interval = OHLC_INTERVAL_DEFAULT }: { interval?: unknown } = {},
+  {
+    interval = OHLC_INTERVAL_DEFAULT,
+    limit,
+  }: { interval?: unknown; limit?: number } = {},
 ): Row {
   const normalizedInterval = normalizeInterval(interval);
   if (netuid === 0) {
@@ -156,14 +159,23 @@ export function buildSubnetOhlcFromBuckets(
       netuid: 0,
       interval: normalizedInterval,
       candles: [],
+      candle_count: 0,
       root_excluded: true,
     };
   }
 
   const bucketStarts = [...buckets.keys()].sort((a, b) => a - b);
+  // `limit` narrows the same way MAX_CANDLES caps -- newest-first -- because a
+  // caller asking for fewer candles of a price series wants the recent end,
+  // and answering with the oldest 24 hours of an 83-day window would be a
+  // technically-correct page of the wrong data.
+  const ceiling = Math.max(
+    1,
+    Math.min(MAX_CANDLES, Number.isFinite(limit) ? Number(limit) : MAX_CANDLES),
+  );
   const cappedStarts =
-    bucketStarts.length > MAX_CANDLES
-      ? bucketStarts.slice(bucketStarts.length - MAX_CANDLES)
+    bucketStarts.length > ceiling
+      ? bucketStarts.slice(bucketStarts.length - ceiling)
       : bucketStarts;
 
   const candles = cappedStarts.map((bucketStart) => {
@@ -186,6 +198,11 @@ export function buildSubnetOhlcFromBuckets(
     netuid,
     interval: normalizedInterval,
     candles,
+    // The WINDOW's candle count, not the page's. A caller that narrowed with
+    // `limit` still needs the denominator it narrowed against -- the same
+    // reason #10249 made subnet_count stop tracking `?limit=`, and the same
+    // convention /chain/deregistrations already publishes.
+    candle_count: bucketStarts.length,
     root_excluded: false,
   };
 }
@@ -209,7 +226,10 @@ export function buildSubnetOhlcFromBuckets(
 export function buildSubnetOhlc(
   rows: Row[] | null | undefined,
   netuid: number,
-  { interval = OHLC_INTERVAL_DEFAULT }: { interval?: unknown } = {},
+  {
+    interval = OHLC_INTERVAL_DEFAULT,
+    limit,
+  }: { interval?: unknown; limit?: number } = {},
 ): Row {
   const normalizedInterval = normalizeInterval(interval);
 
@@ -219,6 +239,7 @@ export function buildSubnetOhlc(
   if (netuid === 0) {
     return buildSubnetOhlcFromBuckets(new Map(), netuid, {
       interval: normalizedInterval,
+      limit,
     });
   }
 
@@ -270,5 +291,6 @@ export function buildSubnetOhlc(
 
   return buildSubnetOhlcFromBuckets(buckets, netuid, {
     interval: normalizedInterval,
+    limit,
   });
 }

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -24526,7 +24526,15 @@ describe("MCP get_subnet_ohlc — Postgres tier wiring", () => {
     );
     assert.equal(res.body.result.isError, false);
     assert.equal(res.body.result.structuredContent.marker, "from-postgres");
-    assert.equal(captured, "/api/v1/subnets/7/ohlc?interval=1d&days=30");
+    // `limit` rides along even when the caller did not name one (#10318). The
+    // tool's page size is 168 where the route's default is the 2,000-candle
+    // cap, so the tier has to be told which one it is answering -- forwarding
+    // interval and days but not limit is how the two surfaces would come to
+    // disagree about the page while agreeing about the window.
+    assert.equal(
+      captured,
+      "/api/v1/subnets/7/ohlc?interval=1d&days=30&limit=168",
+    );
   });
 
   test("flag=postgres falls back to the schema-stable empty shape on failure", async () => {

--- a/tests/subnet-ohlc.test.ts
+++ b/tests/subnet-ohlc.test.ts
@@ -458,11 +458,12 @@ describe("buildSubnetOhlc — MAX_CANDLES cap", () => {
 });
 
 describe("buildSubnetOhlc — output shape", () => {
-  test("top-level shape carries schema_version, netuid, interval, candles, root_excluded", () => {
+  test("top-level shape carries schema_version, netuid, interval, candles, candle_count, root_excluded", () => {
     const data = buildSubnetOhlc([trade(STAKE_ADDED_KIND, 1, 1, BASE)], 12, {
       interval: "1d",
     });
     assert.deepEqual(Object.keys(data).sort(), [
+      "candle_count",
       "candles",
       "interval",
       "netuid",
@@ -471,6 +472,34 @@ describe("buildSubnetOhlc — output shape", () => {
     ]);
     assert.equal(data.netuid, 12);
     assert.equal(data.interval, "1d");
+  });
+
+  // #10318: `limit` narrows the PAGE, never the window. The route capped this
+  // response at MAX_CANDLES from the day it shipped and published no way to
+  // ask for fewer -- 486 KB and 13.5 s, the largest and slowest answer this
+  // API gives.
+  test("limit narrows the page from the recent end and keeps the denominator", () => {
+    const trades = Array.from({ length: 5 }, (_, i) =>
+      trade(STAKE_ADDED_KIND, 1, 1, BASE + i * 24 * 60 * 60 * 1000),
+    );
+    const full = buildSubnetOhlc(trades, 12, { interval: "1d" });
+    const paged = buildSubnetOhlc(trades, 12, { interval: "1d", limit: 2 });
+    assert.equal((full.candles as unknown[]).length, 5);
+    assert.equal((paged.candles as unknown[]).length, 2);
+    // The window is what it was; only the page moved.
+    assert.equal(paged.candle_count, 5);
+    assert.equal(full.candle_count, 5);
+    // NEWEST-first: a caller asking for two candles of a price series wants
+    // the recent end, not the oldest two of a 90-day window.
+    const newest = (full.candles as { bucket_start: number }[]).slice(-2);
+    assert.deepEqual(paged.candles, newest);
+  });
+
+  test("root reports a zero candle_count rather than omitting it", () => {
+    const data = buildSubnetOhlc([], 0, { interval: "1d" });
+    assert.equal(data.root_excluded, true);
+    assert.deepEqual(data.candles, []);
+    assert.equal(data.candle_count, 0);
   });
 
   test("each candle carries exactly the documented fields", () => {

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -3995,6 +3995,7 @@ export async function handleSubnetOhlc(
 ) {
   const interval = routeValue<string>(url, "interval");
   const daysResult = routeValue<number>(url, "days");
+  const candleLimit = pageLimit(url);
   const { data, generatedAt } = ((await tryPostgresTier(
     env,
     request,
@@ -4011,8 +4012,12 @@ export async function handleSubnetOhlc(
     (await loadSubnetOhlcColdTier(env, netuid, {
       interval,
       days: daysResult,
+      limit: candleLimit,
     })) ?? {
-      data: buildSubnetOhlc([], Number(netuid), { interval }),
+      data: buildSubnetOhlc([], Number(netuid), {
+        interval,
+        limit: candleLimit,
+      }),
       generatedAt: null,
     };
   return envelopeResponse(


### PR DESCRIPTION
## The largest and slowest answer this API gives, from one missing parameter

Measured live 2026-08-09:

```
get_subnet_ohlc {netuid: 64}   486,277 bytes   13,504 ms
```

`src/subnet-ohlc.ts` has capped this response at `MAX_CANDLES = 2000` since it shipped. The cap is
load-bearing and appears **nowhere in the contract** — a caller cannot ask for fewer and cannot learn
that 2,000 is all it will ever get. At the default `1h` over the default 90 days, everyone receives
2,000 candles whether they asked a question that needed them or not.

## Capability now, default change separately

That split is #9981's own safe order, and it is why this breaks nothing:

| | |
|---|---|
| `limit` on the route | ceiling `MAX_CANDLES`, **default `MAX_CANDLES`** — today's answer is byte-identical for every existing consumer |
| `candle_count` | what the **window** holds, not what the page carries, so a narrowed caller keeps its denominator — the convention #10249 restored to `subnet_count` |
| `get_subnet_ohlc` default | **168**, a week of hourly candles. The route keeps its cap, the tool serves a page — the split #10027 already made for `get_health_trends` |

Narrowing takes the **recent** end, the same direction `MAX_CANDLES` already truncated: a caller
asking for 24 candles of a price series wants today, not the oldest day of an 83-day window.

The tool's page size is published once as `GET_SUBNET_OHLC_CANDLE_DEFAULT` and read by the dispatcher
rather than restated there (#10096).

## Three surfaces, one page

REST forwards it through `pageLimit`; MCP forwards it to the Postgres tier — or the two would agree
about the window and disagree about the page; GraphQL takes it as an argument.

**The GraphQL resolver does not hand-write the bound.** It calls `assertRouteArgs`, which
`safeParse`s against the same Zod object `openapi.json` is emitted from, and reads the published
default back through a new `parseRouteArgs` — the arguments twin of `routeValue`, added because a
resolver receives args rather than a URL and so had no way to read a published default without
restating it.

Only **8 of the 165** resolvers in that file validate that way; the other **250** checks are
hand-written. Adding a 251st would have been the easy thing and the wrong one — #10316 tracks giving
GraphQL the dispatch-level parse REST already has.

## Three gates caught this while it was being written

Worth listing, because it is the system working rather than three problems:

```
graphql-component-parity   the SDL did not declare candle_count
graphql-route-parity       the SDL took no limit argument
mcp-server.test            the forwarded tier path lost the page size
```

## Validation

```
npm run typecheck / lint / format:check   clean
npx vitest run                            18,121 passed, 11 skipped
all 40 validate:* scripts                 pass
npm run build                             regenerated artifacts committed
scan:public-safety                        clean
```

Closes #10318
