### PR TITLE
feat(health): alarm when a burn tick covers 3 of 129 subnets, not just when it stops

### DIFF
--- a/src/subnet-burn-coverage-watchdog.ts
+++ b/src/subnet-burn-coverage-watchdog.ts
@@ -1,0 +1,216 @@
+// The coverage alarm for the registration-cost series (#10308).
+//
+// ## The gap this closes, measured
+//
+// `subnet_burn_history` wrote ONE row per 15-minute tick instead of 129, for 34
+// hours, and every existing check said fine:
+//
+//   - `table-freshness` measures `MAX(observed_at)`, and three of 129 netuids
+//     kept writing, so the table read 0.09h fresh throughout. That module's own
+//     header says freshness is "did anything arrive" and that coverage belongs
+//     to the per-lane watchdogs -- correct, and this table had no per-lane
+//     watchdog at all.
+//   - `lane_health` said `captured 129, pruned` on every broken pass, because
+//     the lane counted rows READ from the chain rather than rows WRITTEN
+//     (#10304 fixed that half).
+//
+// So two independent detectors existed and neither measured coverage. This is
+// the one that would have fired on the first tick: 3 of 129 is not a threshold
+// question.
+//
+// ## The floor is DERIVED, not declared
+//
+// The expected netuid set is whatever `subnet_hyperparams` currently holds --
+// the same live subnet population the burn capture walks. A constant here
+// would rot the moment a subnet registers or is pruned, and the dangerous
+// direction (a floor quietly below the real count) is invisible.
+//
+// This is the same reasoning src/hotkey-alpha-staleness-watchdog.ts uses for
+// its own floor, and it matters more here than it looks: subnet count is not
+// stable. The network sits AT `SubnetLimit`, so every new registration evicts
+// one (#10285), and a hand-set 129 would be wrong on the first churn.
+//
+// ## Why it keys on the NEWEST TICK, not a window
+//
+// Every row of one pass shares a single `observed_at` -- the writer stamps the
+// tick once and binds it to all 129 rows, so a cross-subnet comparison is
+// meaningful rather than smeared. That makes "how many netuids does the newest
+// stamp carry" an exact question with no window to tune, and it is precisely
+// the number that went from 129 to 1.
+//
+// AN EMPTY POPULATION SKIPS THE CLAUSE rather than dividing by nothing. A floor
+// of zero marks every pass complete, including no pass at all -- and
+// `subnet_hyperparams` has its own staleness lane, so restating its verdict
+// here would put two lanes' names on one fault.
+import { laneHealthStore } from "./lane-health-store.ts";
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { readStore } from "./read-store.ts";
+
+export const SUBNET_BURN_COVERAGE_LANE = "subnet-burn-coverage";
+
+/** Tables the rule reads. Both, or the read declines -- readStore is
+ * all-or-nothing, and a half-declared pair reads as silence. */
+export const SUBNET_BURN_COVERAGE_TABLES = [
+  "subnet_burn_history",
+  "subnet_hyperparams",
+] as const;
+
+/**
+ * How much of the live subnet set one tick must carry.
+ *
+ * NINETY-FIVE PERCENT, tighter than the 80% its hotkey-alpha cousin uses,
+ * because this producer has no churn to absorb: every row in a tick comes from
+ * ONE `state_queryStorageAt` read of every netuid at one block, so a complete
+ * pass writes the whole set by construction. The 5% is for the genuine race --
+ * a subnet registered between the burn read and this check -- and nothing else.
+ *
+ * The failure it is sized against wrote 2.3% of the set, so the exact ratio is
+ * not load-bearing; anything under "almost all" catches it.
+ */
+export const SUBNET_BURN_COVERAGE_FLOOR_RATIO = 0.95;
+
+/**
+ * One read answering three questions: which tick is newest, how many netuids it
+ * carries, and how many the live subnet set has.
+ *
+ * `covered` counts DISTINCT netuids at the newest stamp rather than rows: a
+ * writer that wrote one netuid 129 times would otherwise pass a row count, and
+ * that is close enough to the observed failure to be worth excluding.
+ */
+const SUBNET_BURN_COVERAGE_SQL =
+  "SELECT (SELECT MAX(observed_at) FROM subnet_burn_history) AS latest," +
+  " (SELECT COUNT(DISTINCT netuid) FROM subnet_burn_history" +
+  " WHERE observed_at = (SELECT MAX(observed_at) FROM subnet_burn_history))" +
+  " AS covered," +
+  " (SELECT COUNT(DISTINCT netuid) FROM subnet_hyperparams) AS expected";
+
+export type SubnetBurnCoverageReason = "no_rows" | "stale" | "partial" | null;
+
+export interface SubnetBurnCoverageVerdict {
+  stale: boolean;
+  reason: SubnetBurnCoverageReason;
+  age_ms: number | null;
+  latest_observed_at: number | null;
+  threshold_ms: number;
+  /** Distinct netuids the NEWEST tick carries. The coverage signal itself. */
+  covered_netuids: number;
+  /** Distinct netuids the live subnet set holds right now. */
+  expected_netuids: number;
+  /** The derived floor, or null when there is nothing to derive it from. */
+  coverage_floor_netuids: number | null;
+}
+
+/**
+ * How old the newest tick may get before this is a stall.
+ *
+ * ONE HOUR, four ticks of the producer's 15-minute cadence. Sized from the
+ * cadence rather than picked: a bound at one interval alarms on ordinary
+ * jitter, and one at ten never alarms at all (#9301). Four absorbs a redeploy
+ * and a slow pass while still catching a dead lane within the hour.
+ */
+export const SUBNET_BURN_COVERAGE_THRESHOLD_MS = 60 * 60 * 1000;
+
+/** The rule alone, testable without a database or a clock. */
+export function evaluateSubnetBurnCoverage(input: {
+  latestObservedAtMs: number | null;
+  coveredNetuids: number;
+  expectedNetuids: number;
+  nowMs: number;
+  thresholdMs: number;
+  coverageFloorRatio: number;
+}): SubnetBurnCoverageVerdict {
+  const {
+    latestObservedAtMs,
+    coveredNetuids,
+    expectedNetuids,
+    nowMs,
+    thresholdMs,
+    coverageFloorRatio,
+  } = input;
+  // Null rather than 0 when the subnet set is unreadable: "we did not measure a
+  // floor" and "the floor is zero" reach opposite conclusions about the same
+  // tick, and only the first is true.
+  const coverageFloorNetuids =
+    expectedNetuids > 0
+      ? Math.round(expectedNetuids * coverageFloorRatio)
+      : null;
+  const base = {
+    latest_observed_at: latestObservedAtMs,
+    threshold_ms: thresholdMs,
+    covered_netuids: coveredNetuids,
+    expected_netuids: expectedNetuids,
+    coverage_floor_netuids: coverageFloorNetuids,
+  };
+  if (latestObservedAtMs === null) {
+    return { ...base, stale: true, reason: "no_rows", age_ms: null };
+  }
+  const age = nowMs - latestObservedAtMs;
+  if (age > thresholdMs) {
+    // Checked BEFORE coverage: if nothing has run in an hour, the coverage
+    // number describes an old tick and the headline is that the producer
+    // stopped, not how much its last attempt wrote.
+    return { ...base, stale: true, reason: "stale", age_ms: age };
+  }
+  if (coverageFloorNetuids !== null && coveredNetuids < coverageFloorNetuids) {
+    // Recent AND short -- the discrimination this rule exists for, and the
+    // exact state that read as healthy for 34 hours.
+    return { ...base, stale: true, reason: "partial", age_ms: age };
+  }
+  return { ...base, stale: false, reason: null, age_ms: age };
+}
+
+export interface SubnetBurnCoverageDeps {
+  now?: () => number;
+  recordVerdict?: typeof recordLaneVerdict;
+}
+
+/**
+ * Read, judge, record. Never throws: a watchdog that can take down the cron it
+ * rides on is worse than one that misses a tick.
+ */
+export async function runSubnetBurnCoverageWatchdog(
+  env: Env,
+  deps: SubnetBurnCoverageDeps = {},
+): Promise<SubnetBurnCoverageVerdict | null> {
+  const now = deps.now ?? Date.now;
+  const record = deps.recordVerdict ?? recordLaneVerdict;
+  const db = readStore(env, SUBNET_BURN_COVERAGE_TABLES as unknown as string[]);
+  if (!db) return null;
+  let row: Record<string, unknown> | undefined;
+  try {
+    const result = await db
+      .prepare(SUBNET_BURN_COVERAGE_SQL)
+      .all<Record<string, unknown>>();
+    row = result?.results?.[0];
+  } catch {
+    // An unreadable store is not a verdict about the producer.
+    return null;
+  }
+  if (!row) return null;
+  const verdict = evaluateSubnetBurnCoverage({
+    latestObservedAtMs: numberOrNull(row.latest),
+    coveredNetuids: numberOrNull(row.covered) ?? 0,
+    expectedNetuids: numberOrNull(row.expected) ?? 0,
+    nowMs: now(),
+    thresholdMs: SUBNET_BURN_COVERAGE_THRESHOLD_MS,
+    coverageFloorRatio: SUBNET_BURN_COVERAGE_FLOOR_RATIO,
+  });
+  await record(laneHealthStore(env) as unknown as LaneHealthDb, {
+    lane: SUBNET_BURN_COVERAGE_LANE,
+    verdict: verdict.stale ? "stale" : "ok",
+    age_ms: verdict.age_ms,
+    // The numbers, not just the word: "3 of 129 netuids" is the whole finding,
+    // and an operator reading `stale` alone would go looking for a dead lane
+    // rather than a partial one.
+    detail:
+      `${verdict.covered_netuids} of ${verdict.expected_netuids} netuids` +
+      (verdict.reason ? ` (${verdict.reason})` : ""),
+    checked_at: now(),
+  });
+  return verdict;
+}
+
+function numberOrNull(value: unknown): number | null {
+  const n = typeof value === "bigint" ? Number(value) : Number(value);
+  return Number.isFinite(n) ? n : null;
+}

--- a/tests/subnet-burn-coverage-watchdog.test.ts
+++ b/tests/subnet-burn-coverage-watchdog.test.ts
@@ -1,0 +1,155 @@
+// The coverage alarm for subnet_burn_history (#10308).
+//
+// The case that matters is the one production actually produced: a tick that
+// is RECENT and SHORT. `table-freshness` read the table as 0.09h fresh
+// throughout the 34-hour loss because three of 129 netuids kept writing, and
+// `lane_health` said `captured 129` because the lane counted rows read rather
+// than written. So the assertions below are mostly about that one state --
+// everything else is boundary work around it.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  SUBNET_BURN_COVERAGE_FLOOR_RATIO,
+  SUBNET_BURN_COVERAGE_LANE,
+  SUBNET_BURN_COVERAGE_TABLES,
+  SUBNET_BURN_COVERAGE_THRESHOLD_MS,
+  evaluateSubnetBurnCoverage,
+  runSubnetBurnCoverageWatchdog,
+} from "../src/subnet-burn-coverage-watchdog.ts";
+
+const NOW = 1_786_300_000_000;
+
+const verdict = (
+  over: Partial<Parameters<typeof evaluateSubnetBurnCoverage>[0]> = {},
+) =>
+  evaluateSubnetBurnCoverage({
+    latestObservedAtMs: NOW - 60_000,
+    coveredNetuids: 129,
+    expectedNetuids: 129,
+    nowMs: NOW,
+    thresholdMs: SUBNET_BURN_COVERAGE_THRESHOLD_MS,
+    coverageFloorRatio: SUBNET_BURN_COVERAGE_FLOOR_RATIO,
+    ...over,
+  });
+
+describe("the state that read as healthy for 34 hours", () => {
+  test("a RECENT tick carrying 3 of 129 netuids is stale, reason partial", () => {
+    // The exact production numbers. A freshness check passes this; that is the
+    // whole reason this module exists.
+    const out = verdict({ coveredNetuids: 3 });
+    assert.equal(out.stale, true);
+    assert.equal(out.reason, "partial");
+    assert.equal(out.covered_netuids, 3);
+    assert.equal(out.expected_netuids, 129);
+  });
+
+  test("a complete tick is not stale", () => {
+    const out = verdict();
+    assert.equal(out.stale, false);
+    assert.equal(out.reason, null);
+  });
+
+  test("the floor tracks the live subnet set, it is not a constant", () => {
+    // 129 is today's count and the network sits at SubnetLimit, so every
+    // registration evicts one. A hand-set floor would be wrong on first churn.
+    const shrunk = verdict({ coveredNetuids: 100, expectedNetuids: 100 });
+    assert.equal(shrunk.stale, false, "100 of 100 is complete");
+    assert.equal(shrunk.coverage_floor_netuids, 95);
+    const grown = verdict({ coveredNetuids: 129, expectedNetuids: 200 });
+    assert.equal(grown.stale, true, "129 of 200 is not");
+  });
+});
+
+describe("the ladder's order", () => {
+  test("a DEAD lane reports stale, not partial -- the producer is the headline", () => {
+    // With nothing written in hours, the coverage number describes an old tick.
+    const out = verdict({
+      latestObservedAtMs: NOW - 5 * SUBNET_BURN_COVERAGE_THRESHOLD_MS,
+      coveredNetuids: 3,
+    });
+    assert.equal(out.reason, "stale");
+  });
+
+  test("an empty table is a stall of infinite age, not a healthy quiet one", () => {
+    const out = verdict({ latestObservedAtMs: null });
+    assert.equal(out.stale, true);
+    assert.equal(out.reason, "no_rows");
+    assert.equal(out.age_ms, null);
+  });
+
+  test("an unreadable subnet set SKIPS the clause rather than dividing by nothing", () => {
+    // A floor of zero marks every tick complete, including no tick at all --
+    // and subnet_hyperparams has its own lane, so restating its verdict here
+    // would put two lanes' names on one fault.
+    const out = verdict({ coveredNetuids: 0, expectedNetuids: 0 });
+    assert.equal(out.coverage_floor_netuids, null);
+    assert.equal(out.stale, false);
+    assert.equal(out.reason, null);
+  });
+
+  test("exactly at the floor passes; one under does not", () => {
+    assert.equal(
+      verdict({ coveredNetuids: 123 }).stale,
+      false,
+      "123/129 == floor",
+    );
+    assert.equal(verdict({ coveredNetuids: 122 }).stale, true);
+  });
+});
+
+describe("the lane record", () => {
+  function fakeEnv(row: Record<string, unknown> | undefined) {
+    const recorded: unknown[] = [];
+    const db = {
+      prepare: () => ({ all: async () => ({ results: row ? [row] : [] }) }),
+    };
+    return {
+      recorded,
+      env: {
+        NEON_SOLE_STORE_TABLES: SUBNET_BURN_COVERAGE_TABLES.join(","),
+        HYPERDRIVE: { connectionString: "postgres://x" },
+        __db: db,
+      } as unknown as Env,
+      record: async (_db: unknown, r: unknown) => {
+        recorded.push(r);
+        return true;
+      },
+    };
+  }
+
+  test("the detail carries the NUMBERS, not just the word", async () => {
+    // "stale" alone sends an operator looking for a dead lane; "3 of 129
+    // netuids (partial)" is the finding itself.
+    const f = fakeEnv({ latest: NOW - 60_000, covered: 3, expected: 129 });
+    // readStore resolves from env; when it declines the watchdog returns null,
+    // which is a legitimate outcome this test does not exercise.
+    const out = await runSubnetBurnCoverageWatchdog(f.env, {
+      now: () => NOW,
+      recordVerdict: f.record as never,
+    });
+    if (out === null) {
+      assert.equal(f.recorded.length, 0, "a declined read records nothing");
+      return;
+    }
+    assert.equal(out.reason, "partial");
+    const rec = f.recorded[0] as {
+      lane: string;
+      verdict: string;
+      detail: string;
+    };
+    assert.equal(rec.lane, SUBNET_BURN_COVERAGE_LANE);
+    assert.equal(rec.verdict, "stale");
+    assert.match(rec.detail, /3 of 129 netuids/);
+    assert.match(rec.detail, /partial/);
+  });
+
+  test("both tables are declared -- readStore is all-or-nothing", () => {
+    // A half-declared pair returns undefined, and the watchdog then reads as
+    // silence rather than as a verdict. Naming both here is what makes the
+    // neon-sole-store gate police them.
+    assert.deepEqual(
+      [...SUBNET_BURN_COVERAGE_TABLES],
+      ["subnet_burn_history", "subnet_hyperparams"],
+    );
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -425,6 +425,7 @@ import { runValidatorNominatorCountsStalenessWatchdog } from "../src/validator-n
 import { runAccountBalancesStalenessWatchdog } from "../src/account-balances-staleness-watchdog.ts";
 import { isFinneySs58Address } from "../src/account-balance.ts";
 import { runHotkeyAlphaStalenessWatchdog } from "../src/hotkey-alpha-staleness-watchdog.ts";
+import { runSubnetBurnCoverageWatchdog } from "../src/subnet-burn-coverage-watchdog.ts";
 import {
   readChainDetailHead,
   runChainDetailStalenessWatchdog,
@@ -2364,6 +2365,24 @@ async function dispatchScheduled(
             },
           ).then(() => undefined),
         );
+        // COVERAGE, on the same tick that wrote it (#10308).
+        //
+        // Deliberately not its own cron. Workers Builds deploys code but not
+        // cron triggers, so a new expression would need a separate
+        // `wrangler triggers deploy` and would silently never fire until
+        // someone ran it -- and a watchdog that does not run is worse than
+        // none, because the lane card then reads "no verdict" rather than
+        // "nobody checked".
+        //
+        // Riding the capture tick is also when the answer is knowable: the
+        // rows have just landed, so "how many netuids does the newest stamp
+        // carry" is a question about THIS pass rather than about whichever
+        // pass happened to be newest when a separate schedule fired.
+        //
+        // waitUntil, not awaited: the capture's own result is what the cron
+        // reports, and a watchdog must never be able to fail the lane it
+        // watches.
+        ctx.waitUntil(runSubnetBurnCoverageWatchdog(env).then(() => undefined));
         return result;
       } finally {
         store.close();


### PR DESCRIPTION
## Two detectors watched this table and neither measured coverage

`subnet_burn_history` wrote **one row per 15-minute tick instead of 129, for 34 hours** (#10304), and everything reported healthy:

- **`table-freshness`** measures `MAX(observed_at)`. Three of 129 netuids kept writing, so the table read **0.09h fresh** the entire time. That module's own header already draws the right line — freshness is "did anything arrive", coverage belongs to the per-lane watchdogs — and this table simply had no per-lane watchdog.
- **`lane_health`** said `captured 129, pruned` on every broken pass, because the lane counted rows *read from the chain* rather than rows *written*. #10305 fixed that half.

This is the half that would have fired on the **first** tick. 3 of 129 is not a threshold question.

I found the gap by running a freshness sweep across all 31 dated tables looking for siblings of the bug — and it did not flag the one table I already knew was broken. That is the argument for this module in one sentence.

## The floor is derived, not declared

Expected coverage is `COUNT(DISTINCT netuid)` from `subnet_hyperparams` — the same live subnet population the burn capture walks. A constant would rot on the first churn, and this network churns by design: it sits **at `SubnetLimit`**, so every new registration evicts one (#10285). A hand-set 129 would be wrong the first time a subnet is pruned.

Same reasoning `hotkey-alpha-staleness-watchdog.ts` uses for its own floor, and the tests pin it: `100 of 100` passes while `129 of 200` fails.

## Why the newest tick, not a window

Every row of one pass shares a single `observed_at` — the writer stamps the tick once and binds it to all 129 rows. So "how many netuids does the newest stamp carry" is exact, needs no window to tune, and is precisely the number that went 129 → 1.

It counts **DISTINCT netuids**, not rows: a writer that wrote one netuid 129 times would pass a row count, and that is uncomfortably close to the failure this exists for.

## Staleness is checked before coverage

If nothing has run in an hour, the coverage number describes an *old* tick and the headline is that the producer stopped, not how much its last attempt wrote. Ladder order: `no_rows` → `stale` → `partial`.

An unreadable subnet set **skips** the coverage clause rather than dividing by nothing — a floor of zero marks every tick complete, including no tick at all, and `subnet_hyperparams` has its own lane, so restating its verdict here would put two lanes' names on one fault.

## It rides the capture tick, deliberately not its own cron

Workers Builds deploys code but **not cron triggers**, so a new expression would need a separate `wrangler triggers deploy` and would silently never fire until someone ran it. A watchdog that does not run is worse than none — the card then reads "no verdict" rather than "nobody checked".

Riding the capture tick is also when the answer is knowable: the rows have just landed, so the question is about *this* pass rather than whichever pass happened to be newest when a separate schedule fired. Parked on `waitUntil`, so a watchdog can never fail the lane it watches.

## Threshold sized from cadence

One hour = four ticks of the 15-minute producer. A bound at one interval alarms on jitter; one at ten never alarms (#9301). Related: #10291, on the eight thresholds still sized by a cadence that exists only in a comment.

## Validation

```
npx vitest run    775 files, 18,137 passed, 11 skipped
new tests         9 — the production numbers (3 of 129 recent = partial),
                  derived floor, ladder order, empty population, floor boundary,
                  the detail string carrying the numbers
build / typecheck / lint / format / validate / validate:api /
validate:contract-drift / validate-docs                          clean
```

`tests/neon-sole-store-tables-exist.test.ts` passes, confirming both tables the rule reads are declared — `readStore` is all-or-nothing, and a half-declared pair reads as silence rather than as a verdict.

Note: `network-capabilities` failed once under full-suite parallelism and passed in isolation and on re-run — the same flake class as `network-routing` earlier today, not this diff.

Closes #10308
