### PR TITLE
fix(scripts): point the documented run command at the pinned project

### DIFF
--- a/scripts/backfill-neuron-history.py
+++ b/scripts/backfill-neuron-history.py
@@ -27,7 +27,7 @@ read); it accrues daily forward via the live rollup.
 
 Run (one-time; resumable):
   NEURON_DAILY_BACKFILL_SECRET=... \
-  uv run --with bittensor --with xxhash==3.5.0 python scripts/backfill-neuron-history.py --days 365
+  uv run --project scripts --with xxhash==3.5.0 python scripts/backfill-neuron-history.py --days 365
 """
 import argparse
 import ipaddress

--- a/scripts/backfill-stake-monthly.py
+++ b/scripts/backfill-stake-monthly.py
@@ -30,7 +30,7 @@ retains historical state. In bittensor 10.4.x the metagraph helpers live on
 
 Run (one-time; resumable):
   NEURON_DAILY_BACKFILL_SECRET=... \
-  uv run --with bittensor python scripts/backfill-stake-monthly.py --months 8
+  uv run --project scripts python scripts/backfill-stake-monthly.py --months 8
 """
 import argparse
 import ipaddress

--- a/scripts/fetch-metagraph-native.py
+++ b/scripts/fetch-metagraph-native.py
@@ -19,7 +19,7 @@ Units (verified by the parity check vs the prior Taostats data, #1348):
     floor take. Hotkeys with no Delegates entry get take=None (never
     registered as a delegate, not "0% take").
 
-Run: uv run --with bittensor python scripts/fetch-metagraph-native.py
+Run: uv run --project scripts python scripts/fetch-metagraph-native.py
 """
 import argparse
 import ipaddress

--- a/scripts/fetch-subnet-locks.py
+++ b/scripts/fetch-subnet-locks.py
@@ -44,7 +44,7 @@ from any previously-assumed "default") -- MaturityRate read 311622 against
 UnlockRate's 934866 -- so baking either into this snapshot would go stale
 silently the moment governance adjusts one.
 
-Run: uv run --with bittensor python scripts/fetch-subnet-locks.py
+Run: uv run --project scripts python scripts/fetch-subnet-locks.py
 """
 import argparse
 import json

--- a/tests/script-python-pins.test.ts
+++ b/tests/script-python-pins.test.ts
@@ -1,0 +1,82 @@
+// A recovery script's documented command must resolve the version it was
+// written against (#10331).
+//
+// `scripts/pyproject.toml` pins `bittensor==10.5.0`, and every chain-direct
+// script's docstring told you to run it with a BARE `--with bittensor`, which
+// consults nothing and resolves latest. Latest is 11.x, where `bt.SubtensorApi`
+// no longer exists, so the documented command for all four failed at the first
+// line that touches the SDK:
+//
+//     AttributeError: module 'bittensor' has no attribute 'SubtensorApi'
+//
+// These are the RECOVERY tools -- each one exists to reconstruct data the live
+// lanes missed, so each is run rarely, by someone under time pressure, at the
+// moment a gap has been found. Nothing exercises them between incidents, which
+// is why the breakage sat there invisibly and why a static check is worth
+// having: it costs one read of four files and it fires on the commit rather
+// than during the next incident.
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, test } from "vitest";
+
+const SCRIPTS_DIR = path.join(process.cwd(), "scripts");
+
+/** Every `uv run …` line in the scripts' own docstrings. */
+function runLines(): { file: string; line: string }[] {
+  return fs
+    .readdirSync(SCRIPTS_DIR)
+    .filter((f) => f.endsWith(".py"))
+    .flatMap((file) =>
+      fs
+        .readFileSync(path.join(SCRIPTS_DIR, file), "utf8")
+        .split("\n")
+        .filter((line) => line.includes("uv run"))
+        .map((line) => ({ file, line: line.trim() })),
+    );
+}
+
+describe("the documented run command", () => {
+  test("exists -- these lines are the only install instructions there are", () => {
+    // If this ever reads zero the checks below pass vacuously, which is the
+    // one way a gate like this fails silently.
+    assert.ok(runLines().length >= 4, `found ${runLines().length} run lines`);
+  });
+
+  test("never installs bittensor UNPINNED", () => {
+    // `--with bittensor` overrides nothing and consults nothing.
+    for (const { file, line } of runLines()) {
+      assert.ok(
+        !/--with\s+bittensor(?![=<>])/.test(line),
+        `${file}: '--with bittensor' resolves latest, not the pinned 10.5.0 -- ` +
+          `use '--project scripts' so pyproject.toml is consulted:\n  ${line}`,
+      );
+    }
+  });
+
+  test("reaches the pin through --project, not a second copy of the version", () => {
+    // Restating `==10.5.0` in five docstrings would work today and drift on the
+    // next bump; `--project scripts` has one place to change.
+    for (const { file, line } of runLines()) {
+      if (!/scripts\/\S+\.py/.test(line)) continue;
+      assert.match(
+        line,
+        /--project\s+scripts/,
+        `${file}: run line does not use --project scripts:\n  ${line}`,
+      );
+    }
+  });
+});
+
+describe("the pin itself", () => {
+  test("is declared, and is the version the scripts' API expects", () => {
+    // bt.SubtensorApi is what all five callers use, and it exists in 10.x and
+    // not in 11.x. Asserting the exact pin means a bump has to come with a
+    // decision about that API rather than as a silent dependency drift.
+    const toml = fs.readFileSync(
+      path.join(SCRIPTS_DIR, "pyproject.toml"),
+      "utf8",
+    );
+    assert.match(toml, /bittensor==10\.5\.0/);
+  });
+});


### PR DESCRIPTION
## Every recovery script's documented command was broken

```
uv run --with bittensor --with xxhash==3.5.0 python scripts/backfill-neuron-history.py --days 1
```
```
AttributeError: module 'bittensor' has no attribute 'SubtensorApi'. Did you mean: 'Subtensor'?
```

`--with bittensor` consults nothing and resolves **latest**, which is 11.0.2 — where `bt.SubtensorApi` no longer exists. Meanwhile `scripts/pyproject.toml` has pinned the right version the whole time:

```toml
dependencies = ["bittensor==10.5.0"]
```

Confirmed both directions:

```
bittensor 11.0.2 | SubtensorApi: False
bittensor 10.5.0 | SubtensorApi: True
```

The pin was right. The instructions never consulted it — and the instructions are what anyone actually copies.

| script | before | after |
|---|---|---|
| `backfill-neuron-history.py` | `--with bittensor --with xxhash==3.5.0` | `--project scripts --with xxhash==3.5.0` |
| `backfill-stake-monthly.py` | `--with bittensor` | `--project scripts` |
| `fetch-metagraph-native.py` | `--with bittensor` | `--project scripts` |
| `fetch-subnet-locks.py` | `--with bittensor` | `--project scripts` |

`--project scripts` reads that pyproject. Restating `==10.5.0` in four docstrings would also work today and would drift on the next bump; this has one place to change.

## Why it earned a gate

These are the **recovery** tools. Each exists to reconstruct data the live lanes missed, so each is run rarely, by someone under time pressure, at the moment a gap has been found — and nothing exercises them in between, so the breakage stays invisible until it is expensive.

Found exactly that way: reaching for `backfill-neuron-history.py` to close the 2026-08-06 metagraph hole and getting an `AttributeError` instead of a backfill.

`tests/script-python-pins.test.ts` reads the docstrings and fails on a bare `--with bittensor`, on a run line that does not reach the project, and on the pin going missing. It also asserts at least four run lines exist, so it cannot pass vacuously.

**Proven able to fail** — reverting one script to the old form:

```
× never installs bittensor UNPINNED
  fetch-subnet-locks.py: '--with bittensor' resolves latest, not the pinned 10.5.0 --
  use '--project scripts' so pyproject.toml is consulted
× reaches the pin through --project, not a second copy of the version
```

## Verified end to end

With `--project scripts`, `backfill-neuron-history.py` ran against the archive and closed the 2026-08-06 hole in `neuron_daily` / `account_position_daily` — 30,104 rows, 129 subnets, block 8783214. Both tables now report **`interior gaps: NONE`** across their full span.

## Not in scope

Five scripts call `bt.SubtensorApi`, so whether 11.x is a straight migration or a real port is a live question — but a separate one from making the documented command work today.

Closes #10331