### PR TITLE
fix(health): size a freshness bound in ticks of its producer, not hours

### DIFF
--- a/src/producer-cadence.ts
+++ b/src/producer-cadence.ts
@@ -69,6 +69,17 @@ export const PRODUCER_CADENCE_SECS = {
   metagraph: 900,
   /** The top-holders flow materialization, rebuilt daily. */
   top_holders_flow: 86_400,
+  /**
+   * ACCOUNT_IDENTITY_POLL_SECS. Twenty-four hours, and its absence from this
+   * table is what let `TABLE_FRESHNESS` bound the table it writes at TWELVE --
+   * half a tick, so a healthy lane read `stale` for the back half of every
+   * cycle (#10329). Measured 2026-08-09: `account_identity` 21.6h old, the
+   * lane's own verdict for that pass `ok | 129 scanned, 456 written`.
+   */
+  account_identity: 86_400,
+  /** SUBNET_HYPERPARAMS_POLL_SECS. Hourly, the fastest of the poller's
+   * non-firehose lanes; observed writing at :05 every hour. */
+  subnet_hyperparams: 3_600,
 } as const;
 
 export type ProducerLane = keyof typeof PRODUCER_CADENCE_SECS;

--- a/src/table-freshness-watchdog.ts
+++ b/src/table-freshness-watchdog.ts
@@ -34,6 +34,7 @@ import { laneHealthStore } from "./lane-health-store.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { readStore } from "./read-store.ts";
 import { neonOwnsTable } from "./neon-write.ts";
+import { missedTicksMs, type ProducerLane } from "./producer-cadence.ts";
 
 /** This watchdog's own lane. */
 export const TABLE_FRESHNESS_LANE = "table-freshness";
@@ -50,6 +51,22 @@ export interface FreshnessExpectation {
   maxAgeMs: number | null;
   /** Why that number, or why null. Read by whoever gets the alarm. */
   reason: string;
+  /**
+   * The producer whose cadence this bound is derived from, when it is.
+   *
+   * DECLARED so the relationship can be CHECKED. `maxAgeMs` alone cannot be
+   * audited -- 12 hours is either generous or guaranteed-to-alarm depending
+   * entirely on a number that used to live only in prose, and #10329 is the
+   * case where it was the second one. With the producer named,
+   * tests/table-freshness-cadence.test.ts can assert every derived bound
+   * clears one full tick, which is the rule this map's own header states.
+   *
+   * Absent for the crons and the measured bounds -- `chain-detail` is sized
+   * against a DOWNSTREAM consumer's lag and `rpc-usage` against a traffic
+   * floor, so naming a producer there would assert a derivation that does not
+   * exist.
+   */
+  producer?: ProducerLane;
   /** An open issue explaining a table that is ALREADY breaching, so the alarm
    * points somewhere instead of merely being loud. */
   knownIssue?: string;
@@ -128,31 +145,46 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
   },
 
   // --- the metagraph family: 15-minute producer --------------------------
+  //
+  // TICKS, NOT HOURS, for every poller-backed bound below (#10329). The rule
+  // this map states two paragraphs up -- "a threshold under one producer
+  // interval alarms forever" -- can only be checked against the interval, and
+  // the interval lived in `metagraphed-infra` and reached this file as prose.
+  // `account_identity` is what that cost: bounded at 12h against an 86,400s
+  // producer, so a working lane read `stale` for half of every cycle.
+  //
+  // `missedTicksMs` reads src/producer-cadence.ts, the same table the two
+  // staleness watchdogs already derive from, so the multiple is arithmetic a
+  // reader can verify and a cadence change moves every bound with it.
   neurons: {
     column: "captured_at",
     kind: "ms",
-    maxAgeMs: 2 * HOUR,
-    reason: "metagraph sync every 15 min",
+    maxAgeMs: missedTicksMs("metagraph", 8),
+    reason: "8 ticks of METAGRAPH_POLL_SECS (15 min)",
+    producer: "metagraph",
   },
   // Added by 0030 after this map was written -- the same coverage test that
   // caught 0029's two tables caught this one, which is what it is for.
   neurons_passes: {
     column: "captured_at",
     kind: "ms",
-    maxAgeMs: 2 * HOUR,
+    maxAgeMs: missedTicksMs("metagraph", 8),
     reason: "written with neurons",
+    producer: "metagraph",
   },
   neuron_daily: {
     column: "captured_at",
     kind: "ms",
-    maxAgeMs: 2 * HOUR,
+    maxAgeMs: missedTicksMs("metagraph", 8),
     reason: "derived from the same sync",
+    producer: "metagraph",
   },
   account_position_daily: {
     column: "captured_at",
     kind: "ms",
-    maxAgeMs: 2 * HOUR,
+    maxAgeMs: missedTicksMs("metagraph", 8),
     reason: "derived from the same sync",
+    producer: "metagraph",
   },
   subnet_snapshots: {
     column: "captured_at",
@@ -160,43 +192,66 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
     maxAgeMs: 4 * HOUR,
     reason: "health prober",
   },
+  // Twelve ticks is LOOSE, and stays that way on purpose: loose is the safe
+  // direction here, this lane carries its own `subnet-hyperparams` verdict,
+  // and #10232 now catches a silent lane by its own cadence regardless.
+  // Tightening it is a judgement about how fast a dead hyperparams lane must
+  // be noticed -- a separate question from fixing a false alarm.
   subnet_hyperparams: {
     column: "captured_at",
     kind: "ms",
-    maxAgeMs: 12 * HOUR,
-    reason: "hyperparams sync",
+    maxAgeMs: missedTicksMs("subnet_hyperparams", 12),
+    reason: "12 ticks of SUBNET_HYPERPARAMS_POLL_SECS (1h)",
+    producer: "subnet_hyperparams",
   },
+  // THE FIX. This read 12 hours against an 86,400s producer -- half a tick --
+  // so `table-freshness` reported `stale` for the back half of every cycle on
+  // a lane whose own verdict for the same pass was `ok | 129 scanned, 456
+  // written, 0 error(s)`. 2.5 ticks is what its 24-hour sibling hotkey_alpha
+  // already uses, so the two lanes on one cadence now share one ratio.
   account_identity: {
     column: "captured_at",
     kind: "ms",
-    maxAgeMs: 12 * HOUR,
-    reason: "identity sync",
+    maxAgeMs: missedTicksMs("account_identity", 2.5),
+    reason: "2.5 ticks of ACCOUNT_IDENTITY_POLL_SECS (24h)",
+    producer: "account_identity",
   },
 
-  // --- slow ledgers: 12h/30h/48h producers, measured 4.9-5.2h old ---------
+  // --- slow ledgers -------------------------------------------------------
+  //
+  // The header this replaced said "12h/30h/48h producers". NONE of those three
+  // numbers is a cadence this poller has: account_balances is 21,600s (6h),
+  // the nominator pair 86,400s (24h), hotkey_alpha 86,400s (24h). Every bound
+  // still landed somewhere safe, but the stated basis for each was a producer
+  // that does not exist -- and prose is what the next bound gets sized
+  // against, which is exactly how account_identity got its.
   account_balances: {
     column: "captured_at",
     kind: "ms",
-    maxAgeMs: 24 * HOUR,
-    reason: "12h producer; matches ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS x2",
+    maxAgeMs: missedTicksMs("account_balances", 4),
+    reason: "4 ticks of ACCOUNT_BALANCES_POLL_SECS (6h)",
+    producer: "account_balances",
   },
   account_balances_passes: {
     column: "captured_at",
     kind: "ms",
-    maxAgeMs: 24 * HOUR,
+    maxAgeMs: missedTicksMs("account_balances", 4),
     reason: "written with account_balances",
+    producer: "account_balances",
   },
   hotkey_alpha: {
     column: "captured_at",
     kind: "ms",
-    maxAgeMs: 60 * HOUR,
-    reason: "48h producer; HOTKEY_ALPHA_STALENESS_THRESHOLD_MS is 48h",
+    maxAgeMs: missedTicksMs("hotkey_alpha", 2.5),
+    reason: "2.5 ticks of HOTKEY_ALPHA_POLL_SECS (24h)",
+    producer: "hotkey_alpha",
   },
   hotkey_alpha_passes: {
     column: "captured_at",
     kind: "ms",
-    maxAgeMs: 60 * HOUR,
+    maxAgeMs: missedTicksMs("hotkey_alpha", 2.5),
     reason: "written with hotkey_alpha",
+    producer: "hotkey_alpha",
   },
   // Added by 0029 while this map was being written -- which is the coverage
   // test doing its job: a new table arrived and was unwatched until named.
@@ -205,26 +260,30 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
   nominator_positions_passes: {
     column: "captured_at",
     kind: "ms",
-    maxAgeMs: 36 * HOUR,
+    maxAgeMs: missedTicksMs("validator_nominators", 1.5),
     reason: "written with nominator_positions",
+    producer: "validator_nominators",
   },
   validator_nominator_counts_passes: {
     column: "captured_at",
     kind: "ms",
-    maxAgeMs: 36 * HOUR,
+    maxAgeMs: missedTicksMs("validator_nominators", 1.5),
     reason: "written with validator_nominator_counts",
+    producer: "validator_nominators",
   },
   nominator_positions: {
     column: "captured_at",
     kind: "ms",
-    maxAgeMs: 36 * HOUR,
-    reason: "30h producer",
+    maxAgeMs: missedTicksMs("validator_nominators", 1.5),
+    reason: "1.5 ticks of VALIDATOR_NOMINATORS_POLL_SECS (24h)",
+    producer: "validator_nominators",
   },
   validator_nominator_counts: {
     column: "captured_at",
     kind: "ms",
-    maxAgeMs: 36 * HOUR,
+    maxAgeMs: missedTicksMs("validator_nominators", 1.5),
     reason: "written with nominator_positions",
+    producer: "validator_nominators",
   },
 
   // --- probe/rollup lanes -------------------------------------------------

--- a/tests/table-freshness-cadence.test.ts
+++ b/tests/table-freshness-cadence.test.ts
@@ -1,0 +1,102 @@
+// A freshness bound must clear one full tick of its producer (#10329).
+//
+// TABLE_FRESHNESS's own header states the rule -- "A threshold under one
+// producer interval alarms forever; one at ten times it never alarms at all"
+// -- and nothing enforced it, because the interval was not in this repo. It
+// reached the file as prose beside each constant, so `12 * HOUR` next to
+// `reason: "identity sync"` looked exactly like a considered bound and was in
+// fact half a tick: `account_identity` read `stale` for the back half of every
+// 24-hour cycle while its own lane verdict said `ok | 129 scanned, 456
+// written, 0 error(s)`.
+//
+// With `producer` declared on each derived entry, the relationship is data and
+// the rule is checkable. That is the whole point of the field -- a bound alone
+// cannot be audited, since 12 hours is generous or guaranteed-to-alarm
+// depending on a number stored somewhere else.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { TABLE_FRESHNESS } from "../src/table-freshness-watchdog.ts";
+import {
+  PRODUCER_CADENCE_SECS,
+  cadenceMs,
+  type ProducerLane,
+} from "../src/producer-cadence.ts";
+
+const HOUR = 60 * 60 * 1000;
+
+const derived = Object.entries(TABLE_FRESHNESS).filter(
+  ([, spec]) => spec.producer !== undefined,
+) as [
+  string,
+  { maxAgeMs: number | null; producer: ProducerLane; reason: string },
+][];
+
+describe("every cadence-derived bound", () => {
+  test("names a producer this repo actually knows the cadence of", () => {
+    // A typo'd lane would otherwise be a silent `undefined` cadence and the
+    // checks below would compare against NaN, which passes nothing and fails
+    // nothing.
+    assert.ok(derived.length >= 14, `only ${derived.length} derived bounds`);
+    for (const [table, spec] of derived) {
+      assert.ok(
+        spec.producer in PRODUCER_CADENCE_SECS,
+        `${table} names an unknown producer ${spec.producer}`,
+      );
+    }
+  });
+
+  test("clears ONE FULL TICK -- the rule account_identity broke", () => {
+    // Under one tick the table is guaranteed to breach between two ordinary
+    // passes, so the alarm is on for part of every cycle no matter how healthy
+    // the lane is. That is #9301's shape and it is what makes an alarm
+    // unreadable.
+    for (const [table, spec] of derived) {
+      const ticks = spec.maxAgeMs! / cadenceMs(spec.producer);
+      assert.ok(
+        ticks >= 1,
+        `${table}: ${spec.maxAgeMs! / HOUR}h is ${ticks.toFixed(2)} ticks of ` +
+          `${spec.producer} (${cadenceMs(spec.producer) / HOUR}h) -- alarms every cycle`,
+      );
+    }
+  });
+
+  test("is not so loose it can never alarm", () => {
+    // The other half of the same sentence. Twelve is the current ceiling and
+    // `subnet_hyperparams` sits exactly there deliberately (its own lane
+    // verdict plus #10232's silence bound cover the gap); anything past it is
+    // a bound that has stopped being one.
+    for (const [table, spec] of derived) {
+      const ticks = spec.maxAgeMs! / cadenceMs(spec.producer);
+      assert.ok(
+        ticks <= 12,
+        `${table}: ${ticks.toFixed(2)} ticks of ${spec.producer} never alarms`,
+      );
+    }
+  });
+
+  test("declares a real bound, never null", () => {
+    // `maxAgeMs: null` means "staleness is meaningless here" -- true of the
+    // append-on-change histories, and incompatible with having named a
+    // producer whose cadence you are deriving from.
+    for (const [table, spec] of derived) {
+      assert.notEqual(
+        spec.maxAgeMs,
+        null,
+        `${table} derives from a cadence but bounds nothing`,
+      );
+    }
+  });
+});
+
+describe("account_identity specifically", () => {
+  test("is bounded above its 24-hour producer, not below it", () => {
+    // The regression this file exists for, pinned by name: 12h against an
+    // 86,400s producer is the exact state found in production 2026-08-09.
+    const spec = TABLE_FRESHNESS.account_identity!;
+    assert.equal(spec.producer, "account_identity");
+    assert.ok(
+      spec.maxAgeMs! > 24 * HOUR,
+      `${spec.maxAgeMs! / HOUR}h does not clear the 24h cadence`,
+    );
+  });
+});


### PR DESCRIPTION
## The alarm that cannot turn off

`table-freshness` is reporting this in production right now:

```
table-freshness   stale   account_identity 21.6h > 12h
```

It is not stale. `metagraphed-infra`, `roles/indexer-rust/tasks/main.yml:129`:

```yaml
ACCOUNT_IDENTITY_POLL_SECS: "{{ account_identity_poll_secs | default('86400') }}"
```

No override exists, so the producer runs every **24 hours** against a **12-hour** bound — **0.5 ticks**. The table is *guaranteed* to breach for the back half of every cycle, forever. Verified against Neon: 502 rows at `captured_at = 2026-08-08T23:09:12Z`, and the `account-identity` lane's own verdict for that same pass is `ok | 129 scanned, 456 written, 0 error(s)`. The producer is healthy; the bound is wrong.

An alarm that is always on is an alarm nobody reads — #9301, re-derived, sitting next to real signals in the same watchdog's output.

## The rule was already written down

`TABLE_FRESHNESS`'s own header:

> Thresholds are set from MEASURED cadence with headroom, not from what the producer claims. **A threshold under one producer interval alarms forever; one at ten times it never alarms at all.**

Nothing could enforce it, because the interval was not in this repo. It arrived as prose beside each constant, so `12 * HOUR` next to `reason: "identity sync"` looked exactly like a considered bound.

## Two more `reason` strings had already drifted

```ts
account_balances: { maxAgeMs: 24 * HOUR, reason: "12h producer; …" },   // it is 21600s = 6h
hotkey_alpha:     { maxAgeMs: 60 * HOUR, reason: "48h producer; …" },   // it is 86400s = 24h
```

Both bounds land somewhere safe anyway, but the stated basis for each is a cadence the producer does not have — and prose is what the next bound gets sized against. That is how `account_identity` got its.

## The change

Every poller-backed bound now reads `missedTicksMs(lane, ticks)` off `src/producer-cadence.ts` — the table both staleness watchdogs already derive from — with `account_identity` (86400) and `subnet_hyperparams` (3600) added to it.

| table | before | after | ticks |
|---|---|---|---|
| **account_identity** | **12h** | **60h** | 0.50 → **2.50** |
| neurons / neurons_passes / neuron_daily / account_position_daily | 2h | 2h | 8.00 |
| subnet_hyperparams | 12h | 12h | 12.00 |
| account_balances (+passes) | 24h | 24h | 4.00 |
| hotkey_alpha (+passes) | 60h | 60h | 2.50 |
| nominator_positions / validator_nominator_counts (+passes) | 36h | 36h | 1.50 |

**Twelve of thirteen values are unchanged.** Only `account_identity` moves, to the 2.5 ticks its 24-hour sibling `hotkey_alpha` already uses — two lanes on one cadence, one ratio.

## Why `producer` is a field now

A bound alone **cannot be audited**: 12 hours is generous or guaranteed-to-alarm depending entirely on a number stored in another repo. Declaring the producer makes the relationship data, so the rule becomes a test.

`tests/table-freshness-cadence.test.ts` asserts every derived bound clears one full tick, stays under twelve, names a producer this repo knows, and is not null.

**Proven able to fail** — restoring the exact production state:

```
× clears ONE FULL TICK -- the rule account_identity broke
  account_identity: 12h is 0.50 ticks of account_identity (24h) -- alarms every cycle
× is bounded above its 24-hour producer, not below it
  12h does not clear the 24h cadence
```

The crons and the two measured bounds declare **no** producer — `chain-detail` is sized against a downstream consumer's lag and `rpc-usage` against a measured traffic floor — so the gate does not assert a derivation they never had.

## Deliberately not changed

`subnet_hyperparams` stays at twelve ticks. Loose is the safe direction, it carries its own `subnet-hyperparams` lane verdict, and #10232 now catches a silent lane by its own cadence regardless. Tightening it is a judgement about how fast a dead hyperparams lane must be noticed — a separate question from fixing a false alarm.

## Verification

- 100 tests pass across the freshness, cadence and lane-alarm suites.
- Patch coverage by diff intersection: **0 uncovered statements, 0 uncovered branches** across all 91 changed lines.
- `tsc` clean, eslint clean, `npm run build` produces no artifact drift.

Closes #10329