### PR TITLE
feat(graphql): declare the 15 component projections so a gate can check them

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -9025,7 +9025,7 @@ export interface components {
             kind: components["schemas"]["ProviderKind"];
             logo_url?: string;
             name: string;
-            netuids?: number[];
+            netuids: number[];
             notes?: string;
             public_notes?: string;
             /** @constant */
@@ -34853,6 +34853,9 @@ export interface operations {
                      *             "id": "example-subnet",
                      *             "kind": "data-provider",
                      *             "name": "Example Subnet",
+                     *             "netuids": [
+                     *               7
+                     *             ],
                      *             "schema_version": 1,
                      *             "website_url": "https://api.metagraph.sh/example"
                      *           }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -6920,6 +6920,9 @@
                 "id": "example-subnet",
                 "kind": "data-provider",
                 "name": "Example Subnet",
+                "netuids": [
+                  7
+                ],
                 "schema_version": 1,
                 "website_url": "https://api.metagraph.sh/example"
               }
@@ -36075,7 +36078,8 @@
           "name",
           "kind",
           "website_url",
-          "authority"
+          "authority",
+          "netuids"
         ],
         "type": "object"
       },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -9025,7 +9025,7 @@ export interface components {
             kind: components["schemas"]["ProviderKind"];
             logo_url?: string;
             name: string;
-            netuids?: number[];
+            netuids: number[];
             notes?: string;
             public_notes?: string;
             /** @constant */
@@ -34853,6 +34853,9 @@ export interface operations {
                      *             "id": "example-subnet",
                      *             "kind": "data-provider",
                      *             "name": "Example Subnet",
+                     *             "netuids": [
+                     *               7
+                     *             ],
                      *             "schema_version": 1,
                      *             "website_url": "https://api.metagraph.sh/example"
                      *           }

--- a/schemas-src/graphql/published-names.ts
+++ b/schemas-src/graphql/published-names.ts
@@ -1180,36 +1180,83 @@ export const QUERY_BINDINGS: readonly QueryBinding[] = [
   { field: "sudo", route: "/api/v1/sudo", returns: "ExtrinsicList" },
 ];
 
+/** A published type the resolver PROJECTS from a component (#10214). */
+export interface ProjectedType {
+  /** The component it picks its fields from. */
+  readonly component: string;
+  /**
+   * Fields the resolver adds that the component does not supply -- an
+   * association it resolves separately, or a value it computes. Declared so a
+   * typo'd or invented field is a failure rather than a silent extra.
+   */
+  readonly added: readonly string[];
+}
+
+/**
+ * Published types assembled BY a resolver FROM a component.
+ *
+ * These were all listed as `RESOLVER_BUILT_TYPES` -- "no component behind
+ * them" -- which was true of the shape and false of the fields: 141 of their
+ * fields are picked straight from a component that already exists, and eleven
+ * of the fifteen types add nothing at all.
+ *
+ * The distinction is load-bearing because it decides whether anything checks
+ * them. `validate-graphql-component-parity` pairs a type with its component by
+ * traversing from Query's `Mirrors GET` annotations, and a resolver-built type
+ * has no such annotation to traverse from -- so **all fifteen were reached by
+ * exactly zero gates**, and an over-promise in any of them (the class that
+ * nulled `SelfHealthLane.detail` on every request, #10215) was invisible.
+ *
+ * A projection is NOT a mirror: it deliberately publishes a subset, so the
+ * mirror rule "every component field must appear" does not apply to it. What
+ * does apply is every rule about the fields it DOES publish -- nullability and
+ * scalar narrowing -- and that is what the projection pass now checks.
+ */
+export const PROJECTED_TYPES: Readonly<Record<string, ProjectedType>> = {
+  Subnet: {
+    component: "SubnetIndexEntry",
+    added: ["health", "economics", "surfaces", "endpoints"],
+  },
+  Provider: { component: "Provider", added: ["subnets", "endpoints"] },
+  Surface: { component: "Surface", added: [] },
+  Endpoint: { component: "EndpointResource", added: [] },
+  SubnetHealth: { component: "HealthSubnetSummary", added: [] },
+  OpportunityEntry: {
+    component: "SubnetDetailArtifactEconomics",
+    added: ["validator_headroom"],
+  },
+  ScoreDistribution: {
+    component: "ChainYieldArtifactDistribution",
+    added: ["p50"],
+  },
+  ExtrinsicDetail: { component: "ExtrinsicDetailArtifact", added: [] },
+  ChainBurn: { component: "ChainBurnArtifact", added: [] },
+  SubnetBurnHistory: { component: "SubnetBurnHistoryArtifact", added: [] },
+  SubnetBurnHistoryPoint: { component: "SubnetBurnHistoryPoint", added: [] },
+  ChainBurnEntry: { component: "ChainBurnEntry", added: [] },
+  BlockChainEvents: { component: "BlockEventsArtifact", added: [] },
+  AccountEntry: { component: "AccountsListArtifactAccounts", added: [] },
+  AccountSubnet: { component: "AccountPortfolioArtifactPositions", added: [] },
+};
+
 /**
  * Types a resolver builds, with no component behind them.
  *
  * A pagination view (`{items, total, next_cursor}`) is the resolver's shape,
- * not a mirror of the artifact it pages over, and the eight static readers
- * above return hand-shaped cards. The generator emits these from the resolver
- * side; the component emitter never sees them.
+ * not a mirror of the artifact it pages over, and the remaining entries are
+ * hand-shaped cards. The generator emits these from the resolver side; the
+ * component emitter never sees them.
+ *
+ * Anything that picks its fields from a component belongs in `PROJECTED_TYPES`
+ * instead, where it gets checked.
  */
 export const RESOLVER_BUILT_TYPES: readonly string[] = [
   "SubnetList",
-  "Subnet",
   "ProviderList",
-  "Provider",
-  "Surface",
-  "Endpoint",
   "GlobalHealth",
-  "SubnetHealth",
   "OpportunityBoards",
-  "OpportunityEntry",
   "SubnetTrajectoryDelta",
   "EmissionGateChange",
-  "ScoreDistribution",
-  "ExtrinsicDetail",
-  "ChainBurn",
-  "SubnetBurnHistory",
-  "SubnetBurnHistoryPoint",
-  "ChainBurnEntry",
-  "BlockChainEvents",
-  "AccountEntry",
-  "AccountSubnet",
   "Subscription",
   "ChainEvent",
 ];

--- a/schemas-src/routes/providers-rpc.ts
+++ b/schemas-src/routes/providers-rpc.ts
@@ -74,7 +74,13 @@ export const ProviderSchema = z
     authority: AuthoritySchema,
     public_notes: z.string().optional(),
     notes: z.string().optional(),
-    netuids: z.array(z.int().min(0)).optional(),
+    // Required, not optional (#10214). `scripts/build-artifacts.ts`'s
+    // enrichedProviders sets `netuids` on EVERY provider it emits -- an empty
+    // array for one with no surfaces, never an absent key -- so `.optional()`
+    // published a possibility the producer cannot express. GraphQL had it
+    // right (`[Int]!`) and the component disagreed; nothing compared them
+    // until the projection pass.
+    netuids: z.array(z.int().min(0)),
     subnet_count: z.int().min(0).optional(),
     surface_count: z.int().min(0).optional(),
     endpoint_count: z.int().min(0).optional(),

--- a/scripts/validate-graphql-component-parity.ts
+++ b/scripts/validate-graphql-component-parity.ts
@@ -33,6 +33,7 @@ import type {
   TypeNode,
 } from "graphql";
 import { emitTypes } from "../schemas-src/graphql/emit.ts";
+import { PROJECTED_TYPES } from "../schemas-src/graphql/published-names.ts";
 
 /** Only the sliver of the OpenAPI document this gate reads. */
 export interface OpenApiDocument {
@@ -96,6 +97,9 @@ export interface ParityReport {
   comparedTypes: number;
   comparedFields: number;
   projections: string[];
+  /** Declared projections checked -- see `PROJECTED_TYPES` (#10214). */
+  projectedTypes: number;
+  projectedFields: number;
 }
 
 /** Pull the SDL out of the TypeScript template literal that holds it. */
@@ -226,6 +230,8 @@ export function checkComponentParity(
   const matched = new Set<string>();
   let comparedTypes = 0;
   let comparedFields = 0;
+  let projectedTypes = 0;
+  let projectedFields = 0;
 
   for (const [sdlName, components] of paired) {
     const sdlFields = new Set(
@@ -304,12 +310,83 @@ export function checkComponentParity(
     }
   }
 
+  // ── the declared projections ─────────────────────────────────────────────
+  //
+  // A projection PICKS a subset of its component, so the mirror rule "every
+  // component field must appear" is not its rule. Every rule about the fields
+  // it does publish still is -- and until #10214 nothing applied them, because
+  // the traversal above only reaches a type through a `Mirrors GET` annotation
+  // and a resolver-built type has none. All fifteen were reached by zero
+  // gates.
+  for (const [sdlName, projection] of Object.entries(PROJECTED_TYPES)) {
+    const sdlType = sdlTypes.get(sdlName);
+    const genType = generated.get(projection.component);
+    if (!sdlType) {
+      violations.push(
+        `${sdlName} -- PROJECTED_TYPES declares it, the SDL has no such type`,
+      );
+      continue;
+    }
+    if (!genType) {
+      violations.push(
+        `${sdlName} -- projects ${projection.component}, which no component emits`,
+      );
+      continue;
+    }
+    projectedTypes += 1;
+    const genFields = genType.getFields();
+    const added = new Set(projection.added);
+    const usedAdded = new Set<string>();
+    for (const field of sdlType.fields ?? []) {
+      const name = field.name.value;
+      const genField = genFields[name];
+      if (!genField) {
+        if (added.has(name)) usedAdded.add(name);
+        else
+          violations.push(
+            `${sdlName}.${name} -- neither ${projection.component} nor the ` +
+              `declared \`added\` list supplies it`,
+          );
+        continue;
+      }
+      projectedFields += 1;
+      // Same two checks the mirrors get. A projection publishing a non-null
+      // over a nullable component field is the response-shaped outage: one
+      // null and graphql-js nulls the whole surrounding object.
+      if (sdlIsNonNull(field.type) && !generatedIsNonNull(genField.type)) {
+        violations.push(
+          `${sdlName}.${name} -- the SDL declares it non-null, ` +
+            `${projection.component} says it is nullable`,
+        );
+      }
+      if (
+        sdlScalarName(field.type) === "Int" &&
+        generatedScalarName(genField.type) === "Float"
+      ) {
+        violations.push(
+          `${sdlName}.${name} -- the SDL declares Int, ` +
+            `${projection.component} emits Float`,
+        );
+      }
+    }
+    for (const name of added) {
+      if (!usedAdded.has(name)) {
+        violations.push(
+          `${sdlName}.${name} -- declared as resolver-added, but the SDL ` +
+            `no longer publishes it (or ${projection.component} now supplies it)`,
+        );
+      }
+    }
+  }
+
   return {
     violations,
     stale: Object.keys(declared).filter((key) => !matched.has(key)),
     comparedTypes,
     comparedFields,
     projections,
+    projectedTypes,
+    projectedFields,
   };
 }
 
@@ -328,7 +405,8 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   console.log(
     `graphql-component-parity: ${report.comparedTypes} mirror type(s), ` +
       `${report.comparedFields} field(s) compared, ` +
-      `${report.projections.length} resolver-built projection(s) skipped.`,
+      `${report.projectedTypes} declared projection(s) (${report.projectedFields} field(s)), ` +
+      `${report.projections.length} pagination view(s) skipped.`,
   );
   if (report.violations.length) {
     console.error(

--- a/scripts/validate-published-names.ts
+++ b/scripts/validate-published-names.ts
@@ -26,6 +26,7 @@ import {
   ALIASED_TYPE_NAMES,
   PUBLISHED_TYPE_NAMES,
   QUERY_BINDINGS,
+  PROJECTED_TYPES,
   RESOLVER_BUILT_TYPES,
 } from "../schemas-src/graphql/published-names.ts";
 import {
@@ -229,20 +230,30 @@ if (bindingProblems.length) {
   );
 }
 
-// ── the resolver-built list ──────────────────────────────────────────────────
+// ── the resolver-built list, and the projections ─────────────────────────────
+//
+// A type the traversal cannot reach has to be accounted for by ONE of two
+// declarations: `PROJECTED_TYPES` if it picks its fields from a component (and
+// is therefore checked field-by-field by validate-graphql-component-parity),
+// or `RESOLVER_BUILT_TYPES` if the resolver shapes it from nothing. Splitting
+// them matters because only the first is checked: everything in the second is
+// taken on trust, so that list is the debt and should only shrink.
+const projected = new Set(Object.keys(PROJECTED_TYPES));
 const unpaired = [...sdlTypes.keys()]
   .filter((name) => name !== "Query" && !paired.has(name))
   .sort();
 const declaredResolverBuilt = [...RESOLVER_BUILT_TYPES].sort();
 const missingResolverBuilt = unpaired.filter(
-  (name) => !declaredResolverBuilt.includes(name),
+  (name) => !declaredResolverBuilt.includes(name) && !projected.has(name),
 );
 const staleResolverBuilt = declaredResolverBuilt.filter(
   (name) => !unpaired.includes(name),
 );
+const bothLists = declaredResolverBuilt.filter((name) => projected.has(name));
+const projectedButReached = [...projected].filter((name) => paired.has(name));
 if (missingResolverBuilt.length) {
   errors.push(
-    `${missingResolverBuilt.length} SDL type(s) no component reaches and RESOLVER_BUILT_TYPES does not list:\n` +
+    `${missingResolverBuilt.length} SDL type(s) no component reaches, and neither PROJECTED_TYPES nor RESOLVER_BUILT_TYPES accounts for:\n` +
       missingResolverBuilt.map((name) => `    ${name}`).join("\n"),
   );
 }
@@ -250,6 +261,18 @@ if (staleResolverBuilt.length) {
   errors.push(
     `${staleResolverBuilt.length} RESOLVER_BUILT_TYPES entr(y/ies) now reached from a component -- delete them:\n` +
       staleResolverBuilt.map((name) => `    ${name}`).join("\n"),
+  );
+}
+if (bothLists.length) {
+  errors.push(
+    `${bothLists.length} type(s) in BOTH PROJECTED_TYPES and RESOLVER_BUILT_TYPES -- a type is one or the other:\n` +
+      bothLists.map((name) => `    ${name}`).join("\n"),
+  );
+}
+if (projectedButReached.length) {
+  errors.push(
+    `${projectedButReached.length} PROJECTED_TYPES entr(y/ies) the traversal now reaches as a full mirror -- delete them:\n` +
+      projectedButReached.map((name) => `    ${name}`).join("\n"),
   );
 }
 
@@ -265,6 +288,7 @@ console.log(
   `Published-name validation passed: ${Object.keys(PUBLISHED_TYPE_NAMES).length} component name(s), ` +
     `${new Set(Object.values(PUBLISHED_TYPE_NAMES)).size} published type(s), ` +
     `${QUERY_BINDINGS.length} Query binding(s), ` +
+    `${Object.keys(PROJECTED_TYPES).length} declared projection(s), ` +
     `${RESOLVER_BUILT_TYPES.length} resolver-built type(s), ` +
     `${Object.keys(ALIASED_TYPE_NAMES).length} declared alias(es).`,
 );

--- a/tests/graphql-component-parity.test.ts
+++ b/tests/graphql-component-parity.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 import { GraphQLObjectType } from "graphql";
 import { emitTypes, pascalCase } from "../schemas-src/graphql/emit.ts";
+import { PROJECTED_TYPES } from "../schemas-src/graphql/published-names.ts";
 import {
   checkComponentParity,
   extractSdl,
@@ -152,6 +153,89 @@ describe("graphql component parity gate (#10214)", () => {
     assert.ok(
       report.projections.some((p) => p.startsWith("EndpointList ")),
       `expected EndpointList among the projections, got ${report.projections.join(", ")}`,
+    );
+  });
+});
+
+/** Rewrite one field inside ONE named type, so a fixture cannot land on a
+ * same-named field in another type and quietly test nothing. */
+function inType(
+  source: string,
+  typeName: string,
+  find: RegExp,
+  replace: string,
+): string {
+  const start = source.search(new RegExp(`^ {2}type ${typeName} \\{$`, "m"));
+  assert.notEqual(start, -1, `no type ${typeName} in the SDL`);
+  const end = source.indexOf("\n  }\n", start) + "\n  }\n".length;
+  const block = source.slice(start, end);
+  const rewritten = block.replace(find, replace);
+  assert.notEqual(rewritten, block, `${find} did not match inside ${typeName}`);
+  return source.slice(0, start) + rewritten + source.slice(end);
+}
+
+describe("declared projections (#10214)", () => {
+  test("every declared projection is checked, and against real fields", () => {
+    const report = checkComponentParity(sdl, openapi);
+    assert.deepEqual(report.violations, []);
+    assert.equal(
+      report.projectedTypes,
+      Object.keys(PROJECTED_TYPES).length,
+      "every declaration must be reached -- a skipped one is unchecked",
+    );
+    // These 15 types were reached by ZERO gates before this pass: the mirror
+    // traversal seeds from Query's `Mirrors GET` annotations and a
+    // resolver-built type has none, so nothing ever compared their fields.
+    assert.ok(
+      report.projectedFields > 100,
+      `only ${report.projectedFields} projected fields compared`,
+    );
+  });
+
+  test("it FAILS when a projection promises non-null over a nullable field", () => {
+    // The response-shaped outage this pass exists for: graphql-js cannot hold
+    // a null in a non-null position, so it nulls the whole surrounding object
+    // and attaches an error. `Surface.status` is nullable in its component.
+    const broken = inType(
+      sdl,
+      "Surface",
+      /^ {4}status: String$/m,
+      "    status: String!",
+    );
+    const report = checkComponentParity(broken, openapi);
+    assert.ok(
+      report.violations.some((v) => /the SDL declares it non-null/.test(v)),
+      `expected a non-null violation, got: ${report.violations.join("; ")}`,
+    );
+  });
+
+  test("it FAILS on a field neither the component nor `added` supplies", () => {
+    const broken = inType(
+      sdl,
+      "Surface",
+      /^ {2}type Surface \{$/m,
+      "  type Surface {\n    invented_field: String",
+    );
+    const report = checkComponentParity(broken, openapi);
+    assert.ok(
+      report.violations.some((v) =>
+        v.startsWith("Surface.invented_field -- neither"),
+      ),
+      `expected the invented field to be reported, got: ${report.violations.join("; ")}`,
+    );
+  });
+
+  test("a stale `added` entry fails, so the list can only shrink", () => {
+    // ScoreDistribution declares `p50` as resolver-added. Remove it from the
+    // SDL and the declaration has to go too -- otherwise `added` accumulates
+    // permissions for fields that no longer exist.
+    const broken = inType(sdl, "ScoreDistribution", /^ {4}p50: Float\n/m, "");
+    const report = checkComponentParity(broken, openapi);
+    assert.ok(
+      report.violations.some((v) =>
+        v.startsWith("ScoreDistribution.p50 -- declared as resolver-added"),
+      ),
+      `expected the stale added entry to be reported, got: ${report.violations.join("; ")}`,
     );
   });
 });

--- a/tests/zod-schemas.test.ts
+++ b/tests/zod-schemas.test.ts
@@ -3478,6 +3478,11 @@ describe("batch 10 (#8064) route artifact schemas parse real builder output", ()
           website_url: "https://www.404.xyz/",
           authority: "community",
           social: { x: "https://x.com/404gen_" },
+          // Required since #10214, and present on all 137 rows the builder
+          // emits -- `enrichedProviders` computes it for every provider, an
+          // empty array for one with no surfaces. The fixture had omitted it,
+          // which is why the schema could claim `.optional()` unchallenged.
+          netuids: [17],
         },
       ],
     };


### PR DESCRIPTION
## Summary

`RESOLVER_BUILT_TYPES` described 23 published types as *"types a resolver builds, with no component behind them."* True of the shape, false of the fields — and the difference decides whether anything checks them.

**15 of the 23 pick their fields from a component that already exists**: 141 fields picked straight through, 69 widened, 8 genuinely added. Eleven add nothing at all.

**No gate reached any of them.** `validate-graphql-component-parity` pairs a type with its component by traversing from Query's `Mirrors GET <path>` annotations, and a resolver-built type has none to traverse from. Replicating the gate's own pairing pass confirms it: **0 of 15 reached**. So 161 published fields were checked by nothing — including the class that nulled `SelfHealthLane.detail` on every request (#10215), where the SDL promises non-null over a component field that can be null and graphql-js nulls the whole surrounding object.

## The declaration

`PROJECTED_TYPES` maps published name → component + the fields the resolver genuinely adds. The parity gate gains a projection pass.

A projection is **not** a mirror. It publishes a subset deliberately, so the mirror rule *"every component field must appear"* does not apply to it. Every rule about the fields it **does** publish still does — nullability and scalar narrowing — and those are exactly what was unchecked.

Splitting the two lists also makes the debt legible: `PROJECTED_TYPES` is checked, `RESOLVER_BUILT_TYPES` is taken on trust. The trusted list is now **8 entries**, and the gate fails on a stale one, so it can only shrink.

## What the pass found on its first run

**`ChainBurnEntry`** — paired against the wrong component. `ChainBurnEntrySchema` is registered under that exact name and matches field for field. The mismatch was in my declaration, not the schema; it came from pairing by field-name overlap, which is the same mistake that produced the false positive in #10368. The pairing is now declared, which is the point.

**`Provider.netuids`** — a real disagreement. GraphQL publishes `[Int]!`; the component said `.optional()`.

```ts
// scripts/build-artifacts.ts:1106-1142 — set on EVERY provider it emits
const netuids = [...new Set(providerSurfaces.map((s) => s.netuid)
  .filter((n) => Number.isInteger(n)))].sort((a, b) => a - b);
return { ...safeProvider, netuids, subnet_count: netuids.length, … };
```

An empty array for a provider with no surfaces, never an absent key — and all **137 rows** in the built artifact carry it. GraphQL was right; the component published a possibility the producer cannot express. Now required.

`tests/zod-schemas.test.ts`'s providers fixture had omitted `netuids`, which is how `.optional()` went unchallenged for so long: a partial fixture cannot contradict a schema that is too loose. Fixed to match what the builder emits.

The only contract movement is that one field joining `required` (plus the derived example). On a **response** schema that is a strengthened promise: the generated type goes `netuids?: number[]` -> `netuids: number[]`, so a consumer *reading* it keeps compiling (their `?.` is now merely redundant). A consumer *constructing* a `Provider` — a mock or a test double — would have to supply the field. In-repo there are none; `npm run typecheck` and the full suite cover every construction site here.

## Proving the gate can fail

Three of the four new tests break the schema on purpose:

| fixture | expected failure |
|---|---|
| `Surface.status` → `String!` over a nullable component | non-null over nullable |
| an invented field on `Surface` | neither the component nor `added` supplies it |
| delete `ScoreDistribution.p50` | stale `added` entry |

A gate only ever run against a passing tree proves that it runs, not that it can fail. The fixtures are anchored inside their named type via a helper, after the first attempt matched a same-named field in an unrelated type and tested nothing.

## Validation

```
npm run typecheck / lint / format:check      clean
npx vitest run                               18,245 passed, 11 skipped, 0 failed
npm run build                                openapi.json: +5 / -1
validate:contract-drift                      passed
validate:graphql-component-parity            299 mirrors (2,228 fields),
                                             15 declared projections (161 fields),
                                             25 pagination views skipped
validate:published-names                     323 components, 313 published types,
                                             196 Query bindings, 15 projections,
                                             8 resolver-built, 1 alias
validate:graphql-route-parity                1,153 fields + 657 arguments, 0 divergences
validate:graphql-types-drift                 current
scan:public-safety                           passed
```

Closes #10370
Refs #10214
