### PR TITLE
fix(health): bound silence by the LONGEST observed gap, not the mean

### DIFF
--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -190,6 +190,84 @@ export const LANE_CADENCE_SQL =
   "SELECT lane, COUNT(*) AS n, MIN(checked_at) AS first, MAX(checked_at) AS last " +
   "FROM lane_health WHERE checked_at > ? GROUP BY lane";
 
+/**
+ * The LONGEST gap between consecutive rows, per lane (#10333).
+ *
+ * A DIFFERENT QUESTION FROM `laneCadenceMs`, which is why it is a second query
+ * rather than a tweak to the first. The mean answers "how often does this lane
+ * usually speak" and feeds the alarm; this answers "how long has it gone quiet
+ * before while still being healthy", which is the only thing a silence bound
+ * can honestly be built from.
+ *
+ * The mean cannot do it, for two structural reasons rather than incidental
+ * ones:
+ *
+ *   - CONTAINER REBOOTS FIRE EVERY LANE'S FIRST TICK IMMEDIATELY (see
+ *     src/producer-cadence.ts), so every slow lane's sample carries a cluster
+ *     of near-zero gaps that drags the mean far under the real interval.
+ *   - A MIRROR LANE WRITES MANY ROWS PER PASS. `neon:account-balances` logged
+ *     6,268 rows in seven days against a six-hour producer, so "gap between
+ *     rows" is not "gap between passes" there at all, and the mean AND the
+ *     median both collapse toward zero.
+ *
+ * Measured over seven days, in minutes, against each lane's declared cadence:
+ *
+ *     lane                    rows  declared   mean  median   MAX
+ *     hotkey-alpha              15      1440    286      76   973
+ *     account-identity          18      1440    235      48   970
+ *     neon:account-balances   6268       360      1       0   359
+ *     metagraph                353        15     16      15    46
+ *
+ * The max is the only column that survives all of them. It reads UNDER the
+ * declared cadence for the 24-hour lanes because seven days holds few passes,
+ * and that is fine: the bound is three intervals, so 973 becomes 2,919 minutes
+ * against a 1,440-minute cycle.
+ *
+ * A single long outage in the sample inflates this and makes the bound lax.
+ * That is the SAFE direction -- a bound that is too loose misses a dead lane
+ * for one extra cycle, while one that is too tight invents alarms on lanes
+ * that are working, which is the #9301 failure the whole lane-alarm design is
+ * shaped around.
+ */
+export const LANE_MAX_GAP_SQL =
+  "SELECT lane, COUNT(*) AS n, MAX(gap) AS max_gap FROM (" +
+  "SELECT lane, checked_at - LAG(checked_at) OVER " +
+  "(PARTITION BY lane ORDER BY checked_at) AS gap " +
+  "FROM lane_health WHERE checked_at > ?" +
+  ") g WHERE gap IS NOT NULL GROUP BY lane";
+
+/**
+ * Longest observed gap per lane, or null where there is too little history.
+ *
+ * Declines to `{}` on any failure, exactly as loadLaneCadence does: without a
+ * sample there is no bound that is not a guess, and withLaneHealth leaves every
+ * verdict alone when it gets none.
+ */
+export async function loadLaneMaxGap(
+  db: D1Like | null | undefined,
+  sinceMs: number,
+): Promise<Record<string, number | null>> {
+  if (!db?.prepare) return {};
+  try {
+    const result = await db.prepare(LANE_MAX_GAP_SQL).bind(sinceMs).all?.();
+    const rows = (result?.results ?? []) as Record<string, unknown>[];
+    const out: Record<string, number | null> = {};
+    for (const row of rows) {
+      const lane = row.lane == null ? "" : String(row.lane);
+      if (!lane) continue;
+      // The same sample floor the mean uses. `n` here counts GAPS, one fewer
+      // than rows, so a lane with exactly the minimum rows still qualifies.
+      const n = toInt(row.n);
+      const gap = toInt(row.max_gap);
+      out[lane] =
+        n + 1 >= LANE_ALARM_MIN_CADENCE_SAMPLES && gap > 0 ? gap : null;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
 /** Mean gap between ticks, or null when there is not enough history to say. */
 export function laneCadenceMs(sample: {
   n: number;

--- a/src/producer-cadence.ts
+++ b/src/producer-cadence.ts
@@ -84,6 +84,69 @@ export const PRODUCER_CADENCE_SECS = {
 
 export type ProducerLane = keyof typeof PRODUCER_CADENCE_SECS;
 
+/**
+ * Which `lane_health` lane names are written by a producer we know the cadence
+ * of (#10333).
+ *
+ * EXPLICIT, not derived by string surgery. The obvious rule -- strip a `neon:`
+ * prefix and a `-pass` suffix, swap dashes for underscores -- gets four of
+ * these right and `neon:nominator-positions-pass` wrong, because that lane's
+ * producer is `validator_nominators`: ONE poller writes both the counts and the
+ * positions, which is why PRODUCER_CADENCE_SECS is keyed by producer rather
+ * than by watchdog. A rule that is right most of the time here fails silently,
+ * in the direction of a bound that is too tight.
+ *
+ * The declared cadence is a FLOOR under the observed one, never a replacement.
+ * Observation is what catches a lane whose real interval has drifted from the
+ * configured one; the floor is what stops a sample that is a burst followed by
+ * silence -- which is what a `-pass` mirror's seven days look like -- from
+ * producing a bound tighter than a single tick.
+ */
+export const LANE_PRODUCER: Readonly<Record<string, ProducerLane>> = {
+  "account-balances": "account_balances",
+  "neon:account-balances": "account_balances",
+  "neon:account-balances-pass": "account_balances",
+  "hotkey-alpha": "hotkey_alpha",
+  "neon:hotkey-alpha": "hotkey_alpha",
+  "neon:hotkey-alpha-pass": "hotkey_alpha",
+  "validator-nominators": "validator_nominators",
+  "neon:validator-nominator-counts": "validator_nominators",
+  "neon:validator-nominator-counts-pass": "validator_nominators",
+  "neon:nominator-positions": "validator_nominators",
+  "neon:nominator-positions-pass": "validator_nominators",
+  "neon:nominator-positions-prune": "validator_nominators",
+  "account-identity": "account_identity",
+  "neon:account-identity": "account_identity",
+  "subnet-hyperparams": "subnet_hyperparams",
+  "neon:subnet-hyperparams": "subnet_hyperparams",
+  metagraph: "metagraph",
+  "neon:neurons": "metagraph",
+  "neon:neurons-pass": "metagraph",
+  "neon:neuron_daily": "metagraph",
+  "neon:account_position_daily": "metagraph",
+} as const;
+
+/**
+ * The cadence to judge one lane's silence by: its own observed maximum gap,
+ * floored by its producer's declared cadence where we have one.
+ *
+ * `null` in means null out -- no sample and no declaration is no bound, and
+ * withLaneHealth then leaves the verdict alone rather than guessing.
+ */
+export function laneSilenceCadenceMs(
+  lane: string,
+  observedMaxGapMs: number | null | undefined,
+): number | null {
+  const declared = LANE_PRODUCER[lane];
+  const floor = declared ? cadenceMs(declared) : null;
+  const observed =
+    typeof observedMaxGapMs === "number" && observedMaxGapMs > 0
+      ? observedMaxGapMs
+      : null;
+  if (observed === null) return floor;
+  return floor === null ? observed : Math.max(observed, floor);
+}
+
 /** One producer's cadence in milliseconds. */
 export function cadenceMs(lane: ProducerLane): number {
   return PRODUCER_CADENCE_SECS[lane] * 1000;

--- a/src/self-health-mcp.ts
+++ b/src/self-health-mcp.ts
@@ -70,7 +70,7 @@ import { createPgSql } from "./pg-sql.ts";
 import { loadLatestLaneHealth } from "./lane-health.ts";
 import { laneHealthStore } from "./lane-health-store.ts";
 import { withLaneHealth, type SelfHealth } from "./self-health.ts";
-import { loadLaneCadence, LANE_ALARM_CADENCE_WINDOW_MS } from "./lane-alarm.ts";
+import { loadLaneMaxGap, LANE_ALARM_CADENCE_WINDOW_MS } from "./lane-alarm.ts";
 import {
   GetSelfHealthInputSchema,
   GetSelfHealthOutputSchema,
@@ -213,12 +213,12 @@ export async function loadSelfHealth(
       ctx.env as unknown as Record<string, unknown>,
     ) as unknown as Parameters<typeof loadLatestLaneHealth>[0],
   );
-  // Same cadence sample the REST twin takes (#10232), so both surfaces judge
-  // a silent lane identically rather than one of them serving a dead verdict.
-  const cadences = await loadLaneCadence(
+  // Same sample the REST twin takes (#10232/#10333), so both surfaces judge a
+  // silent lane identically rather than one of them serving a dead verdict.
+  const cadences = await loadLaneMaxGap(
     laneHealthStore(
       ctx.env as unknown as Record<string, unknown>,
-    ) as unknown as Parameters<typeof loadLaneCadence>[0],
+    ) as unknown as Parameters<typeof loadLaneMaxGap>[0],
     Date.now() - LANE_ALARM_CADENCE_WINDOW_MS,
   );
   return withLaneHealth(card as SelfHealth, lanes, { cadences });

--- a/src/self-health.ts
+++ b/src/self-health.ts
@@ -19,6 +19,7 @@
 /** The components the poller writes. Order is display order. */
 import type { LaneHealthRecord } from "./lane-health.ts";
 import { laneSilenceThresholdMs } from "./lane-alarm.ts";
+import { laneSilenceCadenceMs } from "./producer-cadence.ts";
 
 export const SELF_HEALTH_COMPONENTS = ["api", "site", "publish"] as const;
 export type SelfHealthComponent = (typeof SELF_HEALTH_COMPONENTS)[number];
@@ -321,7 +322,12 @@ export function withLaneHealth(
   const { cadences, nowMs = Date.now() } = options;
   const lanes: SelfHealthLaneView[] = Object.values(laneRows)
     .map((row) => {
-      const cadence = cadences?.[row.lane];
+      // The lane's own observed maximum gap, floored by its producer's
+      // declared cadence where one exists (#10333). Neither alone is enough:
+      // observation drifts to zero for a mirror that writes many rows per
+      // pass, and a declaration alone cannot notice a lane whose real interval
+      // has moved away from the configured one.
+      const cadence = laneSilenceCadenceMs(row.lane, cadences?.[row.lane]);
       const quietFor = nowMs - row.checked_at;
       const silent =
         typeof cadence === "number" &&

--- a/tests/lane-silence-cadence.test.ts
+++ b/tests/lane-silence-cadence.test.ts
@@ -1,0 +1,226 @@
+// The silence bound's cadence: observed maximum gap, floored by the declared
+// one (#10333).
+//
+// #10232 shipped with `laneCadenceMs` -- span / (n-1), the MEAN gap -- and put
+// 14 of 49 healthy production lanes into `unknown`. Two structural reasons, and
+// both matter for any future estimator here:
+//
+//   1. Container reboots fire every lane's first tick immediately, so every
+//      slow lane's sample carries a cluster of near-zero gaps.
+//   2. A mirror lane writes many rows PER PASS -- `neon:account-balances`
+//      logged 6,268 in seven days against a six-hour producer -- so "gap
+//      between rows" is not "gap between passes" there at all.
+//
+// Measured over seven days of production, in minutes:
+//
+//     lane                    rows  declared   mean  median   MAX
+//     hotkey-alpha              15      1440    286      76   973
+//     neon:account-balances   6268       360      1       0   359
+//     metagraph                353        15     16      15    46
+//
+// The max survives all of them; the mean is wrong on six of seven. The
+// declared cadence then floors it, for the case the max cannot reach: a lane
+// whose seven days are a burst followed by silence reads a max of ~48 minutes
+// against a 24-hour producer.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  LANE_PRODUCER,
+  PRODUCER_CADENCE_SECS,
+  cadenceMs,
+  laneSilenceCadenceMs,
+} from "../src/producer-cadence.ts";
+import {
+  LANE_ALARM_MIN_CADENCE_SAMPLES,
+  LANE_MAX_GAP_SQL,
+  loadLaneMaxGap,
+} from "../src/lane-alarm.ts";
+
+const MIN = 60_000;
+
+describe("laneSilenceCadenceMs", () => {
+  test("takes the observed gap when it exceeds the declared cadence", () => {
+    // Observation is the half that notices a real interval drifting away from
+    // the configured one -- the floor must not throw that away.
+    const observed = 40 * 60 * MIN; // 40h, past hotkey_alpha's declared 24h
+    assert.equal(laneSilenceCadenceMs("hotkey-alpha", observed), observed);
+  });
+
+  test("takes the declared cadence when the observation reads short", () => {
+    // The `neon:*-pass` case: a burst then silence, so the max gap inside the
+    // burst is minutes against a 24-hour producer.
+    assert.equal(
+      laneSilenceCadenceMs("neon:hotkey-alpha-pass", 48 * MIN),
+      cadenceMs("hotkey_alpha"),
+    );
+  });
+
+  test("a mirror writing many rows per pass cannot drive the bound to zero", () => {
+    // The measured `neon:account-balances` pathology: mean 1 minute, median 0.
+    // Even handed a 1-minute observation the bound stays at its producer's 6h.
+    assert.equal(
+      laneSilenceCadenceMs("neon:account-balances", 1 * MIN),
+      cadenceMs("account_balances"),
+    );
+  });
+
+  test("an undeclared lane still gets its observation", () => {
+    assert.equal(laneSilenceCadenceMs("table-freshness", 25 * MIN), 25 * MIN);
+  });
+
+  test("no observation and no declaration is NO BOUND, not a guess", () => {
+    // withLaneHealth leaves the verdict alone on null, which is the whole
+    // safety property: a lane we cannot calibrate is never called silent.
+    assert.equal(laneSilenceCadenceMs("table-freshness", null), null);
+    assert.equal(laneSilenceCadenceMs("table-freshness", undefined), null);
+    assert.equal(laneSilenceCadenceMs("table-freshness", 0), null);
+  });
+
+  test("no observation but a declaration still bounds the lane", () => {
+    assert.equal(
+      laneSilenceCadenceMs("account-identity", null),
+      cadenceMs("account_identity"),
+    );
+  });
+});
+
+describe("LANE_PRODUCER", () => {
+  test("every value names a producer whose cadence is declared", () => {
+    for (const [lane, producer] of Object.entries(LANE_PRODUCER)) {
+      assert.ok(
+        producer in PRODUCER_CADENCE_SECS,
+        `${lane} -> ${producer} has no declared cadence`,
+      );
+    }
+  });
+
+  test("the nominator lanes map to their PRODUCER, not to their own name", () => {
+    // The case that makes this table explicit rather than string surgery: one
+    // poller writes both the counts and the positions, so `nominator_positions`
+    // is not a producer key and a strip-the-prefix rule would miss it.
+    for (const lane of [
+      "neon:nominator-positions",
+      "neon:nominator-positions-pass",
+      "neon:nominator-positions-prune",
+      "neon:validator-nominator-counts",
+    ]) {
+      assert.equal(LANE_PRODUCER[lane], "validator_nominators", lane);
+    }
+  });
+
+  test("a mirror shares its parent's producer", () => {
+    for (const [mirror, parent] of [
+      ["neon:account-balances", "account-balances"],
+      ["neon:hotkey-alpha", "hotkey-alpha"],
+      ["neon:account-identity", "account-identity"],
+      ["neon:subnet-hyperparams", "subnet-hyperparams"],
+    ] as const) {
+      assert.equal(LANE_PRODUCER[mirror], LANE_PRODUCER[parent], mirror);
+    }
+  });
+});
+
+// --- the loader --------------------------------------------------------------
+
+/** A db whose `all()` returns the given rows, recording what it was asked. */
+function db(rows: unknown[], onSql?: (sql: string, values: unknown[]) => void) {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...values: unknown[]) {
+          onSql?.(sql, values);
+          return { all: async () => ({ results: rows }) };
+        },
+      };
+    },
+  } as unknown as Parameters<typeof loadLaneMaxGap>[0];
+}
+
+describe("loadLaneMaxGap", () => {
+  test("returns the max gap per lane, and asks Postgres for exactly that", () => {
+    // The SQL is the fix. A window function over `checked_at` is the only way
+    // to get a per-pass interval out of a table where a mirror writes many rows
+    // per pass, and asserting it here is cheaper than discovering a rewritten
+    // query has silently gone back to an aggregate over rows.
+    assert.match(LANE_MAX_GAP_SQL, /LAG\(checked_at\) OVER/);
+    assert.match(LANE_MAX_GAP_SQL, /PARTITION BY lane ORDER BY checked_at/);
+    assert.match(LANE_MAX_GAP_SQL, /MAX\(gap\)/);
+  });
+
+  test("reads rows into a lane -> gap map", async () => {
+    let asked: [string, unknown[]] | null = null;
+    const out = await loadLaneMaxGap(
+      db(
+        [
+          { lane: "neurons", n: 20, max_gap: 900_000 },
+          { lane: "metagraph", n: 50, max_gap: 2_760_000 },
+        ],
+        (sql, values) => {
+          asked = [sql, values];
+        },
+      ),
+      1_786_000_000_000,
+    );
+    assert.deepEqual(out, { neurons: 900_000, metagraph: 2_760_000 });
+    assert.equal(asked![0], LANE_MAX_GAP_SQL);
+    assert.deepEqual(asked![1], [1_786_000_000_000]);
+  });
+
+  test("a lane under the sample floor reads null, not a bound", async () => {
+    // `n` counts GAPS, one fewer than rows, so the comparison is n + 1.
+    const gaps = LANE_ALARM_MIN_CADENCE_SAMPLES - 2;
+    const out = await loadLaneMaxGap(
+      db([{ lane: "sparse", n: gaps, max_gap: 900_000 }]),
+      0,
+    );
+    assert.equal(out.sparse, null);
+    const out2 = await loadLaneMaxGap(
+      db([{ lane: "just_enough", n: gaps + 1, max_gap: 900_000 }]),
+      0,
+    );
+    assert.equal(out2.just_enough, 900_000);
+  });
+
+  test("a non-positive gap reads null", async () => {
+    const out = await loadLaneMaxGap(
+      db([{ lane: "flat", n: 99, max_gap: 0 }]),
+      0,
+    );
+    assert.equal(out.flat, null);
+  });
+
+  test("a row with no lane is skipped rather than keyed on empty string", async () => {
+    const out = await loadLaneMaxGap(
+      db([
+        { lane: null, n: 99, max_gap: 900_000 },
+        { lane: "real", n: 99, max_gap: 900_000 },
+      ]),
+      0,
+    );
+    assert.deepEqual(Object.keys(out), ["real"]);
+  });
+
+  test("declines to {} without a db, and on a throw", async () => {
+    // A failed read must cost today's behaviour, never a false alarm:
+    // withLaneHealth leaves every verdict alone when it gets no bound.
+    assert.deepEqual(await loadLaneMaxGap(null, 0), {});
+    assert.deepEqual(await loadLaneMaxGap(undefined, 0), {});
+    const exploding = {
+      prepare: () => ({
+        bind: () => ({
+          all: async () => {
+            throw new Error("neon down");
+          },
+        }),
+      }),
+    } as unknown as Parameters<typeof loadLaneMaxGap>[0];
+    assert.deepEqual(await loadLaneMaxGap(exploding, 0), {});
+  });
+
+  test("a result with no results array yields an empty map", async () => {
+    const empty = {
+      prepare: () => ({ bind: () => ({ all: async () => null }) }),
+    } as unknown as Parameters<typeof loadLaneMaxGap>[0];
+    assert.deepEqual(await loadLaneMaxGap(empty, 0), {});
+  });
+});

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -267,7 +267,7 @@ import { loadSelfHealthColdTier } from "../../src/self-health-cold-tier.ts";
 import { loadLatestLaneHealth } from "../../src/lane-health.ts";
 import { withLaneHealth } from "../../src/self-health.ts";
 import {
-  loadLaneCadence,
+  loadLaneMaxGap,
   LANE_ALARM_CADENCE_WINDOW_MS,
 } from "../../src/lane-alarm.ts";
 import { loadTopHoldersFlowTier } from "../../src/top-holders-flow-tier.ts";
@@ -2060,14 +2060,14 @@ export async function handleSelfHealth(
       typeof loadLatestLaneHealth
     >[0],
   );
-  // The cadence sample the silence bound needs (#10232). One extra GROUP BY
-  // over the same table the read above already touched, and it is what stops a
-  // dead lane serving its last verdict forever. loadLaneCadence declines to a
-  // {} on any failure, and withLaneHealth then leaves every verdict alone --
-  // so a cadence read that fails costs today's behaviour, never a false alarm.
-  const cadences = await loadLaneCadence(
+  // The sample the silence bound needs (#10232), as the LONGEST observed gap
+  // rather than the mean (#10333). One extra GROUP BY over the table the read
+  // above already touched. loadLaneMaxGap declines to a {} on any failure, and
+  // withLaneHealth then leaves every verdict alone -- so a failed read costs
+  // today's behaviour, never a false alarm.
+  const cadences = await loadLaneMaxGap(
     laneHealthStore(env as unknown as Record<string, unknown>) as Parameters<
-      typeof loadLaneCadence
+      typeof loadLaneMaxGap
     >[0],
     Date.now() - LANE_ALARM_CADENCE_WINDOW_MS,
   );


### PR DESCRIPTION
## The regression

#10232/#10326 shipped the silence bound reading `laneCadenceMs` — `span / (n-1)`, the **mean** gap. On the live card that puts **14 of 49 healthy lanes** into `unknown`:

```
account-identity       | no verdict for 1357m (cadence ~235m)
hotkey-alpha           | no verdict for 1343m (cadence ~286m)
neon:account-balances  | no verdict for  274m (cadence ~1m)
neon:hotkey-alpha      | no verdict for 1342m (cadence ~4m)
```

`ACCOUNT_IDENTITY_POLL_SECS` and `HOTKEY_ALPHA_POLL_SECS` are **86400**; `ACCOUNT_BALANCES_POLL_SECS` is **21600**. Every lane above is quiet for *less than one of its own intervals*. They are working.

## Why the mean cannot do this job

Two structural reasons, not incidental ones:

1. **Container reboots fire every lane's first tick immediately** — `src/producer-cadence.ts` already documents this — so every slow lane's sample carries a cluster of near-zero gaps that drags the mean under the real interval.
2. **A mirror writes many rows per pass.** `neon:account-balances` logged **6,268 rows in seven days** against a six-hour producer. "Gap between rows" is not "gap between passes" there at all, and the mean *and* the median both collapse toward zero.

Seven days of production, in minutes:

| lane | rows | declared | mean | median | **max** |
|---|---|---|---|---|---|
| hotkey-alpha | 15 | 1440 | 286 ✗ | 76 ✗ | **973** |
| account-identity | 18 | 1440 | 235 ✗ | 48 ✗ | **970** |
| account-balances | 21 | 360 | 253 ✗ | 347 | **361** |
| neon:account-balances | 6268 | 360 | 1 ✗ | 0 ✗ | **359** |
| neon:hotkey-alpha | 499 | 1440 | 4 ✗ | 0 ✗ | **855** |
| validator-nominators | 13 | 1440 | 331 ✗ | 293 ✗ | **971** |
| metagraph | 353 | 15 | 16 | 15 | **46** |

**The max is the only column that survives all seven.** The mean is wrong on six.

So the bound reads a new `LANE_MAX_GAP_SQL` — a window function over `checked_at`, the only shape that yields a per-*pass* interval from a table where one pass writes many rows.

`laneCadenceMs` and `loadLaneCadence` are **untouched**: `lane-alarm` consumes them and its behaviour is not part of this bug.

## Why a declared floor as well

The max alone still leaves two lanes wrong. A `-pass` mirror whose seven days are a burst followed by silence reads a 48-minute max against a 24-hour producer. So the **declared** cadence floors the observed one, through an explicit `LANE_PRODUCER` table.

Explicit rather than string surgery, deliberately. The obvious rule — strip `neon:`, strip `-pass`, swap dashes for underscores — gets four right and **`neon:nominator-positions-pass` wrong**: that lane's producer is `validator_nominators`, because one poller writes both the counts and the positions. That is exactly why `PRODUCER_CADENCE_SECS` is keyed by producer rather than by watchdog. A rule that is right most of the time fails silently here, in the direction of a bound that is too tight.

**A floor, never a replacement** — observation is the half that notices a real interval drifting away from the configured one.

## Measured against all 49 production lanes

| | false `unknown` |
|---|---|
| today (mean) | **14** |
| max gap alone | 2 |
| max gap + declared floor | **0** |

And it still fires — a bound that never triggers would be worse than none:

| | bound to read `unknown` |
|---|---|
| `metagraph`, `subnet-burn`, `registry-sync`, … | 90 min (the floor) |
| `hotkey-alpha`, `account-identity` | 72 h (3 × 24 h) |
| `neon:nominator-positions` | 100 h |

Two lanes have too little history for any bound and are left alone entirely, which is the existing safety property: a lane we cannot calibrate is never called silent.

## Verification

- **483 tests pass** across the eight lane/self-health/entities suites.
- 16 new tests: the estimator's resolution rules, `LANE_PRODUCER`'s integrity, and `loadLaneMaxGap`'s decline paths.
- **Proven able to fail** — removing the floor fails three by name (`takes the declared cadence when the observation reads short`, `a mirror writing many rows per pass cannot drive the bound to zero`, `no observation but a declaration still bounds the lane`).
- Patch coverage by diff intersection: **0 uncovered statements, 0 uncovered branches** across all 161 changed lines in the five source files.
- `tsc` clean, eslint clean, `npm run build` no artifact drift.

Closes #10333