### PR TITLE
fix(workers): stop data-api bundling the MCP server, GraphQL and the main Worker (#10238)

### DIFF
--- a/src/alert-triggers.ts
+++ b/src/alert-triggers.ts
@@ -20,7 +20,11 @@ import {
   isPublicWebhookUrl,
   timingSafeEqual,
 } from "./webhooks.ts";
-import { CHAIN_FIREHOSE_TABLES } from "../workers/chain-firehose-hub.ts";
+// FROM THE LEAF (#10238). Importing this from workers/chain-firehose-hub.ts
+// pulled that Durable Object -- and the GraphQL schema and MCP server it
+// imports -- into every bundle reaching alert-triggers, which is what put
+// metagraphed-data-api over the Worker startup CPU limit.
+import { CHAIN_FIREHOSE_TABLES } from "./chain-firehose-topics.ts";
 
 // Anti-abuse gate on trigger CREATION (public but shared-secret-gated,
 // mirroring METAGRAPH_WEBHOOK_SUBSCRIPTION_TOKEN's exact role) -- every

--- a/src/api-tiers.ts
+++ b/src/api-tiers.ts
@@ -24,7 +24,10 @@
 // tests/api-tiers.test.ts asserts every envVar below exists in wrangler.jsonc
 // with the limit its policy claims, so that mismatch cannot come back.
 
-import type { RateLimitTierPolicy } from "../workers/tiered-rate-limit.ts";
+import type {
+  RateLimitTierPolicy,
+  TieredRateLimitConfig,
+} from "../workers/tiered-rate-limit.ts";
 
 /**
  * Per-minute ceiling as a multiple of the surface's existing keyed limit.
@@ -89,3 +92,39 @@ export function buildTierPolicies(
     ]),
   ) as Record<ApiTier, RateLimitTierPolicy>;
 }
+
+/**
+ * The MCP surface's tiered rate-limit policy.
+ *
+ * #8520: anonymous callers keep the existing MCP_RATE_LIMITER ceiling (100/60s,
+ * IP-keyed, unchanged); a caller presenting a valid mg_... key gets the 5x
+ * MCP_RATE_LIMITER_KEYED tier, keyed by account id via the SEPARATE binding --
+ * never the same binding at a different number.
+ *
+ * HERE RATHER THAN IN src/mcp-server.ts, which is where it lived (#10238).
+ * workers/data-api.ts imports it for ONE number, and that import dragged
+ * mcp-server -- and through it src/graphql.ts and workers/api.ts -- into
+ * data-api's bundle, pushing it over the Worker STARTUP CPU limit. Measured:
+ * cutting that edge and one other took data-api from 1072 KiB gzip / ~600 ms
+ * module init to 377 KiB / ~220 ms.
+ *
+ * This module is the right home anyway: buildTierPolicies is already here, and
+ * a rate-limit ceiling is tier configuration rather than protocol handling.
+ * mcp-server.ts re-exports it so nothing else had to change.
+ */
+export const MCP_TIERED_RATE_LIMIT: TieredRateLimitConfig = {
+  anonymous: { envVar: "MCP_RATE_LIMITER", limit: 100, windowSeconds: 60 },
+  // Fallback for a valid key on a tier not priced below -- never an outage.
+  keyed: { envVar: "MCP_RATE_LIMITER_KEYED", limit: 500, windowSeconds: 60 },
+  // #8608: the ceilings as code, one entry per rpc_accounts.tier. Until now
+  // every key got the single `keyed` policy regardless of tier, so a paid
+  // account and a free one were throttled identically -- the tier was resolved
+  // by validateApiKey and then discarded.
+  //
+  // `free` reuses MCP_RATE_LIMITER_KEYED at its existing 500/min, so nobody
+  // holding a key today loses headroom. `community` and `paid` get bindings of
+  // their OWN -- see the note on buildTierPolicies for why sharing one is not
+  // an option.
+  tiers: buildTierPolicies("MCP_RATE_LIMITER", 500),
+  keyPrefix: "mcp",
+};

--- a/src/chain-firehose-topics.ts
+++ b/src/chain-firehose-topics.ts
@@ -1,0 +1,56 @@
+// The chain-firehose topic vocabulary, as a LEAF module.
+//
+// ## Why these two sets do not live in workers/chain-firehose-hub.ts
+//
+// They did, and `src/alert-triggers.ts` imported CHAIN_FIREHOSE_TABLES from
+// there to validate a subscription's `table_filter`. That single constant
+// import dragged the whole Durable Object into every bundle that touches
+// alert-triggers -- and the hub imports `src/graphql.ts` for the subscription
+// schema, which imports `src/mcp-server.ts`, which imports `workers/api.ts`.
+//
+// Measured 2026-08-10 (#10238): `metagraphed-data-api` therefore bundled the
+// entire MCP server (697 KiB), all of GraphQL (388 KiB) and the main Worker
+// (352 KiB) to check four strings, and its module init ran ~600 ms against
+// Cloudflare's ~400 ms STARTUP CPU limit. Deploys failed with
+// `code: 10021 Script startup exceeded CPU time limit` -- non-deterministically,
+// because a Worker at the edge of that limit passes or fails with the load on
+// the validating host. Cutting this edge and one other took data-api to
+// 377 KiB gzip and ~220 ms.
+//
+// A VOCABULARY IS NOT AN IMPLEMENTATION. Four topic names have no reason to be
+// reachable only through a WebSocket fan-out Durable Object; keeping them here
+// means a validator can ask "is this a real topic" without importing a server.
+
+/**
+ * Every topic the firehose accepts.
+ *
+ * Matched the retired `notify_chain_firehose()` Postgres trigger (#9426) -- the
+ * only four tables it ever fired `table:` for. `account_events` (#4984
+ * prerequisite) carries netuid/hotkey/coldkey/amount_tao directly, unlike the
+ * other three, because the alerter's trigger conditions need those columns
+ * without a per-event round-trip.
+ */
+export const CHAIN_FIREHOSE_TABLES: ReadonlySet<string> = new Set([
+  "blocks",
+  "extrinsics",
+  "chain_events",
+  "account_events",
+]);
+
+/**
+ * The subset that actually has a producer today.
+ *
+ * #9583: of the four topics above only `blocks` is published. The box-side relay
+ * that fed all four died with Postgres (#9426), and the head poller that
+ * replaced it (#204) publishes the blocks lane alone -- decoding the other three
+ * needs runtime metadata, which is the Containers indexer's job (#209), and a
+ * Worker faking them from undecoded bytes would serve wrong data.
+ *
+ * A topic filter is still ACCEPTED for all four, so a producer arriving later
+ * does not require a client change. But a subscriber asking only for
+ * unpublished topics gets a well-formed stream that never emits, which is
+ * indistinguishable from a quiet chain -- so the hub says so once, at connect.
+ */
+export const CHAIN_FIREHOSE_PUBLISHED_TABLES: ReadonlySet<string> = new Set([
+  "blocks",
+]);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -218,9 +218,8 @@ import {
   spendDeferredDailyQuota,
   tieredRejectionResponse,
   type RateLimitTierPolicy,
-  type TieredRateLimitConfig,
 } from "../workers/tiered-rate-limit.ts";
-import { buildTierPolicies } from "./api-tiers.ts";
+import { MCP_TIERED_RATE_LIMIT } from "./api-tiers.ts";
 import { recordApiKeyUsage } from "../workers/api.ts";
 import { DAY_PATTERN } from "../workers/request-params.ts";
 import { applyMcpQueryFilters } from "./mcp-list-query.ts";
@@ -2421,26 +2420,12 @@ const JSONRPC_VERSION = "2.0";
 // JSON-RPC batches.
 export const MAX_MCP_BODY_BYTES = 64 * 1024;
 export const MAX_MCP_BATCH_LENGTH = 10;
-// #8520: tiered rate-limit config for the MCP surface. Anonymous callers keep
-// the existing MCP_RATE_LIMITER ceiling (100/60s, IP-keyed, unchanged); a caller
-// presenting a valid mg_... key gets the 5x MCP_RATE_LIMITER_KEYED tier, keyed by
-// account id via the SEPARATE binding (never the same binding at a different
-// number). Exported for the tiered-rate-limit regression tests.
-export const MCP_TIERED_RATE_LIMIT: TieredRateLimitConfig = {
-  anonymous: { envVar: "MCP_RATE_LIMITER", limit: 100, windowSeconds: 60 },
-  // Fallback for a valid key on a tier not priced below -- never an outage.
-  keyed: { envVar: "MCP_RATE_LIMITER_KEYED", limit: 500, windowSeconds: 60 },
-  // #8608: the ceilings as code, one entry per rpc_accounts.tier. Until now
-  // every key got the single `keyed` policy regardless of tier, so a paid
-  // account and a free one were throttled identically -- the tier was resolved
-  // by validateApiKey and then discarded.
-  //
-  // `free` reuses MCP_RATE_LIMITER_KEYED at its existing 500/min, so nobody
-  // holding a key today loses headroom. `community` and `paid` get bindings of
-  // their OWN -- see src/api-tiers.ts for why sharing one is not an option.
-  tiers: buildTierPolicies("MCP_RATE_LIMITER", 500),
-  keyPrefix: "mcp",
-};
+// MCP_TIERED_RATE_LIMIT moved to src/api-tiers.ts (#10238). It lived here and
+// workers/data-api.ts imported it for ONE number -- which dragged this whole
+// module, and through it src/graphql.ts and workers/api.ts, into data-api's
+// bundle and over the Worker startup CPU limit. Re-exported so every existing
+// importer is unaffected; data-api now takes it from the leaf directly.
+export { MCP_TIERED_RATE_LIMIT };
 
 // JSON-RPC error codes (subset of the spec we emit).
 const RPC_PARSE_ERROR = -32700;

--- a/tests/data-api-bundle-boundary.test.ts
+++ b/tests/data-api-bundle-boundary.test.ts
@@ -1,0 +1,128 @@
+// metagraphed-data-api must not bundle the main Worker, the MCP server or
+// GraphQL (#10238).
+//
+// ## What this exists to have caught
+//
+// data-api sits near Cloudflare's ~400 ms Worker STARTUP CPU limit. When it is
+// over, deploys fail with:
+//
+//     ✘ Your Worker failed validation because it exceeded startup limits.
+//       - Error: Script startup exceeded CPU time limit.  [code: 10021]
+//
+// and they fail NON-DETERMINISTICALLY, because startup CPU is judged on
+// Cloudflare's validating host: a Worker at the edge passes or fails with that
+// host's load. #10355 failed once and passed on a byte-identical retry; #10375
+// failed twice. That is what makes this class so expensive to diagnose — it
+// reads as flaky CI for as long as you let it.
+//
+// The cause was two CONSTANT imports:
+//
+//   workers/data-api.ts  -> src/mcp-server.ts            (one rate-limit number)
+//   src/alert-triggers.ts -> workers/chain-firehose-hub.ts (four topic names)
+//                         -> src/graphql.ts -> src/mcp-server.ts -> workers/api.ts
+//
+// For those, data-api bundled the MCP server (697 KiB), GraphQL (388 KiB) and
+// workers/api.ts (352 KiB) -- 5.0 MB of first-party source once transitive
+// imports are counted, against 3.3 MB after. Cutting both took the Worker from
+// 1072 KiB gzip / ~600 ms module init to 377 KiB / ~190 ms.
+//
+// ## Why the assertion is on the import GRAPH
+//
+// Not on bundle bytes and not on a timing: bytes are a poor proxy (the earlier
+// investigation in #10121 correctly observed the failing bundle was SMALLER
+// than main's and concluded size was irrelevant — startup CPU tracks how much
+// code RUNS at import, not how much exists), and a timing assertion would be
+// flaky in CI for exactly the reason the deploys are.
+//
+// The graph is the thing that actually changed and the thing a future edit
+// would change again.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, describe, test } from "vitest";
+
+const workdir = mkdtempSync(path.join(tmpdir(), "data-api-graph-"));
+const metafile = path.join(workdir, "meta.json");
+
+afterAll(() => rmSync(workdir, { recursive: true, force: true }));
+
+/** data-api's real module graph, from esbuild rather than from a grep. */
+function inputs(): Record<string, { bytes: number }> {
+  execFileSync(
+    "npx",
+    [
+      "esbuild",
+      "workers/data-api.ts",
+      "--bundle",
+      "--format=esm",
+      "--platform=node",
+      `--metafile=${metafile}`,
+      "--outfile=/dev/null",
+      "--log-level=error",
+      "--external:cloudflare:workers",
+      "--external:node:*",
+    ],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+  return JSON.parse(readFileSync(metafile, "utf8")).inputs;
+}
+
+const graph = inputs();
+
+describe("data-api's bundle boundary", () => {
+  test("the graph was actually resolved", () => {
+    // Without this the assertions below pass on an empty object, which is the
+    // usual way a scanning check stops checking.
+    assert.ok(
+      Object.keys(graph).length > 100,
+      `only ${Object.keys(graph).length} inputs resolved -- esbuild failed?`,
+    );
+    assert.ok(graph["workers/data-api.ts"], "its own entry point is missing");
+  });
+
+  for (const forbidden of [
+    "src/mcp-server.ts",
+    "src/graphql.ts",
+    "src/graphql-sdl.ts",
+    "workers/api.ts",
+    "workers/chain-firehose-hub.ts",
+  ]) {
+    test(`does not bundle ${forbidden}`, () => {
+      assert.ok(
+        !graph[forbidden],
+        `workers/data-api.ts pulls in ${forbidden} ` +
+          `(${((graph[forbidden]?.bytes ?? 0) / 1024).toFixed(0)} KiB of source ` +
+          `that runs at import). That is what put this Worker over the startup ` +
+          `CPU limit in #10238. Find the edge with:\n` +
+          `  npx esbuild workers/data-api.ts --bundle --metafile=meta.json ...\n` +
+          `and move whatever constant or type is being reached for into a LEAF ` +
+          `module -- src/api-tiers.ts and src/chain-firehose-topics.ts are the ` +
+          `two that already exist for this reason.`,
+      );
+    });
+  }
+
+  test("first-party source stays well under what broke it", () => {
+    // A backstop for an edge nobody thought to name above. MEASURED rather than
+    // guessed, because the first draft of this threshold was a guess and it was
+    // wrong by a factor of three: the five named modules are ~1.7 MB on their
+    // own, but their transitive closure was 5.0 MB.
+    //
+    //   before the fix   8328 KiB of first-party source
+    //   after            3280 KiB
+    //
+    // 4,600,000 bytes (~4492 KiB) leaves ~37% headroom for ordinary growth
+    // while still failing on a re-import of anything approaching what was
+    // removed.
+    const firstParty = Object.entries(graph)
+      .filter(([k]) => /^(src|workers|schemas-src|generated)\//.test(k))
+      .reduce((sum, [, v]) => sum + v.bytes, 0);
+    assert.ok(
+      firstParty < 4_600_000,
+      `first-party source in data-api's bundle is ${(firstParty / 1024).toFixed(0)} KiB; ` +
+        `something large was re-imported. See the named checks above.`,
+    );
+  });
+});

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -55,6 +55,10 @@ import {
 } from "../src/usage-telemetry.ts";
 import { resolveClientIp } from "./config.ts";
 import {
+  CHAIN_FIREHOSE_PUBLISHED_TABLES,
+  CHAIN_FIREHOSE_TABLES,
+} from "../src/chain-firehose-topics.ts";
+import {
   GRAPHQL_MAX_COMPLEXITY,
   GRAPHQL_MAX_QUERY_BYTES,
   GRAPHQL_MAX_DEPTH,
@@ -69,30 +73,15 @@ import { mirrorBlocksHeadToNeon } from "../src/capture-state-neon-write.ts";
 
 export const CHAIN_FIREHOSE_INGEST_TOKEN_HEADER = "x-chain-firehose-sync-token";
 
-// Matched the retired notify_chain_firehose() Postgres trigger (#9426) --
-// the only four tables it ever fires `table:` for. account_events (#4984
-// prerequisite) carries netuid/hotkey/coldkey/amount_tao directly, unlike
-// the other three -- the alerter's trigger conditions need those columns
-// without a per-event Postgres round-trip.
-export const CHAIN_FIREHOSE_TABLES = new Set([
-  "blocks",
-  "extrinsics",
-  "chain_events",
-  "account_events",
-]);
-
-// #9583: of the four topics above, only `blocks` has a producer today. The
-// box-side relay that fed all four died with Postgres (#9426) and the head
-// poller that replaced it (#204) publishes the blocks lane alone -- decoding
-// the other three needs runtime metadata, which is the Containers indexer's
-// job (#209), and a Worker faking them from undecoded bytes would serve wrong
-// data.
-//
-// A topic filter is still ACCEPTED for all four, because a producer arriving
-// later must not require a client change. But a subscriber that asks only for
-// unpublished topics gets a well-formed stream that never emits, which is
-// indistinguishable from a quiet chain -- so say so once, at connect.
-export const CHAIN_FIREHOSE_PUBLISHED_TABLES = new Set(["blocks"]);
+// The topic vocabulary moved to src/chain-firehose-topics.ts (#10238) -- see
+// that file for why. Re-exported here so nothing that already imports it from
+// the hub had to change; new callers should take it from the leaf, which does
+// not drag this Durable Object (and through it GraphQL and the MCP server)
+// into their bundle.
+export {
+  CHAIN_FIREHOSE_TABLES,
+  CHAIN_FIREHOSE_PUBLISHED_TABLES,
+} from "../src/chain-firehose-topics.ts";
 
 /**
  * Requested topics that no producer currently publishes, sorted for a stable

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -426,7 +426,10 @@ import {
   scoreUsageAnomalies,
 } from "../src/api-key-abuse.ts";
 import { BLOCKLIST_KV_KEY, BLOCKLIST_KV_TTL } from "./tiered-rate-limit.ts";
-import { MCP_TIERED_RATE_LIMIT } from "../src/mcp-server.ts";
+// FROM THE LEAF, NOT src/mcp-server.ts (#10238). Importing it from there for
+// one number pulled the MCP server, src/graphql.ts and workers/api.ts into
+// this bundle and pushed it over the Worker startup CPU limit.
+import { MCP_TIERED_RATE_LIMIT } from "../src/api-tiers.ts";
 import { createPgSql } from "../src/pg-sql.ts";
 import type { ChainAlertTriggers } from "../generated/db/types.ts";
 import { recordLaneVerdict } from "../src/lane-health.ts";


### PR DESCRIPTION
Closes #10238. Diagnosed from a build log — thank you for pasting it; the Workers Builds API returns 403 to wrangler's local OAuth token, so this was otherwise unreachable.

```
✘ Your Worker failed validation because it exceeded startup limits.
  - Error: Script startup exceeded CPU time limit.  [code: 10021]
```

## It was never a flake

Startup CPU is judged on Cloudflare's validating host, so a Worker at the edge of the ~400 ms limit passes or fails with that host's load. #10355 failed once and passed on a **byte-identical** retry; #10375 failed twice. Locally, module init ran **570–692 ms** and varied ~25% run-to-run on one bundle — the same coin, weighted.

I had this wrong twice and it is worth recording why, because both mistakes are easy to repeat:

- I called it "non-deterministic on Cloudflare's side rather than ours." It is ours.
- I ruled out size against the **3 MB bundle** ceiling. Wrong ceiling — startup CPU is a separate limit, and bundle size only feeds it through how much code *runs at import*.

## Two constant imports cost 5 MB

```
workers/data-api.ts   -> src/mcp-server.ts               one rate-limit number
src/alert-triggers.ts -> workers/chain-firehose-hub.ts   four topic names
                      -> src/graphql.ts -> src/mcp-server.ts -> workers/api.ts
```

To check four strings and read the number `500`, data-api bundled the MCP server (697 KiB), all of GraphQL (388 KiB) and `workers/api.ts` (352 KiB).

Both constants move to **leaf** modules — `MCP_TIERED_RATE_LIMIT` to `src/api-tiers.ts` where `buildTierPolicies` already lives (a rate ceiling is tier configuration, not protocol handling), and the firehose vocabulary to a new `src/chain-firehose-topics.ts`. Both old homes re-export, so nothing else changed.

| | before | after |
|---|---:|---:|
| first-party source | 8328 KiB | **3280 KiB** |
| bundle | 5316 KiB | **1830 KiB** |
| gzip | 1072 KiB | **378 KiB** |
| module init | ~600 ms | **~190 ms** |

All four Workers still build. data-api is now the second smallest rather than the largest.

## The guard asserts the import graph

Not bytes, not a timing. Bytes are a poor proxy — the #10121 investigation correctly observed the failing bundle was *smaller* than main's and concluded size was irrelevant, which was right for the wrong reason: startup CPU tracks how much code **runs** at import. And a timing assertion would be flaky in CI for exactly the reason the deploys are.

Proven to fail: against the pre-fix tree it reports **6 of 7 red**, each naming the module and its size, with the remedy in the failure text.

Its byte backstop is **measured, not guessed** — my first threshold was a guess and was wrong by 3x, because the five named modules are 1.7 MB alone but 5.0 MB transitively.

## Also

This closes a mystery from 2026-08-08 (#10121): adding one import to `contracts.ts` failed this build twice, and that session recorded *"What I could NOT establish: the mechanism — the Cloudflare build log is only in the dashboard."* Same mechanism. Any import adding module-scope work tips a Worker already at the ceiling.

Worth retitling #10238 on merge: it is not "the build fails intermittently", it is "data-api exceeded the Worker startup CPU limit".