### PR TITLE
feat(schemas): a builder's prose reaches the spec, and ordered pairs say so (#10219)

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -13555,13 +13555,17 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 author?: string;
                 spec_version?: number;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
                 min_extrinsics?: number;
                 min_events?: number;
@@ -14321,10 +14325,12 @@ export interface operations {
             query?: {
                 pallet?: string;
                 method?: string;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block?: number;
                 extrinsic?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 before?: number;
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
@@ -15536,6 +15542,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to tx_count. */
                 sort?: "tx_count" | "total_fee_tao";
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
@@ -16109,6 +16116,7 @@ export interface operations {
                 window?: "7d" | "30d";
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25. */
                 limit?: number;
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to volume. */
                 sort?: "volume" | "count";
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -16789,7 +16797,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "alpha_fdv_tao" | "alpha_market_cap_tao" | "alpha_price_change_1d" | "alpha_price_change_1h" | "alpha_price_change_1m" | "alpha_price_change_7d" | "alpha_price_tao" | "block" | "emission_share" | "max_stake_alpha" | "max_uids" | "max_validators" | "miner_count" | "miner_readiness" | "name" | "netuid" | "open_slots" | "registration_cost_tao" | "subnet_volume_tao" | "total_stake_alpha" | "validator_count";
@@ -17077,8 +17085,9 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block?: number;
                 signer?: string;
                 call_module?: string;
@@ -17086,9 +17095,13 @@ export interface operations {
                 /** @description Requires call_module so the decoded call-args JSON scan stays scoped. */
                 call_hash?: string;
                 success?: "true" | "false";
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -17832,6 +17845,7 @@ export interface operations {
             query?: {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
+                /** @description Comma-separated subnet ids to restrict the result to, e.g. `1,7,64`. At most 128 ids, each 0-65535. Unknown ids match nothing rather than erroring. */
                 netuids?: string;
                 coverage_level?: "native-only" | "manifested" | "probed";
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
@@ -17860,7 +17874,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "block" | "candidate_count" | "coverage_level" | "curation_level" | "integration_readiness" | "mechanism_count" | "name" | "netuid" | "participant_count" | "probed_surface_count" | "status" | "subnet_type" | "surface_count" | "tempo";
@@ -18790,6 +18804,7 @@ export interface operations {
     accountsList: {
         parameters: {
             query?: {
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to total_stake. */
                 sort?: "total_stake" | "total_emission" | "subnet_count" | "uid_count" | "validator_count" | "stake_dominance" | "last_active";
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
@@ -19825,16 +19840,19 @@ export interface operations {
     accountEvents: {
         parameters: {
             query?: {
+                /** @description Restrict the result to this kind, matched exactly against the value the rows carry. Open set, so a value nothing matches yields an empty result rather than an error. Omit for every kind. */
                 kind?: string;
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -19956,13 +19974,15 @@ export interface operations {
     accountExtrinsics: {
         parameters: {
             query?: {
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -20086,13 +20106,15 @@ export interface operations {
             query?: {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
+                /** @description Inclusive first day of the range to read, as YYYY-MM-DD. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: string;
+                /** @description Inclusive last day of the range to read, as YYYY-MM-DD. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -20328,7 +20350,7 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -21316,6 +21338,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d";
+                /** @description Which side of the flow to count, relative to the account or subnet this route is scoped to. Omit to count both. Options are per-route; see this parameter's enum. */
                 direction?: "all" | "in" | "out";
             };
             header?: never;
@@ -21802,14 +21825,17 @@ export interface operations {
     accountTransfers: {
         parameters: {
             query?: {
+                /** @description Which side of the flow to count, relative to the account or subnet this route is scoped to. Omit to count both. Options are per-route; see this parameter's enum. */
                 direction?: "all" | "sent" | "received";
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -22050,6 +22076,7 @@ export interface operations {
     topHolders: {
         parameters: {
             query?: {
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to total_tao. */
                 sort?: "total_tao" | "free_tao" | "delegated_tao" | "net_flow_7d" | "net_flow_30d" | "net_flow_90d";
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
@@ -22960,13 +22987,17 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 author?: string;
                 spec_version?: number;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
                 min_extrinsics?: number;
                 min_events?: number;
@@ -23884,15 +23915,17 @@ export interface operations {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 id?: string;
                 confidence?: "low" | "medium" | "high";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "confidence" | "id" | "kind" | "name" | "netuid" | "provider" | "state";
@@ -24025,10 +24058,12 @@ export interface operations {
             query?: {
                 pallet?: string;
                 method?: string;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block?: number;
                 extrinsic?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 before?: number;
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
@@ -25273,7 +25308,9 @@ export interface operations {
         parameters: {
             query?: {
                 lens?: "emission" | "stake" | "entity_emission" | "entity_stake" | "validator_stake";
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to nakamoto_coefficient. */
                 sort?: "nakamoto_coefficient" | "gini" | "holders" | "top_1pct_share" | "total" | "netuid";
+                /** @description Sort direction for the chosen sort key: `asc` smallest-first, `desc` largest-first. Defaults to desc. */
                 order?: "asc" | "desc";
                 /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
@@ -25713,7 +25750,9 @@ export interface operations {
             query?: {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. */
                 sort?: "final_share" | "emission_share" | "weighted_share" | "gated_share" | "gate_delta" | "distance_to_bar" | "tao_in_emission" | "excess_tao" | "tao_total" | "liquidity_fraction" | "miner_burned" | "netuid";
+                /** @description Sort direction for the chosen sort key: `asc` smallest-first, `desc` largest-first. */
                 order?: "asc" | "desc";
                 /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
@@ -26015,6 +26054,7 @@ export interface operations {
     emissionGateChanges: {
         parameters: {
             query?: {
+                /** @description Restrict the result to this kind. Options are per-tool; see this parameter's enum. */
                 kind?: "param" | "subnet" | "flow";
                 /** @description Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
@@ -26135,6 +26175,7 @@ export interface operations {
     chainHolders: {
         parameters: {
             query?: {
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to top1_share. */
                 sort?: "top1_share" | "top5_share" | "top10_share" | "top20_share" | "holder_count" | "total_alpha";
                 /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
@@ -27205,6 +27246,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to tx_count. */
                 sort?: "tx_count" | "total_fee_tao";
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
@@ -27891,6 +27933,7 @@ export interface operations {
                 window?: "7d" | "30d";
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25. */
                 limit?: number;
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to volume. */
                 sort?: "volume" | "count";
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -28843,6 +28886,7 @@ export interface operations {
     compare: {
         parameters: {
             query?: {
+                /** @description Comma-separated subnet ids to restrict the result to, e.g. `1,7,64`. At most 128 ids, each 0-65535. Unknown ids match nothing rather than erroring. */
                 netuids?: string;
                 dimensions?: string;
             };
@@ -29376,7 +29420,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "agent_status" | "blocker_level" | "name" | "netuid" | "priority_score" | "score" | "tier";
@@ -29836,7 +29880,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "coverage_level" | "curation_level" | "name" | "netuid";
@@ -30227,7 +30271,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "alpha_fdv_tao" | "alpha_market_cap_tao" | "alpha_price_change_1d" | "alpha_price_change_1h" | "alpha_price_change_1m" | "alpha_price_change_7d" | "alpha_price_tao" | "block" | "emission_share" | "max_stake_alpha" | "max_uids" | "max_validators" | "miner_count" | "miner_readiness" | "name" | "netuid" | "open_slots" | "registration_cost_tao" | "subnet_volume_tao" | "total_stake_alpha" | "validator_count";
@@ -30516,6 +30560,7 @@ export interface operations {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 severity?: "critical" | "warning" | "info";
@@ -30524,7 +30569,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "detected_at" | "endpoint_id" | "kind" | "last_checked" | "netuid" | "provider" | "severity" | "state" | "status";
@@ -30670,6 +30715,7 @@ export interface operations {
     endpointPools: {
         parameters: {
             query?: {
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 id?: string;
                 kind?: "subtensor-rpc" | "subtensor-wss" | "archive";
                 min_eligible_count?: number;
@@ -30680,7 +30726,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "eligible_count" | "endpoint_count" | "id" | "kind";
@@ -30853,6 +30899,7 @@ export interface operations {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
                 pool_eligible?: "true" | "false";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
@@ -30864,7 +30911,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "kind" | "last_checked" | "latency_ms" | "layer" | "netuid" | "pool_eligible" | "provider" | "publication_state" | "score" | "status";
@@ -31029,7 +31076,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "claim" | "source_url" | "subject" | "verified_at";
@@ -31270,8 +31317,9 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block?: number;
                 signer?: string;
                 call_module?: string;
@@ -31279,9 +31327,13 @@ export interface operations {
                 /** @description Requires call_module so the decoded call-args JSON scan stays scoped. */
                 call_hash?: string;
                 success?: "true" | "false";
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -31534,9 +31586,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -31584,9 +31636,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -31632,9 +31684,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -31680,9 +31732,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -31728,9 +31780,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -31778,9 +31830,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -31826,9 +31878,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -31874,9 +31926,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -31922,9 +31974,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -31972,9 +32024,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32020,9 +32072,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32068,9 +32120,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32116,9 +32168,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32169,9 +32221,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32220,9 +32272,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32271,9 +32323,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32322,9 +32374,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32372,9 +32424,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32420,9 +32472,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32468,9 +32520,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32516,9 +32568,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32568,9 +32620,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32618,9 +32670,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32668,9 +32720,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -33090,7 +33142,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "coverage_level" | "curation_level" | "gap_count" | "name" | "netuid";
@@ -33223,14 +33275,19 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block?: number;
                 call_function?: string;
                 success?: "true" | "false";
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -33366,7 +33423,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "avg_latency_ms" | "degraded_count" | "failed_count" | "last_checked" | "last_ok" | "name" | "netuid" | "ok_count" | "status" | "surface_count" | "unknown_count";
@@ -33496,6 +33553,7 @@ export interface operations {
                 window?: "7d" | "30d" | "90d" | "180d";
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
+                /** @description Restrict the result to this kind, matched exactly against the value the rows carry. Open set, so a value nothing matches yields an empty result rather than an error. Omit for every kind. */
                 kind?: string;
             };
             header?: never;
@@ -33630,6 +33688,7 @@ export interface operations {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
@@ -33637,7 +33696,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "classification" | "kind" | "last_checked" | "last_ok" | "latency_ms" | "netuid" | "provider" | "status" | "status_code" | "surface_id" | "verified_at";
@@ -33914,7 +33973,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "downtime_ms" | "incident_count" | "netuid" | "surface_id";
@@ -34777,6 +34836,7 @@ export interface operations {
                 netuid?: number;
                 subnet_type?: "root" | "application";
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 review_state?: string;
                 confidence?: "low" | "medium" | "high";
                 profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
@@ -34786,7 +34846,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "candidate_count" | "completeness_score" | "curation_level" | "interface_count" | "missing_critical_count" | "name" | "netuid" | "operational_interface_count" | "profile_level" | "review_state";
@@ -35042,6 +35102,7 @@ export interface operations {
     providers: {
         parameters: {
             query?: {
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 id?: string;
                 kind?: "data-provider" | "docs-provider" | "infrastructure-provider" | "registry" | "subnet-team";
                 authority?: "community" | "official" | "provider-claimed" | "registry-observed";
@@ -35049,7 +35110,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "authority" | "id" | "kind" | "name";
@@ -35327,7 +35388,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "kind" | "last_checked" | "latency_ms" | "layer" | "netuid" | "pool_eligible" | "provider" | "publication_state" | "score" | "status";
@@ -35747,13 +35808,14 @@ export interface operations {
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 candidate_api_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 operational_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 reason_codes?: string;
                 recommended_adapter_kind?: "custom-adapter" | "data-artifact-adapter" | "generic-openapi-or-custom" | "stream-adapter";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "candidate_api_count" | "candidate_api_kinds" | "curation_level" | "name" | "netuid" | "operational_kinds" | "operational_surface_count" | "priority_score" | "recommended_adapter_kind";
@@ -35920,7 +35982,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "evidence_action" | "lane" | "name" | "netuid" | "priority_score";
@@ -36081,7 +36143,9 @@ export interface operations {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
                 profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 reason_codes?: string;
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 review_state?: string;
                 manual_review_required?: "true" | "false";
                 /** @description Free-text search query, matched case-insensitively against the collection's indexed text fields. Whitespace-separated terms narrow the result (AND), and an empty or whitespace-only value is treated as no filter rather than as a search matching nothing. */
@@ -36090,7 +36154,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "adapter_score" | "candidate_count" | "completeness_score" | "curation_level" | "endpoint_count" | "evidence_action" | "identity_level" | "identity_surface_count" | "lane" | "name" | "netuid" | "operational_interface_count" | "priority_score" | "profile_level" | "review_state" | "stale_candidate_count" | "surface_count" | "verified_candidate_count";
@@ -36302,6 +36366,7 @@ export interface operations {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
                 profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 reason_codes?: string;
                 submission_route?: "direct-candidate-pr" | "adapter-request" | "maintainer-review" | "status-report";
                 target_action?: "submit-new-candidate" | "replace-stale-candidate" | "verify-existing-candidate" | "review-existing-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
@@ -36312,7 +36377,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "auto_review_candidate" | "evidence_action" | "identity_level" | "kind" | "lane" | "manual_review_required" | "name" | "netuid" | "priority_score" | "profile_level" | "submission_route" | "target_action" | "target_type";
@@ -36522,12 +36587,13 @@ export interface operations {
                 netuid?: number;
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 review_state?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "candidate_count" | "curation_level" | "missing_kinds" | "name" | "netuid" | "priority_score" | "surface_count" | "verified_candidate_count";
@@ -36671,7 +36737,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "candidate_count" | "completeness_score" | "identity_level" | "identity_promotion_kind_count" | "identity_surface_count" | "live_identity_candidate_kind_count" | "missing_critical_count" | "name" | "native_identity_signal_count" | "native_name_quality" | "netuid" | "priority_score" | "profile_level" | "stale_identity_candidate_kind_count";
@@ -36873,6 +36939,7 @@ export interface operations {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
                 pool_eligible?: "true" | "false";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
@@ -36884,7 +36951,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "kind" | "last_checked" | "latency_ms" | "layer" | "netuid" | "pool_eligible" | "provider" | "publication_state" | "score" | "status";
@@ -37016,6 +37083,7 @@ export interface operations {
     rpcPools: {
         parameters: {
             query?: {
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 id?: string;
                 kind?: "subtensor-rpc" | "subtensor-wss" | "archive";
                 min_eligible_count?: number;
@@ -37026,7 +37094,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "eligible_count" | "endpoint_count" | "id" | "kind";
@@ -37603,7 +37671,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "netuid" | "slug" | "title" | "type";
@@ -37733,7 +37801,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "netuid" | "slug" | "title" | "type";
@@ -38349,7 +38417,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "id" | "kind" | "path" | "record_count";
@@ -38478,6 +38546,7 @@ export interface operations {
             query?: {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
+                /** @description Comma-separated subnet ids to restrict the result to, e.g. `1,7,64`. At most 128 ids, each 0-65535. Unknown ids match nothing rather than erroring. */
                 netuids?: string;
                 coverage_level?: "native-only" | "manifested" | "probed";
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
@@ -38506,7 +38575,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "block" | "candidate_count" | "coverage_level" | "curation_level" | "integration_readiness" | "mechanism_count" | "name" | "netuid" | "participant_count" | "probed_surface_count" | "status" | "subnet_type" | "surface_count" | "tempo";
@@ -39315,15 +39384,17 @@ export interface operations {
         parameters: {
             query?: {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 id?: string;
                 confidence?: "low" | "medium" | "high";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "confidence" | "id" | "kind" | "name" | "netuid" | "provider" | "state";
@@ -40137,6 +40208,7 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 layer?: "bittensor-base" | "data-provider" | "docs-provider" | "subnet-app";
                 pool_eligible?: "true" | "false";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
@@ -40148,7 +40220,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "kind" | "last_checked" | "latency_ms" | "layer" | "netuid" | "pool_eligible" | "provider" | "publication_state" | "score" | "status";
@@ -40459,14 +40531,17 @@ export interface operations {
     subnetEvents: {
         parameters: {
             query?: {
+                /** @description Restrict the result to this kind, matched exactly against the value the rows carry. Open set, so a value nothing matches yields an empty result rather than an error. Omit for every kind. */
                 kind?: string;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -40594,7 +40669,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "claim" | "source_url" | "subject" | "verified_at";
@@ -40722,12 +40797,13 @@ export interface operations {
             query?: {
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 review_state?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "candidate_count" | "curation_level" | "missing_kinds" | "name" | "netuid" | "priority_score" | "surface_count" | "verified_candidate_count";
@@ -40938,6 +41014,7 @@ export interface operations {
         parameters: {
             query?: {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
@@ -40945,7 +41022,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "classification" | "kind" | "last_checked" | "last_ok" | "latency_ms" | "netuid" | "provider" | "status" | "status_code" | "surface_id" | "verified_at";
@@ -41843,7 +41920,7 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -41969,7 +42046,7 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -44633,6 +44710,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d";
+                /** @description Which side of the flow to count, relative to the account or subnet this route is scoped to. Omit to count both. Options are per-route; see this parameter's enum. */
                 direction?: "all" | "in" | "out";
             };
             header?: never;
@@ -44854,6 +44932,7 @@ export interface operations {
         parameters: {
             query?: {
                 amount?: number;
+                /** @description Which side of the trade to price: `stake` buys alpha with TAO, `unstake` sells alpha for TAO. Omit for `stake`. */
                 direction?: "stake" | "unstake";
             };
             header?: never;
@@ -45199,7 +45278,9 @@ export interface operations {
         parameters: {
             query?: {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 id?: string;
                 auth_required?: "true" | "false";
                 public_safe?: "true" | "false";
@@ -45208,7 +45289,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "id" | "kind" | "name" | "netuid" | "provider";
@@ -46766,6 +46847,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d";
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to stake. */
                 sort?: "stake" | "emission" | "validators" | "neurons";
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
@@ -46920,14 +47002,19 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block?: number;
                 call_function?: string;
                 success?: "true" | "false";
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -47166,7 +47253,9 @@ export interface operations {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 id?: string;
                 auth_required?: "true" | "false";
                 public_safe?: "true" | "false";
@@ -47175,7 +47264,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "id" | "kind" | "name" | "netuid" | "provider";
@@ -47419,6 +47508,7 @@ export interface operations {
     globalValidators: {
         parameters: {
             query?: {
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to subnet_count. */
                 sort?: "avg_validator_trust" | "max_validator_trust" | "stake_dominance" | "subnet_count" | "total_emission" | "total_stake" | "uid_count";
                 /** @description Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
@@ -47865,11 +47955,13 @@ export interface operations {
                 basis?: "flow" | "positions";
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d";
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to net_staked. */
                 sort?: "net_staked" | "gross_staked" | "last_activity";
                 /** @description Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
+                /** @description An SS58 account address (47-48 base58 characters). Coldkey or hotkey depending on the tool — see the tool description for which this expects. */
                 coldkey?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -48001,6 +48093,7 @@ export interface operations {
     validatorEconomicsRanking: {
         parameters: {
             query?: {
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to earning_floor_cost_tao. */
                 sort?: "earning_floor_cost_tao" | "permit_floor_cost_tao" | "permit_to_earning_multiple" | "tao_inflow_per_day" | "validator_headroom";
                 /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -2024,14 +2024,14 @@
           }
         },
         {
-          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
           "name": "since",
           "schema": {
             "type": "string"
           }
         },
         {
-          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
           "name": "until",
           "schema": {
             "type": "string"
@@ -2078,14 +2078,14 @@
           }
         },
         {
-          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
           "name": "since",
           "schema": {
             "type": "string"
           }
         },
         {
-          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
           "name": "until",
           "schema": {
             "type": "string"
@@ -2132,14 +2132,14 @@
           }
         },
         {
-          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
           "name": "since",
           "schema": {
             "type": "string"
           }
         },
         {
-          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
           "name": "until",
           "schema": {
             "type": "string"
@@ -2186,14 +2186,14 @@
           }
         },
         {
-          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
           "name": "since",
           "schema": {
             "type": "string"
           }
         },
         {
-          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
           "name": "until",
           "schema": {
             "type": "string"
@@ -2240,14 +2240,14 @@
           }
         },
         {
-          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
           "name": "since",
           "schema": {
             "type": "string"
           }
         },
         {
-          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
           "name": "until",
           "schema": {
             "type": "string"
@@ -2311,14 +2311,14 @@
           }
         },
         {
-          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
           "name": "since",
           "schema": {
             "type": "string"
           }
         },
         {
-          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
           "name": "until",
           "schema": {
             "type": "string"
@@ -2424,6 +2424,7 @@
           }
         },
         {
+          "description": "Comma-separated subnet ids to restrict the result to, e.g. `1,7,64`. At most 128 ids, each 0-65535. Unknown ids match nothing rather than erroring.",
           "name": "netuids",
           "schema": {
             "maxLength": 767,
@@ -2618,6 +2619,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -2746,6 +2748,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "review_state",
           "schema": {
             "maxLength": 100,
@@ -2800,6 +2803,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -2968,6 +2972,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "provider",
           "schema": {
             "maxLength": 100,
@@ -2975,6 +2980,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "id",
           "schema": {
             "maxLength": 100,
@@ -3028,6 +3034,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -3118,6 +3125,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "provider",
           "schema": {
             "maxLength": 100,
@@ -3125,6 +3133,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "id",
           "schema": {
             "maxLength": 100,
@@ -3178,6 +3187,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -3299,6 +3309,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "provider",
           "schema": {
             "maxLength": 100,
@@ -3372,6 +3383,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -3489,6 +3501,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "provider",
           "schema": {
             "maxLength": 100,
@@ -3562,6 +3575,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -3665,6 +3679,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "provider",
           "schema": {
             "maxLength": 100,
@@ -3686,6 +3701,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "id",
           "schema": {
             "maxLength": 100,
@@ -3720,6 +3736,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -3811,6 +3828,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "provider",
           "schema": {
             "maxLength": 100,
@@ -3832,6 +3850,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "id",
           "schema": {
             "maxLength": 100,
@@ -3866,6 +3885,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -3933,6 +3953,7 @@
       ],
       "query_parameters": [
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "id",
           "schema": {
             "maxLength": 100,
@@ -3981,6 +4002,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -4182,6 +4204,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -4342,6 +4365,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -4452,6 +4476,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -4646,6 +4671,7 @@
           }
         },
         {
+          "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum.",
           "name": "sort",
           "schema": {
             "enum": [
@@ -4666,6 +4692,7 @@
           }
         },
         {
+          "description": "Sort direction for the chosen sort key: `asc` smallest-first, `desc` largest-first.",
           "name": "order",
           "schema": {
             "enum": [
@@ -4901,6 +4928,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -5002,6 +5030,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -5100,6 +5129,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "review_state",
           "schema": {
             "maxLength": 100,
@@ -5123,6 +5153,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -5227,6 +5258,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "review_state",
           "schema": {
             "maxLength": 100,
@@ -5250,6 +5282,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -5414,6 +5447,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -5557,6 +5591,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "reason_codes",
           "schema": {
             "maxLength": 100,
@@ -5592,6 +5627,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -5787,6 +5823,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "reason_codes",
           "schema": {
             "maxLength": 100,
@@ -5794,6 +5831,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "review_state",
           "schema": {
             "maxLength": 100,
@@ -5834,6 +5872,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -6016,6 +6055,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -6203,6 +6243,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "reason_codes",
           "schema": {
             "maxLength": 100,
@@ -6272,6 +6313,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -6368,6 +6410,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -6459,6 +6502,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "provider",
           "schema": {
             "maxLength": 100,
@@ -6513,6 +6557,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -6595,6 +6640,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "provider",
           "schema": {
             "maxLength": 100,
@@ -6649,6 +6695,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -7285,6 +7332,7 @@
           }
         },
         {
+          "description": "Which side of the flow to count, relative to the account or subnet this route is scoped to. Omit to count both. Options are per-route; see this parameter's enum.",
           "name": "direction",
           "schema": {
             "enum": [
@@ -7383,6 +7431,7 @@
           }
         },
         {
+          "description": "Which side of the trade to price: `stake` buys alpha with TAO, `unstake` sells alpha for TAO. Omit for `stake`.",
           "name": "direction",
           "schema": {
             "default": "stake",
@@ -7456,6 +7505,7 @@
       "query_filter_names": [],
       "query_parameters": [
         {
+          "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to earning_floor_cost_tao.",
           "name": "sort",
           "schema": {
             "default": "earning_floor_cost_tao",
@@ -7530,6 +7580,7 @@
           }
         },
         {
+          "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to stake.",
           "name": "sort",
           "schema": {
             "default": "stake",
@@ -7582,6 +7633,7 @@
       "query_filter_names": [],
       "query_parameters": [
         {
+          "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to subnet_count.",
           "name": "sort",
           "schema": {
             "default": "subnet_count",
@@ -7637,6 +7689,7 @@
       "query_filter_names": [],
       "query_parameters": [
         {
+          "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to total_stake.",
           "name": "sort",
           "schema": {
             "default": "total_stake",
@@ -7692,6 +7745,7 @@
       "query_filter_names": [],
       "query_parameters": [
         {
+          "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to total_tao.",
           "name": "sort",
           "schema": {
             "default": "total_tao",
@@ -7785,6 +7839,7 @@
           }
         },
         {
+          "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to net_staked.",
           "name": "sort",
           "schema": {
             "default": "net_staked",
@@ -7816,6 +7871,7 @@
           }
         },
         {
+          "description": "An SS58 account address (47-48 base58 characters). Coldkey or hotkey depending on the tool — see the tool description for which this expects.",
           "name": "coldkey",
           "schema": {
             "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
@@ -7996,6 +8052,7 @@
           }
         },
         {
+          "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
           "name": "cursor",
           "schema": {
             "type": "string"
@@ -8239,12 +8296,14 @@
       "query_filter_names": [],
       "query_parameters": [
         {
+          "description": "Restrict the result to this kind, matched exactly against the value the rows carry. Open set, so a value nothing matches yields an empty result rather than an error. Omit for every kind.",
           "name": "kind",
           "schema": {
             "type": "string"
           }
         },
         {
+          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "block_start",
           "schema": {
             "minimum": 0,
@@ -8252,6 +8311,7 @@
           }
         },
         {
+          "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
           "name": "block_end",
           "schema": {
             "minimum": 0,
@@ -8279,6 +8339,7 @@
           }
         },
         {
+          "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
           "name": "cursor",
           "schema": {
             "type": "string"
@@ -8435,6 +8496,7 @@
           }
         },
         {
+          "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
           "name": "cursor",
           "schema": {
             "type": "string"
@@ -8502,6 +8564,7 @@
       "query_filter_names": [],
       "query_parameters": [
         {
+          "description": "Restrict the result to this kind, matched exactly against the value the rows carry. Open set, so a value nothing matches yields an empty result rather than an error. Omit for every kind.",
           "name": "kind",
           "schema": {
             "type": "string"
@@ -8516,6 +8579,7 @@
           }
         },
         {
+          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "block_start",
           "schema": {
             "minimum": 0,
@@ -8523,6 +8587,7 @@
           }
         },
         {
+          "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
           "name": "block_end",
           "schema": {
             "minimum": 0,
@@ -8550,6 +8615,7 @@
           }
         },
         {
+          "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
           "name": "cursor",
           "schema": {
             "type": "string"
@@ -8593,6 +8659,7 @@
           }
         },
         {
+          "description": "Inclusive first day of the range to read, as YYYY-MM-DD. Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "from",
           "schema": {
             "format": "date",
@@ -8601,6 +8668,7 @@
           }
         },
         {
+          "description": "Inclusive last day of the range to read, as YYYY-MM-DD. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
           "name": "to",
           "schema": {
             "format": "date",
@@ -8629,6 +8697,7 @@
           }
         },
         {
+          "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
           "name": "cursor",
           "schema": {
             "type": "string"
@@ -8664,6 +8733,7 @@
       "query_filter_names": [],
       "query_parameters": [
         {
+          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "block_start",
           "schema": {
             "minimum": 0,
@@ -8671,6 +8741,7 @@
           }
         },
         {
+          "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
           "name": "block_end",
           "schema": {
             "minimum": 0,
@@ -8698,6 +8769,7 @@
           }
         },
         {
+          "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
           "name": "cursor",
           "schema": {
             "type": "string"
@@ -8733,6 +8805,7 @@
       "query_filter_names": [],
       "query_parameters": [
         {
+          "description": "Which side of the flow to count, relative to the account or subnet this route is scoped to. Omit to count both. Options are per-route; see this parameter's enum.",
           "name": "direction",
           "schema": {
             "enum": [
@@ -8744,6 +8817,7 @@
           }
         },
         {
+          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "block_start",
           "schema": {
             "minimum": 0,
@@ -8751,6 +8825,7 @@
           }
         },
         {
+          "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
           "name": "block_end",
           "schema": {
             "minimum": 0,
@@ -8778,6 +8853,7 @@
           }
         },
         {
+          "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
           "name": "cursor",
           "schema": {
             "type": "string"
@@ -8873,6 +8949,7 @@
           }
         },
         {
+          "description": "Which side of the flow to count, relative to the account or subnet this route is scoped to. Omit to count both. Options are per-route; see this parameter's enum.",
           "name": "direction",
           "schema": {
             "enum": [
@@ -9218,6 +9295,7 @@
           }
         },
         {
+          "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
           "name": "cursor",
           "schema": {
             "type": "string"
@@ -9563,6 +9641,7 @@
       "query_filter_names": [],
       "query_parameters": [
         {
+          "description": "Restrict the result to this kind. Options are per-tool; see this parameter's enum.",
           "name": "kind",
           "schema": {
             "enum": [
@@ -9601,6 +9680,7 @@
       "query_filter_names": [],
       "query_parameters": [
         {
+          "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to top1_share.",
           "name": "sort",
           "schema": {
             "default": "top1_share",
@@ -9664,6 +9744,7 @@
           }
         },
         {
+          "description": "Restrict the result to this kind, matched exactly against the value the rows carry. Open set, so a value nothing matches yields an empty result rather than an error. Omit for every kind.",
           "name": "kind",
           "schema": {
             "type": "string"
@@ -9935,6 +10016,7 @@
           }
         },
         {
+          "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
           "name": "cursor",
           "schema": {
             "type": "string"
@@ -9954,6 +10036,7 @@
           }
         },
         {
+          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "from",
           "schema": {
             "minimum": 0,
@@ -9961,6 +10044,7 @@
           }
         },
         {
+          "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
           "name": "to",
           "schema": {
             "minimum": 0,
@@ -9968,6 +10052,7 @@
           }
         },
         {
+          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "block_start",
           "schema": {
             "minimum": 0,
@@ -9975,6 +10060,7 @@
           }
         },
         {
+          "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
           "name": "block_end",
           "schema": {
             "minimum": 0,
@@ -10184,6 +10270,7 @@
           }
         },
         {
+          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "block",
           "schema": {
             "minimum": 0,
@@ -10198,6 +10285,7 @@
           }
         },
         {
+          "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
           "name": "cursor",
           "schema": {
             "description": "Opaque block_number.event_index cursor returned as next_cursor; both parts are non-negative safe integers.",
@@ -10205,6 +10293,7 @@
           }
         },
         {
+          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "before",
           "schema": {
             "minimum": 0,
@@ -10322,12 +10411,14 @@
           }
         },
         {
+          "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
           "name": "cursor",
           "schema": {
             "type": "string"
           }
         },
         {
+          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "block",
           "schema": {
             "minimum": 0,
@@ -10372,6 +10463,7 @@
           }
         },
         {
+          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "block_start",
           "schema": {
             "minimum": 0,
@@ -10379,6 +10471,7 @@
           }
         },
         {
+          "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
           "name": "block_end",
           "schema": {
             "minimum": 0,
@@ -10386,6 +10479,7 @@
           }
         },
         {
+          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "from",
           "schema": {
             "minimum": 0,
@@ -10393,6 +10487,7 @@
           }
         },
         {
+          "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
           "name": "to",
           "schema": {
             "minimum": 0,
@@ -10468,12 +10563,14 @@
           }
         },
         {
+          "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
           "name": "cursor",
           "schema": {
             "type": "string"
           }
         },
         {
+          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "block",
           "schema": {
             "minimum": 0,
@@ -10497,6 +10594,7 @@
           }
         },
         {
+          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "block_start",
           "schema": {
             "minimum": 0,
@@ -10504,6 +10602,7 @@
           }
         },
         {
+          "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
           "name": "block_end",
           "schema": {
             "minimum": 0,
@@ -10511,6 +10610,7 @@
           }
         },
         {
+          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "from",
           "schema": {
             "minimum": 0,
@@ -10518,6 +10618,7 @@
           }
         },
         {
+          "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
           "name": "to",
           "schema": {
             "minimum": 0,
@@ -10574,12 +10675,14 @@
           }
         },
         {
+          "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
           "name": "cursor",
           "schema": {
             "type": "string"
           }
         },
         {
+          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "block",
           "schema": {
             "minimum": 0,
@@ -10603,6 +10706,7 @@
           }
         },
         {
+          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "block_start",
           "schema": {
             "minimum": 0,
@@ -10610,6 +10714,7 @@
           }
         },
         {
+          "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
           "name": "block_end",
           "schema": {
             "minimum": 0,
@@ -10617,6 +10722,7 @@
           }
         },
         {
+          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "from",
           "schema": {
             "minimum": 0,
@@ -10624,6 +10730,7 @@
           }
         },
         {
+          "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
           "name": "to",
           "schema": {
             "minimum": 0,
@@ -10835,6 +10942,7 @@
           }
         },
         {
+          "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to tx_count.",
           "name": "sort",
           "schema": {
             "default": "tx_count",
@@ -10969,6 +11077,7 @@
           }
         },
         {
+          "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to volume.",
           "name": "sort",
           "schema": {
             "default": "volume",
@@ -11655,6 +11764,7 @@
           }
         },
         {
+          "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to nakamoto_coefficient.",
           "name": "sort",
           "schema": {
             "default": "nakamoto_coefficient",
@@ -11670,6 +11780,7 @@
           }
         },
         {
+          "description": "Sort direction for the chosen sort key: `asc` smallest-first, `desc` largest-first. Defaults to desc.",
           "name": "order",
           "schema": {
             "default": "desc",
@@ -11944,6 +12055,7 @@
       "query_filter_names": [],
       "query_parameters": [
         {
+          "description": "Comma-separated subnet ids to restrict the result to, e.g. `1,7,64`. At most 128 ids, each 0-65535. Unknown ids match nothing rather than erroring.",
           "name": "netuids",
           "schema": {
             "maxLength": 767,
@@ -12123,6 +12235,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -12194,6 +12307,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -12281,6 +12395,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -12389,6 +12504,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "provider",
           "schema": {
             "maxLength": 100,
@@ -12462,6 +12578,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -12519,6 +12636,7 @@
       ],
       "query_parameters": [
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "id",
           "schema": {
             "maxLength": 100,
@@ -12577,6 +12695,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -12628,6 +12747,7 @@
       ],
       "query_parameters": [
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "id",
           "schema": {
             "maxLength": 100,
@@ -12686,6 +12806,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -12771,6 +12892,7 @@
           }
         },
         {
+          "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
           "name": "provider",
           "schema": {
             "maxLength": 100,
@@ -12827,6 +12949,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -12917,6 +13040,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -13042,6 +13166,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,
@@ -13135,6 +13260,7 @@
           }
         },
         {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
           "name": "cursor",
           "schema": {
             "minimum": 0,

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -2464,14 +2464,14 @@
           }
         },
         {
-          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
           "name": "since",
           "schema": {
             "type": "string"
           }
         },
         {
-          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
           "name": "until",
           "schema": {
             "type": "string"
@@ -2518,14 +2518,14 @@
           }
         },
         {
-          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
           "name": "since",
           "schema": {
             "type": "string"
           }
         },
         {
-          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
           "name": "until",
           "schema": {
             "type": "string"
@@ -2572,14 +2572,14 @@
           }
         },
         {
-          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
           "name": "since",
           "schema": {
             "type": "string"
           }
         },
         {
-          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
           "name": "until",
           "schema": {
             "type": "string"
@@ -2626,14 +2626,14 @@
           }
         },
         {
-          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
           "name": "since",
           "schema": {
             "type": "string"
           }
         },
         {
-          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
           "name": "until",
           "schema": {
             "type": "string"
@@ -2680,14 +2680,14 @@
           }
         },
         {
-          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
           "name": "since",
           "schema": {
             "type": "string"
           }
         },
         {
-          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
           "name": "until",
           "schema": {
             "type": "string"
@@ -2751,14 +2751,14 @@
           }
         },
         {
-          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+          "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
           "name": "since",
           "schema": {
             "type": "string"
           }
         },
         {
-          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+          "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
           "name": "until",
           "schema": {
             "type": "string"

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -57674,7 +57674,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -57700,6 +57700,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "from",
             "required": false,
@@ -57709,6 +57710,7 @@
             }
           },
           {
+            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "to",
             "required": false,
@@ -57718,6 +57720,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "block_start",
             "required": false,
@@ -57727,6 +57730,7 @@
             }
           },
           {
+            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "block_end",
             "required": false,
@@ -58631,6 +58635,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "block",
             "required": false,
@@ -58649,7 +58654,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -58659,6 +58664,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "before",
             "required": false,
@@ -60091,6 +60097,7 @@
             }
           },
           {
+            "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to tx_count.",
             "in": "query",
             "name": "sort",
             "required": false,
@@ -60798,6 +60805,7 @@
             }
           },
           {
+            "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to volume.",
             "in": "query",
             "name": "sort",
             "required": false,
@@ -61533,7 +61541,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -61878,7 +61886,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -61887,6 +61895,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "block",
             "required": false,
@@ -61943,6 +61952,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "block_start",
             "required": false,
@@ -61952,6 +61962,7 @@
             }
           },
           {
+            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "block_end",
             "required": false,
@@ -61961,6 +61972,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "from",
             "required": false,
@@ -61970,6 +61982,7 @@
             }
           },
           {
+            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "to",
             "required": false,
@@ -62729,6 +62742,7 @@
             }
           },
           {
+            "description": "Comma-separated subnet ids to restrict the result to, e.g. `1,7,64`. At most 128 ids, each 0-65535. Unknown ids match nothing rather than erroring.",
             "in": "query",
             "name": "netuids",
             "required": false,
@@ -62976,7 +62990,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -63767,6 +63781,7 @@
         "operationId": "accountsList",
         "parameters": [
           {
+            "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to total_stake.",
             "in": "query",
             "name": "sort",
             "required": false,
@@ -64758,6 +64773,7 @@
             }
           },
           {
+            "description": "Restrict the result to this kind, matched exactly against the value the rows carry. Open set, so a value nothing matches yields an empty result rather than an error. Omit for every kind.",
             "in": "query",
             "name": "kind",
             "required": false,
@@ -64777,6 +64793,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "block_start",
             "required": false,
@@ -64786,6 +64803,7 @@
             }
           },
           {
+            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "block_end",
             "required": false,
@@ -64821,7 +64839,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -64961,6 +64979,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "block_start",
             "required": false,
@@ -64970,6 +64989,7 @@
             }
           },
           {
+            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "block_end",
             "required": false,
@@ -65005,7 +65025,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -65156,6 +65176,7 @@
             }
           },
           {
+            "description": "Inclusive first day of the range to read, as YYYY-MM-DD. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "from",
             "required": false,
@@ -65166,6 +65187,7 @@
             }
           },
           {
+            "description": "Inclusive last day of the range to read, as YYYY-MM-DD. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "to",
             "required": false,
@@ -65202,7 +65224,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -65474,7 +65496,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -66425,6 +66447,7 @@
             }
           },
           {
+            "description": "Which side of the flow to count, relative to the account or subnet this route is scoped to. Omit to count both. Options are per-route; see this parameter's enum.",
             "in": "query",
             "name": "direction",
             "required": false,
@@ -66908,6 +66931,7 @@
             }
           },
           {
+            "description": "Which side of the flow to count, relative to the account or subnet this route is scoped to. Omit to count both. Options are per-route; see this parameter's enum.",
             "in": "query",
             "name": "direction",
             "required": false,
@@ -66921,6 +66945,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "block_start",
             "required": false,
@@ -66930,6 +66955,7 @@
             }
           },
           {
+            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "block_end",
             "required": false,
@@ -66965,7 +66991,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -67218,6 +67244,7 @@
         "operationId": "topHolders",
         "parameters": [
           {
+            "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to total_tao.",
             "in": "query",
             "name": "sort",
             "required": false,
@@ -68020,7 +68047,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -68046,6 +68073,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "from",
             "required": false,
@@ -68055,6 +68083,7 @@
             }
           },
           {
+            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "to",
             "required": false,
@@ -68064,6 +68093,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "block_start",
             "required": false,
@@ -68073,6 +68103,7 @@
             }
           },
           {
+            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "block_end",
             "required": false,
@@ -68994,6 +69025,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "provider",
             "required": false,
@@ -69019,6 +69051,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "id",
             "required": false,
@@ -69063,7 +69096,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -69244,6 +69277,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "block",
             "required": false,
@@ -69262,7 +69296,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -69272,6 +69306,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "before",
             "required": false,
@@ -70456,6 +70491,7 @@
             }
           },
           {
+            "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to nakamoto_coefficient.",
             "in": "query",
             "name": "sort",
             "required": false,
@@ -70473,6 +70509,7 @@
             }
           },
           {
+            "description": "Sort direction for the chosen sort key: `asc` smallest-first, `desc` largest-first. Defaults to desc.",
             "in": "query",
             "name": "order",
             "required": false,
@@ -70860,6 +70897,7 @@
             }
           },
           {
+            "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum.",
             "in": "query",
             "name": "sort",
             "required": false,
@@ -70882,6 +70920,7 @@
             }
           },
           {
+            "description": "Sort direction for the chosen sort key: `asc` smallest-first, `desc` largest-first.",
             "in": "query",
             "name": "order",
             "required": false,
@@ -71176,6 +71215,7 @@
         "operationId": "emissionGateChanges",
         "parameters": [
           {
+            "description": "Restrict the result to this kind. Options are per-tool; see this parameter's enum.",
             "in": "query",
             "name": "kind",
             "required": false,
@@ -71300,6 +71340,7 @@
         "operationId": "chainHolders",
         "parameters": [
           {
+            "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to top1_share.",
             "in": "query",
             "name": "sort",
             "required": false,
@@ -72299,6 +72340,7 @@
             }
           },
           {
+            "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to tx_count.",
             "in": "query",
             "name": "sort",
             "required": false,
@@ -73095,6 +73137,7 @@
             }
           },
           {
+            "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to volume.",
             "in": "query",
             "name": "sort",
             "required": false,
@@ -74031,6 +74074,7 @@
         "operationId": "compare",
         "parameters": [
           {
+            "description": "Comma-separated subnet ids to restrict the result to, e.g. `1,7,64`. At most 128 ids, each 0-65535. Unknown ids match nothing rather than erroring.",
             "in": "query",
             "name": "netuids",
             "required": false,
@@ -74553,7 +74597,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -74989,7 +75033,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -75401,7 +75445,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -75755,6 +75799,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "provider",
             "required": false,
@@ -75825,7 +75870,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -75967,6 +76012,7 @@
         "operationId": "endpointPools",
         "parameters": [
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "id",
             "required": false,
@@ -76043,7 +76089,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -76240,6 +76286,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "provider",
             "required": false,
@@ -76333,7 +76380,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -76531,7 +76578,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -76801,7 +76848,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -76810,6 +76857,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "block",
             "required": false,
@@ -76866,6 +76914,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "block_start",
             "required": false,
@@ -76875,6 +76924,7 @@
             }
           },
           {
+            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "block_end",
             "required": false,
@@ -76884,6 +76934,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "from",
             "required": false,
@@ -76893,6 +76944,7 @@
             }
           },
           {
+            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "to",
             "required": false,
@@ -77147,7 +77199,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -77156,7 +77208,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -77246,7 +77298,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -77255,7 +77307,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -77335,7 +77387,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -77344,7 +77396,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -77424,7 +77476,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -77433,7 +77485,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -77513,7 +77565,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -77522,7 +77574,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -77612,7 +77664,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -77621,7 +77673,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -77701,7 +77753,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -77710,7 +77762,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -77790,7 +77842,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -77799,7 +77851,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -77879,7 +77931,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -77888,7 +77940,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -77978,7 +78030,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -77987,7 +78039,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -78067,7 +78119,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -78076,7 +78128,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -78156,7 +78208,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -78165,7 +78217,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -78255,7 +78307,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -78264,7 +78316,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -78364,7 +78416,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -78373,7 +78425,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -78463,7 +78515,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -78472,7 +78524,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -78562,7 +78614,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -78571,7 +78623,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -78651,7 +78703,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -78660,7 +78712,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -78750,7 +78802,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -78759,7 +78811,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -78839,7 +78891,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -78848,7 +78900,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -78928,7 +78980,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -78937,7 +78989,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -79017,7 +79069,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -79026,7 +79078,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -79126,7 +79178,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -79135,7 +79187,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -79225,7 +79277,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -79234,7 +79286,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -79324,7 +79376,7 @@
             }
           },
           {
-            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+            "description": "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "since",
             "required": false,
@@ -79333,7 +79385,7 @@
             }
           },
           {
-            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+            "description": "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "until",
             "required": false,
@@ -79777,7 +79829,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -79940,7 +79992,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -79949,6 +80001,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "block",
             "required": false,
@@ -79978,6 +80031,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "block_start",
             "required": false,
@@ -79987,6 +80041,7 @@
             }
           },
           {
+            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "block_end",
             "required": false,
@@ -79996,6 +80051,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "from",
             "required": false,
@@ -80005,6 +80061,7 @@
             }
           },
           {
+            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "to",
             "required": false,
@@ -80184,7 +80241,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -80354,6 +80411,7 @@
             }
           },
           {
+            "description": "Restrict the result to this kind, matched exactly against the value the rows carry. Open set, so a value nothing matches yields an empty result rather than an error. Omit for every kind.",
             "in": "query",
             "name": "kind",
             "required": false,
@@ -80504,6 +80562,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "provider",
             "required": false,
@@ -80570,7 +80629,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -80896,7 +80955,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -81686,6 +81745,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "review_state",
             "required": false,
@@ -81755,7 +81815,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -81922,6 +81982,7 @@
         "operationId": "providers",
         "parameters": [
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "id",
             "required": false,
@@ -81982,7 +82043,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -82403,7 +82464,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -82877,6 +82938,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "reason_codes",
             "required": false,
@@ -82922,7 +82984,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -83210,7 +83272,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -83484,6 +83546,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "reason_codes",
             "required": false,
@@ -83493,6 +83556,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "review_state",
             "required": false,
@@ -83546,7 +83610,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -83865,6 +83929,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "reason_codes",
             "required": false,
@@ -83951,7 +84016,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -84149,6 +84214,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "review_state",
             "required": false,
@@ -84180,7 +84246,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -84457,7 +84523,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -84690,6 +84756,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "provider",
             "required": false,
@@ -84783,7 +84850,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -84925,6 +84992,7 @@
         "operationId": "rpcPools",
         "parameters": [
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "id",
             "required": false,
@@ -85001,7 +85069,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -85527,7 +85595,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -85719,7 +85787,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -86324,7 +86392,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -86471,6 +86539,7 @@
             }
           },
           {
+            "description": "Comma-separated subnet ids to restrict the result to, e.g. `1,7,64`. At most 128 ids, each 0-65535. Unknown ids match nothing rather than erroring.",
             "in": "query",
             "name": "netuids",
             "required": false,
@@ -86718,7 +86787,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -87388,6 +87457,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "provider",
             "required": false,
@@ -87413,6 +87483,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "id",
             "required": false,
@@ -87457,7 +87528,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -88289,6 +88360,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "provider",
             "required": false,
@@ -88382,7 +88454,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -88694,6 +88766,7 @@
             }
           },
           {
+            "description": "Restrict the result to this kind, matched exactly against the value the rows carry. Open set, so a value nothing matches yields an empty result rather than an error. Omit for every kind.",
             "in": "query",
             "name": "kind",
             "required": false,
@@ -88702,6 +88775,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "block_start",
             "required": false,
@@ -88711,6 +88785,7 @@
             }
           },
           {
+            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "block_end",
             "required": false,
@@ -88746,7 +88821,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -88919,7 +88994,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -89105,6 +89180,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "review_state",
             "required": false,
@@ -89136,7 +89212,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -89335,6 +89411,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "provider",
             "required": false,
@@ -89401,7 +89478,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -90288,7 +90365,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -90455,7 +90532,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -92710,6 +92787,7 @@
             }
           },
           {
+            "description": "Which side of the flow to count, relative to the account or subnet this route is scoped to. Omit to count both. Options are per-route; see this parameter's enum.",
             "in": "query",
             "name": "direction",
             "required": false,
@@ -92962,6 +93040,7 @@
             }
           },
           {
+            "description": "Which side of the trade to price: `stake` buys alpha with TAO, `unstake` sells alpha for TAO. Omit for `stake`.",
             "in": "query",
             "name": "direction",
             "required": false,
@@ -93350,6 +93429,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "provider",
             "required": false,
@@ -93359,6 +93439,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "id",
             "required": false,
@@ -93426,7 +93507,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -95034,6 +95115,7 @@
             }
           },
           {
+            "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to stake.",
             "in": "query",
             "name": "sort",
             "required": false,
@@ -95211,7 +95293,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -95220,6 +95302,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "block",
             "required": false,
@@ -95249,6 +95332,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "block_start",
             "required": false,
@@ -95258,6 +95342,7 @@
             }
           },
           {
+            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "block_end",
             "required": false,
@@ -95267,6 +95352,7 @@
             }
           },
           {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "from",
             "required": false,
@@ -95276,6 +95362,7 @@
             }
           },
           {
+            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "to",
             "required": false,
@@ -95542,6 +95629,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "provider",
             "required": false,
@@ -95551,6 +95639,7 @@
             }
           },
           {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
             "in": "query",
             "name": "id",
             "required": false,
@@ -95618,7 +95707,7 @@
             }
           },
           {
-            "description": "Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page.",
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
             "in": "query",
             "name": "cursor",
             "required": false,
@@ -95885,6 +95974,7 @@
         "operationId": "globalValidators",
         "parameters": [
           {
+            "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to subnet_count.",
             "in": "query",
             "name": "sort",
             "required": false,
@@ -96317,6 +96407,7 @@
             }
           },
           {
+            "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to net_staked.",
             "in": "query",
             "name": "sort",
             "required": false,
@@ -96356,6 +96447,7 @@
             }
           },
           {
+            "description": "An SS58 account address (47-48 base58 characters). Coldkey or hotkey depending on the tool — see the tool description for which this expects.",
             "in": "query",
             "name": "coldkey",
             "required": false,
@@ -96488,6 +96580,7 @@
         "operationId": "validatorEconomicsRanking",
         "parameters": [
           {
+            "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to earning_floor_cost_tao.",
             "in": "query",
             "name": "sort",
             "required": false,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -13555,13 +13555,17 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 author?: string;
                 spec_version?: number;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
                 min_extrinsics?: number;
                 min_events?: number;
@@ -14321,10 +14325,12 @@ export interface operations {
             query?: {
                 pallet?: string;
                 method?: string;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block?: number;
                 extrinsic?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 before?: number;
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
@@ -15536,6 +15542,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to tx_count. */
                 sort?: "tx_count" | "total_fee_tao";
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
@@ -16109,6 +16116,7 @@ export interface operations {
                 window?: "7d" | "30d";
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25. */
                 limit?: number;
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to volume. */
                 sort?: "volume" | "count";
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -16789,7 +16797,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "alpha_fdv_tao" | "alpha_market_cap_tao" | "alpha_price_change_1d" | "alpha_price_change_1h" | "alpha_price_change_1m" | "alpha_price_change_7d" | "alpha_price_tao" | "block" | "emission_share" | "max_stake_alpha" | "max_uids" | "max_validators" | "miner_count" | "miner_readiness" | "name" | "netuid" | "open_slots" | "registration_cost_tao" | "subnet_volume_tao" | "total_stake_alpha" | "validator_count";
@@ -17077,8 +17085,9 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block?: number;
                 signer?: string;
                 call_module?: string;
@@ -17086,9 +17095,13 @@ export interface operations {
                 /** @description Requires call_module so the decoded call-args JSON scan stays scoped. */
                 call_hash?: string;
                 success?: "true" | "false";
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -17832,6 +17845,7 @@ export interface operations {
             query?: {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
+                /** @description Comma-separated subnet ids to restrict the result to, e.g. `1,7,64`. At most 128 ids, each 0-65535. Unknown ids match nothing rather than erroring. */
                 netuids?: string;
                 coverage_level?: "native-only" | "manifested" | "probed";
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
@@ -17860,7 +17874,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "block" | "candidate_count" | "coverage_level" | "curation_level" | "integration_readiness" | "mechanism_count" | "name" | "netuid" | "participant_count" | "probed_surface_count" | "status" | "subnet_type" | "surface_count" | "tempo";
@@ -18790,6 +18804,7 @@ export interface operations {
     accountsList: {
         parameters: {
             query?: {
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to total_stake. */
                 sort?: "total_stake" | "total_emission" | "subnet_count" | "uid_count" | "validator_count" | "stake_dominance" | "last_active";
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
@@ -19825,16 +19840,19 @@ export interface operations {
     accountEvents: {
         parameters: {
             query?: {
+                /** @description Restrict the result to this kind, matched exactly against the value the rows carry. Open set, so a value nothing matches yields an empty result rather than an error. Omit for every kind. */
                 kind?: string;
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -19956,13 +19974,15 @@ export interface operations {
     accountExtrinsics: {
         parameters: {
             query?: {
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -20086,13 +20106,15 @@ export interface operations {
             query?: {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
+                /** @description Inclusive first day of the range to read, as YYYY-MM-DD. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: string;
+                /** @description Inclusive last day of the range to read, as YYYY-MM-DD. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -20328,7 +20350,7 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -21316,6 +21338,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d";
+                /** @description Which side of the flow to count, relative to the account or subnet this route is scoped to. Omit to count both. Options are per-route; see this parameter's enum. */
                 direction?: "all" | "in" | "out";
             };
             header?: never;
@@ -21802,14 +21825,17 @@ export interface operations {
     accountTransfers: {
         parameters: {
             query?: {
+                /** @description Which side of the flow to count, relative to the account or subnet this route is scoped to. Omit to count both. Options are per-route; see this parameter's enum. */
                 direction?: "all" | "sent" | "received";
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -22050,6 +22076,7 @@ export interface operations {
     topHolders: {
         parameters: {
             query?: {
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to total_tao. */
                 sort?: "total_tao" | "free_tao" | "delegated_tao" | "net_flow_7d" | "net_flow_30d" | "net_flow_90d";
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
@@ -22960,13 +22987,17 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 author?: string;
                 spec_version?: number;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
                 min_extrinsics?: number;
                 min_events?: number;
@@ -23884,15 +23915,17 @@ export interface operations {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 id?: string;
                 confidence?: "low" | "medium" | "high";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "confidence" | "id" | "kind" | "name" | "netuid" | "provider" | "state";
@@ -24025,10 +24058,12 @@ export interface operations {
             query?: {
                 pallet?: string;
                 method?: string;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block?: number;
                 extrinsic?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 before?: number;
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
@@ -25273,7 +25308,9 @@ export interface operations {
         parameters: {
             query?: {
                 lens?: "emission" | "stake" | "entity_emission" | "entity_stake" | "validator_stake";
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to nakamoto_coefficient. */
                 sort?: "nakamoto_coefficient" | "gini" | "holders" | "top_1pct_share" | "total" | "netuid";
+                /** @description Sort direction for the chosen sort key: `asc` smallest-first, `desc` largest-first. Defaults to desc. */
                 order?: "asc" | "desc";
                 /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
@@ -25713,7 +25750,9 @@ export interface operations {
             query?: {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. */
                 sort?: "final_share" | "emission_share" | "weighted_share" | "gated_share" | "gate_delta" | "distance_to_bar" | "tao_in_emission" | "excess_tao" | "tao_total" | "liquidity_fraction" | "miner_burned" | "netuid";
+                /** @description Sort direction for the chosen sort key: `asc` smallest-first, `desc` largest-first. */
                 order?: "asc" | "desc";
                 /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
@@ -26015,6 +26054,7 @@ export interface operations {
     emissionGateChanges: {
         parameters: {
             query?: {
+                /** @description Restrict the result to this kind. Options are per-tool; see this parameter's enum. */
                 kind?: "param" | "subnet" | "flow";
                 /** @description Maximum number of rows to return in one page (at most 200). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
@@ -26135,6 +26175,7 @@ export interface operations {
     chainHolders: {
         parameters: {
             query?: {
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to top1_share. */
                 sort?: "top1_share" | "top5_share" | "top10_share" | "top20_share" | "holder_count" | "total_alpha";
                 /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
@@ -27205,6 +27246,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d";
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to tx_count. */
                 sort?: "tx_count" | "total_fee_tao";
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;
@@ -27891,6 +27933,7 @@ export interface operations {
                 window?: "7d" | "30d";
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 25. */
                 limit?: number;
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to volume. */
                 sort?: "volume" | "count";
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -28843,6 +28886,7 @@ export interface operations {
     compare: {
         parameters: {
             query?: {
+                /** @description Comma-separated subnet ids to restrict the result to, e.g. `1,7,64`. At most 128 ids, each 0-65535. Unknown ids match nothing rather than erroring. */
                 netuids?: string;
                 dimensions?: string;
             };
@@ -29376,7 +29420,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "agent_status" | "blocker_level" | "name" | "netuid" | "priority_score" | "score" | "tier";
@@ -29836,7 +29880,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "coverage_level" | "curation_level" | "name" | "netuid";
@@ -30227,7 +30271,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "alpha_fdv_tao" | "alpha_market_cap_tao" | "alpha_price_change_1d" | "alpha_price_change_1h" | "alpha_price_change_1m" | "alpha_price_change_7d" | "alpha_price_tao" | "block" | "emission_share" | "max_stake_alpha" | "max_uids" | "max_validators" | "miner_count" | "miner_readiness" | "name" | "netuid" | "open_slots" | "registration_cost_tao" | "subnet_volume_tao" | "total_stake_alpha" | "validator_count";
@@ -30516,6 +30560,7 @@ export interface operations {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 severity?: "critical" | "warning" | "info";
@@ -30524,7 +30569,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "detected_at" | "endpoint_id" | "kind" | "last_checked" | "netuid" | "provider" | "severity" | "state" | "status";
@@ -30670,6 +30715,7 @@ export interface operations {
     endpointPools: {
         parameters: {
             query?: {
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 id?: string;
                 kind?: "subtensor-rpc" | "subtensor-wss" | "archive";
                 min_eligible_count?: number;
@@ -30680,7 +30726,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "eligible_count" | "endpoint_count" | "id" | "kind";
@@ -30853,6 +30899,7 @@ export interface operations {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
                 pool_eligible?: "true" | "false";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
@@ -30864,7 +30911,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "kind" | "last_checked" | "latency_ms" | "layer" | "netuid" | "pool_eligible" | "provider" | "publication_state" | "score" | "status";
@@ -31029,7 +31076,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "claim" | "source_url" | "subject" | "verified_at";
@@ -31270,8 +31317,9 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block?: number;
                 signer?: string;
                 call_module?: string;
@@ -31279,9 +31327,13 @@ export interface operations {
                 /** @description Requires call_module so the decoded call-args JSON scan stays scoped. */
                 call_hash?: string;
                 success?: "true" | "false";
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -31534,9 +31586,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -31584,9 +31636,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -31632,9 +31684,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -31680,9 +31732,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -31728,9 +31780,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -31778,9 +31830,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -31826,9 +31878,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -31874,9 +31926,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -31922,9 +31974,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -31972,9 +32024,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32020,9 +32072,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32068,9 +32120,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32116,9 +32168,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32169,9 +32221,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32220,9 +32272,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32271,9 +32323,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32322,9 +32374,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32372,9 +32424,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32420,9 +32472,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32468,9 +32520,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32516,9 +32568,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32568,9 +32620,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32618,9 +32670,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -32668,9 +32720,9 @@ export interface operations {
             query?: {
                 /** @description Return only items carrying this tag (e.g. `upgrade`, `incident`, `subnet`). Exact match against the item's `tags` array. */
                 tag?: string;
-                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. */
+                /** @description Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored. Must not be later than the range's upper bound. */
                 since?: string;
-                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. */
+                /** @description Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day. Must not be earlier than the range's lower bound. */
                 until?: string;
                 /** @description Maximum items to return (1-50). Defaults to 50. */
                 limit?: number;
@@ -33090,7 +33142,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "coverage_level" | "curation_level" | "gap_count" | "name" | "netuid";
@@ -33223,14 +33275,19 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block?: number;
                 call_function?: string;
                 success?: "true" | "false";
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -33366,7 +33423,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "avg_latency_ms" | "degraded_count" | "failed_count" | "last_checked" | "last_ok" | "name" | "netuid" | "ok_count" | "status" | "surface_count" | "unknown_count";
@@ -33496,6 +33553,7 @@ export interface operations {
                 window?: "7d" | "30d" | "90d" | "180d";
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
+                /** @description Restrict the result to this kind, matched exactly against the value the rows carry. Open set, so a value nothing matches yields an empty result rather than an error. Omit for every kind. */
                 kind?: string;
             };
             header?: never;
@@ -33630,6 +33688,7 @@ export interface operations {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
@@ -33637,7 +33696,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "classification" | "kind" | "last_checked" | "last_ok" | "latency_ms" | "netuid" | "provider" | "status" | "status_code" | "surface_id" | "verified_at";
@@ -33914,7 +33973,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "downtime_ms" | "incident_count" | "netuid" | "surface_id";
@@ -34777,6 +34836,7 @@ export interface operations {
                 netuid?: number;
                 subnet_type?: "root" | "application";
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 review_state?: string;
                 confidence?: "low" | "medium" | "high";
                 profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
@@ -34786,7 +34846,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "candidate_count" | "completeness_score" | "curation_level" | "interface_count" | "missing_critical_count" | "name" | "netuid" | "operational_interface_count" | "profile_level" | "review_state";
@@ -35042,6 +35102,7 @@ export interface operations {
     providers: {
         parameters: {
             query?: {
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 id?: string;
                 kind?: "data-provider" | "docs-provider" | "infrastructure-provider" | "registry" | "subnet-team";
                 authority?: "community" | "official" | "provider-claimed" | "registry-observed";
@@ -35049,7 +35110,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "authority" | "id" | "kind" | "name";
@@ -35327,7 +35388,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "kind" | "last_checked" | "latency_ms" | "layer" | "netuid" | "pool_eligible" | "provider" | "publication_state" | "score" | "status";
@@ -35747,13 +35808,14 @@ export interface operations {
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 candidate_api_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 operational_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 reason_codes?: string;
                 recommended_adapter_kind?: "custom-adapter" | "data-artifact-adapter" | "generic-openapi-or-custom" | "stream-adapter";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "candidate_api_count" | "candidate_api_kinds" | "curation_level" | "name" | "netuid" | "operational_kinds" | "operational_surface_count" | "priority_score" | "recommended_adapter_kind";
@@ -35920,7 +35982,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "evidence_action" | "lane" | "name" | "netuid" | "priority_score";
@@ -36081,7 +36143,9 @@ export interface operations {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
                 profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 reason_codes?: string;
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 review_state?: string;
                 manual_review_required?: "true" | "false";
                 /** @description Free-text search query, matched case-insensitively against the collection's indexed text fields. Whitespace-separated terms narrow the result (AND), and an empty or whitespace-only value is treated as no filter rather than as a search matching nothing. */
@@ -36090,7 +36154,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "adapter_score" | "candidate_count" | "completeness_score" | "curation_level" | "endpoint_count" | "evidence_action" | "identity_level" | "identity_surface_count" | "lane" | "name" | "netuid" | "operational_interface_count" | "priority_score" | "profile_level" | "review_state" | "stale_candidate_count" | "surface_count" | "verified_candidate_count";
@@ -36302,6 +36366,7 @@ export interface operations {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
                 profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 reason_codes?: string;
                 submission_route?: "direct-candidate-pr" | "adapter-request" | "maintainer-review" | "status-report";
                 target_action?: "submit-new-candidate" | "replace-stale-candidate" | "verify-existing-candidate" | "review-existing-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
@@ -36312,7 +36377,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "auto_review_candidate" | "evidence_action" | "identity_level" | "kind" | "lane" | "manual_review_required" | "name" | "netuid" | "priority_score" | "profile_level" | "submission_route" | "target_action" | "target_type";
@@ -36522,12 +36587,13 @@ export interface operations {
                 netuid?: number;
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 review_state?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "candidate_count" | "curation_level" | "missing_kinds" | "name" | "netuid" | "priority_score" | "surface_count" | "verified_candidate_count";
@@ -36671,7 +36737,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "candidate_count" | "completeness_score" | "identity_level" | "identity_promotion_kind_count" | "identity_surface_count" | "live_identity_candidate_kind_count" | "missing_critical_count" | "name" | "native_identity_signal_count" | "native_name_quality" | "netuid" | "priority_score" | "profile_level" | "stale_identity_candidate_kind_count";
@@ -36873,6 +36939,7 @@ export interface operations {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
                 pool_eligible?: "true" | "false";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
@@ -36884,7 +36951,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "kind" | "last_checked" | "latency_ms" | "layer" | "netuid" | "pool_eligible" | "provider" | "publication_state" | "score" | "status";
@@ -37016,6 +37083,7 @@ export interface operations {
     rpcPools: {
         parameters: {
             query?: {
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 id?: string;
                 kind?: "subtensor-rpc" | "subtensor-wss" | "archive";
                 min_eligible_count?: number;
@@ -37026,7 +37094,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "eligible_count" | "endpoint_count" | "id" | "kind";
@@ -37603,7 +37671,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "netuid" | "slug" | "title" | "type";
@@ -37733,7 +37801,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "netuid" | "slug" | "title" | "type";
@@ -38349,7 +38417,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "id" | "kind" | "path" | "record_count";
@@ -38478,6 +38546,7 @@ export interface operations {
             query?: {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
+                /** @description Comma-separated subnet ids to restrict the result to, e.g. `1,7,64`. At most 128 ids, each 0-65535. Unknown ids match nothing rather than erroring. */
                 netuids?: string;
                 coverage_level?: "native-only" | "manifested" | "probed";
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
@@ -38506,7 +38575,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "block" | "candidate_count" | "coverage_level" | "curation_level" | "integration_readiness" | "mechanism_count" | "name" | "netuid" | "participant_count" | "probed_surface_count" | "status" | "subnet_type" | "surface_count" | "tempo";
@@ -39315,15 +39384,17 @@ export interface operations {
         parameters: {
             query?: {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 id?: string;
                 confidence?: "low" | "medium" | "high";
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "confidence" | "id" | "kind" | "name" | "netuid" | "provider" | "state";
@@ -40137,6 +40208,7 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 layer?: "bittensor-base" | "data-provider" | "docs-provider" | "subnet-app";
                 pool_eligible?: "true" | "false";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
@@ -40148,7 +40220,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "kind" | "last_checked" | "latency_ms" | "layer" | "netuid" | "pool_eligible" | "provider" | "publication_state" | "score" | "status";
@@ -40459,14 +40531,17 @@ export interface operations {
     subnetEvents: {
         parameters: {
             query?: {
+                /** @description Restrict the result to this kind, matched exactly against the value the rows carry. Open set, so a value nothing matches yields an empty result rather than an error. Omit for every kind. */
                 kind?: string;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 100. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -40594,7 +40669,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "claim" | "source_url" | "subject" | "verified_at";
@@ -40722,12 +40797,13 @@ export interface operations {
             query?: {
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 review_state?: string;
                 /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "candidate_count" | "curation_level" | "missing_kinds" | "name" | "netuid" | "priority_score" | "surface_count" | "verified_candidate_count";
@@ -40938,6 +41014,7 @@ export interface operations {
         parameters: {
             query?: {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
@@ -40945,7 +41022,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "classification" | "kind" | "last_checked" | "last_ok" | "latency_ms" | "netuid" | "provider" | "status" | "status_code" | "surface_id" | "verified_at";
@@ -41843,7 +41920,7 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -41969,7 +42046,7 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -44633,6 +44710,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d";
+                /** @description Which side of the flow to count, relative to the account or subnet this route is scoped to. Omit to count both. Options are per-route; see this parameter's enum. */
                 direction?: "all" | "in" | "out";
             };
             header?: never;
@@ -44854,6 +44932,7 @@ export interface operations {
         parameters: {
             query?: {
                 amount?: number;
+                /** @description Which side of the trade to price: `stake` buys alpha with TAO, `unstake` sells alpha for TAO. Omit for `stake`. */
                 direction?: "stake" | "unstake";
             };
             header?: never;
@@ -45199,7 +45278,9 @@ export interface operations {
         parameters: {
             query?: {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 id?: string;
                 auth_required?: "true" | "false";
                 public_safe?: "true" | "false";
@@ -45208,7 +45289,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "id" | "kind" | "name" | "netuid" | "provider";
@@ -46766,6 +46847,7 @@ export interface operations {
             query?: {
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d";
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to stake. */
                 sort?: "stake" | "emission" | "validators" | "neurons";
                 /** @description Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
@@ -46920,14 +47002,19 @@ export interface operations {
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset. */
                 cursor?: string;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block?: number;
                 call_function?: string;
                 success?: "true" | "false";
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
+                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
+                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -47166,7 +47253,9 @@ export interface operations {
                 /** @description Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's. */
                 netuid?: number;
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 provider?: string;
+                /** @description Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error. */
                 id?: string;
                 auth_required?: "true" | "false";
                 public_safe?: "true" | "false";
@@ -47175,7 +47264,7 @@ export interface operations {
                 fields?: string;
                 /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
                 limit?: number;
-                /** @description Opaque keyset pagination token. Echo the `next_cursor` from the previous response back VERBATIM -- it encodes an internal sort position, not a row number, so it must never be constructed, incremented, parsed or compared. Omit it for the first page; a response with no `next_cursor` is the last page. */
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
                 sort?: "id" | "kind" | "name" | "netuid" | "provider";
@@ -47419,6 +47508,7 @@ export interface operations {
     globalValidators: {
         parameters: {
             query?: {
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to subnet_count. */
                 sort?: "avg_validator_trust" | "max_validator_trust" | "stake_dominance" | "subnet_count" | "total_emission" | "total_stake" | "uid_count";
                 /** @description Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
@@ -47865,11 +47955,13 @@ export interface operations {
                 basis?: "flow" | "positions";
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d";
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to net_staked. */
                 sort?: "net_staked" | "gross_staked" | "last_activity";
                 /** @description Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20. */
                 limit?: number;
                 /** @description Number of rows to skip before the page begins. Correct only in combination with the page size the response actually returned -- prefer `cursor` for anything beyond the first few pages, since a row inserted mid-scan shifts every later offset. */
                 offset?: number;
+                /** @description An SS58 account address (47-48 base58 characters). Coldkey or hotkey depending on the tool — see the tool description for which this expects. */
                 coldkey?: string;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -48001,6 +48093,7 @@ export interface operations {
     validatorEconomicsRanking: {
         parameters: {
             query?: {
+                /** @description Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to earning_floor_cost_tao. */
                 sort?: "earning_floor_cost_tao" | "permit_floor_cost_tao" | "permit_to_earning_multiple" | "tao_inflow_per_day" | "validator_headroom";
                 /** @description Maximum number of rows to return in one page (at most 512). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50. */
                 limit?: number;

--- a/schemas-src/query-params.ts
+++ b/schemas-src/query-params.ts
@@ -205,8 +205,16 @@ export const windowSchema = <T extends readonly [string, ...string[]]>(
     .enum(values)
     .describe(
       "Trailing time window to aggregate over, ending at the latest data " +
-        "point rather than a calendar boundary. Options are per-tool; see this " +
-        "parameter's enum." +
+        "point rather than a calendar boundary. Options are per-tool: " +
+        // NAMED, not deferred to "see this parameter's enum". The builder is
+        // handed the values, so listing them is a derivation rather than a
+        // restatement -- it cannot drift from the `enum` beside it, because
+        // both come from this one argument. The deferral was written when the
+        // shared name-keyed description interpolated them at emit time; that
+        // rung no longer runs for `window` (#10219), so the sentence has to
+        // carry them itself or the option set becomes invisible in prose.
+        values.map((value) => `\`${value}\``).join(", ") +
+        "." +
         (fallback === undefined ? "" : ` Defaults to ${fallback}.`),
     )
     .meta(
@@ -288,6 +296,34 @@ export const sortSchema = <T extends readonly [string, ...string[]]>(
     );
 
 /**
+ * What an ORDERED PAIR's two halves promise about each other (#10219).
+ *
+ * 41 pairs are published across the GET routes -- `from`/`to`,
+ * `block_start`/`block_end`, `since`/`until` -- and before this, not one of
+ * them said which way round they go. JSON Schema has no way to relate two
+ * sibling properties, so the relationship lived in the handler or nowhere, and
+ * a caller reading the contract could not tell an ordered pair from two
+ * independent filters.
+ *
+ * STATED, NOT ENFORCED, and that distinction is the decision here. Measured
+ * across every route publishing an ordered pair: 20 reject an inverted range
+ * and 12 answer an empty page instead, and the 12 are deliberate -- an
+ * inverted range provably matches nothing, so skipping the read is the point,
+ * and nine tests pin exactly that. Adding `.refine()` would flip all twelve to
+ * rejecting, which is a behaviour change on twelve routes made by a refactor
+ * rather than by a decision. The sentence makes the pair legible without
+ * touching what either surface does with it.
+ *
+ * Derived from the edge the builder already carries, so a route cannot state
+ * it one way for `from` and another for `to`.
+ */
+export function orderingNote(edge: "first" | "last"): string {
+  return edge === "first"
+    ? " Must not be later than the range's upper bound."
+    : " Must not be earlier than the range's lower bound.";
+}
+
+/**
  * A block height bound. Inclusive on both ends, which is the one thing a
  * caller cannot infer from the name and gets wrong by one row.
  */
@@ -297,7 +333,8 @@ export const blockBoundSchema = (edge: "first" | "last") =>
     .min(0)
     .describe(
       `Inclusive ${edge} block height of the range to read. ` +
-        "Omit for an unbounded end.",
+        "Omit for an unbounded end." +
+        orderingNote(edge),
     )
     .meta({ examples: [8783000] });
 
@@ -406,6 +443,36 @@ export const blockEventCursorSchema = () =>
  * make no promise about its contents. If a length ever needs enforcing, the
  * place is `decodeCursor`, where every surface already funnels.
  */
+/**
+ * A feed's `since`/`until` bound.
+ *
+ * NO PATTERN, deliberately, and this reverses nothing: `src/feeds.ts` accepts a
+ * whole UTC day or an ISO instant with an explicit zone, range-checks the
+ * calendar, and rejects a malformed value with a message naming which form was
+ * expected. Publishing a regex would make the router's derived message preempt
+ * that better one on all 24 feed paths -- a worse answer for the caller, in
+ * exchange for a `pattern` keyword.
+ *
+ * What DID need fixing is that these published `{"type":"string"}` and nothing
+ * else: no accepted forms, no ordering, no example. The handler knowing more
+ * than a schema can say is a reason not to move the CHECK; it was never a
+ * reason to say nothing.
+ */
+export const feedInstantSchema = (edge: "first" | "last") =>
+  z
+    .string()
+    .describe(
+      `Inclusive ${edge} instant of the window to read: either a whole UTC ` +
+        "day as YYYY-MM-DD, or an ISO-8601 date-time with an explicit zone " +
+        "(e.g. 2026-06-01T00:00:00Z). A bare day resolves to that day's " +
+        (edge === "first" ? "first" : "last") +
+        " instant, so the named day is included either way." +
+        orderingNote(edge),
+    )
+    .meta({
+      examples: [edge === "first" ? "2026-06-01" : "2026-06-30T23:59:59Z"],
+    });
+
 export const keysetCursorSchema = () =>
   z
     .string()
@@ -475,7 +542,8 @@ export const daySchema = (edge: "first" | "last") =>
     .meta({ format: "date", examples: ["2026-08-01"] })
     .describe(
       `Inclusive ${edge} day of the range to read, as YYYY-MM-DD. ` +
-        "Omit for an unbounded end.",
+        "Omit for an unbounded end." +
+        orderingNote(edge),
     );
 
 /**

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -210,6 +210,7 @@ import {
   netuidSchema,
   offsetSchema,
   orderSchema,
+  feedInstantSchema,
   querySchema,
   SERVING_BOUND,
   sortSchema,
@@ -361,16 +362,21 @@ export const NO_QUERY_PARAMETERS: readonly string[] = [
  * different array. What that cost: all 24 published feed paths declare
  * `limit` maximum 50 and nothing enforced it, so `?limit=51` answered 200.
  *
- * `since`/`until` stay plain strings: `src/feeds.ts` accepts a whole UTC day
- * OR an offset-bearing date-time and rejects a malformed one with a message
- * naming which, so this is a case where the handler genuinely knows more than
- * a schema can say -- unlike the bound above it, which is a number.
+ * `since`/`until` carry no PATTERN, for the reason they never did: `src/feeds.ts`
+ * accepts a whole UTC day OR an offset-bearing date-time and rejects a malformed
+ * one with a message naming which, and a published regex would make the router's
+ * derived message preempt that better one on all 24 paths.
+ *
+ * They no longer publish NOTHING, though (#10219). `feedInstantSchema` states the
+ * two accepted forms, which end of the day a bare date resolves to, and the
+ * ordering between the pair -- the three things a caller cannot infer and the
+ * handler was never going to tell them in advance.
  */
 export const FEED_QUERY_SCHEMAS = {
   common: z.object({
     tag: filterTokenSchema().optional(),
-    since: z.string().optional(),
-    until: z.string().optional(),
+    since: feedInstantSchema("first").optional(),
+    until: feedInstantSchema("last").optional(),
     limit: limitSchema(FEED_LIMIT_MAX, FEED_LIMIT_MAX).optional(),
   }),
   /** `/api/v1/feeds/watch` -- the URL-carried watchlist. */

--- a/scripts/scan-public-safety.ts
+++ b/scripts/scan-public-safety.ts
@@ -248,9 +248,16 @@ const patterns: SafetyPattern[] = [
     regex: /\bcoldkey\b/i,
     // Bare "coldkey" as a public API field name (JSON property / required entry /
     // TS type member) is legitimate metagraph vocabulary (#1304) — an ss58 coldkey
-    // is public on-chain data, not a secret. Also allow the "hotkey or coldkey" /
-    // "hotkey/coldkey" field-pair phrase (account routes #1347 doc text + the
-    // generated MCP server-card prose), generated CSV headers for public exports,
+    // is public on-chain data, not a secret. Also allow the field-pair phrase in
+    // EITHER order -- "hotkey or coldkey", "coldkey or hotkey", "hotkey/coldkey",
+    // "coldkey/hotkey" (account routes #1347 doc text + the generated MCP
+    // server-card prose). It accepted only the hotkey-first order until #10219,
+    // which is an arbitrary distinction the rule never meant to draw: the two
+    // orders are the same legitimate vocabulary, and `ss58Schema()`'s own
+    // sentence ("Coldkey or hotkey depending on the tool") tripped it the moment
+    // a builder's prose started reaching the published spec. Widened rather than
+    // reworded, so the next writer does not hit the same arbitrary wall.
+    // Also allowed: generated CSV headers for public exports,
     // the "coldkey-only" behaviour descriptor (a coldkey-only ss58 address has no
     // hotkey-attributed rollup), and "coldkey" as a bare SQL/code identifier —
     // one comprehensive alternation covering the common ways a column/field
@@ -288,7 +295,7 @@ const patterns: SafetyPattern[] = [
     // a lowercase identifier + `(` matches the method-call shape without
     // loosening the bare `\bcoldkey\b` trigger itself.
     allow:
-      /"coldkey"\s*:?|\bcoldkey\s*\??\s*:|\bcoldkey\?\.|\bcoldkey\.[a-z_]+\(|\bhotkey(?:\s+or\s+|\s*\/\s*)coldkey\b|\bcoldkey-only(?![-A-Za-z0-9_])|\bcoldkey\s*(?:=|!=|<>|IS\s+(?:NOT\s+)?NULL\b|IN\s*\()|\bcoldkey\s*(?:,|\)|\]|\}|;|`)|\bcoldkey\s+(?:ASC|DESC|AS\b|TEXT|VARCHAR|CHAR|INTEGER|BIGINT|NUMERIC|BOOLEAN)\b|'coldkey'|\bcoldkey\s*\/\s*[a-z_]+\b|\b[a-z_]+\s*\/\s*coldkey\b|\b[a-z]+-coldkey\b|\bcoldkey\s*\(/gi,
+      /"coldkey"\s*:?|\bcoldkey\s*\??\s*:|\bcoldkey\?\.|\bcoldkey\.[a-z_]+\(|\b(?:hotkey(?:\s+or\s+|\s*\/\s*)coldkey|coldkey(?:\s+or\s+|\s*\/\s*)hotkey)\b|\bcoldkey-only(?![-A-Za-z0-9_])|\bcoldkey\s*(?:=|!=|<>|IS\s+(?:NOT\s+)?NULL\b|IN\s*\()|\bcoldkey\s*(?:,|\)|\]|\}|;|`)|\bcoldkey\s+(?:ASC|DESC|AS\b|TEXT|VARCHAR|CHAR|INTEGER|BIGINT|NUMERIC|BOOLEAN)\b|'coldkey'|\bcoldkey\s*\/\s*[a-z_]+\b|\b[a-z_]+\s*\/\s*coldkey\b|\b[a-z]+-coldkey\b|\bcoldkey\s*\(/gi,
     soft: true,
   },
   {

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -6,6 +6,7 @@ import {
   netuidListSchema,
   netuidSchema,
   numericCursorSchema,
+  orderingNote,
   orderSchema,
   querySchema,
   RPC_POOL_KIND_VALUES,
@@ -78,6 +79,35 @@ const CHAIN_CONCENTRATION_SUBNETS_DESCRIPTION =
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Row = Record<string, any>;
+
+/**
+ * The parameter names `SHARED_QUERY_PARAMETER_DESCRIPTIONS` covers.
+ *
+ * A SECOND declaration of that map's keys, which normally would not survive
+ * review here -- and the reason it does is a hard ordering constraint rather
+ * than a preference. `route()` runs at module load, hundreds of lines above
+ * where the map is declared, so reading the map from the parameter emitter is
+ * a temporal dead zone: it throws `Cannot access ... before initialization`
+ * during import. Hoisting the map itself would move ~200 lines of prose past
+ * every route in the file.
+ *
+ * The list is therefore small, adjacent to its purpose, and GATED --
+ * `tests/shared-query-parameter-descriptions.test.ts` asserts it equals the
+ * map's own keys, so the two cannot drift.
+ *
+ * What it decides: whether a parameter's prose may fall back to the builder's
+ * `.describe()` (#10219). A name in here has a sentence that differs per
+ * SURFACE -- `limit` is rejected on REST and clamped on MCP -- and a builder
+ * shared by both surfaces must not be able to overwrite it.
+ */
+export const SHARED_DESCRIPTION_NAMES: ReadonlySet<string> = new Set([
+  "fields",
+  "limit",
+  "netuid",
+  "offset",
+  "q",
+  "window",
+]);
 
 interface QueryParameterSpec {
   name: string;
@@ -4820,14 +4850,22 @@ const FEED_COMMON_PARAMETERS = [
   },
   {
     name: "since",
+    // The feed-specific opening is written here because it names what the
+    // items ARE, which the vocabulary cannot. The ORDERING half is appended
+    // from `orderingNote`, the same declaration `blockBoundSchema` and
+    // `daySchema` read (#10219) -- a second copy of that sentence is exactly
+    // the drift this epic removes, and 41 published pairs all say it the same
+    // way because only one of them says it.
     description:
-      "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored.",
+      "Inclusive lower bound on item timestamps, as an ISO-8601 date (`2026-06-01`, a whole UTC day) or date-time with an explicit offset. Malformed values are a 400, never silently ignored." +
+      orderingNote("first"),
     schema: parameterSchema(FEED_QUERY_SCHEMAS.common.shape.since),
   },
   {
     name: "until",
     description:
-      "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day.",
+      "Inclusive upper bound, same format as `since`. A bare date covers the whole named UTC day." +
+      orderingNote("last"),
     schema: parameterSchema(FEED_QUERY_SCHEMAS.common.shape.until),
   },
   {
@@ -5636,12 +5674,26 @@ export const SHARED_QUERY_PARAMETER_DESCRIPTIONS: Record<
     "combination with the page size the response actually returned -- prefer " +
     "`cursor` for anything beyond the first few pages, since a row inserted " +
     "mid-scan shifts every later offset.",
-  cursor: () =>
-    "Opaque keyset pagination token. Echo the `next_cursor` from the previous " +
-    "response back VERBATIM -- it encodes an internal sort position, not a " +
-    "row number, so it must never be constructed, incremented, parsed or " +
-    "compared. Omit it for the first page; a response with no `next_cursor` " +
-    "is the last page.",
+  // `cursor` USED TO LIVE HERE and had to leave (#10219).
+  //
+  // Its sentence said "echo the next_cursor back VERBATIM -- it encodes an
+  // internal sort position, not a row number", which is true of the keyset
+  // feeds and flatly false of the ~40 collection routes whose `cursor` is an
+  // integer ROW OFFSET. Telling a caller to echo an offset back verbatim is
+  // precisely the silent skip-or-repeat paging loop the sentence was written to
+  // prevent, published as guidance on the routes that most needed the other
+  // advice.
+  //
+  // This is the failure #10060 named when it called a NAME-keyed description
+  // "structurally unable to be right": one name, two shapes, one sentence. It
+  // could not be fixed by rewording -- only by letting each shape speak for
+  // itself. `numericCursorSchema` and `keysetCursorSchema` each carry their own
+  // sentence, and since #10219 a builder's prose reaches the spec for any
+  // parameter this map does not claim.
+  //
+  // `tests/shared-query-parameter-descriptions.test.ts` now asserts per shape:
+  // an integer cursor must say "offset" and must NOT say "verbatim", and an
+  // opaque one must say the opposite.
   window: (parameter) => {
     const values = parameter.schema?.enum;
     // The allowed windows differ per route (7d/30d, +90d, +1y/all), so they
@@ -5690,6 +5742,7 @@ function withSharedParameterDescription<T extends object>(parameter: T): T {
       minimum?: number;
       enum?: unknown[];
       default?: unknown;
+      description?: unknown;
     };
   };
   if (typeof spec.name !== "string" || spec.description) return parameter;
@@ -6290,13 +6343,31 @@ function route(
  * where that proof gets cashed in: the `schema` object on every published
  * parameter now comes from the Zod, so there is nothing left to keep in step.
  *
- * WHAT STILL COMES FROM THE CALL SITE. Only `description`. A parameter's prose
- * is per-route -- it names what the rows are -- and 135 of the 678 published
- * parameters carry one written at the `route()` call rather than in
- * `SHARED_QUERY_PARAMETER_DESCRIPTIONS`. Taking descriptions from Zod too
- * would move all 135 (`formatSchema()` has one sentence; the routes have
- * three), and that is a contract change worth making deliberately, not one to
- * smuggle into a refactor that claims to change nothing.
+ * WHERE THE PROSE COMES FROM, three sources in precedence order (#10219):
+ *
+ *   1. the route's own inline `description` -- it names what the rows are, and
+ *      135 parameters have one for that reason;
+ *   2. `SHARED_QUERY_PARAMETER_DESCRIPTIONS`, keyed by name;
+ *   3. the BUILDER's `.describe()`, taken from the Zod.
+ *
+ * Rung 3 is new, and #10063 deferred it correctly: that step's whole value was
+ * being a provable no-op, and moving sentences inside it would have made the
+ * proof meaningless. The reason to add it now is measurable -- 310 of 910
+ * published query parameters carried NO description at all, including every
+ * `block_start`, `block_end`, `from` and `to`, which are exactly the ones whose
+ * prose holds something a caller cannot infer. `blockBoundSchema(edge)` knows
+ * it is the first or last end of a range and which way the pair is ordered;
+ * none of that reached `openapi.json` while the builder's sentence was dropped.
+ *
+ * THE BUILDER GOES LAST, NOT SECOND, and that ordering is the whole care in
+ * this change. The first attempt put it above the shared map and would have
+ * published a contract lie on ~130 routes: `limitSchema`'s sentence says an
+ * over-ceiling value "is clamped to the ceiling rather than rejected", which is
+ * true of MCP and false of REST, where it is a 400. The shared map exists
+ * BECAUSE the two surfaces behave differently for that one parameter -- see its
+ * own header, which measured both -- so it has to outrank a builder shared by
+ * both surfaces. A parameter the map does not cover falls through to the
+ * builder, which is where the 310 get their prose.
  *
  * ORDER IS THE ZOD'S. Object keys are authored in the order the route
  * published them, which is what makes this emit an identical parameter list
@@ -6306,6 +6377,20 @@ function route(
  * `validate:route-query-parity` passes -- it fails on any unclassified route --
  * but falling back beats emitting nothing if it ever does.
  */
+/**
+ * The builder's own sentence, lifted out of the emitted schema object.
+ *
+ * `.describe()` lands INSIDE the JSON Schema, and a published parameter carries
+ * its prose at the PARAMETER level. `parameterSchemaFor` strips it from the
+ * schema below, so this is the only chance to keep it.
+ */
+function describedByBuilder(property: Row): string | undefined {
+  const description = property.description;
+  return typeof description === "string" && description.length > 0
+    ? description
+    : undefined;
+}
+
 function queryParametersFromSchema(
   pathValue: string,
   querySpec: ReturnType<typeof normalizeQueryParameters>,
@@ -6327,7 +6412,22 @@ function queryParametersFromSchema(
   }) as Row;
   return Object.entries((emitted.properties ?? {}) as Record<string, Row>).map(
     ([name, property]) => {
-      const description = describedBy.get(name);
+      // All three rungs resolve here, because this is the only point where all
+      // three are still visible: `parameterSchemaFor` strips the builder's
+      // sentence out of the schema object below, so a later pass cannot see it.
+      //
+      // Rung 2 is checked by NAME rather than applied here --
+      // `withSharedParameterDescription` still owns the wording, and it
+      // interpolates each route's own ceiling/enum into it. Asking only
+      // "does the map cover this name" keeps one owner for the sentence, stops
+      // the builder from pre-empting it, and avoids reading the map itself
+      // from a point where it is not yet initialized (see
+      // SHARED_DESCRIPTION_NAMES).
+      const description =
+        describedBy.get(name) ??
+        (SHARED_DESCRIPTION_NAMES.has(name)
+          ? undefined
+          : describedByBuilder(property));
       return {
         name,
         ...(description === undefined ? {} : { description }),

--- a/tests/ordered-pair-prose.test.ts
+++ b/tests/ordered-pair-prose.test.ts
@@ -1,0 +1,108 @@
+// A published ORDERED PAIR says which way round it goes (#10219).
+//
+// 41 pairs are published across the GET routes -- `from`/`to`,
+// `block_start`/`block_end`, `since`/`until` -- and before this, not one said.
+// JSON Schema cannot relate two sibling properties, so the relationship lived
+// in the handler or nowhere, and a caller reading the contract could not tell
+// an ordered pair from two independent filters.
+//
+// STATED, NOT ENFORCED, and that is the decision this pins. Measured across
+// every route publishing a pair: 20 reject an inverted range and 12 answer an
+// empty page, and the 12 are deliberate -- an inverted range provably matches
+// nothing, so skipping the read is the point, and nine tests pin exactly that.
+// A `.refine()` would flip all twelve to rejecting: a behaviour change on
+// twelve routes made by a refactor rather than by a decision. The sentence
+// makes the pair legible without touching what either surface does with it.
+//
+// ONE DECLARATION, three readers. `orderingNote(edge)` is the only place the
+// sentence exists; `blockBoundSchema` and `daySchema` append it from the edge
+// they already carry, and the feed routes compose it onto their own
+// item-specific opening. A second copy is what this epic removes, so a test
+// that merely checked "says something about ordering" would miss the failure
+// that matters -- two halves of one pair disagreeing.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { orderingNote } from "../schemas-src/query-params.ts";
+
+interface Parameter {
+  name: string;
+  description?: string;
+  schema?: { description?: string };
+}
+
+/** The two halves of every ordered pair this API publishes. */
+const PAIRS: readonly (readonly [string, string])[] = [
+  ["from", "to"],
+  ["block_start", "block_end"],
+  ["start_date", "end_date"],
+  ["since", "until"],
+  ["after", "before"],
+];
+
+const spec = JSON.parse(
+  readFileSync("public/metagraph/openapi.json", "utf8"),
+) as {
+  paths: Record<string, Record<string, { parameters?: Parameter[] }>>;
+};
+
+const prose = (parameter: Parameter): string =>
+  parameter.description ?? parameter.schema?.description ?? "";
+
+function publishedPairs(): {
+  route: string;
+  lower: Parameter;
+  upper: Parameter;
+}[] {
+  const found: { route: string; lower: Parameter; upper: Parameter }[] = [];
+  for (const [route, methods] of Object.entries(spec.paths)) {
+    const parameters = methods.get?.parameters ?? [];
+    const byName = new Map(parameters.map((p) => [p.name, p]));
+    for (const [lo, hi] of PAIRS) {
+      const lower = byName.get(lo);
+      const upper = byName.get(hi);
+      if (lower && upper) found.push({ route, lower, upper });
+    }
+  }
+  return found;
+}
+
+describe("every published ordered pair states its ordering", () => {
+  test("both halves carry the note, and it is the shared one", () => {
+    const pairs = publishedPairs();
+    // 41 today. The floor guards against the scan quietly matching nothing --
+    // a "no pair is silent" assertion passes perfectly when no pair is found.
+    assert.ok(
+      pairs.length >= 40,
+      `expected the pair scan to find the published pairs, got ${pairs.length}`,
+    );
+
+    const silent: string[] = [];
+    for (const { route, lower, upper } of pairs) {
+      if (!prose(lower).endsWith(orderingNote("first"))) {
+        silent.push(`${route} ${lower.name} (lower)`);
+      }
+      if (!prose(upper).endsWith(orderingNote("last"))) {
+        silent.push(`${route} ${upper.name} (upper)`);
+      }
+    }
+    assert.deepEqual(
+      silent,
+      [],
+      `these publish one half of an ordered pair without saying which way it ` +
+        `goes:\n  ${silent.join("\n  ")}\n` +
+        "Build the bound with `blockBoundSchema`/`daySchema`, or append " +
+        "`orderingNote(edge)` to the route's own prose. Do not write the " +
+        "sentence out -- one declaration is what keeps 41 pairs agreeing.",
+    );
+  });
+
+  test("the two halves say OPPOSITE things", () => {
+    // The failure a "says something about ordering" check would miss: both
+    // halves carrying the lower-bound sentence reads as consistent and is
+    // exactly backwards for one of them.
+    assert.notEqual(orderingNote("first"), orderingNote("last"));
+    assert.match(orderingNote("first"), /not be later/);
+    assert.match(orderingNote("last"), /not be earlier/);
+  });
+});

--- a/tests/shared-query-parameter-descriptions.test.ts
+++ b/tests/shared-query-parameter-descriptions.test.ts
@@ -34,7 +34,7 @@ interface Parameter {
   name?: string;
   in?: string;
   description?: string;
-  schema?: { maximum?: number; enum?: unknown[] };
+  schema?: { maximum?: number; enum?: unknown[]; type?: string };
 }
 
 function queryParameters(): { path: string; parameter: Parameter }[] {
@@ -115,12 +115,38 @@ describe("shared query parameters are described in the published spec (#9131)", 
       `expected the cursor parameters, found ${cursors.length} ` +
         `across ${SPEC_PATHS} paths`,
     );
+    // PER SHAPE, not one sentence for all of them -- which is what this used
+    // to assert, and it was enforcing the defect #10060 named: the shared
+    // name-keyed description said "echo it back verbatim" on every `cursor`,
+    // while ~40 collection routes take a ROW OFFSET. Telling a caller to echo
+    // an integer offset back verbatim is precisely the paging loop the comment
+    // above warns about, published as guidance.
+    //
+    // Since #10219 the builder's own sentence reaches the spec, so each cursor
+    // says what it actually is. The property worth pinning is that it says
+    // WHICH -- an opaque token must not read as an offset and vice versa.
     for (const { path, parameter } of cursors) {
-      assert.match(
-        parameter.description ?? "",
-        /verbatim/i,
-        `${path}'s cursor description must say to echo it back verbatim`,
-      );
+      const prose = parameter.description ?? "";
+      const numeric = parameter.schema?.type === "integer";
+      if (numeric) {
+        assert.match(
+          prose,
+          /offset|position/i,
+          `${path}'s cursor is an integer offset and must say so`,
+        );
+        assert.doesNotMatch(
+          prose,
+          /verbatim/i,
+          `${path}'s cursor is an offset -- telling a caller to echo it back ` +
+            "verbatim is the paging loop this test exists to prevent",
+        );
+      } else {
+        assert.match(
+          prose,
+          /verbatim/i,
+          `${path}'s cursor is opaque and must say to echo it back verbatim`,
+        );
+      }
     }
   });
 


### PR DESCRIPTION
## The builder's sentence never reached the spec

Three sources decide a published parameter's description, and the **builder was not one of them**.
#10063 emitted the schema object from Zod and kept taking prose from the call site — deliberately, and
its comment says why:

> Taking descriptions from Zod too … is a contract change **worth making deliberately**, not one to
> smuggle into a refactor that claims to change nothing.

It deferred correctly. The deferral was then never picked up, and the cost is measurable on the
emitted contract:

```
910 published query parameters
600 carry a description
310 carry none  ← every block_start, block_end, from, to
```

Those are exactly the parameters whose prose holds something a caller cannot infer.

## Precedence: route inline → shared map → builder

**The builder goes last, not second, and that ordering is the whole care in this change.**

My first attempt put it second. It would have published a **contract lie on ~130 routes**:
`limitSchema`'s sentence says an over-ceiling value *"is clamped to the ceiling rather than
rejected"* — true of MCP, false of REST where it is a 400. The shared map exists *because* those two
surfaces behave differently for that parameter; its own header measured both. So it must outrank a
builder that both surfaces share.

A parameter the map does not claim falls through to the builder. That is where the 310 get their
prose.

*(The name check is against a small hoisted `SHARED_DESCRIPTION_NAMES` set rather than the map
itself: `route()` runs at module load, hundreds of lines above the map, so reading it there is a
temporal dead zone that throws during import. The set is gated against the map's keys so the two
cannot drift.)*

## `cursor` leaves the shared map

Its one sentence said *"echo the next_cursor back VERBATIM — it encodes an internal sort position,
not a row number"*. True of the keyset feeds. **False of the ~40 collection routes whose `cursor` is
an integer row offset** — where telling a caller to echo it back verbatim is precisely the silent
skip-or-repeat paging loop the sentence was written to prevent.

This is the failure #10060 named when it called a name-keyed description *"structurally unable to be
right"*: one name, two shapes, one sentence, unfixable by rewording. `numericCursorSchema` and
`keysetCursorSchema` each say what they are, and the test now asserts **per shape** — an integer
cursor must say "offset" and must *not* say "verbatim" — instead of asserting the wrong sentence on
every route.

## 41 ordered pairs, 0 said which way round

`from`/`to`, `block_start`/`block_end`, `since`/`until`. JSON Schema cannot relate two sibling
properties, so the relationship lived in the handler or nowhere, and a caller could not tell an
ordered pair from two independent filters.

All 41 now state it, from **one declaration** — `orderingNote(edge)`, which the bound builders append
from the edge they already carry and the feed routes compose onto their own item-specific opening.

**Stated, not enforced.** Across every route publishing a pair, **20 reject an inverted range and 12
answer an empty page**, and the 12 are deliberate — an inverted range provably matches nothing, and
nine tests pin the short-circuit. A `.refine()` would flip all twelve to rejecting: a behaviour
change on twelve routes made by a refactor rather than by a decision.

## Two things fixed on the way, neither of them the task

- **`windowSchema` names its own allowed values** instead of deferring to *"see this parameter's
  enum"*. It is handed the values, so listing them is a derivation, not a restatement. The deferral
  was written when the shared map interpolated them at emit time — that rung no longer runs for
  `window`.
- **`scan:public-safety` accepted the hotkey/coldkey pair phrase in one word order only.** An
  arbitrary distinction the rule never meant to draw; it fired the moment `ss58Schema()`'s *"Coldkey
  or hotkey depending on the tool"* reached the spec. Widened to either order rather than reworded,
  so the next writer does not hit the same wall.

## The gate

`tests/ordered-pair-prose.test.ts` checks both halves of all 41 pairs against the shared note, and
asserts the two halves say **opposite** things — the failure a "mentions ordering" check would miss,
since both halves carrying the lower-bound sentence reads as consistent and is backwards for one of
them. **Proven to fail** by dropping the note from `blockBoundSchema`.

## Validation

```
npm run typecheck / lint / format:check   clean
npx vitest run                            18,209 passed, 11 skipped, 0 failed
npm run validate                          exit 0
npm run scan:public-safety                clean
npm run build                             regenerated artifacts committed
```

Closes #10219
