### PR TITLE
fix(ci): run the live smoke after its own declarations, not before them (#10363)

### DIFF
--- a/scripts/smoke-live-api.ts
+++ b/scripts/smoke-live-api.ts
@@ -19,16 +19,6 @@ const baseUrl = normalizeBaseUrl(
 );
 const timeoutMs = Number(process.env.METAGRAPH_LIVE_SMOKE_TIMEOUT_MS || 15000);
 
-// Only fire the live smoke when this file is executed directly (npm run
-// smoke:live). Importing it for the PR-time substitution unit test must not hit
-// the network.
-if (
-  process.argv[1] &&
-  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
-) {
-  await runLiveSmoke();
-}
-
 async function runLiveSmoke(): Promise<void> {
   const healthDate = await discoverHealthHistoryDate();
   const fixtureSurfaceId =
@@ -706,4 +696,32 @@ function normalizeBaseUrl(value: string): string {
   url.search = "";
   url.hash = "";
   return url.toString().replace(/\/$/, "");
+}
+
+// Only fire the live smoke when this file is executed directly (npm run
+// smoke:live). Importing it for the PR-time substitution unit test must not hit
+// the network.
+//
+// AT THE FOOT OF THE FILE, and that is load-bearing rather than tidiness. This
+// call used to sit at line 29 of 709, which meant `runLiveSmoke` executed while
+// every `const` below it was still in its temporal dead zone. Function
+// DECLARATIONS hoist and initialise, so the call worked; `const` and `let` do
+// not, so the script was correct only for as long as nothing it reached touched
+// one.
+//
+// On 2026-08-08 something did. `CALLER_OWNED_ROUTE_IDS` was declared at line 646
+// and read at 622, and the production publish gate died with
+// `ReferenceError: Cannot access 'CALLER_OWNED_ROUTE_IDS' before initialization`
+// on every attempt for two days -- while the retry wrapper reported it as
+// "edge cache may still be revalidating" and burned four attempts and six
+// minutes on a deterministic crash.
+//
+// Running last means every declaration in the module is initialised first, so
+// the whole class is gone rather than this one instance of it. Do not move it
+// back up to be near what it calls.
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  await runLiveSmoke();
 }

--- a/tests/smoke-route-substitution.test.ts
+++ b/tests/smoke-route-substitution.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 import { API_ROUTES } from "../src/contracts.ts";
 import {
@@ -144,5 +145,57 @@ describe("the live smoke supplies every required query param (#9663)", () => {
     for (const [routePath] of REQUIRES) {
       assert.ok(paths.has(routePath), `${routePath} is no longer a route`);
     }
+  });
+});
+
+describe("the entry point runs after every declaration", () => {
+  // WHY THE 214 TESTS ABOVE CANNOT CATCH THIS. They all import
+  // scripts/smoke-live-api.ts and call liveSmokeApiRoutes -- and importing a
+  // module RUNS IT TO COMPLETION first, so by the time any of them calls
+  // anything, every `const` is initialised. The hazard is the opposite order:
+  // the script invokes runLiveSmoke at MODULE SCOPE, so it executes while
+  // later declarations are still in their temporal dead zone.
+  //
+  // On 2026-08-08 that killed the production publish gate for two days.
+  // `CALLER_OWNED_ROUTE_IDS` was declared at line 646 and read at 622, and the
+  // run died with `ReferenceError: Cannot access ... before initialization` on
+  // every attempt. These 214 tests were green throughout, and the retry wrapper
+  // reported it as "edge cache may still be revalidating".
+  //
+  // MY FIRST ATTEMPT AT THIS TEST WAS VACUOUS and is worth recording. It
+  // spawned the script against a closed port and asserted the output carried no
+  // ReferenceError -- which passed on the BROKEN file, because the first thing
+  // runLiveSmoke does is a network call, and pointing at a dead host makes it
+  // throw long before it reaches the line that would have crashed. A subprocess
+  // that reproduces the bug needs the network to WORK, which is not a unit test.
+  //
+  // So this asserts the STRUCTURE instead: the invocation must come after the
+  // last top-level declaration. That is the invariant the fix established, it
+  // is checkable without running anything, and it fails on the broken file.
+  const source = readFileSync("scripts/smoke-live-api.ts", "utf8");
+
+  test("the invocation is below every top-level const and let", () => {
+    const call = source.indexOf("await runLiveSmoke()");
+    assert.notEqual(call, -1, "the entry-point call was not found -- renamed?");
+
+    const declarations = [...source.matchAll(/^(?:const|let) \w+/gm)];
+    // Anchored on the one that actually broke, not only on a count. Four is
+    // the real number today and a bare `>= 4` would survive the scan silently
+    // matching something else; requiring CALLER_OWNED_ROUTE_IDS by name ties
+    // this to the incident it exists for.
+    assert.ok(
+      declarations.some((d) => d[0].includes("CALLER_OWNED_ROUTE_IDS")),
+      `the scan did not find CALLER_OWNED_ROUTE_IDS among ${declarations.length} ` +
+        `top-level declarations -- it stopped working, so this assertion is ` +
+        `passing on nothing`,
+    );
+    const last = declarations[declarations.length - 1]!;
+    assert.ok(
+      call > last.index,
+      `\`await runLiveSmoke()\` is at ${call} but a top-level declaration ` +
+        `(${last[0]}) is at ${last.index}. Everything below the call is in its ` +
+        `temporal dead zone when it runs -- move the call to the foot of the ` +
+        `file, not the declaration up.`,
+    );
   });
 });


### PR DESCRIPTION
Closes #10363. **The production publish gate has crashed before probing anything since 2026-08-08.** Scheduled `Publish Cloudflare Backend` failed on 08-08 and 08-09; last success 08-07.

```
ReferenceError: Cannot access 'CALLER_OWNED_ROUTE_IDS' before initialization
    at scripts/smoke-live-api.ts:622:8
    at liveSmokeApiRoutes (scripts/smoke-live-api.ts:618:21)
    at runLiveSmoke (scripts/smoke-live-api.ts:37:21)
```

Reproduced locally against `origin/main`, byte-identical to CI.

## The root cause is the call site, not that one const

`await runLiveSmoke()` sat at **line 29 of a 709-line file**. Function *declarations* hoist and initialise, so the call worked; `const`/`let` do not — so nearly the whole file was in its temporal dead zone while the program ran. The script was correct only for as long as nothing it reached touched one. `CALLER_OWNED_ROUTE_IDS` (declared 646, read 622) was the one that did.

Moving the invocation to the foot of the file kills the class, not this instance.

## Three things kept it invisible

**The retry wrapper misdiagnoses it.** Four attempts, 90s apart, each logging `edge cache may still be revalidating after kv:publish` — for a deterministic ReferenceError. Six minutes per run on something that cannot succeed.

**The alert is wrong about what failed.** It fires `R2/KV may go stale`, but the publish *succeeded* — `METAGRAPH_PUBLISHED_AT: 2026-08-09T08:04:05.050Z` matches what the live artifacts serve. The post-deploy gate died, not the publish.

**214 unit tests cover this exact module and stayed green.** `tests/smoke-route-substitution.test.ts` imports `scripts/smoke-live-api.ts` and calls `liveSmokeApiRoutes`. Importing a module runs it to completion first, so every `const` is initialised before any test calls anything. The hazard is call order *at module scope*, which importing erases — invisible to an import-time test by construction.

`no-use-before-define` is not enabled either, so nothing caught it statically.

## The regression test, and the one I threw away

My first attempt spawned the script against a closed port and asserted the output carried no ReferenceError. **It passed on the broken file.** `runLiveSmoke`'s first act is a network call that throws long before the crashing line — so a subprocess that reproduces this needs the network to *work*, which is not a unit test. Recording that in the test comment, because the trap is inviting.

The check that survives asserts **structure**: the invocation must come after the last top-level declaration. Proven both ways —

```
✗ on origin/main:  `await runLiveSmoke()` is at 1211 but a top-level declaration
                   (const CALLER_OWNED_ROUTE_IDS) is at 24333.
✓ on this branch:  215 passed
```

Its floor is anchored on `CALLER_OWNED_ROUTE_IDS` **by name** rather than a count: the real count is 4, and a bare `>= 4` would survive the scan silently matching something else. That floor earned its keep immediately — it caught my first regex being too narrow to see the declarations at all.

## This unmasks a real problem, and I am not claiming otherwise

With the crash gone the gate does its job and reports two timeouts:

```
/api/v1/accounts/{ss58}/counterparties: aborted due to timeout
/api/v1/accounts/{ss58}/serving:        aborted due to timeout
```

Measured directly against production: `counterparties` is **12.6s** against the smoke's 15s budget; `serving` is 2.2s alone, so its timeout is contention. That is #10312's tail — `counterparties` is already its slowest REST route at 10.8s — now reaching the publish gate.

**Fixing the crash may not by itself turn the publish green.** That would be the gate working, not a regression, and it is a better failure than the one it replaces: a real latency problem named honestly instead of a ReferenceError dressed up as edge-cache revalidation.