### PR TITLE
fix(ci): compare each Worker against what it was asked to build, not main (#10372)

### DIFF
--- a/.github/workflows/check-worker-deploys.yml
+++ b/.github/workflows/check-worker-deploys.yml
@@ -30,6 +30,9 @@ on:
 
 permissions:
   contents: read
+  # check-runs, to read which commit Cloudflare actually built for each
+  # Worker -- see buildTargetSha in scripts/check-worker-deploys.ts.
+  checks: read
 
 concurrency:
   group: check-worker-deploys
@@ -40,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      checks: read
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -65,4 +69,8 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # `gh api` reads the check runs that say which commit each Worker was
+          # last asked to build. The default token is enough -- this is a read
+          # of the repo's own checks, not a secret.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run check:worker-deploys

--- a/scripts/check-worker-deploys.ts
+++ b/scripts/check-worker-deploys.ts
@@ -141,7 +141,11 @@ export function judgeDeploy(input: {
     };
   }
   if (behind === 0) {
-    return { ...base, verdict: "ok", detail: "running main's HEAD" };
+    return {
+      ...base,
+      verdict: "ok",
+      detail: "running the newest commit it was asked to build",
+    };
   }
   if (headAgeMs < graceMs) {
     return {
@@ -238,11 +242,101 @@ const git = (args: string[]) =>
     stdio: ["ignore", "pipe", "ignore"],
   }).trim();
 
+/**
+ * How far back to look for a commit that built this Worker.
+ *
+ * Thirty is generous: the longest observed run of commits that rebuild nothing
+ * is a handful of scripts/tests/docs merges. Past it the answer is `unknown`
+ * rather than a guess -- a Worker whose last build is 30 commits back is either
+ * genuinely untouched for a long time or something is wrong with the wiring,
+ * and both deserve a look rather than a green tick.
+ */
+export const BUILD_TARGET_SEARCH_DEPTH = 30;
+
+/**
+ * The newest commit on main that actually produced a build for this Worker.
+ *
+ * NOT `origin/main` HEAD, and this is the correction that matters (#10370).
+ * Workers Builds is PATH-FILTERED: a merge touching only `scripts/`, `tests/`
+ * or `migrations/` rebuilds nothing, so the deployed SHA legitimately sits
+ * behind main -- forever, until something in that Worker's inputs changes.
+ * Measured on main:
+ *
+ *   09517ffa  scripts + tests + migrations  ->  built: wss-lb only
+ *   5524f90f  schemas-src                   ->  built: all four
+ *
+ * Comparing against HEAD therefore reported `stale -- the build did not land`
+ * for a Worker that was correctly never asked to build. A watchdog that fires
+ * during ordinary operation is the #9301 failure, and this one would have hit
+ * it on a large share of merges.
+ *
+ * The target is read from Cloudflare's OWN decision rather than by
+ * reimplementing its path filter: a build leaves a
+ * `Workers Builds: <worker>` check run on the commit, so the newest commit
+ * carrying one is the newest commit this Worker was supposed to deploy.
+ * Duplicating the watch paths here would be a second copy to drift.
+ */
+export function newestCommitWithBuild(
+  worker: string,
+  commits: readonly string[],
+  checkRunsFor: (sha: string) => readonly string[] | null,
+): string | null {
+  for (const sha of commits) {
+    const names = checkRunsFor(sha);
+    // `null` is "could not ask", which is not evidence of "never built" --
+    // keep walking rather than let one transient API failure decide.
+    if (names === null) continue;
+    if (names.includes(`Workers Builds: ${worker}`)) return sha;
+  }
+  return null;
+}
+
+/** The check-run names GitHub records for one commit, or null if unreadable. */
+function checkRunNames(sha: string): readonly string[] | null {
+  try {
+    return execFileSync(
+      "gh",
+      [
+        "api",
+        `repos/JSONbored/metagraphed/commits/${sha}/check-runs`,
+        "--jq",
+        '[.check_runs[].name] | join("\\n")',
+      ],
+      { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    )
+      .split("\n")
+      .filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+export function buildTargetSha(
+  worker: string,
+  depth = BUILD_TARGET_SEARCH_DEPTH,
+): string | null {
+  const commits = git([
+    "log",
+    "--format=%H",
+    "-n",
+    String(depth),
+    "origin/main",
+  ])
+    .split("\n")
+    .filter(Boolean);
+  return newestCommitWithBuild(worker, commits, checkRunNames);
+}
+
 export function checkWorkerDeploys(nowMs = Date.now()): DeployStatus[] {
   git(["fetch", "origin", "main", "--quiet"]);
-  const headAgeMs =
-    nowMs - Number(git(["log", "-1", "--format=%ct", "origin/main"])) * 1000;
   return WORKER_CONFIGS.map((config) => {
+    const worker = workerName(config);
+    // The commit this Worker was last asked to deploy, falling back to HEAD
+    // when no build is visible in the window -- which keeps the old behaviour
+    // for a repo state this cannot explain, rather than silently passing.
+    const target = buildTargetSha(worker) ?? "origin/main";
+    const targetAgeMs =
+      nowMs - Number(git(["log", "-1", "--format=%ct", target])) * 1000;
     const read = deployedSha(config);
     const deployed = "sha" in read ? read.sha : null;
     let ancestor = false;
@@ -251,20 +345,20 @@ export function checkWorkerDeploys(nowMs = Date.now()): DeployStatus[] {
       try {
         git(["merge-base", "--is-ancestor", deployed, "origin/main"]);
         ancestor = true;
-        behind = Number(
-          git(["rev-list", "--count", `${deployed}..origin/main`]),
-        );
+        // Counted to the BUILD TARGET, not to HEAD: commits that rebuilt
+        // nothing for this Worker are not commits it is behind on.
+        behind = Number(git(["rev-list", "--count", `${deployed}..${target}`]));
       } catch {
         ancestor = false;
       }
     }
     return judgeDeploy({
       config,
-      worker: workerName(config),
+      worker,
       deployed,
       ancestor,
       behind,
-      headAgeMs,
+      headAgeMs: targetAgeMs,
       failure: "failure" in read ? read.failure : undefined,
     });
   });

--- a/tests/worker-deploy-drift.test.ts
+++ b/tests/worker-deploy-drift.test.ts
@@ -12,7 +12,9 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  BUILD_TARGET_SEARCH_DEPTH,
   DEPLOY_GRACE_MS,
+  newestCommitWithBuild,
   WORKER_CONFIGS,
   classifyDeployReadError,
   judgeDeploy,
@@ -183,5 +185,89 @@ describe("classifying wrangler's stderr", () => {
     ]) {
       assert.equal(classifyDeployReadError(stderr), "unreadable", stderr);
     }
+  });
+});
+
+describe("the build target, not main's HEAD (#10370)", () => {
+  // THE FALSE ALARM THIS CORRECTS. Workers Builds is PATH-FILTERED, so a merge
+  // touching only scripts/, tests/ or migrations/ rebuilds nothing and the
+  // deployed SHA legitimately sits behind main until that Worker's own inputs
+  // change. Measured on main:
+  //
+  //   09517ffa  scripts + tests + migrations  ->  built: wss-lb only
+  //   5524f90f  schemas-src                   ->  built: all four
+  //
+  // Comparing against HEAD reported `stale -- the build did not land` for a
+  // Worker that was never asked to build. That is #9301: an alarm during
+  // ordinary operation, which teaches people to ignore the alarm.
+  //
+  // The target is read from Cloudflare's OWN filtering decision -- the
+  // `Workers Builds: <worker>` check run it leaves on a commit -- rather than
+  // by reimplementing its watch paths here, which would be a second copy to
+  // drift from the first.
+  const runs: Record<string, string[]> = {
+    c3: ["test", "Workers Builds: metagraphed-wss-lb"],
+    c2: ["test"],
+    c1: ["test", "Workers Builds: metagraphed-data-api"],
+  };
+  const lookup = (sha: string) => runs[sha] ?? [];
+
+  test("skips commits that did not build this Worker", () => {
+    assert.equal(
+      newestCommitWithBuild("metagraphed-data-api", ["c3", "c2", "c1"], lookup),
+      "c1",
+    );
+  });
+
+  test("takes the newest one that did", () => {
+    assert.equal(
+      newestCommitWithBuild("metagraphed-wss-lb", ["c3", "c2", "c1"], lookup),
+      "c3",
+    );
+  });
+
+  test("a Worker that never built in the window is null, not the newest commit", () => {
+    // Returning c3 here is the tempting shortcut and it is the bug again: it
+    // would call a Worker current because something ELSE built.
+    assert.equal(
+      newestCommitWithBuild(
+        "metagraphed-registry-sync-api",
+        ["c3", "c2", "c1"],
+        lookup,
+      ),
+      null,
+    );
+  });
+
+  test("an unreadable commit is skipped, never treated as `never built`", () => {
+    // null is "could not ask". Letting one transient API failure end the walk
+    // would silently move the target to an older commit.
+    const flaky = (sha: string) => (sha === "c3" ? null : (runs[sha] ?? []));
+    assert.equal(
+      newestCommitWithBuild("metagraphed-wss-lb", ["c3", "c2", "c1"], flaky),
+      null,
+      "wss-lb only built at c3, which was unreadable",
+    );
+    assert.equal(
+      newestCommitWithBuild("metagraphed-data-api", ["c3", "c2", "c1"], flaky),
+      "c1",
+      "and the walk continued past it",
+    );
+  });
+
+  test("an exact name match, not a prefix", () => {
+    // "Workers Builds: metagraphed" must not satisfy "metagraphed-data-api",
+    // nor the reverse -- the main Worker and data-api differ by a suffix.
+    const only = (): string[] => ["Workers Builds: metagraphed"];
+    assert.equal(
+      newestCommitWithBuild("metagraphed-data-api", ["c1"], only),
+      null,
+    );
+    assert.equal(newestCommitWithBuild("metagraphed", ["c1"], only), "c1");
+  });
+
+  test("the search depth is bounded and stated", () => {
+    assert.ok(BUILD_TARGET_SEARCH_DEPTH >= 10);
+    assert.ok(BUILD_TARGET_SEARCH_DEPTH <= 100);
   });
 });


### PR DESCRIPTION
Closes #10372. A correction to #10353, which I shipped earlier today.

**Workers Builds is path-filtered.** Comparing each Worker's deployed SHA against `origin/main` HEAD is therefore the wrong target, and the check false-alarms. Measured on main:

```
09517ffa  scripts + tests + migrations   ->  built: wss-lb only
08ea965c  graphql component declaration  ->  built: metagraphed, wss-lb
5524f90f  schemas-src                    ->  built: all four
```

After a scripts-only merge, `metagraphed-data-api` legitimately sits behind main — forever, until something in its own inputs changes. The check called that STALE once HEAD passed the grace window:

```
judgeDeploy({ deployed: "5524f90f", behind: 2, headAgeMs: 45min })
-> stale -- 2 commit(s) behind and HEAD is 45m old -- the build did not land
```

That is **#9301** — and my own PR description for #10353 cited #9301 as the thing to avoid. An alarm that fires during ordinary operation teaches people to ignore it, and docs/scripts/tests merges rebuild nothing, so it would have fired on a large share of merges.

## The fix

The target is the **newest commit that actually produced a build for that Worker**. Both `behind` and the grace-window age are measured against it.

**Read from Cloudflare's own decision**, not by reimplementing its watch paths here: a build leaves a `Workers Builds: <worker>` check run on the commit, so the newest commit carrying one is the newest commit that Worker was supposed to deploy. Copying the path filter into this repo would be a second copy free to drift from the first — the same mistake as the migration runner and `0011` disagreeing (#10365).

## Two failure modes kept distinct

Collapsing either is how a check like this goes quiet:

- A commit whose check runs **cannot be read** is skipped, not treated as "never built". One transient API failure must not silently move the target to an older commit.
- A Worker with **no build in the 30-commit window** returns `null` rather than falling back to the newest commit — "something else built" is not evidence that *this* Worker is current.

The walk is extracted as a pure function so both are tested, along with exact name matching: `Workers Builds: metagraphed` must not satisfy `metagraphed-data-api`, and those two differ only by a suffix.

## Verification

20 tests (was 14). Against production, all four now report:

```
OK  metagraphed                    running the newest commit it was asked to build
OK  metagraphed-data-api           running the newest commit it was asked to build
OK  metagraphed-registry-sync-api  running the newest commit it was asked to build
OK  metagraphed-wss-lb             running the newest commit it was asked to build
```

The workflow gains `checks: read` and `GH_TOKEN` (the default token — this reads the repo's own check runs, not a secret).

## Separately confirmed

The hourly schedule **does** fire. GitHub delivered the `02:47` cron at `03:30` — a **43-minute delay**. Two earlier looks fell inside that window, which is why it appeared to be skipping. Worth knowing that the practical resolution of this check is "within a couple of hours", not hourly, which is still well inside the failure it targets.