### PR TITLE
fix(health): bound a lane verdict by the lane's own cadence

### DIFF
--- a/src/self-health-mcp.ts
+++ b/src/self-health-mcp.ts
@@ -70,6 +70,7 @@ import { createPgSql } from "./pg-sql.ts";
 import { loadLatestLaneHealth } from "./lane-health.ts";
 import { laneHealthStore } from "./lane-health-store.ts";
 import { withLaneHealth, type SelfHealth } from "./self-health.ts";
+import { loadLaneCadence, LANE_ALARM_CADENCE_WINDOW_MS } from "./lane-alarm.ts";
 import {
   GetSelfHealthInputSchema,
   GetSelfHealthOutputSchema,
@@ -212,7 +213,15 @@ export async function loadSelfHealth(
       ctx.env as unknown as Record<string, unknown>,
     ) as unknown as Parameters<typeof loadLatestLaneHealth>[0],
   );
-  return withLaneHealth(card as SelfHealth, lanes);
+  // Same cadence sample the REST twin takes (#10232), so both surfaces judge
+  // a silent lane identically rather than one of them serving a dead verdict.
+  const cadences = await loadLaneCadence(
+    laneHealthStore(
+      ctx.env as unknown as Record<string, unknown>,
+    ) as unknown as Parameters<typeof loadLaneCadence>[0],
+    Date.now() - LANE_ALARM_CADENCE_WINDOW_MS,
+  );
+  return withLaneHealth(card as SelfHealth, lanes, { cadences });
 }
 
 export const GET_SELF_HEALTH_INSTRUCTIONS =

--- a/src/self-health.ts
+++ b/src/self-health.ts
@@ -18,6 +18,7 @@
 
 /** The components the poller writes. Order is display order. */
 import type { LaneHealthRecord } from "./lane-health.ts";
+import { laneSilenceThresholdMs } from "./lane-alarm.ts";
 
 export const SELF_HEALTH_COMPONENTS = ["api", "site", "publish"] as const;
 export type SelfHealthComponent = (typeof SELF_HEALTH_COMPONENTS)[number];
@@ -291,15 +292,60 @@ export function buildSelfHealth(
 export function withLaneHealth(
   card: SelfHealth,
   laneRows: Record<string, LaneHealthRecord>,
+  /**
+   * A SILENT lane's last verdict is not a current one (#10232).
+   *
+   * `loadLatestLaneHealth` takes the newest row per lane with no liveness
+   * bound, so a lane that stopped reporting keeps serving whatever it last
+   * said -- forever, and in both directions. A lane whose last word was `ok`
+   * and then died reads healthy while nothing runs; one whose last word was
+   * `stale` reads as an alarm nobody can clear.
+   *
+   * A single cutoff cannot work: cadences here differ by more than 100x
+   * (`chain-detail` every ~30s, `hotkey-alpha` every 24h). One tight enough to
+   * catch a dead 30-second lane marks every 24-hour lane absent between ticks.
+   * So the bound is the lane's OWN observed cadence, reusing the pair the
+   * alarm path already computes -- `laneCadenceMs` (span / n-1) and
+   * `laneSilenceThresholdMs` (3 intervals, floored at 90 min).
+   *
+   * OMITTING `cadences` LEAVES EVERY VERDICT ALONE, deliberately. Without a
+   * sample there is no bound that is not a guess, and a guess here invents
+   * alarms on lanes that are working -- the #9301 failure. A caller that has
+   * not paid for the cadence query gets exactly today's behaviour.
+   */
+  options: {
+    cadences?: Record<string, number | null>;
+    nowMs?: number;
+  } = {},
 ): SelfHealth {
+  const { cadences, nowMs = Date.now() } = options;
   const lanes: SelfHealthLaneView[] = Object.values(laneRows)
-    .map((row) => ({
-      lane: row.lane,
-      verdict: row.verdict,
-      age_ms: row.age_ms,
-      detail: row.detail,
-      checked_at: toIso(row.checked_at),
-    }))
+    .map((row) => {
+      const cadence = cadences?.[row.lane];
+      const quietFor = nowMs - row.checked_at;
+      const silent =
+        typeof cadence === "number" &&
+        cadence > 0 &&
+        row.checked_at > 0 &&
+        quietFor > laneSilenceThresholdMs(cadence);
+      return {
+        lane: row.lane,
+        // `unknown` rather than a new verdict: the union already publishes it
+        // for "a verdict this build cannot interpret", and a lane that has
+        // stopped speaking is the same claim -- we cannot say. It also drops
+        // out of `stale_lane_count` below, which is right: we do not know that
+        // it is BEHIND, only that it is quiet.
+        verdict: silent ? ("unknown" as const) : row.verdict,
+        // The AGE OF THE SILENCE, not the age the dead verdict carried. That
+        // number described whatever the lane was measuring when it last ran
+        // and says nothing about now.
+        age_ms: silent ? quietFor : row.age_ms,
+        detail: silent
+          ? `no verdict for ${Math.round(quietFor / 60_000)}m (cadence ~${Math.round(cadence / 60_000)}m)`
+          : row.detail,
+        checked_at: toIso(row.checked_at),
+      };
+    })
     .sort(
       (a, b) =>
         Number(b.verdict === "stale") - Number(a.verdict === "stale") ||

--- a/tests/lane-health-silence.test.ts
+++ b/tests/lane-health-silence.test.ts
@@ -1,0 +1,187 @@
+// A silent lane's last verdict is not a current one (#10232).
+//
+// `loadLatestLaneHealth` takes the newest row per lane with no liveness bound,
+// so a lane that stopped reporting keeps serving whatever it last said. That
+// is wrong in BOTH directions, which is why neither a "hide stale rows" nor a
+// "trust the newest row" rule is sufficient:
+//
+//   - a lane whose last word was `ok` and then died reads healthy forever,
+//     while nothing runs;
+//   - one whose last word was `stale` reads as an alarm nobody can clear.
+//
+// A single cutoff cannot work either: cadences here differ by >100x. The bound
+// has to be the lane's OWN, which is what these assert.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { buildSelfHealth, withLaneHealth } from "../src/self-health.ts";
+import {
+  LANE_ALARM_MIN_SILENCE_MS,
+  laneSilenceThresholdMs,
+} from "../src/lane-alarm.ts";
+import type { LaneHealthRecord } from "../src/lane-health.ts";
+
+const NOW = 1_786_300_000_000;
+const MIN = 60_000;
+
+const record = (over: Partial<LaneHealthRecord> = {}): LaneHealthRecord => ({
+  lane: "neurons",
+  verdict: "ok",
+  age_ms: 1_000,
+  detail: "fresh",
+  checked_at: NOW - MIN,
+  ...over,
+});
+
+const card = () => buildSelfHealth([], []);
+const view = (
+  rows: Record<string, LaneHealthRecord>,
+  cadences?: Record<string, number | null>,
+) => withLaneHealth(card(), rows, { cadences, nowMs: NOW }).lanes;
+
+describe("a lane past its own silence bound reads unknown", () => {
+  test("an OK lane that died stops reporting ok", () => {
+    // The direction that matters most: the card said healthy while nothing ran.
+    //
+    // Every quiet period here is DERIVED from laneSilenceThresholdMs rather
+    // than multiplied out by hand: a 15-minute lane's three intervals are 45
+    // minutes, which the floor lifts to 90, so an arithmetic guess lands
+    // inside the bound and asserts nothing.
+    const cadence = 15 * MIN;
+    const quiet = laneSilenceThresholdMs(cadence) + MIN;
+    const [lane] = view(
+      { neurons: record({ verdict: "ok", checked_at: NOW - quiet }) },
+      { neurons: cadence },
+    );
+    assert.equal(lane!.verdict, "unknown");
+  });
+
+  test("a STALE lane that died stops reporting an alarm nobody can clear", () => {
+    const cadence = 15 * MIN;
+    const quiet = laneSilenceThresholdMs(cadence) + MIN;
+    const [lane] = view(
+      { neurons: record({ verdict: "stale", checked_at: NOW - quiet }) },
+      { neurons: cadence },
+    );
+    assert.equal(lane!.verdict, "unknown");
+  });
+
+  test("age_ms becomes the age of the SILENCE, not the dead verdict's", () => {
+    // The old number described whatever the lane was measuring when it last
+    // ran, and says nothing about now.
+    const cadence = 15 * MIN;
+    const quiet = laneSilenceThresholdMs(cadence) * 2;
+    const [lane] = view(
+      { neurons: record({ age_ms: 42, checked_at: NOW - quiet }) },
+      { neurons: cadence },
+    );
+    assert.equal(lane!.age_ms, quiet);
+    assert.match(lane!.detail ?? "", /no verdict for/);
+  });
+});
+
+describe("the bound is the lane's own cadence, not a global one", () => {
+  test("a 24h lane quiet for 3h is NOT silent", () => {
+    // A cutoff tight enough for a 30-second lane would mark this absent
+    // between every pair of ticks -- the #9301 shape.
+    const [lane] = view(
+      {
+        hotkey_alpha: record({
+          lane: "hotkey_alpha",
+          checked_at: NOW - 3 * 60 * MIN,
+        }),
+      },
+      { hotkey_alpha: 24 * 60 * MIN },
+    );
+    assert.equal(lane!.verdict, "ok");
+  });
+
+  test("a 30s lane quiet for 3h IS silent", () => {
+    const [lane] = view(
+      {
+        chain_detail: record({
+          lane: "chain_detail",
+          checked_at: NOW - 3 * 60 * MIN,
+        }),
+      },
+      { chain_detail: 30_000 },
+    );
+    assert.equal(lane!.verdict, "unknown");
+  });
+
+  test("the 90-minute floor holds for a very fast lane", () => {
+    // 3 intervals of a 30s cadence is 90 SECONDS; without the floor a lane
+    // would read silent between two ordinary ticks after a deploy.
+    const [lane] = view(
+      {
+        chain_detail: record({
+          lane: "chain_detail",
+          checked_at: NOW - (LANE_ALARM_MIN_SILENCE_MS - MIN),
+        }),
+      },
+      { chain_detail: 30_000 },
+    );
+    assert.equal(lane!.verdict, "ok");
+  });
+});
+
+describe("without a cadence sample, nothing changes", () => {
+  test("no cadences at all leaves every verdict alone", () => {
+    // A caller that has not paid for the cadence query gets exactly today's
+    // behaviour -- inventing a bound would invent alarms.
+    const ancient = record({
+      verdict: "ok",
+      checked_at: NOW - 30 * 24 * 60 * MIN,
+    });
+    assert.equal(view({ neurons: ancient })[0]!.verdict, "ok");
+  });
+
+  test("a lane with too little history to derive a cadence is left alone", () => {
+    // loadLaneCadence returns null for a lane under the sample floor.
+    const ancient = record({
+      verdict: "ok",
+      checked_at: NOW - 30 * 24 * 60 * MIN,
+    });
+    assert.equal(
+      view({ neurons: ancient }, { neurons: null })[0]!.verdict,
+      "ok",
+    );
+  });
+
+  test("a lane that has never been checked is left alone", () => {
+    // checked_at 0 is "no row", not "silent since 1970".
+    const [lane] = view(
+      { neurons: record({ checked_at: 0 }) },
+      { neurons: 15 * MIN },
+    );
+    assert.equal(lane!.verdict, "ok");
+  });
+});
+
+describe("stale_lane_count", () => {
+  test("a silent lane does NOT count as stale", () => {
+    // We do not know it is behind; we know it is quiet. Counting it as stale
+    // would assert a measurement nobody made.
+    const cadence = 15 * MIN;
+    const out = withLaneHealth(
+      card(),
+      {
+        neurons: record({
+          verdict: "stale",
+          checked_at: NOW - laneSilenceThresholdMs(cadence) * 2,
+        }),
+      },
+      { cadences: { neurons: cadence }, nowMs: NOW },
+    );
+    assert.equal(out.stale_lane_count, 0);
+    assert.equal(out.lanes.length, 1, "but it stays LISTED, never dropped");
+  });
+
+  test("a live stale lane still counts", () => {
+    const out = withLaneHealth(
+      card(),
+      { neurons: record({ verdict: "stale" }) },
+      { cadences: { neurons: 15 * MIN }, nowMs: NOW },
+    );
+    assert.equal(out.stale_lane_count, 1);
+  });
+});

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -266,6 +266,10 @@ import { answerAccountEntities } from "../../src/account-entities-answer.ts";
 import { loadSelfHealthColdTier } from "../../src/self-health-cold-tier.ts";
 import { loadLatestLaneHealth } from "../../src/lane-health.ts";
 import { withLaneHealth } from "../../src/self-health.ts";
+import {
+  loadLaneCadence,
+  LANE_ALARM_CADENCE_WINDOW_MS,
+} from "../../src/lane-alarm.ts";
 import { loadTopHoldersFlowTier } from "../../src/top-holders-flow-tier.ts";
 import { buildBlocksSummary } from "../../src/blocks-summary.ts";
 import { loadBlocksSummaryFromArtifact } from "../../src/blocks-summary-artifact.ts";
@@ -2056,7 +2060,18 @@ export async function handleSelfHealth(
       typeof loadLatestLaneHealth
     >[0],
   );
-  const withLanes = withLaneHealth(data, lanes);
+  // The cadence sample the silence bound needs (#10232). One extra GROUP BY
+  // over the same table the read above already touched, and it is what stops a
+  // dead lane serving its last verdict forever. loadLaneCadence declines to a
+  // {} on any failure, and withLaneHealth then leaves every verdict alone --
+  // so a cadence read that fails costs today's behaviour, never a false alarm.
+  const cadences = await loadLaneCadence(
+    laneHealthStore(env as unknown as Record<string, unknown>) as Parameters<
+      typeof loadLaneCadence
+    >[0],
+    Date.now() - LANE_ALARM_CADENCE_WINDOW_MS,
+  );
+  const withLanes = withLaneHealth(data, lanes, { cadences });
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## The bug

`loadLatestLaneHealth` takes the newest row per lane with **no liveness bound**. A lane that stops reporting keeps serving whatever it last said, forever — and it is wrong in both directions:

| last word | lane then dies | `/self-health` says | reality |
|---|---|---|---|
| `ok` | producer stops | `ok`, indefinitely | nothing is running |
| `stale` | producer retired | `stale`, indefinitely | an alarm nobody can clear |

The first is the dangerous one: a green card over a dead lane is exactly the state #10304 spent 34 hours in.

## Why a single cutoff cannot work

Cadences on this table differ by more than **100x**:

| lane | cadence |
|---|---|
| `chain-detail` | ~30s |
| `subnet-burn-coverage` | 15m |
| `hotkey-alpha` | 24h |

A cutoff tight enough to catch a dead 30-second lane marks every 24-hour lane absent between two ordinary ticks — the #9301 shape, an alarm that fires on healthy lanes and then gets ignored.

## The bound is the lane's own

`lane-alarm.ts` already derives exactly this pair and this PR reuses both rather than recomputing them, so the card and the alarm cannot disagree about which lanes are speaking:

- `laneCadenceMs` — span / (n−1) over the 7-day `LANE_ALARM_CADENCE_WINDOW_MS` sample;
- `laneSilenceThresholdMs` — three intervals, floored at 90 minutes so a fast lane is not called silent between two ticks after a redeploy.

Past that bound the lane reads:

- **`unknown`** — an existing member of the published `"ok" | "stale" | "unknown"` union, so **no schema change**;
- **`age_ms` = the age of the SILENCE**, not the age the dead verdict carried (that number described whatever the lane was measuring when it last ran, and says nothing about now);
- **`detail` = `no verdict for 214m (cadence ~15m)`** — the two numbers an operator needs to tell a dead lane from a slow one.

A silent lane **drops out of `stale_lane_count` but stays LISTED**. We do not know it is behind; we know it is quiet, and counting it as stale would assert a measurement nobody made.

## Omitting `cadences` changes nothing

`withLaneHealth(card, rows)` with no options behaves exactly as it does today. Without a sample there is no bound that is not a guess, and a guess here invents alarms on working lanes. `loadLaneCadence` declines to `{}` on any failure, so **a failed cadence read costs today's behaviour, never a false alarm**.

Both surfaces take the sample — the REST handler and the MCP twin — so they judge a silent lane identically.

## Verification

- 11 new tests in `tests/lane-health-silence.test.ts`, both directions, both bound edges, and the three no-cadence declines.
- **The guard was proven able to fail**: neutering the silence condition fails 5 of the 11; restoring it passes all 11.
- Quiet periods in the tests are **derived from `laneSilenceThresholdMs`**, not multiplied out by hand — my first draft guessed `cadence × 4` on a 15-minute lane (60 min), which the 90-minute floor lifts back inside the bound, so the assertions proved nothing until they were derived.
- 164 tests pass across the 10 lane/self-health suites.
- Patch coverage measured by diff intersection: **0 uncovered statements and 0 uncovered branches** across all 82 changed lines in the three source files.
- `tsc` clean, eslint clean, `npm run build` produces no artifact drift.

Closes #10232