### PR TITLE
fix(graphql): `required` is not `non-null`, and the emitter conflated them (#10214)

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -61,7 +61,7 @@ export type AccountBalance = {
 /** One child hotkey's delegated-stake proportion on a subnet. proportion is the raw stringified u64 (0..u64::MAX represents 0..100%); proportion_fraction is the same value pre-divided to a 0..1 float. */
 export type AccountChildEntry = {
   __typename?: 'AccountChildEntry';
-  child: Scalars['String']['output'];
+  child?: Maybe<Scalars['String']['output']>;
   proportion: Scalars['String']['output'];
   proportion_fraction: Scalars['Float']['output'];
 };
@@ -338,7 +338,7 @@ export type AccountList = {
 
 export type AccountModuleCall = {
   __typename?: 'AccountModuleCall';
-  call_module: Scalars['String']['output'];
+  call_module?: Maybe<Scalars['String']['output']>;
   count: Scalars['Int']['output'];
 };
 
@@ -354,7 +354,7 @@ export type AccountOwnershipTie = {
 /** One parent hotkey's delegated-stake proportion on a subnet. proportion is the raw stringified u64 (0..u64::MAX represents 0..100%); proportion_fraction is the same value pre-divided to a 0..1 float. */
 export type AccountParentEntry = {
   __typename?: 'AccountParentEntry';
-  parent: Scalars['String']['output'];
+  parent?: Maybe<Scalars['String']['output']>;
   proportion: Scalars['String']['output'];
   proportion_fraction: Scalars['Float']['output'];
 };
@@ -459,11 +459,11 @@ export type AccountPositions = {
 export type AccountPositionsDegraded = {
   __typename?: 'AccountPositionsDegraded';
   /** The newest StakeAdded/StakeRemoved this account has on chain, when that is what contradicts the zero. */
-  latest_stake_event_at: Scalars['String']['output'];
+  latest_stake_event_at?: Maybe<Scalars['String']['output']>;
   /** `tier_unavailable`: every tier declined, so this zero is a read failure. `snapshot_predates_stake_activity`: the position ledger answered zero, but this account has an on-chain StakeAdded/StakeRemoved NEWER than the ledger's own snapshot -- it was demonstrably staking after the ledger was captured, so `positions: 0` is a claim the ledger is not entitled to make. `positions_unpriceable`: the ledger HAS rows for this account, but one or more could not be priced against the live neurons table -- they are excluded from `positions` and from `total_stake_alpha` rather than reported with a fabricated zero, so the total understates the real holding. */
   reason: Scalars['String']['output'];
   /** The LEDGER's own capture stamp, not this account's -- present even when the account has no rows in it, which is the case this field exists for. */
-  snapshot_captured_at: Scalars['String']['output'];
+  snapshot_captured_at?: Maybe<Scalars['String']['output']>;
 };
 
 /** One account's Prometheus telemetry-serving footprint (#5703) across subnets over a 7d/30d/90d window. Mirrors GET /api/v1/accounts/{ss58}/prometheus. */
@@ -2019,11 +2019,11 @@ export type DeregistrationDerivation = {
 export type DeregistrationTenure = {
   __typename?: 'DeregistrationTenure';
   censored: Scalars['Boolean']['output'];
-  max_blocks: Scalars['Int']['output'];
-  median_blocks: Scalars['Int']['output'];
-  min_blocks: Scalars['Int']['output'];
-  p10_blocks: Scalars['Int']['output'];
-  p90_blocks: Scalars['Int']['output'];
+  max_blocks?: Maybe<Scalars['Int']['output']>;
+  median_blocks?: Maybe<Scalars['Int']['output']>;
+  min_blocks?: Maybe<Scalars['Int']['output']>;
+  p10_blocks?: Maybe<Scalars['Int']['output']>;
+  p90_blocks?: Maybe<Scalars['Int']['output']>;
   sample_count: Scalars['Int']['output'];
 };
 
@@ -2044,9 +2044,9 @@ export type DomainSummary = {
   netuids: Array<Scalars['Int']['output']>;
   schema_version: Scalars['Int']['output'];
   subnet_count: Scalars['Int']['output'];
-  total_emission_share: Scalars['Float']['output'];
+  total_emission_share?: Maybe<Scalars['Float']['output']>;
   /** Member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051), rather than a sum of incomparable per-subnet alpha tokens. */
-  total_stake_tao: Scalars['Float']['output'];
+  total_stake_tao?: Maybe<Scalars['Float']['output']>;
 };
 
 export type EconomicsList = {
@@ -2748,7 +2748,7 @@ export type NominatorList = {
   hotkey: Scalars['String']['output'];
   limit: Scalars['Int']['output'];
   /** Total distinct nominating coldkeys in the window, before limit/offset paging. */
-  nominator_count: Scalars['Int']['output'];
+  nominator_count?: Maybe<Scalars['Int']['output']>;
   nominator_gini?: Maybe<Scalars['Float']['output']>;
   nominators: Array<Nominator>;
   offset: Scalars['Int']['output'];
@@ -5261,7 +5261,7 @@ export type SubnetDeregistrationEvent = {
   hotkey: Scalars['String']['output'];
   observed_at: Scalars['String']['output'];
   replaced_by_hotkey: Scalars['String']['output'];
-  tenure_blocks: Scalars['Int']['output'];
+  tenure_blocks?: Maybe<Scalars['Int']['output']>;
   uid: Scalars['Int']['output'];
 };
 
@@ -7387,7 +7387,7 @@ export type AccountBalanceResolvers<ContextType = GqlContext, ParentType extends
 }>;
 
 export type AccountChildEntryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['AccountChildEntry'] = ResolversParentTypes['AccountChildEntry']> = ResolversObject<{
-  child?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  child?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   proportion?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   proportion_fraction?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
 }>;
@@ -7620,7 +7620,7 @@ export type AccountListResolvers<ContextType = GqlContext, ParentType extends Re
 }>;
 
 export type AccountModuleCallResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['AccountModuleCall'] = ResolversParentTypes['AccountModuleCall']> = ResolversObject<{
-  call_module?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  call_module?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
@@ -7632,7 +7632,7 @@ export type AccountOwnershipTieResolvers<ContextType = GqlContext, ParentType ex
 }>;
 
 export type AccountParentEntryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['AccountParentEntry'] = ResolversParentTypes['AccountParentEntry']> = ResolversObject<{
-  parent?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  parent?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   proportion?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   proportion_fraction?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
 }>;
@@ -7715,9 +7715,9 @@ export type AccountPositionsResolvers<ContextType = GqlContext, ParentType exten
 }>;
 
 export type AccountPositionsDegradedResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['AccountPositionsDegraded'] = ResolversParentTypes['AccountPositionsDegraded']> = ResolversObject<{
-  latest_stake_event_at?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  latest_stake_event_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   reason?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  snapshot_captured_at?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  snapshot_captured_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type AccountPrometheusResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['AccountPrometheus'] = ResolversParentTypes['AccountPrometheus']> = ResolversObject<{
@@ -8949,11 +8949,11 @@ export type DeregistrationDerivationResolvers<ContextType = GqlContext, ParentTy
 
 export type DeregistrationTenureResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['DeregistrationTenure'] = ResolversParentTypes['DeregistrationTenure']> = ResolversObject<{
   censored?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  max_blocks?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  median_blocks?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  min_blocks?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  p10_blocks?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  p90_blocks?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  max_blocks?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  median_blocks?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  min_blocks?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  p10_blocks?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  p90_blocks?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   sample_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
@@ -8969,8 +8969,8 @@ export type DomainSummaryResolvers<ContextType = GqlContext, ParentType extends 
   netuids?: Resolver<Array<ResolversTypes['Int']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   subnet_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  total_emission_share?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
-  total_stake_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  total_emission_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  total_stake_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;
 
 export type EconomicsListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['EconomicsList'] = ResolversParentTypes['EconomicsList']> = ResolversObject<{
@@ -9530,7 +9530,7 @@ export type NominatorListResolvers<ContextType = GqlContext, ParentType extends 
   concentration_complete?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   hotkey?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  nominator_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  nominator_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   nominator_gini?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   nominators?: Resolver<Array<ResolversTypes['Nominator']>, ParentType, ContextType>;
   offset?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -10246,7 +10246,7 @@ export type SubnetDeregistrationEventResolvers<ContextType = GqlContext, ParentT
   hotkey?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   observed_at?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   replaced_by_hotkey?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  tenure_blocks?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  tenure_blocks?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   uid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 

--- a/schemas-src/graphql/emit.ts
+++ b/schemas-src/graphql/emit.ts
@@ -46,7 +46,7 @@ import { openApiComponentRegistry } from "../openapi-registry.ts";
 /** The subset of JSON Schema 2020-12 that Zod's emitter actually produces. */
 interface SchemaNode {
   $ref?: string;
-  type?: string;
+  type?: string | string[];
   properties?: Record<string, SchemaNode>;
   required?: string[];
   items?: SchemaNode;
@@ -176,6 +176,35 @@ export interface EmittedTypes {
   nullOnly: string[];
 }
 
+/**
+ * Can this schema's value be `null`?
+ *
+ * `required` and nullability are ORTHOGONAL in JSON Schema, and conflating them
+ * is what made the first version of this emitter publish 797 fields as non-null
+ * that the hand-written SDL correctly published as nullable. `required` means
+ * THE KEY IS PRESENT. A Zod `.nullable()` field is required -- the key is always
+ * there -- and its value may still be null, which the emitted schema states as
+ * `anyOf: [{type: number}, {type: null}]`.
+ *
+ * Reading only `required` therefore promised a non-null `concentration` on a
+ * route that answers `"concentration": null` in production today. GraphQL
+ * enforces non-null at execution: the resolver returning null would not be a
+ * documentation error, it would null the whole parent object and attach an
+ * error to the response.
+ *
+ * `openapi.json` had this right all along -- it publishes both the `anyOf` and
+ * the `required` entry, which together say exactly the true thing.
+ */
+function admitsNull(schema: SchemaNode | undefined): boolean {
+  if (!schema) return false;
+  if (schema.type === "null") return true;
+  if (Array.isArray(schema.type) && schema.type.includes("null")) return true;
+  for (const branch of [...(schema.anyOf ?? []), ...(schema.oneOf ?? [])]) {
+    if (admitsNull(branch)) return true;
+  }
+  return false;
+}
+
 /** A name the GraphQL spec allows: a letter or underscore, then word chars. */
 function isNameable(key: string): boolean {
   return /^[_A-Za-z][_A-Za-z0-9]*$/.test(key);
@@ -240,7 +269,13 @@ export function emitTypes(): EmittedTypes {
             `${typeName}${pascalCase(key)}`,
           );
           fields[key] = {
-            type: required.has(key) ? new GraphQLNonNull(inner) : inner,
+            // BOTH conditions. `required` alone says the key is present, which
+            // is not the same claim as "the value is never null" -- see
+            // `admitsNull`.
+            type:
+              required.has(key) && !admitsNull(raw)
+                ? new GraphQLNonNull(inner)
+                : inner,
             description: raw?.description,
           };
         }

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -3476,7 +3476,7 @@ export const SDL = /* GraphQL */ `
     limit: Int!
     offset: Int!
     "Total distinct nominating coldkeys in the window, before limit/offset paging."
-    nominator_count: Int!
+    nominator_count: Int
     nominators: [Nominator!]!
     concentration_complete: Boolean
     top_nominator_share: Float
@@ -3755,8 +3755,8 @@ export const SDL = /* GraphQL */ `
     subnet_count: Int!
     netuids: [Int!]!
     "Member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051), rather than a sum of incomparable per-subnet alpha tokens."
-    total_stake_tao: Float!
-    total_emission_share: Float!
+    total_stake_tao: Float
+    total_emission_share: Float
     "Within-domain emission concentration scorecard; null when the domain has no members. Declared Float until #9889 — the route has served the full 12-key scorecard for long enough that the scalar coerced to null on every domain, which this type's own comment then read as 'no members'."
     emission_concentration: ConcentrationMetrics
   }
@@ -4328,7 +4328,7 @@ export const SDL = /* GraphQL */ `
 
   "One child hotkey's delegated-stake proportion on a subnet. proportion is the raw stringified u64 (0..u64::MAX represents 0..100%); proportion_fraction is the same value pre-divided to a 0..1 float."
   type AccountChildEntry {
-    child: String!
+    child: String
     proportion: String!
     proportion_fraction: Float!
   }
@@ -4353,7 +4353,7 @@ export const SDL = /* GraphQL */ `
 
   "One parent hotkey's delegated-stake proportion on a subnet. proportion is the raw stringified u64 (0..u64::MAX represents 0..100%); proportion_fraction is the same value pre-divided to a 0..1 float."
   type AccountParentEntry {
-    parent: String!
+    parent: String
     proportion: String!
     proportion_fraction: Float!
   }
@@ -5071,7 +5071,7 @@ export const SDL = /* GraphQL */ `
   }
 
   type AccountModuleCall {
-    call_module: String!
+    call_module: String
     count: Int!
   }
 
@@ -5333,7 +5333,7 @@ export const SDL = /* GraphQL */ `
     replaced_by_hotkey: String!
     block_number: Int!
     observed_at: String!
-    tenure_blocks: Int!
+    tenure_blocks: Int
   }
 
   type BuildArtifactBudget {
@@ -5396,11 +5396,11 @@ export const SDL = /* GraphQL */ `
     """
     The LEDGER's own capture stamp, not this account's -- present even when the account has no rows in it, which is the case this field exists for.
     """
-    snapshot_captured_at: String!
+    snapshot_captured_at: String
     """
     The newest StakeAdded/StakeRemoved this account has on chain, when that is what contradicts the zero.
     """
-    latest_stake_event_at: String!
+    latest_stake_event_at: String
   }
 
   """
@@ -5424,11 +5424,11 @@ export const SDL = /* GraphQL */ `
 
   type DeregistrationTenure {
     sample_count: Int!
-    median_blocks: Int!
-    p10_blocks: Int!
-    p90_blocks: Int!
-    min_blocks: Int!
-    max_blocks: Int!
+    median_blocks: Int
+    p10_blocks: Int
+    p90_blocks: Int
+    min_blocks: Int
+    max_blocks: Int
     censored: Boolean!
   }
 `;


### PR DESCRIPTION
## Generating the SDL is blocked on the emitter being right. It was not.

`schemas-src/graphql/emit.ts` decided non-null from `required` membership alone:

```ts
type: required.has(key) ? new GraphQLNonNull(inner) : inner
```

**`required` and nullability are orthogonal in JSON Schema.** `required` means *the key is present*.
A Zod `.nullable()` field is required — the key is always there — and its value may still be null,
which the emitted schema states as `anyOf: [{type: number}, {type: null}]`.

So the emitter promised a non-null `concentration` on a route that answers `"concentration": null`
**in production right now**. That is not a documentation error: GraphQL enforces non-null at
*execution*, so a resolver returning null there nulls the whole parent object and attaches an error
to the response.

**797 of 2,433 fields, every one in the same direction** — which is the tell. A hand-written mirror
does not accidentally get 797 fields more right than its generator unless the generator is wrong.

`openapi.json` had it right all along: it publishes both the `anyOf` **and** the `required` entry,
which together say exactly the true thing. The hand-written SDL had it right too. The two agreed with
each other and disagreed only with the emitter.

**797 → 225** with the predicate corrected.

## The gate could not see this class, and now can

`validate:graphql-component-parity` compares the SDL against the emitted components. While the
emitter was wrong in the same direction *everywhere*, a nullability difference read as normal. With
the predicate fixed, the gate immediately reported **19 fields the SDL over-promises** — the
dangerous direction, where the SDL says `Int!` and the component says the value can be null:

```
DeregistrationTenure  median/p10/p90/min/max_blocks   (both parents)
AccountChildEntry.child            AccountParentEntry.parent
AccountPositionsDegraded.snapshot_captured_at, .latest_stake_event_at
DomainSummary.total_stake_tao, .total_emission_share
NominatorList.nominator_count      SubnetDeregistrationEvent.tenure_blocks
AccountModuleCall.call_module
```

Latent rather than firing — `tenure` is itself nullable and answers `null` today, so the inner
promises are never tested — but each is a response-shaped outage waiting for its parent to become
non-null. All 14 loosened to match the component that produces them.

## A correction to how the migration was verified

Worth recording, because it explains why this survived four gates. The Zod migration proved
**parity**: `openapi.json` stayed byte-identical when the source of truth moved, and
`validate:route-query-parity` still fails on any drift. That was the right gate for a cutover, and it
is not a correctness gate — *"the new source emits what the old source emitted"* preserves an
existing error perfectly.

The emitter was written after that, against the same components, and inherited nothing to check it.
The hand-written SDL was the only artifact that had been corrected against reality, and it was the
one treated as the thing to replace.

## Where #10214 stands after this

Measured, not estimated:

| | |
|---|---|
| published types the emitter already produces with an identical field set | **317 of 348** |
| of the 31 remaining, list projections following one uniform rule | **28** |
| genuine one-offs | **5** (`DegradedInfo.detail`, `Changelog.coverage_delta`, `EndpointIncident`, `SubnetUptime.observed_at`, `Validator.featured`) |
| Query root | 1,007 lines, generatable from `QUERY_BINDINGS` (196 fields, already declared and gated) |

The 28 projections are the interesting number: every one turns an artifact's
`{contract_version, schema_version, <rows>}` into `{items/total/returned/limit/cursor}`. That is a
rule nobody has declared, not 28 decisions — so it generates once declared, and the scope note in
`emit.ts` claiming the Query root cannot be derived is stale, since `QUERY_BINDINGS` is exactly that
derivation.

This PR is the prerequisite: the emitter has to be trustworthy before anything is generated from it.

## Validation

```
npm run typecheck / lint / format:check      clean
npx vitest run                               18,229 passed, 11 skipped, 0 failed
validate:graphql-component-parity            324 types, 2,380 fields, OK
validate:graphql-route-parity                657 argument pairs, 0 divergences
validate:graphql-types-drift                 current
npm run build                                regenerated codegen types committed
```

Refs #10214
