### PR TITLE
fix(mcp): read the economics ladder, not just its bottom rung (#10307)

### DIFF
--- a/scripts/check-cross-surface-values.ts
+++ b/scripts/check-cross-surface-values.ts
@@ -73,21 +73,24 @@ const TIME_DEPENDENT = /_age_ms$|^age_ms$|_at$|^now$|elapsed|uptime_seconds/;
  * Keyed `<tool>.<field>`, because a difference is per-surface-pair per-field
  * and "this route disagrees somewhere" is not a fact anyone can act on.
  */
-const DECLARED: Record<string, string> = {
-  // #10306: the dispatcher applies its own page size instead of the default the
-  // tool publishes -- 100 against a published 50 here, and NOTHING at all on
-  // get_subnet_identity_history, which is why that one answers `entry_count: 0`
-  // for a subnet that has changed identity.
-  "get_chain_subnet_lifecycle.entry_count": "#10306",
-  "get_chain_subnet_lifecycle.subnet_count": "#10306",
-  "get_chain_subnet_lifecycle.limit": "#10306",
-  "get_subnet_identity_history.entry_count": "#10306",
-  "get_subnet_identity_history.entries": "#10306",
-  // #10307: REST answers 89.4820752 and MCP 91.04839199999999 for the same
-  // subnet, both stable across repeated calls, so it is not a moving window
-  // read at two instants.
-  "get_subnet_validator_economics.tao_inflow_per_day": "#10307",
-};
+/**
+ * EMPTY, which is the goal state rather than a missing list.
+ *
+ * Every entry this sweep opened with has been closed rather than tolerated:
+ *
+ *   #10306  five entries -- `get_chain_subnet_lifecycle` served 100 against a
+ *           published 50, and `get_subnet_identity_history` applied no page
+ *           default at all, so it answered `entry_count: 0` for a subnet that
+ *           had changed identity. The MCP dispatcher now serves the default
+ *           each tool publishes.
+ *   #10307  one entry -- `tao_inflow_per_day`, 89.4820752 on REST against
+ *           91.04839199999999 on MCP for the same subnet, both stable. The
+ *           tool was reading the published artifact where REST reads the live
+ *           tier first; both now climb one shared ladder.
+ *
+ * A stale entry FAILS this script, so the list cannot grow back quietly.
+ */
+const DECLARED: Record<string, string> = {};
 
 interface Divergence {
   tool: string;

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -690,6 +690,7 @@ import {
 } from "./mcp-input-schema.ts";
 import {
   buildSubnetValidatorEconomicsPayload,
+  resolveEconomicsBlob,
   buildSubnetValidatorEconomicsHistoryPayload,
   buildValidatorEconomicsRankingPayload,
 } from "../workers/request-handlers/entities.ts";
@@ -5507,20 +5508,28 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         netuid,
         {
           loadEconomicsRow: async () => {
+            // The SAME live-then-artifact ladder REST climbs (#10307), with only
+            // the artifact READ supplied from here. Reading the artifact alone
+            // -- which this did -- made the tool answer
+            // `tao_inflow_per_day: 91.04839199999999` where REST answered
+            // 89.4820752 for the same subnet, both stable: two blobs refreshed
+            // on different cadences, not a moving window read twice.
+            //
             // A cold economics artifact DEGRADES this answer, it does not 404 it:
             // the artifact is an input to the derivation, not its subject, and the
             // floors in units are still true without the reserves. loadArtifactData
             // raises not_found for a missing artifact, which would otherwise turn a
             // partial answer into no answer at all.
-            let blob: Record<string, unknown> | null;
-            try {
-              blob = (await loadArtifactData(
-                ctx,
-                "/metagraph/economics.json",
-              )) as Record<string, unknown> | null;
-            } catch {
-              blob = null;
-            }
+            const blob = await resolveEconomicsBlob(ctx.env, async () => {
+              try {
+                return (await loadArtifactData(
+                  ctx,
+                  "/metagraph/economics.json",
+                )) as Record<string, unknown> | null;
+              } catch {
+                return null;
+              }
+            });
             const rows = Array.isArray(blob?.subnets)
               ? (blob.subnets as Array<Record<string, unknown>>)
               : [];

--- a/tests/economics-tier-ladder.test.ts
+++ b/tests/economics-tier-ladder.test.ts
@@ -1,0 +1,145 @@
+// REST and MCP read the economics blob off the SAME ladder (#10307).
+//
+// The cross-surface sweep found them answering different numbers for the same
+// subnet, both stable across repeated calls:
+//
+//   GET /api/v1/subnets/64/validator-economics   tao_inflow_per_day 89.4820752
+//   get_subnet_validator_economics {netuid: 64}  tao_inflow_per_day 91.0483919
+//
+// 1.7% apart. Not a moving window read at two instants -- two blobs refreshed
+// on different cadences. `get_subnet_validator_economics` overrides the
+// economics reader because MCP resolves artifacts through `ctx` rather than off
+// `env`, a correct fix for #9229 that in making it dropped the LIVE rung and
+// read the published artifact alone.
+//
+// WHAT THIS PINS is the property that makes the two agree: the ladder tries
+// live-KV first and falls back to the artifact, and the artifact READER is the
+// only part a caller supplies. A surface cannot acquire one tier and miss the
+// other by overriding a loader, because the ORDER is not a thing it passes.
+//
+// Driving `resolveEconomicsBlob` directly rather than the two handlers: the
+// handlers differ in a dozen ways that are not this, and a test that stood them
+// up whole would pass or fail for reasons unrelated to which tier each read.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { resolveEconomicsBlob } from "../workers/request-handlers/entities.ts";
+import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.ts";
+import { handleMcpRequest } from "../src/mcp-server.ts";
+import type { Row } from "./row-type.ts";
+
+/** A live blob that clears every gate `resolveLiveEconomics` applies. */
+function liveBlob(taoInEmission: number): Row {
+  return {
+    captured_at: new Date().toISOString(),
+    summary: { with_economics_count: 1 },
+    subnets: [
+      { netuid: 64, tao_in_emission_tao: taoInEmission, emission_share: 1 },
+    ],
+  };
+}
+
+/** An env whose KV holds `blob` under the economics key, or nothing. */
+function envWith(blob: Row | null) {
+  return {
+    // `readHealthKv` calls `get(key, { type: "json" })`, so the double hands
+    // back the parsed object rather than a string.
+    METAGRAPH_CONTROL: {
+      get: async (key: string) => (key === KV_ECONOMICS_CURRENT ? blob : null),
+    },
+  } as unknown as Parameters<typeof resolveEconomicsBlob>[0];
+}
+
+/** The live value, distinct from the artifact so the two are tellable apart. */
+const LIVE_TAO_IN_EMISSION = 0.0124281;
+
+const ARTIFACT: Row = {
+  captured_at: new Date().toISOString(),
+  subnets: [{ netuid: 64, tao_in_emission_tao: 0.0126456, emission_share: 1 }],
+};
+
+describe("the economics tier ladder is shared, not per-surface", () => {
+  test("the live tier wins when it has rows", async () => {
+    const blob = await resolveEconomicsBlob(
+      envWith(liveBlob(0.0124281)),
+      async () => ARTIFACT,
+    );
+    assert.equal(
+      (blob?.subnets as Row[])[0].tao_in_emission_tao,
+      0.0124281,
+      "a live blob that passes every gate must outrank the published artifact",
+    );
+  });
+
+  test("the artifact is the fallback, not the first choice", async () => {
+    const blob = await resolveEconomicsBlob(
+      envWith(null),
+      async () => ARTIFACT,
+    );
+    assert.equal((blob?.subnets as Row[])[0].tao_in_emission_tao, 0.0126456);
+  });
+
+  test("both readers reach the same blob for the same env", async () => {
+    // The two surfaces differ ONLY in how they read the artifact. Given a live
+    // tier, that difference must not be observable -- which is exactly what
+    // #10307 was: the MCP reader was consulted where REST's never would be.
+    const env = envWith(liveBlob(0.0124281));
+    const viaWorkerReader = await resolveEconomicsBlob(
+      env,
+      async () => ARTIFACT,
+    );
+    const viaCtxReader = await resolveEconomicsBlob(env, async () => {
+      throw new Error("a ctx read must not happen while the live tier answers");
+    });
+    assert.deepEqual(viaCtxReader, viaWorkerReader);
+  });
+
+  test("neither tier answering is null, not an empty blob", async () => {
+    // A schema-stable empty object here would read as "this subnet has no
+    // economics" rather than "we could not read them" -- the #9803 shape.
+    assert.equal(
+      await resolveEconomicsBlob(envWith(null), async () => null),
+      null,
+    );
+  });
+});
+
+describe("the MCP tool climbs that ladder, not a private one", () => {
+  // THE regression test. The three above prove the ladder is correct; this one
+  // proves `get_subnet_validator_economics` is on it, which is the half #10307
+  // was actually about -- the tool had a working ladder available and read
+  // around it. Without this, reverting the tool to its private artifact read
+  // leaves every assertion above green.
+  test("a live economics blob reaches get_subnet_validator_economics", async () => {
+    const response = await handleMcpRequest(
+      new Request("https://api.metagraph.sh/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "get_subnet_validator_economics",
+            arguments: { netuid: 64 },
+          },
+        }),
+      }),
+      envWith(liveBlob(LIVE_TAO_IN_EMISSION)) as Parameters<
+        typeof handleMcpRequest
+      >[1],
+    );
+    const body = (await response.json()) as Row;
+    const card = (body?.result as Row)?.structuredContent as Row;
+    // `tao_inflow_per_day` is `tao_in_emission_tao * BLOCKS_PER_DAY`, and the
+    // 7200 is not restated here -- the point is that the number came from the
+    // LIVE blob rather than any artifact, which only the live value can show.
+    assert.equal(
+      card?.tao_inflow_per_day,
+      LIVE_TAO_IN_EMISSION * 7200,
+      "the tool must read the live tier before the published artifact",
+    );
+  });
+});

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -3171,27 +3171,57 @@ async function resolveSubnetMarketCapTao(env: Env, netuid: number) {
     : null;
 }
 
-// One subnet's live AMM pool reserves (#5235) — the constant-product inputs the
-// stake-quote math needs — resolved from the same live-KV-then-committed-R2
-// economics tiers as resolveSubnetMarketCapTao, plus the blob's freshness stamp
-// for the response meta. Returns { row: null } when neither tier has a row.
-export async function resolveSubnetEconomicsRow(env: Env, netuid: number) {
+/**
+ * The economics blob, from the LIVE tier if it has one and the published
+ * artifact otherwise (#10307).
+ *
+ * ── Why the ladder is a function and not two copies ────────────────────────
+ *
+ * It was two copies, and they answered different numbers.
+ * `get_subnet_validator_economics` overrides the economics reader because MCP
+ * resolves artifacts through `ctx` rather than off `env` -- a correct fix for
+ * #9229, which in making it dropped the LIVE rung and read the artifact alone.
+ * REST and GraphQL kept both. The result, verified live for SN64 with both
+ * values stable across repeated calls:
+ *
+ *   GET /api/v1/subnets/64/validator-economics   tao_inflow_per_day 89.4820752
+ *   get_subnet_validator_economics {netuid: 64}  tao_inflow_per_day 91.0483919
+ *
+ * 1.7% apart -- large enough to be a different answer, small enough that
+ * neither looks wrong to a reader. Both surfaces compute
+ * `tao_in_emission_tao * BLOCKS_PER_DAY` from the same field; they were reading
+ * it out of blobs refreshed on different cadences.
+ *
+ * The LADDER is the shared thing; the artifact READER is not. A caller supplies
+ * its own, so MCP keeps the ctx-based read #9229 needed and still gets the live
+ * rung first -- and a surface can no longer acquire one tier and miss the other
+ * by overriding a loader, because the ORDER is not something a caller passes.
+ */
+export async function resolveEconomicsBlob(
+  env: Env,
+  readPublishedArtifact: () => Promise<Record<string, unknown> | null>,
+): Promise<Record<string, unknown> | null> {
   const live = await resolveLiveEconomics({
     readHealthKv: (e) => readHealthKv(e, KV_ECONOMICS_CURRENT),
     env,
     contractVersion: contractVersion(env),
   });
-  let blob: Record<string, unknown> | null = Array.isArray(live?.data?.subnets)
-    ? live.data
-    : null;
-  if (!blob) {
+  if (Array.isArray(live?.data?.subnets)) return live.data;
+  const artifact = await readPublishedArtifact();
+  return artifact && Array.isArray(artifact.subnets) ? artifact : null;
+}
+
+// One subnet's live AMM pool reserves (#5235) — the constant-product inputs the
+// stake-quote math needs — resolved from the same live-KV-then-committed-R2
+// economics tiers as resolveSubnetMarketCapTao, plus the blob's freshness stamp
+// for the response meta. Returns { row: null } when neither tier has a row.
+export async function resolveSubnetEconomicsRow(env: Env, netuid: number) {
+  const blob = await resolveEconomicsBlob(env, async () => {
     const artifact = await readArtifact(env, "/metagraph/economics.json");
-    const artifactData = artifact.ok
-      ? (artifact.data as Record<string, unknown> | undefined)
-      : undefined;
-    blob =
-      artifactData && Array.isArray(artifactData.subnets) ? artifactData : null;
-  }
+    return artifact.ok
+      ? ((artifact.data as Record<string, unknown> | undefined) ?? null)
+      : null;
+  });
   const rows = Array.isArray(blob?.subnets)
     ? (blob.subnets as Array<Record<string, unknown>>)
     : [];


### PR DESCRIPTION
## Two surfaces, one field, two numbers

Found by the cross-surface sweep (#10217), both values stable across repeated calls — so not a
moving window read at two instants:

```
GET /api/v1/subnets/64/validator-economics   tao_inflow_per_day  89.4820752
get_subnet_validator_economics {netuid: 64}  tao_inflow_per_day  91.04839199999999
```

**1.7% apart** — large enough to be a different answer, small enough that neither looks wrong to a
reader. Both surfaces compute `tao_in_emission_tao * BLOCKS_PER_DAY` from the same field, through the
same composer. They were reading it out of **two blobs refreshed on different cadences**.

## The cause is a fix that took one rung off a ladder

`resolveSubnetEconomicsRow` tries the live KV tier first and falls back to the published R2 artifact.
`get_subnet_validator_economics` overrides that reader — correctly, for #9229: MCP resolves artifacts
through `ctx` (which carries the resource cache and the test seam), not off `env` the way a Worker
request handler does, and letting the composer's default run there would answer degraded for every
subnet.

In supplying its own reader, the override replaced the whole ladder with its bottom rung. REST and
GraphQL kept both.

## The ladder is the shared thing; the reader is not

`resolveEconomicsBlob(env, readPublishedArtifact)` owns the order. A caller supplies only how to read
the artifact, so MCP keeps the ctx-based read #9229 needed **and** tries live-KV first.

The structural point: a surface can no longer acquire one tier and miss the other by overriding a
loader, because **the order is not something a caller passes**. That is the same shape as
`no surface owns the tier cascade` — an override that looks local silently changes which store
answers.

## The sweep's DECLARED list is now empty

```
#10306  five entries  → closed by the dispatcher serving each tool's published default
#10307  one entry     → closed here
```

That list must shrink or the sweep fails, and it has reached zero rather than being tolerated.

## The gate, and which half of it matters

`tests/economics-tier-ladder.test.ts` — four cases pin the ladder (live wins, artifact is the
fallback, both readers reach the same blob, neither tier is `null` not an empty card) and a fifth
drives the **real MCP dispatcher** with a live blob in KV.

That fifth one is the test that would have caught this. **Proven:** reverting the tool to its private
artifact read turns exactly that assertion red and leaves the four ladder assertions green — which is
the trap, since a ladder test alone would have shipped happily alongside a tool that ignores it.

## Validation

```
npm run typecheck / lint / format:check   clean
npx vitest run                            18,207 passed, 11 skipped, 0 failed
```

Closes #10307
