### PR TITLE
refactor(health): put the producer cadence in one place and derive the bounds from it

### DIFF
--- a/src/account-balances-staleness-watchdog.ts
+++ b/src/account-balances-staleness-watchdog.ts
@@ -87,6 +87,7 @@
 // on the case above.
 
 import { laneHealthStore } from "./lane-health-store.ts";
+import { missedTicksMs, passWindowMs } from "./producer-cadence.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { readStore } from "./read-store.ts";
@@ -111,7 +112,10 @@ import { readStore } from "./read-store.ts";
  * Overridable per-deployment via ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS so the
  * number can follow the Container's cadence without a code deploy.
  */
-export const ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS = 12 * 60 * 60 * 1000;
+export const ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS = missedTicksMs(
+  "account_balances",
+  2,
+);
 
 /**
  * How many accounts a COMPLETE pass is expected to write.
@@ -175,7 +179,10 @@ export const ACCOUNT_BALANCES_COVERAGE_FLOOR_ROWS = Math.round(
  * Overridable via ACCOUNT_BALANCES_PASS_WINDOW_MS, which must be re-sized
  * against the poll interval if that interval ever shortens.
  */
-export const ACCOUNT_BALANCES_PASS_WINDOW_MS = 2 * 60 * 60 * 1000;
+export const ACCOUNT_BALANCES_PASS_WINDOW_MS = passWindowMs(
+  "account_balances",
+  1 / 3,
+);
 
 /**
  * One read, answering both questions: how fresh the newest pass is, and how

--- a/src/chain-detail-staleness-watchdog.ts
+++ b/src/chain-detail-staleness-watchdog.ts
@@ -43,6 +43,12 @@ import { readStore } from "./read-store.ts";
  * further behind than that is on its way to a coverage hole, and this is the
  * only warning before recent blocks start declining.
  */
+// NOT DERIVED FROM THIS PRODUCER'S CADENCE, deliberately -- see
+// src/producer-cadence.ts. The lane ticks every ~24s; this bound is a
+// statement about the DOWNSTREAM consumer (the hourly decode lane's ~1h lag
+// that the hot tier covers), so expressing it as N missed ticks of a 24s
+// cadence would be arithmetic that means nothing. Left explicit so "not
+// cadence-derived" reads as a decision rather than an oversight.
 export const CHAIN_DETAIL_STALENESS_THRESHOLD_MS = 20 * 60 * 1000;
 
 export interface ChainDetailStalenessVerdict {

--- a/src/hotkey-alpha-staleness-watchdog.ts
+++ b/src/hotkey-alpha-staleness-watchdog.ts
@@ -61,6 +61,7 @@
 // lanes' names on one fault and send whoever reads it to the wrong producer.
 
 import { laneHealthStore } from "./lane-health-store.ts";
+import { missedTicksMs, passWindowMs } from "./producer-cadence.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { readStore } from "./read-store.ts";
@@ -83,7 +84,10 @@ import { readStore } from "./read-store.ts";
  * Overridable via HOTKEY_ALPHA_STALENESS_THRESHOLD_MS so the number can follow
  * the Container's cadence without a code deploy.
  */
-export const HOTKEY_ALPHA_STALENESS_THRESHOLD_MS = 48 * 60 * 60 * 1000;
+export const HOTKEY_ALPHA_STALENESS_THRESHOLD_MS = missedTicksMs(
+  "hotkey_alpha",
+  2,
+);
 
 /**
  * How much of the referenced pool set a single pass must cover to count.
@@ -107,7 +111,7 @@ export const HOTKEY_ALPHA_COVERAGE_FLOOR_RATIO = 0.8;
  * pass sitting on a complete one sums to full coverage and reports fine, which
  * is the bug reintroduced. Six is a quarter of the interval.
  */
-export const HOTKEY_ALPHA_PASS_WINDOW_MS = 6 * 60 * 60 * 1000;
+export const HOTKEY_ALPHA_PASS_WINDOW_MS = passWindowMs("hotkey_alpha", 1 / 4);
 
 /**
  * One read answering three questions: how fresh the newest pass is, how many

--- a/src/neurons-staleness-watchdog.ts
+++ b/src/neurons-staleness-watchdog.ts
@@ -43,6 +43,7 @@
 // so ~2.9M D1 rows read a day.
 
 import { laneHealthStore } from "./lane-health-store.ts";
+import { missedTicksMs, passWindowMs } from "./producer-cadence.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { readStore } from "./read-store.ts";
@@ -50,7 +51,7 @@ import { readStore } from "./read-store.ts";
 /** Three missed 15-minute ticks: one restart is routine (a deploy or an
  * eviction costs one tick by design), two could be an unlucky pair, three is
  * a stall. */
-export const NEURONS_STALENESS_THRESHOLD_MS = 45 * 60 * 1000;
+export const NEURONS_STALENESS_THRESHOLD_MS = missedTicksMs("metagraph", 3);
 
 /**
  * How many subnets a COMPLETE pass is expected to cover.
@@ -102,7 +103,7 @@ export const NEURONS_COVERAGE_FLOOR_NETUIDS = Math.round(
  * Overridable via NEURONS_PASS_WINDOW_MS, which must be re-sized against the
  * poller's tick if that tick ever changes.
  */
-export const NEURONS_PASS_WINDOW_MS = 5 * 60 * 1000;
+export const NEURONS_PASS_WINDOW_MS = passWindowMs("metagraph", 1 / 3);
 
 /**
  * One read, answering both questions: how fresh the newest pass is, and how

--- a/src/nominator-positions-staleness-watchdog.ts
+++ b/src/nominator-positions-staleness-watchdog.ts
@@ -53,6 +53,7 @@
 // ~6M D1 rows read a day.
 
 import { laneHealthStore } from "./lane-health-store.ts";
+import { missedTicksMs, passWindowMs } from "./producer-cadence.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { readStore } from "./read-store.ts";
@@ -83,7 +84,10 @@ import { readStore } from "./read-store.ts";
  * Overridable per-deployment via NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS so
  * the number can follow the Container's cadence without a code deploy.
  */
-export const NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS = 30 * 60 * 60 * 1000;
+export const NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS = missedTicksMs(
+  "validator_nominators",
+  1.25,
+);
 
 /**
  * How many coldkeys a COMPLETE pass is expected to cover.
@@ -132,7 +136,10 @@ export const NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS = Math.round(
  * Overridable via NOMINATOR_POSITIONS_PASS_WINDOW_MS, which must be re-sized
  * against the poll interval if that interval ever shortens.
  */
-export const NOMINATOR_POSITIONS_PASS_WINDOW_MS = 4 * 60 * 60 * 1000;
+export const NOMINATOR_POSITIONS_PASS_WINDOW_MS = passWindowMs(
+  "validator_nominators",
+  1 / 6,
+);
 
 /**
  * One read, answering both questions: how fresh the newest pass is, and how

--- a/src/producer-cadence.ts
+++ b/src/producer-cadence.ts
@@ -1,0 +1,113 @@
+// How often each producer lane actually runs (#10291).
+//
+// ## The fact this centralises
+//
+// Every staleness watchdog needs one number: its producer's cadence. That
+// number is configured in metagraphed-infra (`*_POLL_SECS`, read by
+// `services/indexer-rs/src/bin/poller/main.rs`) and reached this repo only as
+// PROSE, restated in a doc comment beside each threshold:
+//
+//     * it runs four times less often: `HOTKEY_ALPHA_POLL_SECS` defaults to
+//     * 86400 (24 h) against `account_balances`' 21600 (6 h). Two full
+//     * cadences of slack…
+//     export const HOTKEY_ALPHA_STALENESS_THRESHOLD_MS = 48 * 60 * 60 * 1000;
+//
+// `48h` IS `2 × 86400s`, and nothing in the codebase said so. The arithmetic
+// lived in a sentence, so a reader could not check it and a change to the
+// producer could not invalidate it.
+//
+// #10243 is what that costs: a report proposed cutting hotkey-alpha's bound
+// from 48h to 1–2h, in good faith, because the 24h cadence was not visible
+// anywhere near the constant. Against a 24h producer that alarms for ~22 of
+// every 24 hours on a working lane -- the #9301 regression, re-derived.
+//
+// ## What this is NOT
+//
+// It is not a claim that every threshold should be a multiple of a cadence.
+// Two deliberately are not, and forcing them would be a regression:
+//
+//   - `chain-detail` runs every ~24s but is bounded at 20 MINUTES, sized
+//     against the hourly decode lane's ~1h lag that the hot tier exists to
+//     cover. Its threshold is a statement about a DOWNSTREAM consumer, not
+//     about its own tick.
+//   - `rpc-usage` is bounded at 2h from a MEASURED traffic floor (103
+//     consecutive hours, quietest hour 600 requests) plus one tick of the
+//     hourly watchdog cron -- a different cron from its producer's.
+//
+// Both keep their constants. What changes is that they now say so explicitly,
+// so "not cadence-derived" is a recorded decision rather than something
+// indistinguishable from an oversight.
+//
+// ## Still a copy, and still worth it
+//
+// These seconds are transcribed from infra. That does not go away here -- the
+// honest fix is the producer reporting its own cadence with each pass (#10291
+// option b), which needs an infra change and a column. What this removes is
+// the number being restated once per watchdog in prose that cannot be checked:
+// one place to update, and the multiples become arithmetic a reader can verify.
+
+/**
+ * Producer cadences in SECONDS, transcribed from metagraphed-infra's
+ * `roles/indexer-rust/tasks/main.yml` defaults and the binary's own fallbacks
+ * in `services/indexer-rs/src/bin/poller/main.rs`.
+ *
+ * Keyed by producer, not by watchdog: `nominator-positions` and
+ * `validator-nominator-counts` are two watchdogs over ONE producer, and giving
+ * them one key is what stops them drifting apart.
+ */
+export const PRODUCER_CADENCE_SECS = {
+  /** ACCOUNT_BALANCES_POLL_SECS. Measured 2026-08-09: p50 gap 5.79h, max 6.01h
+   * across 19 passes -- the configured value, confirmed. */
+  account_balances: 21_600,
+  /** HOTKEY_ALPHA_POLL_SECS. Measured 2026-08-09: 13 passes, max gap 23.64h,
+   * never exceeding the interval. The short gaps are container reboots, which
+   * fire every lane's first tick immediately -- see #10243. */
+  hotkey_alpha: 86_400,
+  /** VALIDATOR_NOMINATORS_POLL_SECS. One producer, two watchdogs. */
+  validator_nominators: 86_400,
+  /** METAGRAPH_POLL_SECS. The one cadence buildEnvVars sets unconditionally. */
+  metagraph: 900,
+  /** The top-holders flow materialization, rebuilt daily. */
+  top_holders_flow: 86_400,
+} as const;
+
+export type ProducerLane = keyof typeof PRODUCER_CADENCE_SECS;
+
+/** One producer's cadence in milliseconds. */
+export function cadenceMs(lane: ProducerLane): number {
+  return PRODUCER_CADENCE_SECS[lane] * 1000;
+}
+
+/**
+ * A staleness bound expressed as MISSED TICKS of the producer's own cadence.
+ *
+ * Ticks rather than hours, because ticks is the unit the judgement is actually
+ * in: "two full cadences of slack" survives a change to the producer, "48
+ * hours" does not. Fractional is allowed -- `nominator-positions` sits at 1.25
+ * ticks and forcing it to an integer would change a threshold for the sake of
+ * the abstraction.
+ */
+export function missedTicksMs(lane: ProducerLane, ticks: number): number {
+  return Math.round(cadenceMs(lane) * ticks);
+}
+
+/**
+ * How far back from the newest stamp still counts as "the newest pass".
+ *
+ * MUST stay strictly under the producer's cadence, or two consecutive passes
+ * merge into one coverage count -- a truncated pass sitting on a complete one
+ * then sums to full coverage and reports fine, which is the bug the coverage
+ * clause exists to catch. `tests/producer-cadence.test.ts` asserts that
+ * structurally for every lane rather than leaving it in a comment, which is
+ * where it lived before:
+ *
+ *     "the window must stay under ACCOUNT_BALANCES_POLL_SECS (21600)"
+ *
+ * A string in a test cannot fail.
+ */
+export function passWindowMs(
+  lane: ProducerLane,
+  fractionOfCadence: number,
+): number {
+  return Math.round(cadenceMs(lane) * fractionOfCadence);
+}

--- a/src/rpc-usage-staleness-watchdog.ts
+++ b/src/rpc-usage-staleness-watchdog.ts
@@ -45,6 +45,11 @@ import { RPC_USAGE_DATASET } from "./rpc-usage-capture.ts";
  * real detection lands 2-3 hours after a writer stops, against the day-plus
  * this outage actually ran for.
  */
+// NOT DERIVED FROM THE PRODUCER'S CADENCE, deliberately -- see
+// src/producer-cadence.ts. The 2h is a MEASURED traffic floor (103
+// consecutive hours, quietest 600 requests) plus one tick of the HOURLY
+// WATCHDOG cron -- a different clock from the producer's. Left explicit so the
+// exception is recorded rather than inferred.
 export const RPC_USAGE_STALENESS_THRESHOLD_MS = 2 * 60 * 60 * 1000;
 
 /** How far back the freshness query looks. Bounded so a lane that has been

--- a/src/top-holders-staleness-watchdog.ts
+++ b/src/top-holders-staleness-watchdog.ts
@@ -49,6 +49,7 @@
 // None of them is suppressed, on #9475's reasoning, which stands unchanged.
 
 import { laneHealthStore } from "./lane-health-store.ts";
+import { missedTicksMs } from "./producer-cadence.ts";
 import {
   TOP_HOLDERS_FLOW_PROJECTION_KEY,
   topHoldersFlowRows,
@@ -68,7 +69,10 @@ import { recordExceptionEvent } from "./usage-telemetry.ts";
  *
  * Overridable per-deployment via TOP_HOLDERS_FLOW_STALENESS_THRESHOLD_MS.
  */
-export const TOP_HOLDERS_FLOW_STALENESS_THRESHOLD_MS = 48 * 60 * 60 * 1000;
+export const TOP_HOLDERS_FLOW_STALENESS_THRESHOLD_MS = missedTicksMs(
+  "top_holders_flow",
+  2,
+);
 
 export type TopHoldersStalenessReason =
   "absent" | "unreadable" | "empty" | "stale" | null;

--- a/src/validator-nominator-counts-staleness-watchdog.ts
+++ b/src/validator-nominator-counts-staleness-watchdog.ts
@@ -44,6 +44,7 @@
 // ~5.4M D1 rows read a day.
 
 import { laneHealthStore } from "./lane-health-store.ts";
+import { passWindowMs } from "./producer-cadence.ts";
 import { readStore } from "./read-store.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
@@ -124,7 +125,10 @@ export const VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS = Math.round(
  * Overridable via VALIDATOR_NOMINATOR_COUNTS_PASS_WINDOW_MS, which must be
  * re-sized against the poll interval if that interval ever shortens.
  */
-export const VALIDATOR_NOMINATOR_COUNTS_PASS_WINDOW_MS = 4 * 60 * 60 * 1000;
+export const VALIDATOR_NOMINATOR_COUNTS_PASS_WINDOW_MS = passWindowMs(
+  "validator_nominators",
+  1 / 6,
+);
 
 /**
  * One read, answering both questions: how fresh the newest pass is, and how

--- a/tests/producer-cadence.test.ts
+++ b/tests/producer-cadence.test.ts
@@ -1,0 +1,132 @@
+// Producer cadences, and the invariant that used to live in a string (#10291).
+//
+// Before this, each watchdog restated its producer's cadence in prose beside a
+// hardcoded threshold, and the pass-window rule was asserted as a MESSAGE:
+//
+//     "the window must stay under ACCOUNT_BALANCES_POLL_SECS (21600)"
+//
+// A string cannot fail. This file makes both the arithmetic and the rule
+// checkable, and pins the thresholds against their pre-refactor values so a
+// future edit to the cadence table cannot silently move an alarm.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  PRODUCER_CADENCE_SECS,
+  cadenceMs,
+  missedTicksMs,
+  passWindowMs,
+  type ProducerLane,
+} from "../src/producer-cadence.ts";
+import {
+  ACCOUNT_BALANCES_PASS_WINDOW_MS,
+  ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS,
+} from "../src/account-balances-staleness-watchdog.ts";
+import {
+  HOTKEY_ALPHA_PASS_WINDOW_MS,
+  HOTKEY_ALPHA_STALENESS_THRESHOLD_MS,
+} from "../src/hotkey-alpha-staleness-watchdog.ts";
+import {
+  NEURONS_PASS_WINDOW_MS,
+  NEURONS_STALENESS_THRESHOLD_MS,
+} from "../src/neurons-staleness-watchdog.ts";
+import {
+  NOMINATOR_POSITIONS_PASS_WINDOW_MS,
+  NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS,
+} from "../src/nominator-positions-staleness-watchdog.ts";
+import { VALIDATOR_NOMINATOR_COUNTS_PASS_WINDOW_MS } from "../src/validator-nominator-counts-staleness-watchdog.ts";
+import { TOP_HOLDERS_FLOW_STALENESS_THRESHOLD_MS } from "../src/top-holders-staleness-watchdog.ts";
+
+const HOUR = 60 * 60 * 1000;
+const MINUTE = 60 * 1000;
+
+/** Every pass window, with the producer whose cadence bounds it. */
+const WINDOWS: [string, ProducerLane, number][] = [
+  ["account-balances", "account_balances", ACCOUNT_BALANCES_PASS_WINDOW_MS],
+  ["hotkey-alpha", "hotkey_alpha", HOTKEY_ALPHA_PASS_WINDOW_MS],
+  ["neurons", "metagraph", NEURONS_PASS_WINDOW_MS],
+  [
+    "nominator-positions",
+    "validator_nominators",
+    NOMINATOR_POSITIONS_PASS_WINDOW_MS,
+  ],
+  [
+    "validator-nominator-counts",
+    "validator_nominators",
+    VALIDATOR_NOMINATOR_COUNTS_PASS_WINDOW_MS,
+  ],
+];
+
+describe("a pass window must stay under its producer's cadence", () => {
+  // The rule this file exists for. A window at or above the cadence merges two
+  // consecutive passes into one coverage count -- a truncated pass sitting on
+  // a complete one then sums to full coverage and reports fine, which is
+  // exactly the bug the coverage clause exists to catch.
+  for (const [name, lane, window] of WINDOWS) {
+    test(`${name}: window < ${lane} cadence`, () => {
+      assert.ok(
+        window < cadenceMs(lane),
+        `${name} window ${window}ms is not under the ${cadenceMs(lane)}ms cadence -- ` +
+          "two passes can merge into one coverage count",
+      );
+    });
+  }
+
+  test("the list covers every window that exists", () => {
+    // A watchdog that gains a pass window and is not added here is unguarded,
+    // and the rule is invisible again. Counted rather than described.
+    assert.equal(WINDOWS.length, 5);
+  });
+});
+
+describe("thresholds are unchanged by the refactor", () => {
+  // Pinned against the pre-#10291 literals. These are the numbers production
+  // alarms on; the point of the change was to make the arithmetic visible, not
+  // to move any of them.
+  test("every migrated constant equals its former hardcoded value", () => {
+    assert.equal(ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS, 12 * HOUR);
+    assert.equal(ACCOUNT_BALANCES_PASS_WINDOW_MS, 2 * HOUR);
+    assert.equal(HOTKEY_ALPHA_STALENESS_THRESHOLD_MS, 48 * HOUR);
+    assert.equal(HOTKEY_ALPHA_PASS_WINDOW_MS, 6 * HOUR);
+    assert.equal(NEURONS_STALENESS_THRESHOLD_MS, 45 * MINUTE);
+    assert.equal(NEURONS_PASS_WINDOW_MS, 5 * MINUTE);
+    assert.equal(NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS, 30 * HOUR);
+    assert.equal(NOMINATOR_POSITIONS_PASS_WINDOW_MS, 4 * HOUR);
+    assert.equal(VALIDATOR_NOMINATOR_COUNTS_PASS_WINDOW_MS, 4 * HOUR);
+    assert.equal(TOP_HOLDERS_FLOW_STALENESS_THRESHOLD_MS, 48 * HOUR);
+  });
+});
+
+describe("the cadence table", () => {
+  test("every cadence is a positive whole number of seconds", () => {
+    for (const [lane, secs] of Object.entries(PRODUCER_CADENCE_SECS)) {
+      assert.ok(
+        Number.isInteger(secs) && secs > 0,
+        `${lane} cadence ${secs} is not a positive integer`,
+      );
+    }
+  });
+
+  test("hotkey-alpha runs four times less often than account-balances", () => {
+    // The relationship the prose asserted and nothing checked. It is the whole
+    // reason hotkey-alpha's bound is 48h and its sibling's is 12h, and #10243
+    // proposed cutting the former to 1-2h precisely because this ratio was not
+    // visible anywhere near the constant.
+    assert.equal(
+      PRODUCER_CADENCE_SECS.hotkey_alpha /
+        PRODUCER_CADENCE_SECS.account_balances,
+      4,
+    );
+  });
+
+  test("missedTicksMs is the cadence times the ticks, fractional allowed", () => {
+    // nominator-positions sits at 1.25 ticks; forcing an integer would change
+    // a live threshold for the sake of the abstraction.
+    assert.equal(missedTicksMs("account_balances", 2), 12 * HOUR);
+    assert.equal(missedTicksMs("validator_nominators", 1.25), 30 * HOUR);
+  });
+
+  test("passWindowMs is a fraction of the same cadence", () => {
+    assert.equal(passWindowMs("hotkey_alpha", 1 / 4), 6 * HOUR);
+    assert.equal(passWindowMs("metagraph", 1 / 3), 5 * MINUTE);
+  });
+});


### PR DESCRIPTION
## The arithmetic lived in a sentence

Every staleness watchdog needs one fact — its producer's cadence — and that fact reached this repo only as prose:

```ts
 * it runs four times less often: `HOTKEY_ALPHA_POLL_SECS` defaults to
 * 86400 (24 h) against `account_balances`' 21600 (6 h). Two full cadences…
export const HOTKEY_ALPHA_STALENESS_THRESHOLD_MS = 48 * 60 * 60 * 1000;
```

`48h` **is** `2 × 86400s`, and nothing in the codebase said so. A reader could not check it, and a change to the producer could not invalidate it.

#10243 is what that costs: a report proposed cutting that bound to 1–2h, in good faith, because the 24h cadence was invisible next to the constant. Against a 24h producer that alarms for ~22 of every 24 hours on a working lane — the #9301 regression, re-derived from scratch.

## The issue was partly wrong, and the fix is narrower for it

I filed #10291 claiming eight thresholds should be cadence-derived. Reading each rationale, **two deliberately should not be**, and forcing them would have been a regression:

| watchdog | bound | sized against |
|---|---|---|
| `chain-detail` | 20 min | the **hourly decode lane's** ~1h lag the hot tier covers — its own cadence is ~24s |
| `rpc-usage` | 2 h | a **measured traffic floor** (103 consecutive hours, quietest 600 requests) plus one tick of the *watchdog's* hourly cron |

Both keep their constants and now say so explicitly, so "not cadence-derived" reads as a decision rather than an oversight. Expressing `chain-detail` as N ticks of 24s would be arithmetic that means nothing.

## What changed

`src/producer-cadence.ts` holds the five cadences once, keyed **by producer, not by watchdog** — `nominator-positions` and `validator-nominator-counts` watch one producer, and one key is what stops them drifting. Six constants across five watchdogs became `missedTicksMs(lane, ticks)` / `passWindowMs(lane, fraction)`.

Fractional ticks are allowed on purpose: `nominator-positions` sits at 1.25, and rounding it to an integer would move a live threshold for the sake of the abstraction.

## Every value is byte-identical

This is a pure refactor and the PR proves it rather than asserting it — all ten constants pinned against their pre-refactor literals:

```
account-balances threshold   43200000 == 43200000
hotkey-alpha threshold      172800000 == 172800000
neurons threshold             2700000 == 2700000
nominator-positions thr     108000000 == 108000000
…                                  ALL VALUES UNCHANGED
```

## The rule that was a string

The pass-window invariant lived in a test *message*:

```ts
"the window must stay under ACCOUNT_BALANCES_POLL_SECS (21600)"
```

A string cannot fail. It is now structural for all five windows: a window at or above its cadence merges two consecutive passes into one coverage count, so a truncated pass sitting on a complete one sums to full coverage and reports fine — the exact bug the coverage clause exists to catch.

**Verified it fails when violated.** Widening hotkey-alpha's window to a full cadence turns both guards red:

```
× hotkey-alpha: window < hotkey_alpha cadence
× every migrated constant equals its former hardcoded value
```

## Still a copy

These seconds are transcribed from infra, and that does not go away here. The honest end state is the producer reporting its own cadence with each pass (#10291's option b), which needs an infra change and a column, and would degrade to this table when absent. What this removes is the number being restated once per watchdog in prose nothing can check.

## Validation

```
npx vitest run    775 files, 18,139 passed, 11 skipped
new tests         11 — the window invariant per lane, the value pins, the
                  4× hotkey-alpha/account-balances ratio the prose asserted
                  and nothing checked
build / typecheck / lint / format / validate / validate:api /
validate:contract-drift                                        clean
```

Closes #10291
