### PR TITLE
fix(data): drop the deregistration lane's artifact fallback, which cannot work (#10374)

### DIFF
--- a/tests/subnet-deregistration-daily.test.ts
+++ b/tests/subnet-deregistration-daily.test.ts
@@ -355,3 +355,83 @@ describe("the lane", () => {
     );
   });
 });
+
+describe("the published artifact cannot feed this lane", () => {
+  // MEASURED against https://api.metagraph.sh/metagraph/economics.json on
+  // 2026-08-10. The artifact carries `moving_price_pinned` and NONE of the
+  // other three inputs a ranking needs:
+  //
+  //   chain_state keys: block, block_hash, emission_bar_quantile,
+  //                     emission_gate_bar, emission_gate_exponent,
+  //                     total_issuance_tao      <- no network_immunity_period
+  //   subnets[].registered_at_block  null
+  //   subnets[].subnet_mechanism     null
+  //
+  // Only the live KV blob (meta.source: live-cron-prober) has them, which is
+  // why /api/v1/chain/deregistration-ranking answers 112 ranked / 16 immune
+  // from it while the artifact would answer nothing.
+  //
+  // The lane is therefore wired to KV with NO artifact fallback: a fallback
+  // that provably cannot succeed would give `economics_unavailable` two
+  // possible causes and make an operator rule one out. This test is here so
+  // that re-adding the fallback -- which looks like an obvious robustness
+  // improvement -- fails rather than quietly doing nothing.
+  const publishedArtifactShape = {
+    chain_state: {
+      block: 8_805_503,
+      block_hash: "0x5280512b",
+      emission_bar_quantile: 0.75,
+      emission_gate_bar: 0.007511840648689622,
+      emission_gate_exponent: null,
+      total_issuance_tao: 1,
+    },
+    subnets: Array.from({ length: 129 }, (_, i) => ({
+      netuid: i,
+      moving_price_pinned: 0.08837078302167356,
+      registered_at_block: null,
+      subnet_mechanism: null,
+    })),
+  };
+
+  test("yields null -- there is no ranking to store", () => {
+    assert.equal(
+      deregistrationDailyRows(publishedArtifactShape, DATE, T),
+      null,
+      "the artifact must not be treated as a usable source",
+    );
+  });
+
+  test("and the one missing field alone is enough to refuse", () => {
+    // Adding the two per-subnet fields is still not sufficient: without
+    // network_immunity_period the ordering is a DIFFERENT ordering that looks
+    // identical, which is the #10285 argument for refusing rather than
+    // approximating.
+    const withSubnetFields = {
+      ...publishedArtifactShape,
+      subnets: publishedArtifactShape.subnets.map((s) => ({
+        ...s,
+        registered_at_block: 1_000_000,
+        subnet_mechanism: 1,
+      })),
+    };
+    assert.equal(deregistrationDailyRows(withSubnetFields, DATE, T), null);
+  });
+
+  test("the KV blob's shape DOES work, which is the contrast", () => {
+    const live = {
+      chain_state: {
+        block: 8_805_503,
+        network_immunity_period: 864_000,
+      },
+      subnets: publishedArtifactShape.subnets.map((s) => ({
+        ...s,
+        registered_at_block: 1_000_000,
+        subnet_mechanism: 1,
+      })),
+    };
+    const rows = deregistrationDailyRows(live, DATE, T);
+    assert.ok(rows, "the live blob must project");
+    assert.equal(rows.length, 129);
+    assert.equal(rows[0]!.network_immunity_period, 864_000);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -2673,13 +2673,22 @@ async function dispatchScheduled(
             // handing it over directly would bind a cache key into a clock.
             readHealthKv: (e: Env) => readEconomicsCurrentKv(e),
             contractVersion: contractVersion(env),
-            readArtifact: async () => {
-              const artifact = await readArtifact(
-                env,
-                "/metagraph/economics.json",
-              );
-              return artifact?.ok ? artifact.data : null;
-            },
+            // NO ARTIFACT FALLBACK, deliberately. The published
+            // /metagraph/economics.json cannot produce a ranking -- measured
+            // 2026-08-10, it carries `moving_price_pinned` and NOTHING ELSE
+            // this needs:
+            //
+            //   chain_state.network_immunity_period   absent
+            //   subnets[].registered_at_block         null
+            //   subnets[].subnet_mechanism            null
+            //
+            // Only the live KV blob (meta.source: live-cron-prober) has them,
+            // which is why /api/v1/chain/deregistration-ranking answers from
+            // it. Passing a fallback that provably cannot succeed would mean an
+            // `economics_unavailable` verdict has two possible causes and the
+            // operator has to rule one out; with KV as the only source it has
+            // exactly one.
+            readArtifact: async () => null,
           }),
       },
     );


### PR DESCRIPTION
Closes #10374. Follow-up to #10362, found by dry-running the lane's own extraction against real production data **before its first scheduled tick** rather than waiting to see what happened at 05:17.

The lane read the economics blob through `resolveEmissionPipelineEconomics`, which tries KV first and falls back to `/metagraph/economics.json`. That fallback can never succeed. Measured against the published artifact, 2026-08-10:

```
chain_state keys: block, block_hash, emission_bar_quantile,
                  emission_gate_bar, emission_gate_exponent, total_issuance_tao
                  ^ no network_immunity_period

subnets[].moving_price_pinned    present
subnets[].registered_at_block    null
subnets[].subnet_mechanism       null
```

Three of the four measured inputs are absent. Only the live KV blob has them — `/api/v1/chain/deregistration-ranking` answers `112 ranked / 16 immune / next 70` with `network_immunity_period: 864000` and `meta.source: live-cron-prober`.

## The lane still works; what the fallback costs is diagnosis

KV is tried first and has the data, so the 05:17 tick is fine either way. But a fallback that provably cannot succeed gives an `economics_unavailable` verdict **two** possible causes, and an operator debugging it has to rule one out. With KV as the only declared source it has exactly one.

It also invites the opposite mistake later: someone reads "no fallback" as a robustness gap and adds one back, and it silently does nothing.

## Three tests, and the third is the one worth reading

They pin the two shapes against each other so re-adding the fallback fails a build:

1. the published artifact shape yields `null`;
2. the KV shape projects 129 rows carrying `network_immunity_period: 864000`;
3. **adding only the two per-subnet fields is still insufficient.** Without `network_immunity_period` the ordering is a *different* ordering that looks identical — which is #10285's own argument for refusing rather than approximating, and the trap someone patching (1) would fall into.

19 tests in the file, `tsc`/`lint`/`format:check` clean.