### PR TITLE
feat(ui): render subnet lifecycle and deregistration standing (#10387)

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-lifecycle-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-lifecycle-panel.tsx
@@ -1,0 +1,221 @@
+import { useQuery } from "@tanstack/react-query";
+import { subnetDeregistrationStandingQuery, subnetLifecycleQuery } from "@/lib/metagraphed/queries";
+import type { DeregistrationStanding, SubnetLifecycleEntry } from "@/lib/metagraphed/types";
+import { StatTile, TimeAgo } from "@jsonbored/ui-kit";
+import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
+import { formatNumber } from "@/lib/metagraphed/format";
+
+/**
+ * When this subnet registered, and how close it is to being deregistered.
+ *
+ * Two routes that were published and rendered nowhere (#10300): the lifecycle
+ * timeline (#10262) and the chain's own pruning order (#10285). They belong
+ * together — "when did it arrive" and "is it at risk" are the same question
+ * asked from either end, and neither is legible alone.
+ *
+ * ## Three distinctions this panel exists to preserve
+ *
+ * A naive rendering collapses each of them, and each collapse states something
+ * false:
+ *
+ *   1. `predates_capture` is NOT "registered at block 0". Every subnet alive
+ *      when the lane first ran was registered before we were watching, so its
+ *      block is null. Printing 0 would claim it launched at genesis.
+ *
+ *   2. IMMUNE IS NOT RANK 0. An immune subnet has `rank: null` — it is not
+ *      near the top of the pruning order, it is not IN the order at all, and it
+ *      cannot be deregistered until its window lapses. Showing it as "#1" or
+ *      "#0" inverts the meaning entirely.
+ *
+ *   3. `comparison_price` is what the pallet compares; `moving_price` is the
+ *      raw read. They differ only for a Stable-mechanism subnet, where the
+ *      pallet substitutes a flat 1.0 — which moves it from the top of a price
+ *      order to near the bottom. Showing one number hides that substitution;
+ *      #10285 exists because ordering on the raw price gets position one wrong.
+ */
+export function SubnetLifecyclePanel({ netuid }: { netuid: number }) {
+  const lifecycleQ = useQuery(subnetLifecycleQuery(netuid));
+  const standingQ = useQuery(subnetDeregistrationStandingQuery(netuid));
+
+  return (
+    <div className="space-y-6">
+      <StandingCard
+        isLoading={standingQ.isLoading}
+        isError={standingQ.isError}
+        error={standingQ.error}
+        onRetry={() => standingQ.refetch()}
+        standing={standingQ.data?.data.standing ?? null}
+        rankedCount={standingQ.data?.data.ranked_count ?? null}
+      />
+      <TimelineSection
+        isLoading={lifecycleQ.isLoading}
+        isError={lifecycleQ.isError}
+        error={lifecycleQ.error}
+        onRetry={() => lifecycleQ.refetch()}
+        entries={lifecycleQ.data?.data ?? []}
+      />
+    </div>
+  );
+}
+
+function StandingCard({
+  isLoading,
+  isError,
+  error,
+  onRetry,
+  standing,
+  rankedCount,
+}: {
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+  onRetry: () => void;
+  standing: DeregistrationStanding | null;
+  rankedCount: number | null;
+}) {
+  if (isError) {
+    return <ErrorState error={error} onRetry={onRetry} context="deregistration standing" />;
+  }
+  if (isLoading) return <Skeleton className="h-32 w-full" />;
+
+  // In NEITHER list. Root is the obvious case — it is never a pruning
+  // candidate — and saying "not a candidate" is a different statement from
+  // "rank unknown", so it gets its own branch rather than an empty rank.
+  if (!standing) {
+    return (
+      <Panel title="Deregistration standing">
+        <EmptyState
+          title="Not a pruning candidate"
+          description="This subnet does not appear in the chain's deregistration order. Root is never a candidate."
+        />
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel
+      title="Deregistration standing"
+      caption="The pallet's own order, not a price sort — immunity and the Stable-mechanism substitution both change it."
+    >
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {standing.immune ? (
+          <>
+            {/* Deliberately NOT a rank. An immune subnet is outside the
+                ranking, and a number here would read as a position in it. */}
+            <StatTile eyebrow="Status" value="Immune" />
+            <StatTile
+              eyebrow="Until block"
+              value={
+                standing.immune_until_block === null
+                  ? "—"
+                  : formatNumber(standing.immune_until_block)
+              }
+            />
+            <StatTile
+              eyebrow="Blocks remaining"
+              value={
+                standing.blocks_until_prunable === null
+                  ? "—"
+                  : formatNumber(standing.blocks_until_prunable)
+              }
+            />
+          </>
+        ) : (
+          <>
+            <StatTile
+              eyebrow="Rank"
+              value={standing.rank === null ? "—" : `#${standing.rank}`}
+              hint={rankedCount === null ? undefined : `of ${formatNumber(rankedCount)} prunable`}
+            />
+            <StatTile eyebrow="Status" value="Prunable" />
+          </>
+        )}
+        <StatTile
+          eyebrow="Comparison price"
+          value={formatAlphaPrice(standing.comparison_price)}
+          hint={
+            standing.comparison_price !== null &&
+            standing.moving_price !== null &&
+            standing.comparison_price !== standing.moving_price
+              ? `moving price ${formatAlphaPrice(standing.moving_price)} — Stable substitution`
+              : undefined
+          }
+        />
+      </div>
+      {standing.subnet_mechanism === 0 ? (
+        <p className="mt-3 text-xs text-ink-muted">
+          This is a Stable subnet (mechanism 0). The pallet compares a flat 1.0 for it rather than
+          reading its moving price, which is why the two figures above differ.
+        </p>
+      ) : null}
+    </Panel>
+  );
+}
+
+function TimelineSection({
+  isLoading,
+  isError,
+  error,
+  onRetry,
+  entries,
+}: {
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+  onRetry: () => void;
+  entries: SubnetLifecycleEntry[];
+}) {
+  if (isError) {
+    return <ErrorState error={error} onRetry={onRetry} context="subnet lifecycle" />;
+  }
+  if (isLoading) return <Skeleton className="h-24 w-full" />;
+
+  if (entries.length === 0) {
+    return (
+      <Panel title="Lifecycle">
+        <EmptyState
+          title="No recorded transitions"
+          description="No registration or deregistration has been observed for this subnet since capture began."
+        />
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel title="Lifecycle" caption="Registration and deregistration, newest first.">
+      <ul className="divide-y divide-border">
+        {entries.map((entry, i) => (
+          <li
+            key={`${entry.event}-${entry.observed_at ?? i}`}
+            className="flex flex-wrap items-baseline justify-between gap-2 py-2"
+          >
+            <span className="mg-type-label uppercase text-ink-strong">{entry.event}</span>
+            <span className="text-xs text-ink-muted">
+              {/* THE DISTINCTION. A null block with predates_capture means the
+                  transition is older than our record, which is a different
+                  claim from "at block 0" and must not render as one. */}
+              {entry.predates_capture
+                ? "before capture began"
+                : entry.block_number === null
+                  ? "block unattributed"
+                  : `block ${formatNumber(entry.block_number)}`}
+              {entry.observed_at ? (
+                <>
+                  {" · observed "}
+                  <TimeAgo at={entry.observed_at} />
+                </>
+              ) : null}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </Panel>
+  );
+}
+
+/** Alpha prices run to eight significant figures; a 2dp format shows 0.00. */
+function formatAlphaPrice(value: number | null): string {
+  if (value === null) return "—";
+  return value.toFixed(8);
+}

--- a/apps/ui/src/lib/metagraphed/queries.subnet-lifecycle.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-lifecycle.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { subnetDeregistrationStandingQuery, subnetLifecycleQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "https://example.test",
+  });
+}
+
+async function run<T>(opts: { queryFn?: unknown; queryKey: readonly unknown[] }): Promise<T> {
+  const fn = opts.queryFn as ((c: Record<string, unknown>) => Promise<T>) | undefined;
+  if (!fn) throw new Error("expected a queryFn");
+  return fn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  });
+}
+
+beforeEach(() => mockedApiFetch.mockReset());
+
+describe("subnetLifecycleQuery", () => {
+  it("keeps a pre-capture transition's block NULL rather than zero", async () => {
+    // THE DISTINCTION. Every subnet alive when the lane first ran was
+    // registered before we were watching, so its block is null. Coercing that
+    // to 0 would claim it launched at genesis -- and 0 is a real block, so the
+    // lie is not even detectable downstream.
+    resolveWith({
+      entries: [
+        {
+          netuid: 64,
+          event: "registered",
+          block_number: null,
+          observed_at: "2026-08-09T01:06:16.110Z",
+          predates_capture: true,
+        },
+      ],
+    });
+    const out = await run<{ data: Array<Record<string, unknown>> }>(subnetLifecycleQuery(64));
+    expect(out.data[0]?.block_number).toBeNull();
+    expect(out.data[0]?.block_number).not.toBe(0);
+    expect(out.data[0]?.predates_capture).toBe(true);
+  });
+
+  it("keeps a real block 0 distinguishable from a missing one", async () => {
+    resolveWith({
+      entries: [
+        {
+          netuid: 1,
+          event: "registered",
+          block_number: 0,
+          observed_at: null,
+          predates_capture: false,
+        },
+      ],
+    });
+    const out = await run<{ data: Array<Record<string, unknown>> }>(subnetLifecycleQuery(1));
+    expect(out.data[0]?.block_number).toBe(0);
+    expect(out.data[0]?.predates_capture).toBe(false);
+  });
+
+  it("drops entries with no netuid or no event rather than inventing one", async () => {
+    resolveWith({ entries: [{ event: "registered" }, { netuid: 5 }, {}] });
+    const out = await run<{ data: unknown[] }>(subnetLifecycleQuery(5));
+    expect(out.data).toEqual([]);
+  });
+
+  it("an empty list is a real answer, not an error", async () => {
+    resolveWith({ entries: [] });
+    const out = await run<{ data: unknown[] }>(subnetLifecycleQuery(9));
+    expect(out.data).toEqual([]);
+  });
+});
+
+describe("subnetDeregistrationStandingQuery", () => {
+  const ranked = {
+    netuid: 70,
+    rank: 1,
+    comparison_price: 0.0014243,
+    moving_price: 0.0014243,
+    registered_at_block: 7787562,
+    subnet_mechanism: 1,
+    immune: false,
+    immune_until_block: null,
+    blocks_until_prunable: 0,
+  };
+  const immune = {
+    netuid: 78,
+    rank: null,
+    comparison_price: 0.0027054,
+    moving_price: 0.0027054,
+    registered_at_block: 7966145,
+    subnet_mechanism: 1,
+    immune: true,
+    immune_until_block: 8830145,
+    blocks_until_prunable: 18832,
+  };
+  const payload = {
+    ranked: [ranked],
+    immune: [immune],
+    ranked_count: 112,
+    immune_count: 16,
+    next_to_deregister: 70,
+  };
+
+  it("finds a subnet in the ranked list", async () => {
+    resolveWith(payload);
+    const out = await run<{ data: { standing: { rank: number } | null } }>(
+      subnetDeregistrationStandingQuery(70),
+    );
+    expect(out.data.standing?.rank).toBe(1);
+  });
+
+  it("finds a subnet in the IMMUNE list, where rank is null not zero", async () => {
+    // An immune subnet is not near the top of the pruning order -- it is not in
+    // the order at all. `rank: 0` would read as "first to be pruned", the exact
+    // inverse of the truth, so null must survive normalisation.
+    resolveWith(payload);
+    const out = await run<{
+      data: { standing: { rank: number | null; immune: boolean } | null };
+    }>(subnetDeregistrationStandingQuery(78));
+    expect(out.data.standing?.immune).toBe(true);
+    expect(out.data.standing?.rank).toBeNull();
+    expect(out.data.standing?.rank).not.toBe(0);
+  });
+
+  it("a subnet in neither list is null, not a fabricated standing", async () => {
+    // Root is the live case: never a pruning candidate. "Not a candidate" and
+    // "rank unknown" are different statements and the panel renders them
+    // differently, so this must not resolve to an empty object.
+    resolveWith(payload);
+    const out = await run<{ data: { standing: unknown } }>(subnetDeregistrationStandingQuery(0));
+    expect(out.data.standing).toBeNull();
+  });
+
+  it("keeps comparison_price and moving_price separate", async () => {
+    // They differ only for a Stable-mechanism subnet, where the pallet
+    // substitutes a flat 1.0 -- which moves it from the top of a price order to
+    // near the bottom. Collapsing them hides the substitution, and #10285
+    // exists because ordering on the raw price gets position one wrong.
+    resolveWith({
+      ranked: [
+        { ...ranked, netuid: 12, subnet_mechanism: 0, comparison_price: 1, moving_price: 0.004 },
+      ],
+      immune: [],
+      ranked_count: 1,
+    });
+    const out = await run<{
+      data: {
+        standing: { comparison_price: number; moving_price: number } | null;
+      };
+    }>(subnetDeregistrationStandingQuery(12));
+    expect(out.data.standing?.comparison_price).toBe(1);
+    expect(out.data.standing?.moving_price).toBe(0.004);
+  });
+
+  it("carries the ranked total, since a rank means little without it", async () => {
+    resolveWith(payload);
+    const out = await run<{ data: { ranked_count: number | null } }>(
+      subnetDeregistrationStandingQuery(70),
+    );
+    expect(out.data.ranked_count).toBe(112);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -230,6 +230,8 @@ import type {
   SubnetHolders,
   SubnetOwnershipHistory,
   SubnetLeaseState,
+  SubnetLifecycleEntry,
+  DeregistrationStanding,
   SubnetLeaseTerms,
   SubnetLeaseHistory,
   SubnetLeaseEvent,
@@ -5437,6 +5439,96 @@ export function normalizeSubnetLeaseState(netuid: number, raw: unknown): SubnetL
     leased,
     lease: normalizeSubnetLeaseTerms(d.lease),
     queried_at: firstString(d.queried_at) ?? null,
+  };
+}
+
+/**
+ * One subnet's registration/deregistration timeline (#10262).
+ *
+ * Newest first. A subnet with no recorded event returns an empty list at 200 --
+ * absence of events is a real answer, distinct from an unknown netuid (404).
+ */
+export const subnetLifecycleQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-lifecycle", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<{ entries?: unknown }>(`/api/v1/subnets/${netuid}/lifecycle`, {
+        signal,
+      });
+      const raw = isRecord(res.data) ? res.data.entries : null;
+      const entries = (Array.isArray(raw) ? raw : [])
+        .map(normalizeSubnetLifecycleEntry)
+        .filter((e): e is SubnetLifecycleEntry => e !== null);
+      return { data: entries, meta: res.meta, url: res.url };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeSubnetLifecycleEntry(raw: unknown): SubnetLifecycleEntry | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid) ?? null;
+  const event = firstString(raw.event);
+  if (netuid === null || !event) return null;
+  return {
+    netuid,
+    event,
+    // NULLABLE ON PURPOSE. A transition older than capture has no block, and
+    // coercing it to 0 would claim it happened at genesis.
+    block_number: firstFiniteNumber(raw.block_number) ?? null,
+    observed_at: firstString(raw.observed_at) ?? null,
+    predates_capture: raw.predates_capture === true,
+  };
+}
+
+/**
+ * This subnet's place in the chain's pruning order, or null if it has none
+ * (#10285).
+ *
+ * The route answers network-wide; this picks the one entry out of `ranked` OR
+ * `immune`. Those two lists are disjoint and a subnet in neither is not a
+ * pruning candidate at all -- root, most obviously.
+ */
+export const subnetDeregistrationStandingQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-dereg-standing", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>("/api/v1/chain/deregistration-ranking", {
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      const pick = (list: unknown) =>
+        (Array.isArray(list) ? list : [])
+          .map(normalizeDeregistrationStanding)
+          .find((e) => e?.netuid === netuid) ?? null;
+      return {
+        data: {
+          standing: pick(d.ranked) ?? pick(d.immune),
+          ranked_count: firstFiniteNumber(d.ranked_count) ?? null,
+          immune_count: firstFiniteNumber(d.immune_count) ?? null,
+          next_to_deregister: firstFiniteNumber(d.next_to_deregister) ?? null,
+        },
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeDeregistrationStanding(raw: unknown): DeregistrationStanding | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid) ?? null;
+  if (netuid === null) return null;
+  return {
+    netuid,
+    // null iff immune -- see the type's note; not interchangeable with 0.
+    rank: firstFiniteNumber(raw.rank) ?? null,
+    comparison_price: firstFiniteNumber(raw.comparison_price) ?? null,
+    moving_price: firstFiniteNumber(raw.moving_price) ?? null,
+    registered_at_block: firstFiniteNumber(raw.registered_at_block) ?? null,
+    subnet_mechanism: firstFiniteNumber(raw.subnet_mechanism) ?? null,
+    immune: raw.immune === true,
+    immune_until_block: firstFiniteNumber(raw.immune_until_block) ?? null,
+    blocks_until_prunable: firstFiniteNumber(raw.blocks_until_prunable) ?? null,
   };
 }
 

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -4103,3 +4103,41 @@ export interface AlertTriggerCreated {
   match_count: number;
   owner_token: string;
 }
+
+/**
+ * One registration/deregistration transition for a subnet (#10262).
+ *
+ * `predates_capture` is load-bearing rather than decorative: every subnet alive
+ * when the lane first ran was registered before we were watching, so its row
+ * carries a NULL block. A reader must be able to tell "registered before
+ * capture" from "registered at block 0", which is why the block is nullable and
+ * the flag travels beside it.
+ */
+export interface SubnetLifecycleEntry {
+  netuid: number;
+  event: string;
+  block_number: number | null;
+  observed_at: string | null;
+  predates_capture: boolean;
+}
+
+/**
+ * One subnet's standing in the chain's own pruning order (#10285).
+ *
+ * `rank` is null exactly when `immune` is true -- an immune subnet is not in
+ * the ranking at all, it is waiting to join it, which is why the two fields are
+ * not redundant. `comparison_price` is what the pallet compares and
+ * `moving_price` the raw read; they differ only for a Stable-mechanism subnet,
+ * where the pallet substitutes a flat 1.0.
+ */
+export interface DeregistrationStanding {
+  netuid: number;
+  rank: number | null;
+  comparison_price: number | null;
+  moving_price: number | null;
+  registered_at_block: number | null;
+  subnet_mechanism: number | null;
+  immune: boolean;
+  immune_until_block: number | null;
+  blocks_until_prunable: number | null;
+}

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -67,6 +67,7 @@ import { SubnetConvictionLeaderboard } from "@/components/metagraphed/subnet-con
 import { SubnetHoldersLeaderboard } from "@/components/metagraphed/subnet-holders-leaderboard";
 import { SubnetOwnershipHistory } from "@/components/metagraphed/subnet-ownership-history";
 import { SubnetLeasePanel } from "@/components/metagraphed/subnet-lease-panel";
+import { SubnetLifecyclePanel } from "@/components/metagraphed/subnet-lifecycle-panel";
 import { MetagraphTableLoader } from "@/components/metagraphed/metagraph-panel";
 import { ValidatorsTableLoader } from "@/components/metagraphed/validators-panel";
 import { DistributionPanel } from "@/components/metagraphed/concentration-panel";
@@ -700,6 +701,17 @@ function GovernancePanel({ netuid }: { netuid: number }) {
       >
         <QueryErrorBoundary>
           <SubnetOwnershipHistory netuid={netuid} />
+        </QueryErrorBoundary>
+      </SectionAnchor>
+
+      <SectionAnchor
+        id="lifecycle"
+        title="Lifecycle & deregistration standing"
+        subtitle="When this subnet registered, and where it sits in the order the chain would prune."
+        info="GET /api/v1/subnets/{netuid}/lifecycle and /api/v1/chain/deregistration-ranking — an append-only registration/deregistration log (a transition older than capture carries a NULL block and says so, rather than reading as block 0), beside the pallet's own pruning order. That order is NOT a price sort: immunity excludes a subnet entirely, and a Stable-mechanism subnet is compared at a flat 1.0 rather than its moving price."
+      >
+        <QueryErrorBoundary>
+          <SubnetLifecyclePanel netuid={netuid} />
         </QueryErrorBoundary>
       </SectionAnchor>
 


### PR DESCRIPTION
Closes #10387. Part of #10300 — its remaining half, now that the TAO-price half is confirmed shipped.

Re-measured 2026-08-10: **27 of 204** published GET routes have no home in the UI (the issue said 30 of 205; three were picked up since). This renders two of them, and they are the two that belong together:

```
/api/v1/subnets/{netuid}/lifecycle     #10262 — registration/deregistration log
/api/v1/chain/deregistration-ranking   #10285 — the chain's own pruning order
```

"When did this subnet arrive" and "is it at risk" are the same question from either end. Both went live earlier today and nothing displayed either.

## Three distinctions a naive rendering collapses

Each collapse states something false, so each gets an explicit branch rather than a shared formatter:

**`predates_capture` is not "registered at block 0".** Every subnet alive when the lane first ran was registered before we were watching, so its block is `null`. Printing `0` claims it launched at genesis — and 0 is a real block, so nothing downstream could catch it. Renders as *"before capture began"*.

**Immune is not rank 0.** An immune subnet has `rank: null` — not near the top of the pruning order, not *in* the order, and not deregisterable until its window lapses. Rendering `#0` inverts the meaning exactly. Immune subnets get a different tile set entirely: status, until-block, blocks-remaining — no rank anywhere.

**`comparison_price` is not `moving_price`.** They differ only for a Stable-mechanism subnet, where the pallet substitutes a flat 1.0 — moving it from the top of a price order to near the bottom. #10285 exists because ordering on the raw price names netuid 86 where the chain names 70. Both are shown, with the substitution called out when they differ.

A subnet in **neither** list is its own case: root is never a pruning candidate, and *"not a candidate"* is a different statement from *"rank unknown"*.

## Tests

9, pinning all four cases — including that a **real block 0 stays distinguishable from a missing one**. That is the reverse direction, and a null-check alone passes it while still being wrong.

## Verification

`tsc` clean in both the repo and `apps/ui`; `lint` and `format:check` clean. The panel sits on the governance tab beside ownership history and lease.

Screenshots waived per the standing maintainer arrangement.

## Context

The data behind this was verified in production this morning — the capture lane's first tick recorded `ok :: captured 129 subnet(s) at block 8811313`, and replaying **only the stored rows** through `rankDeregistration` reproduced the live route exactly (112 ranked / 16 immune / next 70), which is the argument for storing measured inputs rather than the derived rank.