### PR TITLE
feat(data): capture the deregistration ranking's measured inputs daily (#10361)

### DIFF
--- a/migrations/neon/0015_subnet_deregistration_daily.sql
+++ b/migrations/neon/0015_subnet_deregistration_daily.sql
@@ -1,0 +1,104 @@
+-- A daily record of what the deregistration ranking was computed FROM (#10296).
+--
+-- #10285 ships the current ranking: "how close is this subnet to being pruned",
+-- answered with the pallet's own rule. It is computed per request and stored
+-- nowhere, so a caller can see today's answer and nothing else -- and a single
+-- day's rank is noise. `rank: 94` tells a subnet owner almost nothing; "94, was
+-- 71 a month ago, and the gap to the bar has halved" tells them exactly what
+-- they need.
+--
+-- ## THIS TABLE STORES THE INPUTS, NOT THE RANK
+--
+-- That is the whole design decision, and it is not a preference.
+--
+-- `src/subnet-deregistration-ranking.ts` already splits its fields two ways.
+-- Four are MEASURED -- `SubnetMovingPrice`, `NetworkRegisteredAt`,
+-- `SubnetMechanism`, `NetworkImmunityPeriod` -- and everything a caller reads
+-- off the card (`rank`, `comparison_price`, `immune`, `blocks_until_prunable`,
+-- `next_to_deregister`) is declared `kind: "reconstructed", storage: null`.
+-- They are derived by a RULE, and #10285 exists because that rule is subtle
+-- enough to get wrong: a price-only order puts netuid 86 at position one when
+-- the chain's answer is netuid 70, because immunity and the Stable-mechanism
+-- substitution both bite.
+--
+-- Persisting `rank` would freeze one version of that rule into history. If the
+-- rule is ever corrected, a stored-rank series becomes a permanent record of
+-- the old answers, indistinguishable from the new ones. Persisting the inputs
+-- means the same fix corrects every past day for free, and every row stays
+-- auditable against the chain: it states what was read, at which block, and
+-- `projectDeregistrationRanking` replays it unchanged.
+--
+-- ## Why a table of its own rather than columns on subnet_snapshots
+--
+-- #10296 asked whether this belongs on the existing daily rollup. It does not.
+-- That rollup does NOT already carry the moving price -- measured 2026-08-10,
+-- its 27 columns hold `alpha_price_tao` (the spot price) and the only
+-- `%moving%` columns in the database are `subnet_hyperparams.bonds_moving_avg_raw`
+-- and its history twin, an unrelated hyperparameter. So every input here is a
+-- new column either way, and `pipeline_block` is the only real overlap.
+--
+-- Coupling them would also tie this write to that rollup's completeness: a
+-- partial read here would either block the daily snapshot or land NULLs in it.
+--
+-- ## Carried-forward days are visible, not guessed at
+--
+-- The economics sweep pins one block; a day on which no fresh sweep landed
+-- repeats the previous observation. `/subnets/{netuid}/emission-pipeline/history`
+-- documents that trap and this series inherits it exactly -- two consecutive
+-- points can be the SAME observation, and a rank that was simply not
+-- re-measured must not read as a rank that held steady.
+--
+-- `pinned_block` is what makes that answerable without a heuristic: distinct
+-- observations are distinct `pinned_block` values over the window, so a reader
+-- publishes `distinct_observations` beside `point_count` by counting, never by
+-- comparing ranks for equality.
+--
+-- ## Accrues forward only
+--
+-- Unlike the hyperparameters backfill (#5597) the inputs cannot be
+-- reconstructed cheaply: reproducing a past day means reading all four storages
+-- for every netuid at that day's block, one archive sweep per day. Possible,
+-- but a backfill project rather than a lane.
+
+CREATE TABLE IF NOT EXISTS subnet_deregistration_daily (
+  netuid                  INTEGER NOT NULL,
+  -- ISO date, the same daily key subnet_snapshots uses.
+  snapshot_date           TEXT    NOT NULL,
+  -- `SubnetMovingPrice`, decoded. NULL when the sweep could not read it --
+  -- a subnet with no price is not a subnet priced at zero, and the ranking
+  -- treats the two differently.
+  moving_price            DOUBLE PRECISION,
+  -- `NetworkRegisteredAt`, in blocks. Half of the immunity window.
+  registered_at_block     BIGINT,
+  -- `SubnetMechanism`; 0 is Stable and forces the comparison price to a flat
+  -- 1.0 regardless of moving_price. Every mainnet subnet reads 1 today, so the
+  -- clause is invisible until one sudo call makes it decisive -- which is
+  -- exactly why the raw value is stored rather than the price it implies.
+  subnet_mechanism        INTEGER,
+  -- `NetworkImmunityPeriod`, in blocks. Network-wide rather than per-subnet,
+  -- and stored per row anyway so a row replays on its own without a join to
+  -- whatever the period happened to be that day.
+  network_immunity_period BIGINT,
+  -- The block the economics sweep pinned every read to. The whole row is one
+  -- observation at one block, which is what makes it auditable -- and repeated
+  -- values are how a carried-forward day is detected.
+  pinned_block            BIGINT,
+  captured_at             BIGINT  NOT NULL,
+  PRIMARY KEY (netuid, snapshot_date),
+  -- The same epoch-milliseconds floor 0010 put on the daily tables: 1e12 is
+  -- 2001-09-09 and a seconds-valued stamp this decade is ~1.79e9. #9782 is what
+  -- this prevents -- a stamp missing three digits produced a row dated 1970
+  -- that no later pass could revise.
+  CONSTRAINT subnet_deregistration_daily_captured_at_is_millis
+    CHECK (captured_at >= 1000000000000)
+);
+
+-- One subnet's trajectory, newest first: the per-netuid history read.
+CREATE INDEX IF NOT EXISTS idx_subnet_dereg_daily_netuid_date
+  ON subnet_deregistration_daily (netuid, snapshot_date DESC);
+
+-- A whole day across every subnet, which is what a ranking replay needs: the
+-- rank is relative, so reconstructing one subnet's rank requires every other
+-- subnet's row for that date.
+CREATE INDEX IF NOT EXISTS idx_subnet_dereg_daily_date
+  ON subnet_deregistration_daily (snapshot_date DESC);

--- a/src/subnet-deregistration-daily.ts
+++ b/src/subnet-deregistration-daily.ts
@@ -1,0 +1,288 @@
+// A daily row per subnet of what the deregistration ranking is computed FROM
+// (#10296), so a trajectory exists rather than only today's answer.
+//
+// ## It stores the INPUTS, and that is the whole design
+//
+// `src/subnet-deregistration-ranking.ts` splits its fields two ways: four are
+// MEASURED (`SubnetMovingPrice`, `NetworkRegisteredAt`, `SubnetMechanism`,
+// `NetworkImmunityPeriod`) and everything a caller reads off the card -- `rank`,
+// `comparison_price`, `immune`, `blocks_until_prunable` -- is declared
+// `kind: "reconstructed", storage: null`. Those are produced by a RULE, and
+// #10285 exists because the rule is subtle: a price-only order names netuid 86
+// first where the chain names 70, because immunity and the Stable-mechanism
+// substitution both bite.
+//
+// Persisting `rank` would freeze one version of that rule into history, and a
+// later correction could not reach the old rows. Persisting the inputs means
+// the same fix corrects every past day, and `projectDeregistrationRanking`
+// replays them unchanged. See migrations/neon/0015 for the fuller argument.
+//
+// ## No new chain reads
+//
+// The economics sweep already captures all four and pins them to one block --
+// the live route computes from exactly this blob per request. This lane reads
+// the same thing once a day and appends; there is no producer change.
+//
+// ## Why the writes are guarded rather than trusted
+//
+// A lane that appends whatever it read will happily write a day of nulls when
+// the blob is missing or half-built, and a null day is indistinguishable from a
+// subnet that genuinely had no price. Both guards below exist for that: the
+// blob must project at all, and it must cover a plausible number of subnets.
+
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { laneHealthStore } from "./lane-health-store.ts";
+import { createPgSql } from "./pg-sql.ts";
+import { projectDeregistrationRanking } from "./subnet-deregistration-ranking.ts";
+
+interface WaitUntilLike {
+  waitUntil: (promise: Promise<unknown>) => void;
+}
+
+export const SUBNET_DEREGISTRATION_DAILY_LANE = "subnet-deregistration-daily";
+
+export const SUBNET_DEREGISTRATION_DAILY_TABLE = "subnet_deregistration_daily";
+
+/**
+ * Fewest subnets a pass may cover before it is treated as partial.
+ *
+ * The same shape as the lifecycle lane's floor and for the same reason: a short
+ * read is not a small day. Mainnet has run 128-129 subnets for months, so 100
+ * is comfortably below any real field while still catching a blob that was
+ * half-built -- which is the failure that would otherwise write a day of rows
+ * for a third of the network and look like a successful tick.
+ */
+export const DEREGISTRATION_DAILY_COVERAGE_FLOOR = 100;
+
+/** One subnet's measured inputs on one day. */
+export interface DeregistrationDailyRow {
+  netuid: number;
+  snapshot_date: string;
+  moving_price: number | null;
+  registered_at_block: number | null;
+  subnet_mechanism: number | null;
+  network_immunity_period: number | null;
+  pinned_block: number | null;
+  captured_at: number;
+}
+
+interface EconomicsBlob {
+  chain_state?: {
+    block?: unknown;
+    network_immunity_period?: unknown;
+  } | null;
+  subnets?: unknown;
+}
+
+const numberOrNull = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null;
+
+/**
+ * The rows one economics blob yields, or `null` when it cannot be trusted.
+ *
+ * PURE, so the extraction is testable without a store, a clock or a network --
+ * which matters more than usual here because every field is nullable and a
+ * silent all-null day is exactly the failure mode.
+ *
+ * Returns null rather than [] when the blob does not project: `[]` would be
+ * written as "a day with no subnets", and the caller must be able to tell that
+ * from "we could not read".
+ */
+export function deregistrationDailyRows(
+  economics: unknown,
+  snapshotDate: string,
+  capturedAt: number,
+): DeregistrationDailyRow[] | null {
+  // Gate on the PROJECTOR, not on the raw blob. It is the thing that decides
+  // whether these inputs are usable at all -- it returns null when the block or
+  // the immunity period is missing, and a ranking cannot be replayed without
+  // either. Re-deriving that judgement here would be a second opinion that can
+  // drift from the one the route uses.
+  if (!projectDeregistrationRanking(economics)) return null;
+
+  const blob = (economics ?? {}) as EconomicsBlob;
+  const chainState = blob.chain_state ?? {};
+  const pinnedBlock = numberOrNull(chainState.block);
+  const immunityPeriod = numberOrNull(chainState.network_immunity_period);
+  const rows = Array.isArray(blob.subnets) ? blob.subnets : [];
+
+  const out: DeregistrationDailyRow[] = [];
+  for (const row of rows as Record<string, unknown>[]) {
+    if (!Number.isInteger(row?.netuid)) continue;
+    out.push({
+      netuid: row.netuid as number,
+      snapshot_date: snapshotDate,
+      // `moving_price_pinned` is the blob's name for SubnetMovingPrice read at
+      // the pinned block -- the same field projectDeregistrationRanking reads,
+      // named the same way on purpose so the two cannot diverge.
+      moving_price: numberOrNull(row.moving_price_pinned),
+      registered_at_block: numberOrNull(row.registered_at_block),
+      subnet_mechanism: numberOrNull(row.subnet_mechanism),
+      network_immunity_period: immunityPeriod,
+      pinned_block: pinnedBlock,
+      captured_at: capturedAt,
+    });
+  }
+  return out;
+}
+
+/**
+ * The upsert.
+ *
+ * ON CONFLICT rather than a plain append because the lane may tick more than
+ * once a day, and a second tick on the same date is a re-observation of that
+ * day -- not a second day and not an error.
+ *
+ * THE GUARD IS THE POINT. The update only applies when the incoming row is at a
+ * block at least as new as the stored one, so a late tick reading an older
+ * pinned blob cannot overwrite a fresher observation with a staler one. That is
+ * the same out-of-order protection the other Neon write paths carry, and it is
+ * why `pinned_block` is compared rather than `captured_at`: the wall clock says
+ * when we looked, the block says what we saw.
+ *
+ * `COALESCE(existing, -1)` so a stored NULL block always loses to a real one.
+ */
+export const DEREGISTRATION_DAILY_UPSERT_TAIL =
+  " ON CONFLICT (netuid, snapshot_date) DO UPDATE SET " +
+  "moving_price = EXCLUDED.moving_price, " +
+  "registered_at_block = EXCLUDED.registered_at_block, " +
+  "subnet_mechanism = EXCLUDED.subnet_mechanism, " +
+  "network_immunity_period = EXCLUDED.network_immunity_period, " +
+  "pinned_block = EXCLUDED.pinned_block, " +
+  "captured_at = EXCLUDED.captured_at " +
+  `WHERE COALESCE(EXCLUDED.pinned_block, -1) >= COALESCE(${SUBNET_DEREGISTRATION_DAILY_TABLE}.pinned_block, -1)`;
+
+const COLUMNS = [
+  "netuid",
+  "snapshot_date",
+  "moving_price",
+  "registered_at_block",
+  "subnet_mechanism",
+  "network_immunity_period",
+  "pinned_block",
+  "captured_at",
+] as const;
+
+/** `INSERT … VALUES ($1,…), ($9,…) … ON CONFLICT …` for `rowCount` rows. */
+export function deregistrationDailyUpsertSql(rowCount: number): string {
+  const groups: string[] = [];
+  for (let row = 0; row < rowCount; row += 1) {
+    const params = COLUMNS.map(
+      (_, col) => `$${row * COLUMNS.length + col + 1}`,
+    );
+    groups.push(`(${params.join(", ")})`);
+  }
+  return (
+    `INSERT INTO ${SUBNET_DEREGISTRATION_DAILY_TABLE} (${COLUMNS.join(", ")}) ` +
+    `VALUES ${groups.join(", ")}${DEREGISTRATION_DAILY_UPSERT_TAIL}`
+  );
+}
+
+/** Row objects flattened to one positional bind list, in COLUMNS order. */
+export function deregistrationDailyBinds(
+  rows: readonly DeregistrationDailyRow[],
+): unknown[] {
+  return rows.flatMap((row) => COLUMNS.map((column) => row[column]));
+}
+
+export interface DeregistrationDailyDeps {
+  /** The economics blob this tick should record. */
+  readEconomics: () => Promise<unknown>;
+  sql?: {
+    unsafe(text: string, values?: unknown[]): Promise<unknown>;
+  } | null;
+  laneHealthDb?: LaneHealthDb | null;
+  now?: () => number;
+  coverageFloor?: number;
+  ctx?: WaitUntilLike | null;
+}
+
+/** `YYYY-MM-DD` in UTC, the key subnet_snapshots uses. */
+export function snapshotDateFor(nowMs: number): string {
+  return new Date(nowMs).toISOString().slice(0, 10);
+}
+
+/**
+ * One tick. Returns a summary rather than throwing, like the rest of the lane
+ * family -- a capture lane that can take down the cron it shares would be worse
+ * than a gap in the series.
+ */
+export async function runSubnetDeregistrationDailyLane(
+  env: Record<string, unknown> | null | undefined,
+  deps: DeregistrationDailyDeps,
+): Promise<Record<string, unknown>> {
+  const now = deps.now ?? Date.now;
+  const floor = deps.coverageFloor ?? DEREGISTRATION_DAILY_COVERAGE_FLOOR;
+  const capturedAt = now();
+
+  const record = async (
+    verdict: "ok" | "stale",
+    detail: string,
+  ): Promise<void> => {
+    await recordLaneVerdict(laneHealthStore(env, deps.laneHealthDb), {
+      lane: SUBNET_DEREGISTRATION_DAILY_LANE,
+      verdict,
+      age_ms: null,
+      detail,
+      checked_at: capturedAt,
+    });
+  };
+
+  // Same derivation as the lifecycle lane: readStore hands back a READ handle
+  // with no run()/unsafe(), so an append needs its own runner. The bare
+  // `waitUntil: () => {}` covers callers with no ExecutionContext -- calling
+  // ctx.waitUntil on a `{}` throws, and taking the lane down over connection
+  // bookkeeping would be worse than the connection outliving the tick.
+  const hyperdrive = env?.HYPERDRIVE as
+    { connectionString: string } | undefined;
+  const sql =
+    deps.sql ??
+    (hyperdrive?.connectionString
+      ? createPgSql(hyperdrive, deps.ctx ?? { waitUntil: () => {} })
+      : null);
+  if (!sql?.unsafe) {
+    await record("stale", "no store bound");
+    return { ok: false, reason: "no_store_bound" };
+  }
+
+  try {
+    const rows = deregistrationDailyRows(
+      await deps.readEconomics(),
+      snapshotDateFor(capturedAt),
+      capturedAt,
+    );
+    if (rows === null) {
+      // The blob did not project. NOT an empty day -- writing nothing and
+      // reporting ok would let a broken economics sweep read as a quiet one.
+      await record("stale", "economics blob did not project a ranking");
+      return { ok: false, reason: "economics_unavailable" };
+    }
+    if (rows.length < floor) {
+      await record(
+        "stale",
+        `partial: ${rows.length} subnet(s) under the ${floor} floor -- nothing written`,
+      );
+      return { ok: false, reason: "partial_coverage", captured: rows.length };
+    }
+
+    await sql.unsafe(
+      deregistrationDailyUpsertSql(rows.length),
+      deregistrationDailyBinds(rows),
+    );
+    const block = rows[0]?.pinned_block ?? null;
+    await record(
+      "ok",
+      `captured ${rows.length} subnet(s) at block ${block ?? "unknown"}`,
+    );
+    return {
+      ok: true,
+      captured: rows.length,
+      snapshot_date: rows[0]?.snapshot_date ?? null,
+      pinned_block: block,
+    };
+  } catch (error) {
+    const reason = String((error as Error)?.message ?? error);
+    await record("stale", `write failed: ${reason}`);
+    return { ok: false, reason: "write_failed", detail: reason };
+  }
+}

--- a/tests/subnet-deregistration-daily.test.ts
+++ b/tests/subnet-deregistration-daily.test.ts
@@ -1,0 +1,357 @@
+// The daily deregistration-input series (#10296), executed on real Postgres.
+//
+// The upsert here carries an out-of-order guard in SQL -- a late tick reading an
+// older pinned block must not overwrite a fresher row -- and a guard expressed
+// as `WHERE COALESCE(EXCLUDED.pinned_block, -1) >= COALESCE(t.pinned_block, -1)`
+// is a claim about what an ENGINE does with NULLs on a conflicting insert. That
+// is not checkable by reading the string, and it is exactly the class the
+// retired SQLite double used to answer wrongly, so these run the real
+// migration on pglite and read the rows back.
+import fs from "node:fs";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { PGlite } from "@electric-sql/pglite";
+import { beforeAll, beforeEach, describe, test } from "vitest";
+import {
+  DEREGISTRATION_DAILY_COVERAGE_FLOOR,
+  deregistrationDailyBinds,
+  deregistrationDailyRows,
+  deregistrationDailyUpsertSql,
+  runSubnetDeregistrationDailyLane,
+  snapshotDateFor,
+  SUBNET_DEREGISTRATION_DAILY_LANE,
+} from "../src/subnet-deregistration-daily.ts";
+
+const MIGRATIONS = ["migrations/neon/0015_subnet_deregistration_daily.sql"].map(
+  (f) => fs.readFileSync(path.join(process.cwd(), f), "utf8"),
+);
+
+const T = 1_786_300_000_000;
+const DATE = snapshotDateFor(T);
+
+let db: PGlite;
+
+beforeAll(async () => {
+  db = new PGlite();
+  for (const sql of MIGRATIONS) await db.exec(sql);
+});
+
+beforeEach(async () => {
+  // Re-apply rather than only TRUNCATE: one instance serves the file and a test
+  // below drops the table on purpose. The migration is IF NOT EXISTS.
+  for (const sql of MIGRATIONS) await db.exec(sql);
+  await db.exec("TRUNCATE subnet_deregistration_daily");
+});
+
+/** The `unsafe(text, values)` seam the lane writes through. */
+const sql = {
+  unsafe: async (text: string, values?: unknown[]) =>
+    (await db.query(text, (values ?? []) as never[])).rows,
+};
+
+/** An economics blob that projects: chain_state plus `count` subnets. */
+function blob(count: number, block = 8_808_300, immunity = 50_000) {
+  return {
+    chain_state: { block, network_immunity_period: immunity },
+    subnets: Array.from({ length: count }, (_, i) => ({
+      netuid: i + 1,
+      moving_price_pinned: 0.5 + i / 1000,
+      registered_at_block: 1_000_000 + i,
+      subnet_mechanism: 1,
+    })),
+  };
+}
+
+const rowsFor = (netuid: number) =>
+  db
+    .query("SELECT * FROM subnet_deregistration_daily WHERE netuid = $1", [
+      netuid,
+    ] as never[])
+    .then((r) => r.rows as Record<string, unknown>[]);
+
+describe("extracting the measured inputs", () => {
+  test("a blob that does not project yields null, NOT an empty day", () => {
+    // The distinction this test exists for. `[]` would be written as "a day on
+    // which no subnet existed"; null is "we could not read". Collapsing them is
+    // how a broken economics sweep reads as a quiet network.
+    for (const bad of [
+      null,
+      undefined,
+      {},
+      { subnets: [] },
+      // chain_state present but unusable: no block to judge immunity at.
+      {
+        chain_state: { network_immunity_period: 50_000 },
+        subnets: [{ netuid: 1 }],
+      },
+      // …and no immunity period, which the projector also refuses.
+      { chain_state: { block: 100 }, subnets: [{ netuid: 1 }] },
+    ]) {
+      assert.equal(
+        deregistrationDailyRows(bad, DATE, T),
+        null,
+        JSON.stringify(bad),
+      );
+    }
+  });
+
+  test("every row carries the block and immunity period it was judged at", () => {
+    const rows = deregistrationDailyRows(blob(3), DATE, T)!;
+    assert.equal(rows.length, 3);
+    for (const row of rows) {
+      assert.equal(row.pinned_block, 8_808_300);
+      assert.equal(row.network_immunity_period, 50_000);
+      assert.equal(row.snapshot_date, DATE);
+      assert.equal(row.captured_at, T);
+    }
+  });
+
+  test("a missing price is null, never zero", () => {
+    // A subnet with no price is not a subnet priced at zero, and the ranking
+    // treats the two differently -- 0 sorts first, null is excluded.
+    const rows = deregistrationDailyRows(
+      {
+        chain_state: { block: 10, network_immunity_period: 5 },
+        subnets: [{ netuid: 1 }, { netuid: 2, moving_price_pinned: 0 }],
+      },
+      DATE,
+      T,
+    )!;
+    assert.equal(rows[0]!.moving_price, null);
+    assert.equal(rows[1]!.moving_price, 0);
+  });
+
+  test("a non-integer netuid is skipped rather than coerced", () => {
+    const rows = deregistrationDailyRows(
+      {
+        chain_state: { block: 10, network_immunity_period: 5 },
+        subnets: [{ netuid: 1 }, { netuid: "2" }, { netuid: 3.5 }, {}],
+      },
+      DATE,
+      T,
+    )!;
+    assert.deepEqual(
+      rows.map((r) => r.netuid),
+      [1],
+    );
+  });
+});
+
+describe("the upsert, on real Postgres", () => {
+  test("writes a day and reads it back with the types the schema declares", async () => {
+    const rows = deregistrationDailyRows(blob(2), DATE, T)!;
+    await sql.unsafe(
+      deregistrationDailyUpsertSql(rows.length),
+      deregistrationDailyBinds(rows),
+    );
+    const [row] = await rowsFor(1);
+    assert.equal(Number(row!.netuid), 1);
+    assert.equal(row!.snapshot_date, DATE);
+    assert.equal(Number(row!.moving_price), 0.5);
+    assert.equal(Number(row!.pinned_block), 8_808_300);
+  });
+
+  test("a second tick on the same date REPLACES rather than duplicating", async () => {
+    const first = deregistrationDailyRows(blob(2, 100), DATE, T)!;
+    await sql.unsafe(
+      deregistrationDailyUpsertSql(first.length),
+      deregistrationDailyBinds(first),
+    );
+    const second = deregistrationDailyRows(blob(2, 200), DATE, T + 60_000)!;
+    await sql.unsafe(
+      deregistrationDailyUpsertSql(second.length),
+      deregistrationDailyBinds(second),
+    );
+    const got = await rowsFor(1);
+    assert.equal(got.length, 1, "the primary key must collapse the two ticks");
+    assert.equal(Number(got[0]!.pinned_block), 200);
+  });
+
+  test("a LATE tick at an OLDER block does not overwrite the fresher row", async () => {
+    // The guard. Ticks are not ordered -- a retry can land after a newer pass
+    // has already written -- and the wall clock says when we looked while the
+    // block says what we saw, which is why the WHERE compares pinned_block.
+    const fresh = deregistrationDailyRows(blob(1, 900), DATE, T)!;
+    await sql.unsafe(
+      deregistrationDailyUpsertSql(1),
+      deregistrationDailyBinds(fresh),
+    );
+    const stale = deregistrationDailyRows(blob(1, 100), DATE, T + 60_000)!;
+    await sql.unsafe(
+      deregistrationDailyUpsertSql(1),
+      deregistrationDailyBinds(stale),
+    );
+    const [row] = await rowsFor(1);
+    assert.equal(Number(row!.pinned_block), 900, "the older block won");
+    assert.equal(
+      Number(row!.captured_at),
+      T,
+      "and it did not smuggle its stamp in",
+    );
+  });
+
+  test("a real block beats a stored NULL block", async () => {
+    // COALESCE(existing, -1): a row written before a block was readable must
+    // not become permanently unwritable.
+    await sql.unsafe(
+      "INSERT INTO subnet_deregistration_daily (netuid, snapshot_date, pinned_block, captured_at) VALUES ($1,$2,$3,$4)",
+      [1, DATE, null, T],
+    );
+    const rows = deregistrationDailyRows(blob(1, 500), DATE, T + 1000)!;
+    await sql.unsafe(
+      deregistrationDailyUpsertSql(1),
+      deregistrationDailyBinds(rows),
+    );
+    const [row] = await rowsFor(1);
+    assert.equal(Number(row!.pinned_block), 500);
+  });
+
+  test("the epoch-millis CHECK rejects a seconds-valued stamp", async () => {
+    // #9782: a stamp missing three digits produced a row dated 1970 that no
+    // later pass could revise. The constraint is the only thing that catches it.
+    await assert.rejects(
+      sql.unsafe(
+        "INSERT INTO subnet_deregistration_daily (netuid, snapshot_date, captured_at) VALUES ($1,$2,$3)",
+        [1, DATE, 1_786_300_000],
+      ),
+      /captured_at_is_millis|violates check constraint/i,
+    );
+  });
+
+  test("two dates for one subnet are two rows -- the series accrues", async () => {
+    const day1 = deregistrationDailyRows(blob(1, 100), "2026-08-01", T)!;
+    const day2 = deregistrationDailyRows(blob(1, 200), "2026-08-02", T)!;
+    await sql.unsafe(
+      deregistrationDailyUpsertSql(1),
+      deregistrationDailyBinds(day1),
+    );
+    await sql.unsafe(
+      deregistrationDailyUpsertSql(1),
+      deregistrationDailyBinds(day2),
+    );
+    const got = await rowsFor(1);
+    assert.equal(got.length, 2);
+  });
+});
+
+describe("the lane", () => {
+  // Statement TEXT, not a call count. recordLaneVerdict issues two statements
+  // per verdict -- the INSERT and a retention DELETE -- so counting calls
+  // asserts an implementation detail of lane-health and breaks the day it
+  // gains or drops one. What this file cares about is that a verdict row was
+  // written on every path.
+  const statements: string[] = [];
+  const laneHealthDb = {
+    prepare: (text: string) => ({
+      bind: () => ({
+        run: async () => {
+          statements.push(text);
+          return { meta: { changes: 1 } };
+        },
+      }),
+    }),
+  } as never;
+  const verdicts = () =>
+    statements.filter((text) => /INSERT INTO lane_health/i.test(text));
+  const env = {} as Record<string, unknown>;
+
+  beforeEach(() => {
+    statements.length = 0;
+  });
+
+  test("writes the day and reports ok", async () => {
+    const out = await runSubnetDeregistrationDailyLane(env, {
+      readEconomics: async () => blob(DEREGISTRATION_DAILY_COVERAGE_FLOOR),
+      sql,
+      laneHealthDb,
+      now: () => T,
+    });
+    assert.equal(out.ok, true);
+    assert.equal(out.captured, DEREGISTRATION_DAILY_COVERAGE_FLOOR);
+    const written = await db.query(
+      "SELECT count(*)::int AS n FROM subnet_deregistration_daily",
+    );
+    assert.equal(
+      (written.rows[0] as { n: number }).n,
+      DEREGISTRATION_DAILY_COVERAGE_FLOOR,
+    );
+  });
+
+  test("a SHORT pass writes NOTHING and says so", async () => {
+    // A third of the network is not a small day, it is a broken read. Writing
+    // it would look like a successful tick forever after.
+    const out = await runSubnetDeregistrationDailyLane(env, {
+      readEconomics: async () => blob(DEREGISTRATION_DAILY_COVERAGE_FLOOR - 1),
+      sql,
+      laneHealthDb,
+      now: () => T,
+    });
+    assert.equal(out.ok, false);
+    assert.equal(out.reason, "partial_coverage");
+    const written = await db.query(
+      "SELECT count(*)::int AS n FROM subnet_deregistration_daily",
+    );
+    assert.equal(
+      (written.rows[0] as { n: number }).n,
+      0,
+      "nothing may be written",
+    );
+  });
+
+  test("an unreadable blob is stale, not a quiet ok", async () => {
+    const out = await runSubnetDeregistrationDailyLane(env, {
+      readEconomics: async () => ({}),
+      sql,
+      laneHealthDb,
+      now: () => T,
+    });
+    assert.equal(out.ok, false);
+    assert.equal(out.reason, "economics_unavailable");
+  });
+
+  test("a failing write is reported, never swallowed", async () => {
+    await db.exec("DROP TABLE subnet_deregistration_daily");
+    const out = await runSubnetDeregistrationDailyLane(env, {
+      readEconomics: async () => blob(DEREGISTRATION_DAILY_COVERAGE_FLOOR),
+      sql,
+      laneHealthDb,
+      now: () => T,
+    });
+    assert.equal(out.ok, false);
+    assert.equal(out.reason, "write_failed");
+  });
+
+  test("every path records a verdict, including the failures", async () => {
+    // The lane returns rather than throwing, so the verdict is the ONLY thing
+    // a watchdog can see. A path that returns quietly is a silent lane.
+    for (const readEconomics of [
+      async () => blob(DEREGISTRATION_DAILY_COVERAGE_FLOOR),
+      async () => blob(1),
+      async () => ({}),
+    ]) {
+      statements.length = 0;
+      await runSubnetDeregistrationDailyLane(env, {
+        readEconomics,
+        sql,
+        laneHealthDb,
+        now: () => T,
+      });
+      assert.equal(verdicts().length, 1);
+    }
+    statements.length = 0;
+    await runSubnetDeregistrationDailyLane(env, {
+      readEconomics: async () => blob(200),
+      sql: null,
+      laneHealthDb,
+      now: () => T,
+    });
+    assert.equal(verdicts().length, 1, "an unbound store must still report");
+  });
+
+  test("the lane name is stable", () => {
+    assert.equal(
+      SUBNET_DEREGISTRATION_DAILY_LANE,
+      "subnet-deregistration-daily",
+    );
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -434,6 +434,8 @@ import { runRegistrySyncLane } from "../src/registry-sync-lane.ts";
 import { runRegistryResyncLane } from "../src/registry-resync-lane.ts";
 import { runDailySeriesCoverageWatchdog } from "../src/daily-series-coverage-watchdog.ts";
 import { runSubnetLifecycleLane } from "../src/subnet-lifecycle.ts";
+import { runSubnetDeregistrationDailyLane } from "../src/subnet-deregistration-daily.ts";
+import { resolveEmissionPipelineEconomics } from "../src/emission-pipeline-surface.ts";
 import { pruneChainDetail } from "../src/chain-detail-prune.ts";
 import { runRpcUsageStalenessWatchdog } from "../src/rpc-usage-staleness-watchdog.ts";
 import { runTopHoldersStalenessWatchdog } from "../src/top-holders-staleness-watchdog.ts";
@@ -517,6 +519,7 @@ import {
   CHAIN_CONCENTRATION_ROLLUP_CRON,
   CHAIN_DETAIL_STALENESS_WATCHDOG_CRON,
   TOP_HOLDERS_FLOW_CRON,
+  SUBNET_DEREGISTRATION_DAILY_CRON,
   TOP_HOLDERS_STALENESS_WATCHDOG_CRON,
   ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON,
   HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON,
@@ -2153,6 +2156,8 @@ function cronLabel(cron: string): string {
   if (cron === ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON)
     return "account-balances-staleness-watchdog";
   if (cron === TOP_HOLDERS_FLOW_CRON) return "top-holders-flow";
+  if (cron === SUBNET_DEREGISTRATION_DAILY_CRON)
+    return "subnet-deregistration-daily";
   if (cron === LIVE_ECONOMICS_REFRESH_CRON) return "live-economics-refresh";
   // Every unmatched cron falls through to the health prober, matching dispatch.
   return "health-prober";
@@ -2645,6 +2650,38 @@ async function dispatchScheduled(
     // watchdog:chain-detail-staleness, the project's alert channel.
     return runChainDetailStalenessWatchdog(
       env as unknown as Record<string, unknown>,
+    );
+  }
+  if (cron === SUBNET_DEREGISTRATION_DAILY_CRON) {
+    // #10296: one row per subnet per day of what the deregistration ranking is
+    // computed FROM. It stores the four MEASURED inputs, never the derived
+    // rank -- so a later correction to the ranking rule reaches the whole
+    // series instead of leaving it a record of the old rule's answers.
+    //
+    // Reads the same economics blob the live route does, so there is no
+    // producer change and no new chain read. Never throws: a capture lane that
+    // could take down the cron it shares would be worse than a gap.
+    return runSubnetDeregistrationDailyLane(
+      env as unknown as Record<string, unknown>,
+      {
+        ctx,
+        readEconomics: () =>
+          resolveEmissionPipelineEconomics({
+            env,
+            // Wrapped rather than passed by reference: readEconomicsCurrentKv's
+            // second parameter is `now`, not the `key` this seam declares, and
+            // handing it over directly would bind a cache key into a clock.
+            readHealthKv: (e: Env) => readEconomicsCurrentKv(e),
+            contractVersion: contractVersion(env),
+            readArtifact: async () => {
+              const artifact = await readArtifact(
+                env,
+                "/metagraph/economics.json",
+              );
+              return artifact?.ok ? artifact.data : null;
+            },
+          }),
+      },
     );
   }
   if (cron === TOP_HOLDERS_FLOW_CRON) {

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -371,6 +371,26 @@ export const PROJECTION_LANES_CRON = "11,41 * * * *";
 // on the LITERAL cron string, so this must be unique here as well as matching
 // a wrangler.jsonc `triggers.crons` entry.
 export const TOP_HOLDERS_FLOW_CRON = "34 1 * * *";
+
+/**
+ * Daily capture of the deregistration ranking's MEASURED inputs (#10296).
+ *
+ * The current ranking is computed per request and stored nowhere, so a caller
+ * sees today's answer and nothing else -- and a single day's rank is noise. One
+ * row per subnet per day makes it a trajectory.
+ *
+ * 05:17 UTC. Daily, because the inputs move on the scale the immunity window
+ * does rather than per block, and a finer cadence would store the same
+ * observation repeatedly -- `pinned_block` already records which observation a
+ * row is, so nothing is gained by sampling faster than the economics sweep
+ * pins. Minute 17 is used by no other cron in this file, hourly ones included,
+ * and dispatch keys on the LITERAL string, so it must stay unique here AND
+ * match a wrangler.jsonc `triggers.crons` entry.
+ *
+ * ~2h after the 03:26 leg of LIVE_ECONOMICS_REFRESH_CRON, which is fine: the
+ * lane records the block it read rather than assuming freshness.
+ */
+export const SUBNET_DEREGISTRATION_DAILY_CRON = "17 5 * * *";
 // The live-economics refresh, moved off .github/workflows/refresh-economics.yml
 // -- the last GitHub Actions data lane. Same 3-hourly cadence that workflow
 // ran (it was `41 */3 * * *`), on minute :26, which is the nearest free minute:

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -958,6 +958,10 @@
       // the twice-hourly cadence would cost 79 GB/day for windows measured in
       // weeks -- see TOP_HOLDERS_FLOW_CRON in workers/config.ts.
       "34 1 * * *",
+      // 05:17 daily = the deregistration-input series (#10296). See
+      // SUBNET_DEREGISTRATION_DAILY_CRON in workers/config.ts: dispatch keys on
+      // this LITERAL string, so it must match that constant exactly.
+      "17 5 * * *",
       // 3,13,... = the 10-minute emission-gate sampler (#8748/#8750), moved
       // off its GitHub Actions schedule -- offset from :0-based grids so it
       // never stacks on the */5 raw-capture tick's busiest minute.


### PR DESCRIPTION
Closes #10361. The capture half of #10296, split from its API surface the way
#10262 was split from #10263.

#10285 ships the current ranking — computed per request from the pinned
economics blob, stored nowhere. A caller sees today's answer and nothing else,
and *a single day's rank is noise*.

## It stores the inputs, never the rank

`DEREGISTRATION_FIELD_SOURCES` already draws the line:

| | kind |
|---|---|
| `SubnetMovingPrice`, `NetworkRegisteredAt`, `SubnetMechanism`, `NetworkImmunityPeriod` | **measured** |
| `rank`, `comparison_price`, `immune`, `immune_until_block`, `blocks_until_prunable`, `next_to_deregister` | **reconstructed**, `storage: null` |

Persisting a reconstructed value freezes one version of a *rule* into history —
and #10285 exists because that rule is subtle enough to get wrong: a price-only
order names netuid 86 first where the chain names 70, because immunity and the
Stable-mechanism substitution both bite. Storing the inputs means a later
correction reaches every past day, and `projectDeregistrationRanking` replays
them unchanged.

## A table of its own, and #10296's premise was wrong

#10296 asked whether this belongs as columns on `subnet_snapshots`, on the basis
that *"that rollup already has the moving price"*. Measured against production
2026-08-10: **it does not.** Its 27 columns carry `alpha_price_tao` — the spot
price — and the only `%moving%` columns in the entire database are
`subnet_hyperparams.bonds_moving_avg_raw` and its history twin, an unrelated
hyperparameter.

So every input is a new column either way, `pipeline_block` is the only real
overlap, and coupling the write would tie it to that rollup's completeness: a
partial read would either block the daily snapshot or land NULLs in it.

## No new chain reads

All four inputs are already captured and pinned to one block by the economics
sweep — the live route computes from exactly this blob. The lane reads it once a
day and appends. No producer change.

## The upsert is guarded, not trusted

```sql
ON CONFLICT (netuid, snapshot_date) DO UPDATE SET …
WHERE COALESCE(EXCLUDED.pinned_block, -1) >= COALESCE(t.pinned_block, -1)
```

Ticks are not ordered — a retry can land after a newer pass has written.
`pinned_block` rather than `captured_at`, because **the wall clock says when we
looked and the block says what we saw**. Repeated `pinned_block` values are also
how a carried-forward day is detected without comparing ranks for equality,
which is the trap `/subnets/{netuid}/emission-pipeline/history` documents and
that this series inherits exactly.

## Two write guards

A lane that appends whatever it read writes a day of nulls when the blob is
half-built, and a null day is indistinguishable from a subnet that genuinely had
no price.

1. The blob must **project at all** — `deregistrationDailyRows` returns `null`,
   never `[]`, so "could not read" can never be stored as "no subnets existed".
2. It must cover **≥100 subnets**. A short pass writes **nothing** and reports
   `stale`. A third of the network is not a small day, it is a broken read.

## Verification

Executed on **real Postgres** (pglite, `migrations/neon/0015` applied verbatim),
because the out-of-order guard is a claim about what an engine does with NULLs
on a conflicting insert — not checkable by reading the statement. 16 tests,
including:

- a late tick at an older block does not overwrite, and does not smuggle its own
  `captured_at` in either
- a real block beats a stored NULL block (the `COALESCE(…, -1)` half)
- the epoch-millis CHECK rejects a seconds-valued stamp (#9782)
- a short pass leaves the table **empty**
- every path records exactly one lane verdict — asserted on statement TEXT, not
  call count, because `recordLaneVerdict` issues two statements and counting
  calls would pin an implementation detail of lane-health

`tsc`, `lint`, `format:check`, `validate:migrations` (15 files, sequential),
`validate:workflows`, `validate:unreferenced-modules` and `validate:db-types-drift`
all clean; `api-coverage` (327 tests) green, which is where the cron
declarations are checked.

## Deploying this needs one manual step

Merging deploys code, **not the schedule** — Workers Builds does not apply cron
triggers. After the migration is applied, `wrangler triggers deploy` is needed
for `"17 5 * * *"` to fire. Until then the lane is dormant rather than broken,
and if it runs before the migration lands it reports `stale — write failed`
rather than failing silently.