### PR TITLE
feat(ci): alarm when a Worker is not running what was merged

### DIFF
--- a/.github/workflows/check-worker-deploys.yml
+++ b/.github/workflows/check-worker-deploys.yml
@@ -1,0 +1,68 @@
+name: Check worker deploys
+
+# Is production RUNNING what was merged? (#10238)
+#
+# Workers Builds is the deploy path, and a build that fails on the merge commit
+# leaves main merged and production on the previous version with nothing that
+# reads as an incident: the PR is green, the branch is deleted, and the only
+# symptom is that the fix does not take effect. metagraphed-data-api failed
+# twice on 2026-08-08 and passed on retry with a byte-identical diff, so this is
+# observed rather than hypothetical. Between "landed" and "running" there was no
+# automated relationship at all.
+#
+# WHY THIS IS AN ACTION AND NOT A WORKER CRON, against the standing preference
+# for Worker-native lanes. A Worker that failed to deploy is RUNNING THE
+# PREVIOUS VERSION, so asking it what it is running gets the previous version's
+# answer, confidently. The check has to observe from outside the thing it is
+# checking -- the same reasoning as "a Worker cannot probe its own route", one
+# level up. It also reads Cloudflare's own deployment record rather than
+# anything the Worker reports about itself, which is the other half of the same
+# property.
+#
+# This is not a data lane: it moves no rows and writes no store.
+on:
+  schedule:
+    # Hourly at :47, off every producer minute in wrangler.jsonc so a red run is
+    # never competing with a capture for attention. A build takes minutes, so
+    # hourly is several times finer than the thing being watched.
+    - cron: "47 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-worker-deploys
+  cancel-in-progress: false
+
+jobs:
+  deploys:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # FULL HISTORY: the check asks whether the deployed SHA is an ancestor
+          # of main and how far behind it is, and a shallow clone cannot answer
+          # either -- merge-base would fail on a commit it never fetched and the
+          # verdict would read `forked` on a perfectly current Worker.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.2
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Compare every Worker's deployed SHA against main
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npm run check:worker-deploys

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "format:check": "prettier --check .",
     "pretypecheck": "npm run build --workspace=packages/chain-summaries",
     "typecheck": "tsc --noEmit",
+    "check:worker-deploys": "node scripts/check-worker-deploys.ts",
     "check": "npm run lint && npm run format:check && npm run typecheck && npm run pipeline:check && npm run validate:docs",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/scripts/check-worker-deploys.ts
+++ b/scripts/check-worker-deploys.ts
@@ -1,0 +1,246 @@
+// Is what production is RUNNING the code that was merged? (#10238)
+//
+// ## The gap this closes
+//
+// Workers Builds is the deploy path, and a build that fails on the merge commit
+// leaves `main` merged and production running the previous version with nothing
+// that reads as an incident: the PR is green, the branch is deleted, and the
+// only symptom is that the fix does not take effect. `metagraphed-data-api`
+// failed twice on 2026-08-08 and passed on retry with a byte-identical diff, so
+// this is observed rather than hypothetical.
+//
+// Between "landed" and "running" there was no automated relationship at all --
+// the same shape as #10190 and #9779.
+//
+// ## Why this cannot be a Worker cron, unlike every other watchdog here
+//
+// A Worker that failed to deploy is RUNNING THE PREVIOUS VERSION, so asking it
+// what it is running gets the previous version's answer, confidently. The check
+// has to observe from outside the thing it is checking -- the same reasoning as
+// "a Worker cannot probe its own route", one level up.
+//
+// It reads Cloudflare's own record instead: Workers Builds stamps the commit
+// SHA as the deployment message, so nothing has to be injected at build time
+// and no bundle changes.
+//
+// ## THERE IS A CLEANER PATH, and it is one deploy flag away
+//
+// Every Worker here already binds CF_VERSION_METADATA, which hands the runtime
+// its own version `{id, tag, timestamp}` with NO credential and NO API call.
+// That would let each Worker self-report, and a checker would need nothing from
+// Cloudflare's control plane at all.
+//
+// It does not work TODAY for one narrow reason: Workers Builds puts the commit
+// SHA in the deployment MESSAGE, and the binding exposes the TAG, which is
+// empty --
+//
+//     Tag:      -
+//     Message:  ea6baa13cbb4747861fc7f8893b7dd0a92958f03
+//
+// Set the tag to the SHA at deploy and this script's Cloudflare read collapses
+// into a binding read. Worth doing; it is a deploy-configuration change rather
+// than a token, and it is tracked on #10238.
+//
+// ## The three verdicts, and why "behind" alone is not one
+//
+// Deploys are not instant and the four Workers are not the same size --
+// `metagraphed-wss-lb` was at HEAD while the ~1 MB gzip `data-api` was three
+// commits back, measured minutes after the same merge. A check that demanded
+// `deployed == HEAD` would alarm on every merge for as long as a build takes,
+// which is #9301 again.
+//
+//   FORKED   the deployed SHA is not an ancestor of main. Always wrong: it
+//            means a deploy from a branch, or a rollback nobody recorded.
+//   STALE    behind, and main's HEAD is older than the grace window. This is
+//            the failure the issue is about.
+//   LAGGING  behind, but HEAD is younger than the grace window -- a build in
+//            flight, which is the ordinary state right after a merge.
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { repoRoot, stripJsonComments } from "./lib.ts";
+
+/**
+ * How long a merge may take to reach every Worker before "behind" is a fault.
+ *
+ * THIRTY MINUTES. Measured 2026-08-10: `wss-lb` reached HEAD ~4 minutes after
+ * the merge while `data-api` was still three commits back, and the data-api
+ * bundle is ~1 MB gzip against wss-lb's tens of KB. Thirty is several times the
+ * slowest observed build, which is the right direction to be wrong in: a bound
+ * that alarms during a normal build teaches people to ignore it.
+ */
+export const DEPLOY_GRACE_MS = 30 * 60 * 1000;
+
+/** Every Worker this repo deploys, by its wrangler config. */
+export const WORKER_CONFIGS = [
+  "wrangler.jsonc",
+  "wrangler.data.jsonc",
+  "wrangler.registry.jsonc",
+  "wrangler.wss-lb.jsonc",
+] as const;
+
+export type DeployVerdict = "ok" | "lagging" | "stale" | "forked" | "unknown";
+
+export interface DeployStatus {
+  config: string;
+  worker: string;
+  deployed: string | null;
+  ancestor: boolean;
+  behind: number;
+  verdict: DeployVerdict;
+  detail: string;
+}
+
+/**
+ * Judge one Worker. Pure, so the verdict table is testable without Cloudflare,
+ * git, or a clock.
+ */
+export function judgeDeploy(input: {
+  config: string;
+  worker: string;
+  deployed: string | null;
+  ancestor: boolean;
+  behind: number;
+  headAgeMs: number;
+  graceMs?: number;
+}): DeployStatus {
+  const { config, worker, deployed, ancestor, behind, headAgeMs } = input;
+  const graceMs = input.graceMs ?? DEPLOY_GRACE_MS;
+  const base = { config, worker, deployed, ancestor, behind };
+  if (!deployed) {
+    // Not "everything is fine": we could not read Cloudflare's record, which
+    // is a different claim from the Worker being current and must not be
+    // reported as one.
+    return {
+      ...base,
+      verdict: "unknown",
+      detail: "no deployment record could be read",
+    };
+  }
+  if (!ancestor) {
+    return {
+      ...base,
+      verdict: "forked",
+      detail: `deployed ${deployed.slice(0, 12)} is not an ancestor of main`,
+    };
+  }
+  if (behind === 0) {
+    return { ...base, verdict: "ok", detail: "running main's HEAD" };
+  }
+  if (headAgeMs < graceMs) {
+    return {
+      ...base,
+      verdict: "lagging",
+      detail:
+        `${behind} commit(s) behind, HEAD is ` +
+        `${Math.round(headAgeMs / 60_000)}m old -- inside the ` +
+        `${Math.round(graceMs / 60_000)}m grace`,
+    };
+  }
+  return {
+    ...base,
+    verdict: "stale",
+    detail:
+      `${behind} commit(s) behind and HEAD is ` +
+      `${Math.round(headAgeMs / 60_000)}m old -- the build did not land`,
+  };
+}
+
+/**
+ * `name` out of a wrangler JSONC config.
+ *
+ * Through the SHARED stripper, never a local regex. These configs hold route
+ * globs ending in a slash-star and cron expressions containing a star-slash, so
+ * a regex stripper splices from one to the next and deletes the config in
+ * between -- and it also reads the double slash inside an "https://..." string
+ * as a comment. I wrote that regex here first and it failed on the second
+ * config, which is the same mistake #10210 removed from the CI scripts.
+ *
+ * (Naming those delimiters in prose rather than in backticks, because a literal
+ * one closes this comment. That happened too.)
+ */
+export function workerName(config: string): string {
+  const raw = readFileSync(path.join(repoRoot, config), "utf8");
+  return (
+    (JSON.parse(stripJsonComments(raw)) as { name?: string }).name ?? config
+  );
+}
+
+/**
+ * The commit SHA Cloudflare recorded for the live deployment.
+ *
+ * Workers Builds puts it in the deployment MESSAGE, so this is Cloudflare's own
+ * record rather than anything this repo stamps -- which is what lets the check
+ * run without a build-time change and without trusting the Worker.
+ */
+function deployedSha(config: string): string | null {
+  try {
+    const out = execFileSync(
+      "npx",
+      ["wrangler", "deployments", "list", "--config", config],
+      { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    );
+    const messages = [...out.matchAll(/^Message:\s+([0-9a-f]{7,40})\s*$/gm)];
+    return messages.length ? (messages[messages.length - 1]![1] ?? null) : null;
+  } catch {
+    return null;
+  }
+}
+
+const git = (args: string[]) =>
+  execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+
+export function checkWorkerDeploys(nowMs = Date.now()): DeployStatus[] {
+  git(["fetch", "origin", "main", "--quiet"]);
+  const headAgeMs =
+    nowMs - Number(git(["log", "-1", "--format=%ct", "origin/main"])) * 1000;
+  return WORKER_CONFIGS.map((config) => {
+    const deployed = deployedSha(config);
+    let ancestor = false;
+    let behind = 0;
+    if (deployed) {
+      try {
+        git(["merge-base", "--is-ancestor", deployed, "origin/main"]);
+        ancestor = true;
+        behind = Number(
+          git(["rev-list", "--count", `${deployed}..origin/main`]),
+        );
+      } catch {
+        ancestor = false;
+      }
+    }
+    return judgeDeploy({
+      config,
+      worker: workerName(config),
+      deployed,
+      ancestor,
+      behind,
+      headAgeMs,
+    });
+  });
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const rows = checkWorkerDeploys();
+  for (const r of rows) {
+    process.stdout.write(
+      `${r.verdict.toUpperCase().padEnd(8)} ${r.worker.padEnd(34)} ${r.detail}\n`,
+    );
+  }
+  const bad = rows.filter(
+    (r) => r.verdict === "stale" || r.verdict === "forked",
+  );
+  if (bad.length > 0) {
+    process.stderr.write(
+      `\n${bad.length} Worker(s) are not running main. Check the Workers ` +
+        "Builds log for each: a failed build on a merge commit leaves main " +
+        "merged and production on the previous version.\n",
+    );
+    process.exit(1);
+  }
+  process.stdout.write("\nEvery Worker is running main, or building it.\n");
+}

--- a/tests/worker-deploy-drift.test.ts
+++ b/tests/worker-deploy-drift.test.ts
@@ -1,0 +1,121 @@
+// The deploy-drift verdicts (#10238).
+//
+// Between "merged" and "running" there was no automated relationship. A
+// Workers Build that fails on the merge commit leaves main merged and
+// production on the previous version, and nothing about that reads as an
+// incident -- the PR is green and the branch is deleted.
+//
+// The rule has to distinguish three states that all look like "behind", and
+// getting that wrong in either direction is the whole difficulty: alarm during
+// every normal build and nobody reads the alarm (#9301); wait for a fixed SHA
+// match and a genuinely failed build is indistinguishable from a slow one.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  DEPLOY_GRACE_MS,
+  WORKER_CONFIGS,
+  judgeDeploy,
+  workerName,
+} from "../scripts/check-worker-deploys.ts";
+
+const MIN = 60_000;
+const base = {
+  config: "wrangler.data.jsonc",
+  worker: "metagraphed-data-api",
+  deployed: "9815e6a84d29",
+  ancestor: true,
+};
+
+describe("the three states that all look like `behind`", () => {
+  test("at HEAD is ok", () => {
+    const v = judgeDeploy({ ...base, behind: 0, headAgeMs: 90 * MIN });
+    assert.equal(v.verdict, "ok");
+  });
+
+  test("behind with a FRESH head is lagging, not a fault", () => {
+    // Measured 2026-08-10, minutes after a merge: wss-lb was at HEAD while the
+    // ~1 MB gzip data-api was three commits back. Demanding equality would
+    // alarm on every merge for as long as the slowest build takes.
+    const v = judgeDeploy({ ...base, behind: 3, headAgeMs: 9 * MIN });
+    assert.equal(v.verdict, "lagging");
+    assert.match(v.detail, /inside the 30m grace/);
+  });
+
+  test("behind with an OLD head is stale -- the failure this exists for", () => {
+    const v = judgeDeploy({
+      ...base,
+      behind: 3,
+      headAgeMs: DEPLOY_GRACE_MS + MIN,
+    });
+    assert.equal(v.verdict, "stale");
+    assert.match(v.detail, /the build did not land/);
+  });
+
+  test("the boundary is the grace window, exactly", () => {
+    // A bound nobody can locate is a bound nobody can reason about.
+    const inside = judgeDeploy({
+      ...base,
+      behind: 1,
+      headAgeMs: DEPLOY_GRACE_MS - 1,
+    });
+    const outside = judgeDeploy({
+      ...base,
+      behind: 1,
+      headAgeMs: DEPLOY_GRACE_MS,
+    });
+    assert.equal(inside.verdict, "lagging");
+    assert.equal(outside.verdict, "stale");
+  });
+});
+
+describe("the states that are never merely slow", () => {
+  test("a non-ancestor is FORKED however fresh main is", () => {
+    // A deploy from a branch, or a rollback nobody recorded. Time cannot make
+    // it right, so the grace window must not apply.
+    const v = judgeDeploy({
+      ...base,
+      ancestor: false,
+      behind: 0,
+      headAgeMs: 0,
+    });
+    assert.equal(v.verdict, "forked");
+  });
+
+  test("no deployment record is UNKNOWN, never ok", () => {
+    // "We could not read Cloudflare" and "the Worker is current" are different
+    // claims and only one of them is safe to report as green.
+    const v = judgeDeploy({
+      ...base,
+      deployed: null,
+      ancestor: false,
+      behind: 0,
+      headAgeMs: 0,
+    });
+    assert.equal(v.verdict, "unknown");
+    assert.match(v.detail, /no deployment record/);
+  });
+});
+
+describe("the Worker list", () => {
+  test("names every wrangler config in the repo", () => {
+    // A Worker added without being listed here is invisible to the check --
+    // exactly the silence the check exists to remove.
+    assert.deepEqual([...WORKER_CONFIGS].sort(), [
+      "wrangler.data.jsonc",
+      "wrangler.jsonc",
+      "wrangler.registry.jsonc",
+      "wrangler.wss-lb.jsonc",
+    ]);
+  });
+
+  test("each config's name is readable through the SHARED JSONC stripper", () => {
+    // These configs hold route globs and cron expressions whose delimiters a
+    // regex stripper splices across, and an https:// inside a string reads as a
+    // comment. I wrote that regex first and it deleted a config (#10210 removed
+    // the same mistake from the CI scripts).
+    for (const config of WORKER_CONFIGS) {
+      const name = workerName(config);
+      assert.match(name, /^metagraphed/, `${config} -> ${name}`);
+    }
+  });
+});


### PR DESCRIPTION
## The silence

Workers Builds is the deploy path. A build that fails **on the merge commit** leaves `main` merged and production on the previous version, and nothing about that reads as an incident — the PR is green, the branch is deleted, and the only symptom is that the fix does not take effect. `metagraphed-data-api` failed twice on 2026-08-08 and passed on retry with a **byte-identical** diff.

Between "landed" and "running" there was no automated relationship at all — the same shape as #10190 and #9779.

## "Behind" is not a fault, and that is the whole difficulty

Measured minutes after a merge:

| Worker | state |
|---|---|
| `metagraphed-wss-lb` | at HEAD |
| `metagraphed-data-api` (~1 MB gzip) | 3 commits back |

A check demanding `deployed == HEAD` would alarm on **every merge** for as long as the slowest build takes — #9301 again. So:

| verdict | meaning |
|---|---|
| **FORKED** | not an ancestor of main — a branch deploy or unrecorded rollback. Time cannot fix it, so no grace applies. |
| **STALE** | behind, HEAD older than 30 min. The failure this exists for. |
| **LAGGING** | behind, HEAD younger than that. A build in flight. |
| **UNKNOWN** | Cloudflare's record unreadable — a different claim from "current", never green. |

Thirty minutes is several times the slowest observed build.

## Why an Action, against the Cloudflare-native preference

**A Worker that failed to deploy is running the previous version**, so asking it what it is running gets the previous version's answer, confidently — "a Worker cannot probe its own route", one level up. This reads Cloudflare's own deployment record rather than anything a Worker says about itself.

It moves no rows and writes no store, so it is not a data lane, and it needs **no new secret**: `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` are already repo secrets used by existing workflows.

## A cleaner path exists, and the script says so

Every Worker already binds **`CF_VERSION_METADATA`** — the runtime's own version, **no credential, no API call**. It does not solve this today for one narrow reason:

```
Tag:      -                                          ← what the binding exposes
Message:  ea6baa13cbb4747861fc7f8893b7dd0a92958f03   ← where Workers Builds puts the SHA
```

Set the tag to the SHA at deploy and this script's control-plane read collapses into a binding read. That is a deploy-configuration change rather than a token, and it is the right long-term shape — recorded in the script header and on #10238.

## Verification

- Run against production: correctly reports `wss-lb` at HEAD and the slower Workers `LAGGING` inside the grace, exit 0.
- 8 tests on the pure verdict function, including both grace boundaries exactly.
- **Proven able to fail**: making the grace window always apply — so a failed build reads as `lagging` forever — fails 2 tests by name.
- Config names are read through the **shared** JSONC stripper. I wrote a local regex first and it deleted a config: these files hold route globs and cron expressions whose comment delimiters a regex splices across, and an `https://` inside a string reads as a comment. #10210 removed the same mistake from the CI scripts.
- `validate:workflows` passes over all 30 workflow files; `tsc` and eslint clean.

Closes #10352