### PR TITLE
refactor: name the two coercion helpers after what they coerce (#10359)

### DIFF
--- a/src/account-events.ts
+++ b/src/account-events.ts
@@ -275,9 +275,14 @@ export function formatAccountEvent(
 
 // ---- Entity API builders (#1347) -------------------------------------------
 
-// Coerce a D1 0/1 INTEGER flag cell to a boolean. Numeric strings like "0"
-// must not pass through Boolean(), which treats any non-empty string as true.
-function toD1Flag(value: unknown): boolean {
+// A flag column as a real boolean, in any store's spelling -- see
+// toBooleanFlag in metagraph-neurons.ts for the measurement. This copy is the
+// one with the strongest claim to the coercion: it renders rows from the
+// lakehouse tier, which answers JSON rather than coming through a Postgres
+// driver, so a 0/1 here is not hypothetical.
+//
+// NOT Boolean(value): a numeric string "0" is truthy and would invert the flag.
+function toBooleanFlag(value: unknown): boolean {
   return Number(value) === 1;
 }
 
@@ -299,8 +304,8 @@ export function formatRegistration(
     netuid: toBlockNumber(row.netuid),
     uid: toBlockNumber(row.uid),
     stake_tao: toTaoOrNull(row.stake_tao),
-    validator_permit: toD1Flag(row.validator_permit),
-    active: toD1Flag(row.active),
+    validator_permit: toBooleanFlag(row.validator_permit),
+    active: toBooleanFlag(row.active),
   };
 }
 

--- a/src/extrinsics.ts
+++ b/src/extrinsics.ts
@@ -185,7 +185,7 @@ export function formatExtrinsic(
     // D1 can return the `success` INTEGER column as a numeric string ("1"/"0"),
     // same as block_number/extrinsic_index above — a bare `=== 1` would leave a
     // successful extrinsic mislabeled false. Number()-coerce first, mirroring
-    // toD1Flag in account-events.ts (#2487).
+    // toBooleanFlag in account-events.ts (#2487).
     success: row.success == null ? null : Number(row.success) === 1,
     // fee_tao / tip_tao (D1 REAL columns) — coerce through toTaoOrNull so a
     // numeric string never leaks the string form into the ["number","null"]

--- a/src/metagraph-neurons.ts
+++ b/src/metagraph-neurons.ts
@@ -337,10 +337,26 @@ function round9(value: unknown): number | null {
   return Math.round(Number(value) * RAO_PER_TAO) / RAO_PER_TAO;
 }
 
-// Coerce a D1 0/1 INTEGER flag cell to a boolean. Numeric strings like "0"
-// must not pass through Boolean(), which treats any non-empty string as true.
-// Mirrors the local toD1Flag added to formatRegistration by #2487.
-function toD1Flag(value: unknown): boolean {
+/**
+ * Any store's spelling of a flag column, as a real boolean.
+ *
+ * IT IS NOT A D1 COERCION ANY MORE, which is what the name and the old comment
+ * said. Measured against production Neon 2026-08-10: these columns are BOOLEAN
+ * there and the driver hands back real `true`/`false` --
+ *
+ *     validator_permit=true  (boolean)   validator_permit=false (boolean)
+ *
+ * -- so `Number(value) === 1` is doing nothing for the tier that actually
+ * serves. It is KEPT rather than simplified because this formatter is shared:
+ * the same builder renders the projection and cold tiers, whose rows arrive as
+ * decoded JSON rather than from the driver, and a 0/1 there would become `true`
+ * either way under a looser test.
+ *
+ * NOT `Boolean(value)`. A numeric string "0" is truthy, so the looser spelling
+ * inverts the flag rather than widening it -- the same class as #10088's typing
+ * trap, in the opposite direction.
+ */
+function toBooleanFlag(value: unknown): boolean {
   return Number(value) === 1;
 }
 
@@ -349,7 +365,7 @@ interface ImmunityWindow {
   immunity_expires_at?: string | null;
 }
 
-// coerce the flag columns back to real booleans for the API (toD1Flag
+// coerce the flag columns back to real booleans for the API (toBooleanFlag
 // handles the D1 INTEGER 0/1 cells; nonNegativeInt/nullableNumber coerce
 // string-typed uid/registered_at_block into real integers, and roundTao
 // rounds stake_tao / emission_tao to rao precision). The explicit null
@@ -429,8 +445,8 @@ export function formatNeuron(
     uid: row.uid == null ? null : nonNegativeInt(row.uid),
     hotkey,
     coldkey: row.coldkey ?? null,
-    active: toD1Flag(row.active),
-    validator_permit: toD1Flag(row.validator_permit),
+    active: toBooleanFlag(row.active),
+    validator_permit: toBooleanFlag(row.validator_permit),
     rank: row.rank == null ? null : round(nullableNumber(row.rank)),
     trust: row.trust == null ? null : round(nullableNumber(row.trust)),
     validator_trust:
@@ -449,7 +465,7 @@ export function formatNeuron(
       row.registered_at_block == null
         ? null
         : nonNegativeInt(row.registered_at_block),
-    is_immunity_period: toD1Flag(row.is_immunity_period),
+    is_immunity_period: toBooleanFlag(row.is_immunity_period),
     axon: row.axon ?? null,
     // Global per-hotkey (SubtensorModule::Delegates), not per (netuid, uid) --
     // null means no Delegates entry at capture time (#2548).

--- a/src/subnet-hyperparams.ts
+++ b/src/subnet-hyperparams.ts
@@ -87,8 +87,10 @@ function ratio(value: unknown): number | null {
   return round(nullableNumber(value), 9);
 }
 
-// D1 0/1 INTEGER -> real boolean, matching toD1Flag in metagraph-neurons.ts.
-function toD1Flag(value: unknown): boolean {
+// A flag column as a real boolean, in any store's spelling. The reasoning --
+// and the production measurement behind it -- is on toBooleanFlag in
+// metagraph-neurons.ts; this is the same function, kept local.
+function toBooleanFlag(value: unknown): boolean {
   return Number(value) === 1;
 }
 
@@ -106,7 +108,7 @@ export function formatSubnetHyperparams(
     weights_rate_limit: nonNegativeInt(row.weights_rate_limit),
     activity_cutoff: nonNegativeInt(row.activity_cutoff),
     activity_cutoff_factor: nonNegativeInt(row.activity_cutoff_factor),
-    registration_allowed: toD1Flag(row.registration_allowed),
+    registration_allowed: toBooleanFlag(row.registration_allowed),
     target_regs_per_interval: nonNegativeInt(row.target_regs_per_interval),
     // rao/1e9-exact-split TAO values (rao_to_tao_exact) — round to rao
     // precision (9dp), not formatNeuron's 6dp roundTao, so no low-order rao
@@ -123,18 +125,18 @@ export function formatSubnetHyperparams(
     serving_rate_limit: nonNegativeInt(row.serving_rate_limit),
     max_validators: nonNegativeInt(row.max_validators),
     commit_reveal_period: nonNegativeInt(row.commit_reveal_period),
-    commit_reveal_enabled: toD1Flag(row.commit_reveal_enabled),
+    commit_reveal_enabled: toBooleanFlag(row.commit_reveal_enabled),
     alpha_high_ratio: ratio(row.alpha_high_ratio),
     alpha_low_ratio: ratio(row.alpha_low_ratio),
-    liquid_alpha_enabled: toD1Flag(row.liquid_alpha_enabled),
+    liquid_alpha_enabled: toBooleanFlag(row.liquid_alpha_enabled),
     alpha_sigmoid_steepness: nullableNumber(row.alpha_sigmoid_steepness),
     yuma_version: nonNegativeInt(row.yuma_version),
-    subnet_is_active: toD1Flag(row.subnet_is_active),
-    transfers_enabled: toD1Flag(row.transfers_enabled),
-    bonds_reset_enabled: toD1Flag(row.bonds_reset_enabled),
-    user_liquidity_enabled: toD1Flag(row.user_liquidity_enabled),
-    owner_cut_enabled: toD1Flag(row.owner_cut_enabled),
-    owner_cut_auto_lock_enabled: toD1Flag(row.owner_cut_auto_lock_enabled),
+    subnet_is_active: toBooleanFlag(row.subnet_is_active),
+    transfers_enabled: toBooleanFlag(row.transfers_enabled),
+    bonds_reset_enabled: toBooleanFlag(row.bonds_reset_enabled),
+    user_liquidity_enabled: toBooleanFlag(row.user_liquidity_enabled),
+    owner_cut_enabled: toBooleanFlag(row.owner_cut_enabled),
+    owner_cut_auto_lock_enabled: toBooleanFlag(row.owner_cut_auto_lock_enabled),
     min_childkey_take_ratio: ratio(row.min_childkey_take_ratio),
   };
 }

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -1410,7 +1410,7 @@ async function handleSubnetHyperparamsSync(
   const rows = incoming.map(coerceSubnetHyperparamsSyncRow);
 
   // Hashed ONCE, before either store writes, on the RAW incoming rows
-  // (pre-coercion) -- formatSubnetHyperparams' toD1Flag(value) tolerates
+  // (pre-coercion) -- formatSubnetHyperparams' toBooleanFlag(value) tolerates
   // either a 0/1 number or a real boolean, so the hash is domain-identical no
   // matter which store's diff consumes it. Each store then diffs this same
   // sequence against ITS OWN latest-recorded hashes below (the two histories

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -653,15 +653,25 @@ export function canonicalCompareCachePath(url: URL): string | null {
   return `${url.pathname}?${params.join("&")}`;
 }
 
-// D1 can hand a numeric column back as a string on some read paths (the same
-// class of cell-coercion the feed formatters apply, e.g. formatBlock). Parse a
-// string cell to a number so the CompareArtifact numeric fields never leak a
-// string; leave real numbers, null, and absent cells exactly as-is so the
-// artifact's null/absent contract is unchanged. Booleans (registration_allowed)
-// are intentionally not routed through here. It also normalizes the per-tier
-// Map join key: composeCompareData looks tiers up by numeric requested netuid,
-// so a string-typed row netuid ("7") must key on 7 or the tier drops to null.
-function coerceD1Number(value: unknown): unknown {
+// A numeric cell that arrived as a string, as a number.
+//
+// THIS IS MORE NECESSARY NOW, NOT LESS, which is the opposite of what the D1 in
+// its old name implies. node-postgres returns int8/numeric as STRINGS by
+// design -- they do not fit a JS number safely -- so every BIGINT and every
+// COUNT(*) comes back quoted. Measured against production Neon 2026-08-10:
+//
+//     SELECT count(*) ... -> "30131"   (typeof "string")
+//
+// Parse a string cell to a number so the CompareArtifact numeric fields never
+// leak a string; leave real numbers, null, and absent cells exactly as-is so
+// the artifact's null/absent contract is unchanged. Booleans
+// (registration_allowed) are intentionally not routed through here -- see
+// toBooleanFlag, which is the other half of this and must NOT be widened.
+//
+// It also normalizes the per-tier Map join key: composeCompareData looks tiers
+// up by numeric requested netuid, so a string-typed row netuid ("7") must key
+// on 7 or the tier drops to null.
+function coerceNumericString(value: unknown): unknown {
   if (typeof value !== "string") return value;
   const trimmed = value.trim();
   if (trimmed === "") return value;
@@ -702,40 +712,40 @@ export function composeCompareData({
 
   const structureByNetuid = new Map<number, Record<string, unknown>>();
   for (const row of structureRows || []) {
-    const netuid = coerceD1Number(row.netuid);
+    const netuid = coerceNumericString(row.netuid);
     if (!Number.isInteger(netuid)) continue;
     structureByNetuid.set(netuid as number, {
-      completeness_score: coerceD1Number(row.completeness_score),
-      surface_count: coerceD1Number(row.surface_count),
-      operational_interface_count: coerceD1Number(
+      completeness_score: coerceNumericString(row.completeness_score),
+      surface_count: coerceNumericString(row.surface_count),
+      operational_interface_count: coerceNumericString(
         row.operational_interface_count,
       ),
     });
   }
   const economicsByNetuid = new Map<number, Record<string, unknown>>();
   for (const row of economicsRows || []) {
-    const netuid = coerceD1Number(row.netuid);
+    const netuid = coerceNumericString(row.netuid);
     if (!Number.isInteger(netuid)) continue;
     economicsByNetuid.set(netuid as number, {
-      registration_cost_tao: coerceD1Number(row.registration_cost_tao),
+      registration_cost_tao: coerceNumericString(row.registration_cost_tao),
       registration_allowed: row.registration_allowed,
-      open_slots: coerceD1Number(row.open_slots),
-      emission_share: coerceD1Number(row.emission_share),
-      alpha_price_tao: coerceD1Number(row.alpha_price_tao),
-      validator_count: coerceD1Number(row.validator_count),
-      miner_count: coerceD1Number(row.miner_count),
-      total_stake_alpha: coerceD1Number(row.total_stake_alpha),
-      miner_readiness: coerceD1Number(row.miner_readiness),
+      open_slots: coerceNumericString(row.open_slots),
+      emission_share: coerceNumericString(row.emission_share),
+      alpha_price_tao: coerceNumericString(row.alpha_price_tao),
+      validator_count: coerceNumericString(row.validator_count),
+      miner_count: coerceNumericString(row.miner_count),
+      total_stake_alpha: coerceNumericString(row.total_stake_alpha),
+      miner_readiness: coerceNumericString(row.miner_readiness),
     });
   }
   const healthByNetuid = new Map<number, Record<string, unknown>>();
   for (const row of healthRows || []) {
-    const netuid = coerceD1Number(row.netuid);
+    const netuid = coerceNumericString(row.netuid);
     if (!Number.isInteger(netuid)) continue;
     healthByNetuid.set(netuid as number, {
-      surface_count: coerceD1Number(row.surface_count),
-      ok_count: coerceD1Number(row.ok_count),
-      avg_latency_ms: coerceD1Number(row.avg_latency_ms),
+      surface_count: coerceNumericString(row.surface_count),
+      ok_count: coerceNumericString(row.ok_count),
+      avg_latency_ms: coerceNumericString(row.avg_latency_ms),
     });
   }
 


### PR DESCRIPTION
Closes #10359. A slice of #10228's part 1 — and deliberately **not** a `sed`,
because #10228 flags exactly these two for a look first:

> `toD1Flag` and `coerceD1Number` encode a boolean→1/0 and a numeric coercion
> that D1 needed. Postgres columns typed `int` still need them, so the behaviour
> stays — but confirm which columns before assuming.

Confirmed against production Neon, 2026-08-10. **No behaviour change.** Both
comments were false, in opposite directions.

## `toD1Flag` → `toBooleanFlag`

Three identical copies (`metagraph-neurons.ts`, `subnet-hyperparams.ts`,
`account-events.ts`), each `Number(value) === 1`, each commented *"Coerce a D1
0/1 INTEGER flag cell"*. Those columns are `BOOLEAN` in Neon and the driver
returns real booleans:

```
validator_permit=true  (boolean)  Number(v)===1 -> true
validator_permit=false (boolean)  Number(v)===1 -> false
registration_allowed, commit_reveal_enabled -> boolean, boolean
```

So it is correct — but *incidentally*, via `Number(true) === 1`, not for the
reason stated. I checked the `true` case specifically; the first sample was all
`false`, which would have "passed" without proving anything.

**Kept anyway, and the comment now says why.** The same builders render the
projection and cold tiers, whose rows arrive as decoded JSON rather than through
a Postgres driver, and `account-events.ts`'s copy renders the lakehouse tier
where a 0/1 is not hypothetical.

**It must not become `Boolean(value)`.** A numeric string `"0"` is truthy, so the
looser spelling *inverts* the flag rather than widening it — the same class as
#10088's typing trap, in the opposite direction. That warning is now attached to
the function instead of living in the deleted comment's first line.

## `coerceD1Number` → `coerceNumericString`

This one is **more** necessary than when it was written. node-postgres returns
`int8`/`numeric` as strings by design — they do not fit a JS number safely — so
every BIGINT and every `COUNT(*)` arrives quoted:

```
SELECT count(*) FROM neurons  ->  "30131"  (typeof "string")
```

The `D1` in its name reads as legacy scaffolding a sweep should delete. It is the
opposite: without it the `CompareArtifact` numeric fields leak strings, and the
per-tier Map join keys on `"7"` instead of `7`, dropping that tier to null.

The two helpers now cross-reference, so the instinct to widen one meets the
other's warning first.

## Not in scope

Still open on #10228, with reasons:

- `loadAccountPositionsD1` — its call sites are in `src/graphql.ts` and
  `src/mcp-server.ts`, which are being edited elsewhere right now. A cosmetic
  rename is a bad thing to take a conflict for.
- `loadAlphaPricesByNetuidD1` / `loadD1AlphaPricesByNetuid` — two *different*
  functions in two modules whose obvious target names collide. That needs a
  naming decision, not a rename.

## Verification

`tsc --noEmit`, `npm run lint` and `npm run format:check` all clean; 391 tests
across the five affected suites pass.