### PR TITLE
feat(conformance): time every published operation (#10220)

### DIFF
--- a/.github/workflows/check-operation-latency.yml
+++ b/.github/workflows/check-operation-latency.yml
@@ -1,0 +1,66 @@
+name: Check operation latency
+
+# How long does every published operation actually take? (#10220)
+#
+# Six of 624 operations had ever been timed -- the six in #9789, each found by
+# hand after someone noticed a slow call. This times all of them: every REST
+# route with a subject, every MCP tool the live server advertises, every
+# GraphQL Query field.
+#
+# ONE SAMPLE EACH, so the budget is deliberately loose (5s). The point is to
+# catch the ten-second operation and to build a daily series, not to police
+# 300ms against 500ms -- a tighter budget would fail on weather.
+#
+# Out of band rather than in CI, for the same reason its four siblings are: it
+# needs production, and a check that cannot run on a pull request should not
+# pretend to.
+on:
+  schedule:
+    # Daily, and LAST of the five: after check-response-conformance (06:41),
+    # check-mcp-conformance (07:17), check-graphql-conformance (07:53) and
+    # check-cross-surface-values (08:31). A sweep measuring latency must not
+    # share the Worker with a sweep generating load, or it times the sibling.
+    - cron: "23 9 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-operation-latency
+  cancel-in-progress: false
+
+jobs:
+  latency:
+    name: Time every published operation
+    runs-on: ubuntu-latest
+    # ~620 serial calls at 1.6s spacing is ~17 minutes of spacing alone, plus
+    # the calls themselves; the ceiling leaves room for the slow tail without
+    # letting a hung fetch hold a runner all day.
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.2
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Time every operation
+        run: |
+          node scripts/check-operation-latency.ts | tee latency.log
+          {
+            echo '## Operation latency'
+            echo '```'
+            cat latency.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/check-cross-surface-values.ts
+++ b/scripts/check-cross-surface-values.ts
@@ -25,6 +25,7 @@ import { buildSchema } from "graphql";
 import { SDL } from "../src/graphql-sdl.ts";
 import { MCP_TOOL_ROUTES } from "../src/mcp-route-map.ts";
 import { planAll, type FieldPlan } from "./check-graphql-conformance.ts";
+import { concreteRoute, toolArguments } from "./conformance-subjects.ts";
 
 type Row = Record<string, unknown>;
 
@@ -201,57 +202,6 @@ async function mcpTool(name: string, args: Row): Promise<Row | null> {
 }
 
 /**
- * The four spellings one SS58 path parameter takes across the route table, and
- * the subject every surface is asked about.
- *
- * The PATTERN is built from the array rather than written as a literal
- * alternation. `scan:public-safety` allows a quoted field name and refuses a
- * bare one inside a regex alternation -- correctly, since an alternation is
- * exactly where a bare mention would hide from a reviewer. Deriving the
- * pattern from the array also means the fixture and the pattern cannot drift.
- */
-const ACCOUNT_PARAMETER_NAMES = ["ss58", "hotkey", "coldkey", "address"];
-const ACCOUNT_PATH_PARAMETERS = new RegExp(
-  `\\{(?:${ACCOUNT_PARAMETER_NAMES.join(String.fromCharCode(124))})\\}`,
-  "g",
-);
-const ACCOUNT_FIXTURE = "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3";
-
-/**
- * The path a route template takes once its parameters are filled from the same
- * fixtures the GraphQL sweep uses, or null when a parameter has no fixture.
- *
- * Shared subjects, deliberately: a triple compared with three different
- * subjects compares nothing.
- */
-export function concreteRoute(template: string): string | null {
-  const filled = template
-    .replace("{netuid}", "64")
-    .replace("{uid}", "0")
-    .replace(ACCOUNT_PATH_PARAMETERS, ACCOUNT_FIXTURE)
-    .replace("{ref}", "4200000")
-    .replace("{slug}", "opentensor-foundation")
-    .replace("{date}", "2026-08-01")
-    .replace("{crowdloan_id}", "0");
-  return filled.includes("{") ? null : filled;
-}
-
-/** Arguments for the MCP tool that mirrors this route. */
-export function toolArgumentsFor(template: string): Row {
-  const args: Row = {};
-  if (template.includes("{netuid}")) args.netuid = 64;
-  if (template.includes("{uid}")) args.uid = 0;
-  for (const key of ACCOUNT_PARAMETER_NAMES) {
-    if (template.includes(`{${key}}`)) args[key] = ACCOUNT_FIXTURE;
-  }
-  if (template.includes("{ref}")) args.ref = "4200000";
-  if (template.includes("{slug}")) args.slug = "opentensor-foundation";
-  if (template.includes("{date}")) args.date = "2026-08-01";
-  if (template.includes("{crowdloan_id}")) args.crowdloan_id = 0;
-  return args;
-}
-
-/**
  * Compare the top level of two answers to one question.
  *
  * SCALARS AND EMPTINESS only. A number that differs is the #10246 shape; an
@@ -345,7 +295,7 @@ export async function run(): Promise<CrossSurfaceReport> {
 
     const rest = await restBody(path);
     await sleep(CALL_SPACING_MS);
-    const mcp = await mcpTool(tool, toolArgumentsFor(template));
+    const mcp = await mcpTool(tool, toolArguments(template));
     await sleep(CALL_SPACING_MS);
     const graphql = await graphqlField(plan);
     await sleep(CALL_SPACING_MS);

--- a/scripts/check-operation-latency.ts
+++ b/scripts/check-operation-latency.ts
@@ -1,0 +1,466 @@
+// How long does every published operation actually take? (#10220)
+//
+// Performance had been measured on SIX operations out of 624 -- the six named
+// in #9789, found by hand when someone noticed a slow call. Nothing had ever
+// timed the other 618, so "which of our endpoints is slow" was answerable only
+// for the ones somebody had already complained about.
+//
+// WHAT IT TIMES. Every REST route in `API_ROUTES` and `FEED_ROUTES` whose path
+// parameters have a subject, every MCP tool the live server advertises whose
+// required arguments have one, and every GraphQL Query field the conformance
+// sweep can plan -- one call each, wall clock, serial.
+//
+// The subjects come from `conformance-subjects.ts`, shared with the
+// cross-surface sweep, and a route whose parameter has no subject is SKIPPED
+// rather than filled with a placeholder. Timing `/api/v1/subnets/x/ohlc` times
+// a 404 and reports the route as broken.
+//
+// ONE CALL EACH, NOT A BENCHMARK, and the report says so. A single sample
+// cannot separate a slow operation from a cold isolate or a noisy hop, which is
+// why the budget below is deliberately loose: it exists to catch the ten-second
+// operation, not to police the difference between 300ms and 500ms. Anything
+// tighter would fail on weather.
+//
+// SERIAL AND SPACED, for the reason the MCP sweep records: the endpoint
+// rate-limits per client, and a parallel run turns healthy operations into
+// `Too many MCP requests` -- a sweep manufacturing failures that read exactly
+// like real defects.
+//
+// Out of band, like its siblings: it needs production, and a check that cannot
+// run on a pull request should not pretend to.
+import { buildSchema } from "graphql";
+import { API_ROUTES, FEED_ROUTES } from "../src/contracts.ts";
+import { SDL } from "../src/graphql-sdl.ts";
+import { planAll, type FieldPlan } from "./check-graphql-conformance.ts";
+import { argumentsForRequired, concreteRoute } from "./conformance-subjects.ts";
+
+type Row = Record<string, unknown>;
+
+const REST_ORIGIN = process.env.REST_ORIGIN ?? "https://api.metagraph.sh";
+const MCP_ENDPOINT = process.env.MCP_ENDPOINT ?? "https://api.metagraph.sh/mcp";
+const GRAPHQL_ENDPOINT =
+  process.env.GRAPHQL_ENDPOINT ?? "https://api.metagraph.sh/api/v1/graphql";
+const CALL_SPACING_MS = Number(process.env.LATENCY_SPACING_MS ?? 1600);
+const REQUEST_TIMEOUT_MS = 45000;
+
+/**
+ * The ceiling an operation may not cross, in milliseconds.
+ *
+ * FIVE SECONDS because that is the number #9789 was filed against and the one
+ * an agent's own timeout is usually set near -- past it, a caller gives up
+ * rather than waits. Loose on purpose: one sample per operation cannot tell a
+ * slow query from a cold start, so a tight budget would report weather.
+ */
+const BUDGET_MS = Number(process.env.LATENCY_BUDGET_MS ?? 5000);
+
+/**
+ * How far under budget an operation must come in before its DECLARED entry is
+ * called stale, as a fraction of the budget.
+ *
+ * The "a stale entry FAILS" idiom is what stops an exemption list growing
+ * quietly, and every other gate in this repo uses it unconditionally because
+ * every other gate is DETERMINISTIC. Latency is not. An operation declared at
+ * 5306ms that happens to answer in 4900ms tomorrow is the same operation, and
+ * failing the run for it would report weather -- the exact thing the loose
+ * budget above exists to avoid, reintroduced through the back door.
+ *
+ * So the list still cannot hold an entry that stopped being true, but "stopped
+ * being true" means comfortably under rather than a millisecond under. A
+ * genuinely fixed operation lands far below the line; a borderline one does
+ * not flap.
+ */
+const STALE_MARGIN = 0.5;
+
+/**
+ * Operations known to exceed the budget, each with the issue that owns it.
+ *
+ * The list must SHRINK: an entry whose operation now answers well under budget
+ * (see STALE_MARGIN) fails this script, so a fix cannot leave a stale exemption
+ * behind -- the same idiom the MCP input-parity, vocabulary and cross-surface
+ * gates use.
+ *
+ * SEEDED FROM A REAL RUN, 2026-08-09, not from reading the code, and the
+ * milliseconds are recorded so the next reader can see whether an entry is
+ * drifting rather than merely present. All 30 belong to #10312, and they are
+ * not 30 independent problems: 21 of them are the ACCOUNT family and its
+ * mirrors on the other two surfaces -- the same read, timed three times.
+ */
+const DECLARED: Record<string, string> = {
+  "graphql:account_transfers":
+    "#10312 -- 12590ms on the run that seeded this list",
+  "graphql:account_counterparties":
+    "#10312 -- 11986ms on the run that seeded this list",
+  "graphql:account_history":
+    "#10312 -- 10227ms on the run that seeded this list",
+  "graphql:validator_nominators":
+    "#10312 -- 8348ms on the run that seeded this list",
+  "graphql:account_extrinsics":
+    "#10312 -- 6822ms on the run that seeded this list",
+  "graphql:account_events": "#10312 -- 6122ms on the run that seeded this list",
+  "graphql:subnet_weight_setters":
+    "#10312 -- 5306ms on the run that seeded this list",
+  "mcp:get_account_counterparties":
+    "#10312 -- 15416ms on the run that seeded this list",
+  "mcp:get_account_history":
+    "#10312 -- 11670ms on the run that seeded this list",
+  "mcp:get_account_transfers":
+    "#10312 -- 9877ms on the run that seeded this list",
+  "mcp:get_subnet_weight_setters":
+    "#10312 -- 7760ms on the run that seeded this list",
+  "mcp:get_account": "#10312 -- 7481ms on the run that seeded this list",
+  "mcp:get_validator_nominators":
+    "#10312 -- 7299ms on the run that seeded this list",
+  "mcp:get_subnet_ownership_history":
+    "#10312 -- 7231ms on the run that seeded this list",
+  "mcp:get_sudo": "#10312 -- 6973ms on the run that seeded this list",
+  "mcp:get_account_stake_flow":
+    "#10312 -- 5907ms on the run that seeded this list",
+  "mcp:get_account_events": "#10312 -- 5512ms on the run that seeded this list",
+  "mcp:get_subnet_events": "#10312 -- 5295ms on the run that seeded this list",
+  "rest:/api/v1/accounts/{ss58}/transfers":
+    "#10312 -- 11101ms on the run that seeded this list",
+  "rest:/api/v1/accounts/{ss58}/history":
+    "#10312 -- 9038ms on the run that seeded this list",
+  "rest:/api/v1/accounts/{ss58}":
+    "#10312 -- 7855ms on the run that seeded this list",
+  "rest:/api/v1/subnets/{netuid}/event-summary":
+    "#10312 -- 7798ms on the run that seeded this list",
+  "rest:/api/v1/accounts/{ss58}/extrinsics":
+    "#10312 -- 7464ms on the run that seeded this list",
+  "rest:/api/v1/accounts/{ss58}/counterparties":
+    "#10312 -- 6760ms on the run that seeded this list",
+  "rest:/api/v1/subnets/{netuid}/events":
+    "#10312 -- 6700ms on the run that seeded this list",
+  "rest:/api/v1/accounts/{ss58}/events":
+    "#10312 -- 6548ms on the run that seeded this list",
+  "rest:/api/v1/subnets/{netuid}/ohlc":
+    "#10312 -- 6428ms on the run that seeded this list",
+  "rest:/api/v1/accounts/{ss58}/weight-setters":
+    "#10312 -- 6366ms on the run that seeded this list",
+  "rest:/api/v1/validators/{hotkey}/nominators":
+    "#10312 -- 6095ms on the run that seeded this list",
+  "rest:/api/v1/subnets/{netuid}/ownership-history":
+    "#10312 -- 5642ms on the run that seeded this list",
+};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * What came back, in the only three categories a latency sweep can act on.
+ *
+ * `unaskable` is the one worth explaining. The first full run reported 24
+ * operations as "did not answer", and the two spot-checked were both THIS
+ * SWEEP'S fault: `/api/v1/ask` is POST-only and answered 405, and
+ * `/api/v1/providers/{slug}` 404'd because the subject was not a real provider
+ * id. A sweep whose failure list is mostly its own bad questions trains the
+ * reader to ignore the list -- so a 4xx, which is the server saying the REQUEST
+ * was wrong, is separated from a 5xx/timeout, which is the server failing to
+ * answer a fair one. Only the second is the operation's problem.
+ */
+type Answer = "ok" | "unaskable" | "failed";
+
+export interface Timing {
+  surface: "rest" | "mcp" | "graphql";
+  operation: string;
+  ms: number;
+  answer: Answer;
+}
+
+export interface LatencyReport {
+  timings: Timing[];
+  overBudget: Timing[];
+  failed: Timing[];
+  /** Calls the sweep could not pose properly -- its problem, not the API's. */
+  unaskable: Timing[];
+  stale: string[];
+}
+
+export const key = (timing: Pick<Timing, "surface" | "operation">): string =>
+  `${timing.surface}:${timing.operation}`;
+
+/** A 4xx says the question was wrong; anything else here is the answer's fault. */
+const classify = (status: number): Answer =>
+  status >= 200 && status < 300
+    ? "ok"
+    : status >= 400 && status < 500
+      ? "unaskable"
+      : "failed";
+
+async function timed(run: () => Promise<Answer>): Promise<[number, Answer]> {
+  const started = Date.now();
+  let answer: Answer;
+  try {
+    answer = await run();
+  } catch {
+    // A throw is a call that did not answer at all -- a timeout or a dropped
+    // connection, which is the operation's problem however it is spelled.
+    answer = "failed";
+  }
+  return [Date.now() - started, answer];
+}
+
+function withTimeout(): [AbortSignal, () => void] {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  return [controller.signal, () => clearTimeout(timer)];
+}
+
+async function timeRest(path: string): Promise<[number, Answer]> {
+  return timed(async () => {
+    const [signal, done] = withTimeout();
+    try {
+      const res = await fetch(`${REST_ORIGIN}${path}`, { signal });
+      // Drain the body: a route is not "done" until its bytes are, and the
+      // biggest answers here are the whole point (#10318 was 486 KB).
+      await res.arrayBuffer();
+      return classify(res.status);
+    } finally {
+      done();
+    }
+  });
+}
+
+/**
+ * MCP error codes that mean the ARGUMENTS were wrong rather than the tool.
+ *
+ * An MCP failure is a 200 with `isError`, so HTTP status cannot make this
+ * distinction the way it can for REST -- the code in the body is the only
+ * signal, and these are the two the dispatcher raises for a question it cannot
+ * accept (`src/mcp-server.ts`'s `toolError("invalid_params", ...)` and the
+ * not-found path behind it).
+ */
+const UNASKABLE_MCP_CODES = new Set(["invalid_params", "not_found"]);
+
+let rpcId = 0;
+async function timeMcp(name: string, args: Row): Promise<[number, Answer]> {
+  return timed(async () => {
+    const [signal, done] = withTimeout();
+    try {
+      const res = await fetch(MCP_ENDPOINT, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: (rpcId += 1),
+          method: "tools/call",
+          params: { name, arguments: args },
+        }),
+        signal,
+      });
+      if (!res.ok) return classify(res.status);
+      const body = (await res.json()) as Row;
+      const result = body?.result as Row | undefined;
+      if (!result) return "failed";
+      if (!result.isError) return "ok";
+      const structured = (result.structuredContent ?? {}) as Row;
+      const code = String((structured.error as Row | undefined)?.code ?? "");
+      return UNASKABLE_MCP_CODES.has(code) ? "unaskable" : "failed";
+    } finally {
+      done();
+    }
+  });
+}
+
+async function timeGraphql(plan: FieldPlan): Promise<[number, Answer]> {
+  return timed(async () => {
+    const [signal, done] = withTimeout();
+    try {
+      const res = await fetch(GRAPHQL_ENDPOINT, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ query: plan.query }),
+        signal,
+      });
+      if (!res.ok) return classify(res.status);
+      const body = (await res.json()) as Row;
+      if (body?.data) return "ok";
+      // A GraphQL error with BAD_USER_INPUT is this sweep's argument fixture
+      // being wrong, the same class as a REST 400.
+      const errors = (body?.errors ?? []) as Row[];
+      const badInput = errors.some(
+        (error) =>
+          ((error?.extensions ?? {}) as Row).code === "BAD_USER_INPUT" ||
+          ((error?.extensions ?? {}) as Row).code ===
+            "GRAPHQL_VALIDATION_FAILED",
+      );
+      return badInput ? "unaskable" : "failed";
+    } finally {
+      done();
+    }
+  });
+}
+
+/** Every tool the live server advertises, following tools/list pagination. */
+async function listLiveTools(): Promise<{ name: string; args: Row }[]> {
+  const tools: { name: string; args: Row }[] = [];
+  let cursor: string | undefined;
+  do {
+    const [signal, done] = withTimeout();
+    let body: Row;
+    try {
+      const res = await fetch(MCP_ENDPOINT, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: (rpcId += 1),
+          method: "tools/list",
+          params: cursor ? { cursor } : {},
+        }),
+        signal,
+      });
+      body = (await res.json()) as Row;
+    } finally {
+      done();
+    }
+    const result = (body?.result ?? {}) as Row;
+    for (const tool of (result.tools ?? []) as Row[]) {
+      const schema = (tool.inputSchema ?? {}) as Row;
+      const args = argumentsForRequired((schema.required ?? []) as string[]);
+      if (args) tools.push({ name: String(tool.name), args });
+    }
+    cursor = result.nextCursor as string | undefined;
+    if (cursor) await sleep(CALL_SPACING_MS);
+  } while (cursor);
+  return tools;
+}
+
+export async function run(): Promise<LatencyReport> {
+  const timings: Timing[] = [];
+
+  for (const route of [...API_ROUTES, ...FEED_ROUTES]) {
+    // GET only. `/api/v1/ask` is the one POST route in the table, and asking it
+    // with a GET times a 405 -- the sweep measuring its own wrong verb.
+    if (route.method !== "GET") continue;
+    const path = concreteRoute(route.path);
+    if (path === null) continue;
+    const [ms, answer] = await timeRest(path);
+    timings.push({ surface: "rest", operation: route.path, ms, answer });
+    process.stderr.write(`rest ${ms}ms ${answer} ${route.path}\n`);
+    await sleep(CALL_SPACING_MS);
+  }
+
+  for (const tool of await listLiveTools()) {
+    const [ms, answer] = await timeMcp(tool.name, tool.args);
+    timings.push({ surface: "mcp", operation: tool.name, ms, answer });
+    process.stderr.write(`mcp ${ms}ms ${answer} ${tool.name}\n`);
+    await sleep(CALL_SPACING_MS);
+  }
+
+  const { plans } = planAll(buildSchema(SDL));
+  for (const plan of plans) {
+    const [ms, answer] = await timeGraphql(plan);
+    timings.push({ surface: "graphql", operation: plan.field, ms, answer });
+    process.stderr.write(`graphql ${ms}ms ${answer} ${plan.field}\n`);
+    await sleep(CALL_SPACING_MS);
+  }
+
+  return summarise(timings);
+}
+
+/** The verdict, split out so a recorded run can be re-scored without calling. */
+export function summarise(timings: Timing[]): LatencyReport {
+  const overBudget = timings.filter(
+    (timing) =>
+      timing.answer === "ok" && timing.ms > BUDGET_MS && !DECLARED[key(timing)],
+  );
+  // An entry stays warranted while its operation is still anywhere near the
+  // line, and an operation this run could not ASK keeps its entry too -- a 4xx
+  // from a bad subject is not evidence the operation got faster.
+  const stillSlow = new Set(
+    timings
+      .filter(
+        (timing) =>
+          timing.answer !== "ok" || timing.ms > BUDGET_MS * STALE_MARGIN,
+      )
+      .map(key)
+      .filter((name) => DECLARED[name]),
+  );
+  return {
+    timings,
+    overBudget,
+    // A FAILED call is not a slow one, and mixing them would bury both -- the
+    // conformance sweeps are what report an operation that declines.
+    failed: timings.filter((timing) => timing.answer === "failed"),
+    unaskable: timings.filter((timing) => timing.answer === "unaskable"),
+    stale: Object.keys(DECLARED).filter((name) => !stillSlow.has(name)),
+  };
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const index = Math.min(
+    sorted.length - 1,
+    Math.floor((p / 100) * sorted.length),
+  );
+  return sorted[index];
+}
+
+export function formatReport(report: LatencyReport): string {
+  const lines: string[] = [];
+  for (const surface of ["rest", "mcp", "graphql"] as const) {
+    const ms = report.timings
+      .filter((timing) => timing.surface === surface && timing.answer === "ok")
+      .map((timing) => timing.ms)
+      .sort((a, b) => a - b);
+    if (ms.length === 0) continue;
+    lines.push(
+      `${surface}: ${ms.length} timed, p50 ${percentile(ms, 50)}ms, ` +
+        `p90 ${percentile(ms, 90)}ms, p99 ${percentile(ms, 99)}ms, max ${ms[ms.length - 1]}ms`,
+    );
+  }
+  const slowest = [...report.timings]
+    .filter((timing) => timing.answer === "ok")
+    .sort((a, b) => b.ms - a.ms)
+    .slice(0, 15);
+  lines.push("", "slowest 15:");
+  for (const timing of slowest) {
+    lines.push(
+      `  ${String(timing.ms).padStart(6)}ms  ${timing.surface}  ${timing.operation}`,
+    );
+  }
+  if (report.failed.length > 0) {
+    lines.push("", `${report.failed.length} operation(s) did not answer:`);
+    for (const timing of report.failed.slice(0, 30)) {
+      lines.push(`  ${timing.surface}  ${timing.operation}`);
+    }
+  }
+  if (report.unaskable.length > 0) {
+    lines.push(
+      "",
+      `${report.unaskable.length} could not be asked (4xx -- this sweep's subject or arguments, not the operation):`,
+    );
+    for (const timing of report.unaskable.slice(0, 30)) {
+      lines.push(`  ${timing.surface}  ${timing.operation}`);
+    }
+  }
+  if (report.overBudget.length > 0) {
+    lines.push(
+      "",
+      `${report.overBudget.length} over the ${BUDGET_MS}ms budget:`,
+    );
+    for (const timing of report.overBudget) {
+      lines.push(`  ${timing.ms}ms  ${timing.surface}  ${timing.operation}`);
+    }
+  }
+  if (report.stale.length > 0) {
+    lines.push(
+      "",
+      `${report.stale.length} stale DECLARED entr(y/ies) -- now comfortably under budget, delete them:`,
+    );
+    for (const name of report.stale) lines.push(`  ${name}`);
+  }
+  return lines.join("\n");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const report = await run();
+  console.log(formatReport(report));
+  if (report.overBudget.length > 0 || report.stale.length > 0) process.exit(1);
+}

--- a/scripts/conformance-subjects.ts
+++ b/scripts/conformance-subjects.ts
@@ -1,0 +1,122 @@
+// The production subjects every out-of-band sweep asks about (#10220).
+//
+// A sweep that compares three surfaces has to ask all three about the SAME
+// entity, or it compares nothing -- and a sweep that times an operation has to
+// ask about an entity production actually holds data for, or it times a 404.
+// Both needs are the same table, and before this file each sweep carried its
+// own copy of it.
+//
+// NOT `tests/concrete-path.ts`, and the two must not be merged. That helper
+// fills every remaining placeholder with "x" because its job is "a path the
+// ROUTER will match" -- shape-valid is the whole requirement, and a value that
+// matches no row is fine. This table's job is "a path production ANSWERS", so
+// an unfixtured parameter must make the sweep decline the route rather than
+// call it with a subject that does not exist. Same-looking strings, opposite
+// contracts.
+//
+// ONE TABLE, three readers. `concreteRoute` fills a REST path, `toolArguments`
+// fills an MCP tool call from the route template it mirrors, and
+// `argumentsForRequired` fills one from a tool's own `required` list. All three
+// read `SUBJECTS`, so a subject cannot be right on one surface and stale on
+// another -- which is exactly the divergence these sweeps exist to catch.
+
+type Row = Record<string, unknown>;
+
+/**
+ * The four spellings one SS58 path parameter takes across the route table.
+ *
+ * Kept as an ARRAY rather than a regex alternation. `scan:public-safety`
+ * allows a quoted field name and refuses a bare one inside an alternation --
+ * correctly, since an alternation is exactly where a bare mention would hide
+ * from a reviewer.
+ */
+const ACCOUNT_PARAMETER_NAMES = ["ss58", "hotkey", "coldkey", "address"];
+
+/** A public on-chain account with history on every account-scoped route. */
+const ACCOUNT_FIXTURE = "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3";
+
+/**
+ * Every path/argument parameter a sweep knows a real subject for.
+ *
+ * A parameter ABSENT here is the signal to skip: `concreteRoute` returns null
+ * and `argumentsForRequired` returns null, so an operation is never called
+ * with a made-up subject and then reported as slow or divergent when the only
+ * thing wrong was the question.
+ */
+export const SUBJECTS: Readonly<
+  Record<string, string | number | readonly number[]>
+> = {
+  netuid: 64,
+  uid: 0,
+  ref: "4200000",
+  // A provider that EXISTS. `opentensor-foundation` -- the subject both sweeps
+  // carried before this file -- is not a provider id, and
+  // `/api/v1/providers/opentensor-foundation` 404s with `artifact_not_found`.
+  // The cross-surface sweep had been declining that route and its endpoints
+  // sibling for that reason, reported as "did not answer". A provider's
+  // identifier is its `id` (`academia`, `allways`, `404-gen`), not a separate
+  // slug field, which is what made the wrong guess look plausible.
+  slug: "academia",
+  date: "2026-08-01",
+  crowdloan_id: 0,
+  query: "inference",
+  q: "inference",
+  // The two PLURAL arguments, which only the comparison tools take. No route
+  // spells either as a path parameter, so they exist for
+  // `argumentsForRequired` alone.
+  netuids: [1, 64],
+  hotkeys: ACCOUNT_FIXTURE,
+  ...Object.fromEntries(
+    ACCOUNT_PARAMETER_NAMES.map((name) => [name, ACCOUNT_FIXTURE]),
+  ),
+};
+
+/** The parameter names a route template still carries, `{netuid}` → `netuid`. */
+function placeholders(template: string): string[] {
+  return [...template.matchAll(/\{([^}]+)\}/g)].map((match) => match[1]);
+}
+
+/**
+ * The path a route template takes once its parameters are filled, or null when
+ * any parameter has no subject.
+ *
+ * Null rather than a best-effort fill: a sweep that calls
+ * `/api/v1/subnets/x/ohlc` gets a 404 and reports it as the route failing,
+ * which reads exactly like a real outage.
+ */
+export function concreteRoute(template: string): string | null {
+  let filled = template;
+  for (const name of placeholders(template)) {
+    const subject = SUBJECTS[name];
+    if (subject === undefined) return null;
+    filled = filled.replace(`{${name}}`, String(subject));
+  }
+  return filled;
+}
+
+/** Arguments for the MCP tool that mirrors this route template. */
+export function toolArguments(template: string): Row {
+  const args: Row = {};
+  for (const name of placeholders(template)) {
+    if (SUBJECTS[name] !== undefined) args[name] = SUBJECTS[name];
+  }
+  return args;
+}
+
+/**
+ * Arguments satisfying a tool's own `required` list, or null when one of them
+ * has no subject.
+ *
+ * The by-name entry point, for a sweep reading `tools/list` rather than the
+ * route table. A tool that declines for a missing required argument would be
+ * timing our own bad call.
+ */
+export function argumentsForRequired(required: string[]): Row | null {
+  const args: Row = {};
+  for (const name of required) {
+    const subject = SUBJECTS[name];
+    if (subject === undefined) return null;
+    args[name] = subject;
+  }
+  return args;
+}

--- a/tests/operation-latency-verdict.test.ts
+++ b/tests/operation-latency-verdict.test.ts
@@ -1,0 +1,92 @@
+// The latency sweep's VERDICT, without calling production (#10220).
+//
+// The sweep itself is out of band -- it needs the deployed surface and ~620
+// serial calls -- so what runs in CI is the part that decides. `summarise` is
+// split out of `run` for exactly this: feed it recorded timings and check that
+// each of the four rulings is the one a reader would expect.
+//
+// Worth having because three of those rulings are easy to get subtly wrong, and
+// two of them WERE wrong in the first draft of this script: a 4xx counted as
+// "the operation failed" when it means "the sweep asked badly", and a declared
+// entry went stale the moment its operation dipped a millisecond under budget,
+// which for a stochastic measurement is a gate that fails on weather.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { summarise, type Timing } from "../scripts/check-operation-latency.ts";
+
+/** A declared operation, so the fixtures below name something real. */
+const DECLARED_OPERATION = "mcp:get_account_counterparties";
+const [DECLARED_SURFACE, DECLARED_NAME] = ["mcp", "get_account_counterparties"];
+
+const timing = (over: Partial<Timing> = {}): Timing => ({
+  surface: "rest",
+  operation: "/api/v1/subnets",
+  ms: 100,
+  answer: "ok",
+  ...over,
+});
+
+describe("what the latency sweep rules on", () => {
+  test("an undeclared operation over budget is reported", () => {
+    const report = summarise([timing({ ms: 9000 })]);
+    assert.equal(report.overBudget.length, 1);
+    assert.equal(report.overBudget[0].operation, "/api/v1/subnets");
+  });
+
+  test("a declared operation over budget is not", () => {
+    const report = summarise([
+      timing({ surface: "mcp", operation: DECLARED_NAME, ms: 9000 }),
+    ]);
+    assert.deepEqual(report.overBudget, []);
+    assert.ok(
+      !report.stale.includes(DECLARED_OPERATION),
+      "still slow, so still warranted",
+    );
+  });
+
+  test("a declared operation just under budget is NOT stale", () => {
+    // 4900ms against a 5000ms budget is the same operation having a good run.
+    // Calling that stale is how a stochastic gate starts failing on weather.
+    const report = summarise([
+      timing({ surface: "mcp", operation: DECLARED_NAME, ms: 4900 }),
+    ]);
+    assert.ok(!report.stale.includes(DECLARED_OPERATION));
+  });
+
+  test("a declared operation comfortably under budget IS stale", () => {
+    // 400ms against a 5000ms budget is a fix, not a good run, and the entry
+    // has to come out or the list stops meaning anything.
+    const report = summarise([
+      timing({ surface: "mcp", operation: DECLARED_NAME, ms: 400 }),
+    ]);
+    assert.ok(
+      report.stale.includes(DECLARED_OPERATION),
+      `expected ${DECLARED_OPERATION} to be stale, got ${report.stale.length} stale`,
+    );
+  });
+
+  test("a 4xx is the sweep's bad question, not a failure or a slow answer", () => {
+    const report = summarise([
+      timing({ ms: 9000, answer: "unaskable" }),
+      timing({ operation: "/api/v1/other", ms: 20, answer: "failed" }),
+    ]);
+    assert.deepEqual(report.overBudget, [], "an unasked call is not slow");
+    assert.equal(report.failed.length, 1, "only the 5xx is a failure");
+    assert.equal(report.unaskable.length, 1);
+    assert.equal(report.failed[0].operation, "/api/v1/other");
+  });
+
+  test("an operation that could not be asked keeps its declared entry", () => {
+    // A 404 from a subject that no longer exists says nothing about speed, so
+    // treating it as "under budget" would delete a warranted exemption.
+    const report = summarise([
+      timing({
+        surface: DECLARED_SURFACE as Timing["surface"],
+        operation: DECLARED_NAME,
+        ms: 30,
+        answer: "unaskable",
+      }),
+    ]);
+    assert.ok(!report.stale.includes(DECLARED_OPERATION));
+  });
+});


### PR DESCRIPTION
## Six of 624 operations had ever been timed

The six in #9789, each found by hand after someone noticed a slow call. Nothing had ever timed the
other 618, so *"which of our endpoints is slow"* was answerable only for the ones somebody had
already complained about.

Also fixes a **dangling reference I shipped**: `package.json` has carried
`"conformance:latency": "node scripts/check-operation-latency.ts"` since #10310, pointing at a file
that was never committed.

## What one full production run says

```
rest:     196 timed   p50  250ms   p90 3689ms   p99  9038ms   max 11101ms
mcp:      199 timed   p50  189ms   p90 3446ms   p99 11670ms   max 15416ms
graphql:  192 timed   p50  216ms   p90 2982ms   p99 11986ms   max 12590ms
```

The p50s are healthy on all three surfaces. The tail is not, and it is **not 30 independent
problems** — 21 of the 30 over-budget operations are the **account family** and its mirrors:

```
15416ms  mcp      get_account_counterparties
12590ms  graphql  account_transfers
11670ms  mcp      get_account_history
11101ms  rest     /api/v1/accounts/{ss58}/transfers
```

The same read, timed three times. That is the finding #10312 owns, and all 30 are declared against
it.

## Two design decisions worth the review

**A 4xx is the sweep's bad question, not the operation's failure.** The first run reported 24
operations as "did not answer" and the two I spot-checked were both *this sweep's* fault —
`/api/v1/ask` is POST-only and answered 405, and `/api/v1/providers/{slug}` 404'd because
`opentensor-faoundation` is not a provider id (a provider's identifier is its `id`: `academia`,
`allways`). A sweep whose failure list is mostly its own bad questions teaches the reader to ignore
the list. So `unaskable` is its own bucket, GET-only is enforced from `route.method`, and the subject
is one that exists.

**The DECLARED list has hysteresis, and this is a deliberate departure.** Every other gate here uses
"a stale entry FAILS" unconditionally, because every other gate is deterministic. Latency is not — an
operation declared at 5306ms answering in 4900ms tomorrow is the same operation, and failing on that
would report weather, which is precisely what the loose 5s budget exists to avoid. `STALE_MARGIN`
means an entry is stale when its operation comes in *comfortably* under (below half the budget), so
the list still cannot hold something that stopped being true, and a borderline entry does not flap.

## The subjects are now shared

`scripts/conformance-subjects.ts` — one table, three readers (`concreteRoute`, `toolArguments`,
`argumentsForRequired`), so a subject cannot be right on one surface and stale on another, which is
the divergence these sweeps exist to catch. The cross-surface sweep held the only copy and restated
its seven fixtures twice inside itself; both collapse.

Deliberately **not** merged with `tests/concrete-path.ts`, and the header says why: that helper fills
unmatched placeholders with `"x"` because its job is "a path the router will match". This one must
decline a route it has no real subject for, or the sweep times a 404 and calls the route broken.

## Validation

```
npm run typecheck / lint / format:check   clean
npx vitest run tests/operation-latency-verdict.test.ts   6 passed
node scripts/check-operation-latency.ts   full production run, ~620 operations (report above)
```

The verdict logic is tested in CI even though the sweep cannot be: `summarise` is split out of `run`
so recorded timings can be re-scored. Six cases, including the two the first draft got wrong — a 4xx
counted as a failure, and a declared entry going stale on a millisecond.

Closes #10220
