### PR TITLE
fix(mcp): serve the page default the tool publishes (#10306)

### DIFF
--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -8763,7 +8763,7 @@
           "name": "limit",
           "schema": {
             "default": 20,
-            "description": "Max counterparties to return in list mode (default 20), or max transfer evidence rows in relationship drilldown mode when ?counterparty is present (default 50).",
+            "description": "Max counterparties to return in list mode, or max transfer evidence rows in relationship drilldown mode when ?counterparty is present. One page size for both modes.",
             "maximum": 100,
             "minimum": 1,
             "type": "integer"

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -64368,7 +64368,7 @@
             "required": false,
             "schema": {
               "default": 20,
-              "description": "Max counterparties to return in list mode (default 20), or max transfer evidence rows in relationship drilldown mode when ?counterparty is present (default 50).",
+              "description": "Max counterparties to return in list mode, or max transfer evidence rows in relationship drilldown mode when ?counterparty is present. One page size for both modes.",
               "maximum": 100,
               "minimum": 1,
               "type": "integer"

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -3418,7 +3418,13 @@ export const API_ROUTES = [
           minimum: 1,
           maximum: 100,
           description:
-            "Max counterparties to return in list mode (default 20), or max transfer evidence rows in relationship drilldown mode when ?counterparty is present (default 50).",
+            // The "(default 50)" this used to claim for drilldown mode was
+            // stale: the handler reads ONE `pageLimit(url)` and passes it to
+            // both branches, so both resolve the single published default. A
+            // second default stated only in prose is exactly what #10060 set
+            // out to remove -- and it is what made #10306's fix look like a
+            // narrowing here when it is not.
+            "Max counterparties to return in list mode, or max transfer evidence rows in relationship drilldown mode when ?counterparty is present. One page size for both modes.",
         },
       },
     ]),

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -3663,8 +3663,23 @@ async function rankSubnetsForTask(
   return { mode: "keyword", ranked };
 }
 
-function validateToolArguments(tool: Row, args: Row) {
-  if (args === undefined || args === null) return {};
+/**
+ * The arguments a handler actually receives, from the ones a caller sent.
+ *
+ * EXPORTED for `tests/mcp-published-default.test.ts`, which drives all 230
+ * tools through it. This is the one place every `tools/call` passes on its way
+ * to a handler -- intent stripped, `limit` clamped to the published ceiling,
+ * omitted arguments filled from the published defaults -- so a gate that runs
+ * here covers every tool at once, where a gate per handler covers whichever
+ * ones somebody remembered.
+ */
+export function validateToolArguments(tool: Row, args: Row) {
+  // `arguments` absent entirely is the same request as `arguments: {}` -- the
+  // caller supplied nothing either way, so it must resolve to the same defaults
+  // rather than to a bare {}. Returning early here is how the omitted-argument
+  // path skipped them (#10306).
+  if (args === undefined || args === null)
+    return applyPublishedDefaults(tool, {});
   if (
     typeof args !== "object" ||
     Array.isArray(args) ||
@@ -3684,7 +3699,56 @@ function validateToolArguments(tool: Row, args: Row) {
   // merely a courtesy: several handlers forward their whole argument object
   // into a query builder or an upstream call, where an unexpected key becomes
   // a filter, a cache-key difference, or a 400 from someone else's API.
-  return clampPublishedLimit(tool, splitMcpIntent(args).rest);
+  return applyPublishedDefaults(
+    tool,
+    clampPublishedLimit(tool, splitMcpIntent(args).rest),
+  );
+}
+
+/**
+ * Fill every omitted argument the tool PUBLISHES a default for (#10306).
+ *
+ * A tool that advertises `"default": 100` and then serves nothing is lying to
+ * its caller, and two tools were:
+ *
+ *   get_subnet_identity_history   publishes 100   served entry_count 0
+ *   get_chain_subnet_lifecycle    publishes  50   served 100
+ *
+ * The first is a confident zero in the #9803 sense -- `entry_count: 0` with no
+ * degraded marker reads as "this subnet has never changed its identity", and
+ * SN64 changed it on 2026-07-11. Passing `limit` explicitly returned the row,
+ * so the handler was fine and nothing was applying the default.
+ *
+ * WHY HERE. #10096 made the published `default` the single source for REST:
+ * `limitSchema(max, fallback)` records it in `.meta({default})` and
+ * `routeValue(url, name)` reads it back, so a handler cannot restate it. MCP
+ * dispatch does no schema validation -- a settled decision (#8942) and not
+ * revisited here -- and therefore never consulted that default, leaving each
+ * handler to apply its own or none. 137 of 230 tools publish at least one
+ * default; the two above are just where the divergence was visible.
+ *
+ * Reading the TOOL'S OWN inputSchema, not the route's, because the tool is what
+ * the caller was promised. Several tools deliberately publish a narrower page
+ * than their route (#9701, sized to a context window), and honouring the route
+ * there would serve a page the tool never advertised.
+ *
+ * This is not validation. It supplies a value the caller was already told they
+ * would get for omitting the argument -- the same thing `pageLimit` does on the
+ * REST side, at the one place every tools/call passes through rather than in
+ * the 230 handlers behind it.
+ */
+function applyPublishedDefaults(tool: Row, args: Row): Row {
+  const properties = tool.inputSchema?.properties as
+    Record<string, Row> | undefined;
+  if (!properties) return args;
+  let filled: Row | null = null;
+  for (const [name, schema] of Object.entries(properties)) {
+    if (schema?.default === undefined) continue;
+    if (args[name] !== undefined) continue;
+    filled ??= { ...args };
+    filled[name] = schema.default;
+  }
+  return filled ?? args;
 }
 
 /**

--- a/tests/mcp-published-default.test.ts
+++ b/tests/mcp-published-default.test.ts
@@ -1,0 +1,159 @@
+// Does a tool serve the default it publishes? (#10306)
+//
+// Two did not, and the cross-surface sweep (#10217) found both on its first
+// working run:
+//
+//   get_subnet_identity_history   publishes limit 100   served entry_count 0
+//   get_chain_subnet_lifecycle    publishes limit  50   served 100
+//
+// The first is a CONFIDENT ZERO in the #9803 sense. `entry_count: 0` with no
+// degraded marker reads as "this subnet has never changed its identity", and
+// SN64 changed it on 2026-07-11. Passing `limit` explicitly returned the row,
+// so the handler was right and nothing was applying the default.
+//
+// WHY A GATE AND NOT TWO FIXES. #10096 made the published `default` the single
+// source on the REST side -- `limitSchema(max, fallback)` writes it and
+// `routeValue` reads it back, so a handler cannot restate it. MCP dispatch does
+// no schema validation (settled, #8942) and so consulted nothing; each of the
+// 230 handlers applied its own default or none. 137 tools publish at least one.
+// Fixing two of them leaves 135 relying on a handler remembering.
+//
+// So the assertion below is on the DISPATCH CHOKEPOINT -- the one function
+// every tools/call passes through -- and it runs for every tool and every
+// default the served schema advertises. There is no per-tool list to keep up to
+// date, which is the point: a tool added tomorrow is covered the day it ships.
+//
+// Measured against `listToolDefinitions()`, the SERVED list, not `MCP_TOOLS`.
+// The two differ (`stripSentinelIntegerBounds` runs in between) and the served
+// one is what the caller was actually promised (#10280).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  handleMcpRequest,
+  listToolDefinitions,
+  validateToolArguments,
+} from "../src/mcp-server.ts";
+import {
+  assertArtifactsBuilt,
+  createLocalArtifactEnv,
+} from "../scripts/lib.ts";
+import type { Row } from "./row-type.ts";
+
+/** The published defaults one served tool advertises, argument -> value. */
+function publishedDefaults(tool: Row): [string, unknown][] {
+  const properties = (tool.inputSchema?.properties ?? {}) as Record<
+    string,
+    Row
+  >;
+  return Object.entries(properties)
+    .filter(([, schema]) => schema?.default !== undefined)
+    .map(([name, schema]) => [name, schema.default]);
+}
+
+describe("a tool serves the default it publishes", () => {
+  const tools = listToolDefinitions() as Row[];
+
+  test("every published default reaches the handler when omitted", () => {
+    const missed: string[] = [];
+    let checked = 0;
+    for (const tool of tools) {
+      const defaults = publishedDefaults(tool);
+      if (defaults.length === 0) continue;
+      // The caller sent nothing. Whatever the schema says they get for that is
+      // what the handler must receive.
+      const resolved = validateToolArguments(tool, {}) as Row;
+      for (const [name, value] of defaults) {
+        checked += 1;
+        if (JSON.stringify(resolved[name]) !== JSON.stringify(value)) {
+          missed.push(
+            `${tool.name}.${name}: publishes ${JSON.stringify(value)}, handler receives ${JSON.stringify(resolved[name])}`,
+          );
+        }
+      }
+    }
+    assert.equal(
+      missed.length,
+      0,
+      `${missed.length} published default(s) never reach the handler:\n${missed.join("\n")}`,
+    );
+    // Not a round number anyone chose -- it is however many the schemas
+    // publish, and it exists so this test cannot quietly stop covering
+    // anything. If it drops, a tool lost a default rather than this passing
+    // more easily.
+    assert.ok(
+      checked >= 180,
+      `only ${checked} published defaults were checked; the suite covered 189`,
+    );
+  });
+
+  test("absent `arguments` resolves the same as an empty object", () => {
+    // A tools/call may omit `arguments` entirely. That is the same request as
+    // `arguments: {}` -- the caller supplied nothing either way -- and the
+    // early return for it used to skip defaults altogether.
+    for (const tool of tools) {
+      if (publishedDefaults(tool).length === 0) continue;
+      assert.deepEqual(
+        validateToolArguments(tool, undefined as unknown as Row),
+        validateToolArguments(tool, {}),
+        `${tool.name} answers differently for absent vs empty arguments`,
+      );
+    }
+  });
+});
+
+describe("the two tools #10306 was filed for, through the real dispatcher", () => {
+  const call = async (name: string, args: Row): Promise<Row> => {
+    await assertArtifactsBuilt();
+    // The same cast tests/pagination-bound-parity.test.ts uses: the local
+    // artifact env carries the readers these tools need and none of the 69
+    // bindings the Worker Env type declares.
+    const env = createLocalArtifactEnv() as unknown as Parameters<
+      typeof handleMcpRequest
+    >[1];
+    const response = await handleMcpRequest(
+      new Request("https://api.metagraph.sh/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name, arguments: args },
+        }),
+      }),
+      env,
+    );
+    const body = (await response.json()) as Row;
+    return (body?.result?.structuredContent ?? {}) as Row;
+  };
+
+  // The APPLIED limit each answer echoes, rather than the rows it carries.
+  // The rows depend on what the local artifacts hold and both of these read a
+  // tier that is empty here, so asserting on them would be asserting on
+  // nothing -- two empty pages compare equal whatever the page size was. The
+  // echoed `limit` is the field that actually diverged in production (100 vs
+  // 50, null vs 100) and it is exactly as wrong locally when the default is
+  // not applied.
+  test("get_chain_subnet_lifecycle applies the 50 it publishes, not 100", async () => {
+    const omitted = await call("get_chain_subnet_lifecycle", {});
+    assert.equal(omitted.limit, 50);
+    assert.deepEqual(
+      omitted,
+      await call("get_chain_subnet_lifecycle", { limit: 50 }),
+      "omitting `limit` must be the same request as passing the published default",
+    );
+  });
+
+  test("get_subnet_identity_history applies its published 100 rather than none", async () => {
+    const omitted = await call("get_subnet_identity_history", { netuid: 1 });
+    assert.equal(omitted.limit, 100);
+    assert.deepEqual(
+      omitted,
+      await call("get_subnet_identity_history", { netuid: 1, limit: 100 }),
+      "omitting `limit` must be the same request as passing the published default",
+    );
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -113,6 +113,26 @@ import { assertValid } from "./helpers/assert-valid.ts";
 
 const MCP_URL = "https://api.metagraph.sh/mcp";
 
+/**
+ * The default one served tool publishes for one argument (#10306).
+ *
+ * Read from `listToolDefinitions()` rather than written into the assertion, so
+ * a test about "the tool forwards what it advertises" cannot pass while the two
+ * disagree -- which is the whole shape of the bug it guards. Throws for an
+ * argument with no published default: that is the test naming a parameter the
+ * tool does not default, not a value of undefined.
+ */
+function publishedDefaultOf(tool: string, argument: string): unknown {
+  const served = (listToolDefinitions() as Row[]).find(
+    (candidate) => candidate.name === tool,
+  );
+  const schema = served?.inputSchema?.properties?.[argument] as Row | undefined;
+  if (schema?.default === undefined) {
+    throw new Error(`${tool} publishes no default for ${argument}`);
+  }
+  return schema.default;
+}
+
 // Fresh prober run time for live KV fixtures — resolveLiveHealth rejects a
 // health:current whose last_run_at is older than the 25-min freshness window.
 const FRESH_RUN = new Date(Date.now() - 60_000).toISOString();
@@ -12712,7 +12732,13 @@ describe("MCP economics + metagraph data tools", () => {
       assert.equal(seenUrl!.searchParams.get("limit"), "25");
     });
 
-    test("flag=postgres omits the limit param when not supplied", async () => {
+    // Was "omits the limit param when not supplied", which pinned the #10306
+    // bug: the tool published a `limit` default and forwarded nothing, so the
+    // page a caller got was whatever the route re-derived rather than the one
+    // the tool advertised. The expected value is READ from the served schema
+    // rather than written here, so this cannot drift from what the tool
+    // publishes.
+    test("flag=postgres forwards the limit default the tool publishes", async () => {
       let seenUrl: URL | undefined;
       const env = {
         METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
@@ -12730,7 +12756,10 @@ describe("MCP economics + metagraph data tools", () => {
       };
       await callTool("get_chain_identity_history", {}, { env });
       assert.equal(seenUrl!.pathname, "/api/v1/chain/identity-history");
-      assert.equal(seenUrl!.searchParams.has("limit"), false);
+      assert.equal(
+        seenUrl!.searchParams.get("limit"),
+        String(publishedDefaultOf("get_chain_identity_history", "limit")),
+      );
     });
   });
 
@@ -18668,7 +18697,15 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
       assert.equal(seenUrl!.searchParams.get("cursor"), "abc");
     });
 
-    test("flag=postgres omits pagination params when not supplied", async () => {
+    // THE tool #10306 was filed for. This test used to assert
+    // `searchParams.has("limit") === false`, which is precisely the defect:
+    // the tool advertised "1-1000, default 100", forwarded no limit, and the
+    // read came back empty -- `entry_count: 0` for a subnet that had changed
+    // its identity, with no degraded marker to say otherwise.
+    //
+    // `cursor` still has no default and must stay absent, which is what keeps
+    // this from being a blanket "everything is forwarded now" assertion.
+    test("flag=postgres forwards the pagination defaults the tool publishes", async () => {
       let seenUrl: URL | undefined;
       const env = {
         METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
@@ -18686,8 +18723,14 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
       };
       await callTool("get_subnet_identity_history", { netuid: 86 }, { env });
       assert.equal(seenUrl!.pathname, "/api/v1/subnets/86/identity-history");
-      assert.equal(seenUrl!.searchParams.has("limit"), false);
-      assert.equal(seenUrl!.searchParams.has("offset"), false);
+      assert.equal(
+        seenUrl!.searchParams.get("limit"),
+        String(publishedDefaultOf("get_subnet_identity_history", "limit")),
+      );
+      assert.equal(
+        seenUrl!.searchParams.get("offset"),
+        String(publishedDefaultOf("get_subnet_identity_history", "offset")),
+      );
       assert.equal(seenUrl!.searchParams.has("cursor"), false);
     });
   });
@@ -24137,7 +24180,12 @@ describe("MCP account_events-tier subnet/validator activity tools — Postgres t
     {
       tool: "get_account_history",
       args: { ss58: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5" },
-      path: "/api/v1/accounts/5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5/history",
+      // `?limit=100&offset=0` since #10306 -- the tool's own published
+      // defaults, forwarded rather than left for the route to re-derive. The
+      // sibling `get_account_events` case above already carried them because
+      // its handler passed them through by hand; this one did not, which is
+      // the inconsistency the dispatcher-level fill removes.
+      path: "/api/v1/accounts/5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5/history?limit=100&offset=0",
     },
     {
       tool: "get_account_history",
@@ -24173,7 +24221,7 @@ describe("MCP account_events-tier subnet/validator activity tools — Postgres t
     {
       tool: "get_account_counterparties",
       args: { ss58: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5" },
-      path: "/api/v1/accounts/5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5/counterparties",
+      path: "/api/v1/accounts/5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5/counterparties?limit=20",
     },
     {
       tool: "get_account_counterparties",
@@ -24189,7 +24237,12 @@ describe("MCP account_events-tier subnet/validator activity tools — Postgres t
         ss58: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
         counterparty: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
       },
-      path: "/api/v1/accounts/5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5/counterparties?counterparty=5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+      // `&limit=20` is the tool's own published default, forwarded explicitly
+      // since #10306 rather than left off for the route to re-derive. The route
+      // resolves the same 20 through `pageLimit`, so the ANSWER is unchanged --
+      // what changed is that the page size is now stated by the surface that
+      // advertised it instead of being reapplied downstream.
+      path: "/api/v1/accounts/5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5/counterparties?counterparty=5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty&limit=20",
     },
     {
       tool: "get_account_counterparties",
@@ -25377,15 +25430,22 @@ describe("MCP health-tier analytics tools — Postgres tier wiring", () => {
       args: { netuid: 7, window: "30d" },
       path: "/api/v1/subnets/7/health/incidents?window=30d",
     },
+    // `&limit=20` is #10306, and here it is a BEHAVIOUR change rather than a
+    // restatement: `/api/v1/incidents` publishes no `limit` default, so
+    // forwarding nothing returned every matching row while the tool's own
+    // schema said "Defaults to 20 when omitted". The tool now serves the 20 it
+    // advertises. Same class as the two tools #10306 was filed for -- a
+    // published default that nothing applied -- found by this suite rather
+    // than by the cross-surface sweep.
     {
       tool: "get_global_incidents",
       args: {},
-      path: "/api/v1/incidents?window=7d",
+      path: "/api/v1/incidents?window=7d&limit=20",
     },
     {
       tool: "get_global_incidents",
       args: { window: "30d" },
-      path: "/api/v1/incidents?window=30d",
+      path: "/api/v1/incidents?window=30d&limit=20",
     },
     {
       tool: "get_subnet_uptime",


### PR DESCRIPTION
## A tool that advertises a default and serves something else

Found by the cross-surface sweep (#10217) on its first working run:

```
get_subnet_identity_history   publishes limit 100   served entry_count 0
get_chain_subnet_lifecycle    publishes limit  50   served 100
```

The first is a **confident zero** in the #9803 sense — `entry_count: 0` with no degraded marker reads
as *"this subnet has never changed its identity"*, and SN64 changed it on 2026-07-11. Passing `limit`
explicitly returned the row, so the handler was right and nothing was applying the default.

## Why the chokepoint and not two fixes

#10096 made the published `default` the single source on the REST side — `limitSchema(max, fallback)`
writes it, `routeValue` reads it back, and a handler cannot restate it. MCP dispatch does no schema
validation — settled at #8942 and **not revisited here** — and so consulted nothing, leaving each of
230 handlers to apply its own default or none.

**137 of 230 tools publish at least one default.** Fixing two leaves 135 relying on a handler
remembering. So the fill happens once, in `validateToolArguments`, reading the tool's **own** served
`inputSchema` — not the route's, because several tools deliberately publish a narrower page than
their route (#9701, sized to a context window) and honouring the route there would serve a page the
tool never advertised.

This is not validation. It supplies the value the caller was already told they would get for omitting
the argument.

## Two more the suite found, that the sweep had not

| tool | published | served before |
|---|---|---|
| `get_global_incidents` | `limit` default 20 | every matching row — the route publishes no `limit` default, so forwarding nothing returned all of them |
| `get_account_history` | `limit` 100, `offset` 0 | neither — while its sibling `get_account_events` forwarded both by hand |

Also fixed: a `tools/call` omitting `arguments` entirely returned a bare `{}` and skipped defaults
altogether, and the counterparties `limit` description claimed a second default (`50` in drilldown
mode) that no code applies — the handler reads one `pageLimit(url)` for both branches.

## The gate

`tests/mcp-published-default.test.ts` drives **all 230 served tools** through the dispatch chokepoint
and checks **189 published defaults**. No per-tool list, so a tool added tomorrow is covered the day
it ships. Measured against `listToolDefinitions()` — the served list, not `MCP_TOOLS` (#10280).

**Proven to fail.** With the fill disabled, 3 of its 4 tests go red and name each divergence:

```
search_subnets.limit: publishes 10, handler receives undefined
list_subnets.limit: publishes 50, handler receives undefined
get_subnet_health_percentiles.window: publishes "7d", handler receives undefined
...
```

Two of the four drive the real dispatcher end to end, per the issue's "done when".

## Validation

```
npm run typecheck / lint / format:check   clean
npx vitest run                            18,143 tests — 7 failures triaged below, then green
npm run build                             regenerated openapi.json + api-index.json committed
```

The 7 suite failures were all this change being correct: tests pinning the old forwarded URL. Two
were named *"omits the limit param when not supplied"* — they pinned the defect itself. Both now
assert the forwarded value **read from the served schema** rather than written into the assertion, so
they cannot pass while tool and dispatch disagree.

Closes #10306
