### PR TITLE
fix(neon): let a migration declare it cannot run inside a transaction (#10365)

### DIFF
--- a/migrations/neon/0011_index_hygiene.sql
+++ b/migrations/neon/0011_index_hygiene.sql
@@ -58,6 +58,13 @@
 -- BEGIN/COMMIT. A CONCURRENTLY build that fails leaves an INVALID index behind
 -- that must be dropped before retrying; check with
 --   SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid;
+--
+-- The line below is that instruction in a form the runner can read. It was
+-- prose only, and scripts/neon-migrate.ts wrapped this file in BEGIN/COMMIT
+-- anyway -- so it failed on every push for two days and blocked 0012-0015
+-- behind it (#10365). Every statement here is IF NOT EXISTS / IF EXISTS, which
+-- is what makes giving up atomicity safe: a half-applied run is re-runnable.
+-- neon:no-transaction
 
 -- 1. The miss: replace the raw-column index with the expression the query uses.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chain_detail_extrinsics_hash_lower

--- a/migrations/neon/0012_hot_query_indexes.sql
+++ b/migrations/neon/0012_hot_query_indexes.sql
@@ -58,6 +58,12 @@
 -- As 0011. Apply statement by statement; a failed build leaves an INVALID index
 -- to drop before retrying (`SELECT indexrelid::regclass FROM pg_index WHERE NOT
 -- indisvalid`).
+--
+-- Machine-readable, as in 0011: the prose above was addressed to a human and
+-- scripts/neon-migrate.ts wrapped the file in BEGIN/COMMIT regardless (#10365).
+-- Every statement is IF NOT EXISTS, so a half-applied run is re-runnable --
+-- which is what pays for having no rollback.
+-- neon:no-transaction
 
 -- 1. Block-by-hash, case-insensitively.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_head_hash_lower

--- a/scripts/neon-migrate.ts
+++ b/scripts/neon-migrate.ts
@@ -30,9 +30,21 @@
 //   `DO $$ BEGIN ... EXCEPTION WHEN duplicate_object THEN NULL; END $$`;
 //   CREATE TABLE/INDEX take IF NOT EXISTS directly.
 // - ORDERED. Lexical by filename, so `0001_` precedes `0002_`.
-// - ATOMIC PER FILE. Each migration and its bookkeeping row commit together,
-//   so a failure halfway through leaves the file unrecorded and re-runnable
-//   rather than half-applied and marked done.
+// - ATOMIC PER FILE, EXCEPT WHERE POSTGRES FORBIDS IT. Each migration and its
+//   bookkeeping row commit together, so a failure halfway through leaves the
+//   file unrecorded and re-runnable rather than half-applied and marked done.
+//   `CREATE INDEX CONCURRENTLY` cannot run inside a transaction at all, so a
+//   file needing it declares `-- neon:no-transaction` and gives up atomicity;
+//   see NO_TRANSACTION_MARKER below for why that is opt-in and gated.
+//
+//   #10365 is what the absence of this cost. 0011 uses CONCURRENTLY seven
+//   times and says so in its own header -- "why this file is not
+//   idempotent-by-transaction" -- while this runner unconditionally opened
+//   one. Neither was wrong alone; they were never checked against each other.
+//   The runner then retried 0011 on every push for two days and never reached
+//   0012-0015, while the schema moved by hand and `schema_migrations` stayed
+//   at 0010. A ledger that stops describing the database is worse than a
+//   failure that stops the line.
 // - HALTS ON FAILURE. A later migration may depend on an earlier one, so
 //   continuing past an error would apply it against a schema that does not
 //   exist yet.
@@ -41,6 +53,117 @@ import { join } from "node:path";
 import pg from "pg";
 
 const DIR = "migrations/neon";
+
+/**
+ * A migration declares it must run OUTSIDE a transaction with this line.
+ *
+ * EXPLICIT, not sniffed from the SQL. The obvious shortcut is to look for
+ * "CONCURRENTLY" in the file, and it is wrong in both directions: 0011's own
+ * header discusses CONCURRENTLY in prose, so a text scan matches files that
+ * merely talk about it, and a future statement with the same constraint and a
+ * different keyword would be missed. A marker says what the file NEEDS rather
+ * than guessing from what it mentions.
+ */
+export const NO_TRANSACTION_MARKER = "-- neon:no-transaction";
+
+/**
+ * A CONCURRENTLY statement, as opposed to the word appearing in a comment.
+ *
+ * Used only to REFUSE a file that needs the marker and does not carry one --
+ * so the failure is "0011 needs -- neon:no-transaction" rather than Postgres'
+ * "cannot run inside a transaction block", which names the symptom and leaves
+ * the reader to discover the runner wraps everything.
+ */
+const CONCURRENTLY_STATEMENT =
+  /^\s*(?:CREATE|DROP|REINDEX)\b[^;]*\bCONCURRENTLY\b/im;
+
+/**
+ * Split SQL into statements on top-level semicolons.
+ *
+ * NEEDED ONLY FOR THE NO-TRANSACTION PATH, and it is not optional there:
+ * node-postgres sends a multi-statement string over the SIMPLE QUERY protocol,
+ * which Postgres executes as ONE IMPLICIT TRANSACTION. Deleting the explicit
+ * BEGIN/COMMIT is therefore not enough on its own -- the statements have to
+ * arrive separately or CONCURRENTLY fails exactly as before.
+ *
+ * Aware of the three things that make a semicolon not a separator: quoted
+ * strings, dollar-quoted blocks (`$$ ... $$`, which the DO/EXCEPTION guard in
+ * these migrations uses), and comments.
+ */
+export function splitStatements(sql: string): string[] {
+  const out: string[] = [];
+  let current = "";
+  let i = 0;
+  while (i < sql.length) {
+    const rest = sql.slice(i);
+    if (rest.startsWith("--")) {
+      const end = sql.indexOf("\n", i);
+      const stop = end === -1 ? sql.length : end;
+      current += sql.slice(i, stop);
+      i = stop;
+      continue;
+    }
+    if (rest.startsWith("/*")) {
+      const end = sql.indexOf("*/", i + 2);
+      const stop = end === -1 ? sql.length : end + 2;
+      current += sql.slice(i, stop);
+      i = stop;
+      continue;
+    }
+    if (sql[i] === "'") {
+      const end = sql.indexOf("'", i + 1);
+      const stop = end === -1 ? sql.length : end + 1;
+      current += sql.slice(i, stop);
+      i = stop;
+      continue;
+    }
+    const dollar = /^\$[A-Za-z_]*\$/.exec(rest);
+    if (dollar) {
+      const tag = dollar[0];
+      const end = sql.indexOf(tag, i + tag.length);
+      const stop = end === -1 ? sql.length : end + tag.length;
+      current += sql.slice(i, stop);
+      i = stop;
+      continue;
+    }
+    if (sql[i] === ";") {
+      out.push(current);
+      current = "";
+      i += 1;
+      continue;
+    }
+    current += sql[i];
+    i += 1;
+  }
+  out.push(current);
+  // A "statement" of only comments and whitespace is what trails the final
+  // semicolon and what sits between statements; sending it would be an error.
+  return out.filter((s) => s.replace(/--[^\n]*/g, "").trim() !== "");
+}
+
+/** Whether this file must be applied without a wrapping transaction. */
+export function runsOutsideTransaction(sql: string): boolean {
+  return sql.includes(NO_TRANSACTION_MARKER);
+}
+
+/**
+ * The reason this file cannot be applied, or null.
+ *
+ * A GATE RATHER THAN A GUESS. A file with a CONCURRENTLY statement and no
+ * marker is the #10365 contradiction, and refusing it here names the fix.
+ */
+export function migrationRefusal(file: string, sql: string): string | null {
+  if (CONCURRENTLY_STATEMENT.test(sql) && !runsOutsideTransaction(sql)) {
+    return (
+      `${file} has a CONCURRENTLY statement but no \`${NO_TRANSACTION_MARKER}\` ` +
+      `marker. Postgres cannot run it inside a transaction and this runner ` +
+      `wraps every file in one, so it would fail on every push. Add the marker ` +
+      `on its own line, and make every statement idempotent -- a file applied ` +
+      `outside a transaction can fail half-done.`
+    );
+  }
+  return null;
+}
 
 /** The bookkeeping table, created by this script rather than by a migration --
  * it has to exist before the first one can be recorded. */
@@ -84,9 +207,45 @@ async function main(): Promise<void> {
       return;
     }
 
+    // Refuse the whole run before applying ANYTHING if any pending file is
+    // malformed. Checking up front rather than per file means a bad migration
+    // three deep does not leave the two before it applied and the run red.
+    for (const file of pending) {
+      const refusal = migrationRefusal(
+        file,
+        readFileSync(join(DIR, file), "utf8"),
+      );
+      if (refusal) throw new Error(refusal);
+    }
+
     for (const file of pending) {
       const sql = readFileSync(join(DIR, file), "utf8");
-      console.log(`neon: applying ${file}`);
+      const outside = runsOutsideTransaction(sql);
+      console.log(
+        `neon: applying ${file}${outside ? " (outside a transaction)" : ""}`,
+      );
+      if (outside) {
+        // NO BEGIN/COMMIT, and one statement per round trip -- a multi-statement
+        // string would be an implicit transaction and fail identically. There is
+        // no rollback to offer: a failure here leaves the earlier statements
+        // applied, which is why the gate above requires them to be idempotent.
+        // The bookkeeping row goes last, so a partial apply stays unrecorded and
+        // is retried rather than marked done.
+        try {
+          for (const statement of splitStatements(sql)) {
+            await client.query(statement);
+          }
+          await client.query(
+            "INSERT INTO schema_migrations (filename) VALUES ($1)",
+            [file],
+          );
+        } catch (error) {
+          throw new Error(`${file} failed: ${(error as Error).message}`, {
+            cause: error,
+          });
+        }
+        continue;
+      }
       await client.query("BEGIN");
       try {
         await client.query(sql);

--- a/tests/neon-migrate-no-transaction.test.ts
+++ b/tests/neon-migrate-no-transaction.test.ts
@@ -1,0 +1,167 @@
+// The no-transaction path in scripts/neon-migrate.ts (#10365).
+//
+// WHAT THIS EXISTS TO HAVE CAUGHT. `CREATE INDEX CONCURRENTLY` cannot run
+// inside a transaction and the runner wrapped every file in one, so
+// 0011_index_hygiene.sql failed on every push for two days and blocked
+// 0012-0015 behind it. The schema moved by hand in the meantime and
+// `schema_migrations` stayed at 0010 -- a ledger that no longer described the
+// database.
+//
+// 0011 SAID SO IN ITS OWN HEADER: "apply this file statement by statement
+// (psql does this by default), NOT wrapped in BEGIN/COMMIT". That instruction
+// was prose, addressed to a human who was not in the loop. These tests are the
+// same instruction in a form that fails a build.
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  NO_TRANSACTION_MARKER,
+  migrationRefusal,
+  runsOutsideTransaction,
+  splitStatements,
+} from "../scripts/neon-migrate.ts";
+
+describe("refusing the contradiction rather than hitting it", () => {
+  test("a CONCURRENTLY statement without the marker is refused, by name", () => {
+    const refusal = migrationRefusal(
+      "0099_x.sql",
+      "CREATE INDEX CONCURRENTLY IF NOT EXISTS i ON t (c);",
+    );
+    assert.ok(refusal, "a bare CONCURRENTLY file must be refused");
+    assert.match(refusal, /0099_x\.sql/);
+    assert.match(refusal, /neon:no-transaction/);
+  });
+
+  test("the same file WITH the marker is accepted", () => {
+    assert.equal(
+      migrationRefusal(
+        "0099_x.sql",
+        `${NO_TRANSACTION_MARKER}\nCREATE INDEX CONCURRENTLY IF NOT EXISTS i ON t (c);`,
+      ),
+      null,
+    );
+  });
+
+  test("prose mentioning CONCURRENTLY is NOT refused", () => {
+    // The reason detection is a marker and not a text scan. 0011's own header
+    // discusses CONCURRENTLY at length; a file that only TALKS about it still
+    // wants the atomicity a transaction gives.
+    const sql =
+      "-- ## CONCURRENTLY, and why this file is not idempotent-by-transaction\n" +
+      "-- Every statement is CONCURRENTLY so a live table is never locked.\n" +
+      "CREATE TABLE IF NOT EXISTS t (a INT);";
+    assert.equal(migrationRefusal("0099_x.sql", sql), null);
+    assert.equal(runsOutsideTransaction(sql), false);
+  });
+
+  test("an ordinary migration does not opt out", () => {
+    assert.equal(
+      runsOutsideTransaction("CREATE TABLE IF NOT EXISTS t (a INT);"),
+      false,
+    );
+  });
+});
+
+describe("splitting statements", () => {
+  // THE SPLIT IS NOT COSMETIC. node-postgres sends a multi-statement string
+  // over the simple query protocol, which Postgres runs as ONE IMPLICIT
+  // TRANSACTION -- so dropping the explicit BEGIN/COMMIT is not enough on its
+  // own and CONCURRENTLY would fail exactly as before.
+  test("splits on top-level semicolons and drops comment-only trailers", () => {
+    assert.deepEqual(
+      splitStatements("SELECT 1; SELECT 2;\n-- trailing comment\n").map((s) =>
+        s.trim(),
+      ),
+      ["SELECT 1", "SELECT 2"],
+    );
+  });
+
+  test("a semicolon inside a string is not a separator", () => {
+    const parts = splitStatements("INSERT INTO t VALUES ('a;b'); SELECT 1;");
+    assert.equal(parts.length, 2);
+    assert.match(parts[0]!, /'a;b'/);
+  });
+
+  test("a semicolon inside a dollar-quoted block is not a separator", () => {
+    // The DO/EXCEPTION guard these migrations use for ADD CONSTRAINT, which
+    // Postgres has no IF NOT EXISTS for. A naive split on ";" tears it into
+    // four fragments, none of which parse.
+    const sql =
+      "DO $$ BEGIN ALTER TABLE t ADD CONSTRAINT c CHECK (a > 0); " +
+      "EXCEPTION WHEN duplicate_object THEN NULL; END $$;\nSELECT 1;";
+    const parts = splitStatements(sql);
+    assert.equal(parts.length, 2, parts.join(" || "));
+    assert.match(parts[0]!, /EXCEPTION WHEN duplicate_object/);
+  });
+
+  test("a semicolon inside a line comment is not a separator", () => {
+    const parts = splitStatements("-- a; b\nSELECT 1;");
+    assert.equal(parts.length, 1);
+  });
+
+  test("a semicolon inside a block comment is not a separator", () => {
+    const parts = splitStatements("/* a; b */ SELECT 1;");
+    assert.equal(parts.length, 1);
+  });
+
+  test("never yields an empty statement, which Postgres rejects", () => {
+    for (const sql of [";;", "\n\n", "-- only a comment\n", ""]) {
+      assert.deepEqual(splitStatements(sql), [], JSON.stringify(sql));
+    }
+  });
+});
+
+describe("0011 itself, which is the file that broke", () => {
+  const sql = readFileSync("migrations/neon/0011_index_hygiene.sql", "utf8");
+
+  test("carries the marker", () => {
+    assert.ok(
+      runsOutsideTransaction(sql),
+      "0011 uses CONCURRENTLY and must declare it",
+    );
+  });
+
+  test("is accepted by the gate", () => {
+    assert.equal(migrationRefusal("0011_index_hygiene.sql", sql), null);
+  });
+
+  test("splits into its four real statements, not its seven mentions", () => {
+    // `grep -c CONCURRENTLY` says 7; three of those are prose. Asserting the
+    // count keeps the splitter honest about comments in both directions.
+    const parts = splitStatements(sql);
+    assert.equal(parts.length, 4, parts.join("\n---\n"));
+    for (const part of parts) {
+      assert.match(part, /CONCURRENTLY/);
+    }
+  });
+
+  test("every statement is idempotent, which is what pays for no rollback", () => {
+    // A file applied outside a transaction can fail half-done and WILL be
+    // retried, because the bookkeeping row is only written after the last
+    // statement. That is only safe while re-running is a no-op.
+    for (const part of splitStatements(sql)) {
+      assert.match(
+        part,
+        /IF NOT EXISTS|IF EXISTS/,
+        `not re-runnable: ${part.trim().slice(0, 80)}`,
+      );
+    }
+  });
+});
+
+describe("every migration on disk", () => {
+  test("is accepted by the gate", () => {
+    // The check the runner does before applying anything, run at build time so
+    // a bad file fails a PR rather than a deploy.
+    const files = readdirSync("migrations/neon")
+      .filter((f) => f.endsWith(".sql"))
+      .sort();
+    assert.ok(files.length >= 15, `only ${files.length} migrations found`);
+    const refusals: (string | null)[] = files
+      .map((f) =>
+        migrationRefusal(f, readFileSync(`migrations/neon/${f}`, "utf8")),
+      )
+      .filter(Boolean);
+    assert.deepEqual(refusals, []);
+  });
+});


### PR DESCRIPTION
Closes #10365.

**No Neon migration had applied by the automated path since 2026-08-08 22:06.** The runner retried `0011` on every push, failed identically, and never reached 0012–0015.

```
neon: applying 0011_index_hygiene.sql
Error: CREATE INDEX CONCURRENTLY cannot run inside a transaction block
```

## The contradiction was written down and never reconciled

`0011`'s own header says:

> apply this file statement by statement (psql does this by default), **NOT wrapped in BEGIN/COMMIT**

That is prose, addressed to a human who was not in the loop. `scripts/neon-migrate.ts` opened a transaction unconditionally. Neither was wrong alone.

**The cost is not the failed runs.** `schema_migrations` stopped at 0010 while the schema kept moving by hand — 0011's four statements, 0012's three indexes, 0013's table and 0014's two ALTERs were all in production and none recorded, while 0015 (#10362) existed nowhere. A ledger that no longer describes the database is worse than a failure that stops the line, because nothing distinguishes it from being up to date.

## The fix

A file declares `-- neon:no-transaction` and is applied unwrapped.

**A marker, not a text scan.** The shortcut — grep the file for `CONCURRENTLY` — is wrong in both directions: 0011's header discusses it in prose, and a future statement with the same constraint under another keyword would be missed. A marker states what a file *needs* rather than guessing from what it mentions.

**Splitting is not cosmetic.** Removing `BEGIN`/`COMMIT` is insufficient: node-postgres sends a multi-statement string over the simple query protocol, which Postgres runs as **one implicit transaction** — so `CONCURRENTLY` would fail exactly as before. The statements must arrive separately. The splitter handles quoted strings, dollar-quoted blocks (the `DO $$ … EXCEPTION $$` guard these migrations use for `ADD CONSTRAINT`) and both comment forms.

**And a gate**, so this cannot recur silently: a file with a CONCURRENTLY *statement* and no marker is refused **before anything is applied**, naming the file and the fix rather than leaving Postgres to report a symptom.

> That gate found `0012_hot_query_indexes.sql` has the same defect on its first run. Fixing 0011 alone would have moved the wall one file along.

## Applied to production, and the ledger is reconciled

I verified each unrecorded migration was *fully* landed before letting the runner record it — not just that its table existed:

| | in database | evidence |
|---|---|---|
| 0011 | ✅ | new index present, **all three** old indexes dropped (4/4 statements) |
| 0012 | ✅ | 3/3 indexes present |
| 0013 | ✅ | table, 6/6 columns, 2/2 check constraints, 2/2 indexes |
| 0014 | ✅ | `bigint` on both `subnet_hyperparams` and `_history` |
| 0015 | ❌ | absent |

Every one is re-runnable (`IF [NOT] EXISTS`, and `ALTER … TYPE BIGINT` on an already-bigint column is a successful no-op), so **no ledger rows were hand-written** — the fixed runner reconciled itself:

```
neon: applying 0011_index_hygiene.sql (outside a transaction)
neon: applying 0012_hot_query_indexes.sql (outside a transaction)
neon: applying 0013_subnet_lifecycle.sql
neon: applying 0014_weights_version_bigint.sql
neon: applying 0015_subnet_deregistration_daily.sql
neon: applied 5 migration(s)
```

`schema_migrations` now holds 0001–0015, and `subnet_deregistration_daily` exists with all 8 columns, both indexes and its primary key. The `17 5 * * *` trigger for that lane is deployed.

## Tests

15, including the three that would each have caught this: prose mentioning CONCURRENTLY must **not** trip the marker; a dollar-quoted `;` must not split; and every migration on disk must pass the gate — which is the assertion that found 0012.