### PR TITLE
ci: run every declared validator, and make "declared" mean "enrolled"

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -396,6 +396,13 @@ jobs:
           npm run validate:published-names
           npm run validate:graphql-tier-parity
           npm run validate:committed-seed
+          # Both of these were reachable only from the LOCAL gate, so a
+          # contract-only PR -- the exact PR that invalidates them -- got no CI
+          # coverage at all (#10251). They live in this step rather than the
+          # `ui` job because that job is gated on a path filter that matches
+          # neither schemas-src/ nor public/metagraph/openapi.json.
+          npm run validate:ui-docs-drift
+          npm run validate:readme-catalog
 
       # Stage artifacts for BOTH halves: the suite's reader tests serve R2-only artifacts with NO
       # committed fallback (dist/metagraph-r2/metagraph/*), and every post-build validator below reads

--- a/scripts/pipeline.ts
+++ b/scripts/pipeline.ts
@@ -115,6 +115,14 @@ function checkCommands(): Step[] {
     // check lived in the separately path-gated `ui` CI job. Checked here so
     // the PR that causes the drift can see it locally.
     step("validate:ui-docs-drift"),
+    // Same shape, and it was in neither the pipeline nor CI until #10251: the
+    // registry README's catalog section is generated, so a registry change
+    // invalidates it without touching the README.
+    step("validate:readme-catalog"),
+    // Runs in publish-cloudflare.yml / sync-subnets.yml, so it had CI coverage
+    // but no local one -- 0.2s, and an adapter edit is exactly the change a
+    // contributor wants told about before pushing (#10251).
+    step("validate:adapters"),
     step("validate:intake"),
     step("validate:surface"),
     // #8658: runs after the build steps above, so the staged surfaces.json
@@ -210,6 +218,14 @@ function refreshCommands(refreshTimestamp: string): Step[] {
     // check lived in the separately path-gated `ui` CI job. Checked here so
     // the PR that causes the drift can see it locally.
     step("validate:ui-docs-drift"),
+    // Same shape, and it was in neither the pipeline nor CI until #10251: the
+    // registry README's catalog section is generated, so a registry change
+    // invalidates it without touching the README.
+    step("validate:readme-catalog"),
+    // Runs in publish-cloudflare.yml / sync-subnets.yml, so it had CI coverage
+    // but no local one -- 0.2s, and an adapter edit is exactly the change a
+    // contributor wants told about before pushing (#10251).
+    step("validate:adapters"),
     step("validate:intake"),
     step("validate:surface"),
     // #8658: runs after the build steps above, so the staged surfaces.json

--- a/tests/pipeline-validator-parity.test.ts
+++ b/tests/pipeline-validator-parity.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, test } from "vitest";
 import { repoRoot } from "../scripts/lib.ts";
@@ -14,6 +14,17 @@ import { repoRoot } from "../scripts/lib.ts";
 
 const PIPELINE_PATH = path.join(repoRoot, "scripts/pipeline.ts");
 const WORKFLOW_PATH = path.join(repoRoot, ".github/workflows/validate.yml");
+const WORKFLOW_DIR = path.join(repoRoot, ".github/workflows");
+const PACKAGE_PATH = path.join(repoRoot, "package.json");
+
+/**
+ * Validators that run somewhere other than a workflow, with the reason.
+ *
+ * AN ALLOWLIST, so "not in CI" has to be a decision someone wrote down rather
+ * than the default state of a new script. Empty today; the entries that used to
+ * belong here were the bug (#10251).
+ */
+const NOT_IN_CI: Readonly<Record<string, string>> = {};
 
 // Every `validate:*` script wired through `step("validate:...")` in pipeline.ts
 // (covers both checkCommands and refreshCommands).
@@ -35,6 +46,98 @@ function workflowValidators() {
   }
   return scripts;
 }
+
+/** Every `validate:*` script package.json declares. */
+function declaredValidators() {
+  const pkg = JSON.parse(readFileSync(PACKAGE_PATH, "utf8")) as {
+    scripts: Record<string, string>;
+  };
+  return new Set(
+    Object.keys(pkg.scripts).filter((name) => name.startsWith("validate:")),
+  );
+}
+
+/**
+ * Every `validate:*` any workflow runs -- not just validate.yml.
+ *
+ * ALL of them, because `validate:adapters` legitimately runs from
+ * publish-cloudflare.yml and sync-subnets.yml, and a check that only read
+ * validate.yml would report it as a gap and teach the next person to silence
+ * the test rather than fix it.
+ */
+function ciValidators() {
+  const scripts = new Set<string>();
+  for (const file of readdirSync(WORKFLOW_DIR)) {
+    if (!file.endsWith(".yml") && !file.endsWith(".yaml")) continue;
+    const source = readFileSync(path.join(WORKFLOW_DIR, file), "utf8");
+    for (const match of source.matchAll(/npm run (validate:[^\s]+)/g)) {
+      scripts.add(match[1]!);
+    }
+  }
+  return scripts;
+}
+
+// THE DIRECTION THE ORIGINAL TEST COULD NOT SEE (#10251).
+//
+// #1767 asserted pipeline ⊇ validate.yml, which catches "CI runs something the
+// local gate does not". It is silent on the opposite drift, and both instances
+// of it were live: `validate:ui-docs-drift` sat in the pipeline and in NO
+// workflow, and `validate:readme-catalog` was in neither -- so the 298
+// generated API-reference pages and the registry README catalog had no CI
+// coverage on exactly the PR that invalidates them, a contract-only change.
+//
+// Declaring a script is now what enrols it. A validator that exists and runs
+// nowhere is the failure mode, and it looks identical to a working one from
+// every angle except this test.
+describe("every declared validator runs somewhere (#10251)", () => {
+  test("the parsers matched something", () => {
+    assert.ok(declaredValidators().size > 0, "no validate:* in package.json");
+    assert.ok(
+      ciValidators().size > 0,
+      "no `npm run validate:*` in any workflow",
+    );
+  });
+
+  test("every declared validator runs in CI", () => {
+    const missing = [...declaredValidators()]
+      .filter((script) => !ciValidators().has(script) && !(script in NOT_IN_CI))
+      .sort();
+    assert.deepEqual(
+      missing,
+      [],
+      `declared but run by no workflow: ${missing.join(", ")}. ` +
+        "Add each to .github/workflows/ (validate.yml's contract step is the " +
+        "usual home), or to NOT_IN_CI with the reason it belongs elsewhere.",
+    );
+  });
+
+  test("every declared validator runs in the local gate", () => {
+    // The other half of the same claim: `npm run check` should not pass while
+    // a declared validator has never been invoked.
+    const missing = [...declaredValidators()]
+      .filter((script) => !pipelineValidators().has(script))
+      .sort();
+    assert.deepEqual(
+      missing,
+      [],
+      `declared but not in scripts/pipeline.ts: ${missing.join(", ")}.`,
+    );
+  });
+
+  test("NOT_IN_CI carries a reason for every entry, and none is stale", () => {
+    for (const [script, reason] of Object.entries(NOT_IN_CI)) {
+      assert.ok(reason.length > 20, `${script}: give a real reason`);
+      assert.ok(
+        declaredValidators().has(script),
+        `${script} is exempted but no longer declared -- drop the entry`,
+      );
+      assert.ok(
+        !ciValidators().has(script),
+        `${script} is exempted but DOES run in CI -- drop the entry`,
+      );
+    }
+  });
+});
 
 describe("pipeline ↔ validate.yml validator parity (#1767)", () => {
   test("both sets are non-empty (the parsers actually matched something)", () => {


### PR DESCRIPTION
## The PR that causes the drift is the one PR guaranteed not to check for it

`apps/ui/content/docs/api-reference/**` is **298 pages** generated entirely from `public/metagraph/openapi.json`. What invalidates them is a **contract change** — which lands in a backend PR that need never touch `apps/ui`.

The only CI check lived in the `ui` job, gated on a filter matching neither `schemas-src/` nor `public/metagraph/openapi.json`:

```
changed: schemas-src/routes/foo.ts, public/metagraph/openapi.json
  -> filter does not match -> ui job SKIPPED -> drift never checked
```

`validate:ui-docs-drift` exists for exactly this and ran **nowhere in CI** — `scripts/pipeline.ts` only. Its own header says it was added because the check *"runs on a different path filter and nothing in the root `npm run check` covered"*. The local half got fixed; the CI half was left exactly as described.

## Measured — three gaps, not one

44 declared `validate:*` scripts:

| script | state |
|---|---|
| `validate:ui-docs-drift` | pipeline only — **no workflow at all** |
| `validate:readme-catalog` | **neither** pipeline nor workflow — run by nothing, ever |
| `validate:adapters` | in `publish-cloudflare.yml` / `sync-subnets.yml`, but not locally |

`validate:readme-catalog` is the one the issue missed and it is the worse case: the registry README's catalog section is generated, so a registry change invalidates it without touching the README, and **nothing anywhere ran the check**.

## The fix

Both drift checks now run in **validate.yml's contract step** — the `test` job, which runs regardless of the UI path filter. Both complete in under a second from the repo root with no `apps/ui` build:

```
API reference docs are current (298 generated page(s)).
README catalog up to date (129 curated overlays, incl. root).
```

`validate:adapters` joins the local gate (0.2s — an adapter edit is exactly the change a contributor wants told about before pushing).

## Why the meta-test could not see any of it

#1767's parity test asserts **pipeline ⊇ validate.yml**. That catches *"CI runs something the local gate does not"* and is silent on the reverse. **Both live instances were the reverse.**

It now reads `package.json` as the source of truth and asserts every declared validator runs in **both**:

- **in some workflow** — all of them, not just `validate.yml`, because `validate:adapters` legitimately runs elsewhere and a narrower check would report a false gap and teach the next person to silence the test rather than fix it;
- **in the local pipeline**.

`NOT_IN_CI` is an allowlist, **empty today**, requiring a written reason — so "runs nowhere" has to be a decision someone recorded rather than the default state of a new script. Two further tests keep the allowlist honest: an entry must name a still-declared script, and must not name one that *does* run in CI.

**Proven able to fail** — removing `validate:ui-docs-drift` from validate.yml, the exact state this fixes:

```
× every declared validator runs in CI
  declared but run by no workflow: validate:ui-docs-drift. Add each to
  .github/workflows/ (validate.yml's contract step is the usual home), or to
  NOT_IN_CI with the reason it belongs elsewhere.
```

## Verification

- 23 tests pass across the parity, workflow-env and workflow-observability suites.
- `tsc` clean, eslint clean, `npm run build` no artifact drift.
- Both newly-wired validators pass from a clean root.

Closes #10251