### PR TITLE
feat(economics): one primitive for alpha in USD, with composed availability (#10380)

### DIFF
--- a/src/alpha-usd.ts
+++ b/src/alpha-usd.ts
@@ -1,0 +1,178 @@
+// Alpha priced in USD, and the reasons it sometimes cannot be (#10380).
+//
+// Every alpha economic figure we publish is denominated in TAO --
+// `alpha_price_tao`, `alpha_market_cap_tao`, `alpha_fdv_tao`, `subnet_volume_tao`
+// -- and we publish a TAO/USD index with better provenance than any third
+// party (ADR 0025). Nothing composes them, so "what is this subnet's alpha
+// worth in dollars" has no answer from us (#10379).
+//
+// ## The multiply is trivial; composing the two PROPERTIES is not
+//
+// PROVENANCE COMPOSES. `alpha_price_tao` is measured from the subnet AMM;
+// `usd_per_tao` is a liquidity-weighted median across qualifying wTAO/WETH
+// pools through an ETH/USDC anchor. Their product is RECONSTRUCTED, not
+// measured, and `field_sources` has to say so -- the same distinction #10285
+// draws for `comparison_price`, and for the same reason: labelling a
+// derivation as a measurement attributes our arithmetic to the chain.
+//
+// AVAILABILITY COMPOSES, and this is the half that fails quietly. The index
+// publishes `usd_per_tao: null` with `price_basis: "insufficient_pools"`
+// whenever fewer than the quorum of pools qualify -- a STATED outcome, not a
+// gap. A helper that multiplied whatever it last saw would serve a stale rate
+// confidently and indefinitely, which is #9704 in a new place: a read with no
+// live writer behind it, at 200 OK.
+//
+// So this returns a value with the block it came from, or a REASON. There is
+// no third shape, and callers cannot get a number without its provenance.
+//
+// ## Why this is one module and not a helper per surface
+//
+// Six surfaces want USD (#10381, #10382, #10383). Six multiplications would be
+// six chances to skip the staleness check, six places to fix a rounding rule,
+// and six different words for the same unavailability. The point of a
+// primitive is that the unhappy paths are written once.
+
+import type { FiatPriceBasis } from "./tao-usd-index.ts";
+
+/**
+ * How old the TAO/USD reading may be before a price derived from it is refused.
+ *
+ * TWO HOURS, matching `tao_usd_index`'s own freshness bound in
+ * src/table-freshness-watchdog.ts, which is sized against
+ * `TAO_USD_INDEX_CRON` running every minute. Deliberately the SAME number
+ * rather than a tighter one invented here: if a reading is fresh enough for the
+ * watchdog to stay quiet, refusing to multiply by it would mean this module and
+ * the watchdog disagree about whether the index is working, and an operator
+ * would have two answers with no way to tell which to believe.
+ *
+ * It is generous against a one-minute cadence, which is the right direction --
+ * the failure this guards is a rate frozen for hours, not one a few ticks old.
+ */
+export const TAO_USD_MAX_AGE_MS = 2 * 60 * 60 * 1000;
+
+/** Why a USD figure could not be produced. Every value is a stated outcome. */
+export type AlphaUsdUnavailable =
+  /** No TAO/USD reading at all -- the index has never written, or the read failed. */
+  | "no_index_reading"
+  /** A reading exists and carries no price: ADR 0025's `insufficient_pools`. */
+  | "index_unpriced"
+  /** The newest reading is older than TAO_USD_MAX_AGE_MS. */
+  | "index_stale"
+  /** The alpha side is missing. A subnet with no price is not one priced at 0. */
+  | "no_alpha_price";
+
+/** The newest TAO/USD reading, in the shape `latest` already publishes. */
+export interface TaoUsdReading {
+  usd_per_tao: number | null;
+  observed_at: string | null;
+  block_number: number | null;
+  price_basis: FiatPriceBasis | string | null;
+}
+
+/**
+ * A USD figure with the provenance that produced it.
+ *
+ * The multiplier's block travels WITH the value rather than beside it in some
+ * envelope, so a caller cannot serialise the number and drop the audit trail --
+ * which is exactly what happened to `comparison_price` before #10285 published
+ * `moving_price` next to it.
+ */
+export interface AlphaUsdValue {
+  usd: number;
+  usd_per_tao: number;
+  tao_usd_block: number | null;
+  tao_usd_observed_at: string | null;
+  tao_usd_basis: FiatPriceBasis | string | null;
+}
+
+export type AlphaUsdResult =
+  | { ok: true; value: AlphaUsdValue }
+  | { ok: false; reason: AlphaUsdUnavailable };
+
+const finite = (v: unknown): v is number =>
+  typeof v === "number" && Number.isFinite(v);
+
+/**
+ * Whether this reading may be multiplied by, and why not if it may not.
+ *
+ * Split from `alphaUsd` because every surface asks it once per response and
+ * then prices many rows -- checking per row would be the same answer N times,
+ * and a caller that forgot would be indistinguishable from one that asked.
+ */
+export function taoUsdUsable(
+  reading: TaoUsdReading | null | undefined,
+  nowMs: number,
+  maxAgeMs: number = TAO_USD_MAX_AGE_MS,
+): { ok: true } | { ok: false; reason: AlphaUsdUnavailable } {
+  if (!reading) return { ok: false, reason: "no_index_reading" };
+  // `usd_per_tao: null` is `insufficient_pools`, which the CHECK constraint on
+  // tao_usd_index guarantees is paired with that basis. It is a published
+  // decline, not a missing field, and must never read as a price of zero.
+  if (!finite(reading.usd_per_tao) || reading.usd_per_tao <= 0) {
+    return { ok: false, reason: "index_unpriced" };
+  }
+  const observedMs = reading.observed_at
+    ? Date.parse(reading.observed_at)
+    : NaN;
+  // An unparseable or absent stamp is treated as STALE rather than fresh. A
+  // reading that cannot say when it was taken cannot be shown to be current,
+  // and defaulting the unknown direction to "usable" is how a frozen rate
+  // survives a staleness check.
+  if (!Number.isFinite(observedMs)) return { ok: false, reason: "index_stale" };
+  if (nowMs - observedMs > maxAgeMs)
+    return { ok: false, reason: "index_stale" };
+  return { ok: true };
+}
+
+/**
+ * One alpha price in USD, or the reason there is none.
+ *
+ * `alphaTao` is a price, market cap, FDV or volume already denominated in TAO
+ * -- the multiplication is identical for all of them, which is why this takes a
+ * number rather than a named field.
+ */
+export function alphaUsd(
+  alphaTao: number | null | undefined,
+  reading: TaoUsdReading | null | undefined,
+  nowMs: number,
+  maxAgeMs: number = TAO_USD_MAX_AGE_MS,
+): AlphaUsdResult {
+  const usable = taoUsdUsable(reading, nowMs, maxAgeMs);
+  if (!usable.ok) return { ok: false, reason: usable.reason };
+  // Checked AFTER the index, so a caller with both problems is told about the
+  // one that affects every row rather than the one affecting this row.
+  //
+  // ZERO IS A PRICE. `alpha_price_tao: 0` is a real reading -- a subnet whose
+  // pool has no TAO in it -- and 0 x rate is a legitimate $0. Only null and
+  // non-finite are refused, which is the same line src/subnet-deregistration-
+  // ranking.ts draws for `moving_price`.
+  if (!finite(alphaTao)) return { ok: false, reason: "no_alpha_price" };
+
+  const rate = (reading as TaoUsdReading).usd_per_tao as number;
+  return {
+    ok: true,
+    value: {
+      // NOT rounded here. Rounding is a presentation decision and the right
+      // number of places differs per field -- a per-alpha price needs eight,
+      // a market cap needs none. Rounding at the source would silently cap the
+      // precision every downstream surface could ever have.
+      usd: alphaTao * rate,
+      usd_per_tao: rate,
+      tao_usd_block: (reading as TaoUsdReading).block_number ?? null,
+      tao_usd_observed_at: (reading as TaoUsdReading).observed_at ?? null,
+      tao_usd_basis: (reading as TaoUsdReading).price_basis ?? null,
+    },
+  };
+}
+
+/**
+ * The `field_sources` entry every USD field must carry.
+ *
+ * RECONSTRUCTED, never measured. The product of two measurements is our
+ * arithmetic, and `storage: null` says there is no single chain read behind it
+ * -- the same shape DEREGISTRATION_FIELD_SOURCES uses for `comparison_price`.
+ */
+export const ALPHA_USD_FIELD_SOURCE = {
+  kind: "reconstructed",
+  storage: null,
+} as const;

--- a/tests/alpha-usd.test.ts
+++ b/tests/alpha-usd.test.ts
@@ -1,0 +1,188 @@
+// The alpha-in-USD composition primitive (#10380).
+//
+// The multiply is one line. Everything worth testing is the unhappy paths,
+// because that is where the failure is SILENT: a helper that multiplies
+// whatever rate it last saw keeps serving a number, and a stale dollar figure
+// looks exactly like a fresh one. #9704 is the same shape — a read with no live
+// writer behind it, at 200 OK — and it cost two days of a frozen snapshot.
+//
+// So the declining cases come first here, and the happy path is one test.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { TABLE_FRESHNESS } from "../src/table-freshness-watchdog.ts";
+import {
+  ALPHA_USD_FIELD_SOURCE,
+  TAO_USD_MAX_AGE_MS,
+  alphaUsd,
+  taoUsdUsable,
+  type TaoUsdReading,
+} from "../src/alpha-usd.ts";
+
+const NOW = Date.parse("2026-08-10T06:00:00.000Z");
+const iso = (msAgo: number) => new Date(NOW - msAgo).toISOString();
+
+const healthy: TaoUsdReading = {
+  usd_per_tao: 204.125,
+  observed_at: iso(60_000),
+  block_number: 25_719_199,
+  price_basis: "wrapped_onchain_median",
+};
+
+describe("the index must be usable before anything is priced", () => {
+  test("no reading at all is refused, not treated as zero", () => {
+    for (const empty of [null, undefined]) {
+      assert.deepEqual(taoUsdUsable(empty, NOW), {
+        ok: false,
+        reason: "no_index_reading",
+      });
+    }
+  });
+
+  test("`insufficient_pools` is a DECLINE, never a price of zero", () => {
+    // ADR 0025: below the pool quorum the index publishes nothing, and the
+    // CHECK constraint pairs that null with this basis. Reading it as 0 would
+    // make every alpha figure worth $0 — a confident, wrong, plausible number.
+    const unpriced: TaoUsdReading = {
+      usd_per_tao: null,
+      observed_at: iso(60_000),
+      block_number: 25_719_199,
+      price_basis: "insufficient_pools",
+    };
+    assert.deepEqual(taoUsdUsable(unpriced, NOW), {
+      ok: false,
+      reason: "index_unpriced",
+    });
+  });
+
+  test("a non-positive rate is refused too", () => {
+    for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const r = { ...healthy, usd_per_tao: bad };
+      assert.equal(taoUsdUsable(r, NOW).ok, false, String(bad));
+    }
+  });
+
+  test("a reading older than the bound is stale", () => {
+    const old = { ...healthy, observed_at: iso(TAO_USD_MAX_AGE_MS + 1000) };
+    assert.deepEqual(taoUsdUsable(old, NOW), {
+      ok: false,
+      reason: "index_stale",
+    });
+  });
+
+  test("one millisecond inside the bound is still usable", () => {
+    // Pins the boundary, so a later change to the comparison is deliberate
+    // rather than an off-by-one nobody notices until a rate freezes.
+    const edge = { ...healthy, observed_at: iso(TAO_USD_MAX_AGE_MS - 1) };
+    assert.equal(taoUsdUsable(edge, NOW).ok, true);
+  });
+
+  test("a reading that cannot say WHEN is stale, not fresh", () => {
+    // Defaulting the unknown direction to "usable" is how a frozen rate
+    // survives a staleness check forever.
+    for (const stamp of [null, "", "not-a-date"]) {
+      const r = { ...healthy, observed_at: stamp };
+      assert.deepEqual(taoUsdUsable(r, NOW), {
+        ok: false,
+        reason: "index_stale",
+      });
+    }
+  });
+
+  test("the bound IS the table's own freshness bound, not a copy of it", () => {
+    // Compared against the DECLARATION rather than against a literal. Writing
+    // `assert.equal(TAO_USD_MAX_AGE_MS, 2 * 60 * 60 * 1000)` would restate this
+    // module's own constant and pass forever while the watchdog moved
+    // underneath it -- the one-directional-parity trap. If these two ever
+    // disagree, this module and the watchdog disagree about whether the index
+    // is working, and an operator gets two answers with no way to choose.
+    const declared = TABLE_FRESHNESS.tao_usd_index?.maxAgeMs;
+    assert.ok(
+      typeof declared === "number",
+      "tao_usd_index has no declared freshness bound to agree with",
+    );
+    assert.equal(TAO_USD_MAX_AGE_MS, declared);
+  });
+});
+
+describe("pricing alpha", () => {
+  test("a healthy reading yields the product WITH its provenance", () => {
+    const out = alphaUsd(0.088370705, healthy, NOW);
+    assert.equal(out.ok, true);
+    if (!out.ok) return;
+    assert.equal(out.value.usd, 0.088370705 * 204.125);
+    assert.equal(out.value.usd_per_tao, 204.125);
+    assert.equal(out.value.tao_usd_block, 25_719_199);
+    assert.equal(out.value.tao_usd_basis, "wrapped_onchain_median");
+  });
+
+  test("ZERO IS A PRICE, and prices to $0", () => {
+    // `alpha_price_tao: 0` is a real reading — a pool with no TAO in it — and
+    // 0 x rate is a legitimate $0. Refusing it would turn a measured zero into
+    // "unavailable", which is the opposite error to the one above and just as
+    // wrong. Same line src/subnet-deregistration-ranking.ts draws for
+    // moving_price.
+    const out = alphaUsd(0, healthy, NOW);
+    assert.equal(out.ok, true);
+    if (!out.ok) return;
+    assert.equal(out.value.usd, 0);
+  });
+
+  test("a missing alpha price is refused, not zeroed", () => {
+    for (const missing of [null, undefined, Number.NaN]) {
+      const out = alphaUsd(missing as number | null, healthy, NOW);
+      assert.deepEqual(out, { ok: false, reason: "no_alpha_price" });
+    }
+  });
+
+  test("the INDEX reason wins when both sides are missing", () => {
+    // The index problem affects every row in the response; the alpha one
+    // affects this row. Reporting the row-level cause would send an operator
+    // looking at one subnet when the whole surface is unpriced.
+    const out = alphaUsd(null, null, NOW);
+    assert.deepEqual(out, { ok: false, reason: "no_index_reading" });
+  });
+
+  test("a stale index refuses even a perfectly good alpha price", () => {
+    const old = { ...healthy, observed_at: iso(TAO_USD_MAX_AGE_MS + 1) };
+    assert.deepEqual(alphaUsd(0.5, old, NOW), {
+      ok: false,
+      reason: "index_stale",
+    });
+  });
+
+  test("does NOT round — that is the caller's decision", () => {
+    // A per-alpha price needs eight places, a market cap needs none. Rounding
+    // here would cap the precision every downstream surface could ever have.
+    const out = alphaUsd(1 / 3, { ...healthy, usd_per_tao: 3 }, NOW);
+    assert.equal(out.ok, true);
+    if (!out.ok) return;
+    assert.equal(out.value.usd, (1 / 3) * 3);
+  });
+
+  test("every unavailability is a named reason, never a null value", () => {
+    // The shape guarantee: a caller can never receive `{ok: true}` carrying an
+    // absent number, so it cannot serialise a USD field with nothing in it.
+    const cases: Array<[number | null, TaoUsdReading | null]> = [
+      [null, healthy],
+      [1, null],
+      [1, { ...healthy, usd_per_tao: null }],
+      [1, { ...healthy, observed_at: iso(TAO_USD_MAX_AGE_MS + 1) }],
+    ];
+    for (const [tao, r] of cases) {
+      const out = alphaUsd(tao, r, NOW);
+      assert.equal(out.ok, false);
+      if (out.ok) continue;
+      assert.ok(out.reason.length > 0);
+    }
+  });
+});
+
+describe("the field-source declaration", () => {
+  test("USD is RECONSTRUCTED, never measured", () => {
+    // The product of two measurements is our arithmetic. Labelling it
+    // `measured` would attribute the multiplication to the chain — the same
+    // reason comparison_price is reconstructed in #10285.
+    assert.equal(ALPHA_USD_FIELD_SOURCE.kind, "reconstructed");
+    assert.equal(ALPHA_USD_FIELD_SOURCE.storage, null);
+  });
+});


### PR DESCRIPTION
Closes #10380. Sub-issue 1 of #10379 and the load-bearing one — #10381, #10382 and #10383 are all unsafe without it.

Every alpha figure we publish is TAO-denominated. We publish a TAO/USD index with better provenance than any third party (ADR 0025). Nothing composes them.

## The multiply is one line; composing the two properties is the work

**Provenance composes.** `alpha_price_tao` is measured from the subnet AMM; `usd_per_tao` is a liquidity-weighted median across qualifying wTAO/WETH pools through an ETH/USDC anchor. Their product is `reconstructed`, and `field_sources` says so — labelling a derivation `measured` attributes our arithmetic to the chain, the distinction #10285 draws for `comparison_price`.

**Availability composes, and that half fails quietly.** The index publishes `usd_per_tao: null` with `price_basis: "insufficient_pools"` below the pool quorum — a *stated decline* that a CHECK constraint pairs with that basis. A helper multiplying whatever it last saw would serve a stale rate confidently and indefinitely: **#9704 in a new place**, a read with no live writer behind it at 200 OK.

So the result is a value carrying the block it came from, **or** a named reason. There is no third shape, and the multiplier's block travels *inside* the value rather than beside it — serialising cannot drop the audit trail.

```
no_index_reading · index_unpriced · index_stale · no_alpha_price
```

## Two directions that are easy to get backwards

Both pinned, because they fail in opposite ways and fixing one invites the other:

- **A reading that cannot say *when* it was taken is stale, not fresh.** Defaulting the unknown direction to usable is how a frozen rate survives a staleness check forever.
- **Zero is a price.** `alpha_price_tao: 0` is a real reading — a pool with no TAO in it — and `0 × rate` is a legitimate $0. Refusing it would turn a *measured* zero into "unavailable", which is just as wrong in the other direction. Same line `subnet-deregistration-ranking.ts` draws for `moving_price`.

## The staleness bound is not a number I invented

It is asserted **equal to `tao_usd_index`'s own entry in `TABLE_FRESHNESS`** — against the declaration, not a literal. Writing `assert.equal(TAO_USD_MAX_AGE_MS, 2 * 60 * 60 * 1000)` would restate this module's own constant and pass forever while the watchdog moved underneath it.

Proven to fail: changing the watchdog to 3h turns it red.

If these two ever disagree, this module and the watchdog disagree about whether the index is working, and an operator gets two answers with no way to choose.

## Smaller decisions worth flagging

- **The index reason wins** when both sides are missing — that one affects every row in a response, the alpha one affects a single row. Reporting the row-level cause sends someone to look at one subnet when the whole surface is unpriced.
- **Not rounded.** A per-alpha price needs eight places, a market cap none. Rounding at the source caps what every downstream surface could ever show.
- **`taoUsdUsable` is split out** so a surface asks once per response rather than once per row.

15 tests, declining paths first. `tsc`, `lint`, `format:check` clean.